### PR TITLE
Log question create payload sharing intent

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -200,12 +200,15 @@ describe('POST /api/questions shareToFeed', () => {
   })
 
   it('creates feed rows for legacy share-with-friends payload flags', async () => {
+    const consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
 
     const response = await POST(questionRequest({ share_with_friends: 'true' }))
     const body = await response.json()
+    const createPayloadLogCall = consoleInfoMock.mock.calls.find(([label]) => label === '[questions/createPayload]')
 
     expect(response.status).toBe(201)
+    expect(createPayloadLogCall?.[1]).toEqual(expect.objectContaining({ shareToFeed: true }))
     expect(body.feedShare).toEqual({
       requested: true,
       createdCount: 1,

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -41,6 +41,19 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json().catch(() => null) as Record<string, unknown> | null;
   const { value, errors } = readCreateQuestionPayload(body);
+  console.info('[questions/createPayload]', {
+    userId: session.userId,
+    hasErrors: errors.length > 0,
+    shareToFeed: value.shareToFeed,
+    sendToFriendCount: value.sendToFriendIds.length,
+    payloadShareKeysPresent: {
+      shareToFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareToFeed'),
+      shareWithFriends: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareWithFriends'),
+      share_with_friends: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_with_friends'),
+      share_to_feed: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_to_feed'),
+      sharedToFriendsFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'sharedToFriendsFeed'),
+    },
+  });
   if (errors.length > 0) {
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }


### PR DESCRIPTION
### Motivation
- Capture parsed sharing intent and minimal diagnostics immediately after payload parsing so parsed intent can be compared with later share creation logs while avoiding sensitive content.

### Description
- Add a redacted info log `console.info('[questions/createPayload]', ...)` immediately after `readCreateQuestionPayload` that records `userId`, `hasErrors`, `shareToFeed`, `sendToFriendCount`, and `payloadShareKeysPresent` booleans for `shareToFeed`, `shareWithFriends`, `share_with_friends`, `share_to_feed`, and `sharedToFriendsFeed` without logging question text, answer text, or recipient IDs in `src/app/api/questions/route.ts`.
- Preserve the existing `[questions/shareToFeed]` log so parsed intent can be compared to created feed rows.
- Add a route test in `src/app/api/questions/__tests__/route.test.ts` that spies on `console.info` and asserts the create-payload log includes `shareToFeed: true` when posting `share_with_friends: 'true'`.

### Testing
- Ran `npx tsc --noEmit` which succeeded for the change set.
- Ran targeted lint `npx eslint src/app/api/questions/route.ts src/app/api/questions/__tests__/route.test.ts --ext .ts` which succeeded for the modified files.
- Attempted `npx vitest run src/app/api/questions/__tests__/route.test.ts` but it was blocked because `vitest` is not installed/registry access returned `403 Forbidden` so tests could not be executed end-to-end in this environment.
- Running the full repo lint (`npm run lint`) was blocked by pre-existing lint errors outside the touched files and was not used to validate this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060fcf97d8832eb5650a77b899f595)