### PR TITLE
Lower mastery thresholds and propagate changes to UI, logic, and tests

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -41,9 +41,9 @@ const DIFFICULTIES: { value: Difficulty; label: string; copy: string }[] = [
 ];
 
 const TIER_NEXT_POINTS = {
-  establishing: 500,
-  familiar: 1500,
-  solid: 3500,
+  establishing: 100,
+  familiar: 1000,
+  solid: 2000,
   mastery: Number.POSITIVE_INFINITY,
 };
 

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -35,9 +35,9 @@ const TIER_LABEL: Record<MasteryTier, string> = {
 
 const TIER_POINTS: Record<MasteryTier, number> = {
   establishing: 0,
-  familiar: 50,
-  solid: 200,
-  mastery: 500,
+  familiar: 100,
+  solid: 1000,
+  mastery: 2000,
 };
 
 function formatRange(start: string, end: string): string {

--- a/src/server/mastery/__tests__/tier-progress.test.ts
+++ b/src/server/mastery/__tests__/tier-progress.test.ts
@@ -10,16 +10,16 @@ import { getMasteryTierThresholds } from '@/server/mastery/tiers';
 describe('tier progress', () => {
   it('progressWithinCurrentTier is half at midpoint of establishing band', () => {
     expect(progressWithinCurrentTier(0)).toBe(0);
-    expect(progressWithinCurrentTier(250)).toBeCloseTo(0.5, 5);
-    expect(progressWithinCurrentTier(500)).toBe(0);
-    expect(progressWithinCurrentTier(1000)).toBeCloseTo(0.5, 5);
+    expect(progressWithinCurrentTier(50)).toBeCloseTo(0.5, 5);
+    expect(progressWithinCurrentTier(100)).toBe(0);
+    expect(progressWithinCurrentTier(550)).toBeCloseTo(0.5, 5);
   });
 
   it('getMasteryTierProgress reports points to next tier', () => {
-    const p = getMasteryTierProgress(250);
+    const p = getMasteryTierProgress(50);
     expect(p.tier).toBe('establishing');
     expect(p.nextTier).toBe('familiar');
-    expect(p.pointsToNext).toBe(250);
+    expect(p.pointsToNext).toBe(50);
     expect(p.barFillRatio).toBeCloseTo(0.5, 5);
   });
 
@@ -33,10 +33,10 @@ describe('tier progress', () => {
 
   it('portrait bars use band width for current tier', () => {
     const t = getMasteryTierThresholds();
-    expect(getTierBandWidthForPortraitBars('establishing', t)).toBe(500);
-    expect(getTierBandWidthForPortraitBars('familiar', t)).toBe(1000);
-    expect(getTierBandWidthForPortraitBars('solid', t)).toBe(2000);
-    expect(getTierBandWidthForPortraitBars('mastery', t)).toBe(2000);
-    expect(portraitScoreBarRatio(250, 'establishing', t)).toBeCloseTo(0.5, 5);
+    expect(getTierBandWidthForPortraitBars('establishing', t)).toBe(100);
+    expect(getTierBandWidthForPortraitBars('familiar', t)).toBe(900);
+    expect(getTierBandWidthForPortraitBars('solid', t)).toBe(1000);
+    expect(getTierBandWidthForPortraitBars('mastery', t)).toBe(1000);
+    expect(portraitScoreBarRatio(50, 'establishing', t)).toBeCloseTo(0.5, 5);
   });
 });

--- a/src/server/mastery/__tests__/tiers.test.ts
+++ b/src/server/mastery/__tests__/tiers.test.ts
@@ -13,22 +13,22 @@ describe('mastery tiers', () => {
 
   it('resolveTier maps point totals (naive — ignores creator gate)', () => {
     expect(resolveTier(0)).toBe('establishing');
-    expect(resolveTier(499)).toBe('establishing');
-    expect(resolveTier(500)).toBe('familiar');
-    expect(resolveTier(1499)).toBe('familiar');
-    expect(resolveTier(1500)).toBe('solid');
-    expect(resolveTier(3499)).toBe('solid');
-    expect(resolveTier(3500)).toBe('mastery');
+    expect(resolveTier(99)).toBe('establishing');
+    expect(resolveTier(100)).toBe('familiar');
+    expect(resolveTier(999)).toBe('familiar');
+    expect(resolveTier(1000)).toBe('solid');
+    expect(resolveTier(1999)).toBe('solid');
+    expect(resolveTier(2000)).toBe('mastery');
   });
 
-  it('effectiveTier applies the Mastery creator-share gate at 3500+', () => {
-    expect(effectiveTier(4000, 799)).toBe('solid'); // 799/4000 < 20%
-    expect(effectiveTier(4000, 800)).toBe('mastery'); // exactly 20%
-    expect(effectiveTier(3499, 0)).toBe('solid');
+  it('effectiveTier applies the Mastery creator-share gate at 2000+', () => {
+    expect(effectiveTier(2500, 499)).toBe('solid'); // 499/2500 < 20%
+    expect(effectiveTier(2500, 500)).toBe('mastery'); // exactly 20%
+    expect(effectiveTier(1999, 0)).toBe('solid');
   });
 
   it('effectiveTier requires creator credit from multiple distinct questions for Mastery', () => {
-    expect(effectiveTier(4000, 1000, 1)).toBe('solid');
-    expect(effectiveTier(4000, 1000, 2)).toBe('mastery');
+    expect(effectiveTier(2500, 1000, 1)).toBe('solid');
+    expect(effectiveTier(2500, 1000, 2)).toBe('mastery');
   });
 });

--- a/src/server/mastery/awards.ts
+++ b/src/server/mastery/awards.ts
@@ -9,7 +9,7 @@
 
 import { invalidateMultitudesCacheForUser } from '@/server/profile/multitudes';
 import type { AnswerState, DifficultyEstimate, MasteryTier } from '@/types/db';
-import { effectiveTier } from '@/server/mastery/tiers';
+import { effectiveTier, TIER_THRESHOLD_POINTS } from '@/server/mastery/tiers';
 
 // TODO R2: replace Prisma transaction/client shapes with Drizzle equivalents.
 type DbClient = any;
@@ -265,7 +265,7 @@ async function applyMasteryAward(
   const upgradedTier = effectiveTier(nextPoints, authorCreditInDomain, authorCreditDistinctQuestionCount);
   const tierCrossed = upgradedTier !== previousTier;
   if (
-    nextPoints >= 3500 &&
+    nextPoints >= TIER_THRESHOLD_POINTS.mastery &&
     upgradedTier === 'solid' &&
     authorCreditInDomain / nextPoints < 0.2
   ) {

--- a/src/server/mastery/tiers.ts
+++ b/src/server/mastery/tiers.ts
@@ -3,9 +3,9 @@ import type { MasteryTier } from '@/types/db';
 /** PRD §8.32 — minimum points to enter each tier (establishing is default below familiar). */
 export const TIER_THRESHOLD_POINTS: Record<MasteryTier, number> = {
   establishing: 0,
-  familiar: 500,
-  solid: 1500,
-  mastery: 3500,
+  familiar: 100,
+  solid: 1000,
+  mastery: 2000,
 };
 
 /**


### PR DESCRIPTION
### Motivation
- Update mastery tier thresholds and related UI/formatting to reflect the revised PRD §8.32 point bands and remove scattered magic numbers.
- Ensure server logic, award gating, and share/portrait UI use a single source of truth for threshold values.

### Description
- Lowered tier thresholds in `src/server/mastery/tiers.ts` to `familiar: 100`, `solid: 1000`, and `mastery: 2000` (establishing remains 0).
- Propagated thresholds to the frontend by updating `TIER_NEXT_POINTS` in `src/app/daily/setup/page.tsx` and `TIER_POINTS` in `src/components/ShareCard.tsx` to match the new bands.
- Replaced a hardcoded mastery check (`nextPoints >= 3500`) in `src/server/mastery/awards.ts` with `TIER_THRESHOLD_POINTS.mastery` and imported the thresholds constant.
- Updated unit tests in `src/server/mastery/__tests__/tiers.test.ts` and `src/server/mastery/__tests__/tier-progress.test.ts` to assert the new breakpoints and portrait bar calculations.

### Testing
- Ran the server mastery unit tests with `vitest` covering `tiers.test.ts` and `tier-progress.test.ts`, and the updated assertions passed.
- Ran the project test suite via `vitest` and there were no test failures after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033e72bdb4832ea3f98004ccaa9450)