### PR TITLE
Fix daily chat composer visibility when mobile keyboard opens

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -289,7 +289,7 @@ export default function DailyPage() {
         />
       </header>
 
-      <section className="flex-1 overflow-y-auto px-4 py-4" style={{ paddingBottom: '160px' }}>
+      <section className="flex-1 overflow-y-auto px-4 py-4">
         {loading ? (
           <p className="text-sm text-[var(--text-muted)]">Loading today...</p>
         ) : error ? (
@@ -303,7 +303,7 @@ export default function DailyPage() {
 
       {currentSlot && !loading ? (
         <form
-          className="fixed inset-x-0 bottom-16 z-30 mx-auto max-w-lg border-t px-4 py-3 md:bottom-0"
+          className="sticky bottom-0 z-30 mt-auto border-t px-4 py-3"
           style={{
             borderColor: 'var(--border)',
             background: 'color-mix(in srgb, var(--surface) 94%, transparent)',


### PR DESCRIPTION
### Motivation
- The fixed-position answer composer caused the question thread to be hidden when the on-screen keyboard opened on mobile (notably iOS), so the composer should behave like a Messages-style bottom composer and remain in the normal layout flow.

### Description
- Updated `src/app/daily/page.tsx` to remove the hardcoded bottom padding on the scrollable messages `section` and changed the answer composer `form` from `fixed inset-x-0 bottom-16 ...` to `sticky bottom-0 ...` so it stays in the page flow above the keyboard.

### Testing
- Ran `npm run -s lint`, which executed but reported existing unrelated lint errors in the repo and did not introduce new lint failures from this change.
- Attempted `npm run -s typecheck`, but a `typecheck` script is not defined in `package.json` so no typecheck was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72da5d840832eb22e433eb8deefea)