### PR TITLE
Use server `verifyOtp` in verify-otp route

### DIFF
--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull, or } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
-import { normalizePhone } from '@/server/auth';
+import { verifyOtp } from '@/server/auth';
 import { createSession } from '@/server/auth/session';
 import { db, friendInvitations, friendships, users } from '@/server/db';
 
@@ -122,14 +122,14 @@ export async function POST(request: Request) {
       );
     }
 
-    if (code !== '000000') {
+    const normalizedPhone = await verifyOtp(phone, code);
+
+    if (!normalizedPhone) {
       return NextResponse.json(
         { error: 'invalid_code', message: 'Code invalid or expired' },
         { status: 401 },
       );
     }
-
-    const normalizedPhone = normalizePhone(phone);
 
     const user = await getOrCreateUserForLogin(normalizedPhone);
 


### PR DESCRIPTION
### Motivation
- The endpoint previously used a hardcoded bypass (`'000000'`) and normalized phone locally, which allowed a false-positive bypass and diverged from the centralized OTP persistence and expiry logic. 
- Aligning the route with the server OTP store prevents incorrect server errors and ensures codes are validated against stored, time-limited entries.

### Description
- Replaced the inline bypass and local normalization in `src/app/api/auth/verify-otp/route.ts` with the shared `verifyOtp(phone, code)` import from `@/server/auth`.
- The route now calls `verifyOtp` to obtain a `normalizedPhone` and returns `401` with `{ error: 'invalid_code' }` when verification fails.
- Preserved the existing session creation (`createSession`) and invitation acceptance flow so they only run after successful verification.

### Testing
- Ran `npm run lint -- src/app/api/auth/verify-otp/route.ts` and confirmed no new lint errors were introduced in the modified file. 
- The lint command exited non-zero due to existing unrelated repository-wide lint issues, which were not changed by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f63d39e2b4832e8c23c71dde2a411d)