### PR TITLE
Update Knowledge page headline to “A mind that is …”

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -75,8 +75,8 @@ function domainKey(value: string): string {
 
 function displayMind(domains: DomainMastery[], declaredInterests: string[]): string {
   const top = domains.filter((domain) => domain.points > 0).slice(0, 3).map((domain) => domain.displayName);
-  if (top.length >= 2) return `Your mind is building around ${top.slice(0, -1).join(', ')} and ${top.at(-1)}.`;
-  if (top.length === 1) return `Your mind is building around ${top[0]}.`;
+  if (top.length >= 2) return `A mind that is building around ${top.slice(0, -1).join(', ')} and ${top.at(-1)}.`;
+  if (top.length === 1) return `A mind that is building around ${top[0]}.`;
   if (declaredInterests.length > 0) return `Your mind is ready to explore ${declaredInterests.slice(0, 3).join(', ')}.`;
   return 'Your mind will take shape as you play and write questions.';
 }


### PR DESCRIPTION
### Motivation
- Adjust the Knowledge page headline copy so the populated variants read `A mind that is ...` instead of `Your mind is ...` for the intended phrasing.

### Description
- Replace the two populated `displayMind` headline strings in `src/app/knowledge/page.tsx` to start with `A mind that is` (affects the multi-item and single-item variants returned by `displayMind`).

### Testing
- Ran `npm run lint` which failed due to existing unrelated lint errors elsewhere in the repo, so the copy change itself did not introduce new lint issues.
- Attempted local verification via `npm run dev` and a Playwright script, but the dev server reported a DB migration issue and the Playwright run failed because `@playwright/test` is not installed in the workspace.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045e243c18832eade56bbea5ada4e8)