### PR TITLE
Reintroduce opt-in broadcast sharing

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -78,6 +78,14 @@ function ActivityCopy({ item }: { item: ActivityItemView }) {
     return <>{actorName(item)} sent you a note about a question you missed</>;
   }
 
+  if (item.type === 'authored_question_shared') {
+    const shared = item.reference.authoredSharedQuestion;
+    const count = shared?.recipientCount ?? 0;
+    const friendWord = count === 1 ? 'friend' : 'friends';
+    const domain = shared?.domain ?? 'a domain';
+    return <>You shared a question with {count} {friendWord} — {domain}</>;
+  }
+
   if (item.type === 'friend_answered_your_question') {
     const faq = item.reference.friendAnsweredQuestion;
     const domain = faq?.domain;
@@ -191,6 +199,10 @@ function ActivityCta({ item }: { item: ActivityItemView }) {
 
   if (item.type === 'received_direct_question') {
     return <Link href="/feed" className="btn-primary">Answer</Link>;
+  }
+
+  if (item.type === 'authored_question_shared') {
+    return null;
   }
 
   if (item.type === 'declared_promoted') {

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -77,8 +77,7 @@ export async function GET() {
       .then((rows) => rows[0]?.value ?? 0),
   ]);
 
-  // authored_shared is deprecated — filter inert rows until cleanup script removes them
-  const feed = rawFeed.filter((item) => item.sourceType !== 'authored_shared');
+  const feed = rawFeed;
   const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
   const sourceUserIds = [...new Set(feed.map((item) => item.sourceUserId))];
   const gameIds = feed.map((item) => item.joshingGameId).filter((id): id is string => Boolean(id));
@@ -121,10 +120,11 @@ export async function GET() {
         source_attribution = `${sourceName} sent this to you`;
       } else if (item.sourceType === 'friend_answered') {
         source_attribution = friendAnsweredAttribution(item, userById, domain);
+      } else if (item.sourceType === 'authored_shared') {
+        source_attribution = `${sourceName} wrote this`;
       } else if (item.sourceType === 'joshing_game') {
         source_attribution = `${sourceName} sent you a Joshing Game`;
       } else {
-        // legacy thumbs_upped (authored_shared rows are inert and filtered before this)
         source_attribution = thumbsupAttribution(sourceName, item.thumbsUpCount);
       }
 

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,9 +1,9 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { QUESTION_DOMAIN_KEYS } from '@/lib/game-constants';
 import { getSession } from '@/server/auth/session';
-import { db, feedItems, questions, users } from '@/server/db';
+import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
   createQuestion,
   getQuestion,
@@ -17,6 +17,7 @@ import {
 } from '@/server/db/queries/feed';
 import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
+import { writeActivity } from '@/server/activity/write-activity';
 
 export const dynamic = 'force-dynamic';
 
@@ -83,6 +84,7 @@ function readCreatePayload(body: Record<string, unknown> | null) {
   const rawSendToFriendIds = Array.isArray(body?.sendToFriendIds)
     ? (body.sendToFriendIds as unknown[]).filter((id): id is string => typeof id === 'string').slice(0, 20)
     : [];
+  const shareToFeed = body?.shareToFeed === true;
 
   const errors: string[] = [];
   if (!text || text.length > 300) errors.push('text');
@@ -94,9 +96,10 @@ function readCreatePayload(body: Record<string, unknown> | null) {
   if (verified === null) errors.push('verified');
   if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
   if (!Number.isInteger(difficultyValue) || difficultyValue < 1 || difficultyValue > 5) errors.push('difficulty');
+  if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
 
   return {
-    value: { text, correctAnswer, alternateAnswers, explanation, creatorNote, domain, difficulty: difficultyValue, verified: verified ?? true, llmSuggestedAnswer, critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0, sendToFriendIds: rawSendToFriendIds },
+    value: { text, correctAnswer, alternateAnswers, explanation, creatorNote, domain, difficulty: difficultyValue, verified: verified ?? true, llmSuggestedAnswer, critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0, sendToFriendIds: rawSendToFriendIds, shareToFeed },
     errors,
   };
 }
@@ -118,7 +121,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
 
-  const { sendToFriendIds, ...questionFields } = value;
+  const { sendToFriendIds, shareToFeed, ...questionFields } = value;
 
   const created = await createQuestion({ authorId: session.userId, ...questionFields });
   console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified });
@@ -129,6 +132,71 @@ export async function POST(request: NextRequest) {
     questionId: created.id,
   });
   const question = await getQuestion(created.id, session.userId);
+
+  if (shareToFeed) {
+    try {
+      const friends = await getFriends(session.userId);
+      const concurrency = 5;
+      let sharedCount = 0;
+
+      for (let index = 0; index < friends.length; index += concurrency) {
+        const batch = friends.slice(index, index + concurrency);
+        const results = await Promise.all(batch.map(async (friend) => {
+          const [dismissed] = await db
+            .select({ id: feedDismissedDomains.id })
+            .from(feedDismissedDomains)
+            .where(and(
+              eq(feedDismissedDomains.userId, friend.id),
+              eq(feedDismissedDomains.canonicalSubcategory, questionFields.domain),
+              isNull(feedDismissedDomains.reinstatedAt),
+            ))
+            .limit(1);
+
+          if (dismissed) return false;
+
+          const [existing] = await db
+            .select({ id: feedItems.id })
+            .from(feedItems)
+            .where(and(
+              eq(feedItems.recipientUserId, friend.id),
+              eq(feedItems.questionId, created.id),
+            ))
+            .limit(1);
+
+          if (existing) return false;
+
+          await db.insert(feedItems).values({
+            recipientUserId: friend.id,
+            sourceUserId: session.userId,
+            questionId: created.id,
+            sourceType: 'authored_shared',
+            sourceResult: null,
+            state: 'active',
+            isPinned: false,
+            sourceEventAt: new Date(),
+          });
+          await rollOffOldItems(friend.id);
+          return true;
+        }));
+        sharedCount += results.filter(Boolean).length;
+      }
+
+      await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
+      await writeActivity({
+        userId: session.userId,
+        type: 'authored_question_shared',
+        referenceId: created.id,
+        referenceType: 'question',
+      });
+      console.info('[questions/shareToFeed]', { questionId: created.id, userId: session.userId, recipientCount: sharedCount });
+    } catch (error) {
+      console.error('[questions/shareToFeed] broadcast share failed (suppressed):', {
+        questionId: created.id,
+        userId: session.userId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
 
   if (sendToFriendIds.length > 0) {
     // Validate that all recipients are actual friends

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -368,7 +368,14 @@ function KnowledgePageContent() {
     if (!response.ok) throw new Error(body?.message ?? 'Could not save that question.');
     setSendQuestionOpen(false);
     setWriteQuestionOpen(false);
-    setQuestionToast('Question saved.');
+    if (values.sendToFriendIds.length > 0) {
+      const n = values.sendToFriendIds.length;
+      setQuestionToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
+    } else if (values.shareToFeed) {
+      setQuestionToast('Saved and shared with your friends.');
+    } else {
+      setQuestionToast('Saved to your bank.');
+    }
     window.setTimeout(() => setQuestionToast(null), 2500);
   };
 

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -181,6 +181,8 @@ function QuestionsPageContent() {
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
+    } else if (values.shareToFeed) {
+      setToast('Saved and shared with your friends.');
     } else {
       setToast('Saved to your bank.');
     }

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -445,8 +445,12 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
 
                 {/* Attribution line */}
                 <div className="mt-2 flex items-center gap-1.5">
+                  {item.source_type === 'authored_shared' ? <span className="text-sm text-muted-foreground" aria-hidden>✎</span> : null}
                   <p className="text-sm font-medium text-foreground">{item.source_attribution}</p>
                 </div>
+                {item.source_type === 'authored_shared' ? (
+                  <p className="mt-1 text-sm italic text-muted-foreground">Shared with their friends</p>
+                ) : null}
                 {item.personal_message ? (
                   <p className="mt-1 text-sm italic text-muted-foreground">&ldquo;{item.personal_message}&rdquo;</p>
                 ) : null}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -17,6 +17,7 @@ export type QuestionFormValues = {
   llmSuggestedAnswer?: string | null;
   critiqueIterations: number;
   sendToFriendIds: string[];
+  shareToFeed?: boolean;
 };
 
 type CritiqueResult =
@@ -67,6 +68,7 @@ type State = {
   suggestionError: string | null;
   suggesting: boolean;
   specificMode: boolean;
+  shareToFeed: boolean;
   friends: FriendOption[];
   friendsLoading: boolean;
   sendToFriendIds: string[];
@@ -91,6 +93,7 @@ type Action =
   | { type: 'SUBMITTING' }
   | { type: 'DONE' }
   | { type: 'SPECIFIC_MODE'; value: boolean }
+  | { type: 'SHARE_TO_FEED'; value: boolean }
   | { type: 'FRIENDS_LOADING'; value: boolean }
   | { type: 'FRIENDS_LOADED'; friends: FriendOption[] }
   | { type: 'TOGGLE_FRIEND'; id: string };
@@ -123,6 +126,7 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     suggestionError: null,
     suggesting: false,
     specificMode: initialSpecificMode,
+    shareToFeed: initialValues?.shareToFeed ?? false,
     friends: [],
     friendsLoading: false,
     sendToFriendIds: initialValues?.sendToFriendIds ?? [],
@@ -165,7 +169,8 @@ function reducer(state: State, action: Action): State {
     case 'BACK_TO_EDIT': return { ...state, stage: 'ANSWERING' };
     case 'SUBMITTING': return { ...state, stage: 'SUBMITTING', error: null };
     case 'DONE': return { ...state, stage: 'DONE' };
-    case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, sendToFriendIds: [] };
+    case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, shareToFeed: action.value ? false : state.shareToFeed, sendToFriendIds: [] };
+    case 'SHARE_TO_FEED': return { ...state, shareToFeed: action.value, specificMode: action.value ? false : state.specificMode, sendToFriendIds: action.value ? [] : state.sendToFriendIds };
     case 'FRIENDS_LOADING': return { ...state, friendsLoading: action.value };
     case 'FRIENDS_LOADED': return { ...state, friends: action.friends, friendsLoading: false };
     case 'TOGGLE_FRIEND': {
@@ -261,6 +266,10 @@ export function QuestionForm({
     if (on) void loadFriends();
   }
 
+  function toggleShareToFeed(on: boolean) {
+    dispatch({ type: 'SHARE_TO_FEED', value: on });
+  }
+
   async function runCritique() {
     const questionText = state.questionText.trim();
     if (!questionText) return;
@@ -346,7 +355,8 @@ export function QuestionForm({
         verified,
         llmSuggestedAnswer: state.llmSuggestedAnswer,
         critiqueIterations: state.critiqueIterations,
-        sendToFriendIds: state.sendToFriendIds,
+        sendToFriendIds: state.specificMode ? state.sendToFriendIds : [],
+        shareToFeed: state.shareToFeed,
       });
       dispatch({ type: 'DONE' });
     } catch (caught) {
@@ -497,7 +507,8 @@ export function QuestionForm({
             <div className="rounded-md border bg-muted/40 p-4">
               <p className="mb-3 text-xs uppercase tracking-[0.1em] text-muted-foreground">Destinations</p>
               <label className="mb-2 flex cursor-default items-center gap-2 text-sm"><input type="checkbox" checked readOnly disabled className="rounded" /><span className="text-foreground">Save to bank</span></label>
-              <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.specificMode} onChange={(event) => toggleSpecificMode(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Send to specific friends</span></label>
+              <label className="mb-2 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.shareToFeed} onChange={(event) => toggleShareToFeed(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Share with all friends</span></label>
+              <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.specificMode} onChange={(event) => toggleSpecificMode(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Send to specific friends only</span></label>
               {state.specificMode ? (
                 <div className="mt-1">
                   {state.friendsLoading ? <p className="text-xs text-muted-foreground">Loading friends...</p> : state.friends.length === 0 ? <p className="text-xs text-muted-foreground">No friends found.</p> : (
@@ -510,7 +521,7 @@ export function QuestionForm({
                   )}
                 </div>
               ) : null}
-              <p className="mt-3 text-xs text-muted-foreground">{state.specificMode ? 'Sent directly to the friends you pick.' : 'Saved to your bank.'}</p>
+              <p className="mt-3 text-xs text-muted-foreground">{state.specificMode ? 'Sent directly to the friends you pick.' : state.shareToFeed ? "Your friends will see this in their feed (except friends who've marked this domain as Not my focus)." : 'Saved to your bank only.'}</p>
             </div>
           ) : null}
 

--- a/src/server/activity/write-activity.ts
+++ b/src/server/activity/write-activity.ts
@@ -13,6 +13,7 @@ export type ActivityItemType =
   | 'question_curated'
   | 'creator_note_received'
   | 'friend_answered_your_question'
+  | 'authored_question_shared'
   | 'declared_promoted';
 
 export async function writeActivity(params: {

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -62,6 +62,10 @@ export type ActivityItemView = Pick<
       domain: string | null;
       result: 'correct' | 'incorrect';
     };
+    authoredSharedQuestion?: {
+      domain: string;
+      recipientCount: number;
+    };
     declaredPromoted?: {
       domain: string;
       questionText: string;
@@ -101,6 +105,7 @@ function isActivityType(value: string): value is ActivityItemType {
     'question_curated',
     'creator_note_received',
     'friend_answered_your_question',
+    'authored_question_shared',
     'declared_promoted',
   ].includes(value);
 }
@@ -463,6 +468,44 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
   );
 }
 
+async function hydrateAuthoredSharedQuestions(items: ActivityItemRow[]) {
+  const relevant = items.filter(
+    (item) => item.type === 'authored_question_shared' && item.referenceType === 'question' && item.referenceId,
+  );
+  if (relevant.length === 0) {
+    return new Map<string, NonNullable<ActivityItemView['reference']['authoredSharedQuestion']>>();
+  }
+
+  const questionIds = [...new Set(relevant.map((item) => item.referenceId!))];
+  const [questionRows, recipientRows] = await Promise.all([
+    db
+      .select({ id: questions.id, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+      .from(questions)
+      .where(inArray(questions.id, questionIds)),
+    db
+      .select({ questionId: feedItems.questionId, value: count() })
+      .from(feedItems)
+      .where(and(
+        inArray(feedItems.questionId, questionIds),
+        eq(feedItems.sourceType, 'authored_shared'),
+      ))
+      .groupBy(feedItems.questionId),
+  ]);
+
+  const questionById = new Map(questionRows.map((row) => [row.id, row]));
+  const countByQuestionId = new Map(recipientRows.map((row) => [row.questionId, row.value]));
+
+  return new Map(
+    relevant.map((item) => {
+      const question = questionById.get(item.referenceId!);
+      return [item.id, {
+        domain: question ? (question.canonicalSubcategory ?? question.broadCategory ?? question.category) : 'General',
+        recipientCount: Number(countByQuestionId.get(item.referenceId!) ?? 0),
+      }] as const;
+    }),
+  );
+}
+
 async function hydrateDeclaredPromoted(items: ActivityItemRow[]) {
   const relevant = items.filter(
     (item) => item.type === 'declared_promoted' && item.referenceType === 'question' && item.referenceId,
@@ -501,7 +544,7 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
     .orderBy(desc(activityItems.createdAt))
     .limit(100);
 
-  const [actorsById, gamesById, masteryEventsById, reactionsById, directQuestionsById, curatedQuestionsById, creatorNotesById, friendAnsweredQuestionsById, declaredPromotedById] = await Promise.all([
+  const [actorsById, gamesById, masteryEventsById, reactionsById, directQuestionsById, curatedQuestionsById, creatorNotesById, friendAnsweredQuestionsById, authoredSharedQuestionsById, declaredPromotedById] = await Promise.all([
     hydrateActors(rows),
     hydrateGames(rows, userId),
     hydrateMasteryEvents(rows),
@@ -510,6 +553,7 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
     hydrateCuratedQuestions(rows),
     hydrateCreatorNotes(rows),
     hydrateFriendAnsweredQuestions(rows),
+    hydrateAuthoredSharedQuestions(rows),
     hydrateDeclaredPromoted(rows),
   ]);
 
@@ -543,6 +587,9 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
           : undefined,
         friendAnsweredQuestion: row.type === 'friend_answered_your_question'
           ? friendAnsweredQuestionsById.get(row.id)
+          : undefined,
+        authoredSharedQuestion: row.type === 'authored_question_shared'
+          ? authoredSharedQuestionsById.get(row.id)
           : undefined,
         declaredPromoted: row.type === 'declared_promoted'
           ? declaredPromotedById.get(row.id)


### PR DESCRIPTION
### Motivation
- Restore an opt-in broadcast share destination when creating a question so authors can deliberately share with all friends while keeping bank-only as the default.
- Ensure broadcast shares respect recipient domain dismissals, are idempotent per recipient, and do not trigger SMS notifications.
- Surface broadcast shares in the Feed and Activities so authors have an audit trail of the broadcast.

### Description
- Added an opt-in `Share with all friends` toggle (default OFF) to the REVIEWING destinations panel in `src/components/QuestionForm.tsx` and made it mutually exclusive with `Send to specific friends`. (`shareToFeed` state and submit payload updated.)
- Extended the questions POST API at `src/app/api/questions/route.ts` to accept `shareToFeed?: boolean`, validate mutual exclusivity with `sendToFriendIds`, and, when true, create non-pinned `authored_shared` `FeedItem` rows for eligible friends while skipping dismissed domains and existing feed items, marking `questions.sharedToFriendsFeed = true`, and swallowing/logging errors so creation cannot fail on share errors.
- Restored `authored_shared` rendering and attribution in the feed pipeline by including the source type in `src/app/api/feed/route.ts` and adding the ✎ icon + italic subline `Shared with their friends` to question cards in `src/components/FeedList.tsx` for `authored_shared` items.
- Wrote an author-side activity item type `authored_question_shared` and hydrated domain/recipient counts for that activity in `src/server/db/queries/activity.ts`, and added rendering for the activity message in `src/app/activities/page.tsx`.
- Updated UI toast copy in question creation surfaces (`src/app/questions/page.tsx` and `src/app/knowledge/page.tsx`) to show `Saved and shared with your friends.` when broadcast sharing is used.

### Testing
- Ran `npx tsc --noEmit` with no type errors (succeeded).
- Ran `git diff --check` to confirm no whitespace/check issues (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a020bb6b30c832e8e198798b4cac32f)