### PR TITLE
Set app font to Montserrat

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,12 @@
 import type { Metadata } from 'next'
+import { Montserrat } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
+
+
+const montserrat = Montserrat({
+  subsets: ['latin'],
+})
 
 export const metadata: Metadata = {
   title: 'Joshing',
@@ -14,7 +20,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="font-sans">
-      <body>
+      <body className={montserrat.className}>
         <Nav />
         {children}
       </body>


### PR DESCRIPTION
### Motivation
- Use Montserrat as the primary app font so the UI has consistent typography across the site.

### Description
- In `src/app/layout.tsx` import `Montserrat` from `next/font/google`, instantiate it with `subsets: ['latin']`, and apply `montserrat.className` to the `<body>` element so the whole app renders using Montserrat.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f779d2c918832e8d593eb16a25f01c)