### PR TITLE
Fix friend-answer feed propagation and single-friend attribution

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -222,7 +222,7 @@ export async function POST(request: NextRequest) {
         });
       }
 
-      void createFeedItemsForFriendsFromAnswer(
+      await createFeedItemsForFriendsFromAnswer(
         session.userId,
         persisted.questionId,
         isCorrect ? 'correct' : 'incorrect',

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -142,7 +142,7 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    void createFeedItemsForFriendsFromAnswer(
+    await createFeedItemsForFriendsFromAnswer(
       session.userId,
       persisted.questionId,
       isCorrect ? 'correct' : 'incorrect',

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -158,7 +158,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   }
 
   // Propagate this answer to the answering user's friends' Feeds
-  void createFeedItemsForFriendsFromAnswer(
+  await createFeedItemsForFriendsFromAnswer(
     session.userId,
     question.id,
     isCorrect ? 'correct' : 'incorrect',

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -121,7 +121,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       });
     }
 
-    void createFeedItemsForFriendsFromAnswer(
+    await createFeedItemsForFriendsFromAnswer(
       session.userId,
       parsed.questionId,
       grade.isCorrect ? 'correct' : 'incorrect',

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -34,7 +34,7 @@ async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<Collapsed
   // Collect all source user IDs we need display names for
   const sourceUserIds = new Set<string>();
   friendAnsweredByQuestion.forEach((group) => {
-    if (group.length > 1) group.forEach((item) => sourceUserIds.add(item.sourceUserId));
+    group.forEach((item) => sourceUserIds.add(item.sourceUserId));
   });
 
   const nameById = new Map<string, string>();
@@ -52,7 +52,7 @@ async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<Collapsed
   const hiddenIds = new Set<string>();
   const collapsedById = new Map<string, CollapsedFeedItem>();
 
-  friendAnsweredByQuestion.forEach((group, _questionId) => {
+  friendAnsweredByQuestion.forEach((group) => {
     if (group.length <= 1) return;
     const sorted = [...group].sort((a, b) => b.sourceEventAt.getTime() - a.sourceEventAt.getTime());
     const [mostRecent, ...older] = sorted;


### PR DESCRIPTION
### Motivation
- Ensure friend-answer feed items are persisted before API responses complete so friends reliably see a played round in their Feed. 
- Ensure single "friend answered" feed items show the actual friend display name instead of falling back to a generic label.

### Description
- Await `createFeedItemsForFriendsFromAnswer` in answer handlers so propagation completes before returning from the following routes: `src/app/api/joshing-games/[id]/answer/route.ts`, `src/app/api/daily/answer/route.ts`, `src/app/api/daily/catchup/answer/route.ts`, and `src/app/api/feed/[feedItemId]/answer/route.ts`.
- Load display names for all `friend_answered` items (including single-item groups) in `collapseFriendAnsweredItems` so single-friend attributions use the real display name; updated `src/server/db/queries/feed.ts` accordingly.
- Minor refactor to the grouping iteration to simplify the collapse logic.

### Testing
- Ran `npx tsc --noEmit --project tsconfig.json` which completed successfully.
- Ran `npx eslint` against the modified files (`src/server/db/queries/feed.ts`, `src/server/feed/create-feed-items-for-answer.ts`, `src/app/api/joshing-games/[id]/answer/route.ts`, `src/app/api/feed/[feedItemId]/answer/route.ts`, `src/app/api/daily/catchup/answer/route.ts`, `src/app/api/daily/answer/route.ts`) which succeeded for those files.
- Ran `npm run lint` which failed due to existing, unrelated repo-wide lint errors (pre-existing `react`/type issues) and not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0503a322f0832e8dc58b81df5f7cc6)