### PR TITLE
Fix declared interest saves without legacy territory column

### DIFF
--- a/src/server/ceremony/compute-beats.ts
+++ b/src/server/ceremony/compute-beats.ts
@@ -131,14 +131,13 @@ async function computeBeat2(userId: string, cycleStart: Date, cycleEndExclusive:
       )),
     readCorrectQuestionIds(userId, cycleStart, cycleEndExclusive),
     db
-      .select({ domain: declaredInterests.domain })
-      .from(declaredInterests)
+      .select({ domain: playerMastery.canonicalSubcategory })
+      .from(playerMastery)
       .where(and(
-        eq(declaredInterests.userId, userId),
-        eq(declaredInterests.isActive, true),
-        sql`${declaredInterests.territoryType} = 'declared'`,
-        gte(declaredInterests.declaredAt, cycleStart),
-        lt(declaredInterests.declaredAt, cycleEndExclusive),
+        eq(playerMastery.userId, userId),
+        eq(playerMastery.territoryType, 'declared'),
+        gte(playerMastery.updatedAt, cycleStart),
+        lt(playerMastery.updatedAt, cycleEndExclusive),
       )),
     db
       .select({ domain: masteryEvents.canonicalSubcategory })

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -388,7 +388,6 @@ async function _legacyInsertDeclared(
       userId,
       domain,
       broadCategory: broadCategory ?? null,
-      territoryType: 'declared',
     })
     .onConflictDoNothing({
       target: [declaredInterests.userId, declaredInterests.domain],
@@ -401,14 +400,6 @@ async function _legacyInsertDeclared(
  * called. Scheduled for removal in v11.2.
  */
 export async function upgradeKBDomainToDemonstrated(userId: string, domain: string): Promise<void> {
-  const existing = await getKBDomainEntry(userId, domain);
-  if (existing && existing.territoryType === 'declared') {
-    await db
-      .update(declaredInterests)
-      .set({ territoryType: 'demonstrated' })
-      .where(and(
-        eq(declaredInterests.userId, userId),
-        eq(declaredInterests.domain, domain),
-      ));
-  }
+  const { openKBDomain } = await import('@/server/knowledge/open-domain');
+  await openKBDomain({ userId, domain, via: 'answered_correctly' });
 }

--- a/src/server/db/queries/declared-interests.ts
+++ b/src/server/db/queries/declared-interests.ts
@@ -1,7 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 
 import { db, declaredInterests } from '@/server/db';
-import { pgErrorCode } from '@/server/db/pg-error';
 
 export type ActiveDeclaredInterestRow = {
   id: string;
@@ -13,28 +12,22 @@ export type ActiveDeclaredInterestRow = {
   territoryType: 'declared' | 'demonstrated';
 };
 
-// Returns active declared interests for a user. Falls back to a column-narrowed
-// query when the territory_type column is missing on the deployed DB (migration
-// 0014 not yet applied), defaulting territoryType to 'declared'.
+// DeclaredInterest is now only the user's editable interest list. Territory
+// state lives on PLAYER_MASTERY, so keep this query column-narrowed and never
+// select the legacy DeclaredInterest.territory_type column. Some deployed
+// databases do not have that column, and selecting it breaks onboarding saves.
 export async function getActiveDeclaredInterests(userId: string): Promise<ActiveDeclaredInterestRow[]> {
-  try {
-    return await db
-      .select()
-      .from(declaredInterests)
-      .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)));
-  } catch (err) {
-    if (pgErrorCode(err) !== '42703') throw err;
-    const rows = await db
-      .select({
-        id: declaredInterests.id,
-        userId: declaredInterests.userId,
-        domain: declaredInterests.domain,
-        broadCategory: declaredInterests.broadCategory,
-        declaredAt: declaredInterests.declaredAt,
-        isActive: declaredInterests.isActive,
-      })
-      .from(declaredInterests)
-      .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)));
-    return rows.map((row) => ({ ...row, territoryType: 'declared' as const }));
-  }
+  const rows = await db
+    .select({
+      id: declaredInterests.id,
+      userId: declaredInterests.userId,
+      domain: declaredInterests.domain,
+      broadCategory: declaredInterests.broadCategory,
+      declaredAt: declaredInterests.declaredAt,
+      isActive: declaredInterests.isActive,
+    })
+    .from(declaredInterests)
+    .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)));
+
+  return rows.map((row) => ({ ...row, territoryType: 'declared' as const }));
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -620,7 +620,6 @@ export const declaredInterests = pgTable(
     broadCategory: text('broadCategory'),
     declaredAt: timestamp('declaredAt', { withTimezone: true }).notNull().defaultNow(),
     isActive: boolean('isActive').notNull().default(true),
-    territoryType: text('territory_type').$type<'declared' | 'demonstrated'>().notNull().default('declared'),
   },
   (table) => [
     unique('DeclaredInterest_userId_domain_key').on(table.userId, table.domain),


### PR DESCRIPTION
### Motivation
- Onboarding and profile interest saves were generating `INSERT` statements that referenced the legacy `DeclaredInterest.territory_type` column which is missing in some deployed databases, causing failures. 
- The product territory model has moved to `PLAYER_MASTERY`, so reads and promotion logic should align with that canonical source rather than rely on a deprecated column. 

### Description
- Removed the legacy `territory_type` field from the `DeclaredInterest` Drizzle schema so writes no longer reference the missing column (`src/server/db/schema.ts`).
- Tightened `getActiveDeclaredInterests` to explicitly select stable `DeclaredInterest` columns and synthesize an in-memory `territoryType: 'declared'` for legacy consumers (`src/server/db/queries/declared-interests.ts`).
- Stopped writing the legacy `territoryType` in `_legacyInsertDeclared` and routed the deprecated upgrade path to the `PLAYER_MASTERY`-based flow by calling `openKBDomain` with `via: 'answered_correctly'` in `upgradeKBDomainToDemonstrated` (`src/server/db/queries/daily.ts`).
- Switched the ceremony authored-declared lookup to read declared territory from `PLAYER_MASTERY` (`src/server/ceremony/compute-beats.ts`) so promotion/discovery logic uses the current model.

### Testing
- ✅ Type-check: ran `npx tsc --noEmit` with no TypeScript errors introduced.
- ❌ Lint: ran `npm run lint` which failed due to pre-existing unrelated lint issues across the codebase; failures are unrelated to these changes.
- ✅ Basic compile/run checks: updated code built & unit type checks passed locally (see `npx tsc --noEmit`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a024ec0c110832eaa6b303eb42e9b06)