### PR TITLE
Fix player mastery merge upsert fallback

### DIFF
--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { and, asc, desc, eq, gte, inArray, lte, sql } from 'drizzle-orm';
 
 import {
@@ -15,7 +17,7 @@ import { pgErrorCode, pgErrorMessage } from '@/server/db/pg-error';
 import { effectiveTier, resolveTier } from '@/server/mastery/tiers';
 import type { MasteryTier } from '@/types/db';
 
-type DbClient = any;
+type DbClient = Parameters<Parameters<typeof db.transaction>[0]>[0];
 
 type MasteryMovementInput = {
   userId: string;
@@ -126,6 +128,7 @@ async function upsertMergedPlayerMastery(
     await tx
       .insert(playerMastery)
       .values({
+        id: randomUUID(),
         userId: values.userId,
         canonicalSubcategory: values.canonicalSubcategory,
         broadCategory: values.broadCategory,
@@ -163,19 +166,19 @@ async function upsertMergedPlayerMastery(
       "season_points_start",
       "updated_at"
     ) values (
-      gen_random_uuid()::text,
+      ${randomUUID()},
       ${values.userId},
       ${values.canonicalSubcategory},
       ${values.broadCategory},
       ${values.totalPoints},
-      ${values.tier}::"MasteryTier",
+      ${values.tier}::"public"."MasteryTier",
       null,
       ${values.seasonPointsStart},
       ${values.updatedAt}
     ) on conflict ("user_id", "canonical_subcategory") do update set
       "broad_category" = ${values.broadCategory},
       "total_points" = ${values.totalPoints},
-      "tier" = ${values.tier}::"MasteryTier",
+      "tier" = ${values.tier}::"public"."MasteryTier",
       "updated_at" = ${values.updatedAt}
   `);
 }


### PR DESCRIPTION
### Motivation

- The ceremony merge upsert fallback path relied on database-side `gen_random_uuid()` and an unqualified `MasteryTier` enum cast which can fail in some Postgres setups. 
- The legacy raw-SQL fallback path needed to align with application expectations for the `PLAYER_MASTERY` insert so merges don't break when the Drizzle insert path throws a `territory_type`-related error. 
- The ceremony helper used a loose `any` DB client type which reduced type-safety for transaction callbacks. 

### Description

- Generate IDs in application code by importing `randomUUID` and adding `id: randomUUID()` to the `playerMastery` insert values in `src/server/mastery/ceremony.ts`. 
- Update the legacy raw SQL fallback to use an application-generated UUID and a schema-qualified enum cast (`::"public"."MasteryTier"`) for the `tier` column in `src/server/mastery/ceremony.ts`. 
- Replace the loose `type DbClient = any;` with the transaction callback parameter type `type DbClient = Parameters<Parameters<typeof db.transaction>[0]>[0];` in `src/server/mastery/ceremony.ts`. 

### Testing

- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `npm run lint` which still fails due to unrelated existing lint violations elsewhere in the repo (errors are outside the modified file).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0229e7a248832eaa4cda659a54279b)