### PR TITLE
Run database migrations before build

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "db:migrate": "drizzle-kit migrate",
-    "build": "next build",
+    "build": "drizzle-kit migrate && next build",
     "start": "next start",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",


### PR DESCRIPTION
## Summary
Updated the build script to automatically run database migrations before building the Next.js application.

## Changes
- Modified the `build` script in `package.json` to execute `drizzle-kit migrate` before `next build`
- This ensures the database schema is up-to-date whenever a production build is created

## Details
This change prevents build failures or runtime errors caused by missing database migrations. By running migrations as part of the build process, we guarantee that the database schema matches what the application expects at deployment time.

https://claude.ai/code/session_01Bq1ko65uR1zfxZ2KYvFzn8