### PR TITLE
Include user-safe error messages for Daily answer API and client fallback

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -23,6 +23,10 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+function errorResponse(error: string, message: string, status: number) {
+  return NextResponse.json({ error, message }, { status });
+}
+
 function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string } | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
@@ -41,160 +45,162 @@ function parseBody(value: unknown): { queueId: string; slotIndex: number; submit
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-
-  const parsed = parseBody(await request.json().catch(() => null));
-  if (!parsed) {
-    return NextResponse.json(
-      { error: 'validation', message: 'queue_id, slot_index, and submitted_answer are required' },
-      { status: 400 },
-    );
-  }
-
-  const [queue] = await db
-    .select()
-    .from(dailyQueues)
-    .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
-    .limit(1);
-
-  if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
-
-  const slots = asQueueSlots(queue.slots);
-  const slot = slots[parsed.slotIndex];
-  if (!slot) {
-    return NextResponse.json({ error: 'validation', message: 'slot_index out of range' }, { status: 400 });
-  }
-  if (slot.answered || slot.skipped) {
-    return NextResponse.json({ error: 'invalid_state', message: 'slot is already closed' }, { status: 400 });
-  }
-  if (!slot.generated_question_id) {
-    return NextResponse.json({ error: 'invalid_state', message: 'daily slot has no generated question' }, { status: 400 });
-  }
-
-  const [question] = await db
-    .select()
-    .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.id, slot.generated_question_id),
-      eq(generatedQuestions.userId, session.userId),
-    ))
-    .limit(1);
-
-  if (!question) return NextResponse.json({ error: 'question_not_found' }, { status: 404 });
-
-  const grade = await gradeAnswer(
-    parsed.submittedAnswer,
-    question.answer,
-    [],
-    question.questionText,
-    'factual',
-  );
-  const isCorrect = grade.result === 'correct';
-  const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
-  const answerState = isCorrect ? 'correct' : 'incorrect';
-  const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-  const breadcrumb = await generateBreadcrumb({
-    questionId: question.id,
-    questionText: question.questionText,
-    correctAnswer: question.answer,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain: question.canonicalSubcategory,
-  }).catch(() => null);
-
-  const nextSlots = slots.map((item, index) => {
-    if (index !== parsed.slotIndex) return item;
-    return {
-      ...item,
-      answered: true,
-      answer_state: answerState,
-      submitted_answer: parsed.submittedAnswer,
-      awarded_points: pointsAwarded,
-      reveal_canonical_answer: question.answer,
-      reveal_explainer: question.explainer,
-      reveal_breadcrumb: breadcrumb,
-      reveal_quip: grade.consolation,
-      quip,
-    } satisfies QueueSlot;
-  });
-
-  await db
-    .update(dailyQueues)
-    .set({ slots: nextSlots })
-    .where(eq(dailyQueues.id, queue.id));
-
-  let masteryDelta = null;
   try {
-    masteryDelta = await writeMasteryEvent({
-      userId: session.userId,
-      questionId: question.id,
-      domain: question.canonicalSubcategory,
-      answerState: isCorrect ? 'first_correct' : 'incorrect',
-      pointsAwarded,
-      sourceType: 'daily',
-      sourceId: `${queue.id}:${parsed.slotIndex}`,
-      broadCategory: question.broadCategory,
-      eventQuestionId: null,
-      basePoints: question.basePoints,
-      weight: 1,
-    });
-  } catch (error) {
-    console.warn('[daily/answer] writeMasteryEvent failed', error);
-  }
+    const session = await getSession();
+    if (!session) return errorResponse('unauthorized', "Please sign in to answer today's question.", 401);
 
-  await updateDomainDifficultyOnAnswer(
-    session.userId,
-    question.canonicalSubcategory,
-    isCorrect,
-  ).catch((err) => {
-    console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
-  });
+    const parsed = parseBody(await request.json().catch(() => null));
+    if (!parsed) {
+      return errorResponse('validation', 'queue_id, slot_index, and submitted_answer are required', 400);
+    }
 
-  try {
-    const persisted = await persistGeneratedQuestion(question.id);
-    const [persistedQuestion] = await db
-      .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
-      .from(questions)
-      .where(eq(questions.id, persisted.questionId))
+    const [queue] = await db
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
       .limit(1);
-    const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
 
-    if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
-      void promoteDeclaredToDemonstrated({
-        userId: persistedQuestion.creatorId,
-        domain: persistedDomain,
-        triggeringFriendId: session.userId,
-        questionId: persisted.questionId,
+    if (!queue) return errorResponse('not_found', "We could not find today's Daily Five.", 404);
+
+    const slots = asQueueSlots(queue.slots);
+    const slot = slots[parsed.slotIndex];
+    if (!slot) {
+      return errorResponse('validation', 'slot_index out of range', 400);
+    }
+    if (slot.answered || slot.skipped) {
+      return errorResponse('invalid_state', 'slot is already closed', 400);
+    }
+    if (!slot.generated_question_id) {
+      return errorResponse('invalid_state', 'daily slot has no generated question', 400);
+    }
+
+    const [question] = await db
+      .select()
+      .from(generatedQuestions)
+      .where(and(
+        eq(generatedQuestions.id, slot.generated_question_id),
+        eq(generatedQuestions.userId, session.userId),
+      ))
+      .limit(1);
+
+    if (!question) return errorResponse('question_not_found', 'We could not find that Daily Five question.', 404);
+
+    const grade = await gradeAnswer(
+      parsed.submittedAnswer,
+      question.answer,
+      [],
+      question.questionText,
+      'factual',
+    );
+    const isCorrect = grade.result === 'correct';
+    const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
+    const answerState = isCorrect ? 'correct' : 'incorrect';
+    const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+    const breadcrumb = await generateBreadcrumb({
+      questionId: question.id,
+      questionText: question.questionText,
+      correctAnswer: question.answer,
+      submittedAnswer: parsed.submittedAnswer,
+      isCorrect,
+      domain: question.canonicalSubcategory,
+    }).catch(() => null);
+
+    const nextSlots = slots.map((item, index) => {
+      if (index !== parsed.slotIndex) return item;
+      return {
+        ...item,
+        answered: true,
+        answer_state: answerState,
+        submitted_answer: parsed.submittedAnswer,
+        awarded_points: pointsAwarded,
+        reveal_canonical_answer: question.answer,
+        reveal_explainer: question.explainer,
+        reveal_breadcrumb: breadcrumb,
+        reveal_quip: grade.consolation,
+        quip,
+      } satisfies QueueSlot;
+    });
+
+    await db
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, queue.id));
+
+    let masteryDelta = null;
+    try {
+      masteryDelta = await writeMasteryEvent({
+        userId: session.userId,
+        questionId: question.id,
+        domain: question.canonicalSubcategory,
+        answerState: isCorrect ? 'first_correct' : 'incorrect',
+        pointsAwarded,
+        sourceType: 'daily',
+        sourceId: `${queue.id}:${parsed.slotIndex}`,
+        broadCategory: question.broadCategory,
+        eventQuestionId: null,
+        basePoints: question.basePoints,
+        weight: 1,
+      });
+    } catch (error) {
+      console.warn('[daily/answer] writeMasteryEvent failed', error);
+    }
+
+    await updateDomainDifficultyOnAnswer(
+      session.userId,
+      question.canonicalSubcategory,
+      isCorrect,
+    ).catch((err) => {
+      console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
+    });
+
+    try {
+      const persisted = await persistGeneratedQuestion(question.id);
+      const [persistedQuestion] = await db
+        .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+        .from(questions)
+        .where(eq(questions.id, persisted.questionId))
+        .limit(1);
+      const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+
+      if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
+        void promoteDeclaredToDemonstrated({
+          userId: persistedQuestion.creatorId,
+          domain: persistedDomain,
+          triggeringFriendId: session.userId,
+          questionId: persisted.questionId,
+        });
+      }
+
+      void createFeedItemsForFriendsFromAnswer(
+        session.userId,
+        persisted.questionId,
+        isCorrect ? 'correct' : 'incorrect',
+      );
+    } catch (error) {
+      console.warn('[daily/answer] failed to persist generated question for feed propagation', {
+        generatedQuestionId: question.id,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
 
-    void createFeedItemsForFriendsFromAnswer(
-      session.userId,
-      persisted.questionId,
-      isCorrect ? 'correct' : 'incorrect',
-    );
-  } catch (error) {
-    console.warn('[daily/answer] failed to persist generated question for feed propagation', {
-      generatedQuestionId: question.id,
-      error: error instanceof Error ? error.message : String(error),
+    return NextResponse.json({
+      isCorrect,
+      explanation: question.explainer,
+      pointsAwarded,
+      answerState,
+      breadcrumb,
+      masteryDelta,
+      correctAnswer: question.answer,
+      consolation: grade.consolation,
+      correct: isCorrect,
+      answer: question.answer,
+      explainer: question.explainer,
+      awarded_points: pointsAwarded,
+      mastery_delta: masteryDelta,
+      quip,
     });
+  } catch (error) {
+    console.error('[daily/answer] unexpected failure', error);
+    return errorResponse('unexpected', 'Something went wrong while recording that answer.', 500);
   }
-
-  return NextResponse.json({
-    isCorrect,
-    explanation: question.explainer,
-    pointsAwarded,
-    answerState,
-    breadcrumb,
-    masteryDelta,
-    correctAnswer: question.answer,
-    consolation: grade.consolation,
-    correct: isCorrect,
-    answer: question.answer,
-    explainer: question.explainer,
-    awarded_points: pointsAwarded,
-    mastery_delta: masteryDelta,
-    quip,
-  });
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -19,6 +19,26 @@ type QueueResponse = {
   slots: QueueSlot[];
 };
 
+type AnswerErrorResponse = {
+  message?: string;
+  error?: string;
+};
+
+const ANSWER_ERROR_MESSAGES: Record<string, string> = {
+  unauthorized: "Please sign in to answer today's question.",
+  not_found: "We could not find today's Daily Five.",
+  question_not_found: 'We could not find that Daily Five question.',
+  validation: 'Please check your answer and try again.',
+  invalid_state: 'That Daily Five question is already closed.',
+  unexpected: 'Something went wrong while recording that answer.',
+};
+
+function answerFailureMessage(body: AnswerErrorResponse | null): string {
+  return body?.message
+    ?? (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined)
+    ?? 'Could not record that answer.';
+}
+
 type AnswerResponse = {
   isCorrect?: boolean;
   correct?: boolean;
@@ -215,7 +235,7 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  }, [allDone, currentSlot?.slot_index, queue, skipCurrent]);
+  }, [allDone, currentSlot?.slot_index, queue]);
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
@@ -242,12 +262,17 @@ export default function DailyPage() {
           submitted_answer: submittedAnswer,
         }),
       });
-      const body = await response.json().catch(() => null) as AnswerResponse | null;
-      if (!response.ok || !body) {
-        throw new Error((body as { message?: string } | null)?.message ?? 'Could not record that answer.');
+      const body = await response.json().catch(() => null) as AnswerResponse | AnswerErrorResponse | null;
+      if (!response.ok) {
+        throw new Error(answerFailureMessage(body as AnswerErrorResponse | null));
       }
 
-      const isCorrect = Boolean(body.isCorrect ?? body.correct);
+      if (!body) {
+        throw new Error('Could not record that answer.');
+      }
+
+      const answerBody = body as AnswerResponse;
+      const isCorrect = Boolean(answerBody.isCorrect ?? answerBody.correct);
       setQueue((existing) => existing
         ? {
             ...existing,
@@ -258,11 +283,11 @@ export default function DailyPage() {
                     answered: true,
                     answer_state: isCorrect ? 'correct' : 'incorrect',
                     submitted_answer: submittedAnswer,
-                    awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
-                    reveal_canonical_answer: body.correctAnswer ?? body.answer,
-                    reveal_explainer: body.explanation ?? body.explainer,
-                    reveal_breadcrumb: body.breadcrumb ?? null,
-                    reveal_quip: body.consolation ?? body.quip ?? null,
+                    awarded_points: answerBody.pointsAwarded ?? answerBody.awarded_points ?? 0,
+                    reveal_canonical_answer: answerBody.correctAnswer ?? answerBody.answer,
+                    reveal_explainer: answerBody.explanation ?? answerBody.explainer,
+                    reveal_breadcrumb: answerBody.breadcrumb ?? null,
+                    reveal_quip: answerBody.consolation ?? answerBody.quip ?? null,
                   }
                 : slot
             ),


### PR DESCRIPTION
### Motivation
- Ensure every non-2xx path from `/api/daily/answer` returns both an `error` code and a user-safe `message` so the client can reliably surface friendly copy for auth, missing queue/question, validation/invalid-state, and unexpected failures.
- Make the Daily client surface meaningful fallback messages when the server returns structured error JSON or an error code, instead of only showing a generic failure string.

### Description
- Add an `errorResponse(error, message, status)` helper and wrap the `POST` handler in a top-level `try/catch` so all non-2xx branches return `{ error, message }` for `unauthorized`, `validation`, `not_found`, `question_not_found`, `invalid_state`, and unexpected errors. (edited `src/app/api/daily/answer/route.ts`)
- Preserve existing behavior for successful answers and keep internal side-effects (mastery, propagation, persistence) but return a safe `message` on unexpected exceptions. (edited `src/app/api/daily/answer/route.ts`)
- Update the Daily page `submitAnswer` flow to parse failed JSON as `{ message?: string; error?: string }`, add an `ANSWER_ERROR_MESSAGES` map keyed by error codes, and prefer `body.message` then error-code fallback before using the generic "Could not record that answer." message; then apply the successful response shape as before. (edited `src/app/daily/page.tsx`)
- Remove the stale `skipCurrent` dependency from a `useMemo` to avoid an unnecessary dependency while touching that area. (edited `src/app/daily/page.tsx`)

### Testing
- Ran `npx tsc --noEmit --incremental false` which completed without emitting and signaled type-checking succeeded for the edited files. (succeeded)
- Ran `npx eslint src/app/api/daily/answer/route.ts src/app/daily/page.tsx` with no new lint failures in the modified files. (succeeded for the touched files)
- Ran the project linter via `npm run lint` which failed due to pre-existing lint errors in unrelated files; those failures are not caused by these changes. (failed, unrelated pre-existing issues)
- Verified formatting with `prettier --write` during the rollout and committed the updated files. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02311584e0832eafb5d2693523e7ce)