### PR TITLE
Make daily answer recording resilient to mastery write failures

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -119,24 +119,29 @@ export async function POST(request: NextRequest) {
     } satisfies QueueSlot;
   });
 
-  const masteryDelta = await writeMasteryEvent({
-    userId: session.userId,
-    questionId: question.id,
-    domain: question.canonicalSubcategory,
-    answerState: isCorrect ? 'first_correct' : 'incorrect',
-    pointsAwarded,
-    sourceType: 'daily',
-    sourceId: `${queue.id}:${parsed.slotIndex}`,
-    broadCategory: question.broadCategory,
-    eventQuestionId: null,
-    basePoints: question.basePoints,
-    weight: 1,
-  });
-
   await db
     .update(dailyQueues)
     .set({ slots: nextSlots })
     .where(eq(dailyQueues.id, queue.id));
+
+  let masteryDelta = null;
+  try {
+    masteryDelta = await writeMasteryEvent({
+      userId: session.userId,
+      questionId: question.id,
+      domain: question.canonicalSubcategory,
+      answerState: isCorrect ? 'first_correct' : 'incorrect',
+      pointsAwarded,
+      sourceType: 'daily',
+      sourceId: `${queue.id}:${parsed.slotIndex}`,
+      broadCategory: question.broadCategory,
+      eventQuestionId: null,
+      basePoints: question.basePoints,
+      weight: 1,
+    });
+  } catch (error) {
+    console.warn('[daily/answer] writeMasteryEvent failed', error);
+  }
 
   await updateDomainDifficultyOnAnswer(
     session.userId,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -31,6 +31,8 @@ type AnswerResponse = {
   consolation?: string | null;
   quip?: string | null;
   breadcrumb?: string | null;
+  masteryDelta?: unknown | null;
+  mastery_delta?: unknown | null;
 };
 
 function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {


### PR DESCRIPTION
### Motivation
- Ensure a user's answer is always recorded even if updating mastery fails, and make the UI tolerant of a missing mastery delta so submission errors are not shown for mastery-side failures.

### Description
- Persist updated queue slots first by updating `dailyQueues` before attempting mastery updates in `src/app/api/daily/answer/route.ts`.
- Wrap `writeMasteryEvent(...)` in a `try/catch`, log `[daily/answer] writeMasteryEvent failed`, and use a nullable `masteryDelta` fallback so the route still returns a normal graded answer when mastery writes fail.
- Return `masteryDelta` and `mastery_delta` (nullable) in the JSON response to preserve backward compatibility with different clients.
- Update the client-side `AnswerResponse` type in `src/app/daily/page.tsx` to accept `masteryDelta?: unknown | null` and `mastery_delta?: unknown | null` so the UI does not treat a null value as a generic submission failure.

### Testing
- Ran `npx tsc --noEmit`, which completed successfully for the changed files.
- Ran targeted ESLint on the modified files with `npx eslint src/app/api/daily/answer/route.ts src/app/daily/page.tsx`, which passed for those files.
- Ran `npm run lint`, which surfaced pre-existing unrelated lint errors across the repo (these are not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022dfe9ef0832e8fc63aa6b94beddf)