### PR TITLE
Harden unread reaction count fallback for legacy QuestionReaction schema

### DIFF
--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -485,7 +485,9 @@ export async function getUnreadCount(userId: string): Promise<number> {
   } catch (error) {
     const pgError = error as { code?: string; message?: string };
     const missingCamelCaseColumn = pgError.code === '42703'
-      && (pgError.message?.includes('recipientUserId') || pgError.message?.includes('repliedAt'));
+      && (pgError.message?.includes('recipientUserId')
+        || pgError.message?.includes('repliedAt')
+        || pgError.message?.includes('QuestionReaction'));
     if (!missingCamelCaseColumn) throw error;
 
     const result = await db.execute(sql<{ value: string }>`

--- a/src/server/db/queries/reactions.ts
+++ b/src/server/db/queries/reactions.ts
@@ -157,7 +157,9 @@ export async function getUnrepliedReactionCount(userId: string): Promise<number>
   } catch (error) {
     const pgError = error as { code?: string; message?: string };
     const missingCamelCaseColumn = pgError.code === '42703'
-      && (pgError.message?.includes('recipientUserId') || pgError.message?.includes('repliedAt'));
+      && (pgError.message?.includes('recipientUserId')
+        || pgError.message?.includes('repliedAt')
+        || pgError.message?.includes('QuestionReaction'));
     if (!missingCamelCaseColumn) throw error;
 
     const result = await db.execute(sql<{ value: string }>`


### PR DESCRIPTION
### Motivation
- Preview deployments can run against databases where the `QuestionReaction` table still uses legacy snake_case column names, causing camelCase Drizzle queries to raise PostgreSQL `42703` errors and surface 500s for endpoints like `/api/knowledge`.
- The existing fallback only checked for specific camelCase column names in the PG error message, which was too narrow and sometimes failed to trigger the legacy-query fallback.

### Description
- Broadened the PostgreSQL `42703` fallback detection to also trigger when the error message references `QuestionReaction` in addition to `recipientUserId` and `repliedAt`.
- Applied this change to `getUnreadCount` in `src/server/db/queries/activity.ts` and to `getUnrepliedReactionCount` in `src/server/db/queries/reactions.ts` so the legacy SQL fallback runs reliably.
- The fallback continues to run a raw SQL query against legacy snake_case columns (`creator_id` / `creator_responded_at`) when the detection matches.

### Testing
- Ran `pnpm -s eslint src/server/db/queries/activity.ts src/server/db/queries/reactions.ts` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f737902634832ea1dba24577787406)