### PR TITLE
Guard CreatorNote cleanup during account deletion when table is missing

### DIFF
--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -145,7 +145,19 @@ export async function deleteUserAccount(userId: string): Promise<void> {
     ) {
       await tx.execute(sql`delete from "QuestionReaction" where "answerer_id" = ${userId} or "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
     }
-    await tx.execute(sql`delete from "CreatorNote" where "authorUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    const creatorNoteTableResult = await tx.execute<{ exists: boolean }>(sql`
+      select exists (
+        select 1
+        from information_schema.tables
+        where table_schema = 'public'
+          and table_name = 'CreatorNote'
+      ) as "exists"
+    `);
+
+    if (creatorNoteTableResult.rows[0]?.exists) {
+      await tx.execute(sql`delete from "CreatorNote" where "authorUserId" = ${userId} or "recipientUserId" = ${userId} or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);
+    }
+
     await tx.execute(sql`delete from "GradeDispute" where "creator_id" = ${userId} or "question_id" in (select id from "Question" where "creator_id" = ${userId})`);
 
     await tx.execute(sql`delete from "JoshingGameResponse" where "userId" = ${userId} or "gameId" in (select id from "JoshingGame" where "creatorId" = ${userId}) or "questionId" in (select id from "Question" where "creator_id" = ${userId})`);


### PR DESCRIPTION
### Motivation
- Prevent account deletion from failing with SQL "relation does not exist" errors on databases that don't have the `CreatorNote` table (legacy deployments or before running the migration). 

### Description
- Added an `information_schema.tables` existence check and only run the `DELETE from "CreatorNote" ...` statement when the `CreatorNote` table exists. 
- Kept the rest of the account-cleanup transaction intact so other related deletes continue to run as before. 
- Change implemented in `src/server/db/queries/account.ts` and typed the query result as `{ exists: boolean }`.

### Testing
- Ran `npx eslint src/server/db/queries/account.ts` and it passed for the touched file. 
- Ran `npx tsc --noEmit` which completed successfully. 
- Ran `npm run lint` which failed due to pre-existing lint errors in unrelated files. 
- Ran `npm run build` which failed due to Next.js being unable to fetch Google Fonts (`Montserrat`) during the build (external network/font fetch issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04f82e7854832ebd543793c014ac81)