### PR TITLE
Render full FeedList on /feed (Option B)

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -1,5 +1,22 @@
-import FriendsHubPage from '@/components/FriendsHubPage'
+import FeedList from '@/components/FeedList'
 
 export default function FeedPage() {
-  return <FriendsHubPage />
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24 md:py-10">
+      <section className="space-y-6">
+        <div>
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
+            Feed
+          </p>
+          <h1 className="text-foreground mt-3 font-serif text-4xl leading-tight font-semibold md:text-5xl">
+            What&apos;s happening
+          </h1>
+          <p className="text-muted-foreground mt-4 max-w-xl text-base leading-7">
+            Keep up with the moments where your friends recognize each other&apos;s questions.
+          </p>
+        </div>
+        <FeedList />
+      </section>
+    </main>
+  )
 }


### PR DESCRIPTION
### Motivation
- `/feed` should not render `FriendsHubPage` because `/friends` already owns that page, and we want a dedicated secondary feed URL for the full feed experience.

### Description
- Replace the `/feed` route implementation in `src/app/feed/page.tsx` to render the full `FeedList` with the page header and surrounding layout instead of `FriendsHubPage`.
- Leave `src/app/friends/page.tsx` unchanged so the friends hub continues to render `FriendsHubPage`.
- Preserve the existing homepage "Feed" link that points to `/feed` in `src/app/page.tsx` so navigation still leads to the full feed.

### Testing
- Ran `npx eslint src/app/feed/page.tsx` which completed for the changed file without introducing new lint errors.
- Ran `npx tsc --noEmit` which completed successfully with no type errors for the change.
- Ran `npm run lint` (project-wide) which fails due to pre-existing lint/type errors in unrelated files and not caused by this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e3fcdf34832ea3a9f17bf0d7916f)