### PR TITLE
Include drizzle migrations in Vercel serverless output

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,10 @@ const nextConfig: NextConfig = {
   typescript: {
     ignoreBuildErrors: false,
   },
+  outputFileTracingIncludes: {
+    // Include migration SQL files so drizzle migrate() works in Vercel serverless
+    '/api/**': ['./drizzle/**'],
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
## Summary
Configure Next.js output file tracing to include Drizzle migration SQL files in the build output for Vercel serverless deployments.

## Changes
- Added `outputFileTracingIncludes` configuration to `next.config.ts`
- Configured the `/api/**` routes to include all files from the `./drizzle/**` directory in the build output
- This ensures that Drizzle's `migrate()` function can access migration SQL files when running in Vercel serverless environments

## Details
By default, Next.js output file tracing may not include SQL migration files since they're not directly imported in the code. This configuration explicitly tells Next.js to bundle the drizzle migrations directory with API routes, allowing database migrations to execute properly in serverless functions.

https://claude.ai/code/session_015N4znesPgBtdHa1XxLEUZa