### PR TITLE
Remove progression level chart from Knowledge page

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -2,14 +2,13 @@
 
 import Link from 'next/link';
 import { Suspense, useEffect, useMemo, useState, type CSSProperties } from 'react';
-import { useRouter, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import { Combine, Plus, Repeat2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 
 import { DomainCard } from '@/components/knowledge/DomainCard';
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
-import { ProgressionLandscape, type ProgressionDomain } from '@/components/knowledge/ProgressionLandscape';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
 import type { KnowledgeDomain } from '@/server/profile/knowledge-types';
@@ -117,19 +116,6 @@ function toPortraitEntry(domain: DomainMastery): PortraitEntry {
   };
 }
 
-function toProgressionDomain(domain: DomainMastery): ProgressionDomain {
-  return {
-    canonicalSubcategory: domain.displayName,
-    canonicalSubcategorySlug: toCanonicalDomainSlug(domain.domain),
-    broadCategory: domain.broadCategory,
-    currentTier: asTier(domain.tier),
-    correctAnswerCount: domain.questionsCorrect,
-    authoredCount: domain.questionsAnswered,
-    iconKey: domain.iconKey,
-    territoryType: (domain.territoryType as 'declared' | 'demonstrated' | undefined) ?? 'demonstrated',
-  };
-}
-
 function emptyDomain(domain: string): DomainMastery {
   return {
     domain,
@@ -168,7 +154,6 @@ export default function KnowledgePage() {
 }
 
 function KnowledgePageContent() {
-  const router = useRouter();
   const searchParams = useSearchParams();
   const highlightedDomainSlug = searchParams.get('domain');
   const tierCrossed = searchParams.get('tier_crossed');
@@ -263,11 +248,6 @@ function KnowledgePageContent() {
 
   const activeDomains = useMemo(() => sortedDomains.map(toKnowledgeDomain), [sortedDomains]);
   const portraitEntries = useMemo(() => sortedDomains.map(toPortraitEntry), [sortedDomains]);
-  const progressionDomains = useMemo(() => sortedDomains.map(toProgressionDomain), [sortedDomains]);
-  const maxCorrectAnswerCount = useMemo(
-    () => Math.max(...progressionDomains.map((domain) => domain.correctAnswerCount), 1),
-    [progressionDomains],
-  );
   const declaredSlots = useMemo(() => {
     if (!data) return [];
     const byKey = new Map(data.pageData.allDomains.map((domain) => [domainKey(domain.domain), domain]));
@@ -514,14 +494,6 @@ function KnowledgePageContent() {
             ) : (
               <div id="portrait-circles-section">
                 <PortraitCircles entries={portraitEntries} />
-                <div style={{ marginTop: 24 }}>
-                  <ProgressionLandscape
-                    domains={progressionDomains}
-                    maxCorrectAnswerCount={maxCorrectAnswerCount}
-                    highlightSlug={activeSlug}
-                    onDomainSelect={(domain) => router.push(`/knowledge/${encodeURIComponent(domain)}`)}
-                  />
-                </div>
                 <div style={sharePortraitWrapStyle}>
                   <button type="button" style={sharePortraitBtnStyle} onClick={() => setShareModalOpen(true)}>
                     Share portrait


### PR DESCRIPTION
### Motivation

- The bottom-most, level-sorted progression chart in the Knowledge progression view should be removed to simplify the UI and avoid a redundant visualization beneath the portrait circles.
- Removing the chart also lets us drop the now-unused progression mapping and router navigation tied to that component.

### Description

- Removed the `ProgressionLandscape` import and the `toProgressionDomain` helper from `src/app/knowledge/page.tsx` and deleted the memoized `progressionDomains` and `maxCorrectAnswerCount` values.
- Removed the `useRouter` import and the `router.push` usage that was only used for the progression chart’s `onDomainSelect` handler.
- Deleted the JSX block rendering the progression chart while leaving the portrait circles and the share button intact.
- Kept surrounding logic and data used elsewhere (declared slots, domain lists, and portrait entries) unchanged.

### Testing

- Ran `npx tsc --noEmit --pretty false` which completed without type errors for the modified file.
- Ran `git diff --check` which reported no whitespace/format issues for the change.
- Ran `npm run lint` which failed due to pre-existing lint errors across unrelated files and pre-existing hook warnings (not introduced by this change).
- Started the dev server via `npm run dev`, which launched but reported a DB migration/connection warning in this environment, and `curl -I http://localhost:3000/knowledge` returned a `307` redirect to `/login` (no authenticated rendering captured).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc818be264832e97fd6b05e4348a42)