### PR TITLE
Move feed preview to home sidebar and repurpose Feed tab as Friends list

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,14 +1,14 @@
-import FeedList from '@/components/FeedList';
+import FriendsList from '@/components/FriendsList';
 
 export default function FeedPage() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
       <header className="mb-5 border-b pb-4">
-        <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Feed</p>
-        <h1 className="font-serif text-2xl font-semibold text-foreground">Friend-curated questions</h1>
+        <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Friends</p>
+        <h1 className="font-serif text-2xl font-semibold text-foreground">Your friends</h1>
       </header>
 
-      <FeedList />
+      <FriendsList />
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -52,21 +52,16 @@ export default async function Home() {
         </div>
         <div className="mt-6 w-full space-y-3 md:mt-0 md:max-w-xs">
           <TodaysFiveCard />
+          <div className="rounded-lg border bg-card p-4 text-card-foreground">
+            <p className="mb-3 text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">What's happening</p>
+            <FeedList limit={3} />
+            <div className="mt-2 flex justify-end">
+              <Link href="/feed" className="text-sm font-medium underline-offset-4 hover:underline">
+                Friends
+              </Link>
+            </div>
+          </div>
           {catchupCount > 0 ? <CatchupCard count={catchupCount} /> : null}
-        </div>
-      </section>
-
-      <section className="border-b py-6">
-        <div className="mb-4 flex items-center justify-between gap-4">
-          <h2 className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
-            What&apos;s happening
-          </h2>
-        </div>
-        <FeedList limit={5} />
-        <div className="mt-1 flex justify-end">
-          <Link href="/feed" className="text-sm font-medium text-foreground underline-offset-4 hover:underline">
-            See more
-          </Link>
         </div>
       </section>
 

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+type Friend = {
+  id: string;
+  displayName: string;
+};
+
+export default function FriendsList() {
+  const [friends, setFriends] = useState<Friend[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/users', { cache: 'no-store', credentials: 'include' })
+      .then(async (response) => {
+        const body = await response.json().catch(() => null);
+        if (!response.ok || !Array.isArray(body)) {
+          throw new Error(body?.message ?? 'Could not load friends.');
+        }
+        setFriends(body);
+      })
+      .catch((caught) => {
+        setError(caught instanceof Error ? caught.message : 'Could not load friends.');
+      })
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) return <p className="text-sm text-muted-foreground">Loading friends...</p>;
+  if (error) return <p className="text-sm text-destructive">{error}</p>;
+  if (friends.length === 0) {
+    return (
+      <div className="rounded-lg border bg-card p-4 text-card-foreground">
+        <p className="text-sm text-muted-foreground">No friends yet.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {friends.map((friend) => (
+        <div key={friend.id} className="flex items-center justify-between rounded-lg border bg-card p-4 text-card-foreground">
+          <p className="font-medium">{friend.displayName}</p>
+          <Link href="/new-game" className="text-sm underline-offset-2 hover:underline">
+            Play now
+          </Link>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -17,7 +17,7 @@ type MeResponse = {
 
 const navItems = [
   { href: '/', label: 'Home', Icon: Home },
-  { href: '/feed', label: 'Feed', Icon: Rss },
+  { href: '/feed', label: 'Friends', Icon: Rss },
   { href: '/knowledge', label: 'Knowledge', Icon: Brain },
   { href: '/activities', label: 'Activities', Icon: Bell },
   { href: '/account', label: 'Account', Icon: User },


### PR DESCRIPTION
### Motivation
- Surface the social feed next to the Play / "Today's five" area on the homepage for quicker context and make the `/feed` route focused on people rather than feed items.

### Description
- Embedded a compact feed preview in the homepage right column by adding `FeedList limit={3}` under the `TodaysFiveCard` and removed the prior full-width "What's happening" section in `src/app/page.tsx`.
- Repurposed the `/feed` page to show a friends list by replacing `FeedList` with a new client component `FriendsList` in `src/app/feed/page.tsx` and updated headings accordingly.
- Added `src/components/FriendsList.tsx`, a client component that fetches `/api/users` and renders loading, empty, and error states plus a quick "Play now" action per friend.
- Updated the navigation label for the `/feed` route from `Feed` to `Friends` in `src/components/Nav.tsx` while keeping the same route and leaving the original `FeedList` and feed APIs intact.

### Testing
- Ran the linter with `npm run -s lint` which reported existing, unrelated issues across the codebase and caused the lint run to fail; no new lint problems were introduced by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a0ae682c832e8750a13fa6846c96)