### PR TITLE
Remove authored difficulty from quick-add payload and strengthen create-payload tests

### DIFF
--- a/src/components/QuickAddQuestionModal.tsx
+++ b/src/components/QuickAddQuestionModal.tsx
@@ -82,7 +82,6 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
           breadcrumb_context: bc,
           short_label: shortLabel.trim() || null,
           answer_source: 'creator_written',
-          difficulty: 3,
           verified: true,
           critiqueIterations: 0,
         }),
@@ -216,7 +215,7 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
           <div style={{ padding: '10px 12px', border: '1px solid var(--border)', borderRadius: 'var(--radius-md)', background: 'color-mix(in srgb, var(--muted, #f5f5f5) 55%, var(--bg))' }}>
             <p style={{ ...monoStyle, color: 'var(--text-muted)', marginBottom: '4px' }}>AI classification</p>
             <p style={{ margin: 0, fontSize: '0.85rem', color: 'var(--text-muted)', lineHeight: 1.45 }}>
-              Joshing will read the question and answer when you save, then choose the category and specific area automatically.
+              Joshing will read the question and answer when you save, then choose the category, specific area, and difficulty automatically.
             </p>
           </div>
 

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -16,7 +16,9 @@ describe('create question payload categorization', () => {
       ...basePayload,
       category: 'literature',
       broadCategory: 'Literature',
+      broad_category: 'Literature',
       canonicalSubcategory: '  The   Waste Land  ',
+      canonical_subcategory: '  Poetry  ',
       subcategory: 'Modernist Poetry',
       domain: 'TS Eliot',
     });
@@ -24,7 +26,9 @@ describe('create question payload categorization', () => {
     expect(result.errors).toEqual([]);
     expect('category' in result.value).toBe(false);
     expect('broadCategory' in result.value).toBe(false);
+    expect('broad_category' in result.value).toBe(false);
     expect('canonicalSubcategory' in result.value).toBe(false);
+    expect('canonical_subcategory' in result.value).toBe(false);
     expect('subcategory' in result.value).toBe(false);
     expect('domain' in result.value).toBe(false);
   });
@@ -53,14 +57,22 @@ describe('create question payload categorization', () => {
     expect('domain' in result.value).toBe(false);
   });
 
-  it('does not accept a user-supplied difficulty', () => {
+  it('ignores user-supplied difficulty fields', () => {
     const result = readCreateQuestionPayload({
       ...basePayload,
       difficulty: 5,
+      calibratedDifficulty: 1,
+      calibrated_difficulty: 2,
+      llmDifficulty: 4,
+      llm_difficulty: 5,
     });
 
     expect(result.errors).toEqual([]);
     expect('difficulty' in result.value).toBe(false);
+    expect('calibratedDifficulty' in result.value).toBe(false);
+    expect('calibrated_difficulty' in result.value).toBe(false);
+    expect('llmDifficulty' in result.value).toBe(false);
+    expect('llm_difficulty' in result.value).toBe(false);
   });
 
   it('does not require friends when sharing to feed', () => {


### PR DESCRIPTION
### Motivation
- Prevent UI from supplying category/domain/difficulty values so the server's LLM classification remains the single source of broad category, canonical subcategory/domain, and numeric difficulty.

### Description
- Removed the hard-coded `difficulty` field from the quick-add POST payload in `src/components/QuickAddQuestionModal.tsx` and updated the modal copy to clarify category, specific area, and difficulty are chosen automatically.
- Expanded `src/server/questions/__tests__/create-payload.test.ts` to assert user-supplied `category`/`broadCategory`/`broad_category`, `canonicalSubcategory`/`canonical_subcategory`, `subcategory`, `domain`, and several difficulty aliases are ignored by `readCreateQuestionPayload`.

### Testing
- Ran type-checking with `npx tsc --noEmit -p tsconfig.typecheck.json` which completed without errors.
- Ran ESLint on the changed files with `npx eslint src/components/QuickAddQuestionModal.tsx src/server/questions/__tests__/create-payload.test.ts` which completed without errors.
- Attempted to run the single test file with `npx vitest run src/server/questions/__tests__/create-payload.test.ts` but it was blocked due to `npm` registry access returning `403 Forbidden` while fetching `vitest`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05b9e5fea0832e8aec7b2697d883d6)