### PR TITLE
Stack homepage content in one column

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24 md:py-10">
-      <section className="border-b pb-6 md:flex md:items-end md:justify-between md:gap-8">
+      <section className="space-y-6 border-b pb-6">
         <div className="max-w-2xl">
           <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
             Joshing
@@ -25,7 +25,7 @@ export default async function Home() {
             and how your map keeps changing.
           </p>
         </div>
-        <div className="mt-6 w-full space-y-3 md:mt-0 md:max-w-xs">
+        <div className="w-full max-w-2xl space-y-3">
           <TodaysFiveCard />
           {catchupCount > 0 ? (
             <CatchupCard count={catchupCount} expiringCount={expiringCount} />

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -141,7 +141,7 @@ export default function TodaysFiveCard() {
   }
 
   return (
-    <div className="bg-card text-card-foreground mt-6 w-full rounded-lg border p-4 md:mt-0 md:max-w-xs">
+    <div className="bg-card text-card-foreground w-full rounded-lg border p-4">
       <div className="flex items-start gap-3">
         <span className="bg-muted text-foreground grid size-10 shrink-0 place-items-center rounded-md">
           {isComplete ? (


### PR DESCRIPTION
### Motivation
- Move the main homepage hero from a two-column desktop layout into a single vertical column so headline, Today’s Five, catch-up, and feed content read top-to-bottom without a side rail.

### Description
- Replace the desktop flex layout on the main `<section>` with a stacked layout by changing its class to `space-y-6 border-b pb-6` in `src/app/page.tsx`.
- Keep the headline block at the top and render `<TodaysFiveCard />`, catch-up card, and the feed summary beneath it inside a shared `max-w-2xl` content column in `src/app/page.tsx`.
- Remove the `md:max-w-xs` desktop width constraint from the homepage wrapper and from the card itself by updating `src/app/page.tsx` and `src/components/TodaysFiveCard.tsx` so `TodaysFiveCard` no longer forces `md:max-w-xs`.

### Testing
- Ran `npx eslint src/app/page.tsx src/components/TodaysFiveCard.tsx`, which passed for the modified files.
- Ran `npm run lint`, which failed due to pre-existing lint errors elsewhere in the repo unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0329a6b968832e8900f6c9289218e6)