### PR TITLE
Add DB pre-migration guards for domain-merge backfill, improve backfill logging, and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Open `.env.local` and fill in:
 **3. Run database migrations** *(once schema is ready — Phase 1.2)*
 
 ```bash
-npx prisma migrate dev
+npm run db:migrate
 ```
 
 **4. Start the dev server**
@@ -61,5 +61,5 @@ Open [http://localhost:3000](http://localhost:3000).
 npm run build      # production build
 npm run lint       # ESLint
 npm run format     # Prettier
-npx prisma studio  # browse the database
+npx prisma studio  # browse the database (read-only; Drizzle migrations are authoritative)
 ```

--- a/scripts/backfill-domains.ts
+++ b/scripts/backfill-domains.ts
@@ -35,6 +35,25 @@ if (DRY_RUN) {
   console.log('[backfill-domains] APPLY mode — data will be modified.\n');
 }
 
+
+function logDatabaseErrorCause(err: unknown) {
+  const cause = err instanceof Error ? err.cause : undefined;
+  if (!cause || typeof cause !== 'object') return;
+
+  const pgCause = cause as Record<string, unknown>;
+  const fields = ['code', 'schema', 'table', 'column', 'constraint', 'detail']
+    .map((key) => [key, pgCause[key]] as const)
+    .filter((entry): entry is readonly [string, string] => typeof entry[1] === 'string' && entry[1].length > 0);
+
+  const causeMessage = cause instanceof Error ? cause.message : undefined;
+  if (causeMessage) {
+    console.error(`[backfill-domains] database cause: ${causeMessage}`);
+  }
+  if (fields.length > 0) {
+    console.error(`[backfill-domains] database details: ${fields.map(([key, value]) => `${key}=${value}`).join(' ')}`);
+  }
+}
+
 async function main() {
   const userIds: string[] = [];
 
@@ -65,6 +84,7 @@ async function main() {
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`[backfill-domains] user=${userId} ERROR: ${message}`);
+      logDatabaseErrorCause(err);
       totalErrors += 1;
     }
   }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -24,6 +24,30 @@ export async function register() {
       // Table or columns may not exist yet — that's fine, migrate() will create them
     }
 
+    // Domain-merge mastery events were introduced after the base table in
+    // drizzle/0009_domain_merge_events.sql. Some preview/production databases
+    // can have that migration recorded without the enum value or metadata column
+    // present, which makes the domain cleanup audit insert in ceremony.ts fail.
+    // Add both pieces idempotently before migrate() so the backfill can proceed.
+    try {
+      await db.execute(sql`
+        ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'curator_credit'
+      `);
+      await db.execute(sql`
+        ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'domain_merged'
+      `);
+      await db.execute(sql`
+        ALTER TYPE "public"."MasterySourceType" ADD VALUE IF NOT EXISTS 'declared_promoted'
+      `);
+      await db.execute(sql`
+        ALTER TABLE "MASTERY_EVENTS"
+          ADD COLUMN IF NOT EXISTS "metadata" jsonb
+      `);
+    } catch {
+      // MASTERY_EVENTS or MasterySourceType may not exist yet — migrate() handles
+      // initial creation and the additive migration will add these schema pieces.
+    }
+
     // PlayerMastery.territory_type was introduced after the base table. Preview
     // databases can have the migration recorded without the column present, which
     // makes Drizzle selects fail with Postgres 42703 before app code can recover.

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -674,7 +674,6 @@ export async function applyMergesForUser(
         sourceType: 'domain_merged',
         questionId: null,
         answeredByUserId: userId,
-        answerId: `domain_merged:${userId}:${Date.now()}:${applied.length}`,
         basePoints: 0,
         weight: 0,
         awardedPoints: 0,


### PR DESCRIPTION
### Motivation

- Prevent migration failures and runtime errors when preview/production databases have migrations recorded but lack additive schema pieces needed for domain-merge backfills. 
- Improve diagnostic information when the backfill script hits database errors to make debugging faster. 
- Update developer docs to reflect the current migration command and clarify `prisma studio` is read-only when Drizzle migrations are authoritative.

### Description

- Add idempotent pre-migration SQL in `src/instrumentation.ts` to ensure the `MasterySourceType` enum contains `curator_credit`, `domain_merged`, and `declared_promoted`, and to add a `metadata` jsonb column to `MASTERY_EVENTS` if missing. 
- Add `logDatabaseErrorCause` helper and call it from `scripts/backfill-domains.ts` so Postgres error cause details are logged on failures. 
- Stop setting an explicit `answerId` for `domain_merged` mastery event inserts in `src/server/mastery/ceremony.ts` to avoid constructing potentially conflicting IDs. 
- Update `README.md` to recommend `npm run db:migrate` instead of `npx prisma migrate dev` and annotate `npx prisma studio` as read-only when using Drizzle migrations.

### Testing

- Ran `npm run build` to verify TypeScript compilation succeeds and it passed. 
- Ran `npm run lint` to verify code style and lint checks and it passed. 
- No automated unit tests were modified by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03391ed6cc832e80d9e7beb780a97d)