### PR TITLE
Have LLM set authored question difficulty (Establishing → Solid → Skilled → Master)

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { broadCategoryDisplayName, isBroadQuestionCategory, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { getSession } from '@/server/auth/session';
+import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { db, questions } from '@/server/db';
 import {
   deleteQuestion,
@@ -79,13 +80,6 @@ function validatePatchPayload(body: Record<string, unknown> | null) {
       values.subcategory = canonicalSubcategory;
     }
   }
-  if (body?.difficulty !== undefined) {
-    values.difficulty = typeof body.difficulty === 'number' ? body.difficulty : Number.NaN;
-    if (!Number.isInteger(values.difficulty) || values.difficulty < 1 || values.difficulty > 5) {
-      errors.push('difficulty');
-    }
-  }
-
   return { values, errors };
 }
 
@@ -127,6 +121,29 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   const body = await request.json().catch(() => null) as Record<string, unknown> | null;
   const { values, errors } = validatePatchPayload(body);
   if (errors.length > 0) return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
+
+  const existing = await getQuestion(id, session.userId);
+  if (!existing) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  if (existing.usedInGamesCount > 0) {
+    return NextResponse.json({ error: 'Question has been used in a game and cannot be edited.' }, { status: 409 });
+  }
+
+  const shouldReassessDifficulty = values.text !== undefined
+    || values.correctAnswer !== undefined
+    || values.explanation !== undefined
+    || values.category !== undefined
+    || values.canonicalSubcategory !== undefined;
+
+  if (shouldReassessDifficulty) {
+    const difficultyAssessment = await assessQuestionDifficulty({
+      questionText: values.text ?? existing.text,
+      correctAnswer: values.correctAnswer ?? existing.correctAnswer,
+      broadCategory: values.broadCategory ?? existing.broadCategory,
+      canonicalSubcategory: values.canonicalSubcategory ?? existing.canonicalSubcategory ?? existing.domain,
+      explanation: values.explanation ?? existing.explanation,
+    });
+    values.difficulty = difficultyAssessment.difficulty;
+  }
 
   const result = await updateQuestion({ questionId: id, userId: session.userId, ...values });
   if (!result.ok && result.reason === 'in_use') {

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -18,6 +18,7 @@ import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
 import { writeActivity } from '@/server/activity/write-activity';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
+import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 
 export const dynamic = 'force-dynamic';
 
@@ -38,7 +39,15 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
 
-  const { sendToFriendIds, shareToFeed, ...questionFields } = value;
+  const { sendToFriendIds, shareToFeed, ...rawQuestionFields } = value;
+  const difficultyAssessment = await assessQuestionDifficulty({
+    questionText: rawQuestionFields.text,
+    correctAnswer: rawQuestionFields.correctAnswer,
+    broadCategory: rawQuestionFields.broadCategory,
+    canonicalSubcategory: rawQuestionFields.canonicalSubcategory,
+    explanation: rawQuestionFields.explanation,
+  });
+  const questionFields = { ...rawQuestionFields, difficulty: difficultyAssessment.difficulty };
 
   if (sendToFriendIds.length > 0) {
     const friends = await getFriends(session.userId);
@@ -54,7 +63,7 @@ export async function POST(request: NextRequest) {
   }
 
   const created = await createQuestion({ authorId: session.userId, ...questionFields });
-  console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified });
+  console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified, difficultyTier: difficultyAssessment.tier });
   const kbResult = await openKBDomain({
     userId: session.userId,
     domain: questionFields.canonicalSubcategory,

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -35,11 +35,11 @@ function isNoQuestionsResponse(response: Response, body: QuestionsApiResponse | 
 }
 
 const DIFFICULTY_COPY: Record<number, string> = {
-  1: 'Accessible',
-  2: 'Accessible → Moderate',
-  3: 'Moderate',
-  4: 'Moderate → Specialist',
-  5: 'Specialist',
+  1: 'Establishing',
+  2: 'Establishing → Solid',
+  3: 'Solid',
+  4: 'Skilled',
+  5: 'Master',
 };
 
 const DOMAIN_COLORS: Record<string, string> = {
@@ -367,10 +367,10 @@ function QuestionsPageContent() {
                   >
                     {question.domainDisplayName}
                   </span>
-                  <span className="font-mono text-xs text-muted-foreground" aria-label={`Difficulty ${question.difficulty} of 5 (${DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'})`}>
+                  <span className="font-mono text-xs text-muted-foreground" aria-label={`LLM-rated difficulty: ${DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}`}>
                     {difficultyDots(question.difficulty)}
                     {' · '}
-                    {question.difficulty}/5 {DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}
+                    {DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}
                   </span>
                   <span className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
                     {isOwnAuthored ? 'Written by you' : `From ${question.authorName ?? 'a friend'}`}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -15,7 +15,7 @@ export type QuestionFormValues = {
   category: string;
   canonicalSubcategory: string;
   domain?: string;
-  difficulty: number;
+  difficulty?: number;
   verified: boolean;
   llmSuggestedAnswer?: string | null;
   critiqueIterations: number;
@@ -64,7 +64,6 @@ type State = {
   category: string;
   canonicalSubcategory: string;
   domain?: string;
-  difficulty: number;
   critiqueResult: CritiqueResult | null;
   critiqueIterations: number;
   remainingCritiquesToday: number | null;
@@ -82,7 +81,6 @@ type State = {
 type Action =
   | { type: 'RESET'; state: State }
   | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote' | 'category' | 'canonicalSubcategory'; value: string }
-  | { type: 'DIFFICULTY'; value: number }
   | { type: 'ERROR'; value: string | null }
   | { type: 'START_CRITIQUE'; text: string }
   | { type: 'CRITIQUE_RESULT'; response: CritiqueResponse }
@@ -103,14 +101,6 @@ type Action =
   | { type: 'FRIENDS_LOADED'; friends: FriendOption[] }
   | { type: 'TOGGLE_FRIEND'; id: string };
 
-const DIFFICULTY_SCALE: Record<number, { label: string; hint: string }> = {
-  1: { label: 'Accessible', hint: 'Most players should be able to get this one.' },
-  2: { label: 'Accessible → Moderate', hint: 'Leans approachable but needs some recall.' },
-  3: { label: 'Moderate', hint: 'Balanced challenge with topic familiarity.' },
-  4: { label: 'Moderate → Specialist', hint: 'Leans advanced and rewards deeper knowledge.' },
-  5: { label: 'Specialist', hint: 'Best for enthusiasts or experts in the domain.' },
-};
-
 function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecificMode = false): State {
   return {
     stage: 'WRITING',
@@ -123,7 +113,6 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     creatorNote: initialValues?.creatorNote ?? '',
     category: initialValues?.category ?? 'other',
     canonicalSubcategory: initialValues?.canonicalSubcategory ?? initialValues?.domain ?? '',
-    difficulty: initialValues?.difficulty ?? 3,
     critiqueResult: null,
     critiqueIterations: initialValues?.critiqueIterations ?? 0,
     remainingCritiquesToday: null,
@@ -143,7 +132,6 @@ function reducer(state: State, action: Action): State {
   switch (action.type) {
     case 'RESET': return action.state;
     case 'FIELD': return { ...state, [action.field]: action.value, error: null };
-    case 'DIFFICULTY': return { ...state, difficulty: action.value };
     case 'ERROR': return { ...state, error: action.value };
     case 'START_CRITIQUE': return { ...state, stage: 'CRITIQUING', lastCritiquedText: action.text, error: null };
     case 'CRITIQUE_RESULT': {
@@ -214,7 +202,6 @@ function validate(state: State): string | null {
   const canonicalSubcategory = normalizeCanonicalSubcategory(state.canonicalSubcategory);
   if (!canonicalSubcategory) return 'Enter a specific area.';
   if (CATEGORIES.includes(canonicalSubcategory as (typeof CATEGORIES)[number])) return 'Specific area must be more precise than the broad category.';
-  if (!Number.isInteger(state.difficulty) || state.difficulty < 1 || state.difficulty > 5) return 'Choose a difficulty from 1 to 5.';
   if (state.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
   return null;
 }
@@ -362,7 +349,6 @@ export function QuestionForm({
         category: state.category,
         canonicalSubcategory: normalizeCanonicalSubcategory(state.canonicalSubcategory),
         domain: normalizeCanonicalSubcategory(state.canonicalSubcategory),
-        difficulty: state.difficulty,
         verified,
         llmSuggestedAnswer: state.llmSuggestedAnswer,
         critiqueIterations: state.critiqueIterations,
@@ -490,12 +476,9 @@ export function QuestionForm({
               <input id="canonical-subcategory" value={state.canonicalSubcategory} onChange={(event) => dispatch({ type: 'FIELD', field: 'canonicalSubcategory', value: event.target.value })} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary" placeholder="The Waste Land" />
               <p className="mt-1 text-xs text-muted-foreground">Use a precise domain like T. S. Eliot, The Waste Land, or Modernist Poetry.</p>
             </div>
-            <div>
-              <label htmlFor="difficulty" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Difficulty</label>
-              <select id="difficulty" value={state.difficulty} onChange={(event) => dispatch({ type: 'DIFFICULTY', value: Number(event.target.value) })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
-                {[1, 2, 3, 4, 5].map((difficulty) => <option key={difficulty} value={difficulty}>{difficulty} · {DIFFICULTY_SCALE[difficulty].label}</option>)}
-              </select>
-              <p className="mt-1 text-xs text-muted-foreground">Rank {state.difficulty}/5 — {DIFFICULTY_SCALE[state.difficulty].label}. {DIFFICULTY_SCALE[state.difficulty].hint}</p>
+            <div className="rounded-md border bg-muted/30 p-3 sm:col-span-2">
+              <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Difficulty</p>
+              <p className="mt-1 text-sm text-muted-foreground">Joshing will rate this with the LLM after you save, using the domain-relative Establishing → Solid → Skilled → Master scale.</p>
             </div>
           </div>
 

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -8,7 +8,6 @@ describe('create question payload categorization', () => {
     text: 'Which 1922 poem opens with April as the cruelest month?',
     correctAnswer: 'The Waste Land',
     verified: true,
-    difficulty: 3,
     critiqueIterations: 0,
   };
 
@@ -49,6 +48,18 @@ describe('create question payload categorization', () => {
     });
 
     expect(result.errors).toContain('canonicalSubcategory');
+  });
+
+
+  it('does not require a user-supplied difficulty', () => {
+    const result = readCreateQuestionPayload({
+      ...basePayload,
+      category: 'literature',
+      canonicalSubcategory: 'The Waste Land',
+    });
+
+    expect(result.errors).toEqual([]);
+    expect('difficulty' in result.value).toBe(false);
   });
 
   it('does not require friends when sharing to feed', () => {

--- a/src/server/questions/__tests__/llm-difficulty.test.ts
+++ b/src/server/questions/__tests__/llm-difficulty.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+import { fallbackQuestionDifficulty, parseQuestionDifficultyAssessment } from '@/server/questions/llm-difficulty';
+
+describe('question LLM difficulty assessment', () => {
+  it('maps domain-relative tier labels to persisted numeric difficulty', () => {
+    expect(parseQuestionDifficultyAssessment('{"tier":"establishing"}')).toEqual({ tier: 'establishing', difficulty: 1 });
+    expect(parseQuestionDifficultyAssessment('{"tier":"solid"}')).toEqual({ tier: 'solid', difficulty: 3 });
+    expect(parseQuestionDifficultyAssessment('{"tier":"skilled"}')).toEqual({ tier: 'skilled', difficulty: 4 });
+    expect(parseQuestionDifficultyAssessment('{"tier":"master"}')).toEqual({ tier: 'master', difficulty: 5 });
+  });
+
+  it('accepts mastery as an alias for master', () => {
+    expect(parseQuestionDifficultyAssessment('{"difficultyTier":"mastery"}')).toEqual({ tier: 'master', difficulty: 5 });
+  });
+
+  it('falls back to solid when no LLM rating is available', () => {
+    expect(fallbackQuestionDifficulty()).toEqual({ tier: 'solid', difficulty: 3 });
+  });
+});

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -13,12 +13,6 @@ function splitAlternates(value: unknown): string[] {
   return [];
 }
 
-function difficultyFromLegacy(value: unknown): number | null {
-  if (value === 'accessible') return 1;
-  if (value === 'moderate') return 3;
-  if (value === 'specialist') return 5;
-  return null;
-}
 
 export function readCreateQuestionPayload(body: Record<string, unknown> | null) {
   const text = typeof body?.text === 'string'
@@ -58,10 +52,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   const canonicalSubcategory = normalizeCanonicalSubcategory(rawCanonicalSubcategory);
   const broadCategory = normalizeBroadQuestionCategory(rawBroadCategory) ?? '';
   const broadCategoryLabel = broadCategory ? broadCategoryDisplayName(broadCategory) : null;
-  const difficulty = typeof body?.difficulty === 'number'
-    ? body.difficulty
-    : difficultyFromLegacy(body?.difficulty_estimate) ?? (isLegacyPayload ? 3 : null);
-  const difficultyValue = difficulty ?? Number.NaN;
   const verified = typeof body?.verified === 'boolean' ? body.verified : null;
   const llmSuggestedAnswer = typeof body?.llmSuggestedAnswer === 'string'
     ? body.llmSuggestedAnswer.trim() || null
@@ -84,7 +74,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   if (canonicalSubcategory && isBroadQuestionCategory(canonicalSubcategory)) errors.push('canonicalSubcategory');
   if (verified === null) errors.push('verified');
   if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
-  if (!Number.isInteger(difficultyValue) || difficultyValue < 1 || difficultyValue > 5) errors.push('difficulty');
   if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
 
   return {
@@ -99,7 +88,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
       canonicalSubcategory,
       subcategory: canonicalSubcategory,
       domain: canonicalSubcategory,
-      difficulty: difficultyValue,
       verified: verified ?? true,
       llmSuggestedAnswer,
       critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0,

--- a/src/server/questions/llm-difficulty.ts
+++ b/src/server/questions/llm-difficulty.ts
@@ -1,0 +1,86 @@
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+
+export type QuestionDifficultyTier = 'establishing' | 'solid' | 'skilled' | 'master';
+
+export type QuestionDifficultyAssessment = {
+  tier: QuestionDifficultyTier;
+  difficulty: 1 | 3 | 4 | 5;
+};
+
+const TIER_TO_DIFFICULTY: Record<QuestionDifficultyTier, QuestionDifficultyAssessment['difficulty']> = {
+  establishing: 1,
+  solid: 3,
+  skilled: 4,
+  master: 5,
+};
+
+function asDifficultyTier(value: unknown): QuestionDifficultyTier | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim().toLowerCase();
+  if (normalized === 'establishing') return 'establishing';
+  if (normalized === 'solid') return 'solid';
+  if (normalized === 'skilled') return 'skilled';
+  if (normalized === 'master' || normalized === 'mastery') return 'master';
+  return null;
+}
+
+export function parseQuestionDifficultyAssessment(rawText: string): QuestionDifficultyAssessment | null {
+  const parsed = parseJsonObject(rawText);
+  const tier = asDifficultyTier(parsed?.tier ?? parsed?.difficultyTier ?? parsed?.difficulty);
+  if (!tier) return null;
+  return { tier, difficulty: TIER_TO_DIFFICULTY[tier] };
+}
+
+export function fallbackQuestionDifficulty(): QuestionDifficultyAssessment {
+  return { tier: 'solid', difficulty: TIER_TO_DIFFICULTY.solid };
+}
+
+export async function assessQuestionDifficulty(params: {
+  questionText: string;
+  correctAnswer: string;
+  broadCategory: string | null;
+  canonicalSubcategory: string;
+  explanation?: string | null;
+}): Promise<QuestionDifficultyAssessment> {
+  const questionText = params.questionText.trim();
+  const correctAnswer = params.correctAnswer.trim();
+  const canonicalSubcategory = params.canonicalSubcategory.trim();
+  if (!questionText || !correctAnswer || !canonicalSubcategory) return fallbackQuestionDifficulty();
+
+  const client = getAnthropicClient();
+  if (!client) return fallbackQuestionDifficulty();
+
+  const prompt = `Rate the difficulty of this trivia question relative to its specific domain, not by the author's opinion.
+
+Domain: ${canonicalSubcategory}
+Broad category: ${params.broadCategory ?? 'Unknown'}
+Question: ${questionText}
+Correct answer: ${correctAnswer}
+Explanation: ${params.explanation?.trim() || 'None provided'}
+
+Use this domain-relative scale:
+- establishing: a newcomer to the domain could reasonably answer it, or it checks core recognition.
+- solid: a generally knowledgeable person in the domain should know it.
+- skilled: requires deeper domain fluency, specific context, or non-obvious recall.
+- master: a specialist-level deep cut even within the domain.
+
+Respond in JSON only: { "tier": "establishing" | "solid" | "skilled" | "master" }`;
+
+  try {
+    const response = await client.messages.create({
+      model: ANTHROPIC_MODEL,
+      max_tokens: 120,
+      temperature: 0,
+      system: 'Return only valid JSON. No markdown or prose outside JSON.',
+      messages: [{ role: 'user', content: prompt }],
+    });
+
+    return parseQuestionDifficultyAssessment(extractTextContent(response.content)) ?? fallbackQuestionDifficulty();
+  } catch (error) {
+    console.warn('[questions/difficulty] LLM assessment unavailable; using fallback', {
+      domain: canonicalSubcategory,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return fallbackQuestionDifficulty();
+  }
+}


### PR DESCRIPTION
### Motivation
- Prevent authors from arbitrarily setting difficulty and instead derive a domain-relative difficulty from the LLM that matches the app's mastery vocabulary: Establishing, Solid, Skilled, Master.
- Keep persisted difficulty consistent with other systems that already use tier vocab (player mastery, daily difficulty mapping) and avoid client-side trust for difficulty values.

### Description
- Added an LLM-backed assessor `src/server/questions/llm-difficulty.ts` that prompts the model for a domain-relative tier (`establishing | solid | skilled | master`) and maps those to numeric difficulty values (`1 | 3 | 4 | 5`), with a fallback of `solid` when unavailable.
- Wired creation and edit flows to compute difficulty server-side by calling `assessQuestionDifficulty` before persisting: `src/app/api/questions/route.ts` and `src/app/api/questions/[id]/route.ts` now invoke the assessor and persist the mapped numeric difficulty.
- Removed client-side difficulty input and validation:
  - `src/components/QuestionForm.tsx` no longer exposes a difficulty control and does not submit a user-supplied difficulty; UI now shows explanatory copy that the LLM rates difficulty after save.
  - `src/server/questions/create-payload.ts` no longer requires/validates a `difficulty` field and the create-payload tests were updated accordingly.
- Updated display labels in question list to use the new tier language and adjusted the accessibility label to reflect LLM-rated difficulty: `src/app/questions/page.tsx`.
- Added unit tests for the difficulty parser and fallback: `src/server/questions/__tests__/llm-difficulty.test.ts` and updated payload tests: `src/server/questions/__tests__/create-payload.test.ts`.

### Testing
- Type-check: ran `npx tsc --noEmit --project tsconfig.json` which completed successfully.
- Targeted lint: ran `npx eslint` against the touched files (`src/components/QuestionForm.tsx`, `src/app/questions/page.tsx`, `src/app/api/questions/route.ts`, `src/app/api/questions/[id]/route.ts`, `src/server/questions/create-payload.ts`, `src/server/questions/llm-difficulty.ts`, and the new/updated tests`), which completed for those files; however `npm run lint` (full repo) still reports pre-existing unrelated lint errors in other files.
- Repo check: `git diff --check` returned no issues.
- Unit tests: added `llm-difficulty` parser tests and updated `create-payload` tests, but running `npx vitest run ...` failed due to a registry (npm) 403 while attempting to fetch `vitest` in this environment, so tests couldn't be executed here.

Notes: The LLM assessor calls the configured Anthropic client and will gracefully fall back to the `solid` rating when the LLM or client is unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a4edcb3c832ebeb79d83a8dca13a)