### PR TITLE
Fix OTP request/verification flow for login

### DIFF
--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server';
 
-import { isUsPhoneNumber, normalizePhone } from '@/server/auth/phone';
+import { isUsPhoneNumber, normalizePhone, requestOtp } from '@/server/auth';
 
 export async function POST(request: Request) {
   try {
@@ -22,8 +22,13 @@ export async function POST(request: Request) {
     }
 
     const phone = normalizePhone(rawPhone);
+    const { code } = await requestOtp(phone);
 
-    return NextResponse.json({ ok: true, phone });
+    return NextResponse.json({
+      ok: true,
+      phone,
+      ...(process.env.NODE_ENV !== 'production' ? { debugCode: code } : {}),
+    });
   } catch (error) {
     console.error('[auth/request-otp] failed', error);
     return NextResponse.json(

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,11 +1,9 @@
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
+import { verifyOtp } from '@/server/auth';
 import { createSession } from '@/server/auth/session';
-import { isUsPhoneNumber, normalizePhone } from '@/server/auth/phone';
 import { db, friendInvitations, friendships, users } from '@/server/db';
-
-const TEMPORARY_OTP_CODE = '000000';
 
 type VerifyOtpBody = {
   phone?: unknown;
@@ -124,21 +122,15 @@ export async function POST(request: Request) {
       );
     }
 
-    if (!isUsPhoneNumber(phone)) {
-      return NextResponse.json(
-        { error: 'invalid_phone', message: 'US phone number required' },
-        { status: 400 },
-      );
-    }
+    const normalizedPhone = await verifyOtp(phone, code);
 
-    if (code !== TEMPORARY_OTP_CODE) {
+    if (!normalizedPhone) {
       return NextResponse.json(
         { error: 'invalid_code', message: 'Code invalid or expired' },
         { status: 401 },
       );
     }
 
-    const normalizedPhone = normalizePhone(phone);
     const user = await getOrCreateUserForLogin(normalizedPhone);
 
     await createSession(user.id);

--- a/src/server/auth/otp-store.ts
+++ b/src/server/auth/otp-store.ts
@@ -41,9 +41,9 @@ export async function verifyOtp(phone: string, code: string): Promise<string | n
     .orderBy(desc(otpCodes.createdAt))
     .limit(1);
 
-  if (entry) {
-    await db.delete(otpCodes).where(eq(otpCodes.phoneNumber, normalized));
-  }
+  if (!entry) return null;
+
+  await db.delete(otpCodes).where(eq(otpCodes.phoneNumber, normalized));
 
   return normalized;
 }


### PR DESCRIPTION
### Motivation
- The login flow was inconsistent: the request endpoint validated phone formatting but did not generate/store an OTP, while verification used a hardcoded temporary code, causing valid logins to fail with "Code invalid or expired." 
- `verifyOtp` in the OTP store returned a normalized phone even when no matching/valid OTP existed, which hid verification failures. 

### Description
- Updated `src/app/api/auth/request-otp/route.ts` to call `requestOtp` so requests generate and persist a 6-digit OTP, and to return a non-production `debugCode` field to aid local testing. 
- Updated `src/app/api/auth/verify-otp/route.ts` to use `verifyOtp(phone, code)` and to reject when it returns `null`, removing the previous hardcoded `000000` bypass. 
- Fixed `src/server/auth/otp-store.ts` so `verifyOtp` returns `null` when no valid OTP is found and only deletes stored codes after a successful verification. 

### Testing
- Ran the linter with `npm run -s lint`, which failed due to many pre-existing repository lint errors unrelated to these changes (reported: 39 errors, 9 warnings). 
- Ran the repository test command targeted at auth with `npm run -s test -- src/server/auth`, which did not report any failing auth tests (no OTP-specific unit tests were added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f62ddbc108832e918900d1b28d2153)