### PR TITLE
Shift feed to correct-answer social moments

### DIFF
--- a/drizzle/0029_correct_answer_social_feed.sql
+++ b/drizzle/0029_correct_answer_social_feed.sql
@@ -1,0 +1,19 @@
+ALTER TABLE "FeedItem" ADD COLUMN IF NOT EXISTS "sourceAnswerId" text;
+
+CREATE UNIQUE INDEX IF NOT EXISTS "FeedItem_recipientUserId_sourceAnswerId_key"
+  ON "FeedItem" ("recipientUserId", "sourceAnswerId")
+  WHERE "sourceAnswerId" IS NOT NULL;
+
+-- Feed items caused by question authorship/publication are no longer valid main-feed material.
+-- The underlying questions stay intact, and answer-based social feed events are preserved.
+UPDATE "FeedItem"
+SET "state" = 'rolled_off'
+WHERE "sourceType" IN ('authored_shared', 'thumbs_upped')
+  AND "state" IN ('active', 'skipped');
+
+-- Incorrect answers are intentionally private/review-only and should not remain normal Feed cards.
+UPDATE "FeedItem"
+SET "state" = 'rolled_off'
+WHERE "sourceType" = 'friend_answered'
+  AND COALESCE("sourceResult", '') <> 'correct'
+  AND "state" IN ('active', 'skipped');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1778616900000,
       "tag": "0028_remove_other_question_category",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1778714100000,
+      "tag": "0029_correct_answer_social_feed",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -226,6 +226,7 @@ export async function POST(request: NextRequest) {
         session.userId,
         persisted.questionId,
         isCorrect ? 'correct' : 'incorrect',
+        `daily:${question.id}:${session.userId}`,
       );
     } catch (error) {
       console.warn('[daily/answer] failed to persist generated question for feed propagation', {

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -146,6 +146,7 @@ export async function POST(request: NextRequest) {
       session.userId,
       persisted.questionId,
       isCorrect ? 'correct' : 'incorrect',
+      `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
     );
   } catch (error) {
     console.warn('[daily/catchup/answer] failed to persist generated question for feed propagation', {

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -162,6 +162,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     session.userId,
     question.id,
     isCorrect ? 'correct' : 'incorrect',
+    `feed:${feedItemId}:${session.userId}`,
   );
 
   if (!isCorrect) {

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -2,9 +2,10 @@ import { and, count, eq, inArray, or } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { db, feedItems, friendships, joshingGames, questions, users } from '@/server/db';
+import { db, feedItems, friendships, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem } from '@/server/db/queries/feed';
+import { socialFeedDomainLabel } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,38 +13,27 @@ function displayName(name: string | null, fallback = 'A friend') {
   return name?.trim() || fallback;
 }
 
-function domainPill(question: typeof questions.$inferSelect | undefined) {
-  return question?.canonicalSubcategory || question?.broadCategory || question?.category || 'General';
-}
-
-function resultVerb(result: string | null, name: string): string {
-  return result === 'correct' ? `${name} got this right` : `${name} couldn't get this`;
-}
-
-function friendAnsweredAttribution(item: CollapsedFeedItem, userById: Map<string, { displayName: string | null }>, domain: string): string {
+function friendAnsweredAttribution(
+  item: CollapsedFeedItem,
+  userById: Map<string, { displayName: string | null }>,
+  domain: string | null,
+  authorName: string,
+): string {
   const results = item.friendResults;
   if (!results || results.length === 0) {
     const name = displayName(userById.get(item.sourceUserId)?.displayName ?? null);
-    const verb = resultVerb(item.sourceResult ?? null, name);
-    return `${verb} — ${domain}`;
+    return domain ? `${name} knew ${authorName}’s question — ${domain}` : `${name} knew ${authorName}’s question`;
   }
 
   if (results.length === 1) {
-    const { displayName: dn, result } = results[0];
-    return `${resultVerb(result, dn)} — ${domain}`;
+    const { displayName: answererName } = results[0];
+    return domain
+      ? `Common ground in ${domain}: ${answererName} knew ${authorName}’s question`
+      : `${answererName} and ${authorName} share this one`;
   }
 
-  // Multiple friends: "Robyn got this right · Greg couldn't get it — Domain"
-  const parts = results
-    .slice(0, 3) // cap at 3 names for readability
-    .map(({ displayName: dn, result }) => (result === 'correct' ? `${dn} got this right` : `${dn} couldn't get it`));
-  return `${parts.join(' · ')} — ${domain}`;
-}
-
-function thumbsupAttribution(sourceName: string, count: number | undefined) {
-  if (!count || count <= 1) return `${sourceName} thumbed up`;
-  if (count === 2) return `${sourceName} + 1 other thumbed up`;
-  return `${sourceName} + ${count - 1} others thumbed up`;
+  const names = results.slice(0, 3).map(({ displayName: answererName }) => answererName).join(' · ');
+  return domain ? `Common ground in ${domain}: ${names}` : `${names} share this one`;
 }
 
 export async function GET() {
@@ -64,14 +54,19 @@ export async function GET() {
     db
       .select({ value: count() })
       .from(feedItems)
-      .where(eq(feedItems.recipientUserId, session.userId))
+      .where(and(
+        eq(feedItems.recipientUserId, session.userId),
+        eq(feedItems.sourceType, 'friend_answered'),
+        eq(feedItems.sourceResult, 'correct'),
+      ))
       .then((rows) => rows[0]?.value ?? 0),
-    // Items in active/skipped state before domain filtering — distinguishes "focused" from "caught up"
     db
       .select({ value: count() })
       .from(feedItems)
       .where(and(
         eq(feedItems.recipientUserId, session.userId),
+        eq(feedItems.sourceType, 'friend_answered'),
+        eq(feedItems.sourceResult, 'correct'),
         inArray(feedItems.state, ['active', 'skipped']),
       ))
       .then((rows) => rows[0]?.value ?? 0),
@@ -79,25 +74,23 @@ export async function GET() {
 
   const feed = rawFeed;
   const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
-  const sourceUserIds = [...new Set(feed.map((item) => item.sourceUserId))];
-  const gameIds = feed.map((item) => item.joshingGameId).filter((id): id is string => Boolean(id));
 
-  const [questionRows, sourceRows, gameRows, bankedById] = await Promise.all([
+  const [questionRows, bankedById] = await Promise.all([
     questionIds.length
       ? db.select().from(questions).where(inArray(questions.id, questionIds))
-      : Promise.resolve([]),
-    sourceUserIds.length
-      ? db.select().from(users).where(inArray(users.id, sourceUserIds))
-      : Promise.resolve([]),
-    gameIds.length
-      ? db.select().from(joshingGames).where(inArray(joshingGames.id, gameIds))
       : Promise.resolve([]),
     checkBankedQuestions(session.userId, questionIds),
   ]);
 
   const questionById = new Map(questionRows.map((q) => [q.id, q]));
-  const userById = new Map(sourceRows.map((u) => [u.id, u]));
-  const gameById = new Map(gameRows.map((g) => [g.id, g]));
+  const userIds = [...new Set([
+    ...feed.map((item) => item.sourceUserId),
+    ...questionRows.map((question) => question.creatorId).filter((id): id is string => Boolean(id)),
+  ])];
+  const userRows = userIds.length
+    ? await db.select({ id: users.id, displayName: users.displayName }).from(users).where(inArray(users.id, userIds))
+    : [];
+  const userById = new Map(userRows.map((u) => [u.id, u]));
 
   return NextResponse.json({
     viewer_user_id: session.userId,
@@ -112,32 +105,19 @@ export async function GET() {
       const question = item.questionId ? questionById.get(item.questionId) : undefined;
       const sourceUser = userById.get(item.sourceUserId);
       const sourceName = displayName(sourceUser?.displayName ?? null);
-      const game = item.joshingGameId ? gameById.get(item.joshingGameId) : undefined;
-      const domain = domainPill(question);
-
-      let source_attribution: string;
-      if (item.sourceType === 'direct_sent') {
-        source_attribution = `${sourceName} sent this to you`;
-      } else if (item.sourceType === 'friend_answered') {
-        source_attribution = friendAnsweredAttribution(item, userById, domain);
-      } else if (item.sourceType === 'authored_shared') {
-        source_attribution = `${sourceName} wrote this`;
-      } else if (item.sourceType === 'joshing_game') {
-        source_attribution = `${sourceName} sent you a Joshing Game`;
-      } else {
-        source_attribution = thumbsupAttribution(sourceName, item.thumbsUpCount);
-      }
+      const authorName = displayName(question?.creatorId ? userById.get(question.creatorId)?.displayName ?? null : null, 'the author');
+      const domain = socialFeedDomainLabel(question);
 
       return {
         id: item.id,
-        kind: item.sourceType === 'joshing_game' ? 'joshing_game' : 'question',
+        kind: 'question',
         question_id: item.questionId,
         joshing_game_id: item.joshingGameId,
         source_type: item.sourceType,
         source_user_id: item.sourceUserId,
         source_result: item.sourceResult ?? null,
         source_friend_display_name: sourceName,
-        source_attribution,
+        source_attribution: friendAnsweredAttribution(item, userById, domain, authorName),
         friend_results: item.friendResults ?? null,
         source_event_at: item.sourceEventAt,
         personal_message: item.personalMessage,
@@ -148,7 +128,7 @@ export async function GET() {
         is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
         explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
         domain_pill: domain,
-        game_title: game?.title ?? null,
+        game_title: null,
         difficulty: question?.calibratedDifficulty ?? question?.llmDifficulty ?? question?.difficultyEstimate ?? null,
       };
     }),

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -125,6 +125,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       session.userId,
       parsed.questionId,
       grade.isCorrect ? 'correct' : 'incorrect',
+      `joshing_game:${id}:${parsed.questionId}:${session.userId}`,
     );
 
     if (!grade.isCorrect) {

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,10 +1,10 @@
-import { and, eq, isNull } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
-import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
+import { db, feedItems, questions, users } from '@/server/db';
 import {
   createQuestion,
   getQuestion,
@@ -18,7 +18,6 @@ import {
 } from '@/server/db/queries/feed';
 import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
-import { writeActivity } from '@/server/activity/write-activity';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 
@@ -87,68 +86,11 @@ export async function POST(request: NextRequest) {
   const question = await getQuestion(created.id, session.userId);
 
   if (shareToFeed) {
-    try {
-      const friends = await getFriends(session.userId);
-      const concurrency = 5;
-      let sharedCount = 0;
-
-      for (let index = 0; index < friends.length; index += concurrency) {
-        const batch = friends.slice(index, index + concurrency);
-        const results = await Promise.all(batch.map(async (friend) => {
-          const [dismissed] = await db
-            .select({ id: feedDismissedDomains.id })
-            .from(feedDismissedDomains)
-            .where(and(
-              eq(feedDismissedDomains.userId, friend.id),
-              eq(feedDismissedDomains.canonicalSubcategory, categorizedQuestionFields.canonicalSubcategory),
-              isNull(feedDismissedDomains.reinstatedAt),
-            ))
-            .limit(1);
-
-          if (dismissed) return false;
-
-          const [existing] = await db
-            .select({ id: feedItems.id })
-            .from(feedItems)
-            .where(and(
-              eq(feedItems.recipientUserId, friend.id),
-              eq(feedItems.questionId, created.id),
-            ))
-            .limit(1);
-
-          if (existing) return false;
-
-          await db.insert(feedItems).values({
-            recipientUserId: friend.id,
-            sourceUserId: session.userId,
-            questionId: created.id,
-            sourceType: 'authored_shared',
-            sourceResult: null,
-            state: 'active',
-            isPinned: false,
-            sourceEventAt: new Date(),
-          });
-          await rollOffOldItems(friend.id);
-          return true;
-        }));
-        sharedCount += results.filter(Boolean).length;
-      }
-
-      await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
-      await writeActivity({
-        userId: session.userId,
-        type: 'authored_question_shared',
-        referenceId: created.id,
-        referenceType: 'question',
-      });
-      console.info('[questions/shareToFeed]', { questionId: created.id, userId: session.userId, recipientCount: sharedCount });
-    } catch (error) {
-      console.error('[questions/shareToFeed] broadcast share failed (suppressed):', {
-        questionId: created.id,
-        userId: session.userId,
-        error: error instanceof Error ? error.message : String(error),
-      });
-    }
+    console.info('[questions/shareToFeed]', {
+      questionId: created.id,
+      userId: session.userId,
+      skipped: 'created questions are managed in Questions until a non-author answers correctly',
+    });
   }
 
   if (sendToFriendIds.length > 0) {

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { Send, SkipForward, ThumbsDown, ThumbsUp, X } from 'lucide-react';
+import { Send, SkipForward, X } from 'lucide-react';
 
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
@@ -16,7 +16,7 @@ type FriendResult = {
 
 type FeedApiItem = {
   id: string;
-  kind: 'question' | 'joshing_game';
+  kind: 'question';
   question_id: string | null;
   source_type: string;
   source_user_id: string;
@@ -28,12 +28,10 @@ type FeedApiItem = {
   personal_message: string | null;
   state: string;
   is_pinned: boolean;
-  joshing_game_id: string | null;
   question_text: string | null;
   verified: boolean;
   is_in_bank: boolean;
-  domain_pill: string;
-  game_title: string | null;
+  domain_pill: string | null;
   difficulty: string | null;
 };
 
@@ -62,8 +60,6 @@ type AnswerResponse = {
   answer?: string;
   correctAnswer?: string;
   explanation?: string | null;
-  awarded_points?: number;
-  pointsAwarded?: number;
   quip?: string | null;
   consolation?: string | null;
   breadcrumb?: string | null;
@@ -73,22 +69,8 @@ type ResultState = {
   correct: boolean;
   answer: string;
   explanation: string | null;
-  points: number;
   quip: string | null;
   breadcrumb: string | null;
-};
-
-type JoshingGameFeedView = {
-  game: { id: string; title: string };
-  creator: { displayName: string };
-  questions: Array<{ questionId: string }>;
-  recipients: Array<{ userId: string; displayName: string; completedAt: string | null; score: number | null }>;
-  responses: Array<{ userId: string; questionId: string; isCorrect: boolean | null }>;
-  viewerStatus: 'not_started' | 'in_progress' | 'complete';
-};
-
-type FeedListProps = {
-  limit?: number;
 };
 
 function formatEventTime(value: string) {
@@ -103,70 +85,14 @@ function comparisonCopy(playerCorrect: boolean, friendResults: FriendResult[] | 
   const friendCorrect = primaryFriend?.result === 'correct';
 
   if (playerCorrect && friendCorrect) return 'You both had it.';
-  if (playerCorrect && !friendCorrect) return `You got it. ${friendName} couldn't.`;
-  if (!playerCorrect && friendCorrect) return `${friendName} had it. You'll get it next time.`;
-  return 'Neither of you got it. Good question.';
+  if (playerCorrect && !friendCorrect) return `You found a connection ${friendName} missed.`;
+  if (!playerCorrect && friendCorrect) return `${friendName} recognized this one. You might next time.`;
+  return 'This one is still waiting for common ground.';
 }
 
-function JoshingGameCard({ item, viewerId }: { item: FeedApiItem; viewerId: string | null }) {
-  const [game, setGame] = useState<JoshingGameFeedView | null>(null);
-  const [error, setError] = useState<string | null>(null);
-
-  useEffect(() => {
-    if (!item.joshing_game_id) return;
-    fetch(`/api/joshing-games/${item.joshing_game_id}`, { cache: 'no-store', credentials: 'include' })
-      .then(async (response) => {
-        const body = await response.json().catch(() => null);
-        if (!response.ok) throw new Error(body?.message ?? 'Could not load this game.');
-        setGame(body);
-      })
-      .catch((caught) => setError(caught instanceof Error ? caught.message : 'Could not load this game.'));
-  }, [item.joshing_game_id]);
-
-  const questionCount = game?.questions.length ?? 0;
-  const href = game?.viewerStatus === 'complete'
-    ? `/games/${game.game.id}/summary`
-    : `/games/${game?.game.id ?? item.joshing_game_id}`;
-  const cta = game?.viewerStatus === 'complete' ? 'See results' : 'Play';
-
-  return (
-    <article className="rounded-lg border bg-card p-4 text-card-foreground">
-      <div className="mb-3 flex items-center justify-between gap-3">
-        <span className="rounded-full bg-primary px-2.5 py-1 text-xs text-primary-foreground">Pinned</span>
-        <span className="text-xs text-muted-foreground">{formatEventTime(item.source_event_at)}</span>
-      </div>
-      <h2 className="font-serif text-xl font-semibold">🎯 {game?.game.title ?? item.game_title ?? 'Joshing Game'}</h2>
-      <p className="mt-1 text-sm text-muted-foreground">From {game?.creator.displayName ?? item.source_friend_display_name}</p>
-
-      <div className="mt-4 space-y-2">
-        {error ? <p className="text-sm text-destructive">{error}</p> : null}
-        {!game && !error ? <p className="text-sm text-muted-foreground">Loading game...</p> : null}
-        {game?.recipients.map((recipient) => {
-          const answered = game.responses.filter((r) => r.userId === recipient.userId);
-          const score = recipient.score ?? answered.filter((r) => r.isCorrect).length;
-          const label = recipient.completedAt
-            ? `✅ ${score}/${questionCount}`
-            : answered.length > 0
-              ? '⏳ Playing...'
-              : '— Not started';
-          return (
-            <div key={recipient.userId} className="flex items-center justify-between gap-3 text-sm">
-              <span>{recipient.userId === viewerId ? 'You' : recipient.displayName}</span>
-              <span className="text-muted-foreground">{label}</span>
-            </div>
-          );
-        })}
-      </div>
-
-      <div className="mt-5 flex items-center justify-between gap-3">
-        <Link href={href} className="btn-primary">
-          {cta}
-        </Link>
-        <span className="text-sm text-muted-foreground">{questionCount || ''} {questionCount === 1 ? 'question' : 'questions'}</span>
-      </div>
-    </article>
-  );
-}
+type FeedListProps = {
+  limit?: number;
+};
 
 type QuestionCardState = 'unanswered' | 'answered' | 'reacted';
 
@@ -178,8 +104,6 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
   const [results, setResults] = useState<Record<string, ResultState>>({});
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({});
   const [toasts, setToasts] = useState<Record<string, string>>({});
-  const [thumbsDownState, setThumbsDownState] = useState<Record<string, 'removed' | 'restored'>>({});
-  const thumbsDownTimers = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -208,7 +132,10 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
   }, []);
 
   useEffect(() => {
-    void loadFeed();
+    const timer = window.setTimeout(() => {
+      void loadFeed();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [loadFeed]);
 
   const visibleItems = useMemo(() => items.slice(0, limit), [items, limit]);
@@ -216,13 +143,13 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
   const emptyCopy = useMemo(() => {
     if (loading) return 'Loading your Feed...';
     if (error) return error;
-    if (!feedMeta?.has_friends) return "When your friends play, their questions will show up here.";
+    if (!feedMeta?.has_friends) return "When friends recognize each other’s questions, those moments will appear here.";
     // pre_filter_active_count > 0 means items exist in active/skipped state but are hidden by domain filters
     if (feedMeta.has_dismissed_domains && feedMeta.pre_filter_active_count > 0) {
       return "You've focused your Feed. You can re-open domains from your Knowledge page.";
     }
-    if (feedMeta.total_item_count > 0) return "You're caught up.";
-    return "Quiet today. Check back when your friends have played.";
+    if (feedMeta.total_item_count > 0) return "You're caught up. Answer questions to reveal more common ground.";
+    return "Answer questions to reveal common ground.";
   }, [error, feedMeta, loading]);
 
   const showToast = useCallback((itemId: string, message: string) => {
@@ -301,7 +228,6 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
           correct: Boolean(body.correct ?? body.isCorrect),
           answer: body.answer ?? body.correctAnswer ?? '',
           explanation: body.explanation ?? null,
-          points: body.awarded_points ?? body.pointsAwarded ?? 0,
           quip: body.quip ?? body.consolation ?? null,
           breadcrumb: body.breadcrumb ?? null,
         },
@@ -313,52 +239,6 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
       setBusyId(null);
     }
   }, [answers]);
-
-  const thumbsup = useCallback(async (itemId: string) => {
-    setBusyId(itemId);
-    try {
-      await fetch(`/api/feed/${itemId}/thumbsup`, { method: 'POST', credentials: 'include' });
-    } finally {
-      setBusyId(null);
-    }
-  }, []);
-
-  const thumbsdown = useCallback(async (itemId: string) => {
-    const current = thumbsDownState[itemId];
-    setBusyId(itemId);
-    try {
-      if (current === 'removed') {
-        // Undo: restore the item
-        const response = await fetch(`/api/feed/${itemId}/thumbsdown`, { method: 'DELETE', credentials: 'include' });
-        if (response.ok) {
-          if (thumbsDownTimers.current[itemId]) {
-            clearTimeout(thumbsDownTimers.current[itemId]);
-            delete thumbsDownTimers.current[itemId];
-          }
-          setThumbsDownState((s) => ({ ...s, [itemId]: 'restored' }));
-          // Auto-fade restored message after 4s
-          thumbsDownTimers.current[itemId] = setTimeout(() => {
-            setThumbsDownState((s) => { const next = { ...s }; delete next[itemId]; return next; });
-            delete thumbsDownTimers.current[itemId];
-          }, 4000);
-        }
-      } else {
-        // First tap: dismiss and show confirmation
-        const response = await fetch(`/api/feed/${itemId}/thumbsdown`, { method: 'POST', credentials: 'include' });
-        if (response.ok) {
-          setThumbsDownState((s) => ({ ...s, [itemId]: 'removed' }));
-          // Auto-remove from list after 4s
-          thumbsDownTimers.current[itemId] = setTimeout(() => {
-            removeItem(itemId);
-            setThumbsDownState((s) => { const next = { ...s }; delete next[itemId]; return next; });
-            delete thumbsDownTimers.current[itemId];
-          }, 4000);
-        }
-      }
-    } finally {
-      setBusyId(null);
-    }
-  }, [removeItem, thumbsDownState]);
 
   return (
     <>
@@ -392,31 +272,22 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
             const cardState = cardStates[item.id] ?? (item.state === 'answered' ? 'answered' : 'unanswered');
             const toast = toasts[item.id];
 
-            if (item.kind === 'joshing_game') {
-              return <JoshingGameCard key={item.id} item={item} viewerId={viewerId} />;
-            }
-
-            const thumbsDownMsg = thumbsDownState[item.id];
 
             return (
               <article
                 key={item.id}
-                className={[
-                  'rounded-lg border bg-card p-4 text-card-foreground',
-                  item.source_type === 'direct_sent' ? 'border-l-4 border-l-primary shadow-sm' : '',
-                ].join(' ')}
+                className="rounded-lg border bg-card p-4 text-card-foreground"
               >
                 {/* Header row */}
                 <div className="mb-3 flex flex-wrap items-center gap-2">
-                  {item.source_type === 'direct_sent' ? (
-                    <span className="rounded-full bg-primary px-2.5 py-1 text-xs text-primary-foreground">Sent to you</span>
-                  ) : null}
                   {item.is_pinned ? (
                     <span className="rounded-full bg-primary px-2.5 py-1 text-xs text-primary-foreground">Pinned</span>
                   ) : null}
-                  <span className="rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground">
-                    {item.domain_pill}
-                  </span>
+                  {item.domain_pill ? (
+                    <span className="rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground">
+                      {item.domain_pill}
+                    </span>
+                  ) : null}
                   {!item.verified ? (
                     <button
                       type="button"
@@ -445,12 +316,8 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
 
                 {/* Attribution line */}
                 <div className="mt-2 flex items-center gap-1.5">
-                  {item.source_type === 'authored_shared' ? <span className="text-sm text-muted-foreground" aria-hidden>✎</span> : null}
                   <p className="text-sm font-medium text-foreground">{item.source_attribution}</p>
                 </div>
-                {item.source_type === 'authored_shared' ? (
-                  <p className="mt-1 text-sm italic text-muted-foreground">Shared with their friends</p>
-                ) : null}
                 {item.personal_message ? (
                   <p className="mt-1 text-sm italic text-muted-foreground">&ldquo;{item.personal_message}&rdquo;</p>
                 ) : null}
@@ -460,14 +327,6 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
                   <p className="mt-2 text-sm text-muted-foreground">{toast}</p>
                 ) : null}
 
-                {/* Thumbs-down inline confirmation */}
-                {thumbsDownMsg ? (
-                  <p className="mt-2 text-xs italic text-muted-foreground">
-                    {thumbsDownMsg === 'removed'
-                      ? "Removed from your feed. Won’t pass to your friends."
-                      : 'Restored. This may pass to your friends.'}
-                  </p>
-                ) : null}
 
                 {/* State 2 — Answered */}
                 {cardState === 'answered' && result ? (
@@ -476,7 +335,7 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
                     <p className="font-medium">
                       {item.source_type === 'friend_answered'
                         ? comparisonCopy(result.correct, item.friend_results)
-                        : result.correct ? `Correct. +${result.points}` : 'Not quite.'}
+                        : result.correct ? 'This one connected.' : 'Not quite.'}
                     </p>
                     {!result.correct ? <p className="mt-1">Answer: {result.answer}</p> : null}
                     {result.explanation ? <p className="mt-1 text-muted-foreground">{result.explanation}</p> : null}
@@ -485,29 +344,9 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
 
                     {/* Post-answer actions */}
                     <div className="mt-3 flex flex-wrap gap-2">
-                      <button
-                        className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm"
-                        type="button"
-                        onClick={() => void thumbsup(item.id)}
-                        disabled={busyId === item.id}
-                        title="Great question"
-                      >
-                        <ThumbsUp className="size-4" />
-                        Great question
-                      </button>
-                      <button
-                        className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm text-muted-foreground"
-                        type="button"
-                        onClick={() => void thumbsdown(item.id)}
-                        disabled={busyId === item.id}
-                        title="Not a fair question"
-                      >
-                        <ThumbsDown className="size-4" />
-                        Not fair
-                      </button>
                       {item.question_id ? (
                         <SendQuestionAction
-                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill }}
+                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill ?? '' }}
                           label="Send to friend"
                           className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm hover:bg-muted"
                         />
@@ -577,15 +416,15 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
                       <button
                         className="inline-flex h-11 items-center gap-1.5 rounded-md border px-3 text-sm text-muted-foreground"
                         type="button"
-                        onClick={() => void dismissDomain(item.id, item.domain_pill)}
-                        disabled={busyId === item.id}
-                        title={`Not my focus: ${item.domain_pill}`}
+                        onClick={() => item.domain_pill ? void dismissDomain(item.id, item.domain_pill) : undefined}
+                        disabled={busyId === item.id || !item.domain_pill}
+                        title={item.domain_pill ? `Not my focus: ${item.domain_pill}` : 'No category to focus'}
                       >
                         Not my focus
                       </button>
                       {item.question_id ? (
                         <SendQuestionAction
-                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill }}
+                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill ?? '' }}
                           label=""
                           className="inline-flex h-11 w-11 items-center justify-center rounded-md border hover:bg-muted"
                         />

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
+import { isMainFeedSourceVisible } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -24,7 +25,7 @@ async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<Collapsed
   const friendAnsweredByQuestion = new Map<string, FeedItem[]>();
 
   for (const item of items) {
-    if (item.sourceType === 'friend_answered' && item.questionId) {
+    if (isMainFeedSourceVisible(item.sourceType, item.sourceResult) && item.questionId) {
       const group = friendAnsweredByQuestion.get(item.questionId) ?? [];
       group.push(item);
       friendAnsweredByQuestion.set(item.questionId, group);
@@ -72,7 +73,7 @@ async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<Collapsed
     .map((item) => {
       if (collapsedById.has(item.id)) return collapsedById.get(item.id)!;
       // Single friend_answered item — wrap in friendResults for consistent display
-      if (item.sourceType === 'friend_answered') {
+      if (isMainFeedSourceVisible(item.sourceType, item.sourceResult)) {
         return {
           ...item,
           friendResults: [{
@@ -202,6 +203,8 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
       .where(and(
         eq(feedItems.recipientUserId, userId),
         eq(feedItems.isPinned, true),
+        eq(feedItems.sourceType, 'friend_answered'),
+        eq(feedItems.sourceResult, 'correct'),
         inArray(feedItems.state, VISIBLE_FEED_STATES),
       ))
       .orderBy(desc(feedItems.sourceEventAt)),
@@ -211,6 +214,8 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
       .where(and(
         eq(feedItems.recipientUserId, userId),
         eq(feedItems.isPinned, false),
+        eq(feedItems.sourceType, 'friend_answered'),
+        eq(feedItems.sourceResult, 'correct'),
         inArray(feedItems.state, VISIBLE_FEED_STATES),
       ))
       .orderBy(desc(feedItems.sourceEventAt))
@@ -226,13 +231,14 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
 
   const scoreRows = allQuestionIds.length > 0
     ? await db
-        .select({ id: questions.id, score: questions.surfacePriorityScore, canonicalSubcategory: questions.canonicalSubcategory })
+        .select({ id: questions.id, score: questions.surfacePriorityScore, canonicalSubcategory: questions.canonicalSubcategory, visibility: questions.visibility, deletedAt: questions.deletedAt })
         .from(questions)
         .where(inArray(questions.id, allQuestionIds))
     : [];
 
   const scoreByQuestionId = new Map(scoreRows.map((r) => [r.id, r.score ?? 0]));
   const domainByQuestionId = new Map(scoreRows.map((r) => [r.id, r.canonicalSubcategory]));
+  const visibleQuestionIds = new Set(scoreRows.filter((r) => r.visibility === 'public' && !r.deletedAt).map((r) => r.id));
 
   // Sort non-pinned by surface_priority_score DESC then sourceEventAt DESC
   const nonPinned = [...nonPinnedRaw].sort((a, b) => {
@@ -243,7 +249,9 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
   });
 
   const filterItem = (item: FeedItem) => {
-    if (!item.questionId || dismissedSet.size === 0) return true;
+    if (!isMainFeedSourceVisible(item.sourceType, item.sourceResult)) return false;
+    if (!item.questionId || !visibleQuestionIds.has(item.questionId)) return false;
+    if (dismissedSet.size === 0) return true;
     const domain = domainByQuestionId.get(item.questionId);
     return !domain || !dismissedSet.has(domain);
   };

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -684,6 +684,7 @@ export const feedItems = pgTable(
     sourceEventAt: timestamp('sourceEventAt', { withTimezone: true }).notNull().defaultNow(),
     personalMessage: text('personalMessage'),
     submittedAnswer: text('submittedAnswer'),
+    sourceAnswerId: text('sourceAnswerId'),
     state: text('state').notNull().default('active'),
     isPinned: boolean('isPinned').notNull().default(false),
     quip: text('quip'),
@@ -692,6 +693,7 @@ export const feedItems = pgTable(
   (table) => [
     index('FeedItem_recipientUserId_state_idx').on(table.recipientUserId, table.state, table.sourceEventAt.desc()),
     index('FeedItem_recipientUserId_pinned_idx').on(table.recipientUserId, table.isPinned).where(sql`"isPinned" = TRUE`),
+    uniqueIndex('FeedItem_recipientUserId_sourceAnswerId_key').on(table.recipientUserId, table.sourceAnswerId).where(sql`"sourceAnswerId" IS NOT NULL`),
   ],
 );
 

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { isCorrectAnswerFeedEligible, isMainFeedSourceVisible, socialFeedDomainLabel } from '@/server/feed/visibility';
+
+const publicQuestion = {
+  creatorId: 'author-1',
+  visibility: 'public' as const,
+  deletedAt: null,
+};
+
+describe('correct-answer social feed eligibility', () => {
+  it('rejects newly-created/authored feed sources and game-publication sources from the main feed', () => {
+    expect(isMainFeedSourceVisible('authored_shared', null)).toBe(false);
+    expect(isMainFeedSourceVisible('joshing_game', null)).toBe(false);
+    expect(isMainFeedSourceVisible('direct_sent', null)).toBe(false);
+  });
+
+  it('allows a correct answer by someone other than the author in a visible social context', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: publicQuestion,
+      hasVisibleSocialContext: true,
+    })).toBe(true);
+    expect(isMainFeedSourceVisible('friend_answered', 'correct')).toBe(true);
+  });
+
+  it('rejects a correct answer by the author', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'author-1',
+      question: publicQuestion,
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+  });
+
+  it('rejects wrong answers', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: false,
+      answererUserId: 'answerer-1',
+      question: publicQuestion,
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+    expect(isMainFeedSourceVisible('friend_answered', 'incorrect')).toBe(false);
+  });
+
+  it('rejects private or non-visible questions for unauthorized viewers', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: { ...publicQuestion, visibility: 'private' as const },
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: publicQuestion,
+      hasVisibleSocialContext: false,
+    })).toBe(false);
+  });
+
+  it('suppresses forbidden fallback categories on feed cards', () => {
+    expect(socialFeedDomainLabel({ canonicalSubcategory: 'Other', broadCategory: 'Uncategorized', category: 'Unknown' })).toBeNull();
+    expect(socialFeedDomainLabel({ canonicalSubcategory: ' ', broadCategory: 'Bowie-era Glam Rock', category: 'Unknown' })).toBe('Bowie-era Glam Rock');
+  });
+});

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -4,14 +4,16 @@ import { db, feedDismissedDomains, feedItems, masteryEvents, questionFeedback, q
 import { writeActivity } from '@/server/activity/write-activity';
 import { getFriends } from '@/server/db/queries/friends';
 import { rollOffOldItems, userAnsweredQuestionCorrectly } from '@/server/db/queries/feed';
+import { isCorrectAnswerFeedEligible } from '@/server/feed/visibility';
 
 export async function createFeedItemsForFriendsFromAnswer(
   userId: string,
   questionId: string,
   result: 'correct' | 'incorrect',
+  sourceAnswerId?: string,
 ): Promise<void> {
   try {
-    await _createFeedItemsForFriendsFromAnswer(userId, questionId, result);
+    await _createFeedItemsForFriendsFromAnswer(userId, questionId, result, sourceAnswerId);
   } catch (error) {
     console.error('[createFeedItemsForFriendsFromAnswer] propagation error (suppressed):', {
       userId,
@@ -25,7 +27,10 @@ async function _createFeedItemsForFriendsFromAnswer(
   userId: string,
   questionId: string,
   result: 'correct' | 'incorrect',
+  sourceAnswerId?: string,
 ): Promise<void> {
+  if (result !== 'correct') return;
+
   // Don't propagate if the answering user thumbed this question down via either signal path
   const [thumbsDown] = await db
     .select({ id: questionFeedback.id })
@@ -50,12 +55,17 @@ async function _createFeedItemsForFriendsFromAnswer(
   if (thumbsDown || ratingDown) return;
 
   const [question] = await db
-    .select({ canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
+    .select({ creatorId: questions.creatorId, visibility: questions.visibility, deletedAt: questions.deletedAt, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
     .from(questions)
     .where(eq(questions.id, questionId))
     .limit(1);
 
-  if (!question) return;
+  if (!isCorrectAnswerFeedEligible({
+    answerIsCorrect: result === 'correct',
+    answererUserId: userId,
+    question,
+    hasVisibleSocialContext: true,
+  })) return;
 
   const domain = question.canonicalSubcategory ?? question.broadCategory;
   if (!domain) return;
@@ -93,6 +103,19 @@ async function _createFeedItemsForFriendsFromAnswer(
 
     if (existing) continue;
 
+    if (sourceAnswerId) {
+      const [answerEvent] = await db
+        .select({ id: feedItems.id })
+        .from(feedItems)
+        .where(and(
+          eq(feedItems.recipientUserId, friend.id),
+          eq(feedItems.sourceAnswerId, sourceAnswerId),
+        ))
+        .limit(1);
+
+      if (answerEvent) continue;
+    }
+
     await db.insert(feedItems).values({
       recipientUserId: friend.id,
       questionId,
@@ -100,6 +123,7 @@ async function _createFeedItemsForFriendsFromAnswer(
       sourceUserId: userId,
       sourceResult: result,
       sourceEventAt: new Date(),
+      sourceAnswerId,
       state: 'active',
       isPinned: false,
     });

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -1,0 +1,39 @@
+import type { questions } from '@/server/db';
+
+export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
+
+const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown', 'general', 'general knowledge']);
+
+type QuestionLike = Pick<typeof questions.$inferSelect, 'creatorId' | 'visibility' | 'canonicalSubcategory' | 'broadCategory' | 'category' | 'deletedAt'>;
+
+export type FeedEventEligibilityInput = {
+  answerIsCorrect: boolean;
+  answererUserId: string;
+  question: Pick<QuestionLike, 'creatorId' | 'visibility' | 'deletedAt'> | null | undefined;
+  hasVisibleSocialContext: boolean;
+};
+
+export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): boolean {
+  if (!input.answerIsCorrect) return false;
+  if (!input.hasVisibleSocialContext) return false;
+  if (!input.question) return false;
+  if (input.question.deletedAt) return false;
+  if (input.question.visibility !== 'public') return false;
+  if (!input.question.creatorId) return false;
+  return input.answererUserId !== input.question.creatorId;
+}
+
+export function isMainFeedSourceVisible(sourceType: string, sourceResult: string | null): boolean {
+  return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
+}
+
+export function socialFeedDomainLabel(question: Pick<QuestionLike, 'canonicalSubcategory' | 'broadCategory' | 'category'> | null | undefined): string | null {
+  const candidates = [question?.canonicalSubcategory, question?.broadCategory, question?.category];
+  for (const candidate of candidates) {
+    const label = typeof candidate === 'string' ? candidate.trim() : '';
+    if (!label) continue;
+    if (SUPPRESSED_CATEGORY_LABELS.has(label.toLowerCase())) continue;
+    return label;
+  }
+  return null;
+}


### PR DESCRIPTION
### Motivation
- The Feed should surface socially validated moments (when someone other than the author answers correctly) instead of showing raw question-creation events.
- Prevent leakage of private/author-only creations into the main Feed and reframe cards as shared recognition/common ground rather than performance/score artifacts.

### Description
- Add `src/server/feed/visibility.ts` with the eligibility rules (`isCorrectAnswerFeedEligible`, `isMainFeedSourceVisible`, `socialFeedDomainLabel`) requiring a correct non-author answer, visible social context, and public/non-deleted question for main-feed inclusion.
- Gate propagation on answer submission by updating answer routes to pass a deterministic `sourceAnswerId` and updating `createFeedItemsForFriendsFromAnswer` to only propagate correct answers, enforce eligibility and deduplicate by `sourceAnswerId`.
- Restrict feed queries to only return `friend_answered` items with `sourceResult = 'correct'`, filter out non-public/deleted questions before rendering, collapse friend results, and collapse legacy thumbs-up groups in `src/server/db/queries/feed.ts` and `src/app/api/feed/route.ts`.
- Update Feed UI/copy in `src/components/FeedList.tsx` to emphasize common ground (new empty-state and card strings), suppress forbidden fallback categories, remove created-question visual variants, and simplify actions; add a DB schema column `sourceAnswerId` plus a migration script `drizzle/0029_correct_answer_social_feed.sql` to add the column, create a uniqueness index, and roll off legacy authored/thumbs/incorrect feed items.

### Testing
- Typecheck: ran `npx tsc --noEmit`, which succeeded for the modified codebase files touched by this change.
- Lint (scoped): ran `npx eslint` against the changed feed-related sources (`src/server/feed/visibility.ts`, `src/server/feed/create-feed-items-for-answer.ts`, `src/server/db/queries/feed.ts`, `src/app/api/feed/route.ts`, `src/app/api/questions/route.ts`, `src/components/FeedList.tsx`, `src/server/feed/__tests__/visibility.test.ts`), and the feed-area lint checks passed for the edits; repository-wide `npm run lint` still fails on unrelated pre-existing lint issues.
- Unit test (added): added `src/server/feed/__tests__/visibility.test.ts` covering eligibility and domain-label suppression, but running Vitest in this environment was blocked by registry access (Vitest install/registry 403), so the test file is present but could not be executed here.
- Repository checks: `git diff --check` reported no new diff errors and changes were validated locally; migration SQL `drizzle/0029_correct_answer_social_feed.sql` was added to apply the `sourceAnswerId` column and to roll off legacy authored/thumbs/incorrect feed items.

If you want, I can split this into smaller commits (migration, server logic, API, UI, tests) or run additional scoped tests if the environment can install dev dependencies (Vitest) or run the full lint suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0504c17bb4832ea37bed146cb229a1)