### PR TITLE
Restore LLM critique loop + unverified tagging; add schema, endpoint, and form state machine

### DIFF
--- a/drizzle/0020_question_critique_verification.sql
+++ b/drizzle/0020_question_critique_verification.sql
@@ -1,0 +1,16 @@
+ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "verified" boolean DEFAULT true NOT NULL;
+ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "llm_suggested_answer" text;
+ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "critique_iterations" integer DEFAULT 0 NOT NULL;
+
+UPDATE "Question" SET "verified" = true WHERE "verified" IS DISTINCT FROM true;
+
+CREATE TABLE IF NOT EXISTS "CritiqueUsageDaily" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+  "user_id" text NOT NULL REFERENCES "User"("id") ON DELETE cascade,
+  "usage_date" date NOT NULL,
+  "critique_count" integer DEFAULT 0 NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "CritiqueUsageDaily_user_id_usage_date_key" UNIQUE("user_id", "usage_date")
+);
+
+CREATE INDEX IF NOT EXISTS "CritiqueUsageDaily_user_id_usage_date_idx" ON "CritiqueUsageDaily" ("user_id", "usage_date");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -141,6 +141,13 @@
       "when": 1778508000000,
       "tag": "0019_feed_item_nullable_columns_hotfix",
       "breakpoints": true
+    },
+    {
+      "idx": 20,
+      "version": "7",
+      "when": 1778510000000,
+      "tag": "0020_question_critique_verification",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -144,6 +144,7 @@ export async function GET() {
         state: item.state,
         is_pinned: item.isPinned,
         question_text: question?.questionText ?? null,
+        verified: question?.verified ?? true,
         is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
         explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
         domain_pill: domain,

--- a/src/app/api/questions/critique/route.ts
+++ b/src/app/api/questions/critique/route.ts
@@ -1,0 +1,74 @@
+import { and, eq, sql } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { db, critiqueUsageDaily } from '@/server/db';
+import { critiqueQuestion } from '@/server/llm/critique';
+
+export const dynamic = 'force-dynamic';
+
+const DAILY_LIMIT = 5;
+
+type CritiqueResponse = {
+  ok: boolean;
+  issues?: string[];
+  reformulations?: string[];
+  limitReached: boolean;
+  remaining: number | null;
+};
+
+function utcDateString(date = new Date()): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function passResponse(extra: Partial<CritiqueResponse> = {}): CritiqueResponse {
+  return { ok: true, limitReached: false, remaining: null, ...extra };
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  try {
+    const body = await request.json().catch(() => null) as { questionText?: unknown } | null;
+    const questionText = typeof body?.questionText === 'string' ? body.questionText.trim() : '';
+    if (!questionText) return NextResponse.json(passResponse({ remaining: null }));
+
+    const usageDate = utcDateString();
+    const [usage] = await db
+      .select({ critiqueCount: critiqueUsageDaily.critiqueCount })
+      .from(critiqueUsageDaily)
+      .where(and(eq(critiqueUsageDaily.userId, session.userId), eq(critiqueUsageDaily.usageDate, usageDate)))
+      .limit(1);
+
+    if ((usage?.critiqueCount ?? 0) >= DAILY_LIMIT) {
+      return NextResponse.json(passResponse({ limitReached: true, remaining: 0 }));
+    }
+
+    const critiqueResult = await critiqueQuestion({ questionText });
+
+    const rows = await db.execute<{ critique_count: number }>(sql`
+      INSERT INTO "CritiqueUsageDaily" ("user_id", "usage_date", "critique_count", "updated_at")
+      VALUES (${session.userId}, ${usageDate}::date, 1, now())
+      ON CONFLICT ("user_id", "usage_date") DO UPDATE
+      SET "critique_count" = "CritiqueUsageDaily"."critique_count" + 1,
+          "updated_at" = now()
+      WHERE "CritiqueUsageDaily"."critique_count" < ${DAILY_LIMIT}
+      RETURNING "critique_count"
+    `);
+    const incremented = Array.isArray(rows) ? rows[0] : rows.rows?.[0];
+    if (!incremented) {
+      return NextResponse.json(passResponse({ limitReached: true, remaining: 0 }));
+    }
+
+    const newCount = Number(incremented.critique_count ?? DAILY_LIMIT);
+    return NextResponse.json({
+      ...critiqueResult,
+      limitReached: false,
+      remaining: Math.max(DAILY_LIMIT - newCount, 0),
+    } satisfies CritiqueResponse);
+  } catch (error) {
+    console.warn('[api/questions/critique] fail_open', error);
+    return NextResponse.json(passResponse());
+  }
+}

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -56,6 +56,9 @@ function readCreatePayload(body: Record<string, unknown> | null) {
   const alternateAnswers = splitAlternates(body?.alternateAnswers ?? body?.accepted_alternatives).slice(0, 5);
   const explanation = typeof body?.explanation === 'string'
     ? body.explanation.trim() || null
+    : null;
+  const creatorNote = typeof body?.creatorNote === 'string'
+    ? body.creatorNote.trim() || null
     : typeof body?.creator_note === 'string'
       ? body.creator_note.trim() || null
       : null;
@@ -71,6 +74,11 @@ function readCreatePayload(body: Record<string, unknown> | null) {
     ? body.difficulty
     : difficultyFromLegacy(body?.difficulty_estimate) ?? (isLegacyPayload ? 3 : null);
   const difficultyValue = difficulty ?? Number.NaN;
+  const verified = typeof body?.verified === 'boolean' ? body.verified : null;
+  const llmSuggestedAnswer = typeof body?.llmSuggestedAnswer === 'string'
+    ? body.llmSuggestedAnswer.trim() || null
+    : null;
+  const critiqueIterations = typeof body?.critiqueIterations === 'number' ? body.critiqueIterations : Number.NaN;
 
   const rawSendToFriendIds = Array.isArray(body?.sendToFriendIds)
     ? (body.sendToFriendIds as unknown[]).filter((id): id is string => typeof id === 'string').slice(0, 20)
@@ -81,11 +89,14 @@ function readCreatePayload(body: Record<string, unknown> | null) {
   if (!correctAnswer || correctAnswer.length > 200) errors.push('correctAnswer');
   if (alternateAnswers.length > 5 || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
   if (explanation && explanation.length > 500) errors.push('explanation');
+  if (creatorNote && creatorNote.length > 200) errors.push('creatorNote');
   if (!VALID_DOMAINS.has(domain)) errors.push('domain');
+  if (verified === null) errors.push('verified');
+  if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
   if (!Number.isInteger(difficultyValue) || difficultyValue < 1 || difficultyValue > 5) errors.push('difficulty');
 
   return {
-    value: { text, correctAnswer, alternateAnswers, explanation, domain, difficulty: difficultyValue, sendToFriendIds: rawSendToFriendIds },
+    value: { text, correctAnswer, alternateAnswers, explanation, creatorNote, domain, difficulty: difficultyValue, verified: verified ?? true, llmSuggestedAnswer, critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0, sendToFriendIds: rawSendToFriendIds },
     errors,
   };
 }
@@ -110,6 +121,7 @@ export async function POST(request: NextRequest) {
   const { sendToFriendIds, ...questionFields } = value;
 
   const created = await createQuestion({ authorId: session.userId, ...questionFields });
+  console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified });
   const kbResult = await openKBDomain({
     userId: session.userId,
     domain: questionFields.domain,

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -30,6 +30,7 @@ type ArchiveItem = {
   myRating: 'up' | 'down' | null;
   canUseQuestionActions?: boolean;
   creatorNote: { authorName: string; noteText: string } | null;
+  verified: boolean;
 };
 
 type ArchiveFacet = {
@@ -114,6 +115,7 @@ export default function ArchivePage() {
   const [source, setSource] = useState<ArchiveSource | ''>('');
   const [domain, setDomain] = useState('');
   const [result, setResult] = useState<ArchiveResult | ''>('');
+  const [showOnlyVerified, setShowOnlyVerified] = useState(false);
   const [search, setSearch] = useState('');
   const [items, setItems] = useState<ArchiveItem[]>([]);
   const [domains, setDomains] = useState<ArchiveFacet[]>([]);
@@ -173,13 +175,14 @@ export default function ArchivePage() {
 
   const visibleItems = useMemo(() => {
     const query = search.trim().toLowerCase();
-    if (!query) return items;
-    return items.filter((item) => (
-      item.questionText.toLowerCase().includes(query)
-      || item.correctAnswer.toLowerCase().includes(query)
-      || item.domainDisplayName.toLowerCase().includes(query)
-    ));
-  }, [items, search]);
+    return items
+      .filter((item) => !showOnlyVerified || item.verified)
+      .filter((item) => !query || (
+        item.questionText.toLowerCase().includes(query)
+        || item.correctAnswer.toLowerCase().includes(query)
+        || item.domainDisplayName.toLowerCase().includes(query)
+      ));
+  }, [items, search, showOnlyVerified]);
 
   const activeFilters = useMemo(() => {
     const chips: Array<{ key: string; label: string; clear: () => void }> = [];
@@ -192,8 +195,9 @@ export default function ArchivePage() {
       });
     }
     if (result) chips.push({ key: 'result', label: resultOptions.find((option) => option.value === result)?.label ?? result, clear: () => setResult('') });
+    if (showOnlyVerified) chips.push({ key: 'verified', label: 'Only verified', clear: () => setShowOnlyVerified(false) });
     return chips;
-  }, [domain, domains, result, source]);
+  }, [domain, domains, result, source, showOnlyVerified]);
 
   const hasServerFilters = Boolean(source || domain || result);
   const isFilteredEmpty = !loading && items.length === 0 && hasServerFilters;
@@ -255,6 +259,16 @@ export default function ArchivePage() {
           </label>
         </div>
 
+        <label className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+          <input
+            type="checkbox"
+            checked={showOnlyVerified}
+            onChange={(event) => setShowOnlyVerified(event.target.checked)}
+            className="rounded"
+          />
+          <span>Show only verified</span>
+        </label>
+
         <label className="relative mt-3 block">
           <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
           <input
@@ -285,6 +299,7 @@ export default function ArchivePage() {
                 setSource('');
                 setDomain('');
                 setResult('');
+                setShowOnlyVerified(false);
               }}
             >
               Clear all
@@ -383,6 +398,9 @@ function ArchiveCard({ item }: { item: ArchiveItem }) {
         >
           {item.domainDisplayName}
         </Link>
+        {!item.verified ? (
+          <span className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground" title="The author wrote their own answer instead of using the LLM's suggestion. The answer may not be standard.">⚠ unverified</span>
+        ) : null}
         {item.pointsAwarded !== null ? (
           <span className="font-mono font-semibold text-foreground">+{Math.round(item.pointsAwarded)} pts</span>
         ) : null}

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -66,6 +66,9 @@ function initialValues(question: QuestionView): QuestionFormValues {
     explanation: question.explanation,
     domain: question.domain,
     difficulty: question.difficulty,
+    verified: question.verified,
+    llmSuggestedAnswer: question.llmSuggestedAnswer,
+    critiqueIterations: question.critiqueIterations,
     sendToFriendIds: [],
   };
 }

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -30,6 +30,7 @@ type FeedApiItem = {
   is_pinned: boolean;
   joshing_game_id: string | null;
   question_text: string | null;
+  verified: boolean;
   is_in_bank: boolean;
   domain_pill: string;
   game_title: string | null;
@@ -370,7 +371,7 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
             <span className="mt-0.5 text-lg" aria-hidden>✦</span>
             <div>
               <p className="font-medium">Your two-week reflection is ready</p>
-              <p className="mt-1 text-sm text-stone-700">See what you've been up to {'->'}</p>
+              <p className="mt-1 text-sm text-stone-700">See what you&rsquo;ve been up to {'->'}</p>
             </div>
           </div>
         </Link>
@@ -416,6 +417,16 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
                   <span className="rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground">
                     {item.domain_pill}
                   </span>
+                  {!item.verified ? (
+                    <button
+                      type="button"
+                      className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground"
+                      title="The author wrote their own answer instead of using the LLM's suggestion. The answer may not be standard."
+                      onClick={() => showToast(item.id, "The author wrote their own answer instead of using the LLM's suggestion. The answer may not be standard.")}
+                    >
+                      ⚠ unverified
+                    </button>
+                  ) : null}
                   {item.difficulty ? (
                     <span className={[
                       'rounded-full px-2.5 py-1 text-xs font-medium',

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Sparkles } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useReducer, useRef } from 'react';
 
 import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
@@ -10,9 +10,22 @@ export type QuestionFormValues = {
   correctAnswer: string;
   alternateAnswers: string[];
   explanation: string | null;
+  creatorNote?: string | null;
   domain: string;
   difficulty: number;
+  verified: boolean;
+  llmSuggestedAnswer?: string | null;
+  critiqueIterations: number;
   sendToFriendIds: string[];
+};
+
+type CritiqueResult =
+  | { ok: true }
+  | { ok: false; issues: string[]; reformulations: string[] };
+
+type CritiqueResponse = CritiqueResult & {
+  limitReached: boolean;
+  remaining: number | null;
 };
 
 type SuggestionResponse = {
@@ -21,10 +34,9 @@ type SuggestionResponse = {
   explanation: string;
 };
 
-type FriendOption = {
-  id: string;
-  displayName: string;
-};
+type FriendOption = { id: string; displayName: string };
+
+type Stage = 'WRITING' | 'CRITIQUING' | 'CRITIQUED' | 'ANSWERING' | 'REVIEWING' | 'SUBMITTING' | 'DONE';
 
 type Props = {
   mode?: 'create' | 'edit';
@@ -36,6 +48,52 @@ type Props = {
   onCancel?: () => void;
 };
 
+type State = {
+  stage: Stage;
+  questionText: string;
+  lastCritiquedText: string | null;
+  llmSuggestedAnswer: string | null;
+  userAnswer: string;
+  alternateText: string;
+  explanation: string;
+  creatorNote: string;
+  domain: string;
+  difficulty: number;
+  critiqueResult: CritiqueResult | null;
+  critiqueIterations: number;
+  remainingCritiquesToday: number | null;
+  limitReachedThisSession: boolean;
+  error: string | null;
+  suggestionError: string | null;
+  suggesting: boolean;
+  specificMode: boolean;
+  friends: FriendOption[];
+  friendsLoading: boolean;
+  sendToFriendIds: string[];
+};
+
+type Action =
+  | { type: 'RESET'; state: State }
+  | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote' | 'domain'; value: string }
+  | { type: 'DIFFICULTY'; value: number }
+  | { type: 'ERROR'; value: string | null }
+  | { type: 'START_CRITIQUE'; text: string }
+  | { type: 'CRITIQUE_RESULT'; response: CritiqueResponse }
+  | { type: 'USE_REFORMULATION'; text: string }
+  | { type: 'KEEP_VERSION' }
+  | { type: 'EDIT_RECHECK' }
+  | { type: 'ANSWERING' }
+  | { type: 'START_SUGGESTION' }
+  | { type: 'SUGGESTION_RESULT'; suggestion: SuggestionResponse }
+  | { type: 'SUGGESTION_ERROR'; value: string | null }
+  | { type: 'REVIEW' }
+  | { type: 'BACK_TO_EDIT' }
+  | { type: 'SUBMITTING' }
+  | { type: 'DONE' }
+  | { type: 'SPECIFIC_MODE'; value: boolean }
+  | { type: 'FRIENDS_LOADING'; value: boolean }
+  | { type: 'FRIENDS_LOADED'; friends: FriendOption[] }
+  | { type: 'TOGGLE_FRIEND'; id: string };
 
 const DIFFICULTY_SCALE: Record<number, { label: string; hint: string }> = {
   1: { label: 'Accessible', hint: 'Most players should be able to get this one.' },
@@ -45,38 +103,114 @@ const DIFFICULTY_SCALE: Record<number, { label: string; hint: string }> = {
   5: { label: 'Specialist', hint: 'Best for enthusiasts or experts in the domain.' },
 };
 
-const defaults: QuestionFormValues = {
-  text: '',
-  correctAnswer: '',
-  alternateAnswers: [],
-  explanation: '',
-  domain: 'other',
-  difficulty: 3,
-  sendToFriendIds: [],
-};
-
-function normalizeInitialValues(initialValues?: Partial<QuestionFormValues>): QuestionFormValues {
+function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecificMode = false): State {
   return {
-    ...defaults,
-    ...initialValues,
-    alternateAnswers: initialValues?.alternateAnswers ?? defaults.alternateAnswers,
-    explanation: initialValues?.explanation ?? defaults.explanation,
-    sendToFriendIds: initialValues?.sendToFriendIds ?? defaults.sendToFriendIds,
+    stage: 'WRITING',
+    questionText: initialValues?.text ?? '',
+    lastCritiquedText: null,
+    llmSuggestedAnswer: initialValues?.llmSuggestedAnswer ?? null,
+    userAnswer: initialValues?.correctAnswer ?? '',
+    alternateText: (initialValues?.alternateAnswers ?? []).join(', '),
+    explanation: initialValues?.explanation ?? '',
+    creatorNote: initialValues?.creatorNote ?? '',
+    domain: initialValues?.domain ?? 'other',
+    difficulty: initialValues?.difficulty ?? 3,
+    critiqueResult: null,
+    critiqueIterations: initialValues?.critiqueIterations ?? 0,
+    remainingCritiquesToday: null,
+    limitReachedThisSession: false,
+    error: null,
+    suggestionError: null,
+    suggesting: false,
+    specificMode: initialSpecificMode,
+    friends: [],
+    friendsLoading: false,
+    sendToFriendIds: initialValues?.sendToFriendIds ?? [],
   };
 }
 
-function validate(values: QuestionFormValues): string | null {
-  if (!values.text.trim()) return 'Question text is required.';
-  if (values.text.trim().length > 300) return 'Question text must be 300 characters or fewer.';
-  if (!values.correctAnswer.trim()) return 'Correct answer is required.';
-  if (values.correctAnswer.trim().length > 200) return 'Correct answer must be 200 characters or fewer.';
-  if (values.alternateAnswers.length > 5) return 'Use at most 5 alternate answers.';
-  if (values.alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
-  if ((values.explanation ?? '').length > 500) return 'Explanation must be 500 characters or fewer.';
-  if (!CATEGORIES.includes(values.domain as (typeof CATEGORIES)[number])) return 'Choose a valid domain.';
-  if (!Number.isInteger(values.difficulty) || values.difficulty < 1 || values.difficulty > 5) return 'Choose a difficulty from 1 to 5.';
-  if (values.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
+function reducer(state: State, action: Action): State {
+  switch (action.type) {
+    case 'RESET': return action.state;
+    case 'FIELD': return { ...state, [action.field]: action.value, error: null };
+    case 'DIFFICULTY': return { ...state, difficulty: action.value };
+    case 'ERROR': return { ...state, error: action.value };
+    case 'START_CRITIQUE': return { ...state, stage: 'CRITIQUING', lastCritiquedText: action.text, error: null };
+    case 'CRITIQUE_RESULT': {
+      if (action.response.limitReached) {
+        return { ...state, stage: 'ANSWERING', limitReachedThisSession: true, remainingCritiquesToday: 0, critiqueResult: { ok: true } };
+      }
+      const nextIterations = action.response.remaining === null ? state.critiqueIterations : state.critiqueIterations + 1;
+      if (action.response.ok) {
+        return { ...state, stage: 'ANSWERING', remainingCritiquesToday: action.response.remaining, critiqueIterations: nextIterations, critiqueResult: { ok: true } };
+      }
+      return { ...state, stage: 'CRITIQUED', remainingCritiquesToday: action.response.remaining, critiqueIterations: nextIterations, critiqueResult: action.response };
+    }
+    case 'USE_REFORMULATION': return { ...state, questionText: action.text, lastCritiquedText: action.text, stage: 'ANSWERING' };
+    case 'KEEP_VERSION': return { ...state, stage: 'ANSWERING' };
+    case 'EDIT_RECHECK': return { ...state, stage: 'WRITING', critiqueResult: null };
+    case 'ANSWERING': return { ...state, stage: 'ANSWERING' };
+    case 'START_SUGGESTION': return { ...state, suggesting: true, suggestionError: null };
+    case 'SUGGESTION_RESULT': return {
+      ...state,
+      suggesting: false,
+      suggestionError: null,
+      userAnswer: action.suggestion.correctAnswer,
+      llmSuggestedAnswer: action.suggestion.correctAnswer,
+      explanation: state.explanation.trim() ? state.explanation : action.suggestion.explanation,
+      alternateText: state.alternateText.trim() || action.suggestion.alternateAnswers.length === 0 ? state.alternateText : action.suggestion.alternateAnswers.join(', '),
+    };
+    case 'SUGGESTION_ERROR': return { ...state, suggesting: false, suggestionError: action.value };
+    case 'REVIEW': return { ...state, stage: 'REVIEWING', error: null };
+    case 'BACK_TO_EDIT': return { ...state, stage: 'ANSWERING' };
+    case 'SUBMITTING': return { ...state, stage: 'SUBMITTING', error: null };
+    case 'DONE': return { ...state, stage: 'DONE' };
+    case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, sendToFriendIds: [] };
+    case 'FRIENDS_LOADING': return { ...state, friendsLoading: action.value };
+    case 'FRIENDS_LOADED': return { ...state, friends: action.friends, friendsLoading: false };
+    case 'TOGGLE_FRIEND': {
+      const selected = state.sendToFriendIds.includes(action.id);
+      return { ...state, sendToFriendIds: selected ? state.sendToFriendIds.filter((id) => id !== action.id) : [...state.sendToFriendIds, action.id] };
+    }
+    default: return state;
+  }
+}
+
+function alternateAnswersFrom(text: string): string[] {
+  return text.split(',').map((answer) => answer.trim()).filter(Boolean).slice(0, 5);
+}
+
+function answersMatch(a: string, b: string | null): boolean {
+  if (!b) return true;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
+}
+
+function computedVerified(state: State): boolean {
+  return !state.llmSuggestedAnswer || answersMatch(state.userAnswer, state.llmSuggestedAnswer);
+}
+
+function validate(state: State): string | null {
+  const alternateAnswers = alternateAnswersFrom(state.alternateText);
+  if (!state.questionText.trim()) return 'Question text is required.';
+  if (state.questionText.trim().length > 300) return 'Question text must be 300 characters or fewer.';
+  if (!state.userAnswer.trim()) return 'Correct answer is required.';
+  if (state.userAnswer.trim().length > 200) return 'Correct answer must be 200 characters or fewer.';
+  if (alternateAnswers.length > 5) return 'Use at most 5 alternate answers.';
+  if (alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
+  if (state.explanation.length > 500) return 'Explanation must be 500 characters or fewer.';
+  if (state.creatorNote.length > 200) return 'Creator note must be 200 characters or fewer.';
+  if (!CATEGORIES.includes(state.domain as (typeof CATEGORIES)[number])) return 'Choose a valid domain.';
+  if (!Number.isInteger(state.difficulty) || state.difficulty < 1 || state.difficulty > 5) return 'Choose a difficulty from 1 to 5.';
+  if (state.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
   return null;
+}
+
+function remainingCopy(state: State): string | null {
+  const remaining = state.remainingCritiquesToday;
+  if (state.limitReachedThisSession || remaining === null || remaining > 2) return null;
+  if (remaining === 2) return '2 reviews left today';
+  if (remaining === 1) return '1 review left today';
+  return 'Last review for today';
 }
 
 export function QuestionForm({
@@ -88,79 +222,87 @@ export function QuestionForm({
   loadingLabel = 'Saving...',
   onCancel,
 }: Props) {
-  const [values, setValues] = useState<QuestionFormValues>(() => normalizeInitialValues(initialValues));
-  const [alternateText, setAlternateText] = useState(() => (initialValues?.alternateAnswers ?? []).join(', '));
-  const [submitting, setSubmitting] = useState(false);
-  const [suggesting, setSuggesting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [suggestionError, setSuggestionError] = useState<string | null>(null);
-
-  // Specific-friends mode state
-  const [specificMode, setSpecificMode] = useState(initialSpecificMode);
-  const [friends, setFriends] = useState<FriendOption[]>([]);
-  const [friendsLoading, setFriendsLoading] = useState(false);
+  const [state, dispatch] = useReducer(reducer, undefined, () => initialState(initialValues, initialSpecificMode));
+  const questionRef = useRef<HTMLTextAreaElement | null>(null);
 
   useEffect(() => {
-    setValues(normalizeInitialValues(initialValues));
-    setAlternateText((initialValues?.alternateAnswers ?? []).join(', '));
-    setError(null);
-    setSuggestionError(null);
-  }, [initialValues]);
+    dispatch({ type: 'RESET', state: initialState(initialValues, initialSpecificMode) });
+  }, [initialValues, initialSpecificMode]);
 
   useEffect(() => {
     if (initialSpecificMode) void loadFriends();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  useEffect(() => {
+    if (state.stage === 'WRITING') questionRef.current?.focus();
+  }, [state.stage]);
+
+  const alternateAnswers = useMemo(() => alternateAnswersFrom(state.alternateText), [state.alternateText]);
+  const showDestinations = mode === 'create';
+  const verified = computedVerified(state);
+  const submitDisabled = state.stage === 'SUBMITTING';
+  const resolvedSubmitLabel = submitLabel ?? (mode === 'edit' ? 'Update question' : 'Save question');
+
   async function loadFriends() {
-    if (friends.length > 0 || friendsLoading) return;
-    setFriendsLoading(true);
+    if (state.friends.length > 0 || state.friendsLoading) return;
+    dispatch({ type: 'FRIENDS_LOADING', value: true });
     try {
       const response = await fetch('/api/users', { cache: 'no-store', credentials: 'include' });
       const body = await response.json().catch(() => null) as FriendOption[] | null;
-      if (response.ok && Array.isArray(body)) setFriends(body);
-    } finally {
-      setFriendsLoading(false);
+      dispatch({ type: 'FRIENDS_LOADED', friends: response.ok && Array.isArray(body) ? body : [] });
+    } catch {
+      dispatch({ type: 'FRIENDS_LOADED', friends: [] });
     }
   }
 
   function toggleSpecificMode(on: boolean) {
-    setSpecificMode(on);
-    if (on) {
-      setValues((current) => ({ ...current, sendToFriendIds: [] }));
-      void loadFriends();
-    } else {
-      setValues((current) => ({ ...current, sendToFriendIds: [] }));
+    dispatch({ type: 'SPECIFIC_MODE', value: on });
+    if (on) void loadFriends();
+  }
+
+  async function runCritique() {
+    const questionText = state.questionText.trim();
+    if (!questionText) return;
+    if (mode === 'edit') {
+      dispatch({ type: 'ANSWERING' });
+      return;
     }
-  }
-
-  function toggleFriendPick(friendId: string) {
-    setValues((current) => {
-      const already = current.sendToFriendIds.includes(friendId);
-      return {
-        ...current,
-        sendToFriendIds: already
-          ? current.sendToFriendIds.filter((id) => id !== friendId)
-          : [...current.sendToFriendIds, friendId],
-      };
-    });
-  }
-
-  const resolvedSubmitLabel = submitLabel ?? (mode === 'edit' ? 'Update question' : 'Save question');
-  const alternateAnswers = useMemo(
-    () => alternateText.split(',').map((answer) => answer.trim()).filter(Boolean).slice(0, 5),
-    [alternateText],
-  );
-
-  async function requestSuggestion() {
-    const questionText = values.text.trim();
-    if (!questionText) {
-      setSuggestionError('Write the question first.');
+    if (state.limitReachedThisSession) {
+      dispatch({ type: 'ANSWERING' });
+      return;
+    }
+    if (questionText === state.lastCritiquedText && state.stage !== 'CRITIQUED') {
+      dispatch({ type: 'ANSWERING' });
       return;
     }
 
-    setSuggesting(true);
-    setSuggestionError(null);
+    dispatch({ type: 'START_CRITIQUE', text: questionText });
+    try {
+      const response = await fetch('/api/questions/critique', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ questionText }),
+      });
+      const body = await response.json().catch(() => null) as CritiqueResponse | null;
+      dispatch({ type: 'CRITIQUE_RESULT', response: body ?? { ok: true, limitReached: false, remaining: null } });
+    } catch {
+      dispatch({ type: 'CRITIQUE_RESULT', response: { ok: true, limitReached: false, remaining: null } });
+    }
+  }
+
+  async function requestSuggestion() {
+    if (state.stage === 'WRITING') {
+      await runCritique();
+      return;
+    }
+    const questionText = state.questionText.trim();
+    if (!questionText) {
+      dispatch({ type: 'SUGGESTION_ERROR', value: 'Write the question first.' });
+      return;
+    }
+    dispatch({ type: 'START_SUGGESTION' });
     try {
       const response = await fetch('/api/questions/suggest', {
         method: 'POST',
@@ -168,249 +310,223 @@ export function QuestionForm({
         credentials: 'include',
         body: JSON.stringify({ questionText }),
       });
-      const body = await response.json().catch(() => null) as SuggestionResponse | { error?: string } | null;
-      if (!response.ok || !body || !('correctAnswer' in body)) throw new Error('Suggestion unavailable');
-
-      setValues((current) => ({
-        ...current,
-        correctAnswer: current.correctAnswer.trim() ? current.correctAnswer : body.correctAnswer,
-        explanation: current.explanation?.trim() ? current.explanation : body.explanation,
-      }));
-      if (!alternateText.trim() && body.alternateAnswers.length > 0) {
-        setAlternateText(body.alternateAnswers.join(', '));
-      }
+      const body = await response.json().catch(() => null) as SuggestionResponse | null;
+      if (!response.ok || !body?.correctAnswer) throw new Error('Suggestion unavailable');
+      dispatch({ type: 'SUGGESTION_RESULT', suggestion: body });
     } catch {
-      setSuggestionError('Suggestion unavailable');
-    } finally {
-      setSuggesting(false);
+      dispatch({ type: 'SUGGESTION_ERROR', value: 'Suggestion unavailable' });
     }
   }
 
-  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    const nextValues = {
-      ...values,
-      text: values.text.trim(),
-      correctAnswer: values.correctAnswer.trim(),
-      alternateAnswers,
-      explanation: values.explanation?.trim() || null,
-    };
-    const validationError = validate(nextValues);
+  function review() {
+    const validationError = validate(state);
     if (validationError) {
-      setError(validationError);
+      dispatch({ type: 'ERROR', value: validationError });
       return;
     }
+    dispatch({ type: 'REVIEW' });
+  }
 
-    setSubmitting(true);
-    setError(null);
+  async function finalSave() {
+    const validationError = validate(state);
+    if (validationError) {
+      dispatch({ type: 'ERROR', value: validationError });
+      return;
+    }
+    dispatch({ type: 'SUBMITTING' });
     try {
-      await onSubmit(nextValues);
+      await onSubmit({
+        text: state.questionText.trim(),
+        correctAnswer: state.userAnswer.trim(),
+        alternateAnswers,
+        explanation: state.explanation.trim() || null,
+        creatorNote: state.creatorNote.trim() || null,
+        domain: state.domain,
+        difficulty: state.difficulty,
+        verified,
+        llmSuggestedAnswer: state.llmSuggestedAnswer,
+        critiqueIterations: state.critiqueIterations,
+        sendToFriendIds: state.sendToFriendIds,
+      });
+      dispatch({ type: 'DONE' });
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not save that question.');
-    } finally {
-      setSubmitting(false);
+      dispatch({ type: 'ERROR', value: caught instanceof Error ? caught.message : 'Could not save that question.' });
+      dispatch({ type: 'ANSWERING' });
     }
   }
 
-  // Only show destinations panel in create mode
-  const showDestinations = mode === 'create';
+  const critique = state.critiqueResult;
+  const counter = remainingCopy(state);
+  const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' || mode === 'edit';
 
   return (
-    <form onSubmit={handleSubmit} className="space-y-5">
-      {error ? (
-        <p className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">
-          {error}
-        </p>
+    <div className="space-y-5">
+      {state.error ? <p className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">{state.error}</p> : null}
+      {state.limitReachedThisSession ? (
+        <p className="text-xs italic text-muted-foreground">5/5 question reviews used today. You can still save your question; AI review returns tomorrow.</p>
       ) : null}
 
       <div>
-        <label htmlFor="question-text" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-          Question
-        </label>
+        <label htmlFor="question-text" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Question</label>
         <textarea
+          ref={questionRef}
           id="question-text"
-          value={values.text}
-          onChange={(event) => setValues((current) => ({ ...current, text: event.target.value.slice(0, 300) }))}
+          value={state.questionText}
+          onChange={(event) => dispatch({ type: 'FIELD', field: 'questionText', value: event.target.value.slice(0, 300) })}
+          onBlur={() => { if (state.stage === 'WRITING') void runCritique(); }}
           rows={4}
           maxLength={300}
           required
           className="w-full rounded-md border bg-background px-3 py-2 text-base outline-none focus:border-primary"
           placeholder="What is the name of Alexander the Great's horse?"
+          readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'}
         />
-        <p className="mt-1 text-right text-xs text-muted-foreground">{values.text.length}/300</p>
-      </div>
-
-      <div className="flex flex-wrap items-center gap-3">
-        <button
-          type="button"
-          onClick={() => void requestSuggestion()}
-          disabled={suggesting || !values.text.trim()}
-          className="inline-flex min-h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50"
-        >
-          <Sparkles className={suggesting ? 'size-4 animate-pulse' : 'size-4'} />
-          {suggesting ? 'Suggesting...' : 'Suggest answer'}
-        </button>
-        {suggestionError ? <span className="text-sm text-destructive">{suggestionError}</span> : null}
-      </div>
-
-      <div>
-        <label htmlFor="correct-answer" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-          Correct answer
-        </label>
-        <input
-          id="correct-answer"
-          value={values.correctAnswer}
-          onChange={(event) => setValues((current) => ({ ...current, correctAnswer: event.target.value.slice(0, 200) }))}
-          maxLength={200}
-          required
-          className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary"
-          placeholder="Bucephalus"
-        />
-      </div>
-
-      <div>
-        <label htmlFor="alternate-answers" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-          Alternate answers
-        </label>
-        <input
-          id="alternate-answers"
-          value={alternateText}
-          onChange={(event) => setAlternateText(event.target.value)}
-          className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary"
-          placeholder="Accepted variations, separated by commas"
-        />
-        <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/5 alternates</p>
-      </div>
-
-      <div>
-        <label htmlFor="explanation" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-          Explanation
-        </label>
-        <textarea
-          id="explanation"
-          value={values.explanation ?? ''}
-          onChange={(event) => setValues((current) => ({ ...current, explanation: event.target.value.slice(0, 500) }))}
-          rows={4}
-          maxLength={500}
-          className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary"
-          placeholder="A short note that helps someone learn if they miss it."
-        />
-        <p className="mt-1 text-right text-xs text-muted-foreground">{(values.explanation ?? '').length}/500</p>
-      </div>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <div>
-          <label htmlFor="domain" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-            Domain
-          </label>
-          <select
-            id="domain"
-            value={values.domain}
-            onChange={(event) => setValues((current) => ({ ...current, domain: event.target.value }))}
-            className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary"
-          >
-            {CATEGORIES.map((category) => (
-              <option key={category} value={category}>
-                {categoryLabel(category)}
-              </option>
-            ))}
-          </select>
-        </div>
-
-        <div>
-          <label htmlFor="difficulty" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">
-            Difficulty
-          </label>
-          <select
-            id="difficulty"
-            value={values.difficulty}
-            onChange={(event) => setValues((current) => ({ ...current, difficulty: Number(event.target.value) }))}
-            className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary"
-          >
-            {[1, 2, 3, 4, 5].map((difficulty) => (
-              <option key={difficulty} value={difficulty}>
-                {difficulty} · {DIFFICULTY_SCALE[difficulty].label}
-              </option>
-            ))}
-          </select>
-          <p className="mt-1 text-xs text-muted-foreground">
-            Rank {values.difficulty}/5 — {DIFFICULTY_SCALE[values.difficulty].label}. {DIFFICULTY_SCALE[values.difficulty].hint}
-          </p>
+        <div className="mt-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+          <span>{state.stage === 'CRITIQUING' ? 'Reviewing your question...' : null}</span>
+          <span>{state.questionText.length}/300</span>
         </div>
       </div>
 
-      {showDestinations ? (
-        <div className="rounded-md border bg-muted/40 p-4">
-          <p className="mb-3 text-xs uppercase tracking-[0.1em] text-muted-foreground">Destinations</p>
-
-          {/* Save to bank — always on */}
-          <label className="mb-2 flex cursor-default items-center gap-2 text-sm">
-            <input type="checkbox" checked readOnly disabled className="rounded" />
-            <span className="text-foreground">Save to bank</span>
-          </label>
-
-          {/* Send to specific friends */}
-          <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm">
-            <input
-              type="checkbox"
-              checked={specificMode}
-              onChange={(event) => toggleSpecificMode(event.target.checked)}
-              className="rounded"
-            />
-            <span className="text-foreground">Send to specific friends</span>
-          </label>
-
-          {/* Friend picker */}
-          {specificMode ? (
-            <div className="mt-1">
-              {friendsLoading ? (
-                <p className="text-xs text-muted-foreground">Loading friends...</p>
-              ) : friends.length === 0 ? (
-                <p className="text-xs text-muted-foreground">No friends found.</p>
-              ) : (
-                <div className="flex flex-wrap gap-2">
-                  {friends.map((friend) => {
-                    const selected = values.sendToFriendIds.includes(friend.id);
-                    return (
-                      <button
-                        key={friend.id}
-                        type="button"
-                        onClick={() => toggleFriendPick(friend.id)}
-                        className={[
-                          'rounded-full border px-3 py-1 text-sm transition',
-                          selected
-                            ? 'border-primary bg-primary text-primary-foreground'
-                            : 'border-border bg-background hover:bg-muted',
-                        ].join(' ')}
-                      >
-                        {friend.displayName}
-                      </button>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          ) : null}
-
-          {/* Helper text */}
-          <p className="mt-3 text-xs text-muted-foreground">
-            {specificMode
-              ? 'Sent directly to the friends you pick.'
-              : 'Saved to your bank.'}
-          </p>
+      {state.stage === 'CRITIQUED' && critique && !critique.ok ? (
+        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+          <p className="font-medium">⚠ This question might be unclear:</p>
+          <ul className="mt-2 list-disc space-y-1 pl-5">
+            {critique.issues.map((issue) => <li key={issue}>{issue}</li>)}
+          </ul>
+          <p className="mt-3 font-medium">Try one of these instead:</p>
+          <div className="mt-2 space-y-2">
+            {critique.reformulations.map((text) => (
+              <button key={text} type="button" onClick={() => dispatch({ type: 'USE_REFORMULATION', text })} className="block w-full rounded-md border bg-background px-3 py-2 text-left text-sm hover:bg-muted">
+                <span className="font-medium">Use this</span> {text}
+              </button>
+            ))}
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button type="button" className="rounded-md border px-3 py-2 text-sm" onClick={() => dispatch({ type: 'KEEP_VERSION' })}>Keep my version anyway</button>
+            <button type="button" className="rounded-md border px-3 py-2 text-sm" onClick={() => dispatch({ type: 'EDIT_RECHECK' })}>Edit and recheck</button>
+          </div>
         </div>
       ) : null}
 
-      <div className="flex flex-wrap items-center gap-3 pt-2">
-        <button type="submit" disabled={submitting} className="btn-primary">
-          {submitting ? loadingLabel : resolvedSubmitLabel}
-        </button>
-        {onCancel ? (
-          <button type="button" onClick={onCancel} className="btn-ghost" disabled={submitting}>
-            Cancel
+      {!canShowAnswering ? (
+        <div className="flex flex-wrap items-center gap-3">
+          <button type="button" onClick={() => void runCritique()} disabled={!state.questionText.trim() || state.stage === 'CRITIQUING'} className="btn-primary">
+            {state.stage === 'CRITIQUING' ? 'Reviewing...' : 'Continue'}
           </button>
-        ) : null}
-      </div>
-    </form>
+          {counter ? <span className="text-xs text-muted-foreground">{counter}</span> : null}
+          {onCancel ? <button type="button" onClick={onCancel} className="btn-ghost">Cancel</button> : null}
+        </div>
+      ) : null}
+
+      {canShowAnswering ? (
+        <>
+          {state.stage !== 'REVIEWING' && state.stage !== 'SUBMITTING' ? (
+            <div className="flex flex-wrap items-center gap-3">
+              <button type="button" onClick={() => void requestSuggestion()} disabled={state.suggesting || !state.questionText.trim()} className="inline-flex min-h-10 items-center gap-2 rounded-md border px-3 text-sm font-medium hover:bg-muted disabled:opacity-50">
+                <Sparkles className={state.suggesting ? 'size-4 animate-pulse' : 'size-4'} />
+                {state.suggesting ? 'Suggesting...' : 'Suggest answer'}
+              </button>
+              {counter ? <span className="text-xs text-muted-foreground">{counter}</span> : null}
+              {state.suggestionError ? <span className="text-sm text-destructive">{state.suggestionError}</span> : null}
+            </div>
+          ) : null}
+
+          <div>
+            <label htmlFor="correct-answer" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Correct answer</label>
+            <input
+              id="correct-answer"
+              value={state.userAnswer}
+              onChange={(event) => dispatch({ type: 'FIELD', field: 'userAnswer', value: event.target.value.slice(0, 200) })}
+              maxLength={200}
+              required
+              readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'}
+              className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary"
+              placeholder="Bucephalus"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="alternate-answers" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Alternate answers</label>
+            <input id="alternate-answers" value={state.alternateText} onChange={(event) => dispatch({ type: 'FIELD', field: 'alternateText', value: event.target.value })} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Accepted variations, separated by commas" />
+            <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/5 alternates</p>
+          </div>
+
+          <div>
+            <label htmlFor="explanation" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Explanation</label>
+            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={4} maxLength={500} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="A short note that helps someone learn if they miss it." />
+            <p className="mt-1 text-right text-xs text-muted-foreground">{state.explanation.length}/500</p>
+          </div>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div>
+              <label htmlFor="domain" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Domain</label>
+              <select id="domain" value={state.domain} onChange={(event) => dispatch({ type: 'FIELD', field: 'domain', value: event.target.value })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
+                {CATEGORIES.map((category) => <option key={category} value={category}>{categoryLabel(category)}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="difficulty" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Difficulty</label>
+              <select id="difficulty" value={state.difficulty} onChange={(event) => dispatch({ type: 'DIFFICULTY', value: Number(event.target.value) })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
+                {[1, 2, 3, 4, 5].map((difficulty) => <option key={difficulty} value={difficulty}>{difficulty} · {DIFFICULTY_SCALE[difficulty].label}</option>)}
+              </select>
+              <p className="mt-1 text-xs text-muted-foreground">Rank {state.difficulty}/5 — {DIFFICULTY_SCALE[state.difficulty].label}. {DIFFICULTY_SCALE[state.difficulty].hint}</p>
+            </div>
+          </div>
+
+          {state.stage === 'REVIEWING' && state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (
+            <div className="rounded-md border bg-muted/40 p-3 text-sm">
+              <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">LLM suggestion</p>
+              <p className="mt-1 line-through decoration-amber-500">{state.llmSuggestedAnswer}</p>
+            </div>
+          ) : null}
+
+          {state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' ? (
+            <>
+              <div>
+                <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Creator note</label>
+                <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Optional context for recipients" />
+                <p className="mt-1 text-right text-xs text-muted-foreground">{state.creatorNote.length}/200</p>
+              </div>
+              <p className={verified ? 'text-sm text-emerald-700' : 'text-sm text-amber-700'}>
+                {verified ? '✓ Verified — matches LLM suggestion' : "⚠ Unverified — your answer differs from the LLM's suggestion. Recipients will see this."}
+              </p>
+            </>
+          ) : null}
+
+          {showDestinations ? (
+            <div className="rounded-md border bg-muted/40 p-4">
+              <p className="mb-3 text-xs uppercase tracking-[0.1em] text-muted-foreground">Destinations</p>
+              <label className="mb-2 flex cursor-default items-center gap-2 text-sm"><input type="checkbox" checked readOnly disabled className="rounded" /><span className="text-foreground">Save to bank</span></label>
+              <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.specificMode} onChange={(event) => toggleSpecificMode(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Send to specific friends</span></label>
+              {state.specificMode ? (
+                <div className="mt-1">
+                  {state.friendsLoading ? <p className="text-xs text-muted-foreground">Loading friends...</p> : state.friends.length === 0 ? <p className="text-xs text-muted-foreground">No friends found.</p> : (
+                    <div className="flex flex-wrap gap-2">
+                      {state.friends.map((friend) => {
+                        const selected = state.sendToFriendIds.includes(friend.id);
+                        return <button key={friend.id} type="button" onClick={() => dispatch({ type: 'TOGGLE_FRIEND', id: friend.id })} className={['rounded-full border px-3 py-1 text-sm transition', selected ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-muted'].join(' ')}>{friend.displayName}</button>;
+                      })}
+                    </div>
+                  )}
+                </div>
+              ) : null}
+              <p className="mt-3 text-xs text-muted-foreground">{state.specificMode ? 'Sent directly to the friends you pick.' : 'Saved to your bank.'}</p>
+            </div>
+          ) : null}
+
+          <div className="flex flex-wrap items-center gap-3 pt-2">
+            {state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' ? (
+              <>
+                <button type="button" onClick={() => dispatch({ type: 'BACK_TO_EDIT' })} className="btn-ghost" disabled={submitDisabled}>Back to edit</button>
+                <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">{submitDisabled ? loadingLabel : resolvedSubmitLabel}</button>
+              </>
+            ) : (
+              <button type="button" onClick={review} className="btn-primary">Review</button>
+            )}
+            {onCancel ? <button type="button" onClick={onCancel} className="btn-ghost" disabled={submitDisabled}>Cancel</button> : null}
+          </div>
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -37,6 +37,7 @@ export type ArchiveItem = {
   myRating: 'up' | 'down' | null;
   canUseQuestionActions: boolean;
   creatorNote: DeliveredCreatorNote | null;
+  verified: boolean;
 };
 
 export type ArchiveResult = {
@@ -203,6 +204,7 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
           myRating: null,
           canUseQuestionActions: Boolean(slot.question_id),
           creatorNote: null,
+          verified: bankQuestion?.verified ?? true,
         } satisfies ArchiveItem;
       }),
   );
@@ -273,6 +275,7 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       myRating: null,
       canUseQuestionActions: true,
       creatorNote: null,
+      verified: question.verified,
     } satisfies ArchiveItem;
   });
 }
@@ -310,6 +313,7 @@ async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
       myRating: null,
       canUseQuestionActions: true,
       creatorNote: null,
+      verified: question.verified,
     } satisfies ArchiveItem;
   });
 }
@@ -363,6 +367,7 @@ async function readWrittenByMeItems(userId: string): Promise<ArchiveItem[]> {
       myRating: null,
       canUseQuestionActions: true,
       creatorNote: null,
+      verified: question.verified,
     } satisfies ArchiveItem;
   });
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -47,6 +47,9 @@ export type QuestionView = {
   isInBank?: boolean;
   isOwnAuthored?: boolean;
   authorName?: string;
+  verified: boolean;
+  llmSuggestedAnswer: string | null;
+  critiqueIterations: number;
 };
 
 export type QuestionMutationResult = { ok: boolean; reason?: 'not_found' | 'in_use' };
@@ -154,6 +157,9 @@ export async function toQuestionView(row: QuestionRow): Promise<QuestionView> {
     tags: [],
     asked_count: row.askedCount,
     correct_count: row.correctCount,
+    verified: row.verified,
+    llmSuggestedAnswer: row.llmSuggestedAnswer,
+    critiqueIterations: row.critiqueIterations,
   };
 }
 
@@ -180,6 +186,10 @@ export async function createQuestion(params: {
   explanation: string | null;
   domain: string;
   difficulty: number;
+  creatorNote?: string | null;
+  verified: boolean;
+  llmSuggestedAnswer?: string | null;
+  critiqueIterations: number;
 }): Promise<{ id: string }> {
   const [created] = await db
     .insert(questions)
@@ -189,14 +199,19 @@ export async function createQuestion(params: {
       answerText: params.correctAnswer,
       acceptedAlternatives: params.alternateAnswers,
       factualExplanation: params.explanation,
+      creatorNote: params.creatorNote ?? null,
       category: params.domain as typeof questions.$inferInsert.category,
       categoryOverridden: true,
       difficultyEstimate: numberToDifficulty(params.difficulty),
       llmDifficulty: numberToDifficulty(params.difficulty),
       calibratedDifficulty: numberToDifficulty(params.difficulty),
-      answerSource: 'creator_written',
+      answerSource: params.llmSuggestedAnswer ? (params.verified ? 'llm_suggested' : 'llm_edited') : 'creator_written',
       questionType: 'factual',
       visibility: 'public',
+      verified: params.verified,
+      status: params.verified ? 'verified' : 'unverified',
+      llmSuggestedAnswer: params.llmSuggestedAnswer ?? null,
+      critiqueIterations: params.critiqueIterations,
     })
     .returning({ id: questions.id });
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -235,6 +235,9 @@ export const questions = pgTable(
     explainerFullExpired: text('explainer_full_expired'),
     shortLabel: text('short_label'),
     status: questionStatusEnum('status').notNull().default('verified'),
+    verified: boolean('verified').notNull().default(true),
+    llmSuggestedAnswer: text('llm_suggested_answer'),
+    critiqueIterations: integer('critique_iterations').notNull().default(0),
     visibility: questionVisibilityEnum('visibility').notNull().default('public'),
     publicStatus: publicStatusEnum('public_status').notNull().default('not_scored'),
     publicEligibilityScore: doublePrecision('public_eligibility_score'),
@@ -309,6 +312,22 @@ export const playerMastery = pgTable(
     unique('PLAYER_MASTERY_user_id_canonical_subcategory_key').on(table.userId, table.canonicalSubcategory),
     index('PLAYER_MASTERY_user_id_idx').on(table.userId),
     index('PLAYER_MASTERY_canonical_subcategory_idx').on(table.canonicalSubcategory),
+  ],
+);
+
+
+export const critiqueUsageDaily = pgTable(
+  'CritiqueUsageDaily',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    usageDate: date('usage_date').notNull(),
+    critiqueCount: integer('critique_count').notNull().default(0),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    unique('CritiqueUsageDaily_user_id_usage_date_key').on(table.userId, table.usageDate),
+    index('CritiqueUsageDaily_user_id_usage_date_idx').on(table.userId, table.usageDate),
   ],
 );
 

--- a/src/server/llm/critique.ts
+++ b/src/server/llm/critique.ts
@@ -1,0 +1,86 @@
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+
+export type CritiqueResult =
+  | { ok: true }
+  | { ok: false; issues: string[]; reformulations: string[] };
+
+const CRITIQUE_TIMEOUT_MS = 8_000;
+
+function cleanStringArray(value: unknown, max: number): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .slice(0, max);
+}
+
+function parseCritique(rawText: string): CritiqueResult {
+  const parsed = parseJsonObject(rawText);
+  if (!parsed || parsed.ok === true) return { ok: true };
+  if (parsed.ok !== false) return { ok: true };
+
+  const issues = cleanStringArray(parsed.issues, 3);
+  const reformulations = cleanStringArray(parsed.reformulations, 4);
+  if (issues.length === 0 || reformulations.length < 2) return { ok: true };
+  return { ok: false, issues, reformulations };
+}
+
+export async function critiqueQuestion(params: { questionText: string }): Promise<CritiqueResult> {
+  const questionText = params.questionText.trim();
+  if (!questionText) return { ok: true };
+
+  const client = getAnthropicClient();
+  if (!client) return { ok: true };
+
+  const prompt = `You are reviewing a trivia question for ambiguity, scope, and answerability. Your job is to flag questions that have problems — not to be a perfectionist about every minor phrasing issue.
+
+A question is OK if:
+- It has a single, clear, factual answer (or a small set of obviously equivalent answers)
+- It is specific enough that a knowledgeable person would know what is being asked
+- It is about facts, not opinions or preferences
+- It is grammatically clear
+
+A question is NOT OK if:
+- It has multiple equally valid answers ("What's the best Beatles song?" — opinion; "What year was Casablanca made?" — single fact, OK)
+- It is too vague to answer ("Tell me about Tchaikovsky" — too open)
+- It asks for an opinion or preference
+- It contains factual errors or false premises
+- It is so broad that a correct answer could be any of dozens of things
+
+Question to review: ${JSON.stringify(questionText)}
+
+Respond in JSON only.
+If the question is OK: { "ok": true }
+If the question has problems: { "ok": false, "issues": ["brief issue 1", "brief issue 2"], "reformulations": [ "alternative phrasing 1", "alternative phrasing 2", "alternative phrasing 3" ] }
+
+Issue descriptions should be short (under 12 words each), specific, and helpful. Examples:
+- "Multiple Tchaikovsky symphonies could be the answer."
+- "Asks for opinion rather than fact."
+- "Date range is too broad to have a single answer."
+
+Reformulations should preserve the author's apparent intent while fixing the issue. Provide 2-4 reformulations, ordered most to least faithful to the original.`;
+
+  try {
+    const response = await Promise.race([
+      client.messages.create({
+        model: ANTHROPIC_MODEL,
+        max_tokens: 700,
+        temperature: 0.2,
+        system: 'Return only valid JSON. No markdown or prose outside JSON.',
+        messages: [{ role: 'user', content: prompt }],
+      }),
+      new Promise<never>((_, reject) => setTimeout(() => reject(new Error('critique timeout')), CRITIQUE_TIMEOUT_MS)),
+    ]);
+    const rawText = extractTextContent(response.content);
+    const result = parseCritique(rawText);
+    console.info('[llm/critique] completed', { input: questionText, output: result });
+    return result;
+  } catch (error) {
+    console.warn('[llm/critique] fail_open', {
+      input: questionText,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { ok: true };
+  }
+}


### PR DESCRIPTION
### Motivation
- Restore the v10.25-style question-critique flow so authored questions are LLM-reviewed for ambiguity and offered reformulations before answering.
- Track and cap per-user daily critique cycles (5/day) and surface a soft-pass when the cap is hit so creation never blocks.
- Surface an explicit “unverified” signal when an author’s final answer differs from the LLM suggestion so recipients can see this in Feed/Archive.

### Description
- Schema: added `verified` (boolean, default true), `llmSuggestedAnswer` (text, nullable), and `critiqueIterations` (integer, default 0) to the `Question` table and created a new `CritiqueUsageDaily` table; included a Drizzle migration `drizzle/0020_question_critique_verification.sql` to add columns/table and backfill existing rows to `verified = true`.
- LLM service: implemented `src/server/llm/critique.ts` which calls Claude (via existing LLM client) with an 8s timeout, returns a JSON-only `CritiqueResult`, logs inputs/outputs, and fails open (`{ ok: true }`) on errors/timeouts.
- API: added POST `/api/questions/critique` at `src/app/api/questions/critique/route.ts` which enforces the daily 5-call soft limit using `CritiqueUsageDaily` (atomic UPSERT), returns the critique result or a `limitReached` soft-pass, and reports `remaining` budget.
- Form/UI and flows: reworked `src/components/QuestionForm.tsx` into a multi-stage reducer-driven state machine (WRITING → CRITIQUING → CRITIQUED → ANSWERING → REVIEWING → SUBMITTING → DONE), wired the critique endpoint on `onBlur` / explicit button actions, integrated LLM answer suggestions to populate and track `llmSuggestedAnswer`, and computed `verified` (true if no suggestion or answer matches suggestion; false if user edited after suggestion).
- Questions API/server: updated question creation POST (`src/app/api/questions/route.ts`) and DB query helpers (`src/server/db/queries/questions.ts`) to accept and persist `verified`, `llmSuggestedAnswer`, `critiqueIterations`, and `creatorNote`; added audit log output on create.
- Migration & wiring: added Drizzle migration file and updated DB schema definitions; wired critique usage increments atomically and preserved fail-open semantics so errors do not block creation.

### Testing
- Migration: generated `drizzle/0020_question_critique_verification.sql` to add new columns and the `CritiqueUsageDaily` table (file present in `drizzle/`).
- Automated tests: none were executed as part of this rollout; no unit/integration test suite was run here. Recommend running `npx tsc --noEmit` and applying DB migrations (`npm run db:migrate` / `drizzle-kit migrate`) and exercising the critique flow end-to-end (critique happy path, unverified path, and daily-cap behavior) in an environment with an LLM key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01f78dadcc832e8b8602491576a523)