### PR TITLE
Fix category enum migration startup

### DIFF
--- a/drizzle/0028_remove_other_question_category.sql
+++ b/drizzle/0028_remove_other_question_category.sql
@@ -1,3 +1,4 @@
-ALTER TYPE "public"."Category" ADD VALUE IF NOT EXISTS 'general_knowledge';--> statement-breakpoint
-ALTER TABLE "Question" ALTER COLUMN "category" SET DEFAULT 'general_knowledge';--> statement-breakpoint
-UPDATE "Question" SET "category" = 'general_knowledge' WHERE "category" = 'other';
+-- Add the replacement Category enum value separately from the default/data
+-- migration that consumes it. The app startup preflight also commits this enum
+-- addition before Drizzle's transaction when multiple migrations are pending.
+ALTER TYPE "public"."Category" ADD VALUE IF NOT EXISTS 'general_knowledge';

--- a/drizzle/0030_apply_general_knowledge_category.sql
+++ b/drizzle/0030_apply_general_knowledge_category.sql
@@ -1,0 +1,4 @@
+-- Now that drizzle/0028 has committed the enum value, it is safe to use it
+-- in column defaults and data updates.
+ALTER TABLE "Question" ALTER COLUMN "category" SET DEFAULT 'general_knowledge';
+UPDATE "Question" SET "category" = 'general_knowledge' WHERE "category" = 'other';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1778714100000,
       "tag": "0029_correct_answer_social_feed",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1778714200000,
+      "tag": "0030_apply_general_knowledge_category",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -134,6 +134,27 @@ export async function register() {
       // FeedItem table may not exist yet — migrate() handles initial creation.
     }
 
+    // Migration 0028 adds the Category.general_knowledge enum value and migration
+    // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
+    // migrations in one transaction, but Postgres requires a newly-added enum value
+    // to be committed before it can be used. Pre-apply the enum addition and data
+    // change outside the migrator transaction so production startup cannot get
+    // stuck on `unsafe use of new value "general_knowledge"`.
+    try {
+      await db.execute(sql`
+        ALTER TYPE "public"."Category" ADD VALUE IF NOT EXISTS 'general_knowledge'
+      `);
+      await db.execute(sql`
+        ALTER TABLE "Question" ALTER COLUMN "category" SET DEFAULT 'general_knowledge'
+      `);
+      await db.execute(sql`
+        UPDATE "Question" SET "category" = 'general_knowledge' WHERE "category" = 'other'
+      `);
+    } catch {
+      // Fresh databases may not have Category or Question yet. In that case the
+      // normal migration sequence will create the base schema first.
+    }
+
     // If the Category enum type already exists but migration 0000 isn't recorded,
     // the migrator fails at the very first CREATE TYPE statement and aborts — leaving
     // all subsequent migrations (0006 recipientUserId, 0014 territory_type, etc.)


### PR DESCRIPTION
### Motivation
- Prevent production startup failures caused by Postgres rejecting the "unsafe use of new value \"general_knowledge\"" when a migration adds an enum value and immediately uses it in the same transaction.
- Ensure the app can safely run Drizzle's transactional migrator on databases that already have partial migration state so the feed and other reads don't fail at startup.

### Description
- Pre-apply the enum addition and the default/backfill change during app startup in `src/instrumentation.ts` so the `Category.general_knowledge` value is committed before Drizzle runs migrations.
- Split the original migration so `drizzle/0028_remove_other_question_category.sql` only adds the enum value and no longer sets defaults or updates data.
- Add a follow-up migration `drizzle/0030_apply_general_knowledge_category.sql` that sets the `Question.category` default and backfills `other` → `general_knowledge` after the enum value is present.
- Register the new migration in `drizzle/meta/_journal.json` so Drizzle will apply the follow-up migration in order.

### Testing
- Type-checking was run with `npx tsc --noEmit` and completed successfully.
- Linting was run with `npm run lint` and reported pre-existing lint errors unrelated to the migration changes, so lint did not block this migration fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05aced5c54832eb615b75572758147)