### PR TITLE
Handle legacy QuestionReaction column names in unreplied reaction count

### DIFF
--- a/src/server/db/queries/reactions.ts
+++ b/src/server/db/queries/reactions.ts
@@ -147,12 +147,26 @@ export async function getReactionsForUser(userId: string): Promise<ReactionView[
 }
 
 export async function getUnrepliedReactionCount(userId: string): Promise<number> {
-  const rows = await db
-    .select({ id: questionReactions.id })
-    .from(questionReactions)
-    .where(and(eq(questionReactions.recipientUserId, userId), isNull(questionReactions.repliedAt)));
+  try {
+    const rows = await db
+      .select({ id: questionReactions.id })
+      .from(questionReactions)
+      .where(and(eq(questionReactions.recipientUserId, userId), isNull(questionReactions.repliedAt)));
 
-  return rows.length;
+    return rows.length;
+  } catch (error) {
+    const pgError = error as { code?: string; message?: string };
+    const missingCamelCaseColumn = pgError.code === '42703'
+      && (pgError.message?.includes('recipientUserId') || pgError.message?.includes('repliedAt'));
+    if (!missingCamelCaseColumn) throw error;
+
+    const result = await db.execute(sql<{ value: string }>`
+      select count(*)::text as value
+      from "QuestionReaction"
+      where "creator_id" = ${userId} and "creator_responded_at" is null
+    `);
+    return Number(result.rows[0]?.value ?? 0);
+  }
 }
 
 export async function markReactionReplied(reactionId: string, userId: string): Promise<boolean> {


### PR DESCRIPTION
### Motivation
- Prevent runtime failures when querying unreplied reaction counts against preview or legacy databases where the `QuestionReaction` table still uses snake_case column names, which caused errors like `column QuestionReaction.recipientUserId does not exist`.

### Description
- Updated `getUnrepliedReactionCount` in `src/server/db/queries/reactions.ts` to run the existing camelCase Drizzle query inside a `try` and catch Postgres `42703` missing-column errors.
- Added a fallback raw SQL count that queries `

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f73018de04832e9c0e44c4088e0796)