### PR TITLE
Persist daily-generated questions, add PlayerMastery territory, and enforce friend validation on send

### DIFF
--- a/drizzle/0018_daily_generated_and_player_mastery_territory.sql
+++ b/drizzle/0018_daily_generated_and_player_mastery_territory.sql
@@ -1,0 +1,17 @@
+ALTER TABLE "Question" ALTER COLUMN "creator_id" DROP NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "generated_question_id" text;
+--> statement-breakpoint
+ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'authored' NOT NULL;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "Question" ADD CONSTRAINT "Question_generated_question_id_GeneratedQuestion_id_fk" FOREIGN KEY ("generated_question_id") REFERENCES "GeneratedQuestion"("id") ON DELETE set null;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "Question_generated_question_id_key" ON "Question" USING btree ("generated_question_id");
+--> statement-breakpoint
+ALTER TABLE "PLAYER_MASTERY" ADD COLUMN IF NOT EXISTS "territory_type" text DEFAULT 'demonstrated' NOT NULL;
+--> statement-breakpoint
+UPDATE "PLAYER_MASTERY" SET "territory_type" = 'demonstrated' WHERE "territory_type" IS DISTINCT FROM 'demonstrated';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1777840400000,
       "tag": "0017_creator_notes",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1777840500000,
+      "tag": "0018_daily_generated_and_player_mastery_territory",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -8,10 +8,13 @@ import {
   dailyQueues,
   db,
   generatedQuestions,
+  questions,
 } from '@/server/db';
 import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
+import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
+import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { type QueueSlot } from '@/server/daily/types';
 
 export const dynamic = 'force-dynamic';
@@ -143,11 +146,35 @@ export async function POST(request: NextRequest) {
     console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
   });
 
-  void createFeedItemsForFriendsFromAnswer(
-    session.userId,
-    question.id,
-    isCorrect ? 'correct' : 'incorrect',
-  );
+  try {
+    const persisted = await persistGeneratedQuestion(question.id);
+    const [persistedQuestion] = await db
+      .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+      .from(questions)
+      .where(eq(questions.id, persisted.questionId))
+      .limit(1);
+    const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+
+    if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
+      void promoteDeclaredToDemonstrated({
+        userId: persistedQuestion.creatorId,
+        domain: persistedDomain,
+        triggeringFriendId: session.userId,
+        questionId: persisted.questionId,
+      });
+    }
+
+    void createFeedItemsForFriendsFromAnswer(
+      session.userId,
+      persisted.questionId,
+      isCorrect ? 'correct' : 'incorrect',
+    );
+  } catch (error) {
+    console.warn('[daily/answer] failed to persist generated question for feed propagation', {
+      generatedQuestionId: question.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   return NextResponse.json({
     isCorrect,

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -4,13 +4,15 @@ import { NextRequest } from 'next/server';
 import { gradeAnswer, selectQuip } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
 import { getSession } from '@/server/auth/session';
-import { dailyQueues, db } from '@/server/db';
+import { dailyQueues, db, questions } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
+import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
+import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
 
 export const dynamic = 'force-dynamic';
@@ -122,11 +124,35 @@ export async function POST(request: NextRequest) {
     console.warn('[daily/catchup/answer] updateDomainDifficultyOnAnswer failed', err);
   });
 
-  void createFeedItemsForFriendsFromAnswer(
-    session.userId,
-    catchupItem.questionId,
-    isCorrect ? 'correct' : 'incorrect',
-  );
+  try {
+    const persisted = await persistGeneratedQuestion(catchupItem.questionId);
+    const [persistedQuestion] = await db
+      .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+      .from(questions)
+      .where(eq(questions.id, persisted.questionId))
+      .limit(1);
+    const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+
+    if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
+      void promoteDeclaredToDemonstrated({
+        userId: persistedQuestion.creatorId,
+        domain: persistedDomain,
+        triggeringFriendId: session.userId,
+        questionId: persisted.questionId,
+      });
+    }
+
+    void createFeedItemsForFriendsFromAnswer(
+      session.userId,
+      persisted.questionId,
+      isCorrect ? 'correct' : 'incorrect',
+    );
+  } catch (error) {
+    console.warn('[daily/catchup/answer] failed to persist generated question for feed propagation', {
+      generatedQuestionId: catchupItem.questionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 
   const nextItem = (await getCatchupQuestions(session.userId))[0] ?? null;
 

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -148,7 +148,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   });
 
   // Promote author's declared territory to demonstrated when a non-author answers correctly
-  if (isCorrect && !alreadyCorrect && session.userId !== question.creatorId) {
+  if (isCorrect && !alreadyCorrect && question.creatorId && session.userId !== question.creatorId) {
     void promoteDeclaredToDemonstrated({
       userId: question.creatorId,
       domain,

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -14,6 +14,7 @@ import {
   submitJoshingGameResponse,
 } from '@/server/db/queries/joshing-game';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
+import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
 
 export const dynamic = 'force-dynamic';
@@ -110,6 +111,15 @@ export async function POST(request: NextRequest, context: RouteContext) {
           domain,
         }).catch(() => null)
       : null;
+
+    if (grade.isCorrect && answeredQuestion?.question.creatorId && answeredQuestion.question.creatorId !== session.userId) {
+      void promoteDeclaredToDemonstrated({
+        userId: answeredQuestion.question.creatorId,
+        domain,
+        triggeringFriendId: session.userId,
+        questionId: parsed.questionId,
+      });
+    }
 
     void createFeedItemsForFriendsFromAnswer(
       session.userId,

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -10,70 +10,10 @@ import {
   userAnsweredQuestionCorrectly,
   userHasQuestionInBlockingFeed,
 } from '@/server/db/queries/feed';
+import { getFriends } from '@/server/db/queries/friends';
 import { sendSms } from '@/server/sms';
 
 export const dynamic = 'force-dynamic';
-
-function parseBody(value: unknown): { questionId: string; recipientUserId: string; personalMessage: string | null } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const questionId = typeof record.question_id === 'string'
-    ? record.question_id
-    : typeof record.questionId === 'string'
-      ? record.questionId
-      : null;
-  const recipientUserId = typeof record.recipient_user_id === 'string'
-    ? record.recipient_user_id
-    : typeof record.friend_id === 'string'
-      ? record.friend_id
-      : typeof record.recipientUserId === 'string'
-        ? record.recipientUserId
-        : null;
-  const rawMessage = typeof record.personalMessage === 'string'
-    ? record.personalMessage
-    : typeof record.personal_message === 'string'
-      ? record.personal_message
-      : '';
-  const personalMessage = rawMessage.trim().slice(0, 200) || null;
-
-  return questionId && recipientUserId ? { questionId, recipientUserId, personalMessage } : null;
-}
-
-function lastTwentyFourHours(date = new Date()) {
-  return new Date(date.getTime() - 24 * 60 * 60 * 1000);
-}
-
-async function resolveQuestionIdForSend(questionId: string, senderUserId: string): Promise<string | null> {
-  const [question] = await db.select({ id: questions.id }).from(questions).where(eq(questions.id, questionId)).limit(1);
-  if (question) return question.id;
-
-  const [generated] = await db
-    .select()
-    .from(generatedQuestions)
-    .where(eq(generatedQuestions.id, questionId))
-    .limit(1);
-
-  if (!generated) return null;
-
-  const [created] = await db
-    .insert(questions)
-    .values({
-      creatorId: senderUserId,
-      sourceQuestionId: generated.id,
-      questionText: generated.questionText,
-      answerText: generated.answer,
-      factualExplanation: generated.explainer,
-      category: 'other',
-      broadCategory: generated.broadCategory,
-      canonicalSubcategory: generated.canonicalSubcategory,
-      difficultyEstimate: generated.difficultyEstimate === 'accessible' || generated.difficultyEstimate === 'moderate' || generated.difficultyEstimate === 'specialist'
-        ? generated.difficultyEstimate
-        : null,
-    })
-    .returning({ id: questions.id });
-
-  return created?.id ?? null;
-}
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -88,6 +28,11 @@ export async function POST(request: NextRequest) {
   }
   if (parsed.recipientUserId === session.userId) {
     return NextResponse.json({ error: 'validation', message: 'Choose a friend to send this to.' }, { status: 400 });
+  }
+
+  const friends = await getFriends(session.userId);
+  if (!friends.some((friend) => friend.id === parsed.recipientUserId)) {
+    return NextResponse.json({ error: 'Recipient is not a friend.' }, { status: 403 });
   }
 
   const sendableQuestionId = await resolveQuestionIdForSend(parsed.questionId, session.userId);
@@ -170,4 +115,66 @@ export async function POST(request: NextRequest) {
   }
 
   return NextResponse.json({ item: created }, { status: 201 });
+}
+
+function parseBody(value: unknown): { questionId: string; recipientUserId: string; personalMessage: string | null } | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const record = value as Record<string, unknown>;
+  const questionId = typeof record.question_id === 'string'
+    ? record.question_id
+    : typeof record.questionId === 'string'
+      ? record.questionId
+      : null;
+  const recipientUserId = typeof record.recipient_user_id === 'string'
+    ? record.recipient_user_id
+    : typeof record.friend_id === 'string'
+      ? record.friend_id
+      : typeof record.recipientUserId === 'string'
+        ? record.recipientUserId
+        : null;
+  const rawMessage = typeof record.personalMessage === 'string'
+    ? record.personalMessage
+    : typeof record.personal_message === 'string'
+      ? record.personal_message
+      : '';
+  const personalMessage = rawMessage.trim().slice(0, 200) || null;
+
+  return questionId && recipientUserId ? { questionId, recipientUserId, personalMessage } : null;
+}
+
+function lastTwentyFourHours(date = new Date()) {
+  return new Date(date.getTime() - 24 * 60 * 60 * 1000);
+}
+
+async function resolveQuestionIdForSend(questionId: string, senderUserId: string): Promise<string | null> {
+  const [question] = await db.select({ id: questions.id }).from(questions).where(eq(questions.id, questionId)).limit(1);
+  if (question) return question.id;
+
+  const [generated] = await db
+    .select()
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.id, questionId))
+    .limit(1);
+
+  if (!generated) return null;
+
+  const [created] = await db
+    .insert(questions)
+    .values({
+      creatorId: senderUserId,
+      sourceQuestionId: generated.id,
+      source: 'authored',
+      questionText: generated.questionText,
+      answerText: generated.answer,
+      factualExplanation: generated.explainer,
+      category: 'other',
+      broadCategory: generated.broadCategory,
+      canonicalSubcategory: generated.canonicalSubcategory,
+      difficultyEstimate: generated.difficultyEstimate === 'accessible' || generated.difficultyEstimate === 'moderate' || generated.difficultyEstimate === 'specialist'
+        ? generated.difficultyEstimate
+        : null,
+    })
+    .returning({ id: questions.id });
+
+  return created?.id ?? null;
 }

--- a/src/server/ceremony/compute-beats.ts
+++ b/src/server/ceremony/compute-beats.ts
@@ -206,9 +206,11 @@ async function computeBeat3(userId: string, cycleStart: Date, cycleEndExclusive:
   ]);
 
   const counts = new Map<string, number>();
-  gameRows.forEach((row) => counts.set(row.contributorId, (counts.get(row.contributorId) ?? 0) + 1));
+  gameRows.forEach((row) => {
+    if (row.contributorId) counts.set(row.contributorId, (counts.get(row.contributorId) ?? 0) + 1);
+  });
   feedRows.forEach((row) => {
-    if (row.questionId && correctQuestionIds.has(row.questionId)) {
+    if (row.contributorId && row.questionId && correctQuestionIds.has(row.questionId)) {
       counts.set(row.contributorId, (counts.get(row.contributorId) ?? 0) + 1);
     }
   });

--- a/src/server/creator-notes.ts
+++ b/src/server/creator-notes.ts
@@ -47,7 +47,7 @@ export async function promptCreatorNoteAfterWrongAnswer(params: {
       .where(eq(questions.id, params.questionId))
       .limit(1);
 
-    if (!row || row.authorUserId === params.recipientUserId) return;
+    if (!row?.authorUserId || row.authorUserId === params.recipientUserId) return;
     if (!row.authorPhoneNumber || row.authorSmsOptIn === 'opted_out') return;
 
     const since = new Date(Date.now() - 24 * 60 * 60 * 1000);

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -57,7 +57,7 @@ export async function addToBank(params: {
     .set({ sharedToFriendsFeed: true, updatedAt: new Date() })
     .where(eq(questions.id, params.questionId));
 
-  if (question.creatorId !== params.userId) {
+  if (question.creatorId && question.creatorId !== params.userId) {
     const domain = questionDomain(question);
     await Promise.all([
       writeMasteryEvent({

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -13,7 +13,6 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { categoryLabel } from '@/lib/questions-types';
 import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
 import type { QueueSlot } from '@/server/daily/types';
-import { pgErrorCode } from '@/server/db/pg-error';
 import {
   catchUpExpiresAt,
   expiresWithin24Hours,
@@ -70,89 +69,33 @@ function normalizeDomain(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
 }
 
-async function getDeclaredInterests(userId: string) {
-  try {
-    return await db
-      .select({
-        domain: declaredInterests.domain,
-        broadCategory: declaredInterests.broadCategory,
-        territoryType: declaredInterests.territoryType,
-      })
-      .from(declaredInterests)
-      .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)))
-      .orderBy(asc(declaredInterests.declaredAt));
-  } catch (err) {
-    if (pgErrorCode(err) !== '42703') throw err;
-    // territory_type column not yet migrated — default to 'declared'
-    const rows = await db
-      .select({
-        domain: declaredInterests.domain,
-        broadCategory: declaredInterests.broadCategory,
-      })
-      .from(declaredInterests)
-      .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)))
-      .orderBy(asc(declaredInterests.declaredAt));
-    return rows.map((r) => ({ ...r, territoryType: 'declared' as const }));
-  }
-}
-
 export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDomain[]> {
-  const [declared, demonstrated] = await Promise.all([
-    getDeclaredInterests(userId),
-    db
-      .select({
-        domain: playerMastery.canonicalSubcategory,
-        broadCategory: playerMastery.broadCategory,
-        totalPoints: playerMastery.totalPoints,
-        tier: playerMastery.tier,
-      })
-      .from(playerMastery)
-      .where(and(
-        eq(playerMastery.userId, userId),
-        sql`exists (
-          select 1
-          from "MASTERY_EVENTS" me
-          where me."user_id" = ${userId}
-            and me."canonical_subcategory" = ${playerMastery.canonicalSubcategory}
-            and me."source_type" in ('live_correct', 'catchup_correct')
-            and me."question_id" is not null
-        )`,
-      ))
-      .orderBy(asc(playerMastery.canonicalSubcategory)),
-  ]);
+  const rows = await db
+    .select({
+      domain: playerMastery.canonicalSubcategory,
+      broadCategory: playerMastery.broadCategory,
+      territoryType: playerMastery.territoryType,
+      totalPoints: playerMastery.totalPoints,
+      tier: playerMastery.tier,
+    })
+    .from(playerMastery)
+    .where(eq(playerMastery.userId, userId))
+    .orderBy(asc(playerMastery.canonicalSubcategory));
 
-  const domains = new Map<string, KnowledgeBaseDomain>();
-
-  for (const row of declared) {
-    const domain = normalizeDomain(row.domain);
-    if (!domain) continue;
-    const territoryType = row.territoryType ?? 'declared';
-    domains.set(domain.toLowerCase(), {
-      domain,
-      broadCategory: row.broadCategory,
-      source: 'declared',
-      territoryType,
-      totalPoints: 0,
-      tier: 'establishing',
-    });
-  }
-
-  for (const row of demonstrated) {
-    const domain = normalizeDomain(row.domain);
-    if (!domain) continue;
-    const key = domain.toLowerCase();
-    const existing = domains.get(key);
-    domains.set(key, {
-      domain: existing?.domain ?? domain,
-      broadCategory: existing?.broadCategory ?? row.broadCategory,
-      source: existing?.source ?? 'friend_mediated',
-      territoryType: 'demonstrated',
-      totalPoints: row.totalPoints,
-      tier: row.tier,
-    });
-  }
-
-  return [...domains.values()];
+  return rows
+    .map((row): KnowledgeBaseDomain | null => {
+      const domain = normalizeDomain(row.domain);
+      if (!domain) return null;
+      return {
+        domain,
+        broadCategory: row.broadCategory,
+        source: row.territoryType === 'declared' ? 'declared' : 'friend_mediated',
+        territoryType: row.territoryType,
+        totalPoints: row.totalPoints,
+        tier: row.tier,
+      };
+    })
+    .filter((row): row is KnowledgeBaseDomain => Boolean(row));
 }
 
 export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow | null> {
@@ -390,6 +333,11 @@ async function _legacyInsertDeclared(
     });
 }
 
+/**
+ * @deprecated Use promoteDeclaredToDemonstrated. This function
+ * still exists for any in-flight code paths but should not be
+ * called. Scheduled for removal in v11.2.
+ */
 export async function upgradeKBDomainToDemonstrated(userId: string, domain: string): Promise<void> {
   const existing = await getKBDomainEntry(userId, domain);
   if (existing && existing.territoryType === 'declared') {

--- a/src/server/db/queries/joshing-game.ts
+++ b/src/server/db/queries/joshing-game.ts
@@ -422,7 +422,7 @@ export async function submitJoshingGameResponse(params: {
     weight: 1,
   });
 
-  if (isCorrect && question.creatorId !== params.userId) {
+  if (isCorrect && question.creatorId && question.creatorId !== params.userId) {
     const existingAuthorCredits = await countAuthorCreditEvents(params.questionId, question.creatorId);
     const authorAward = creatorMasteryAwardForNthCorrect(
       question.correctCount + 1,

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -30,7 +30,7 @@ export type QuestionView = {
   accepted_alternatives: string[];
   category: string;
   difficulty_estimate: 'accessible' | 'moderate' | 'specialist' | null;
-  creator_id: string;
+  creator_id: string | null;
   created_at: string;
   updated_at: string;
   breadcrumb_context: string | null;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -202,7 +202,9 @@ export const questions = pgTable(
   'Question',
   {
     id: id(),
-    creatorId: text('creator_id').notNull().references(() => users.id),
+    creatorId: text('creator_id').references(() => users.id),
+    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id, { onDelete: 'set null' }),
+    source: text('source').$type<'authored' | 'daily_generated'>().notNull().default('authored'),
     sourceQuestionId: text('source_question_id'),
     sourceCreatorId: text('source_creator_id'),
     questionText: text('question_text').notNull(),
@@ -253,6 +255,7 @@ export const questions = pgTable(
     index('Question_canonical_subcategory_idx').on(table.canonicalSubcategory),
     index('Question_source_question_id_idx').on(table.sourceQuestionId),
     index('Question_source_creator_id_idx').on(table.sourceCreatorId),
+    uniqueIndex('Question_generated_question_id_key').on(table.generatedQuestionId),
   ],
 );
 
@@ -299,6 +302,7 @@ export const playerMastery = pgTable(
     tier: masteryTierEnum('tier').notNull().default('establishing'),
     tierReachedAt: timestamp('tier_reached_at', { withTimezone: true }),
     seasonPointsStart: doublePrecision('season_points_start').notNull().default(0),
+    territoryType: text('territory_type').$type<'declared' | 'demonstrated'>().notNull().default('demonstrated'),
     updatedAt: updatedAt(),
   },
   (table) => [

--- a/src/server/knowledge/open-domain.ts
+++ b/src/server/knowledge/open-domain.ts
@@ -1,44 +1,46 @@
-import { and, eq, sql } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 
-import { activityItems, db, declaredInterests } from '@/server/db';
+import { activityItems, db, masteryEvents, playerMastery } from '@/server/db';
 import type { ActivityItemType } from '@/server/activity/write-activity';
+
+type TerritoryType = 'declared' | 'demonstrated';
 
 export async function openKBDomain(params: {
   userId: string;
   domain: string;
-  via: 'friend_answered' | 'authorship' | 'onboarding';
+  via: 'friend_answered' | 'authorship' | 'onboarding' | 'answered_correctly';
   broadCategory?: string | null;
   questionId?: string;
-}): Promise<{ opened: boolean; alreadyExisted: boolean }> {
-  const existing = await db
-    .select({ id: declaredInterests.id })
-    .from(declaredInterests)
+}): Promise<{ opened: boolean; alreadyExisted: boolean; territoryType: TerritoryType }> {
+  const desiredTerritoryType: TerritoryType = params.via === 'authorship' ? 'declared' : 'demonstrated';
+
+  const [existing] = await db
+    .select({ id: playerMastery.id, territoryType: playerMastery.territoryType })
+    .from(playerMastery)
     .where(and(
-      eq(declaredInterests.userId, params.userId),
-      eq(declaredInterests.domain, params.domain),
-      eq(declaredInterests.isActive, true),
+      eq(playerMastery.userId, params.userId),
+      eq(playerMastery.canonicalSubcategory, params.domain),
     ))
     .limit(1);
 
-  if (existing.length > 0) {
-    return { opened: false, alreadyExisted: true };
+  if (existing) {
+    return { opened: false, alreadyExisted: true, territoryType: existing.territoryType };
   }
 
-  const territoryType: 'declared' | 'demonstrated' =
-    params.via === 'authorship' ? 'declared' : 'demonstrated';
-
   await db
-    .insert(declaredInterests)
+    .insert(playerMastery)
     .values({
       userId: params.userId,
-      domain: params.domain,
+      canonicalSubcategory: params.domain,
       broadCategory: params.broadCategory ?? null,
-      territoryType,
-      isActive: true,
+      totalPoints: 0,
+      tier: 'establishing',
+      seasonPointsStart: 0,
+      territoryType: desiredTerritoryType,
     })
-    .onConflictDoNothing({ target: [declaredInterests.userId, declaredInterests.domain] });
+    .onConflictDoNothing({ target: [playerMastery.userId, playerMastery.canonicalSubcategory] });
 
-  return { opened: true, alreadyExisted: false };
+  return { opened: true, alreadyExisted: false, territoryType: desiredTerritoryType };
 }
 
 export async function promoteDeclaredToDemonstrated(params: {
@@ -46,49 +48,61 @@ export async function promoteDeclaredToDemonstrated(params: {
   domain: string;
   triggeringFriendId: string;
   questionId: string;
-}): Promise<{ promoted: boolean }> {
-  const [row] = await db
-    .select({ id: declaredInterests.id, territoryType: declaredInterests.territoryType })
-    .from(declaredInterests)
-    .where(and(
-      eq(declaredInterests.userId, params.userId),
-      eq(declaredInterests.domain, params.domain),
-      eq(declaredInterests.isActive, true),
-    ))
-    .limit(1);
-
-  if (!row || row.territoryType !== 'declared') {
-    return { promoted: false };
-  }
-
-  await db
-    .update(declaredInterests)
-    .set({ territoryType: 'demonstrated' })
-    .where(and(
-      eq(declaredInterests.userId, params.userId),
-      eq(declaredInterests.domain, params.domain),
-    ));
-
-  const answerId = `declared_promoted:${params.domain}:${params.questionId}:${params.triggeringFriendId}`;
-
+}): Promise<
+  | { promoted: true }
+  | { promoted: false; reason: 'no_row' | 'already_demonstrated' | 'error' }
+> {
   try {
-    await db.execute(sql`
-      insert into "MASTERY_EVENTS" (
-        "user_id", "canonical_subcategory", "source_type",
-        "question_id", "answered_by_user_id", "answer_id",
-        "base_points", "weight", "awarded_points", "session_context"
-      ) values (
-        ${params.userId}, ${params.domain}, 'declared_promoted',
-        ${params.questionId}, ${params.triggeringFriendId}, ${answerId},
-        0, 0, 0, 'declared_promoted'
-      )
-      on conflict ("answer_id") do nothing
-    `);
-  } catch {
-    // Non-fatal — traceability only
-  }
+    const [row] = await db
+      .select({ id: playerMastery.id, territoryType: playerMastery.territoryType })
+      .from(playerMastery)
+      .where(and(
+        eq(playerMastery.userId, params.userId),
+        eq(playerMastery.canonicalSubcategory, params.domain),
+      ))
+      .limit(1);
 
-  try {
+    if (!row) {
+      console.warn('[promoteDeclaredToDemonstrated] no PlayerMastery row', {
+        userId: params.userId,
+        domain: params.domain,
+        triggeringFriendId: params.triggeringFriendId,
+        questionId: params.questionId,
+      });
+      return { promoted: false, reason: 'no_row' };
+    }
+
+    if (row.territoryType === 'demonstrated') {
+      return { promoted: false, reason: 'already_demonstrated' };
+    }
+
+    await db
+      .update(playerMastery)
+      .set({ territoryType: 'demonstrated', updatedAt: new Date() })
+      .where(and(
+        eq(playerMastery.userId, params.userId),
+        eq(playerMastery.canonicalSubcategory, params.domain),
+      ));
+
+    const answerId = `declared_promoted:${params.domain}:${params.questionId}:${params.triggeringFriendId}`;
+
+    await db
+      .insert(masteryEvents)
+      .values({
+        userId: params.userId,
+        canonicalSubcategory: params.domain,
+        sourceType: 'declared_promoted',
+        questionId: params.questionId,
+        answeredByUserId: params.triggeringFriendId,
+        answerId,
+        basePoints: 0,
+        weight: 0,
+        awardedPoints: 0,
+        sessionContext: 'declared_promoted',
+        metadata: { byUserId: params.triggeringFriendId, domain: params.domain },
+      })
+      .onConflictDoNothing({ target: masteryEvents.answerId });
+
     await db.insert(activityItems).values({
       userId: params.userId,
       type: 'declared_promoted' satisfies ActivityItemType,
@@ -97,9 +111,16 @@ export async function promoteDeclaredToDemonstrated(params: {
       referenceType: 'question',
       read: false,
     });
-  } catch {
-    // Non-fatal
-  }
 
-  return { promoted: true };
+    return { promoted: true };
+  } catch (error) {
+    console.warn('[promoteDeclaredToDemonstrated] promotion failed', {
+      userId: params.userId,
+      domain: params.domain,
+      triggeringFriendId: params.triggeringFriendId,
+      questionId: params.questionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { promoted: false, reason: 'error' };
+  }
 }

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -1,0 +1,73 @@
+import { eq } from 'drizzle-orm';
+
+import { db, generatedQuestions, questions } from '@/server/db';
+
+type PersistGeneratedQuestionResult = {
+  questionId: string;
+  alreadyExisted: boolean;
+};
+
+function asDifficulty(value: string): 'accessible' | 'moderate' | 'specialist' | null {
+  if (value === 'accessible' || value === 'moderate' || value === 'specialist') return value;
+  return null;
+}
+
+export async function persistGeneratedQuestion(generatedQuestionId: string): Promise<PersistGeneratedQuestionResult> {
+  try {
+    const [existing] = await db
+      .select({ id: questions.id })
+      .from(questions)
+      .where(eq(questions.generatedQuestionId, generatedQuestionId))
+      .limit(1);
+
+    if (existing) {
+      return { questionId: existing.id, alreadyExisted: true };
+    }
+
+    const [generated] = await db
+      .select()
+      .from(generatedQuestions)
+      .where(eq(generatedQuestions.id, generatedQuestionId))
+      .limit(1);
+
+    if (!generated) {
+      throw new Error(`Generated question not found: ${generatedQuestionId}`);
+    }
+
+    const [created] = await db
+      .insert(questions)
+      .values({
+        creatorId: null,
+        generatedQuestionId,
+        source: 'daily_generated',
+        questionText: generated.questionText,
+        answerText: generated.answer,
+        factualExplanation: generated.explainer,
+        acceptedAlternatives: [],
+        answerSource: 'llm_suggested',
+        questionType: 'factual',
+        category: 'other',
+        broadCategory: generated.broadCategory,
+        canonicalSubcategory: generated.canonicalSubcategory || generated.broadCategory,
+        categoryOverridden: true,
+        difficultyEstimate: asDifficulty(generated.difficultyEstimate),
+        llmDifficulty: asDifficulty(generated.difficultyEstimate),
+        calibratedDifficulty: asDifficulty(generated.difficultyEstimate),
+        status: 'verified',
+        visibility: 'public',
+      })
+      .returning({ id: questions.id });
+
+    if (!created) {
+      throw new Error(`Failed to persist generated question: ${generatedQuestionId}`);
+    }
+
+    return { questionId: created.id, alreadyExisted: false };
+  } catch (error) {
+    console.error('[persistGeneratedQuestion] failed', {
+      generatedQuestionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix broken Daily/Catchup -> Feed propagation by ensuring generated questions are persisted to `Question` and `FeedItem.questionId` always references a `Question.id` (resolution A). 
- Finish the territory-model migration by moving `territoryType` semantics to `PLAYER_MASTERY` so `openKBDomain` and promotion logic operate on `PlayerMastery`. 
- Close a security/UX gap by requiring `/api/questions/send` recipients to be actual friends.

### Description
- Schema/migrations: added `generated_question_id` (nullable FK -> GeneratedQuestion.id with ON DELETE SET NULL), made `Question.creator_id` nullable, added `Question.source` (text NOT NULL DEFAULT 'authored'), and added `PLAYER_MASTERY.territory_type` (text NOT NULL DEFAULT 'demonstrated'); migration SQL written to `drizzle/0018_daily_generated_and_player_mastery_territory.sql`.
- Persist helper: new `src/server/questions/persist-generated-question.ts` implementing `persistGeneratedQuestion(generatedQuestionId)` which idempotently finds/creates a `Question` row mapped from a `GeneratedQuestion` and returns `{ questionId, alreadyExisted }`.
- Daily/Catchup wiring: `src/app/api/daily/answer/route.ts` and `src/app/api/daily/catchup/answer/route.ts` now call `persistGeneratedQuestion(...)` (wrapped in try/catch so user flow is not blocked) and pass the resulting `Question.id` to `createFeedItemsForFriendsFromAnswer` instead of the generated-question id; they also attempt promotion via `promoteDeclaredToDemonstrated` against the persisted question author when applicable.
- Territory model & promotion: replaced `DeclaredInterest` writes from `openKBDomain` with inserts/reads to/from `PLAYER_MASTERY`, added `promoteDeclaredToDemonstrated` to operate on `PLAYER_MASTERY` (update territoryType, insert `MASTERY_EVENTS` and an `ActivityItem`), and added a deprecation comment above the legacy `upgradeKBDomainToDemonstrated` function.
- Answer routes: wired promotion calls into feed, joshing, daily, and catchup answer flows so correct non-author answers trigger `promoteDeclaredToDemonstrated` where appropriate, guarding on nullable creator ids.
- Send validation: `src/app/api/questions/send/route.ts` now imports `getFriends` and returns `403` if the parsed recipient is not in the sender's friend list before any DB writes.
- Small TS/runtime hardening: multiple call sites updated to tolerate nullable `creatorId` after making `Question.creatorId` nullable.

### Testing
- `npx tsc --noEmit`: succeeded (TypeScript typecheck passed).
- `npx drizzle-kit check`: succeeded (drizzle config and migration files are consistent). 
- `drizzle` migration file created: `drizzle/0018_daily_generated_and_player_mastery_territory.sql` (contains ALTER TABLE statements for `Question` and `PLAYER_MASTERY`).
- `npx drizzle-kit migrate`: attempted but failed because `DATABASE_URL` is not set in this environment, so migrations could not be applied to a live DB; therefore runtime verification (`\d "Question"` / `\d "PLAYER_MASTERY"`) could not be produced here.
- `npm run build`: failed in this environment due to network/font fetch (Next/Turbopack could not fetch Google Font `Montserrat`), unrelated to the code changes.

Notes: the code and migration SQL are present in the branch and routes/imports were updated and type-checked; applying the migration and running DB-level describe/verification requires a reachable Postgres `DATABASE_URL` (and `psql`) which this environment does not provide.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc75120608832e880d1af6d1d84aa9)