### PR TITLE
Fix FeedItem nullable column hotfix migration

### DIFF
--- a/drizzle/0019_feed_item_nullable_columns_hotfix.sql
+++ b/drizzle/0019_feed_item_nullable_columns_hotfix.sql
@@ -1,0 +1,6 @@
+-- Ensure nullable FeedItem columns queried by the feed API exist on partially-migrated databases.
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "personalMessage" text,
+  ADD COLUMN IF NOT EXISTS "sourceResult" text,
+  ADD COLUMN IF NOT EXISTS "submittedAnswer" text,
+  ADD COLUMN IF NOT EXISTS "quip" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1777840500000,
       "tag": "0018_daily_generated_and_player_mastery_territory",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1778508000000,
+      "tag": "0019_feed_item_nullable_columns_hotfix",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -24,14 +24,21 @@ export async function register() {
       // Table or columns may not exist yet — that's fine, migrate() will create them
     }
 
-    // Migration 0012 adds "sourceResult" to FeedItem but the final statement
-    // (ALTER TYPE ... ADD VALUE) can fail in some PostgreSQL environments, leaving
-    // the migration unrecorded and the column absent on every subsequent startup.
-    // Pre-apply the column so the feed query never hits a missing-column error.
+    // Several FeedItem columns were introduced after the original table. In preview
+    // databases with partially-recorded migrations, Drizzle can believe these
+    // migrations already ran while the nullable columns are still absent, causing
+    // feed reads to fail before migrate() gets another chance to reconcile them.
+    // Pre-apply these additive columns idempotently so GET /api/feed remains safe.
     try {
-      await db.execute(sql`ALTER TABLE "FeedItem" ADD COLUMN IF NOT EXISTS "sourceResult" TEXT`);
+      await db.execute(sql`
+        ALTER TABLE "FeedItem"
+          ADD COLUMN IF NOT EXISTS "personalMessage" text,
+          ADD COLUMN IF NOT EXISTS "sourceResult" text,
+          ADD COLUMN IF NOT EXISTS "submittedAnswer" text,
+          ADD COLUMN IF NOT EXISTS "quip" text
+      `);
     } catch {
-      // Column already exists or FeedItem table not yet created — migrate() handles both
+      // FeedItem table may not exist yet — migrate() handles initial creation.
     }
 
     // If the Category enum type already exists but migration 0000 isn't recorded,


### PR DESCRIPTION
### Motivation

- Prevent runtime failures in `/api/feed` caused by missing nullable `FeedItem` columns (notably `personalMessage`) on partially-migrated preview/production databases. 
- Make feed reads resilient by ensuring additive columns exist before the Drizzle migrator runs so the server can recover even when migration bookkeeping is inconsistent.

### Description

- Add an idempotent Drizzle migration `drizzle/0019_feed_item_nullable_columns_hotfix.sql` to create `personalMessage`, `sourceResult`, `submittedAnswer`, and `quip` if they are missing. 
- Pre-apply the same additive `FeedItem` columns during startup instrumentation in `src/instrumentation.ts` so `/api/feed` does not attempt to select columns that may be absent. 
- Register the new migration tag in `drizzle/meta/_journal.json` so the migrator recognizes the hotfix.

### Testing

- Ran `npx tsc --noEmit` and the type-check completed successfully. 
- Verified `drizzle` journal JSON is valid with `node -e "JSON.parse(require('fs').readFileSync('drizzle/meta/_journal.json','utf8'))"` which returned successfully. 
- Ran `npm run lint`, which surfaced existing unrelated lint errors in the repo (React hook and `no-explicit-any` issues) but did not indicate any problems introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01dd9b6de8832e8c204a8f7301732b)