### PR TITLE
Add social ask empty state for missing domains

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -129,8 +129,17 @@ function DailySetupContent() {
 
         const requestedDomain = searchParams.get('domain')?.trim();
         const requestedCustom = searchParams.get('domainMode') === 'custom' && requestedDomain;
+        const availableDomains = body.domains ?? [];
+        if (
+          requestedCustom &&
+          !availableDomains.some((domain) => domain.domain.toLocaleLowerCase('en-US') === requestedDomain.toLocaleLowerCase('en-US'))
+        ) {
+          router.replace(`/knowledge?emptyDomain=${encodeURIComponent(requestedDomain)}`);
+          return;
+        }
+
         setHasUnstartedQueue(Boolean(status.queue_id));
-        setDomains(body.domains ?? []);
+        setDomains(availableDomains);
         setDifficulty(body.preferences?.difficulty ?? 'adaptive');
         setDomainMode(requestedCustom ? 'custom' : body.preferences?.domainMode ?? 'random');
         setSelectedDomains(new Set(requestedCustom ? [requestedDomain] : body.preferences?.selectedDomains ?? []));
@@ -209,6 +218,11 @@ function DailySetupContent() {
       });
       const queueBody = await queueResponse.json().catch(() => null);
       if (!queueResponse.ok) {
+        if (domainMode === 'custom' && selectedDomains.size > 0) {
+          const [domain] = Array.from(selectedDomains);
+          router.push(`/knowledge?emptyDomain=${encodeURIComponent(domain)}`);
+          return;
+        }
         throw new Error(queueBody?.message ?? 'Could not build your round.');
       }
 

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -9,6 +9,7 @@ import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
+import { AskFriendForDomain } from '@/components/knowledge/AskFriendForDomain';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import type { MasteryTier } from '@/types/db';
@@ -133,6 +134,8 @@ function KnowledgePageContent() {
   const highlightedDomainSlug = searchParams.get('domain');
   const tierCrossed = searchParams.get('tier_crossed');
   const manageInterestsParam = searchParams.get('interests');
+  const emptyDomainParam = searchParams.get('emptyDomain')?.trim() || searchParams.get('askDomain')?.trim() || '';
+  const emptyQuestionDomain = emptyDomainParam || null;
 
   const [data, setData] = useState<KnowledgeResponse | null>(null);
   const [loading, setLoading] = useState(true);
@@ -154,6 +157,7 @@ function KnowledgePageContent() {
   const [sendQuestionOpen, setSendQuestionOpen] = useState(false);
   const [writeQuestionOpen, setWriteQuestionOpen] = useState(false);
   const [questionToast, setQuestionToast] = useState<string | null>(null);
+  const [askFriendDomain, setAskFriendDomain] = useState<string | null>(null);
 
   const loadKnowledge = async () => {
     const response = await fetch('/api/knowledge', { cache: 'no-store', credentials: 'include' });
@@ -453,6 +457,23 @@ function KnowledgePageContent() {
         </section>
       )}
 
+
+      {emptyQuestionDomain ? (
+        <section style={emptyQuestionStateStyle} aria-label={`No ${emptyQuestionDomain} questions yet`}>
+          <p style={knowledgeEyebrowStyle}>No matching public questions</p>
+          <h2 style={emptyQuestionHeadingStyle}>We don’t have {emptyQuestionDomain} questions yet. Want to ask someone who might?</h2>
+          <p style={growMapBodyStyle}>Josh is going deep on {emptyQuestionDomain} — and thinks someone in your world might be the one to stump them.</p>
+          <div style={growMapActionsStyle}>
+            <button type="button" style={growMapPrimaryBtnStyle} onClick={() => setAskFriendDomain(emptyQuestionDomain)}>
+              Ask a friend
+            </button>
+            <button type="button" style={growMapSecondaryBtnStyle} onClick={() => setWriteQuestionOpen(true)}>
+              Write one myself
+            </button>
+          </div>
+        </section>
+      ) : null}
+
       <section style={growMapSectionStyle}>
         <h2 style={growMapHeadingStyle}>Grow your map</h2>
         <p style={growMapBodyStyle}>Your map grows in two directions.</p>
@@ -501,6 +522,10 @@ function KnowledgePageContent() {
       {shareModalOpen && (
         <SharePortraitModal entries={portraitEntries} playerDisplayName={displayName} onClose={() => setShareModalOpen(false)} />
       )}
+
+      {askFriendDomain ? (
+        <AskFriendForDomain key={askFriendDomain} domain={askFriendDomain} onClose={() => setAskFriendDomain(null)} />
+      ) : null}
 
       {interestModal ? (
         <div style={{ ...modalOverlayStyle, zIndex: 55 }}>
@@ -582,7 +607,7 @@ function KnowledgePageContent() {
             <div style={modalHeaderStyle}>
               <div>
                 <h2 style={modalTitleStyle}>Tidy up your map?</h2>
-                <p style={modalCopyStyle}>We'll look for domains in your map that could be combined. This is automatic and based on what you've answered.</p>
+                <p style={modalCopyStyle}>We&apos;ll look for domains in your map that could be combined. This is automatic and based on what you&apos;ve answered.</p>
               </div>
               <button type="button" style={iconButtonStyle} onClick={() => setTidyConfirmOpen(false)} aria-label="Close" disabled={tidying}>
                 <X className="size-4" />
@@ -1032,6 +1057,21 @@ const modalPrimaryStyle: CSSProperties = {
   color: '#f5f0e8',
   padding: '0 16px',
   cursor: 'pointer',
+};
+
+const emptyQuestionStateStyle: CSSProperties = {
+  background: '#fff7e8',
+  border: '1px solid #d9b56c',
+  padding: '1.25rem 0.95rem',
+};
+
+const emptyQuestionHeadingStyle: CSSProperties = {
+  margin: '0.4rem 0 0',
+  fontSize: '1.25rem',
+  lineHeight: 1.35,
+  color: '#1a1208',
+  fontFamily: 'var(--font-literata), serif',
+  fontWeight: 600,
 };
 
 const growMapSectionStyle: CSSProperties = {

--- a/src/components/knowledge/AskFriendForDomain.tsx
+++ b/src/components/knowledge/AskFriendForDomain.tsx
@@ -1,0 +1,411 @@
+'use client'
+
+import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import { X } from 'lucide-react'
+
+type FriendOption = {
+  id: string
+  displayName: string
+  declaredInterests?: string[]
+}
+
+type InviteResult = {
+  ok: true
+  type?: 'friend_invitation' | 'friendship_request'
+  state?: string
+  inviteUrl?: string | null
+  message?: string | null
+  inviteeDisplayName: string
+  inviteePhone: string
+  suggestedInterests: string[]
+}
+
+type ErrorResponse = { error?: string; message?: string }
+
+type Props = {
+  domain: string
+  onClose: () => void
+}
+
+function normalizeInterestList(values: string[]) {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  for (const value of values) {
+    const normalized = value.trim().replace(/\s+/g, ' ')
+    if (!normalized) continue
+    const key = normalized.toLocaleLowerCase('en-US')
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push(normalized)
+    if (result.length === 3) break
+  }
+
+  return result
+}
+
+function looksLikeUsPhone(phone: string) {
+  const digits = phone.replace(/\D/g, '')
+  return (
+    digits.length === 10 || (digits.length === 11 && digits.startsWith('1'))
+  )
+}
+
+function buildDomainAskMessage(domain: string, inviteUrl?: string | null) {
+  const base = `Josh is going deep on ${domain} — and thinks you might be the one to stump them.`
+  const ask = `If you have a good ${domain} question, send one their way in Joshing.`
+  return inviteUrl ? `${base} ${ask} ${inviteUrl}` : `${base} ${ask}`
+}
+
+function buildSmsHref(phone: string, message: string) {
+  return `sms:${encodeURIComponent(phone)}?body=${encodeURIComponent(message)}`
+}
+
+export function AskFriendForDomain({ domain, onClose }: Props) {
+  const [friends, setFriends] = useState<FriendOption[]>([])
+  const [loadingFriends, setLoadingFriends] = useState(true)
+  const [mode, setMode] = useState<'friend' | 'new'>('friend')
+  const [selectedFriend, setSelectedFriend] = useState<FriendOption | null>(
+    null
+  )
+  const [name, setName] = useState('')
+  const [phone, setPhone] = useState('')
+  const [interests, setInterests] = useState([domain, '', ''])
+  const [result, setResult] = useState<InviteResult | null>(null)
+  const [handoffMessage, setHandoffMessage] = useState('')
+  const [copyLabel, setCopyLabel] = useState('Copy message')
+  const [error, setError] = useState<string | null>(null)
+  const [submitting, setSubmitting] = useState(false)
+  const messageRef = useRef<HTMLTextAreaElement | null>(null)
+
+  useEffect(() => {
+    let active = true
+    fetch('/api/friends', { cache: 'no-store', credentials: 'include' })
+      .then(async (response) => {
+        const body = (await response.json().catch(() => null)) as {
+          friends?: FriendOption[]
+          message?: string
+        } | null
+        if (!response.ok || !body?.friends)
+          throw new Error(body?.message ?? 'Could not load friends.')
+        if (active) {
+          setFriends(body.friends)
+          if (body.friends.length === 0) setMode('new')
+        }
+      })
+      .catch((caught) => {
+        if (active) {
+          setError(
+            caught instanceof Error ? caught.message : 'Could not load friends.'
+          )
+          setMode('new')
+        }
+      })
+      .finally(() => {
+        if (active) setLoadingFriends(false)
+      })
+
+    return () => {
+      active = false
+    }
+  }, [])
+
+  const normalizedInterests = useMemo(
+    () => normalizeInterestList(interests),
+    [interests]
+  )
+  const smsHref =
+    result?.inviteePhone && handoffMessage
+      ? buildSmsHref(result.inviteePhone, handoffMessage)
+      : null
+
+  function chooseFriend(friend: FriendOption) {
+    setSelectedFriend(friend)
+    setHandoffMessage(buildDomainAskMessage(domain))
+    setResult(null)
+    setError(null)
+  }
+
+  function updateInterest(index: number, value: string) {
+    if (index === 0) return
+    setInterests((current) =>
+      current.map((interest, i) => (i === index ? value : interest))
+    )
+  }
+
+  async function createInvite(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    const trimmedName = name.trim()
+    if (!trimmedName) {
+      setError('Name is required.')
+      return
+    }
+    if (!looksLikeUsPhone(phone)) {
+      setError('US phone number required.')
+      return
+    }
+
+    setSubmitting(true)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          inviteeDisplayName: trimmedName,
+          phone,
+          suggestedInterests: normalizedInterests,
+        }),
+      })
+      const body = (await response.json().catch(() => null)) as
+        | InviteResult
+        | ErrorResponse
+        | null
+      if (!response.ok || !body || !('ok' in body)) {
+        throw new Error(body?.message ?? 'Could not create that ask.')
+      }
+
+      setResult(body)
+      setHandoffMessage(buildDomainAskMessage(domain, body.inviteUrl))
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : 'Could not create that ask.'
+      )
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  async function copyMessage() {
+    if (!handoffMessage) return
+    try {
+      await navigator.clipboard.writeText(handoffMessage)
+      setCopyLabel('Copied ✓')
+      window.setTimeout(() => setCopyLabel('Copy message'), 1800)
+    } catch {
+      messageRef.current?.focus()
+      messageRef.current?.select()
+      setCopyLabel('Select text')
+    }
+  }
+
+  const showingHandoff = Boolean(selectedFriend || result)
+  const handoffName =
+    selectedFriend?.displayName ?? result?.inviteeDisplayName ?? 'your friend'
+
+  return (
+    <div
+      className="fixed inset-0 z-[70] flex items-end bg-black/35 p-0 sm:items-center sm:justify-center sm:p-4"
+      role="dialog"
+      aria-modal="true"
+    >
+      <button
+        type="button"
+        className="absolute inset-0 cursor-default"
+        aria-label="Close"
+        onClick={onClose}
+      />
+      <section className="bg-background relative max-h-[92dvh] w-full overflow-y-auto rounded-t-2xl border p-5 shadow-xl sm:max-w-xl sm:rounded-2xl">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
+              Ask someone
+            </p>
+            <h2 className="mt-2 font-serif text-3xl font-semibold">
+              Ask a friend about {domain}
+            </h2>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              Suggested interests start with {domain}. Add up to two more if
+              they fit; they can keep, edit, or ignore them.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="inline-flex size-10 items-center justify-center rounded-md border"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        {showingHandoff ? (
+          <div className="mt-6 space-y-4">
+            <div className="bg-card rounded-xl border p-4">
+              <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
+                For {handoffName}
+              </p>
+              <p className="text-muted-foreground mt-2 text-sm leading-6">
+                This is a lightweight ask — no pressure, no forced interest, and
+                no empty round.
+              </p>
+              <label className="mt-4 block text-sm font-medium">
+                Message
+                <textarea
+                  ref={messageRef}
+                  className="bg-background focus:border-foreground mt-2 min-h-32 w-full rounded-xl border p-3 text-sm leading-6 outline-none"
+                  value={handoffMessage}
+                  onChange={(event) => setHandoffMessage(event.target.value)}
+                />
+              </label>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row">
+              <button
+                type="button"
+                className="btn-primary min-h-12 flex-1 rounded-full"
+                onClick={() => void copyMessage()}
+              >
+                {copyLabel}
+              </button>
+              {smsHref ? (
+                <a
+                  className="btn-ghost min-h-12 flex-1 rounded-full"
+                  href={smsHref}
+                >
+                  Open Messages
+                </a>
+              ) : null}
+              <button
+                type="button"
+                className="text-muted-foreground min-h-12 px-4 text-sm"
+                onClick={onClose}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        ) : (
+          <>
+            <div className="bg-card mt-6 grid rounded-full border p-1 text-sm font-medium">
+              <div className="grid grid-cols-2">
+                <button
+                  type="button"
+                  className={`min-h-11 rounded-full transition ${mode === 'friend' ? 'bg-foreground text-background' : 'text-muted-foreground'}`}
+                  onClick={() => setMode('friend')}
+                  disabled={friends.length === 0 && !loadingFriends}
+                >
+                  Existing friend
+                </button>
+                <button
+                  type="button"
+                  className={`min-h-11 rounded-full transition ${mode === 'new' ? 'bg-foreground text-background' : 'text-muted-foreground'}`}
+                  onClick={() => setMode('new')}
+                >
+                  New friend
+                </button>
+              </div>
+            </div>
+
+            {mode === 'friend' ? (
+              <div className="mt-5 rounded-xl border">
+                {loadingFriends ? (
+                  <p className="text-muted-foreground p-4 text-sm">
+                    Loading friends…
+                  </p>
+                ) : friends.length === 0 ? (
+                  <p className="text-muted-foreground p-4 text-sm">
+                    No active friends yet. Enter a name and phone instead.
+                  </p>
+                ) : (
+                  friends.map((friend) => (
+                    <button
+                      key={friend.id}
+                      type="button"
+                      className="hover:bg-muted/60 block w-full border-b px-4 py-3 text-left last:border-b-0"
+                      onClick={() => chooseFriend(friend)}
+                    >
+                      <span className="font-medium">{friend.displayName}</span>
+                      {friend.declaredInterests?.length ? (
+                        <span className="text-muted-foreground mt-1 block text-xs">
+                          Into {friend.declaredInterests.slice(0, 3).join(', ')}
+                        </span>
+                      ) : null}
+                    </button>
+                  ))
+                )}
+              </div>
+            ) : (
+              <form className="mt-5 space-y-4" onSubmit={createInvite}>
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <label className="block text-sm font-medium">
+                    Name
+                    <input
+                      className="bg-background focus:border-foreground mt-2 h-12 w-full rounded-xl border px-3 text-base outline-none"
+                      value={name}
+                      onChange={(event) => setName(event.target.value)}
+                      placeholder="Their name"
+                      autoComplete="name"
+                    />
+                  </label>
+                  <label className="block text-sm font-medium">
+                    Phone number
+                    <input
+                      className="bg-background focus:border-foreground mt-2 h-12 w-full rounded-xl border px-3 text-base outline-none"
+                      value={phone}
+                      onChange={(event) => setPhone(event.target.value)}
+                      placeholder="(555) 123-4567"
+                      autoComplete="tel"
+                      inputMode="tel"
+                    />
+                  </label>
+                </div>
+
+                <div className="bg-card space-y-3 rounded-xl border p-4">
+                  <p className="text-sm font-medium">Suggested interests</p>
+                  {interests.map((interest, index) => (
+                    <label
+                      key={index}
+                      className="text-muted-foreground block text-xs font-medium tracking-[0.08em] uppercase"
+                    >
+                      {index === 0
+                        ? 'Prefilled from your search'
+                        : `Optional interest ${index + 1}`}
+                      <input
+                        className="bg-background text-foreground focus:border-foreground disabled:bg-muted mt-2 h-11 w-full rounded-lg border px-3 text-sm tracking-normal normal-case outline-none"
+                        value={interest}
+                        disabled={index === 0}
+                        onChange={(event) =>
+                          updateInterest(index, event.target.value)
+                        }
+                        placeholder={
+                          index === 1
+                            ? 'Another thing they know'
+                            : 'One more, if useful'
+                        }
+                      />
+                    </label>
+                  ))}
+                </div>
+
+                {error ? (
+                  <p className="text-destructive text-sm font-medium">
+                    {error}
+                  </p>
+                ) : null}
+
+                <div className="flex items-center gap-3">
+                  <button
+                    type="submit"
+                    className="btn-primary min-h-12 flex-1 rounded-full"
+                    disabled={submitting}
+                  >
+                    {submitting ? 'Creating ask…' : 'Create ask'}
+                  </button>
+                  <button
+                    type="button"
+                    className="text-muted-foreground px-3 text-sm"
+                    onClick={onClose}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              </form>
+            )}
+          </>
+        )}
+      </section>
+    </div>
+  )
+}


### PR DESCRIPTION
### Motivation
- When a user requests questions in a domain and there are no matching public questions, the UI should avoid AI-generated filler and surface a social flow to ask someone who might know. 
- Provide a clear empty state on the Knowledge page that makes it easy to invite or ask a friend with the searched domain prefilled as an interest. 
- Route failed/invalid custom Daily requests back to the Knowledge empty state to avoid creating an empty personal round.

### Description
- Added a new client component `AskFriendForDomain` at `src/components/knowledge/AskFriendForDomain.tsx` that loads existing friends, supports selecting an existing friend or entering a new friend name/phone, pre-fills the searched domain as the first suggested interest, and allows up to two additional interests; it uses the existing `/api/friend-invitations` and friendship request paths for creation. 
- Integrated an empty-state card into `src/app/knowledge/page.tsx` that is shown when the query param `emptyDomain` / `askDomain` is present, with copy: "We don’t have [Domain] questions yet. Want to ask someone who might?", a primary action `Ask a friend` (opens `AskFriendForDomain`) and secondary action `Write one myself` (opens the normal question creation flow). 
- Updated `src/app/daily/setup/page.tsx` to detect requested custom domains that are not present in the user’s available domains and redirect to the Knowledge empty state (`/knowledge?emptyDomain=...`), and to similarly redirect when custom queue creation fails for a missing domain, preventing empty/no-question personal rounds.

### Testing
- Ran TypeScript build checks with `npx tsc --noEmit --project tsconfig.json`, which completed successfully. 
- Ran ESLint on the new component with `npx eslint src/components/knowledge/AskFriendForDomain.tsx`, which completed successfully. 
- Formatted touched files with `prettier` during the rollout; no runtime tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a2019c4c832eb4c6be2b4d998a37)