### PR TITLE
Move "Don't show questions like this" dismissal from gameplay to summary

### DIFF
--- a/src/app/api/users/domain-exclusions/[domain]/route.ts
+++ b/src/app/api/users/domain-exclusions/[domain]/route.ts
@@ -1,0 +1,31 @@
+import { and, eq } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { db, userDomainExclusions } from '@/server/db';
+
+export const dynamic = 'force-dynamic';
+
+type RouteContext = {
+  params: Promise<{ domain: string }>;
+};
+
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { domain: rawDomain } = await context.params;
+  const domain = decodeURIComponent(rawDomain).trim().replace(/\s+/g, ' ');
+  if (!domain) {
+    return NextResponse.json({ error: 'validation', message: 'domain is required' }, { status: 400 });
+  }
+
+  await db
+    .delete(userDomainExclusions)
+    .where(and(
+      eq(userDomainExclusions.userId, session.userId),
+      eq(userDomainExclusions.canonicalSubcategory, domain),
+    ));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/users/domain-exclusions/route.ts
+++ b/src/app/api/users/domain-exclusions/route.ts
@@ -1,0 +1,51 @@
+import { and, eq } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { db, userDomainExclusions } from '@/server/db';
+
+export const dynamic = 'force-dynamic';
+
+function parseDomain(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const domain = (value as Record<string, unknown>).canonical_subcategory;
+  return typeof domain === 'string' && domain.trim() ? domain.trim().replace(/\s+/g, ' ') : null;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const domain = parseDomain(await request.json().catch(() => null));
+  if (!domain) {
+    return NextResponse.json({ error: 'validation', message: 'canonical_subcategory is required' }, { status: 400 });
+  }
+
+  await db
+    .insert(userDomainExclusions)
+    .values({ userId: session.userId, canonicalSubcategory: domain })
+    .onConflictDoNothing({
+      target: [userDomainExclusions.userId, userDomainExclusions.canonicalSubcategory],
+    });
+
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const domain = parseDomain(await request.json().catch(() => null));
+  if (!domain) {
+    return NextResponse.json({ error: 'validation', message: 'canonical_subcategory is required' }, { status: 400 });
+  }
+
+  await db
+    .delete(userDomainExclusions)
+    .where(and(
+      eq(userDomainExclusions.userId, session.userId),
+      eq(userDomainExclusions.canonicalSubcategory, domain),
+    ));
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { ThumbsDown, ThumbsUp } from 'lucide-react';
-import { type CSSProperties, useCallback, useEffect, useMemo, useState, useTransition } from 'react';
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState, useTransition } from 'react';
 
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { AddToBankAction } from '@/components/AddToBankAction';
@@ -278,6 +278,7 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
       ) : null}
       <div className="mt-4 flex flex-wrap items-center justify-end gap-2">
         <DailyQuestionFeedbackButtons questionId={question.questionId} />
+        <DomainExclusionAffordance domain={question.domain} domainDisplayName={question.domainDisplayName} />
         <SendQuestionAction
           question={{ id: question.questionId, text: question.questionText, domain: question.domainDisplayName }}
           label=""
@@ -294,6 +295,89 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
         ) : null}
       </div>
     </article>
+  );
+}
+
+
+type ExclusionState =
+  | { kind: 'idle' }
+  | { kind: 'confirmed' }
+  | { kind: 'undone' };
+
+function DomainExclusionAffordance({
+  domain,
+  domainDisplayName,
+}: {
+  domain: string;
+  domainDisplayName: string;
+}) {
+  const [state, setState] = useState<ExclusionState>({ kind: 'idle' });
+  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleExclude = useCallback(async () => {
+    setState({ kind: 'confirmed' });
+    undoTimerRef.current = setTimeout(() => {
+      undoTimerRef.current = null;
+    }, 5000);
+    try {
+      await fetch('/api/users/domain-exclusions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ canonical_subcategory: domain }),
+      });
+    } catch {
+      // Optimistic UI is acceptable here; the next summary load will reflect persisted state.
+    }
+  }, [domain]);
+
+  const handleUndo = useCallback(async () => {
+    if (undoTimerRef.current) {
+      clearTimeout(undoTimerRef.current);
+      undoTimerRef.current = null;
+    }
+    setState({ kind: 'undone' });
+    try {
+      await fetch(`/api/users/domain-exclusions/${encodeURIComponent(domain)}`, {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+    } catch {
+      // Fire-and-forget; the affordance returns on reload if persistence failed.
+    }
+  }, [domain]);
+
+  useEffect(() => {
+    return () => {
+      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
+    };
+  }, []);
+
+  if (state.kind === 'undone') return null;
+
+  if (state.kind === 'confirmed') {
+    return (
+      <div className="flex items-center gap-2 rounded-md border bg-muted/40 px-3 py-2 text-xs text-muted-foreground">
+        <span>{domainDisplayName} won&apos;t appear in your daily queue anymore.</span>
+        <button
+          type="button"
+          onClick={handleUndo}
+          className="font-medium uppercase tracking-[0.08em] underline underline-offset-4"
+        >
+          Undo
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleExclude}
+      className="inline-flex min-h-9 items-center rounded-md border px-3 text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground transition hover:bg-muted hover:text-foreground"
+    >
+      Don&apos;t show questions like this
+    </button>
   );
 }
 

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -3,7 +3,7 @@
  */
 
 import Link from 'next/link';
-import { useCallback, useEffect, useRef, useState, type CSSProperties } from 'react';
+import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
 import { SessionCloseMessage } from '@/components/play/SessionCloseMessage';
 import { CANNED_REACTIONS, type ReactionKey } from '@/lib/reactions';
@@ -450,109 +450,6 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
   );
 }
 
-type ExclusionState =
-  | { kind: 'idle' }
-  | { kind: 'confirmed' }
-  | { kind: 'undone' };
-
-function DomainExclusionAffordance({ canonicalSubcategory }: { canonicalSubcategory: string }) {
-  const [state, setState] = useState<ExclusionState>({ kind: 'idle' });
-  const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleExclude = useCallback(async () => {
-    setState({ kind: 'confirmed' });
-    undoTimerRef.current = setTimeout(() => {
-      undoTimerRef.current = null;
-    }, 5000);
-    try {
-      await fetch('/api/users/domain-exclusions', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ canonical_subcategory: canonicalSubcategory }),
-      });
-    } catch {
-      // fire-and-forget; optimistic UI is acceptable here
-    }
-  }, [canonicalSubcategory]);
-
-  const handleUndo = useCallback(async () => {
-    if (undoTimerRef.current) {
-      clearTimeout(undoTimerRef.current);
-      undoTimerRef.current = null;
-    }
-    setState({ kind: 'undone' });
-    try {
-      await fetch(`/api/users/domain-exclusions/${encodeURIComponent(canonicalSubcategory)}`, {
-        method: 'DELETE',
-      });
-    } catch {
-      // fire-and-forget
-    }
-  }, [canonicalSubcategory]);
-
-  useEffect(() => {
-    return () => {
-      if (undoTimerRef.current) clearTimeout(undoTimerRef.current);
-    };
-  }, []);
-
-  if (state.kind === 'undone') return null;
-
-  if (state.kind === 'confirmed') {
-    return (
-      <div style={{ marginTop: '10px', display: 'flex', alignItems: 'baseline', gap: '8px', flexWrap: 'wrap' }}>
-        <p style={{ ...monoStyle, fontSize: '0.6rem', color: 'var(--text-muted)' }}>
-          Got it — {canonicalSubcategory} won&apos;t appear in your daily queue anymore.
-        </p>
-        <button
-          type="button"
-          onClick={handleUndo}
-          style={{
-            background: 'none',
-            border: 'none',
-            padding: 0,
-            cursor: 'pointer',
-            fontFamily: 'var(--font-mono)',
-            fontSize: '0.6rem',
-            textTransform: 'uppercase',
-            letterSpacing: '0.06em',
-            color: 'var(--text-muted)',
-            textDecoration: 'underline',
-            textUnderlineOffset: '2px',
-          }}
-        >
-          Undo
-        </button>
-      </div>
-    );
-  }
-
-  return (
-    <div style={{ marginTop: '10px' }}>
-      <button
-        type="button"
-        onClick={handleExclude}
-        style={{
-          background: 'none',
-          border: 'none',
-          padding: 0,
-          cursor: 'pointer',
-          fontFamily: 'var(--font-mono)',
-          fontSize: '0.6rem',
-          textTransform: 'uppercase',
-          letterSpacing: '0.06em',
-          color: 'var(--text-muted)',
-          textDecoration: 'underline',
-          textUnderlineOffset: '2px',
-          opacity: 0.75,
-        }}
-      >
-        Remove this topic from my rotation
-      </button>
-    </div>
-  );
-}
-
 function QuipLine({ text }: { text: string }) {
   const [visible, setVisible] = useState(false);
   useEffect(() => {
@@ -585,7 +482,6 @@ function ResultRow({
   copyVariant,
   creatorName,
   relationalFeedbackLine,
-  canonicalSubcategory,
   reactionPrompt,
   pointsAwarded,
   pointsLabel,
@@ -676,9 +572,6 @@ function ResultRow({
           </p>
         ) : null}
       </div>
-      {canonicalSubcategory ? (
-        <DomainExclusionAffordance canonicalSubcategory={canonicalSubcategory} />
-      ) : null}
       {reactionPrompt ? <QuestionReactionPrompt prompt={reactionPrompt} /> : null}
     </div>
   );

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -8,6 +8,7 @@ import {
   generatedQuestions,
   masteryEvents,
   playerMastery,
+  userDomainExclusions,
 } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
@@ -71,6 +72,20 @@ function normalizeDomain(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
 }
 
+async function getExcludedKnowledgeDomains(userId: string): Promise<Set<string>> {
+  try {
+    const rows = await db
+      .select({ domain: userDomainExclusions.canonicalSubcategory })
+      .from(userDomainExclusions)
+      .where(eq(userDomainExclusions.userId, userId));
+
+    return new Set(rows.map((row) => normalizeDomain(row.domain).toLowerCase()).filter(Boolean));
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return new Set();
+    throw error;
+  }
+}
+
 async function getPlayerMasteryKnowledgeRows(userId: string) {
   try {
     return await db
@@ -103,9 +118,10 @@ async function getPlayerMasteryKnowledgeRows(userId: string) {
 }
 
 export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDomain[]> {
-  const [masteryRows, declaredRows] = await Promise.all([
+  const [masteryRows, declaredRows, excludedDomains] = await Promise.all([
     getPlayerMasteryKnowledgeRows(userId),
     getActiveDeclaredInterests(userId),
+    getExcludedKnowledgeDomains(userId),
   ]);
 
   const domainsByKey = new Map<string, KnowledgeBaseDomain>();
@@ -113,7 +129,9 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
   for (const row of masteryRows) {
     const domain = normalizeDomain(row.domain);
     if (!domain) continue;
-    domainsByKey.set(domain.toLowerCase(), {
+    const key = domain.toLowerCase();
+    if (excludedDomains.has(key)) continue;
+    domainsByKey.set(key, {
       domain,
       broadCategory: row.broadCategory,
       source: row.territoryType === 'declared' ? 'declared' : 'friend_mediated',
@@ -127,6 +145,7 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     const domain = normalizeDomain(row.domain);
     if (!domain) continue;
     const key = domain.toLowerCase();
+    if (excludedDomains.has(key)) continue;
     const existing = domainsByKey.get(key);
     domainsByKey.set(key, {
       domain: existing?.domain ?? domain,


### PR DESCRIPTION
### Motivation
- The dismissal control that hides a topic currently appears inline in the gameplay chat, which interrupts the play flow; it should live on the post-game summary where users review questions.
- Persisting dismissed domains ensures they are excluded from future Daily Five generation.

### Description
- Removed the in-chat domain-exclusion affordance from the gameplay thread (`src/components/play/GameplayChat.tsx`).
- Added a `DomainExclusionAffordance` action to each question card on the Daily Summary page (`src/app/daily/summary/page.tsx`) that shows an optimistic confirmation and an `Undo` button.
- Added authenticated API endpoints to save and delete user exclusions at `POST /api/users/domain-exclusions` and `DELETE /api/users/domain-exclusions/[domain]` (`src/app/api/users/domain-exclusions/route.ts` and the dynamic route).
- Filtered excluded domains out of the Daily Five knowledge base used to pick round domains by reading `USER_DOMAIN_EXCLUSIONS` in the server query (`src/server/db/queries/daily.ts`).

### Testing
- Type-check: ran `npx tsc --noEmit -p tsconfig.json` and it completed successfully.
- Static checks: ran `npx eslint` against the changed files (`src/app/daily/summary/page.tsx`, `src/components/play/GameplayChat.tsx`, `src/server/db/queries/daily.ts`, and the new API routes) which completed with existing repo warnings but no new errors related to this change.
- Project lint: `npm run lint` was run and failed due to pre-existing unrelated lint errors elsewhere in the repo (these errors are outside the scope of this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023dff856c832e858456bb1e81fab2)