### PR TITLE
Refine Add Friend invitation warmth and safety

### DIFF
--- a/src/app/activities/FriendRequestActions.tsx
+++ b/src/app/activities/FriendRequestActions.tsx
@@ -5,7 +5,11 @@ import { useState } from 'react'
 
 type Action = 'accept' | 'ignore'
 
-export function FriendRequestActions({ friendshipId }: { friendshipId: string }) {
+export function FriendRequestActions({
+  friendshipId,
+}: {
+  friendshipId: string
+}) {
   const router = useRouter()
   const [pendingAction, setPendingAction] = useState<Action | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -17,12 +21,15 @@ export function FriendRequestActions({ friendshipId }: { friendshipId: string })
     setError(null)
 
     try {
-      const response = await fetch(`/api/friend-requests/${friendshipId}/${action}`, {
-        method: 'POST',
-      })
+      const response = await fetch(
+        `/api/friend-requests/${friendshipId}/${action}`,
+        {
+          method: 'POST',
+        }
+      )
 
       if (!response.ok) {
-        setError('Could not update this request.')
+        setError('Could not update this note.')
         return
       }
 
@@ -41,7 +48,7 @@ export function FriendRequestActions({ friendshipId }: { friendshipId: string })
           disabled={Boolean(pendingAction)}
           onClick={() => void submit('accept')}
         >
-          {pendingAction === 'accept' ? 'Accepting…' : 'Accept'}
+          {pendingAction === 'accept' ? 'Joining…' : 'Accept'}
         </button>
         <button
           type="button"
@@ -49,10 +56,12 @@ export function FriendRequestActions({ friendshipId }: { friendshipId: string })
           disabled={Boolean(pendingAction)}
           onClick={() => void submit('ignore')}
         >
-          {pendingAction === 'ignore' ? 'Ignoring…' : 'Ignore'}
+          {pendingAction === 'ignore' ? 'Setting aside…' : 'Not now'}
         </button>
       </div>
-      {error ? <p className="max-w-40 text-right text-xs text-destructive">{error}</p> : null}
+      {error ? (
+        <p className="text-destructive max-w-40 text-right text-xs">{error}</p>
+      ) : null}
     </div>
   )
 }

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,209 +1,286 @@
-import Link from 'next/link';
-import { redirect } from 'next/navigation';
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
 
-import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton';
-import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
-import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead';
-import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
-import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer';
-import { getSession } from '@/server/auth/session';
-import { getActivitiesForUser, type ActivityItemView } from '@/server/db/queries/activity';
+import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton'
+import { FriendRequestActions } from '@/app/activities/FriendRequestActions'
+import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead'
+import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton'
+import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer'
+import { getSession } from '@/server/auth/session'
+import {
+  getActivitiesForUser,
+  type ActivityItemView,
+} from '@/server/db/queries/activity'
 
 function formatActivityTime(value: Date) {
-  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(value);
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(value)
 }
 
 function actorName(item: ActivityItemView) {
-  return item.actor?.displayName ?? 'Someone';
+  return item.actor?.displayName ?? 'Someone'
 }
 
 function isUnread(item: ActivityItemView) {
-  if (item.type === 'reaction_received') return !item.reference.reaction?.repliedAt;
-  return !item.read;
+  if (item.type === 'reaction_received')
+    return !item.reference.reaction?.repliedAt
+  return !item.read
 }
 
 function ActivityCopy({ item }: { item: ActivityItemView }) {
-  const game = item.reference.game;
-  const title = game?.title ?? 'a Joshing Game';
-  const masteryEvent = item.reference.masteryEvent;
+  const game = item.reference.game
+  const title = game?.title ?? 'a Joshing Game'
+  const masteryEvent = item.reference.masteryEvent
 
   if (item.type === 'received_joshing_game') {
     if (game?.viewerStatus === 'complete') {
       return (
         <>
-          {actorName(item)} sent you {title} <span className="text-muted-foreground">· You got {game.viewerScore}/{game.totalQuestions}</span>
+          {actorName(item)} sent you {title}{' '}
+          <span className="text-muted-foreground">
+            · You got {game.viewerScore}/{game.totalQuestions}
+          </span>
         </>
-      );
+      )
     }
 
-    return <>{actorName(item)} sent you a Joshing Game: {title}</>;
+    return (
+      <>
+        {actorName(item)} sent you a Joshing Game: {title}
+      </>
+    )
   }
 
   if (item.type === 'joshing_game_progress') {
-    return <>{actorName(item)} played {title} <span className="text-muted-foreground">· {game?.completedCount ?? 0} of {game?.totalRecipients ?? 0} have played</span></>;
+    return (
+      <>
+        {actorName(item)} played {title}{' '}
+        <span className="text-muted-foreground">
+          · {game?.completedCount ?? 0} of {game?.totalRecipients ?? 0} have
+          played
+        </span>
+      </>
+    )
   }
 
   if (item.type === 'joshing_game_result') {
-    return <>Everyone played {title}</>;
+    return <>Everyone played {title}</>
   }
 
   if (item.type === 'friend_mastery') {
-    return <>{actorName(item)} reached {masteryEvent?.tier ?? 'a new tier'} in {masteryEvent?.domain ?? 'a domain'}</>;
+    return (
+      <>
+        {actorName(item)} reached {masteryEvent?.tier ?? 'a new tier'} in{' '}
+        {masteryEvent?.domain ?? 'a domain'}
+      </>
+    )
   }
 
   if (item.type === 'ceremony_ready') {
-    return <>Your two-week reflection is ready</>;
+    return <>Your two-week reflection is ready</>
   }
 
   if (item.type === 'friend_request') {
-    return <>{actorName(item)} wants to add you on Joshing.</>;
+    return <>{actorName(item)} thought of you for Joshing.</>
   }
 
   if (item.type === 'friend_request_accepted') {
-    return <>You and {actorName(item)} are now friends</>;
+    return <>You and {actorName(item)} are now friends</>
   }
 
   if (item.type === 'reaction_received') {
-    return <>{actorName(item)} reacted to your question</>;
+    return <>{actorName(item)} reacted to your question</>
   }
 
   if (item.type === 'received_direct_question') {
-    return <>{actorName(item)} sent you a question</>;
+    return <>{actorName(item)} sent you a question</>
   }
 
   if (item.type === 'question_curated') {
-    return <>{actorName(item)} saved your question</>;
+    return <>{actorName(item)} saved your question</>
   }
 
   if (item.type === 'creator_note_received') {
-    return <>{actorName(item)} sent you a note about a question you missed</>;
+    return <>{actorName(item)} sent you a note about a question you missed</>
   }
 
   if (item.type === 'authored_question_shared') {
-    const shared = item.reference.authoredSharedQuestion;
-    const count = shared?.recipientCount ?? 0;
-    const friendWord = count === 1 ? 'friend' : 'friends';
-    const domain = shared?.domain ?? 'a domain';
-    return <>You shared a question with {count} {friendWord} — {domain}</>;
+    const shared = item.reference.authoredSharedQuestion
+    const count = shared?.recipientCount ?? 0
+    const friendWord = count === 1 ? 'friend' : 'friends'
+    const domain = shared?.domain ?? 'a domain'
+    return (
+      <>
+        You shared a question with {count} {friendWord} — {domain}
+      </>
+    )
   }
 
   if (item.type === 'friend_answered_your_question') {
-    const faq = item.reference.friendAnsweredQuestion;
-    const domain = faq?.domain;
-    const domainText = domain ? ` ${domain}` : '';
-    return faq?.result === 'correct'
-      ? <>{actorName(item)} got your{domainText} question right</>
-      : <>{actorName(item)} answered your{domainText} question — couldn&apos;t get it</>;
+    const faq = item.reference.friendAnsweredQuestion
+    const domain = faq?.domain
+    const domainText = domain ? ` ${domain}` : ''
+    return faq?.result === 'correct' ? (
+      <>
+        {actorName(item)} got your{domainText} question right
+      </>
+    ) : (
+      <>
+        {actorName(item)} answered your{domainText} question — couldn&apos;t get
+        it
+      </>
+    )
   }
 
   if (item.type === 'declared_promoted') {
-    const dp = item.reference.declaredPromoted;
-    const domain = dp?.domain;
-    return domain
-      ? <>{actorName(item)} answered your {domain} question — that domain is now proven territory on your map</>
-      : <>{actorName(item)} answered your question — a domain is now proven territory on your map</>;
+    const dp = item.reference.declaredPromoted
+    const domain = dp?.domain
+    return domain ? (
+      <>
+        {actorName(item)} answered your {domain} question — that domain is now
+        proven territory on your map
+      </>
+    ) : (
+      <>
+        {actorName(item)} answered your question — a domain is now proven
+        territory on your map
+      </>
+    )
   }
 
-  return <>Something happened on Joshing</>;
+  return <>Something happened on Joshing</>
 }
 
 export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
   if (item.type === 'creator_note_received') {
-    const note = item.reference.creatorNote;
-    if (!note) return null;
+    const note = item.reference.creatorNote
+    if (!note) return null
     return (
       <CreatorNoteReadButton noteId={note.id}>
-        <div className="rounded-md border bg-background p-3 text-sm leading-6">
-          <p><span className="font-medium text-foreground">Question:</span> {note.questionText}</p>
-          <p className="mt-1 text-muted-foreground">
-            <span className="font-medium text-foreground">Answer:</span> {note.correctAnswer}
+        <div className="bg-background rounded-md border p-3 text-sm leading-6">
+          <p>
+            <span className="text-foreground font-medium">Question:</span>{' '}
+            {note.questionText}
           </p>
-          <p className="mt-1 text-muted-foreground">
-            <span className="font-medium text-foreground">You said:</span>{' '}
+          <p className="text-muted-foreground mt-1">
+            <span className="text-foreground font-medium">Answer:</span>{' '}
+            {note.correctAnswer}
+          </p>
+          <p className="text-muted-foreground mt-1">
+            <span className="text-foreground font-medium">You said:</span>{' '}
             {creatorNoteSubmittedAnswerText(note.submittedAnswer, 'Your')}
           </p>
-          <blockquote className="mt-3 border-l-4 border-primary/40 bg-muted/50 px-3 py-2 text-foreground">
+          <blockquote className="border-primary/40 bg-muted/50 text-foreground mt-3 border-l-4 px-3 py-2">
             {note.noteText}
           </blockquote>
         </div>
       </CreatorNoteReadButton>
-    );
+    )
   }
 
   if (item.type === 'received_direct_question') {
-    const directQuestion = item.reference.directQuestion;
-    if (!directQuestion) return null;
+    const directQuestion = item.reference.directQuestion
+    if (!directQuestion) return null
 
     return (
-      <div className="mt-1 space-y-1 text-sm text-muted-foreground">
+      <div className="text-muted-foreground mt-1 space-y-1 text-sm">
         {directQuestion.personalMessage ? (
-          <p className="italic">&ldquo;{directQuestion.personalMessage}&rdquo;</p>
+          <p className="italic">
+            &ldquo;{directQuestion.personalMessage}&rdquo;
+          </p>
         ) : null}
         <p className="line-clamp-2">{directQuestion.questionText}</p>
       </div>
-    );
+    )
   }
 
   if (item.type === 'question_curated') {
-    const curatedQuestion = item.reference.curatedQuestion;
-    if (!curatedQuestion) return null;
-    return <p className="mt-1 line-clamp-2 text-sm text-muted-foreground">{curatedQuestion.questionText}</p>;
+    const curatedQuestion = item.reference.curatedQuestion
+    if (!curatedQuestion) return null
+    return (
+      <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
+        {curatedQuestion.questionText}
+      </p>
+    )
   }
 
   if (item.type === 'friend_request') {
-    const interests = item.reference.friendshipRequest?.suggestedInterests ?? [];
-    if (interests.length === 0) return null;
+    const interests = item.reference.friendshipRequest?.suggestedInterests ?? []
+    if (interests.length === 0) return null
 
-    const label = interests.length === 1
-      ? interests[0]
-      : interests.length === 2
-        ? `${interests[0]} and ${interests[1]}`
-        : `${interests[0]}, ${interests[1]}, and ${interests[2]}`;
+    const label =
+      interests.length === 1
+        ? interests[0]
+        : interests.length === 2
+          ? `${interests[0]} and ${interests[1]}`
+          : `${interests[0]}, ${interests[1]}, and ${interests[2]}`
 
     return (
-      <p className="mt-1 text-sm text-muted-foreground">
-        They thought you might like questions about {label}.
+      <p className="text-muted-foreground mt-1 text-sm">
+        They left a few ideas: {label}. Keep, edit, or ignore them.
       </p>
-    );
+    )
   }
 
-  if (item.type !== 'reaction_received') return null;
-  const reaction = item.reference.reaction;
-  if (!reaction) return null;
+  if (item.type !== 'reaction_received') return null
+  const reaction = item.reference.reaction
+  if (!reaction) return null
 
   return (
-    <div className="mt-1 space-y-1 text-sm text-muted-foreground">
+    <div className="text-muted-foreground mt-1 space-y-1 text-sm">
       <p>
-        {reaction.reactionEmoji ? `${reaction.reactionEmoji} ` : ''}{reaction.reactionLabel}
+        {reaction.reactionEmoji ? `${reaction.reactionEmoji} ` : ''}
+        {reaction.reactionLabel}
         {reaction.customMessage ? ` - ${reaction.customMessage}` : ''}
       </p>
       <p className="line-clamp-2 italic">{reaction.questionText}</p>
     </div>
-  );
+  )
 }
 
 function ActivityCta({ item }: { item: ActivityItemView }) {
-  if (!item.referenceId) return null;
+  if (!item.referenceId) return null
 
   if (item.type === 'received_joshing_game') {
-    const complete = item.reference.game?.viewerStatus === 'complete';
+    const complete = item.reference.game?.viewerStatus === 'complete'
     return (
-      <Link href={complete ? `/games/${item.referenceId}/summary` : `/games/${item.referenceId}`} className="btn-primary">
+      <Link
+        href={
+          complete
+            ? `/games/${item.referenceId}/summary`
+            : `/games/${item.referenceId}`
+        }
+        className="btn-primary"
+      >
         {complete ? 'See results' : 'Play'}
       </Link>
-    );
+    )
   }
 
   if (item.type === 'joshing_game_progress') {
-    return <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">See so far</Link>;
+    return (
+      <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">
+        See so far
+      </Link>
+    )
   }
 
   if (item.type === 'joshing_game_result') {
-    return <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">See results</Link>;
+    return (
+      <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">
+        See results
+      </Link>
+    )
   }
 
   if (item.type === 'ceremony_ready') {
-    return <Link href={`/ceremony/${item.referenceId}`} className="btn-primary">See it now</Link>;
+    return (
+      <Link href={`/ceremony/${item.referenceId}`} className="btn-primary">
+        See it now
+      </Link>
+    )
   }
 
   if (item.type === 'reaction_received') {
@@ -212,52 +289,70 @@ function ActivityCta({ item }: { item: ActivityItemView }) {
         reactionId={item.reference.reaction?.id ?? item.referenceId}
         replied={Boolean(item.reference.reaction?.repliedAt)}
       />
-    );
+    )
   }
 
   if (item.type === 'received_direct_question') {
-    return <Link href="/feed" className="btn-primary">Answer</Link>;
+    return (
+      <Link href="/feed" className="btn-primary">
+        Answer
+      </Link>
+    )
   }
 
   if (item.type === 'friend_request') {
-    const request = item.reference.friendshipRequest;
-    if (!request || request.status !== 'pending' || request.requestedByUserId === item.userId) {
-      return null;
+    const request = item.reference.friendshipRequest
+    if (
+      !request ||
+      request.status !== 'pending' ||
+      request.requestedByUserId === item.userId
+    ) {
+      return null
     }
 
-    return <FriendRequestActions friendshipId={request.id} />;
+    return <FriendRequestActions friendshipId={request.id} />
   }
 
   if (item.type === 'authored_question_shared') {
-    return null;
+    return null
   }
 
   if (item.type === 'declared_promoted') {
-    const domain = item.reference.declaredPromoted?.domain;
-    const href = domain ? `/knowledge/${encodeURIComponent(domain)}` : '/knowledge';
-    return <Link href={href} className="btn-primary">See your map</Link>;
+    const domain = item.reference.declaredPromoted?.domain
+    const href = domain
+      ? `/knowledge/${encodeURIComponent(domain)}`
+      : '/knowledge'
+    return (
+      <Link href={href} className="btn-primary">
+        See your map
+      </Link>
+    )
   }
 
-  return null;
+  return null
 }
 
 export default async function ActivitiesPage() {
-  const session = await getSession();
-  if (!session) redirect('/login');
+  const session = await getSession()
+  if (!session) redirect('/login')
 
-  const items = await getActivitiesForUser(session.userId);
+  const items = await getActivitiesForUser(session.userId)
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
       <MarkActivitiesRead />
       <header className="mb-5 border-b pb-4">
-        <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Activities</p>
-        <h1 className="font-serif text-2xl font-semibold text-foreground">What happened lately</h1>
+        <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
+          Notes
+        </p>
+        <h1 className="text-foreground font-serif text-2xl font-semibold">
+          Recent notes
+        </h1>
       </header>
 
       {items.length === 0 ? (
         <section className="flex flex-1 items-center justify-center py-16 text-center">
-          <p className="max-w-sm text-sm text-muted-foreground">
+          <p className="text-muted-foreground max-w-sm text-sm">
             Nothing here yet. Play some questions and send a Joshing Game.
           </p>
         </section>
@@ -266,9 +361,16 @@ export default async function ActivitiesPage() {
           {items.map((item) => (
             <article
               key={item.id}
+              id={
+                item.type === 'friend_request'
+                  ? `friendship-${item.referenceId}`
+                  : undefined
+              }
               className={[
-                'rounded-lg border bg-card p-4 text-card-foreground transition',
-                isUnread(item) ? 'border-l-[3px] border-l-primary' : 'border-l-transparent opacity-75',
+                'bg-card text-card-foreground rounded-lg border p-4 transition',
+                isUnread(item)
+                  ? 'border-l-primary border-l-[3px]'
+                  : 'border-l-transparent opacity-75',
               ].join(' ')}
             >
               <div className="flex items-start justify-between gap-4">
@@ -277,7 +379,9 @@ export default async function ActivitiesPage() {
                     <ActivityCopy item={item} />
                   </p>
                   <ActivitySubcopy item={item} />
-                  <p className="mt-1 text-xs text-muted-foreground">{formatActivityTime(item.createdAt)}</p>
+                  <p className="text-muted-foreground mt-1 text-xs">
+                    {formatActivityTime(item.createdAt)}
+                  </p>
                 </div>
                 <ActivityCta item={item} />
               </div>
@@ -286,5 +390,5 @@ export default async function ActivitiesPage() {
         </section>
       )}
     </main>
-  );
+  )
 }

--- a/src/app/api/friend-invitations/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/__tests__/route.test.ts
@@ -110,6 +110,7 @@ import {
   POST,
   buildFriendInvitationMessage,
   validateCreateFriendInvitationBody,
+  resetFriendInvitationRateLimitForTests,
 } from '@/app/api/friend-invitations/route'
 import { sendSms } from '@/server/sms'
 
@@ -138,6 +139,7 @@ function mockInvitation(overrides: Record<string, unknown> = {}) {
 describe('POST /api/friend-invitations', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    resetFriendInvitationRateLimitForTests()
     getSessionMock.mockResolvedValue({ userId: 'user-inviter' })
     state.existingUser = null
     state.existingFriendship = null
@@ -166,7 +168,7 @@ describe('POST /api/friend-invitations', () => {
         id: 'inv-1',
         inviteUrl: 'https://joshing.example/invite/token-1',
         message:
-          'Hey — come play Joshing with me. No app to download — just tap this: https://joshing.example/invite/token-1',
+          'Hey — I thought you’d like this corner of Joshing. No app to download — just tap this: https://joshing.example/invite/token-1',
         inviteeDisplayName: 'Sara',
         inviteePhone: '+17345551234',
         suggestedInterests: [],
@@ -194,7 +196,7 @@ describe('POST /api/friend-invitations', () => {
       })
     )
     expect(body.message).toBe(
-      'Hey — come play Joshing with me. I added something I think you might like: Sondheim. No app to download — just tap this: https://joshing.example/invite/token-1'
+      'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Sondheim. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1'
     )
   })
 
@@ -218,7 +220,7 @@ describe('POST /api/friend-invitations', () => {
       })
     )
     expect(body.message).toBe(
-      'Hey — come play Joshing with me. I added a couple areas I think you might like: Sondheim and Mrs. Dalloway. No app to download — just tap this: https://joshing.example/invite/token-1'
+      'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Sondheim and Mrs. Dalloway. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1'
     )
   })
 
@@ -251,7 +253,7 @@ describe('POST /api/friend-invitations', () => {
       })
     )
     expect(body.message).toBe(
-      'Hey — come play Joshing with me. I added a few areas I think you might like: Sondheim, Mrs. Dalloway, and 1980s Saturday morning cartoons. No app to download — just tap this: https://joshing.example/invite/token-1'
+      'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Sondheim, Mrs. Dalloway, and 1980s Saturday morning cartoons. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1'
     )
   })
 
@@ -293,7 +295,9 @@ describe('POST /api/friend-invitations', () => {
         type: 'friendship_request',
         state: 'created',
         invitationId: null,
-        inviteUrl: null,
+        inviteUrl: 'https://joshing.example/activities#friendship-friendship-1',
+        message:
+          'Hey — I thought you’d like this corner of Joshing. I added a few areas I think overlap with your world — Poetry. Keep, edit, or ignore them. Tap this when you have a minute: https://joshing.example/activities#friendship-friendship-1',
         suggestedInterests: ['Poetry'],
       })
     )
@@ -431,26 +435,30 @@ describe('POST /api/friend-invitations', () => {
 })
 
 describe('friend invitation validation and message QA contract', () => {
+  beforeEach(() => {
+    resetFriendInvitationRateLimitForTests()
+  })
+
   it.each([
     {
       interests: [],
       expected:
-        'Hey — come play Joshing with me. No app to download — just tap this: https://joshing.example/invite/token-1',
+        'Hey — I thought you’d like this corner of Joshing. No app to download — just tap this: https://joshing.example/invite/token-1',
     },
     {
       interests: ['Jazz'],
       expected:
-        'Hey — come play Joshing with me. I added something I think you might like: Jazz. No app to download — just tap this: https://joshing.example/invite/token-1',
+        'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Jazz. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1',
     },
     {
       interests: ['Jazz', 'Poetry'],
       expected:
-        'Hey — come play Joshing with me. I added a couple areas I think you might like: Jazz and Poetry. No app to download — just tap this: https://joshing.example/invite/token-1',
+        'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Jazz and Poetry. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1',
     },
     {
       interests: ['Jazz', 'Poetry', 'Film'],
       expected:
-        'Hey — come play Joshing with me. I added a few areas I think you might like: Jazz, Poetry, and Film. No app to download — just tap this: https://joshing.example/invite/token-1',
+        'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Jazz, Poetry, and Film. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1',
     },
   ])(
     'formats copy for $interests.length suggested interests without leaderboard or score language',

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -15,9 +15,132 @@ import { logTelemetry } from '@/server/telemetry'
 
 export const dynamic = 'force-dynamic'
 
-const MAX_INVITEE_DISPLAY_NAME_LENGTH = 80
+const MAX_INVITEE_DISPLAY_NAME_LENGTH = 60
 const MAX_SUGGESTED_INTERESTS = 3
-const MAX_SUGGESTED_INTEREST_LENGTH = 80
+const MAX_SUGGESTED_INTEREST_LENGTH = 60
+const INVITES_PER_USER_WINDOW = 12
+const INVITES_PER_PHONE_WINDOW = 4
+const INVITE_WINDOW_MS = 1000 * 60 * 60
+const SAME_PHONE_COOLDOWN_MS = 1000 * 60 * 10
+const CANCELLED_PHONE_COOLDOWN_MS = 1000 * 60 * 20
+const IGNORED_PHONE_COOLDOWN_MS = 1000 * 60 * 60 * 24
+
+const inviteAttemptsByUser = new Map<string, number[]>()
+const inviteAttemptsByPhone = new Map<string, number[]>()
+const recentInviteByUserPhone = new Map<string, number>()
+const cancelledInviteCooldowns = new Map<string, number>()
+const ignoredRequestCooldowns = new Map<string, number>()
+
+const ABUSIVE_WORDS = ['fuck', 'shit', 'bitch', 'cunt', 'slur']
+const SPAMMY_PATTERN = /(https?:\/\/|www\.|<[^>]+>|script|javascript:)/i
+const CONTROL_CHAR_PATTERN = /[\u0000-\u001f\u007f-\u009f]/
+
+function pruneWindow(values: number[], nowMs: number, windowMs: number) {
+  return values.filter((value) => nowMs - value < windowMs)
+}
+
+function rateLimitKey(userId: string, phone: string) {
+  return `${userId}:${phone}`
+}
+
+function checkInviteRateLimit(userId: string, phone: string, now = new Date()) {
+  const nowMs = now.getTime()
+  const userAttempts = pruneWindow(
+    inviteAttemptsByUser.get(userId) ?? [],
+    nowMs,
+    INVITE_WINDOW_MS
+  )
+  const phoneAttempts = pruneWindow(
+    inviteAttemptsByPhone.get(phone) ?? [],
+    nowMs,
+    INVITE_WINDOW_MS
+  )
+  const userPhoneKey = rateLimitKey(userId, phone)
+  const lastSamePhoneAttempt = recentInviteByUserPhone.get(userPhoneKey) ?? 0
+  const cancelledUntil = cancelledInviteCooldowns.get(userPhoneKey) ?? 0
+  const ignoredUntil = ignoredRequestCooldowns.get(userPhoneKey) ?? 0
+
+  if (userAttempts.length >= INVITES_PER_USER_WINDOW) return 'user_window'
+  if (phoneAttempts.length >= INVITES_PER_PHONE_WINDOW) return 'phone_window'
+  if (nowMs - lastSamePhoneAttempt < SAME_PHONE_COOLDOWN_MS) {
+    return 'same_phone_cooldown'
+  }
+  if (cancelledUntil > nowMs) return 'cancelled_cooldown'
+  if (ignoredUntil > nowMs) return 'ignored_cooldown'
+
+  return null
+}
+
+function recordInviteAttempt(userId: string, phone: string, now = new Date()) {
+  const nowMs = now.getTime()
+  const userAttempts = pruneWindow(
+    inviteAttemptsByUser.get(userId) ?? [],
+    nowMs,
+    INVITE_WINDOW_MS
+  )
+  const phoneAttempts = pruneWindow(
+    inviteAttemptsByPhone.get(phone) ?? [],
+    nowMs,
+    INVITE_WINDOW_MS
+  )
+
+  userAttempts.push(nowMs)
+  phoneAttempts.push(nowMs)
+  inviteAttemptsByUser.set(userId, userAttempts)
+  inviteAttemptsByPhone.set(phone, phoneAttempts)
+  recentInviteByUserPhone.set(rateLimitKey(userId, phone), nowMs)
+}
+
+function rememberCancelledInvite(
+  userId: string,
+  phone: string,
+  now = new Date()
+) {
+  cancelledInviteCooldowns.set(
+    rateLimitKey(userId, phone),
+    now.getTime() + CANCELLED_PHONE_COOLDOWN_MS
+  )
+}
+
+export function rememberIgnoredFriendRequest(
+  requesterUserId: string,
+  inviteeUserId: string,
+  now = new Date()
+) {
+  ignoredRequestCooldowns.set(
+    rateLimitKey(requesterUserId, inviteeUserId),
+    now.getTime() + IGNORED_PHONE_COOLDOWN_MS
+  )
+}
+
+export function resetFriendInvitationRateLimitForTests() {
+  inviteAttemptsByUser.clear()
+  inviteAttemptsByPhone.clear()
+  recentInviteByUserPhone.clear()
+  cancelledInviteCooldowns.clear()
+  ignoredRequestCooldowns.clear()
+}
+
+function containsAbusiveText(value: string) {
+  const lower = value.toLocaleLowerCase('en-US')
+  return ABUSIVE_WORDS.some((word) => lower.includes(word))
+}
+
+function hasGiantUnicodeSpam(value: string) {
+  const symbols = Array.from(value).filter((char) =>
+    /[^\p{L}\p{N}\p{P}\p{Zs}]/u.test(char)
+  )
+  return symbols.length > 6 || /(.)\1{8,}/u.test(value)
+}
+
+function textLooksUnsafe(value: string) {
+  return (
+    CONTROL_CHAR_PATTERN.test(value) ||
+    SPAMMY_PATTERN.test(value) ||
+    containsAbusiveText(value) ||
+    hasGiantUnicodeSpam(value)
+  )
+}
 
 type CreateFriendInvitationBody = {
   inviteeDisplayName: string
@@ -70,12 +193,15 @@ export function validateCreateFriendInvitationBody(
     }
   }
 
-  if (inviteeDisplayName.length > MAX_INVITEE_DISPLAY_NAME_LENGTH) {
+  if (
+    inviteeDisplayName.length > MAX_INVITEE_DISPLAY_NAME_LENGTH ||
+    textLooksUnsafe(inviteeDisplayName)
+  ) {
     return {
       ok: false,
       status: 400,
       error: 'invalid_invitee_display_name',
-      message: `inviteeDisplayName must be ${MAX_INVITEE_DISPLAY_NAME_LENGTH} characters or fewer.`,
+      message: `Use a real display name, ${MAX_INVITEE_DISPLAY_NAME_LENGTH} characters or fewer.`,
     }
   }
 
@@ -110,12 +236,15 @@ export function validateCreateFriendInvitationBody(
     const normalizedInterest = normalizeText(interest)
     if (!normalizedInterest) continue
 
-    if (normalizedInterest.length > MAX_SUGGESTED_INTEREST_LENGTH) {
+    if (
+      normalizedInterest.length > MAX_SUGGESTED_INTEREST_LENGTH ||
+      textLooksUnsafe(normalizedInterest)
+    ) {
       return {
         ok: false,
         status: 400,
         error: 'invalid_suggested_interests',
-        message: `Each suggested interest must be ${MAX_SUGGESTED_INTEREST_LENGTH} characters or fewer.`,
+        message: `Each idea should be a short, friendly phrase (${MAX_SUGGESTED_INTEREST_LENGTH} characters or fewer).`,
       }
     }
 
@@ -145,6 +274,17 @@ export function validateCreateFriendInvitationBody(
   }
 }
 
+function interestPhrase(suggestedInterests: string[]) {
+  if (suggestedInterests.length === 1) return suggestedInterests[0]
+  if (suggestedInterests.length === 2) {
+    return `${suggestedInterests[0]} and ${suggestedInterests[1]}`
+  }
+  if (suggestedInterests.length === 3) {
+    return `${suggestedInterests[0]}, ${suggestedInterests[1]}, and ${suggestedInterests[2]}`
+  }
+  return null
+}
+
 export function buildFriendInvitationMessage({
   inviteUrl,
   suggestedInterests,
@@ -152,19 +292,27 @@ export function buildFriendInvitationMessage({
   inviteUrl: string
   suggestedInterests: string[]
 }): string {
-  if (suggestedInterests.length === 1) {
-    return `Hey — come play Joshing with me. I added something I think you might like: ${suggestedInterests[0]}. No app to download — just tap this: ${inviteUrl}`
-  }
+  const ideas = interestPhrase(suggestedInterests)
+  const ideaCopy = ideas
+    ? ` I added a few ideas that made me think of you — ${ideas}. Keep, edit, or ignore them.`
+    : ''
 
-  if (suggestedInterests.length === 2) {
-    return `Hey — come play Joshing with me. I added a couple areas I think you might like: ${suggestedInterests[0]} and ${suggestedInterests[1]}. No app to download — just tap this: ${inviteUrl}`
-  }
+  return `Hey — I thought you’d like this corner of Joshing.${ideaCopy} No app to download — just tap this: ${inviteUrl}`
+}
 
-  if (suggestedInterests.length === 3) {
-    return `Hey — come play Joshing with me. I added a few areas I think you might like: ${suggestedInterests[0]}, ${suggestedInterests[1]}, and ${suggestedInterests[2]}. No app to download — just tap this: ${inviteUrl}`
-  }
+export function buildExistingUserFriendInvitationMessage({
+  inviteUrl,
+  suggestedInterests,
+}: {
+  inviteUrl: string
+  suggestedInterests: string[]
+}): string {
+  const ideas = interestPhrase(suggestedInterests)
+  const ideaCopy = ideas
+    ? ` I added a few areas I think overlap with your world — ${ideas}. Keep, edit, or ignore them.`
+    : ''
 
-  return `Hey — come play Joshing with me. No app to download — just tap this: ${inviteUrl}`
+  return `Hey — I thought you’d like this corner of Joshing.${ideaCopy} Tap this when you have a minute: ${inviteUrl}`
 }
 
 function maskPhoneNumber(phone: string): string {
@@ -279,6 +427,12 @@ export async function DELETE(request: Request) {
       )
     }
 
+    rememberCancelledInvite(session.userId, invitation.inviteePhone)
+    logTelemetry('add_friend_invite_cancelled', {
+      inviter_user_id: session.userId,
+      invitation_id: invitation.id,
+    })
+
     return NextResponse.json({
       ok: true,
       invitationId: invitation.id,
@@ -310,6 +464,23 @@ export async function POST(request: Request) {
 
   try {
     const { inviteeDisplayName, phone, suggestedInterests } = parsed.value
+    const rateLimitReason = checkInviteRateLimit(session.userId, phone)
+    if (rateLimitReason) {
+      logTelemetry('add_friend_invite_rate_limited', {
+        inviter_user_id: session.userId,
+        invitee_phone_hash: phone.slice(-4),
+        reason: rateLimitReason,
+      })
+      return NextResponse.json(
+        {
+          error: 'invite_cooldown',
+          message:
+            'Give this invite a little breathing room before trying again.',
+        },
+        { status: 429 }
+      )
+    }
+
     const existingUser = await getUserByPhone(phone)
 
     if (existingUser) {
@@ -320,12 +491,40 @@ export async function POST(request: Request) {
         )
       }
 
+      const ignoredCooldownReason = checkInviteRateLimit(
+        session.userId,
+        existingUser.id
+      )
+      if (ignoredCooldownReason === 'ignored_cooldown') {
+        logTelemetry('friend_request_reinvite_after_ignore_limited', {
+          inviter_user_id: session.userId,
+          invitee_user_id: existingUser.id,
+        })
+        return NextResponse.json(
+          {
+            error: 'invite_cooldown',
+            message:
+              'Give this invite a little breathing room before trying again.',
+          },
+          { status: 429 }
+        )
+      }
+
       const { friendship: friendshipRequest, state } =
         await createOrReusePendingFriendshipRequest({
           inviterUserId: session.userId,
           inviteeUserId: existingUser.id,
           suggestedInterests,
         })
+
+      const inviteUrl = `${getBaseUrl(request)}/activities#friendship-${encodeURIComponent(friendshipRequest.id)}`
+      const message = buildExistingUserFriendInvitationMessage({
+        inviteUrl,
+        suggestedInterests,
+      })
+
+      recordInviteAttempt(session.userId, phone)
+      recordInviteAttempt(session.userId, existingUser.id)
 
       logTelemetry('friend_request_existing_user_created', {
         inviter_user_id: session.userId,
@@ -341,8 +540,8 @@ export async function POST(request: Request) {
         state,
         id: friendshipRequest.id,
         invitationId: null,
-        inviteUrl: null,
-        message: null,
+        inviteUrl,
+        message,
         inviteeDisplayName,
         inviteePhone: phone,
         suggestedInterests,
@@ -368,6 +567,8 @@ export async function POST(request: Request) {
       inviteUrl,
       suggestedInterests,
     })
+
+    recordInviteAttempt(session.userId, phone)
 
     logTelemetry('add_friend_invite_created', {
       inviter_user_id: session.userId,

--- a/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 
 import { getSession } from '@/server/auth/session'
 import { logTelemetry } from '@/server/telemetry'
+import { rememberIgnoredFriendRequest } from '@/app/api/friend-invitations/route'
 import { ignorePendingFriendshipRequest } from '@/server/friends/friendships'
 
 export const dynamic = 'force-dynamic'
@@ -11,7 +12,8 @@ export async function POST(
   { params }: { params: Promise<{ friendshipId: string }> }
 ) {
   const session = await getSession()
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
 
   const { friendshipId } = await params
   const friendship = await ignorePendingFriendshipRequest({
@@ -26,10 +28,16 @@ export async function POST(
     )
   }
 
+  rememberIgnoredFriendRequest(friendship.requestedByUserId, session.userId)
+
   logTelemetry('friend_request_ignored', {
     friendship_id: friendship.id,
+    requester_user_id: friendship.requestedByUserId,
     user_id: session.userId,
   })
 
-  return NextResponse.json({ ok: true, friendship: { id: friendship.id, status: friendship.status } })
+  return NextResponse.json({
+    ok: true,
+    friendship: { id: friendship.id, status: friendship.status },
+  })
 }

--- a/src/app/invite/[token]/__tests__/page.test.tsx
+++ b/src/app/invite/[token]/__tests__/page.test.tsx
@@ -33,7 +33,7 @@ describe('/invite/[token] landing QA states', () => {
     expect(getFriendInvitationLandingByTokenMock).toHaveBeenCalledWith(
       'valid-token'
     )
-    expect(html).toContain('Alex Inviter invited you to Joshing.')
+    expect(html).toContain('Alex Inviter thought of you for Joshing.')
     expect(html).toContain('Jazz')
     expect(html).toContain('Poetry')
     expect(html).toContain('href="/login?invitationToken=valid-token"')

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -14,7 +14,7 @@ function inviteLoginHref(token: string) {
 function InviteShell({ children }: { children: ReactNode }) {
   return (
     <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="bg-card w-full max-w-sm rounded-lg border p-5 shadow-sm">
+      <section className="bg-card w-full max-w-sm rounded-2xl border p-5 shadow-sm">
         {children}
       </section>
     </main>
@@ -31,30 +31,30 @@ export default async function InvitePage({ params }: InvitePageProps) {
         <div className="space-y-5">
           <div>
             <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-              Friend invite
+              A note from a friend
             </p>
             <h1 className="mt-2 text-3xl font-semibold tracking-normal">
-              {invitation.inviterName} invited you to Joshing.
+              {invitation.inviterName} thought of you for Joshing.
             </h1>
           </div>
 
           {invitation.suggestedInterests.length > 0 ? (
             <div className="bg-background/60 space-y-3 rounded-lg border p-4">
               <p className="text-sm leading-6 font-medium">
-                They thought you might like questions about:
+                They left a few ideas for your first corner:
               </p>
               <div className="flex flex-wrap gap-2">
                 {invitation.suggestedInterests.map((interest) => (
                   <span
                     key={interest.label}
-                    className="bg-card text-foreground rounded-full border px-3 py-1 text-sm shadow-sm"
+                    className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm shadow-sm"
                   >
                     {interest.label}
                   </span>
                 ))}
               </div>
               <p className="text-muted-foreground text-sm">
-                You can change these.
+                You can keep, edit, or ignore these before anything is saved.
               </p>
             </div>
           ) : null}
@@ -63,7 +63,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
             href={inviteLoginHref(token)}
             className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
           >
-            Continue
+            See the note
           </Link>
         </div>
       </InviteShell>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -1,55 +1,62 @@
-'use client';
+'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react';
-import type { ReactNode } from 'react';
-import { useRouter } from 'next/navigation';
-import { Check, Edit3, Loader2, Plus, X } from 'lucide-react';
-import { COUNTRIES } from '@/lib/onboarding/countries';
-import { US_STATES } from '@/lib/onboarding/us-regions';
+import { useEffect, useMemo, useRef, useState } from 'react'
+import type { ReactNode } from 'react'
+import { useRouter } from 'next/navigation'
+import { Check, Edit3, Loader2, Plus, X } from 'lucide-react'
+import { COUNTRIES } from '@/lib/onboarding/countries'
+import { US_STATES } from '@/lib/onboarding/us-regions'
 
-type CurrentStep = 'welcome' | 'background' | 'warmup' | 'review' | 'pick' | 'complete';
+type CurrentStep =
+  | 'welcome'
+  | 'background'
+  | 'warmup'
+  | 'review'
+  | 'pick'
+  | 'complete'
 
 export type WarmupAnswers = {
-  deepDive?: string;
-  hourLongTopic?: string;
-  anythingElse?: string;
-};
+  deepDive?: string
+  hourLongTopic?: string
+  anythingElse?: string
+}
 
 export type ProposedInterest = {
-  domain: string;
-  broadCategory: string;
-  rationale?: string | null;
-};
+  domain: string
+  broadCategory: string
+  rationale?: string | null
+}
 
 type SelectedInterest = {
-  domain: string;
-  broadCategory: string;
-};
+  domain: string
+  broadCategory: string
+}
 
-export type PreSeededInterest = ProposedInterest;
+export type PreSeededInterest = ProposedInterest
 
 type OnboardingFlowProps = {
-  preSeededInterests: PreSeededInterest[];
-  inviterName?: string | null;
-};
+  preSeededInterests: PreSeededInterest[]
+  inviterName?: string | null
+}
 
 type CanonicalSuggestion = {
-  original: string;
-  suggested: string;
-  broadCategory: string;
-  explanation: string | null;
-};
+  original: string
+  suggested: string
+  broadCategory: string
+  explanation: string | null
+}
 
 const WARMUP_FIELDS: Array<{
-  field: keyof WarmupAnswers;
-  label: string;
-  placeholder: string;
-  optional?: boolean;
+  field: keyof WarmupAnswers
+  label: string
+  placeholder: string
+  optional?: boolean
 }> = [
   {
     field: 'deepDive',
-    label: 'A book, composer, or filmmaker you\'ve gone deep on?',
-    placeholder: 'e.g. Middlemarch, or Tchaikovsky\'s symphonies, or Werner Herzog',
+    label: "A book, composer, or filmmaker you've gone deep on?",
+    placeholder:
+      "e.g. Middlemarch, or Tchaikovsky's symphonies, or Werner Herzog",
   },
   {
     field: 'hourLongTopic',
@@ -62,43 +69,50 @@ const WARMUP_FIELDS: Array<{
     placeholder: 'Anything',
     optional: true,
   },
-];
-
+]
 
 const LOADING_COPY = [
   'Reading your answers...',
   'Looking for connections...',
   'Building your map...',
-];
+]
 
 const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
   { step: 'background', label: 'About You' },
   { step: 'warmup', label: 'Warmup' },
   { step: 'review', label: 'Review' },
   { step: 'pick', label: 'Confirm' },
-];
+]
 
 function normalizeDomain(domain: string) {
-  return domain.trim().replace(/\s+/g, ' ');
+  return domain.trim().replace(/\s+/g, ' ')
 }
 
 function selectedKey(interest: SelectedInterest) {
-  return interest.domain.trim().toLowerCase();
+  return interest.domain.trim().toLowerCase()
 }
 
 function toSelected(interest: ProposedInterest): SelectedInterest | null {
-  const domain = normalizeDomain(interest.domain);
-  if (domain.length < 2) return null;
+  const domain = normalizeDomain(interest.domain)
+  if (domain.length < 2) return null
 
   return {
     domain,
-    broadCategory: normalizeDomain(interest.broadCategory || 'Other') || 'Other',
-  };
+    broadCategory:
+      normalizeDomain(interest.broadCategory || 'Other') || 'Other',
+  }
 }
 
-function isSelected(selectedInterests: SelectedInterest[], interest: ProposedInterest) {
-  const selected = toSelected(interest);
-  return selected ? selectedInterests.some((item) => selectedKey(item) === selectedKey(selected)) : false;
+function isSelected(
+  selectedInterests: SelectedInterest[],
+  interest: ProposedInterest
+) {
+  const selected = toSelected(interest)
+  return selected
+    ? selectedInterests.some(
+        (item) => selectedKey(item) === selectedKey(selected)
+      )
+    : false
 }
 
 function isBeforeNoonEastern() {
@@ -106,9 +120,11 @@ function isBeforeNoonEastern() {
     timeZone: 'America/New_York',
     hour: 'numeric',
     hourCycle: 'h23',
-  }).formatToParts(new Date());
-  const hour = Number(easternParts.find((part) => part.type === 'hour')?.value ?? '12');
-  return hour < 12;
+  }).formatToParts(new Date())
+  const hour = Number(
+    easternParts.find((part) => part.type === 'hour')?.value ?? '12'
+  )
+  return hour < 12
 }
 
 function Spinner({ small = false }: { small?: boolean }) {
@@ -117,21 +133,28 @@ function Spinner({ small = false }: { small?: boolean }) {
       className={`${small ? 'size-4' : 'size-7'} animate-spin`}
       aria-hidden="true"
     />
-  );
+  )
 }
 
 function ProgressDots({ currentStep }: { currentStep: CurrentStep }) {
-  const activeIndex = currentStep === 'welcome'
-    ? -1
-    : currentStep === 'complete'
-      ? STEP_DOTS.length
-      : Math.max(0, STEP_DOTS.findIndex((item) => item.step === currentStep));
+  const activeIndex =
+    currentStep === 'welcome'
+      ? -1
+      : currentStep === 'complete'
+        ? STEP_DOTS.length
+        : Math.max(
+            0,
+            STEP_DOTS.findIndex((item) => item.step === currentStep)
+          )
 
   return (
-    <div className="flex items-center justify-center gap-3" aria-label="Onboarding progress">
+    <div
+      className="flex items-center justify-center gap-3"
+      aria-label="Onboarding progress"
+    >
       {STEP_DOTS.map((item, index) => {
-        const active = index <= activeIndex;
-        const current = item.step === currentStep;
+        const active = index <= activeIndex
+        const current = item.step === currentStep
 
         return (
           <div key={item.step} className="flex items-center gap-2">
@@ -139,205 +162,255 @@ function ProgressDots({ currentStep }: { currentStep: CurrentStep }) {
               className={[
                 'block size-2.5 rounded-full transition',
                 active ? 'bg-foreground' : 'bg-border',
-                current ? 'ring-4 ring-foreground/10' : '',
+                current ? 'ring-foreground/10 ring-4' : '',
               ].join(' ')}
             />
             <span className="sr-only">{item.label}</span>
           </div>
-        );
+        )
       })}
     </div>
-  );
+  )
 }
 
 function StepHeader({ title, subtitle }: { title: string; subtitle: string }) {
   return (
     <div className="space-y-2">
-      <h1 className="text-3xl font-semibold tracking-normal text-balance sm:text-4xl">{title}</h1>
-      <p className="text-base leading-7 text-muted-foreground">{subtitle}</p>
+      <h1 className="text-3xl font-semibold tracking-normal text-balance sm:text-4xl">
+        {title}
+      </h1>
+      <p className="text-muted-foreground text-base leading-7">{subtitle}</p>
     </div>
-  );
+  )
 }
 
-export default function OnboardingFlow({ preSeededInterests, inviterName }: OnboardingFlowProps) {
-  const router = useRouter();
-  const [currentStep, setCurrentStep] = useState<CurrentStep>('welcome');
-  const [birthYear, setBirthYear] = useState('');
-  const [grewUpCountry, setGrewUpCountry] = useState('');
-  const [grewUpRegion, setGrewUpRegion] = useState('');
-  const [warmupAnswers, setWarmupAnswers] = useState<WarmupAnswers>({});
-  const [proposedInterests, setProposedInterests] = useState<ProposedInterest[] | null>(null);
-  const [inviteInterests, setInviteInterests] = useState<PreSeededInterest[]>(() => preSeededInterests);
-  const [selectedInterests, setSelectedInterests] = useState<SelectedInterest[]>(
-    () => preSeededInterests.flatMap((interest) => {
-      const selected = toSelected(interest);
-      return selected ? [selected] : [];
-    }).slice(0, 5),
-  );
-  const [isLoading, setIsLoading] = useState(false);
-  const [isCanonicalizing, setIsCanonicalizing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [loadingCopyIndex, setLoadingCopyIndex] = useState(0);
-  const [editingKey, setEditingKey] = useState<string | null>(null);
-  const [editingDomain, setEditingDomain] = useState('');
-  const [showComposer, setShowComposer] = useState(false);
-  const [customInput, setCustomInput] = useState('');
-  const [canonicalSuggestion, setCanonicalSuggestion] = useState<CanonicalSuggestion | null>(null);
-  const [customChoice, setCustomChoice] = useState<'suggested' | 'mine' | null>(null);
-  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const showDailySetup = useMemo(() => isBeforeNoonEastern(), []);
+export default function OnboardingFlow({
+  preSeededInterests,
+  inviterName,
+}: OnboardingFlowProps) {
+  const router = useRouter()
+  const [currentStep, setCurrentStep] = useState<CurrentStep>('welcome')
+  const [birthYear, setBirthYear] = useState('')
+  const [grewUpCountry, setGrewUpCountry] = useState('')
+  const [grewUpRegion, setGrewUpRegion] = useState('')
+  const [warmupAnswers, setWarmupAnswers] = useState<WarmupAnswers>({})
+  const [proposedInterests, setProposedInterests] = useState<
+    ProposedInterest[] | null
+  >(null)
+  const [inviteInterests, setInviteInterests] = useState<PreSeededInterest[]>(
+    () => preSeededInterests
+  )
+  const [selectedInterests, setSelectedInterests] = useState<
+    SelectedInterest[]
+  >(() =>
+    preSeededInterests
+      .flatMap((interest) => {
+        const selected = toSelected(interest)
+        return selected ? [selected] : []
+      })
+      .slice(0, 5)
+  )
+  const [isLoading, setIsLoading] = useState(false)
+  const [isCanonicalizing, setIsCanonicalizing] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [loadingCopyIndex, setLoadingCopyIndex] = useState(0)
+  const [editingKey, setEditingKey] = useState<string | null>(null)
+  const [editingDomain, setEditingDomain] = useState('')
+  const [showComposer, setShowComposer] = useState(false)
+  const [customInput, setCustomInput] = useState('')
+  const [canonicalSuggestion, setCanonicalSuggestion] =
+    useState<CanonicalSuggestion | null>(null)
+  const [customChoice, setCustomChoice] = useState<'suggested' | 'mine' | null>(
+    null
+  )
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const showDailySetup = useMemo(() => isBeforeNoonEastern(), [])
 
-  const displayInviterName = inviterName?.trim() ? inviterName.trim() : 'A friend';
+  const displayInviterName = inviterName?.trim()
+    ? inviterName.trim()
+    : 'A friend'
 
-  const parsedBirthYear = parseInt(birthYear, 10);
-  const maxBirthYear = new Date().getFullYear() - 13;
-  const birthYearValid = birthYear.length === 4 && parsedBirthYear >= 1920 && parsedBirthYear <= maxBirthYear;
+  const parsedBirthYear = parseInt(birthYear, 10)
+  const maxBirthYear = new Date().getFullYear() - 13
+  const birthYearValid =
+    birthYear.length === 4 &&
+    parsedBirthYear >= 1920 &&
+    parsedBirthYear <= maxBirthYear
   const canAdvanceBackground =
     birthYearValid &&
     grewUpCountry !== '' &&
-    (grewUpCountry !== 'US' || grewUpRegion !== '');
+    (grewUpCountry !== 'US' || grewUpRegion !== '')
 
   const canGenerate =
     normalizeDomain(warmupAnswers.deepDive ?? '').length > 0 &&
-    normalizeDomain(warmupAnswers.hourLongTopic ?? '').length > 0;
+    normalizeDomain(warmupAnswers.hourLongTopic ?? '').length > 0
 
   const reviewInterests = useMemo(
     () => [
       ...inviteInterests,
       ...(proposedInterests ?? []).filter(
-        (interest) => !inviteInterests.some(
-          (seeded) => selectedKey(toSelected(seeded) ?? { domain: '', broadCategory: '' }) === selectedKey(toSelected(interest) ?? { domain: '', broadCategory: '' }),
-        ),
+        (interest) =>
+          !inviteInterests.some(
+            (seeded) =>
+              selectedKey(
+                toSelected(seeded) ?? { domain: '', broadCategory: '' }
+              ) ===
+              selectedKey(
+                toSelected(interest) ?? { domain: '', broadCategory: '' }
+              )
+          )
       ),
     ],
-    [inviteInterests, proposedInterests],
-  );
+    [inviteInterests, proposedInterests]
+  )
 
   useEffect(() => {
-    if (!isLoading || currentStep !== 'warmup') return;
+    if (!isLoading || currentStep !== 'warmup') return
 
     const interval = window.setInterval(() => {
-      setLoadingCopyIndex((current) => (current + 1) % LOADING_COPY.length);
-    }, 3000);
+      setLoadingCopyIndex((current) => (current + 1) % LOADING_COPY.length)
+    }, 3000)
 
-    return () => window.clearInterval(interval);
-  }, [currentStep, isLoading]);
+    return () => window.clearInterval(interval)
+  }, [currentStep, isLoading])
 
   useEffect(() => {
-    const rawInput = normalizeDomain(customInput);
+    const rawInput = normalizeDomain(customInput)
     const resetTimer = window.setTimeout(() => {
-      setCanonicalSuggestion(null);
-      setCustomChoice(null);
-      if (!showComposer || rawInput.length <= 3) setIsCanonicalizing(false);
-    }, 0);
+      setCanonicalSuggestion(null)
+      setCustomChoice(null)
+      if (!showComposer || rawInput.length <= 3) setIsCanonicalizing(false)
+    }, 0)
 
     if (!showComposer || rawInput.length <= 3) {
-      return () => window.clearTimeout(resetTimer);
+      return () => window.clearTimeout(resetTimer)
     }
 
-    const controller = new AbortController();
+    const controller = new AbortController()
     const timer = window.setTimeout(async () => {
-      setIsCanonicalizing(true);
+      setIsCanonicalizing(true)
       try {
         const response = await fetch('/api/onboarding/canonicalize', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ rawInput }),
           signal: controller.signal,
-        });
-        const data = await response.json().catch(() => ({}));
+        })
+        const data = await response.json().catch(() => ({}))
 
-        if (!response.ok || typeof data?.suggested !== 'string') return;
+        if (!response.ok || typeof data?.suggested !== 'string') return
 
         setCanonicalSuggestion({
           original: data.original ?? rawInput,
           suggested: data.suggested,
           broadCategory: data.broadCategory ?? 'Other',
           explanation: data.explanation ?? null,
-        });
+        })
       } catch (fetchError) {
-        if (!(fetchError instanceof DOMException && fetchError.name === 'AbortError')) {
-          setCanonicalSuggestion(null);
+        if (
+          !(
+            fetchError instanceof DOMException &&
+            fetchError.name === 'AbortError'
+          )
+        ) {
+          setCanonicalSuggestion(null)
         }
       } finally {
-        if (!controller.signal.aborted) setIsCanonicalizing(false);
+        if (!controller.signal.aborted) setIsCanonicalizing(false)
       }
-    }, 800);
+    }, 800)
 
     return () => {
-      controller.abort();
-      window.clearTimeout(resetTimer);
-      window.clearTimeout(timer);
-    };
-  }, [customInput, showComposer]);
+      controller.abort()
+      window.clearTimeout(resetTimer)
+      window.clearTimeout(timer)
+    }
+  }, [customInput, showComposer])
 
   function updateWarmupAnswer(field: keyof WarmupAnswers, value: string) {
-    setWarmupAnswers((current) => ({ ...current, [field]: value.slice(0, 200) }));
+    setWarmupAnswers((current) => ({
+      ...current,
+      [field]: value.slice(0, 200),
+    }))
   }
 
   function toggleInterest(interest: ProposedInterest) {
-    const selected = toSelected(interest);
-    if (!selected) return;
+    const selected = toSelected(interest)
+    if (!selected) return
 
     setSelectedInterests((current) => {
-      const exists = current.some((item) => selectedKey(item) === selectedKey(selected));
-      if (exists) return current.filter((item) => selectedKey(item) !== selectedKey(selected));
-      if (current.length >= 5) return current;
-      return [...current, selected];
-    });
+      const exists = current.some(
+        (item) => selectedKey(item) === selectedKey(selected)
+      )
+      if (exists)
+        return current.filter(
+          (item) => selectedKey(item) !== selectedKey(selected)
+        )
+      if (current.length >= 5) return current
+      return [...current, selected]
+    })
   }
 
   function beginEdit(interest: ProposedInterest) {
-    const selected = toSelected(interest);
-    if (!selected) return;
+    const selected = toSelected(interest)
+    if (!selected) return
 
-    setEditingKey(selectedKey(selected));
-    setEditingDomain(selected.domain);
+    setEditingKey(selectedKey(selected))
+    setEditingDomain(selected.domain)
   }
 
   function saveEdit(interest: ProposedInterest) {
-    const selected = toSelected(interest);
-    const nextDomain = normalizeDomain(editingDomain);
-    if (!selected || nextDomain.length < 2) return;
+    const selected = toSelected(interest)
+    const nextDomain = normalizeDomain(editingDomain)
+    if (!selected || nextDomain.length < 2) return
 
-    const edited = { ...interest, domain: nextDomain };
-    setInviteInterests((current) => current.map((item) => (
-      selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) === selectedKey(selected)
-        ? edited
-        : item
-    )));
-    setProposedInterests((current) => current?.map((item) => (
-      selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) === selectedKey(selected)
-        ? edited
-        : item
-    )) ?? current);
-    setSelectedInterests((current) => current.map((item) => (
-      selectedKey(item) === selectedKey(selected)
-        ? { ...item, domain: nextDomain }
-        : item
-    )));
-    setEditingKey(null);
-    setEditingDomain('');
+    const edited = { ...interest, domain: nextDomain }
+    setInviteInterests((current) =>
+      current.map((item) =>
+        selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) ===
+        selectedKey(selected)
+          ? edited
+          : item
+      )
+    )
+    setProposedInterests(
+      (current) =>
+        current?.map((item) =>
+          selectedKey(toSelected(item) ?? { domain: '', broadCategory: '' }) ===
+          selectedKey(selected)
+            ? edited
+            : item
+        ) ?? current
+    )
+    setSelectedInterests((current) =>
+      current.map((item) =>
+        selectedKey(item) === selectedKey(selected)
+          ? { ...item, domain: nextDomain }
+          : item
+      )
+    )
+    setEditingKey(null)
+    setEditingDomain('')
   }
 
   function startLongPress(interest: ProposedInterest) {
-    clearLongPress();
-    longPressTimer.current = setTimeout(() => beginEdit(interest), 500);
+    clearLongPress()
+    longPressTimer.current = setTimeout(() => beginEdit(interest), 500)
   }
 
   function clearLongPress() {
     if (longPressTimer.current) {
-      clearTimeout(longPressTimer.current);
-      longPressTimer.current = null;
+      clearTimeout(longPressTimer.current)
+      longPressTimer.current = null
     }
   }
 
   async function generateProposals() {
-    if (!canGenerate) return;
+    if (!canGenerate) return
 
-    setError(null);
-    setIsLoading(true);
-    setLoadingCopyIndex(0);
+    setError(null)
+    setIsLoading(true)
+    setLoadingCopyIndex(0)
 
     try {
       const response = await fetch('/api/onboarding/propose-interests', {
@@ -345,34 +418,41 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           warmupAnswers,
-          culturalAnchor: birthYearValid && grewUpCountry ? {
-            birthYear: parsedBirthYear,
-            grewUpCountry,
-            grewUpRegion: grewUpRegion || undefined,
-          } : undefined,
+          culturalAnchor:
+            birthYearValid && grewUpCountry
+              ? {
+                  birthYear: parsedBirthYear,
+                  grewUpCountry,
+                  grewUpRegion: grewUpRegion || undefined,
+                }
+              : undefined,
         }),
-      });
-      const data = await response.json().catch(() => ({}));
+      })
+      const data = await response.json().catch(() => ({}))
 
       if (!response.ok || !Array.isArray(data?.proposedInterests)) {
-        setError("We couldn't generate suggestions. You can try again or write your own.");
-        return;
+        setError(
+          "We couldn't generate suggestions. You can try again or write your own."
+        )
+        return
       }
 
-      setProposedInterests(data.proposedInterests);
-      setCurrentStep('review');
+      setProposedInterests(data.proposedInterests)
+      setCurrentStep('review')
     } catch {
-      setError("We couldn't generate suggestions. You can try again or write your own.");
+      setError(
+        "We couldn't generate suggestions. You can try again or write your own."
+      )
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
   }
 
   async function skipInviteInterests() {
-    if (inviteInterests.length === 0) return;
+    if (inviteInterests.length === 0) return
 
-    setError(null);
-    setIsLoading(true);
+    setError(null)
+    setIsLoading(true)
 
     try {
       const response = await fetch('/api/onboarding/save-interests', {
@@ -385,47 +465,51 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
             inviteSelectedCount: 0,
           },
         }),
-      });
-      const data = await response.json().catch(() => ({}));
+      })
+      const data = await response.json().catch(() => ({}))
 
       if (!response.ok || data?.ok !== true) {
-        setError(data?.message ?? data?.error ?? 'Unable to skip invited interests.');
-        return;
+        setError(
+          data?.message ?? data?.error ?? 'Unable to skip invited interests.'
+        )
+        return
       }
 
-      setSelectedInterests([]);
-      setInviteInterests([]);
-      setCurrentStep('complete');
-      router.refresh();
+      setSelectedInterests([])
+      setInviteInterests([])
+      setCurrentStep('complete')
+      router.refresh()
     } catch {
-      setError('Unable to skip invited interests.');
+      setError('Unable to skip invited interests.')
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
   }
 
   async function saveInterests() {
     const cleanSelected = selectedInterests
       .flatMap((interest) => {
-        const selected = toSelected(interest);
-        return selected ? [selected] : [];
+        const selected = toSelected(interest)
+        return selected ? [selected] : []
       })
-      .slice(0, 5);
+      .slice(0, 5)
 
     const inviteSelectedCount = inviteInterests.filter((interest) => {
-      const selected = toSelected(interest);
+      const selected = toSelected(interest)
       return selected
-        ? cleanSelected.some((item) => selectedKey(item) === selectedKey(selected))
-        : false;
-    }).length;
+        ? cleanSelected.some(
+            (item) => selectedKey(item) === selectedKey(selected)
+          )
+        : false
+    }).length
 
     if (cleanSelected.length === 0) {
-      setError('Pick at least 1 to continue.');
-      return;
+      setError('Pick at least 1 to continue.')
+      return
     }
 
-    setError(null);
-    setIsLoading(true);
+    setError(null)
+    setIsLoading(true)
 
     try {
       const response = await fetch('/api/onboarding/save-interests', {
@@ -438,64 +522,68 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
             inviteSelectedCount,
           },
         }),
-      });
-      const data = await response.json().catch(() => ({}));
+      })
+      const data = await response.json().catch(() => ({}))
 
       if (!response.ok || data?.ok !== true) {
-        setError(data?.message ?? data?.error ?? 'Unable to save interests.');
-        return;
+        setError(data?.message ?? data?.error ?? 'Unable to save interests.')
+        return
       }
 
-      setCurrentStep('complete');
-      router.refresh();
+      setCurrentStep('complete')
+      router.refresh()
     } catch {
-      setError('Unable to save interests.');
+      setError('Unable to save interests.')
     } finally {
-      setIsLoading(false);
+      setIsLoading(false)
     }
   }
 
   function skipSuggestions() {
-    setError(null);
-    setProposedInterests([]);
-    setShowComposer(true);
-    setCurrentStep('review');
+    setError(null)
+    setProposedInterests([])
+    setShowComposer(true)
+    setCurrentStep('review')
   }
 
   function addCustomInterest() {
-    const rawInput = normalizeDomain(customInput);
-    const chosenDomain = customChoice === 'suggested' && canonicalSuggestion
-      ? canonicalSuggestion.suggested
-      : rawInput;
-    const broadCategory = canonicalSuggestion?.broadCategory ?? 'Other';
-    const selected = toSelected({ domain: chosenDomain, broadCategory });
+    const rawInput = normalizeDomain(customInput)
+    const chosenDomain =
+      customChoice === 'suggested' && canonicalSuggestion
+        ? canonicalSuggestion.suggested
+        : rawInput
+    const broadCategory = canonicalSuggestion?.broadCategory ?? 'Other'
+    const selected = toSelected({ domain: chosenDomain, broadCategory })
 
-    if (!selected || selectedInterests.length >= 5) return;
+    if (!selected || selectedInterests.length >= 5) return
 
     setSelectedInterests((current) => {
-      if (current.some((item) => selectedKey(item) === selectedKey(selected))) return current;
-      return [...current, selected].slice(0, 5);
-    });
-    setCustomInput('');
-    setCanonicalSuggestion(null);
-    setCustomChoice(null);
+      if (current.some((item) => selectedKey(item) === selectedKey(selected)))
+        return current
+      return [...current, selected].slice(0, 5)
+    })
+    setCustomInput('')
+    setCanonicalSuggestion(null)
+    setCustomChoice(null)
   }
 
   if (isLoading && currentStep === 'warmup') {
     return (
-      <main className="grid min-h-screen place-items-center bg-background px-5 py-12 text-foreground">
+      <main className="bg-background text-foreground grid min-h-screen place-items-center px-5 py-12">
         <div className="flex max-w-sm flex-col items-center gap-5 text-center">
-          <div className="grid size-16 place-items-center rounded-full border bg-card shadow-sm">
+          <div className="bg-card grid size-16 place-items-center rounded-full border shadow-sm">
             <Spinner />
           </div>
-          <p className="text-xl font-semibold">{LOADING_COPY[loadingCopyIndex]}</p>
+          <p className="text-xl font-semibold">
+            {LOADING_COPY[loadingCopyIndex]}
+          </p>
         </div>
       </main>
-    );
+    )
   }
 
   return (
-    <main className="min-h-screen bg-background px-4 pb-10 pt-8 text-foreground sm:px-6 sm:pt-12">
+    <main className="bg-background text-foreground min-h-screen px-4 pt-8 pb-10 sm:px-6 sm:pt-12">
       <section className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-2xl flex-col">
         <ProgressDots currentStep={currentStep} />
 
@@ -506,24 +594,36 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                 title="Welcome to Joshing"
                 subtitle="The trivia you wish you were asked."
               />
-              <div className="space-y-4 text-base leading-7 text-muted-foreground">
-                <p>Every day, you&apos;ll get five questions calibrated to your intellectual world.</p>
-                <p>First, let&apos;s figure out what that world looks like.</p>
+              <div className="text-muted-foreground space-y-4 text-base leading-7">
+                <p>
+                  Every day, you&apos;ll get five questions tuned around the
+                  things you care about.
+                </p>
+                <p>
+                  First, sketch a little of that world. You can change it
+                  anytime.
+                </p>
                 <p>It takes about two minutes.</p>
               </div>
 
               {inviteInterests.length > 0 ? (
-                <div className="rounded-lg border bg-card p-4 text-sm leading-6 shadow-sm">
+                <div className="bg-card rounded-lg border p-4 text-sm leading-6 shadow-sm">
                   <p className="font-medium">
-                    {displayInviterName} thought you might like:
+                    {displayInviterName} left a few ideas for you:
                   </p>
-                  <ul className="mt-2 space-y-1 text-muted-foreground">
+                  <ul className="text-muted-foreground mt-2 space-y-1">
                     {inviteInterests.slice(0, 3).map((interest) => (
-                      <li key={interest.domain}>- {interest.domain}</li>
+                      <li
+                        key={interest.domain}
+                        className="border-primary/10 bg-primary/5 text-foreground inline-flex rounded-full border px-3 py-1"
+                      >
+                        {interest.domain}
+                      </li>
                     ))}
                   </ul>
-                  <p className="mt-3 text-muted-foreground">
-                    They&apos;re preselected, but you can edit, remove, or skip them before anything is saved.
+                  <p className="text-muted-foreground mt-3">
+                    They&apos;re just a starting point — keep, edit, or ignore
+                    them before anything is saved.
                   </p>
                   {error ? <ErrorPanel message={error} /> : null}
                   <button
@@ -532,12 +632,16 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                     onClick={skipInviteInterests}
                     disabled={isLoading}
                   >
-                    {isLoading ? 'Skipping...' : 'Skip invited interests'}
+                    {isLoading ? 'Skipping…' : 'Skip these ideas'}
                   </button>
                 </div>
               ) : null}
 
-              <button type="button" className="btn-primary h-12 w-full" onClick={() => setCurrentStep('background')}>
+              <button
+                type="button"
+                className="btn-primary h-12 w-full"
+                onClick={() => setCurrentStep('background')}
+              >
                 Let&apos;s go
               </button>
             </div>
@@ -552,10 +656,12 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
 
               <div className="space-y-5">
                 <label className="block">
-                  <span className="text-sm font-medium">What year were you born?</span>
+                  <span className="text-sm font-medium">
+                    What year were you born?
+                  </span>
                   <input
                     type="number"
-                    className="mt-2 h-12 w-full rounded-md border bg-card px-3 text-base outline-none transition placeholder:text-muted-foreground/70 focus:ring-2 focus:ring-ring"
+                    className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
                     placeholder="e.g. 1978"
                     min={1920}
                     max={2010}
@@ -563,25 +669,29 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                     onChange={(e) => setBirthYear(e.target.value.slice(0, 4))}
                   />
                   {birthYear.length === 4 && !birthYearValid ? (
-                    <span className="mt-1 block text-xs text-destructive">
+                    <span className="text-destructive mt-1 block text-xs">
                       Please enter a year between 1920 and {maxBirthYear}.
                     </span>
                   ) : null}
                 </label>
 
                 <label className="block">
-                  <span className="text-sm font-medium">Where did you grow up?</span>
+                  <span className="text-sm font-medium">
+                    Where did you grow up?
+                  </span>
                   <select
-                    className="mt-2 h-12 w-full rounded-md border bg-card px-3 text-base outline-none transition focus:ring-2 focus:ring-ring"
+                    className="bg-card focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
                     value={grewUpCountry}
                     onChange={(e) => {
-                      setGrewUpCountry(e.target.value);
-                      setGrewUpRegion('');
+                      setGrewUpCountry(e.target.value)
+                      setGrewUpRegion('')
                     }}
                   >
                     <option value="">Select a country</option>
                     {COUNTRIES.map((c) => (
-                      <option key={c.code} value={c.code}>{c.name}</option>
+                      <option key={c.code} value={c.code}>
+                        {c.name}
+                      </option>
                     ))}
                   </select>
                 </label>
@@ -590,13 +700,15 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                   <label className="block">
                     <span className="text-sm font-medium">Which state?</span>
                     <select
-                      className="mt-2 h-12 w-full rounded-md border bg-card px-3 text-base outline-none transition focus:ring-2 focus:ring-ring"
+                      className="bg-card focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
                       value={grewUpRegion}
                       onChange={(e) => setGrewUpRegion(e.target.value)}
                     >
                       <option value="">Select a state</option>
                       {US_STATES.map((s) => (
-                        <option key={s.code} value={s.name}>{s.name}</option>
+                        <option key={s.code} value={s.name}>
+                          {s.name}
+                        </option>
                       ))}
                     </select>
                   </label>
@@ -604,7 +716,11 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
               </div>
 
               <div className="mt-auto grid grid-cols-2 gap-3 pt-2">
-                <button type="button" className="btn-ghost h-12" onClick={() => setCurrentStep('welcome')}>
+                <button
+                  type="button"
+                  className="btn-ghost h-12"
+                  onClick={() => setCurrentStep('welcome')}
+                >
                   Back
                 </button>
                 <button
@@ -627,49 +743,70 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
               />
 
               <div className="space-y-4">
-                {WARMUP_FIELDS.map(({ field, label, placeholder, optional }) => {
-                  const value = warmupAnswers[field] ?? '';
-                  return (
-                    <label key={field} className="block">
-                      <span className="text-sm font-medium">
-                        {label}
-                        {optional ? <span className="text-muted-foreground"> optional</span> : null}
-                      </span>
-                      <input
-                        className="mt-2 h-12 w-full rounded-md border bg-card px-3 text-base outline-none transition placeholder:text-muted-foreground/70 focus:ring-2 focus:ring-ring"
-                        maxLength={200}
-                        placeholder={placeholder}
-                        value={value}
-                        onChange={(event) => updateWarmupAnswer(field, event.target.value)}
-                      />
-                      {value.length > 150 ? (
-                        <span className="mt-1 block text-right text-xs text-muted-foreground">
-                          {value.length}/200
+                {WARMUP_FIELDS.map(
+                  ({ field, label, placeholder, optional }) => {
+                    const value = warmupAnswers[field] ?? ''
+                    return (
+                      <label key={field} className="block">
+                        <span className="text-sm font-medium">
+                          {label}
+                          {optional ? (
+                            <span className="text-muted-foreground">
+                              {' '}
+                              optional
+                            </span>
+                          ) : null}
                         </span>
-                      ) : null}
-                    </label>
-                  );
-                })}
+                        <input
+                          className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
+                          maxLength={200}
+                          placeholder={placeholder}
+                          value={value}
+                          onChange={(event) =>
+                            updateWarmupAnswer(field, event.target.value)
+                          }
+                        />
+                        {value.length > 150 ? (
+                          <span className="text-muted-foreground mt-1 block text-right text-xs">
+                            {value.length}/200
+                          </span>
+                        ) : null}
+                      </label>
+                    )
+                  }
+                )}
               </div>
 
               {error ? (
                 <ErrorPanel
                   message={error}
-                  actions={(
+                  actions={
                     <>
-                      <button type="button" className="btn-primary h-10" onClick={generateProposals}>
+                      <button
+                        type="button"
+                        className="btn-primary h-10"
+                        onClick={generateProposals}
+                      >
                         Try again
                       </button>
-                      <button type="button" className="btn-ghost h-10" onClick={skipSuggestions}>
+                      <button
+                        type="button"
+                        className="btn-ghost h-10"
+                        onClick={skipSuggestions}
+                      >
                         Skip suggestions
                       </button>
                     </>
-                  )}
+                  }
                 />
               ) : null}
 
               <div className="mt-auto grid grid-cols-2 gap-3 pt-2">
-                <button type="button" className="btn-ghost h-12" onClick={() => setCurrentStep('background')}>
+                <button
+                  type="button"
+                  className="btn-ghost h-12"
+                  onClick={() => setCurrentStep('background')}
+                >
                   Back
                 </button>
                 <button
@@ -693,22 +830,38 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
 
               <div className="space-y-3">
                 {reviewInterests.map((interest) => {
-                  const selected = isSelected(selectedInterests, interest);
-                  const normalized = toSelected(interest);
-                  const atCap = selectedInterests.length >= 5 && !selected;
-                  const fromInvite = inviteInterests.some((seeded) => selectedKey(toSelected(seeded) ?? { domain: '', broadCategory: '' }) === selectedKey(normalized ?? { domain: '', broadCategory: '' }));
-                  const key = `${interest.domain}-${interest.broadCategory}`;
-                  const editing = normalized ? editingKey === selectedKey(normalized) : false;
+                  const selected = isSelected(selectedInterests, interest)
+                  const normalized = toSelected(interest)
+                  const atCap = selectedInterests.length >= 5 && !selected
+                  const fromInvite = inviteInterests.some(
+                    (seeded) =>
+                      selectedKey(
+                        toSelected(seeded) ?? { domain: '', broadCategory: '' }
+                      ) ===
+                      selectedKey(
+                        normalized ?? { domain: '', broadCategory: '' }
+                      )
+                  )
+                  const key = `${interest.domain}-${interest.broadCategory}`
+                  const editing = normalized
+                    ? editingKey === selectedKey(normalized)
+                    : false
 
                   return (
                     <div
                       key={key}
                       className={[
                         'rounded-lg border p-4 transition',
-                        selected ? 'border-foreground bg-foreground text-background' : 'bg-card',
+                        selected
+                          ? 'border-foreground bg-foreground text-background'
+                          : 'bg-card',
                         atCap ? 'opacity-45' : '',
                       ].join(' ')}
-                      title={atCap ? '5 max - deselect one to add another' : undefined}
+                      title={
+                        atCap
+                          ? '5 max - deselect one to add another'
+                          : undefined
+                      }
                       onPointerDown={() => startLongPress(interest)}
                       onPointerUp={clearLongPress}
                       onPointerLeave={clearLongPress}
@@ -716,16 +869,26 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                       {editing ? (
                         <div className="space-y-3">
                           <input
-                            className="h-11 w-full rounded-md border bg-background px-3 text-base text-foreground outline-none focus:ring-2 focus:ring-ring"
+                            className="bg-background text-foreground focus:ring-ring h-11 w-full rounded-md border px-3 text-base outline-none focus:ring-2"
                             value={editingDomain}
                             maxLength={100}
-                            onChange={(event) => setEditingDomain(event.target.value)}
+                            onChange={(event) =>
+                              setEditingDomain(event.target.value)
+                            }
                           />
                           <div className="flex gap-2">
-                            <button type="button" className="btn-primary h-9" onClick={() => saveEdit(interest)}>
+                            <button
+                              type="button"
+                              className="btn-primary h-9"
+                              onClick={() => saveEdit(interest)}
+                            >
                               Save
                             </button>
-                            <button type="button" className="btn-ghost h-9" onClick={() => setEditingKey(null)}>
+                            <button
+                              type="button"
+                              className="btn-ghost h-9"
+                              onClick={() => setEditingKey(null)}
+                            >
                               Cancel
                             </button>
                           </div>
@@ -738,17 +901,25 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                             onClick={() => toggleInterest(interest)}
                             disabled={atCap}
                           >
-                            <span className="block text-xl font-semibold tracking-normal">{interest.domain}</span>
-                            <span className={`mt-1 block text-xs font-medium uppercase ${selected ? 'text-background/70' : 'text-muted-foreground'}`}>
+                            <span className="block text-xl font-semibold tracking-normal">
+                              {interest.domain}
+                            </span>
+                            <span
+                              className={`mt-1 block text-xs font-medium uppercase ${selected ? 'text-background/70' : 'text-muted-foreground'}`}
+                            >
                               {interest.broadCategory}
                             </span>
                             {interest.rationale ? (
-                              <span className={`mt-3 block text-sm italic leading-6 ${selected ? 'text-background/80' : 'text-muted-foreground'}`}>
+                              <span
+                                className={`mt-3 block text-sm leading-6 italic ${selected ? 'text-background/80' : 'text-muted-foreground'}`}
+                              >
                                 {interest.rationale}
                               </span>
                             ) : null}
                             {fromInvite ? (
-                              <span className={`mt-3 inline-flex rounded-sm border px-2 py-1 text-[11px] font-semibold uppercase ${selected ? 'border-background/30 text-background/80' : 'text-muted-foreground'}`}>
+                              <span
+                                className={`mt-3 inline-flex rounded-sm border px-2 py-1 text-[11px] font-semibold uppercase ${selected ? 'border-background/30 text-background/80' : 'text-muted-foreground'}`}
+                              >
                                 From {displayInviterName}
                               </span>
                             ) : null}
@@ -765,7 +936,7 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                         </div>
                       )}
                     </div>
-                  );
+                  )
                 })}
               </div>
 
@@ -781,10 +952,10 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                     Write your own
                   </button>
                 ) : (
-                  <div className="rounded-lg border bg-card p-4">
+                  <div className="bg-card rounded-lg border p-4">
                     <div className="flex items-center gap-2">
                       <input
-                        className="h-11 min-w-0 flex-1 rounded-md border bg-background px-3 text-base outline-none focus:ring-2 focus:ring-ring"
+                        className="bg-background focus:ring-ring h-11 min-w-0 flex-1 rounded-md border px-3 text-base outline-none focus:ring-2"
                         placeholder="Write an interest"
                         value={customInput}
                         maxLength={100}
@@ -793,7 +964,7 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                       />
                       <button
                         type="button"
-                        className="grid size-11 place-items-center rounded-md border hover:bg-muted"
+                        className="hover:bg-muted grid size-11 place-items-center rounded-md border"
                         aria-label="Close composer"
                         title="Close"
                         onClick={() => setShowComposer(false)}
@@ -804,15 +975,18 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
 
                     <div className="mt-3 min-h-11 text-sm">
                       {isCanonicalizing ? (
-                        <p className="flex items-center gap-2 text-muted-foreground">
+                        <p className="text-muted-foreground flex items-center gap-2">
                           <Spinner small />
                           Checking wording...
                         </p>
                       ) : null}
                       {canonicalSuggestion ? (
-                        <div className="space-y-3 rounded-md border bg-background p-3">
+                        <div className="bg-background space-y-3 rounded-md border p-3">
                           <p>
-                            Suggested: <span className="font-medium">{canonicalSuggestion.suggested}</span>
+                            Suggested:{' '}
+                            <span className="font-medium">
+                              {canonicalSuggestion.suggested}
+                            </span>
                           </p>
                           <div className="flex flex-wrap gap-2">
                             <button
@@ -851,16 +1025,26 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                 )}
               </div>
 
-              <div className="sticky bottom-0 mt-auto border-t bg-background/95 py-4 backdrop-blur">
+              <div className="bg-background/95 sticky bottom-0 mt-auto border-t py-4 backdrop-blur">
                 <div className="mb-3 flex items-center justify-between text-sm">
-                  <span className="font-medium">{selectedInterests.length} of 5 selected</span>
+                  <span className="font-medium">
+                    {selectedInterests.length} of 5 selected
+                  </span>
                   <span className="text-muted-foreground">
-                    {selectedInterests.length === 0 ? 'Pick at least 1 to continue' : null}
-                    {selectedInterests.length === 5 ? '5 max - deselect one to add another' : null}
+                    {selectedInterests.length === 0
+                      ? 'Pick at least 1 to continue'
+                      : null}
+                    {selectedInterests.length === 5
+                      ? '5 max - deselect one to add another'
+                      : null}
                   </span>
                 </div>
                 <div className="grid grid-cols-2 gap-3">
-                  <button type="button" className="btn-ghost h-12" onClick={() => setCurrentStep('warmup')}>
+                  <button
+                    type="button"
+                    className="btn-ghost h-12"
+                    onClick={() => setCurrentStep('warmup')}
+                  >
                     Back
                   </button>
                   <button
@@ -885,13 +1069,18 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
 
               <ol className="space-y-3">
                 {selectedInterests.map((interest, index) => (
-                  <li key={`${interest.domain}-${index}`} className="flex gap-3 rounded-lg border bg-card p-4">
-                    <span className="grid size-8 shrink-0 place-items-center rounded-full bg-foreground text-sm font-semibold text-background">
+                  <li
+                    key={`${interest.domain}-${index}`}
+                    className="bg-card flex gap-3 rounded-lg border p-4"
+                  >
+                    <span className="bg-foreground text-background grid size-8 shrink-0 place-items-center rounded-full text-sm font-semibold">
                       {index + 1}
                     </span>
                     <span className="min-w-0 pt-1">
-                      <span className="block font-semibold">{interest.domain}</span>
-                      <span className="mt-1 block text-sm text-muted-foreground">
+                      <span className="block font-semibold">
+                        {interest.domain}
+                      </span>
+                      <span className="text-muted-foreground mt-1 block text-sm">
                         {interest.broadCategory}
                       </span>
                     </span>
@@ -902,10 +1091,20 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
               {error ? <ErrorPanel message={error} /> : null}
 
               <div className="mt-auto grid grid-cols-2 gap-3 pt-4">
-                <button type="button" className="btn-ghost h-12" onClick={() => setCurrentStep('review')} disabled={isLoading}>
+                <button
+                  type="button"
+                  className="btn-ghost h-12"
+                  onClick={() => setCurrentStep('review')}
+                  disabled={isLoading}
+                >
                   Back
                 </button>
-                <button type="button" className="btn-primary h-12" onClick={saveInterests} disabled={isLoading}>
+                <button
+                  type="button"
+                  className="btn-primary h-12"
+                  onClick={saveInterests}
+                  disabled={isLoading}
+                >
                   {isLoading ? 'Saving...' : 'Lock it in'}
                 </button>
               </div>
@@ -918,13 +1117,23 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
                 title="You're set."
                 subtitle="Your first daily round will be ready at noon EST."
               />
-              <p className="text-base leading-7 text-muted-foreground">Until then, take a look around.</p>
+              <p className="text-muted-foreground text-base leading-7">
+                Until then, take a look around.
+              </p>
               <div className="space-y-3">
-                <button type="button" className="btn-primary h-12 w-full" onClick={() => router.push('/')}>
+                <button
+                  type="button"
+                  className="btn-primary h-12 w-full"
+                  onClick={() => router.push('/')}
+                >
                   Go to home
                 </button>
                 {showDailySetup ? (
-                  <button type="button" className="btn-ghost h-12 w-full" onClick={() => router.push('/daily/setup')}>
+                  <button
+                    type="button"
+                    className="btn-ghost h-12 w-full"
+                    onClick={() => router.push('/daily/setup')}
+                  >
                     Set up today&apos;s round now
                   </button>
                 ) : null}
@@ -934,14 +1143,22 @@ export default function OnboardingFlow({ preSeededInterests, inviterName }: Onbo
         </div>
       </section>
     </main>
-  );
+  )
 }
 
-function ErrorPanel({ message, actions }: { message: string; actions?: ReactNode }) {
+function ErrorPanel({
+  message,
+  actions,
+}: {
+  message: string
+  actions?: ReactNode
+}) {
   return (
-    <div className="rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-sm text-destructive">
+    <div className="border-destructive/30 bg-destructive/10 text-destructive rounded-lg border p-4 text-sm">
       <p>{message}</p>
-      {actions ? <div className="mt-3 flex flex-wrap gap-2">{actions}</div> : null}
+      {actions ? (
+        <div className="mt-3 flex flex-wrap gap-2">{actions}</div>
+      ) : null}
     </div>
-  );
+  )
 }

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -19,10 +19,10 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('Alex Inviter thought you might like:')
+    expect(html).toContain('Alex Inviter left a few ideas for you:')
     expect(html).toContain('Sondheim')
     expect(html).toContain(
-      'They&#x27;re preselected, but you can edit, remove, or skip them before anything is saved.'
+      'They&#x27;re just a starting point — keep, edit, or ignore them before anything is saved.'
     )
   })
 
@@ -36,7 +36,7 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('A friend thought you might like:')
+    expect(html).toContain('A friend left a few ideas for you:')
   })
 
   it('still renders regular onboarding with no invite', () => {
@@ -45,7 +45,7 @@ describe('OnboardingFlow invited-interest copy', () => {
     )
 
     expect(html).toContain('The trivia you wish you were asked.')
-    expect(html).not.toContain('thought you might like:')
+    expect(html).not.toContain('left a few ideas for you:')
   })
 })
 
@@ -63,8 +63,8 @@ describe('OnboardingFlow Add Friend regression copy', () => {
       <OnboardingFlow preSeededInterests={[]} />
     )
 
-    expect(invitedHtml).toContain('Skip invited interests')
-    expect(regularHtml).not.toContain('Skip invited interests')
+    expect(invitedHtml).toContain('Skip these ideas')
+    expect(regularHtml).not.toContain('Skip these ideas')
     expect(regularHtml).toContain('The trivia you wish you were asked.')
   })
 })

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -12,6 +12,10 @@ const ERROR_COPY: Record<string, string> = {
   invalid_phone: 'Use a US mobile number.',
   too_many_suggested_interests: 'Choose up to three.',
   missing_invitee_display_name: 'Add their name first.',
+  invalid_invitee_display_name: 'Use a shorter, real display name.',
+  invalid_suggested_interests: 'Keep each idea short and friendly.',
+  invite_cooldown:
+    'Give this invite a little breathing room before trying again.',
 }
 
 type Step = 'identity' | 'interests' | 'handoff'
@@ -226,12 +230,12 @@ export default function AddFriendInvite() {
 
   if (!expanded) {
     return (
-      <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
+      <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-sm">
         <p className="text-foreground text-sm font-medium">
           Bring a friend into Joshing.
         </p>
         <p className="text-muted-foreground mt-1 text-sm leading-6">
-          Send a warm invite with a few things you think they might enjoy.
+          Send a warm note with just a few ideas they can keep, edit, or ignore.
         </p>
         <button
           type="button"
@@ -248,7 +252,7 @@ export default function AddFriendInvite() {
   }
 
   return (
-    <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
+    <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-sm">
       {step === 'identity' ? (
         <form className="space-y-5" onSubmit={goToInterests}>
           <div>
@@ -256,7 +260,7 @@ export default function AddFriendInvite() {
               Add friend
             </p>
             <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
-              Who are you bringing in?
+              Who came to mind?
             </h2>
           </div>
 
@@ -273,6 +277,8 @@ export default function AddFriendInvite() {
                 }}
                 autoComplete="name"
                 placeholder="Their name"
+                maxLength={60}
+                enterKeyHint="next"
               />
             </label>
             <label className="text-foreground block text-sm font-medium">
@@ -287,6 +293,7 @@ export default function AddFriendInvite() {
                 autoComplete="tel"
                 inputMode="tel"
                 placeholder="(555) 123-4567"
+                enterKeyHint="next"
               />
             </label>
           </div>
@@ -295,16 +302,16 @@ export default function AddFriendInvite() {
             <p className="text-destructive text-sm font-medium">{error}</p>
           ) : null}
 
-          <div className="flex items-center gap-3">
+          <div className="space-y-3">
             <button
               type="submit"
-              className="btn-primary min-h-12 flex-1 rounded-full"
+              className="btn-primary min-h-12 w-full rounded-full"
             >
               Next
             </button>
             <button
               type="button"
-              className="text-muted-foreground px-3 text-sm"
+              className="text-muted-foreground w-full py-2 text-sm"
               onClick={resetFlow}
             >
               Cancel
@@ -320,11 +327,11 @@ export default function AddFriendInvite() {
               For {trimmedName}
             </p>
             <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
-              What might they like?
+              A few ideas, lightly held
             </h2>
             <p className="text-muted-foreground mt-2 text-sm leading-6">
-              Add up to three areas you think they’d enjoy. They can keep, edit,
-              or ignore these.
+              Add up to three areas that made you think of them. Just a few
+              ideas — they can keep, edit, or ignore these.
             </p>
           </div>
 
@@ -334,14 +341,16 @@ export default function AddFriendInvite() {
                 key={placeholder}
                 className="text-foreground block text-sm font-medium"
               >
-                Interest {index + 1}
+                Idea {index + 1}
                 <input
-                  className="bg-background focus:border-foreground focus:ring-ring mt-2 h-12 w-full rounded-xl border px-3 text-base transition outline-none focus:ring-2"
+                  className="bg-background focus:border-foreground focus:ring-ring mt-2 h-12 w-full rounded-full border px-4 text-base transition outline-none focus:ring-2"
                   value={interests[index] ?? ''}
                   onChange={(event) =>
                     updateInterest(index, event.target.value)
                   }
                   placeholder={placeholder}
+                  maxLength={60}
+                  enterKeyHint={index === 2 ? 'done' : 'next'}
                 />
               </label>
             ))}
@@ -357,7 +366,7 @@ export default function AddFriendInvite() {
               className="btn-primary min-h-12 w-full rounded-full"
               disabled={submitting}
             >
-              {submitting ? 'Creating invite…' : 'Create invite'}
+              {submitting ? 'Warming it up…' : 'Make the note'}
             </button>
             <button
               type="button"
@@ -375,16 +384,17 @@ export default function AddFriendInvite() {
           <div>
             <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
               {result.type === 'friendship_request'
-                ? 'Friend request'
+                ? 'Warm note ready'
                 : 'Invite ready'}
             </p>
             <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
               {result.type === 'friendship_request'
-                ? `Request sent to ${result.inviteeDisplayName}.`
-                : `Send it to ${result.inviteeDisplayName}.`}
+                ? `Send this to ${result.inviteeDisplayName}.`
+                : `Send this to ${result.inviteeDisplayName}.`}
             </h2>
             <p className="text-muted-foreground mt-2 text-sm leading-6">
-              {result.inviteePhone}
+              You’ll send the message yourself — Joshing won’t text them for
+              you.
             </p>
           </div>
 
@@ -393,7 +403,7 @@ export default function AddFriendInvite() {
               {result.suggestedInterests.map((interest) => (
                 <span
                   key={interest}
-                  className="bg-muted text-foreground rounded-full px-3 py-1 text-sm"
+                  className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm shadow-sm"
                 >
                   {interest}
                 </span>
@@ -401,68 +411,52 @@ export default function AddFriendInvite() {
             </div>
           ) : (
             <p className="bg-muted text-muted-foreground rounded-xl px-3 py-2 text-sm">
-              No suggested interests this time — just a simple invitation.
+              No ideas attached this time — just a simple invitation.
             </p>
           )}
 
-          {result.type === 'friend_invitation' ? (
-            <>
-              <label className="text-foreground block text-sm font-medium">
-                Message
-                <textarea
-                  ref={messageRef}
-                  className="bg-background focus:border-foreground focus:ring-ring mt-2 min-h-36 w-full rounded-xl border p-3 text-base leading-6 transition outline-none focus:ring-2"
-                  value={messageText}
-                  onChange={(event) => setMessageText(event.target.value)}
-                />
-              </label>
+          <label className="text-foreground block text-sm font-medium">
+            Message you can send
+            <textarea
+              ref={messageRef}
+              className="bg-background focus:border-foreground focus:ring-ring mt-2 min-h-36 w-full rounded-xl border p-3 text-base leading-6 transition outline-none focus:ring-2"
+              value={messageText}
+              onChange={(event) => setMessageText(event.target.value)}
+            />
+          </label>
 
-              {!messageText.includes(result.inviteUrl ?? '') ? (
-                <p className="text-destructive text-sm">
-                  Generated message includes link — keep it in the message so
-                  they can join.
-                </p>
-              ) : null}
-            </>
-          ) : (
-            <p className="bg-muted text-muted-foreground rounded-xl px-3 py-2 text-sm">
-              They’ll see your request in Joshing.
+          {!messageText.includes(result.inviteUrl ?? '') ? (
+            <p className="text-destructive text-sm">
+              Keep the link in your note so they have somewhere to land.
             </p>
-          )}
+          ) : null}
 
           <div className="space-y-3">
-            {result.type === 'friend_invitation' ? (
-              <>
-                <button
-                  type="button"
-                  className="btn-primary min-h-12 w-full rounded-full"
-                  onClick={copyMessage}
-                >
-                  {copyLabel}
-                </button>
-                {smsHref ? (
-                  <a
-                    className="btn-ghost min-h-12 w-full rounded-full"
-                    href={smsHref}
-                    onClick={() =>
-                      sendTelemetry('add_friend_sms_handoff_opened', {
-                        invitation_id: result.invitationId ?? result.id,
-                        suggested_interest_count: result.suggestedInterests.length,
-                      })
-                    }
-                  >
-                    Open Messages
-                  </a>
-                ) : null}
-              </>
+            <button
+              type="button"
+              className="btn-primary min-h-12 w-full rounded-full"
+              onClick={copyMessage}
+            >
+              {copyLabel}
+            </button>
+            {smsHref ? (
+              <a
+                className="btn-ghost min-h-12 w-full rounded-full"
+                href={smsHref}
+                onClick={() =>
+                  sendTelemetry('add_friend_sms_handoff_opened', {
+                    invitation_id: result.invitationId ?? result.id,
+                    suggested_interest_count: result.suggestedInterests.length,
+                    invite_type: result.type,
+                  })
+                }
+              >
+                Open Messages
+              </a>
             ) : null}
             <button
               type="button"
-              className={
-                result.type === 'friend_invitation'
-                  ? 'text-muted-foreground w-full py-2 text-sm'
-                  : 'btn-primary min-h-12 w-full rounded-full'
-              }
+              className="text-muted-foreground w-full py-2 text-sm"
               onClick={resetFlow}
             >
               Done

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -20,7 +20,7 @@ export default function FriendsHubPage() {
             Friends
           </h1>
           <p className="text-muted-foreground mt-2 text-sm leading-6">
-            Invite your people, respond to requests, and keep your circle close.
+            Invite your people, answer warm notes, and keep your circle close.
           </p>
         </div>
         <button

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -41,7 +41,9 @@ function openAddFriend() {
 
 export default function FriendsList() {
   const [friends, setFriends] = useState<Friend[]>([])
-  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>([])
+  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>(
+    []
+  )
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [pendingRequest, setPendingRequest] = useState<string | null>(null)
@@ -70,7 +72,9 @@ export default function FriendsList() {
       setFriends(body.friends)
       setIncomingRequests(body.incomingRequests)
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not load friends.')
+      setError(
+        caught instanceof Error ? caught.message : 'Could not load friends.'
+      )
     } finally {
       setLoading(false)
     }
@@ -85,11 +89,16 @@ export default function FriendsList() {
     setError(null)
 
     try {
-      const response = await fetch(`/api/friend-requests/${requestId}/${action}`, {
-        method: 'POST',
-        credentials: 'include',
-      })
-      const body = (await response.json().catch(() => null)) as { message?: string } | null
+      const response = await fetch(
+        `/api/friend-requests/${requestId}/${action}`,
+        {
+          method: 'POST',
+          credentials: 'include',
+        }
+      )
+      const body = (await response.json().catch(() => null)) as {
+        message?: string
+      } | null
 
       if (!response.ok) {
         throw new Error(body?.message ?? 'Could not update this request.')
@@ -97,7 +106,11 @@ export default function FriendsList() {
 
       await loadFriends()
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not update this request.')
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : 'Could not update this request.'
+      )
     } finally {
       setPendingRequest(null)
     }
@@ -114,7 +127,8 @@ export default function FriendsList() {
             Joshing gets better when your people are here.
           </h2>
           <p className="text-muted-foreground mt-2 text-sm leading-6">
-            Invite someone you already trade facts, recommendations, and inside jokes with.
+            Invite someone you already trade facts, recommendations, and inside
+            jokes with.
           </p>
           <button
             type="button"
@@ -133,7 +147,7 @@ export default function FriendsList() {
               Requests
             </p>
             <h2 className="mt-1 font-serif text-xl font-semibold">
-              Incoming friend requests
+              Invitations from friends
             </h2>
           </div>
           <button
@@ -150,16 +164,21 @@ export default function FriendsList() {
         ) : incomingRequests.length > 0 ? (
           <div className="space-y-3">
             {incomingRequests.map((request) => (
-              <article key={request.id} className="bg-background rounded-xl border p-3">
+              <article
+                key={request.id}
+                className="bg-background rounded-xl border p-3"
+              >
                 <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                   <div>
-                    <h3 className="text-foreground font-medium">{request.requesterName}</h3>
+                    <h3 className="text-foreground font-medium">
+                      {request.requesterName}
+                    </h3>
                     {request.suggestedInterests.length > 0 ? (
                       <div className="mt-3 flex flex-wrap gap-2">
                         {request.suggestedInterests.map((interest) => (
                           <span
                             key={interest}
-                            className="bg-muted text-foreground rounded-full px-3 py-1 text-sm"
+                            className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
                           >
                             {interest}
                           </span>
@@ -167,7 +186,7 @@ export default function FriendsList() {
                       </div>
                     ) : (
                       <p className="text-muted-foreground mt-1 text-sm">
-                        No suggested interests yet — just a friendly hello.
+                        No ideas attached — just a friendly hello.
                       </p>
                     )}
                   </div>
@@ -179,7 +198,9 @@ export default function FriendsList() {
                       disabled={Boolean(pendingRequest)}
                       onClick={() => void updateRequest(request.id, 'accept')}
                     >
-                      {pendingRequest === `${request.id}:accept` ? 'Accepting…' : 'Accept'}
+                      {pendingRequest === `${request.id}:accept`
+                        ? 'Accepting…'
+                        : 'Accept'}
                     </button>
                     <button
                       type="button"
@@ -187,7 +208,9 @@ export default function FriendsList() {
                       disabled={Boolean(pendingRequest)}
                       onClick={() => void updateRequest(request.id, 'ignore')}
                     >
-                      {pendingRequest === `${request.id}:ignore` ? 'Ignoring…' : 'Ignore'}
+                      {pendingRequest === `${request.id}:ignore`
+                        ? 'Setting aside…'
+                        : 'Not now'}
                     </button>
                   </div>
                 </div>
@@ -195,7 +218,7 @@ export default function FriendsList() {
             ))}
           </div>
         ) : (
-          <p className="text-muted-foreground rounded-xl bg-muted px-3 py-2 text-sm">
+          <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
             No incoming requests right now.
           </p>
         )}
@@ -208,10 +231,14 @@ export default function FriendsList() {
           <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
             Friends
           </p>
-          <h2 className="mt-1 font-serif text-xl font-semibold">Active friends</h2>
+          <h2 className="mt-1 font-serif text-xl font-semibold">
+            Active friends
+          </h2>
         </div>
 
-        {error ? <p className="text-destructive mb-3 text-sm font-medium">{error}</p> : null}
+        {error ? (
+          <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
+        ) : null}
 
         {loading ? (
           <p className="text-muted-foreground text-sm">Loading friends…</p>
@@ -225,11 +252,13 @@ export default function FriendsList() {
                 <Link
                   key={friend.id}
                   href={`/users/${friend.id}`}
-                  className="bg-background block rounded-xl border p-3 transition hover:border-foreground/30 hover:shadow-sm"
+                  className="bg-background hover:border-foreground/30 block rounded-xl border p-3 transition hover:shadow-sm"
                 >
                   <div className="flex items-start justify-between gap-3">
                     <div>
-                      <h3 className="text-foreground font-medium">{friend.displayName}</h3>
+                      <h3 className="text-foreground font-medium">
+                        {friend.displayName}
+                      </h3>
                       {interests ? (
                         <p className="text-muted-foreground mt-1 text-sm leading-6">
                           Into {interests}
@@ -251,8 +280,10 @@ export default function FriendsList() {
             })}
           </div>
         ) : (
-          <div className="rounded-xl bg-muted px-3 py-2">
-            <p className="text-muted-foreground text-sm">No active friends yet.</p>
+          <div className="bg-muted rounded-xl px-3 py-2">
+            <p className="text-muted-foreground text-sm">
+              No active friends yet.
+            </p>
           </div>
         )}
       </section>

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -24,10 +24,10 @@ type InvitationsResponse = {
 }
 
 const STATUS_COPY: Record<InviteStatus, string> = {
-  pending: 'Pending',
+  pending: 'Ready to share',
   accepted: 'Accepted',
-  expired: 'Expired',
-  cancelled: 'Cancelled',
+  expired: 'Needs fresh note',
+  cancelled: 'Set aside',
 }
 
 function buildSmsHref(phone: string, message: string) {
@@ -49,7 +49,9 @@ function friendlyDate(value: string) {
 function statusDetail(invite: OutgoingInvite) {
   if (invite.status === 'pending') {
     const expires = friendlyDate(invite.expiresAt)
-    return expires ? `Expires ${expires}` : 'Invite is ready to send again.'
+    return expires
+      ? `Link rests after ${expires}`
+      : 'Your note is ready to share.'
   }
 
   if (invite.status === 'accepted') {
@@ -59,11 +61,11 @@ function statusDetail(invite: OutgoingInvite) {
 
   if (invite.status === 'expired') {
     const expired = friendlyDate(invite.expiresAt)
-    return expired ? `Expired ${expired}` : 'This invite link expired.'
+    return expired ? `Link rested ${expired}` : 'This link needs a fresh note.'
   }
 
   const cancelled = invite.cancelledAt ? friendlyDate(invite.cancelledAt) : null
-  return cancelled ? `Cancelled ${cancelled}` : 'This invite was cancelled.'
+  return cancelled ? `Set aside ${cancelled}` : 'This note was set aside.'
 }
 
 export default function PeopleYouInvited() {
@@ -144,13 +146,13 @@ export default function PeopleYouInvited() {
       } | null
 
       if (!response.ok) {
-        throw new Error(body?.message ?? 'Could not cancel invite.')
+        throw new Error(body?.message ?? 'Could not set this aside.')
       }
 
       await loadInvites()
     } catch (caught) {
       setError(
-        caught instanceof Error ? caught.message : 'Could not cancel invite.'
+        caught instanceof Error ? caught.message : 'Could not set this aside.'
       )
     } finally {
       setCancellingId(null)
@@ -173,7 +175,9 @@ export default function PeopleYouInvited() {
   if (loading) {
     return (
       <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
-        <h2 className="font-serif text-xl font-semibold">People you invited</h2>
+        <h2 className="font-serif text-xl font-semibold">
+          People you thought of
+        </h2>
         <p className="text-muted-foreground mt-2 text-sm">Loading invites…</p>
       </section>
     )
@@ -186,10 +190,10 @@ export default function PeopleYouInvited() {
       <div className="mb-4 flex items-start justify-between gap-3">
         <div>
           <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-            Invitations
+            Notes sent
           </p>
           <h2 className="mt-1 font-serif text-xl font-semibold">
-            People you invited
+            People you thought of
           </h2>
         </div>
         <button
@@ -236,7 +240,7 @@ export default function PeopleYouInvited() {
                   {invite.suggestedInterests.map((interest) => (
                     <span
                       key={interest}
-                      className="bg-muted text-foreground rounded-full px-3 py-1 text-sm"
+                      className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
                     >
                       {interest}
                     </span>
@@ -244,7 +248,7 @@ export default function PeopleYouInvited() {
                 </div>
               ) : (
                 <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
-                  No suggested interests on this invite.
+                  No ideas attached to this note.
                 </p>
               )}
 
@@ -254,8 +258,8 @@ export default function PeopleYouInvited() {
 
               {invite.status === 'accepted' ? (
                 <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
-                  They accepted your invitation and can now become part of your
-                  friend circle.
+                  They accepted your note — now you can trade questions more
+                  easily.
                 </p>
               ) : null}
 
@@ -266,7 +270,7 @@ export default function PeopleYouInvited() {
                     className="btn-ghost min-h-11 w-full rounded-full"
                     onClick={() => createNewInvite(invite)}
                   >
-                    Create new invite
+                    Write a fresh note
                   </button>
                 </div>
               ) : null}
@@ -296,8 +300,8 @@ export default function PeopleYouInvited() {
                     disabled={cancellingId === invite.id}
                   >
                     {cancellingId === invite.id
-                      ? 'Cancelling…'
-                      : 'Cancel invite'}
+                      ? 'Setting aside…'
+                      : 'Set aside'}
                   </button>
                 </div>
               ) : null}

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -33,9 +33,9 @@ describe('Friends page QA surface', () => {
   it('renders request, invite, active friend, and empty-state sections from the initial loading shell', () => {
     const html = renderToStaticMarkup(<FriendsList />)
 
-    expect(html).toContain('Incoming friend requests')
+    expect(html).toContain('Invitations from friends')
     expect(html).toContain('Loading requests')
-    expect(html).toContain('People you invited')
+    expect(html).toContain('People you thought of')
     expect(html).toContain('Loading invites')
     expect(html).toContain('Active friends')
     expect(html).toContain('Loading friends')

--- a/src/components/knowledge/AskFriendForDomain.tsx
+++ b/src/components/knowledge/AskFriendForDomain.tsx
@@ -55,8 +55,8 @@ export function buildDomainAskMessage(
   domain: string,
   inviteUrl?: string | null
 ) {
-  const base = `Josh is going deep on ${domain} — and thinks you might be the one to stump them.`
-  const ask = `If you have a good ${domain} question, send one their way in Joshing.`
+  const base = `I thought of you for this corner of Joshing: ${domain}.`
+  const ask = `If a good question comes to mind, send it their way. No pressure.`
   return inviteUrl ? `${base} ${ask} ${inviteUrl}` : `${base} ${ask}`
 }
 
@@ -220,8 +220,8 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
               Ask a friend about {domain}
             </h2>
             <p className="text-muted-foreground mt-2 text-sm leading-6">
-              Suggested interests start with {domain}. Add up to two more if
-              they fit; they can keep, edit, or ignore them.
+              Start with {domain}, then add up to two more ideas if they feel
+              right. They can keep, edit, or ignore them.
             </p>
           </div>
           <button
@@ -241,11 +241,11 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                 For {handoffName}
               </p>
               <p className="text-muted-foreground mt-2 text-sm leading-6">
-                This is a lightweight ask — no pressure, no forced interest, and
-                no empty round.
+                You send this yourself — Joshing won’t text them for you. Keep
+                it light and personal.
               </p>
               <label className="mt-4 block text-sm font-medium">
-                Message
+                Message you can send
                 <textarea
                   ref={messageRef}
                   className="bg-background focus:border-foreground mt-2 min-h-32 w-full rounded-xl border p-3 text-sm leading-6 outline-none"
@@ -309,7 +309,7 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                   </p>
                 ) : friends.length === 0 ? (
                   <p className="text-muted-foreground p-4 text-sm">
-                    No active friends yet. Enter a name and phone instead.
+                    No friends here yet. Enter a name and phone instead.
                   </p>
                 ) : (
                   friends.map((friend) => (
@@ -322,7 +322,8 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                       <span className="font-medium">{friend.displayName}</span>
                       {friend.declaredInterests?.length ? (
                         <span className="text-muted-foreground mt-1 block text-xs">
-                          Into {friend.declaredInterests.slice(0, 3).join(', ')}
+                          Has shared{' '}
+                          {friend.declaredInterests.slice(0, 3).join(', ')}
                         </span>
                       ) : null}
                     </button>
@@ -356,15 +357,15 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                 </div>
 
                 <div className="bg-card space-y-3 rounded-xl border p-4">
-                  <p className="text-sm font-medium">Suggested interests</p>
+                  <p className="text-sm font-medium">A few ideas</p>
                   {interests.map((interest, index) => (
                     <label
                       key={index}
                       className="text-muted-foreground block text-xs font-medium tracking-[0.08em] uppercase"
                     >
                       {index === 0
-                        ? 'Prefilled from your search'
-                        : `Optional interest ${index + 1}`}
+                        ? 'First idea'
+                        : `Optional idea ${index + 1}`}
                       <input
                         className="bg-background text-foreground focus:border-foreground disabled:bg-muted mt-2 h-11 w-full rounded-lg border px-3 text-sm tracking-normal normal-case outline-none"
                         value={interest}
@@ -374,7 +375,7 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                         }
                         placeholder={
                           index === 1
-                            ? 'Another thing they know'
+                            ? 'Another idea, if useful'
                             : 'One more, if useful'
                         }
                       />
@@ -394,7 +395,7 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                     className="btn-primary min-h-12 flex-1 rounded-full"
                     disabled={submitting}
                   >
-                    {submitting ? 'Creating ask…' : 'Create ask'}
+                    {submitting ? 'Warming it up…' : 'Make the note'}
                   </button>
                   <button
                     type="button"

--- a/src/components/knowledge/__tests__/AskFriendForDomain.test.tsx
+++ b/src/components/knowledge/__tests__/AskFriendForDomain.test.tsx
@@ -20,9 +20,7 @@ describe('Knowledge-page Ask a friend integration', () => {
     )
 
     expect(html).toContain('Ask a friend about Italian Renaissance painting')
-    expect(html).toContain(
-      'Suggested interests start with Italian Renaissance painting'
-    )
+    expect(html).toContain('Start with Italian Renaissance painting')
     expect(html).toContain('Existing friend')
     expect(html).toContain('New friend')
     expect(html).not.toMatch(/leaderboard|ranking|score|points?|percent|%/i)

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -3,6 +3,8 @@ import { createHash } from 'crypto'
 export type TelemetryEventName =
   | 'add_friend_started'
   | 'add_friend_invite_created'
+  | 'add_friend_invite_cancelled'
+  | 'add_friend_invite_rate_limited'
   | 'add_friend_message_copied'
   | 'add_friend_sms_handoff_opened'
   | 'friend_invite_link_opened'
@@ -13,6 +15,7 @@ export type TelemetryEventName =
   | 'friend_onboarding_interests_partial'
   | 'friend_onboarding_interests_skipped'
   | 'friend_request_existing_user_created'
+  | 'friend_request_reinvite_after_ignore_limited'
   | 'friend_request_accepted'
   | 'friend_request_ignored'
 


### PR DESCRIPTION
### Motivation
- QA found the Add Friend flow felt mechanical and recommendation-like, which undermines Joshing’s “I thought of you” philosophy.  
- Existing-user handoffs were too generic and resembled social-network friend admin UX.  
- The invite feature needed lightweight abuse/ spam constraints without adding punitive friction or new moderation infrastructure.

### Description
- Softened copy and UX everywhere the invite tone appeared: `AddFriendInvite`, invite landing, onboarding, activities, `AskFriendForDomain`, and invite lists so suggested interests read as optional ideas (soft chips) and the handoff explicitly states the inviter sends the message.  
- Implemented existing-user personal handoff: existing-user invitations now return a warm `message` plus a deep link into the activities anchor for the specific friendship request instead of only a null invite URL.  
- Added lightweight in-process throttling and cooldowns in `POST /api/friend-invitations`: per-user/per-phone windows, same-phone cooldown, cancelled-invite and ignored-request cooldowns, plus helpers `recordInviteAttempt`, `rememberCancelledInvite`, `rememberIgnoredFriendRequest`, and `resetFriendInvitationRateLimitForTests`.  
- Hardened validation: shorter max lengths and unsafe-text checks for display names and suggested interests (control chars, spammy patterns, abusive words, giant unicode spam); dedupe and trim behavior preserved.  
- Telemetry/events extended to record invite rate-limits, cancellations, and reinvite-after-ignore attempts; test helpers exported for resetting in-memory limits.  
- Small mobile and flow refinements: keyboard hints, one-primary-action per step, clearer CTA wording, friend-request/activities copy changed from “friend request”/“invite admin” to conversational phrases like “warm note” / “thought of you”, and invite-list copy changed to “notes/ideas” language.  
- Tests and QA contracts updated to reflect copy and deep-link behavior (server and component tests adjusted); no backend SMS was added and core architecture/DB flows left intact.

### Testing
- Type-check: `npx tsc --noEmit --pretty false` — succeeded.  
- Linters (targeted): `npx eslint` run against modified files listed in the PR — passed for the touched files; full-repo lint still reports unrelated pre-existing issues.  
- Unit tests: updated QA expectations in `src/app/api/friend-invitations/__tests__/route.test.ts` and component tests that assert copy/landing behavior; attempted to run `vitest` but local `node_modules` `vitest` binary was unavailable and `npx vitest` could not fetch due to registry policy, so those suites were not executed in this environment.  
- Build: `npm run build` attempted but blocked by an external `next/font` Google Fonts fetch failure (Montserrat) unrelated to the changes, so a production build artifact was not produced.  

Notes: the rate-limit implementation is intentionally in-process and lightweight to avoid cross-instance complexity; for distributed deployments a durable store should be considered later.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04bbcecd9c832e9c4bddb789278098)