### PR TITLE
Update authored shared feed attribution

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -21,6 +21,10 @@ function displayName(name: string | null, fallback = 'A friend') {
   return name?.trim() || fallback;
 }
 
+function authoredSharedAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} shared a question — ${domain}` : `${sourceName} shared a question`;
+}
+
 function friendAnsweredAttribution(
   item: CollapsedFeedItem,
   userById: Map<string, { displayName: string | null }>,
@@ -114,6 +118,12 @@ export async function GET() {
       const authorName = displayName(question?.creatorId ? userById.get(question.creatorId)?.displayName ?? null : null, 'the author');
       const domain = socialFeedDomainLabel(question);
 
+      const sourceAttribution = item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE
+        ? authoredSharedAttribution(sourceName, domain)
+        : item.sourceType === SOCIAL_FEED_SOURCE_TYPE
+          ? friendAnsweredAttribution(item, userById, domain, authorName)
+          : sourceName;
+
       return {
         id: item.id,
         kind: 'question',
@@ -123,7 +133,7 @@ export async function GET() {
         source_user_id: item.sourceUserId,
         source_result: item.sourceResult ?? null,
         source_friend_display_name: sourceName,
-        source_attribution: friendAnsweredAttribution(item, userById, domain, authorName),
+        source_attribution: sourceAttribution,
         friend_results: item.friendResults ?? null,
         source_event_at: item.sourceEventAt,
         personal_message: item.personalMessage,


### PR DESCRIPTION
### Motivation
- Ensure authored-shared feed items render a clear attribution copy like `${sourceName} shared a question` and append the domain when available.
- Prevent `friendAnsweredAttribution(...)` from being used for non-social feed sources so its friend-centric language is only used for `friend_answered` items.

### Description
- Added a new helper `authoredSharedAttribution(sourceName, domain)` which returns `${sourceName} shared a question` and includes the domain when present.
- Compute a `sourceAttribution` when mapping feed items that uses `authoredSharedAttribution(...)` for `AUTHORED_SHARED_FEED_SOURCE_TYPE`, `friendAnsweredAttribution(...)` only for `SOCIAL_FEED_SOURCE_TYPE`, and falls back to the `sourceName` otherwise.
- Updated the feed JSON output to use the computed `sourceAttribution` for `source_attribution` instead of always calling `friendAnsweredAttribution(...)`.

### Testing
- Ran `npx eslint src/app/api/feed/route.ts`, which completed for the modified file without new errors.
- Ran `npm run lint`, which failed due to pre-existing lint issues elsewhere in the repository and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e400f4fc832eb42d79d5fb1a2654)