### PR TITLE
Hotfix: idempotently add UserQuestionBank provenance columns before migrations

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -37,6 +37,20 @@ export async function register() {
       // PLAYER_MASTERY may not exist yet — migrate() handles initial creation.
     }
 
+    // UserQuestionBank provenance columns were added after the original table. If
+    // a preview/production database has the migration marked as applied without
+    // these additive columns present, Drizzle selects fail with Postgres 42703.
+    // Add them idempotently before migrate() so question-bank reads stay safe.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "UserQuestionBank"
+          ADD COLUMN IF NOT EXISTS "added_from_context_type" text,
+          ADD COLUMN IF NOT EXISTS "added_from_context_id" text
+      `);
+    } catch {
+      // UserQuestionBank may not exist yet — migrate() handles initial creation.
+    }
+
     // Several FeedItem columns were introduced after the original table. In preview
     // databases with partially-recorded migrations, Drizzle can believe these
     // migrations already ran while the nullable columns are still absent, causing


### PR DESCRIPTION
### Motivation
- Avoid Postgres 42703 errors when a database has the provenance migration recorded but the additive `UserQuestionBank` columns are not present, which causes Drizzle selects to fail before migrations run.
- Ensure question-bank reads remain safe in preview/production databases with partially-applied migrations by pre-applying additive columns idempotently.

### Description
- Add an instrumentation-time idempotent `ALTER TABLE` block to `src/instrumentation.ts` that runs before `migrate()` and `CREATE SCHEMA` to add `added_from_context_type` and `added_from_context_id` to `UserQuestionBank` if they do not exist.
- Wrap the `ALTER TABLE` in a `try/catch` with a comment noting that the table may not exist yet so `migrate()` will handle initial creation.
- Keep change localized to `src/instrumentation.ts` and follow the same pattern used for other pre-applied additive columns (e.g., `PLAYER_MASTERY`, `FeedItem`).

### Testing
- Ran `npx eslint src/instrumentation.ts` which completed successfully for the modified file.
- Ran `npm run lint` which failed due to unrelated, pre-existing lint issues across the repo and not the instrumentation change.
- Ran `npm run build` which failed in this environment because Next failed to fetch the Google Font `Montserrat` from `fonts.googleapis.com`, blocking a full production build in the current network-limited environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0284897674832e80b74e3a42e99855)