### PR TITLE
Build friends relationship hub

### DIFF
--- a/src/app/api/friends/route.ts
+++ b/src/app/api/friends/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { getFriendsHub } from '@/server/db/queries/friends'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const hub = await getFriendsHub(session.userId)
+
+  return NextResponse.json({ ok: true, ...hub })
+}

--- a/src/app/friends/page.tsx
+++ b/src/app/friends/page.tsx
@@ -1,5 +1,5 @@
 import FriendsHubPage from '@/components/FriendsHubPage'
 
-export default function FeedPage() {
+export default function FriendsPage() {
   return <FriendsHubPage />
 }

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -1,0 +1,39 @@
+'use client'
+
+import AddFriendInvite from '@/components/AddFriendInvite'
+import FriendsList from '@/components/FriendsList'
+
+function openAddFriend() {
+  window.dispatchEvent(new CustomEvent('friend-invitations:create-new'))
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+export default function FriendsHubPage() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
+      <header className="mb-5 flex items-start justify-between gap-4 border-b pb-4">
+        <div>
+          <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
+            Joshing
+          </p>
+          <h1 className="text-foreground font-serif text-3xl font-semibold">
+            Friends
+          </h1>
+          <p className="text-muted-foreground mt-2 text-sm leading-6">
+            Invite your people, respond to requests, and keep your circle close.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn-primary min-h-11 shrink-0 rounded-full px-5"
+          onClick={openAddFriend}
+        >
+          Add friend
+        </button>
+      </header>
+
+      <AddFriendInvite />
+      <FriendsList />
+    </main>
+  )
+}

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -1,53 +1,261 @@
-'use client';
+'use client'
 
-import { useEffect, useState } from 'react';
+import Link from 'next/link'
+import PeopleYouInvited from '@/components/PeopleYouInvited'
+import { useCallback, useEffect, useState } from 'react'
 
 type Friend = {
-  id: string;
-  displayName: string;
-};
+  id: string
+  displayName: string
+  declaredInterests: string[]
+  sharedInterests: string[]
+}
+
+type IncomingRequest = {
+  id: string
+  requesterId: string
+  requesterName: string
+  suggestedInterests: string[]
+  createdAt: string
+}
+
+type FriendsHubResponse = {
+  ok: boolean
+  friends: Friend[]
+  incomingRequests: IncomingRequest[]
+}
+
+type RequestAction = 'accept' | 'ignore'
+
+function previewInterests(interests: string[]) {
+  if (interests.length === 0) return null
+  const visible = interests.slice(0, 3).join(', ')
+  const remainder = interests.length - 3
+  return remainder > 0 ? `${visible}, +${remainder} more` : visible
+}
+
+function openAddFriend() {
+  window.dispatchEvent(new CustomEvent('friend-invitations:create-new'))
+  window.scrollTo({ top: 0, behavior: 'smooth' })
+}
 
 export default function FriendsList() {
-  const [friends, setFriends] = useState<Friend[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [friends, setFriends] = useState<Friend[]>([])
+  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [pendingRequest, setPendingRequest] = useState<string | null>(null)
+
+  const loadFriends = useCallback(async () => {
+    setError(null)
+
+    try {
+      const response = await fetch('/api/friends', {
+        cache: 'no-store',
+        credentials: 'include',
+      })
+      const body = (await response.json().catch(() => null)) as
+        | FriendsHubResponse
+        | { message?: string }
+        | null
+
+      if (!response.ok || !body || !('friends' in body)) {
+        throw new Error(
+          body && 'message' in body && body.message
+            ? body.message
+            : 'Could not load friends.'
+        )
+      }
+
+      setFriends(body.friends)
+      setIncomingRequests(body.incomingRequests)
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not load friends.')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
 
   useEffect(() => {
-    fetch('/api/users', { cache: 'no-store', credentials: 'include' })
-      .then(async (response) => {
-        const body = await response.json().catch(() => null);
-        if (!response.ok || !Array.isArray(body)) {
-          throw new Error(body?.message ?? 'Could not load friends.');
-        }
-        setFriends(body);
-      })
-      .catch((caught) => {
-        setError(caught instanceof Error ? caught.message : 'Could not load friends.');
-      })
-      .finally(() => setLoading(false));
-  }, []);
+    queueMicrotask(() => void loadFriends())
+  }, [loadFriends])
 
-  if (loading) return <p className="text-sm text-muted-foreground">Loading friends...</p>;
-  if (error) return <p className="text-sm text-destructive">{error}</p>;
-  if (friends.length === 0) {
-    return (
-      <div className="rounded-lg border bg-card p-4 text-card-foreground">
-        <p className="text-sm text-muted-foreground">No friends yet.</p>
-      </div>
-    );
+  async function updateRequest(requestId: string, action: RequestAction) {
+    setPendingRequest(`${requestId}:${action}`)
+    setError(null)
+
+    try {
+      const response = await fetch(`/api/friend-requests/${requestId}/${action}`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      const body = (await response.json().catch(() => null)) as { message?: string } | null
+
+      if (!response.ok) {
+        throw new Error(body?.message ?? 'Could not update this request.')
+      }
+
+      await loadFriends()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not update this request.')
+    } finally {
+      setPendingRequest(null)
+    }
   }
 
+  const hasNoRelationships =
+    !loading && !error && friends.length === 0 && incomingRequests.length === 0
+
   return (
-    <div className="space-y-2">
-      {friends.map((friend) => (
-        <div key={friend.id} className="flex items-center justify-between rounded-lg border bg-card p-4 text-card-foreground">
-          <p className="font-medium">{friend.displayName}</p>
-          {/*
-            // v11.1: Joshing Game creation disabled at FAB level. Re-enable
-            // when game creation flow is restored.
-          */}
+    <div className="space-y-5">
+      {hasNoRelationships ? (
+        <section className="bg-card text-card-foreground rounded-2xl border p-5 text-center shadow-sm">
+          <h2 className="font-serif text-2xl font-semibold">
+            Joshing gets better when your people are here.
+          </h2>
+          <p className="text-muted-foreground mt-2 text-sm leading-6">
+            Invite someone you already trade facts, recommendations, and inside jokes with.
+          </p>
+          <button
+            type="button"
+            className="btn-primary mt-4 min-h-12 w-full rounded-full sm:w-auto sm:px-6"
+            onClick={openAddFriend}
+          >
+            Add friend
+          </button>
+        </section>
+      ) : null}
+
+      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+              Requests
+            </p>
+            <h2 className="mt-1 font-serif text-xl font-semibold">
+              Incoming friend requests
+            </h2>
+          </div>
+          <button
+            type="button"
+            className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
+            onClick={() => void loadFriends()}
+          >
+            Refresh
+          </button>
         </div>
-      ))}
+
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading requests…</p>
+        ) : incomingRequests.length > 0 ? (
+          <div className="space-y-3">
+            {incomingRequests.map((request) => (
+              <article key={request.id} className="bg-background rounded-xl border p-3">
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                  <div>
+                    <h3 className="text-foreground font-medium">{request.requesterName}</h3>
+                    {request.suggestedInterests.length > 0 ? (
+                      <div className="mt-3 flex flex-wrap gap-2">
+                        {request.suggestedInterests.map((interest) => (
+                          <span
+                            key={interest}
+                            className="bg-muted text-foreground rounded-full px-3 py-1 text-sm"
+                          >
+                            {interest}
+                          </span>
+                        ))}
+                      </div>
+                    ) : (
+                      <p className="text-muted-foreground mt-1 text-sm">
+                        No suggested interests yet — just a friendly hello.
+                      </p>
+                    )}
+                  </div>
+
+                  <div className="grid grid-cols-2 gap-2 sm:min-w-48">
+                    <button
+                      type="button"
+                      className="btn-primary min-h-11 rounded-full"
+                      disabled={Boolean(pendingRequest)}
+                      onClick={() => void updateRequest(request.id, 'accept')}
+                    >
+                      {pendingRequest === `${request.id}:accept` ? 'Accepting…' : 'Accept'}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-ghost min-h-11 rounded-full"
+                      disabled={Boolean(pendingRequest)}
+                      onClick={() => void updateRequest(request.id, 'ignore')}
+                    >
+                      {pendingRequest === `${request.id}:ignore` ? 'Ignoring…' : 'Ignore'}
+                    </button>
+                  </div>
+                </div>
+              </article>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground rounded-xl bg-muted px-3 py-2 text-sm">
+            No incoming requests right now.
+          </p>
+        )}
+      </section>
+
+      <PeopleYouInvited />
+
+      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <div className="mb-4">
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+            Friends
+          </p>
+          <h2 className="mt-1 font-serif text-xl font-semibold">Active friends</h2>
+        </div>
+
+        {error ? <p className="text-destructive mb-3 text-sm font-medium">{error}</p> : null}
+
+        {loading ? (
+          <p className="text-muted-foreground text-sm">Loading friends…</p>
+        ) : friends.length > 0 ? (
+          <div className="space-y-3">
+            {friends.map((friend) => {
+              const interests = previewInterests(friend.declaredInterests)
+              const sharedInterest = friend.sharedInterests[0]
+
+              return (
+                <Link
+                  key={friend.id}
+                  href={`/users/${friend.id}`}
+                  className="bg-background block rounded-xl border p-3 transition hover:border-foreground/30 hover:shadow-sm"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h3 className="text-foreground font-medium">{friend.displayName}</h3>
+                      {interests ? (
+                        <p className="text-muted-foreground mt-1 text-sm leading-6">
+                          Into {interests}
+                        </p>
+                      ) : (
+                        <p className="text-muted-foreground mt-1 text-sm leading-6">
+                          Interests will appear here as they declare them.
+                        </p>
+                      )}
+                    </div>
+                    {sharedInterest ? (
+                      <span className="bg-muted text-foreground shrink-0 rounded-full px-3 py-1 text-xs font-medium">
+                        Shared: {sharedInterest}
+                      </span>
+                    ) : null}
+                  </div>
+                </Link>
+              )
+            })}
+          </div>
+        ) : (
+          <div className="rounded-xl bg-muted px-3 py-2">
+            <p className="text-muted-foreground text-sm">No active friends yet.</p>
+          </div>
+        )}
+      </section>
     </div>
-  );
+  )
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -14,7 +14,7 @@ type MeResponse = {
 
 const navItems = [
   { href: '/', label: 'Home', Icon: Home },
-  { href: '/feed', label: 'Friends', Icon: Rss },
+  { href: '/friends', label: 'Friends', Icon: Rss },
   { href: '/questions', label: 'Questions', Icon: Pencil },
   { href: '/knowledge', label: 'Knowledge', Icon: Brain },
   { href: '/account', label: 'Account', Icon: User },

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -1,9 +1,45 @@
-import { and, asc, eq, inArray, or } from 'drizzle-orm';
+import { and, asc, eq, inArray, ne, or } from 'drizzle-orm';
 
-import { db, friendships, users } from '@/server/db';
+import { db, declaredInterests, friendships, users } from '@/server/db';
 
 export type User = typeof users.$inferSelect;
 export type Friendship = typeof friendships.$inferSelect;
+
+export type FriendHubFriend = {
+  id: string
+  displayName: string
+  declaredInterests: string[]
+  sharedInterests: string[]
+}
+
+export type IncomingFriendRequest = {
+  id: string
+  requesterId: string
+  requesterName: string
+  suggestedInterests: string[]
+  createdAt: Date
+}
+
+export type FriendsHub = {
+  friends: FriendHubFriend[]
+  incomingRequests: IncomingFriendRequest[]
+}
+
+function displayName(name: string | null, fallback: string): string {
+  return name?.trim() || fallback
+}
+
+function normalizeSuggestedInterests(value: unknown): string[] {
+  if (!value || typeof value !== 'object' || !('suggestedInterests' in value)) return []
+
+  const suggestedInterests = (value as { suggestedInterests?: unknown }).suggestedInterests
+  if (!Array.isArray(suggestedInterests)) return []
+
+  return suggestedInterests
+    .filter((interest): interest is string => typeof interest === 'string')
+    .map((interest) => interest.trim())
+    .filter(Boolean)
+}
 
 export async function getFriends(userId: string): Promise<User[]> {
   const rows = await db
@@ -23,6 +59,89 @@ export async function getFriends(userId: string): Promise<User[]> {
     .from(users)
     .where(inArray(users.id, friendIds))
     .orderBy(asc(users.displayName), asc(users.phoneNumber));
+}
+
+export async function getFriendsHub(userId: string): Promise<FriendsHub> {
+  const activeFriendships = await db
+    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
+    .from(friendships)
+    .where(and(
+      eq(friendships.status, 'active'),
+      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
+    ))
+
+  const friendIds = activeFriendships.map((friendship) => (
+    friendship.userAId === userId ? friendship.userBId : friendship.userAId
+  ))
+
+  const friendRows = friendIds.length === 0
+    ? []
+    : await db
+      .select({
+        id: users.id,
+        displayName: users.displayName,
+        phoneNumber: users.phoneNumber,
+      })
+      .from(users)
+      .where(inArray(users.id, friendIds))
+      .orderBy(asc(users.displayName), asc(users.phoneNumber))
+
+  const interestRows = friendIds.length === 0
+    ? []
+    : await db
+      .select({ userId: declaredInterests.userId, domain: declaredInterests.domain })
+      .from(declaredInterests)
+      .where(and(
+        eq(declaredInterests.isActive, true),
+        inArray(declaredInterests.userId, [userId, ...friendIds]),
+      ))
+      .orderBy(asc(declaredInterests.domain))
+
+  const interestsByUser = new Map<string, string[]>()
+  for (const row of interestRows) {
+    const current = interestsByUser.get(row.userId) ?? []
+    current.push(row.domain)
+    interestsByUser.set(row.userId, current)
+  }
+
+  const viewerInterests = new Set(interestsByUser.get(userId) ?? [])
+
+  const incomingRows = await db
+    .select({
+      id: friendships.id,
+      requesterId: users.id,
+      requesterDisplayName: users.displayName,
+      requesterPhoneNumber: users.phoneNumber,
+      requestContext: friendships.requestContext,
+      createdAt: friendships.createdAt,
+    })
+    .from(friendships)
+    .innerJoin(users, eq(users.id, friendships.requestedByUserId))
+    .where(and(
+      eq(friendships.status, 'pending'),
+      ne(friendships.requestedByUserId, userId),
+      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
+    ))
+    .orderBy(asc(friendships.createdAt))
+
+  return {
+    friends: friendRows.map((friend) => {
+      const friendInterests = interestsByUser.get(friend.id) ?? []
+      return {
+        id: friend.id,
+        displayName: displayName(friend.displayName, friend.phoneNumber),
+        declaredInterests: friendInterests,
+        sharedInterests: friendInterests.filter((interest) => viewerInterests.has(interest)),
+      }
+    }),
+    incomingRequests: incomingRows.map((request) => ({
+      id: request.id,
+      requesterId: request.requesterId,
+      requesterName: displayName(request.requesterDisplayName, request.requesterPhoneNumber),
+      suggestedInterests: normalizeSuggestedInterests(request.requestContext),
+      createdAt: request.createdAt,
+    })),
+  }
 }
 
 export async function getFriendship(userAId: string, userBId: string): Promise<Friendship | null> {


### PR DESCRIPTION
### Motivation

- Provide a dedicated Friends surface that functions as a relationship hub with Add Friend as the primary action.
- Surface incoming friend requests, pending invites, and active friends in one place and reuse existing invite flows and components.
- Fix an orphaned `FriendsList` by turning it into a usable relationship UI while keeping other global navigation intact.

### Description

- Add a server API and richer query for the hub by introducing `GET /api/friends` backed by `getFriendsHub` in `src/server/db/queries/friends.ts` which returns active friends, declared interests, shared-interest indicators, and incoming requests.
- Implement a reusable Friends hub UI in `src/components/FriendsHubPage.tsx` and a route at `src/app/friends/page.tsx`, and make `/feed` render the same hub for compatibility (`src/app/feed/page.tsx`).
- Expand `src/components/FriendsList.tsx` into the relationship surface to render the header/empty state, incoming requests (Accept / Ignore with action calls), pending invites via `PeopleYouInvited`, and active friend cards linking to profiles.
- Update navigation to point the Friends nav item to `/friends` and wire the existing `AddFriendInvite` / `PeopleYouInvited` components into the new hub (`src/components/Nav.tsx`, `src/components/AddFriendInvite.tsx`, `src/components/PeopleYouInvited.tsx`).

### Testing

- Ran targeted lint checks with `npx eslint` against the changed files and iterated until the introduced code passed the targeted rules (fixed a `useEffect` sync setState lint by deferring load with `queueMicrotask`).
- Ran type checking with `npx tsc --noEmit` which completed successfully for the modified files.
- Ran the project-wide `npm run lint` which surfaced pre-existing unrelated lint errors elsewhere in the repo; those issues were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a07c1710832e9cd0b5441647224b)