### PR TITLE
fix: run Drizzle migrations before build to apply missing DB columns

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "license": "UNLICENSED",
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "db:migrate": "drizzle-kit migrate",
+    "build": "npm run db:migrate && next build",
     "start": "next start",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",


### PR DESCRIPTION
The MASTERY_EVENTS.metadata and QuestionReaction.recipientUserId columns
were missing at runtime because no migration runner was hooked into
the deployment pipeline. Adding db:migrate to the build step ensures
all pending Drizzle migrations (including 0011_preview_schema_hotfix)
are applied on every Vercel deployment before the app starts serving.

https://claude.ai/code/session_01EESwctmSZey87zospBxFip