### PR TITLE
Separate broad category and canonical subcategory for authored questions

### DIFF
--- a/scripts/backfill-authored-literature-domains.ts
+++ b/scripts/backfill-authored-literature-domains.ts
@@ -1,0 +1,122 @@
+import 'dotenv/config';
+import { Pool } from 'pg';
+
+const QUESTION_IDS = [process.env.QUESTION_ID_1, process.env.QUESTION_ID_2].filter(Boolean) as string[];
+const USER_ID = process.env.USER_ID;
+
+type QuestionRow = {
+  id: string;
+  creator_id: string;
+  question_text: string;
+  answer_text: string;
+  category: string | null;
+  broad_category: string | null;
+  subcategory: string | null;
+  canonical_subcategory: string | null;
+  category_overridden: boolean | null;
+  sharedToFriendsFeed: boolean | null;
+  created_at: Date;
+};
+
+function inferLiteratureDomain(row: QuestionRow): string {
+  const combined = `${row.question_text} ${row.answer_text}`.toLowerCase();
+  if (combined.includes('waste land') || combined.includes('cruelest month') || combined.includes('cruellest month')) {
+    return 'The Waste Land';
+  }
+  if (combined.includes('four quartets')) return 'Four Quartets';
+  if (combined.includes('eliot') || combined.includes('prufrock')) return 'T. S. Eliot';
+  if (combined.includes('modernist') || combined.includes('modernism')) return 'Modernist Poetry';
+  return 'T. S. Eliot';
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) throw new Error('DATABASE_URL is required.');
+  if (QUESTION_IDS.length === 0 && !USER_ID) {
+    throw new Error('Set QUESTION_ID_1 and QUESTION_ID_2, or set USER_ID to update the two most recent authored questions for that user.');
+  }
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  try {
+    const questions = QUESTION_IDS.length > 0
+      ? (await pool.query<QuestionRow>(`
+          SELECT id, creator_id, question_text, answer_text, category, broad_category, subcategory,
+                 canonical_subcategory, category_overridden, "sharedToFriendsFeed", created_at
+          FROM "Question"
+          WHERE id = ANY($1::text[])
+          ORDER BY created_at DESC
+        `, [QUESTION_IDS])).rows
+      : (await pool.query<QuestionRow>(`
+          SELECT id, creator_id, question_text, answer_text, category, broad_category, subcategory,
+                 canonical_subcategory, category_overridden, "sharedToFriendsFeed", created_at
+          FROM "Question"
+          WHERE creator_id = $1 AND deleted_at IS NULL
+          ORDER BY created_at DESC
+          LIMIT 2
+        `, [USER_ID])).rows;
+
+    console.table(questions.map((row) => ({
+      id: row.id,
+      creator_id: row.creator_id,
+      question_text: row.question_text,
+      category: row.category,
+      broad_category: row.broad_category,
+      subcategory: row.subcategory,
+      canonical_subcategory: row.canonical_subcategory,
+      category_overridden: row.category_overridden,
+      sharedToFriendsFeed: row.sharedToFriendsFeed,
+      created_at: row.created_at,
+    })));
+
+    for (const row of questions) {
+      const canonical = inferLiteratureDomain(row);
+      await pool.query('BEGIN');
+      try {
+        await pool.query(`
+          UPDATE "Question"
+          SET category = 'literature'::"Category",
+              broad_category = 'Literature',
+              subcategory = $2,
+              canonical_subcategory = $2,
+              category_overridden = true,
+              updated_at = now()
+          WHERE id = $1
+        `, [row.id, canonical]);
+
+        await pool.query(`
+          INSERT INTO "PLAYER_MASTERY" (
+            id, user_id, canonical_subcategory, broad_category, total_points, tier,
+            season_points_start, territory_type, updated_at
+          )
+          VALUES (gen_random_uuid()::text, $1, $2, 'Literature', 0, 'establishing', 0, 'declared', now())
+          ON CONFLICT (user_id, canonical_subcategory) DO UPDATE
+          SET broad_category = COALESCE("PLAYER_MASTERY".broad_category, EXCLUDED.broad_category),
+              territory_type = CASE
+                WHEN "PLAYER_MASTERY".territory_type = 'demonstrated' THEN 'demonstrated'
+                ELSE 'declared'
+              END,
+              updated_at = now()
+        `, [row.creator_id, canonical]);
+
+        await pool.query(`
+          UPDATE "MASTERY_EVENTS"
+          SET canonical_subcategory = $2
+          WHERE question_id = $1
+            AND canonical_subcategory IN ('literature', 'Literature')
+        `, [row.id, canonical]);
+
+        await pool.query('COMMIT');
+        console.log(`Backfilled ${row.id} -> ${canonical}`);
+      } catch (error) {
+        await pool.query('ROLLBACK');
+        throw error;
+      }
+    }
+  } finally {
+    await pool.end();
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { QUESTION_DOMAIN_KEYS } from '@/lib/game-constants';
+import { broadCategoryDisplayName, isBroadQuestionCategory, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { getSession } from '@/server/auth/session';
 import { db, questions } from '@/server/db';
 import {
@@ -13,8 +13,6 @@ import {
 type RouteContext = {
   params: Promise<{ id: string }>;
 };
-
-const VALID_DOMAINS = new Set<string>(QUESTION_DOMAIN_KEYS);
 
 function splitAlternates(value: unknown): string[] | undefined {
   if (value === undefined) return undefined;
@@ -33,7 +31,10 @@ function validatePatchPayload(body: Record<string, unknown> | null) {
     correctAnswer?: string;
     alternateAnswers?: string[];
     explanation?: string;
-    domain?: string;
+    category?: string;
+    broadCategory?: string | null;
+    subcategory?: string;
+    canonicalSubcategory?: string;
     difficulty?: number;
   } = {};
   const errors: string[] = [];
@@ -56,9 +57,27 @@ function validatePatchPayload(body: Record<string, unknown> | null) {
     values.explanation = typeof body.explanation === 'string' ? body.explanation.trim() : '';
     if (values.explanation.length > 500) errors.push('explanation');
   }
-  if (body?.domain !== undefined) {
-    values.domain = typeof body.domain === 'string' ? body.domain : '';
-    if (!VALID_DOMAINS.has(values.domain)) errors.push('domain');
+  const rawBroadCategory = body?.category ?? body?.broadCategory;
+  if (rawBroadCategory !== undefined) {
+    const category = typeof rawBroadCategory === 'string' ? normalizeBroadQuestionCategory(rawBroadCategory) : null;
+    if (!category) {
+      errors.push('category');
+    } else {
+      values.category = category;
+      values.broadCategory = broadCategoryDisplayName(category);
+    }
+  }
+  const rawCanonicalSubcategory = body?.canonicalSubcategory ?? body?.canonical_subcategory ?? body?.domain;
+  if (rawCanonicalSubcategory !== undefined) {
+    const canonicalSubcategory = typeof rawCanonicalSubcategory === 'string'
+      ? normalizeCanonicalSubcategory(rawCanonicalSubcategory)
+      : '';
+    if (!canonicalSubcategory || isBroadQuestionCategory(canonicalSubcategory)) {
+      errors.push('canonicalSubcategory');
+    } else {
+      values.canonicalSubcategory = canonicalSubcategory;
+      values.subcategory = canonicalSubcategory;
+    }
   }
   if (body?.difficulty !== undefined) {
     values.difficulty = typeof body.difficulty === 'number' ? body.difficulty : Number.NaN;

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,7 +1,6 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { QUESTION_DOMAIN_KEYS } from '@/lib/game-constants';
 import { getSession } from '@/server/auth/session';
 import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
@@ -18,91 +17,9 @@ import {
 import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
 import { writeActivity } from '@/server/activity/write-activity';
+import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 
 export const dynamic = 'force-dynamic';
-
-const VALID_DOMAINS = new Set<string>(QUESTION_DOMAIN_KEYS);
-
-function splitAlternates(value: unknown): string[] {
-  if (Array.isArray(value)) {
-    return value
-      .filter((item): item is string => typeof item === 'string')
-      .map((item) => item.trim())
-      .filter(Boolean);
-  }
-  if (typeof value === 'string') {
-    return value.split(',').map((item) => item.trim()).filter(Boolean);
-  }
-  return [];
-}
-
-function difficultyFromLegacy(value: unknown): number | null {
-  if (value === 'accessible') return 1;
-  if (value === 'moderate') return 3;
-  if (value === 'specialist') return 5;
-  return null;
-}
-
-function readCreatePayload(body: Record<string, unknown> | null) {
-  const text = typeof body?.text === 'string'
-    ? body.text.trim()
-    : typeof body?.question_text === 'string'
-      ? body.question_text.trim()
-      : '';
-  const correctAnswer = typeof body?.correctAnswer === 'string'
-    ? body.correctAnswer.trim()
-    : typeof body?.answer_text === 'string'
-      ? body.answer_text.trim()
-      : '';
-  const alternateAnswers = splitAlternates(body?.alternateAnswers ?? body?.accepted_alternatives).slice(0, 5);
-  const explanation = typeof body?.explanation === 'string'
-    ? body.explanation.trim() || null
-    : null;
-  const creatorNote = typeof body?.creatorNote === 'string'
-    ? body.creatorNote.trim() || null
-    : typeof body?.creator_note === 'string'
-      ? body.creator_note.trim() || null
-      : null;
-  const isLegacyPayload = typeof body?.question_text === 'string' || typeof body?.answer_text === 'string';
-  const domain = typeof body?.domain === 'string'
-    ? body.domain
-    : typeof body?.category === 'string'
-      ? body.category
-      : isLegacyPayload
-        ? 'other'
-        : '';
-  const difficulty = typeof body?.difficulty === 'number'
-    ? body.difficulty
-    : difficultyFromLegacy(body?.difficulty_estimate) ?? (isLegacyPayload ? 3 : null);
-  const difficultyValue = difficulty ?? Number.NaN;
-  const verified = typeof body?.verified === 'boolean' ? body.verified : null;
-  const llmSuggestedAnswer = typeof body?.llmSuggestedAnswer === 'string'
-    ? body.llmSuggestedAnswer.trim() || null
-    : null;
-  const critiqueIterations = typeof body?.critiqueIterations === 'number' ? body.critiqueIterations : Number.NaN;
-
-  const rawSendToFriendIds = Array.isArray(body?.sendToFriendIds)
-    ? (body.sendToFriendIds as unknown[]).filter((id): id is string => typeof id === 'string').slice(0, 20)
-    : [];
-  const shareToFeed = body?.shareToFeed === true;
-
-  const errors: string[] = [];
-  if (!text || text.length > 300) errors.push('text');
-  if (!correctAnswer || correctAnswer.length > 200) errors.push('correctAnswer');
-  if (alternateAnswers.length > 5 || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
-  if (explanation && explanation.length > 500) errors.push('explanation');
-  if (creatorNote && creatorNote.length > 200) errors.push('creatorNote');
-  if (!VALID_DOMAINS.has(domain)) errors.push('domain');
-  if (verified === null) errors.push('verified');
-  if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
-  if (!Number.isInteger(difficultyValue) || difficultyValue < 1 || difficultyValue > 5) errors.push('difficulty');
-  if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
-
-  return {
-    value: { text, correctAnswer, alternateAnswers, explanation, creatorNote, domain, difficulty: difficultyValue, verified: verified ?? true, llmSuggestedAnswer, critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0, sendToFriendIds: rawSendToFriendIds, shareToFeed },
-    errors,
-  };
-}
 
 export async function GET() {
   const session = await getSession();
@@ -116,7 +33,7 @@ export async function POST(request: NextRequest) {
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
   const body = await request.json().catch(() => null) as Record<string, unknown> | null;
-  const { value, errors } = readCreatePayload(body);
+  const { value, errors } = readCreateQuestionPayload(body);
   if (errors.length > 0) {
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
@@ -140,8 +57,9 @@ export async function POST(request: NextRequest) {
   console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified });
   const kbResult = await openKBDomain({
     userId: session.userId,
-    domain: questionFields.domain,
+    domain: questionFields.canonicalSubcategory,
     via: 'authorship',
+    broadCategory: questionFields.broadCategory,
     questionId: created.id,
   });
   const question = await getQuestion(created.id, session.userId);
@@ -160,7 +78,7 @@ export async function POST(request: NextRequest) {
             .from(feedDismissedDomains)
             .where(and(
               eq(feedDismissedDomains.userId, friend.id),
-              eq(feedDismissedDomains.canonicalSubcategory, questionFields.domain),
+              eq(feedDismissedDomains.canonicalSubcategory, questionFields.canonicalSubcategory),
               isNull(feedDismissedDomains.reinstatedAt),
             ))
             .limit(1);
@@ -261,7 +179,7 @@ export async function POST(request: NextRequest) {
       ...created,
       question,
       ...(question ?? {}),
-      openedDomain: kbResult.opened ? questionFields.domain : null,
+      openedDomain: kbResult.opened ? questionFields.canonicalSubcategory : null,
     },
     { status: 201 },
   );

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -6,7 +6,6 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
-import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 import type { QuestionView } from '@/server/db/queries/questions';
 
 type SortMode = 'newest' | 'most_answered' | 'hardest' | 'easiest';
@@ -82,6 +81,8 @@ function initialValues(question: QuestionView): QuestionFormValues {
     correctAnswer: question.correctAnswer,
     alternateAnswers: question.alternateAnswers,
     explanation: question.explanation,
+    category: question.category,
+    canonicalSubcategory: question.canonicalSubcategory ?? question.domain,
     domain: question.domain,
     difficulty: question.difficulty,
     verified: question.verified,
@@ -159,10 +160,11 @@ function QuestionsPageContent() {
     return () => window.clearTimeout(timer);
   }, [toast]);
 
-  const availableDomains = useMemo(() => {
-    const seen = new Set(questions.map((question) => question.domain));
-    return CATEGORIES.filter((category) => seen.has(category));
-  }, [questions]);
+  const availableDomains = useMemo(() => (
+    [...new Map(questions.map((question) => [question.domain, question.domainDisplayName] as const)).entries()]
+      .map(([domain, label]) => ({ domain, label }))
+      .sort((a, b) => a.label.localeCompare(b.label))
+  ), [questions]);
 
   const filteredQuestions = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -302,8 +304,8 @@ function QuestionsPageContent() {
           aria-label="Filter by domain"
         >
           <option value="all">All domains</option>
-          {availableDomains.map((domain) => (
-            <option key={domain} value={domain}>{categoryLabel(domain)}</option>
+          {availableDomains.map((item) => (
+            <option key={item.domain} value={item.domain}>{item.label}</option>
           ))}
         </select>
         <select
@@ -350,7 +352,7 @@ function QuestionsPageContent() {
           {filteredQuestions.map((question) => {
             const isOwnAuthored = question.isOwnAuthored ?? true;
             const inUse = question.usedInGamesCount > 0;
-            const color = DOMAIN_COLORS[question.domain] ?? '#64748b';
+            const color = DOMAIN_COLORS[question.category] ?? '#64748b';
             const deleting = removingId === question.id;
 
             return (

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -3,6 +3,7 @@
 import { Sparkles } from 'lucide-react';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 
+import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
 export type QuestionFormValues = {
@@ -11,7 +12,9 @@ export type QuestionFormValues = {
   alternateAnswers: string[];
   explanation: string | null;
   creatorNote?: string | null;
-  domain: string;
+  category: string;
+  canonicalSubcategory: string;
+  domain?: string;
   difficulty: number;
   verified: boolean;
   llmSuggestedAnswer?: string | null;
@@ -58,7 +61,9 @@ type State = {
   alternateText: string;
   explanation: string;
   creatorNote: string;
-  domain: string;
+  category: string;
+  canonicalSubcategory: string;
+  domain?: string;
   difficulty: number;
   critiqueResult: CritiqueResult | null;
   critiqueIterations: number;
@@ -76,7 +81,7 @@ type State = {
 
 type Action =
   | { type: 'RESET'; state: State }
-  | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote' | 'domain'; value: string }
+  | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote' | 'category' | 'canonicalSubcategory'; value: string }
   | { type: 'DIFFICULTY'; value: number }
   | { type: 'ERROR'; value: string | null }
   | { type: 'START_CRITIQUE'; text: string }
@@ -116,7 +121,8 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     alternateText: (initialValues?.alternateAnswers ?? []).join(', '),
     explanation: initialValues?.explanation ?? '',
     creatorNote: initialValues?.creatorNote ?? '',
-    domain: initialValues?.domain ?? 'other',
+    category: initialValues?.category ?? 'other',
+    canonicalSubcategory: initialValues?.canonicalSubcategory ?? initialValues?.domain ?? '',
     difficulty: initialValues?.difficulty ?? 3,
     critiqueResult: null,
     critiqueIterations: initialValues?.critiqueIterations ?? 0,
@@ -204,7 +210,10 @@ function validate(state: State): string | null {
   if (alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
   if (state.explanation.length > 500) return 'Explanation must be 500 characters or fewer.';
   if (state.creatorNote.length > 200) return 'Creator note must be 200 characters or fewer.';
-  if (!CATEGORIES.includes(state.domain as (typeof CATEGORIES)[number])) return 'Choose a valid domain.';
+  if (!CATEGORIES.includes(state.category as (typeof CATEGORIES)[number])) return 'Choose a valid broad category.';
+  const canonicalSubcategory = normalizeCanonicalSubcategory(state.canonicalSubcategory);
+  if (!canonicalSubcategory) return 'Enter a specific area.';
+  if (CATEGORIES.includes(canonicalSubcategory as (typeof CATEGORIES)[number])) return 'Specific area must be more precise than the broad category.';
   if (!Number.isInteger(state.difficulty) || state.difficulty < 1 || state.difficulty > 5) return 'Choose a difficulty from 1 to 5.';
   if (state.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
   return null;
@@ -350,7 +359,9 @@ export function QuestionForm({
         alternateAnswers,
         explanation: state.explanation.trim() || null,
         creatorNote: state.creatorNote.trim() || null,
-        domain: state.domain,
+        category: state.category,
+        canonicalSubcategory: normalizeCanonicalSubcategory(state.canonicalSubcategory),
+        domain: normalizeCanonicalSubcategory(state.canonicalSubcategory),
         difficulty: state.difficulty,
         verified,
         llmSuggestedAnswer: state.llmSuggestedAnswer,
@@ -469,10 +480,15 @@ export function QuestionForm({
 
           <div className="grid gap-4 sm:grid-cols-2">
             <div>
-              <label htmlFor="domain" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Domain</label>
-              <select id="domain" value={state.domain} onChange={(event) => dispatch({ type: 'FIELD', field: 'domain', value: event.target.value })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
+              <label htmlFor="broad-category" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Broad category</label>
+              <select id="broad-category" value={state.category} onChange={(event) => dispatch({ type: 'FIELD', field: 'category', value: event.target.value })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
                 {CATEGORIES.map((category) => <option key={category} value={category}>{categoryLabel(category)}</option>)}
               </select>
+            </div>
+            <div>
+              <label htmlFor="canonical-subcategory" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Specific area</label>
+              <input id="canonical-subcategory" value={state.canonicalSubcategory} onChange={(event) => dispatch({ type: 'FIELD', field: 'canonicalSubcategory', value: event.target.value })} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary" placeholder="The Waste Land" />
+              <p className="mt-1 text-xs text-muted-foreground">Use a precise domain like T. S. Eliot, The Waste Land, or Modernist Poetry.</p>
             </div>
             <div>
               <label htmlFor="difficulty" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Difficulty</label>

--- a/src/components/QuickAddQuestionModal.tsx
+++ b/src/components/QuickAddQuestionModal.tsx
@@ -6,7 +6,9 @@
  */
 
 import { type CSSProperties, useEffect, useRef, useState } from 'react';
+import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { validateBreadcrumbContext } from '@/lib/breadcrumb-validation';
+import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
 type Props = {
   onClose: () => void;
@@ -38,6 +40,8 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
   const [questionText, setQuestionText] = useState('');
   const [answerText, setAnswerText] = useState('');
   const [breadcrumbContext, setBreadcrumbContext] = useState('');
+  const [category, setCategory] = useState('other');
+  const [canonicalSubcategory, setCanonicalSubcategory] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
@@ -60,8 +64,9 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
     const qt = questionText.trim();
     const at = answerText.trim();
     const bc = breadcrumbContext.trim();
-    if (!qt || !at || !bc) {
-      setError('Question, answer, and context are required.');
+    const canonical = normalizeCanonicalSubcategory(canonicalSubcategory);
+    if (!qt || !at || !bc || !canonical) {
+      setError('Question, answer, context, and a specific area are required.');
       return;
     }
     const bcErr = validateBreadcrumbContext(bc);
@@ -82,6 +87,12 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
           breadcrumb_context: bc,
           short_label: shortLabel.trim() || null,
           answer_source: 'creator_written',
+          category,
+          canonicalSubcategory: canonical,
+          domain: canonical,
+          difficulty: 3,
+          verified: true,
+          critiqueIterations: 0,
         }),
       });
       if (!res.ok) {
@@ -208,6 +219,36 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
               placeholder="e.g. Snorlax"
               style={inputStyle}
             />
+          </div>
+
+          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
+            <div>
+              <label htmlFor="qqm-category" style={{ ...monoStyle, display: 'block', color: 'var(--text-muted)', marginBottom: '5px' }}>
+                Broad category
+              </label>
+              <select
+                id="qqm-category"
+                value={category}
+                onChange={(e) => setCategory(e.target.value)}
+                style={inputStyle}
+              >
+                {CATEGORIES.map((item) => <option key={item} value={item}>{categoryLabel(item)}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="qqm-specific-area" style={{ ...monoStyle, display: 'block', color: 'var(--text-muted)', marginBottom: '5px' }}>
+                Specific area
+              </label>
+              <input
+                id="qqm-specific-area"
+                type="text"
+                required
+                value={canonicalSubcategory}
+                onChange={(e) => setCanonicalSubcategory(e.target.value)}
+                placeholder="e.g. The Waste Land"
+                style={inputStyle}
+              />
+            </div>
           </div>
 
           <div>

--- a/src/lib/question-categorization.ts
+++ b/src/lib/question-categorization.ts
@@ -1,0 +1,31 @@
+import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
+
+export type BroadQuestionCategory = (typeof CATEGORIES)[number];
+
+const CATEGORY_VALUES = new Set<string>(CATEGORIES);
+const CATEGORY_LABEL_TO_VALUE = new Map<string, BroadQuestionCategory>(
+  CATEGORIES.map((category) => [categoryLabel(category).toLowerCase(), category]),
+);
+
+export function isBroadQuestionCategory(value: string): value is BroadQuestionCategory {
+  return CATEGORY_VALUES.has(value);
+}
+
+export function normalizeBroadQuestionCategory(value: string): BroadQuestionCategory | null {
+  const normalized = value.trim();
+  if (isBroadQuestionCategory(normalized)) return normalized;
+  return CATEGORY_LABEL_TO_VALUE.get(normalized.toLowerCase()) ?? null;
+}
+
+export function normalizeCanonicalSubcategory(value: string): string {
+  const normalized = value.trim().replace(/\s+/g, ' ');
+  const eliotNormalized = normalized.replace(/\./g, '').replace(/\s+/g, ' ').toLowerCase();
+  if (eliotNormalized === 'ts eliot' || eliotNormalized === 't s eliot') {
+    return 'T. S. Eliot';
+  }
+  return normalized;
+}
+
+export function broadCategoryDisplayName(category: string): string {
+  return isBroadQuestionCategory(category) ? categoryLabel(category) : category;
+}

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -8,7 +8,7 @@ import {
   questions,
   userQuestionBank,
 } from '@/server/db';
-import { categoryLabel } from '@/lib/questions-types';
+import { broadCategoryDisplayName } from '@/lib/question-categorization';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type QuestionView = {
@@ -19,6 +19,9 @@ export type QuestionView = {
   explanation: string | null;
   domain: string;
   domainDisplayName: string;
+  broadCategory: string | null;
+  canonicalSubcategory: string | null;
+  subcategory: string | null;
   difficulty: number;
   timesAnswered: number;
   timesCorrect: number;
@@ -183,7 +186,7 @@ async function readQuestionStats(questionId: string) {
 
 export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView> {
   const stats = await readQuestionStats(row.id);
-  const domain = row.category;
+  const domain = row.canonicalSubcategory ?? row.category;
   const createdAt = toIso(row.createdAt) ?? new Date().toISOString();
   const updatedAt = toIso(row.updatedAt) ?? createdAt;
 
@@ -194,7 +197,10 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
     alternateAnswers: row.acceptedAlternatives ?? [],
     explanation: explanationFor(row),
     domain,
-    domainDisplayName: categoryLabel(domain),
+    domainDisplayName: row.canonicalSubcategory ?? broadCategoryDisplayName(domain),
+    broadCategory: row.broadCategory,
+    canonicalSubcategory: row.canonicalSubcategory,
+    subcategory: row.subcategory,
     difficulty: difficultyToNumber(row.difficultyEstimate),
     timesAnswered: stats.timesAnswered,
     timesCorrect: stats.timesCorrect,
@@ -248,7 +254,11 @@ export async function createQuestion(params: {
   correctAnswer: string;
   alternateAnswers: string[];
   explanation: string | null;
-  domain: string;
+  category: string;
+  broadCategory: string | null;
+  subcategory: string;
+  canonicalSubcategory: string;
+  domain?: string;
   difficulty: number;
   creatorNote?: string | null;
   verified: boolean;
@@ -265,7 +275,10 @@ export async function createQuestion(params: {
     acceptedAlternatives: params.alternateAnswers,
     factualExplanation: params.explanation,
     creatorNote: params.creatorNote ?? null,
-    category: params.domain as typeof questions.$inferInsert.category,
+    category: params.category as typeof questions.$inferInsert.category,
+    broadCategory: params.broadCategory,
+    subcategory: params.subcategory,
+    canonicalSubcategory: params.canonicalSubcategory,
     categoryOverridden: true,
     difficultyEstimate: difficulty,
     llmDifficulty: difficulty,
@@ -299,6 +312,9 @@ export async function createQuestion(params: {
         "answer_source",
         "question_type",
         "category",
+        "broad_category",
+        "subcategory",
+        "canonical_subcategory",
         "category_overridden",
         "creator_note",
         "difficulty_estimate",
@@ -315,7 +331,10 @@ export async function createQuestion(params: {
         ${params.alternateAnswers}::text[],
         ${answerSource}::"AnswerSource",
         'factual'::"QuestionType",
-        ${params.domain}::"Category",
+        ${params.category}::"Category",
+        ${params.broadCategory},
+        ${params.subcategory},
+        ${params.canonicalSubcategory},
         true,
         ${params.creatorNote ?? null},
         ${difficulty}::"DifficultyEstimate",
@@ -343,7 +362,8 @@ export async function createQuestion(params: {
     if (pgErrorCode(error) !== '42703') throw error;
     console.warn('[questions/create] current question columns unavailable; retrying legacy-compatible question insert', {
       userId: params.authorId,
-      domain: params.domain,
+      category: params.category,
+      canonicalSubcategory: params.canonicalSubcategory,
     });
     try {
       created = await createWithValues(baseValues as typeof questions.$inferInsert);
@@ -351,7 +371,8 @@ export async function createQuestion(params: {
       if (pgErrorCode(fallbackError) !== '42703') throw fallbackError;
       console.warn('[questions/create] drizzle insert still references unavailable columns; saving with raw legacy-compatible insert', {
         userId: params.authorId,
-        domain: params.domain,
+        category: params.category,
+      canonicalSubcategory: params.canonicalSubcategory,
       });
       created = await createWithLegacyColumns();
     }
@@ -378,7 +399,10 @@ export async function updateQuestion(params: {
   correctAnswer?: string;
   alternateAnswers?: string[];
   explanation?: string;
-  domain?: string;
+  category?: string;
+  broadCategory?: string | null;
+  subcategory?: string;
+  canonicalSubcategory?: string;
   difficulty?: number;
 }): Promise<QuestionMutationResult> {
   const existing = await getQuestion(params.questionId, params.userId);
@@ -390,10 +414,13 @@ export async function updateQuestion(params: {
   if (params.correctAnswer !== undefined) values.answerText = params.correctAnswer;
   if (params.alternateAnswers !== undefined) values.acceptedAlternatives = params.alternateAnswers;
   if (params.explanation !== undefined) values.factualExplanation = params.explanation || null;
-  if (params.domain !== undefined) {
-    values.category = params.domain as typeof questions.$inferInsert.category;
+  if (params.category !== undefined) {
+    values.category = params.category as typeof questions.$inferInsert.category;
     values.categoryOverridden = true;
   }
+  if (params.broadCategory !== undefined) values.broadCategory = params.broadCategory;
+  if (params.subcategory !== undefined) values.subcategory = params.subcategory;
+  if (params.canonicalSubcategory !== undefined) values.canonicalSubcategory = params.canonicalSubcategory;
   if (params.difficulty !== undefined) {
     const difficulty = numberToDifficulty(params.difficulty);
     values.difficultyEstimate = difficulty;

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { readCreateQuestionPayload } from '@/server/questions/create-payload';
+
+describe('create question payload categorization', () => {
+  const basePayload = {
+    text: 'Which 1922 poem opens with April as the cruelest month?',
+    correctAnswer: 'The Waste Land',
+    verified: true,
+    difficulty: 3,
+    critiqueIterations: 0,
+  };
+
+  it('persists a broad enum category plus a specific canonical subcategory', () => {
+    const result = readCreateQuestionPayload({
+      ...basePayload,
+      category: 'literature',
+      canonicalSubcategory: '  The   Waste Land  ',
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.value.category).toBe('literature');
+    expect(result.value.broadCategory).toBe('Literature');
+    expect(result.value.canonicalSubcategory).toBe('The Waste Land');
+    expect(result.value.subcategory).toBe('The Waste Land');
+    expect(result.value.domain).toBe('The Waste Land');
+  });
+
+  it('accepts domain as the backwards-compatible specific area field', () => {
+    const result = readCreateQuestionPayload({
+      ...basePayload,
+      broadCategory: 'Literature',
+      domain: 'TS Eliot',
+      shareToFeed: true,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.value.category).toBe('literature');
+    expect(result.value.canonicalSubcategory).toBe('T. S. Eliot');
+    expect(result.value.shareToFeed).toBe(true);
+  });
+
+  it('rejects broad-only authored question payloads', () => {
+    const result = readCreateQuestionPayload({
+      ...basePayload,
+      category: 'literature',
+      domain: 'literature',
+    });
+
+    expect(result.errors).toContain('canonicalSubcategory');
+  });
+
+  it('does not require friends when sharing to feed', () => {
+    const result = readCreateQuestionPayload({
+      ...basePayload,
+      category: 'literature',
+      canonicalSubcategory: 'The Waste Land',
+      shareToFeed: true,
+    });
+
+    expect(result.errors).toEqual([]);
+    expect(result.value.sendToFriendIds).toEqual([]);
+  });
+});
+
+describe('normalizeCanonicalSubcategory', () => {
+  it('normalizes common T. S. Eliot variants without lowercasing other titles', () => {
+    expect(normalizeCanonicalSubcategory('T S Eliot')).toBe('T. S. Eliot');
+    expect(normalizeCanonicalSubcategory('The   Waste Land')).toBe('The Waste Land');
+  });
+});

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -1,0 +1,111 @@
+import { broadCategoryDisplayName, isBroadQuestionCategory, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+
+function splitAlternates(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .filter((item): item is string => typeof item === 'string')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value.split(',').map((item) => item.trim()).filter(Boolean);
+  }
+  return [];
+}
+
+function difficultyFromLegacy(value: unknown): number | null {
+  if (value === 'accessible') return 1;
+  if (value === 'moderate') return 3;
+  if (value === 'specialist') return 5;
+  return null;
+}
+
+export function readCreateQuestionPayload(body: Record<string, unknown> | null) {
+  const text = typeof body?.text === 'string'
+    ? body.text.trim()
+    : typeof body?.question_text === 'string'
+      ? body.question_text.trim()
+      : '';
+  const correctAnswer = typeof body?.correctAnswer === 'string'
+    ? body.correctAnswer.trim()
+    : typeof body?.answer_text === 'string'
+      ? body.answer_text.trim()
+      : '';
+  const alternateAnswers = splitAlternates(body?.alternateAnswers ?? body?.accepted_alternatives).slice(0, 5);
+  const explanation = typeof body?.explanation === 'string'
+    ? body.explanation.trim() || null
+    : null;
+  const creatorNote = typeof body?.creatorNote === 'string'
+    ? body.creatorNote.trim() || null
+    : typeof body?.creator_note === 'string'
+      ? body.creator_note.trim() || null
+      : null;
+  const isLegacyPayload = typeof body?.question_text === 'string' || typeof body?.answer_text === 'string';
+  const rawBroadCategory = typeof body?.category === 'string'
+    ? body.category.trim()
+    : typeof body?.broadCategory === 'string'
+      ? body.broadCategory.trim()
+      : isLegacyPayload
+        ? 'other'
+        : '';
+  const rawCanonicalSubcategory = typeof body?.canonicalSubcategory === 'string'
+    ? body.canonicalSubcategory
+    : typeof body?.canonical_subcategory === 'string'
+      ? body.canonical_subcategory
+      : typeof body?.domain === 'string'
+        ? body.domain
+        : '';
+  const canonicalSubcategory = normalizeCanonicalSubcategory(rawCanonicalSubcategory);
+  const broadCategory = normalizeBroadQuestionCategory(rawBroadCategory) ?? '';
+  const broadCategoryLabel = broadCategory ? broadCategoryDisplayName(broadCategory) : null;
+  const difficulty = typeof body?.difficulty === 'number'
+    ? body.difficulty
+    : difficultyFromLegacy(body?.difficulty_estimate) ?? (isLegacyPayload ? 3 : null);
+  const difficultyValue = difficulty ?? Number.NaN;
+  const verified = typeof body?.verified === 'boolean' ? body.verified : null;
+  const llmSuggestedAnswer = typeof body?.llmSuggestedAnswer === 'string'
+    ? body.llmSuggestedAnswer.trim() || null
+    : null;
+  const critiqueIterations = typeof body?.critiqueIterations === 'number' ? body.critiqueIterations : Number.NaN;
+
+  const rawSendToFriendIds = Array.isArray(body?.sendToFriendIds)
+    ? (body.sendToFriendIds as unknown[]).filter((id): id is string => typeof id === 'string').slice(0, 20)
+    : [];
+  const shareToFeed = body?.shareToFeed === true;
+
+  const errors: string[] = [];
+  if (!text || text.length > 300) errors.push('text');
+  if (!correctAnswer || correctAnswer.length > 200) errors.push('correctAnswer');
+  if (alternateAnswers.length > 5 || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
+  if (explanation && explanation.length > 500) errors.push('explanation');
+  if (creatorNote && creatorNote.length > 200) errors.push('creatorNote');
+  if (!broadCategory) errors.push('category');
+  if (!canonicalSubcategory) errors.push('canonicalSubcategory');
+  if (canonicalSubcategory && isBroadQuestionCategory(canonicalSubcategory)) errors.push('canonicalSubcategory');
+  if (verified === null) errors.push('verified');
+  if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
+  if (!Number.isInteger(difficultyValue) || difficultyValue < 1 || difficultyValue > 5) errors.push('difficulty');
+  if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
+
+  return {
+    value: {
+      text,
+      correctAnswer,
+      alternateAnswers,
+      explanation,
+      creatorNote,
+      category: broadCategory,
+      broadCategory: broadCategoryLabel,
+      canonicalSubcategory,
+      subcategory: canonicalSubcategory,
+      domain: canonicalSubcategory,
+      difficulty: difficultyValue,
+      verified: verified ?? true,
+      llmSuggestedAnswer,
+      critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0,
+      sendToFriendIds: rawSendToFriendIds,
+      shareToFeed,
+    },
+    errors,
+  };
+}


### PR DESCRIPTION
### Motivation

- Authoring was treating the single `domain` field as both the broad enum category and the KB canonical domain, so newly authored questions saved only broad categories (e.g. `literature`) and opened KB domains with that broad enum instead of hyper-specific domains like `The Waste Land` or `T. S. Eliot`.
- The goal is to persist both a broad enum category and a normalized, specific `canonical_subcategory` for authored questions so the author’s KB and question bank surface hyper-specific domains even when those domains are outside declared interests.

### Description

- Add `src/lib/question-categorization.ts` helpers to validate/normalize broad categories and normalize canonical subcategories (trim/collapse spaces and normalize common variants such as `TS Eliot` → `T. S. Eliot`).
- Implement a dedicated payload reader `src/server/questions/create-payload.ts` that accepts `category`/`broadCategory` (broad enum) and `canonicalSubcategory`/legacy `domain` (specific area), validates the broad enum only against known categories, requires and normalizes the specific canonical subcategory, and returns both fields for persistence.
- Persist both broad and specific fields through create/edit: update `createQuestion` and `updateQuestion` to set `category`, `broad_category`, `subcategory`, and `canonical_subcategory`, and keep banking to `UserQuestionBank` intact so authored questions are still saved to the author’s bank.
- Open and insert KB domains using the specific `canonicalSubcategory` (pass `canonicalSubcategory` to `openKBDomain` and include `broadCategory` metadata), and use `canonicalSubcategory` for feed dismissal checks and opened-domain reporting.
- Update UI to expose both fields: `QuestionForm` and `QuickAddQuestionModal` now show a “Broad category” select and a “Specific area” free-text field, validate the specific area presence, and submit both values; update questions list and view shaping to prefer `canonicalSubcategory` for domain display while preserving broad-category color mapping.
- Add an idempotent backfill script `scripts/backfill-authored-literature-domains.ts` to retroactively assign sensible canonical subcategories and ensure `PLAYER_MASTERY` rows for the two affected literature questions, and add unit tests for the create-payload normalization/validation (`src/server/questions/__tests__/create-payload.test.ts`).

### Testing

- Ran typecheck with `npx tsc --noEmit` which succeeded. 
- Ran targeted linting (`npx eslint` on the changed files) and the new files passed lint checks; a full `npm run lint` still reports pre-existing unrelated errors elsewhere in the repo. 
- Added unit tests for payload parsing/normalization; running `npx vitest` in this environment failed due to registry/network/package availability (registry 403), so tests were added but not executed here.
- Backfill script creation was verified but could not be executed in this environment because `DATABASE_URL` is not configured; the script is ready to run in a properly configured environment (instructions in the PR notes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a29aa5f0832e9862a61c34892109)