### PR TITLE
Keep asked questions visible above sticky answer bar on mobile

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -289,7 +289,10 @@ export default function DailyPage() {
         />
       </header>
 
-      <section className="flex-1 overflow-y-auto px-4 py-4">
+      <section
+        className="flex-1 overflow-y-auto px-4 py-4"
+        style={{ paddingBottom: "calc(140px + env(safe-area-inset-bottom))" }}
+      >
         {loading ? (
           <p className="text-sm text-[var(--text-muted)]">Loading today...</p>
         ) : error ? (

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -170,7 +170,10 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
         <h1 className="font-serif text-xl font-semibold">{game.game.title}</h1>
         <p className="text-sm text-muted-foreground">{answeredIds.size} of {orderedQuestions.length}</p>
       </header>
-      <section className="flex-1 px-4 py-4" style={{ paddingBottom: '96px' }}>
+      <section
+        className="flex-1 overflow-y-auto px-4 py-4"
+        style={{ paddingBottom: 'calc(140px + env(safe-area-inset-bottom))' }}
+      >
         <GameplayChatThread messages={messages} />
         {error ? <p className="mt-4 rounded-md border border-destructive p-3 text-sm text-destructive">{error}</p> : null}
       </section>


### PR DESCRIPTION
### Motivation
- Prevent chat items (especially the current question) from being obscured by the sticky answer composer on small screens and devices with safe-area insets.  

### Description
- Increased bottom spacing for the gameplay chat container in `src/app/games/[id]/play-client.tsx` by adding `style={{ paddingBottom: 'calc(140px + env(safe-area-inset-bottom))' }}` and making the section scrollable with `overflow-y-auto`.  
- Applied the same bottom-padding change to the Daily Five chat container in `src/app/daily/page.tsx` using `style={{ paddingBottom: "calc(140px + env(safe-area-inset-bottom))" }}` for consistent behavior.  
- Replaced the previous fixed `paddingBottom: '96px'` with the new safe-area-aware calculation to accommodate the sticky composer and mobile safe areas.  

### Testing
- Ran `npm run lint` which failed due to pre-existing lint and type issues in the repository that are unrelated to this change.  
- No other automated tests were added or modified for this spacing change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f72e58b3f4832e8807728fe5c7c5e7)