### PR TITLE
Repair Question generated-question schema guard

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -51,6 +51,48 @@ export async function register() {
       // UserQuestionBank may not exist yet — migrate() handles initial creation.
     }
 
+    // Question generated-question provenance columns and constraints were added
+    // in migration 0018. If that migration is recorded without these additive
+    // pieces present, "my questions" reads can fail before migrate() repairs them.
+    // Add the columns, foreign key, and unique index idempotently before migrate().
+    try {
+      await db.execute(sql`
+        ALTER TABLE "Question"
+          ADD COLUMN IF NOT EXISTS "generated_question_id" text,
+          ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'authored' NOT NULL
+      `);
+      await db.execute(sql`
+        DO $$
+        DECLARE
+          question_table regclass := to_regclass('public."Question"');
+          generated_question_table regclass := to_regclass('public."GeneratedQuestion"');
+        BEGIN
+          IF question_table IS NOT NULL
+            AND generated_question_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM pg_constraint
+              WHERE conname = 'Question_generated_question_id_GeneratedQuestion_id_fk'
+                AND conrelid = question_table
+            )
+          THEN
+            ALTER TABLE "Question"
+              ADD CONSTRAINT "Question_generated_question_id_GeneratedQuestion_id_fk"
+              FOREIGN KEY ("generated_question_id")
+              REFERENCES "GeneratedQuestion"("id")
+              ON DELETE set null;
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "Question_generated_question_id_key"
+        ON "Question" USING btree ("generated_question_id")
+      `);
+    } catch {
+      // Question or GeneratedQuestion may not exist yet — migrate() handles
+      // initial creation and the 0018 migration will add these schema pieces.
+    }
+
     // Several FeedItem columns were introduced after the original table. In preview
     // databases with partially-recorded migrations, Drizzle can believe these
     // migrations already ran while the nullable columns are still absent, causing


### PR DESCRIPTION
### Motivation
- Migration `0018` adds additive `Question` columns and constraints that may be recorded as applied on databases where those columns/constraints are still missing, causing Drizzle selects to fail with Postgres 42703 and breaking the "my questions" paths. 
- Pre-apply the additive pieces idempotently before calling `migrate()` so runtime reads remain safe while allowing normal migrations to run on fresh databases. 
- Keep behavior consistent with existing instrumentation: perform guarded SQL and swallow errors when the relevant tables are not yet present.

### Description
- Added a guarded pre-`migrate()` block in `src/instrumentation.ts` that runs `ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "generated_question_id" text` and `ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'authored' NOT NULL` inside a `try/catch` so fresh DBs are not blocked. 
- Added an idempotent creation of the foreign key `Question_generated_question_id_GeneratedQuestion_id_fk` using a `DO $$ ... END $$` block that first checks `to_regclass('public."Question"')` and `to_regclass('public."GeneratedQuestion"')` and only adds the constraint when both tables exist and the constraint is absent. 
- Created the unique index `Question_generated_question_id_key` with `CREATE UNIQUE INDEX IF NOT EXISTS` and preserved the existing swallow-on-error instrumentation style so normal migrations handle initial schema creation.

### Testing
- `npx tsc --noEmit --incremental false` was run and passed. 
- `npm run lint` was executed and reported failures, but those are existing unrelated lint errors in other files (for example `src/app/account/page.tsx` and `src/app/ceremony/[ceremonyId]/page.tsx`) and are not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a032382f01c832e9b862e8f7576576d)