### PR TITLE
Centralize feed source visibility

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -4,10 +4,12 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/server/auth/session';
 import { db, feedItems, friendships, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
-import { getDismissedDomains, getFeedForUser, visibleFeedSourcePredicate, type CollapsedFeedItem, type FeedCursor } from '@/server/db/queries/feed';
-import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, socialFeedDomainLabel } from '@/server/feed/visibility';
+import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem, type FeedCursor } from '@/server/db/queries/feed';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, socialFeedDomainLabel, visibleFeedSourcePredicate } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
+
+const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
 
 const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 50;
@@ -117,7 +119,7 @@ export async function GET(request: NextRequest) {
       .from(feedItems)
       .where(and(
         eq(feedItems.recipientUserId, session.userId),
-        visibleFeedSourcePredicate,
+        visibleSourcePredicate,
       ))
       .then((rows) => rows[0]?.value ?? 0),
     db
@@ -125,7 +127,7 @@ export async function GET(request: NextRequest) {
       .from(feedItems)
       .where(and(
         eq(feedItems.recipientUserId, session.userId),
-        visibleFeedSourcePredicate,
+        visibleSourcePredicate,
         inArray(feedItems.state, ['active', 'skipped']),
       ))
       .then((rows) => rows[0]?.value ?? 0),

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -18,7 +18,7 @@ import {
 } from '@/server/db/queries/feed';
 import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
-import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 
@@ -138,7 +138,7 @@ export async function POST(request: NextRequest) {
       await db.insert(feedItems).values({
         recipientUserId: friend.id,
         questionId: created.id,
-        sourceType: 'authored_shared',
+        sourceType: AUTHORED_SHARED_FEED_SOURCE_TYPE,
         sourceUserId: session.userId,
         sourceEventAt: new Date(),
         state: 'active',

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,7 +1,7 @@
 import { and, count, desc, eq, inArray, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
-import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import { isVisibleFriendAnsweredSource, visibleFeedSourcePredicate } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -21,18 +21,7 @@ export type CollapsedFeedItem = FeedItem & {
 const VISIBLE_FEED_STATES = ['active', 'skipped'] as const;
 const BLOCKING_FEED_STATES = ['active', 'skipped', 'dismissed'] as const;
 
-export const visibleFeedSourcePredicate = or(
-  eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
-  eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
-  and(
-    eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
-    eq(feedItems.sourceResult, 'correct'),
-  ),
-);
-
-function isVisibleFriendAnsweredSource(sourceType: string, sourceResult: string | null): boolean {
-  return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
-}
+const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
 
 async function collapseFriendAnsweredItems(items: FeedItem[]): Promise<CollapsedFeedItem[]> {
   const friendAnsweredByQuestion = new Map<string, FeedItem[]>();
@@ -272,7 +261,7 @@ async function fetchVisibleFeedItems(
     .where(and(
       eq(feedItems.recipientUserId, userId),
       eq(feedItems.isPinned, options.pinned ?? false),
-      visibleFeedSourcePredicate,
+      visibleSourcePredicate,
       inArray(feedItems.state, VISIBLE_FEED_STATES),
       visibleQuestionPredicate(dismissedDomains),
       cursorPredicate,
@@ -300,7 +289,7 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
       .innerJoin(questions, eq(feedItems.questionId, questions.id))
       .where(and(
         eq(feedItems.recipientUserId, userId),
-        visibleFeedSourcePredicate,
+        visibleSourcePredicate,
         inArray(feedItems.state, VISIBLE_FEED_STATES),
         visibleQuestionPredicate(dismissedDomains),
       )),

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { isCorrectAnswerFeedEligible, isMainFeedSourceVisible, socialFeedDomainLabel } from '@/server/feed/visibility';
+import {
+  QUESTION_SHARING_FEED_SOURCE_VISIBILITY,
+  isCorrectAnswerFeedEligible,
+  isMainFeedSourceVisible,
+  socialFeedDomainLabel,
+} from '@/server/feed/visibility';
 
 const publicQuestion = {
   creatorId: 'author-1',
@@ -58,6 +63,24 @@ describe('correct-answer social feed eligibility', () => {
       question: publicQuestion,
       hasVisibleSocialContext: false,
     })).toBe(false);
+  });
+
+  it('documents visibility for every source type created by question-sharing routes', () => {
+    expect(QUESTION_SHARING_FEED_SOURCE_VISIBILITY).toEqual(expect.arrayContaining([
+      expect.objectContaining({ sourceType: 'authored_shared' }),
+      expect.objectContaining({ sourceType: 'direct_sent' }),
+      expect.objectContaining({ sourceType: 'friend_answered' }),
+    ]));
+
+    for (const { sourceType, sourceResult, visible, reason } of QUESTION_SHARING_FEED_SOURCE_VISIBILITY) {
+      expect(isMainFeedSourceVisible(sourceType, sourceResult)).toBe(visible);
+      if (visible) {
+        expect(reason).toBeNull();
+      } else {
+        expect(reason).toEqual(expect.any(String));
+        expect(reason?.length).toBeGreaterThan(0);
+      }
+    }
   });
 
   it('suppresses forbidden fallback categories on feed cards', () => {

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -4,7 +4,7 @@ import { db, feedDismissedDomains, feedItems, masteryEvents, questionFeedback, q
 import { writeActivity } from '@/server/activity/write-activity';
 import { getFriends } from '@/server/db/queries/friends';
 import { rollOffOldItems, userAnsweredQuestionCorrectly } from '@/server/db/queries/feed';
-import { isCorrectAnswerFeedEligible } from '@/server/feed/visibility';
+import { isCorrectAnswerFeedEligible, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 export async function createFeedItemsForFriendsFromAnswer(
   userId: string,
@@ -119,7 +119,7 @@ async function _createFeedItemsForFriendsFromAnswer(
     await db.insert(feedItems).values({
       recipientUserId: friend.id,
       questionId,
-      sourceType: 'friend_answered',
+      sourceType: SOCIAL_FEED_SOURCE_TYPE,
       sourceUserId: userId,
       sourceResult: result,
       sourceEventAt: new Date(),

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -1,12 +1,36 @@
-import type { questions } from '@/server/db';
+import { and, eq, or } from 'drizzle-orm';
+
+import type { feedItems, questions } from '@/server/db';
 
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
 export const AUTHORED_SHARED_FEED_SOURCE_TYPE = 'authored_shared' as const;
 export const DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent' as const;
 
+export const ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES = [
+  AUTHORED_SHARED_FEED_SOURCE_TYPE,
+  DIRECT_SENT_FEED_SOURCE_TYPE,
+] as const;
+
+export const RESULT_GATED_MAIN_FEED_SOURCE_TYPES = {
+  [SOCIAL_FEED_SOURCE_TYPE]: ['correct'],
+} as const;
+
+export const QUESTION_SHARING_FEED_SOURCE_VISIBILITY = [
+  { sourceType: AUTHORED_SHARED_FEED_SOURCE_TYPE, sourceResult: null, visible: true, reason: null },
+  { sourceType: DIRECT_SENT_FEED_SOURCE_TYPE, sourceResult: null, visible: true, reason: null },
+  { sourceType: SOCIAL_FEED_SOURCE_TYPE, sourceResult: 'correct', visible: true, reason: null },
+  {
+    sourceType: SOCIAL_FEED_SOURCE_TYPE,
+    sourceResult: 'incorrect',
+    visible: false,
+    reason: 'Incorrect answer shares are intentionally excluded so the main feed only amplifies successful friend activity.',
+  },
+] as const;
+
 const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown', 'general', 'general knowledge']);
 
 type QuestionLike = Pick<typeof questions.$inferSelect, 'creatorId' | 'visibility' | 'canonicalSubcategory' | 'broadCategory' | 'category' | 'deletedAt'>;
+type FeedItemsVisibilityColumns = Pick<typeof feedItems, 'sourceType' | 'sourceResult'>;
 
 export type FeedEventEligibilityInput = {
   answerIsCorrect: boolean;
@@ -25,10 +49,25 @@ export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): b
   return input.answererUserId !== input.question.creatorId;
 }
 
+export function isVisibleFriendAnsweredSource(sourceType: string, sourceResult: string | null): boolean {
+  return sourceType === SOCIAL_FEED_SOURCE_TYPE
+    && (RESULT_GATED_MAIN_FEED_SOURCE_TYPES[SOCIAL_FEED_SOURCE_TYPE] as readonly string[]).includes(sourceResult ?? '');
+}
+
 export function isMainFeedSourceVisible(sourceType: string, sourceResult: string | null): boolean {
-  if (sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE) return true;
-  if (sourceType === DIRECT_SENT_FEED_SOURCE_TYPE) return true;
-  return sourceType === SOCIAL_FEED_SOURCE_TYPE && sourceResult === 'correct';
+  if ((ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES as readonly string[]).includes(sourceType)) return true;
+  return isVisibleFriendAnsweredSource(sourceType, sourceResult);
+}
+
+export function visibleFeedSourcePredicate(feedItemColumns: FeedItemsVisibilityColumns) {
+  return or(
+    eq(feedItemColumns.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
+    eq(feedItemColumns.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
+    and(
+      eq(feedItemColumns.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+      eq(feedItemColumns.sourceResult, 'correct'),
+    ),
+  );
 }
 
 export function socialFeedDomainLabel(question: Pick<QuestionLike, 'canonicalSubcategory' | 'broadCategory' | 'category'> | null | undefined): string | null {


### PR DESCRIPTION
### Motivation
- Unify duplicated feed-source visibility logic so feed counts, queries, and API response logic use one canonical definition and avoid drift. 
- Make source-type constants re-usable by routes that insert feed rows and provide a small Drizzle predicate builder to avoid circular imports while allowing query composition.

### Description
- Added canonical source-type constants, a documented `QUESTION_SHARING_FEED_SOURCE_VISIBILITY` matrix, result-gated helpers, and a Drizzle predicate builder `visibleFeedSourcePredicate` in `src/server/feed/visibility.ts`.
- Replaced duplicated visibility predicates in `src/server/db/queries/feed.ts` and `src/app/api/feed/route.ts` to use the shared predicate (exposed as a function that accepts `feedItems` columns) and the friend-answer visibility helper `isVisibleFriendAnsweredSource`.
- Switched hardcoded source-type strings to the shared constants when creating feed rows in `src/app/api/questions/route.ts` and `src/server/feed/create-feed-items-for-answer.ts`.
- Added a test in `src/server/feed/__tests__/visibility.test.ts` that asserts every question-sharing source/result pair is either visible or intentionally excluded with a documented `reason`.

### Testing
- Ran TypeScript checks with `npx tsc --noEmit` which completed successfully.
- Ran ESLint against the modified files (`src/server/feed/visibility.ts`, `src/server/db/queries/feed.ts`, `src/app/api/feed/route.ts`, `src/app/api/questions/route.ts`, `src/server/feed/create-feed-items-for-answer.ts`, `src/server/feed/__tests__/visibility.test.ts`) which passed for those files.
- Attempted to run the unit test file with `npx vitest run src/server/feed/__tests__/visibility.test.ts` but the run was blocked due to missing local `vitest` installation / registry `403` error.
- Note: a full repo lint (`npm run lint`) surfaced unrelated existing lint errors outside the touched files and is not caused by these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0604bce248832e91968deb3d72fcfd)