### PR TITLE
fix: move DB migrations from build to server startup instrumentation hook

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,9 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  experimental: {
+    instrumentationHook: true,
+  },
 }
 
 export default nextConfig

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "db:migrate": "drizzle-kit migrate",
-    "build": "npm run db:migrate && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,17 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { migrate } = await import('drizzle-orm/node-postgres/migrator');
+    const { drizzle } = await import('drizzle-orm/node-postgres');
+    const { Pool } = await import('pg');
+    const path = await import('path');
+
+    const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+    const db = drizzle(pool);
+
+    await migrate(db, {
+      migrationsFolder: path.join(process.cwd(), 'drizzle'),
+    });
+
+    await pool.end();
+  }
+}


### PR DESCRIPTION
Running drizzle-kit migrate during Vercel build fails because the build
container cannot reach the database. Migrations now run via Next.js
instrumentation.ts at server startup, where DATABASE_URL is available.

https://claude.ai/code/session_01WWh8yUcRQ7ScxCJVGEr4XJ