### PR TITLE
Include direct-sent feed items in main feed visibility

### DIFF
--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { checkBankedQuestionsMock, dbMock, getDismissedDomainsMock, getFeedForUserMock, getSessionMock } = vi.hoisted(() => {
+  const getSessionMock = vi.fn();
+  const getFeedForUserMock = vi.fn();
+  const getDismissedDomainsMock = vi.fn();
+  const checkBankedQuestionsMock = vi.fn();
+
+  function thenable(rows: unknown[]) {
+    return {
+      where: vi.fn(() => thenable(rows)),
+      innerJoin: vi.fn(() => ({ where: vi.fn(() => thenable(rows)) })),
+      then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) => Promise.resolve(rows).then(resolve, reject),
+    };
+  }
+
+  const dbMock = {
+    select: vi.fn((selection?: unknown) => ({
+      from: vi.fn((table: unknown) => {
+        if (table === 'questions') {
+          return thenable([{
+            id: 'question-1',
+            questionText: 'What is the direct question?',
+            creatorId: 'sender-1',
+            verified: true,
+            explainerBrief: 'A brief explanation.',
+            factualExplanation: null,
+            canonicalSubcategory: 'Music',
+            broadCategory: 'Arts',
+            category: 'music',
+            calibratedDifficulty: null,
+            llmDifficulty: null,
+            difficultyEstimate: null,
+          }]);
+        }
+        if ((selection as { id?: unknown; displayName?: unknown })?.id && (selection as { id?: unknown; displayName?: unknown })?.displayName) {
+          return thenable([
+            { id: 'sender-1', displayName: 'Sender Friend' },
+          ]);
+        }
+        return thenable([{ value: 0 }]);
+      }),
+    })),
+  };
+
+  return { checkBankedQuestionsMock, dbMock, getDismissedDomainsMock, getFeedForUserMock, getSessionMock };
+});
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  count: vi.fn(() => ({ expression: 'count' })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/bank', () => ({ checkBankedQuestions: checkBankedQuestionsMock }));
+vi.mock('@/server/db/queries/feed', () => ({
+  getDismissedDomains: getDismissedDomainsMock,
+  getFeedForUser: getFeedForUserMock,
+  visibleFeedSourcePredicate: { op: 'visibleFeedSourcePredicate' },
+}));
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  feedItems: {
+    recipientUserId: 'feedItems.recipientUserId',
+    state: 'feedItems.state',
+  },
+  friendships: {
+    status: 'friendships.status',
+    userAId: 'friendships.userAId',
+    userBId: 'friendships.userBId',
+  },
+  questions: 'questions',
+  users: {
+    id: 'users.id',
+    displayName: 'users.displayName',
+  },
+}));
+
+import { GET } from '@/app/api/feed/route';
+
+describe('GET /api/feed', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ userId: 'recipient-1' });
+    getDismissedDomainsMock.mockResolvedValue([]);
+    checkBankedQuestionsMock.mockResolvedValue({});
+    getFeedForUserMock.mockResolvedValue({
+      items: [{
+        id: 'feed-direct-1',
+        questionId: 'question-1',
+        joshingGameId: null,
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:00:00.000Z'),
+        personalMessage: 'Try this one.',
+        state: 'active',
+        isPinned: true,
+      }],
+      nextCursor: null,
+      hasMore: false,
+      totalCount: 1,
+    });
+  });
+
+  it('includes direct_sent items in the API feed response', async () => {
+    const response = await GET(new Request('https://joshing.example/api/feed') as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items).toEqual([
+      expect.objectContaining({
+        id: 'feed-direct-1',
+        source_type: 'direct_sent',
+        state: 'active',
+        is_pinned: true,
+        personal_message: 'Try this one.',
+        question_text: 'What is the direct question?',
+        source_attribution: 'Sender Friend sent you a question — Music',
+      }),
+    ]);
+    expect(body.meta.active_item_count).toBe(1);
+  });
+});

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -4,18 +4,10 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/server/auth/session';
 import { db, feedItems, friendships, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
-import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem, type FeedCursor } from '@/server/db/queries/feed';
-import { AUTHORED_SHARED_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE, socialFeedDomainLabel } from '@/server/feed/visibility';
+import { getDismissedDomains, getFeedForUser, visibleFeedSourcePredicate, type CollapsedFeedItem, type FeedCursor } from '@/server/db/queries/feed';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, socialFeedDomainLabel } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
-
-const visibleFeedSourcePredicate = or(
-  eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
-  and(
-    eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
-    eq(feedItems.sourceResult, 'correct'),
-  ),
-);
 
 const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 50;
@@ -71,6 +63,10 @@ function displayName(name: string | null, fallback = 'A friend') {
 
 function authoredSharedAttribution(sourceName: string, domain: string | null): string {
   return domain ? `${sourceName} shared a question — ${domain}` : `${sourceName} shared a question`;
+}
+
+function directSentAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} sent you a question — ${domain}` : `${sourceName} sent you a question`;
 }
 
 function friendAnsweredAttribution(
@@ -191,7 +187,9 @@ export async function GET(request: NextRequest) {
         source_friend_display_name: sourceName,
         source_attribution: item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE
           ? authoredSharedAttribution(sourceName, domain)
-          : friendAnsweredAttribution(item, userById, domain, authorName),
+          : item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE
+            ? directSentAttribution(sourceName, domain)
+            : friendAnsweredAttribution(item, userById, domain, authorName),
         friend_results: item.friendResults ?? null,
         source_event_at: item.sourceEventAt,
         personal_message: item.personalMessage,

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -18,6 +18,7 @@ import {
 } from '@/server/db/queries/feed';
 import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
+import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 
@@ -178,7 +179,7 @@ export async function POST(request: NextRequest) {
       await db.insert(feedItems).values({
         recipientUserId: recipientId,
         questionId: created.id,
-        sourceType: 'direct_sent',
+        sourceType: DIRECT_SENT_FEED_SOURCE_TYPE,
         sourceUserId: session.userId,
         sourceEventAt: new Date(),
         state: 'active',

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/server/db/queries/feed';
 import { getFriends } from '@/server/db/queries/friends';
 import { sendSms } from '@/server/sms';
+import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
 
@@ -70,7 +71,7 @@ export async function POST(request: NextRequest) {
     .where(and(
       eq(feedItems.recipientUserId, parsed.recipientUserId),
       eq(feedItems.sourceUserId, session.userId),
-      eq(feedItems.sourceType, 'direct_sent'),
+      eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
       gt(feedItems.createdAt, lastTwentyFourHours()),
     ));
 
@@ -84,7 +85,7 @@ export async function POST(request: NextRequest) {
   const created = await createFeedItem({
     recipientUserId: parsed.recipientUserId,
     questionId: sendableQuestionId!,
-    sourceType: 'direct_sent',
+    sourceType: DIRECT_SENT_FEED_SOURCE_TYPE,
     sourceUserId: session.userId,
     sourceEventAt: new Date(),
     personalMessage: parsed.personalMessage,

--- a/src/server/db/queries/__tests__/feed.test.ts
+++ b/src/server/db/queries/__tests__/feed.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const { dbMock, state } = vi.hoisted(() => {
+  type Predicate =
+    | { op: 'eq'; column: string; value: unknown }
+    | { op: 'and'; predicates: Array<Predicate | undefined> }
+    | { op: 'or'; predicates: Array<Predicate | undefined> }
+    | { op: 'inArray'; column: string; values: readonly unknown[] }
+    | { op: 'isNull'; column: string }
+    | { op: 'notInArray'; column: string; values: readonly unknown[] }
+    | { op: 'lt'; column: string; value: unknown };
+
+  type FeedRow = {
+    id: string;
+    recipientUserId: string;
+    questionId: string;
+    sourceType: string;
+    sourceUserId: string;
+    sourceResult: string | null;
+    sourceEventAt: Date;
+    personalMessage: string | null;
+    state: string;
+    isPinned: boolean;
+    joshingGameId: string | null;
+  };
+
+  type QuestionRow = {
+    id: string;
+    visibility: string;
+    deletedAt: Date | null;
+    canonicalSubcategory: string | null;
+  };
+
+  const state = {
+    feedRows: [] as FeedRow[],
+    questionRows: [] as QuestionRow[],
+  };
+
+  function columnValue(column: string, feedItem: FeedRow, question: QuestionRow | undefined) {
+    if (column.startsWith('feedItems.')) return feedItem[column.slice('feedItems.'.length) as keyof FeedRow];
+    if (column.startsWith('questions.')) return question?.[column.slice('questions.'.length) as keyof QuestionRow];
+    return undefined;
+  }
+
+  function evaluate(predicate: Predicate | undefined, feedItem: FeedRow, question: QuestionRow | undefined): boolean {
+    if (!predicate) return true;
+    switch (predicate.op) {
+      case 'eq':
+        return columnValue(predicate.column, feedItem, question) === predicate.value;
+      case 'and':
+        return predicate.predicates.every((part) => evaluate(part, feedItem, question));
+      case 'or':
+        return predicate.predicates.some((part) => evaluate(part, feedItem, question));
+      case 'inArray':
+        return predicate.values.includes(columnValue(predicate.column, feedItem, question));
+      case 'isNull':
+        return columnValue(predicate.column, feedItem, question) == null;
+      case 'notInArray':
+        return !predicate.values.includes(columnValue(predicate.column, feedItem, question));
+      case 'lt':
+        return String(columnValue(predicate.column, feedItem, question)) < String(predicate.value);
+    }
+  }
+
+  function queryRows(predicate: Predicate | undefined, selection: unknown) {
+    const matched = state.feedRows
+      .map((feedItem) => ({ feedItem, question: state.questionRows.find((question) => question.id === feedItem.questionId) }))
+      .filter(({ feedItem, question }) => Boolean(question) && evaluate(predicate, feedItem, question));
+
+    if ((selection as { value?: unknown })?.value) return [{ value: matched.length }];
+    return matched.map(({ feedItem }) => ({ item: feedItem }));
+  }
+
+  function makeThenable(rows: unknown[]) {
+    return {
+      orderBy: vi.fn(() => ({
+        limit: vi.fn(async (limit: number) => rows.slice(0, limit)),
+      })),
+      then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) => Promise.resolve(rows).then(resolve, reject),
+    };
+  }
+
+  const dbMock = {
+    select: vi.fn((selection?: unknown) => ({
+      from: vi.fn(() => ({
+        where: vi.fn((predicate: Predicate | undefined) => makeThenable(predicate ? [] : [])),
+        innerJoin: vi.fn(() => ({
+          where: vi.fn((predicate: Predicate | undefined) => makeThenable(queryRows(predicate, selection))),
+        })),
+      })),
+    })),
+  };
+
+  return { dbMock, state };
+});
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...predicates) => ({ op: 'and', predicates })),
+  count: vi.fn(() => ({ expression: 'count' })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
+  lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  notInArray: vi.fn((column, values) => ({ op: 'notInArray', column, values })),
+  or: vi.fn((...predicates) => ({ op: 'or', predicates })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  feedDismissedDomains: {
+    userId: 'feedDismissedDomains.userId',
+    canonicalSubcategory: 'feedDismissedDomains.canonicalSubcategory',
+    reinstatedAt: 'feedDismissedDomains.reinstatedAt',
+  },
+  feedItems: {
+    id: 'feedItems.id',
+    recipientUserId: 'feedItems.recipientUserId',
+    questionId: 'feedItems.questionId',
+    sourceType: 'feedItems.sourceType',
+    sourceUserId: 'feedItems.sourceUserId',
+    sourceResult: 'feedItems.sourceResult',
+    sourceEventAt: 'feedItems.sourceEventAt',
+    state: 'feedItems.state',
+    isPinned: 'feedItems.isPinned',
+  },
+  masteryEvents: {},
+  questions: {
+    id: 'questions.id',
+    visibility: 'questions.visibility',
+    deletedAt: 'questions.deletedAt',
+    canonicalSubcategory: 'questions.canonicalSubcategory',
+  },
+  users: { id: 'users.id', displayName: 'users.displayName' },
+}));
+
+vi.mock('@/server/db/pg-error', () => ({ pgErrorCode: vi.fn(() => null) }));
+
+import { getFeedForUser } from '@/server/db/queries/feed';
+
+describe('getFeedForUser feed visibility', () => {
+  it('returns an active pinned direct_sent feed item', async () => {
+    const sourceEventAt = new Date('2026-05-14T12:00:00.000Z');
+    state.questionRows = [{ id: 'question-1', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' }];
+    state.feedRows = [{
+      id: 'feed-direct-1',
+      recipientUserId: 'recipient-1',
+      questionId: 'question-1',
+      sourceType: 'direct_sent',
+      sourceUserId: 'sender-1',
+      sourceResult: null,
+      sourceEventAt,
+      personalMessage: 'Try this one.',
+      state: 'active',
+      isPinned: true,
+      joshingGameId: null,
+    }];
+
+    const result = await getFeedForUser('recipient-1');
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: 'feed-direct-1',
+        sourceType: 'direct_sent',
+        state: 'active',
+        isPinned: true,
+      }),
+    ]);
+    expect(result.totalCount).toBe(1);
+  });
+});

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,7 +1,7 @@
 import { and, count, desc, eq, inArray, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
-import { AUTHORED_SHARED_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -21,8 +21,9 @@ export type CollapsedFeedItem = FeedItem & {
 const VISIBLE_FEED_STATES = ['active', 'skipped'] as const;
 const BLOCKING_FEED_STATES = ['active', 'skipped', 'dismissed'] as const;
 
-const visibleFeedSourcePredicate = or(
+export const visibleFeedSourcePredicate = or(
   eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
+  eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
   and(
     eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
     eq(feedItems.sourceResult, 'correct'),

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -9,11 +9,11 @@ const publicQuestion = {
 };
 
 describe('correct-answer social feed eligibility', () => {
-  it('allows authored sharing but rejects game-publication and direct-sent sources from the main feed', () => {
+  it('allows authored and direct-sent sharing but rejects game-publication sources from the main feed', () => {
     expect(isMainFeedSourceVisible('authored_shared', null)).toBe(true);
     expect(isMainFeedSourceVisible('authored_shared', 'incorrect')).toBe(true);
     expect(isMainFeedSourceVisible('joshing_game', null)).toBe(false);
-    expect(isMainFeedSourceVisible('direct_sent', null)).toBe(false);
+    expect(isMainFeedSourceVisible('direct_sent', null)).toBe(true);
   });
 
   it('allows a correct answer by someone other than the author in a visible social context', () => {

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -2,6 +2,7 @@ import type { questions } from '@/server/db';
 
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
 export const AUTHORED_SHARED_FEED_SOURCE_TYPE = 'authored_shared' as const;
+export const DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent' as const;
 
 const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown', 'general', 'general knowledge']);
 
@@ -26,6 +27,7 @@ export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): b
 
 export function isMainFeedSourceVisible(sourceType: string, sourceResult: string | null): boolean {
   if (sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE) return true;
+  if (sourceType === DIRECT_SENT_FEED_SOURCE_TYPE) return true;
   return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
 }
 


### PR DESCRIPTION
### Motivation
- Make sure feed items created by one user sending a question directly to another (`direct_sent`) are considered part of the main `/api/feed` results so recipients see them in their feed.
- Centralize the visibility predicate to avoid the API and DB diverging in which source types are considered visible.

### Description
- Added `DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent'` and made `isMainFeedSourceVisible` treat `direct_sent` as visible in the main feed. (src/server/feed/visibility.ts)
- Exported and extended the shared `visibleFeedSourcePredicate` in the DB queries to include `direct_sent` so `getFeedForUser` will return those items. (src/server/db/queries/feed.ts)
- Updated the `/api/feed` handler to reuse the centralized `visibleFeedSourcePredicate` and to render a direct-send specific `source_attribution`. (src/app/api/feed/route.ts)
- Switched direct-send insertion sites to use the shared `DIRECT_SENT_FEED_SOURCE_TYPE` constant while preserving `state: 'active'` and `isPinned: true`. (src/app/api/questions/route.ts, src/app/api/questions/send/route.ts)
- Added/updated tests that assert `direct_sent` items appear in `getFeedForUser` and in the `/api/feed` response, and updated visibility unit tests to expect `direct_sent` to be visible. (src/server/db/queries/__tests__/feed.test.ts, src/app/api/feed/__tests__/route.test.ts, src/server/feed/__tests__/visibility.test.ts)

### Testing
- Ran the TypeScript compiler with `./node_modules/.bin/tsc --noEmit --pretty false`, which succeeded.
- Ran `eslint` targeting the changed files, which passed for those files (`src/server/feed/visibility.ts`, `src/server/db/queries/feed.ts`, `src/app/api/feed/route.ts`, `src/app/api/questions/route.ts`, `src/app/api/questions/send/route.ts`, and the new/updated tests).
- Attempted to run unit tests with `npx vitest`, but the run was blocked by the environment’s npm registry returning `403 Forbidden`; tests were added and are included in the PR but could not be executed end-to-end in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06016f8254832e882ebf8648df03e4)