### PR TITLE
Add feed GET diagnostics

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -133,6 +133,29 @@ export async function GET(request: NextRequest) {
       .then((rows) => rows[0]?.value ?? 0),
   ]);
 
+  const verboseFeedDebug = process.env.FEED_DEBUG_VERBOSE === 'true';
+
+  console.info('[feed/get]', {
+    userId: session.userId,
+    limit,
+    cursorPresent: Boolean(cursor),
+    friendCount,
+    dismissedDomainCount: dismissedDomains.length,
+    totalItemCount,
+    preFilterActiveCount,
+    activeItemCount: feedPage.totalCount,
+    pageItemCount: feedPage.items.length,
+    hasMore: feedPage.hasMore,
+    ...(verboseFeedDebug
+      ? {
+          preview: feedPage.items.map((item) => ({
+            id: item.id,
+            sourceType: item.sourceType,
+          })),
+        }
+      : {}),
+  });
+
   const activeItemCount = feedPage.totalCount;
   const feed = feedPage.items;
   const nextCursor = encodeCursor(feedPage.nextCursor);


### PR DESCRIPTION
### Motivation
- Provide structured server-side diagnostics for the feed GET path immediately after pagination/count metrics are computed to make feed behavior easier to debug without exposing sensitive details.
- Keep default logs compact and privacy-preserving by omitting question text and friend IDs while allowing optional verbose previews when `FEED_DEBUG_VERBOSE=true`.

### Description
- Insert a `console.info('[feed/get]', { ... })` call in `src/app/api/feed/route.ts` after `feedPage`, `friendCount`, `dismissedDomains`, `totalItemCount`, and `preFilterActiveCount` are resolved.
- Log `userId`, `limit`, `cursorPresent`, `friendCount`, `dismissedDomainCount`, `totalItemCount`, `preFilterActiveCount`, `activeItemCount`, `pageItemCount`, and `hasMore` in a structured object.
- Add optional verbose preview controlled by `process.env.FEED_DEBUG_VERBOSE === 'true'` that includes only feed item `id` and `sourceType` for diagnostics, and do not log question text or friend IDs by default.

### Testing
- Ran `npx eslint src/app/api/feed/route.ts`, which passed for the modified file.
- Ran `npm run lint`, which failed due to pre-existing lint errors in unrelated files outside the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a060fd2632c832eb9c1799c0390c545)