### PR TITLE
Fix daily answer reveal ordering and canonical-answer handling

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -16,6 +16,8 @@ import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-i
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { type QueueSlot } from '@/server/daily/types';
+import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
+import { suggestAnswer } from '@/lib/llm';
 
 export const dynamic = 'force-dynamic';
 
@@ -33,6 +35,39 @@ function dailyAnswerErrorResponse(status: number, error: DailyAnswerErrorCode, m
 
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
+}
+
+async function resolveCanonicalAnswer(question: typeof generatedQuestions.$inferSelect): Promise<string> {
+  const currentAnswer = normalizeCanonicalAnswerLabel(question.answer);
+  if (!isGenericCanonicalAnswer(currentAnswer)) return currentAnswer;
+
+  const suggestion = await suggestAnswer(question.questionText).catch((error) => {
+    console.warn('[daily/answer] failed to repair generic canonical answer', {
+      generatedQuestionId: question.id,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  });
+  const repairedAnswer = suggestion?.suggested_answer
+    ? normalizeCanonicalAnswerLabel(suggestion.suggested_answer)
+    : null;
+
+  if (!repairedAnswer || isGenericCanonicalAnswer(repairedAnswer)) {
+    return currentAnswer;
+  }
+
+  await db
+    .update(generatedQuestions)
+    .set({ answer: repairedAnswer })
+    .where(eq(generatedQuestions.id, question.id))
+    .catch((error) => {
+      console.warn('[daily/answer] failed to persist repaired canonical answer', {
+        generatedQuestionId: question.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+
+  return repairedAnswer;
 }
 
 function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string } | null {
@@ -99,9 +134,11 @@ export async function POST(request: NextRequest) {
       return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
     }
 
+    const canonicalAnswer = await resolveCanonicalAnswer(question);
+
     const grade = await gradeAnswer(
       parsed.submittedAnswer,
-      question.answer,
+      canonicalAnswer,
       [],
       question.questionText,
       'factual',
@@ -113,7 +150,7 @@ export async function POST(request: NextRequest) {
     const breadcrumb = await generateBreadcrumb({
       questionId: question.id,
       questionText: question.questionText,
-      correctAnswer: question.answer,
+      correctAnswer: canonicalAnswer,
       submittedAnswer: parsed.submittedAnswer,
       isCorrect,
       domain: question.canonicalSubcategory,
@@ -127,7 +164,7 @@ export async function POST(request: NextRequest) {
         answer_state: answerState,
         submitted_answer: parsed.submittedAnswer,
         awarded_points: pointsAwarded,
-        reveal_canonical_answer: question.answer,
+        reveal_canonical_answer: canonicalAnswer,
         reveal_explainer: question.explainer,
         reveal_breadcrumb: breadcrumb,
         reveal_quip: grade.consolation,
@@ -204,10 +241,10 @@ export async function POST(request: NextRequest) {
       answerState,
       breadcrumb,
       masteryDelta,
-      correctAnswer: question.answer,
+      correctAnswer: canonicalAnswer,
       consolation: grade.consolation,
       correct: isCorrect,
-      answer: question.answer,
+      answer: canonicalAnswer,
       explainer: question.explainer,
       awarded_points: pointsAwarded,
       mastery_delta: masteryDelta,

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -551,14 +551,14 @@ function ResultRow({
               <span style={{ color: '#8b1f16', marginRight: '6px' }}>✕</span>
               {wrongHeadline(copyVariant)}
             </p>
-            {consolation ? (
-              <p style={{ marginTop: '6px', fontSize: '0.88rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
-                {consolation}
+            {correctAnswer ? (
+              <p style={{ marginTop: '8px', fontSize: '0.9rem', color: 'var(--text)' }}>
+                <span style={{ fontWeight: 600 }}>Answer:</span> {correctAnswer}
               </p>
             ) : null}
-            {correctAnswer ? (
-              <p style={{ marginTop: '10px', fontSize: '0.9rem', color: 'var(--text)' }}>
-                {correctAnswer}
+            {consolation ? (
+              <p style={{ marginTop: '8px', fontSize: '0.88rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                {consolation}
               </p>
             ) : null}
           </>

--- a/src/server/answers/canonical-answer.ts
+++ b/src/server/answers/canonical-answer.ts
@@ -1,0 +1,23 @@
+const GENERIC_ANSWER_VALUES = new Set([
+  'answer',
+  'the answer',
+  'correct answer',
+  'the correct answer',
+  'canonical answer',
+  'the canonical answer',
+]);
+
+export function normalizeCanonicalAnswerLabel(value: string): string {
+  return value
+    .trim()
+    .replace(/^['"“”‘’]+|['"“”‘’]+$/g, '')
+    .replace(/[.!?]+$/g, '')
+    .replace(/\s+/g, ' ');
+}
+
+export function isGenericCanonicalAnswer(value: string | null | undefined): boolean {
+  if (!value) return true;
+  const normalized = normalizeCanonicalAnswerLabel(value).toLowerCase();
+  if (GENERIC_ANSWER_VALUES.has(normalized)) return true;
+  return /^the answer\s+(?:is|was|would be)$/i.test(normalized);
+}

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -14,6 +14,7 @@ import {
 import { getKnowledgeBase, getRecentDailyQuestionTexts } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
+import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { resolveDailyBasePoints } from './types';
 
 export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
@@ -184,11 +185,14 @@ function parseQuestions(raw: string): LlmQuestion[] {
     if (!canonical || !broad || !questionText || !answer || !explainer || !difficulty) {
       continue;
     }
+    if (isGenericCanonicalAnswer(answer)) {
+      continue;
+    }
     result.push({
       canonical_subcategory: canonical,
       broad_category: broad,
       question_text: questionText,
-      answer,
+      answer: normalizeCanonicalAnswerLabel(answer),
       explainer,
       difficulty_estimate: difficulty,
     });


### PR DESCRIPTION
### Motivation
- Move the revealed canonical answer above the consolation/commentary so the answer is shown first and is clearly labeled.
- Prevent UI and grading from exposing or using generic placeholder answers like “the answer.”
- Ensure generated Daily questions do not include placeholder answers and attempt to repair any existing placeholder answers at submit time.

### Description
- Reordered wrong-answer result cards in `GameplayChat` to show a labeled `Answer:` line before the commentary text.
- Added `src/server/answers/canonical-answer.ts` with `normalizeCanonicalAnswerLabel` and `isGenericCanonicalAnswer` utilities to normalize and detect placeholder answers.
- Updated Daily question parsing in `src/server/daily/generate-questions.ts` to skip questions whose `answer` is a generic placeholder and to normalize accepted answers before storing.
- Enhanced the answer submission flow in `src/app/api/daily/answer/route.ts` to attempt to repair generic canonical answers by calling `suggestAnswer`, persist a repaired answer when available, and then use the resolved canonical answer for grading, breadcrumb generation, queue reveals, and the API response.

### Testing
- Ran targeted ESLint on the changed files with `npx eslint src/app/api/daily/answer/route.ts src/components/play/GameplayChat.tsx src/server/daily/generate-questions.ts src/server/answers/canonical-answer.ts` and the checked files passed.
- Ran TypeScript typecheck with `npx tsc --noEmit --incremental false --pretty false` which completed successfully.
- Ran full lint `npm run lint` which failed due to pre-existing, unrelated lint errors elsewhere in the repo and did not block the targeted changes (changed files passed the targeted lint run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0241e8d61c832eb142141d6a7dde5d)