### PR TITLE
Align home page content width

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,9 @@ export default async function Home() {
   const expiringCount = catchupItems.filter((item) => item.expiresSoon).length
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24 md:py-10">
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24 md:py-10">
       <section className="space-y-6 border-b pb-6">
-        <div className="max-w-2xl">
+        <div className="w-full">
           <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
             Joshing
           </p>
@@ -25,7 +25,7 @@ export default async function Home() {
             and how your map keeps changing.
           </p>
         </div>
-        <div className="w-full max-w-2xl space-y-3">
+        <div className="w-full space-y-3">
           <TodaysFiveCard />
           {catchupCount > 0 ? (
             <CatchupCard count={catchupCount} expiringCount={expiringCount} />


### PR DESCRIPTION
### Motivation
- The homepage container was `max-w-4xl` while the hero and card column used `max-w-2xl`, causing the lower content to appear narrower and left-aligned inside a wider shell.

### Description
- Adjust `src/app/page.tsx` so the page shell uses `max-w-2xl` and remove the nested `max-w-2xl` caps by replacing them with `w-full`, so the hero, Today’s Five card, and feed card share a single centered column.

### Testing
- Ran `npx eslint src/app/page.tsx`, which completed successfully for the modified file.
- Ran `npm run lint`, which surfaced pre-existing lint errors elsewhere in the repo and thus failed (these errors are unrelated to this change).
- Attempted an automated visual check with Playwright (`npx --yes playwright@latest screenshot ...`), but the Playwright install was blocked by the registry policy (403), so the screenshot step could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0338d53aa4832e8436c6b3cec61318)