### PR TITLE
Preserve feed diagnostics with pagination

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -1,5 +1,5 @@
 import { and, count, eq, inArray, or } from 'drizzle-orm';
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import { db, feedItems, friendships, questions, users } from '@/server/db';
@@ -16,6 +16,23 @@ const visibleFeedSourcePredicate = or(
     eq(feedItems.sourceResult, 'correct'),
   ),
 );
+
+const DEFAULT_PAGE_LIMIT = 25;
+const MAX_PAGE_LIMIT = 50;
+
+function parsePagination(request: NextRequest) {
+  const limitParam = request.nextUrl.searchParams.get('limit');
+  const offsetParam = request.nextUrl.searchParams.get('offset');
+  const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : DEFAULT_PAGE_LIMIT;
+  const parsedOffset = offsetParam ? Number.parseInt(offsetParam, 10) : 0;
+
+  const limit = Number.isFinite(parsedLimit)
+    ? Math.min(Math.max(parsedLimit, 1), MAX_PAGE_LIMIT)
+    : DEFAULT_PAGE_LIMIT;
+  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+
+  return { limit, offset };
+}
 
 function displayName(name: string | null, fallback = 'A friend') {
   return name?.trim() || fallback;
@@ -44,11 +61,13 @@ function friendAnsweredAttribution(
   return domain ? `Common ground in ${domain}: ${names}` : `${names} share this one`;
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const [rawFeed, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
+  const { limit, offset } = parsePagination(request);
+
+  const [allVisibleFeed, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
     getFeedForUser(session.userId),
     db
       .select({ value: count() })
@@ -78,7 +97,8 @@ export async function GET() {
       .then((rows) => rows[0]?.value ?? 0),
   ]);
 
-  const feed = rawFeed;
+  const activeItemCount = allVisibleFeed.length;
+  const feed = allVisibleFeed.slice(offset, offset + limit);
   const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
 
   const [questionRows, bankedById] = await Promise.all([
@@ -104,8 +124,12 @@ export async function GET() {
       has_friends: friendCount > 0,
       has_dismissed_domains: dismissedDomains.length > 0,
       total_item_count: totalItemCount,
-      active_item_count: feed.length,
+      active_item_count: activeItemCount,
       pre_filter_active_count: preFilterActiveCount,
+      page_item_count: feed.length,
+      limit,
+      offset,
+      has_more: offset + feed.length < activeItemCount,
     },
     items: feed.map((item) => {
       const question = item.questionId ? questionById.get(item.questionId) : undefined;

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -107,11 +107,21 @@ export async function POST(request: NextRequest) {
     }
 
     let sharedCount = 0;
+    const sharedRecipientIds: string[] = [];
+    const skippedDismissedDomainRecipientIds: string[] = [];
+    const skippedExistingFeedRecipientIds: string[] = [];
+
     for (const friend of friends) {
-      if (dismissedRecipientIds.has(friend.id)) continue;
+      if (dismissedRecipientIds.has(friend.id)) {
+        skippedDismissedDomainRecipientIds.push(friend.id);
+        continue;
+      }
 
       const alreadyInFeed = await userHasQuestionInBlockingFeed(friend.id, created.id);
-      if (alreadyInFeed) continue;
+      if (alreadyInFeed) {
+        skippedExistingFeedRecipientIds.push(friend.id);
+        continue;
+      }
 
       await db.insert(feedItems).values({
         recipientUserId: friend.id,
@@ -122,6 +132,7 @@ export async function POST(request: NextRequest) {
         state: 'active',
       });
       await rollOffOldItems(friend.id);
+      sharedRecipientIds.push(friend.id);
       sharedCount += 1;
     }
 
@@ -136,7 +147,11 @@ export async function POST(request: NextRequest) {
       userId: session.userId,
       friendCount: friends.length,
       sharedCount,
-      skippedDismissedDomainCount: dismissedRecipientIds.size,
+      sharedRecipientIds,
+      skippedDismissedDomainCount: skippedDismissedDomainRecipientIds.length,
+      skippedDismissedDomainRecipientIds,
+      skippedExistingFeedCount: skippedExistingFeedRecipientIds.length,
+      skippedExistingFeedRecipientIds,
     });
   }
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -42,6 +42,10 @@ type FeedMeta = {
   total_item_count: number;
   active_item_count: number;
   pre_filter_active_count: number;
+  page_item_count?: number;
+  limit?: number;
+  offset?: number;
+  has_more?: boolean;
 };
 
 type FeedResponse = {
@@ -114,7 +118,7 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/feed', { cache: 'no-store', credentials: 'include' });
+      const response = await fetch(`/api/feed?limit=${encodeURIComponent(String(limit))}`, { cache: 'no-store', credentials: 'include' });
       const body = await response.json().catch(() => null) as FeedResponse | { message?: string } | null;
       if (!response.ok || !body || !('items' in body)) {
         throw new Error((body as { message?: string } | null)?.message ?? 'Could not load your Feed.');
@@ -130,7 +134,7 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [limit]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -152,6 +156,22 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
     if (feedMeta.total_item_count > 0) return "You're caught up. Answer questions to reveal more common ground.";
     return "Answer questions to reveal common ground.";
   }, [error, feedMeta, loading]);
+
+  const emptyDiagnostics = useMemo(() => {
+    if (process.env.NODE_ENV === 'production' || !feedMeta) return null;
+
+    return [
+      `has_friends=${String(feedMeta.has_friends)}`,
+      `has_dismissed_domains=${String(feedMeta.has_dismissed_domains)}`,
+      `total_item_count=${feedMeta.total_item_count}`,
+      `pre_filter_active_count=${feedMeta.pre_filter_active_count}`,
+      `active_item_count=${feedMeta.active_item_count}`,
+      `page_item_count=${feedMeta.page_item_count ?? items.length}`,
+      `limit=${feedMeta.limit ?? limit}`,
+      `offset=${feedMeta.offset ?? 0}`,
+      `has_more=${String(feedMeta.has_more ?? false)}`,
+    ].join(' · ');
+  }, [feedMeta, items.length, limit]);
 
   const showToast = useCallback((itemId: string, message: string) => {
     setToasts((t) => ({ ...t, [itemId]: message }));
@@ -261,6 +281,11 @@ export default function FeedList({ limit = 25 }: FeedListProps) {
       {visibleItems.length === 0 ? (
         <section className="flex min-h-48 flex-col items-center justify-center gap-3 py-12 text-center">
           <p className={error ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}>{emptyCopy}</p>
+          {emptyDiagnostics ? (
+            <p className="max-w-xl break-words rounded bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+              {emptyDiagnostics}
+            </p>
+          ) : null}
           {/*
             // v11.1: Joshing Game creation disabled at FAB level. Re-enable
             // when game creation flow is restored.

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -204,9 +204,16 @@ export async function reinstateDomain(userId: string, canonicalSubcategory: stri
     ));
 }
 
-export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[]> {
+type FeedForUserOptions = {
+  limit?: number;
+  offset?: number;
+};
+
+export async function getFeedForUser(userId: string, options: FeedForUserOptions = {}): Promise<CollapsedFeedItem[]> {
   const dismissedDomains = await getDismissedDomains(userId);
   const dismissedSet = new Set(dismissedDomains);
+  const limit = options.limit;
+  const offset = options.offset ?? 0;
 
   const [pinned, nonPinnedRaw] = await Promise.all([
     db
@@ -228,8 +235,7 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
         visibleFeedSourcePredicate,
         inArray(feedItems.state, VISIBLE_FEED_STATES),
       ))
-      .orderBy(desc(feedItems.sourceEventAt))
-      .limit(50), // fetch extra to account for domain filtering and sorting
+      .orderBy(desc(feedItems.sourceEventAt)),
   ]);
 
   // Fetch surface_priority_score for all question IDs so we can sort by it
@@ -266,10 +272,13 @@ export async function getFeedForUser(userId: string): Promise<CollapsedFeedItem[
     return !domain || !dismissedSet.has(domain);
   };
 
-  const filteredNonPinned = nonPinned.filter(filterItem).slice(0, 25);
+  const filteredNonPinned = nonPinned.filter(filterItem);
   const all = [...pinned.filter(filterItem), ...filteredNonPinned];
   const afterThumbsUp = await collapseThumbsUpItems(all);
-  return collapseFriendAnsweredItems(afterThumbsUp);
+  const collapsed = await collapseFriendAnsweredItems(afterThumbsUp);
+
+  if (typeof limit !== 'number') return collapsed;
+  return collapsed.slice(offset, offset + limit);
 }
 
 export async function createFeedItem(data: NewFeedItem): Promise<FeedItem> {


### PR DESCRIPTION
### Motivation
- Keep existing Feed diagnostics (which recipients received or were skipped and the global item counts) working as the Feed API moves to paginated responses.
- Ensure `meta.total_item_count`, `meta.pre_filter_active_count`, and `meta.active_item_count` remain global counts and are not truncated by page slicing.
- Surface development-only diagnostics in the empty Feed UI to help debug feed state during development.

### Description
- Add pagination parsing to the feed API (`/api/feed`) with `limit` and `offset` and return pagination metadata (`page_item_count`, `limit`, `offset`, `has_more`) while preserving global counts (`total_item_count`, `pre_filter_active_count`, `active_item_count`). (`src/app/api/feed/route.ts`)
- Make `getFeedForUser` pagination-capable by accepting options and performing slicing after building the full, filtered/collapsed feed so global diagnostics remain accurate. (`src/server/db/queries/feed.ts`)
- Expand `[questions/shareToFeed]` diagnostics to record arrays of `sharedRecipientIds`, `skippedDismissedDomainRecipientIds`, and `skippedExistingFeedRecipientIds` so callers can see exactly which friend IDs were shared or skipped. (`src/app/api/questions/route.ts`)
- Update `FeedList` to request the API with the component `limit` and show a development-only diagnostics panel in empty state derived from `feedMeta`. (`src/components/FeedList.tsx`)

### Testing
- Ran `npx eslint` for the modified files (`src/app/api/feed/route.ts`, `src/app/api/questions/route.ts`, `src/components/FeedList.tsx`, `src/server/db/queries/feed.ts`) and it passed for those files. 
- Ran TypeScript check with `npx tsc --noEmit` and it succeeded. 
- Ran repository lint via `npm run lint` which surfaced pre-existing lint errors outside the touched files (linter failures are unrelated to these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e3fff7b8832ea640dcfb4915829e)