### PR TITLE
Limit knowledge card to top five domains and sync circle colors with portrait

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -238,7 +238,7 @@ function KnowledgePageContent() {
       .sort((a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName));
   }, [data, declaredKeys]);
 
-  const topCardDomains = useMemo(() => sortedDomains.filter((domain) => domain.points > 0).slice(0, 8), [sortedDomains]);
+  const topCardDomains = useMemo(() => sortedDomains.filter((domain) => domain.points > 0).slice(0, 5), [sortedDomains]);
   const yourMind = data ? displayMind(sortedDomains, data.pageData.declaredInterests) : '';
   const displayName = 'You';
   const hasAnything = sortedDomains.length > 0;
@@ -420,6 +420,7 @@ function KnowledgePageContent() {
               currentTier: asTier(domain.tier),
               lifetimePoints: domain.points,
               iconKey: domain.iconKey,
+              broadCategory: domain.broadCategory,
             }))}
             overflowCount={Math.max(0, sortedDomains.filter((domain) => domain.points > 0).length - topCardDomains.length)}
             tierSignature={`${formatNumber(data.mastery.totalPoints)} knowledge points across ${sortedDomains.length} territories`}

--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -1,4 +1,6 @@
 import { DOMAIN_ICON_COMPONENTS, DomainInitialIcon } from '@/components/icons/domain-icons';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
 import type { MasteryTier } from '@/types/db';
 import type { CSSProperties } from 'react';
 
@@ -21,6 +23,7 @@ type DomainCircleProps = {
   /** Whether to render the tier label below the domain name. Defaults to true. */
   showTierLabel?: boolean;
   territoryType?: 'declared' | 'demonstrated';
+  broadCategory?: string | null;
   onTap?: () => void;
 };
 
@@ -35,11 +38,18 @@ export function DomainCircle({
   isGhost = false,
   showTierLabel = true,
   territoryType,
+  broadCategory,
   onTap,
 }: DomainCircleProps) {
   const iconSize = Math.round(diameter * 0.4);
   const Icon = (DOMAIN_ICON_COMPONENTS as Record<string, (typeof DOMAIN_ICON_COMPONENTS)[keyof typeof DOMAIN_ICON_COMPONENTS] | undefined>)[iconKey];
   const yourQsCount = Math.min(showYourQs, 5);
+  const normalizedCategory = normalizeBroadCategory(broadCategory) ?? null;
+  const domainColor = normalizedCategory ? getPortraitDomainColor(normalizedCategory) : null;
+  const circleBackground = domainColor
+    ? `radial-gradient(circle at 38% 38%, ${domainColor.light.replace('0.12', '0.22')}, ${domainColor.light})`
+    : territoryType === 'declared' ? 'rgba(245, 240, 232, 0.3)' : '#f5f0e8';
+  const circleBorder = highlighted ? '#1a1208' : domainColor?.primary ?? '#d4cfc7';
 
   if (isGhost) {
     return (
@@ -82,8 +92,8 @@ export function DomainCircle({
           width: `${diameter}px`,
           height: `${diameter}px`,
           borderRadius: '999px',
-          border: `1px solid ${highlighted ? '#1a1208' : '#d4cfc7'}`,
-          background: territoryType === 'declared' ? 'rgba(245, 240, 232, 0.3)' : '#f5f0e8',
+          border: `1px solid ${circleBorder}`,
+          background: circleBackground,
           margin: '0 auto',
           display: 'grid',
           placeItems: 'center',

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -11,6 +11,7 @@ export interface KnowledgeDomainCircle {
   currentTier: MasteryTier;
   lifetimePoints: number;
   iconKey: string;
+  broadCategory?: string | null;
 }
 
 export interface KnowledgeCardProps {
@@ -39,6 +40,8 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
   const [copyLabel, setCopyLabel] = useState('Copy');
   const [shareLabel, setShareLabel] = useState('Share');
   const sorted = useMemo(() => [...props.domains].sort((a, b) => b.lifetimePoints - a.lifetimePoints), [props.domains]);
+  const visibleDomains = sorted.slice(0, 5);
+  const totalOverflowCount = props.overflowCount + Math.max(0, sorted.length - visibleDomains.length);
   const maxPoints = sorted[0]?.lifetimePoints ?? 1;
 
   const onCopy = async () => {
@@ -70,7 +73,7 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
 
       <div style={{ borderTop: '1px solid #e8e2d6', padding: '24px 20px' }}>
         <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'flex-end', columnGap: 16, rowGap: 20 }}>
-          {sorted.map((domain) => {
+          {visibleDomains.map((domain) => {
             const diameter = getCircleDiameter(domain.lifetimePoints, maxPoints, typeof window !== 'undefined' ? window.innerWidth < 400 : false);
             return (
               <DomainCircle
@@ -79,13 +82,14 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
                 diameter={diameter}
                 iconKey={domain.iconKey}
                 canonicalSubcategory={domain.canonicalSubcategory}
+                broadCategory={domain.broadCategory}
                 currentTier={domain.currentTier}
                 highlighted={props.highlightedSlug === domain.canonicalSubcategorySlug}
               />
             );
           })}
         </div>
-        {props.overflowCount > 0 && <p style={{ marginTop: 14, fontSize: 11, color: '#8a8070', textAlign: 'center' }}>+{props.overflowCount} more territories</p>}
+        {totalOverflowCount > 0 && <p style={{ marginTop: 14, fontSize: 11, color: '#8a8070', textAlign: 'center' }}>+{totalOverflowCount} more territories</p>}
       </div>
 
       <div style={{ borderTop: '1px solid #e8e2d6', padding: 20 }}>


### PR DESCRIPTION
### Motivation

- The knowledge card should show only the top five territories in its area to match visual priorities and reduce clutter.
- Circles in the card should use the same color palette/gradients as the portrait below so visuals are consistent.

### Description

- Limit the knowledge card source list to the top five scored domains by slicing to `slice(0, 5)` in `src/app/knowledge/page.tsx` and add defensive capping in `KnowledgeCard` itself.  
- Add `broadCategory` to the domain shape and pass `broadCategory` from `page.tsx` into `KnowledgeCard` and then into each `DomainCircle` so circles can pick matching colors.  
- Update `DomainCircle` to accept an optional `broadCategory`, normalize it with `normalizeBroadCategory`, and use `getPortraitDomainColor` to build the same radial gradient and primary color border used by the portrait circles.  
- Adjust overflow counting so the displayed `+N more territories` reflects both the page-level overflow and any additional domains trimmed by the card’s local cap.

### Testing

- Ran TypeScript checks with `npx tsc --noEmit --pretty false`, which succeeded after adding the new optional property.  
- Linted the changed files with `npx eslint src/components/knowledge/DomainCircle.tsx src/components/knowledge/KnowledgeCard.tsx`, which passed for the modified files.  
- Ran the project lint with `npm run lint`, which surfaced unrelated, pre-existing repository-wide lint errors (e.g. `react-hooks/set-state-in-effect` and `@typescript-eslint/no-explicit-any`) and therefore did not fully pass; these issues are outside this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03809eb538832ea46076a3e1cb2f1a)