### PR TITLE
Allow daily game reset in production

### DIFF
--- a/src/app/api/daily/reset/route.ts
+++ b/src/app/api/daily/reset/route.ts
@@ -8,10 +8,6 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 export const dynamic = 'force-dynamic';
 
 export async function POST() {
-  if (process.env.NODE_ENV === 'production') {
-    return NextResponse.json({ error: 'forbidden', message: 'Reset is only available outside production.' }, { status: 403 });
-  }
-
   const session = await getSession();
   if (!session?.userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 


### PR DESCRIPTION
### Motivation
- Enable the "Reset game for today and play again" UI action in production by removing an environment guard that blocked resets in production.

### Description
- Removed the production-only 403 guard from `src/app/api/daily/reset/route.ts` so the `POST /api/daily/reset` endpoint allows authenticated users to clear their current-day `dailyQueues` in all environments.

### Testing
- No automated tests were executed for this trivial change; the modification was inspected via local diff and committed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f730886660832eb7f4c089b5526b9d)