### PR TITLE
Fix daily setup difficulty button spacing

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -256,7 +256,7 @@ function DailySetupContent() {
         <p className="mb-3 text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground">
           Difficulty
         </p>
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+        <div className="flex flex-wrap gap-3">
           {DIFFICULTIES.map((item) => {
             const active = difficulty === item.value;
             return (
@@ -264,7 +264,7 @@ function DailySetupContent() {
                 key={item.value}
                 type="button"
                 onClick={() => setDifficulty(item.value)}
-                className={`min-h-11 rounded-full border px-3 text-xs font-medium uppercase tracking-[0.08em] transition ${
+                className={`min-h-11 whitespace-nowrap rounded-full border px-5 text-xs font-medium uppercase tracking-[0.08em] transition ${
                   active ? 'bg-primary text-primary-foreground' : 'bg-card text-muted-foreground'
                 }`}
                 aria-pressed={active}


### PR DESCRIPTION
### Motivation
- Prevent difficulty labels from colliding and improve layout responsiveness in the Daily Setup UI by replacing the rigid grid with a wrapping layout and ensuring buttons keep their spacing.

### Description
- Replace the fixed five-column grid with a wrapping flex row by changing the container from `className="grid grid-cols-2 gap-2 sm:grid-cols-5"` to `className="flex flex-wrap gap-3"` in `src/app/daily/setup/page.tsx`.
- Add `whitespace-nowrap` and increase horizontal padding (`px-5`) on each difficulty button so longer labels remain readable and do not wrap.

### Testing
- Ran `npx eslint src/app/daily/setup/page.tsx`, which passed for the modified file.
- Attempted `npm run lint` for the whole repo, which surfaced unrelated pre-existing lint errors in other files and therefore did not fully pass, but those failures are outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04cb234bb8832e9ed16c00f31bc323)