### PR TITLE
fix(db): remove import-time env gate to prevent auth API 500s

### DIFF
--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -1,14 +1,10 @@
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { Pool } from 'pg';
 
-import checkEnv from '@/env-check';
 import * as schema from './schema';
 
 const connectionString = process.env.DATABASE_URL;
 
-if (process.env.NODE_ENV === 'production' && process.env.NEXT_PHASE !== 'phase-production-build') {
-  checkEnv();
-}
 
 if (!connectionString) {
   throw new Error('DATABASE_URL is required to initialize the database client.');


### PR DESCRIPTION
### Motivation
- Importing the DB client triggered `checkEnv()` at module initialization, which required unrelated production env vars and caused runtime function initialization to fail and return 500s for auth endpoints.

### Description
- Removed the `checkEnv` import and the conditional `checkEnv()` call from `src/server/db/index.ts`, keeping only the `DATABASE_URL` presence check.

### Testing
- Ran `npm run -s lint`, which failed due to pre-existing repository lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f634c6de8c832e875c6255d359780b)