### PR TITLE
Remove middleware.ts re-export file

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as default, config } from './proxy';


### PR DESCRIPTION
## Summary
Removed the `src/middleware.ts` file that was serving as a re-export barrel for the proxy module.

## Key Changes
- Deleted `src/middleware.ts` which contained re-exports of `proxy` as default and `config` from `./proxy`

## Details
This file appears to have been a convenience re-export layer. Removing it suggests either:
- Direct imports from `./proxy` are now preferred
- The middleware entry point is being consolidated elsewhere
- Simplifying the module structure by eliminating unnecessary indirection

https://claude.ai/code/session_01MBGufuHBf8osvaqmWkP5wr