### PR TITLE
Distinguish authored shared feed attribution

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -21,6 +21,10 @@ function displayName(name: string | null, fallback = 'A friend') {
   return name?.trim() || fallback;
 }
 
+function authoredSharedAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} shared a question — ${domain}` : `${sourceName} shared a question`;
+}
+
 function friendAnsweredAttribution(
   item: CollapsedFeedItem,
   userById: Map<string, { displayName: string | null }>,
@@ -123,7 +127,9 @@ export async function GET() {
         source_user_id: item.sourceUserId,
         source_result: item.sourceResult ?? null,
         source_friend_display_name: sourceName,
-        source_attribution: friendAnsweredAttribution(item, userById, domain, authorName),
+        source_attribution: item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE
+          ? authoredSharedAttribution(sourceName, domain)
+          : friendAnsweredAttribution(item, userById, domain, authorName),
         friend_results: item.friendResults ?? null,
         source_event_at: item.sourceEventAt,
         personal_message: item.personalMessage,


### PR DESCRIPTION
### Motivation
- Make authored shares visually distinct from friend-answer events by rendering a clear “shared a question” attribution when the feed item is an authored share.

### Description
- Add `authoredSharedAttribution(sourceName, domain)` and use it in the feed mapping when `item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE`, otherwise keep `friendAnsweredAttribution(...)` unchanged.

### Testing
- Ran `npx eslint src/app/api/feed/route.ts` which passed for the modified file.
- Ran `npm run lint` which failed due to unrelated lint errors elsewhere in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e35fdeb4832e8f62b44b7b689add)