### PR TITLE
Restore homepage headline and move Today’s Five messaging into card

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,37 +1,45 @@
-import Link from 'next/link';
-import FeedList from '@/components/FeedList';
-import TodaysFiveCard from '@/components/TodaysFiveCard';
-import { getSession } from '@/server/auth/session';
-import { getCatchupQuestions } from '@/server/db/queries/daily';
+import Link from 'next/link'
+import FeedList from '@/components/FeedList'
+import TodaysFiveCard from '@/components/TodaysFiveCard'
+import { getSession } from '@/server/auth/session'
+import { getCatchupQuestions } from '@/server/db/queries/daily'
 
 export default async function Home() {
-  const session = await getSession();
-  const catchupItems = session ? await getCatchupQuestions(session.userId) : [];
-  const catchupCount = catchupItems.length;
-  const expiringCount = catchupItems.filter((item) => item.expiresSoon).length;
+  const session = await getSession()
+  const catchupItems = session ? await getCatchupQuestions(session.userId) : []
+  const catchupCount = catchupItems.length
+  const expiringCount = catchupItems.filter((item) => item.expiresSoon).length
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24 md:py-10">
       <section className="border-b pb-6 md:flex md:items-end md:justify-between md:gap-8">
         <div className="max-w-2xl">
-          <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
             Joshing
           </p>
-          <h1 className="mt-3 font-serif text-4xl font-semibold leading-tight text-foreground md:text-5xl">
-            Today&apos;s five is ready when you are.
+          <h1 className="text-foreground mt-3 font-serif text-4xl leading-tight font-semibold md:text-5xl">
+            You contain multitudes.
           </h1>
-          <p className="mt-4 max-w-xl text-base leading-7 text-muted-foreground">
-            Play five questions, build your knowledge map, and keep the day moving.
+          <p className="text-muted-foreground mt-4 max-w-xl text-base leading-7">
+            A small daily game for seeing what you know, what your friends know,
+            and how your map keeps changing.
           </p>
         </div>
         <div className="mt-6 w-full space-y-3 md:mt-0 md:max-w-xs">
           <TodaysFiveCard />
-          {catchupCount > 0 ? <CatchupCard count={catchupCount} expiringCount={expiringCount} /> : null}
-          <div className="rounded-lg border bg-card p-4 text-card-foreground">
-            <p className="mb-3 text-xs font-medium uppercase tracking-[0.1em] text-muted-foreground">What&apos;s happening</p>
+          {catchupCount > 0 ? (
+            <CatchupCard count={catchupCount} expiringCount={expiringCount} />
+          ) : null}
+          <div className="bg-card text-card-foreground rounded-lg border p-4">
+            <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
+              What&apos;s happening
+            </p>
             <FeedList limit={3} />
             <div className="mt-2 flex justify-end">
-              <Link href="/feed" className="text-sm font-medium underline-offset-4 hover:underline">
+              <Link
+                href="/feed"
+                className="text-sm font-medium underline-offset-4 hover:underline"
+              >
                 Feed
               </Link>
             </div>
@@ -39,30 +47,49 @@ export default async function Home() {
         </div>
       </section>
     </main>
-  );
+  )
 }
 
-function CatchupCard({ count, expiringCount }: { count: number; expiringCount: number }) {
+function CatchupCard({
+  count,
+  expiringCount,
+}: {
+  count: number
+  expiringCount: number
+}) {
   return (
     <div
-      className="rounded-lg border bg-card p-4 text-card-foreground"
-      style={expiringCount > 0 ? {
-        borderColor: 'color-mix(in srgb, #b45309 32%, var(--border))',
-        boxShadow: '0 0 0 1px color-mix(in srgb, #b45309 10%, transparent)',
-      } : undefined}
+      className="bg-card text-card-foreground rounded-lg border p-4"
+      style={
+        expiringCount > 0
+          ? {
+              borderColor: 'color-mix(in srgb, #b45309 32%, var(--border))',
+              boxShadow:
+                '0 0 0 1px color-mix(in srgb, #b45309 10%, transparent)',
+            }
+          : undefined
+      }
     >
-      <p className="text-sm font-semibold text-foreground">
+      <p className="text-foreground text-sm font-semibold">
         {count} {count === 1 ? 'question' : 'questions'} you missed
       </p>
-      <p className="mt-1 text-sm leading-6 text-muted-foreground">Catch up - 0.25x points</p>
+      <p className="text-muted-foreground mt-1 text-sm leading-6">
+        Catch up - 0.25x points
+      </p>
       {expiringCount > 0 ? (
-        <p className="mt-1 text-xs font-medium uppercase tracking-[0.08em]" style={{ color: '#b45309' }}>
+        <p
+          className="mt-1 text-xs font-medium tracking-[0.08em] uppercase"
+          style={{ color: '#b45309' }}
+        >
           {expiringCount} expires tomorrow
         </p>
       ) : null}
-      <Link href="/daily/catchup" className="btn-ghost mt-4 min-h-11 w-full justify-center">
+      <Link
+        href="/daily/catchup"
+        className="btn-ghost mt-4 min-h-11 w-full justify-center"
+      >
         Catch up →
       </Link>
     </div>
-  );
+  )
 }

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -1,16 +1,16 @@
-'use client';
+'use client'
 
-import Link from 'next/link';
-import { CheckCircle2, Clock, MessageCircleQuestion } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import Link from 'next/link'
+import { CheckCircle2, Clock, MessageCircleQuestion } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
 
 type DailyStatus = {
-  questionsRemaining: number;
-  questionsAnswered: number;
-  isComplete: boolean;
-  nextRoundAt: string;
-  queueId: string | null;
-};
+  questionsRemaining: number
+  questionsAnswered: number
+  isComplete: boolean
+  nextRoundAt: string
+  queueId: string | null
+}
 
 const FALLBACK_STATUS: DailyStatus = {
   questionsRemaining: 5,
@@ -18,46 +18,48 @@ const FALLBACK_STATUS: DailyStatus = {
   isComplete: false,
   nextRoundAt: new Date().toISOString(),
   queueId: null,
-};
+}
 
 function formatCountdown(targetIso: string, nowMs: number): string {
-  const targetMs = Date.parse(targetIso);
-  if (!Number.isFinite(targetMs)) return 'any second now';
+  const targetMs = Date.parse(targetIso)
+  if (!Number.isFinite(targetMs)) return 'any second now'
 
-  const remainingMs = targetMs - nowMs;
-  if (remainingMs < 60_000) return 'any second now';
+  const remainingMs = targetMs - nowMs
+  if (remainingMs < 60_000) return 'any second now'
 
-  const totalMinutes = Math.ceil(remainingMs / 60_000);
+  const totalMinutes = Math.ceil(remainingMs / 60_000)
   if (totalMinutes > 60) {
-    const hours = Math.floor(totalMinutes / 60);
-    const minutes = totalMinutes % 60;
-    return `${hours}h ${minutes}m`;
+    const hours = Math.floor(totalMinutes / 60)
+    const minutes = totalMinutes % 60
+    return `${hours}h ${minutes}m`
   }
 
-  return `${totalMinutes}m`;
+  return `${totalMinutes}m`
 }
 
 export default function TodaysFiveCard() {
-  const [status, setStatus] = useState<DailyStatus | null>(null);
-  const [nowMs, setNowMs] = useState(() => Date.now());
-  const [resetting, setResetting] = useState(false);
-  const [resetError, setResetError] = useState<string | null>(null);
+  const [status, setStatus] = useState<DailyStatus | null>(null)
+  const [nowMs, setNowMs] = useState(() => Date.now())
+  const [resetting, setResetting] = useState(false)
+  const [resetError, setResetError] = useState<string | null>(null)
 
   useEffect(() => {
-    let cancelled = false;
+    let cancelled = false
 
     async function loadStatus() {
       try {
         const response = await fetch('/api/daily/status', {
           cache: 'no-store',
           credentials: 'include',
-        });
-        if (!response.ok) throw new Error('daily status unavailable');
-        const body = await response.json();
-        if (cancelled) return;
+        })
+        if (!response.ok) throw new Error('daily status unavailable')
+        const body = await response.json()
+        if (cancelled) return
         setStatus({
           questionsRemaining:
-            typeof body.questionsRemaining === 'number' ? body.questionsRemaining : FALLBACK_STATUS.questionsRemaining,
+            typeof body.questionsRemaining === 'number'
+              ? body.questionsRemaining
+              : FALLBACK_STATUS.questionsRemaining,
           questionsAnswered:
             typeof body.questionsAnswered === 'number'
               ? body.questionsAnswered
@@ -70,60 +72,78 @@ export default function TodaysFiveCard() {
               : typeof body.complete === 'boolean'
                 ? body.complete
                 : FALLBACK_STATUS.isComplete,
-          nextRoundAt: typeof body.nextRoundAt === 'string' ? body.nextRoundAt : FALLBACK_STATUS.nextRoundAt,
+          nextRoundAt:
+            typeof body.nextRoundAt === 'string'
+              ? body.nextRoundAt
+              : FALLBACK_STATUS.nextRoundAt,
           queueId: typeof body.queue_id === 'string' ? body.queue_id : null,
-        });
+        })
       } catch {
-        if (!cancelled) setStatus(FALLBACK_STATUS);
+        if (!cancelled) setStatus(FALLBACK_STATUS)
       }
     }
 
-    void loadStatus();
+    void loadStatus()
 
     return () => {
-      cancelled = true;
-    };
-  }, []);
+      cancelled = true
+    }
+  }, [])
 
   useEffect(() => {
-    const timer = window.setInterval(() => setNowMs(Date.now()), 60_000);
-    return () => window.clearInterval(timer);
-  }, []);
+    const timer = window.setInterval(() => setNowMs(Date.now()), 60_000)
+    return () => window.clearInterval(timer)
+  }, [])
 
-  const effectiveStatus = status ?? FALLBACK_STATUS;
-  const answered = Math.max(0, Math.min(effectiveStatus.questionsAnswered, 5));
-  const isComplete = effectiveStatus.isComplete || effectiveStatus.questionsRemaining <= 0;
-  const hasStartedRound = Boolean(effectiveStatus.queueId) && answered > 0;
-  const playHref = isComplete ? '/daily/summary' : hasStartedRound ? '/daily' : '/daily/setup';
+  const effectiveStatus = status ?? FALLBACK_STATUS
+  const answered = Math.max(0, Math.min(effectiveStatus.questionsAnswered, 5))
+  const isComplete =
+    effectiveStatus.isComplete || effectiveStatus.questionsRemaining <= 0
+  const hasStartedRound = Boolean(effectiveStatus.queueId) && answered > 0
+  const playHref = isComplete
+    ? '/daily/summary'
+    : hasStartedRound
+      ? '/daily'
+      : '/daily/setup'
+  const actionLabel = isComplete
+    ? 'See your recap'
+    : hasStartedRound
+      ? 'Resume round'
+      : 'Play now'
   const subtext = useMemo(() => {
     if (isComplete) {
-      return `Done for today. Next round in ${formatCountdown(effectiveStatus.nextRoundAt, nowMs)}.`;
+      return `Done for today. Next round in ${formatCountdown(effectiveStatus.nextRoundAt, nowMs)}.`
     }
-    return answered > 0 ? `${answered} of 5 answered` : 'Ready when you are';
-  }, [answered, effectiveStatus.nextRoundAt, isComplete, nowMs]);
+    return answered > 0 ? `${answered} of 5 answered` : 'Ready when you are'
+  }, [answered, effectiveStatus.nextRoundAt, isComplete, nowMs])
 
   const resetForToday = async () => {
-    if (resetting) return;
-    setResetError(null);
-    setResetting(true);
+    if (resetting) return
+    setResetError(null)
+    setResetting(true)
     try {
       const response = await fetch('/api/daily/reset', {
         method: 'POST',
         credentials: 'include',
-      });
-      const body = await response.json().catch(() => null);
-      if (!response.ok) throw new Error(body?.message ?? 'Could not reset daily round.');
-      window.location.assign('/daily/setup');
+      })
+      const body = await response.json().catch(() => null)
+      if (!response.ok)
+        throw new Error(body?.message ?? 'Could not reset daily round.')
+      window.location.assign('/daily/setup')
     } catch (caught) {
-      setResetError(caught instanceof Error ? caught.message : 'Could not reset daily round.');
-      setResetting(false);
+      setResetError(
+        caught instanceof Error
+          ? caught.message
+          : 'Could not reset daily round.'
+      )
+      setResetting(false)
     }
-  };
+  }
 
   return (
-    <div className="mt-6 w-full rounded-lg border bg-card p-4 text-card-foreground md:mt-0 md:max-w-xs">
+    <div className="bg-card text-card-foreground mt-6 w-full rounded-lg border p-4 md:mt-0 md:max-w-xs">
       <div className="flex items-start gap-3">
-        <span className="grid size-10 shrink-0 place-items-center rounded-md bg-muted text-foreground">
+        <span className="bg-muted text-foreground grid size-10 shrink-0 place-items-center rounded-md">
           {isComplete ? (
             <CheckCircle2 className="size-5" aria-hidden="true" />
           ) : (
@@ -131,13 +151,21 @@ export default function TodaysFiveCard() {
           )}
         </span>
         <div className="min-w-0 flex-1">
-          <p className="text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
             Today&apos;s Five
           </p>
-          <p className="mt-2 text-sm leading-6 text-muted-foreground">{subtext}</p>
-          <div className="mt-3 flex items-center gap-1.5" aria-label={`${answered} of 5 answered`}>
+          <p className="text-foreground mt-2 text-sm leading-6">
+            Five questions to keep your knowledge map moving.
+          </p>
+          <p className="text-muted-foreground mt-1 text-sm leading-6">
+            {subtext}
+          </p>
+          <div
+            className="mt-3 flex items-center gap-1.5"
+            aria-label={`${answered} of 5 answered`}
+          >
             {Array.from({ length: 5 }, (_, index) => {
-              const filled = index < answered;
+              const filled = index < answered
               return (
                 <span
                   key={index}
@@ -146,11 +174,13 @@ export default function TodaysFiveCard() {
                     width: filled ? 9 : 8,
                     height: filled ? 9 : 8,
                     background: filled ? 'var(--foreground)' : 'transparent',
-                    border: filled ? 'none' : '1px solid color-mix(in srgb, var(--foreground) 35%, transparent)',
+                    border: filled
+                      ? 'none'
+                      : '1px solid color-mix(in srgb, var(--foreground) 35%, transparent)',
                     opacity: filled ? 0.85 : 0.7,
                   }}
                 />
-              );
+              )
             })}
           </div>
         </div>
@@ -158,28 +188,36 @@ export default function TodaysFiveCard() {
 
       {isComplete ? (
         <>
-          <Link href={playHref} className="btn-ghost mt-4 min-h-11 w-full justify-center gap-2">
+          <Link
+            href={playHref}
+            className="btn-ghost mt-4 min-h-11 w-full justify-center gap-2"
+          >
             <Clock className="size-4" aria-hidden="true" />
-            See your recap
+            {actionLabel}
           </Link>
           <button
             type="button"
             onClick={() => {
-              void resetForToday();
+              void resetForToday()
             }}
             disabled={resetting}
-            className="mt-2 w-full text-center text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4 disabled:opacity-60"
+            className="text-muted-foreground mt-2 w-full text-center text-xs font-medium tracking-[0.08em] uppercase underline underline-offset-4 disabled:opacity-60"
           >
             {resetting ? 'Resetting…' : 'Reset game for today and play again'}
           </button>
-          {resetError ? <p className="mt-2 text-xs text-destructive">{resetError}</p> : null}
+          {resetError ? (
+            <p className="text-destructive mt-2 text-xs">{resetError}</p>
+          ) : null}
         </>
       ) : (
-        <Link href={playHref} className="btn-primary mt-4 min-h-11 w-full justify-center gap-2">
+        <Link
+          href={playHref}
+          className="btn-primary mt-4 min-h-11 w-full justify-center gap-2"
+        >
           <MessageCircleQuestion className="size-4" aria-hidden="true" />
-          Play now
+          {actionLabel}
         </Link>
       )}
     </div>
-  );
+  )
 }


### PR DESCRIPTION
### Motivation
- Avoid making a global availability claim in the homepage hero and restore the previous brand headline so the page is state-neutral. 
- Ensure Today’s Five availability and CTA copy are driven by the client-side daily status rather than a hard-coded hero line. 

### Description
- Replace the homepage hero `h1` in `src/app/page.tsx` with the brand headline `You contain multitudes.` and update the supporting paragraph to state-neutral copy. 
- Remove the hard-coded claim `Today’s five is ready when you are` from the main page and move game-specific copy into the Today’s Five component. 
- Update `src/components/TodaysFiveCard.tsx` to compute an `actionLabel` from the daily state (`Play now` / `Resume round` / `See your recap`) and add a short lead-in sentence inside the card so the hero no longer needs to assert availability. 
- Minor formatting/tailwind class adjustments in the two files for consistent styling and Prettier formatting. 

### Testing
- Ran `npx prettier --check src/app/page.tsx src/components/TodaysFiveCard.tsx` which passed after auto-formatting. 
- Ran `npx eslint src/app/page.tsx src/components/TodaysFiveCard.tsx` which reported no errors for the modified files. 
- Ran `npm run lint` which fails due to pre-existing lint issues elsewhere in the repo (unrelated to this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0327ecd07c832e91adc06d26eecc37)