### PR TITLE
Remove classic knowledge view and show portrait circles (Domain/Mastery) only

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -6,12 +6,10 @@ import { useSearchParams } from 'next/navigation';
 import { Combine, Plus, Repeat2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 
-import { DomainCard } from '@/components/knowledge/DomainCard';
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
-import type { KnowledgeDomain } from '@/server/profile/knowledge-types';
 import type { MasteryTier } from '@/types/db';
 
 type DomainMastery = {
@@ -61,17 +59,6 @@ type TidyResult = {
   details: Array<{ sources: string[]; target: string; rationale: string }>;
 };
 
-type KnowledgeView = 'classic' | 'progression';
-
-const KNOWLEDGE_VIEW_KEY = 'joshing_knowledge_view';
-
-function readSavedView(): KnowledgeView {
-  if (typeof window === 'undefined') return 'progression';
-  const raw = localStorage.getItem(KNOWLEDGE_VIEW_KEY);
-  if (raw === 'classic' || raw === 'progression') return raw;
-  return 'progression';
-}
-
 function asTier(value: string): MasteryTier {
   if (value === 'familiar' || value === 'solid' || value === 'mastery') return value;
   return 'establishing';
@@ -91,19 +78,6 @@ function displayMind(domains: DomainMastery[], declaredInterests: string[]): str
   if (top.length === 1) return `Your mind is building around ${top[0]}.`;
   if (declaredInterests.length > 0) return `Your mind is ready to explore ${declaredInterests.slice(0, 3).join(', ')}.`;
   return 'Your mind will take shape as you play and write questions.';
-}
-
-function toKnowledgeDomain(domain: DomainMastery): KnowledgeDomain {
-  return {
-    name: domain.displayName,
-    tier: asTier(domain.tier),
-    progressWithinTier: domain.tierProgress / 100,
-    masteryPoints: domain.points,
-    declaredQuestionCount: domain.isDeclaredInterest ? Math.max(1, domain.questionsAnswered) : domain.questionsAnswered,
-    provenCorrectCount: domain.questionsCorrect,
-    isVisibleOnProfile: true,
-    broadCategory: domain.broadCategory,
-  };
 }
 
 function toPortraitEntry(domain: DomainMastery): PortraitEntry {
@@ -162,9 +136,7 @@ function KnowledgePageContent() {
   const [data, setData] = useState<KnowledgeResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [view, setView] = useState<KnowledgeView>('progression');
   const [activeSlug, setActiveSlug] = useState<string | null>(highlightedDomainSlug);
-  const [isFading, setIsFading] = useState(false);
   const [shareModalOpen, setShareModalOpen] = useState(false);
   const [interestModal, setInterestModal] = useState<InterestModalState | null>(null);
   const [selectedInterest, setSelectedInterest] = useState<ProposedInterest | null>(null);
@@ -193,7 +165,6 @@ function KnowledgePageContent() {
 
   useEffect(() => {
     let active = true;
-    setView(readSavedView());
     setLoading(true);
     setError(null);
 
@@ -251,7 +222,6 @@ function KnowledgePageContent() {
     [data],
   );
 
-  const activeDomains = useMemo(() => sortedDomains.map(toKnowledgeDomain), [sortedDomains]);
   const portraitEntries = useMemo(() => sortedDomains.map(toPortraitEntry), [sortedDomains]);
   const declaredSlots = useMemo(() => {
     if (!data) return [];
@@ -271,16 +241,6 @@ function KnowledgePageContent() {
   const yourMind = data ? displayMind(sortedDomains, data.pageData.declaredInterests) : '';
   const displayName = 'You';
   const hasAnything = sortedDomains.length > 0;
-
-  const onToggleView = (nextView: KnowledgeView) => {
-    if (nextView === view) return;
-    setIsFading(true);
-    window.setTimeout(() => {
-      setView(nextView);
-      localStorage.setItem(KNOWLEDGE_VIEW_KEY, nextView);
-      setIsFading(false);
-    }, 150);
-  };
 
   const openInterestModal = (slotIndex: number, currentDomain: string | null) => {
     setInterestModal({ slotIndex, currentDomain });
@@ -480,39 +440,13 @@ function KnowledgePageContent() {
             <p style={knowledgeSubtitleStyle}>SEE HOW YOUR KNOWLEDGE IS BUILDING -&gt;</p>
           </div>
 
-          <div style={toggleRowStyle} aria-label="Knowledge view toggle">
-            <div style={toggleWrapStyle}>
-              <button type="button" onClick={() => onToggleView('classic')} style={view === 'classic' ? activeToggleStyle : inactiveToggleStyle} aria-pressed={view === 'classic'}>
-                Classic
-              </button>
-              <button type="button" onClick={() => onToggleView('progression')} style={view === 'progression' ? activeToggleStyle : inactiveToggleStyle} aria-pressed={view === 'progression'}>
-                Progression
+          <div id="portrait-circles-section">
+            <PortraitCircles entries={portraitEntries} />
+            <div style={sharePortraitWrapStyle}>
+              <button type="button" style={sharePortraitBtnStyle} onClick={() => setShareModalOpen(true)}>
+                Share portrait
               </button>
             </div>
-          </div>
-
-          <div style={{ ...contentShellStyle, opacity: isFading ? 0 : 1 }}>
-            {view === 'classic' ? (
-              <div style={cardStackStyle}>
-                {activeDomains.map((domain) => (
-                  <div key={domain.name} id={`knowledge-domain-${toCanonicalDomainSlug(domain.name)}`}>
-                    <DomainCard
-                      domain={domain}
-                      highlighted={activeSlug === toCanonicalDomainSlug(domain.name)}
-                    />
-                  </div>
-                ))}
-              </div>
-            ) : (
-              <div id="portrait-circles-section">
-                <PortraitCircles entries={portraitEntries} />
-                <div style={sharePortraitWrapStyle}>
-                  <button type="button" style={sharePortraitBtnStyle} onClick={() => setShareModalOpen(true)}>
-                    Share portrait
-                  </button>
-                </div>
-              </div>
-            )}
           </div>
         </section>
       )}
@@ -815,51 +749,6 @@ const knowledgeSubtitleStyle: CSSProperties = {
   color: '#8a8070',
   letterSpacing: '0.06em',
   fontFamily: 'var(--font-neutral), system-ui, sans-serif',
-};
-
-const toggleRowStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  margin: '0.75rem 0',
-};
-
-const toggleWrapStyle: CSSProperties = {
-  display: 'flex',
-  gap: 8,
-};
-
-const activeToggleStyle: CSSProperties = {
-  minHeight: 34,
-  padding: '0 14px',
-  borderRadius: 999,
-  border: 'none',
-  background: '#1a1208',
-  color: '#f5f0e8',
-  cursor: 'pointer',
-  fontFamily: 'inherit',
-  fontSize: 14,
-};
-
-const inactiveToggleStyle: CSSProperties = {
-  minHeight: 34,
-  padding: '0 12px',
-  borderRadius: 999,
-  border: 'none',
-  background: 'transparent',
-  color: '#8a8070',
-  cursor: 'pointer',
-  fontFamily: 'inherit',
-  fontSize: 14,
-};
-
-const contentShellStyle: CSSProperties = {
-  transition: 'opacity 150ms ease',
-};
-
-const cardStackStyle: CSSProperties = {
-  display: 'grid',
-  gap: '0.6rem',
 };
 
 const emptyStyle: CSSProperties = {

--- a/src/components/knowledge/KnowledgeOverviewClient.tsx
+++ b/src/components/knowledge/KnowledgeOverviewClient.tsx
@@ -2,15 +2,11 @@
 
 import Link from 'next/link';
 import { useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
-import { DomainCard } from '@/components/knowledge/DomainCard';
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
-import type { KnowledgeDomain, KnowledgeOverview } from '@/server/profile/knowledge-types';
+import type { KnowledgeOverview } from '@/server/profile/knowledge-types';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
-
-type KnowledgeView = 'classic' | 'progression';
-const KNOWLEDGE_VIEW_KEY = 'joshing_knowledge_view';
 
 type KnowledgeOverviewClientProps = {
   overview: KnowledgeOverview;
@@ -37,31 +33,12 @@ type KnowledgeCardApi = {
   share_card_expires_at: string;
 };
 
-function readSavedView(): KnowledgeView {
-  if (typeof window === 'undefined') return 'progression';
-  const raw = localStorage.getItem(KNOWLEDGE_VIEW_KEY);
-  // Migrate old 'portrait' value to 'classic'
-  if (raw === 'portrait') {
-    localStorage.setItem(KNOWLEDGE_VIEW_KEY, 'classic');
-    return 'classic';
-  }
-  if (raw === 'classic' || raw === 'progression') return raw;
-  return 'progression';
-}
-
 export function KnowledgeOverviewClient({
   overview,
   highlightedDomainSlug,
   tierCrossed,
 }: KnowledgeOverviewClientProps) {
-  const [view, setView] = useState<KnowledgeView>(readSavedView);
   const [activeSlug, setActiveSlug] = useState<string | null>(highlightedDomainSlug ?? null);
-  const [isFading, setIsFading] = useState(false);
-  const [activeDomains, setActiveDomains] = useState<KnowledgeDomain[]>(() => overview.allDomains);
-  const [excludedDomains, setExcludedDomains] = useState<KnowledgeDomain[]>(() => overview.excludedDomains);
-  const [excludedExpanded, setExcludedExpanded] = useState(false);
-  const [restoringDomain, setRestoringDomain] = useState<string | null>(null);
-  const [editMode, setEditMode] = useState(false);
   const [knowledgeCard, setKnowledgeCard] = useState<KnowledgeCardApi | null>(null);
   const [portraitEntries, setPortraitEntries] = useState<PortraitEntry[]>([]);
   const [portraitError, setPortraitError] = useState(false);
@@ -71,13 +48,8 @@ export function KnowledgeOverviewClient({
   const cardRef = useRef<HTMLDivElement | null>(null);
 
   const domainNameBySlug = useMemo(
-    () => new Map(activeDomains.map((domain) => [toCanonicalDomainSlug(domain.name), domain.name])),
-    [activeDomains],
-  );
-
-  const highlightedDomainInGraph = useMemo(
-    () => activeDomains.slice(0, overview.topDomains.length).some((domain) => toCanonicalDomainSlug(domain.name) === activeSlug),
-    [activeDomains, overview.topDomains.length, activeSlug],
+    () => new Map(overview.allDomains.map((domain) => [toCanonicalDomainSlug(domain.name), domain.name])),
+    [overview.allDomains],
   );
 
   // Clean up ?tier_crossed= param
@@ -97,9 +69,9 @@ export function KnowledgeOverviewClient({
     }).catch(() => undefined);
   }, [overview.userId]);
 
-  // Fetch portrait + mastery data (lazy — only when view becomes 'progression')
+  // Fetch portrait + mastery data
   useEffect(() => {
-    if (view !== 'progression' || portraitFetchedRef.current) return;
+    if (portraitFetchedRef.current) return;
     portraitFetchedRef.current = true;
     Promise.all([
       fetch(`/api/users/${overview.userId}/portrait`).then((r) => r.ok ? r.json() : null),
@@ -129,22 +101,14 @@ export function KnowledgeOverviewClient({
       setPortraitError(true);
       setPortraitLoaded(true);
     });
-  }, [view, overview.userId]);
+  }, [overview.userId]);
 
   // Deep-link highlight handler
   useEffect(() => {
     if (!highlightedDomainSlug) return;
 
-    if (view === 'progression') {
-      const portraitEl = document.getElementById('portrait-circles-section');
-      if (portraitEl) portraitEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-    } else {
-      // Classic view: scroll to the domain row
-      const element = document.getElementById(`knowledge-domain-${highlightedDomainSlug}`);
-      if (!highlightedDomainInGraph && element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'center' });
-      }
-    }
+    const portraitEl = document.getElementById('portrait-circles-section');
+    if (portraitEl) portraitEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
 
     const timer = window.setTimeout(() => {
       const url = new URL(window.location.href);
@@ -154,61 +118,9 @@ export function KnowledgeOverviewClient({
     }, 900);
 
     return () => window.clearTimeout(timer);
-  }, [highlightedDomainSlug, view, highlightedDomainInGraph]);
+  }, [highlightedDomainSlug]);
 
-  const onToggleView = (nextView: KnowledgeView) => {
-    if (nextView === view) return;
-    setIsFading(true);
-    window.setTimeout(() => {
-      setView(nextView);
-      localStorage.setItem(KNOWLEDGE_VIEW_KEY, nextView);
-      setIsFading(false);
-      if (portraitError) {
-        setPortraitError(false);
-        setPortraitLoaded(false);
-        portraitFetchedRef.current = false;
-      }
-    }, 150);
-  };
-
-  const handleExclude = (domain: KnowledgeDomain) => {
-    setActiveDomains((prev) => prev.filter((d) => d.name !== domain.name));
-    setExcludedDomains((prev) => [domain, ...prev]);
-    void fetch('/api/users/domain-exclusions', {
-      method: 'POST',
-      credentials: 'include',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ canonical_subcategory: domain.name }),
-    });
-  };
-
-  const handleRestore = async (domain: KnowledgeDomain) => {
-    setRestoringDomain(domain.name);
-    try {
-      const res = await fetch(`/api/users/domain-exclusions/${encodeURIComponent(domain.name)}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      });
-      if (res.ok) {
-        setExcludedDomains((prev) => prev.filter((d) => d.name !== domain.name));
-        setActiveDomains((prev) => {
-          const next = [...prev, domain];
-          next.sort((a, b) => {
-            if (b.masteryPoints !== a.masteryPoints) return b.masteryPoints - a.masteryPoints;
-            const aW = a.declaredQuestionCount + a.provenCorrectCount;
-            const bW = b.declaredQuestionCount + b.provenCorrectCount;
-            if (bW !== aW) return bW - aW;
-            return a.name.localeCompare(b.name);
-          });
-          return next;
-        });
-      }
-    } finally {
-      setRestoringDomain(null);
-    }
-  };
-
-  const hasAnything = activeDomains.length > 0 || excludedDomains.length > 0 || portraitEntries.length > 0;
+  const hasAnything = overview.allDomains.length > 0 || overview.excludedDomains.length > 0 || portraitEntries.length > 0;
 
   return (
     <main style={mainStyle}>
@@ -255,7 +167,7 @@ export function KnowledgeOverviewClient({
         </section>
       )}
 
-      {/* Section header + toggle + domain list (only if player has any knowledge) */}
+      {/* Section header + portrait circles (only if player has any knowledge) */}
       {hasAnything && (
         <section style={sectionStyle} aria-label="Knowledge progression">
           {/* Section header */}
@@ -264,116 +176,26 @@ export function KnowledgeOverviewClient({
             <p style={knowledgeSubtitleStyle}>SEE HOW YOUR KNOWLEDGE IS BUILDING →</p>
           </div>
 
-          {/* Toggle */}
-          <div style={toggleRowStyle} aria-label="Knowledge view toggle">
-            <div style={toggleWrapStyle}>
-              <button
-                type="button"
-                onClick={() => onToggleView('classic')}
-                style={view === 'classic' ? activeToggleStyle : inactiveToggleStyle}
-                aria-pressed={view === 'classic'}
-              >
-                Classic
-              </button>
-              <button
-                type="button"
-                onClick={() => onToggleView('progression')}
-                style={view === 'progression' ? activeToggleStyle : inactiveToggleStyle}
-                aria-pressed={view === 'progression'}
-              >
-                Progression
-              </button>
-            </div>
-            {view === 'classic' && (
-              <button
-                type="button"
-                onClick={() => setEditMode((v) => !v)}
-                style={manageButtonStyle}
-              >
-                {editMode ? 'Done' : 'Manage'}
-              </button>
-            )}
-          </div>
-
-          {/* Domain list — fades between views */}
-          <div style={{ ...contentShellStyle, opacity: isFading ? 0 : 1 }}>
-            {view === 'classic' ? (
-              <div style={cardStackStyle}>
-                {activeDomains.map((domain) => (
-                  <div key={domain.name} id={`knowledge-domain-${toCanonicalDomainSlug(domain.name)}`}>
-                    <DomainCard
-                      domain={domain}
-                      highlighted={activeSlug === toCanonicalDomainSlug(domain.name)}
-                      trailingControl={editMode ? (
-                        <button
-                          type="button"
-                          onClick={() => handleExclude(domain)}
-                          style={excludeButtonStyle}
-                          aria-label={`Remove ${domain.name} from rotation`}
-                        >
-                          ✕
-                        </button>
-                      ) : undefined}
-                    />
-                  </div>
-                ))}
-                {activeDomains.length === 0 && excludedDomains.length === 0 && (
-                  <p style={emptyStyle}>Play a round and your domains will start to appear here.</p>
-                )}
-                {excludedDomains.length > 0 && (
-                  <div style={excludedSectionStyle}>
-                    <button
-                      type="button"
-                      onClick={() => setExcludedExpanded((v) => !v)}
-                      style={excludedHeaderStyle}
-                      aria-expanded={excludedExpanded}
-                    >
-                      <span>{excludedDomains.length} excluded topic{excludedDomains.length !== 1 ? 's' : ''}</span>
-                      <span style={excludedChevronStyle} aria-hidden>{excludedExpanded ? '▲' : '▼'}</span>
-                    </button>
-                    {excludedExpanded && (
-                      <div style={excludedListStyle}>
-                        {excludedDomains.map((domain) => (
-                          <div key={domain.name} style={excludedItemStyle}>
-                            <span style={excludedDomainNameStyle}>{domain.name}</span>
-                            <button
-                              type="button"
-                              disabled={restoringDomain === domain.name}
-                              onClick={() => { void handleRestore(domain); }}
-                              style={restoreLinkStyle}
-                            >
-                              {restoringDomain === domain.name ? 'Restoring…' : 'Restore'}
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
+          <div id="portrait-circles-section">
+            {portraitError ? (
+              <p style={emptyStyle}>Could not load your portrait data. Try refreshing.</p>
+            ) : portraitEntries.length === 0 && portraitLoaded ? (
+              <p style={emptyStyle}>Play a round and your portrait will start to appear here.</p>
+            ) : portraitEntries.length > 0 ? (
+              <>
+                <PortraitCircles entries={portraitEntries} />
+                <div style={sharePortraitWrapStyle}>
+                  <button
+                    type="button"
+                    style={sharePortraitBtnStyle}
+                    onClick={() => setShareModalOpen(true)}
+                  >
+                    Share portrait
+                  </button>
+                </div>
+              </>
             ) : (
-              <div id="portrait-circles-section">
-                {portraitError ? (
-                  <p style={emptyStyle}>Could not load your portrait data. Try refreshing.</p>
-                ) : portraitEntries.length === 0 && portraitLoaded ? (
-                  <p style={emptyStyle}>Play a round and your portrait will start to appear here.</p>
-                ) : portraitEntries.length > 0 ? (
-                  <>
-                    <PortraitCircles entries={portraitEntries} />
-                    <div style={sharePortraitWrapStyle}>
-                      <button
-                        type="button"
-                        style={sharePortraitBtnStyle}
-                        onClick={() => setShareModalOpen(true)}
-                      >
-                        Share portrait
-                      </button>
-                    </div>
-                  </>
-                ) : (
-                  <p style={emptyStyle}>Loading…</p>
-                )}
-              </div>
+              <p style={emptyStyle}>Loading…</p>
             )}
           </div>
         </section>
@@ -424,46 +246,6 @@ const tierCrossedBannerStyle: CSSProperties = {
   fontSize: 16,
 };
 
-const toggleRowStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  margin: '0.75rem 0',
-};
-
-const toggleWrapStyle: CSSProperties = {
-  display: 'flex',
-  gap: 8,
-};
-
-const activeToggleStyle: CSSProperties = {
-  minHeight: 34,
-  padding: '0 14px',
-  borderRadius: 999,
-  border: 'none',
-  background: '#1a1208',
-  color: '#f5f0e8',
-  cursor: 'pointer',
-  fontFamily: 'inherit',
-  fontSize: 14,
-};
-
-const inactiveToggleStyle: CSSProperties = {
-  minHeight: 34,
-  padding: '0 12px',
-  borderRadius: 999,
-  border: 'none',
-  background: 'transparent',
-  color: '#8a8070',
-  cursor: 'pointer',
-  fontFamily: 'inherit',
-  fontSize: 14,
-};
-
-const contentShellStyle: CSSProperties = {
-  transition: 'opacity 150ms ease',
-};
-
 const eyebrowStyle: CSSProperties = {
   margin: 0,
   fontSize: '0.72rem',
@@ -503,11 +285,6 @@ const knowledgeSubtitleStyle: CSSProperties = {
   fontFamily: 'var(--font-neutral), system-ui, sans-serif',
 };
 
-const cardStackStyle: CSSProperties = {
-  display: 'grid',
-  gap: '0.6rem',
-};
-
 const emptyStyle: CSSProperties = {
   margin: 0,
   color: '#696257',
@@ -530,80 +307,4 @@ const sharePortraitBtnStyle: CSSProperties = {
   textTransform: 'uppercase',
   cursor: 'pointer',
   boxShadow: '2px 2px 0 #3a3a3a',
-};
-
-const excludedSectionStyle: CSSProperties = {
-  marginTop: '0.25rem',
-};
-
-const excludedHeaderStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  width: '100%',
-  background: 'none',
-  border: 'none',
-  padding: '0.6rem 0.2rem',
-  cursor: 'pointer',
-  color: 'var(--text-muted)',
-  fontSize: '0.82rem',
-  fontFamily: 'inherit',
-  textAlign: 'left',
-};
-
-const excludedChevronStyle: CSSProperties = {
-  fontSize: '0.65rem',
-  color: 'var(--text-muted)',
-};
-
-const excludedListStyle: CSSProperties = {
-  display: 'grid',
-  gap: '0.1rem',
-  paddingBottom: '0.25rem',
-};
-
-const excludedItemStyle: CSSProperties = {
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'space-between',
-  padding: '0.55rem 0.2rem',
-  borderTop: '1px solid var(--border)',
-};
-
-const excludedDomainNameStyle: CSSProperties = {
-  color: 'var(--text-muted)',
-  fontSize: '0.92rem',
-};
-
-const restoreLinkStyle: CSSProperties = {
-  background: 'none',
-  border: 'none',
-  padding: 0,
-  cursor: 'pointer',
-  color: 'var(--text-muted)',
-  fontSize: '0.76rem',
-  textDecoration: 'underline',
-  fontFamily: 'inherit',
-};
-
-const manageButtonStyle: CSSProperties = {
-  background: 'none',
-  border: 'none',
-  padding: 0,
-  cursor: 'pointer',
-  color: 'var(--text-muted)',
-  fontSize: '0.76rem',
-  fontFamily: 'var(--font-mono)',
-  textTransform: 'uppercase',
-  letterSpacing: '0.07em',
-};
-
-const excludeButtonStyle: CSSProperties = {
-  background: 'none',
-  border: 'none',
-  padding: '0 0.2rem',
-  cursor: 'pointer',
-  color: '#9a8e82',
-  fontSize: '1rem',
-  lineHeight: 1,
 };

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -197,9 +197,12 @@ export function PortraitDomainCircle({
 export function PortraitCircles({ entries }: PortraitCirclesProps) {
   const [sortMode, setSortMode] = useState<SortMode>('domain');
 
-  const validEntries = entries.filter((e) => e.broadCategory && e.broadCategory !== 'Other');
+  const validEntries = useMemo(
+    () => entries.filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
+    [entries],
+  );
   const isSparse = validEntries.length < SPARSE_THRESHOLD;
-  const sections = buildSections(validEntries, sortMode);
+  const sections = useMemo(() => buildSections(validEntries, sortMode), [validEntries, sortMode]);
 
   const maxPointsByTier = useMemo(() => {
     const result: Record<string, number> = { establishing: 1, familiar: 1, solid: 1, mastery: 1 };
@@ -221,7 +224,7 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
             style={sortMode === mode ? activeToggleStyle : inactiveToggleStyle}
             aria-pressed={sortMode === mode}
           >
-            {mode === 'domain' ? 'By Domain' : 'By Mastery'}
+            {mode === 'domain' ? 'Domain' : 'Mastery'}
           </button>
         ))}
       </div>


### PR DESCRIPTION
### Motivation
- The knowledge page should stop switching between a legacy “Classic” list and the progression portrait and instead present the portrait view with a simple Domain/Mastery sort toggle. This simplifies the UI and matches the requested UX of only toggling Domain vs Mastery.

### Description
- Removed the Classic/Progression view state and rendering path so the knowledge section now directly renders the portrait circles instead of switching to a classic DomainCard list (changes in `src/app/knowledge/page.tsx`).
- Updated the client overview component to always fetch and render portrait/mastery data and removed the classic-view state and related domain-exclusion UI logic (`src/components/knowledge/KnowledgeOverviewClient.tsx`).
- Memoized portrait filtering and section building in `PortraitCircles` and renamed the sort labels from “By Domain” / “By Mastery” to “Domain” / “Mastery” to reflect the streamlined toggle (`src/components/knowledge/PortraitCircles.tsx`).
- Removed unused styles and helper functions related to the classic view to keep the code focused on the portrait UI (multiple style constants and conversion helpers trimmed).

### Testing
- Type-checked the code with `npx tsc --noEmit --pretty false --incremental false` (completed successfully).
- Ran ESLint for the modified components with `npx eslint src/components/knowledge/KnowledgeOverviewClient.tsx src/components/knowledge/PortraitCircles.tsx` (no new errors reported for those files).
- Ran repository lint `npm run lint`, which failed due to existing unrelated repository-wide lint issues (e.g. `react-hooks/set-state-in-effect`, `@typescript-eslint/no-explicit-any`) not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033c2b097c832e91eea595bdc9c212)