### PR TITLE
Redact production share-to-feed recipient diagnostics

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   assessQuestionDifficultyMock,
@@ -152,6 +152,11 @@ describe('POST /api/questions shareToFeed', () => {
     userHasQuestionInBlockingFeedMock.mockResolvedValue(false)
   })
 
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
   it('creates authored_shared feed rows for active friends when shareToFeed is true', async () => {
     getFriendsMock.mockResolvedValue([
       { id: 'friend-1', displayName: 'Friend One' },
@@ -234,5 +239,64 @@ describe('POST /api/questions shareToFeed', () => {
     expect(body.feedShare).toEqual({ requested: true, createdCount: 0 })
     expect(state.feedInsertValues).toEqual([])
     expect(state.questionUpdateValues).toEqual([])
+  })
+
+  it('redacts share-to-feed recipient ids from production responses and logs', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    const consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    getFriendsMock.mockResolvedValue([
+      { id: 'friend-1', displayName: 'Friend One' },
+      { id: 'friend-2', displayName: 'Friend Two' },
+      { id: 'friend-3', displayName: 'Friend Three' },
+    ])
+    state.dismissedRows = [{ userId: 'friend-3' }]
+    userHasQuestionInBlockingFeedMock.mockImplementation(async (userId: string) => userId === 'friend-2')
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const body = await response.json()
+    const shareLogCall = consoleInfoMock.mock.calls.find(([label]) => label === '[questions/shareToFeed]')
+
+    expect(response.status).toBe(201)
+    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
+    expect(JSON.stringify(body)).not.toContain('friend-1')
+    expect(JSON.stringify(body)).not.toContain('friend-2')
+    expect(JSON.stringify(body)).not.toContain('friend-3')
+    expect(shareLogCall).toBeDefined()
+    expect(shareLogCall?.[1]).toEqual({
+      questionId: 'question-1',
+      userId: 'creator-1',
+      requested: true,
+      friendCount: 3,
+      sharedCount: 1,
+      skippedDismissedDomainCount: 1,
+      skippedExistingFeedCount: 1,
+    })
+    expect(JSON.stringify(shareLogCall)).not.toContain('friend-1')
+    expect(JSON.stringify(shareLogCall)).not.toContain('friend-2')
+    expect(JSON.stringify(shareLogCall)).not.toContain('friend-3')
+  })
+
+  it('includes share-to-feed recipient ids when production diagnostics debug mode is enabled', async () => {
+    vi.stubEnv('NODE_ENV', 'production')
+    vi.stubEnv('SHARE_TO_FEED_DEBUG_RECIPIENT_IDS', 'true')
+    const consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    getFriendsMock.mockResolvedValue([
+      { id: 'friend-1', displayName: 'Friend One' },
+      { id: 'friend-2', displayName: 'Friend Two' },
+      { id: 'friend-3', displayName: 'Friend Three' },
+    ])
+    state.dismissedRows = [{ userId: 'friend-3' }]
+    userHasQuestionInBlockingFeedMock.mockImplementation(async (userId: string) => userId === 'friend-2')
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const shareLogCall = consoleInfoMock.mock.calls.find(([label]) => label === '[questions/shareToFeed]')
+
+    expect(response.status).toBe(201)
+    expect(shareLogCall?.[1]).toEqual(expect.objectContaining({
+      requested: true,
+      sharedRecipientIds: ['friend-1'],
+      skippedDismissedDomainRecipientIds: ['friend-3'],
+      skippedExistingFeedRecipientIds: ['friend-2'],
+    }))
   })
 })

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -23,6 +23,10 @@ import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 
 export const dynamic = 'force-dynamic';
 
+function shouldIncludeShareRecipientDiagnostics() {
+  return process.env.NODE_ENV !== 'production' || process.env.SHARE_TO_FEED_DEBUG_RECIPIENT_IDS === 'true';
+}
+
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -142,16 +146,18 @@ export async function POST(request: NextRequest) {
       await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
     }
 
+    const includeRecipientDiagnostics = shouldIncludeShareRecipientDiagnostics();
     console.info('[questions/shareToFeed]', {
       questionId: created.id,
       userId: session.userId,
+      requested: true,
       friendCount: friends.length,
       sharedCount,
-      sharedRecipientIds,
+      ...(includeRecipientDiagnostics ? { sharedRecipientIds } : {}),
       skippedDismissedDomainCount: skippedDismissedDomainRecipientIds.length,
-      skippedDismissedDomainRecipientIds,
+      ...(includeRecipientDiagnostics ? { skippedDismissedDomainRecipientIds } : {}),
       skippedExistingFeedCount: skippedExistingFeedRecipientIds.length,
-      skippedExistingFeedRecipientIds,
+      ...(includeRecipientDiagnostics ? { skippedExistingFeedRecipientIds } : {}),
     });
   }
 


### PR DESCRIPTION
### Motivation
- Prevent leaking raw recipient IDs in production logs and API responses while preserving useful summary counts for observability.
- Make raw recipient diagnostics available only in non-production or when explicitly enabled for debugging via `SHARE_TO_FEED_DEBUG_RECIPIENT_IDS=true`.
- Ensure the diagnostics payload explicitly marks a share request with `requested: true` so consumers can rely on the field even when recipient IDs are redacted.

### Description
- Add a helper `shouldIncludeShareRecipientDiagnostics()` and use it in `src/app/api/questions/route.ts` to gate inclusion of raw recipient ID arrays in the `console.info` diagnostics payload.
- Add `requested: true` to the `questions/shareToFeed` diagnostics object while always emitting count fields like `friendCount`, `sharedCount`, and skipped-recipient counts.
- Extend `src/app/api/questions/__tests__/route.test.ts` with tests that verify production-mode redaction and that enabling `SHARE_TO_FEED_DEBUG_RECIPIENT_IDS` in production includes recipient ID arrays, and add an `afterEach` to restore env/mocks.

### Testing
- Ran TypeScript type check with `tsc --noEmit` which completed without errors for the changed files.
- Ran ESLint against the changed files via `./node_modules/.bin/eslint src/app/api/questions/route.ts src/app/api/questions/__tests__/route.test.ts` which succeeded for those files.
- Ran `prettier --write` on the modified files to normalize formatting which completed successfully.
- Attempted to run the route tests with Vitest but the local `vitest` install attempt failed due to an npm registry `403` (so the new tests were added but could not be executed in this environment); `npm run lint` reported pre-existing lint issues elsewhere in the repo unrelated to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06005da31c832ea21b9c6532f5ee08)