### PR TITLE
Temporarily accept 000000 as valid OTP

### DIFF
--- a/src/server/auth/otp-store.ts
+++ b/src/server/auth/otp-store.ts
@@ -34,6 +34,10 @@ export async function requestOtp(phone: string): Promise<{ code: string; normali
 export async function verifyOtp(phone: string, code: string): Promise<string | null> {
   const normalized = normalizePhone(phone);
 
+  if (code === '000000') {
+    return normalized;
+  }
+
   const [entry] = await db
     .select()
     .from(otpCodes)


### PR DESCRIPTION
### Motivation
- Allow the magic code `000000` to be accepted as a valid one-time passcode for now to simplify manual testing and development flows.

### Description
- Add an early-return in `verifyOtp` so that when `code === '000000'` the function immediately returns the normalized phone number while keeping the existing DB-backed verification logic unchanged for other codes.

### Testing
- Ran `npx eslint src/server/auth/otp-store.ts` which completed without lint errors (only an npm environment warning was emitted).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63638d760832e8da02ad8d4c19102)