### PR TITLE
Preserve invite routes through proxy

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from 'next/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { proxy } from '@/proxy'
+
+function makeRequest(path: string) {
+  return new NextRequest(new URL(path, 'https://joshing.test'))
+}
+
+describe('proxy unauthenticated route preservation', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('passes invite pages through without clearing or rewriting the invite token', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), { status: 401 })
+    )
+
+    const response = await proxy(makeRequest('/invite/keep-this-token'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('location')).toBeNull()
+  })
+
+  it('still redirects other unauthenticated pages to login without a stale query', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ user: null }), { status: 401 })
+    )
+
+    const response = await proxy(
+      makeRequest('/dashboard?invitationToken=drop-me')
+    )
+
+    expect(response.status).toBe(307)
+    expect(response.headers.get('location')).toBe('https://joshing.test/login')
+  })
+})

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -23,11 +23,14 @@ function normalizePhone(phone: string): string {
   return phone.startsWith('+') ? phone : `+${digits}`;
 }
 
+export function readInvitationToken(searchParams: URLSearchParams) {
+  return searchParams.get('invitationToken') ?? searchParams.get('invite') ?? searchParams.get('token');
+}
+
 export default function LoginPanel() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const invitationToken =
-    searchParams.get('invitationToken') ?? searchParams.get('invite') ?? searchParams.get('token');
+  const invitationToken = readInvitationToken(searchParams);
 
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');

--- a/src/app/login/__tests__/LoginPanel.test.ts
+++ b/src/app/login/__tests__/LoginPanel.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+
+import { readInvitationToken } from '@/app/login/LoginPanel'
+
+describe('LoginPanel invitation token query aliases', () => {
+  it.each([
+    ['invitationToken', 'alpha-token'],
+    ['invite', 'bravo-token'],
+    ['token', 'charlie-token'],
+  ])('accepts %s as an invitation token source', (queryKey, token) => {
+    expect(readInvitationToken(new URLSearchParams([[queryKey, token]]))).toBe(
+      token
+    )
+  })
+})

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -27,6 +27,7 @@ export async function proxy(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
   const isLoginPage = pathname === '/login';
+  const isInvitePage = pathname.startsWith('/invite/');
   const isOnboardingPage = pathname === '/onboarding';
   const isAllowedOnboardingPath =
     isOnboardingPage ||
@@ -37,7 +38,7 @@ export async function proxy(request: NextRequest) {
   const user = await getAuthenticatedUser(request);
 
   if (!user) {
-    if (isLoginPage) return NextResponse.next();
+    if (isLoginPage || isInvitePage) return NextResponse.next();
 
     const loginUrl = request.nextUrl.clone();
     loginUrl.pathname = '/login';


### PR DESCRIPTION
### Motivation
- Ensure invite landing pages at `/invite/<token>` are reachable by unauthenticated visitors and that invite tokens are not stripped or rewritten by the middleware proxy.
- Keep the login flow able to accept invitation tokens from any of the query alias names so invite handoff continues to function through `LoginPanel`.

### Description
- Add `isInvitePage` detection (`pathname.startsWith('/invite/')`) to the proxy and allow unauthenticated requests for invite pages to `NextResponse.next()` just like `/login` so the invite path and token are preserved.
- Do not clear or rewrite the invite token in the proxy logic; invite pages are passed through unchanged for unauthenticated users.
- Extract `readInvitationToken(searchParams)` from `LoginPanel` and use it so the component continues to accept `invitationToken`, `invite`, and `token` aliases and to include `invitationToken` in the OTP verification payload.
- Add focused tests: `src/__tests__/proxy.test.ts` verifying invite passthrough and redirect behavior for other unauthenticated pages, and `src/app/login/__tests__/LoginPanel.test.ts` verifying the three invitation query aliases; existing invite landing tests already assert the Continue link targets `/login?invitationToken=<token>`.

### Testing
- Ran `npx eslint src/proxy.ts src/__tests__/proxy.test.ts src/app/login/LoginPanel.tsx src/app/login/__tests__/LoginPanel.test.ts --ext .ts,.tsx` which succeeded for the touched files.
- Ran `npx tsc --noEmit` which completed without errors.
- Attempted `npx vitest run src/__tests__/proxy.test.ts src/app/invite/[token]/__tests__/page.test.tsx src/app/login/__tests__/LoginPanel.test.ts` but execution was blocked because `vitest` could not be fetched from the npm registry (403 Forbidden), so unit tests could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d12f2674832ea425594d0be39ae1)