### PR TITLE
Place “Your Growth Recap” under Total on Daily and Game summary pages

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -9,7 +9,7 @@ import { AddToBankAction } from '@/components/AddToBankAction';
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay';
 import MasteryMoment from '@/components/review/MasteryMoment';
 import { cn } from '@/lib/utils';
-import type { DailySummaryView, QuestionRecap, TierCrossing } from '@/server/db/queries/daily-summary';
+import type { DailySummaryView, QuestionRecap } from '@/server/db/queries/daily-summary';
 
 type FeedbackSignal = 'thumbs_up' | 'thumbs_down';
 
@@ -187,15 +187,6 @@ export default function DailySummaryPage() {
         </p>
       </section>
 
-      <section className="mt-6">
-        <h2 style={titleStyle}>Round Recap</h2>
-        <div className="mt-3 space-y-3">
-          {summary.questions.map((question) => (
-            <QuestionCard key={question.questionId} question={question} />
-          ))}
-        </div>
-      </section>
-
       <section className="card mt-4 px-5 py-4">
         <h2 style={titleStyle}>Your Growth Recap</h2>
         <CategoryGainsDisplay
@@ -212,6 +203,15 @@ export default function DailySummaryPage() {
       ) : null}
 
       {line ? <InterpretiveLine text={line} /> : null}
+
+      <section className="mt-6">
+        <h2 style={titleStyle}>Round Recap</h2>
+        <div className="mt-3 space-y-3">
+          {summary.questions.map((question) => (
+            <QuestionCard key={question.questionId} question={question} />
+          ))}
+        </div>
+      </section>
 
       <div className="mt-6 flex flex-col gap-3 sm:flex-row">
         <Link className="btn-primary sm:flex-1" href="/knowledge">See your knowledge map</Link>
@@ -435,13 +435,5 @@ function DailyQuestionFeedbackButtons({ questionId }: { questionId: string }) {
         <ThumbsDown className="size-4" />
       </button>
     </div>
-  );
-}
-
-function TierLabel({ crossing }: { crossing: TierCrossing }) {
-  return (
-    <p style={{ ...monoStyle, fontSize: '0.52rem', color: 'var(--success)' }}>
-      ↑ Now {formatTier(crossing.toTier)}
-    </p>
   );
 }

--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -223,6 +223,21 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
         </p>
       </section>
 
+      <section className="card mt-4 px-5 py-4">
+        <h2 style={titleStyle}>Your Growth Recap</h2>
+        <CategoryGainsDisplay
+          gameItems={growthCircleItems}
+          emptyMessage="No mastery movement was recorded for this game."
+        />
+      </section>
+
+      {firstTierCrossing ? (
+        <MasteryMoment
+          subcategory={firstTierCrossing.canonical_subcategory}
+          newTier={firstTierCrossing.tier_after}
+        />
+      ) : null}
+
       {viewerHasPlayed ? (
         <section className="mt-6">
           <h2 style={titleStyle}>Round Recap</h2>
@@ -302,21 +317,6 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
             })}
           </div>
         </section>
-      ) : null}
-
-      <section className="card mt-4 px-5 py-4">
-        <h2 style={titleStyle}>Your Growth Recap</h2>
-        <CategoryGainsDisplay
-          gameItems={growthCircleItems}
-          emptyMessage="No mastery movement was recorded for this game."
-        />
-      </section>
-
-      {firstTierCrossing ? (
-        <MasteryMoment
-          subcategory={firstTierCrossing.canonical_subcategory}
-          newTier={firstTierCrossing.tier_after}
-        />
       ) : null}
 
       <section className="card mt-4 px-5 py-4">


### PR DESCRIPTION
### Motivation
- Surface the growth/movement summary higher on summary pages by placing the “Your Growth Recap” card directly underneath the Total card so users see mastery movement immediately.
- Keep the round-by-round details accessible but lower on the page to reduce visual clutter near the total score.
- Remove a now-unused helper import/label introduced while touching the daily summary layout.

### Description
- Moved the Growth Recap JSX block in `src/app/daily/summary/page.tsx` to sit directly after the Total card and before the Round Recap and interpretive elements.
- Moved the Growth Recap JSX block in `src/app/games/[id]/summary/page.tsx` to sit directly after the Total card and before the Round Recap and Impact Recap.
- Removed the unused `TierCrossing` type import and the `TierLabel` helper function from the daily summary file as they were no longer referenced.
- Adjusted surrounding layout order only; no changes to the `CategoryGainsDisplay` API or data calculations.

### Testing
- Ran `npx eslint src/app/daily/summary/page.tsx 'src/app/games/[id]/summary/page.tsx'`, which succeeded with one non-blocking warning for the touched files.
- Ran `npm run lint`, which failed due to existing repo-wide lint errors unrelated to these layout changes.
- Ran `npm run build`, which failed in this environment because Next.js could not fetch the Google Font (`Montserrat`) during the build.
- Started the dev server (`npm run dev`) and probed the summary endpoint with `curl -I http://localhost:3000/daily/summary`, which returned a `307` redirect to `/login` (expected without an authenticated session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037fb22634832eaa7c3de055ff7eab)