### PR TITLE
Wrap knowledge page useSearchParams in Suspense boundary

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useEffect, useMemo, useState, type CSSProperties } from 'react';
+import { Suspense, useEffect, useMemo, useState, type CSSProperties } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Combine, Plus, Repeat2, X } from 'lucide-react';
 
@@ -157,6 +157,14 @@ function LoadingSkeleton() {
 }
 
 export default function KnowledgePage() {
+  return (
+    <Suspense fallback={<LoadingSkeleton />}>
+      <KnowledgePageContent />
+    </Suspense>
+  );
+}
+
+function KnowledgePageContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');


### PR DESCRIPTION
Fixes Vercel build error: useSearchParams() must be wrapped in a Suspense
boundary for static prerendering to succeed.

https://claude.ai/code/session_016T3RWYkSBY4nFS8yAeWULA