### PR TITLE
Support multiple JWT secret env vars and improve secret decoding for session JWTs

### DIFF
--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -14,6 +14,10 @@ import { userSessions } from '@/server/db/schema';
 const SESSION_COOKIE_NAME = 'joshing_session';
 const SESSION_DAYS = 90;
 
+const SESSION_SECRET_KEYS = ['JWT_SECRET', 'AUTH_SECRET', 'NEXTAUTH_SECRET'] as const;
+const MISSING_SECRET_ERROR =
+  'JWT_SECRET (or AUTH_SECRET/NEXTAUTH_SECRET) is required in production. Configure it in your deployment environment variables.';
+
 type SessionJwtPayload = {
   sid: string;
 };
@@ -23,22 +27,40 @@ export type Session = {
   userId: string;
 };
 
+function readConfiguredSessionSecret(): string | null {
+  for (const key of SESSION_SECRET_KEYS) {
+    const value = process.env[key]?.trim();
+    if (value) return value;
+  }
+
+  const cronFallback = process.env.CRON_SECRET?.trim();
+  if (cronFallback) {
+    if (process.env.NODE_ENV === 'production') {
+      console.warn(
+        '[auth/session] Using CRON_SECRET as JWT fallback. Set JWT_SECRET (or AUTH_SECRET/NEXTAUTH_SECRET) in deployment env vars.',
+      );
+    }
+    return cronFallback;
+  }
+
+  return null;
+}
+
 function getJwtSecret(): Uint8Array {
-  const secret = process.env.JWT_SECRET;
+  const secret = readConfiguredSessionSecret();
 
   if (!secret && process.env.NODE_ENV === 'production') {
-    throw new Error('JWT_SECRET is required in production.');
+    throw new Error(MISSING_SECRET_ERROR);
   }
 
   if (!secret) {
     return new TextEncoder().encode('development-only-joshing-session-secret');
   }
 
-  try {
-    return Buffer.from(secret, 'base64');
-  } catch {
-    return new TextEncoder().encode(secret);
-  }
+  const decoded = Buffer.from(secret, 'base64');
+  if (decoded.length > 0) return decoded;
+
+  return new TextEncoder().encode(secret);
 }
 
 /**


### PR DESCRIPTION
### Motivation

- Allow the session code to accept common deployment secret names (`JWT_SECRET`, `AUTH_SECRET`, `NEXTAUTH_SECRET`) for better compatibility across environments.  
- Provide a temporary fallback to `CRON_SECRET` to ease rollouts where the dedicated JWT secret is not yet set.  
- Make the production error message clearer when no JWT secret is configured.

### Description

- Added `SESSION_SECRET_KEYS` and `readConfiguredSessionSecret()` to search `JWT_SECRET`, `AUTH_SECRET`, and `NEXTAUTH_SECRET`, and to fall back to `CRON_SECRET` with a production warning.  
- Replaced direct `process.env.JWT_SECRET` access in `getJwtSecret()` with the new reader, and introduced `MISSING_SECRET_ERROR` for a clearer failure message in production.  
- Changed secret decoding to prefer a base64-decoded `Buffer` when non-empty and otherwise use `TextEncoder` on the raw secret string.

### Testing

- Ran TypeScript type-check (`tsc`) to ensure the changes compile successfully and there are no type regressions; it passed.  
- Executed the repository's test suite (`npm test`) to validate auth/session behavior; tests passed.  
- Performed linting checks as part of CI (`npm run lint`) and there were no new lint errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f65f2558a8832eb3083b55adc67d04)