### PR TITLE
Polish friend invitation landing

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,0 +1,140 @@
+import type { ReactNode } from 'react'
+import Link from 'next/link'
+
+import { getFriendInvitationLandingByToken } from '@/server/friends/invitations'
+
+type InvitePageProps = {
+  params: Promise<{ token: string }>
+}
+
+function inviteLoginHref(token: string) {
+  return `/login?invitationToken=${encodeURIComponent(token)}`
+}
+
+function InviteShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
+      <section className="bg-card w-full max-w-sm rounded-lg border p-5 shadow-sm">
+        {children}
+      </section>
+    </main>
+  )
+}
+
+export default async function InvitePage({ params }: InvitePageProps) {
+  const { token } = await params
+  const invitation = await getFriendInvitationLandingByToken(token)
+
+  if (invitation.status === 'valid') {
+    return (
+      <InviteShell>
+        <div className="space-y-5">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+              Friend invite
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-normal">
+              {invitation.inviterName} invited you to Joshing.
+            </h1>
+          </div>
+
+          {invitation.suggestedInterests.length > 0 ? (
+            <div className="bg-background/60 space-y-3 rounded-lg border p-4">
+              <p className="text-sm leading-6 font-medium">
+                They thought you might like questions about:
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {invitation.suggestedInterests.map((interest) => (
+                  <span
+                    key={interest.label}
+                    className="bg-card text-foreground rounded-full border px-3 py-1 text-sm shadow-sm"
+                  >
+                    {interest.label}
+                  </span>
+                ))}
+              </div>
+              <p className="text-muted-foreground text-sm">
+                You can change these.
+              </p>
+            </div>
+          ) : null}
+
+          <Link
+            href={inviteLoginHref(token)}
+            className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
+          >
+            Continue
+          </Link>
+        </div>
+      </InviteShell>
+    )
+  }
+
+  if (invitation.status === 'expired') {
+    return (
+      <InviteShell>
+        <div className="space-y-4 text-center">
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Invitation expired
+          </p>
+          <h1 className="text-2xl font-semibold tracking-normal">
+            This invitation has expired. Ask {invitation.inviterName} to send
+            you a new one.
+          </h1>
+          <Link
+            href="/login"
+            className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
+          >
+            Go to login
+          </Link>
+        </div>
+      </InviteShell>
+    )
+  }
+
+  if (invitation.status === 'accepted') {
+    return (
+      <InviteShell>
+        <div className="space-y-4 text-center">
+          <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+            Invitation already used
+          </p>
+          <h1 className="text-2xl font-semibold tracking-normal">
+            This invitation has already been used.
+          </h1>
+          <p className="text-muted-foreground text-sm leading-6">
+            Log in with your phone number to continue to Joshing.
+          </p>
+          <Link
+            href="/login"
+            className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
+          >
+            Go to login
+          </Link>
+        </div>
+      </InviteShell>
+    )
+  }
+
+  return (
+    <InviteShell>
+      <div className="space-y-4 text-center">
+        <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
+          Invalid invitation
+        </p>
+        <h1 className="text-2xl font-semibold tracking-normal">
+          This invitation link is not valid.
+        </h1>
+        <p className="text-muted-foreground text-sm leading-6">
+          Ask your friend to send you a new Joshing invitation.
+        </p>
+        <Link
+          href="/login"
+          className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
+        >
+          Go to login
+        </Link>
+      </div>
+    </InviteShell>
+  )
+}

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -22,18 +22,38 @@ const { dbMock, state } = vi.hoisted(() => {
     friendshipValues: [] as unknown[],
     invitationValues: undefined as Record<string, unknown> | undefined,
     updateValues: undefined as Record<string, unknown> | undefined,
+    inviterName: 'Alex Inviter' as string | null,
   }
 
-  function makeSelectBuilder() {
+  function makeSelectBuilder(selection?: Record<string, unknown>) {
+    const isLandingSelect = Boolean(selection && 'inviterName' in selection)
+    const rows = () => {
+      if (!state.invitation) return []
+      if (!isLandingSelect) return [state.invitation]
+
+      return [
+        {
+          acceptedAt: state.invitation.acceptedAt,
+          cancelledAt: state.invitation.cancelledAt,
+          expiresAt: state.invitation.expiresAt,
+          preSeededInterests: state.invitation.preSeededInterests,
+          inviterName: state.inviterName,
+        },
+      ]
+    }
     const limited = {
-      limit: vi.fn(async () => (state.invitation ? [state.invitation] : [])),
+      limit: vi.fn(async () => rows()),
+    }
+    const whereable = {
+      where: vi.fn(() => ({
+        ...limited,
+        orderBy: vi.fn(() => limited),
+      })),
     }
     return {
       from: vi.fn(() => ({
-        where: vi.fn(() => ({
-          ...limited,
-          orderBy: vi.fn(() => limited),
-        })),
+        ...whereable,
+        leftJoin: vi.fn(() => whereable),
       })),
     }
   }
@@ -93,7 +113,9 @@ const { dbMock, state } = vi.hoisted(() => {
   }
 
   const dbMock = {
-    select: vi.fn(() => makeSelectBuilder()),
+    select: vi.fn((selection?: Record<string, unknown>) =>
+      makeSelectBuilder(selection)
+    ),
     update: vi.fn(() => makeUpdateBuilder()),
     insert: vi.fn(() => makeInsertBuilder()),
     transaction: vi.fn(async (callback: (tx: typeof tx) => unknown) =>
@@ -107,6 +129,10 @@ const { dbMock, state } = vi.hoisted(() => {
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
+  users: {
+    id: 'users.id',
+    displayName: 'users.displayName',
+  },
   friendInvitations: {
     id: 'friendInvitations.id',
     token: 'friendInvitations.token',
@@ -134,6 +160,7 @@ import {
   acceptFriendInvitation,
   cancelFriendInvitation,
   createFriendInvitation,
+  getFriendInvitationLandingByToken,
   getInvitationByToken,
   getPendingInvitationForPhone,
 } from '@/server/friends/invitations'
@@ -292,6 +319,75 @@ describe('friend invitation helpers', () => {
     state.friendshipValues = []
     state.invitationValues = undefined
     state.updateValues = undefined
+    state.inviterName = 'Alex Inviter'
+  })
+
+  it('returns a safe valid landing state with inviter display name and suggested interest chips', async () => {
+    setInvitation({
+      preSeededInterests: [
+        ' Jazz ',
+        { label: 'Poetry' },
+        'jazz',
+        'Film',
+        'Extra ignored',
+      ],
+    })
+
+    await expect(
+      getFriendInvitationLandingByToken('valid-token', now)
+    ).resolves.toEqual({
+      status: 'valid',
+      inviterName: 'Alex Inviter',
+      suggestedInterests: [
+        { label: 'Jazz' },
+        { label: 'Poetry' },
+        { label: 'Film' },
+      ],
+    })
+  })
+
+  it('returns an expired landing state without suggested interests', async () => {
+    setInvitation({
+      expiresAt: new Date('2026-05-12T12:00:00.000Z'),
+      preSeededInterests: ['Jazz'],
+    })
+
+    await expect(
+      getFriendInvitationLandingByToken('expired-token', now)
+    ).resolves.toEqual({
+      status: 'expired',
+      inviterName: 'Alex Inviter',
+      suggestedInterests: [],
+    })
+  })
+
+  it('returns an already accepted landing state that can route safely to login', async () => {
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
+
+    await expect(
+      getFriendInvitationLandingByToken('accepted-token', now)
+    ).resolves.toEqual({
+      status: 'accepted',
+      inviterName: 'Alex Inviter',
+      suggestedInterests: [],
+    })
+  })
+
+  it('returns a generic invalid landing state for missing, cancelled, or blank tokens', async () => {
+    await expect(getFriendInvitationLandingByToken('', now)).resolves.toEqual({
+      status: 'invalid',
+      inviterName: 'Someone',
+      suggestedInterests: [],
+    })
+
+    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') })
+    await expect(
+      getFriendInvitationLandingByToken('cancelled-token', now)
+    ).resolves.toEqual({
+      status: 'invalid',
+      inviterName: 'Someone',
+      suggestedInterests: [],
+    })
   })
 
   it('creates an Add Friend invitation with invitee display name, phone, and suggested interests', async () => {

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -2,7 +2,7 @@ import { randomBytes } from 'crypto'
 
 import { and, desc, eq, gt, isNull, or } from 'drizzle-orm'
 
-import { db, friendInvitations } from '@/server/db'
+import { db, friendInvitations, users } from '@/server/db'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 
 export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
@@ -11,6 +11,12 @@ export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
 const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 14
 
 export type FriendInvitation = typeof friendInvitations.$inferSelect
+
+export type FriendInvitationLanding = {
+  status: 'valid' | 'expired' | 'accepted' | 'invalid'
+  inviterName: string
+  suggestedInterests: { label: string }[]
+}
 
 export type CreateFriendInvitationInput = {
   inviterUserId: string
@@ -35,6 +41,79 @@ export type AcceptFriendInvitationResult =
         | 'phone_mismatch'
         | 'claim_failed'
     }
+
+function displayInviterName(value: string | null | undefined) {
+  const normalized = value?.trim().replace(/\s+/g, ' ')
+  return normalized ? normalized.slice(0, 80) : 'Someone'
+}
+
+function parseLandingInterests(value: unknown): { label: string }[] {
+  if (!Array.isArray(value)) return []
+
+  const seen = new Set<string>()
+  const interests: { label: string }[] = []
+
+  for (const item of value) {
+    const rawLabel =
+      typeof item === 'string'
+        ? item
+        : item && typeof item === 'object' && !Array.isArray(item)
+          ? (item as Record<string, unknown>).label
+          : null
+    const label =
+      typeof rawLabel === 'string' ? rawLabel.trim().replace(/\s+/g, ' ') : ''
+    if (!label) continue
+
+    const key = label.toLocaleLowerCase('en-US')
+    if (seen.has(key)) continue
+
+    seen.add(key)
+    interests.push({ label: label.slice(0, 80) })
+    if (interests.length === 3) break
+  }
+
+  return interests
+}
+
+export async function getFriendInvitationLandingByToken(
+  token: string,
+  now = new Date()
+): Promise<FriendInvitationLanding> {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) {
+    return { status: 'invalid', inviterName: 'Someone', suggestedInterests: [] }
+  }
+
+  const [row] = await db
+    .select({
+      acceptedAt: friendInvitations.acceptedAt,
+      cancelledAt: friendInvitations.cancelledAt,
+      expiresAt: friendInvitations.expiresAt,
+      preSeededInterests: friendInvitations.preSeededInterests,
+      inviterName: users.displayName,
+    })
+    .from(friendInvitations)
+    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
+    .where(eq(friendInvitations.token, normalizedToken))
+    .limit(1)
+
+  if (!row || row.cancelledAt) {
+    return { status: 'invalid', inviterName: 'Someone', suggestedInterests: [] }
+  }
+
+  const inviterName = displayInviterName(row.inviterName)
+  const suggestedInterests = parseLandingInterests(row.preSeededInterests)
+
+  if (row.acceptedAt) {
+    return { status: 'accepted', inviterName, suggestedInterests: [] }
+  }
+
+  if (row.expiresAt <= now) {
+    return { status: 'expired', inviterName, suggestedInterests: [] }
+  }
+
+  return { status: 'valid', inviterName, suggestedInterests }
+}
 
 function normalizeRequiredText(value: string, fieldName: string) {
   const normalized = value.trim().replace(/\s+/g, ' ')


### PR DESCRIPTION
### Motivation
- Provide a lightweight, intentional landing screen for valid friend invite links before phone OTP authentication. 
- Surface suggested interests (if any) and quiet copy so recipients understand and can change seeded onboarding choices. 
- Show safe, non-sensitive states for expired/used/invalid invites and preserve phone-claim protections during OTP acceptance.

### Description
- Add a new invite landing page at `src/app/invite/[token]/page.tsx` that renders the header `"[Inviter Name] invited you to Joshing."`, shows up to three sanitized interest chips with the copy `"You can change these."`, a primary `Continue` action that links to `/login?invitationToken=...`, and safe UI for `expired`, `accepted`, and `invalid` states. 
- Add `getFriendInvitationLandingByToken` to `src/server/friends/invitations.ts` which exposes only a safe inviter display name and up to three deduped/sanitized interest labels and maps token rows to `valid | expired | accepted | invalid` landing states. 
- Keep invitation claim semantics unchanged in the OTP flow: the invitation accept path (`acceptFriendInvitation` / `verify-otp`) still requires the verified phone to match the stored `inviteePhone` and does not expose private inviter data. 
- Add unit test coverage in `src/server/friends/__tests__/invitations.test.ts` for landing-state mapping and suggested-interest parsing.

### Testing
- Ran type-checking with `npx tsc --noEmit -p tsconfig.json` and it succeeded. 
- Formatted changed files with `prettier` and ran targeted linting with `npx eslint` against the modified files (`invitations.ts`, its tests, and the new page) and those checks passed. 
- `npm run lint` (project-wide) failed due to pre-existing unrelated lint issues outside these changes, not caused by this PR. 
- Attempted to run the invitation unit tests with `npx vitest run src/server/friends/__tests__/invitations.test.ts` but the run was blocked because `vitest` could not be fetched from the registry (HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04966dd75c832e88a2b4f5ec6e309c)