### PR TITLE
Add friend invitation creation API

### DIFF
--- a/src/app/api/friend-invitations/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/__tests__/route.test.ts
@@ -1,0 +1,232 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  createFriendInvitationMock,
+  dbMock,
+  getSessionMock,
+  sendSmsMock,
+  state,
+} = vi.hoisted(() => {
+  const state = {
+    existingUser: null as { id: string } | null,
+    updateValues: undefined as Record<string, unknown> | undefined,
+  }
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => (state.existingUser ? [state.existingUser] : [])),
+        })),
+      })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        state.updateValues = values
+        return { where: vi.fn(async () => undefined) }
+      }),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: vi.fn(async () => [
+          {
+            id: 'friendship-1',
+            status: 'pending',
+          },
+        ]),
+      })),
+    })),
+  }
+
+  return {
+    createFriendInvitationMock: vi.fn(),
+    dbMock,
+    getSessionMock: vi.fn(),
+    sendSmsMock: vi.fn(),
+    state,
+  }
+})
+
+vi.mock('@/server/auth', () => ({
+  normalizePhone: (phone: string) => {
+    const digits = phone.replace(/\D/g, '')
+    if (digits.length === 10) return `+1${digits}`
+    if (digits.length === 11 && digits.startsWith('1')) return `+${digits}`
+    return phone.startsWith('+') ? phone : `+${digits}`
+  },
+  isUsPhoneNumber: (phone: string) => /^\+1\d{10}$/.test(
+    phone.replace(/\D/g, '').length === 10
+      ? `+1${phone.replace(/\D/g, '')}`
+      : phone.replace(/\D/g, '').length === 11 && phone.replace(/\D/g, '').startsWith('1')
+        ? `+${phone.replace(/\D/g, '')}`
+        : phone.startsWith('+')
+          ? phone
+          : `+${phone.replace(/\D/g, '')}`
+  ),
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  friendInvitations: { id: 'friendInvitations.id' },
+  friendships: {
+    id: 'friendships.id',
+    userAId: 'friendships.userAId',
+    userBId: 'friendships.userBId',
+  },
+  users: {
+    id: 'users.id',
+    phoneNumber: 'users.phoneNumber',
+  },
+}))
+
+vi.mock('@/server/friends/invitations', () => ({
+  createFriendInvitation: createFriendInvitationMock,
+}))
+
+vi.mock('@/server/sms', () => ({
+  sendSms: sendSmsMock,
+}))
+
+import { POST } from '@/app/api/friend-invitations/route'
+import { sendSms } from '@/server/sms'
+
+const expiresAt = new Date('2026-05-20T12:00:00.000Z')
+
+function jsonRequest(body: unknown) {
+  return new Request('https://joshing.example/api/friend-invitations', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+function mockInvitation(overrides: Record<string, unknown> = {}) {
+  createFriendInvitationMock.mockResolvedValueOnce({
+    id: 'inv-1',
+    token: 'token-1',
+    inviteeDisplayName: 'Sara',
+    inviteePhone: '+17345551234',
+    personalMessage: null,
+    expiresAt,
+    ...overrides,
+  })
+}
+
+describe('POST /api/friend-invitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ userId: 'user-inviter' })
+    state.existingUser = null
+    state.updateValues = undefined
+    process.env.NEXT_PUBLIC_APP_URL = 'https://joshing.example'
+  })
+
+  it('creates invite with 0 interests and returns copyable message', async () => {
+    mockInvitation()
+
+    const response = await POST(jsonRequest({ inviteeDisplayName: ' Sara ', phone: '7345551234' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(createFriendInvitationMock).toHaveBeenCalledWith({
+      inviterUserId: 'user-inviter',
+      inviteePhone: '+17345551234',
+      inviteeDisplayName: 'Sara',
+      preSeededInterests: [],
+    })
+    expect(body).toEqual(expect.objectContaining({
+      id: 'inv-1',
+      inviteUrl: 'https://joshing.example/invite/token-1',
+      message: 'Hey — come play Joshing with me. No app to download — just tap this: https://joshing.example/invite/token-1',
+      inviteeDisplayName: 'Sara',
+      inviteePhone: '+17345551234',
+      suggestedInterests: [],
+      expiresAt: expiresAt.toISOString(),
+    }))
+  })
+
+  it('creates invite with 1 interest', async () => {
+    mockInvitation()
+
+    const response = await POST(jsonRequest({
+      inviteeDisplayName: 'Sara',
+      phone: '7345551234',
+      suggestedInterests: [' Sondheim '],
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(createFriendInvitationMock).toHaveBeenCalledWith(expect.objectContaining({
+      preSeededInterests: ['Sondheim'],
+    }))
+    expect(body.message).toBe('Hey — come play Joshing with me. I added something I think you might like: Sondheim. No app to download — just tap this: https://joshing.example/invite/token-1')
+  })
+
+  it('creates invite with 3 trimmed and deduped interests', async () => {
+    mockInvitation()
+
+    const response = await POST(jsonRequest({
+      inviteeDisplayName: 'Sara',
+      phone: '7345551234',
+      suggestedInterests: ['Sondheim', 'Mrs. Dalloway', '1980s Saturday morning cartoons', 'sondheim', '  '],
+    }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(createFriendInvitationMock).toHaveBeenCalledWith(expect.objectContaining({
+      preSeededInterests: ['Sondheim', 'Mrs. Dalloway', '1980s Saturday morning cartoons'],
+    }))
+    expect(body.message).toBe('Hey — come play Joshing with me. I added a few areas I think you might like: Sondheim, Mrs. Dalloway, and 1980s Saturday morning cartoons. No app to download — just tap this: https://joshing.example/invite/token-1')
+  })
+
+  it('rejects 4 interests', async () => {
+    const response = await POST(jsonRequest({
+      inviteeDisplayName: 'Sara',
+      phone: '7345551234',
+      suggestedInterests: ['A', 'B', 'C', 'D'],
+    }))
+
+    expect(response.status).toBe(400)
+    expect(createFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects invalid phone', async () => {
+    const response = await POST(jsonRequest({ inviteeDisplayName: 'Sara', phone: '123' }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'invalid_phone' }))
+    expect(createFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects missing name', async () => {
+    const response = await POST(jsonRequest({ phone: '7345551234' }))
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual(expect.objectContaining({ error: 'missing_invitee_display_name' }))
+    expect(createFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('prevents duplicate active pending invites by returning the reused invitation', async () => {
+    mockInvitation({ id: 'inv-existing', token: 'existing-token' })
+
+    const response = await POST(jsonRequest({ inviteeDisplayName: 'Sara', phone: '7345551234' }))
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body.id).toBe('inv-existing')
+    expect(body.inviteUrl).toBe('https://joshing.example/invite/existing-token')
+  })
+
+  it('does not call Twilio/sendSms', async () => {
+    mockInvitation()
+
+    await POST(jsonRequest({ inviteeDisplayName: 'Sara', phone: '7345551234' }))
+
+    expect(sendSms).not.toHaveBeenCalled()
+    expect(sendSmsMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -1,0 +1,291 @@
+import { and, eq } from 'drizzle-orm';
+import { NextResponse } from 'next/server';
+
+import { isUsPhoneNumber, normalizePhone } from '@/server/auth';
+import { getSession } from '@/server/auth/session';
+import { db, friendInvitations, friendships, users } from '@/server/db';
+import { createFriendInvitation } from '@/server/friends/invitations';
+import { friendshipPair } from '@/server/friends/friendships';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_INVITEE_DISPLAY_NAME_LENGTH = 80;
+const MAX_SUGGESTED_INTERESTS = 3;
+const MAX_SUGGESTED_INTEREST_LENGTH = 80;
+
+type CreateFriendInvitationBody = {
+  inviteeDisplayName: string;
+  phone: string;
+  suggestedInterests: string[];
+};
+
+type ValidationResult =
+  | { ok: true; value: CreateFriendInvitationBody }
+  | { ok: false; status: number; error: string; message: string };
+
+function getBaseUrl(request: Request): string {
+  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
+  if (configured) return configured.replace(/\/$/, '');
+
+  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
+  const protocol = request.headers.get('x-forwarded-proto') ?? 'https';
+  return host ? `${protocol}://${host}` : new URL(request.url).origin;
+}
+
+function normalizeText(value: string): string {
+  return value.trim().replace(/\s+/g, ' ');
+}
+
+export function validateCreateFriendInvitationBody(body: unknown): ValidationResult {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'invalid_request',
+      message: 'Request body is required.',
+    };
+  }
+
+  const record = body as Record<string, unknown>;
+  const inviteeDisplayName =
+    typeof record.inviteeDisplayName === 'string'
+      ? normalizeText(record.inviteeDisplayName)
+      : '';
+
+  if (!inviteeDisplayName) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'missing_invitee_display_name',
+      message: 'inviteeDisplayName is required.',
+    };
+  }
+
+  if (inviteeDisplayName.length > MAX_INVITEE_DISPLAY_NAME_LENGTH) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'invalid_invitee_display_name',
+      message: `inviteeDisplayName must be ${MAX_INVITEE_DISPLAY_NAME_LENGTH} characters or fewer.`,
+    };
+  }
+
+  const rawPhone = typeof record.phone === 'string' ? record.phone.trim() : '';
+  if (!rawPhone || !isUsPhoneNumber(rawPhone)) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'invalid_phone',
+      message: 'US phone number required.',
+    };
+  }
+
+  if (
+    record.suggestedInterests !== undefined &&
+    (!Array.isArray(record.suggestedInterests) ||
+      !record.suggestedInterests.every((interest) => typeof interest === 'string'))
+  ) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'invalid_suggested_interests',
+      message: 'suggestedInterests must be an array of strings.',
+    };
+  }
+
+  const seen = new Set<string>();
+  const suggestedInterests: string[] = [];
+  for (const interest of (record.suggestedInterests ?? []) as string[]) {
+    const normalizedInterest = normalizeText(interest);
+    if (!normalizedInterest) continue;
+
+    if (normalizedInterest.length > MAX_SUGGESTED_INTEREST_LENGTH) {
+      return {
+        ok: false,
+        status: 400,
+        error: 'invalid_suggested_interests',
+        message: `Each suggested interest must be ${MAX_SUGGESTED_INTEREST_LENGTH} characters or fewer.`,
+      };
+    }
+
+    const dedupeKey = normalizedInterest.toLocaleLowerCase('en-US');
+    if (seen.has(dedupeKey)) continue;
+
+    seen.add(dedupeKey);
+    suggestedInterests.push(normalizedInterest);
+  }
+
+  if (suggestedInterests.length > MAX_SUGGESTED_INTERESTS) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'too_many_suggested_interests',
+      message: `suggestedInterests must contain ${MAX_SUGGESTED_INTERESTS} or fewer values.`,
+    };
+  }
+
+  return {
+    ok: true,
+    value: {
+      inviteeDisplayName,
+      phone: normalizePhone(rawPhone),
+      suggestedInterests,
+    },
+  };
+}
+
+export function buildFriendInvitationMessage({
+  inviteUrl,
+  suggestedInterests,
+}: {
+  inviteUrl: string;
+  suggestedInterests: string[];
+}): string {
+  if (suggestedInterests.length === 1) {
+    return `Hey — come play Joshing with me. I added something I think you might like: ${suggestedInterests[0]}. No app to download — just tap this: ${inviteUrl}`;
+  }
+
+  if (suggestedInterests.length === 2) {
+    return `Hey — come play Joshing with me. I added a couple areas I think you might like: ${suggestedInterests[0]} and ${suggestedInterests[1]}. No app to download — just tap this: ${inviteUrl}`;
+  }
+
+  if (suggestedInterests.length === 3) {
+    return `Hey — come play Joshing with me. I added a few areas I think you might like: ${suggestedInterests[0]}, ${suggestedInterests[1]}, and ${suggestedInterests[2]}. No app to download — just tap this: ${inviteUrl}`;
+  }
+
+  return `Hey — come play Joshing with me. No app to download — just tap this: ${inviteUrl}`;
+}
+
+async function getUserByPhone(phone: string) {
+  const [user] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.phoneNumber, phone))
+    .limit(1);
+
+  return user ?? null;
+}
+
+async function createOrReusePendingFriendshipRequest({
+  inviterUserId,
+  inviteeUserId,
+}: {
+  inviterUserId: string;
+  inviteeUserId: string;
+}) {
+  const pair = friendshipPair(inviterUserId, inviteeUserId);
+
+  const [existingFriendship] = await db
+    .select()
+    .from(friendships)
+    .where(and(eq(friendships.userAId, pair.userAId), eq(friendships.userBId, pair.userBId)))
+    .limit(1);
+
+  if (existingFriendship) return existingFriendship;
+
+  // The current Friendship schema has no column for Add Friend request context,
+  // so suggested interests are intentionally persisted only on FriendInvitation
+  // rows until a friendship-request context column exists.
+  const [friendship] = await db
+    .insert(friendships)
+    .values({
+      ...pair,
+      status: 'pending',
+      requestedByUserId: inviterUserId,
+      formedVia: 'direct_request',
+      formedAt: null,
+      removedAt: null,
+      removedByUserId: null,
+    })
+    .returning();
+
+  if (!friendship) throw new Error('Friendship request could not be created');
+
+  return friendship;
+}
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = validateCreateFriendInvitationBody(await request.json().catch(() => null));
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { error: parsed.error, message: parsed.message },
+      { status: parsed.status },
+    );
+  }
+
+  try {
+    const { inviteeDisplayName, phone, suggestedInterests } = parsed.value;
+    const existingUser = await getUserByPhone(phone);
+
+    if (existingUser) {
+      if (existingUser.id === session.userId) {
+        return NextResponse.json(
+          { error: 'self_invite', message: 'You cannot invite yourself.' },
+          { status: 400 },
+        );
+      }
+
+      const friendshipRequest = await createOrReusePendingFriendshipRequest({
+        inviterUserId: session.userId,
+        inviteeUserId: existingUser.id,
+      });
+
+      return NextResponse.json({
+        ok: true,
+        type: 'friendship_request',
+        id: friendshipRequest.id,
+        invitationId: null,
+        inviteUrl: null,
+        message: null,
+        inviteeDisplayName,
+        inviteePhone: phone,
+        suggestedInterests,
+        expiresAt: null,
+        friendshipRequest: {
+          id: friendshipRequest.id,
+          status: friendshipRequest.status,
+          inviteeUserId: existingUser.id,
+        },
+      });
+    }
+
+    const invitation = await createFriendInvitation({
+      inviterUserId: session.userId,
+      inviteePhone: phone,
+      inviteeDisplayName,
+      preSeededInterests: suggestedInterests,
+    });
+
+    const inviteUrl = `${getBaseUrl(request)}/invite/${invitation.token}`;
+    const message = buildFriendInvitationMessage({ inviteUrl, suggestedInterests });
+
+    if (invitation.personalMessage !== message) {
+      await db
+        .update(friendInvitations)
+        .set({ personalMessage: message })
+        .where(eq(friendInvitations.id, invitation.id));
+    }
+
+    return NextResponse.json({
+      ok: true,
+      type: 'friend_invitation',
+      id: invitation.id,
+      invitationId: invitation.id,
+      inviteUrl,
+      message,
+      inviteeDisplayName: invitation.inviteeDisplayName ?? inviteeDisplayName,
+      inviteePhone: invitation.inviteePhone,
+      suggestedInterests,
+      expiresAt: invitation.expiresAt.toISOString(),
+    });
+  } catch (error) {
+    console.error('[friend-invitations] create failed', error);
+    return NextResponse.json(
+      { error: 'server_error', message: 'Unable to create friend invitation.' },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
### Motivation
- The Add Friend UI needs a backend endpoint to create FriendInvitation rows, produce invite URLs, and return copy-ready invite text so users can send invites themselves.
- The project already has invitation acceptance and storage logic but lacked a route to create or reuse pending invites and to handle phones that belong to existing users.

### Description
- Implemented `POST /api/friend-invitations` with authenticated session enforcement and request parsing/validation for `inviteeDisplayName`, `phone`, and optional `suggestedInterests`.
- Phone handling uses existing `isUsPhoneNumber`/`normalizePhone` helpers and suggested interests are trimmed, empties removed, deduped case-insensitively, limited to 3, and length-checked.
- For existing Joshing users the route creates or reuses a pending `Friendship` request (not a signup invite), and for non-user phones it calls the existing `createFriendInvitation` helper (which generates token/expiresAt) then builds an invite URL and copy-ready message and persists it to `personalMessage` without sending any SMS.
- Added unit tests (`src/app/api/friend-invitations/__tests__/route.test.ts`) that exercise 0/1/3 interest messages, validation failures (name/phone/too many interests), duplicate-pending-invite reuse, returned URL/message shape, and assert that `sendSms` is not called.

### Testing
- Ran typecheck with `npx tsc --noEmit`, which succeeded.
- Ran ESLint against the new files with `npx eslint src/app/api/friend-invitations/route.ts src/app/api/friend-invitations/__tests__/route.test.ts`, which succeeded for the changed files.
- Ran the project linter `npm run lint`, which failed due to pre-existing lint errors outside the changed files and is unrelated to this change.
- Added Vitest cases and attempted `npx vitest run src/app/api/friend-invitations/__tests__/route.test.ts`, but execution was blocked by a `npm` registry error fetching `vitest` (403), so the tests are present but were not runnable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049220217c832eabd1fe15afef8d88)