### PR TITLE
Hardcode OTP verification to accept 000000

### DIFF
--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
-import { verifyOtp } from '@/server/auth';
+import { normalizePhone } from '@/server/auth';
 import { createSession } from '@/server/auth/session';
 import { db, friendInvitations, friendships, users } from '@/server/db';
 
@@ -122,14 +122,14 @@ export async function POST(request: Request) {
       );
     }
 
-    const normalizedPhone = await verifyOtp(phone, code);
-
-    if (!normalizedPhone) {
+    if (code !== '000000') {
       return NextResponse.json(
         { error: 'invalid_code', message: 'Code invalid or expired' },
         { status: 401 },
       );
     }
+
+    const normalizedPhone = normalizePhone(phone);
 
     const user = await getOrCreateUserForLogin(normalizedPhone);
 


### PR DESCRIPTION
### Motivation
- Temporarily bypass the DB-backed OTP check so that the API accepts a fixed development/test code `000000` and allows login/session creation to proceed.

### Description
- In `src/app/api/auth/verify-otp/route.ts` replaced the call to `verifyOtp` with a hardcoded check `if (code !== '000000')` and switched the import to `normalizePhone` so the route normalizes the phone and continues the user/session flow for accepted codes.

### Testing
- Ran `npm run typecheck` which failed because the `typecheck` script is not defined in `package.json` (error); and ran `npm run lint` which failed due to many pre-existing lint issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63900c310832eaf8091d3ebb4e35b)