### PR TITLE
Add lightweight telemetry for Add Friend flow

### DIFF
--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -11,6 +11,7 @@ import {
   type OutgoingFriendInvitation,
 } from '@/server/friends/invitations'
 import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
+import { logTelemetry } from '@/server/telemetry'
 
 export const dynamic = 'force-dynamic'
 
@@ -326,6 +327,14 @@ export async function POST(request: Request) {
           suggestedInterests,
         })
 
+      logTelemetry('friend_request_existing_user_created', {
+        inviter_user_id: session.userId,
+        invitee_user_id: existingUser.id,
+        friendship_id: friendshipRequest.id,
+        state,
+        suggested_interest_count: suggestedInterests.length,
+      })
+
       return NextResponse.json({
         ok: true,
         type: 'friendship_request',
@@ -358,6 +367,12 @@ export async function POST(request: Request) {
     const message = buildFriendInvitationMessage({
       inviteUrl,
       suggestedInterests,
+    })
+
+    logTelemetry('add_friend_invite_created', {
+      inviter_user_id: session.userId,
+      invitation_id: invitation.id,
+      suggested_interest_count: suggestedInterests.length,
     })
 
     if (invitation.personalMessage !== message) {

--- a/src/app/api/friend-requests/[friendshipId]/accept/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/accept/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 
 import { getSession } from '@/server/auth/session'
+import { logTelemetry } from '@/server/telemetry'
 import { acceptPendingFriendshipRequest } from '@/server/friends/friendships'
 
 export const dynamic = 'force-dynamic'
@@ -24,6 +25,11 @@ export async function POST(
       { status: 404 }
     )
   }
+
+  logTelemetry('friend_request_accepted', {
+    friendship_id: friendship.id,
+    user_id: session.userId,
+  })
 
   return NextResponse.json({ ok: true, friendship: { id: friendship.id, status: friendship.status } })
 }

--- a/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
 
 import { getSession } from '@/server/auth/session'
+import { logTelemetry } from '@/server/telemetry'
 import { ignorePendingFriendshipRequest } from '@/server/friends/friendships'
 
 export const dynamic = 'force-dynamic'
@@ -24,6 +25,11 @@ export async function POST(
       { status: 404 }
     )
   }
+
+  logTelemetry('friend_request_ignored', {
+    friendship_id: friendship.id,
+    user_id: session.userId,
+  })
 
   return NextResponse.json({ ok: true, friendship: { id: friendship.id, status: friendship.status } })
 }

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
+import { logTelemetry } from '@/server/telemetry';
 import {
   type DeclaredInterestInput,
   markOnboardingComplete,
@@ -9,6 +10,7 @@ import {
 
 type SaveInterestsBody = {
   interests?: unknown;
+  telemetry?: unknown;
 };
 
 function parseInterest(value: unknown): DeclaredInterestInput | null {
@@ -24,6 +26,24 @@ function parseInterest(value: unknown): DeclaredInterestInput | null {
       ? record.broadCategory.trim().slice(0, 80)
       : null,
   };
+}
+
+function parseOnboardingTelemetry(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { inviteInterestCount: 0, inviteSelectedCount: 0 };
+  }
+
+  const record = value as Record<string, unknown>;
+  const inviteInterestCount =
+    typeof record.inviteInterestCount === 'number' && Number.isFinite(record.inviteInterestCount)
+      ? Math.max(0, Math.min(5, Math.trunc(record.inviteInterestCount)))
+      : 0;
+  const inviteSelectedCount =
+    typeof record.inviteSelectedCount === 'number' && Number.isFinite(record.inviteSelectedCount)
+      ? Math.max(0, Math.min(inviteInterestCount, Math.trunc(record.inviteSelectedCount)))
+      : 0;
+
+  return { inviteInterestCount, inviteSelectedCount };
 }
 
 function parseInterests(value: unknown): DeclaredInterestInput[] | null {
@@ -43,6 +63,7 @@ export async function POST(request: Request) {
 
   const body = (await request.json().catch(() => null)) as SaveInterestsBody | null;
   const interests = parseInterests(body?.interests);
+  const telemetry = parseOnboardingTelemetry(body?.telemetry);
 
   if (!interests) {
     return NextResponse.json(
@@ -54,6 +75,21 @@ export async function POST(request: Request) {
   try {
     await saveDeclaredInterests(session.userId, interests);
     await markOnboardingComplete(session.userId);
+
+    if (telemetry.inviteInterestCount > 0) {
+      const event = telemetry.inviteSelectedCount === 0
+        ? 'friend_onboarding_interests_skipped'
+        : telemetry.inviteSelectedCount >= telemetry.inviteInterestCount
+          ? 'friend_onboarding_interests_accepted_all'
+          : 'friend_onboarding_interests_partial';
+
+      logTelemetry(event, {
+        user_id: session.userId,
+        invite_interest_count: telemetry.inviteInterestCount,
+        invite_interest_selected_count: telemetry.inviteSelectedCount,
+        saved_interest_count: interests.length,
+      });
+    }
 
     return NextResponse.json({ ok: true });
   } catch (error) {

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { logTelemetry, type TelemetryEventName } from '@/server/telemetry'
+
+export const dynamic = 'force-dynamic'
+
+const CLIENT_TELEMETRY_EVENTS = new Set<TelemetryEventName>([
+  'add_friend_started',
+  'add_friend_message_copied',
+  'add_friend_sms_handoff_opened',
+  'friend_invite_auth_started',
+])
+
+type TelemetryBody = {
+  event?: unknown
+  metadata?: unknown
+}
+
+function parseMetadata(value: unknown) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
+
+  const metadata: Record<string, string | number | boolean | null> = {}
+  for (const [key, rawValue] of Object.entries(value)) {
+    if (!/^[a-zA-Z0-9_]{1,40}$/.test(key)) continue
+    if (
+      typeof rawValue === 'string' ||
+      typeof rawValue === 'number' ||
+      typeof rawValue === 'boolean' ||
+      rawValue === null
+    ) {
+      metadata[key] = rawValue
+    }
+  }
+
+  return metadata
+}
+
+export async function POST(request: Request) {
+  const body = (await request.json().catch(() => null)) as TelemetryBody | null
+  const event = typeof body?.event === 'string' ? body.event : ''
+
+  if (!CLIENT_TELEMETRY_EVENTS.has(event as TelemetryEventName)) {
+    return NextResponse.json(
+      { error: 'invalid_event', message: 'Unsupported telemetry event.' },
+      { status: 400 }
+    )
+  }
+
+  const session = await getSession()
+  logTelemetry(event as TelemetryEventName, {
+    ...parseMetadata(body?.metadata),
+    user_id: session?.userId ?? null,
+  })
+
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -6,6 +6,16 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 const US_E164_REGEX = /^\+1\d{10}$/;
 
+function sendTelemetry(event: string) {
+  void fetch('/api/telemetry', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ event }),
+    keepalive: true,
+  }).catch(() => undefined);
+}
+
 function normalizePhone(phone: string): string {
   const digits = phone.replace(/\D/g, '');
   if (digits.length === 10) return `+1${digits}`;
@@ -34,6 +44,8 @@ export default function LoginPanel() {
       setError('Use a US phone number.');
       return;
     }
+
+    if (invitationToken) sendTelemetry('friend_invite_auth_started');
 
     setLoading(true);
     try {

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -376,6 +376,13 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
       })
       .slice(0, 5);
 
+    const inviteSelectedCount = inviteInterests.filter((interest) => {
+      const selected = toSelected(interest);
+      return selected
+        ? cleanSelected.some((item) => selectedKey(item) === selectedKey(selected))
+        : false;
+    }).length;
+
     if (cleanSelected.length === 0) {
       setError('Pick at least 1 to continue.');
       return;
@@ -388,7 +395,13 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
       const response = await fetch('/api/onboarding/save-interests', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ interests: cleanSelected }),
+        body: JSON.stringify({
+          interests: cleanSelected,
+          telemetry: {
+            inviteInterestCount: inviteInterests.length,
+            inviteSelectedCount,
+          },
+        }),
       });
       const data = await response.json().catch(() => ({}));
 

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -20,6 +20,7 @@ type InviteResult = {
   ok: boolean
   type: 'friend_invitation' | 'friendship_request'
   id: string
+  invitationId?: string | null
   inviteUrl: string | null
   message: string | null
   inviteeDisplayName: string
@@ -38,6 +39,16 @@ function normalizeInterestList(interests: string[]) {
 
 function buildSmsHref(phone: string, message: string) {
   return `sms:${encodeURIComponent(phone)}?body=${encodeURIComponent(message)}`
+}
+
+function sendTelemetry(event: string, metadata: Record<string, unknown> = {}) {
+  void fetch('/api/telemetry', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ event, metadata }),
+    keepalive: true,
+  }).catch(() => undefined)
 }
 
 function looksLikeUsMobileNumber(phone: string) {
@@ -75,6 +86,7 @@ export default function AddFriendInvite() {
         }>
       ).detail
 
+      sendTelemetry('add_friend_started', { source: 'custom_event' })
       setExpanded(true)
       setStep('identity')
       setName(detail?.inviteeDisplayName ?? '')
@@ -191,10 +203,19 @@ export default function AddFriendInvite() {
     try {
       await navigator.clipboard.writeText(messageText)
       setCopyLabel('Copied ✓')
+      sendTelemetry('add_friend_message_copied', {
+        invitation_id: result?.invitationId ?? result?.id ?? null,
+        suggested_interest_count: result?.suggestedInterests.length ?? 0,
+      })
       window.setTimeout(() => setCopyLabel('Copy message'), 2000)
     } catch {
       if (navigator.share) {
         await navigator.share({ text: messageText })
+        sendTelemetry('add_friend_message_copied', {
+          invitation_id: result?.invitationId ?? result?.id ?? null,
+          suggested_interest_count: result?.suggestedInterests.length ?? 0,
+          fallback: 'share',
+        })
         return
       }
       messageRef.current?.focus()
@@ -215,7 +236,10 @@ export default function AddFriendInvite() {
         <button
           type="button"
           className="btn-primary mt-4 min-h-12 w-full rounded-full"
-          onClick={() => setExpanded(true)}
+          onClick={() => {
+            sendTelemetry('add_friend_started', { source: 'inline_card' })
+            setExpanded(true)
+          }}
         >
           Add friend
         </button>
@@ -420,6 +444,12 @@ export default function AddFriendInvite() {
                   <a
                     className="btn-ghost min-h-12 w-full rounded-full"
                     href={smsHref}
+                    onClick={() =>
+                      sendTelemetry('add_friend_sms_handoff_opened', {
+                        invitation_id: result.invitationId ?? result.id,
+                        suggested_interest_count: result.suggestedInterests.length,
+                      })
+                    }
                   >
                     Open Messages
                   </a>

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -4,6 +4,7 @@ import { and, desc, eq, gt, isNull, or } from 'drizzle-orm'
 
 import { db, friendInvitations, users } from '@/server/db'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
+import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
 
 export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
   'This invitation could not be accepted.'
@@ -113,6 +114,10 @@ export async function getFriendInvitationLandingByToken(
     .limit(1)
 
   if (!row || row.cancelledAt) {
+    logTelemetry('friend_invite_link_opened', {
+      status: 'invalid',
+      invite_hash: hashTelemetryValue(normalizedToken),
+    })
     return { status: 'invalid', inviterName: 'Someone', suggestedInterests: [] }
   }
 
@@ -120,12 +125,28 @@ export async function getFriendInvitationLandingByToken(
   const suggestedInterests = parseLandingInterests(row.preSeededInterests)
 
   if (row.acceptedAt) {
+    logTelemetry('friend_invite_link_opened', {
+      status: 'accepted',
+      invite_hash: hashTelemetryValue(normalizedToken),
+      suggested_interest_count: 0,
+    })
     return { status: 'accepted', inviterName, suggestedInterests: [] }
   }
 
   if (row.expiresAt <= now) {
+    logTelemetry('friend_invite_link_opened', {
+      status: 'expired',
+      invite_hash: hashTelemetryValue(normalizedToken),
+      suggested_interest_count: 0,
+    })
     return { status: 'expired', inviterName, suggestedInterests: [] }
   }
+
+  logTelemetry('friend_invite_link_opened', {
+    status: 'valid',
+    invite_hash: hashTelemetryValue(normalizedToken),
+    suggested_interest_count: suggestedInterests.length,
+  })
 
   return { status: 'valid', inviterName, suggestedInterests }
 }
@@ -375,6 +396,11 @@ export async function acceptFriendInvitation({
   }
 
   if (invitation.inviteePhone !== verifiedPhone) {
+    logTelemetry('friend_invite_phone_mismatch_rejected', {
+      invitation_id: invitation.id,
+      inviter_user_id: invitation.inviterUserId,
+      invitee_user_id: inviteeUserId,
+    })
     return { accepted: false, reason: 'phone_mismatch' }
   }
 
@@ -411,6 +437,13 @@ export async function acceptFriendInvitation({
   if (!claimedInvitation) {
     return { accepted: false, reason: 'claim_failed' }
   }
+
+  logTelemetry('friend_invite_accepted', {
+    invitation_id: invitation.id,
+    inviter_user_id: invitation.inviterUserId,
+    invitee_user_id: inviteeUserId,
+    suggested_interest_count: parseInvitationInterests(invitation.preSeededInterests).length,
+  })
 
   return { accepted: true }
 }

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -1,0 +1,45 @@
+import { createHash } from 'crypto'
+
+export type TelemetryEventName =
+  | 'add_friend_started'
+  | 'add_friend_invite_created'
+  | 'add_friend_message_copied'
+  | 'add_friend_sms_handoff_opened'
+  | 'friend_invite_link_opened'
+  | 'friend_invite_auth_started'
+  | 'friend_invite_accepted'
+  | 'friend_invite_phone_mismatch_rejected'
+  | 'friend_onboarding_interests_accepted_all'
+  | 'friend_onboarding_interests_partial'
+  | 'friend_onboarding_interests_skipped'
+  | 'friend_request_existing_user_created'
+  | 'friend_request_accepted'
+  | 'friend_request_ignored'
+
+type TelemetryValue = string | number | boolean | null | undefined
+export type TelemetryMetadata = Record<string, TelemetryValue>
+
+const SENSITIVE_KEY_PATTERN = /phone|token|message|interest(s)?$/i
+
+export function hashTelemetryValue(value: string): string {
+  return createHash('sha256').update(value).digest('hex').slice(0, 16)
+}
+
+function sanitizeMetadata(metadata: TelemetryMetadata): TelemetryMetadata {
+  return Object.fromEntries(
+    Object.entries(metadata).filter(([key, value]) => {
+      if (value === undefined) return false
+      return !SENSITIVE_KEY_PATTERN.test(key)
+    })
+  )
+}
+
+export function logTelemetry(
+  event: TelemetryEventName,
+  metadata: TelemetryMetadata = {}
+): void {
+  console.info(`[telemetry] ${event}`, {
+    event,
+    ...sanitizeMetadata(metadata),
+  })
+}


### PR DESCRIPTION
### Motivation
- Provide lightweight, internal instrumentation to measure the friend-invite/friend-request funnel without turning the product into a metrics surface. 
- Capture core signals (create, handoff, copy, link open, auth, accept/reject, onboarding outcomes, request accept/ignore) while avoiding PII or raw tokens. 
- Follow existing telemetry patterns and keep telemetry off the user-facing UI.

### Description
- Add a small server telemetry helper with an allowlisted event type union, metadata sanitization (drops sensitive keys), and a `hashTelemetryValue` helper for invite tokens in `src/server/telemetry.ts`.
- Add a client telemetry endpoint `POST /api/telemetry` that only accepts a whitelisted subset of client events and sanitizes metadata before logging in `src/app/api/telemetry/route.ts`.
- Instrument client Add Friend UI (`src/components/AddFriendInvite.tsx`) to send `add_friend_started`, `add_friend_message_copied`, and `add_friend_sms_handoff_opened` events (no raw phone/token/message/interest labels sent; only IDs and counts). 
- Instrument Login flow (`src/app/login/LoginPanel.tsx`) to emit `friend_invite_auth_started` when an invite token is present, and instrument server routes and helpers to log server-side events: `add_friend_invite_created`, `friend_request_existing_user_created`, `friend_invite_link_opened`, `friend_invite_phone_mismatch_rejected`, `friend_invite_accepted`, `friend_request_accepted`, and `friend_request_ignored` (IDs, counts, and hashed invite identifier used instead of raw token) in `src/app/api/friend-invitations/route.ts`, `src/server/friends/invitations.ts`, and friend-request routes.
- Add onboarding outcome telemetry for invite-sourced interests that logs only counts and outcome buckets (`friend_onboarding_interests_accepted_all|partial|skipped`) in `src/app/onboarding/OnboardingFlow.tsx` and `src/app/api/onboarding/save-interests/route.ts`.
- Ensure sensitive fields (phone, token, message, interest labels) are not included in telemetry and that only bounded/count metadata or hashed identifiers are logged.

### Testing
- Ran TypeScript check: `npx tsc --noEmit --pretty false` — succeeded.
- Ran ESLint on the changed/targeted files: `npx eslint` for the modified telemetry and friend-invite files — succeeded for the instrumented files.
- Ran project lint (`npm run lint`) which fails due to pre-existing, unrelated lint issues elsewhere in the repo (these failures were not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ae612880832e9bbf3e670747f945)