### PR TITLE
Update daily recap result card styling

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -375,19 +375,25 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
   }, [])
 
   return (
-    <article className="card relative p-5">
-      <div className="flex items-start justify-between gap-3 pr-11">
-        <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>
-          JOSHING BOT · {question.domainDisplayName.toUpperCase()}
-        </p>
+    <article
+      className={cn(
+        'card relative p-5',
+        question.isSkipped
+          ? 'border-stone-200 bg-stone-50'
+          : question.isCorrect
+            ? 'border-emerald-200 bg-emerald-50'
+            : 'border-rose-200 bg-rose-50'
+      )}
+    >
+      <div className="flex flex-wrap items-start gap-2 pr-11">
         <span
           className={cn(
             'rounded-sm border px-2 py-1 text-[0.65rem] font-semibold tracking-[0.08em] uppercase',
             question.isSkipped
-              ? 'border-stone-200 bg-stone-50 text-stone-600'
+              ? 'border-stone-300 bg-stone-100 text-stone-700'
               : question.isCorrect
-                ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                : 'border-rose-200 bg-rose-50 text-rose-700'
+                ? 'border-emerald-300 bg-emerald-100 text-emerald-800'
+                : 'border-rose-300 bg-rose-100 text-rose-800'
           )}
         >
           {question.isSkipped
@@ -396,6 +402,9 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
               ? 'CORRECT'
               : 'WRONG'}
         </span>
+        <p className="pt-1" style={{ ...monoStyle, color: 'var(--text-muted)' }}>
+          JOSHING BOT · {question.domainDisplayName.toUpperCase()}
+        </p>
       </div>
 
       <button


### PR DESCRIPTION
### Motivation
- Improve clarity of daily recap question cards by moving the result badge to the left and making the whole card visually reflect the result (green for correct, red for wrong, neutral for skipped).

### Description
- Adjusted `src/app/daily/summary/page.tsx` so the outer `<article>` uses `cn(...)` to apply a result-based `border` and `bg` class depending on `question.isCorrect` / `question.isSkipped`.
- Moved the result badge `<span>` to the left of the domain label and updated its color/tone classes to match the card tint, and adjusted the header layout to `flex-wrap` to keep spacing consistent.
- Tuned the badge and header spacing (`gap`, `pt-1`) so the label reads left-to-right as the result badge followed by the domain line.

### Testing
- Ran `npx eslint src/app/daily/summary/page.tsx` and the file-level linting passed. 
- Ran `npx tsc --noEmit --pretty false` and TypeScript type-checking passed with no errors for the change. 
- Ran `npm run lint` which failed due to pre-existing lint issues in unrelated files, not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0465d78290832e998b88a8c274f4a8)