### PR TITLE
Move missed questions above feed

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,6 +26,7 @@ export default async function Home() {
         </div>
         <div className="mt-6 w-full space-y-3 md:mt-0 md:max-w-xs">
           <TodaysFiveCard />
+          {catchupCount > 0 ? <CatchupCard count={catchupCount} expiringCount={expiringCount} /> : null}
           <div className="rounded-lg border bg-card p-4 text-card-foreground">
             <p className="mb-3 text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">What&apos;s happening</p>
             <FeedList limit={3} />
@@ -35,7 +36,6 @@ export default async function Home() {
               </Link>
             </div>
           </div>
-          {catchupCount > 0 ? <CatchupCard count={catchupCount} expiringCount={expiringCount} /> : null}
         </div>
       </section>
     </main>


### PR DESCRIPTION
### Motivation
- Surface the missed-question catch-up card immediately after Today’s Five so users see catch-up actions before the feed.

### Description
- Reordered JSX in `src/app/page.tsx` to render `CatchupCard` directly after `TodaysFiveCard` (no other content or styles changed).

### Testing
- Ran `npx eslint src/app/page.tsx`, which passed for the modified file, and `npm run lint`, which failed due to unrelated, pre-existing lint errors elsewhere in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe7cd46f0c832e911d7c567fa4fbd2)