### PR TITLE
Add migration and runtime guard to restore missing Question.surface_priority_score column

### DIFF
--- a/drizzle/0024_question_surface_priority_runtime_hotfix.sql
+++ b/drizzle/0024_question_surface_priority_runtime_hotfix.sql
@@ -1,0 +1,5 @@
+-- Runtime compatibility hotfix for preview/prod databases whose migration
+-- journal indicates feed migrations ran but the Question priority column is
+-- absent. Safe to run repeatedly.
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "surface_priority_score" DOUBLE PRECISION NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -169,6 +169,13 @@
       "when": 1778540000000,
       "tag": "0023_profile_domain_visibility_runtime_hotfix",
       "breakpoints": true
+    },
+    {
+      "idx": 24,
+      "version": "7",
+      "when": 1778616500000,
+      "tag": "0024_question_surface_priority_runtime_hotfix",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -57,6 +57,16 @@ export type QuestionMutationResult = { ok: boolean; reason?: 'not_found' | 'in_u
 
 type QuestionRow = typeof questions.$inferSelect;
 
+let ensureQuestionSurfacePriorityColumnPromise: Promise<void> | null = null;
+
+function ensureQuestionSurfacePriorityColumn(): Promise<void> {
+  ensureQuestionSurfacePriorityColumnPromise ??= db.execute(sql`
+    ALTER TABLE "Question"
+      ADD COLUMN IF NOT EXISTS "surface_priority_score" DOUBLE PRECISION NOT NULL DEFAULT 0
+  `).then(() => undefined);
+  return ensureQuestionSurfacePriorityColumnPromise;
+}
+
 const questionTableColumns = getTableColumns(questions);
 const questionViewColumns = {
   id: questionTableColumns.id,
@@ -245,6 +255,8 @@ export async function createQuestion(params: {
   llmSuggestedAnswer?: string | null;
   critiqueIterations: number;
 }): Promise<{ id: string }> {
+  await ensureQuestionSurfacePriorityColumn();
+
   const difficulty = numberToDifficulty(params.difficulty);
   const baseValues = {
     creatorId: params.authorId,


### PR DESCRIPTION
### Motivation
- Fix runtime 500s caused by inserts referencing `surfacePriorityScore` / `surface_priority_score` when the column is missing due to schema drift between migrations and the running database.

### Description
- Add a repeatable Drizzle hotfix `drizzle/0024_question_surface_priority_runtime_hotfix.sql` that runs `ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "surface_priority_score" DOUBLE PRECISION NOT NULL DEFAULT 0`.
- Register the new migration in `drizzle/meta/_journal.json` so drifted preview/prod databases will receive the repair even if earlier feed migrations were marked applied.
- Add a cached runtime self-healing guard `ensureQuestionSurfacePriorityColumn()` in `src/server/db/queries/questions.ts` and `await` it at the start of `createQuestion` so the app attempts to create the missing column before building inserts that include it.
- No behavioral changes to question creation logic beyond ensuring the DB column exists before inserts.

### Testing
- Ran `npx tsc --noEmit`, which succeeded.
- Ran `npm run lint`; lint failed on pre-existing unrelated issues across the repository and did not surface new errors introduced by these changes.
- Ran `git diff --check` as a validation step and it passed with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0387b92ed8832e89b37c80b832c25b)