### PR TITLE
Hide new game shortcut on home

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -37,6 +37,7 @@ export function Nav() {
   const [menuOpen, setMenuOpen] = useState(false);
   const visibleUnreadCount = pathname === '/activities' ? 0 : unreadCount;
   const hidesNewGameShortcut =
+    pathname === '/' ||
     pathname.startsWith('/daily') ||
     pathname === '/replay' ||
     pathname.startsWith('/games/');


### PR DESCRIPTION
### Motivation
- Remove the bottom floating "New Game" navigation treat from the home page while preserving the shortcut on other pages.

### Description
- Add `pathname === '/'` to the `hidesNewGameShortcut` condition in `src/components/Nav.tsx` so the floating New Game `Link` is not shown on the home route.

### Testing
- Ran `npx tsc --noEmit --project tsconfig.json` which succeeded.
- Ran `npm run lint` which failed due to unrelated existing lint errors in the codebase and did not indicate any new issues from this change.
- Attempted to verify visually by running the dev server (`npm run dev`) and capturing a Playwright screenshot, but the screenshot step was blocked by the npm registry `403` and the dev server reported a missing `DATABASE_URL`, preventing a full end-to-end capture.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc859a2704832ebd9da4136135fb77)