### PR TITLE
Remove 'From Joshing' creator label from Daily questions

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -179,7 +179,7 @@ export default function DailyPage() {
           kind: 'question',
           assignmentId: String(slot.slot_index),
           questionText: slot.question_text,
-          creatorName: 'From Joshing',
+          creatorName: null,
           badges: questionBadges(slot),
         });
         if (slot.submitted_answer) {
@@ -215,7 +215,7 @@ export default function DailyPage() {
           kind: 'question',
           assignmentId: String(slot.slot_index),
           questionText: slot.question_text,
-          creatorName: 'From Joshing',
+          creatorName: null,
           badges: questionBadges(slot),
         });
         break;


### PR DESCRIPTION
### Motivation
- Replace the hardcoded “From Joshing” creator label on Daily Five question rows with `null` so the UI no longer shows that attribution and aligns with the catch-up flow.

### Description
- Set `creatorName: null` for answered and current question rows in `src/app/daily/page.tsx` and confirmed `src/components/play/useCatchupFlow.ts` already uses `creatorName: null` for catch-up questions.

### Testing
- Ran `npx eslint src/app/daily/page.tsx --ext .tsx` which passed; ran `git diff --check` which reported no issues; `npm run lint` still fails due to existing unrelated lint errors elsewhere in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023b9efd34832e9d50545cd5d66af1)