### PR TITLE
Require verified phone match for FriendInvitation acceptance

### DIFF
--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { acceptFriendInvitationMock, createSessionMock, dbMock, verifyOtpMock } =
+  vi.hoisted(() => {
+    const user = {
+      id: 'user-1',
+      phoneNumber: '+15551234567',
+      displayName: null,
+      timezone: 'America/New_York',
+    }
+
+    const dbMock = {
+      insert: vi.fn(() => ({
+        values: vi.fn(() => ({
+          onConflictDoNothing: vi.fn(() => ({
+            returning: vi.fn(async () => [user]),
+          })),
+        })),
+      })),
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit: vi.fn(async () => [user]),
+          })),
+        })),
+      })),
+    }
+
+    return {
+      acceptFriendInvitationMock: vi.fn(),
+      createSessionMock: vi.fn(async () => 'session-token'),
+      dbMock,
+      verifyOtpMock: vi.fn(async (phone: string, code: string) =>
+        code === '000000' ? phone : null
+      ),
+    }
+  })
+
+vi.mock('@/server/auth', () => ({
+  verifyOtp: verifyOtpMock,
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  createSession: createSessionMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  users: {
+    id: 'users.id',
+    phoneNumber: 'users.phoneNumber',
+    displayName: 'users.displayName',
+    timezone: 'users.timezone',
+  },
+}))
+
+vi.mock('@/server/friends/invitations', () => ({
+  acceptFriendInvitation: acceptFriendInvitationMock,
+  INVITATION_ACCEPTANCE_ERROR_MESSAGE: 'This invitation could not be accepted.',
+}))
+
+import { POST } from '@/app/api/auth/verify-otp/route'
+
+function jsonRequest(body: unknown) {
+  return new Request('http://localhost/api/auth/verify-otp', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('/api/auth/verify-otp invitation handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    acceptFriendInvitationMock.mockResolvedValue({ accepted: true })
+  })
+
+  it('allows normal login without an invitation using the hardcoded 000000 OTP', async () => {
+    const response = await POST(
+      jsonRequest({ phone: '+15551234567', code: '000000' })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.invitation).toEqual({ accepted: false })
+    expect(verifyOtpMock).toHaveBeenCalledWith('+15551234567', '000000')
+    expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
+    expect(createSessionMock).toHaveBeenCalledWith('user-1')
+  })
+
+  it('accepts an invitation only after OTP verification and passes the verified phone to invitation acceptance', async () => {
+    const response = await POST(
+      jsonRequest({
+        phone: '+15551234567',
+        code: '000000',
+        invitationToken: 'invite-token',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.invitation).toEqual({ accepted: true })
+    expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
+      token: 'invite-token',
+      inviteeUserId: 'user-1',
+      verifiedPhone: '+15551234567',
+    })
+    expect(createSessionMock).toHaveBeenCalledWith('user-1')
+  })
+
+  it('fails invite login with safe copy when invitation acceptance rejects the claim', async () => {
+    acceptFriendInvitationMock.mockResolvedValueOnce({
+      accepted: false,
+      reason: 'phone_mismatch',
+    })
+
+    const response = await POST(
+      jsonRequest({
+        phone: '+15550000000',
+        code: '000000',
+        invitationToken: 'invite-token',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body).toEqual({
+      error: 'invalid_invitation',
+      message: 'This invitation could not be accepted.',
+    })
+    expect(createSessionMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,25 +1,25 @@
-import { and, eq, isNull, or } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
 
-import { verifyOtp } from '@/server/auth';
-import { createSession } from '@/server/auth/session';
-import { db, friendInvitations, friendships, users } from '@/server/db';
+import { verifyOtp } from '@/server/auth'
+import { createSession } from '@/server/auth/session'
+import { db, users } from '@/server/db'
+import {
+  acceptFriendInvitation,
+  INVITATION_ACCEPTANCE_ERROR_MESSAGE,
+} from '@/server/friends/invitations'
 
 type VerifyOtpBody = {
-  phone?: unknown;
-  code?: unknown;
-  invitationToken?: unknown;
-};
+  phone?: unknown
+  code?: unknown
+  invitationToken?: unknown
+}
 
 type AuthUser = {
-  id: string;
-  phoneNumber: string;
-  displayName: string | null;
-  timezone: string;
-};
-
-function friendshipPair(a: string, b: string) {
-  return a < b ? { userAId: a, userBId: b } : { userAId: b, userBId: a };
+  id: string
+  phoneNumber: string
+  displayName: string | null
+  timezone: string
 }
 
 async function getOrCreateUserForLogin(phoneNumber: string): Promise<AuthUser> {
@@ -28,116 +28,90 @@ async function getOrCreateUserForLogin(phoneNumber: string): Promise<AuthUser> {
     phoneNumber: users.phoneNumber,
     displayName: users.displayName,
     timezone: users.timezone,
-  };
+  }
 
   const [createdUser] = await db
     .insert(users)
     .values({ phoneNumber })
     .onConflictDoNothing({ target: users.phoneNumber })
-    .returning(selection);
+    .returning(selection)
 
-  if (createdUser) return createdUser;
+  if (createdUser) return createdUser
 
   const [existingUser] = await db
     .select(selection)
     .from(users)
     .where(eq(users.phoneNumber, phoneNumber))
-    .limit(1);
+    .limit(1)
 
   if (!existingUser) {
-    throw new Error('Unable to find or create user for verified phone number.');
+    throw new Error('Unable to find or create user for verified phone number.')
   }
 
-  return existingUser;
-}
-
-async function acceptInvitation(token: string, inviteeUserId: string) {
-  const [invitation] = await db
-    .select()
-    .from(friendInvitations)
-    .where(eq(friendInvitations.token, token))
-    .limit(1);
-
-  if (!invitation || invitation.acceptedAt || invitation.expiresAt < new Date()) {
-    return { accepted: false };
-  }
-
-  if (invitation.inviterUserId === inviteeUserId) {
-    return { accepted: false };
-  }
-
-  const pair = friendshipPair(invitation.inviterUserId, inviteeUserId);
-  const now = new Date();
-
-  await db.transaction(async (tx) => {
-    await tx
-      .update(friendInvitations)
-      .set({ acceptedAt: now, inviteeUserId })
-      .where(
-        and(
-          eq(friendInvitations.id, invitation.id),
-          or(eq(friendInvitations.inviteeUserId, inviteeUserId), isNull(friendInvitations.inviteeUserId)),
-        ),
-      );
-
-    await tx
-      .insert(friendships)
-      .values({
-        ...pair,
-        status: 'active',
-        requestedByUserId: invitation.inviterUserId,
-        formedVia: 'invitation',
-        formedAt: now,
-        removedAt: null,
-        removedByUserId: null,
-      })
-      .onConflictDoUpdate({
-        target: [friendships.userAId, friendships.userBId],
-        set: {
-          status: 'active',
-          requestedByUserId: invitation.inviterUserId,
-          formedVia: 'invitation',
-          formedAt: now,
-          removedAt: null,
-          removedByUserId: null,
-        },
-      });
-  });
-
-  return { accepted: true };
+  return existingUser
 }
 
 export async function POST(request: Request) {
   try {
-    const body = (await request.json().catch(() => null)) as VerifyOtpBody | null;
-    const phone = typeof body?.phone === 'string' ? body.phone.trim() : '';
-    const code = typeof body?.code === 'string' ? body.code.trim() : '';
+    const body = (await request
+      .json()
+      .catch(() => null)) as VerifyOtpBody | null
+    const phone = typeof body?.phone === 'string' ? body.phone.trim() : ''
+    const code = typeof body?.code === 'string' ? body.code.trim() : ''
+    const hasInvitationToken =
+      body?.invitationToken !== undefined && body?.invitationToken !== null
     const invitationToken =
-      typeof body?.invitationToken === 'string' ? body.invitationToken.trim() : '';
+      typeof body?.invitationToken === 'string'
+        ? body.invitationToken.trim()
+        : ''
 
     if (!phone || !code) {
       return NextResponse.json(
         { error: 'invalid_request', message: 'phone and code are required' },
-        { status: 400 },
-      );
+        { status: 400 }
+      )
     }
 
-    const normalizedPhone = await verifyOtp(phone, code);
+    const normalizedPhone = await verifyOtp(phone, code)
 
     if (!normalizedPhone) {
       return NextResponse.json(
         { error: 'invalid_code', message: 'Code invalid or expired' },
-        { status: 401 },
-      );
+        { status: 401 }
+      )
     }
 
-    const user = await getOrCreateUserForLogin(normalizedPhone);
+    if (hasInvitationToken && !invitationToken) {
+      return NextResponse.json(
+        {
+          error: 'invalid_invitation',
+          message: INVITATION_ACCEPTANCE_ERROR_MESSAGE,
+        },
+        { status: 400 }
+      )
+    }
 
-    await createSession(user.id);
+    const user = await getOrCreateUserForLogin(normalizedPhone)
 
-    const invitation = invitationToken
-      ? await acceptInvitation(invitationToken, user.id)
-      : { accepted: false };
+    const invitation = hasInvitationToken
+      ? await acceptFriendInvitation({
+          token: invitationToken,
+          inviteeUserId: user.id,
+          verifiedPhone: normalizedPhone,
+        })
+      : { accepted: false }
+
+    if (hasInvitationToken && !invitation.accepted) {
+      return NextResponse.json(
+        {
+          error: 'invalid_invitation',
+          message: INVITATION_ACCEPTANCE_ERROR_MESSAGE,
+        },
+        { status: 400 }
+      )
+    }
+
+    await createSession(user.id)
 
     return NextResponse.json({
       user: {
@@ -148,12 +122,12 @@ export async function POST(request: Request) {
         onboardingComplete: false,
       },
       invitation,
-    });
+    })
   } catch (error) {
-    console.error('[auth/verify-otp] failed', error);
+    console.error('[auth/verify-otp] failed', error)
     return NextResponse.json(
       { error: 'server_error', message: 'Unable to verify code.' },
-      { status: 500 },
-    );
+      { status: 500 }
+    )
   }
 }

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -1,0 +1,204 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Invitation = {
+  id: string
+  inviterUserId: string
+  inviteePhone: string
+  inviteeUserId: string | null
+  acceptedAt: Date | null
+  expiresAt: Date
+}
+
+const { dbMock, state } = vi.hoisted(() => {
+  const state = {
+    invitation: undefined as Invitation | undefined,
+    updateReturnsClaim: true,
+    friendshipValues: [] as unknown[],
+  }
+
+  function makeInsertBuilder() {
+    return {
+      values: vi.fn((values: unknown) => {
+        state.friendshipValues.push(values)
+        return {
+          onConflictDoUpdate: vi.fn(async () => undefined),
+        }
+      }),
+    }
+  }
+
+  const tx = {
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () =>
+            state.updateReturnsClaim
+              ? [{ id: state.invitation?.id ?? 'inv-1' }]
+              : []
+          ),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => makeInsertBuilder()),
+  }
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () =>
+            state.invitation ? [state.invitation] : []
+          ),
+        })),
+      })),
+    })),
+    transaction: vi.fn(async (callback: (tx: typeof tx) => unknown) =>
+      callback(tx)
+    ),
+    tx,
+  }
+
+  return { dbMock, state }
+})
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  friendInvitations: {
+    id: 'friendInvitations.id',
+    token: 'friendInvitations.token',
+    acceptedAt: 'friendInvitations.acceptedAt',
+    inviteePhone: 'friendInvitations.inviteePhone',
+    inviteeUserId: 'friendInvitations.inviteeUserId',
+  },
+}))
+
+vi.mock('@/server/db/schema', () => ({
+  friendships: {
+    userAId: 'friendships.userAId',
+    userBId: 'friendships.userBId',
+  },
+}))
+
+import { acceptFriendInvitation } from '@/server/friends/invitations'
+
+const now = new Date('2026-05-13T12:00:00.000Z')
+const matchingPhone = '+15551234567'
+
+function setInvitation(overrides: Partial<Invitation> = {}) {
+  state.invitation = {
+    id: 'inv-1',
+    inviterUserId: 'user-inviter',
+    inviteePhone: matchingPhone,
+    inviteeUserId: null,
+    acceptedAt: null,
+    expiresAt: new Date('2026-05-14T12:00:00.000Z'),
+    ...overrides,
+  }
+}
+
+describe('acceptFriendInvitation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.invitation = undefined
+    state.updateReturnsClaim = true
+    state.friendshipValues = []
+  })
+
+  it('accepts a valid token for the matching verified phone and creates an invitation friendship', async () => {
+    setInvitation()
+
+    const result = await acceptFriendInvitation({
+      token: 'valid-token',
+      inviteeUserId: 'user-invitee',
+      verifiedPhone: matchingPhone,
+      now,
+    })
+
+    expect(result).toEqual({ accepted: true })
+    expect(dbMock.transaction).toHaveBeenCalledTimes(1)
+    expect(state.friendshipValues).toEqual([
+      expect.objectContaining({
+        userAId: 'user-invitee',
+        userBId: 'user-inviter',
+        status: 'active',
+        requestedByUserId: 'user-inviter',
+        formedVia: 'invitation',
+        formedAt: now,
+        removedAt: null,
+        removedByUserId: null,
+      }),
+    ])
+  })
+
+  it('rejects a valid token when the verified phone does not match the invitation phone', async () => {
+    setInvitation()
+
+    const result = await acceptFriendInvitation({
+      token: 'valid-token',
+      inviteeUserId: 'user-invitee',
+      verifiedPhone: '+15557654321',
+      now,
+    })
+
+    expect(result).toEqual({ accepted: false, reason: 'phone_mismatch' })
+    expect(dbMock.transaction).not.toHaveBeenCalled()
+    expect(state.friendshipValues).toEqual([])
+  })
+
+  it('rejects expired invitations', async () => {
+    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') })
+
+    await expect(
+      acceptFriendInvitation({
+        token: 'expired-token',
+        inviteeUserId: 'user-invitee',
+        verifiedPhone: matchingPhone,
+        now,
+      })
+    ).resolves.toEqual({ accepted: false, reason: 'expired' })
+    expect(state.friendshipValues).toEqual([])
+  })
+
+  it('rejects already accepted invitations', async () => {
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
+
+    await expect(
+      acceptFriendInvitation({
+        token: 'accepted-token',
+        inviteeUserId: 'user-invitee',
+        verifiedPhone: matchingPhone,
+        now,
+      })
+    ).resolves.toEqual({ accepted: false, reason: 'accepted' })
+    expect(state.friendshipValues).toEqual([])
+  })
+
+  it('rejects self-invites', async () => {
+    setInvitation({ inviterUserId: 'same-user' })
+
+    await expect(
+      acceptFriendInvitation({
+        token: 'self-token',
+        inviteeUserId: 'same-user',
+        verifiedPhone: matchingPhone,
+        now,
+      })
+    ).resolves.toEqual({ accepted: false, reason: 'self' })
+    expect(state.friendshipValues).toEqual([])
+  })
+
+  it('does not create a friendship when the invitation claim update fails', async () => {
+    setInvitation()
+    state.updateReturnsClaim = false
+
+    await expect(
+      acceptFriendInvitation({
+        token: 'raced-token',
+        inviteeUserId: 'user-invitee',
+        verifiedPhone: matchingPhone,
+        now,
+      })
+    ).resolves.toEqual({ accepted: false, reason: 'claim_failed' })
+    expect(state.friendshipValues).toEqual([])
+  })
+})

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -1,0 +1,54 @@
+import { friendships } from '@/server/db/schema'
+
+type FriendshipWriter = {
+  insert: (table: typeof friendships) => {
+    values: (values: typeof friendships.$inferInsert) => {
+      onConflictDoUpdate: (config: {
+        target: [typeof friendships.userAId, typeof friendships.userBId]
+        set: Partial<typeof friendships.$inferInsert>
+      }) => Promise<unknown>
+    }
+  }
+}
+
+export function friendshipPair(a: string, b: string) {
+  return a < b ? { userAId: a, userBId: b } : { userAId: b, userBId: a }
+}
+
+export async function upsertInvitationFriendship(
+  writer: FriendshipWriter,
+  {
+    inviterUserId,
+    inviteeUserId,
+    formedAt,
+  }: {
+    inviterUserId: string
+    inviteeUserId: string
+    formedAt: Date
+  }
+) {
+  const pair = friendshipPair(inviterUserId, inviteeUserId)
+
+  await writer
+    .insert(friendships)
+    .values({
+      ...pair,
+      status: 'active',
+      requestedByUserId: inviterUserId,
+      formedVia: 'invitation',
+      formedAt,
+      removedAt: null,
+      removedByUserId: null,
+    })
+    .onConflictDoUpdate({
+      target: [friendships.userAId, friendships.userBId],
+      set: {
+        status: 'active',
+        requestedByUserId: inviterUserId,
+        formedVia: 'invitation',
+        formedAt,
+        removedAt: null,
+        removedByUserId: null,
+      },
+    })
+}

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -1,0 +1,96 @@
+import { and, eq, isNull, or } from 'drizzle-orm'
+
+import { db, friendInvitations } from '@/server/db'
+import { upsertInvitationFriendship } from '@/server/friends/friendships'
+
+export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
+  'This invitation could not be accepted.'
+
+export type AcceptFriendInvitationResult =
+  | { accepted: true }
+  | {
+      accepted: false
+      reason:
+        | 'missing'
+        | 'expired'
+        | 'accepted'
+        | 'self'
+        | 'phone_mismatch'
+        | 'claim_failed'
+    }
+
+export async function acceptFriendInvitation({
+  token,
+  inviteeUserId,
+  verifiedPhone,
+  now = new Date(),
+}: {
+  token: string
+  inviteeUserId: string
+  verifiedPhone: string
+  now?: Date
+}): Promise<AcceptFriendInvitationResult> {
+  if (!token) {
+    return { accepted: false, reason: 'missing' }
+  }
+
+  const [invitation] = await db
+    .select()
+    .from(friendInvitations)
+    .where(eq(friendInvitations.token, token))
+    .limit(1)
+
+  if (!invitation) {
+    return { accepted: false, reason: 'missing' }
+  }
+
+  if (invitation.acceptedAt) {
+    return { accepted: false, reason: 'accepted' }
+  }
+
+  if (invitation.expiresAt < now) {
+    return { accepted: false, reason: 'expired' }
+  }
+
+  if (invitation.inviterUserId === inviteeUserId) {
+    return { accepted: false, reason: 'self' }
+  }
+
+  if (invitation.inviteePhone !== verifiedPhone) {
+    return { accepted: false, reason: 'phone_mismatch' }
+  }
+
+  const [claimedInvitation] = await db.transaction(async (tx) => {
+    const [updatedInvitation] = await tx
+      .update(friendInvitations)
+      .set({ acceptedAt: now, inviteeUserId })
+      .where(
+        and(
+          eq(friendInvitations.id, invitation.id),
+          isNull(friendInvitations.acceptedAt),
+          eq(friendInvitations.inviteePhone, verifiedPhone),
+          or(
+            eq(friendInvitations.inviteeUserId, inviteeUserId),
+            isNull(friendInvitations.inviteeUserId)
+          )
+        )
+      )
+      .returning({ id: friendInvitations.id })
+
+    if (!updatedInvitation) return []
+
+    await upsertInvitationFriendship(tx, {
+      inviterUserId: invitation.inviterUserId,
+      inviteeUserId,
+      formedAt: now,
+    })
+
+    return [updatedInvitation]
+  })
+
+  if (!claimedInvitation) {
+    return { accepted: false, reason: 'claim_failed' }
+  }
+
+  return { accepted: true }
+}


### PR DESCRIPTION
### Motivation
- Prevent invite-token misuse by ensuring invite acceptance requires both a valid token and a matching verified phone number before marking an invitation accepted or creating a friendship.
- Keep the existing developer OTP shortcut (`000000`) and preserve current login and onboarding behaviors while tightening the invite claim surface.

### Description
- Require invite acceptance to occur only after OTP verification in `/api/auth/verify-otp` and pass the normalized verified phone to the invitation handler, returning safe non-revealing errors on rejection.
- Add `acceptFriendInvitation` which validates presence of the token, not-found/missing token, expiry, already-accepted, self-invite, and exact `inviteePhone` vs verified-phone match, and only marks `acceptedAt` / `inviteeUserId` and creates friendship in a transaction when the claim succeeds.
- Extract friendship upsert into `upsertInvitationFriendship` to preserve ordered-pair uniqueness, `formedVia = "invitation"`, active semantics, and on-conflict reactivation behavior.
- Add unit tests for invitation flows and route behavior covering success (valid token + matching phone + OTP `000000`), phone-mismatch rejection, expired invite, already-accepted invite, self-invite rejection, normal login without invite, and ensuring failed invite claims do not create friendships.

### Testing
- Type-checking with `npx tsc --noEmit` executed successfully against the codebase.
- ESLint run limited to changed files (`npx eslint ...`) succeeded for the modified files, while a repo-wide `npm run lint` still surfaces pre-existing unrelated issues.
- Unit tests were added under `src/server/friends/__tests__/invitations.test.ts` and `src/app/api/auth/verify-otp/__tests__/route.test.ts`, but running `npx vitest` in this environment was blocked by an npm registry 403, so the new tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a047d77f984832ebe470ca780cee0e7)