### PR TITLE
Import `sql` from drizzle-orm in reactions query

### DIFF
--- a/src/server/db/queries/reactions.ts
+++ b/src/server/db/queries/reactions.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 
 import { CANNED_REACTIONS, getCannedReaction, type ReactionKey } from '@/lib/reactions';
 import { activityItems, db, questionReactions, questions, users } from '@/server/db';


### PR DESCRIPTION
### Motivation
- Fix the TypeScript build error caused by use of the `sql` identifier without importing it in `src/server/db/queries/reactions.ts`.

### Description
- Add `sql` to the Drizzle import: `import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';` in `src/server/db/queries/reactions.ts`.

### Testing
- Ran `npm run build`; the TypeScript `Cannot find name 'sql'` error is resolved and the build progresses, but page data collection fails in this environment due to a missing runtime env var `DATABASE_URL`, so the full production build could not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f730ef4c94832e9e0380b30bbc58d7)