### PR TITLE
Fix Daily setup start action visibility on mobile

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -352,7 +352,7 @@ function DailySetupContent() {
         </p>
       ) : null}
 
-      <div className="fixed inset-x-0 bottom-0 z-30 border-t bg-background/95 px-4 py-3 backdrop-blur">
+      <div className="fixed inset-x-0 bottom-16 z-50 border-t bg-background/95 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur md:bottom-0 md:pb-3">
         <div className="mx-auto flex max-w-xl items-center gap-3">
           <Link href="/" className="btn-ghost min-h-11 px-4">
             Home

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -35,7 +35,7 @@ export function Nav() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [accountInitials, setAccountInitials] = useState<string | null>(null);
   const visibleUnreadCount = pathname === '/activities' ? 0 : unreadCount;
-  const showNewGameShortcut = pathname !== '/daily';
+  const showNewGameShortcut = pathname !== '/daily' && pathname !== '/daily/setup';
 
   const loadUnreadCount = useCallback(async () => {
     try {


### PR DESCRIPTION
### Motivation

- On mobile the Daily setup bottom action was overlapped by the persistent tab bar and iOS safe-area inset, making the `Start round` button hard to tap.
- The floating New Game FAB could also overlap the setup actions on small screens.

### Description

- Raised the Daily setup action bar above the mobile tab bar and added iOS safe-area bottom padding by changing the wrapper to `fixed inset-x-0 bottom-16 z-50 ... pb-[calc(0.75rem+env(safe-area-inset-bottom))] md:bottom-0 md:pb-3` in `src/app/daily/setup/page.tsx`.
- Prevented the floating New Game FAB from rendering on the setup screen by updating the `showNewGameShortcut` condition to exclude `/daily/setup` in `src/components/Nav.tsx`.

### Testing

- Ran `npm run lint -- src/app/daily/setup/page.tsx src/components/Nav.tsx`, which fails due to existing repo-wide lint issues unrelated to these changes, and no new lint errors were introduced in the modified lines.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f69f3c8c64832eab5c63b9b715d12c)