### PR TITLE
Update primary navigation IA

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,12 +3,8 @@
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { Bell, Brain, Home, Menu, Plus, Rss, User, X } from 'lucide-react';
+import { Brain, Home, Menu, Pencil, Plus, Rss, User, X } from 'lucide-react';
 import { CreateChooser } from '@/components/CreateChooser';
-
-type ActivitiesResponse = {
-  unreadCount?: number;
-};
 
 type MeResponse = {
   user?: {
@@ -19,8 +15,8 @@ type MeResponse = {
 const navItems = [
   { href: '/', label: 'Home', Icon: Home },
   { href: '/feed', label: 'Friends', Icon: Rss },
+  { href: '/questions', label: 'Questions', Icon: Pencil },
   { href: '/knowledge', label: 'Knowledge', Icon: Brain },
-  { href: '/activities', label: 'Activities', Icon: Bell },
   { href: '/account', label: 'Account', Icon: User },
 ];
 
@@ -33,30 +29,14 @@ function initialsFor(name: string): string {
 
 export function Nav() {
   const pathname = usePathname();
-  const [unreadCount, setUnreadCount] = useState(0);
   const [accountInitials, setAccountInitials] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
-  const visibleUnreadCount = pathname === '/activities' ? 0 : unreadCount;
   const hidesNewGameShortcut =
     pathname.startsWith('/daily') ||
     pathname === '/replay' ||
     pathname.startsWith('/games/');
   const showNewGameShortcut = !hidesNewGameShortcut;
-
-  const loadUnreadCount = useCallback(async () => {
-    try {
-      const response = await fetch('/api/activities', { cache: 'no-store', credentials: 'include' });
-      if (!response.ok) {
-        setUnreadCount(0);
-        return;
-      }
-      const body = await response.json().catch(() => null) as ActivitiesResponse | null;
-      setUnreadCount(body?.unreadCount ?? 0);
-    } catch {
-      setUnreadCount(0);
-    }
-  }, []);
 
   const loadCurrentUser = useCallback(async () => {
     try {
@@ -77,19 +57,12 @@ export function Nav() {
     if (pathname === '/onboarding') return;
 
     const initialTimer = window.setTimeout(() => {
-      void loadUnreadCount();
       void loadCurrentUser();
     }, 0);
-    const timer = window.setInterval(() => {
-      void loadUnreadCount();
-    }, 60_000);
-
     return () => {
       window.clearTimeout(initialTimer);
-      window.clearInterval(timer);
     };
-  }, [loadCurrentUser, loadUnreadCount, pathname]);
-
+  }, [loadCurrentUser, pathname]);
 
   if (pathname === '/onboarding') {
     return null;
@@ -133,7 +106,6 @@ export function Nav() {
           <div id="nav-menu" className="mx-auto mt-3 grid max-w-4xl gap-1">
             {navItems.map(({ href, label, Icon }) => {
               const active = pathname === href;
-              const showUnreadDot = label === 'Activities' && visibleUnreadCount > 0;
               const isAccount = label === 'Account';
 
               return (
@@ -148,9 +120,6 @@ export function Nav() {
                 >
                   <span className="relative grid size-5 place-items-center">
                     {isAccount ? <AccountIcon active={active} /> : <Icon className="size-4" />}
-                    {showUnreadDot ? (
-                      <span className="absolute right-0 top-0 size-2 rounded-full bg-primary" aria-hidden="true" />
-                    ) : null}
                   </span>
                   {label}
                 </Link>


### PR DESCRIPTION
### Motivation
- Small, low-risk update to the primary navigation IA to surface authored Questions and de-emphasize Activities in the top-level nav while preserving all existing routes and behavior.
- Keep routes and data logic intact and avoid wide refactors; change should be limited to navigation configuration and mobile/menu rendering.

### Description
- Modified `src/components/Nav.tsx` to reorder nav items to: Home (`/`), Friends (`/feed`), Questions (`/questions`), Knowledge (`/knowledge`), Account (`/account`).
- Added a top-level `Questions` item using the existing `lucide-react` `Pencil` icon and removed the `Activities` nav item from the primary menu only.
- Removed nav-specific activities unread polling and the unread dot/UI for the removed top-level item while leaving the `/activities` page and API untouched so the route remains directly accessible.
- Preserved active-state/menu rendering and reused existing icons and routes so no new routes or data changes were introduced.

### Testing
- Ran `npx eslint src/components/Nav.tsx`, which passed for the modified file.
- Ran `git diff --check`, which passed with no whitespace or diff errors related to this change.
- `npm run lint` (project-wide) failed due to pre-existing unrelated lint errors elsewhere in the repo, not caused by this change.
- `npm run build` failed in this environment because Next.js could not fetch the Montserrat Google Font, which is an environment/network issue and unrelated to the nav change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7c741c68832eaf060dbed4665b0e)