### PR TITLE
Handle legacy QuestionReaction columns in activities unread-count

### DIFF
--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, gt, inArray, isNull, ne } from 'drizzle-orm';
+import { and, count, desc, eq, gt, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import {
   activityItems,
@@ -475,12 +475,28 @@ export async function getUnreadCount(userId: string): Promise<number> {
       gt(activityItems.createdAt, activityCutoff()),
     ));
 
-  const [reactionRow] = await db
-    .select({ value: count() })
-    .from(questionReactions)
-    .where(and(eq(questionReactions.recipientUserId, userId), isNull(questionReactions.repliedAt)));
+  let reactionCount = 0;
+  try {
+    const [reactionRow] = await db
+      .select({ value: count() })
+      .from(questionReactions)
+      .where(and(eq(questionReactions.recipientUserId, userId), isNull(questionReactions.repliedAt)));
+    reactionCount = reactionRow?.value ?? 0;
+  } catch (error) {
+    const pgError = error as { code?: string; message?: string };
+    const missingCamelCaseColumn = pgError.code === '42703'
+      && (pgError.message?.includes('recipientUserId') || pgError.message?.includes('repliedAt'));
+    if (!missingCamelCaseColumn) throw error;
 
-  return (row?.value ?? 0) + (reactionRow?.value ?? 0);
+    const result = await db.execute(sql<{ value: string }>`
+      select count(*)::text as value
+      from "QuestionReaction"
+      where "creator_id" = ${userId} and "creator_responded_at" is null
+    `);
+    reactionCount = Number(result.rows[0]?.value ?? 0);
+  }
+
+  return (row?.value ?? 0) + reactionCount;
 }
 
 export async function markAllRead(userId: string): Promise<void> {


### PR DESCRIPTION
### Motivation
- The `/api/activities` endpoint 500ed on preview environments where the `QuestionReaction` table still used legacy snake_case columns instead of the expected camelCase names, causing unread-reaction counting to fail. 

### Description
- Added `sql` import from `drizzle-orm` and updated `getUnreadCount(userId)` to try the existing camelCase Drizzle query first and catch Postgres `42703` missing-column errors. 
- On a missing-column error that mentions `recipientUserId` or `repliedAt`, the code retries using a targeted raw SQL count against legacy columns (`creator_id`, `creator_responded_at`) and converts the result to a number. 
- Kept the primary Drizzle query path unchanged and only added a compatibility fallback to avoid crashing when running against older schemas.

### Testing
- Ran the repository linter via `npm run lint -- src/server/db/queries/activity.ts`, which completed but reported pre-existing lint failures in unrelated files and thus the run did not pass cleanly; the change is limited to `src/server/db/queries/activity.ts` and is syntactically valid. 
- No new unit tests were added for this compatibility path in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72d0dd16c832eb8b56688e5c6a192)