### PR TITLE
Preserve restrictive profile domain visibility when consolidating domains

### DIFF
--- a/src/server/mastery/__tests__/ceremony-domain-merge.test.ts
+++ b/src/server/mastery/__tests__/ceremony-domain-merge.test.ts
@@ -8,11 +8,17 @@ const state = vi.hoisted(() => ({
   questions: [] as Row[],
   generatedQuestions: [] as Row[],
   skippedDailyQuestions: [] as Row[],
+  profileDomainVisibility: [] as Row[],
   sourceDomains: [] as string[],
+  targetDomain: '' as string,
 }));
 
 function isSourceDomain(value: unknown) {
   return typeof value === 'string' && state.sourceDomains.includes(value);
+}
+
+function isMergedDomain(value: unknown) {
+  return isSourceDomain(value) || (typeof value === 'string' && value === state.targetDomain);
 }
 
 vi.mock('@/server/db', async () => {
@@ -44,7 +50,11 @@ vi.mock('@/server/db', async () => {
             }];
           }
           if (kind === 'declaredInterests') return [];
-          if (kind === 'profileDomainVisibility') return [];
+          if (kind === 'profileDomainVisibility') {
+            return state.profileDomainVisibility.filter(
+              (row) => isMergedDomain(row.domain) || isMergedDomain(row.canonicalSubcategory),
+            );
+          }
           return [];
         }),
       })),
@@ -63,6 +73,7 @@ vi.mock('@/server/db', async () => {
           }
         }
         if (kind === 'masteryEvents') state.masteryEvents.push({ ...values });
+        if (kind === 'profileDomainVisibility') state.profileDomainVisibility.push({ ...values });
         return { onConflictDoUpdate: vi.fn(async () => undefined) };
       }),
     })),
@@ -71,6 +82,11 @@ vi.mock('@/server/db', async () => {
         const kind = tableKind(table);
         if (kind === 'playerMastery') {
           state.playerMastery = state.playerMastery.filter((row) => !isSourceDomain(row.canonicalSubcategory));
+        }
+        if (kind === 'profileDomainVisibility') {
+          state.profileDomainVisibility = state.profileDomainVisibility.filter(
+            (row) => !isMergedDomain(row.domain) && !isMergedDomain(row.canonicalSubcategory),
+          );
         }
       }),
     })),
@@ -112,7 +128,9 @@ describe('applyMergesForUser', () => {
     state.questions = [];
     state.generatedQuestions = [];
     state.skippedDailyQuestions = [];
+    state.profileDomainVisibility = [];
     state.sourceDomains = ['Ulysses – Structure & Symbolism'];
+    state.targetDomain = 'Ulysses';
     vi.clearAllMocks();
   });
 
@@ -170,5 +188,53 @@ describe('applyMergesForUser', () => {
     expect(state.questions).toEqual([expect.objectContaining({ canonicalSubcategory: 'Ulysses', broadCategory: 'Literature' })]);
     expect(state.generatedQuestions).toEqual([expect.objectContaining({ canonicalSubcategory: 'Ulysses', broadCategory: 'Literature' })]);
     expect(state.skippedDailyQuestions).toEqual([expect.objectContaining({ canonicalSubcategory: 'Ulysses' })]);
+  });
+
+  it('keeps the tidied target private when any source visibility is private', async () => {
+    const sourceRow = {
+      id: 'mastery-source',
+      userId: 'user-1',
+      canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+      broadCategory: 'Literature',
+      totalPoints: 42,
+      tier: 'solid' as const,
+      tierReachedAt: null,
+      seasonPointsStart: 7,
+      updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    };
+
+    state.playerMastery = [{ ...sourceRow }];
+    state.profileDomainVisibility = [
+      {
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+        domain: 'Ulysses – Structure & Symbolism',
+        visibility: 'private',
+        isVisible: false,
+      },
+      {
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses',
+        domain: 'Ulysses',
+        visibility: 'public',
+        isVisible: true,
+      },
+    ];
+
+    await applyMergesForUser('user-1', [sourceRow], [{
+      sources: ['Ulysses – Structure & Symbolism'],
+      target: 'Ulysses',
+      rationale: 'Facet should roll up to parent work.',
+    }]);
+
+    expect(state.profileDomainVisibility).toEqual([
+      expect.objectContaining({
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses',
+        domain: 'Ulysses',
+        visibility: 'private',
+        isVisible: false,
+      }),
+    ]);
   });
 });

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -185,10 +185,22 @@ async function upsertMergedPlayerMastery(
 
 type DomainVisibility = 'public' | 'friends' | 'private';
 
+const DOMAIN_VISIBILITY_RANK: Record<DomainVisibility, number> = {
+  public: 0,
+  friends: 1,
+  private: 2,
+};
+
 function mostRestrictiveVisibility(rows: Array<{ visibility: DomainVisibility }>): DomainVisibility {
-  if (rows.some((row) => row.visibility === 'private')) return 'private';
-  if (rows.some((row) => row.visibility === 'friends')) return 'friends';
-  return 'public';
+  return rows.reduce<DomainVisibility>((mostRestrictive, row) => (
+    DOMAIN_VISIBILITY_RANK[row.visibility] > DOMAIN_VISIBILITY_RANK[mostRestrictive]
+      ? row.visibility
+      : mostRestrictive
+  ), 'public');
+}
+
+function isProfileDomainVisible(visibility: DomainVisibility): boolean {
+  return visibility !== 'private';
 }
 
 export async function consolidateProfileDomainVisibility(
@@ -231,7 +243,7 @@ export async function consolidateProfileDomainVisibility(
       canonicalSubcategory: target,
       domain: target,
       visibility,
-      isVisible: visibility !== 'private',
+      isVisible: isProfileDomainVisible(visibility),
       updatedAt: values.updatedAt ?? new Date(),
     });
 }


### PR DESCRIPTION
### Motivation

- Ensure domain-merge tidies preserve the most restrictive profile visibility among the merged rows so a private source can make a target private.

### Description

- Add `DOMAIN_VISIBILITY_RANK` and replace the ad-hoc checks with `mostRestrictiveVisibility` that reduces rows by rank to pick the most restrictive value.
- Introduce `isProfileDomainVisible` and derive `isVisible` from the consolidated visibility so only `private` maps to `isVisible: false` and `friends`/`public` map to `true` in `consolidateProfileDomainVisibility` (`src/server/mastery/ceremony.ts`).
- Extend the merge test harness to simulate reading, deleting and inserting `PROFILE_DOMAIN_VISIBILITY` rows and add a regression test that verifies a private source domain makes the tidied target private (`src/server/mastery/__tests__/ceremony-domain-merge.test.ts`).

### Testing

- Attempted to run the domain merge tests with `npx vitest run src/server/mastery/__tests__/ceremony-visibility.test.ts src/server/mastery/__tests__/ceremony-domain-merge.test.ts`, but the run was blocked due to missing `vitest` installation / npm registry `403 Forbidden` error.
- Type-checking with `npx tsc --noEmit` completed successfully.
- Linting the two changed files with `npx eslint src/server/mastery/ceremony.ts src/server/mastery/__tests__/ceremony-domain-merge.test.ts --max-warnings=0` completed successfully, while the project-wide `npm run lint` reported pre-existing unrelated issues outside the touched files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0318ac13c0832e9b5d476435ff18a9)