### PR TITLE
Remove `Other` category fallback (use `General Knowledge` instead)

### DIFF
--- a/drizzle/0028_remove_other_question_category.sql
+++ b/drizzle/0028_remove_other_question_category.sql
@@ -1,0 +1,3 @@
+ALTER TYPE "public"."Category" ADD VALUE IF NOT EXISTS 'general_knowledge';--> statement-breakpoint
+ALTER TABLE "Question" ALTER COLUMN "category" SET DEFAULT 'general_knowledge';--> statement-breakpoint
+UPDATE "Question" SET "category" = 'general_knowledge' WHERE "category" = 'other';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -197,6 +197,13 @@
       "when": 1778616800000,
       "tag": "0027_friendship_request_context",
       "breakpoints": true
+    },
+    {
+      "idx": 28,
+      "version": "7",
+      "when": 1778616900000,
+      "tag": "0028_remove_other_question_category",
+      "breakpoints": true
     }
   ]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,7 +30,7 @@ enum Category {
   philosophy
   pop_culture
   language
-  other
+  general_knowledge
 }
 
 enum QuestionVisibility {
@@ -312,7 +312,7 @@ model Question {
   answer_source             AnswerSource?
   question_type             QuestionType        @default(factual)
   minimum_required          Int?
-  category                  Category            @default(other)
+  category                  Category            @default(general_knowledge)
   broad_category            String?
   subcategory               String?
   canonical_subcategory     String?

--- a/src/app/api/onboarding/canonicalize/route.ts
+++ b/src/app/api/onboarding/canonicalize/route.ts
@@ -32,7 +32,7 @@ export async function POST(request: Request) {
     return NextResponse.json({
       original,
       suggested: original,
-      broadCategory: 'Other',
+      broadCategory: 'General Knowledge',
       explanation: null,
     });
   }

--- a/src/app/api/onboarding/save-interests/__tests__/route.test.ts
+++ b/src/app/api/onboarding/save-interests/__tests__/route.test.ts
@@ -64,6 +64,17 @@ describe('POST /api/onboarding/save-interests', () => {
     ])
   })
 
+  it('normalizes legacy Other broad categories to General Knowledge', async () => {
+    const response = await POST(
+      jsonRequest([{ domain: 'Puzzle Potpourri', broadCategory: 'Other' }])
+    )
+
+    expect(response.status).toBe(200)
+    expect(saveDeclaredInterestsMock).toHaveBeenCalledWith('user-invitee', [
+      { label: 'Puzzle Potpourri', broadCategory: 'General Knowledge' },
+    ])
+  })
+
   it('skip saves none of the invited interests and completes onboarding only after explicit skip telemetry', async () => {
     const response = await POST(
       jsonRequest([], { inviteInterestCount: 3, inviteSelectedCount: 0 })

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { logTelemetry } from '@/server/telemetry';
 import {
   type DeclaredInterestInput,
@@ -20,11 +21,13 @@ function parseInterest(value: unknown): DeclaredInterestInput | null {
   const domain = typeof record.domain === 'string' ? record.domain.trim().replace(/\s+/g, ' ') : '';
   if (domain.length < 2 || domain.length > 100) return null;
 
+  const broadCategory = typeof record.broadCategory === 'string' && record.broadCategory.trim()
+    ? normalizeBroadCategory(record.broadCategory)
+    : null;
+
   return {
     label: domain,
-    broadCategory: typeof record.broadCategory === 'string' && record.broadCategory.trim()
-      ? record.broadCategory.trim().slice(0, 80)
-      : null,
+    broadCategory: broadCategory ? broadCategory.slice(0, 80) : null,
   };
 }
 

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { broadCategoryDisplayName, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
@@ -113,7 +113,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       values.text ?? existing.text,
       values.correctAnswer ?? existing.correctAnswer,
     );
-    const category = normalizeBroadQuestionCategory(categorization.broad_category) ?? 'other';
+    const category = normalizeBroadQuestionCategoryOrDefault(categorization.broad_category);
     const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
     values.category = category;
     values.broadCategory = broadCategoryDisplayName(category);

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,7 +1,7 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { broadCategoryDisplayName, normalizeBroadQuestionCategory, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
+import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
 import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
@@ -43,7 +43,7 @@ export async function POST(request: NextRequest) {
 
   const { sendToFriendIds, shareToFeed, ...rawQuestionFields } = value;
   const categorization = await categorizeQuestion(rawQuestionFields.text, rawQuestionFields.correctAnswer);
-  const category = normalizeBroadQuestionCategory(categorization.broad_category) ?? 'other';
+  const category = normalizeBroadQuestionCategoryOrDefault(categorization.broad_category);
   const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
   const questionFields = {
     ...rawQuestionFields,

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -167,7 +167,7 @@ async function resolveQuestionIdForSend(questionId: string, senderUserId: string
       questionText: generated.questionText,
       answerText: generated.answer,
       factualExplanation: generated.explainer,
-      category: 'other',
+      category: 'general_knowledge',
       broadCategory: generated.broadCategory,
       canonicalSubcategory: generated.canonicalSubcategory,
       difficultyEstimate: generated.difficultyEstimate === 'accessible' || generated.difficultyEstimate === 'moderate' || generated.difficultyEstimate === 'specialist'

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -59,7 +59,7 @@ function masteryDistance(domain: DomainRow): number {
 function groupByCategory(domains: DomainRow[]) {
   const groups = new Map<string, DomainRow[]>();
   for (const domain of domains) {
-    const category = domain.broadCategory ?? 'Other';
+    const category = domain.broadCategory ?? 'General Knowledge';
     groups.set(category, [...(groups.get(category) ?? []), domain]);
   }
   return Array.from(groups.entries())

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -85,7 +85,7 @@ function displayMind(domains: DomainMastery[], declaredInterests: string[]): str
 function toPortraitEntry(domain: DomainMastery): PortraitEntry {
   return {
     canonicalSubcategory: domain.displayName,
-    broadCategory: normalizeBroadCategory(domain.broadCategory) ?? 'Other',
+    broadCategory: normalizeBroadCategory(domain.broadCategory) ?? 'General Knowledge',
     totalMasteryPoints: Math.max(domain.points, domain.isDeclaredInterest ? 1 : 0),
     tier: asTier(domain.tier),
     authoredAnsweredCount: domain.questionsAnswered,

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -100,7 +100,7 @@ function toSelected(interest: ProposedInterest): SelectedInterest | null {
   return {
     domain,
     broadCategory:
-      normalizeDomain(interest.broadCategory || 'Other') || 'Other',
+      normalizeDomain(interest.broadCategory || 'General Knowledge') || 'General Knowledge',
   }
 }
 
@@ -306,7 +306,7 @@ export default function OnboardingFlow({
         setCanonicalSuggestion({
           original: data.original ?? rawInput,
           suggested: data.suggested,
-          broadCategory: data.broadCategory ?? 'Other',
+          broadCategory: data.broadCategory ?? 'General Knowledge',
           explanation: data.explanation ?? null,
         })
       } catch (fetchError) {
@@ -550,7 +550,7 @@ export default function OnboardingFlow({
       customChoice === 'suggested' && canonicalSuggestion
         ? canonicalSuggestion.suggested
         : rawInput
-    const broadCategory = canonicalSuggestion?.broadCategory ?? 'Other'
+    const broadCategory = canonicalSuggestion?.broadCategory ?? 'General Knowledge'
     const selected = toSelected({ domain: chosenDomain, broadCategory })
 
     if (!selected || selectedInterests.length >= 5) return

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -24,7 +24,7 @@ export default async function OnboardingPage() {
   const seeded = await getPreSeededInterestsForUser(session.userId);
   const preSeededInterests: PreSeededInterest[] = seeded.interests.map((interest) => ({
     domain: interest.label,
-    broadCategory: interest.broadCategory ?? 'Other',
+    broadCategory: interest.broadCategory ?? 'General Knowledge',
     rationale: interest.description ?? null,
   }));
 

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -52,7 +52,7 @@ const DOMAIN_COLORS: Record<string, string> = {
   philosophy: '#6d28d9',
   pop_culture: '#db2777',
   language: '#0369a1',
-  other: '#64748b',
+  general_knowledge: '#64748b',
 };
 
 function relativeTime(value: string | null): string {

--- a/src/components/knowledge/KnowledgeOverviewClient.tsx
+++ b/src/components/knowledge/KnowledgeOverviewClient.tsx
@@ -91,7 +91,7 @@ export function KnowledgeOverviewClient({
         (portraitData as { categories: Array<{ canonical_subcategory: string; broad_category: string; declared_score: number; proven_score: number; authored_answered_count: number }> }).categories
       ).map((cat) => ({
         canonicalSubcategory: cat.canonical_subcategory,
-        broadCategory: normalizeBroadCategory(cat.broad_category) ?? 'Other',
+        broadCategory: normalizeBroadCategory(cat.broad_category) ?? 'General Knowledge',
         totalMasteryPoints: (cat.declared_score ?? 0) + (cat.proven_score ?? 0),
         tier: (masteryMap.get(cat.canonical_subcategory) ?? 'establishing') as PortraitEntry['tier'],
         authoredAnsweredCount: cat.authored_answered_count ?? 0,

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -139,7 +139,7 @@ function buildSections(
   if (sortMode === 'domain') {
     const domainMap = new Map<string, PortraitEntry[]>()
     for (const e of entries) {
-      const broadCategory = normalizeBroadCategory(e.broadCategory) ?? 'Other'
+      const broadCategory = normalizeBroadCategory(e.broadCategory) ?? 'General Knowledge'
       const normalizedEntry = { ...e, broadCategory }
       const list = domainMap.get(broadCategory) ?? []
       list.push(normalizedEntry)
@@ -185,7 +185,7 @@ export function PortraitDomainCircle({
   selected?: boolean
   circleSlotSize?: number
 }) {
-  const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'Other'
+  const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge'
   const dc = getPortraitDomainColor(broadCategory)
   const size = Math.round(
     getDomainCircleSize(
@@ -314,9 +314,9 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
       entries
         .map((entry) => ({
           ...entry,
-          broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'Other',
+          broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge',
         }))
-        .filter((e) => e.broadCategory && e.broadCategory !== 'Other'),
+        .filter((e) => e.broadCategory && e.broadCategory !== 'General Knowledge'),
     [entries]
   )
   const isSparse = validEntries.length < SPARSE_THRESHOLD

--- a/src/components/knowledge/ProgressionLandscape.tsx
+++ b/src/components/knowledge/ProgressionLandscape.tsx
@@ -229,7 +229,7 @@ export function ProgressionLandscape({
                 const cellDomains = tierCategoryDomains.get(tier)?.get(category) ?? [];
                 return (
                   <div key={`${category}-${tier}`} style={{ ...cellStyle, borderRight: colIdx < 3 ? '1px solid #e8e2d6' : undefined }}>
-                    <div style={categoryLabelStyle}>{colIdx === 0 ? (category || 'Other') : ''}</div>
+                    <div style={categoryLabelStyle}>{colIdx === 0 ? (category || 'General Knowledge') : ''}</div>
                     {cellDomains.map((domain) => {
                       const isGhost = domain.correctAnswerCount === 0;
                       const diameter = getCircleDiameter(domain.correctAnswerCount, tier, maxPerTier[tier], isMobile);

--- a/src/components/knowledge/SharePortraitCard.tsx
+++ b/src/components/knowledge/SharePortraitCard.tsx
@@ -113,7 +113,7 @@ export type SharePortraitCardProps = {
 export const SharePortraitCard = forwardRef<HTMLDivElement, SharePortraitCardProps>(
   function SharePortraitCard({ entries, playerDisplayName }, ref) {
     const valid = entries
-      .filter((e) => e.totalMasteryPoints > 0 && e.broadCategory && e.broadCategory !== 'Other' && e.broadCategory !== 'other')
+      .filter((e) => e.totalMasteryPoints > 0 && e.broadCategory && e.broadCategory !== 'General Knowledge' && e.broadCategory !== 'general_knowledge' && e.broadCategory !== 'other')
       .sort((a, b) => b.totalMasteryPoints - a.totalMasteryPoints);
 
     const maxPoints = valid.length > 0 ? valid[0].totalMasteryPoints : 1;

--- a/src/lib/knowledge/broad-category.ts
+++ b/src/lib/knowledge/broad-category.ts
@@ -8,6 +8,9 @@ const BROAD_CATEGORY_ALIASES: Record<string, string> = {
   'world history': 'History',
   'pop culture & television': 'Film & Television',
   'pop culture and television': 'Film & Television',
+  'other': 'General Knowledge',
+  'general': 'General Knowledge',
+  'potpourri': 'General Knowledge',
 };
 
 const STABLE_BROAD_CATEGORIES = new Set([
@@ -23,7 +26,7 @@ const STABLE_BROAD_CATEGORIES = new Set([
   'Philosophy',
   'Pop Culture',
   'Language',
-  'Other',
+  'General Knowledge',
 ]);
 
 const LITERATURE_BROAD_CATEGORY_PATTERNS = [

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -249,7 +249,7 @@ function fallbackGrading(): GradingResponse {
 }
 
 function fallbackCategorization(): CategoryResult {
-  return { subcategory: 'General Knowledge', broad_category: 'Other', confidence: 0 };
+  return { subcategory: 'Potpourri', broad_category: 'General Knowledge', confidence: 0 };
 }
 
 function fallbackExplainer(canonicalAnswer: string): ExplainerResult {
@@ -369,7 +369,8 @@ Rules:
 - The subcategory must be as specific as the question demands.
 - Never normalize upward to a broad field if a narrower label is justified.
 - Use title case for both labels.
-- broad_category must be a stable top-level bucket, not an author/work/movement-specific territory (e.g., use "Literature" for James Joyce, Irish Modernism, novels, poetry, or fiction; use "Music", "History", "Film & Television", "Science", "Philosophy", "Language", "Sports", "Pop Culture", "Other").
+- broad_category must be a stable top-level bucket, not an author/work/movement-specific territory (e.g., use "Literature" for James Joyce, Irish Modernism, novels, poetry, or fiction; use "Music", "History", "Film & Television", "Science", "Philosophy", "Language", "Sports", "Pop Culture", or "General Knowledge").
+- Never return "Other" as a broad_category or subcategory. Use "General Knowledge" as the broad_category only when no more precise top-level bucket applies.
 - subcategory should be narrow and portrait-friendly.
 - The subcategory must always be narrower than the broad_category. Never return the broad_category value itself as the subcategory (e.g. if broad_category is "Pop Culture", the subcategory must be something more specific than "Pop Culture"; if broad_category is "Music", the subcategory must be more specific than "Music").
 - For music, film, TV, or pop culture questions: name the specific artist, franchise, era, or cultural moment — not the genre or medium (e.g. "Late-Career David Bowie", "MCU Phase 3", "Drag Race Seasons 1–5", "Early 2010s Internet Memes", "Survivor Original Era").

--- a/src/lib/question-categorization.ts
+++ b/src/lib/question-categorization.ts
@@ -2,6 +2,8 @@ import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 
 export type BroadQuestionCategory = (typeof CATEGORIES)[number];
 
+export const DEFAULT_BROAD_QUESTION_CATEGORY: BroadQuestionCategory = 'general_knowledge';
+
 const CATEGORY_VALUES = new Set<string>(CATEGORIES);
 const CATEGORY_LABEL_TO_VALUE = new Map<string, BroadQuestionCategory>([
   ...CATEGORIES.map((category) => [categoryLabel(category).toLowerCase(), category] as const),
@@ -11,6 +13,10 @@ const CATEGORY_LABEL_TO_VALUE = new Map<string, BroadQuestionCategory>([
   ['tv', 'film_tv'],
   ['television', 'film_tv'],
   ['sports', 'sport'],
+  ['general', 'general_knowledge'],
+  ['general knowledge', 'general_knowledge'],
+  ['potpourri', 'general_knowledge'],
+  ['other', 'general_knowledge'],
 ]);
 
 export function isBroadQuestionCategory(value: string): value is BroadQuestionCategory {
@@ -34,4 +40,9 @@ export function normalizeCanonicalSubcategory(value: string): string {
 
 export function broadCategoryDisplayName(category: string): string {
   return isBroadQuestionCategory(category) ? categoryLabel(category) : category;
+}
+
+export function normalizeBroadQuestionCategoryOrDefault(value: string | null | undefined): BroadQuestionCategory {
+  if (typeof value !== 'string') return DEFAULT_BROAD_QUESTION_CATEGORY;
+  return normalizeBroadQuestionCategory(value) ?? DEFAULT_BROAD_QUESTION_CATEGORY;
 }

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -37,7 +37,7 @@ export const CATEGORIES = [
   'philosophy',
   'pop_culture',
   'language',
-  'other',
+  'general_knowledge',
 ] as const;
 
 export const VISIBILITIES = ['private', 'public'] as const;
@@ -51,5 +51,7 @@ export function categoryLabel(cat: string): string {
     ? 'Film & TV'
     : cat === 'pop_culture'
       ? 'Pop Culture'
-      : cat.charAt(0).toUpperCase() + cat.slice(1).replace('_', ' ');
+      : cat === 'general_knowledge'
+        ? 'General Knowledge'
+        : cat.charAt(0).toUpperCase() + cat.slice(1).replace('_', ' ');
 }

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -339,7 +339,7 @@ function selectDiverseDomains(
   // Group by broad category so we can pick one domain per category
   const byCategory = new Map<string, (typeof knowledgeBase)[number][]>();
   for (const d of knowledgeBase) {
-    const cat = d.broadCategory ?? 'other';
+    const cat = d.broadCategory ?? 'General Knowledge';
     const arr = byCategory.get(cat) ?? [];
     arr.push(d);
     byCategory.set(cat, arr);

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -31,7 +31,7 @@ export const categoryEnum = pgEnum('Category', [
   'philosophy',
   'pop_culture',
   'language',
-  'other',
+  'general_knowledge',
 ]);
 
 export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public']);
@@ -216,7 +216,7 @@ export const questions = pgTable(
     answerSource: answerSourceEnum('answer_source'),
     questionType: questionTypeEnum('question_type').notNull().default('factual'),
     minimumRequired: integer('minimum_required'),
-    category: categoryEnum('category').notNull().default('other'),
+    category: categoryEnum('category').notNull().default('general_knowledge'),
     broadCategory: text('broad_category'),
     subcategory: text('subcategory'),
     canonicalSubcategory: text('canonical_subcategory'),

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -4,6 +4,7 @@ import {
   getAnthropicClient,
   parseJsonObject,
 } from '@/lib/llm';
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 
 export type WarmupAnswers = {
   deepDive?: string;
@@ -111,7 +112,7 @@ function fallbackInterests(cleanAnswers: Array<{ field: keyof WarmupAnswers; ans
 
       return {
         domain,
-        broadCategory: FALLBACK_CATEGORIES[index % FALLBACK_CATEGORIES.length] ?? 'Other',
+        broadCategory: FALLBACK_CATEGORIES[index % FALLBACK_CATEGORIES.length] ?? 'General Knowledge',
         rationale: `Based on your answer for ${WARMUP_LABELS[field]}.`,
       };
     })
@@ -164,7 +165,7 @@ function normalizeInterest(value: unknown): ProposedInterest | null {
 
   return {
     domain: domain.slice(0, 100),
-    broadCategory: broadCategory.slice(0, 80),
+    broadCategory: (normalizeBroadCategory(broadCategory) ?? 'General Knowledge').slice(0, 80),
     rationale: rationale.slice(0, 180),
   };
 }
@@ -211,7 +212,8 @@ Rules:
 - Bad domains: "Music", "Books", "Movies", "History", "General Trivia".
 - Distribute across the warm-up answers. Include at least one candidate per non-empty warm-up field if possible.
 - Each rationale must briefly tie the candidate to a specific warm-up answer or demographic context.
-- broadCategory is a stable top-level bucket, such as Music, Literature, Film & Television, History, Science, Philosophy, Sports, Pop Culture, Language, Other. It must not be an author/work/movement-specific territory; for example, James Joyce, Irish Modernism, novels, poetry, and fiction all use Literature.
+- broadCategory is a stable top-level bucket, such as Music, Literature, Film & Television, History, Science, Philosophy, Sports, Pop Culture, Language, General Knowledge. It must not be an author/work/movement-specific territory; for example, James Joyce, Irish Modernism, novels, poetry, and fiction all use Literature.
+- Never return "Other" as a broadCategory. Use "General Knowledge" only when no more precise top-level bucket applies.
 - Do not invent private facts. Infer plausible interest territories only from the answers and cultural anchor context.${demographicLine ? `\n\n${demographicLine}` : ''}`;
 
   const userMessage = `Warm-up answers:
@@ -267,7 +269,7 @@ export async function canonicalizeInterest(rawInput: string): Promise<Canonicali
   const cleanInput = rawInput.trim().replace(/\s+/g, ' ').slice(0, 100);
   const fallback: CanonicalizedInterest = {
     suggested: cleanInput,
-    broadCategory: 'Other',
+    broadCategory: 'General Knowledge',
     explanation: 'Kept your original wording because a suggestion was not available.',
   };
 
@@ -279,6 +281,7 @@ export async function canonicalizeInterest(rawInput: string): Promise<Canonicali
   const systemPrompt = `The user wants to add this as a declared trivia interest.
 Suggest a more hyper-specific version that would generate good trivia questions. If the input is already specific enough, return it unchanged.
 Avoid broad categories like "Music", "Literature", "History". Prefer forms like "Late Tchaikovsky", "Russian 19th-Century Novels", "Weimar-Era Cinema".
+Never return "Other" as broadCategory; use "General Knowledge" only when no precise top-level bucket applies.
 Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation": "..." }`;
 
   const response = await client.messages.create({
@@ -301,7 +304,7 @@ Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation
 
   return {
     suggested: suggested.slice(0, 100),
-    broadCategory: broadCategory.slice(0, 80),
+    broadCategory: (normalizeBroadCategory(broadCategory) ?? 'General Knowledge').slice(0, 80),
     explanation: explanation.slice(0, 180),
   };
 }

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -595,7 +595,7 @@ export async function applyMergesForUser(
 
       await tx
         .update(generatedQuestions)
-        .set({ canonicalSubcategory: target, broadCategory: broadCategory ?? 'Other' })
+        .set({ canonicalSubcategory: target, broadCategory: broadCategory ?? 'General Knowledge' })
         .where(and(eq(generatedQuestions.userId, userId), inArray(generatedQuestions.canonicalSubcategory, sourceDomains)));
 
       await tx

--- a/src/server/profile/personal-mastery.ts
+++ b/src/server/profile/personal-mastery.ts
@@ -35,7 +35,7 @@ export function sortCategoriesByTierThenActivity(
 export function groupCategoriesByBroadCategory(sortedCategories: CategoryRow[]): Array<[string, CategoryRow[]]> {
   const groups = new Map<string, CategoryRow[]>();
   for (const item of sortedCategories) {
-    const key = item.broad_category || 'Other';
+    const key = item.broad_category || 'General Knowledge';
     const current = groups.get(key) ?? [];
     current.push(item);
     groups.set(key, current);

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -46,7 +46,7 @@ export async function persistGeneratedQuestion(generatedQuestionId: string): Pro
         acceptedAlternatives: [],
         answerSource: 'llm_suggested',
         questionType: 'factual',
-        category: 'other',
+        category: 'general_knowledge',
         broadCategory: generated.broadCategory,
         canonicalSubcategory: generated.canonicalSubcategory || generated.broadCategory,
         categoryOverridden: true,


### PR DESCRIPTION
### Motivation
- Eliminate the legacy and product-ambiguous `Other` category so it is never used as a stored or displayed top-level bucket. 
- Ensure LLM categorization, onboarding, question creation, and display code always prefer a precise bucket and fall back to `General Knowledge` instead of `Other`.

### Description
- Replace the enum/value `other` with `general_knowledge` across schema and DB code and add a migration/backfill at `drizzle/0028_remove_other_question_category.sql`. 
- Add normalization and helpers so incoming or legacy labels like `Other`, `Potpourri`, or `general` map to `general_knowledge` and expose `normalizeBroadQuestionCategoryOrDefault`. 
- Update question creation/editing, generated-question persistence, onboarding canonicalization and save flows, LLM prompts/fallbacks, and portrait/knowledge UI fallbacks to avoid producing or showing `Other`. 
- Update tests to cover onboarding normalization and adjust labels/display helpers (`categoryLabel`, display fallbacks) to use `General Knowledge` where appropriate.

### Testing
- Ran `npx tsc --noEmit` to verify TypeScript compilation, which completed successfully. 
- Ran `npx eslint` against the changed files to validate linting for the modified surface (no new lint issues introduced by these edits). 
- Ran `npm run lint` which surfaced pre-existing, unrelated lint failures in other parts of the repo (these were not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04fd05a560832ebd19c743531888e3)