### PR TITLE
Fix mastery event inserts on preview DBs missing metadata column

### DIFF
--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -80,24 +80,39 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
   const tierChanged = previousTier !== nextTier;
 
   await db.transaction(async (tx) => {
-    await tx.insert(masteryEvents).values({
-      userId: params.userId,
-      canonicalSubcategory: params.domain,
-      sourceType:
-        params.sourceType === 'author_credit' || params.sourceType === 'curator_credit'
-          ? params.sourceType
-          : params.sourceType === 'catchup'
-            ? 'catchup_correct'
-            : 'live_correct',
-      questionId: params.eventQuestionId ?? null,
-      answeredByUserId: params.answeredByUserId ?? params.userId,
-      answerId: `${params.sourceType}:${params.sourceId}:${params.questionId}:${params.answeredByUserId ?? params.userId}`,
-      basePoints: Math.round(params.basePoints ?? params.pointsAwarded),
-      weight: params.weight ?? (params.pointsAwarded > 0 ? 1 : 0),
-      awardedPoints: params.pointsAwarded,
-      answerState: params.sourceType === 'author_credit' || params.sourceType === 'curator_credit' ? null : params.answerState,
-      sessionContext: params.sourceType,
-    });
+    await tx.execute(sql`
+      insert into "MASTERY_EVENTS" (
+        "user_id",
+        "canonical_subcategory",
+        "source_type",
+        "question_id",
+        "answered_by_user_id",
+        "answer_id",
+        "base_points",
+        "weight",
+        "awarded_points",
+        "answer_state",
+        "session_context"
+      ) values (
+        ${params.userId},
+        ${params.domain},
+        ${
+          params.sourceType === 'author_credit' || params.sourceType === 'curator_credit'
+            ? params.sourceType
+            : params.sourceType === 'catchup'
+              ? 'catchup_correct'
+              : 'live_correct'
+        },
+        ${params.eventQuestionId ?? null},
+        ${params.answeredByUserId ?? params.userId},
+        ${`${params.sourceType}:${params.sourceId}:${params.questionId}:${params.answeredByUserId ?? params.userId}`},
+        ${Math.round(params.basePoints ?? params.pointsAwarded)},
+        ${params.weight ?? (params.pointsAwarded > 0 ? 1 : 0)},
+        ${params.pointsAwarded},
+        ${params.sourceType === 'author_credit' || params.sourceType === 'curator_credit' ? null : (params.answerState ?? null)},
+        ${params.sourceType}
+      )
+    `);
 
     if (params.pointsAwarded > 0) {
       await tx


### PR DESCRIPTION
### Motivation
- Vercel runtime logs showed a 500 caused by Postgres error `42703` when inserting into `MASTERY_EVENTS` because preview databases sometimes lack the `metadata` column. 
- Make mastery event writes tolerant of preview schemas so activity routes (e.g. `GET /api/activities`) do not fail when `metadata` is absent.

### Description
- Replaced the Drizzle-style insert `tx.insert(masteryEvents).values({...})` with an explicit SQL `INSERT` statement that lists columns and intentionally omits `metadata` in `src/server/mastery/write-mastery-event.ts`. 
- Kept the existing `sourceType` mapping, answer ID composition, `basePoints` / `weight` / `awardedPoints`, `answerState`, and `sessionContext` behavior unchanged while using `tx.execute(sql\`...\`)` for the insert. 
- Preserved the surrounding transaction and the `PLAYER_MASTERY` upsert logic (`.onConflictDoUpdate`) so points and tier updates remain the same. 

### Testing
- Ran linting on the modified file with `npx eslint src/server/mastery/write-mastery-event.ts` and it passed with one pre-existing warning about an unused `_params` in a TODO helper. 
- No unit tests were added or modified for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72b0a464c832e9bd024609de67ec7)