### PR TITLE
Add invite-suggestions substep to onboarding (defer save until final confirmation)

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import { COUNTRIES } from '@/lib/onboarding/countries'
 import { US_STATES } from '@/lib/onboarding/us-regions'
 
 type CurrentStep =
+  | 'invite-suggestions'
   | 'welcome'
   | 'background'
   | 'warmup'
@@ -138,7 +139,7 @@ function Spinner({ small = false }: { small?: boolean }) {
 
 function ProgressDots({ currentStep }: { currentStep: CurrentStep }) {
   const activeIndex =
-    currentStep === 'welcome'
+    currentStep === 'welcome' || currentStep === 'invite-suggestions'
       ? -1
       : currentStep === 'complete'
         ? STEP_DOTS.length
@@ -189,7 +190,9 @@ export default function OnboardingFlow({
   inviterName,
 }: OnboardingFlowProps) {
   const router = useRouter()
-  const [currentStep, setCurrentStep] = useState<CurrentStep>('welcome')
+  const [currentStep, setCurrentStep] = useState<CurrentStep>(() =>
+    preSeededInterests.length > 0 ? 'invite-suggestions' : 'welcome'
+  )
   const [birthYear, setBirthYear] = useState('')
   const [grewUpCountry, setGrewUpCountry] = useState('')
   const [grewUpRegion, setGrewUpRegion] = useState('')
@@ -448,42 +451,37 @@ export default function OnboardingFlow({
     }
   }
 
-  async function skipInviteInterests() {
-    if (inviteInterests.length === 0) return
-
+  function keepInviteInterests() {
     setError(null)
-    setIsLoading(true)
+    setSelectedInterests(
+      inviteInterests
+        .flatMap((interest) => {
+          const selected = toSelected(interest)
+          return selected ? [selected] : []
+        })
+        .slice(0, 5)
+    )
+    setCurrentStep('background')
+  }
 
-    try {
-      const response = await fetch('/api/onboarding/save-interests', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          interests: [],
-          telemetry: {
-            inviteInterestCount: inviteInterests.length,
-            inviteSelectedCount: 0,
-          },
-        }),
-      })
-      const data = await response.json().catch(() => ({}))
+  function reviewInviteInterests() {
+    setError(null)
+    setSelectedInterests(
+      inviteInterests
+        .flatMap((interest) => {
+          const selected = toSelected(interest)
+          return selected ? [selected] : []
+        })
+        .slice(0, 5)
+    )
+    setCurrentStep('review')
+  }
 
-      if (!response.ok || data?.ok !== true) {
-        setError(
-          data?.message ?? data?.error ?? 'Unable to skip invited interests.'
-        )
-        return
-      }
-
-      setSelectedInterests([])
-      setInviteInterests([])
-      setCurrentStep('complete')
-      router.refresh()
-    } catch {
-      setError('Unable to skip invited interests.')
-    } finally {
-      setIsLoading(false)
-    }
+  function skipInviteInterests() {
+    setError(null)
+    setSelectedInterests([])
+    setInviteInterests([])
+    setCurrentStep('background')
   }
 
   async function saveInterests() {
@@ -588,6 +586,60 @@ export default function OnboardingFlow({
         <ProgressDots currentStep={currentStep} />
 
         <div className="mt-9 flex flex-1 flex-col">
+          {currentStep === 'invite-suggestions' ? (
+            <div className="flex flex-1 flex-col justify-center gap-8">
+              <StepHeader
+                title={`${displayInviterName} suggested these for you.`}
+                subtitle="Keep the ones that fit. You can edit or skip them."
+              />
+
+              <ul className="space-y-3">
+                {inviteInterests.map((interest) => (
+                  <li
+                    key={`${interest.domain}-${interest.broadCategory}`}
+                    className="bg-card rounded-lg border p-4"
+                  >
+                    <span className="block text-xl font-semibold tracking-normal">
+                      {interest.domain}
+                    </span>
+                    <span className="text-muted-foreground mt-1 block text-xs font-medium uppercase">
+                      {interest.broadCategory}
+                    </span>
+                    {interest.rationale ? (
+                      <span className="text-muted-foreground mt-3 block text-sm leading-6 italic">
+                        {interest.rationale}
+                      </span>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+
+              <div className="space-y-3">
+                <button
+                  type="button"
+                  className="btn-primary h-12 w-full"
+                  onClick={keepInviteInterests}
+                >
+                  Keep all
+                </button>
+                <button
+                  type="button"
+                  className="btn-ghost h-12 w-full"
+                  onClick={reviewInviteInterests}
+                >
+                  Choose/edit
+                </button>
+                <button
+                  type="button"
+                  className="btn-ghost h-12 w-full"
+                  onClick={skipInviteInterests}
+                >
+                  Skip
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           {currentStep === 'welcome' ? (
             <div className="flex flex-1 flex-col justify-center gap-8">
               <StepHeader
@@ -605,37 +657,6 @@ export default function OnboardingFlow({
                 </p>
                 <p>It takes about two minutes.</p>
               </div>
-
-              {inviteInterests.length > 0 ? (
-                <div className="bg-card rounded-lg border p-4 text-sm leading-6 shadow-sm">
-                  <p className="font-medium">
-                    {displayInviterName} left a few ideas for you:
-                  </p>
-                  <ul className="text-muted-foreground mt-2 space-y-1">
-                    {inviteInterests.slice(0, 3).map((interest) => (
-                      <li
-                        key={interest.domain}
-                        className="border-primary/10 bg-primary/5 text-foreground inline-flex rounded-full border px-3 py-1"
-                      >
-                        {interest.domain}
-                      </li>
-                    ))}
-                  </ul>
-                  <p className="text-muted-foreground mt-3">
-                    They&apos;re just a starting point — keep, edit, or ignore
-                    them before anything is saved.
-                  </p>
-                  {error ? <ErrorPanel message={error} /> : null}
-                  <button
-                    type="button"
-                    className="btn-ghost mt-3 h-11 w-full"
-                    onClick={skipInviteInterests}
-                    disabled={isLoading}
-                  >
-                    {isLoading ? 'Skipping…' : 'Skip these ideas'}
-                  </button>
-                </div>
-              ) : null}
 
               <button
                 type="button"


### PR DESCRIPTION
### Motivation
- Introduce an explicit initial review when a user arrives with `preSeededInterests` so invited suggestions are presented up front without being persisted automatically. 
- Give users clear, deterministic actions (`Keep all`, `Choose/edit`, `Skip`) to control whether invite interests become part of the normal onboarding flow before any server-side save.

### Description
- Added a new `invite-suggestions` `CurrentStep` and initialize `currentStep` to `invite-suggestions` when `preSeededInterests.length > 0`. 
- Render an invite suggestions screen with the exact copy: title/body `"${displayInviterName} suggested these for you."` and subcopy `"Keep the ones that fit. You can edit or skip them."` and list the invite items. 
- Implemented three local actions: `keepInviteInterests` (selects all invite interests locally and continues to the standard onboarding), `reviewInviteInterests` (pre-selects invite interests and proceeds to the existing review/edit UI), and `skipInviteInterests` (clears invite interests locally and continues without saving). 
- Removed the previous save-on-skip behavior so no call to `/api/onboarding/save-interests` is made from the opening invite card; the only persistence path remains the existing `saveInterests` flow which sends final `selectedInterests` to `/api/onboarding/save-interests`. 
- Kept all unrelated onboarding questions, canonicalization, scoring, and gameplay flows unchanged.

### Testing
- Ran `npx eslint src/app/onboarding/OnboardingFlow.tsx` which passed for the modified file. 
- Ran `npx tsc --noEmit` which completed successfully with no type errors in the changed file. 
- Ran `npm run lint` which surfaced pre-existing lint issues elsewhere in the repo (these are unrelated to the onboarding file); the onboarding changes themselves do not introduce new lint/type failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04d23ddf20832e83121792dca509ac)