### PR TITLE
Align knowledge page circle rows

### DIFF
--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -1,31 +1,35 @@
-import { DOMAIN_ICON_COMPONENTS, DomainInitialIcon } from '@/components/icons/domain-icons';
-import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
-import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
-import type { MasteryTier } from '@/types/db';
-import type { CSSProperties } from 'react';
+import {
+  DOMAIN_ICON_COMPONENTS,
+  DomainInitialIcon,
+} from '@/components/icons/domain-icons'
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+import type { MasteryTier } from '@/types/db'
+import type { CSSProperties } from 'react'
 
 const TIER_LABEL: Record<MasteryTier, string> = {
   establishing: 'Establishing',
   familiar: 'Familiar',
   solid: 'Solid',
   mastery: 'Mastery',
-};
+}
 
 type DomainCircleProps = {
-  diameter: number;
-  iconKey: string;
-  canonicalSubcategory: string;
-  currentTier: MasteryTier | null;
-  showYourQs?: number;
-  highlighted?: boolean;
-  id?: string;
-  isGhost?: boolean;
+  diameter: number
+  iconKey: string
+  canonicalSubcategory: string
+  currentTier: MasteryTier | null
+  showYourQs?: number
+  highlighted?: boolean
+  id?: string
+  isGhost?: boolean
   /** Whether to render the tier label below the domain name. Defaults to true. */
-  showTierLabel?: boolean;
-  territoryType?: 'declared' | 'demonstrated';
-  broadCategory?: string | null;
-  onTap?: () => void;
-};
+  showTierLabel?: boolean
+  territoryType?: 'declared' | 'demonstrated'
+  broadCategory?: string | null
+  circleSlotSize?: number
+  onTap?: () => void
+}
 
 export function DomainCircle({
   diameter,
@@ -39,86 +43,147 @@ export function DomainCircle({
   showTierLabel = true,
   territoryType,
   broadCategory,
+  circleSlotSize,
   onTap,
 }: DomainCircleProps) {
-  const iconSize = Math.round(diameter * 0.4);
-  const Icon = (DOMAIN_ICON_COMPONENTS as Record<string, (typeof DOMAIN_ICON_COMPONENTS)[keyof typeof DOMAIN_ICON_COMPONENTS] | undefined>)[iconKey];
-  const yourQsCount = Math.min(showYourQs, 5);
-  const normalizedCategory = normalizeBroadCategory(broadCategory) ?? null;
-  const domainColor = normalizedCategory ? getPortraitDomainColor(normalizedCategory) : null;
+  const iconSize = Math.round(diameter * 0.4)
+  const Icon = (
+    DOMAIN_ICON_COMPONENTS as Record<
+      string,
+      | (typeof DOMAIN_ICON_COMPONENTS)[keyof typeof DOMAIN_ICON_COMPONENTS]
+      | undefined
+    >
+  )[iconKey]
+  const yourQsCount = Math.min(showYourQs, 5)
+  const normalizedCategory = normalizeBroadCategory(broadCategory) ?? null
+  const domainColor = normalizedCategory
+    ? getPortraitDomainColor(normalizedCategory)
+    : null
   const circleBackground = domainColor
     ? `radial-gradient(circle at 38% 38%, ${domainColor.light.replace('0.12', '0.22')}, ${domainColor.light})`
-    : territoryType === 'declared' ? 'rgba(245, 240, 232, 0.3)' : '#f5f0e8';
-  const circleBorder = highlighted ? '#1a1208' : domainColor?.primary ?? '#d4cfc7';
+    : territoryType === 'declared'
+      ? 'rgba(245, 240, 232, 0.3)'
+      : '#f5f0e8'
+  const circleBorder = highlighted
+    ? '#1a1208'
+    : (domainColor?.primary ?? '#d4cfc7')
+  const resolvedCircleSlotSize = Math.max(circleSlotSize ?? diameter, diameter)
 
   if (isGhost) {
     return (
       <div
         id={id}
-        style={{ textAlign: 'center', width: `${Math.max(80, diameter + 20)}px`, pointerEvents: 'none' }}
+        style={{
+          textAlign: 'center',
+          width: `${Math.max(80, resolvedCircleSlotSize + 20)}px`,
+          pointerEvents: 'none',
+        }}
         aria-hidden
+      >
+        <div
+          style={{
+            ...circleSlotStyle,
+            width: `${resolvedCircleSlotSize}px`,
+            height: `${resolvedCircleSlotSize}px`,
+          }}
+        >
+          <div
+            style={{
+              width: `${diameter}px`,
+              height: `${diameter}px`,
+              borderRadius: '999px',
+              border: '1px dashed #c8c0b0',
+              background: 'transparent',
+              display: 'grid',
+              placeItems: 'center',
+              opacity: 0.5,
+            }}
+          >
+            {Icon ? (
+              <Icon size={iconSize} color="#1a1208" />
+            ) : (
+              <DomainInitialIcon
+                size={iconSize}
+                color="#1a1208"
+                label={canonicalSubcategory}
+              />
+            )}
+          </div>
+        </div>
+        <p style={{ ...nameStyle, opacity: 0.3 }}>{canonicalSubcategory}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div
+      id={id}
+      style={{
+        textAlign: 'center',
+        width: `${Math.max(80, resolvedCircleSlotSize + 20)}px`,
+        cursor: onTap ? 'pointer' : undefined,
+      }}
+      onClick={onTap}
+      role={onTap ? 'button' : undefined}
+    >
+      <div
+        style={{
+          ...circleSlotStyle,
+          width: `${resolvedCircleSlotSize}px`,
+          height: `${resolvedCircleSlotSize}px`,
+        }}
       >
         <div
           style={{
             width: `${diameter}px`,
             height: `${diameter}px`,
             borderRadius: '999px',
-            border: '1px dashed #c8c0b0',
-            background: 'transparent',
-            margin: '0 auto',
+            border: `1px solid ${circleBorder}`,
+            background: circleBackground,
             display: 'grid',
             placeItems: 'center',
-            opacity: 0.5,
+            transition: 'border-color 300ms ease, box-shadow 300ms ease',
+            boxShadow: highlighted ? '0 0 8px #f0c060' : undefined,
           }}
         >
-          {Icon
-            ? <Icon size={iconSize} color="#1a1208" />
-            : <DomainInitialIcon size={iconSize} color="#1a1208" label={canonicalSubcategory} />}
+          {Icon ? (
+            <Icon size={iconSize} color="#1a1208" />
+          ) : (
+            <DomainInitialIcon
+              size={iconSize}
+              color="#1a1208"
+              label={canonicalSubcategory}
+            />
+          )}
         </div>
-        <p style={{ ...nameStyle, opacity: 0.3 }}>{canonicalSubcategory}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div
-      id={id}
-      style={{ textAlign: 'center', width: `${Math.max(80, diameter + 20)}px`, cursor: onTap ? 'pointer' : undefined }}
-      onClick={onTap}
-      role={onTap ? 'button' : undefined}
-    >
-      <div
-        style={{
-          width: `${diameter}px`,
-          height: `${diameter}px`,
-          borderRadius: '999px',
-          border: `1px solid ${circleBorder}`,
-          background: circleBackground,
-          margin: '0 auto',
-          display: 'grid',
-          placeItems: 'center',
-          transition: 'border-color 300ms ease, box-shadow 300ms ease',
-          boxShadow: highlighted ? '0 0 8px #f0c060' : undefined,
-        }}
-      >
-        {Icon
-          ? <Icon size={iconSize} color="#1a1208" />
-          : <DomainInitialIcon size={iconSize} color="#1a1208" label={canonicalSubcategory} />}
       </div>
       <p style={nameStyle}>{canonicalSubcategory}</p>
       {showTierLabel && currentTier && (
         <p style={tierStyle}>{TIER_LABEL[currentTier]}</p>
       )}
       {showYourQs > 0 && (
-        <div style={dotsWrapStyle} aria-label={`Your questions: ${showYourQs > 5 ? '5+' : showYourQs}`}>
+        <div
+          style={dotsWrapStyle}
+          aria-label={`Your questions: ${showYourQs > 5 ? '5+' : showYourQs}`}
+        >
           {Array.from({ length: yourQsCount }).map((_, index) => (
-            <span key={`${canonicalSubcategory}-dot-${index}`} style={dotStyle} />
+            <span
+              key={`${canonicalSubcategory}-dot-${index}`}
+              style={dotStyle}
+            />
           ))}
           {showYourQs > 5 && <span style={plusStyle}>5+</span>}
         </div>
       )}
     </div>
-  );
+  )
+}
+
+const circleSlotStyle: CSSProperties = {
+  margin: '0 auto',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
 }
 
 const nameStyle: CSSProperties = {
@@ -127,13 +192,13 @@ const nameStyle: CSSProperties = {
   color: '#1a1208',
   lineHeight: 1.25,
   overflowWrap: 'anywhere',
-};
+}
 
 const tierStyle: CSSProperties = {
   marginTop: '2px',
   fontSize: '10px',
   color: '#8a8070',
-};
+}
 
 const dotsWrapStyle: CSSProperties = {
   display: 'inline-flex',
@@ -141,17 +206,17 @@ const dotsWrapStyle: CSSProperties = {
   alignItems: 'center',
   justifyContent: 'center',
   marginTop: '4px',
-};
+}
 
 const dotStyle: CSSProperties = {
   width: '6px',
   height: '6px',
   borderRadius: '999px',
   background: '#8a8070',
-};
+}
 
 const plusStyle: CSSProperties = {
   fontSize: '10px',
   color: '#8a8070',
   marginLeft: '2px',
-};
+}

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -1,80 +1,151 @@
-'use client';
+'use client'
 
-import { useMemo, useState } from 'react';
-import type { MasteryTier } from '@/types/db';
-import { DomainCircle } from '@/components/knowledge/DomainCircle';
-import { buildKnowledgeCardPublicUrl } from '@/lib/knowledge-card';
+import { useMemo, useState } from 'react'
+import type { MasteryTier } from '@/types/db'
+import { DomainCircle } from '@/components/knowledge/DomainCircle'
+import { buildKnowledgeCardPublicUrl } from '@/lib/knowledge-card'
 
 export interface KnowledgeDomainCircle {
-  canonicalSubcategory: string;
-  canonicalSubcategorySlug: string;
-  currentTier: MasteryTier;
-  lifetimePoints: number;
-  iconKey: string;
-  broadCategory?: string | null;
+  canonicalSubcategory: string
+  canonicalSubcategorySlug: string
+  currentTier: MasteryTier
+  lifetimePoints: number
+  iconKey: string
+  broadCategory?: string | null
 }
 
 export interface KnowledgeCardProps {
-  playerDisplayName: string;
-  portraitStatement: string;
-  domains: KnowledgeDomainCircle[];
-  overflowCount: number;
-  tierSignature: string;
-  rarestTerritory: string | null;
-  rarestTerritorySolo: boolean;
-  shareText: string;
-  shareCardToken: string;
-  shareCardExpiresAt: string;
-  readOnly?: boolean;
-  highlightedSlug?: string | null;
+  playerDisplayName: string
+  portraitStatement: string
+  domains: KnowledgeDomainCircle[]
+  overflowCount: number
+  tierSignature: string
+  rarestTerritory: string | null
+  rarestTerritorySolo: boolean
+  shareText: string
+  shareCardToken: string
+  shareCardExpiresAt: string
+  readOnly?: boolean
+  highlightedSlug?: string | null
 }
 
-function getCircleDiameter(points: number, maxPoints: number, isMobile: boolean): number {
-  const max = isMobile ? 64 : 80;
-  const min = isMobile ? 24 : 28;
-  const ratio = maxPoints > 0 ? points / maxPoints : 0;
-  return Math.round(min + (ratio * (max - min)));
+function getCircleDiameter(
+  points: number,
+  maxPoints: number,
+  isMobile: boolean
+): number {
+  const max = isMobile ? 64 : 80
+  const min = isMobile ? 24 : 28
+  const ratio = maxPoints > 0 ? points / maxPoints : 0
+  return Math.round(min + ratio * (max - min))
 }
 
 export function KnowledgeCard(props: KnowledgeCardProps) {
-  const [copyLabel, setCopyLabel] = useState('Copy');
-  const [shareLabel, setShareLabel] = useState('Share');
-  const sorted = useMemo(() => [...props.domains].sort((a, b) => b.lifetimePoints - a.lifetimePoints), [props.domains]);
-  const visibleDomains = sorted.slice(0, 5);
-  const totalOverflowCount = props.overflowCount + Math.max(0, sorted.length - visibleDomains.length);
-  const maxPoints = sorted[0]?.lifetimePoints ?? 1;
+  const [copyLabel, setCopyLabel] = useState('Copy')
+  const [shareLabel, setShareLabel] = useState('Share')
+  const sorted = useMemo(
+    () =>
+      [...props.domains].sort((a, b) => b.lifetimePoints - a.lifetimePoints),
+    [props.domains]
+  )
+  const visibleDomains = sorted.slice(0, 5)
+  const totalOverflowCount =
+    props.overflowCount + Math.max(0, sorted.length - visibleDomains.length)
+  const maxPoints = sorted[0]?.lifetimePoints ?? 1
+  const isMobileViewport =
+    typeof window !== 'undefined' ? window.innerWidth < 400 : false
+  const visibleDomainDiameters = visibleDomains.map((domain) =>
+    getCircleDiameter(domain.lifetimePoints, maxPoints, isMobileViewport)
+  )
+  const circleSlotSize = Math.max(...visibleDomainDiameters, 0)
 
   const onCopy = async () => {
-    await navigator.clipboard.writeText(props.shareText);
-    setCopyLabel('Copied ✓');
-    window.setTimeout(() => setCopyLabel('Copy'), 2000);
-  };
+    await navigator.clipboard.writeText(props.shareText)
+    setCopyLabel('Copied ✓')
+    window.setTimeout(() => setCopyLabel('Copy'), 2000)
+  }
 
   const onShare = async () => {
-    const url = buildKnowledgeCardPublicUrl(props.shareCardToken);
+    const url = buildKnowledgeCardPublicUrl(props.shareCardToken)
     if (navigator.share) {
-      await navigator.share({ text: props.shareText, url });
-      return;
+      await navigator.share({ text: props.shareText, url })
+      return
     }
-    await navigator.clipboard.writeText(url);
-    setShareLabel('Link copied');
-    window.setTimeout(() => setShareLabel('Share'), 2000);
-  };
+    await navigator.clipboard.writeText(url)
+    setShareLabel('Link copied')
+    window.setTimeout(() => setShareLabel('Share'), 2000)
+  }
 
   return (
-    <section style={{ background: '#f5f0e8', border: '1px solid #e8e2d6', borderRadius: 14, overflow: 'hidden' }}>
+    <section
+      style={{
+        background: '#f5f0e8',
+        border: '1px solid #e8e2d6',
+        borderRadius: 14,
+        overflow: 'hidden',
+      }}
+    >
       <div style={{ padding: 20 }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-          <p style={{ fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#8a8070' }}>Your Knowledge Portrait</p>
-          <p style={{ fontFamily: 'var(--font-literata), serif', fontStyle: 'italic', fontSize: 15, color: '#1a1208' }}>Joshing</p>
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <p
+            style={{
+              fontSize: 11,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              color: '#8a8070',
+            }}
+          >
+            Your Knowledge Portrait
+          </p>
+          <p
+            style={{
+              fontFamily: 'var(--font-literata), serif',
+              fontStyle: 'italic',
+              fontSize: 15,
+              color: '#1a1208',
+            }}
+          >
+            Joshing
+          </p>
         </div>
-        <p style={{ marginTop: 6, fontSize: 11, textTransform: 'uppercase', letterSpacing: '0.08em', color: '#8a8070' }}>{props.playerDisplayName} · Joshing</p>
+        <p
+          style={{
+            marginTop: 6,
+            fontSize: 11,
+            textTransform: 'uppercase',
+            letterSpacing: '0.08em',
+            color: '#8a8070',
+          }}
+        >
+          {props.playerDisplayName} · Joshing
+        </p>
       </div>
 
       <div style={{ borderTop: '1px solid #e8e2d6', padding: '24px 20px' }}>
-        <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center', alignItems: 'flex-end', columnGap: 16, rowGap: 20 }}>
-          {visibleDomains.map((domain) => {
-            const diameter = getCircleDiameter(domain.lifetimePoints, maxPoints, typeof window !== 'undefined' ? window.innerWidth < 400 : false);
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            justifyContent: 'center',
+            alignItems: 'flex-start',
+            columnGap: 16,
+            rowGap: 20,
+          }}
+        >
+          {visibleDomains.map((domain, index) => {
+            const diameter =
+              visibleDomainDiameters[index] ??
+              getCircleDiameter(
+                domain.lifetimePoints,
+                maxPoints,
+                isMobileViewport
+              )
             return (
               <DomainCircle
                 key={domain.canonicalSubcategorySlug}
@@ -84,30 +155,91 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
                 canonicalSubcategory={domain.canonicalSubcategory}
                 broadCategory={domain.broadCategory}
                 currentTier={domain.currentTier}
-                highlighted={props.highlightedSlug === domain.canonicalSubcategorySlug}
+                highlighted={
+                  props.highlightedSlug === domain.canonicalSubcategorySlug
+                }
+                circleSlotSize={circleSlotSize}
               />
-            );
+            )
           })}
         </div>
-        {totalOverflowCount > 0 && <p style={{ marginTop: 14, fontSize: 11, color: '#8a8070', textAlign: 'center' }}>+{totalOverflowCount} more territories</p>}
+        {totalOverflowCount > 0 && (
+          <p
+            style={{
+              marginTop: 14,
+              fontSize: 11,
+              color: '#8a8070',
+              textAlign: 'center',
+            }}
+          >
+            +{totalOverflowCount} more territories
+          </p>
+        )}
       </div>
 
       <div style={{ borderTop: '1px solid #e8e2d6', padding: 20 }}>
-        <p style={{ fontFamily: 'var(--font-literata), serif', fontStyle: 'italic', fontSize: 18, color: '#1a1208' }}>{props.portraitStatement}</p>
-        <p style={{ marginTop: 8, fontSize: 13, color: '#1a1208' }}>{props.tierSignature}</p>
+        <p
+          style={{
+            fontFamily: 'var(--font-literata), serif',
+            fontStyle: 'italic',
+            fontSize: 18,
+            color: '#1a1208',
+          }}
+        >
+          {props.portraitStatement}
+        </p>
+        <p style={{ marginTop: 8, fontSize: 13, color: '#1a1208' }}>
+          {props.tierSignature}
+        </p>
         {props.rarestTerritory && (
           <p style={{ marginTop: 6, fontSize: 11, color: '#8a8070' }}>
-            Rarest territory: {props.rarestTerritory}{props.rarestTerritorySolo ? " — you're the only one here" : ''}
+            Rarest territory: {props.rarestTerritory}
+            {props.rarestTerritorySolo ? " — you're the only one here" : ''}
           </p>
         )}
-        <p style={{ marginTop: 8, marginBottom: 20, fontSize: 11, color: '#8a8070' }}>{props.playerDisplayName} on Joshing</p>
+        <p
+          style={{
+            marginTop: 8,
+            marginBottom: 20,
+            fontSize: 11,
+            color: '#8a8070',
+          }}
+        >
+          {props.playerDisplayName} on Joshing
+        </p>
         {!props.readOnly && (
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-            <button type="button" onClick={onCopy} style={{ minHeight: 44, borderRadius: 999, border: '1px solid #1a1208', background: 'transparent', color: '#1a1208' }}>{copyLabel}</button>
-            <button type="button" onClick={onShare} style={{ minHeight: 44, borderRadius: 999, border: '1px solid #1a1208', background: '#1a1208', color: '#f5f0e8' }}>{shareLabel}</button>
+          <div
+            style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}
+          >
+            <button
+              type="button"
+              onClick={onCopy}
+              style={{
+                minHeight: 44,
+                borderRadius: 999,
+                border: '1px solid #1a1208',
+                background: 'transparent',
+                color: '#1a1208',
+              }}
+            >
+              {copyLabel}
+            </button>
+            <button
+              type="button"
+              onClick={onShare}
+              style={{
+                minHeight: 44,
+                borderRadius: 999,
+                border: '1px solid #1a1208',
+                background: '#1a1208',
+                color: '#f5f0e8',
+              }}
+            >
+              {shareLabel}
+            </button>
           </div>
         )}
       </div>
     </section>
-  );
+  )
 }

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -1,112 +1,171 @@
-'use client';
+'use client'
 
-import { useState, useMemo, type CSSProperties } from 'react';
-import { getDomainCircleSize, type CircleSizingTier } from '@/lib/knowledge/circle-sizing';
-import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
+import { useState, useMemo, type CSSProperties } from 'react'
+import {
+  getDomainCircleSize,
+  type CircleSizingTier,
+} from '@/lib/knowledge/circle-sizing'
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
 
-type PortraitTier = 'establishing' | 'familiar' | 'solid' | 'mastery';
-type SortMode = 'domain' | 'mastery';
+type PortraitTier = 'establishing' | 'familiar' | 'solid' | 'mastery'
+type SortMode = 'domain' | 'mastery'
 
 export type PortraitEntry = {
-  canonicalSubcategory: string;
-  broadCategory: string;
-  totalMasteryPoints: number;
-  tier: PortraitTier;
-  authoredAnsweredCount: number;
-};
+  canonicalSubcategory: string
+  broadCategory: string
+  totalMasteryPoints: number
+  tier: PortraitTier
+  authoredAnsweredCount: number
+}
 
 type PortraitCirclesProps = {
-  entries: PortraitEntry[];
-};
+  entries: PortraitEntry[]
+}
 
-const TIER_ORDER: PortraitTier[] = ['mastery', 'solid', 'familiar', 'establishing'];
+const TIER_ORDER: PortraitTier[] = [
+  'mastery',
+  'solid',
+  'familiar',
+  'establishing',
+]
 
 const TIER_DISPLAY: Record<PortraitTier, string> = {
   establishing: 'Establishing',
   familiar: 'Familiar',
   solid: 'Solid',
   mastery: 'Mastery',
-};
+}
 
 type DomainColor = {
-  primary: string;
-  light: string;
-  text: string;
-};
+  primary: string
+  light: string
+  text: string
+}
 
 const DOMAIN_COLORS: Record<string, DomainColor> = {
-  Literature:              { primary: '#c0392b', light: 'rgba(192,57,43,0.12)',   text: '#8b1a0e' },
-  Music:                   { primary: '#1a6b8a', light: 'rgba(26,107,138,0.12)',  text: '#0e4060' },
-  'Film & Television':     { primary: '#6b3fa0', light: 'rgba(107,63,160,0.12)', text: '#3d1f6b' },
-  'Architecture & Design': { primary: '#b07d2e', light: 'rgba(176,125,46,0.12)', text: '#7a5010' },
-  'Food & Cuisine':        { primary: '#2e8b57', light: 'rgba(46,139,87,0.12)',  text: '#0e5c30' },
-  Technology:              { primary: '#3a6b8a', light: 'rgba(58,107,138,0.12)', text: '#1a3f5c' },
-  Sports:                  { primary: '#c06b1a', light: 'rgba(192,107,26,0.12)', text: '#8b3e0e' },
-  History:                 { primary: '#5a6b7a', light: 'rgba(90,107,122,0.12)', text: '#2a3f50' },
-  Science:                 { primary: '#5a7a2e', light: 'rgba(90,122,46,0.12)',  text: '#2a4a0e' },
-  Philosophy:              { primary: '#7a5a8a', light: 'rgba(122,90,138,0.12)', text: '#4a2a5c' },
-  'Pop Culture':           { primary: '#8a2a4a', light: 'rgba(138,42,74,0.12)',  text: '#5c0e2a' },
-  Language:                { primary: '#4a7a5a', light: 'rgba(74,122,90,0.12)',  text: '#1e4e30' },
-};
+  Literature: {
+    primary: '#c0392b',
+    light: 'rgba(192,57,43,0.12)',
+    text: '#8b1a0e',
+  },
+  Music: {
+    primary: '#1a6b8a',
+    light: 'rgba(26,107,138,0.12)',
+    text: '#0e4060',
+  },
+  'Film & Television': {
+    primary: '#6b3fa0',
+    light: 'rgba(107,63,160,0.12)',
+    text: '#3d1f6b',
+  },
+  'Architecture & Design': {
+    primary: '#b07d2e',
+    light: 'rgba(176,125,46,0.12)',
+    text: '#7a5010',
+  },
+  'Food & Cuisine': {
+    primary: '#2e8b57',
+    light: 'rgba(46,139,87,0.12)',
+    text: '#0e5c30',
+  },
+  Technology: {
+    primary: '#3a6b8a',
+    light: 'rgba(58,107,138,0.12)',
+    text: '#1a3f5c',
+  },
+  Sports: {
+    primary: '#c06b1a',
+    light: 'rgba(192,107,26,0.12)',
+    text: '#8b3e0e',
+  },
+  History: {
+    primary: '#5a6b7a',
+    light: 'rgba(90,107,122,0.12)',
+    text: '#2a3f50',
+  },
+  Science: {
+    primary: '#5a7a2e',
+    light: 'rgba(90,122,46,0.12)',
+    text: '#2a4a0e',
+  },
+  Philosophy: {
+    primary: '#7a5a8a',
+    light: 'rgba(122,90,138,0.12)',
+    text: '#4a2a5c',
+  },
+  'Pop Culture': {
+    primary: '#8a2a4a',
+    light: 'rgba(138,42,74,0.12)',
+    text: '#5c0e2a',
+  },
+  Language: {
+    primary: '#4a7a5a',
+    light: 'rgba(74,122,90,0.12)',
+    text: '#1e4e30',
+  },
+}
 
 function hashColor(str: string): DomainColor {
-  let h = 0;
+  let h = 0
   for (let i = 0; i < str.length; i++) {
-    h = ((h << 5) - h + str.charCodeAt(i)) | 0;
+    h = ((h << 5) - h + str.charCodeAt(i)) | 0
   }
-  const hue = Math.abs(h) % 360;
+  const hue = Math.abs(h) % 360
   return {
     primary: `hsl(${hue},45%,35%)`,
     light: `hsla(${hue},45%,35%,0.12)`,
     text: `hsl(${hue},45%,25%)`,
-  };
+  }
 }
 
 export function getPortraitDomainColor(domain: string): DomainColor {
-  return DOMAIN_COLORS[domain] ?? hashColor(domain);
+  return DOMAIN_COLORS[domain] ?? hashColor(domain)
 }
 
-const SPARSE_THRESHOLD = 5;
-const MIN_OPACITY = 0.22;
+const SPARSE_THRESHOLD = 5
+const MIN_OPACITY = 0.22
 
 export function getPortraitCircleOpacity(pts: number, maxPts: number): number {
-  const n = pts / Math.max(maxPts, 1);
-  return MIN_OPACITY + n * (1 - MIN_OPACITY);
+  const n = pts / Math.max(maxPts, 1)
+  return MIN_OPACITY + n * (1 - MIN_OPACITY)
 }
 
-type Section = { label: string; color: string; entries: PortraitEntry[] };
+type Section = { label: string; color: string; entries: PortraitEntry[] }
 
-function buildSections(entries: PortraitEntry[], sortMode: SortMode): Section[] {
+function buildSections(
+  entries: PortraitEntry[],
+  sortMode: SortMode
+): Section[] {
   if (sortMode === 'domain') {
-    const domainMap = new Map<string, PortraitEntry[]>();
+    const domainMap = new Map<string, PortraitEntry[]>()
     for (const e of entries) {
-      const broadCategory = normalizeBroadCategory(e.broadCategory) ?? 'Other';
-      const normalizedEntry = { ...e, broadCategory };
-      const list = domainMap.get(broadCategory) ?? [];
-      list.push(normalizedEntry);
-      domainMap.set(broadCategory, list);
+      const broadCategory = normalizeBroadCategory(e.broadCategory) ?? 'Other'
+      const normalizedEntry = { ...e, broadCategory }
+      const list = domainMap.get(broadCategory) ?? []
+      list.push(normalizedEntry)
+      domainMap.set(broadCategory, list)
     }
     return Array.from(domainMap.entries())
       .map(([domain, cats]) => ({
         label: domain,
         color: getPortraitDomainColor(domain).primary,
-        entries: [...cats].sort((a, b) => b.totalMasteryPoints - a.totalMasteryPoints),
+        entries: [...cats].sort(
+          (a, b) => b.totalMasteryPoints - a.totalMasteryPoints
+        ),
       }))
       .sort((a, b) => {
-        const sumA = a.entries.reduce((s, e) => s + e.totalMasteryPoints, 0);
-        const sumB = b.entries.reduce((s, e) => s + e.totalMasteryPoints, 0);
-        return sumB - sumA;
-      });
+        const sumA = a.entries.reduce((s, e) => s + e.totalMasteryPoints, 0)
+        const sumB = b.entries.reduce((s, e) => s + e.totalMasteryPoints, 0)
+        return sumB - sumA
+      })
   }
-  return TIER_ORDER
-    .map((tier) => ({
-      label: TIER_DISPLAY[tier],
-      color: '#6b5535',
-      entries: entries
-        .filter((e) => e.tier === tier)
-        .sort((a, b) => b.totalMasteryPoints - a.totalMasteryPoints),
-    }))
-    .filter((s) => s.entries.length > 0);
+  return TIER_ORDER.map((tier) => ({
+    label: TIER_DISPLAY[tier],
+    color: '#6b5535',
+    entries: entries
+      .filter((e) => e.tier === tier)
+      .sort((a, b) => b.totalMasteryPoints - a.totalMasteryPoints),
+  })).filter((s) => s.entries.length > 0)
 }
 
 export function PortraitDomainCircle({
@@ -116,69 +175,105 @@ export function PortraitDomainCircle({
   showCount = true,
   circleScale = 1,
   selected = false,
+  circleSlotSize,
 }: {
-  entry: PortraitEntry;
-  maxPointsForTier: number;
-  forceFullOpacity?: boolean;
-  showCount?: boolean;
-  circleScale?: number;
-  selected?: boolean;
+  entry: PortraitEntry
+  maxPointsForTier: number
+  forceFullOpacity?: boolean
+  showCount?: boolean
+  circleScale?: number
+  selected?: boolean
+  circleSlotSize?: number
 }) {
-  const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'Other';
-  const dc = getPortraitDomainColor(broadCategory);
-  const size = Math.round(getDomainCircleSize(entry.tier as CircleSizingTier, entry.totalMasteryPoints, maxPointsForTier) * circleScale);
-  const opacity = forceFullOpacity ? 1 : getPortraitCircleOpacity(entry.totalMasteryPoints, maxPointsForTier);
-  const labelOpacity = 0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5;
+  const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'Other'
+  const dc = getPortraitDomainColor(broadCategory)
+  const size = Math.round(
+    getDomainCircleSize(
+      entry.tier as CircleSizingTier,
+      entry.totalMasteryPoints,
+      maxPointsForTier
+    ) * circleScale
+  )
+  const opacity = forceFullOpacity
+    ? 1
+    : getPortraitCircleOpacity(entry.totalMasteryPoints, maxPointsForTier)
+  const labelOpacity =
+    0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5
   const showMasteryCount =
     showCount &&
-    entry.tier !== 'establishing' && entry.authoredAnsweredCount > 0;
+    entry.tier !== 'establishing' &&
+    entry.authoredAnsweredCount > 0
+  const resolvedCircleSlotSize = Math.max(circleSlotSize ?? size, size)
 
   return (
-    <div style={circleItemStyle}>
-      <div style={{ position: 'relative', width: size, height: size }}>
-        <div
-          style={{
-            width: size,
-            height: size,
-            borderRadius: '50%',
-            background: `radial-gradient(circle at 38% 38%, ${dc.light.replace('0.12', '0.22')}, ${dc.light})`,
-            opacity,
-            flexShrink: 0,
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          {showMasteryCount && (
-            <span
-              style={{
-                fontSize: size > 52 ? 13 : 10,
-                color: dc.primary,
-                fontFamily: 'Georgia, "Times New Roman", serif',
-                fontWeight: 'bold',
-                lineHeight: 1,
-              }}
-            >
-              {entry.authoredAnsweredCount}
-            </span>
-          )}
-        </div>
-        {selected && (
+    <div
+      style={{
+        ...circleItemStyle,
+        width: Math.max(90, resolvedCircleSlotSize + 8),
+      }}
+    >
+      <div
+        style={{
+          ...portraitCircleSlotStyle,
+          width: resolvedCircleSlotSize,
+          height: resolvedCircleSlotSize,
+        }}
+      >
+        <div style={{ position: 'relative', width: size, height: size }}>
           <div
-            aria-hidden
             style={{
-              position: 'absolute',
-              inset: -4,
+              width: size,
+              height: size,
               borderRadius: '50%',
-              border: `2px solid ${dc.primary}`,
-              display: 'grid',
-              placeItems: 'center',
-              pointerEvents: 'none',
+              background: `radial-gradient(circle at 38% 38%, ${dc.light.replace('0.12', '0.22')}, ${dc.light})`,
+              opacity,
+              flexShrink: 0,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
             }}
           >
-            <span style={{ position: 'absolute', right: -2, bottom: -2, fontSize: 12, color: dc.primary }}>✓</span>
+            {showMasteryCount && (
+              <span
+                style={{
+                  fontSize: size > 52 ? 13 : 10,
+                  color: dc.primary,
+                  fontFamily: 'Georgia, "Times New Roman", serif',
+                  fontWeight: 'bold',
+                  lineHeight: 1,
+                }}
+              >
+                {entry.authoredAnsweredCount}
+              </span>
+            )}
           </div>
-        )}
+          {selected && (
+            <div
+              aria-hidden
+              style={{
+                position: 'absolute',
+                inset: -4,
+                borderRadius: '50%',
+                border: `2px solid ${dc.primary}`,
+                display: 'grid',
+                placeItems: 'center',
+                pointerEvents: 'none',
+              }}
+            >
+              <span
+                style={{
+                  position: 'absolute',
+                  right: -2,
+                  bottom: -2,
+                  fontSize: 12,
+                  color: dc.primary,
+                }}
+              >
+                ✓
+              </span>
+            </div>
+          )}
+        </div>
       </div>
       <span
         style={{
@@ -195,29 +290,55 @@ export function PortraitDomainCircle({
         {entry.canonicalSubcategory}
       </span>
     </div>
-  );
+  )
+}
+
+function getPortraitEntryCircleSize(
+  entry: PortraitEntry,
+  maxPointsForTier: number
+): number {
+  return Math.round(
+    getDomainCircleSize(
+      entry.tier as CircleSizingTier,
+      entry.totalMasteryPoints,
+      maxPointsForTier
+    )
+  )
 }
 
 export function PortraitCircles({ entries }: PortraitCirclesProps) {
-  const [sortMode, setSortMode] = useState<SortMode>('domain');
+  const [sortMode, setSortMode] = useState<SortMode>('domain')
 
   const validEntries = useMemo(
-    () => entries
-      .map((entry) => ({ ...entry, broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'Other' }))
-      .filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
-    [entries],
-  );
-  const isSparse = validEntries.length < SPARSE_THRESHOLD;
-  const sections = useMemo(() => buildSections(validEntries, sortMode), [validEntries, sortMode]);
+    () =>
+      entries
+        .map((entry) => ({
+          ...entry,
+          broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'Other',
+        }))
+        .filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
+    [entries]
+  )
+  const isSparse = validEntries.length < SPARSE_THRESHOLD
+  const sections = useMemo(
+    () => buildSections(validEntries, sortMode),
+    [validEntries, sortMode]
+  )
 
   const maxPointsByTier = useMemo(() => {
-    const result: Record<string, number> = { establishing: 1, familiar: 1, solid: 1, mastery: 1 };
-    for (const e of validEntries) {
-      if (e.totalMasteryPoints > (result[e.tier] ?? 1)) result[e.tier] = e.totalMasteryPoints;
+    const result: Record<string, number> = {
+      establishing: 1,
+      familiar: 1,
+      solid: 1,
+      mastery: 1,
     }
-    return result;
-  }, [validEntries]);
-  const allDomains = [...new Set(validEntries.map((e) => e.broadCategory))];
+    for (const e of validEntries) {
+      if (e.totalMasteryPoints > (result[e.tier] ?? 1))
+        result[e.tier] = e.totalMasteryPoints
+    }
+    return result
+  }, [validEntries])
+  const allDomains = [...new Set(validEntries.map((e) => e.broadCategory))]
 
   return (
     <div>
@@ -238,7 +359,7 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
       {sortMode === 'domain' ? (
         <div style={legendStyle}>
           {allDomains.map((domain) => {
-            const dc = getPortraitDomainColor(domain);
+            const dc = getPortraitDomainColor(domain)
             return (
               <div key={domain} style={legendItemStyle}>
                 <div
@@ -251,9 +372,11 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
                     flexShrink: 0,
                   }}
                 />
-                <span style={{ fontSize: 9.5, color: dc.text, opacity: 0.85 }}>{domain}</span>
+                <span style={{ fontSize: 9.5, color: dc.text, opacity: 0.85 }}>
+                  {domain}
+                </span>
               </div>
-            );
+            )
           })}
         </div>
       ) : (
@@ -270,7 +393,9 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
                   flexShrink: 0,
                 }}
               />
-              <span style={{ fontSize: 9.5, color: '#8b7355' }}>{TIER_DISPLAY[tier]}</span>
+              <span style={{ fontSize: 9.5, color: '#8b7355' }}>
+                {TIER_DISPLAY[tier]}
+              </span>
             </div>
           ))}
           <span
@@ -288,33 +413,51 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
       )}
 
       <p style={explainerStyle}>
-        Numbers inside circles = questions you&apos;ve written that others have answered
+        Numbers inside circles = questions you&apos;ve written that others have
+        answered
       </p>
 
       <div>
-        {sections.map(({ label, color, entries: sectionEntries }) => (
-          <div key={label} style={{ marginTop: 24 }}>
-            <div
-              style={{
-                fontSize: 10,
-                letterSpacing: '0.18em',
-                textTransform: 'uppercase',
-                color,
-                marginBottom: 14,
-                paddingBottom: 6,
-                borderBottom: `1px solid ${color}33`,
-                fontFamily: 'Georgia, "Times New Roman", serif',
-              }}
-            >
-              {label}
+        {sections.map(({ label, color, entries: sectionEntries }) => {
+          const circleSlotSize = Math.max(
+            ...sectionEntries.map((entry) =>
+              getPortraitEntryCircleSize(
+                entry,
+                maxPointsByTier[entry.tier] ?? 1
+              )
+            ),
+            0
+          )
+
+          return (
+            <div key={label} style={{ marginTop: 24 }}>
+              <div
+                style={{
+                  fontSize: 10,
+                  letterSpacing: '0.18em',
+                  textTransform: 'uppercase',
+                  color,
+                  marginBottom: 14,
+                  paddingBottom: 6,
+                  borderBottom: `1px solid ${color}33`,
+                  fontFamily: 'Georgia, "Times New Roman", serif',
+                }}
+              >
+                {label}
+              </div>
+              <div style={circlesRowStyle}>
+                {sectionEntries.map((entry) => (
+                  <PortraitDomainCircle
+                    key={entry.canonicalSubcategory}
+                    entry={entry}
+                    maxPointsForTier={maxPointsByTier[entry.tier] ?? 1}
+                    circleSlotSize={circleSlotSize}
+                  />
+                ))}
+              </div>
             </div>
-            <div style={circlesRowStyle}>
-              {sectionEntries.map((entry) => (
-                <PortraitDomainCircle key={entry.canonicalSubcategory} entry={entry} maxPointsForTier={maxPointsByTier[entry.tier] ?? 1} />
-              ))}
-            </div>
-          </div>
-        ))}
+          )
+        })}
       </div>
 
       {isSparse && validEntries.length > 0 && (
@@ -323,7 +466,7 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
         </p>
       )}
     </div>
-  );
+  )
 }
 
 // ── Styles ────────────────────────────────────────────────────────────────────
@@ -334,21 +477,27 @@ const circleItemStyle: CSSProperties = {
   alignItems: 'center',
   gap: 7,
   padding: '4px 2px',
-};
+}
+
+const portraitCircleSlotStyle: CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+}
 
 const circlesRowStyle: CSSProperties = {
   display: 'flex',
   flexWrap: 'wrap',
   gap: 14,
-  alignItems: 'flex-end',
-};
+  alignItems: 'flex-start',
+}
 
 const toggleWrapStyle: CSSProperties = {
   display: 'flex',
   justifyContent: 'center',
   gap: 8,
   marginBottom: '0.65rem',
-};
+}
 
 const activeToggleStyle: CSSProperties = {
   minHeight: 34,
@@ -360,7 +509,7 @@ const activeToggleStyle: CSSProperties = {
   cursor: 'pointer',
   fontFamily: 'inherit',
   fontSize: 14,
-};
+}
 
 const inactiveToggleStyle: CSSProperties = {
   minHeight: 34,
@@ -372,7 +521,7 @@ const inactiveToggleStyle: CSSProperties = {
   cursor: 'pointer',
   fontFamily: 'inherit',
   fontSize: 14,
-};
+}
 
 const legendStyle: CSSProperties = {
   display: 'flex',
@@ -380,13 +529,13 @@ const legendStyle: CSSProperties = {
   gap: '6px 10px',
   alignItems: 'center',
   marginBottom: '0.5rem',
-};
+}
 
 const legendItemStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   gap: 5,
-};
+}
 
 const sparsePromptStyle: CSSProperties = {
   marginTop: 24,
@@ -395,7 +544,7 @@ const sparsePromptStyle: CSSProperties = {
   fontStyle: 'italic',
   fontFamily: 'Georgia, "Times New Roman", serif',
   textAlign: 'center',
-};
+}
 
 const explainerStyle: CSSProperties = {
   margin: '6px 0 0',
@@ -403,4 +552,4 @@ const explainerStyle: CSSProperties = {
   color: '#b0a090',
   fontStyle: 'italic',
   fontFamily: 'Georgia, "Times New Roman", serif',
-};
+}


### PR DESCRIPTION
### Motivation
- Improve visual alignment so all circle centers line up horizontally and the text labels start from a consistent top edge across both the beige knowledge card and the white portrait sections.
- Reduce the visual “sloppiness” from mixed circle diameters causing uneven rows and misaligned labels.

### Description
- Add an optional `circleSlotSize` prop to `DomainCircle` so each circle is centered inside a fixed slot before rendering its label (`src/components/knowledge/DomainCircle.tsx`).
- In the beige knowledge card (`src/components/knowledge/KnowledgeCard.tsx`) calculate visible circle diameters, compute a single `circleSlotSize` (largest visible diameter) and pass that into each `DomainCircle` so circles share a consistent row height.
- In the portrait/list view (`src/components/knowledge/PortraitCircles.tsx`) compute a per-section `circleSlotSize` from entries in that section and pass it to each `PortraitDomainCircle`, and switch row alignment to top (`alignItems: 'flex-start'`) so labels align.
- Add small layout helper styles (`circleSlotStyle`, `portraitCircleSlotStyle`) and other housekeeping changes to ensure circles and labels are centered inside their slots without changing visual sizes of the circles themselves.

### Testing
- Ran `npx eslint src/components/knowledge/DomainCircle.tsx src/components/knowledge/KnowledgeCard.tsx src/components/knowledge/PortraitCircles.tsx` and addressed linting for the touched files (succeeded).
- Ran `npx tsc --noEmit --project tsconfig.json` to verify TypeScript type-checking (succeeded).
- Ran `npm run lint` for repository-wide linting which still reports pre-existing unrelated issues elsewhere in the repo (this run is expected to fail due to unrelated existing errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a578bf58832e9a58f82f7fc5bc3b)