### PR TITLE
Fix Daily Five slot lookup by slot_index

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -61,7 +61,7 @@ export async function POST(request: NextRequest) {
   if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
   const slots = asQueueSlots(queue.slots);
-  const slot = slots[parsed.slotIndex];
+  const slot = slots.find((item) => item.slot_index === parsed.slotIndex);
   if (!slot) {
     return NextResponse.json({ error: 'validation', message: 'slot_index out of range' }, { status: 400 });
   }
@@ -103,8 +103,8 @@ export async function POST(request: NextRequest) {
     domain: question.canonicalSubcategory,
   }).catch(() => null);
 
-  const nextSlots = slots.map((item, index) => {
-    if (index !== parsed.slotIndex) return item;
+  const nextSlots = slots.map((item) => {
+    if (item.slot_index !== parsed.slotIndex) return item;
     return {
       ...item,
       answered: true,

--- a/src/app/api/daily/skip/route.ts
+++ b/src/app/api/daily/skip/route.ts
@@ -42,7 +42,7 @@ export async function POST(request: NextRequest) {
   if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
   const slots = asQueueSlots(queue.slots);
-  const slot = slots[parsed.slotIndex];
+  const slot = slots.find((item) => item.slot_index === parsed.slotIndex);
   if (!slot) {
     return NextResponse.json({ error: 'validation', message: 'slot_index out of range' }, { status: 400 });
   }
@@ -58,8 +58,8 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const nextSlots = slots.map((item, index) =>
-    index === parsed.slotIndex ? { ...item, skipped: true } satisfies QueueSlot : item
+  const nextSlots = slots.map((item) =>
+    item.slot_index === parsed.slotIndex ? { ...item, skipped: true } satisfies QueueSlot : item
   );
 
   await db.transaction(async (tx) => {


### PR DESCRIPTION
### Motivation
- Ensure Daily Five answer/skip handlers identify and update the correct queue slot by its `slot_index` field rather than by array position so slot lookups remain correct if the slots array order changes.

### Description
- Replace `slots[parsed.slotIndex]` with `slots.find((item) => item.slot_index === parsed.slotIndex)` in `src/app/api/daily/answer/route.ts` and `src/app/api/daily/skip/route.ts` and update `nextSlots` mapping to compare `item.slot_index === parsed.slotIndex` when marking a slot answered or skipped.

### Testing
- Ran `npx eslint src/app/api/daily/answer/route.ts src/app/api/daily/skip/route.ts` which completed for the modified files without introducing new lint errors.
- Ran `npm run lint` for the repository which failed due to pre-existing lint issues elsewhere in the codebase unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a022fc69308832e8da55650160cd115)