### PR TITLE
Fan out authored questions to friends feed

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  assessQuestionDifficultyMock,
+  categorizeQuestionMock,
+  createQuestionMock,
+  dbMock,
+  getFriendsMock,
+  getQuestionMock,
+  getSessionMock,
+  openKBDomainMock,
+  rollOffOldItemsMock,
+  state,
+  userHasQuestionInBlockingFeedMock,
+} = vi.hoisted(() => {
+  const state = {
+    dismissedRows: [] as Array<{ userId: string }>,
+    feedInsertValues: [] as Array<Record<string, unknown>>,
+    questionUpdateValues: [] as Array<Record<string, unknown>>,
+  }
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(async () => state.dismissedRows),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (values: Record<string, unknown>) => {
+        state.feedInsertValues.push(values)
+        return undefined
+      }),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn((values: Record<string, unknown>) => {
+        state.questionUpdateValues.push(values)
+        return { where: vi.fn(async () => undefined) }
+      }),
+    })),
+  }
+
+  return {
+    assessQuestionDifficultyMock: vi.fn(),
+    categorizeQuestionMock: vi.fn(),
+    createQuestionMock: vi.fn(),
+    dbMock,
+    getFriendsMock: vi.fn(),
+    getQuestionMock: vi.fn(),
+    getSessionMock: vi.fn(),
+    openKBDomainMock: vi.fn(),
+    rollOffOldItemsMock: vi.fn(),
+    state,
+    userHasQuestionInBlockingFeedMock: vi.fn(),
+  }
+})
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn(() => ({ op: 'and' })),
+  eq: vi.fn(() => ({ op: 'eq' })),
+  inArray: vi.fn(() => ({ op: 'inArray' })),
+  isNull: vi.fn(() => ({ op: 'isNull' })),
+}))
+
+vi.mock('@/lib/llm', () => ({
+  categorizeQuestion: categorizeQuestionMock,
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  feedDismissedDomains: {
+    userId: 'feedDismissedDomains.userId',
+    canonicalSubcategory: 'feedDismissedDomains.canonicalSubcategory',
+    reinstatedAt: 'feedDismissedDomains.reinstatedAt',
+  },
+  feedItems: { id: 'feedItems.id' },
+  questions: { id: 'questions.id' },
+  users: {
+    id: 'users.id',
+    displayName: 'users.displayName',
+    phoneNumber: 'users.phoneNumber',
+    smsOptIn: 'users.smsOptIn',
+  },
+}))
+
+vi.mock('@/server/db/queries/questions', () => ({
+  createQuestion: createQuestionMock,
+  getQuestion: getQuestionMock,
+  getQuestionsForUser: vi.fn(async () => []),
+}))
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriends: getFriendsMock,
+}))
+
+vi.mock('@/server/db/queries/feed', () => ({
+  rollOffOldItems: rollOffOldItemsMock,
+  userAnsweredQuestionCorrectly: vi.fn(async () => false),
+  userHasQuestionInBlockingFeed: userHasQuestionInBlockingFeedMock,
+}))
+
+vi.mock('@/server/knowledge/open-domain', () => ({
+  openKBDomain: openKBDomainMock,
+}))
+
+vi.mock('@/server/questions/llm-difficulty', () => ({
+  assessQuestionDifficulty: assessQuestionDifficultyMock,
+}))
+
+vi.mock('@/server/sms', () => ({
+  sendSms: vi.fn(),
+}))
+
+import { POST } from '@/app/api/questions/route'
+
+function questionRequest(body: Record<string, unknown>) {
+  return new Request('https://joshing.example/api/questions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      text: 'Who wrote Middlemarch?',
+      correctAnswer: 'George Eliot',
+      alternateAnswers: [],
+      explanation: 'Mary Ann Evans wrote under the pen name George Eliot.',
+      verified: true,
+      critiqueIterations: 0,
+      ...body,
+    }),
+  })
+}
+
+describe('POST /api/questions shareToFeed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.dismissedRows = []
+    state.feedInsertValues = []
+    state.questionUpdateValues = []
+
+    getSessionMock.mockResolvedValue({ userId: 'creator-1' })
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'Victorian Literature',
+    })
+    assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
+    createQuestionMock.mockResolvedValue({ id: 'question-1' })
+    getQuestionMock.mockResolvedValue({ id: 'question-1', question_text: 'Who wrote Middlemarch?' })
+    openKBDomainMock.mockResolvedValue({ opened: true })
+    rollOffOldItemsMock.mockResolvedValue(0)
+    userHasQuestionInBlockingFeedMock.mockResolvedValue(false)
+  })
+
+  it('creates authored_shared feed rows for active friends when shareToFeed is true', async () => {
+    getFriendsMock.mockResolvedValue([
+      { id: 'friend-1', displayName: 'Friend One' },
+      { id: 'friend-2', displayName: 'Friend Two' },
+    ])
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.id).toBe('question-1')
+    expect(getFriendsMock).toHaveBeenCalledWith('creator-1')
+    expect(state.feedInsertValues).toEqual([
+      expect.objectContaining({
+        recipientUserId: 'friend-1',
+        questionId: 'question-1',
+        sourceType: 'authored_shared',
+        sourceUserId: 'creator-1',
+        state: 'active',
+      }),
+      expect.objectContaining({
+        recipientUserId: 'friend-2',
+        questionId: 'question-1',
+        sourceType: 'authored_shared',
+        sourceUserId: 'creator-1',
+        state: 'active',
+      }),
+    ])
+    expect(state.feedInsertValues[0]?.sourceEventAt).toBeInstanceOf(Date)
+    expect(rollOffOldItemsMock).toHaveBeenCalledWith('friend-1')
+    expect(rollOffOldItemsMock).toHaveBeenCalledWith('friend-2')
+    expect(state.questionUpdateValues).toContainEqual({ sharedToFriendsFeed: true })
+  })
+
+  it('does not require explicit recipient ids for all-friends sharing', async () => {
+    getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+
+    expect(response.status).toBe(201)
+    expect(createQuestionMock).toHaveBeenCalled()
+    expect(state.feedInsertValues).toHaveLength(1)
+    expect(state.feedInsertValues[0]).toEqual(expect.objectContaining({ recipientUserId: 'friend-1' }))
+  })
+
+  it('skips dismissed domains and duplicate blocking feed rows', async () => {
+    getFriendsMock.mockResolvedValue([
+      { id: 'friend-1', displayName: 'Friend One' },
+      { id: 'friend-2', displayName: 'Friend Two' },
+      { id: 'friend-3', displayName: 'Friend Three' },
+    ])
+    state.dismissedRows = [{ userId: 'friend-3' }]
+    userHasQuestionInBlockingFeedMock.mockImplementation(async (userId: string) => userId === 'friend-2')
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+
+    expect(response.status).toBe(201)
+    expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-1', 'question-1')
+    expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-2', 'question-1')
+    expect(userHasQuestionInBlockingFeedMock).not.toHaveBeenCalledWith('friend-3', 'question-1')
+    expect(state.feedInsertValues).toEqual([
+      expect.objectContaining({ recipientUserId: 'friend-1', questionId: 'question-1' }),
+    ])
+    expect(rollOffOldItemsMock).toHaveBeenCalledTimes(1)
+    expect(rollOffOldItemsMock).toHaveBeenCalledWith('friend-1')
+  })
+})

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -1,10 +1,10 @@
-import { eq } from 'drizzle-orm';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
-import { db, feedItems, questions, users } from '@/server/db';
+import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
   createQuestion,
   getQuestion,
@@ -86,10 +86,54 @@ export async function POST(request: NextRequest) {
   const question = await getQuestion(created.id, session.userId);
 
   if (shareToFeed) {
+    const friends = await getFriends(session.userId);
+    const friendIds = friends.map((friend) => friend.id);
+    const dismissedRecipientIds = new Set<string>();
+
+    if (friendIds.length > 0 && categorizedQuestionFields.canonicalSubcategory) {
+      const dismissedRows = await db
+        .select({ userId: feedDismissedDomains.userId })
+        .from(feedDismissedDomains)
+        .where(and(
+          inArray(feedDismissedDomains.userId, friendIds),
+          eq(feedDismissedDomains.canonicalSubcategory, categorizedQuestionFields.canonicalSubcategory),
+          isNull(feedDismissedDomains.reinstatedAt),
+        ));
+
+      for (const row of dismissedRows) {
+        dismissedRecipientIds.add(row.userId);
+      }
+    }
+
+    let sharedCount = 0;
+    for (const friend of friends) {
+      if (dismissedRecipientIds.has(friend.id)) continue;
+
+      const alreadyInFeed = await userHasQuestionInBlockingFeed(friend.id, created.id);
+      if (alreadyInFeed) continue;
+
+      await db.insert(feedItems).values({
+        recipientUserId: friend.id,
+        questionId: created.id,
+        sourceType: 'authored_shared',
+        sourceUserId: session.userId,
+        sourceEventAt: new Date(),
+        state: 'active',
+      });
+      await rollOffOldItems(friend.id);
+      sharedCount += 1;
+    }
+
+    if (sharedCount > 0) {
+      await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
+    }
+
     console.info('[questions/shareToFeed]', {
       questionId: created.id,
       userId: session.userId,
-      skipped: 'created questions are managed in Questions until a non-author answers correctly',
+      friendCount: friends.length,
+      sharedCount,
+      skippedDismissedDomainCount: dismissedRecipientIds.size,
     });
   }
 


### PR DESCRIPTION
### Motivation
- Enable the previously-no-op `shareToFeed` branch so authored questions actually propagate to the creator’s active friends, respecting per-friend dismissed-domain preferences and existing blocking feed rows.
- Prevent duplicate/undesired feed propagation and only mark the question `sharedToFriendsFeed` when at least one friend receives a feed item.

### Description
- Replaced the `shareToFeed` no-op with fan-out logic in `src/app/api/questions/route.ts` that calls `getFriends(session.userId)` to enumerate recipients. 
- Queries `feedDismissedDomains` to skip friends who have dismissed the question’s `canonicalSubcategory`, checks `userHasQuestionInBlockingFeed(friend.id, created.id)` to avoid duplicates, and inserts `feedItems` rows with `sourceType: 'authored_shared'`, `sourceUserId: session.userId`, `sourceEventAt: new Date()`, and `state: 'active'` for each eligible friend.
- Calls `rollOffOldItems(friend.id)` for each recipient and updates the question with `sharedToFriendsFeed: true` only when at least one insertion succeeded.
- Added tests at `src/app/api/questions/__tests__/route.test.ts` covering all-friends sharing behavior, optional recipient handling, dismissed-domain skips, and avoiding duplicate/blocking rows.

### Testing
- Ran type checks with `npx tsc --noEmit`, which succeeded.
- Ran targeted linting with `npx eslint src/app/api/questions/route.ts src/app/api/questions/__tests__/route.test.ts`, which succeeded for the changed files.
- Attempted to run the new unit tests with `npx vitest run src/app/api/questions/__tests__/route.test.ts`, but execution was blocked because `vitest` could not be fetched from the registry (403); the test file was added and is ready to run in CI or a dev environment with test tooling installed.
- Ran `npm run lint` (repo-wide), which surfaced pre-existing lint errors outside the touched files and therefore failed; this is unrelated to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d4a01998832e89fba93feb417416)