### PR TITLE
Fix duplicate feed debug declaration

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -133,29 +133,6 @@ export async function GET(request: NextRequest) {
       .then((rows) => rows[0]?.value ?? 0),
   ]);
 
-  const verboseFeedDebug = process.env.FEED_DEBUG_VERBOSE === 'true';
-
-  console.info('[feed/get]', {
-    userId: session.userId,
-    limit,
-    cursorPresent: Boolean(cursor),
-    friendCount,
-    dismissedDomainCount: dismissedDomains.length,
-    totalItemCount,
-    preFilterActiveCount,
-    activeItemCount: feedPage.totalCount,
-    pageItemCount: feedPage.items.length,
-    hasMore: feedPage.hasMore,
-    ...(verboseFeedDebug
-      ? {
-          preview: feedPage.items.map((item) => ({
-            id: item.id,
-            sourceType: item.sourceType,
-          })),
-        }
-      : {}),
-  });
-
   const activeItemCount = feedPage.totalCount;
   const feed = feedPage.items;
   const pageItemCount = feed.length;


### PR DESCRIPTION
### Motivation
- Prevent a Turbopack build error caused by declaring `verboseFeedDebug` twice in `src/app/api/feed/route.ts`, which produced the error "the name `verboseFeedDebug` is defined multiple times." 

### Description
- Removed the earlier redundant `verboseFeedDebug` declaration and its associated preliminary debug log so the route only declares `verboseFeedDebug` once and retains the consolidated `[feed/get]` log after pagination values are derived.

### Testing
- Ran `npx eslint src/app/api/feed/route.ts`, which completed successfully for the modified file. 
- Ran `git diff --check`, which reported no whitespace/format issues. 
- Attempted `npm run build`, which failed in this environment because Next.js/Turbopack could not fetch the Montserrat Google Font from `fonts.googleapis.com`. 
- Ran the repo-wide `npm run lint`, which failed due to pre-existing unrelated lint errors elsewhere in the repository.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06136b25cc832ebd2fb9a071c895f4)