### PR TITLE
Homepage: switch "What's happening" card to infinite-scroll feed

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -34,15 +34,7 @@ export default async function Home() {
             <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
               What&apos;s happening
             </p>
-            <FeedList limit={3} />
-            <div className="mt-2 flex justify-end">
-              <Link
-                href="/feed"
-                className="text-sm font-medium underline-offset-4 hover:underline"
-              >
-                Feed
-              </Link>
-            </div>
+            <FeedList pageSize={20} infinite />
           </div>
         </div>
       </section>

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { Send, SkipForward, X } from 'lucide-react';
 
@@ -93,11 +93,16 @@ function comparisonCopy(playerCorrect: boolean, friendResults: FriendResult[] | 
 
 type FeedListProps = {
   limit?: number;
+  pageSize?: number;
+  infinite?: boolean;
 };
 
 type QuestionCardState = 'unanswered' | 'answered' | 'reacted';
 
-export default function FeedList({ limit = 25 }: FeedListProps) {
+export default function FeedList({ limit, pageSize, infinite = false }: FeedListProps) {
+  const itemsPerPage = pageSize ?? limit ?? 25;
+  const [visibleCount, setVisibleCount] = useState(itemsPerPage);
+  const loadMoreRef = useRef<HTMLDivElement | null>(null);
   const [items, setItems] = useState<FeedApiItem[]>([]);
   const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null);
   const [viewerId, setViewerId] = useState<string | null>(null);
@@ -139,7 +144,30 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
     return () => window.clearTimeout(timer);
   }, [loadFeed]);
 
-  const visibleItems = useMemo(() => items.slice(0, limit), [items, limit]);
+  const visibleLimit = infinite ? visibleCount : itemsPerPage;
+  const visibleItems = useMemo(() => items.slice(0, visibleLimit), [items, visibleLimit]);
+  const hasMoreItems = visibleItems.length < items.length;
+
+  useEffect(() => {
+    if (!infinite || !hasMoreItems) return;
+
+    const loadMoreNode = loadMoreRef.current;
+    if (!loadMoreNode) return;
+
+    if (!('IntersectionObserver' in window)) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries.some((entry) => entry.isIntersecting)) {
+          setVisibleCount((current) => Math.min(current + itemsPerPage, items.length));
+        }
+      },
+      { rootMargin: '320px 0px' },
+    );
+
+    observer.observe(loadMoreNode);
+    return () => observer.disconnect();
+  }, [hasMoreItems, infinite, items.length, itemsPerPage]);
 
   const emptyCopy = useMemo(() => {
     if (loading) return 'Loading your Feed...';
@@ -449,6 +477,11 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
           })}
         </section>
       )}
+      {infinite && hasMoreItems ? (
+        <div ref={loadMoreRef} className="py-4 text-center" aria-live="polite">
+          <p className="text-muted-foreground text-sm">Loading more Feed...</p>
+        </div>
+      ) : null}
     </>
   );
 }


### PR DESCRIPTION
### Motivation
- The homepage preview should surface the full Feed experience so users can scroll the canonical feed inline instead of a tiny 3-item preview and a separate `/feed` link.
- Provide a configurable infinite-scroll mode on the `FeedList` component to reveal more feed items progressively.

### Description
- Replace the homepage preview `FeedList` call with `<FeedList pageSize={20} infinite />` and remove the small `/feed` link in `src/app/page.tsx`.
- Add `pageSize?: number` and `infinite?: boolean` props to `FeedList` with a fallback to the existing `limit`/`25` behavior in `src/components/FeedList.tsx`.
- Implement an IntersectionObserver sentinel (`loadMoreRef`) and `visibleCount` state to incrementally reveal `itemsPerPage` more items when the sentinel becomes visible, and show a small loading sentinel UI when more items are available.
- Preserve existing feed loading, error and empty-state logic; infinite mode only affects how many items from the already-fetched feed are rendered.

### Testing
- Ran `npx eslint src/components/FeedList.tsx src/app/page.tsx --ext .js,.jsx,.ts,.tsx` which completed for the changed files (no reported errors for these files).
- Ran `npx tsc --noEmit` which completed without type errors.
- Ran `npm run lint` which failed due to pre-existing repo-wide lint issues unrelated to this change (reported existing `react/no-unescaped-entities`, `react-hooks/set-state-in-effect`, and `@typescript-eslint/no-explicit-any` errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e3cce650832e9659d6de7cae2ca5)