### PR TITLE
Move question badges below chat bubble

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -142,37 +142,17 @@ function QuestionRow({
 
   return (
     <div className="flex flex-col gap-0.5">
-      {subhead || badges.length > 0 ? (
+      {subhead ? (
         <div className="flex flex-wrap items-center gap-1.5 pb-1 pl-0.5">
-          {subhead ? (
-            <p
-              style={{
-                ...monoStyle,
-                fontSize: '0.58rem',
-                color: 'var(--text-muted)',
-              }}
-            >
-              {subhead}
-            </p>
-          ) : null}
-          {badges.map((badge) => (
-            <span
-              key={badge.label}
-              style={{
-                ...monoStyle,
-                borderRadius: '999px',
-                border: '1px solid var(--border)',
-                background: badge.tone === 'warning'
-                  ? 'color-mix(in srgb, #b45309 12%, var(--surface))'
-                  : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
-                color: badge.tone === 'warning' ? '#b45309' : 'var(--text-muted)',
-                fontSize: '0.52rem',
-                padding: '2px 6px',
-              }}
-            >
-              {badge.label}
-            </span>
-          ))}
+          <p
+            style={{
+              ...monoStyle,
+              fontSize: '0.58rem',
+              color: 'var(--text-muted)',
+            }}
+          >
+            {subhead}
+          </p>
         </div>
       ) : null}
       {creatorName ? (
@@ -202,6 +182,28 @@ function QuestionRow({
       >
         <p style={{ margin: 0 }}>{questionText}</p>
       </div>
+      {badges.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5 pt-1 pl-0.5">
+          {badges.map((badge) => (
+            <span
+              key={badge.label}
+              style={{
+                ...monoStyle,
+                borderRadius: '999px',
+                border: '1px solid var(--border)',
+                background: badge.tone === 'warning'
+                  ? 'color-mix(in srgb, #b45309 12%, var(--surface))'
+                  : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
+                color: badge.tone === 'warning' ? '#b45309' : 'var(--text-muted)',
+                fontSize: '0.52rem',
+                padding: '2px 6px',
+              }}
+            >
+              {badge.label}
+            </span>
+          ))}
+        </div>
+      ) : null}
       {onDismiss ? (
         dismissed ? (
           <p


### PR DESCRIPTION
### Motivation
- Place mastery/difficulty badges (e.g. `SOLID`, `ESTABLISHING`, `MASTERY`) visually under the question card so they appear below the question text rather than in the top metadata row.
- Preserve non-difficulty `subhead` metadata (used for catch-up labels) above the question so existing UX flows remain intact.

### Description
- Render `subhead` only in the top metadata row and remove badges from that row so catch-up labels still appear before the question bubble.
- Insert the existing `badges.map(...)` block immediately after the question bubble `<div>` that contains `{questionText}` and keep the original badge styling and spacing.
- Keep the `creatorName`, `onDismiss` dismiss flow, and other behavior unchanged.

### Testing
- Ran `git diff --check` which reported no whitespace or index issues.
- Ran `npx eslint src/components/play/GameplayChat.tsx --ext .tsx` which completed with only pre-existing warnings for unused locals in this file.
- Ran `npm run lint` which failed due to unrelated repository-wide lint errors outside this change.
- Ran `npx prettier --check src/components/play/GameplayChat.tsx` which reported a formatting mismatch; full-file formatting was intentionally avoided to minimize unrelated churn.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0236af789c832eb6e75ea8b68731a2)