### PR TITLE
Make knowledge-domain opening non-blocking for friend feed shares; add test

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -199,6 +199,40 @@ describe('POST /api/questions shareToFeed', () => {
     expect(state.questionUpdateValues).toContainEqual({ sharedToFriendsFeed: true })
   })
 
+  it('shares to friends before non-critical knowledge-domain opening can fail', async () => {
+    const consoleErrorMock = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
+    openKBDomainMock.mockRejectedValue(new Error('knowledge write failed'))
+
+    const response = await POST(questionRequest({ shareToFeed: true }))
+    const body = await response.json()
+
+    expect(response.status).toBe(201)
+    expect(body.feedShare).toEqual({
+      requested: true,
+      createdCount: 1,
+      friendCount: 1,
+      sharedRecipientIds: ['friend-1'],
+      skippedDismissedDomainRecipientIds: [],
+      skippedExistingFeedRecipientIds: [],
+    })
+    expect(body.openedDomain).toBeNull()
+    expect(state.feedInsertValues).toEqual([
+      expect.objectContaining({
+        recipientUserId: 'friend-1',
+        questionId: 'question-1',
+        sourceType: 'authored_shared',
+        sourceUserId: 'creator-1',
+        state: 'active',
+      }),
+    ])
+    expect(state.questionUpdateValues).toContainEqual({ sharedToFriendsFeed: true })
+    expect(consoleErrorMock).toHaveBeenCalledWith(
+      '[questions/create] openKBDomain failed after question save/share; continuing response',
+      expect.objectContaining({ questionId: 'question-1', userId: 'creator-1', error: 'knowledge write failed' }),
+    )
+  })
+
   it('does not require explicit recipient ids for all-friends sharing', async () => {
     getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
 

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -81,14 +81,6 @@ export async function POST(request: NextRequest) {
 
   const created = await createQuestion({ authorId: session.userId, ...categorizedQuestionFields });
   console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: categorizedQuestionFields.verified, category: categorizedQuestionFields.category, canonicalSubcategory: categorizedQuestionFields.canonicalSubcategory, difficultyTier: difficultyAssessment.tier });
-  const kbResult = await openKBDomain({
-    userId: session.userId,
-    domain: categorizedQuestionFields.canonicalSubcategory,
-    via: 'authorship',
-    broadCategory: categorizedQuestionFields.broadCategory,
-    questionId: created.id,
-  });
-  const question = await getQuestion(created.id, session.userId);
   const feedShare = {
     requested: shareToFeed,
     createdCount: 0,
@@ -218,12 +210,32 @@ export async function POST(request: NextRequest) {
     await db.update(questions).set({ sharedToFriendsFeed: true }).where(eq(questions.id, created.id));
   }
 
+  let openedDomain: string | null = null;
+  try {
+    const kbResult = await openKBDomain({
+      userId: session.userId,
+      domain: categorizedQuestionFields.canonicalSubcategory,
+      via: 'authorship',
+      broadCategory: categorizedQuestionFields.broadCategory,
+      questionId: created.id,
+    });
+    openedDomain = kbResult.opened ? categorizedQuestionFields.canonicalSubcategory : null;
+  } catch (error) {
+    console.error('[questions/create] openKBDomain failed after question save/share; continuing response', {
+      questionId: created.id,
+      userId: session.userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const question = await getQuestion(created.id, session.userId);
+
   return NextResponse.json(
     {
       ...created,
       question,
       ...(question ?? {}),
-      openedDomain: kbResult.opened ? categorizedQuestionFields.canonicalSubcategory : null,
+      openedDomain,
       feedShare,
     },
     { status: 201 },


### PR DESCRIPTION
### Motivation

- Ensure that sharing a question to friends' feeds succeeds even if the non-critical knowledge-base domain opening (`openKBDomain`) fails.

### Description

- Move the `openKBDomain` call to after the feed-sharing logic so feed inserts and question updates are not blocked by KB errors.
- Wrap the `openKBDomain` invocation in a `try/catch`, log failures with `console.error`, and expose an `openedDomain` variable that is `null` when opening fails.
- Update the JSON response to include `openedDomain` instead of relying on the earlier `kbResult` variable.
- Add a unit test `shares to friends before non-critical knowledge-domain opening can fail` to assert that sharing still returns `201`, that `feedShare` is populated, that `openedDomain` is `null` on error, and that a console error is emitted.

### Testing

- Ran the `src/app/api/questions/__tests__/route.test.ts` unit tests, including the new `shares to friends before non-critical knowledge-domain opening can fail` test, which verifies behavior when `openKBDomain` rejects; the tests passed.
- Executed the related route unit tests for feed sharing and question creation to ensure existing behavior is unchanged; they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0600ade040832e98a76377d61676a7)