### PR TITLE
Attribute invited onboarding interests

### DIFF
--- a/src/app/api/onboarding/save-interests/__tests__/route.test.ts
+++ b/src/app/api/onboarding/save-interests/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSessionMock, markOnboardingCompleteMock, saveDeclaredInterestsMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  markOnboardingCompleteMock: vi.fn(),
+  saveDeclaredInterestsMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/db/queries/users', () => ({
+  markOnboardingComplete: markOnboardingCompleteMock,
+  saveDeclaredInterests: saveDeclaredInterestsMock,
+}))
+
+import { POST } from '@/app/api/onboarding/save-interests/route'
+
+function jsonRequest(interests: unknown) {
+  return new Request('https://joshing.example/api/onboarding/save-interests', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ interests }),
+  })
+}
+
+describe('POST /api/onboarding/save-interests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ userId: 'user-invitee' })
+    saveDeclaredInterestsMock.mockResolvedValue(undefined)
+    markOnboardingCompleteMock.mockResolvedValue(undefined)
+  })
+
+  it('accept all saves selected invited interests', async () => {
+    const response = await POST(jsonRequest([
+      { domain: 'Sondheim', broadCategory: 'Theater' },
+      { domain: 'Jazz', broadCategory: 'Music' },
+    ]))
+
+    expect(response.status).toBe(200)
+    expect(saveDeclaredInterestsMock).toHaveBeenCalledWith('user-invitee', [
+      { label: 'Sondheim', broadCategory: 'Theater' },
+      { label: 'Jazz', broadCategory: 'Music' },
+    ])
+    expect(markOnboardingCompleteMock).toHaveBeenCalledWith('user-invitee')
+  })
+
+  it('partial selection saves only selected interests', async () => {
+    const response = await POST(jsonRequest([
+      { domain: 'Sondheim', broadCategory: 'Theater' },
+    ]))
+
+    expect(response.status).toBe(200)
+    expect(saveDeclaredInterestsMock).toHaveBeenCalledWith('user-invitee', [
+      { label: 'Sondheim', broadCategory: 'Theater' },
+    ])
+  })
+
+  it('skip saves none of the invited interests unless the user adds others', async () => {
+    const response = await POST(jsonRequest([
+      { domain: 'Italian Renaissance painting', broadCategory: 'Art' },
+    ]))
+
+    expect(response.status).toBe(200)
+    expect(saveDeclaredInterestsMock).toHaveBeenCalledWith('user-invitee', [
+      { label: 'Italian Renaissance painting', broadCategory: 'Art' },
+    ])
+    expect(saveDeclaredInterestsMock).not.toHaveBeenCalledWith(
+      'user-invitee',
+      expect.arrayContaining([{ label: 'Sondheim', broadCategory: 'Theater' }]),
+    )
+  })
+
+  it('does not silently save rejected interests from an empty selection', async () => {
+    const response = await POST(jsonRequest([]))
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('invalid_request')
+    expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()
+    expect(markOnboardingCompleteMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -26,12 +26,11 @@ type SelectedInterest = {
   broadCategory: string;
 };
 
-export type PreSeededInterest = ProposedInterest & {
-  inviterName?: string | null;
-};
+export type PreSeededInterest = ProposedInterest;
 
 type OnboardingFlowProps = {
   preSeededInterests: PreSeededInterest[];
+  inviterName?: string | null;
 };
 
 type CanonicalSuggestion = {
@@ -160,7 +159,7 @@ function StepHeader({ title, subtitle }: { title: string; subtitle: string }) {
   );
 }
 
-export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowProps) {
+export default function OnboardingFlow({ preSeededInterests, inviterName }: OnboardingFlowProps) {
   const router = useRouter();
   const [currentStep, setCurrentStep] = useState<CurrentStep>('welcome');
   const [birthYear, setBirthYear] = useState('');
@@ -168,6 +167,7 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
   const [grewUpRegion, setGrewUpRegion] = useState('');
   const [warmupAnswers, setWarmupAnswers] = useState<WarmupAnswers>({});
   const [proposedInterests, setProposedInterests] = useState<ProposedInterest[] | null>(null);
+  const [inviteInterests, setInviteInterests] = useState<PreSeededInterest[]>(() => preSeededInterests);
   const [selectedInterests, setSelectedInterests] = useState<SelectedInterest[]>(
     () => preSeededInterests.flatMap((interest) => {
       const selected = toSelected(interest);
@@ -187,7 +187,7 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const showDailySetup = useMemo(() => isBeforeNoonEastern(), []);
 
-  const inviterName = preSeededInterests.find((interest) => interest.inviterName)?.inviterName ?? 'A friend';
+  const displayInviterName = inviterName?.trim() ? inviterName.trim() : 'A friend';
 
   const parsedBirthYear = parseInt(birthYear, 10);
   const maxBirthYear = new Date().getFullYear() - 13;
@@ -203,14 +203,14 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
 
   const reviewInterests = useMemo(
     () => [
-      ...preSeededInterests,
+      ...inviteInterests,
       ...(proposedInterests ?? []).filter(
-        (interest) => !preSeededInterests.some(
+        (interest) => !inviteInterests.some(
           (seeded) => selectedKey(toSelected(seeded) ?? { domain: '', broadCategory: '' }) === selectedKey(toSelected(interest) ?? { domain: '', broadCategory: '' }),
         ),
       ),
     ],
-    [preSeededInterests, proposedInterests],
+    [inviteInterests, proposedInterests],
   );
 
   useEffect(() => {
@@ -225,12 +225,14 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
 
   useEffect(() => {
     const rawInput = normalizeDomain(customInput);
-    setCanonicalSuggestion(null);
-    setCustomChoice(null);
+    const resetTimer = window.setTimeout(() => {
+      setCanonicalSuggestion(null);
+      setCustomChoice(null);
+      if (!showComposer || rawInput.length <= 3) setIsCanonicalizing(false);
+    }, 0);
 
     if (!showComposer || rawInput.length <= 3) {
-      setIsCanonicalizing(false);
-      return;
+      return () => window.clearTimeout(resetTimer);
     }
 
     const controller = new AbortController();
@@ -264,6 +266,7 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
 
     return () => {
       controller.abort();
+      window.clearTimeout(resetTimer);
       window.clearTimeout(timer);
     };
   }, [customInput, showComposer]);
@@ -298,6 +301,11 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
     if (!selected || nextDomain.length < 2) return;
 
     const edited = { ...interest, domain: nextDomain };
+    setInviteInterests((current) => current.map((item) => (
+      selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) === selectedKey(selected)
+        ? edited
+        : item
+    )));
     setProposedInterests((current) => current?.map((item) => (
       selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) === selectedKey(selected)
         ? edited
@@ -455,18 +463,18 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
                 <p>It takes about two minutes.</p>
               </div>
 
-              {preSeededInterests.length > 0 ? (
+              {inviteInterests.length > 0 ? (
                 <div className="rounded-lg border bg-card p-4 text-sm leading-6 shadow-sm">
                   <p className="font-medium">
-                    {inviterName} thought you&apos;d like questions about:
+                    {displayInviterName} thought you might like:
                   </p>
                   <ul className="mt-2 space-y-1 text-muted-foreground">
-                    {preSeededInterests.slice(0, 3).map((interest) => (
+                    {inviteInterests.slice(0, 3).map((interest) => (
                       <li key={interest.domain}>- {interest.domain}</li>
                     ))}
                   </ul>
                   <p className="mt-3 text-muted-foreground">
-                    We&apos;ll add these in - you can change them later.
+                    They&apos;re preselected, but you can edit, remove, or skip them before anything is saved.
                   </p>
                 </div>
               ) : null}
@@ -630,7 +638,7 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
                   const selected = isSelected(selectedInterests, interest);
                   const normalized = toSelected(interest);
                   const atCap = selectedInterests.length >= 5 && !selected;
-                  const fromInvite = preSeededInterests.some((seeded) => selectedKey(toSelected(seeded) ?? { domain: '', broadCategory: '' }) === selectedKey(normalized ?? { domain: '', broadCategory: '' }));
+                  const fromInvite = inviteInterests.some((seeded) => selectedKey(toSelected(seeded) ?? { domain: '', broadCategory: '' }) === selectedKey(normalized ?? { domain: '', broadCategory: '' }));
                   const key = `${interest.domain}-${interest.broadCategory}`;
                   const editing = normalized ? editingKey === selectedKey(normalized) : false;
 
@@ -683,7 +691,7 @@ export default function OnboardingFlow({ preSeededInterests }: OnboardingFlowPro
                             ) : null}
                             {fromInvite ? (
                               <span className={`mt-3 inline-flex rounded-sm border px-2 py-1 text-[11px] font-semibold uppercase ${selected ? 'border-background/30 text-background/80' : 'text-muted-foreground'}`}>
-                                From {inviterName}
+                                From {displayInviterName}
                               </span>
                             ) : null}
                           </button>

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+
+import OnboardingFlow from '@/app/onboarding/OnboardingFlow'
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+}))
+
+describe('OnboardingFlow invited-interest copy', () => {
+  it('names the inviter when available', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        inviterName="Alex Inviter"
+        preSeededInterests={[{ domain: 'Sondheim', broadCategory: 'Theater', rationale: null }]}
+      />,
+    )
+
+    expect(html).toContain('Alex Inviter thought you might like:')
+    expect(html).toContain('Sondheim')
+    expect(html).toContain("They&#x27;re preselected, but you can edit, remove, or skip them before anything is saved.")
+  })
+
+  it('uses friend fallback when inviter name is unavailable', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        inviterName={null}
+        preSeededInterests={[{ domain: 'Jazz', broadCategory: 'Music', rationale: null }]}
+      />,
+    )
+
+    expect(html).toContain('A friend thought you might like:')
+  })
+
+  it('still renders regular onboarding with no invite', () => {
+    const html = renderToStaticMarkup(<OnboardingFlow preSeededInterests={[]} />)
+
+    expect(html).toContain('The trivia you wish you were asked.')
+    expect(html).not.toContain('thought you might like:')
+  })
+})

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -21,12 +21,12 @@ export default async function OnboardingPage() {
     redirect('/');
   }
 
-  const rawSeeded = await getPreSeededInterestsForUser(session.userId);
-  const preSeededInterests: PreSeededInterest[] = rawSeeded.map((interest) => ({
+  const seeded = await getPreSeededInterestsForUser(session.userId);
+  const preSeededInterests: PreSeededInterest[] = seeded.interests.map((interest) => ({
     domain: interest.label,
     broadCategory: interest.broadCategory ?? 'Other',
     rationale: interest.description ?? null,
   }));
 
-  return <OnboardingFlow preSeededInterests={preSeededInterests} />;
+  return <OnboardingFlow preSeededInterests={preSeededInterests} inviterName={seeded.inviterName} />;
 }

--- a/src/server/db/queries/__tests__/users-preseeded.test.ts
+++ b/src/server/db/queries/__tests__/users-preseeded.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { dbMock, state } = vi.hoisted(() => {
+  const state = {
+    row: undefined as { preSeededInterests: unknown; inviterName: string | null } | undefined,
+  }
+
+  const limited = {
+    limit: vi.fn(async () => (state.row ? [state.row] : [])),
+  }
+  const ordered = {
+    orderBy: vi.fn(() => limited),
+  }
+  const whereable = {
+    where: vi.fn(() => ordered),
+  }
+  const joinable = {
+    leftJoin: vi.fn(() => whereable),
+  }
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => joinable),
+    })),
+  }
+
+  return { dbMock, state }
+})
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  declaredInterests: {},
+  friendInvitations: {
+    preSeededInterests: 'friendInvitations.preSeededInterests',
+    inviterUserId: 'friendInvitations.inviterUserId',
+    inviteeUserId: 'friendInvitations.inviteeUserId',
+    acceptedAt: 'friendInvitations.acceptedAt',
+  },
+  users: {
+    id: 'users.id',
+    displayName: 'users.displayName',
+  },
+}))
+
+import { getPreSeededInterestsForUser } from '@/server/db/queries/users'
+
+describe('getPreSeededInterestsForUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.row = undefined
+  })
+
+  it('loads inviter display name with accepted invite interests', async () => {
+    state.row = {
+      inviterName: '  Alex   Inviter  ',
+      preSeededInterests: [{ label: ' Sondheim ', broadCategory: 'Theater' }],
+    }
+
+    await expect(getPreSeededInterestsForUser('user-invitee')).resolves.toEqual({
+      inviterName: 'Alex Inviter',
+      interests: [{ label: 'Sondheim', description: null, broadCategory: 'Theater' }],
+    })
+  })
+
+  it('returns a null inviter name when unavailable so UI can use friend fallback', async () => {
+    state.row = {
+      inviterName: '   ',
+      preSeededInterests: ['Jazz'],
+    }
+
+    await expect(getPreSeededInterestsForUser('user-invitee')).resolves.toEqual({
+      inviterName: null,
+      interests: [{ label: 'Jazz' }],
+    })
+  })
+
+  it('keeps non-invite onboarding empty', async () => {
+    await expect(getPreSeededInterestsForUser('user-no-invite')).resolves.toEqual({
+      inviterName: null,
+      interests: [],
+    })
+  })
+})

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -17,6 +17,11 @@ export type PreSeededInterest = {
   broadCategory?: string | null;
 };
 
+export type PreSeededInterestsForUser = {
+  interests: PreSeededInterest[];
+  inviterName: string | null;
+};
+
 function normalizeDeclaredInterest(interest: DeclaredInterestInput): DeclaredInterestInput | null {
   const label = interest.label.trim().replace(/\s+/g, ' ');
   if (!label) return null;
@@ -167,13 +172,25 @@ export async function getUserOnboardingProfile(userId: string) {
   return user ?? null;
 }
 
-export async function getPreSeededInterestsForUser(userId: string): Promise<PreSeededInterest[]> {
+function normalizeInviterName(value: string | null | undefined) {
+  const normalized = value?.trim().replace(/\s+/g, ' ');
+  return normalized ? normalized.slice(0, 80) : null;
+}
+
+export async function getPreSeededInterestsForUser(userId: string): Promise<PreSeededInterestsForUser> {
   const [invitation] = await db
-    .select({ preSeededInterests: friendInvitations.preSeededInterests })
+    .select({
+      preSeededInterests: friendInvitations.preSeededInterests,
+      inviterName: users.displayName,
+    })
     .from(friendInvitations)
+    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
     .where(and(eq(friendInvitations.inviteeUserId, userId), isNotNull(friendInvitations.acceptedAt)))
     .orderBy(desc(friendInvitations.acceptedAt))
     .limit(1);
 
-  return parsePreSeededInterests(invitation?.preSeededInterests);
+  return {
+    interests: parsePreSeededInterests(invitation?.preSeededInterests),
+    inviterName: normalizeInviterName(invitation?.inviterName),
+  };
 }


### PR DESCRIPTION
### Motivation
- Make pre-seeded invite interests feel personal by including the inviter's display name in the onboarding UI. 
- Ensure inviter attribution is explicit while preserving the existing optional, editable, and non-permanent behavior of invited interests. 

### Description
- Return inviter display name from the onboarding loader by joining `FriendInvitation.inviterUserId` → `users.displayName` and normalizing the value in `getPreSeededInterestsForUser`, which now returns `{ interests, inviterName }`. 
- Pass the returned `inviterName` into `OnboardingFlow` from `src/app/onboarding/page.tsx` and show the copy `"[Inviter Name] thought you might like:"` with a fallback `"A friend thought you might like:"`. 
- Keep invite interests preselected but editable locally by introducing `inviteInterests` state in `OnboardingFlow`, update invite badges to show the inviter/fallback name, and avoid persisting any invite interests until the user explicitly saves at the end of onboarding. 
- Add unit tests to cover inviter-name loading and fallback, onboarding copy/behavior for invite vs no-invite flows, and `save-interests` behavior for accept-all, partial, skip-with-custom, and empty-selection rejection. 

### Testing
- Type-checking ran with `npx tsc --noEmit` and succeeded for the changed files. 
- Targeted linting ran for the modified files with `eslint` (the touched files passed; repo-wide lint has pre-existing issues unrelated to this change). 
- New unit tests were added for `getPreSeededInterestsForUser`, `OnboardingFlow` copy, and `POST /api/onboarding/save-interests`, but running them with `npx vitest` in this environment was blocked by inability to fetch the test runner from the registry (403), so those tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0499617654832eb11cfbf6a5a42720)