### PR TITLE
Centralize and update difficulty UI copy to Establishing / Solid / Skilled / Master

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -33,10 +33,10 @@ type AdaptiveLevelResponse = {
 };
 
 const DIFFICULTIES: { value: Difficulty; label: string; copy: string }[] = [
-  { value: 'normal', label: 'Normal', copy: 'Approachable. Designed for ~70% correct.' },
-  { value: 'moderate', label: 'Moderate', copy: 'A real challenge. ~50% correct.' },
-  { value: 'challenging', label: 'Challenging', copy: 'Hard. ~30% correct.' },
-  { value: 'ridiculous', label: 'Ridiculous', copy: 'Brutal. ~15% correct.' },
+  { value: 'normal', label: 'Establishing', copy: 'Approachable, core-recognition questions.' },
+  { value: 'moderate', label: 'Solid', copy: 'A steady challenge for generally knowledgeable players.' },
+  { value: 'challenging', label: 'Skilled', copy: 'Deeper-domain questions with more specific recall.' },
+  { value: 'ridiculous', label: 'Master', copy: 'Master-level deep cuts within the domain.' },
   { value: 'adaptive', label: 'Adaptive', copy: 'Calibrated to your recent performance.' },
 ];
 

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -24,6 +24,20 @@ import type {
 
 type FeedbackSignal = 'thumbs_up' | 'thumbs_down'
 
+
+const DAILY_DIFFICULTY_LABELS: Record<string, string> = {
+  normal: 'Establishing',
+  moderate: 'Solid',
+  challenging: 'Skilled',
+  ridiculous: 'Master',
+  adaptive: 'Adaptive',
+}
+
+function dailyDifficultyLabel(value: string | null | undefined): string | null {
+  if (!value) return null
+  return DAILY_DIFFICULTY_LABELS[value] ?? value
+}
+
 const monoStyle: CSSProperties = {
   fontFamily: 'var(--font-mono)',
   fontSize: '0.62rem',
@@ -228,8 +242,8 @@ export default function DailySummaryPage() {
             color: 'var(--text-muted)',
           }}
         >
-          {summary.difficultyMode
-            ? `${summary.difficultyMode.charAt(0).toUpperCase() + summary.difficultyMode.slice(1)} · `
+          {dailyDifficultyLabel(summary.difficultyMode)
+            ? `${dailyDifficultyLabel(summary.difficultyMode)} · `
             : ''}
           {summary.totalCorrect}/{summary.questions.length} correct
           {summary.totalSkipped > 0 ? ` · ${summary.totalSkipped} skipped` : ''}

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -4,12 +4,14 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 import type { JoshingGameView, QuestionRow } from '@/server/db/queries/joshing-game';
 
 function questionBadges(q: QuestionRow): Array<{ label: string; tone?: 'warning' }> | undefined {
   const level = q.calibratedDifficulty ?? q.llmDifficulty ?? q.difficultyEstimate ?? null;
   if (!level) return undefined;
-  const label = level.charAt(0).toUpperCase() + level.slice(1);
+  const label = difficultyCopyFromEstimate(level);
+  if (!label) return undefined;
   return [level === 'specialist' ? { label, tone: 'warning' as const } : { label }];
 }
 

--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -7,6 +7,7 @@ import { QuestionRatingButtons } from '@/components/games/QuestionRatingButtons'
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay';
+import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 import MasteryMoment from '@/components/review/MasteryMoment';
 import { getSession } from '@/server/auth/session';
 import { getDeliveredCreatorNotesForQuestions } from '@/server/creator-notes';
@@ -260,7 +261,7 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
                         const level = resolvedDifficulty(gameQuestion.question);
                         return level ? (
                           <span className={`rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] ${difficultyPillClasses(level)}`}>
-                            {level.charAt(0).toUpperCase() + level.slice(1)}
+                            {difficultyCopyFromEstimate(level) ?? 'Unrated'}
                           </span>
                         ) : null;
                       })()}

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
+import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import type { QuestionView } from '@/server/db/queries/questions';
 
@@ -34,14 +35,6 @@ function isNoQuestionsResponse(response: Response, body: QuestionsApiResponse | 
     || NO_QUESTIONS_PATTERNS.some((pattern) => pattern.test(apiMessage));
 }
 
-const DIFFICULTY_COPY: Record<number, string> = {
-  1: 'Establishing',
-  2: 'Establishing → Solid',
-  3: 'Solid',
-  4: 'Skilled',
-  5: 'Master',
-};
-
 const DOMAIN_COLORS: Record<string, string> = {
   music: '#7c3aed',
   literature: '#0f766e',
@@ -69,10 +62,6 @@ function relativeTime(value: string | null): string {
   if (days === 1) return 'yesterday';
   if (days < 30) return `${days}d ago`;
   return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(date);
-}
-
-function difficultyDots(value: number) {
-  return Array.from({ length: 5 }, (_, index) => index < value ? '●' : '○').join(' ');
 }
 
 function initialValues(question: QuestionView): QuestionFormValues {
@@ -350,6 +339,7 @@ function QuestionsPageContent() {
             const inUse = question.usedInGamesCount > 0;
             const color = DOMAIN_COLORS[question.category] ?? '#64748b';
             const deleting = removingId === question.id;
+            const difficultyLabel = difficultyCopyFromValue(question.difficulty) ?? 'Unrated';
 
             return (
               <article
@@ -363,10 +353,8 @@ function QuestionsPageContent() {
                   >
                     {question.domainDisplayName}
                   </span>
-                  <span className="font-mono text-xs text-muted-foreground" aria-label={`LLM-rated difficulty: ${DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}`}>
-                    {difficultyDots(question.difficulty)}
-                    {' · '}
-                    {DIFFICULTY_COPY[question.difficulty] ?? 'Unrated'}
+                  <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground" aria-label={`LLM-rated difficulty: ${difficultyLabel}`}>
+                    {difficultyLabel}
                   </span>
                   <span className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] text-muted-foreground">
                     {isOwnAuthored ? 'Written by you' : `From ${question.authorName ?? 'a friend'}`}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -7,6 +7,7 @@ import { Send, SkipForward, X } from 'lucide-react';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { QuestionReactionPrompt } from '@/components/play/GameplayChat';
+import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 
 type FriendResult = {
   userId: string;
@@ -305,7 +306,7 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
                       : item.difficulty === 'moderate' ? 'bg-amber-100 text-amber-700'
                       : 'bg-sky-100 text-sky-700',
                     ].join(' ')}>
-                      {item.difficulty.charAt(0).toUpperCase() + item.difficulty.slice(1)}
+                      {difficultyCopyFromEstimate(item.difficulty) ?? 'Unrated'}
                     </span>
                   ) : null}
                   <span className="ml-auto text-xs text-muted-foreground">{formatEventTime(item.source_event_at)}</span>

--- a/src/lib/questions/difficulty-copy.ts
+++ b/src/lib/questions/difficulty-copy.ts
@@ -1,0 +1,46 @@
+export type QuestionDifficultyTier = 'establishing' | 'solid' | 'skilled' | 'master';
+export type DifficultyEstimateValue = 'accessible' | 'moderate' | 'specialist';
+
+export const DIFFICULTY_COPY: Record<number, string> = {
+  1: 'Establishing',
+  2: 'Establishing',
+  3: 'Solid',
+  4: 'Skilled',
+  5: 'Master',
+};
+
+const TIER_COPY: Record<QuestionDifficultyTier, string> = {
+  establishing: 'Establishing',
+  solid: 'Solid',
+  skilled: 'Skilled',
+  master: 'Master',
+};
+
+const ESTIMATE_COPY: Record<DifficultyEstimateValue, string> = {
+  accessible: 'Establishing',
+  moderate: 'Solid',
+  specialist: 'Master',
+};
+
+export function difficultyCopyFromValue(value: number | null | undefined): string | null {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return null;
+  return DIFFICULTY_COPY[Math.round(value)] ?? null;
+}
+
+export function difficultyCopyFromTier(tier: string | null | undefined): string | null {
+  if (!tier) return null;
+  const normalized = tier.trim().toLowerCase();
+  if (normalized === 'mastery') return TIER_COPY.master;
+  return TIER_COPY[normalized as QuestionDifficultyTier] ?? null;
+}
+
+export function difficultyCopyFromEstimate(difficulty: string | null | undefined): string | null {
+  if (!difficulty) return null;
+  const normalized = difficulty.trim().toLowerCase();
+  return ESTIMATE_COPY[normalized as DifficultyEstimateValue] ?? difficultyCopyFromTier(normalized);
+}
+
+export function difficultyCopyFromAssessment(value: string | number | null | undefined): string | null {
+  if (typeof value === 'number') return difficultyCopyFromValue(value);
+  return difficultyCopyFromEstimate(value);
+}

--- a/src/lib/questions/difficulty-tier.ts
+++ b/src/lib/questions/difficulty-tier.ts
@@ -1,13 +1,12 @@
+import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
+
 /**
- * Maps the LLM's 3-tier `difficulty_estimate` to the tier vocabulary already used
- * elsewhere in the app (Establishing / Solid / Mastery). Surfaced as the badge
- * pill on each question card so players see how hard the question objectively is.
+ * Maps the LLM's persisted `difficulty_estimate` to the tier vocabulary used
+ * elsewhere in the app: Establishing / Solid / Master.
  */
 export function difficultyEstimateToTierLabel(
   difficulty: string | null | undefined,
 ): string | null {
-  if (difficulty === 'accessible') return 'ESTABLISHING';
-  if (difficulty === 'moderate') return 'SOLID';
-  if (difficulty === 'specialist') return 'MASTERY';
-  return null;
+  const label = difficultyCopyFromEstimate(difficulty);
+  return label ? label.toUpperCase() : null;
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -201,7 +201,7 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
     broadCategory: row.broadCategory,
     canonicalSubcategory: row.canonicalSubcategory,
     subcategory: row.subcategory,
-    difficulty: difficultyToNumber(row.difficultyEstimate),
+    difficulty: difficultyToNumber(row.calibratedDifficulty ?? row.llmDifficulty ?? row.difficultyEstimate),
     timesAnswered: stats.timesAnswered,
     timesCorrect: stats.timesCorrect,
     correctRate: stats.correctRate,

--- a/src/server/questions/__tests__/llm-difficulty.test.ts
+++ b/src/server/questions/__tests__/llm-difficulty.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { fallbackQuestionDifficulty, parseQuestionDifficultyAssessment } from '@/server/questions/llm-difficulty';
+import { DIFFICULTY_COPY, fallbackQuestionDifficulty, parseQuestionDifficultyAssessment } from '@/server/questions/llm-difficulty';
 
 describe('question LLM difficulty assessment', () => {
   it('maps domain-relative tier labels to persisted numeric difficulty', () => {
@@ -16,5 +16,14 @@ describe('question LLM difficulty assessment', () => {
 
   it('falls back to solid when no LLM rating is available', () => {
     expect(fallbackQuestionDifficulty()).toEqual({ tier: 'solid', difficulty: 3 });
+  });
+
+  it('uses tier names for persisted numeric difficulty display copy', () => {
+    expect(DIFFICULTY_COPY).toMatchObject({
+      1: 'Establishing',
+      3: 'Solid',
+      4: 'Skilled',
+      5: 'Master',
+    });
   });
 });

--- a/src/server/questions/llm-difficulty.ts
+++ b/src/server/questions/llm-difficulty.ts
@@ -1,6 +1,7 @@
 import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { DIFFICULTY_COPY, type QuestionDifficultyTier } from '@/lib/questions/difficulty-copy';
 
-export type QuestionDifficultyTier = 'establishing' | 'solid' | 'skilled' | 'master';
+export { DIFFICULTY_COPY };
 
 export type QuestionDifficultyAssessment = {
   tier: QuestionDifficultyTier;


### PR DESCRIPTION
### Motivation
- Standardize user-facing question difficulty copy to the four tier names (Establishing, Solid, Skilled, Master) and remove legacy labels like “Moderate”/“Specialist”.
- Surface difficulty from the backend-assessed value (prefer calibrated → llm → original estimate) so displayed labels match server assessments.
- Avoid exposing difficulty controls in the add-question form and make difficulty selection clear as an LLM-driven classification.

### Description
- Added a centralized helper `src/lib/questions/difficulty-copy.ts` exporting `DIFFICULTY_COPY` and utility functions to derive display text from numeric values, tiers, or LLM estimates. 
- Re-exported `DIFFICULTY_COPY` from `src/server/questions/llm-difficulty.ts` and updated `difficultyEstimateToTierLabel` to use the new helper, unifying mapping logic. 
- Updated UI to show tier labels instead of legacy rank/dot displays in: `src/app/questions/page.tsx`, `src/components/FeedList.tsx`, `src/app/games/[id]/play-client.tsx`, `src/app/games/[id]/summary/page.tsx`, `src/app/daily/setup/page.tsx`, and `src/app/daily/summary/page.tsx`. 
- Prefer calibrated/LLM assessment when building question views by changing `src/server/db/queries/questions.ts` to use `calibratedDifficulty ?? llmDifficulty ?? difficultyEstimate` when deriving the saved numeric difficulty. 
- Ensured the add-question form does not render difficulty controls and keeps the AI classification copy indicating difficulty will be chosen after save in `src/components/QuestionForm.tsx`. 
- Extended server tests `src/server/questions/__tests__/llm-difficulty.test.ts` to assert the new `DIFFICULTY_COPY` mapping is present.

### Testing
- Typecheck: ran `npx tsc --noEmit --project tsconfig.json` and it completed successfully. 
- Lint (scoped): ran `npx eslint` across the modified files listed in the PR and the targeted files passed linting for this change set. 
- Search verification: ran repository searches to confirm legacy labels and UI patterns were replaced (no remaining user-facing occurrences of the old strings in the modified areas). 
- Unit test runner: attempted `npx vitest run src/server/questions/__tests__/llm-difficulty.test.ts` but it could not run due to an external registry (npm) 403 while fetching Vitest; the test file itself was updated to include the new copy assertion. 

Notes: full-repo linting still reports pre-existing issues outside this change set; those were not introduced by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05bac86094832e9c971cb4ca95622c)