### PR TITLE
Report feed share row creation before showing share toast

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -163,6 +163,7 @@ describe('POST /api/questions shareToFeed', () => {
 
     expect(response.status).toBe(201)
     expect(body.id).toBe('question-1')
+    expect(body.feedShare).toEqual({ requested: true, createdCount: 2 })
     expect(getFriendsMock).toHaveBeenCalledWith('creator-1')
     expect(state.feedInsertValues).toEqual([
       expect.objectContaining({
@@ -193,6 +194,8 @@ describe('POST /api/questions shareToFeed', () => {
 
     expect(response.status).toBe(201)
     expect(createQuestionMock).toHaveBeenCalled()
+    const body = await response.json()
+    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
     expect(state.feedInsertValues).toHaveLength(1)
     expect(state.feedInsertValues[0]).toEqual(expect.objectContaining({ recipientUserId: 'friend-1' }))
   })
@@ -209,6 +212,8 @@ describe('POST /api/questions shareToFeed', () => {
     const response = await POST(questionRequest({ shareToFeed: true }))
 
     expect(response.status).toBe(201)
+    const body = await response.json()
+    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
     expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-1', 'question-1')
     expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-2', 'question-1')
     expect(userHasQuestionInBlockingFeedMock).not.toHaveBeenCalledWith('friend-3', 'question-1')
@@ -217,5 +222,17 @@ describe('POST /api/questions shareToFeed', () => {
     ])
     expect(rollOffOldItemsMock).toHaveBeenCalledTimes(1)
     expect(rollOffOldItemsMock).toHaveBeenCalledWith('friend-1')
+  })
+
+  it('reports zero created rows when all-friends sharing has no eligible recipients', async () => {
+    getFriendsMock.mockResolvedValue([])
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.feedShare).toEqual({ requested: true, createdCount: 0 })
+    expect(state.feedInsertValues).toEqual([])
+    expect(state.questionUpdateValues).toEqual([])
   })
 })

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -84,6 +84,7 @@ export async function POST(request: NextRequest) {
     questionId: created.id,
   });
   const question = await getQuestion(created.id, session.userId);
+  const feedShare = { requested: shareToFeed, createdCount: 0 };
 
   if (shareToFeed) {
     const friends = await getFriends(session.userId);
@@ -123,6 +124,8 @@ export async function POST(request: NextRequest) {
       await rollOffOldItems(friend.id);
       sharedCount += 1;
     }
+
+    feedShare.createdCount = sharedCount;
 
     if (sharedCount > 0) {
       await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
@@ -188,6 +191,7 @@ export async function POST(request: NextRequest) {
       question,
       ...(question ?? {}),
       openedDomain: kbResult.opened ? categorizedQuestionFields.canonicalSubcategory : null,
+      feedShare,
     },
     { status: 201 },
   );

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -337,15 +337,16 @@ function KnowledgePageContent() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(values),
     });
-    const body = await response.json().catch(() => null) as { message?: string } | null;
+    const body = await response.json().catch(() => null) as { message?: string; feedShare?: { requested: boolean; createdCount: number } } | null;
     if (!response.ok) throw new Error(body?.message ?? 'Could not save that question.');
     setSendQuestionOpen(false);
     setWriteQuestionOpen(false);
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setQuestionToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
-    } else if (values.shareToFeed) {
-      setQuestionToast('Saved and shared with your friends.');
+    } else if (body?.feedShare?.createdCount && body.feedShare.createdCount > 0) {
+      const n = body.feedShare.createdCount;
+      setQuestionToast(`Saved and shared with ${n} ${n === 1 ? 'friend' : 'friends'}.`);
     } else {
       setQuestionToast('Saved to your bank.');
     }

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -22,6 +22,16 @@ type QuestionsApiResponse = {
   error?: string;
 };
 
+type CreateQuestionResponse = {
+  question?: QuestionView;
+  id?: string;
+  error?: string;
+  feedShare?: {
+    requested: boolean;
+    createdCount: number;
+  };
+};
+
 const NO_QUESTIONS_PATTERNS = [
   /no questions/i,
   /not found/i,
@@ -183,15 +193,16 @@ function QuestionsPageContent() {
       credentials: 'include',
       body: JSON.stringify(values),
     });
-    const body = await response.json().catch(() => null) as { question?: QuestionView; id?: string; error?: string } | null;
+    const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
     if (!response.ok || !body?.question) throw new Error(body?.error ?? 'Could not save that question.');
     setQuestions((current) => [body.question!, ...current]);
     setDrawer({ mode: 'closed' });
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
-    } else if (values.shareToFeed) {
-      setToast('Saved and shared with your friends.');
+    } else if (body.feedShare?.createdCount && body.feedShare.createdCount > 0) {
+      const n = body.feedShare.createdCount;
+      setToast(`Saved and shared with ${n} ${n === 1 ? 'friend' : 'friends'}.`);
     } else {
       setToast('Saved to your bank.');
     }


### PR DESCRIPTION
### Motivation
- Prevent the UI from promising that a question was shared to friends when the backend did not actually create feed rows for recipients.
- Make the client-side toasts accurately reflect whether all-friends sharing produced feed rows and how many recipients were reached.

### Description
- Add `feedShare` metadata to the question-creation API response (`POST /api/questions`) that contains `{ requested: boolean, createdCount: number }` and set `createdCount` to the number of authored_shared `feedItems` created.
- Preserve the existing all-friends backend fan-out but only mark the question `sharedToFriendsFeed` when at least one feed row was created. (`src/app/api/questions/route.ts`).
- Update client pages to consult the API response before showing a share toast: `src/app/questions/page.tsx` and `src/app/knowledge/page.tsx` now show a toast only when `feedShare.createdCount > 0` and display the actual number of friends reached. 
- Extend the route tests to assert `feedShare` values for successful shares, partial (skipped) shares, and the zero-recipient case (`src/app/api/questions/__tests__/route.test.ts`).

### Testing
- Type-checking succeeded with `npx tsc --noEmit`.
- Targeted linting of changed files succeeded with `npx eslint src/app/api/questions/route.ts src/app/questions/page.tsx src/app/knowledge/page.tsx src/app/api/questions/__tests__/route.test.ts --ext .ts,.tsx`.
- Attempted to run route tests with `npx vitest run ...`, but `npx` failed to fetch `vitest` from the npm registry (403 Forbidden), so full test runs were blocked.
- Running the repository-wide `npm run lint` surfaced pre-existing lint errors outside the scope of these changes and did not pass; the edits here were kept focused and lint-clean for the modified files only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dbbf6f64832e8341d694813307c5)