### PR TITLE
Match mobile navigation drawer design

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -70,13 +70,13 @@ export function Nav() {
 
   function AccountIcon({ active }: { active: boolean }) {
     if (!accountInitials) {
-      return <User className="size-4" />;
+      return <User className="size-5" strokeWidth={1.9} />;
     }
 
     return (
       <span
         className={[
-          'grid size-5 place-items-center rounded-full text-[10px] font-semibold',
+          'grid size-6 place-items-center rounded-full text-[11px] font-semibold',
           active ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
         ].join(' ')}
         aria-hidden="true"
@@ -88,22 +88,47 @@ export function Nav() {
 
   return (
     <>
-      <nav className="sticky top-0 z-40 border-b bg-background/95 px-4 py-3 backdrop-blur">
-        <div className="mx-auto flex max-w-4xl items-center justify-between">
-          <Link href="/" className="font-serif text-lg font-semibold">Joshing</Link>
+      <nav
+        className={[
+          'sticky top-0 z-40 border-b bg-background/95 backdrop-blur',
+          menuOpen ? 'px-6 pb-16 pt-7 md:pb-16' : 'px-4 py-3',
+        ].join(' ')}
+        aria-label="Primary navigation"
+      >
+        <div
+          className={[
+            'mx-auto flex max-w-4xl items-center justify-between',
+            menuOpen ? 'mb-9' : '',
+          ].join(' ')}
+        >
+          <Link
+            href="/"
+            className={[
+              'font-serif font-semibold leading-none text-foreground',
+              menuOpen ? 'text-[2rem]' : 'text-lg',
+            ].join(' ')}
+            onClick={() => setMenuOpen(false)}
+          >
+            Joshing
+          </Link>
           <button
             type="button"
-            className="inline-flex min-h-10 min-w-10 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted hover:text-foreground"
+            className={[
+              'inline-flex items-center justify-center border text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+              menuOpen
+                ? 'size-16 rounded-2xl bg-background text-4xl shadow-sm'
+                : 'min-h-10 min-w-10 rounded-md',
+            ].join(' ')}
             aria-label={menuOpen ? 'Close navigation menu' : 'Open navigation menu'}
             aria-expanded={menuOpen}
             aria-controls="nav-menu"
             onClick={() => setMenuOpen((current) => !current)}
           >
-            {menuOpen ? <X className="size-5" /> : <Menu className="size-5" />}
+            {menuOpen ? <X className="size-8" strokeWidth={1.6} /> : <Menu className="size-5" />}
           </button>
         </div>
         {menuOpen ? (
-          <div id="nav-menu" className="mx-auto mt-3 grid max-w-4xl gap-1">
+          <div id="nav-menu" className="mx-auto grid max-w-4xl gap-8 md:gap-5" role="list">
             {navItems.map(({ href, label, Icon }) => {
               const active = pathname === href;
               const isAccount = label === 'Account';
@@ -113,13 +138,15 @@ export function Nav() {
                   key={href}
                   href={href}
                   onClick={() => setMenuOpen(false)}
+                  aria-current={active ? 'page' : undefined}
                   className={[
-                    'flex min-h-11 items-center gap-3 rounded-md px-3 text-sm transition',
-                    active ? 'bg-muted text-foreground' : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+                    'group flex min-h-14 items-center gap-7 rounded-xl px-8 text-[1.65rem] leading-none transition md:min-h-12 md:text-2xl',
+                    active ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
                   ].join(' ')}
+                  role="listitem"
                 >
-                  <span className="relative grid size-5 place-items-center">
-                    {isAccount ? <AccountIcon active={active} /> : <Icon className="size-4" />}
+                  <span className="relative grid size-7 shrink-0 place-items-center text-muted-foreground transition group-hover:text-foreground">
+                    {isAccount ? <AccountIcon active={active} /> : <Icon className="size-6" strokeWidth={1.9} />}
                   </span>
                   {label}
                 </Link>


### PR DESCRIPTION
### Motivation
- Bring the shared top navigation into alignment with the provided mobile drawer design so the expanded menu reads as a prominent, stacked panel on small screens.
- Improve accessibility and interaction by exposing `aria-current` on active links and ensuring the menu closes when the wordmark or an item is selected.

### Description
- Reworked `src/components/Nav.tsx` to render a larger Joshing wordmark and a spacious stacked menu when the mobile drawer is open, including updated spacing, sizes, and focus-visible styles.
- Replaced a few icon sizes and stroke widths and adjusted the account avatar rendering to match the new visual scale and layout.
- Added role/ARIA attributes (`role="list"`, `role="listitem"`, `aria-current`) and shifted the toggle button appearance to a prominent rounded close button in the open state.
- Kept the original nav item routes intact (`/`, `/feed`, `/questions`, `/knowledge`, `/account`) and preserved the create shortcut behavior outside the expanded menu.

### Testing
- Ran `npx eslint src/components/Nav.tsx` and the file passed focused lint checks.
- Ran `npx tsc --noEmit --pretty false` and TypeScript checks completed with no errors for the changed file.
- Ran `git diff --check` which reported no whitespace or diff-check problems for the change.
- Ran `npm run lint` and `npm run build` in the environment, which surfaced pre-existing repository lint errors and a Google Fonts fetch failure during build respectively, neither of which are caused by the change to the navigation component.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9edbeec0832eab66bcc06da7e096)