### PR TITLE
fix: return 200 for OPTIONS preflight requests in middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,10 @@ async function getAuthenticatedUser(request: NextRequest): Promise<AuthMeRespons
 }
 
 export async function proxy(request: NextRequest) {
+  if (request.method === 'OPTIONS') {
+    return new NextResponse(null, { status: 200 });
+  }
+
   const { pathname } = request.nextUrl;
   const isLoginPage = pathname === '/login';
   const isOnboardingPage = pathname === '/onboarding';


### PR DESCRIPTION
OPTIONS requests to page routes (like /) return 400 because page.tsx
doesn't handle that method. Short-circuit in the middleware before auth
checks so CORS preflight succeeds.

https://claude.ai/code/session_01N94bfXWuL1TiqU3PvwPZ2G