### PR TITLE
Fix daily summary growth point totals

### DIFF
--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -121,12 +121,27 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const pointsByDomain = new Map<string, number>();
   const touchedDomains = new Set<string>();
 
-  for (const slot of slots) {
-    if (slot.domain) touchedDomains.add(slot.domain);
-  }
   for (const event of todayEvents) {
     touchedDomains.add(event.domain);
     pointsByDomain.set(event.domain, (pointsByDomain.get(event.domain) ?? 0) + Number(event.awardedPoints ?? 0));
+  }
+
+  const slotPointsByDomain = new Map<string, number>();
+  for (const slot of slots) {
+    if (!slot.domain) continue;
+    touchedDomains.add(slot.domain);
+
+    const slotPoints = Number(slot.awarded_points ?? 0);
+    if (slotPoints > 0) {
+      slotPointsByDomain.set(slot.domain, (slotPointsByDomain.get(slot.domain) ?? 0) + slotPoints);
+    }
+  }
+
+  for (const [domain, slotPoints] of slotPointsByDomain) {
+    // The queue slot is the source of truth for the visible round total. If the
+    // mastery event write is missing or undercounts a domain, keep the per-domain
+    // recap in sync with the total card instead of showing +0 under a +N total.
+    pointsByDomain.set(domain, Math.max(pointsByDomain.get(domain) ?? 0, slotPoints));
   }
 
   const priorRows = touchedDomains.size > 0
@@ -201,8 +216,8 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const totalSkipped = slots.filter((slot) => slot.skipped).length;
   const totalAnswered = slots.filter((slot) => slot.answered).length;
   const totalCorrect = slots.filter((slot) => slot.answer_state === 'correct').length;
-  const pointsEarned = [...pointsByDomain.values()].reduce((sum, points) => sum + points, 0)
-    || slots.reduce((sum, slot) => sum + Number(slot.awarded_points ?? 0), 0);
+  const pointsEarned = [...pointsByDomain.values()].reduce((sum, points) => sum + points, 0);
+  const gainedDomains = [...touchedDomains].filter((domain) => (pointsByDomain.get(domain) ?? 0) > 0);
 
   return {
     date: dateString,
@@ -212,7 +227,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     pointsEarned,
     difficultyMode: prefs.difficulty,
     questions: recaps,
-    domainGains: [...touchedDomains]
+    domainGains: gainedDomains
       .map((domain) => ({
         domain,
         displayName: displayNameForDomain(domain),


### PR DESCRIPTION
### Motivation
- The Daily Summary UI could show a mismatch where the total card displayed a positive `+N` points but the per-domain growth list showed `+0` because mastery event rows were missing or undercounted for a domain.

### Description
- Aggregate awarded points from answered queue slots and merge them into the `pointsByDomain` map so the queue slot totals are used as a fallback/source-of-truth when mastery events are incomplete. 
- Sum slot-level points per domain and set `pointsByDomain[domain] = Math.max(existing, slotSum)` so per-domain recap is consistent with the visible round total. 
- Compute `pointsEarned` from `pointsByDomain` and restrict `domainGains` to only domains with positive gains so zero-gain domains are hidden from the growth list. 
- Changes are confined to `src/server/db/queries/daily-summary.ts` and preserve existing mastery-event logic for tier crossings.

### Testing
- ✅ Ran `npx eslint src/server/db/queries/daily-summary.ts` (file-level lint passed).
- ✅ Type-check with `npx tsc --noEmit -p tsconfig.typecheck.json` succeeded.
- ⚠️ Ran full project lint `npm run lint` which failed due to pre-existing unrelated lint errors elsewhere in the repo; the modified file does not introduce those failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0254386660832ebfe3df944b5cd7b7)