### PR TITLE
Remove deprecated instrumentationHook experimental config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,9 +4,6 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
-  experimental: {
-    instrumentationHook: true,
-  },
 }
 
 export default nextConfig


### PR DESCRIPTION
instrumentationHook is no longer a valid key in Next.js 16 experimental config;
instrumentation.js is enabled by default and the key causes a TypeScript build error.

https://claude.ai/code/session_012WhSD5YKnUFHdZojPWfSTQ