### PR TITLE
Extend domain merge cleanup to retarget daily prefs, difficulties, exclusions and dismissals

### DIFF
--- a/src/server/mastery/__tests__/ceremony-domain-merge.test.ts
+++ b/src/server/mastery/__tests__/ceremony-domain-merge.test.ts
@@ -9,6 +9,10 @@ const state = vi.hoisted(() => ({
   generatedQuestions: [] as Row[],
   skippedDailyQuestions: [] as Row[],
   profileDomainVisibility: [] as Row[],
+  dailyPreferences: [] as Row[],
+  userDomainDifficulties: [] as Row[],
+  userDomainExclusions: [] as Row[],
+  feedDismissedDomains: [] as Row[],
   sourceDomains: [] as string[],
   targetDomain: '' as string,
 }));
@@ -32,6 +36,10 @@ vi.mock('@/server/db', async () => {
     if (table === schema.skippedDailyQuestions) return 'skippedDailyQuestions';
     if (table === schema.declaredInterests) return 'declaredInterests';
     if (table === schema.profileDomainVisibility) return 'profileDomainVisibility';
+    if (table === schema.dailyPreferences) return 'dailyPreferences';
+    if (table === schema.userDomainDifficulties) return 'userDomainDifficulties';
+    if (table === schema.userDomainExclusions) return 'userDomainExclusions';
+    if (table === schema.feedDismissedDomains) return 'feedDismissedDomains';
     return 'unknown';
   }
 
@@ -50,6 +58,9 @@ vi.mock('@/server/db', async () => {
             }];
           }
           if (kind === 'declaredInterests') return [];
+          if (kind === 'dailyPreferences') return state.dailyPreferences;
+          if (kind === 'userDomainDifficulties') return state.userDomainDifficulties.filter((row) => isMergedDomain(row.canonicalSubcategory));
+          if (kind === 'userDomainExclusions') return state.userDomainExclusions.filter((row) => isSourceDomain(row.canonicalSubcategory));
           if (kind === 'profileDomainVisibility') {
             return state.profileDomainVisibility.filter(
               (row) => isMergedDomain(row.domain) || isMergedDomain(row.canonicalSubcategory),
@@ -74,7 +85,26 @@ vi.mock('@/server/db', async () => {
         }
         if (kind === 'masteryEvents') state.masteryEvents.push({ ...values });
         if (kind === 'profileDomainVisibility') state.profileDomainVisibility.push({ ...values });
-        return { onConflictDoUpdate: vi.fn(async () => undefined) };
+        if (kind === 'userDomainDifficulties') {
+          const existingIndex = state.userDomainDifficulties.findIndex(
+            (row) => row.userId === values.userId && row.canonicalSubcategory === values.canonicalSubcategory,
+          );
+          if (existingIndex >= 0) {
+            state.userDomainDifficulties[existingIndex] = { ...state.userDomainDifficulties[existingIndex], ...values };
+          } else {
+            state.userDomainDifficulties.push({ ...values });
+          }
+        }
+        if (kind === 'userDomainExclusions') {
+          const exists = state.userDomainExclusions.some(
+            (row) => row.userId === values.userId && row.canonicalSubcategory === values.canonicalSubcategory,
+          );
+          if (!exists) state.userDomainExclusions.push({ ...values });
+        }
+        return {
+          onConflictDoUpdate: vi.fn(async () => undefined),
+          onConflictDoNothing: vi.fn(async () => undefined),
+        };
       }),
     })),
     delete: vi.fn((table: unknown) => ({
@@ -88,8 +118,34 @@ vi.mock('@/server/db', async () => {
             (row) => !isMergedDomain(row.domain) && !isMergedDomain(row.canonicalSubcategory),
           );
         }
+        if (kind === 'userDomainDifficulties') {
+          state.userDomainDifficulties = state.userDomainDifficulties.filter((row) => !isSourceDomain(row.canonicalSubcategory));
+        }
+        if (kind === 'userDomainExclusions') {
+          state.userDomainExclusions = state.userDomainExclusions.filter((row) => !isSourceDomain(row.canonicalSubcategory));
+        }
+        if (kind === 'feedDismissedDomains') {
+          state.feedDismissedDomains = state.feedDismissedDomains.filter((row) => !isSourceDomain(row.canonicalSubcategory));
+        }
       }),
     })),
+    execute: vi.fn(async () => {
+      const activeSourceDismissals = state.feedDismissedDomains.filter(
+        (row) => isSourceDomain(row.canonicalSubcategory) && row.reinstatedAt == null,
+      );
+      const hasActiveTarget = state.feedDismissedDomains.some(
+        (row) => row.canonicalSubcategory === state.targetDomain && row.reinstatedAt == null,
+      );
+      if (activeSourceDismissals.length > 0 && !hasActiveTarget) {
+        state.feedDismissedDomains.push({
+          id: 'dismissed-target',
+          userId: 'user-1',
+          canonicalSubcategory: state.targetDomain,
+          dismissedAt: activeSourceDismissals[0].dismissedAt,
+          reinstatedAt: null,
+        });
+      }
+    }),
     update: vi.fn((table: unknown) => ({
       set: vi.fn((values: Row) => ({
         where: vi.fn(async () => {
@@ -102,9 +158,11 @@ vi.mock('@/server/db', async () => {
                 ? state.generatedQuestions
                 : kind === 'skippedDailyQuestions'
                   ? state.skippedDailyQuestions
-                  : [];
+                  : kind === 'dailyPreferences'
+                    ? state.dailyPreferences
+                    : [];
           for (const row of rows) {
-            if (isSourceDomain(row.canonicalSubcategory)) Object.assign(row, values);
+            if (kind === 'dailyPreferences' || isSourceDomain(row.canonicalSubcategory)) Object.assign(row, values);
           }
         }),
       })),
@@ -129,6 +187,10 @@ describe('applyMergesForUser', () => {
     state.generatedQuestions = [];
     state.skippedDailyQuestions = [];
     state.profileDomainVisibility = [];
+    state.dailyPreferences = [];
+    state.userDomainDifficulties = [];
+    state.userDomainExclusions = [];
+    state.feedDismissedDomains = [];
     state.sourceDomains = ['Ulysses – Structure & Symbolism'];
     state.targetDomain = 'Ulysses';
     vi.clearAllMocks();
@@ -236,5 +298,92 @@ describe('applyMergesForUser', () => {
         isVisible: false,
       }),
     ]);
+  });
+
+  it('retargets user domain label tables and removes source domain references', async () => {
+    const sourceRow = {
+      id: 'mastery-source',
+      userId: 'user-1',
+      canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+      broadCategory: 'Literature',
+      totalPoints: 42,
+      tier: 'solid' as const,
+      tierReachedAt: null,
+      seasonPointsStart: 7,
+      updatedAt: new Date('2026-05-01T00:00:00.000Z'),
+    };
+
+    state.playerMastery = [{ ...sourceRow }];
+    state.dailyPreferences = [{
+      id: 'daily-pref-1',
+      userId: 'user-1',
+      selectedDomains: ['Ulysses – Structure & Symbolism', 'Ulysses', 'Modernism'],
+    }];
+    state.userDomainDifficulties = [
+      {
+        id: 'difficulty-source',
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+        servedDifficulty: 'specialist',
+        consecutiveCorrect: 1,
+        consecutiveIncorrect: 0,
+        lastUpdated: new Date('2026-05-05T00:00:00.000Z'),
+      },
+      {
+        id: 'difficulty-target',
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses',
+        servedDifficulty: 'accessible',
+        consecutiveCorrect: 0,
+        consecutiveIncorrect: 1,
+        lastUpdated: new Date('2026-05-01T00:00:00.000Z'),
+      },
+    ];
+    state.userDomainExclusions = [{
+      id: 'exclusion-source',
+      userId: 'user-1',
+      canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+      excludedAt: new Date('2026-05-02T00:00:00.000Z'),
+    }];
+    state.feedDismissedDomains = [
+      {
+        id: 'dismissed-source',
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses – Structure & Symbolism',
+        dismissedAt: new Date('2026-05-03T00:00:00.000Z'),
+        reinstatedAt: null,
+      },
+    ];
+
+    await applyMergesForUser('user-1', [sourceRow], [{
+      sources: ['Ulysses – Structure & Symbolism'],
+      target: 'Ulysses',
+      rationale: 'Facet should roll up to parent work.',
+    }]);
+
+    expect(state.dailyPreferences[0].selectedDomains).toEqual(['Ulysses', 'Modernism']);
+    expect(state.userDomainDifficulties).toEqual([
+      expect.objectContaining({
+        userId: 'user-1',
+        canonicalSubcategory: 'Ulysses',
+        servedDifficulty: 'specialist',
+        consecutiveCorrect: 1,
+        consecutiveIncorrect: 0,
+      }),
+    ]);
+    expect(state.userDomainExclusions).toEqual([
+      expect.objectContaining({ userId: 'user-1', canonicalSubcategory: 'Ulysses' }),
+    ]);
+    expect(state.feedDismissedDomains).toEqual([
+      expect.objectContaining({ userId: 'user-1', canonicalSubcategory: 'Ulysses', reinstatedAt: null }),
+    ]);
+
+    const sourceDomainReferences = [
+      ...state.dailyPreferences.flatMap((row) => row.selectedDomains as string[]),
+      ...state.userDomainDifficulties.map((row) => row.canonicalSubcategory),
+      ...state.userDomainExclusions.map((row) => row.canonicalSubcategory),
+      ...state.feedDismissedDomains.map((row) => row.canonicalSubcategory),
+    ].filter((domain) => domain === 'Ulysses – Structure & Symbolism');
+    expect(sourceDomainReferences).toEqual([]);
   });
 });

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -3,11 +3,15 @@ import { randomUUID } from 'node:crypto';
 import { and, asc, desc, eq, gte, inArray, lte, or, sql } from 'drizzle-orm';
 
 import {
+  dailyPreferences,
   db,
   declaredInterests,
+  feedDismissedDomains,
   generatedQuestions,
   masteryEvents,
   playerMastery,
+  userDomainDifficulties,
+  userDomainExclusions,
   profileDomainVisibility,
   questions,
   skippedDailyQuestions,
@@ -248,6 +252,182 @@ export async function consolidateProfileDomainVisibility(
     });
 }
 
+function mergeDomainList(domains: string[], sourceDomains: string[], target: string): string[] {
+  const sourceKeys = new Set(sourceDomains.map(domainKey));
+  const seen = new Set<string>();
+  const merged: string[] = [];
+
+  for (const rawDomain of domains) {
+    if (typeof rawDomain !== 'string') continue;
+    const normalized = normalizeDomain(rawDomain);
+    if (!normalized) continue;
+    const nextDomain = sourceKeys.has(domainKey(normalized)) ? target : normalized;
+    const nextKey = domainKey(nextDomain);
+    if (seen.has(nextKey)) continue;
+    seen.add(nextKey);
+    merged.push(nextDomain);
+  }
+
+  return merged;
+}
+
+async function consolidateDailyPreferenceDomains(
+  tx: DbClient,
+  values: { userId: string; sourceDomains: string[]; target: string },
+): Promise<void> {
+  const [preference] = await tx
+    .select({ id: dailyPreferences.id, selectedDomains: dailyPreferences.selectedDomains })
+    .from(dailyPreferences)
+    .where(eq(dailyPreferences.userId, values.userId));
+
+  if (!preference) return;
+
+  const selectedDomains = mergeDomainList(preference.selectedDomains ?? [], values.sourceDomains, values.target);
+  const before = (preference.selectedDomains ?? []).filter((domain): domain is string => typeof domain === 'string');
+  const changed = selectedDomains.length !== before.length
+    || selectedDomains.some((domain, index) => domain !== before[index]);
+
+  if (!changed) return;
+
+  await tx
+    .update(dailyPreferences)
+    .set({ selectedDomains, updatedAt: new Date() })
+    .where(eq(dailyPreferences.id, preference.id));
+}
+
+type DomainDifficultyRow = Pick<
+  typeof userDomainDifficulties.$inferSelect,
+  'canonicalSubcategory' | 'servedDifficulty' | 'consecutiveCorrect' | 'consecutiveIncorrect' | 'lastUpdated'
+>;
+
+function mostRecentDomainDifficulty(rows: DomainDifficultyRow[]): DomainDifficultyRow {
+  return [...rows].sort((a, b) => {
+    const bTime = b.lastUpdated?.getTime?.() ?? 0;
+    const aTime = a.lastUpdated?.getTime?.() ?? 0;
+    return bTime - aTime;
+  })[0];
+}
+
+async function consolidateUserDomainDifficulties(
+  tx: DbClient,
+  values: { userId: string; sourceDomains: string[]; sourceDomainsToDelete: string[]; target: string },
+): Promise<void> {
+  const domainsToConsolidate = [...new Set([...values.sourceDomains, values.target].map(normalizeDomain).filter(Boolean))];
+  const rows = await tx
+    .select({
+      canonicalSubcategory: userDomainDifficulties.canonicalSubcategory,
+      servedDifficulty: userDomainDifficulties.servedDifficulty,
+      consecutiveCorrect: userDomainDifficulties.consecutiveCorrect,
+      consecutiveIncorrect: userDomainDifficulties.consecutiveIncorrect,
+      lastUpdated: userDomainDifficulties.lastUpdated,
+    })
+    .from(userDomainDifficulties)
+    .where(and(
+      eq(userDomainDifficulties.userId, values.userId),
+      inArray(userDomainDifficulties.canonicalSubcategory, domainsToConsolidate),
+    ));
+
+  if (rows.length > 0) {
+    // Treat the most recently updated row as the user's current adaptive preference.
+    // Streak counters are kept from that same row so we do not fabricate a cross-domain
+    // consecutive streak while still carrying forward the latest calibration.
+    const selected = mostRecentDomainDifficulty(rows);
+    await tx
+      .insert(userDomainDifficulties)
+      .values({
+        userId: values.userId,
+        canonicalSubcategory: values.target,
+        servedDifficulty: selected.servedDifficulty,
+        consecutiveCorrect: selected.consecutiveCorrect,
+        consecutiveIncorrect: selected.consecutiveIncorrect,
+        lastUpdated: selected.lastUpdated ?? new Date(),
+      })
+      .onConflictDoUpdate({
+        target: [userDomainDifficulties.userId, userDomainDifficulties.canonicalSubcategory],
+        set: {
+          servedDifficulty: selected.servedDifficulty,
+          consecutiveCorrect: selected.consecutiveCorrect,
+          consecutiveIncorrect: selected.consecutiveIncorrect,
+          lastUpdated: selected.lastUpdated ?? new Date(),
+        },
+      });
+  }
+
+  if (values.sourceDomainsToDelete.length > 0) {
+    await tx
+      .delete(userDomainDifficulties)
+      .where(and(
+        eq(userDomainDifficulties.userId, values.userId),
+        inArray(userDomainDifficulties.canonicalSubcategory, values.sourceDomainsToDelete),
+      ));
+  }
+}
+
+async function consolidateUserDomainExclusions(
+  tx: DbClient,
+  values: { userId: string; sourceDomains: string[]; sourceDomainsToDelete: string[]; target: string },
+): Promise<void> {
+  const rows = await tx
+    .select({ excludedAt: userDomainExclusions.excludedAt })
+    .from(userDomainExclusions)
+    .where(and(
+      eq(userDomainExclusions.userId, values.userId),
+      inArray(userDomainExclusions.canonicalSubcategory, values.sourceDomains),
+    ));
+
+  if (rows.length > 0) {
+    const earliestExcludedAt = rows.reduce<Date | null>((earliest, row) => {
+      if (!row.excludedAt) return earliest;
+      return !earliest || row.excludedAt < earliest ? row.excludedAt : earliest;
+    }, null) ?? new Date();
+
+    await tx
+      .insert(userDomainExclusions)
+      .values({
+        userId: values.userId,
+        canonicalSubcategory: values.target,
+        excludedAt: earliestExcludedAt,
+      })
+      .onConflictDoNothing({
+        target: [userDomainExclusions.userId, userDomainExclusions.canonicalSubcategory],
+      });
+  }
+
+  if (values.sourceDomainsToDelete.length > 0) {
+    await tx
+      .delete(userDomainExclusions)
+      .where(and(
+        eq(userDomainExclusions.userId, values.userId),
+        inArray(userDomainExclusions.canonicalSubcategory, values.sourceDomainsToDelete),
+      ));
+  }
+}
+
+async function consolidateFeedDismissedDomains(
+  tx: DbClient,
+  values: { userId: string; sourceDomainsToDelete: string[]; target: string },
+): Promise<void> {
+  if (values.sourceDomainsToDelete.length === 0) return;
+
+  await tx.execute(sql`
+    insert into "FeedDismissedDomain" ("id", "userId", "canonicalSubcategory", "dismissedAt", "reinstatedAt")
+    select ${randomUUID()}, ${values.userId}, ${values.target}, min("dismissedAt"), null
+    from "FeedDismissedDomain"
+    where "userId" = ${values.userId}
+      and "canonicalSubcategory" in (${sql.join(values.sourceDomainsToDelete.map((domain) => sql`${domain}`), sql`, `)})
+      and "reinstatedAt" is null
+    having count(*) > 0
+    on conflict do nothing
+  `);
+
+  await tx
+    .delete(feedDismissedDomains)
+    .where(and(
+      eq(feedDismissedDomains.userId, values.userId),
+      inArray(feedDismissedDomains.canonicalSubcategory, values.sourceDomainsToDelete),
+    ));
+}
+
 function parseSuggestedMerges(raw: unknown): SuggestedMerge[] {
   const record = raw && typeof raw === 'object' && !Array.isArray(raw) ? raw as Record<string, unknown> : null;
   if (!record || !Array.isArray(record.merges)) return [];
@@ -459,6 +639,32 @@ export async function applyMergesForUser(
       await consolidateProfileDomainVisibility(tx, {
         userId,
         sourceDomains,
+        target,
+      });
+
+      await consolidateDailyPreferenceDomains(tx, {
+        userId,
+        sourceDomains,
+        target,
+      });
+
+      await consolidateUserDomainDifficulties(tx, {
+        userId,
+        sourceDomains,
+        sourceDomainsToDelete,
+        target,
+      });
+
+      await consolidateUserDomainExclusions(tx, {
+        userId,
+        sourceDomains,
+        sourceDomainsToDelete,
+        target,
+      });
+
+      await consolidateFeedDismissedDomains(tx, {
+        userId,
+        sourceDomainsToDelete,
         target,
       });
 


### PR DESCRIPTION
### Motivation
- Ensure that when domain labels are merged the application updates every table that stores user domain labels beyond mastery/profile visibility so no stale source references remain.
- Preserve user intent and adaptive state (selected daily domains, per-domain difficulty, explicit exclusions, and active feed dismissals) when consolidating labels.

### Description
- Added helpers in `src/server/mastery/ceremony.ts`: `mergeDomainList`, `consolidateDailyPreferenceDomains`, `consolidateUserDomainDifficulties`, `consolidateUserDomainExclusions`, and `consolidateFeedDismissedDomains`, and imported `dailyPreferences`, `userDomainDifficulties`, `userDomainExclusions`, and `feedDismissedDomains` from the schema.  
- `DailyPreference.selected_domains` are retargeted from source → target with normalization and deduplication and persisted back when changed.  
- `USER_DOMAIN_DIFFICULTY` rows are merged by selecting the most recently updated row to preserve served difficulty and streak counters, upserting to the target, and deleting source rows.  
- `USER_DOMAIN_EXCLUSIONS` are consolidated by ensuring any source exclusion makes the target excluded (preserving the earliest excludedAt) and deleting source exclusion rows.  
- `FeedDismissedDomain` active dismissals are moved using an `INSERT ... SELECT` that resolves unique-index conflicts, then source dismissal rows are deleted.  
- Wired these consolidations into `applyMergesForUser` so they run during the transactional merge flow, and added a regression test exercising these tables in `src/server/mastery/__tests__/ceremony-domain-merge.test.ts` that creates source rows, runs a merge, and verifies no source references remain.

### Testing
- Ran linting: `npx --no-install eslint src/server/mastery/ceremony.ts src/server/mastery/__tests__/ceremony-domain-merge.test.ts` which passed.  
- Type-checked: `npx --no-install tsc --noEmit --incremental false` which passed.  
- Added regression test `ceremony-domain-merge.test.ts` to cover `DailyPreference`, `USER_DOMAIN_DIFFICULTY`, `USER_DOMAIN_EXCLUSIONS`, and `FeedDismissedDomain`; running unit tests with `vitest` was attempted but blocked because `vitest` could not be installed in the environment (npm registry returned 403), so full test run was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a031d334ac0832ea948deb4ba4d15ac)