### PR TITLE
Include authored shares in main feed visibility

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -5,9 +5,17 @@ import { getSession } from '@/server/auth/session';
 import { db, feedItems, friendships, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem } from '@/server/db/queries/feed';
-import { socialFeedDomainLabel } from '@/server/feed/visibility';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE, socialFeedDomainLabel } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
+
+const visibleFeedSourcePredicate = or(
+  eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
+  and(
+    eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+    eq(feedItems.sourceResult, 'correct'),
+  ),
+);
 
 function displayName(name: string | null, fallback = 'A friend') {
   return name?.trim() || fallback;
@@ -56,8 +64,7 @@ export async function GET() {
       .from(feedItems)
       .where(and(
         eq(feedItems.recipientUserId, session.userId),
-        eq(feedItems.sourceType, 'friend_answered'),
-        eq(feedItems.sourceResult, 'correct'),
+        visibleFeedSourcePredicate,
       ))
       .then((rows) => rows[0]?.value ?? 0),
     db
@@ -65,8 +72,7 @@ export async function GET() {
       .from(feedItems)
       .where(and(
         eq(feedItems.recipientUserId, session.userId),
-        eq(feedItems.sourceType, 'friend_answered'),
-        eq(feedItems.sourceResult, 'correct'),
+        visibleFeedSourcePredicate,
         inArray(feedItems.state, ['active', 'skipped']),
       ))
       .then((rows) => rows[0]?.value ?? 0),

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, ne, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
-import { isMainFeedSourceVisible } from '@/server/feed/visibility';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE, isMainFeedSourceVisible } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -21,11 +21,23 @@ export type CollapsedFeedItem = FeedItem & {
 const VISIBLE_FEED_STATES = ['active', 'skipped'] as const;
 const BLOCKING_FEED_STATES = ['active', 'skipped', 'dismissed'] as const;
 
+const visibleFeedSourcePredicate = or(
+  eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
+  and(
+    eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+    eq(feedItems.sourceResult, 'correct'),
+  ),
+);
+
+function isVisibleFriendAnsweredSource(sourceType: string, sourceResult: string | null): boolean {
+  return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
+}
+
 async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<CollapsedFeedItem[]> {
   const friendAnsweredByQuestion = new Map<string, FeedItem[]>();
 
   for (const item of items) {
-    if (isMainFeedSourceVisible(item.sourceType, item.sourceResult) && item.questionId) {
+    if (isVisibleFriendAnsweredSource(item.sourceType, item.sourceResult) && item.questionId) {
       const group = friendAnsweredByQuestion.get(item.questionId) ?? [];
       group.push(item);
       friendAnsweredByQuestion.set(item.questionId, group);
@@ -73,7 +85,7 @@ async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<Collapsed
     .map((item) => {
       if (collapsedById.has(item.id)) return collapsedById.get(item.id)!;
       // Single friend_answered item — wrap in friendResults for consistent display
-      if (isMainFeedSourceVisible(item.sourceType, item.sourceResult)) {
+      if (isVisibleFriendAnsweredSource(item.sourceType, item.sourceResult)) {
         return {
           ...item,
           friendResults: [{
@@ -203,8 +215,7 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
       .where(and(
         eq(feedItems.recipientUserId, userId),
         eq(feedItems.isPinned, true),
-        eq(feedItems.sourceType, 'friend_answered'),
-        eq(feedItems.sourceResult, 'correct'),
+        visibleFeedSourcePredicate,
         inArray(feedItems.state, VISIBLE_FEED_STATES),
       ))
       .orderBy(desc(feedItems.sourceEventAt)),
@@ -214,8 +225,7 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
       .where(and(
         eq(feedItems.recipientUserId, userId),
         eq(feedItems.isPinned, false),
-        eq(feedItems.sourceType, 'friend_answered'),
-        eq(feedItems.sourceResult, 'correct'),
+        visibleFeedSourcePredicate,
         inArray(feedItems.state, VISIBLE_FEED_STATES),
       ))
       .orderBy(desc(feedItems.sourceEventAt))

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -9,8 +9,9 @@ const publicQuestion = {
 };
 
 describe('correct-answer social feed eligibility', () => {
-  it('rejects newly-created/authored feed sources and game-publication sources from the main feed', () => {
-    expect(isMainFeedSourceVisible('authored_shared', null)).toBe(false);
+  it('allows authored sharing but rejects game-publication and direct-sent sources from the main feed', () => {
+    expect(isMainFeedSourceVisible('authored_shared', null)).toBe(true);
+    expect(isMainFeedSourceVisible('authored_shared', 'incorrect')).toBe(true);
     expect(isMainFeedSourceVisible('joshing_game', null)).toBe(false);
     expect(isMainFeedSourceVisible('direct_sent', null)).toBe(false);
   });

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -1,6 +1,7 @@
 import type { questions } from '@/server/db';
 
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
+export const AUTHORED_SHARED_FEED_SOURCE_TYPE = 'authored_shared' as const;
 
 const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown', 'general', 'general knowledge']);
 
@@ -24,6 +25,7 @@ export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): b
 }
 
 export function isMainFeedSourceVisible(sourceType: string, sourceResult: string | null): boolean {
+  if (sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE) return true;
   return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
 }
 


### PR DESCRIPTION
### Motivation
- Make questions that users explicitly share to friends (`authored_shared`) appear in the main feed alongside the existing `friend_answered`+`correct` items.

### Description
- Added `AUTHORED_SHARED_FEED_SOURCE_TYPE = 'authored_shared'` and updated `isMainFeedSourceVisible` to return true for authored shares while preserving the `friend_answered && sourceResult === 'correct'` rule (`src/server/feed/visibility.ts`).
- Updated feed queries to count and fetch visible feed rows using a shared predicate that includes both authored-shares and `friend_answered/correct` for pinned and non-pinned queries (`src/server/db/queries/feed.ts`).
- Kept friend-answer collapsing logic scoped to actual `friend_answered`+`correct` rows by introducing a helper `isVisibleFriendAnsweredSource` so authored-share rows are not folded into friend-result groups (`src/server/db/queries/feed.ts`).
- Updated the feed API meta/count queries to use the same visible-source predicate so `total_item_count` and `pre_filter_active_count` include authored shares (`src/app/api/feed/route.ts`).
- Adjusted the visibility unit test to expect `authored_shared` to be visible on the main feed (`src/server/feed/__tests__/visibility.test.ts`).

### Testing
- Type-check: ran `npx tsc --noEmit` (succeeded for the modified codebase).
- Lint/format: ran `npx eslint` and `npx prettier --write` on touched files (ESLint/Prettier completed for the changed files; full `npm run lint` fails due to unrelated pre-existing lint errors elsewhere in the repo).
- Unit test runner: attempted `npx vitest run src/server/feed/__tests__/visibility.test.ts` but it could not run because `vitest` is not available from the environment/registry (blocked with registry error); the test file was updated to match the new behavior.
- Verified code formatting and no local syntax errors in the modified files with `git diff --check` and editor tooling.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05d8b8e4b4832e82a92cfde6c00ff3)