### PR TITLE
Log safe question create payload diagnostics

### DIFF
--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -41,6 +41,19 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json().catch(() => null) as Record<string, unknown> | null;
   const { value, errors } = readCreateQuestionPayload(body);
+  console.info('[questions/createPayload]', {
+    userId: session.userId,
+    hasErrors: errors.length > 0,
+    shareToFeed: value.shareToFeed,
+    sendToFriendCount: value.sendToFriendIds.length,
+    payloadShareKeysPresent: {
+      shareToFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareToFeed'),
+      shareWithFriends: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareWithFriends'),
+      share_with_friends: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_with_friends'),
+      share_to_feed: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_to_feed'),
+      sharedToFriendsFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'sharedToFriendsFeed'),
+    },
+  });
   if (errors.length > 0) {
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }


### PR DESCRIPTION
### Motivation
- Add a safe diagnostic immediately after payload parsing to help confirm whether create requests that later fail entered the share branch without logging sensitive question or answer content.

### Description
- Log a `[questions/createPayload]` object right after `readCreateQuestionPayload(body)` that includes `userId`, `hasErrors`, `shareToFeed`, `sendToFriendCount`, and `payloadShareKeysPresent` booleans for `shareToFeed`, `shareWithFriends`, `share_with_friends`, `share_to_feed`, and `sharedToFriendsFeed`, while avoiding any question text or answer data.

### Testing
- Ran `npx eslint src/app/api/questions/route.ts` which succeeded for the modified file, and ran `npm run lint` which failed due to pre-existing lint errors in unrelated files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060f1aaa54832e89dd8f7a6d4fc2a4)