### PR TITLE
Normalize portrait broad categories

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -10,6 +10,7 @@ import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import type { MasteryTier } from '@/types/db';
 
 type DomainMastery = {
@@ -83,7 +84,7 @@ function displayMind(domains: DomainMastery[], declaredInterests: string[]): str
 function toPortraitEntry(domain: DomainMastery): PortraitEntry {
   return {
     canonicalSubcategory: domain.displayName,
-    broadCategory: domain.broadCategory ?? 'Other',
+    broadCategory: normalizeBroadCategory(domain.broadCategory) ?? 'Other',
     totalMasteryPoints: Math.max(domain.points, domain.isDeclaredInterest ? 1 : 0),
     tier: asTier(domain.tier),
     authoredAnsweredCount: domain.questionsAnswered,

--- a/src/components/knowledge/KnowledgeOverviewClient.tsx
+++ b/src/components/knowledge/KnowledgeOverviewClient.tsx
@@ -7,6 +7,7 @@ import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/Port
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
 import type { KnowledgeOverview } from '@/server/profile/knowledge-types';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 
 type KnowledgeOverviewClientProps = {
   overview: KnowledgeOverview;
@@ -90,7 +91,7 @@ export function KnowledgeOverviewClient({
         (portraitData as { categories: Array<{ canonical_subcategory: string; broad_category: string; declared_score: number; proven_score: number; authored_answered_count: number }> }).categories
       ).map((cat) => ({
         canonicalSubcategory: cat.canonical_subcategory,
-        broadCategory: cat.broad_category,
+        broadCategory: normalizeBroadCategory(cat.broad_category) ?? 'Other',
         totalMasteryPoints: (cat.declared_score ?? 0) + (cat.proven_score ?? 0),
         tier: (masteryMap.get(cat.canonical_subcategory) ?? 'establishing') as PortraitEntry['tier'],
         authoredAnsweredCount: cat.authored_answered_count ?? 0,

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useMemo, type CSSProperties } from 'react';
 import { getDomainCircleSize, type CircleSizingTier } from '@/lib/knowledge/circle-sizing';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 
 type PortraitTier = 'establishing' | 'familiar' | 'solid' | 'mastery';
 type SortMode = 'domain' | 'mastery';
@@ -79,9 +80,11 @@ function buildSections(entries: PortraitEntry[], sortMode: SortMode): Section[] 
   if (sortMode === 'domain') {
     const domainMap = new Map<string, PortraitEntry[]>();
     for (const e of entries) {
-      const list = domainMap.get(e.broadCategory) ?? [];
-      list.push(e);
-      domainMap.set(e.broadCategory, list);
+      const broadCategory = normalizeBroadCategory(e.broadCategory) ?? 'Other';
+      const normalizedEntry = { ...e, broadCategory };
+      const list = domainMap.get(broadCategory) ?? [];
+      list.push(normalizedEntry);
+      domainMap.set(broadCategory, list);
     }
     return Array.from(domainMap.entries())
       .map(([domain, cats]) => ({
@@ -121,7 +124,8 @@ export function PortraitDomainCircle({
   circleScale?: number;
   selected?: boolean;
 }) {
-  const dc = getPortraitDomainColor(entry.broadCategory);
+  const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'Other';
+  const dc = getPortraitDomainColor(broadCategory);
   const size = Math.round(getDomainCircleSize(entry.tier as CircleSizingTier, entry.totalMasteryPoints, maxPointsForTier) * circleScale);
   const opacity = forceFullOpacity ? 1 : getPortraitCircleOpacity(entry.totalMasteryPoints, maxPointsForTier);
   const labelOpacity = 0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5;
@@ -198,7 +202,9 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
   const [sortMode, setSortMode] = useState<SortMode>('domain');
 
   const validEntries = useMemo(
-    () => entries.filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
+    () => entries
+      .map((entry) => ({ ...entry, broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'Other' }))
+      .filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
     [entries],
   );
   const isSparse = validEntries.length < SPARSE_THRESHOLD;

--- a/src/lib/knowledge/broad-category.test.ts
+++ b/src/lib/knowledge/broad-category.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
+
+describe('normalizeBroadCategory', () => {
+  it('keeps stable broad categories as portrait sections', () => {
+    expect(normalizeBroadCategory('Literature')).toBe('Literature');
+    expect(normalizeBroadCategory('music')).toBe('Music');
+  });
+
+  it('keeps Joyce-specific labels inside Literature rather than making a new section', () => {
+    expect(normalizeBroadCategory('James Joyce & Irish Modernism')).toBe('Literature');
+    expect(normalizeBroadCategory("Joyce's Ulysses")).toBe('Literature');
+  });
+
+  it('normalizes common broad-category aliases', () => {
+    expect(normalizeBroadCategory('Film & TV')).toBe('Film & Television');
+    expect(normalizeBroadCategory('Pop Culture & Television')).toBe('Film & Television');
+  });
+});

--- a/src/lib/knowledge/broad-category.ts
+++ b/src/lib/knowledge/broad-category.ts
@@ -1,0 +1,70 @@
+const BROAD_CATEGORY_ALIASES: Record<string, string> = {
+  'film & tv': 'Film & Television',
+  'film and tv': 'Film & Television',
+  'film and television': 'Film & Television',
+  'television': 'Film & Television',
+  'tv': 'Film & Television',
+  'classical music': 'Music',
+  'world history': 'History',
+  'pop culture & television': 'Film & Television',
+  'pop culture and television': 'Film & Television',
+};
+
+const STABLE_BROAD_CATEGORIES = new Set([
+  'Literature',
+  'Music',
+  'Film & Television',
+  'Architecture & Design',
+  'Food & Cuisine',
+  'Technology',
+  'Sports',
+  'History',
+  'Science',
+  'Philosophy',
+  'Pop Culture',
+  'Language',
+  'Other',
+]);
+
+const LITERATURE_BROAD_CATEGORY_PATTERNS = [
+  /\bliterat(?:ure|ary)\b/i,
+  /\bfiction\b/i,
+  /\bnovels?\b/i,
+  /\bpoe(?:m|try|ts?)\b/i,
+  /\bplaywrights?\b/i,
+  /\bmodernis(?:m|t)\b/i,
+  /\bjames joyce\b/i,
+  /\bjoyce(?:'s|an)?\b/i,
+  /\bvirginia woolf\b/i,
+  /\bshakespeare\b/i,
+];
+
+function cleanBroadCategory(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+/**
+ * Broad categories are the top-level portrait buckets. LLMs sometimes return a
+ * territory-sized label here (for example, "James Joyce & Irish Modernism").
+ * Normalize those labels back to stable buckets so specific territories remain
+ * children of broad categories instead of becoming top-level sections.
+ */
+export function normalizeBroadCategory(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const cleaned = cleanBroadCategory(value);
+  if (!cleaned) return null;
+
+  const exactAlias = BROAD_CATEGORY_ALIASES[cleaned.toLowerCase()];
+  if (exactAlias) return exactAlias;
+
+  const stableMatch = [...STABLE_BROAD_CATEGORIES].find(
+    (category) => category.toLowerCase() === cleaned.toLowerCase(),
+  );
+  if (stableMatch) return stableMatch;
+
+  if (LITERATURE_BROAD_CATEGORY_PATTERNS.some((pattern) => pattern.test(cleaned))) {
+    return 'Literature';
+  }
+
+  return cleaned;
+}

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -369,7 +369,7 @@ Rules:
 - The subcategory must be as specific as the question demands.
 - Never normalize upward to a broad field if a narrower label is justified.
 - Use title case for both labels.
-- broad_category should be a stable domain (e.g., "Classical Music", "Literature", "World History", "Film & Television", "Science", "Philosophy", "Language", "Sports", "Pop Culture", "Other").
+- broad_category must be a stable top-level bucket, not an author/work/movement-specific territory (e.g., use "Literature" for James Joyce, Irish Modernism, novels, poetry, or fiction; use "Music", "History", "Film & Television", "Science", "Philosophy", "Language", "Sports", "Pop Culture", "Other").
 - subcategory should be narrow and portrait-friendly.
 - The subcategory must always be narrower than the broad_category. Never return the broad_category value itself as the subcategory (e.g. if broad_category is "Pop Culture", the subcategory must be something more specific than "Pop Culture"; if broad_category is "Music", the subcategory must be more specific than "Music").
 - For music, film, TV, or pop culture questions: name the specific artist, franchise, era, or cultural moment — not the genre or medium (e.g. "Late-Career David Bowie", "MCU Phase 3", "Drag Race Seasons 1–5", "Early 2010s Internet Memes", "Survivor Original Era").

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -16,6 +16,7 @@ import { getMasteryTierDisplay } from '@/server/mastery/get-mastery-tier-display
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { TIER_THRESHOLD_POINTS } from '@/server/mastery/tiers';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { pgErrorCode } from '@/server/db/pg-error';
 import type { MasteryTier } from '@/types/db';
 
@@ -253,7 +254,7 @@ function toDomainMasteryRow(
     questionsCorrect,
     correctRate: questionsAnswered > 0 ? percent((questionsCorrect / questionsAnswered) * 100) : 0,
     lastActivityAt: toIso(stats?.lastActivityAt),
-    broadCategory: knowledgeDomain.broadCategory ?? row?.broadCategory ?? null,
+    broadCategory: normalizeBroadCategory(knowledgeDomain.broadCategory ?? row?.broadCategory),
     iconKey: toCanonicalDomainSlug(domain),
     isDeclared: knowledgeDomain.isDeclared,
     isDeclaredInterest: knowledgeDomain.isDeclared,

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -211,7 +211,7 @@ Rules:
 - Bad domains: "Music", "Books", "Movies", "History", "General Trivia".
 - Distribute across the warm-up answers. Include at least one candidate per non-empty warm-up field if possible.
 - Each rationale must briefly tie the candidate to a specific warm-up answer or demographic context.
-- broadCategory is stable and broad, such as Classical Music, Literature, Film & Television, History, Science, Philosophy, Sports, Pop Culture, Language, Other.
+- broadCategory is a stable top-level bucket, such as Music, Literature, Film & Television, History, Science, Philosophy, Sports, Pop Culture, Language, Other. It must not be an author/work/movement-specific territory; for example, James Joyce, Irish Modernism, novels, poetry, and fiction all use Literature.
 - Do not invent private facts. Infer plausible interest territories only from the answers and cultural anchor context.${demographicLine ? `\n\n${demographicLine}` : ''}`;
 
   const userMessage = `Warm-up answers:

--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -3,6 +3,7 @@ import { and, eq, sql } from 'drizzle-orm';
 import { db, masteryEvents, playerMastery } from '@/server/db';
 import { effectiveTier } from '@/server/mastery/tiers';
 import type { AnswerState, MasteryTier } from '@/types/db';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 
 type MasteryEventSourceType = 'daily' | 'feed' | 'joshing_game' | 'catchup' | 'author_credit' | 'curator_credit';
 
@@ -48,12 +49,13 @@ async function readAuthorCredit(userId: string, domain: string) {
   };
 }
 
-async function writeTierCrossingActivityForFriends(_params: {
+async function writeTierCrossingActivityForFriends(params: {
   userId: string;
   domain: string;
   previousTier: MasteryTier;
   newTier: MasteryTier;
 }) {
+  void params;
   // TODO Phase 8: write friend_mastery activity for each friend when
   // friend system is built. Friends list: getFriends(userId).
 }
@@ -77,6 +79,7 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
   ]);
 
   const existing = existingMastery[0];
+  const broadCategory = normalizeBroadCategory(params.broadCategory ?? existing?.broadCategory);
   const previousTier: MasteryTier = existing?.tier ?? 'establishing';
   const nextTotalPoints = (existing?.totalPoints ?? 0) + params.pointsAwarded;
   const nextTier = params.pointsAwarded > 0
@@ -125,7 +128,7 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
         .values({
           userId: params.userId,
           canonicalSubcategory: params.domain,
-          broadCategory: params.broadCategory ?? existing?.broadCategory ?? null,
+          broadCategory,
           totalPoints: params.pointsAwarded,
           tier: nextTier,
           tierReachedAt: tierChanged ? new Date() : null,
@@ -135,7 +138,7 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
         .onConflictDoUpdate({
           target: [playerMastery.userId, playerMastery.canonicalSubcategory],
           set: {
-            broadCategory: params.broadCategory ?? existing?.broadCategory ?? null,
+            broadCategory,
             totalPoints: nextTotalPoints,
             tier: nextTier,
             tierReachedAt: tierChanged ? new Date() : existing?.tierReachedAt ?? null,


### PR DESCRIPTION
### Motivation
- LLMs and some inputs were producing author/work/movement-specific labels (e.g. “James Joyce & Irish Modernism”) that ended up as top-level portrait sections instead of grouping under stable buckets like `Literature`.
- Normalize broad-category signals so UI grouping, coloring, and stored mastery rows use stable portrait buckets and avoid creating spurious top-level sections.

### Description
- Add a shared normalizer `normalizeBroadCategory` in `src/lib/knowledge/broad-category.ts` that maps common aliases and detects literature-related territory labels (Joyce, modernism, novels, poems, etc.) to `Literature`.
- Apply normalization when shaping data and rendering portrait entries: `src/app/knowledge/page.tsx`, `src/components/knowledge/KnowledgeOverviewClient.tsx`, and `src/components/knowledge/PortraitCircles.tsx` now call `normalizeBroadCategory` before grouping/coloring.
- Persist normalized buckets when writing mastery rows: `src/server/mastery/write-mastery-event.ts` uses `normalizeBroadCategory` for the `broadCategory` stored with `PLAYER_MASTERY` rows.
- Normalize when building page data: `src/server/db/queries/knowledge.ts` now normalizes `broadCategory` when producing `DomainMastery` rows.
- Tweak LLM prompt wording in `src/lib/llm.ts` and `src/server/llm/interests.ts` to emphasize that `broad_category` / `broadCategory` must be a stable top-level bucket (e.g., `Literature` for Joyce/Irish Modernism), to reduce future mislabeling.
- Add unit tests for the normalizer in `src/lib/knowledge/broad-category.test.ts` covering Joyce -> `Literature` and common aliases.

### Testing
- Ran type check: `npx tsc --noEmit --project tsconfig.json` — succeeded. ✅
- Ran a quick runtime assertion: `npx tsx -e "import { normalizeBroadCategory } from './src/lib/knowledge/broad-category.ts'; ..."` which validated `James Joyce & Irish Modernism` → `Literature` and `Film & TV` → `Film & Television`. ✅
- Ran `git diff --check` to ensure no whitespace/merge artefacts — OK. ✅
- Attempted unit test run `npx vitest run src/lib/knowledge/broad-category.test.ts` but could not run in this environment because `vitest` install failed due to npm registry access (403). ⚠️
- Ran lint/type checks for the modified files; `npm run lint` still reports unrelated baseline issues in other parts of the repo (existing errors), none caused by these changes. ⚠️

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a033fdd6f04832ea92bf18b536558cd)