### PR TITLE
Support AUTH_SECRET as alias for JWT_SECRET (fix production OTP/session error)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,8 @@ ANTHROPIC_API_KEY=""
 # 32+ random bytes, base64-encoded.
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"
 JWT_SECRET=""
+# Optional alias used by some platforms/tooling.
+AUTH_SECRET=""
 
 # ── App ───────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL="http://localhost:3000"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ Open `.env.local` and fill in:
 | `DATABASE_URL` | Supabase pooled connection (port 6543) |
 | `DIRECT_URL` | Supabase direct connection (port 5432) |
 | `ANTHROPIC_API_KEY` | Anthropic API key |
-| `JWT_SECRET` | 32+ random bytes, base64-encoded |
+| `JWT_SECRET` | 32+ random bytes, base64-encoded (preferred) |
+| `AUTH_SECRET` | Alias for `JWT_SECRET` in hosted environments |
 | `NEXT_PUBLIC_APP_URL` | Base URL (e.g. `http://localhost:3000`) |
 
 **3. Run database migrations** *(once schema is ready — Phase 1.2)*

--- a/src/env-check.ts
+++ b/src/env-check.ts
@@ -1,7 +1,6 @@
 const REQUIRED_ENV_VARS = [
   'DATABASE_URL',
   'CRON_SECRET',
-  'JWT_SECRET',
   'ANTHROPIC_API_KEY',
   'TWILIO_ACCOUNT_SID',
   'TWILIO_AUTH_TOKEN',
@@ -11,6 +10,11 @@ const REQUIRED_ENV_VARS = [
 const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL'] as const;
 
 export default function checkEnv() {
+  const jwtSecret = process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim();
+  if (!jwtSecret) {
+    throw new Error('Missing required environment variable: JWT_SECRET (or AUTH_SECRET)');
+  }
+
   for (const key of REQUIRED_ENV_VARS) {
     if (!process.env[key]?.trim()) {
       throw new Error(`Missing required environment variable: ${key}`);

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -24,21 +24,22 @@ export type Session = {
 };
 
 function getJwtSecret(): Uint8Array {
-  const secret = process.env.JWT_SECRET;
+  const secret = process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim();
 
   if (!secret && process.env.NODE_ENV === 'production') {
-    throw new Error('JWT_SECRET is required in production.');
+    throw new Error(
+      'JWT_SECRET (or AUTH_SECRET) is required in production. Configure it in your deployment environment variables.',
+    );
   }
 
   if (!secret) {
     return new TextEncoder().encode('development-only-joshing-session-secret');
   }
 
-  try {
-    return Buffer.from(secret, 'base64');
-  } catch {
-    return new TextEncoder().encode(secret);
-  }
+  const decoded = Buffer.from(secret, 'base64');
+  if (decoded.length > 0) return decoded;
+
+  return new TextEncoder().encode(secret);
 }
 
 /**


### PR DESCRIPTION
### Motivation
- Production OTP verification was failing with `JWT_SECRET is required in production.` when deployments set `AUTH_SECRET` instead of `JWT_SECRET` (a common hosted-platform alias). 
- The goal is to make JWT secret resolution robust across common hosting environments so `createSession()` can sign tokens during login. 

### Description
- Updated `getJwtSecret()` in `src/server/auth/session.ts` to resolve `process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim()` and to return a decoded base64 `Buffer` when possible, falling back to a `TextEncoder`-encoded value when necessary. 
- Improved the production error message in `getJwtSecret()` to explicitly call out both `JWT_SECRET` and `AUTH_SECRET`. 
- Adjusted `src/env-check.ts` to require either `JWT_SECRET` or `AUTH_SECRET` at startup by checking `process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim()`. 
- Documented the alias by adding `AUTH_SECRET` to `.env.example` and noting it in `README.md`. 

### Testing
- Ran `npm run lint` to validate the workspace; the lint command executed but reported pre-existing lint errors across the repo that are unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65f2558a8832eb3083b55adc67d04)