### PR TITLE
Fix missing OTP utility exports in auth barrel

### DIFF
--- a/src/server/auth/index.ts
+++ b/src/server/auth/index.ts
@@ -5,4 +5,4 @@
 
 export { createSession, getSession, getSessionToken, validateSessionToken, destroySession } from './session';
 export { getCurrentUser, requireUser } from './user';
-export { requestOtp, verifyOtp, getStoredCodeForPhone } from './otp-store';
+export { requestOtp, verifyOtp, getStoredCodeForPhone, isUsPhoneNumber, normalizePhone } from './otp-store';


### PR DESCRIPTION
### Motivation
- Ensure `isUsPhoneNumber` and `normalizePhone` are available from the auth barrel so server routes that import them from `@/server/auth` compile under Next.js/Turbopack and Vercel.

### Description
- Re-exported `isUsPhoneNumber` and `normalizePhone` from `src/server/auth/index.ts` alongside existing OTP exports (`requestOtp`, `verifyOtp`, `getStoredCodeForPhone`).

### Testing
- Ran `npm run build`, which removes the original missing-export errors and allows the compile step to succeed, though the build later fails in this environment due to a missing `DATABASE_URL` while collecting page data for `/api/account`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63398f4c8832e986460d6d0fdce0a)