### PR TITLE
Handle Daily Five answer failure responses

### DIFF
--- a/src/app/api/daily/__tests__/answer-route.test.ts
+++ b/src/app/api/daily/__tests__/answer-route.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSessionMock, selectMock, updateMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  selectMock: vi.fn(),
+  updateMock: vi.fn(),
+}))
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...conditions: unknown[]) => ({ conditions })),
+  eq: vi.fn((left: unknown, right: unknown) => ({ left, right })),
+}))
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('@/server/db', () => ({
+  dailyQueues: { id: 'dailyQueues.id', userId: 'dailyQueues.userId' },
+  generatedQuestions: {
+    id: 'generatedQuestions.id',
+    userId: 'generatedQuestions.userId',
+  },
+  questions: {
+    id: 'questions.id',
+    creatorId: 'questions.creatorId',
+    canonicalSubcategory: 'questions.canonicalSubcategory',
+    broadCategory: 'questions.broadCategory',
+    category: 'questions.category',
+  },
+  db: {
+    select: selectMock,
+    update: updateMock,
+  },
+}))
+vi.mock('@/server/grading', () => ({
+  gradeAnswer: vi.fn(),
+  selectQuip: vi.fn(),
+}))
+vi.mock('@/server/adaptive-difficulty', () => ({
+  updateDomainDifficultyOnAnswer: vi.fn(),
+}))
+vi.mock('@/server/daily/generate-breadcrumb', () => ({
+  generateBreadcrumb: vi.fn(),
+}))
+vi.mock('@/server/mastery/write-mastery-event', () => ({
+  writeMasteryEvent: vi.fn(),
+}))
+vi.mock('@/server/feed/create-feed-items-for-answer', () => ({
+  createFeedItemsForFriendsFromAnswer: vi.fn(),
+}))
+vi.mock('@/server/knowledge/open-domain', () => ({
+  promoteDeclaredToDemonstrated: vi.fn(),
+}))
+vi.mock('@/server/questions/persist-generated-question', () => ({
+  persistGeneratedQuestion: vi.fn(),
+}))
+
+import { POST } from '@/app/api/daily/answer/route'
+
+function selectBuilder(rows: unknown[]) {
+  return {
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue(rows),
+  }
+}
+
+function answerRequest(body: unknown) {
+  return new Request('http://localhost/api/daily/answer', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  }) as never
+}
+
+describe('/api/daily/answer failure responses', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    updateMock.mockReturnValue({
+      set: vi
+        .fn()
+        .mockReturnValue({ where: vi.fn().mockResolvedValue(undefined) }),
+    })
+  })
+
+  it('returns a user-safe message for unauthorized users', async () => {
+    getSessionMock.mockResolvedValue(null)
+
+    const response = await POST(
+      answerRequest({
+        queue_id: 'queue-1',
+        slot_index: 0,
+        submitted_answer: 'Paris',
+      })
+    )
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: 'unauthorized',
+      message: "Please sign in to answer today's question.",
+    })
+  })
+
+  it('returns a user-safe message when the daily queue is not found', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'user-1' })
+    selectMock.mockReturnValueOnce(selectBuilder([]))
+
+    const response = await POST(
+      answerRequest({
+        queue_id: 'queue-1',
+        slot_index: 0,
+        submitted_answer: 'Paris',
+      })
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: 'not_found',
+      message: "Could not find today's Daily Five queue.",
+    })
+  })
+
+  it('returns a user-safe message when the generated question is not found', async () => {
+    getSessionMock.mockResolvedValue({ userId: 'user-1' })
+    selectMock
+      .mockReturnValueOnce(
+        selectBuilder([
+          {
+            id: 'queue-1',
+            slots: [
+              {
+                answered: false,
+                skipped: false,
+                generated_question_id: 'generated-question-1',
+              },
+            ],
+          },
+        ])
+      )
+      .mockReturnValueOnce(selectBuilder([]))
+
+    const response = await POST(
+      answerRequest({
+        queue_id: 'queue-1',
+        slot_index: 0,
+        submitted_answer: 'Paris',
+      })
+    )
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({
+      error: 'question_not_found',
+      message: 'Could not find the question for this Daily Five slot.',
+    })
+  })
+
+  it('returns a user-safe message for unexpected exceptions', async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    getSessionMock.mockRejectedValue(new Error('database unavailable'))
+
+    const response = await POST(
+      answerRequest({
+        queue_id: 'queue-1',
+        slot_index: 0,
+        submitted_answer: 'Paris',
+      })
+    )
+
+    expect(response.status).toBe(500)
+    await expect(response.json()).resolves.toEqual({
+      error: 'unexpected',
+      message: 'Could not record that answer right now.',
+    })
+    expect(consoleErrorSpy).toHaveBeenCalled()
+
+    consoleErrorSpy.mockRestore()
+  })
+})

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -23,6 +23,10 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+function errorResponse(error: string, message: string, status: number) {
+  return NextResponse.json({ error, message }, { status });
+}
+
 function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string } | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
@@ -41,155 +45,159 @@ function parseBody(value: unknown): { queueId: string; slotIndex: number; submit
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-
-  const parsed = parseBody(await request.json().catch(() => null));
-  if (!parsed) {
-    return NextResponse.json(
-      { error: 'validation', message: 'queue_id, slot_index, and submitted_answer are required' },
-      { status: 400 },
-    );
-  }
-
-  const [queue] = await db
-    .select()
-    .from(dailyQueues)
-    .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
-    .limit(1);
-
-  if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
-
-  const slots = asQueueSlots(queue.slots);
-  const slot = slots[parsed.slotIndex];
-  if (!slot) {
-    return NextResponse.json({ error: 'validation', message: 'slot_index out of range' }, { status: 400 });
-  }
-  if (slot.answered || slot.skipped) {
-    return NextResponse.json({ error: 'invalid_state', message: 'slot is already closed' }, { status: 400 });
-  }
-  if (!slot.generated_question_id) {
-    return NextResponse.json({ error: 'invalid_state', message: 'daily slot has no generated question' }, { status: 400 });
-  }
-
-  const [question] = await db
-    .select()
-    .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.id, slot.generated_question_id),
-      eq(generatedQuestions.userId, session.userId),
-    ))
-    .limit(1);
-
-  if (!question) return NextResponse.json({ error: 'question_not_found' }, { status: 404 });
-
-  const grade = await gradeAnswer(
-    parsed.submittedAnswer,
-    question.answer,
-    [],
-    question.questionText,
-    'factual',
-  );
-  const isCorrect = grade.result === 'correct';
-  const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
-  const answerState = isCorrect ? 'correct' : 'incorrect';
-  const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-  const breadcrumb = await generateBreadcrumb({
-    questionId: question.id,
-    questionText: question.questionText,
-    correctAnswer: question.answer,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain: question.canonicalSubcategory,
-  }).catch(() => null);
-
-  const nextSlots = slots.map((item, index) => {
-    if (index !== parsed.slotIndex) return item;
-    return {
-      ...item,
-      answered: true,
-      answer_state: answerState,
-      submitted_answer: parsed.submittedAnswer,
-      awarded_points: pointsAwarded,
-      reveal_canonical_answer: question.answer,
-      reveal_explainer: question.explainer,
-      reveal_breadcrumb: breadcrumb,
-      reveal_quip: grade.consolation,
-      quip,
-    } satisfies QueueSlot;
-  });
-
-  const masteryDelta = await writeMasteryEvent({
-    userId: session.userId,
-    questionId: question.id,
-    domain: question.canonicalSubcategory,
-    answerState: isCorrect ? 'first_correct' : 'incorrect',
-    pointsAwarded,
-    sourceType: 'daily',
-    sourceId: `${queue.id}:${parsed.slotIndex}`,
-    broadCategory: question.broadCategory,
-    eventQuestionId: null,
-    basePoints: question.basePoints,
-    weight: 1,
-  });
-
-  await db
-    .update(dailyQueues)
-    .set({ slots: nextSlots })
-    .where(eq(dailyQueues.id, queue.id));
-
-  await updateDomainDifficultyOnAnswer(
-    session.userId,
-    question.canonicalSubcategory,
-    isCorrect,
-  ).catch((err) => {
-    console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
-  });
-
   try {
-    const persisted = await persistGeneratedQuestion(question.id);
-    const [persistedQuestion] = await db
-      .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
-      .from(questions)
-      .where(eq(questions.id, persisted.questionId))
-      .limit(1);
-    const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+    const session = await getSession();
+    if (!session) {
+      return errorResponse('unauthorized', "Please sign in to answer today's question.", 401);
+    }
 
-    if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
-      void promoteDeclaredToDemonstrated({
-        userId: persistedQuestion.creatorId,
-        domain: persistedDomain,
-        triggeringFriendId: session.userId,
-        questionId: persisted.questionId,
+    const parsed = parseBody(await request.json().catch(() => null));
+    if (!parsed) {
+      return errorResponse('validation', 'queue_id, slot_index, and submitted_answer are required', 400);
+    }
+
+    const [queue] = await db
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
+      .limit(1);
+
+    if (!queue) return errorResponse('not_found', "Could not find today's Daily Five queue.", 404);
+
+    const slots = asQueueSlots(queue.slots);
+    const slot = slots[parsed.slotIndex];
+    if (!slot) {
+      return errorResponse('validation', 'slot_index out of range', 400);
+    }
+    if (slot.answered || slot.skipped) {
+      return errorResponse('invalid_state', 'slot is already closed', 400);
+    }
+    if (!slot.generated_question_id) {
+      return errorResponse('invalid_state', 'daily slot has no generated question', 400);
+    }
+
+    const [question] = await db
+      .select()
+      .from(generatedQuestions)
+      .where(and(
+        eq(generatedQuestions.id, slot.generated_question_id),
+        eq(generatedQuestions.userId, session.userId),
+      ))
+      .limit(1);
+
+    if (!question) return errorResponse('question_not_found', 'Could not find the question for this Daily Five slot.', 404);
+
+    const grade = await gradeAnswer(
+      parsed.submittedAnswer,
+      question.answer,
+      [],
+      question.questionText,
+      'factual',
+    );
+    const isCorrect = grade.result === 'correct';
+    const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
+    const answerState = isCorrect ? 'correct' : 'incorrect';
+    const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+    const breadcrumb = await generateBreadcrumb({
+      questionId: question.id,
+      questionText: question.questionText,
+      correctAnswer: question.answer,
+      submittedAnswer: parsed.submittedAnswer,
+      isCorrect,
+      domain: question.canonicalSubcategory,
+    }).catch(() => null);
+
+    const nextSlots = slots.map((item, index) => {
+      if (index !== parsed.slotIndex) return item;
+      return {
+        ...item,
+        answered: true,
+        answer_state: answerState,
+        submitted_answer: parsed.submittedAnswer,
+        awarded_points: pointsAwarded,
+        reveal_canonical_answer: question.answer,
+        reveal_explainer: question.explainer,
+        reveal_breadcrumb: breadcrumb,
+        reveal_quip: grade.consolation,
+        quip,
+      } satisfies QueueSlot;
+    });
+
+    const masteryDelta = await writeMasteryEvent({
+      userId: session.userId,
+      questionId: question.id,
+      domain: question.canonicalSubcategory,
+      answerState: isCorrect ? 'first_correct' : 'incorrect',
+      pointsAwarded,
+      sourceType: 'daily',
+      sourceId: `${queue.id}:${parsed.slotIndex}`,
+      broadCategory: question.broadCategory,
+      eventQuestionId: null,
+      basePoints: question.basePoints,
+      weight: 1,
+    });
+
+    await db
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, queue.id));
+
+    await updateDomainDifficultyOnAnswer(
+      session.userId,
+      question.canonicalSubcategory,
+      isCorrect,
+    ).catch((err) => {
+      console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
+    });
+
+    try {
+      const persisted = await persistGeneratedQuestion(question.id);
+      const [persistedQuestion] = await db
+        .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+        .from(questions)
+        .where(eq(questions.id, persisted.questionId))
+        .limit(1);
+      const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+
+      if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
+        void promoteDeclaredToDemonstrated({
+          userId: persistedQuestion.creatorId,
+          domain: persistedDomain,
+          triggeringFriendId: session.userId,
+          questionId: persisted.questionId,
+        });
+      }
+
+      void createFeedItemsForFriendsFromAnswer(
+        session.userId,
+        persisted.questionId,
+        isCorrect ? 'correct' : 'incorrect',
+      );
+    } catch (error) {
+      console.warn('[daily/answer] failed to persist generated question for feed propagation', {
+        generatedQuestionId: question.id,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
 
-    void createFeedItemsForFriendsFromAnswer(
-      session.userId,
-      persisted.questionId,
-      isCorrect ? 'correct' : 'incorrect',
-    );
-  } catch (error) {
-    console.warn('[daily/answer] failed to persist generated question for feed propagation', {
-      generatedQuestionId: question.id,
-      error: error instanceof Error ? error.message : String(error),
+    return NextResponse.json({
+      isCorrect,
+      explanation: question.explainer,
+      pointsAwarded,
+      answerState,
+      breadcrumb,
+      masteryDelta,
+      correctAnswer: question.answer,
+      consolation: grade.consolation,
+      correct: isCorrect,
+      answer: question.answer,
+      explainer: question.explainer,
+      awarded_points: pointsAwarded,
+      mastery_delta: masteryDelta,
+      quip,
     });
+  } catch (error) {
+    console.error('[daily/answer] unexpected failure', error);
+    return errorResponse('unexpected', 'Could not record that answer right now.', 500);
   }
-
-  return NextResponse.json({
-    isCorrect,
-    explanation: question.explainer,
-    pointsAwarded,
-    answerState,
-    breadcrumb,
-    masteryDelta,
-    correctAnswer: question.answer,
-    consolation: grade.consolation,
-    correct: isCorrect,
-    answer: question.answer,
-    explainer: question.explainer,
-    awarded_points: pointsAwarded,
-    mastery_delta: masteryDelta,
-    quip,
-  });
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -19,6 +19,11 @@ type QueueResponse = {
   slots: QueueSlot[];
 };
 
+type FailedAnswerResponse = {
+  message?: string;
+  error?: string;
+};
+
 type AnswerResponse = {
   isCorrect?: boolean;
   correct?: boolean;
@@ -32,6 +37,27 @@ type AnswerResponse = {
   quip?: string | null;
   breadcrumb?: string | null;
 };
+
+function answerFailureMessage(body: FailedAnswerResponse | null): string {
+  if (body?.message) return body.message;
+
+  switch (body?.error) {
+    case 'unauthorized':
+      return "Please sign in to answer today's question.";
+    case 'not_found':
+      return "Could not find today's Daily Five queue.";
+    case 'question_not_found':
+      return 'Could not find the question for this Daily Five slot.';
+    case 'validation':
+      return 'Check your answer and try again.';
+    case 'invalid_state':
+      return 'That Daily Five question is already closed.';
+    case 'unexpected':
+      return 'Could not record that answer right now.';
+    default:
+      return 'Could not record that answer.';
+  }
+}
 
 function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {
   return slots.find((slot) => !slot.answered && !slot.skipped) ?? null;
@@ -213,7 +239,7 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  }, [allDone, currentSlot?.slot_index, queue, skipCurrent]);
+  }, [allDone, currentSlot?.slot_index, queue]);
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
@@ -240,9 +266,14 @@ export default function DailyPage() {
           submitted_answer: submittedAnswer,
         }),
       });
+      if (!response.ok) {
+        const body = await response.json().catch(() => null) as FailedAnswerResponse | null;
+        throw new Error(answerFailureMessage(body));
+      }
+
       const body = await response.json().catch(() => null) as AnswerResponse | null;
-      if (!response.ok || !body) {
-        throw new Error((body as { message?: string } | null)?.message ?? 'Could not record that answer.');
+      if (!body) {
+        throw new Error('Could not record that answer.');
       }
 
       const isCorrect = Boolean(body.isCorrect ?? body.correct);


### PR DESCRIPTION
### Motivation

- Ensure every non-2xx branch from `/api/daily/answer` returns both a machine `error` code and a user-safe `message` so the client can show clear, non-sensitive feedback for auth, not found, question missing, validation/invalid-state, and unexpected failures.
- Make the Daily Five client resilient to non-JSON or failure payloads by parsing failed responses as `{ message?: string; error?: string }` and mapping known `error` codes to friendly copy.
- Add targeted route tests to lock in the server-side failure shapes so UI behavior can be validated in unit tests.

### Description

- Added an `errorResponse(error, message, status)` helper and wrapped `POST` in `src/app/api/daily/answer/route.ts` with a top-level `try/catch`, converting early-return branches to always return `{ error, message }` for `unauthorized`, `validation`, `not_found`, `invalid_state`, `question_not_found`, and unexpected exceptions.
- Updated `src/app/daily/page.tsx` to parse failed `/api/daily/answer` responses as `FailedAnswerResponse = { message?: string; error?: string }`, added `answerFailureMessage` to map known `error` codes to user-safe text, and fell back to a generic message when needed; adjusted the submit flow to prefer server-provided `message` before the generic fallback.
- Added unit tests at `src/app/api/daily/__tests__/answer-route.test.ts` covering failure responses for `unauthorized`, `not_found` (queue missing), `question_not_found`, and an unexpected exception path that asserts a safe `message` is returned.
- Minor client cleanup: removed an unnecessary dependency from a `useMemo` dependency array to satisfy lint warnings.

### Testing

- Ran `npx eslint src/app/api/daily/answer/route.ts src/app/daily/page.tsx src/app/api/daily/__tests__/answer-route.test.ts` against the modified files and it completed successfully.
- Ran `npx tsc --noEmit` to verify TypeScript types and the build, which completed successfully.
- Attempted `npx vitest run src/app/api/daily/__tests__/answer-route.test.ts` to execute the new route tests, but test runner installation failed (registry returned 403), so the new tests were added but not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022d39ecc0832e9186b6293fb8e83f)