### PR TITLE
Pre-create FeedDismissedDomain table and indexes to tolerate mixed migrations

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -84,6 +84,45 @@ export async function register() {
       // log the error itself
     }
 
+    // Migration 0021 adds a partial unique index on FeedDismissedDomain. Some
+    // deployments may still execute an index-only copy of that migration, or may
+    // have migration 0012 recorded without the table actually present. Create the
+    // table and its non-unique indexes first so either migration shape can finish.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "FeedDismissedDomain" (
+          "id" TEXT PRIMARY KEY DEFAULT gen_random_uuid()::text,
+          "userId" TEXT NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "canonicalSubcategory" TEXT NOT NULL,
+          "dismissedAt" TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+          "reinstatedAt" TIMESTAMPTZ
+        )
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_idx"
+        ON "FeedDismissedDomain" ("userId")
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "FeedDismissedDomain_userId_sub_idx"
+        ON "FeedDismissedDomain" ("userId", "canonicalSubcategory")
+      `);
+      await db.execute(sql`
+        DELETE FROM "FeedDismissedDomain" existing
+        USING "FeedDismissedDomain" newest
+        WHERE existing."userId" = newest."userId"
+          AND existing."canonicalSubcategory" = newest."canonicalSubcategory"
+          AND existing."reinstatedAt" IS NULL
+          AND newest."reinstatedAt" IS NULL
+          AND (
+            existing."dismissedAt" < newest."dismissedAt"
+            OR (existing."dismissedAt" = newest."dismissedAt" AND existing."id" < newest."id")
+          )
+      `);
+    } catch {
+      // Fresh databases may not have the User table yet. In that case migrate()
+      // will create both User and FeedDismissedDomain in normal migration order.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),


### PR DESCRIPTION
### Motivation

- Some deployments have a mixed migration state where migration `0021`'s partial unique index was applied without the table, or migration `0012` is recorded but the table is missing, which can cause later migrations to fail.
- Ensure the `FeedDismissedDomain` table and its non-unique indexes exist so either migration shape can complete and the server can start reliably.

### Description

- Added a guarded block in `src/instrumentation.ts` that runs `CREATE TABLE IF NOT EXISTS "FeedDismissedDomain"` with the expected columns and defaults.
- Creates the non-unique indexes `FeedDismissedDomain_userId_idx` and `FeedDismissedDomain_userId_sub_idx` if they do not exist. 
- Adds a `DELETE` statement to remove duplicate rows while keeping the newest entry when `reinstatedAt` is `NULL` to prepare for the partial-unique-index migration shape.
- The whole sequence is wrapped in a `try`/`catch` so deployment setups that lack the `User` table will fall back to normal migration ordering.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022c031d1c832eb42c7a780ec7acbd)