### PR TITLE
Add confirmed account deletion to Account page

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -76,6 +76,10 @@ export default function AccountPage() {
   const [confirmingLogout, setConfirmingLogout] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
   const [logoutError, setLogoutError] = useState<string | null>(null);
+  const [confirmingDelete, setConfirmingDelete] = useState(false);
+  const [deleteConfirmation, setDeleteConfirmation] = useState('');
+  const [deletingAccount, setDeletingAccount] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const loadProfile = useCallback(async () => {
     setLoading(true);
@@ -104,7 +108,8 @@ export default function AccountPage() {
   }, [router]);
 
   useEffect(() => {
-    void loadProfile();
+    const timer = window.setTimeout(() => void loadProfile(), 0);
+    return () => window.clearTimeout(timer);
   }, [loadProfile]);
 
   useEffect(() => {
@@ -115,6 +120,7 @@ export default function AccountPage() {
 
   const changed = profile ? displayName.trim() !== profile.displayName : false;
   const initials = useMemo(() => initialsFor(profile?.displayName ?? displayName), [displayName, profile]);
+  const canDeleteAccount = deleteConfirmation === 'DELETE';
 
   async function saveDisplayName() {
     if (!profile) return;
@@ -147,6 +153,31 @@ export default function AccountPage() {
       setSaveError(caught instanceof Error ? caught.message : 'Could not update your name.');
     } finally {
       setSaving(false);
+    }
+  }
+
+
+  async function confirmDeleteAccount() {
+    if (!canDeleteAccount) return;
+
+    setDeletingAccount(true);
+    setDeleteError(null);
+
+    try {
+      const response = await fetch('/api/account', {
+        method: 'DELETE',
+        credentials: 'include',
+      });
+      const body = await response.json().catch(() => null) as { error?: string } | null;
+
+      if (!response.ok && response.status !== 401) {
+        throw new Error(body?.error ?? 'Could not delete your account.');
+      }
+
+      router.push('/login');
+    } catch (caught) {
+      setDeleteError(caught instanceof Error ? caught.message : 'Could not delete your account.');
+      setDeletingAccount(false);
     }
   }
 
@@ -270,6 +301,31 @@ export default function AccountPage() {
           <p className="mt-1 text-xs text-muted-foreground">To change your number, contact support.</p>
         </div>
 
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row">
+          <button
+            className="min-h-10 rounded-md border border-destructive px-4 text-sm font-medium text-destructive hover:bg-destructive/10"
+            type="button"
+            onClick={() => {
+              setConfirmingLogout(true);
+              setConfirmingDelete(false);
+              setDeleteError(null);
+            }}
+          >
+            Log out
+          </button>
+          <button
+            className="min-h-10 rounded-md bg-destructive px-4 text-sm font-medium text-destructive-foreground hover:bg-destructive/90"
+            type="button"
+            onClick={() => {
+              setConfirmingDelete(true);
+              setConfirmingLogout(false);
+              setLogoutError(null);
+            }}
+          >
+            Delete account
+          </button>
+        </div>
+
         {confirmingLogout ? (
           <div className="mt-5 rounded-lg border border-destructive/30 p-3">
             <p className="text-sm font-medium">Are you sure you want to log out?</p>
@@ -289,15 +345,54 @@ export default function AccountPage() {
             </div>
             {logoutError ? <p className="mt-2 text-sm text-destructive">{logoutError}</p> : null}
           </div>
-        ) : (
-          <button
-            className="mt-5 min-h-10 rounded-md border border-destructive px-4 text-sm font-medium text-destructive hover:bg-destructive/10"
-            type="button"
-            onClick={() => setConfirmingLogout(true)}
-          >
-            Log out
-          </button>
-        )}
+        ) : null}
+
+        {confirmingDelete ? (
+          <div className="mt-5 rounded-lg border border-destructive bg-destructive/5 p-3">
+            <p className="text-sm font-semibold text-destructive">Delete your account permanently?</p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              This removes your account, sessions, stats, authored questions, games, and friend connections. This cannot be undone.
+            </p>
+            <label className="mt-3 block text-xs font-medium" htmlFor="delete-confirmation">
+              Type DELETE to confirm.
+            </label>
+            <input
+              id="delete-confirmation"
+              value={deleteConfirmation}
+              onChange={(event) => {
+                setDeleteConfirmation(event.target.value);
+                setDeleteError(null);
+              }}
+              className="mt-1 h-10 w-full rounded-md border bg-background px-3 text-sm outline-none focus:border-destructive"
+              autoComplete="off"
+              disabled={deletingAccount}
+            />
+            <div className="mt-3 flex gap-2">
+              <button
+                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md bg-destructive px-3 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:cursor-not-allowed disabled:opacity-60"
+                type="button"
+                onClick={() => void confirmDeleteAccount()}
+                disabled={!canDeleteAccount || deletingAccount}
+              >
+                {deletingAccount ? <Loader2 className="size-4 animate-spin" /> : null}
+                Permanently delete account
+              </button>
+              <button
+                className="rounded-md border px-3 text-sm"
+                type="button"
+                onClick={() => {
+                  setConfirmingDelete(false);
+                  setDeleteConfirmation('');
+                  setDeleteError(null);
+                }}
+                disabled={deletingAccount}
+              >
+                Cancel
+              </button>
+            </div>
+            {deleteError ? <p className="mt-2 text-sm text-destructive">{deleteError}</p> : null}
+          </div>
+        ) : null}
       </section>
 
       {toast ? (

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 
-import { getSession } from '@/server/auth/session';
-import { getUserProfile, updateDisplayName } from '@/server/db/queries/account';
+import { destroySession, getSession } from '@/server/auth/session';
+import { deleteUserAccount, getUserProfile, updateDisplayName } from '@/server/db/queries/account';
 
 const DISPLAY_NAME_ERROR = 'Display name must be 2-30 characters.';
 
@@ -40,6 +40,20 @@ export async function PATCH(request: Request) {
   if (!result.ok && result.reason === 'invalid') {
     return NextResponse.json({ error: DISPLAY_NAME_ERROR }, { status: 400 });
   }
+
+  return NextResponse.json({ ok: true });
+}
+
+
+export async function DELETE() {
+  const session = await getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  await deleteUserAccount(session.userId);
+  await destroySession();
 
   return NextResponse.json({ ok: true });
 }

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -1,4 +1,4 @@
-import { count, countDistinct, eq, isNull, sql } from 'drizzle-orm';
+import { count, countDistinct, eq, sql } from 'drizzle-orm';
 
 import {
   db,
@@ -112,4 +112,54 @@ export async function updateDisplayName(params: {
     .where(eq(users.id, params.userId));
 
   return { ok: true };
+}
+
+
+export async function deleteUserAccount(userId: string): Promise<void> {
+  await db.transaction(async (tx) => {
+    await tx.execute(sql`delete from "FeedItem" where "recipientUserId" = ${userId} or "sourceUserId" = ${userId} or "joshingGameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "ActivityItem" where "userId" = ${userId}`);
+    await tx.execute(sql`update "ActivityItem" set "actorUserId" = null where "actorUserId" = ${userId}`);
+
+    await tx.execute(sql`delete from "QuestionReaction" where "senderUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "CreatorNote" where "authorUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "GradeDispute" where "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+
+    await tx.execute(sql`delete from "JoshingGameResponse" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "JoshingGameRecipient" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId})`);
+    await tx.execute(sql`delete from "JoshingGameQuestion" where "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "JoshingGame" where "creatorId" = ${userId}`);
+
+    await tx.execute(sql`delete from "Friendship" where "userAId" = ${userId} or "userBId" = ${userId} or "requestedByUserId" = ${userId} or "removedByUserId" = ${userId}`);
+    await tx.execute(sql`delete from "FriendInvitation" where "inviterUserId" = ${userId}`);
+    await tx.execute(sql`update "FriendInvitation" set "inviteeUserId" = null where "inviteeUserId" = ${userId}`);
+    await tx.execute(sql`update "DailyPreference" set "friend_ids" = array_remove("friend_ids", ${userId}) where ${userId} = any("friend_ids")`);
+
+    await tx.execute(sql`delete from "SkippedDailyQuestion" where "user_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId}) or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(sql`delete from "DailyQueue" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "DailyPreference" where "user_id" = ${userId}`);
+
+    await tx.execute(sql`delete from "QuestionFeedback" where "user_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId}) or "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(sql`delete from "QuestionRating" where "user_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "UserQuestionBank" where "user_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "QuestionAudienceTag" where "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+    await tx.execute(sql`delete from "MASTERY_EVENTS" where "user_id" = ${userId} or "answered_by_user_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+
+    await tx.execute(sql`delete from "Question" where "creator_id" = ${userId}`);
+    await tx.execute(sql`update "Question" set "generated_question_id" = null where "generated_question_id" in (select id from "GeneratedQuestion" where "user_id" = ${userId})`);
+    await tx.execute(sql`delete from "GeneratedQuestion" where "user_id" = ${userId}`);
+
+    await tx.execute(sql`delete from "PLAYER_MASTERY" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "CritiqueUsageDaily" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "USER_DOMAIN_DIFFICULTY" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "USER_DOMAIN_EXCLUSIONS" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "PROFILE_DOMAIN_VISIBILITY" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "DeclaredInterest" where "userId" = ${userId}`);
+    await tx.execute(sql`delete from "FeedDismissedDomain" where "userId" = ${userId}`);
+    await tx.execute(sql`delete from "BiweeklyCeremony" where "userId" = ${userId}`);
+    await tx.execute(sql`delete from "SmsLog" where "user_id" = ${userId}`);
+    await tx.execute(sql`delete from "UserSession" where "user_id" = ${userId}`);
+
+    await tx.delete(users).where(eq(users.id, userId));
+  });
 }


### PR DESCRIPTION
### Motivation
- Provide a safe, user-initiated way to permanently delete an account and its related data while preventing accidental deletion via a typed confirmation gate.

### Description
- Add UI on the Account page to trigger account deletion, including local state (`confirmingDelete`, `deleteConfirmation`, `deletingAccount`, `deleteError`) and a confirmation dialog that requires typing `DELETE` before enabling the destructive action.  
- Wire the client to call `DELETE /api/account` and redirect to `/login` on success, showing errors when deletion fails.  
- Add a `DELETE` handler in `src/app/api/account/route.ts` that validates the session, calls `deleteUserAccount`, and clears the session via `destroySession`.  
- Implement `deleteUserAccount` in `src/server/db/queries/account.ts` to run a transactional cleanup that removes or updates feed/activity rows, reactions/notes, joshing games and recipients, friendships/invitations, daily data, authored/generated questions, mastery/profile-related rows, sessions, SMS logs, and finally the user row.

### Testing
- Ran `npx tsc --noEmit` and it passed.  
- Ran `npx eslint` against the modified files with `npx eslint src/app/account/page.tsx src/app/api/account/route.ts src/server/db/queries/account.ts` and it passed.  
- Ran `npm run lint` (repo-wide) which still fails due to unrelated, pre-existing lint errors outside these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f2268cb8832e8081a1f3913398d2)