### PR TITLE
FeedList: add cursor pagination and infinite-scroll sentinel

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -22,14 +22,17 @@ const MAX_PAGE_LIMIT = 50;
 
 function parsePagination(request: NextRequest) {
   const limitParam = request.nextUrl.searchParams.get('limit');
+  const cursorParam = request.nextUrl.searchParams.get('cursor');
   const offsetParam = request.nextUrl.searchParams.get('offset');
   const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : DEFAULT_PAGE_LIMIT;
+  const parsedCursor = cursorParam ? Number.parseInt(cursorParam, 10) : null;
   const parsedOffset = offsetParam ? Number.parseInt(offsetParam, 10) : 0;
 
   const limit = Number.isFinite(parsedLimit)
     ? Math.min(Math.max(parsedLimit, 1), MAX_PAGE_LIMIT)
     : DEFAULT_PAGE_LIMIT;
-  const offset = Number.isFinite(parsedOffset) ? Math.max(parsedOffset, 0) : 0;
+  const offsetSource = parsedCursor !== null && Number.isFinite(parsedCursor) ? parsedCursor : parsedOffset;
+  const offset = Number.isFinite(offsetSource) ? Math.max(offsetSource, 0) : 0;
 
   return { limit, offset };
 }
@@ -122,8 +125,12 @@ export async function GET(request: NextRequest) {
     : [];
   const userById = new Map(userRows.map((u) => [u.id, u]));
 
+  const hasMore = offset + feed.length < activeItemCount;
+  const nextCursor = hasMore ? String(offset + feed.length) : null;
+
   return NextResponse.json({
     viewer_user_id: session.userId,
+    nextCursor,
     meta: {
       has_friends: friendCount > 0,
       has_dismissed_domains: dismissedDomains.length > 0,
@@ -133,7 +140,7 @@ export async function GET(request: NextRequest) {
       page_item_count: feed.length,
       limit,
       offset,
-      has_more: offset + feed.length < activeItemCount,
+      has_more: hasMore,
     },
     items: feed.map((item) => {
       const question = item.questionId ? questionById.get(item.questionId) : undefined;

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -52,6 +52,7 @@ type FeedResponse = {
   viewer_user_id: string;
   meta?: FeedMeta;
   items: FeedApiItem[];
+  nextCursor?: string | null;
 };
 
 type CeremonyBanner = {
@@ -96,85 +97,101 @@ function comparisonCopy(playerCorrect: boolean, friendResults: FriendResult[] | 
 }
 
 type FeedListProps = {
-  limit?: number;
   pageSize?: number;
   infinite?: boolean;
 };
 
 type QuestionCardState = 'unanswered' | 'answered' | 'reacted';
 
-export default function FeedList({ limit, pageSize, infinite = false }: FeedListProps) {
-  const itemsPerPage = pageSize ?? limit ?? 25;
-  const [visibleCount, setVisibleCount] = useState(itemsPerPage);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+export default function FeedList({ pageSize = 20, infinite = false }: FeedListProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const [items, setItems] = useState<FeedApiItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
   const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null);
   const [viewerId, setViewerId] = useState<string | null>(null);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [results, setResults] = useState<Record<string, ResultState>>({});
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({});
   const [toasts, setToasts] = useState<Record<string, string>>({});
-  const [loading, setLoading] = useState(true);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(null);
 
-  const loadFeed = useCallback(async () => {
-    setLoading(true);
+  const loadFeed = useCallback(async (cursor?: string | null) => {
+    const isNextPage = Boolean(cursor);
+    if (isNextPage) setLoadingMore(true);
+    else setLoadingInitial(true);
     setError(null);
+
     try {
-      const response = await fetch(`/api/feed?limit=${encodeURIComponent(String(limit))}`, { cache: 'no-store', credentials: 'include' });
+      const searchParams = new URLSearchParams({ limit: String(pageSize) });
+      if (cursor) searchParams.set('cursor', cursor);
+
+      const response = await fetch(`/api/feed?${searchParams.toString()}`, { cache: 'no-store', credentials: 'include' });
       const body = await response.json().catch(() => null) as FeedResponse | { message?: string } | null;
       if (!response.ok || !body || !('items' in body)) {
         throw new Error((body as { message?: string } | null)?.message ?? 'Could not load your Feed.');
       }
+
+      const fallbackNextCursor = body.meta?.has_more
+        ? String((body.meta.offset ?? 0) + body.items.length)
+        : null;
+      const nextPageCursor = body.nextCursor ?? fallbackNextCursor;
+
       setViewerId(body.viewer_user_id);
       setFeedMeta(body.meta ?? null);
-      setItems(body.items);
-      const bannerResponse = await fetch('/api/ceremony/banner', { cache: 'no-store', credentials: 'include' });
-      const bannerBody = await bannerResponse.json().catch(() => null) as { ceremony?: CeremonyBanner | null } | null;
-      setCeremonyBanner(bannerResponse.ok ? bannerBody?.ceremony ?? null : null);
+      setItems((current) => (isNextPage ? [...current, ...body.items] : body.items));
+      setNextCursor(nextPageCursor);
+      setHasMore(Boolean(nextPageCursor));
+
+      if (!isNextPage) {
+        const bannerResponse = await fetch('/api/ceremony/banner', { cache: 'no-store', credentials: 'include' });
+        const bannerBody = await bannerResponse.json().catch(() => null) as { ceremony?: CeremonyBanner | null } | null;
+        setCeremonyBanner(bannerResponse.ok ? bannerBody?.ceremony ?? null : null);
+      }
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load your Feed.');
     } finally {
-      setLoading(false);
+      setLoadingInitial(false);
+      setLoadingMore(false);
     }
-  }, [limit]);
+  }, [pageSize]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      void loadFeed();
+      void loadFeed(null);
     }, 0);
     return () => window.clearTimeout(timer);
   }, [loadFeed]);
 
-  const visibleLimit = infinite ? visibleCount : itemsPerPage;
-  const visibleItems = useMemo(() => items.slice(0, visibleLimit), [items, visibleLimit]);
-  const hasMoreItems = visibleItems.length < items.length;
+  const visibleItems = items;
 
   useEffect(() => {
-    if (!infinite || !hasMoreItems) return;
+    if (!infinite || !hasMore || loadingInitial || loadingMore || !nextCursor) return;
 
-    const loadMoreNode = loadMoreRef.current;
-    if (!loadMoreNode) return;
+    const sentinelNode = sentinelRef.current;
+    if (!sentinelNode) return;
 
     if (!('IntersectionObserver' in window)) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
-          setVisibleCount((current) => Math.min(current + itemsPerPage, items.length));
+          void loadFeed(nextCursor);
         }
       },
       { rootMargin: '320px 0px' },
     );
 
-    observer.observe(loadMoreNode);
+    observer.observe(sentinelNode);
     return () => observer.disconnect();
-  }, [hasMoreItems, infinite, items.length, itemsPerPage]);
+  }, [hasMore, infinite, loadFeed, loadingInitial, loadingMore, nextCursor]);
 
   const emptyCopy = useMemo(() => {
-    if (loading) return 'Loading your Feed...';
+    if (loadingInitial) return 'Loading your Feed...';
     if (error) return error;
     if (!feedMeta?.has_friends) return "When friends recognize each other’s questions, those moments will appear here.";
     // pre_filter_active_count > 0 means items exist in active/skipped state but are hidden by domain filters
@@ -183,7 +200,7 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
     }
     if (feedMeta.total_item_count > 0) return "You're caught up. Answer questions to reveal more common ground.";
     return "Answer questions to reveal common ground.";
-  }, [error, feedMeta, loading]);
+  }, [error, feedMeta, loadingInitial]);
 
   const emptyDiagnostics = useMemo(() => {
     if (process.env.NODE_ENV === 'production' || !feedMeta) return null;
@@ -195,11 +212,12 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
       `pre_filter_active_count=${feedMeta.pre_filter_active_count}`,
       `active_item_count=${feedMeta.active_item_count}`,
       `page_item_count=${feedMeta.page_item_count ?? items.length}`,
-      `limit=${feedMeta.limit ?? limit}`,
+      `limit=${feedMeta.limit ?? pageSize}`,
       `offset=${feedMeta.offset ?? 0}`,
-      `has_more=${String(feedMeta.has_more ?? false)}`,
+      `has_more=${String(hasMore)}`,
+      `next_cursor=${nextCursor ?? ''}`,
     ].join(' · ');
-  }, [feedMeta, items.length, limit]);
+  }, [feedMeta, hasMore, items.length, nextCursor, pageSize]);
 
   const showToast = useCallback((itemId: string, message: string) => {
     setToasts((t) => ({ ...t, [itemId]: message }));
@@ -502,9 +520,9 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
           })}
         </section>
       )}
-      {infinite && hasMoreItems ? (
-        <div ref={loadMoreRef} className="py-4 text-center" aria-live="polite">
-          <p className="text-muted-foreground text-sm">Loading more Feed...</p>
+      {infinite && hasMore ? (
+        <div ref={sentinelRef} className="py-4 text-center" aria-live="polite">
+          <p className="text-muted-foreground text-sm">{loadingMore ? 'Loading more Feed...' : 'Load more Feed'}</p>
         </div>
       ) : null}
     </>


### PR DESCRIPTION
### Motivation
- Replace the single `limit` prop and client-side slicing with a proper paginated model to support server-driven pages. 
- Support an `infinite` mode that requests subsequent pages automatically via a sentinel observer. 
- Surface a server `nextCursor` so the client can reliably request further pages instead of relying on in-memory offsets.

### Description
- Changed `FeedList` props from `limit?: number` to `pageSize?: number` and `infinite?: boolean` and defaulted `pageSize` to `20` in the component. 
- Replaced single-load state with paginated state (`items`, `nextCursor`, `hasMore`, `loadingInitial`, `loadingMore`) and updated `loadFeed` to accept an optional `cursor` argument and append pages when present. 
- Updated client fetches to call `/api/feed?limit=...` for the first page and `/api/feed?limit=...&cursor=...` for subsequent loads, and only fetch the ceremony banner on the initial load. 
- Added an `IntersectionObserver` sentinel (`sentinelRef`) at the bottom of the list that triggers `loadFeed(nextCursor)` when `infinite` is enabled, and updated the feed API to parse a `cursor` param and return `nextCursor` and `has_more` in the response. 

### Testing
- Ran `npx eslint src/components/FeedList.tsx src/app/api/feed/route.ts --ext .ts,.tsx` (linted the modified files). 
- Ran `npx tsc --noEmit` (type-check passed). 
- Ran the project linter via `npm run lint` which surfaced existing unrelated lint errors outside the changed files (these pre-existing issues are not caused by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05eaa1a894832eadd45d88d4fabd49)