### PR TITLE
Return structured errors from /api/daily/answer and handle them client-side

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -19,6 +19,18 @@ import { type QueueSlot } from '@/server/daily/types';
 
 export const dynamic = 'force-dynamic';
 
+type DailyAnswerErrorCode =
+  | 'unauthorized'
+  | 'validation'
+  | 'not_found'
+  | 'invalid_state'
+  | 'question_not_found'
+  | 'unexpected';
+
+function dailyAnswerErrorResponse(status: number, error: DailyAnswerErrorCode, message: string) {
+  return NextResponse.json({ error, message }, { status });
+}
+
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
@@ -41,160 +53,168 @@ function parseBody(value: unknown): { queueId: string; slotIndex: number; submit
 }
 
 export async function POST(request: NextRequest) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-
-  const parsed = parseBody(await request.json().catch(() => null));
-  if (!parsed) {
-    return NextResponse.json(
-      { error: 'validation', message: 'queue_id, slot_index, and submitted_answer are required' },
-      { status: 400 },
-    );
-  }
-
-  const [queue] = await db
-    .select()
-    .from(dailyQueues)
-    .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
-    .limit(1);
-
-  if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
-
-  const slots = asQueueSlots(queue.slots);
-  const slot = slots.find((item) => item.slot_index === parsed.slotIndex);
-  if (!slot) {
-    return NextResponse.json({ error: 'validation', message: 'slot_index out of range' }, { status: 400 });
-  }
-  if (slot.answered || slot.skipped) {
-    return NextResponse.json({ error: 'invalid_state', message: 'slot is already closed' }, { status: 400 });
-  }
-  if (!slot.generated_question_id) {
-    return NextResponse.json({ error: 'invalid_state', message: 'daily slot has no generated question' }, { status: 400 });
-  }
-
-  const [question] = await db
-    .select()
-    .from(generatedQuestions)
-    .where(and(
-      eq(generatedQuestions.id, slot.generated_question_id),
-      eq(generatedQuestions.userId, session.userId),
-    ))
-    .limit(1);
-
-  if (!question) return NextResponse.json({ error: 'question_not_found' }, { status: 404 });
-
-  const grade = await gradeAnswer(
-    parsed.submittedAnswer,
-    question.answer,
-    [],
-    question.questionText,
-    'factual',
-  );
-  const isCorrect = grade.result === 'correct';
-  const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
-  const answerState = isCorrect ? 'correct' : 'incorrect';
-  const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-  const breadcrumb = await generateBreadcrumb({
-    questionId: question.id,
-    questionText: question.questionText,
-    correctAnswer: question.answer,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain: question.canonicalSubcategory,
-  }).catch(() => null);
-
-  const nextSlots = slots.map((item) => {
-    if (item.slot_index !== parsed.slotIndex) return item;
-    return {
-      ...item,
-      answered: true,
-      answer_state: answerState,
-      submitted_answer: parsed.submittedAnswer,
-      awarded_points: pointsAwarded,
-      reveal_canonical_answer: question.answer,
-      reveal_explainer: question.explainer,
-      reveal_breadcrumb: breadcrumb,
-      reveal_quip: grade.consolation,
-      quip,
-    } satisfies QueueSlot;
-  });
-
-  await db
-    .update(dailyQueues)
-    .set({ slots: nextSlots })
-    .where(eq(dailyQueues.id, queue.id));
-
-  let masteryDelta = null;
   try {
-    masteryDelta = await writeMasteryEvent({
-      userId: session.userId,
-      questionId: question.id,
-      domain: question.canonicalSubcategory,
-      answerState: isCorrect ? 'first_correct' : 'incorrect',
-      pointsAwarded,
-      sourceType: 'daily',
-      sourceId: `${queue.id}:${parsed.slotIndex}`,
-      broadCategory: question.broadCategory,
-      eventQuestionId: null,
-      basePoints: question.basePoints,
-      weight: 1,
-    });
-  } catch (error) {
-    console.warn('[daily/answer] writeMasteryEvent failed', error);
-  }
+    const session = await getSession();
+    if (!session) {
+      return dailyAnswerErrorResponse(401, 'unauthorized', "Please sign in to answer today's question.");
+    }
 
-  await updateDomainDifficultyOnAnswer(
-    session.userId,
-    question.canonicalSubcategory,
-    isCorrect,
-  ).catch((err) => {
-    console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
-  });
+    const parsed = parseBody(await request.json().catch(() => null));
+    if (!parsed) {
+      return dailyAnswerErrorResponse(400, 'validation', 'queue_id, slot_index, and submitted_answer are required');
+    }
 
-  try {
-    const persisted = await persistGeneratedQuestion(question.id);
-    const [persistedQuestion] = await db
-      .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
-      .from(questions)
-      .where(eq(questions.id, persisted.questionId))
+    const [queue] = await db
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.id, parsed.queueId), eq(dailyQueues.userId, session.userId)))
       .limit(1);
-    const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
 
-    if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
-      void promoteDeclaredToDemonstrated({
-        userId: persistedQuestion.creatorId,
-        domain: persistedDomain,
-        triggeringFriendId: session.userId,
-        questionId: persisted.questionId,
+    if (!queue) {
+      return dailyAnswerErrorResponse(404, 'not_found', 'We could not find that Daily Five queue.');
+    }
+
+    const slots = asQueueSlots(queue.slots);
+    const slot = slots.find((item) => item.slot_index === parsed.slotIndex);
+    if (!slot) {
+      return dailyAnswerErrorResponse(400, 'validation', 'slot_index out of range');
+    }
+    if (slot.answered || slot.skipped) {
+      return dailyAnswerErrorResponse(400, 'invalid_state', 'That question is already closed.');
+    }
+    if (!slot.generated_question_id) {
+      return dailyAnswerErrorResponse(400, 'invalid_state', 'That Daily Five slot is not ready yet.');
+    }
+
+    const [question] = await db
+      .select()
+      .from(generatedQuestions)
+      .where(and(
+        eq(generatedQuestions.id, slot.generated_question_id),
+        eq(generatedQuestions.userId, session.userId),
+      ))
+      .limit(1);
+
+    if (!question) {
+      return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
+    }
+
+    const grade = await gradeAnswer(
+      parsed.submittedAnswer,
+      question.answer,
+      [],
+      question.questionText,
+      'factual',
+    );
+    const isCorrect = grade.result === 'correct';
+    const pointsAwarded = isCorrect ? Math.round(question.basePoints) : 0;
+    const answerState = isCorrect ? 'correct' : 'incorrect';
+    const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+    const breadcrumb = await generateBreadcrumb({
+      questionId: question.id,
+      questionText: question.questionText,
+      correctAnswer: question.answer,
+      submittedAnswer: parsed.submittedAnswer,
+      isCorrect,
+      domain: question.canonicalSubcategory,
+    }).catch(() => null);
+
+    const nextSlots = slots.map((item) => {
+      if (item.slot_index !== parsed.slotIndex) return item;
+      return {
+        ...item,
+        answered: true,
+        answer_state: answerState,
+        submitted_answer: parsed.submittedAnswer,
+        awarded_points: pointsAwarded,
+        reveal_canonical_answer: question.answer,
+        reveal_explainer: question.explainer,
+        reveal_breadcrumb: breadcrumb,
+        reveal_quip: grade.consolation,
+        quip,
+      } satisfies QueueSlot;
+    });
+
+    await db
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, queue.id));
+
+    let masteryDelta = null;
+    try {
+      masteryDelta = await writeMasteryEvent({
+        userId: session.userId,
+        questionId: question.id,
+        domain: question.canonicalSubcategory,
+        answerState: isCorrect ? 'first_correct' : 'incorrect',
+        pointsAwarded,
+        sourceType: 'daily',
+        sourceId: `${queue.id}:${parsed.slotIndex}`,
+        broadCategory: question.broadCategory,
+        eventQuestionId: null,
+        basePoints: question.basePoints,
+        weight: 1,
+      });
+    } catch (error) {
+      console.warn('[daily/answer] writeMasteryEvent failed', error);
+    }
+
+    await updateDomainDifficultyOnAnswer(
+      session.userId,
+      question.canonicalSubcategory,
+      isCorrect,
+    ).catch((err) => {
+      console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
+    });
+
+    try {
+      const persisted = await persistGeneratedQuestion(question.id);
+      const [persistedQuestion] = await db
+        .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+        .from(questions)
+        .where(eq(questions.id, persisted.questionId))
+        .limit(1);
+      const persistedDomain = persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category;
+
+      if (isCorrect && persistedQuestion?.creatorId && persistedQuestion.creatorId !== session.userId && persistedDomain) {
+        void promoteDeclaredToDemonstrated({
+          userId: persistedQuestion.creatorId,
+          domain: persistedDomain,
+          triggeringFriendId: session.userId,
+          questionId: persisted.questionId,
+        });
+      }
+
+      void createFeedItemsForFriendsFromAnswer(
+        session.userId,
+        persisted.questionId,
+        isCorrect ? 'correct' : 'incorrect',
+      );
+    } catch (error) {
+      console.warn('[daily/answer] failed to persist generated question for feed propagation', {
+        generatedQuestionId: question.id,
+        error: error instanceof Error ? error.message : String(error),
       });
     }
 
-    void createFeedItemsForFriendsFromAnswer(
-      session.userId,
-      persisted.questionId,
-      isCorrect ? 'correct' : 'incorrect',
-    );
-  } catch (error) {
-    console.warn('[daily/answer] failed to persist generated question for feed propagation', {
-      generatedQuestionId: question.id,
-      error: error instanceof Error ? error.message : String(error),
+    return NextResponse.json({
+      isCorrect,
+      explanation: question.explainer,
+      pointsAwarded,
+      answerState,
+      breadcrumb,
+      masteryDelta,
+      correctAnswer: question.answer,
+      consolation: grade.consolation,
+      correct: isCorrect,
+      answer: question.answer,
+      explainer: question.explainer,
+      awarded_points: pointsAwarded,
+      mastery_delta: masteryDelta,
+      quip,
     });
+  } catch (error) {
+    console.error('[daily/answer] unexpected failure', error);
+    return dailyAnswerErrorResponse(500, 'unexpected', 'Could not record that answer.');
   }
-
-  return NextResponse.json({
-    isCorrect,
-    explanation: question.explainer,
-    pointsAwarded,
-    answerState,
-    breadcrumb,
-    masteryDelta,
-    correctAnswer: question.answer,
-    consolation: grade.consolation,
-    correct: isCorrect,
-    answer: question.answer,
-    explainer: question.explainer,
-    awarded_points: pointsAwarded,
-    mastery_delta: masteryDelta,
-    quip,
-  });
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -35,6 +35,24 @@ type AnswerResponse = {
   mastery_delta?: unknown | null;
 };
 
+type FailedAnswerResponse = {
+  message?: string;
+  error?: string;
+};
+
+const ANSWER_ERROR_MESSAGES: Record<string, string> = {
+  unauthorized: "Please sign in to answer today's question.",
+  validation: 'Check your answer and try again.',
+  not_found: 'We could not find that Daily Five queue.',
+  invalid_state: 'That question is already closed.',
+  question_not_found: 'We could not find that Daily Five question.',
+  unexpected: 'Could not record that answer.',
+};
+
+function answerFailureMessage(body: FailedAnswerResponse | null): string {
+  return body?.message ?? (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined) ?? 'Could not record that answer.';
+}
+
 function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {
   return slots.find((slot) => !slot.answered && !slot.skipped) ?? null;
 }
@@ -215,7 +233,7 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  }, [allDone, currentSlot?.slot_index, queue, skipCurrent]);
+  }, [allDone, currentSlot?.slot_index, queue]);
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
@@ -242,9 +260,14 @@ export default function DailyPage() {
           submitted_answer: submittedAnswer,
         }),
       });
+      if (!response.ok) {
+        const failedBody = await response.json().catch(() => null) as FailedAnswerResponse | null;
+        throw new Error(answerFailureMessage(failedBody));
+      }
+
       const body = await response.json().catch(() => null) as AnswerResponse | null;
-      if (!response.ok || !body) {
-        throw new Error((body as { message?: string } | null)?.message ?? 'Could not record that answer.');
+      if (!body) {
+        throw new Error('Could not record that answer.');
       }
 
       const isCorrect = Boolean(body.isCorrect ?? body.correct);


### PR DESCRIPTION
### Motivation

- Ensure the Daily Five answer API always returns a machine-friendly `error` code and a user-safe `message` on every non-2xx branch (including `unauthorized`, `validation`, `not_found`, `invalid_state`, `question_not_found`, and unexpected exceptions). 
- Surface friendly, error-code-aware copy in the client when an answer POST fails so users see a clear, safe message instead of a raw error or generic text.

### Description

- Added a `DailyAnswerErrorCode` type and `dailyAnswerErrorResponse` helper to standardize error JSON shapes and messages in `src/app/api/daily/answer/route.ts`. 
- Wrapped the `POST` handler in `src/app/api/daily/answer/route.ts` with a top-level `try/catch` that logs unexpected failures and returns a safe `500` JSON response with `{ error, message }`.
- Replaced ad-hoc non-2xx `NextResponse.json(...)` branches with calls to `dailyAnswerErrorResponse` for `unauthorized`, `validation`, `not_found`, `invalid_state`, and `question_not_found` cases.
- Updated client-side `submitAnswer` in `src/app/daily/page.tsx` to: parse failed responses as `{ message?: string; error?: string }`, add an `ANSWER_ERROR_MESSAGES` map and `answerFailureMessage` helper, prefer server `message` then mapped code copy, then fall back to a generic message, and throw an `Error` with that text so existing error UI is used.
- Minor client cleanups (dependency array adjustment and formatting) surfaced while integrating the new error handling.

### Testing

- Ran `npx eslint src/app/api/daily/answer/route.ts src/app/daily/page.tsx` (lint completed for the touched files without blocking the change).
- Ran `npx tsc --noEmit` to validate TypeScript types and it succeeded for the modified files.
- Ran `npm run lint`, which reports pre-existing, unrelated lint errors elsewhere in the repo (these are not caused by this change).
- No existing Daily Five route/client tests were found to extend, so no new automated route/client tests were added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0232883320832eb468723ae19356c7)