### PR TITLE
Fix sourceLabel typing for projected mastery event rows

### DIFF
--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -149,7 +149,9 @@ function nextTierFor(tier: MasteryTier): MasteryTier | null {
   return TIER_ORDER[index + 1];
 }
 
-function sourceLabel(row: typeof masteryEvents.$inferSelect): string {
+type SourceLabelRow = Pick<typeof masteryEvents.$inferSelect, 'sourceType' | 'sessionContext'>;
+
+function sourceLabel(row: SourceLabelRow): string {
   if (row.sessionContext === 'daily' || row.sessionContext === 'joshing_game') {
     return row.sessionContext;
   }


### PR DESCRIPTION
### Motivation
- Fix a TypeScript error when passing projected/select-subset mastery event rows into `sourceLabel` by expressing that the function only requires `sourceType` and `sessionContext` fields.

### Description
- Introduced `type SourceLabelRow = Pick<typeof masteryEvents.$inferSelect, 'sourceType' | 'sessionContext'>` and changed the `sourceLabel` signature to `function sourceLabel(row: SourceLabelRow): string` in `src/server/db/queries/knowledge.ts` so it accepts lightweight selects.

### Testing
- Ran `npm run build` where compilation and the TypeScript checks succeeded, and the build later failed during page data collection due to `DATABASE_URL` not being set in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f74747f4e4832e9be380e9c1fff8c0)