### PR TITLE
Add structured feed debug logging

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -135,8 +135,31 @@ export async function GET(request: NextRequest) {
 
   const activeItemCount = feedPage.totalCount;
   const feed = feedPage.items;
+  const pageItemCount = feed.length;
   const nextCursor = encodeCursor(feedPage.nextCursor);
   const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
+  const verboseFeedDebug = process.env.FEED_DEBUG_VERBOSE === 'true';
+
+  console.info('[feed/get]', {
+    userId: session.userId,
+    limit,
+    cursorPresent: Boolean(cursor),
+    friendCount,
+    dismissedDomainCount: dismissedDomains.length,
+    totalItemCount,
+    preFilterActiveCount,
+    activeItemCount,
+    pageItemCount,
+    hasMore: feedPage.hasMore,
+    ...(verboseFeedDebug
+      ? {
+          items: feed.map((item) => ({
+            id: item.id,
+            sourceType: item.sourceType,
+          })),
+        }
+      : {}),
+  });
 
   const [questionRows, bankedById] = await Promise.all([
     questionIds.length
@@ -163,7 +186,7 @@ export async function GET(request: NextRequest) {
       total_item_count: totalItemCount,
       active_item_count: activeItemCount,
       pre_filter_active_count: preFilterActiveCount,
-      page_item_count: feed.length,
+      page_item_count: pageItemCount,
       limit,
       cursor: cursor ? encodeCursor(cursor) : null,
       next_cursor: nextCursor,


### PR DESCRIPTION
### Motivation

- Provide structured diagnostics for the feed endpoint to make debugging pagination, counts, and page metadata easier. 
- Avoid logging sensitive or verbose content by default while allowing enhanced inspection when needed via an env flag.

### Description

- Introduce `pageItemCount` computed from the feed page and reuse it in the JSON response metadata as `page_item_count`.
- Add `verboseFeedDebug = process.env.FEED_DEBUG_VERBOSE === 'true'` and emit a structured `console.info('[feed/get]', {...})` containing `userId`, `limit`, `cursorPresent`, `friendCount`, `dismissedDomainCount`, `totalItemCount`, `preFilterActiveCount`, `activeItemCount`, `pageItemCount`, and `hasMore`.
- Do not include full question text or friend recipient IDs in the log output by default.
- When `FEED_DEBUG_VERBOSE=true`, include only minimal per-item info (`id` and `sourceType`) in the log to assist deeper debugging without exposing question text or recipient IDs.

### Testing

- Ran `npx eslint src/app/api/feed/route.ts`, which passed for the modified file.
- Ran `npm run lint`, which still fails due to pre-existing unrelated lint errors elsewhere in the repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f14d8ac832e8b26529702a6611e)