### PR TITLE
Restore Daily Five setup entrypoint

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -90,6 +90,7 @@ function DailySetupContent() {
   const [sortMode, setSortMode] = useState<DomainSortMode>('category');
   const [selectedDomains, setSelectedDomains] = useState<Set<string>>(new Set());
   const [adaptiveLabel, setAdaptiveLabel] = useState<string | null>(null);
+  const [hasUnstartedQueue, setHasUnstartedQueue] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,7 +113,13 @@ function DailySetupContent() {
         }
 
         const status = await statusResponse.json();
-        if (status.queue_id) {
+        const questionsAnswered =
+          typeof status.questionsAnswered === 'number'
+            ? status.questionsAnswered
+            : typeof status.answered === 'number'
+              ? status.answered
+              : 0;
+        if (status.queue_id && (status.complete || status.isComplete || questionsAnswered > 0)) {
           router.replace(status.complete || status.isComplete ? '/daily/summary' : '/daily');
           return;
         }
@@ -122,6 +129,7 @@ function DailySetupContent() {
 
         const requestedDomain = searchParams.get('domain')?.trim();
         const requestedCustom = searchParams.get('domainMode') === 'custom' && requestedDomain;
+        setHasUnstartedQueue(Boolean(status.queue_id));
         setDomains(body.domains ?? []);
         setDifficulty(body.preferences?.difficulty ?? 'adaptive');
         setDomainMode(requestedCustom ? 'custom' : body.preferences?.domainMode ?? 'random');
@@ -182,6 +190,18 @@ function DailySetupContent() {
         throw new Error(body?.message ?? 'Could not save your setup.');
       }
 
+      if (hasUnstartedQueue) {
+        const resetResponse = await fetch('/api/daily/reset', {
+          method: 'POST',
+          credentials: 'include',
+          cache: 'no-store',
+        });
+        if (!resetResponse.ok) {
+          const body = await resetResponse.json().catch(() => null);
+          throw new Error(body?.message ?? 'Could not refresh your setup.');
+        }
+      }
+
       const queueResponse = await fetch('/api/daily/queue', {
         method: 'POST',
         credentials: 'include',
@@ -197,7 +217,7 @@ function DailySetupContent() {
       setError(caught instanceof Error ? caught.message : 'Could not start your round.');
       setSubmitting(false);
     }
-  }, [canStart, difficulty, domainMode, router, selectedDomains]);
+  }, [canStart, difficulty, domainMode, hasUnstartedQueue, router, selectedDomains]);
 
   if (loading) {
     return (

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -93,7 +93,8 @@ export default function TodaysFiveCard() {
   const effectiveStatus = status ?? FALLBACK_STATUS;
   const answered = Math.max(0, Math.min(effectiveStatus.questionsAnswered, 5));
   const isComplete = effectiveStatus.isComplete || effectiveStatus.questionsRemaining <= 0;
-  const playHref = !effectiveStatus.queueId ? '/daily/setup' : isComplete ? '/daily/summary' : '/daily';
+  const hasStartedRound = Boolean(effectiveStatus.queueId) && answered > 0;
+  const playHref = isComplete ? '/daily/summary' : hasStartedRound ? '/daily' : '/daily/setup';
   const subtext = useMemo(() => {
     if (isComplete) {
       return `Done for today. Next round in ${formatCountdown(effectiveStatus.nextRoundAt, nowMs)}.`;


### PR DESCRIPTION
### Motivation
- The app treated an existing (prebuilt) Daily Five queue as ready-to-play and routed `Play now` straight to gameplay, preventing users from opening the setup to change difficulty or domains. 
- The goal is to keep the setup accessible until the player has actually started answering the round, while preserving redirects for in-progress or completed rounds.
- When a user does change setup for a prebuilt but unstarted queue, the queue must be refreshed so new preferences take effect.

### Description
- Updated `src/components/TodaysFiveCard.tsx` to compute `hasStartedRound = Boolean(effectiveStatus.queueId) && answered > 0` and set `playHref` to `'/daily/setup'` until the round is started (in-progress goes to `'/daily'`, complete goes to `'/daily/summary'`).
- Added `hasUnstartedQueue` state to `src/app/daily/setup/page.tsx` and set it from the `GET /api/daily/status` response so the setup page knows when a prebuilt queue exists but has no answers yet.
- Changed setup-page redirect logic to only auto-redirect when a queue is in-progress or complete; an unstarted prebuilt queue keeps the user on the setup UI.
- When starting a round from setup, the code now calls `POST /api/daily/reset` to clear any unstarted prebuilt queue before creating a new queue so updated difficulty/domains are applied.
- Adjusted effect dependency list to include the new `hasUnstartedQueue` flag and added robust parsing of legacy/modern `questionsAnswered` fields from status.

### Testing
- Ran `npx eslint src/components/TodaysFiveCard.tsx src/app/daily/setup/page.tsx` and it completed successfully for the modified files. 
- Ran `npx tsc --noEmit --project tsconfig.json` and type-checking succeeded with no errors from these changes.
- Ran `npm run lint` (repo-wide) and it reported pre-existing lint errors unrelated to the touched files; those failures are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e99597b4832eabb04641b4bcb353)