### PR TITLE
fix: register migration 0012 in journal and prevent migration crash from breaking server

### DIFF
--- a/drizzle/0012_feed_friend_answered.sql
+++ b/drizzle/0012_feed_friend_answered.sql
@@ -1,9 +1,9 @@
 -- Add source_result column to FeedItem (friend's result when they answered)
 ALTER TABLE "FeedItem" ADD COLUMN IF NOT EXISTS "sourceResult" TEXT;
-
+--> statement-breakpoint
 -- Add surface_priority_score to Question (aggregated thumbs-up quality signal)
 ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "surface_priority_score" DOUBLE PRECISION NOT NULL DEFAULT 0;
-
+--> statement-breakpoint
 -- Create FeedDismissedDomain table for "Not my focus" domain-level dismissals
 CREATE TABLE IF NOT EXISTS "FeedDismissedDomain" (
   "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
@@ -12,9 +12,10 @@ CREATE TABLE IF NOT EXISTS "FeedDismissedDomain" (
   "dismissedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
   "reinstatedAt" TIMESTAMPTZ
 );
-
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_idx" ON "FeedDismissedDomain" ("userId");
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_sub_idx" ON "FeedDismissedDomain" ("userId", "canonicalSubcategory");
-
+--> statement-breakpoint
 -- Add friend_answered_question to SmsMessageType enum
 ALTER TYPE "SmsMessageType" ADD VALUE IF NOT EXISTS 'friend_answered_question';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777771056661,
       "tag": "0011_preview_schema_hotfix",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777839477000,
+      "tag": "0012_feed_friend_answered",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -8,10 +8,14 @@ export async function register() {
     const pool = new Pool({ connectionString: process.env.DATABASE_URL });
     const db = drizzle(pool);
 
-    await migrate(db, {
-      migrationsFolder: path.join(process.cwd(), 'drizzle'),
-    });
-
-    await pool.end();
+    try {
+      await migrate(db, {
+        migrationsFolder: path.join(process.cwd(), 'drizzle'),
+      });
+    } catch (err) {
+      console.error('[instrumentation] DB migration failed — server will start but schema may be out of date:', err);
+    } finally {
+      await pool.end();
+    }
   }
 }


### PR DESCRIPTION
Migration 0012 (feed friend answered) was added as a SQL file but never
registered in _journal.json, so Drizzle's migrate() couldn't apply it
properly. On cold start this caused FUNCTION_INVOCATION_FAILED on every
route (confirmed in Vercel logs: 7ms failure on /api/auth/me).

- Add 0012_feed_friend_answered to _journal.json so migrate() applies it
- Add -->statement-breakpoint markers between each SQL statement so
  ALTER TYPE ... ADD VALUE runs outside any transaction block
- Wrap migrate() in try-catch so a future migration failure logs an error
  but does not crash the entire serverless function

https://claude.ai/code/session_018GPLgg8fmVizjyKT2ipMMX