### PR TITLE
Harden feed dismissed-domain migration (0021) for partially-migrated DBs

### DIFF
--- a/drizzle/0021_feed_dismissed_domains_active_unique.sql
+++ b/drizzle/0021_feed_dismissed_domains_active_unique.sql
@@ -1,3 +1,32 @@
-CREATE UNIQUE INDEX "feed_dismissed_domains_active_unique"
+-- Ensure preview/partially-migrated databases have the dismissed-domain table
+-- before adding the active-row uniqueness constraint. Some environments recorded
+-- the earlier 0012 migration without this table, which made this migration fail
+-- with relation "FeedDismissedDomain" does not exist.
+CREATE TABLE IF NOT EXISTS "FeedDismissedDomain" (
+  "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+  "userId" TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "canonicalSubcategory" TEXT NOT NULL,
+  "dismissedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  "reinstatedAt" TIMESTAMPTZ
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_idx" ON "FeedDismissedDomain" ("userId");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_sub_idx" ON "FeedDismissedDomain" ("userId", "canonicalSubcategory");
+--> statement-breakpoint
+-- If duplicates were inserted before the unique index existed, keep the newest
+-- active dismissal and remove the older active rows so the constraint can apply.
+DELETE FROM "FeedDismissedDomain" existing
+USING "FeedDismissedDomain" newest
+WHERE existing."userId" = newest."userId"
+  AND existing."canonicalSubcategory" = newest."canonicalSubcategory"
+  AND existing."reinstatedAt" IS NULL
+  AND newest."reinstatedAt" IS NULL
+  AND (
+    existing."dismissedAt" < newest."dismissedAt"
+    OR (existing."dismissedAt" = newest."dismissedAt" AND existing."id" < newest."id")
+  );
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "feed_dismissed_domains_active_unique"
 ON "FeedDismissedDomain" ("userId", "canonicalSubcategory")
 WHERE "reinstatedAt" IS NULL;


### PR DESCRIPTION
### Motivation
- Prevent the `0021` migration from failing in environments where the earlier `0012` run recorded without creating the `FeedDismissedDomain` table, which caused `relation "FeedDismissedDomain" does not exist` errors.
- Make the partial-unique-index migration idempotent and able to recover from legacy duplicate active rows that would block the constraint.

### Description
- Add `CREATE TABLE IF NOT EXISTS "FeedDismissedDomain"` so the migration can create the table when it is missing. 
- Recreate lookup indexes idempotently with `CREATE INDEX IF NOT EXISTS` to ensure required indexes exist before creating the unique constraint. 
- Remove older duplicate active rows via a `DELETE ... USING` query that keeps the newest active dismissal per `(userId, canonicalSubcategory)` so the unique constraint can be applied. 
- Create the partial unique index with `CREATE UNIQUE INDEX IF NOT EXISTS "feed_dismissed_domains_active_unique" ... WHERE "reinstatedAt" IS NULL` to allow safe re-runs.

### Testing
- Ran `git diff --check` which reported no whitespace/merge issues and showed the SQL diff. (succeeded)
- Ran `npx tsc --noEmit` TypeScript type-check which completed successfully. (succeeded)
- Ran `npm run lint` which failed on existing unrelated TypeScript/React lint errors in repository files; failures are unrelated to this SQL-only migration change. (unrelated failures)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022a0b1a84832e91eb780f0b0260bd)