### PR TITLE
Add outgoing friend-invite management (list, cancel, UI)

### DIFF
--- a/src/app/api/friend-invitations/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/__tests__/route.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
+  cancelFriendInvitationMock,
   createFriendInvitationMock,
   dbMock,
   getSessionMock,
@@ -42,6 +43,7 @@ const {
   }
 
   return {
+    cancelFriendInvitationMock: vi.fn(),
     createFriendInvitationMock: vi.fn(),
     dbMock,
     getSessionMock: vi.fn(),
@@ -90,7 +92,9 @@ vi.mock('@/server/db', () => ({
 }))
 
 vi.mock('@/server/friends/invitations', () => ({
+  cancelFriendInvitation: cancelFriendInvitationMock,
   createFriendInvitation: createFriendInvitationMock,
+  listOutgoingFriendInvitations: vi.fn(async () => []),
 }))
 
 vi.mock('@/server/sms', () => ({

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -1,56 +1,64 @@
-import { eq } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
+import { eq } from 'drizzle-orm'
+import { NextResponse } from 'next/server'
 
-import { isUsPhoneNumber, normalizePhone } from '@/server/auth';
-import { getSession } from '@/server/auth/session';
-import { db, friendInvitations, users } from '@/server/db';
-import { createFriendInvitation } from '@/server/friends/invitations';
-import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships';
+import { isUsPhoneNumber, normalizePhone } from '@/server/auth'
+import { getSession } from '@/server/auth/session'
+import { db, friendInvitations, users } from '@/server/db'
+import {
+  cancelFriendInvitation,
+  createFriendInvitation,
+  listOutgoingFriendInvitations,
+  type OutgoingFriendInvitation,
+} from '@/server/friends/invitations'
+import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
 
-export const dynamic = 'force-dynamic';
+export const dynamic = 'force-dynamic'
 
-const MAX_INVITEE_DISPLAY_NAME_LENGTH = 80;
-const MAX_SUGGESTED_INTERESTS = 3;
-const MAX_SUGGESTED_INTEREST_LENGTH = 80;
+const MAX_INVITEE_DISPLAY_NAME_LENGTH = 80
+const MAX_SUGGESTED_INTERESTS = 3
+const MAX_SUGGESTED_INTEREST_LENGTH = 80
 
 type CreateFriendInvitationBody = {
-  inviteeDisplayName: string;
-  phone: string;
-  suggestedInterests: string[];
-};
+  inviteeDisplayName: string
+  phone: string
+  suggestedInterests: string[]
+}
 
 type ValidationResult =
   | { ok: true; value: CreateFriendInvitationBody }
-  | { ok: false; status: number; error: string; message: string };
+  | { ok: false; status: number; error: string; message: string }
 
 function getBaseUrl(request: Request): string {
-  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL;
-  if (configured) return configured.replace(/\/$/, '');
+  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL
+  if (configured) return configured.replace(/\/$/, '')
 
-  const host = request.headers.get('x-forwarded-host') ?? request.headers.get('host');
-  const protocol = request.headers.get('x-forwarded-proto') ?? 'https';
-  return host ? `${protocol}://${host}` : new URL(request.url).origin;
+  const host =
+    request.headers.get('x-forwarded-host') ?? request.headers.get('host')
+  const protocol = request.headers.get('x-forwarded-proto') ?? 'https'
+  return host ? `${protocol}://${host}` : new URL(request.url).origin
 }
 
 function normalizeText(value: string): string {
-  return value.trim().replace(/\s+/g, ' ');
+  return value.trim().replace(/\s+/g, ' ')
 }
 
-export function validateCreateFriendInvitationBody(body: unknown): ValidationResult {
+export function validateCreateFriendInvitationBody(
+  body: unknown
+): ValidationResult {
   if (!body || typeof body !== 'object' || Array.isArray(body)) {
     return {
       ok: false,
       status: 400,
       error: 'invalid_request',
       message: 'Request body is required.',
-    };
+    }
   }
 
-  const record = body as Record<string, unknown>;
+  const record = body as Record<string, unknown>
   const inviteeDisplayName =
     typeof record.inviteeDisplayName === 'string'
       ? normalizeText(record.inviteeDisplayName)
-      : '';
+      : ''
 
   if (!inviteeDisplayName) {
     return {
@@ -58,7 +66,7 @@ export function validateCreateFriendInvitationBody(body: unknown): ValidationRes
       status: 400,
       error: 'missing_invitee_display_name',
       message: 'inviteeDisplayName is required.',
-    };
+    }
   }
 
   if (inviteeDisplayName.length > MAX_INVITEE_DISPLAY_NAME_LENGTH) {
@@ -67,37 +75,39 @@ export function validateCreateFriendInvitationBody(body: unknown): ValidationRes
       status: 400,
       error: 'invalid_invitee_display_name',
       message: `inviteeDisplayName must be ${MAX_INVITEE_DISPLAY_NAME_LENGTH} characters or fewer.`,
-    };
+    }
   }
 
-  const rawPhone = typeof record.phone === 'string' ? record.phone.trim() : '';
+  const rawPhone = typeof record.phone === 'string' ? record.phone.trim() : ''
   if (!rawPhone || !isUsPhoneNumber(rawPhone)) {
     return {
       ok: false,
       status: 400,
       error: 'invalid_phone',
       message: 'US phone number required.',
-    };
+    }
   }
 
   if (
     record.suggestedInterests !== undefined &&
     (!Array.isArray(record.suggestedInterests) ||
-      !record.suggestedInterests.every((interest) => typeof interest === 'string'))
+      !record.suggestedInterests.every(
+        (interest) => typeof interest === 'string'
+      ))
   ) {
     return {
       ok: false,
       status: 400,
       error: 'invalid_suggested_interests',
       message: 'suggestedInterests must be an array of strings.',
-    };
+    }
   }
 
-  const seen = new Set<string>();
-  const suggestedInterests: string[] = [];
+  const seen = new Set<string>()
+  const suggestedInterests: string[] = []
   for (const interest of (record.suggestedInterests ?? []) as string[]) {
-    const normalizedInterest = normalizeText(interest);
-    if (!normalizedInterest) continue;
+    const normalizedInterest = normalizeText(interest)
+    if (!normalizedInterest) continue
 
     if (normalizedInterest.length > MAX_SUGGESTED_INTEREST_LENGTH) {
       return {
@@ -105,14 +115,14 @@ export function validateCreateFriendInvitationBody(body: unknown): ValidationRes
         status: 400,
         error: 'invalid_suggested_interests',
         message: `Each suggested interest must be ${MAX_SUGGESTED_INTEREST_LENGTH} characters or fewer.`,
-      };
+      }
     }
 
-    const dedupeKey = normalizedInterest.toLocaleLowerCase('en-US');
-    if (seen.has(dedupeKey)) continue;
+    const dedupeKey = normalizedInterest.toLocaleLowerCase('en-US')
+    if (seen.has(dedupeKey)) continue
 
-    seen.add(dedupeKey);
-    suggestedInterests.push(normalizedInterest);
+    seen.add(dedupeKey)
+    suggestedInterests.push(normalizedInterest)
   }
 
   if (suggestedInterests.length > MAX_SUGGESTED_INTERESTS) {
@@ -121,7 +131,7 @@ export function validateCreateFriendInvitationBody(body: unknown): ValidationRes
       status: 400,
       error: 'too_many_suggested_interests',
       message: `suggestedInterests must contain ${MAX_SUGGESTED_INTERESTS} or fewer values.`,
-    };
+    }
   }
 
   return {
@@ -131,29 +141,74 @@ export function validateCreateFriendInvitationBody(body: unknown): ValidationRes
       phone: normalizePhone(rawPhone),
       suggestedInterests,
     },
-  };
+  }
 }
 
 export function buildFriendInvitationMessage({
   inviteUrl,
   suggestedInterests,
 }: {
-  inviteUrl: string;
-  suggestedInterests: string[];
+  inviteUrl: string
+  suggestedInterests: string[]
 }): string {
   if (suggestedInterests.length === 1) {
-    return `Hey — come play Joshing with me. I added something I think you might like: ${suggestedInterests[0]}. No app to download — just tap this: ${inviteUrl}`;
+    return `Hey — come play Joshing with me. I added something I think you might like: ${suggestedInterests[0]}. No app to download — just tap this: ${inviteUrl}`
   }
 
   if (suggestedInterests.length === 2) {
-    return `Hey — come play Joshing with me. I added a couple areas I think you might like: ${suggestedInterests[0]} and ${suggestedInterests[1]}. No app to download — just tap this: ${inviteUrl}`;
+    return `Hey — come play Joshing with me. I added a couple areas I think you might like: ${suggestedInterests[0]} and ${suggestedInterests[1]}. No app to download — just tap this: ${inviteUrl}`
   }
 
   if (suggestedInterests.length === 3) {
-    return `Hey — come play Joshing with me. I added a few areas I think you might like: ${suggestedInterests[0]}, ${suggestedInterests[1]}, and ${suggestedInterests[2]}. No app to download — just tap this: ${inviteUrl}`;
+    return `Hey — come play Joshing with me. I added a few areas I think you might like: ${suggestedInterests[0]}, ${suggestedInterests[1]}, and ${suggestedInterests[2]}. No app to download — just tap this: ${inviteUrl}`
   }
 
-  return `Hey — come play Joshing with me. No app to download — just tap this: ${inviteUrl}`;
+  return `Hey — come play Joshing with me. No app to download — just tap this: ${inviteUrl}`
+}
+
+function maskPhoneNumber(phone: string): string {
+  const digits = phone.replace(/\D/g, '')
+  const local =
+    digits.length === 11 && digits.startsWith('1') ? digits.slice(1) : digits
+
+  if (local.length === 10) {
+    return `(${local.slice(0, 3)}) •••-${local.slice(6)}`
+  }
+
+  return phone.length > 4 ? `••••${phone.slice(-4)}` : '••••'
+}
+
+function serializeOutgoingInvitation(
+  invitation: OutgoingFriendInvitation,
+  request: Request
+) {
+  const inviteUrl =
+    invitation.status === 'pending'
+      ? `${getBaseUrl(request)}/invite/${invitation.token}`
+      : null
+  const message = inviteUrl
+    ? buildFriendInvitationMessage({
+        inviteUrl,
+        suggestedInterests: invitation.suggestedInterests,
+      })
+    : null
+
+  return {
+    id: invitation.id,
+    inviteeDisplayName: invitation.inviteeDisplayName ?? 'Friend',
+    inviteePhoneMasked: maskPhoneNumber(invitation.inviteePhone),
+    inviteePhoneForActions:
+      invitation.status === 'pending' || invitation.status === 'expired'
+        ? invitation.inviteePhone
+        : null,
+    suggestedInterests: invitation.suggestedInterests,
+    status: invitation.status,
+    sentAt: invitation.sentAt.toISOString(),
+    acceptedAt: invitation.acceptedAt?.toISOString() ?? null,
+    cancelledAt: invitation.cancelledAt?.toISOString() ?? null,
+    expiresAt: invitation.expiresAt.toISOString(),
+    message,
+  }
 }
 
 async function getUserByPhone(phone: string) {
@@ -161,40 +216,115 @@ async function getUserByPhone(phone: string) {
     .select({ id: users.id })
     .from(users)
     .where(eq(users.phoneNumber, phone))
-    .limit(1);
+    .limit(1)
 
-  return user ?? null;
+  return user ?? null
 }
 
-export async function POST(request: Request) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+export async function GET(request: Request) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
-  const parsed = validateCreateFriendInvitationBody(await request.json().catch(() => null));
-  if (!parsed.ok) {
+  try {
+    const invitations = await listOutgoingFriendInvitations({
+      inviterUserId: session.userId,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      invitations: invitations.map((invitation) =>
+        serializeOutgoingInvitation(invitation, request)
+      ),
+    })
+  } catch (error) {
+    console.error('[friend-invitations] list failed', error)
     return NextResponse.json(
-      { error: parsed.error, message: parsed.message },
-      { status: parsed.status },
-    );
+      { error: 'server_error', message: 'Unable to load friend invitations.' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function DELETE(request: Request) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const body = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null
+  const invitationId =
+    typeof body?.invitationId === 'string' ? body.invitationId.trim() : ''
+
+  if (!invitationId) {
+    return NextResponse.json(
+      { error: 'missing_invitation_id', message: 'invitationId is required.' },
+      { status: 400 }
+    )
   }
 
   try {
-    const { inviteeDisplayName, phone, suggestedInterests } = parsed.value;
-    const existingUser = await getUserByPhone(phone);
+    const invitation = await cancelFriendInvitation({
+      invitationId,
+      inviterUserId: session.userId,
+    })
+
+    if (!invitation) {
+      return NextResponse.json(
+        { error: 'not_found', message: 'Pending invitation was not found.' },
+        { status: 404 }
+      )
+    }
+
+    return NextResponse.json({
+      ok: true,
+      invitationId: invitation.id,
+      status: 'cancelled',
+    })
+  } catch (error) {
+    console.error('[friend-invitations] cancel failed', error)
+    return NextResponse.json(
+      { error: 'server_error', message: 'Unable to cancel friend invitation.' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const parsed = validateCreateFriendInvitationBody(
+    await request.json().catch(() => null)
+  )
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { error: parsed.error, message: parsed.message },
+      { status: parsed.status }
+    )
+  }
+
+  try {
+    const { inviteeDisplayName, phone, suggestedInterests } = parsed.value
+    const existingUser = await getUserByPhone(phone)
 
     if (existingUser) {
       if (existingUser.id === session.userId) {
         return NextResponse.json(
           { error: 'self_invite', message: 'You cannot invite yourself.' },
-          { status: 400 },
-        );
+          { status: 400 }
+        )
       }
 
-      const { friendship: friendshipRequest, state } = await createOrReusePendingFriendshipRequest({
-        inviterUserId: session.userId,
-        inviteeUserId: existingUser.id,
-        suggestedInterests,
-      });
+      const { friendship: friendshipRequest, state } =
+        await createOrReusePendingFriendshipRequest({
+          inviterUserId: session.userId,
+          inviteeUserId: existingUser.id,
+          suggestedInterests,
+        })
 
       return NextResponse.json({
         ok: true,
@@ -214,7 +344,7 @@ export async function POST(request: Request) {
           state,
           inviteeUserId: existingUser.id,
         },
-      });
+      })
     }
 
     const invitation = await createFriendInvitation({
@@ -222,16 +352,19 @@ export async function POST(request: Request) {
       inviteePhone: phone,
       inviteeDisplayName,
       preSeededInterests: suggestedInterests,
-    });
+    })
 
-    const inviteUrl = `${getBaseUrl(request)}/invite/${invitation.token}`;
-    const message = buildFriendInvitationMessage({ inviteUrl, suggestedInterests });
+    const inviteUrl = `${getBaseUrl(request)}/invite/${invitation.token}`
+    const message = buildFriendInvitationMessage({
+      inviteUrl,
+      suggestedInterests,
+    })
 
     if (invitation.personalMessage !== message) {
       await db
         .update(friendInvitations)
         .set({ personalMessage: message })
-        .where(eq(friendInvitations.id, invitation.id));
+        .where(eq(friendInvitations.id, invitation.id))
     }
 
     return NextResponse.json({
@@ -245,12 +378,12 @@ export async function POST(request: Request) {
       inviteePhone: invitation.inviteePhone,
       suggestedInterests,
       expiresAt: invitation.expiresAt.toISOString(),
-    });
+    })
   } catch (error) {
-    console.error('[friend-invitations] create failed', error);
+    console.error('[friend-invitations] create failed', error)
     return NextResponse.json(
       { error: 'server_error', message: 'Unable to create friend invitation.' },
-      { status: 500 },
-    );
+      { status: 500 }
+    )
   }
 }

--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,5 +1,6 @@
 import AddFriendInvite from '@/components/AddFriendInvite'
 import FeedList from '@/components/FeedList'
+import PeopleYouInvited from '@/components/PeopleYouInvited'
 
 export default function FeedPage() {
   return (
@@ -14,6 +15,7 @@ export default function FeedPage() {
       </header>
 
       <AddFriendInvite />
+      <PeopleYouInvited />
       <FeedList />
     </main>
   )

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { FormEvent, useRef, useState } from 'react'
+import { FormEvent, useEffect, useRef, useState } from 'react'
 
 const INTEREST_PLACEHOLDERS = [
   'Sondheim',
@@ -64,6 +64,36 @@ export default function AddFriendInvite() {
   const smsHref = result?.message
     ? buildSmsHref(result.inviteePhone, messageText)
     : null
+
+  useEffect(() => {
+    function prefillInvite(event: Event) {
+      const detail = (
+        event as CustomEvent<{
+          inviteeDisplayName?: string
+          phone?: string
+          suggestedInterests?: string[]
+        }>
+      ).detail
+
+      setExpanded(true)
+      setStep('identity')
+      setName(detail?.inviteeDisplayName ?? '')
+      setPhone(detail?.phone ?? '')
+      setInterests([
+        detail?.suggestedInterests?.[0] ?? '',
+        detail?.suggestedInterests?.[1] ?? '',
+        detail?.suggestedInterests?.[2] ?? '',
+      ])
+      setResult(null)
+      setMessageText('')
+      setError(null)
+      setCopyLabel('Copy message')
+    }
+
+    window.addEventListener('friend-invitations:create-new', prefillInvite)
+    return () =>
+      window.removeEventListener('friend-invitations:create-new', prefillInvite)
+  }, [])
 
   function resetFlow() {
     setExpanded(false)
@@ -143,6 +173,7 @@ export default function AddFriendInvite() {
       setResult(body)
       setMessageText(body.message ?? '')
       setStep('handoff')
+      window.dispatchEvent(new Event('friend-invitations:refresh'))
     } catch (caught) {
       setError(
         caught instanceof Error
@@ -319,7 +350,9 @@ export default function AddFriendInvite() {
         <div className="space-y-5">
           <div>
             <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-              {result.type === 'friendship_request' ? 'Friend request' : 'Invite ready'}
+              {result.type === 'friendship_request'
+                ? 'Friend request'
+                : 'Invite ready'}
             </p>
             <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
               {result.type === 'friendship_request'
@@ -362,8 +395,8 @@ export default function AddFriendInvite() {
 
               {!messageText.includes(result.inviteUrl ?? '') ? (
                 <p className="text-destructive text-sm">
-                  Generated message includes link — keep it in the message so they
-                  can join.
+                  Generated message includes link — keep it in the message so
+                  they can join.
                 </p>
               ) : null}
             </>
@@ -395,7 +428,11 @@ export default function AddFriendInvite() {
             ) : null}
             <button
               type="button"
-              className={result.type === 'friend_invitation' ? 'text-muted-foreground w-full py-2 text-sm' : 'btn-primary min-h-12 w-full rounded-full'}
+              className={
+                result.type === 'friend_invitation'
+                  ? 'text-muted-foreground w-full py-2 text-sm'
+                  : 'btn-primary min-h-12 w-full rounded-full'
+              }
               onClick={resetFlow}
             >
               Done

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -1,0 +1,310 @@
+'use client'
+
+import { useCallback, useEffect, useState } from 'react'
+
+type InviteStatus = 'pending' | 'accepted' | 'expired' | 'cancelled'
+
+type OutgoingInvite = {
+  id: string
+  inviteeDisplayName: string
+  inviteePhoneMasked: string
+  inviteePhoneForActions: string | null
+  suggestedInterests: string[]
+  status: InviteStatus
+  sentAt: string
+  acceptedAt: string | null
+  cancelledAt: string | null
+  expiresAt: string
+  message: string | null
+}
+
+type InvitationsResponse = {
+  ok: boolean
+  invitations: OutgoingInvite[]
+}
+
+const STATUS_COPY: Record<InviteStatus, string> = {
+  pending: 'Pending',
+  accepted: 'Accepted',
+  expired: 'Expired',
+  cancelled: 'Cancelled',
+}
+
+function buildSmsHref(phone: string, message: string) {
+  return `sms:${encodeURIComponent(phone)}?body=${encodeURIComponent(message)}`
+}
+
+function friendlyDate(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return null
+
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year:
+      date.getFullYear() === new Date().getFullYear() ? undefined : 'numeric',
+  }).format(date)
+}
+
+function statusDetail(invite: OutgoingInvite) {
+  if (invite.status === 'pending') {
+    const expires = friendlyDate(invite.expiresAt)
+    return expires ? `Expires ${expires}` : 'Invite is ready to send again.'
+  }
+
+  if (invite.status === 'accepted') {
+    const accepted = invite.acceptedAt ? friendlyDate(invite.acceptedAt) : null
+    return accepted ? `Accepted ${accepted}` : 'They joined Joshing.'
+  }
+
+  if (invite.status === 'expired') {
+    const expired = friendlyDate(invite.expiresAt)
+    return expired ? `Expired ${expired}` : 'This invite link expired.'
+  }
+
+  const cancelled = invite.cancelledAt ? friendlyDate(invite.cancelledAt) : null
+  return cancelled ? `Cancelled ${cancelled}` : 'This invite was cancelled.'
+}
+
+export default function PeopleYouInvited() {
+  const [invites, setInvites] = useState<OutgoingInvite[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [copyingId, setCopyingId] = useState<string | null>(null)
+  const [cancellingId, setCancellingId] = useState<string | null>(null)
+
+  const loadInvites = useCallback(async () => {
+    setError(null)
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        cache: 'no-store',
+        credentials: 'include',
+      })
+      const body = (await response.json().catch(() => null)) as
+        | InvitationsResponse
+        | { message?: string }
+        | null
+
+      if (!response.ok || !body || !('invitations' in body)) {
+        throw new Error(
+          body && 'message' in body && body.message
+            ? body.message
+            : 'Could not load invitations.'
+        )
+      }
+
+      setInvites(body.invitations)
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : 'Could not load invitations.'
+      )
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    queueMicrotask(() => void loadInvites())
+
+    function refresh() {
+      void loadInvites()
+    }
+
+    window.addEventListener('friend-invitations:refresh', refresh)
+    return () =>
+      window.removeEventListener('friend-invitations:refresh', refresh)
+  }, [loadInvites])
+
+  async function copyInvite(invite: OutgoingInvite) {
+    if (!invite.message) return
+
+    try {
+      await navigator.clipboard.writeText(invite.message)
+      setCopyingId(invite.id)
+      window.setTimeout(() => setCopyingId(null), 2000)
+    } catch {
+      if (navigator.share) await navigator.share({ text: invite.message })
+    }
+  }
+
+  async function cancelInvite(invite: OutgoingInvite) {
+    setCancellingId(invite.id)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ invitationId: invite.id }),
+      })
+      const body = (await response.json().catch(() => null)) as {
+        message?: string
+      } | null
+
+      if (!response.ok) {
+        throw new Error(body?.message ?? 'Could not cancel invite.')
+      }
+
+      await loadInvites()
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : 'Could not cancel invite.'
+      )
+    } finally {
+      setCancellingId(null)
+    }
+  }
+
+  function createNewInvite(invite: OutgoingInvite) {
+    window.dispatchEvent(
+      new CustomEvent('friend-invitations:create-new', {
+        detail: {
+          inviteeDisplayName: invite.inviteeDisplayName,
+          phone: invite.inviteePhoneForActions ?? '',
+          suggestedInterests: invite.suggestedInterests,
+        },
+      })
+    )
+    window.scrollTo({ top: 0, behavior: 'smooth' })
+  }
+
+  if (loading) {
+    return (
+      <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
+        <h2 className="font-serif text-xl font-semibold">People you invited</h2>
+        <p className="text-muted-foreground mt-2 text-sm">Loading invites…</p>
+      </section>
+    )
+  }
+
+  if (!loading && invites.length === 0 && !error) return null
+
+  return (
+    <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
+      <div className="mb-4 flex items-start justify-between gap-3">
+        <div>
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+            Invitations
+          </p>
+          <h2 className="mt-1 font-serif text-xl font-semibold">
+            People you invited
+          </h2>
+        </div>
+        <button
+          type="button"
+          className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
+          onClick={() => void loadInvites()}
+        >
+          Refresh
+        </button>
+      </div>
+
+      {error ? (
+        <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
+      ) : null}
+
+      <div className="space-y-3">
+        {invites.map((invite) => {
+          const canMessage =
+            invite.status === 'pending' &&
+            invite.message &&
+            invite.inviteePhoneForActions
+
+          return (
+            <article
+              key={invite.id}
+              className="bg-background rounded-xl border p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div>
+                  <h3 className="text-foreground font-medium">
+                    {invite.inviteeDisplayName}
+                  </h3>
+                  <p className="text-muted-foreground mt-1 text-sm">
+                    {invite.inviteePhoneMasked}
+                  </p>
+                </div>
+                <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
+                  {STATUS_COPY[invite.status]}
+                </span>
+              </div>
+
+              {invite.suggestedInterests.length > 0 ? (
+                <div className="mt-3 flex flex-wrap gap-2">
+                  {invite.suggestedInterests.map((interest) => (
+                    <span
+                      key={interest}
+                      className="bg-muted text-foreground rounded-full px-3 py-1 text-sm"
+                    >
+                      {interest}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
+                  No suggested interests on this invite.
+                </p>
+              )}
+
+              <p className="text-muted-foreground mt-3 text-sm">
+                {statusDetail(invite)}
+              </p>
+
+              {invite.status === 'accepted' ? (
+                <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
+                  They accepted your invitation and can now become part of your
+                  friend circle.
+                </p>
+              ) : null}
+
+              {invite.status === 'expired' ? (
+                <div className="mt-3">
+                  <button
+                    type="button"
+                    className="btn-ghost min-h-11 w-full rounded-full"
+                    onClick={() => createNewInvite(invite)}
+                  >
+                    Create new invite
+                  </button>
+                </div>
+              ) : null}
+
+              {canMessage ? (
+                <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                  <button
+                    type="button"
+                    className="btn-primary min-h-11 rounded-full sm:col-span-1"
+                    onClick={() => copyInvite(invite)}
+                  >
+                    {copyingId === invite.id ? 'Copied ✓' : 'Copy message'}
+                  </button>
+                  <a
+                    className="btn-ghost min-h-11 rounded-full sm:col-span-1"
+                    href={buildSmsHref(
+                      invite.inviteePhoneForActions!,
+                      invite.message!
+                    )}
+                  >
+                    Open Messages
+                  </a>
+                  <button
+                    type="button"
+                    className="text-muted-foreground min-h-11 rounded-full border px-4 text-sm font-medium"
+                    onClick={() => cancelInvite(invite)}
+                    disabled={cancellingId === invite.id}
+                  >
+                    {cancellingId === invite.id
+                      ? 'Cancelling…'
+                      : 'Cancel invite'}
+                  </button>
+                </div>
+              ) : null}
+            </article>
+          )
+        })}
+      </div>
+    </section>
+  )
+}

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -12,6 +12,17 @@ const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 14
 
 export type FriendInvitation = typeof friendInvitations.$inferSelect
 
+export type OutgoingFriendInvitationStatus =
+  | 'pending'
+  | 'accepted'
+  | 'expired'
+  | 'cancelled'
+
+export type OutgoingFriendInvitation = FriendInvitation & {
+  status: OutgoingFriendInvitationStatus
+  suggestedInterests: string[]
+}
+
 export type FriendInvitationLanding = {
   status: 'valid' | 'expired' | 'accepted' | 'invalid'
   inviterName: string
@@ -47,11 +58,11 @@ function displayInviterName(value: string | null | undefined) {
   return normalized ? normalized.slice(0, 80) : 'Someone'
 }
 
-function parseLandingInterests(value: unknown): { label: string }[] {
+export function parseInvitationInterests(value: unknown): string[] {
   if (!Array.isArray(value)) return []
 
   const seen = new Set<string>()
-  const interests: { label: string }[] = []
+  const interests: string[] = []
 
   for (const item of value) {
     const rawLabel =
@@ -68,11 +79,15 @@ function parseLandingInterests(value: unknown): { label: string }[] {
     if (seen.has(key)) continue
 
     seen.add(key)
-    interests.push({ label: label.slice(0, 80) })
+    interests.push(label.slice(0, 80))
     if (interests.length === 3) break
   }
 
   return interests
+}
+
+function parseLandingInterests(value: unknown): { label: string }[] {
+  return parseInvitationInterests(value).map((label) => ({ label }))
 }
 
 export async function getFriendInvitationLandingByToken(
@@ -235,6 +250,39 @@ export async function getPendingInvitationForPhone({
   return invitation ?? null
 }
 
+export function getOutgoingFriendInvitationStatus(
+  invitation: Pick<
+    FriendInvitation,
+    'acceptedAt' | 'cancelledAt' | 'expiresAt'
+  >,
+  now = new Date()
+): OutgoingFriendInvitationStatus {
+  if (invitation.cancelledAt) return 'cancelled'
+  if (invitation.acceptedAt) return 'accepted'
+  if (invitation.expiresAt <= now) return 'expired'
+  return 'pending'
+}
+
+export async function listOutgoingFriendInvitations({
+  inviterUserId,
+  now = new Date(),
+}: {
+  inviterUserId: string
+  now?: Date
+}): Promise<OutgoingFriendInvitation[]> {
+  const invitations = await db
+    .select()
+    .from(friendInvitations)
+    .where(eq(friendInvitations.inviterUserId, inviterUserId))
+    .orderBy(desc(friendInvitations.sentAt))
+
+  return invitations.map((invitation) => ({
+    ...invitation,
+    status: getOutgoingFriendInvitationStatus(invitation, now),
+    suggestedInterests: parseInvitationInterests(invitation.preSeededInterests),
+  }))
+}
+
 export async function cancelFriendInvitation({
   invitationId,
   inviterUserId,
@@ -252,7 +300,8 @@ export async function cancelFriendInvitation({
         eq(friendInvitations.id, invitationId),
         eq(friendInvitations.inviterUserId, inviterUserId),
         isNull(friendInvitations.acceptedAt),
-        isNull(friendInvitations.cancelledAt)
+        isNull(friendInvitations.cancelledAt),
+        gt(friendInvitations.expiresAt, now)
       )
     )
     .returning()


### PR DESCRIPTION
### Motivation

- Enable inviters to view and manage the invitations they created (pending/accepted/expired/cancelled) without introducing backend SMS sending or exposing raw tokens. 
- Reuse the same generated invite message template so inviters can copy/open Messages and regenerate invites consistently. 

### Description

- Add server-side support in `src/server/friends/invitations.ts` including `OutgoingFriendInvitation` types, `parseInvitationInterests`, `getOutgoingFriendInvitationStatus`, and `listOutgoingFriendInvitations`, and tighten `cancelFriendInvitation` to only cancel active, unexpired invites. 
- Extend the `POST /api/friend-invitations` route with new `GET` to list outgoing invitations and `DELETE` to cancel an outgoing invite, and add a safe serializer that returns a masked phone, optional messaging phone for client actions, and a generated `message` while avoiding exposing raw tokens (`src/app/api/friend-invitations/route.ts`). 
- Add a client UI component `PeopleYouInvited` that renders the “People you invited” section with status badges, masked phone, suggested-interest chips, friendly date text, actions to copy message and open Messages for pending invites, cancel pending invites, and a “Create new invite” handoff for expired invites (`src/components/PeopleYouInvited.tsx`). 
- Wire invite creation UI (`AddFriendInvite`) to emit/handle events so the outgoing list refreshes after create and expired rows can prefill the invite flow (`src/components/AddFriendInvite.tsx`), and insert the new section into the feed page (`src/app/feed/page.tsx`). 
- Update tests/mocks for the new server/API behavior (`src/app/api/friend-invitations/__tests__/route.test.ts`). 

### Testing

- Ran type check with `npx tsc --noEmit`, which completed successfully. 
- Ran ESLint against the changed files with `npx eslint ...` for the API/server/components, which completed for the touched files. 
- `npm run lint` (full repo) surfaced pre-existing lint errors outside this change and therefore failed. 
- `npm run build` failed in this environment because Next/Turbopack could not fetch the Google Font `Montserrat` (environment network/font fetch issue). 
- Attempted unit test run with `vitest` was blocked by an external registry `403 Forbidden` when fetching `vitest` and could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a049e78f9ac832ea5ec6660ae719d83)