### PR TITLE
Resilient knowledge queries and non-fatal dismissed-domains load

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -195,14 +195,19 @@ function KnowledgePageContent() {
     let active = true;
     setView(readSavedView());
     setLoading(true);
-    Promise.all([
-      loadKnowledge(),
-      fetch('/api/feed/dismissed-domains', { cache: 'no-store', credentials: 'include' })
-        .then((r) => r.json().catch(() => null))
-        .then((body: { domains?: string[] } | null) => {
-          if (active && body?.domains) setDismissedDomains(body.domains);
-        }),
-    ])
+    setError(null);
+
+    const loadDismissedDomains = async () => {
+      try {
+        const response = await fetch('/api/feed/dismissed-domains', { cache: 'no-store', credentials: 'include' });
+        const body = await response.json().catch(() => null) as { domains?: string[] } | null;
+        if (active && response.ok && body?.domains) setDismissedDomains(body.domains);
+      } catch {
+        if (active) setDismissedDomains([]);
+      }
+    };
+
+    Promise.all([loadKnowledge(), loadDismissedDomains()])
       .catch((caught) => {
         if (active) setError(caught instanceof Error ? caught.message : 'Could not load your Knowledge Map.');
       })

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -16,6 +16,7 @@ import { getMasteryTierDisplay } from '@/server/mastery/get-mastery-tier-display
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { TIER_THRESHOLD_POINTS } from '@/server/mastery/tiers';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
+import { pgErrorCode } from '@/server/db/pg-error';
 import type { MasteryTier } from '@/types/db';
 
 export type DomainMastery = {
@@ -124,6 +125,52 @@ type AnswerStats = {
   firstActivityAt?: Date | null;
 };
 
+type PlayerMasteryRow = typeof playerMastery.$inferSelect;
+
+async function getPlayerMasteryRows(userId: string, orderByPoints = false): Promise<PlayerMasteryRow[]> {
+  try {
+    if (orderByPoints) {
+      return await db
+        .select()
+        .from(playerMastery)
+        .where(eq(playerMastery.userId, userId))
+        .orderBy(desc(playerMastery.totalPoints));
+    }
+
+    return await db
+      .select()
+      .from(playerMastery)
+      .where(eq(playerMastery.userId, userId));
+  } catch (error) {
+    if (pgErrorCode(error) !== '42703') throw error;
+
+    const selectWithoutTerritoryType = {
+      id: playerMastery.id,
+      userId: playerMastery.userId,
+      canonicalSubcategory: playerMastery.canonicalSubcategory,
+      broadCategory: playerMastery.broadCategory,
+      totalPoints: playerMastery.totalPoints,
+      tier: playerMastery.tier,
+      tierReachedAt: playerMastery.tierReachedAt,
+      seasonPointsStart: playerMastery.seasonPointsStart,
+      updatedAt: playerMastery.updatedAt,
+    };
+
+    const rows = orderByPoints
+      ? await db
+        .select(selectWithoutTerritoryType)
+        .from(playerMastery)
+        .where(eq(playerMastery.userId, userId))
+        .orderBy(desc(playerMastery.totalPoints))
+      : await db
+        .select(selectWithoutTerritoryType)
+        .from(playerMastery)
+        .where(eq(playerMastery.userId, userId));
+
+    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const }));
+  }
+}
+
 const TIER_ORDER: MasteryTier[] = ['establishing', 'familiar', 'solid', 'mastery'];
 const STREAK_TIME_ZONE = 'America/New_York';
 const FRIEND_MEDIATED_CONTEXTS = ['feed', 'joshing_game'];
@@ -218,11 +265,7 @@ function toDomainMasteryRow(
 export async function getUserMasteryOverview(userId: string): Promise<MasteryOverview> {
   const [declaredRows, masteryRows, eventRows, recentRows] = await Promise.all([
     getActiveDeclaredInterests(userId),
-    db
-      .select()
-      .from(playerMastery)
-      .where(eq(playerMastery.userId, userId))
-      .orderBy(desc(playerMastery.totalPoints)),
+    getPlayerMasteryRows(userId, true),
     db
       .select({
         canonicalSubcategory: masteryEvents.canonicalSubcategory,
@@ -340,11 +383,7 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
 export async function getKnowledgePageData(userId: string): Promise<KnowledgePageData> {
   const [declaredRows, masteryRows, eventRows] = await Promise.all([
     getActiveDeclaredInterests(userId),
-    db
-      .select()
-      .from(playerMastery)
-      .where(eq(playerMastery.userId, userId))
-      .orderBy(desc(playerMastery.totalPoints)),
+    getPlayerMasteryRows(userId, true),
     db
       .select({
         canonicalSubcategory: masteryEvents.canonicalSubcategory,
@@ -460,10 +499,7 @@ export async function getDomainDetail(userId: string, domain: string): Promise<D
 
   const [declaredRows, masteryRows, eventRows, visibilityRows, responseRows, queueRows] = await Promise.all([
     getActiveDeclaredInterests(userId),
-    db
-      .select()
-      .from(playerMastery)
-      .where(eq(playerMastery.userId, userId)),
+    getPlayerMasteryRows(userId),
     db
       .select({
         event: {


### PR DESCRIPTION
### Motivation
- The Knowledge page could fail when the deployed database was missing a newer `territory_type` column on `PLAYER_MASTERY`, and an ancillary `/api/feed/dismissed-domains` failure could blank the map; both should be tolerated so the map still loads.

### Description
- Add `getPlayerMasteryRows(userId, orderByPoints?)` in `src/server/db/queries/knowledge.ts` that catches Postgres missing-column errors (`42703`) and falls back to a column-narrowed select, returning rows with `territoryType: 'demonstrated'` when the column is absent.
- Replace direct `PLAYER_MASTERY` queries in `getUserMasteryOverview`, `getKnowledgePageData`, and `getDomainDetail` with the new helper to make knowledge endpoints resilient to out-of-sync DB migrations.
- Make the client-side Knowledge loader (`src/app/knowledge/page.tsx`) treat `/api/feed/dismissed-domains` as non-fatal by loading dismissed domains in a try/catch and defaulting to an empty list if that fetch fails so the main map load cannot be blocked.
- Add `pgErrorCode` import and small supporting changes to wire in the resilience logic; apply formatting changes in the modified files.

### Testing
- Ran type-check: `npx tsc --noEmit`, which completed successfully.
- Ran lint: `npm run lint`, which surfaced existing repo-wide lint issues (not introduced by this change) and therefore failed.
- Ran production build: `npm run build` / `next build`, which failed in this environment because Next.js could not fetch the Montserrat Google Font (network/font fetch issue) rather than due to the changed logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e0cc74ec832e887d53df1262ae64)