### PR TITLE
Guard against generic LLM subcategories

### DIFF
--- a/src/lib/llm.categorization.test.ts
+++ b/src/lib/llm.categorization.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+import { normalizeCanonicalSubcategory } from '@/lib/question-categorization'
+
+const createMessageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: vi.fn(() => ({
+    messages: {
+      create: createMessageMock,
+    },
+  })),
+}))
+
+function anthropicTextResponse(json: Record<string, unknown>) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(json) }],
+  }
+}
+
+async function importCategorizer() {
+  const mod = await import('@/lib/llm')
+  return mod.categorizeQuestion
+}
+
+describe('categorizeQuestion final subcategory guard', () => {
+  beforeEach(() => {
+    createMessageMock.mockReset()
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-with-enough-length'
+    process.env.LLM_ENABLED = 'true'
+  })
+
+  it('replaces an LLM "Other" subcategory with a specific answer-derived literature domain', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: 'Other',
+          broad_category: 'Literature',
+          confidence: 0.91,
+        })
+      )
+      .mockResolvedValueOnce(anthropicTextResponse({ subcategory: 'Other' }))
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What epic poem by John Milton includes the fall of Adam and Eve?',
+      'Paradise Lost'
+    )
+
+    expect(result).toEqual({
+      subcategory: 'Paradise Lost',
+      broad_category: 'Literature',
+      confidence: 0.91,
+    })
+    expect(result.subcategory).not.toBe('Other')
+  })
+
+  it('replaces a subcategory that repeats its broad category', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: 'Literature',
+          broad_category: 'Literature',
+          confidence: 0.86,
+        })
+      )
+      .mockResolvedValueOnce(
+        anthropicTextResponse({ subcategory: 'Literature' })
+      )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What epic poem by John Milton includes the fall of Adam and Eve?',
+      'Paradise Lost'
+    )
+
+    expect(result.subcategory).toBe('Paradise Lost')
+    expect(result.subcategory).not.toBe(result.broad_category)
+  })
+
+  it('uses the deterministic final guard when refinement also returns a generic value', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: 'Other',
+          broad_category: 'Literature',
+          confidence: 0.72,
+        })
+      )
+      .mockResolvedValueOnce(
+        anthropicTextResponse({ subcategory: 'General Knowledge' })
+      )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What epic poem by John Milton includes the fall of Adam and Eve?',
+      'Paradise Lost'
+    )
+
+    expect(createMessageMock).toHaveBeenCalledTimes(2)
+    expect(result.subcategory).toBe('Paradise Lost')
+  })
+
+  it('keeps the final persisted domain specific and never Other', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: 'Other',
+          broad_category: 'Literature',
+          confidence: 0.8,
+        })
+      )
+      .mockResolvedValueOnce(anthropicTextResponse({ subcategory: 'Trivia' }))
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What epic poem by John Milton includes the fall of Adam and Eve?',
+      'Paradise Lost'
+    )
+    const persistedDomain =
+      normalizeCanonicalSubcategory(result.subcategory) || 'General Knowledge'
+
+    expect(persistedDomain).toBe('Paradise Lost')
+    expect(persistedDomain).not.toBe('Other')
+    expect(persistedDomain).not.toBe('General Knowledge')
+    expect(persistedDomain).not.toBe('Trivia')
+    expect(persistedDomain).not.toBe(result.broad_category)
+  })
+})

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -66,7 +66,9 @@ const GENERIC_SUBCATEGORY_NORMALIZED = new Set([
   'language',
   'other',
   'general knowledge',
+  'general',
   'trivia',
+  'potpourri',
 ]);
 const VALID_SUGGESTION_TYPES = ['factual', 'personal', 'ambiguous', 'factual_uncertain'] as const;
 const VALID_DIFFICULTY_ESTIMATES = ['accessible', 'moderate', 'specialist'] as const;
@@ -168,6 +170,99 @@ function isTooGenericSubcategory(subcategory: string, broadCategory: string): bo
   return GENERIC_SUBCATEGORY_NORMALIZED.has(normalizedSubcategory);
 }
 
+const QUESTION_WORDS_NORMALIZED = new Set([
+  'what',
+  'which',
+  'who',
+  'whom',
+  'whose',
+  'where',
+  'when',
+  'why',
+  'how',
+  'name',
+  'identify',
+  'in',
+]);
+
+function tidySubcategoryCandidate(value: string): string | null {
+  const withoutPrefix = value
+    .replace(/^[\s"'“”‘’`]*(?:the\s+answer\s+is|answer|it\s+is|it's|its|this\s+is)\s*:?\s*/i, '')
+    .replace(/[\s"'“”‘’`]+$/g, '')
+    .replace(/^[\s"'“”‘’`]+/g, '')
+    .trim();
+  const firstClause = withoutPrefix.split(/(?:\s+[-–—]\s+|[.!?;]|\n)/)[0]?.trim() ?? '';
+  const normalized = firstClause.replace(/\s+/g, ' ').trim();
+  if (!normalized) return null;
+
+  const words = normalized.split(/\s+/);
+  if (words.length > 8 || normalized.length > 80) return null;
+  if (QUESTION_WORDS_NORMALIZED.has(normalizeCategoryLabel(normalized))) return null;
+  return normalized;
+}
+
+function subcategoryCandidateIsAllowed(candidate: string, broadCategory: string): boolean {
+  return !isTooGenericSubcategory(candidate, broadCategory);
+}
+
+function quotedCandidates(value: string): string[] {
+  const candidates: string[] = [];
+  for (const match of value.matchAll(/["“”'‘’]([^"“”'‘’]{2,80})["“”'‘’]/g)) {
+    if (match[1]) candidates.push(match[1]);
+  }
+  return candidates;
+}
+
+function capitalizedPhraseCandidates(value: string): string[] {
+  const candidates: string[] = [];
+  const phrasePattern = /\b(?:[A-Z][A-Za-z0-9]*(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,})(?:[-\s]+(?:[A-Z][A-Za-z0-9]*(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,}|of|the|and|for|in|to|a|an))*\b/g;
+  for (const match of value.matchAll(phrasePattern)) {
+    const phrase = match[0]?.trim();
+    if (phrase) candidates.push(phrase);
+  }
+  return candidates;
+}
+
+function deterministicSubcategoryFallback(
+  questionText: string,
+  answerText: string,
+  broadCategory: string
+): string {
+  const candidateSources = [
+    answerText,
+    ...quotedCandidates(answerText),
+    ...quotedCandidates(questionText),
+    ...capitalizedPhraseCandidates(answerText),
+    ...capitalizedPhraseCandidates(questionText),
+  ];
+
+  for (const candidate of candidateSources) {
+    const tidied = tidySubcategoryCandidate(candidate);
+    if (tidied && subcategoryCandidateIsAllowed(tidied, broadCategory)) {
+      return tidied;
+    }
+  }
+
+  return subcategoryCandidateIsAllowed('Specific Question Topic', broadCategory)
+    ? 'Specific Question Topic'
+    : 'Question-Specific Knowledge';
+}
+
+function finalizeCategorization(
+  result: CategoryResult,
+  questionText: string,
+  answerText: string
+): CategoryResult {
+  if (!isTooGenericSubcategory(result.subcategory, result.broad_category)) {
+    return result;
+  }
+
+  return {
+    ...result,
+    subcategory: deterministicSubcategoryFallback(questionText, answerText, result.broad_category),
+  };
+}
+
 function asIntegerOrNull(value: unknown): number | null {
   if (typeof value !== 'number' || !Number.isInteger(value)) return null;
   return value >= 0 ? value : null;
@@ -248,8 +343,12 @@ function fallbackGrading(): GradingResponse {
   return { result: 'wrong', confidence: 0, reason: 'llm_error', consolation: null };
 }
 
-function fallbackCategorization(): CategoryResult {
-  return { subcategory: 'Potpourri', broad_category: 'General Knowledge', confidence: 0 };
+function fallbackCategorization(questionText = '', answerText = ''): CategoryResult {
+  return finalizeCategorization(
+    { subcategory: 'General Knowledge', broad_category: 'General Knowledge', confidence: 0 },
+    questionText,
+    answerText
+  );
 }
 
 function fallbackExplainer(canonicalAnswer: string): ExplainerResult {
@@ -400,7 +499,7 @@ Categorize this question. Return JSON only.`;
   try {
     const client = getAnthropicClient();
     if (!client) {
-      return fallbackCategorization();
+      return fallbackCategorization(questionText, answerText);
     }
 
     const response = await client.messages.create({
@@ -415,14 +514,14 @@ Categorize this question. Return JSON only.`;
     const parsed = parseJsonObject(text);
     if (!parsed) {
       logFallback('categorizeQuestion', 'invalid_json', { responseLength: text.length });
-      return fallbackCategorization();
+      return fallbackCategorization(questionText, answerText);
     }
 
     let subcategory = asTrimmedString(parsed.subcategory);
     const broadCategory = asTrimmedString(parsed.broad_category);
     if (!subcategory || !broadCategory) {
       logFallback('categorizeQuestion', 'missing_required_fields');
-      return fallbackCategorization();
+      return fallbackCategorization(questionText, answerText);
     }
 
     if (isTooGenericSubcategory(subcategory, broadCategory)) {
@@ -464,10 +563,14 @@ Return JSON only.`;
     }
 
     const confidence = clampConfidence(parsed.confidence, 0.8);
-    return { subcategory, broad_category: broadCategory, confidence };
+    return finalizeCategorization(
+      { subcategory, broad_category: broadCategory, confidence },
+      questionText,
+      answerText
+    );
   } catch (error) {
     logFallback('categorizeQuestion', 'request_failed', summarizeError(error));
-    return fallbackCategorization();
+    return fallbackCategorization(questionText, answerText);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Avoid persisting overly generic or forbidden subcategory labels (e.g. `Other`, `General Knowledge`, `Trivia`, broad-category echoes, `Potpourri`) returned by the LLM when categorizing questions. 
- Prefer concise, deterministic, and non-forbidden subcategory labels derived from the question/answer (for work/answer-driven items prefer the work/person/topic from the answer). 

### Description
- Added a final guard that runs before returning a categorization via `finalizeCategorization(...)`, which detects too-generic subcategories using `isTooGenericSubcategory` and replaces them with a deterministic fallback derived from the question/answer (helpers: `tidySubcategoryCandidate`, `quotedCandidates`, `capitalizedPhraseCandidates`, `deterministicSubcategoryFallback`).
- Routed `fallbackCategorization()` through the same final guard so fallback results no longer return the old generic `Potpourri` and instead yield a safer question/answer-derived label when possible. 
- Integrated the final guard into all categorize return paths (normal return, invalid/timeout/refinement/fallback paths) so persisted domains never equal forbidden generic values or repeat their broad category. 
- Added tests in `src/lib/llm.categorization.test.ts` that mock the Anthropic client to cover: LLM returning `Other`, LLM returning the same value as the broad category, refinement also returning a generic value, and the final persisted domain being specific and never `Other`.

### Testing
- Ran the TypeScript check with `npx tsc --noEmit --pretty false` which completed successfully.
- Ran ESLint against the changed files with `npx eslint src/lib/llm.ts src/lib/llm.categorization.test.ts` which succeeded for those files.
- Attempted to run the new unit tests with `npx vitest run src/lib/llm.categorization.test.ts`, but the run was blocked due to inability to fetch `vitest` from the registry (npm returned `E403`).
- Running the repository-wide lint script (`npm run lint`) still fails due to pre-existing unrelated lint issues elsewhere in the repo, but the added files themselves pass targeted checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b8d4dd14832eb5d6241e64153178)