### PR TITLE
Add idempotent DB hotfix and migration journal entries to fix preview schema drift

### DIFF
--- a/drizzle/0011_preview_schema_hotfix.sql
+++ b/drizzle/0011_preview_schema_hotfix.sql
@@ -1,0 +1,54 @@
+-- Preview/prod compatibility hotfix for partially-migrated databases.
+-- Safe to run repeatedly.
+
+-- 1) MASTERY_EVENTS.metadata was introduced after initial launch.
+ALTER TABLE "MASTERY_EVENTS"
+  ADD COLUMN IF NOT EXISTS "metadata" jsonb;
+
+-- 2) QuestionReaction columns were renamed from snake_case -> camelCase.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'creator_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'recipientUserId'
+  ) THEN
+    ALTER TABLE "QuestionReaction" RENAME COLUMN "creator_id" TO "recipientUserId";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'answerer_id'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'senderUserId'
+  ) THEN
+    ALTER TABLE "QuestionReaction" RENAME COLUMN "answerer_id" TO "senderUserId";
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'creator_responded_at'
+  ) AND NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'QuestionReaction' AND column_name = 'repliedAt'
+  ) THEN
+    ALTER TABLE "QuestionReaction" RENAME COLUMN "creator_responded_at" TO "repliedAt";
+  END IF;
+END $$;
+
+ALTER TABLE "QuestionReaction" ADD COLUMN IF NOT EXISTS "recipientUserId" text;
+ALTER TABLE "QuestionReaction" ADD COLUMN IF NOT EXISTS "senderUserId" text;
+ALTER TABLE "QuestionReaction" ADD COLUMN IF NOT EXISTS "repliedAt" timestamp with time zone;
+
+-- 3) FeedItem.personalMessage is optional but queried by feed endpoints.
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "personalMessage" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,27 @@
       "when": 1777784400000,
       "tag": "0008_add_to_bank_provenance",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0009_domain_merge_events",
+      "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0010_feed_submitted_answer",
+      "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1777771056661,
+      "tag": "0011_preview_schema_hotfix",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- Runtime errors during gameplay showed queries referencing columns that aren’t present in some preview DBs (`MASTERY_EVENTS.metadata`, `QuestionReaction.recipientUserId`, `FeedItem.personalMessage`), causing 500s. 
- The Drizzle migration journal was missing entries for migrations that introduce those columns, so preview environments could skip applying those schema changes.

### Description
- Add `drizzle/0011_preview_schema_hotfix.sql`, an idempotent hotfix that `ADD COLUMN IF NOT EXISTS` for `MASTERY_EVENTS.metadata` and `FeedItem.personalMessage`, and that conditionally renames legacy `QuestionReaction` snake_case columns to the camelCase names expected by runtime queries. 
- Ensure `QuestionReaction` has `recipientUserId`, `senderUserId`, and `repliedAt` columns (either renamed from legacy columns or created if missing). 
- Update `drizzle/meta/_journal.json` to include `0009_domain_merge_events`, `0010_feed_submitted_answer`, and the new `0011_preview_schema_hotfix` so these migrations are tracked and applied in preview.

### Testing
- Validated that `drizzle/meta/_journal.json` is valid JSON using `node -e "JSON.parse(require('fs').readFileSync('drizzle/meta/_journal.json','utf8'))"`, which succeeded. 
- Printed and inspected `drizzle/0011_preview_schema_hotfix.sql` and `drizzle/meta/_journal.json` with `nl -ba` to verify the hotfix SQL and journal entries are present and contain the intended idempotent SQL changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a1f43768832e9f1a83e574425b03)