### PR TITLE
Use LLM to auto-classify question category and domain

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,7 +1,8 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { broadCategoryDisplayName, isBroadQuestionCategory, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { broadCategoryDisplayName, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { db, questions } from '@/server/db';
@@ -58,28 +59,6 @@ function validatePatchPayload(body: Record<string, unknown> | null) {
     values.explanation = typeof body.explanation === 'string' ? body.explanation.trim() : '';
     if (values.explanation.length > 500) errors.push('explanation');
   }
-  const rawBroadCategory = body?.category ?? body?.broadCategory;
-  if (rawBroadCategory !== undefined) {
-    const category = typeof rawBroadCategory === 'string' ? normalizeBroadQuestionCategory(rawBroadCategory) : null;
-    if (!category) {
-      errors.push('category');
-    } else {
-      values.category = category;
-      values.broadCategory = broadCategoryDisplayName(category);
-    }
-  }
-  const rawCanonicalSubcategory = body?.canonicalSubcategory ?? body?.canonical_subcategory ?? body?.domain;
-  if (rawCanonicalSubcategory !== undefined) {
-    const canonicalSubcategory = typeof rawCanonicalSubcategory === 'string'
-      ? normalizeCanonicalSubcategory(rawCanonicalSubcategory)
-      : '';
-    if (!canonicalSubcategory || isBroadQuestionCategory(canonicalSubcategory)) {
-      errors.push('canonicalSubcategory');
-    } else {
-      values.canonicalSubcategory = canonicalSubcategory;
-      values.subcategory = canonicalSubcategory;
-    }
-  }
   return { values, errors };
 }
 
@@ -126,6 +105,20 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   if (!existing) return NextResponse.json({ error: 'not_found' }, { status: 404 });
   if (existing.usedInGamesCount > 0) {
     return NextResponse.json({ error: 'Question has been used in a game and cannot be edited.' }, { status: 409 });
+  }
+
+  const shouldRecategorize = values.text !== undefined || values.correctAnswer !== undefined;
+  if (shouldRecategorize) {
+    const categorization = await categorizeQuestion(
+      values.text ?? existing.text,
+      values.correctAnswer ?? existing.correctAnswer,
+    );
+    const category = normalizeBroadQuestionCategory(categorization.broad_category) ?? 'other';
+    const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
+    values.category = category;
+    values.broadCategory = broadCategoryDisplayName(category);
+    values.canonicalSubcategory = canonicalSubcategory;
+    values.subcategory = canonicalSubcategory;
   }
 
   const shouldReassessDifficulty = values.text !== undefined

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,6 +1,8 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { broadCategoryDisplayName, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
 import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
@@ -40,14 +42,25 @@ export async function POST(request: NextRequest) {
   }
 
   const { sendToFriendIds, shareToFeed, ...rawQuestionFields } = value;
+  const categorization = await categorizeQuestion(rawQuestionFields.text, rawQuestionFields.correctAnswer);
+  const category = normalizeBroadQuestionCategory(categorization.broad_category) ?? 'other';
+  const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
+  const questionFields = {
+    ...rawQuestionFields,
+    category,
+    broadCategory: broadCategoryDisplayName(category),
+    canonicalSubcategory,
+    subcategory: canonicalSubcategory,
+    domain: canonicalSubcategory,
+  };
   const difficultyAssessment = await assessQuestionDifficulty({
-    questionText: rawQuestionFields.text,
-    correctAnswer: rawQuestionFields.correctAnswer,
-    broadCategory: rawQuestionFields.broadCategory,
-    canonicalSubcategory: rawQuestionFields.canonicalSubcategory,
-    explanation: rawQuestionFields.explanation,
+    questionText: questionFields.text,
+    correctAnswer: questionFields.correctAnswer,
+    broadCategory: questionFields.broadCategory,
+    canonicalSubcategory: questionFields.canonicalSubcategory,
+    explanation: questionFields.explanation,
   });
-  const questionFields = { ...rawQuestionFields, difficulty: difficultyAssessment.difficulty };
+  const categorizedQuestionFields = { ...questionFields, difficulty: difficultyAssessment.difficulty };
 
   if (sendToFriendIds.length > 0) {
     const friends = await getFriends(session.userId);
@@ -62,13 +75,13 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const created = await createQuestion({ authorId: session.userId, ...questionFields });
-  console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: questionFields.verified, difficultyTier: difficultyAssessment.tier });
+  const created = await createQuestion({ authorId: session.userId, ...categorizedQuestionFields });
+  console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: categorizedQuestionFields.verified, category: categorizedQuestionFields.category, canonicalSubcategory: categorizedQuestionFields.canonicalSubcategory, difficultyTier: difficultyAssessment.tier });
   const kbResult = await openKBDomain({
     userId: session.userId,
-    domain: questionFields.canonicalSubcategory,
+    domain: categorizedQuestionFields.canonicalSubcategory,
     via: 'authorship',
-    broadCategory: questionFields.broadCategory,
+    broadCategory: categorizedQuestionFields.broadCategory,
     questionId: created.id,
   });
   const question = await getQuestion(created.id, session.userId);
@@ -87,7 +100,7 @@ export async function POST(request: NextRequest) {
             .from(feedDismissedDomains)
             .where(and(
               eq(feedDismissedDomains.userId, friend.id),
-              eq(feedDismissedDomains.canonicalSubcategory, questionFields.canonicalSubcategory),
+              eq(feedDismissedDomains.canonicalSubcategory, categorizedQuestionFields.canonicalSubcategory),
               isNull(feedDismissedDomains.reinstatedAt),
             ))
             .limit(1);
@@ -188,7 +201,7 @@ export async function POST(request: NextRequest) {
       ...created,
       question,
       ...(question ?? {}),
-      openedDomain: kbResult.opened ? questionFields.canonicalSubcategory : null,
+      openedDomain: kbResult.opened ? categorizedQuestionFields.canonicalSubcategory : null,
     },
     { status: 201 },
   );

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -3,8 +3,6 @@
 import { Sparkles } from 'lucide-react';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 
-import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
-import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
 export type QuestionFormValues = {
   text: string;
@@ -12,8 +10,8 @@ export type QuestionFormValues = {
   alternateAnswers: string[];
   explanation: string | null;
   creatorNote?: string | null;
-  category: string;
-  canonicalSubcategory: string;
+  category?: string;
+  canonicalSubcategory?: string;
   domain?: string;
   difficulty?: number;
   verified: boolean;
@@ -61,8 +59,8 @@ type State = {
   alternateText: string;
   explanation: string;
   creatorNote: string;
-  category: string;
-  canonicalSubcategory: string;
+  category?: string;
+  canonicalSubcategory?: string;
   domain?: string;
   critiqueResult: CritiqueResult | null;
   critiqueIterations: number;
@@ -80,7 +78,7 @@ type State = {
 
 type Action =
   | { type: 'RESET'; state: State }
-  | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote' | 'category' | 'canonicalSubcategory'; value: string }
+  | { type: 'FIELD'; field: 'questionText' | 'userAnswer' | 'alternateText' | 'explanation' | 'creatorNote'; value: string }
   | { type: 'ERROR'; value: string | null }
   | { type: 'START_CRITIQUE'; text: string }
   | { type: 'CRITIQUE_RESULT'; response: CritiqueResponse }
@@ -198,10 +196,6 @@ function validate(state: State): string | null {
   if (alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
   if (state.explanation.length > 500) return 'Explanation must be 500 characters or fewer.';
   if (state.creatorNote.length > 200) return 'Creator note must be 200 characters or fewer.';
-  if (!CATEGORIES.includes(state.category as (typeof CATEGORIES)[number])) return 'Choose a valid broad category.';
-  const canonicalSubcategory = normalizeCanonicalSubcategory(state.canonicalSubcategory);
-  if (!canonicalSubcategory) return 'Enter a specific area.';
-  if (CATEGORIES.includes(canonicalSubcategory as (typeof CATEGORIES)[number])) return 'Specific area must be more precise than the broad category.';
   if (state.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
   return null;
 }
@@ -346,9 +340,6 @@ export function QuestionForm({
         alternateAnswers,
         explanation: state.explanation.trim() || null,
         creatorNote: state.creatorNote.trim() || null,
-        category: state.category,
-        canonicalSubcategory: normalizeCanonicalSubcategory(state.canonicalSubcategory),
-        domain: normalizeCanonicalSubcategory(state.canonicalSubcategory),
         verified,
         llmSuggestedAnswer: state.llmSuggestedAnswer,
         critiqueIterations: state.critiqueIterations,
@@ -464,22 +455,9 @@ export function QuestionForm({
             <p className="mt-1 text-right text-xs text-muted-foreground">{state.explanation.length}/500</p>
           </div>
 
-          <div className="grid gap-4 sm:grid-cols-2">
-            <div>
-              <label htmlFor="broad-category" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Broad category</label>
-              <select id="broad-category" value={state.category} onChange={(event) => dispatch({ type: 'FIELD', field: 'category', value: event.target.value })} disabled={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary">
-                {CATEGORIES.map((category) => <option key={category} value={category}>{categoryLabel(category)}</option>)}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="canonical-subcategory" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Specific area</label>
-              <input id="canonical-subcategory" value={state.canonicalSubcategory} onChange={(event) => dispatch({ type: 'FIELD', field: 'canonicalSubcategory', value: event.target.value })} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="h-11 w-full rounded-md border bg-background px-3 outline-none focus:border-primary" placeholder="The Waste Land" />
-              <p className="mt-1 text-xs text-muted-foreground">Use a precise domain like T. S. Eliot, The Waste Land, or Modernist Poetry.</p>
-            </div>
-            <div className="rounded-md border bg-muted/30 p-3 sm:col-span-2">
-              <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Difficulty</p>
-              <p className="mt-1 text-sm text-muted-foreground">Joshing will rate this with the LLM after you save, using the domain-relative Establishing → Solid → Skilled → Master scale.</p>
-            </div>
+          <div className="rounded-md border bg-muted/30 p-3">
+            <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">AI classification</p>
+            <p className="mt-1 text-sm text-muted-foreground">Joshing will read the question and answer when you save, then use the LLM to choose the broad category, precise domain, and difficulty.</p>
           </div>
 
           {state.stage === 'REVIEWING' && state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (

--- a/src/components/QuickAddQuestionModal.tsx
+++ b/src/components/QuickAddQuestionModal.tsx
@@ -2,13 +2,11 @@
 
 /**
  * QuickAddQuestionModal — lightweight modal for capturing a question from the homepage.
- * Posts to POST /api/questions. No LLM suggestion; just question, answer, context, and optional short label.
+ * Posts to POST /api/questions. The server classifies category/domain through the LLM.
  */
 
 import { type CSSProperties, useEffect, useRef, useState } from 'react';
-import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { validateBreadcrumbContext } from '@/lib/breadcrumb-validation';
-import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
 type Props = {
   onClose: () => void;
@@ -40,8 +38,6 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
   const [questionText, setQuestionText] = useState('');
   const [answerText, setAnswerText] = useState('');
   const [breadcrumbContext, setBreadcrumbContext] = useState('');
-  const [category, setCategory] = useState('other');
-  const [canonicalSubcategory, setCanonicalSubcategory] = useState('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const firstInputRef = useRef<HTMLInputElement>(null);
@@ -64,9 +60,8 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
     const qt = questionText.trim();
     const at = answerText.trim();
     const bc = breadcrumbContext.trim();
-    const canonical = normalizeCanonicalSubcategory(canonicalSubcategory);
-    if (!qt || !at || !bc || !canonical) {
-      setError('Question, answer, context, and a specific area are required.');
+    if (!qt || !at || !bc) {
+      setError('Question, answer, and context are required.');
       return;
     }
     const bcErr = validateBreadcrumbContext(bc);
@@ -87,9 +82,6 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
           breadcrumb_context: bc,
           short_label: shortLabel.trim() || null,
           answer_source: 'creator_written',
-          category,
-          canonicalSubcategory: canonical,
-          domain: canonical,
           difficulty: 3,
           verified: true,
           critiqueIterations: 0,
@@ -221,34 +213,11 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
             />
           </div>
 
-          <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '12px' }}>
-            <div>
-              <label htmlFor="qqm-category" style={{ ...monoStyle, display: 'block', color: 'var(--text-muted)', marginBottom: '5px' }}>
-                Broad category
-              </label>
-              <select
-                id="qqm-category"
-                value={category}
-                onChange={(e) => setCategory(e.target.value)}
-                style={inputStyle}
-              >
-                {CATEGORIES.map((item) => <option key={item} value={item}>{categoryLabel(item)}</option>)}
-              </select>
-            </div>
-            <div>
-              <label htmlFor="qqm-specific-area" style={{ ...monoStyle, display: 'block', color: 'var(--text-muted)', marginBottom: '5px' }}>
-                Specific area
-              </label>
-              <input
-                id="qqm-specific-area"
-                type="text"
-                required
-                value={canonicalSubcategory}
-                onChange={(e) => setCanonicalSubcategory(e.target.value)}
-                placeholder="e.g. The Waste Land"
-                style={inputStyle}
-              />
-            </div>
+          <div style={{ padding: '10px 12px', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', background: 'color-mix(in srgb, var(--muted, #f5f5f5) 55%, var(--bg))' }}>
+            <p style={{ ...monoStyle, color: 'var(--text-muted)', marginBottom: '4px' }}>AI classification</p>
+            <p style={{ margin: 0, fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.45 }}>
+              Joshing will read the question and answer when you save, then choose the category and specific area automatically.
+            </p>
           </div>
 
           <div>

--- a/src/lib/question-categorization.ts
+++ b/src/lib/question-categorization.ts
@@ -3,9 +3,15 @@ import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 export type BroadQuestionCategory = (typeof CATEGORIES)[number];
 
 const CATEGORY_VALUES = new Set<string>(CATEGORIES);
-const CATEGORY_LABEL_TO_VALUE = new Map<string, BroadQuestionCategory>(
-  CATEGORIES.map((category) => [categoryLabel(category).toLowerCase(), category]),
-);
+const CATEGORY_LABEL_TO_VALUE = new Map<string, BroadQuestionCategory>([
+  ...CATEGORIES.map((category) => [categoryLabel(category).toLowerCase(), category] as const),
+  ['film & television', 'film_tv'],
+  ['film and television', 'film_tv'],
+  ['film television', 'film_tv'],
+  ['tv', 'film_tv'],
+  ['television', 'film_tv'],
+  ['sports', 'sport'],
+]);
 
 export function isBroadQuestionCategory(value: string): value is BroadQuestionCategory {
   return CATEGORY_VALUES.has(value);

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -279,7 +279,7 @@ export async function createQuestion(params: {
     broadCategory: params.broadCategory,
     subcategory: params.subcategory,
     canonicalSubcategory: params.canonicalSubcategory,
-    categoryOverridden: true,
+    categoryOverridden: false,
     difficultyEstimate: difficulty,
     llmDifficulty: difficulty,
     calibratedDifficulty: difficulty,
@@ -335,7 +335,7 @@ export async function createQuestion(params: {
         ${params.broadCategory},
         ${params.subcategory},
         ${params.canonicalSubcategory},
-        true,
+        false,
         ${params.creatorNote ?? null},
         ${difficulty}::"DifficultyEstimate",
         ${difficulty}::"DifficultyEstimate",
@@ -416,7 +416,7 @@ export async function updateQuestion(params: {
   if (params.explanation !== undefined) values.factualExplanation = params.explanation || null;
   if (params.category !== undefined) {
     values.category = params.category as typeof questions.$inferInsert.category;
-    values.categoryOverridden = true;
+    values.categoryOverridden = false;
   }
   if (params.broadCategory !== undefined) values.broadCategory = params.broadCategory;
   if (params.subcategory !== undefined) values.subcategory = params.subcategory;

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -1,5 +1,3 @@
-import { broadCategoryDisplayName, isBroadQuestionCategory, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
-
 function splitAlternates(value: unknown): string[] {
   if (Array.isArray(value)) {
     return value
@@ -34,24 +32,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
     : typeof body?.creator_note === 'string'
       ? body.creator_note.trim() || null
       : null;
-  const isLegacyPayload = typeof body?.question_text === 'string' || typeof body?.answer_text === 'string';
-  const rawBroadCategory = typeof body?.category === 'string'
-    ? body.category.trim()
-    : typeof body?.broadCategory === 'string'
-      ? body.broadCategory.trim()
-      : isLegacyPayload
-        ? 'other'
-        : '';
-  const rawCanonicalSubcategory = typeof body?.canonicalSubcategory === 'string'
-    ? body.canonicalSubcategory
-    : typeof body?.canonical_subcategory === 'string'
-      ? body.canonical_subcategory
-      : typeof body?.domain === 'string'
-        ? body.domain
-        : '';
-  const canonicalSubcategory = normalizeCanonicalSubcategory(rawCanonicalSubcategory);
-  const broadCategory = normalizeBroadQuestionCategory(rawBroadCategory) ?? '';
-  const broadCategoryLabel = broadCategory ? broadCategoryDisplayName(broadCategory) : null;
   const verified = typeof body?.verified === 'boolean' ? body.verified : null;
   const llmSuggestedAnswer = typeof body?.llmSuggestedAnswer === 'string'
     ? body.llmSuggestedAnswer.trim() || null
@@ -69,9 +49,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   if (alternateAnswers.length > 5 || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
   if (explanation && explanation.length > 500) errors.push('explanation');
   if (creatorNote && creatorNote.length > 200) errors.push('creatorNote');
-  if (!broadCategory) errors.push('category');
-  if (!canonicalSubcategory) errors.push('canonicalSubcategory');
-  if (canonicalSubcategory && isBroadQuestionCategory(canonicalSubcategory)) errors.push('canonicalSubcategory');
   if (verified === null) errors.push('verified');
   if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
   if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
@@ -83,11 +60,6 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
       alternateAnswers,
       explanation,
       creatorNote,
-      category: broadCategory,
-      broadCategory: broadCategoryLabel,
-      canonicalSubcategory,
-      subcategory: canonicalSubcategory,
-      domain: canonicalSubcategory,
       verified: verified ?? true,
       llmSuggestedAnswer,
       critiqueIterations: Number.isInteger(critiqueIterations) ? critiqueIterations : 0,


### PR DESCRIPTION
### Motivation
- Automatically derive a question's broad category and precise domain from the question+answer using the LLM so classification is consistent and not manually entered.
- Re-run categorization when a question's text or answer is edited to keep difficulty and domain-opening logic in sync with the content.
- Simplify creation payload and lightweight UIs by removing mandatory manual category/domain input and showing that classification is handled server-side.

### Description
- Call `categorizeQuestion` (from `src/lib/llm.ts`) during question creation (`POST /api/questions`) to compute `category`, `broadCategory`, and `canonicalSubcategory`, then use those values for difficulty assessment and knowledge-domain opening.
- Re-categorize on edits in the question edit route (`PATCH /api/questions/[id]`) when text or correct answer changes, and derive `category`/`canonicalSubcategory` from the LLM instead of trusting user-submitted fields.
- Remove manual category/domain parsing and validation from `readCreateQuestionPayload` so create payloads no longer require `category`/`domain`, and stop sending those fields from lightweight UI paths.
- Update UI components `QuestionForm` and `QuickAddQuestionModal` to remove direct category/domain inputs and display an "AI classification" notice indicating the server will classify on save.
- Add common label aliases in `src/lib/question-categorization.ts` to map LLM label variants (e.g., `Film & Television`, `tv`, `sports`) to internal category values, and mark stored categories as LLM-derived by setting `categoryOverridden` to `false` in create/update DB code.

### Testing
- Ran type check with `npx tsc --noEmit -p tsconfig.json`, which succeeded.
- Ran targeted ESLint for modified files with `npx eslint <files>` which succeeded for the changed files.
- Ran `git diff --check` to ensure no whitespace/merge artifacts, which passed.
- Ran project lint `npm run lint`, which failed due to pre-existing, unrelated repo-wide lint errors outside the scope of these changes (targeted lint of changed files passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03bb0b9b30832e84792c45b5d41824)