### PR TITLE
Hide new game FAB on answer pages

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -36,7 +36,11 @@ export function Nav() {
   const [accountInitials, setAccountInitials] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const visibleUnreadCount = pathname === '/activities' ? 0 : unreadCount;
-  const showNewGameShortcut = pathname !== '/daily' && pathname !== '/daily/setup';
+  const hidesNewGameShortcut =
+    pathname.startsWith('/daily') ||
+    pathname === '/replay' ||
+    pathname.startsWith('/games/');
+  const showNewGameShortcut = !hidesNewGameShortcut;
 
   const loadUnreadCount = useCallback(async () => {
     try {


### PR DESCRIPTION
### Motivation

- The floating New Game FAB overlapped answer/send controls on question-answering screens and needed to be hidden on those routes to avoid blocking the Send button.

### Description

- Updated `src/components/Nav.tsx` to compute a `hidesNewGameShortcut` flag and derive `showNewGameShortcut` from it.
- The FAB is now hidden when `pathname.startsWith('/daily')`, when `pathname === '/replay'`, or when `pathname.startsWith('/games/')`, replacing the prior narrower checks for `/daily` and `/daily/setup`.

### Testing

- Ran `npx eslint src/components/Nav.tsx` which completed for the changed file.
- Ran `npx tsc --noEmit` which succeeded with the current TypeScript setup.
- Ran `npm run lint` which failed due to pre-existing lint errors elsewhere in the repo unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc80d547a8832e8a31581819241dda)