### PR TITLE
Add feed visibility debug endpoint

### DIFF
--- a/src/app/api/feed/debug/route.ts
+++ b/src/app/api/feed/debug/route.ts
@@ -1,0 +1,124 @@
+import { and, desc, eq, isNull, or } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { db, feedDismissedDomains, feedItems, friendships, questions } from '@/server/db';
+import { isMainFeedSourceVisible } from '@/server/feed/visibility';
+
+export const dynamic = 'force-dynamic';
+
+type FeedDebugDiagnosis =
+  | 'no_feed_item_for_viewer'
+  | 'not_friends'
+  | 'domain_dismissed'
+  | 'question_deleted'
+  | 'question_not_public'
+  | 'feed_item_state_hidden'
+  | 'source_type_filtered'
+  | 'should_be_visible';
+
+const VISIBLE_FEED_STATES = new Set(['active', 'skipped']);
+
+function isFeedDebugEnabled() {
+  return process.env.NODE_ENV !== 'production' || process.env.FEED_DEBUG_ENABLED === 'true';
+}
+
+function diagnose(input: {
+  question: typeof questions.$inferSelect | null;
+  feedItem: typeof feedItems.$inferSelect | null;
+  friendshipStatus: string | null;
+  domainDismissed: boolean;
+  viewerUserId: string;
+}): FeedDebugDiagnosis {
+  const { question, feedItem, friendshipStatus, domainDismissed, viewerUserId } = input;
+
+  if (!feedItem) return 'no_feed_item_for_viewer';
+
+  const questionCreatorId = question?.creatorId ?? null;
+  if (questionCreatorId && questionCreatorId !== viewerUserId && friendshipStatus !== 'active') return 'not_friends';
+  if (domainDismissed) return 'domain_dismissed';
+  if (question?.deletedAt) return 'question_deleted';
+  if (question && question.visibility !== 'public') return 'question_not_public';
+  if (!VISIBLE_FEED_STATES.has(feedItem.state)) return 'feed_item_state_hidden';
+  if (!isMainFeedSourceVisible(feedItem.sourceType, feedItem.sourceResult)) return 'source_type_filtered';
+
+  return 'should_be_visible';
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  if (!isFeedDebugEnabled()) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const questionId = request.nextUrl.searchParams.get('question_id')?.trim();
+  if (!questionId) return NextResponse.json({ error: 'question_id_required' }, { status: 400 });
+
+  const [question, feedItem] = await Promise.all([
+    db.select().from(questions).where(eq(questions.id, questionId)).limit(1).then((rows) => rows[0] ?? null),
+    db
+      .select()
+      .from(feedItems)
+      .where(and(
+        eq(feedItems.recipientUserId, session.userId),
+        eq(feedItems.questionId, questionId),
+      ))
+      .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
+      .limit(1)
+      .then((rows) => rows[0] ?? null),
+  ]);
+
+  const questionCreatorId = question?.creatorId ?? null;
+  const [friendship, dismissedDomain] = await Promise.all([
+    questionCreatorId && questionCreatorId !== session.userId
+      ? db
+        .select({ status: friendships.status })
+        .from(friendships)
+        .where(or(
+          and(eq(friendships.userAId, session.userId), eq(friendships.userBId, questionCreatorId)),
+          and(eq(friendships.userAId, questionCreatorId), eq(friendships.userBId, session.userId)),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      : Promise.resolve(null),
+    question?.canonicalSubcategory
+      ? db
+        .select({ id: feedDismissedDomains.id })
+        .from(feedDismissedDomains)
+        .where(and(
+          eq(feedDismissedDomains.userId, session.userId),
+          eq(feedDismissedDomains.canonicalSubcategory, question.canonicalSubcategory),
+          isNull(feedDismissedDomains.reinstatedAt),
+        ))
+        .limit(1)
+        .then((rows) => rows[0] ?? null)
+      : Promise.resolve(null),
+  ]);
+
+  const friendshipStatus = friendship?.status ?? null;
+  const domainDismissed = Boolean(dismissedDomain);
+
+  return NextResponse.json({
+    viewerUserId: session.userId,
+    questionId,
+    questionExists: Boolean(question),
+    questionVisibility: question?.visibility ?? null,
+    questionDeletedAt: question?.deletedAt ?? null,
+    questionCreatorId,
+    friendshipStatus,
+    feedItemExists: Boolean(feedItem),
+    feedItemState: feedItem?.state ?? null,
+    feedItemSourceType: feedItem?.sourceType ?? null,
+    feedItemSourceResult: feedItem?.sourceResult ?? null,
+    domainDismissed,
+    diagnosis: diagnose({
+      question,
+      feedItem,
+      friendshipStatus,
+      domainDismissed,
+      viewerUserId: session.userId,
+    }),
+  });
+}


### PR DESCRIPTION
### Motivation

- Provide a developer-only endpoint to inspect why a given question may or may not appear in a viewer's feed. 
- Consolidate the visibility logic into a single diagnostic response for faster debugging of feed behavior.

### Description

- Add a new debug GET endpoint at `src/app/api/feed/debug/route.ts` that implements the diagnostic logic. 
- The route requires an authenticated session via `getSession()`, accepts `question_id` as a query param, and queries `Question`, `FeedItem`, `FeedDismissedDomain`, and `Friendship` for the current viewer and the specified question. 
- Returns a JSON payload including `viewerUserId`, `questionId`, `questionExists`, `questionVisibility`, `questionDeletedAt`, `questionCreatorId`, `friendshipStatus`, `feedItemExists`, `feedItemState`, `feedItemSourceType`, `feedItemSourceResult`, `domainDismissed`, and a `diagnosis` value. 
- The route is gated to non-production or enabled by the `FEED_DEBUG_ENABLED=true` env flag and contains a centralized diagnosis mapping with values: `no_feed_item_for_viewer`, `not_friends`, `domain_dismissed`, `question_deleted`, `question_not_public`, `feed_item_state_hidden`, `source_type_filtered`, and `should_be_visible`.

### Testing

- Ran `npx eslint src/app/api/feed/debug/route.ts` which succeeded for the new file. 
- Ran `npx tsc --noEmit --pretty false --incremental false` which completed without type errors. 
- Running the repo-wide lint script `npm run lint -- src/app/api/feed/debug/route.ts` reported pre-existing unrelated lint errors elsewhere in `src`, but the new route file itself passes the focused lint check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f0d321c832e94e39419f5ae14df)