### PR TITLE
Add visible difficulty ranking cues for questions

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -17,11 +17,11 @@ type DrawerState =
 
 
 const DIFFICULTY_COPY: Record<number, string> = {
-  1: 'Very easy',
-  2: 'Easy',
-  3: 'Medium',
-  4: 'Hard',
-  5: 'Expert',
+  1: 'Accessible',
+  2: 'Accessible → Moderate',
+  3: 'Moderate',
+  4: 'Moderate → Specialist',
+  5: 'Specialist',
 };
 
 const DOMAIN_COLORS: Record<string, string> = {

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -15,6 +15,15 @@ type DrawerState =
   | { mode: 'create' }
   | { mode: 'edit'; question: QuestionView };
 
+
+const DIFFICULTY_COPY: Record<number, string> = {
+  1: 'Very easy',
+  2: 'Easy',
+  3: 'Medium',
+  4: 'Hard',
+  5: 'Expert',
+};
+
 const DOMAIN_COLORS: Record<string, string> = {
   music: '#7c3aed',
   literature: '#0f766e',
@@ -308,8 +317,10 @@ export default function QuestionsPage() {
                   >
                     {question.domainDisplayName}
                   </span>
-                  <span className="font-mono text-xs text-muted-foreground" aria-label={`Difficulty ${question.difficulty} of 5`}>
+                  <span className="font-mono text-xs text-muted-foreground" aria-label={`Difficulty ${question.difficulty} of 5 (${DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'})`}>
                     {difficultyDots(question.difficulty)}
+                    {' · '}
+                    {question.difficulty}/5 {DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}
                   </span>
                   <span className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
                     {isOwnAuthored ? 'Written by you' : `From ${question.authorName ?? 'a friend'}`}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -29,6 +29,15 @@ type Props = {
   onCancel?: () => void;
 };
 
+
+const DIFFICULTY_SCALE: Record<number, { label: string; hint: string }> = {
+  1: { label: 'Very easy', hint: 'Most players should get this quickly.' },
+  2: { label: 'Easy', hint: 'Familiar fact with a little recall needed.' },
+  3: { label: 'Medium', hint: 'Balanced challenge for the average player.' },
+  4: { label: 'Hard', hint: 'Requires strong domain knowledge.' },
+  5: { label: 'Expert', hint: 'Deep-cut or specialist-level question.' },
+};
+
 const defaults: QuestionFormValues = {
   text: '',
   correctAnswer: '',
@@ -262,10 +271,13 @@ export function QuestionForm({
           >
             {[1, 2, 3, 4, 5].map((difficulty) => (
               <option key={difficulty} value={difficulty}>
-                {difficulty}
+                {difficulty} · {DIFFICULTY_SCALE[difficulty].label}
               </option>
             ))}
           </select>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Rank {values.difficulty}/5 — {DIFFICULTY_SCALE[values.difficulty].label}. {DIFFICULTY_SCALE[values.difficulty].hint}
+          </p>
         </div>
       </div>
 

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -31,11 +31,11 @@ type Props = {
 
 
 const DIFFICULTY_SCALE: Record<number, { label: string; hint: string }> = {
-  1: { label: 'Very easy', hint: 'Most players should get this quickly.' },
-  2: { label: 'Easy', hint: 'Familiar fact with a little recall needed.' },
-  3: { label: 'Medium', hint: 'Balanced challenge for the average player.' },
-  4: { label: 'Hard', hint: 'Requires strong domain knowledge.' },
-  5: { label: 'Expert', hint: 'Deep-cut or specialist-level question.' },
+  1: { label: 'Accessible', hint: 'Most players should be able to get this one.' },
+  2: { label: 'Accessible → Moderate', hint: 'Leans approachable but needs some recall.' },
+  3: { label: 'Moderate', hint: 'Balanced challenge with topic familiarity.' },
+  4: { label: 'Moderate → Specialist', hint: 'Leans advanced and rewards deeper knowledge.' },
+  5: { label: 'Specialist', hint: 'Best for enthusiasts or experts in the domain.' },
 };
 
 const defaults: QuestionFormValues = {


### PR DESCRIPTION
### Motivation
- Authors and players need a clear, consistent indication of how hard a question is so question authoring and the question bank surface convey question difficulty at a glance.

### Description
- Added a `DIFFICULTY_SCALE` mapping in `src/components/QuestionForm.tsx` with human-readable labels and short hints for ranks 1–5 and surfaced those labels in the difficulty dropdown options and a live helper line showing `Rank X/5 — Label`.
- Added a `DIFFICULTY_COPY` map in `src/app/questions/page.tsx` and updated question bank cards to display explicit rank text (e.g. `3/5 Medium`) alongside the existing dot visualization and improved the difficulty `aria-label` for screen readers.
- UI-only change touching `src/components/QuestionForm.tsx` and `src/app/questions/page.tsx`, with no API or database/schema changes.

### Testing
- Ran `npm run lint`; the lint run executed but failed due to pre-existing unrelated lint errors in the repository and not introduced by these UI changes.
- No new automated unit tests were added for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6a2842d80832ebbde3251770ce5e9)