### PR TITLE
Harden friend invitation acceptance

### DIFF
--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -225,6 +225,21 @@ describe('acceptFriendInvitation', () => {
     expect(state.friendshipValues).toEqual([])
   })
 
+  it('rejects invitations at the exact expiration instant', async () => {
+    setInvitation({ expiresAt: now })
+
+    await expect(
+      acceptFriendInvitation({
+        token: 'expired-token',
+        inviteeUserId: 'user-invitee',
+        verifiedPhone: matchingPhone,
+        now,
+      })
+    ).resolves.toEqual({ accepted: false, reason: 'expired' })
+    expect(dbMock.transaction).not.toHaveBeenCalled()
+    expect(state.friendshipValues).toEqual([])
+  })
+
   it('rejects already accepted invitations', async () => {
     setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
 

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -200,6 +200,7 @@ export async function markInvitationAccepted({
         eq(friendInvitations.id, invitationId),
         isNull(friendInvitations.acceptedAt),
         isNull(friendInvitations.cancelledAt),
+        gt(friendInvitations.expiresAt, now),
         eq(friendInvitations.inviteePhone, verifiedPhone),
         or(
           eq(friendInvitations.inviteeUserId, inviteeUserId),
@@ -237,7 +238,7 @@ export async function acceptFriendInvitation({
     return { accepted: false, reason: 'cancelled' }
   }
 
-  if (invitation.expiresAt < now) {
+  if (invitation.expiresAt <= now) {
     return { accepted: false, reason: 'expired' }
   }
 
@@ -258,6 +259,7 @@ export async function acceptFriendInvitation({
           eq(friendInvitations.id, invitation.id),
           isNull(friendInvitations.acceptedAt),
           isNull(friendInvitations.cancelledAt),
+          gt(friendInvitations.expiresAt, now),
           eq(friendInvitations.inviteePhone, verifiedPhone),
           or(
             eq(friendInvitations.inviteeUserId, inviteeUserId),


### PR DESCRIPTION
### Motivation
- Prevent an invitation token from being claimed when the invitation row is no longer valid by ensuring the stored invitation is unaccepted, uncancelled, unexpired, and tied to the verified phone at the moment the DB claim happens.
- Make expiration semantics strict so invites that are exactly at their `expiresAt` instant are treated as expired to avoid a narrow race/edge case.

### Description
- Require `gt(friendInvitations.expiresAt, now)` when marking an invitation accepted in `markInvitationAccepted` so the row is only claimed if it is strictly unexpired at update time (`src/server/friends/invitations.ts`).
- Treat invitations with `expiresAt <= now` as expired in the in-memory pre-check inside `acceptFriendInvitation` to reject exact-instant claims (`src/server/friends/invitations.ts`).
- Add a regression unit test that asserts an invitation with `expiresAt === now` is rejected and does not create a friendship (`src/server/friends/__tests__/invitations.test.ts`).

### Testing
- Ran TypeScript check with `node_modules/.bin/tsc --noEmit`, which succeeded.
- Ran ESLint for the changed files with `node_modules/.bin/eslint src/server/friends/invitations.ts src/server/friends/__tests__/invitations.test.ts`, which succeeded for the changed scope.
- `npm run lint` was executed but failed due to unrelated, pre-existing lint errors elsewhere in the codebase.
- Attempted to run unit tests with `npx vitest run ...`, but the run was blocked because `vitest` was not available locally and registry access returned `403 Forbidden`, so the new test was added but not executed in CI here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04952e2450832e89d21b671256c033)