### PR TITLE
Paginate FeedList loading (cursor-based, infinite scroll)

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -44,13 +44,16 @@ type FeedMeta = {
   pre_filter_active_count: number;
   page_item_count?: number;
   limit?: number;
-  offset?: number;
+  cursor?: string | null;
+  next_cursor?: string | null;
   has_more?: boolean;
 };
 
 type FeedResponse = {
   viewer_user_id: string;
   meta?: FeedMeta;
+  next_cursor?: string | null;
+  has_more?: boolean;
   items: FeedApiItem[];
 };
 
@@ -96,50 +99,66 @@ function comparisonCopy(playerCorrect: boolean, friendResults: FriendResult[] | 
 }
 
 type FeedListProps = {
-  limit?: number;
   pageSize?: number;
   infinite?: boolean;
 };
 
 type QuestionCardState = 'unanswered' | 'answered' | 'reacted';
 
-export default function FeedList({ limit, pageSize, infinite = false }: FeedListProps) {
-  const itemsPerPage = pageSize ?? limit ?? 25;
-  const [visibleCount, setVisibleCount] = useState(itemsPerPage);
-  const loadMoreRef = useRef<HTMLDivElement | null>(null);
+export default function FeedList({ pageSize = 20, infinite = false }: FeedListProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
   const [items, setItems] = useState<FeedApiItem[]>([]);
+  const [nextCursor, setNextCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(false);
+  const [loadingInitial, setLoadingInitial] = useState(true);
+  const [loadingMore, setLoadingMore] = useState(false);
   const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null);
   const [viewerId, setViewerId] = useState<string | null>(null);
   const [answers, setAnswers] = useState<Record<string, string>>({});
   const [results, setResults] = useState<Record<string, ResultState>>({});
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({});
   const [toasts, setToasts] = useState<Record<string, string>>({});
-  const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(null);
 
-  const loadFeed = useCallback(async () => {
-    setLoading(true);
+  const loadFeed = useCallback(async (cursor?: string | null) => {
+    const isNextPage = Boolean(cursor);
+    if (isNextPage) setLoadingMore(true);
+    else setLoadingInitial(true);
     setError(null);
+
     try {
-      const response = await fetch(`/api/feed?limit=${encodeURIComponent(String(limit))}`, { cache: 'no-store', credentials: 'include' });
-      const body = await response.json().catch(() => null) as FeedResponse | { message?: string } | null;
+      const search = new URLSearchParams({ limit: String(pageSize) });
+      if (cursor) search.set('cursor', cursor);
+
+      const response = await fetch(`/api/feed?${search.toString()}`, { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null) as FeedResponse | { message?: string; error?: string } | null;
       if (!response.ok || !body || !('items' in body)) {
-        throw new Error((body as { message?: string } | null)?.message ?? 'Could not load your Feed.');
+        const message = (body as { message?: string; error?: string } | null)?.message
+          ?? (body as { message?: string; error?: string } | null)?.error
+          ?? 'Could not load your Feed.';
+        throw new Error(message);
       }
+
       setViewerId(body.viewer_user_id);
       setFeedMeta(body.meta ?? null);
-      setItems(body.items);
-      const bannerResponse = await fetch('/api/ceremony/banner', { cache: 'no-store', credentials: 'include' });
-      const bannerBody = await bannerResponse.json().catch(() => null) as { ceremony?: CeremonyBanner | null } | null;
-      setCeremonyBanner(bannerResponse.ok ? bannerBody?.ceremony ?? null : null);
+      setItems((current) => (isNextPage ? [...current, ...body.items] : body.items));
+      setNextCursor(body.next_cursor ?? body.meta?.next_cursor ?? null);
+      setHasMore(Boolean(body.has_more ?? body.meta?.has_more));
+
+      if (!isNextPage) {
+        const bannerResponse = await fetch('/api/ceremony/banner', { cache: 'no-store', credentials: 'include' });
+        const bannerBody = await bannerResponse.json().catch(() => null) as { ceremony?: CeremonyBanner | null } | null;
+        setCeremonyBanner(bannerResponse.ok ? bannerBody?.ceremony ?? null : null);
+      }
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load your Feed.');
     } finally {
-      setLoading(false);
+      setLoadingInitial(false);
+      setLoadingMore(false);
     }
-  }, [limit]);
+  }, [pageSize]);
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
@@ -148,33 +167,31 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
     return () => window.clearTimeout(timer);
   }, [loadFeed]);
 
-  const visibleLimit = infinite ? visibleCount : itemsPerPage;
-  const visibleItems = useMemo(() => items.slice(0, visibleLimit), [items, visibleLimit]);
-  const hasMoreItems = visibleItems.length < items.length;
+  const visibleItems = items;
 
   useEffect(() => {
-    if (!infinite || !hasMoreItems) return;
+    if (!infinite || !hasMore || loadingInitial || loadingMore || !nextCursor) return;
 
-    const loadMoreNode = loadMoreRef.current;
-    if (!loadMoreNode) return;
+    const sentinelNode = sentinelRef.current;
+    if (!sentinelNode) return;
 
     if (!('IntersectionObserver' in window)) return;
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
-          setVisibleCount((current) => Math.min(current + itemsPerPage, items.length));
+          void loadFeed(nextCursor);
         }
       },
       { rootMargin: '320px 0px' },
     );
 
-    observer.observe(loadMoreNode);
+    observer.observe(sentinelNode);
     return () => observer.disconnect();
-  }, [hasMoreItems, infinite, items.length, itemsPerPage]);
+  }, [hasMore, infinite, loadFeed, loadingInitial, loadingMore, nextCursor]);
 
   const emptyCopy = useMemo(() => {
-    if (loading) return 'Loading your Feed...';
+    if (loadingInitial) return 'Loading your Feed...';
     if (error) return error;
     if (!feedMeta?.has_friends) return "When friends recognize each other’s questions, those moments will appear here.";
     // pre_filter_active_count > 0 means items exist in active/skipped state but are hidden by domain filters
@@ -183,7 +200,7 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
     }
     if (feedMeta.total_item_count > 0) return "You're caught up. Answer questions to reveal more common ground.";
     return "Answer questions to reveal common ground.";
-  }, [error, feedMeta, loading]);
+  }, [error, feedMeta, loadingInitial]);
 
   const emptyDiagnostics = useMemo(() => {
     if (process.env.NODE_ENV === 'production' || !feedMeta) return null;
@@ -195,11 +212,12 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
       `pre_filter_active_count=${feedMeta.pre_filter_active_count}`,
       `active_item_count=${feedMeta.active_item_count}`,
       `page_item_count=${feedMeta.page_item_count ?? items.length}`,
-      `limit=${feedMeta.limit ?? limit}`,
-      `offset=${feedMeta.offset ?? 0}`,
-      `has_more=${String(feedMeta.has_more ?? false)}`,
+      `limit=${feedMeta.limit ?? pageSize}`,
+      `cursor=${feedMeta.cursor ?? 'none'}`,
+      `next_cursor=${nextCursor ?? 'none'}`,
+      `has_more=${String(hasMore)}`,
     ].join(' · ');
-  }, [feedMeta, items.length, limit]);
+  }, [feedMeta, hasMore, items.length, nextCursor, pageSize]);
 
   const showToast = useCallback((itemId: string, message: string) => {
     setToasts((t) => ({ ...t, [itemId]: message }));
@@ -502,9 +520,9 @@ export default function FeedList({ limit, pageSize, infinite = false }: FeedList
           })}
         </section>
       )}
-      {infinite && hasMoreItems ? (
-        <div ref={loadMoreRef} className="py-4 text-center" aria-live="polite">
-          <p className="text-muted-foreground text-sm">Loading more Feed...</p>
+      {infinite && hasMore ? (
+        <div ref={sentinelRef} className="py-4 text-center" aria-live="polite">
+          {loadingMore ? <p className="text-muted-foreground text-sm">Loading more Feed...</p> : null}
         </div>
       ) : null}
     </>


### PR DESCRIPTION
### Motivation
- Replace the old single-page `limit` prop and client-side `slice` pagination with a cursor-backed paging model to support server-driven pages and infinite scroll.
- Expose `pageSize` and `infinite` props so callers can opt into page size and infinite-loading behavior.

### Description
- Replaced the `limit?: number` prop with `pageSize?: number` and `infinite?: boolean` and defaulted `pageSize` to `20` in `src/components/FeedList.tsx`.
- Replaced single `items` load with paginated state fields: `items`, `nextCursor`, `hasMore`, `loadingInitial`, and `loadingMore`, and updated the component to append page results for subsequent loads.
- Updated `loadFeed` to request `/api/feed?limit=20` for the initial page and `/api/feed?limit=20&cursor=...` for subsequent pages and to set `nextCursor`/`hasMore` from the response.
- Replaced client-side `items.slice(...)` logic with a bottom sentinel `IntersectionObserver` that triggers `loadFeed(nextCursor)` when `infinite` is true, and updated diagnostics to surface cursor values.

### Testing
- Ran `npx eslint src/components/FeedList.tsx`, which passed for the modified file.
- Ran `npx tsc --noEmit`, which succeeded with no type errors from the changed file.
- Ran `npm run lint`, which reported unrelated pre-existing lint issues outside `src/components/FeedList.tsx` (so overall project lint currently fails on unrelated files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05fc9ad1c0832e97f0d825c180c61b)