### PR TITLE
Handle legacy QuestionReaction columns during account deletion

### DIFF
--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -121,7 +121,30 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     await tx.execute(sql`delete from "ActivityItem" where "userId" = ${userId}`);
     await tx.execute(sql`update "ActivityItem" set "actorUserId" = null where "actorUserId" = ${userId}`);
 
-    await tx.execute(sql`delete from "QuestionReaction" where "senderUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    const questionReactionColumnsResult = await tx.execute<{ column_name: string }>(sql`
+      select column_name
+      from information_schema.columns
+      where table_schema = 'public'
+        and table_name = 'QuestionReaction'
+        and column_name in ('senderUserId', 'recipientUserId', 'questionId', 'answerer_id', 'creator_id', 'question_id')
+    `);
+    const questionReactionColumnNames = new Set(
+      questionReactionColumnsResult.rows.map((row) => row.column_name),
+    );
+
+    if (
+      questionReactionColumnNames.has('senderUserId')
+      && questionReactionColumnNames.has('recipientUserId')
+      && questionReactionColumnNames.has('questionId')
+    ) {
+      await tx.execute(sql`delete from "QuestionReaction" where "senderUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    } else if (
+      questionReactionColumnNames.has('answerer_id')
+      && questionReactionColumnNames.has('creator_id')
+      && questionReactionColumnNames.has('question_id')
+    ) {
+      await tx.execute(sql`delete from "QuestionReaction" where "answerer_id" = ${userId} or "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
+    }
     await tx.execute(sql`delete from "CreatorNote" where "authorUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
     await tx.execute(sql`delete from "GradeDispute" where "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
 


### PR DESCRIPTION
### Motivation
- Prevent account deletion from failing with Postgres 42703 when deployed databases still have the legacy snake_case `QuestionReaction` columns instead of the current camelCase names. 
- Make `deleteUserAccount` resilient to schema drift between migrations so account removal can run safely in older previews/production databases.

### Description
- Add a runtime check that queries `information_schema.columns` for the `QuestionReaction` table and builds a set of present column names. 
- Conditionally run the reactions deletion using either the current camelCase columns (`senderUserId`, `recipientUserId`, `questionId`) or the legacy snake_case columns (`answerer_id`, `creator_id`, `question_id`).
- Keep the deletion logic inside the same transaction and preserve all other cleanup steps in `deleteUserAccount`.

### Testing
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `npx eslint src/server/db/queries/account.ts` which passed for the modified file. 
- Ran `npm run lint` which failed due to pre-existing unrelated lint issues elsewhere in the repo (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f6bd0df0832e84c6e8e82f2df92d)