### PR TITLE
Remove database migration from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "next dev",
     "db:migrate": "drizzle-kit migrate",
-    "build": "drizzle-kit migrate && next build",
+    "build": "next build",
     "start": "next start",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",


### PR DESCRIPTION
## Summary
Removed the `drizzle-kit migrate` command from the build script, leaving only the Next.js build step.

## Changes
- Updated the `build` script in `package.json` to run only `next build` instead of `drizzle-kit migrate && next build`
- Database migrations are now expected to be run separately via the dedicated `db:migrate` script

## Rationale
This change decouples database migrations from the application build process, allowing for more flexible deployment strategies where migrations can be managed independently of the build step.

https://claude.ai/code/session_012Qx5YVJzcthjng36jtugbg