### PR TITLE
Deduplicate missed catch-up questions

### DIFF
--- a/scripts/daily-catchup.smoke.mjs
+++ b/scripts/daily-catchup.smoke.mjs
@@ -1,6 +1,11 @@
 import assert from 'node:assert/strict';
 
 import {
+  dedupeCatchUpItems,
+  orderCatchUpItems,
+} from '../src/server/play/catch-up-turn-sequencing.ts';
+
+import {
   dailyQueueItemId,
   findQueueSlotBySlotIndex,
   isCatchupQueueDate,
@@ -48,3 +53,43 @@ const dismissed = replaceQueueSlot(slots, 3, (slot) => ({
 }));
 
 assert.equal(dismissed[0].dismissed_at, '2026-05-01T12:00:00.000Z');
+
+const duplicateCatchupItems = [
+  {
+    dailyQueueItemId: 'queue-1:0',
+    queueDate: '2026-04-29',
+    wasSkipped: false,
+    questionId: 'generated-synergy-1',
+    questionText: 'In the 1980s cartoon Jem, what was the holographic computer called?',
+    correctAnswer: 'Synergy',
+    domain: '1980s Animation',
+  },
+  {
+    dailyQueueItemId: 'queue-2:0',
+    queueDate: '2026-04-30',
+    wasSkipped: false,
+    questionId: 'generated-synergy-2',
+    questionText: 'Jerrica Benton became Jem with help from which holographic computer?',
+    correctAnswer: 'Synergy',
+    domain: '1980s Animation',
+  },
+  {
+    dailyQueueItemId: 'queue-3:0',
+    queueDate: '2026-04-30',
+    wasSkipped: true,
+    questionId: 'generated-bach',
+    questionText: 'Who composed the Mass in B minor?',
+    correctAnswer: 'Bach',
+    domain: 'Classical Music',
+  },
+];
+
+const sortedCatchupItems = orderCatchUpItems(duplicateCatchupItems);
+assert.equal(sortedCatchupItems[0].dailyQueueItemId, 'queue-3:0');
+
+const dedupedCatchupItems = dedupeCatchUpItems(sortedCatchupItems);
+assert.equal(dedupedCatchupItems.length, 2);
+assert.deepEqual(
+  dedupedCatchupItems.map((item) => item.dailyQueueItemId),
+  ['queue-3:0', 'queue-1:0'],
+);

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -23,7 +23,10 @@ import {
   isCatchUpSlotEligible,
   queueAgeInDays,
 } from '@/server/play/catch-up-eligibility';
-import { orderCatchUpItems } from '@/server/play/catch-up-turn-sequencing';
+import {
+  dedupeCatchUpItems,
+  orderCatchUpItems,
+} from '@/server/play/catch-up-turn-sequencing';
 
 function asQueueSlotDifficulty(
   value: string | null | undefined,
@@ -248,7 +251,7 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
 
-  return orderCatchUpItems(mapped);
+  return dedupeCatchUpItems(orderCatchUpItems(mapped));
 }
 
 export async function createDailyQueueItem(

--- a/src/server/play/catch-up-turn-sequencing.ts
+++ b/src/server/play/catch-up-turn-sequencing.ts
@@ -4,6 +4,57 @@ export type CatchUpSequencingItem = {
   wasSkipped: boolean;
 };
 
+export type CatchUpDuplicateItem = CatchUpSequencingItem & {
+  questionId?: string | null;
+  questionText: string;
+  correctAnswer: string;
+  domain: string;
+};
+
+function normalizeCatchUpDuplicateValue(value: string | null | undefined): string {
+  return (value ?? '')
+    .toLowerCase()
+    .replace(/[\u2018\u2019]/g, "'")
+    .replace(/[\u201c\u201d]/g, '"')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+/**
+ * Catch-up can span several daily queues, so a repeated generated question or a
+ * near-identical regenerated prompt can otherwise appear multiple times in one
+ * missed-question session. Keep the first item from the already-sorted list and
+ * suppress later repeats that share the same source question, prompt text, or
+ * canonical answer within a domain.
+ */
+export function dedupeCatchUpItems<T extends CatchUpDuplicateItem>(items: T[]): T[] {
+  const seenQuestionIds = new Set<string>();
+  const seenQuestionTexts = new Set<string>();
+  const seenDomainAnswers = new Set<string>();
+  const uniqueItems: T[] = [];
+
+  for (const item of items) {
+    const questionId = item.questionId?.trim() ?? '';
+    const questionText = normalizeCatchUpDuplicateValue(item.questionText);
+    const domainAnswer = [
+      normalizeCatchUpDuplicateValue(item.domain),
+      normalizeCatchUpDuplicateValue(item.correctAnswer),
+    ].join('::');
+
+    if (questionId && seenQuestionIds.has(questionId)) continue;
+    if (questionText && seenQuestionTexts.has(questionText)) continue;
+    if (domainAnswer !== '::' && seenDomainAnswers.has(domainAnswer)) continue;
+
+    if (questionId) seenQuestionIds.add(questionId);
+    if (questionText) seenQuestionTexts.add(questionText);
+    if (domainAnswer !== '::') seenDomainAnswers.add(domainAnswer);
+    uniqueItems.push(item);
+  }
+
+  return uniqueItems;
+}
+
 export function hasUnresolvedCatchUpPrompt(
   introducedItemIds: Set<string>,
   resultPostedItemIds: Set<string>,


### PR DESCRIPTION
### Motivation
- Prevent the same or near-identical generated question from appearing multiple times in a single missed-questions (catch-up) session by suppressing duplicates that span prior daily queues.

### Description
- Add `dedupeCatchUpItems` in `src/server/play/catch-up-turn-sequencing.ts` which normalizes prompt text and deduplicates by source `questionId`, normalized `questionText`, or `(domain, correctAnswer)` pairs and keeps the first occurrence.
- Apply deduplication in `getCatchupQuestions` by returning `dedupeCatchUpItems(orderCatchUpItems(mapped))` so ordering is preserved before duplicate suppression (`src/server/db/queries/daily.ts`).
- Extend the daily catch-up smoke test to cover ordering + duplicate suppression with a regression case for similarly-worded generated prompts (`scripts/daily-catchup.smoke.mjs`).

### Testing
- Ran `npm run smoke:daily-catchup` and the smoke script completed successfully.  
- Ran `npx tsc --noEmit --pretty false` and TypeScript type-check passed.  
- Ran `npx eslint src/server/play/catch-up-turn-sequencing.ts src/server/db/queries/daily.ts --ext .ts` which passed (one existing unused-symbol warning remains in `daily.ts`).  
- Ran `npm run lint` which fails on unrelated, preexisting repo-wide lint issues (React hook rules, unescaped entities, and `no-explicit-any` violations) not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0283f99030832eb460b2a952ba774f)