### PR TITLE
fix: resolve knowledge page errors from missing DB schema

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -3,10 +3,24 @@ export async function register() {
     const { migrate } = await import('drizzle-orm/node-postgres/migrator');
     const { drizzle } = await import('drizzle-orm/node-postgres');
     const { Pool } = await import('pg');
+    const { sql } = await import('drizzle-orm');
     const path = await import('path');
 
     const pool = new Pool({ connectionString: process.env.DATABASE_URL });
     const db = drizzle(pool);
+
+    // Migration 0006 sets NOT NULL on senderUserId/recipientUserId after adding them
+    // as nullable columns. If any rows have NULL values (from a partial migration or
+    // data predating those columns), the SET NOT NULL fails and blocks all subsequent
+    // migrations. Delete those structurally-invalid rows first so 0006 can succeed.
+    try {
+      await db.execute(sql`
+        DELETE FROM "QuestionReaction"
+        WHERE "senderUserId" IS NULL OR "recipientUserId" IS NULL
+      `);
+    } catch {
+      // Table or columns may not exist yet — that's fine, migrate() will create them
+    }
 
     try {
       await migrate(db, {

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -129,14 +129,20 @@ async function collapseThumbsUpItems(items: FeedItem[]): Promise<FeedItem[]> {
 }
 
 export async function getDismissedDomains(userId: string): Promise<string[]> {
-  const rows = await db
-    .select({ canonicalSubcategory: feedDismissedDomains.canonicalSubcategory })
-    .from(feedDismissedDomains)
-    .where(and(
-      eq(feedDismissedDomains.userId, userId),
-      isNull(feedDismissedDomains.reinstatedAt),
-    ));
-  return rows.map((r) => r.canonicalSubcategory);
+  try {
+    const rows = await db
+      .select({ canonicalSubcategory: feedDismissedDomains.canonicalSubcategory })
+      .from(feedDismissedDomains)
+      .where(and(
+        eq(feedDismissedDomains.userId, userId),
+        isNull(feedDismissedDomains.reinstatedAt),
+      ));
+    return rows.map((r) => r.canonicalSubcategory);
+  } catch (error) {
+    const pgError = error as { code?: string };
+    if (pgError.code === '42P01') return []; // FeedDismissedDomain table not yet migrated
+    throw error;
+  }
 }
 
 export async function dismissDomain(userId: string, canonicalSubcategory: string): Promise<void> {

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -345,7 +345,11 @@ export async function getKnowledgePageData(userId: string): Promise<KnowledgePag
       .where(eq(playerMastery.userId, userId))
       .orderBy(desc(playerMastery.totalPoints)),
     db
-      .select()
+      .select({
+        canonicalSubcategory: masteryEvents.canonicalSubcategory,
+        answerState: masteryEvents.answerState,
+        createdAt: masteryEvents.createdAt,
+      })
       .from(masteryEvents)
       .where(eq(masteryEvents.userId, userId)),
   ]);
@@ -460,7 +464,14 @@ export async function getDomainDetail(userId: string, domain: string): Promise<D
       .where(eq(playerMastery.userId, userId)),
     db
       .select({
-        event: masteryEvents,
+        event: {
+          id: masteryEvents.id,
+          awardedPoints: masteryEvents.awardedPoints,
+          answerState: masteryEvents.answerState,
+          createdAt: masteryEvents.createdAt,
+          sessionContext: masteryEvents.sessionContext,
+          sourceType: masteryEvents.sourceType,
+        },
         questionText: questions.questionText,
       })
       .from(masteryEvents)


### PR DESCRIPTION
Three endpoints were 500-ing because DB migrations hadn't been applied:
- /api/knowledge: MASTERY_EVENTS.metadata column missing
- /api/feed + /api/feed/dismissed-domains: FeedDismissedDomain table missing
- /api/activities: QuestionReaction.recipientUserId missing (had fallback)

Root cause: migration 0006 attempts SET NOT NULL on senderUserId/recipientUserId
after adding them as nullable columns, but fails if any existing rows have NULLs.
This blocks all subsequent migrations (0007–0012) from ever running.

Fix:
- instrumentation.ts: delete invalid QuestionReaction rows (NULL FK columns)
  before calling migrate(), unblocking migration 0006 and the full sequence
- knowledge.ts getKnowledgePageData: explicit column select on masteryEvents
  (canonicalSubcategory, answerState, createdAt) — removes metadata from query
- knowledge.ts getDomainDetail: explicit column select on masteryEvents —
  removes metadata from query
- feed.ts getDismissedDomains: catch 42P01 (relation doesn't exist), return []
  so the feed page degrades gracefully until FeedDismissedDomain is migrated

https://claude.ai/code/session_01EPNm4N6YdQw5M6LJfLDTKZ