### PR TITLE
Expose share-to-feed diagnostics in question creation response

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -168,7 +168,14 @@ describe('POST /api/questions shareToFeed', () => {
 
     expect(response.status).toBe(201)
     expect(body.id).toBe('question-1')
-    expect(body.feedShare).toEqual({ requested: true, createdCount: 2 })
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 2,
+      friendCount: 2,
+      sharedRecipientIds: ['friend-1', 'friend-2'],
+      skippedDismissedDomainRecipientIds: [],
+      skippedExistingFeedRecipientIds: [],
+    })
     expect(getFriendsMock).toHaveBeenCalledWith('creator-1')
     expect(state.feedInsertValues).toEqual([
       expect.objectContaining({
@@ -200,7 +207,14 @@ describe('POST /api/questions shareToFeed', () => {
     expect(response.status).toBe(201)
     expect(createQuestionMock).toHaveBeenCalled()
     const body = await response.json()
-    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 1,
+      friendCount: 1,
+      sharedRecipientIds: ['friend-1'],
+      skippedDismissedDomainRecipientIds: [],
+      skippedExistingFeedRecipientIds: [],
+    })
     expect(state.feedInsertValues).toHaveLength(1)
     expect(state.feedInsertValues[0]).toEqual(expect.objectContaining({ recipientUserId: 'friend-1' }))
   })
@@ -218,7 +232,14 @@ describe('POST /api/questions shareToFeed', () => {
 
     expect(response.status).toBe(201)
     const body = await response.json()
-    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 1,
+      friendCount: 3,
+      sharedRecipientIds: ['friend-1'],
+      skippedDismissedDomainRecipientIds: ['friend-3'],
+      skippedExistingFeedRecipientIds: ['friend-2'],
+    })
     expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-1', 'question-1')
     expect(userHasQuestionInBlockingFeedMock).toHaveBeenCalledWith('friend-2', 'question-1')
     expect(userHasQuestionInBlockingFeedMock).not.toHaveBeenCalledWith('friend-3', 'question-1')
@@ -236,12 +257,43 @@ describe('POST /api/questions shareToFeed', () => {
     const body = await response.json()
 
     expect(response.status).toBe(201)
-    expect(body.feedShare).toEqual({ requested: true, createdCount: 0 })
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 0,
+      friendCount: 0,
+      sharedRecipientIds: [],
+      skippedDismissedDomainRecipientIds: [],
+      skippedExistingFeedRecipientIds: [],
+    })
     expect(state.feedInsertValues).toEqual([])
     expect(state.questionUpdateValues).toEqual([])
   })
 
-  it('redacts share-to-feed recipient ids from production responses and logs', async () => {
+  it('reports visible skip reasons when zero rows are created for non-empty all-friends sharing', async () => {
+    getFriendsMock.mockResolvedValue([
+      { id: 'friend-1', displayName: 'Friend One' },
+      { id: 'friend-2', displayName: 'Friend Two' },
+    ])
+    state.dismissedRows = [{ userId: 'friend-2' }]
+    userHasQuestionInBlockingFeedMock.mockImplementation(async (userId: string) => userId === 'friend-1')
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 0,
+      friendCount: 2,
+      sharedRecipientIds: [],
+      skippedDismissedDomainRecipientIds: ['friend-2'],
+      skippedExistingFeedRecipientIds: ['friend-1'],
+    })
+    expect(state.feedInsertValues).toEqual([])
+    expect(state.questionUpdateValues).toEqual([])
+  })
+
+  it('exposes production response diagnostics while redacting recipient ids from logs by default', async () => {
     vi.stubEnv('NODE_ENV', 'production')
     const consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     getFriendsMock.mockResolvedValue([
@@ -257,10 +309,14 @@ describe('POST /api/questions shareToFeed', () => {
     const shareLogCall = consoleInfoMock.mock.calls.find(([label]) => label === '[questions/shareToFeed]')
 
     expect(response.status).toBe(201)
-    expect(body.feedShare).toEqual({ requested: true, createdCount: 1 })
-    expect(JSON.stringify(body)).not.toContain('friend-1')
-    expect(JSON.stringify(body)).not.toContain('friend-2')
-    expect(JSON.stringify(body)).not.toContain('friend-3')
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 1,
+      friendCount: 3,
+      sharedRecipientIds: ['friend-1'],
+      skippedDismissedDomainRecipientIds: ['friend-3'],
+      skippedExistingFeedRecipientIds: ['friend-2'],
+    })
     expect(shareLogCall).toBeDefined()
     expect(shareLogCall?.[1]).toEqual({
       questionId: 'question-1',

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -89,7 +89,14 @@ export async function POST(request: NextRequest) {
     questionId: created.id,
   });
   const question = await getQuestion(created.id, session.userId);
-  const feedShare = { requested: shareToFeed, createdCount: 0 };
+  const feedShare = {
+    requested: shareToFeed,
+    createdCount: 0,
+    friendCount: 0,
+    sharedRecipientIds: [] as string[],
+    skippedDismissedDomainRecipientIds: [] as string[],
+    skippedExistingFeedRecipientIds: [] as string[],
+  };
 
   if (shareToFeed) {
     const friends = await getFriends(session.userId);
@@ -142,6 +149,10 @@ export async function POST(request: NextRequest) {
     }
 
     feedShare.createdCount = sharedCount;
+    feedShare.friendCount = friends.length;
+    feedShare.sharedRecipientIds = sharedRecipientIds;
+    feedShare.skippedDismissedDomainRecipientIds = skippedDismissedDomainRecipientIds;
+    feedShare.skippedExistingFeedRecipientIds = skippedExistingFeedRecipientIds;
 
     if (sharedCount > 0) {
       await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -63,6 +63,18 @@ type TidyResult = {
   details: Array<{ sources: string[]; target: string; rationale: string }>;
 };
 
+type CreateQuestionResponse = {
+  message?: string;
+  feedShare?: {
+    requested: boolean;
+    createdCount: number;
+    friendCount?: number;
+    sharedRecipientIds?: string[];
+    skippedDismissedDomainRecipientIds?: string[];
+    skippedExistingFeedRecipientIds?: string[];
+  };
+};
+
 function asTier(value: string): MasteryTier {
   if (value === 'familiar' || value === 'solid' || value === 'mastery') return value;
   return 'establishing';
@@ -337,7 +349,7 @@ function KnowledgePageContent() {
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(values),
     });
-    const body = await response.json().catch(() => null) as { message?: string; feedShare?: { requested: boolean; createdCount: number } } | null;
+    const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
     if (!response.ok) throw new Error(body?.message ?? 'Could not save that question.');
     setSendQuestionOpen(false);
     setWriteQuestionOpen(false);
@@ -347,6 +359,8 @@ function KnowledgePageContent() {
     } else if (body?.feedShare?.createdCount && body.feedShare.createdCount > 0) {
       const n = body.feedShare.createdCount;
       setQuestionToast(`Saved and shared with ${n} ${n === 1 ? 'friend' : 'friends'}.`);
+    } else if (body?.feedShare?.requested && body.feedShare.createdCount === 0) {
+      setQuestionToast('No friends received this because they already had it or filtered that domain.');
     } else {
       setQuestionToast('Saved to your bank.');
     }

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -29,6 +29,10 @@ type CreateQuestionResponse = {
   feedShare?: {
     requested: boolean;
     createdCount: number;
+    friendCount?: number;
+    sharedRecipientIds?: string[];
+    skippedDismissedDomainRecipientIds?: string[];
+    skippedExistingFeedRecipientIds?: string[];
   };
 };
 
@@ -203,6 +207,8 @@ function QuestionsPageContent() {
     } else if (body.feedShare?.createdCount && body.feedShare.createdCount > 0) {
       const n = body.feedShare.createdCount;
       setToast(`Saved and shared with ${n} ${n === 1 ? 'friend' : 'friends'}.`);
+    } else if (body.feedShare?.requested && body.feedShare.createdCount === 0) {
+      setToast('No friends received this because they already had it or filtered that domain.');
     } else {
       setToast('Saved to your bank.');
     }


### PR DESCRIPTION
### Motivation
- Let question creators see why a `shareToFeed` attempt delivered no items by exposing counts and skip recipient ids so they can diagnose dismissed domains or duplicates.
- Preserve existing compatibility by keeping `requested` and `createdCount` fields while adding richer diagnostics.

### Description
- Extended the `feedShare` payload returned by `POST /api/questions` to include `friendCount`, `sharedRecipientIds`, `skippedDismissedDomainRecipientIds`, and `skippedExistingFeedRecipientIds` while preserving `requested` and `createdCount` (file: `src/app/api/questions/route.ts`).
- Populated the new fields after the share loop and preserved the existing production logging behavior (recipient ids are only included in logs when `SHARE_TO_FEED_DEBUG_RECIPIENT_IDS` is enabled; otherwise logs are redacted). 
- Updated client types and UX in `src/app/questions/page.tsx` and `src/app/knowledge/page.tsx` to handle the extended `feedShare` shape and show a specific toast when `shareToFeed` was requested but `createdCount === 0`: “No friends received this because they already had it or filtered that domain.”
- Added/updated route tests in `src/app/api/questions/__tests__/route.test.ts` to assert the new diagnostics (including a new test for the zero-created all-friends sharing case that verifies visible skip reasons). 

### Testing
- Ran lint against the touched files with `./node_modules/.bin/eslint src/app/api/questions/route.ts src/app/api/questions/__tests__/route.test.ts src/app/questions/page.tsx src/app/knowledge/page.tsx --ext .ts,.tsx` (no issues for the modified files).
- Ran the TypeScript type check with `./node_modules/.bin/tsc --noEmit` which completed successfully.
- Noted that running the full project lint (`npm run lint`) surfaced unrelated, pre-existing lint errors elsewhere in the repo.
- Attempted to run the route tests with `npx vitest run src/app/api/questions/__tests__/route.test.ts` but could not execute because `vitest` is not installed locally and registry access returned `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0603520538832ebc2e003919eb642f)