### PR TITLE
Improve submitted answer contrast in GameplayChat

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -256,7 +256,7 @@ function UserRow({ text }: { text: string }) {
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
           padding: '10px 14px',
           fontSize: '0.9rem',
-          color: 'var(--accent-contrast)',
+          color: 'var(--accent-foreground)',
         }}
       >
         {text}


### PR DESCRIPTION
### Motivation
- Ensure the user's submitted-answer bubble in the chat is readable in both light and dark themes by using the color token that pairs with `--accent` background in `src/app/globals.css`.

### Description
- Replace the outgoing chat text color in `UserRow` from `var(--accent-contrast)` to `var(--accent-foreground)` in `src/components/play/GameplayChat.tsx` so submitted answers render with sufficient contrast.

### Testing
- Ran `npx eslint src/components/play/GameplayChat.tsx --ext .tsx` which passed (file-level warnings remain but no errors in the changed file).
- Ran `npx tsc --noEmit` which completed without type errors.
- Ran `npm run lint` which reported pre-existing repo-wide lint errors unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0235f3407c832e9819b84f6626b18f)