### PR TITLE
Handle empty question bank state

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -16,6 +16,24 @@ type DrawerState =
   | { mode: 'create' }
   | { mode: 'edit'; question: QuestionView };
 
+type QuestionsApiResponse = {
+  questions?: QuestionView[] | null;
+  message?: string;
+  error?: string;
+};
+
+const NO_QUESTIONS_PATTERNS = [
+  /no questions/i,
+  /not found/i,
+  /empty/i,
+];
+
+function isNoQuestionsResponse(response: Response, body: QuestionsApiResponse | null): boolean {
+  const apiMessage = body?.message ?? body?.error ?? '';
+  return response.status === 204
+    || response.status === 404
+    || NO_QUESTIONS_PATTERNS.some((pattern) => pattern.test(apiMessage));
+}
 
 const DIFFICULTY_COPY: Record<number, string> = {
   1: 'Accessible',
@@ -117,8 +135,12 @@ function QuestionsPageContent() {
     setError(null);
     try {
       const response = await fetch('/api/questions', { cache: 'no-store', credentials: 'include' });
-      const body = await response.json().catch(() => null) as { questions?: QuestionView[]; message?: string } | null;
-      if (!response.ok || !Array.isArray(body?.questions)) throw new Error(body?.message ?? 'Could not load your questions.');
+      const body = await response.json().catch(() => null) as QuestionsApiResponse | null;
+      if (isNoQuestionsResponse(response, body)) {
+        setQuestions([]);
+        return;
+      }
+      if (!response.ok || !Array.isArray(body?.questions)) throw new Error(body?.message ?? body?.error ?? 'Could not load your questions.');
       setQuestions(body.questions);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load your questions.');
@@ -308,7 +330,10 @@ function QuestionsPageContent() {
 
       {questions.length === 0 ? (
         <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
-          <h2 className="font-serif text-2xl font-semibold">You haven&apos;t written any questions yet.</h2>
+          <h2 className="font-serif text-2xl font-semibold">No questions yet.</h2>
+          <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+            Your question bank is empty. Write a question or save one from a friend to build your bank.
+          </p>
           <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
             Write a question
           </button>


### PR DESCRIPTION
### Motivation
- The questions page treated API responses that indicate “no questions” as a load failure, producing a confusing error message instead of showing an empty bank UI.
- The change aims to show a clear empty-state when the user has no banked questions and preserve real error behavior for genuine failures.

### Description
- Added a `QuestionsApiResponse` type, `NO_QUESTIONS_PATTERNS`, and `isNoQuestionsResponse` helper to detect empty/no-question API responses in `src/app/questions/page.tsx`.
- Updated the questions fetch flow to treat 204/404 or API messages matching the patterns as an empty bank by calling `setQuestions([])` and returning early.
- Kept existing error handling for other non-OK responses and JSON shapes, and updated the empty-state UI copy to read "No questions yet." with guidance to write or save questions.
- Changes are contained to `src/app/questions/page.tsx` and committed with message "Handle empty question bank state".

### Testing
- Ran `npx eslint src/app/questions/page.tsx` which passed for the modified file.
- Ran `npx tsc --noEmit --pretty false` which completed without TypeScript errors for the modified file.
- Ran `npm run lint` which failed due to pre-existing unrelated lint errors in other files, not changes introduced in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03110fe3e8832eb66a8542fd12a34a)