### PR TITLE
Log parsed question share payload intent

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -199,16 +199,32 @@ describe('POST /api/questions shareToFeed', () => {
     expect(state.questionUpdateValues).toContainEqual({ sharedToFriendsFeed: true })
   })
 
-  it('creates feed rows for legacy share-with-friends payload flags', async () => {
+  it('logs parsed shareToFeed intent and creates feed rows for legacy share-with-friends payload flags', async () => {
     const consoleInfoMock = vi.spyOn(console, 'info').mockImplementation(() => undefined)
     getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
 
     const response = await POST(questionRequest({ share_with_friends: 'true' }))
     const body = await response.json()
     const createPayloadLogCall = consoleInfoMock.mock.calls.find(([label]) => label === '[questions/createPayload]')
+    const createPayloadLog = createPayloadLogCall?.[1]
 
     expect(response.status).toBe(201)
-    expect(createPayloadLogCall?.[1]).toEqual(expect.objectContaining({ shareToFeed: true }))
+    expect(createPayloadLog).toEqual(expect.objectContaining({
+      userId: 'creator-1',
+      hasErrors: false,
+      shareToFeed: true,
+      sendToFriendCount: 0,
+      payloadShareKeysPresent: {
+        shareToFeed: false,
+        shareWithFriends: false,
+        share_with_friends: true,
+        share_to_feed: false,
+        sharedToFriendsFeed: false,
+      },
+    }))
+    expect(createPayloadLog).not.toHaveProperty('text')
+    expect(createPayloadLog).not.toHaveProperty('correctAnswer')
+    expect(createPayloadLog).not.toHaveProperty('sendToFriendIds')
     expect(body.feedShare).toEqual({
       requested: true,
       createdCount: 1,

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -28,6 +28,10 @@ function shouldIncludeShareRecipientDiagnostics() {
   return process.env.NODE_ENV !== 'production' || process.env.SHARE_TO_FEED_DEBUG_RECIPIENT_IDS === 'true';
 }
 
+function hasPayloadKey(body: Record<string, unknown> | null, key: string) {
+  return Object.prototype.hasOwnProperty.call(body ?? {}, key);
+}
+
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -47,11 +51,11 @@ export async function POST(request: NextRequest) {
     shareToFeed: value.shareToFeed,
     sendToFriendCount: value.sendToFriendIds.length,
     payloadShareKeysPresent: {
-      shareToFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareToFeed'),
-      shareWithFriends: Object.prototype.hasOwnProperty.call(body ?? {}, 'shareWithFriends'),
-      share_with_friends: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_with_friends'),
-      share_to_feed: Object.prototype.hasOwnProperty.call(body ?? {}, 'share_to_feed'),
-      sharedToFriendsFeed: Object.prototype.hasOwnProperty.call(body ?? {}, 'sharedToFriendsFeed'),
+      shareToFeed: hasPayloadKey(body, 'shareToFeed'),
+      shareWithFriends: hasPayloadKey(body, 'shareWithFriends'),
+      share_with_friends: hasPayloadKey(body, 'share_with_friends'),
+      share_to_feed: hasPayloadKey(body, 'share_to_feed'),
+      sharedToFriendsFeed: hasPayloadKey(body, 'sharedToFriendsFeed'),
     },
   });
   if (errors.length > 0) {


### PR DESCRIPTION
### Motivation
- Make question-creation diagnostics safe and actionable by logging parsed share intent and which legacy payload keys were present without exposing question/answer text or recipient IDs.

### Description
- Add `hasPayloadKey` helper and use it in the `[questions/createPayload]` `console.info` to report `userId`, `hasErrors`, `shareToFeed`, `sendToFriendCount`, and booleans for share-related payload keys (`shareToFeed`, `shareWithFriends`, `share_with_friends`, `share_to_feed`, `sharedToFriendsFeed`).
- Preserve the existing `[questions/shareToFeed]` log that reports created feed rows and recipient diagnostics.
- Update the route test for legacy `share_with_friends: 'true'` to assert the create-payload log includes `shareToFeed: true`, includes the expected `payloadShareKeysPresent` booleans, and does not contain `text`, `correctAnswer`, or `sendToFriendIds`.

### Testing
- Ran `./node_modules/.bin/eslint src/app/api/questions/route.ts src/app/api/questions/__tests__/route.test.ts` which completed for the targeted files (no errors reported for those files).
- Ran `./node_modules/.bin/tsc --noEmit --pretty false` which succeeded with no type errors.
- Ran `git diff --check` which reported no repository diff issues.
- Attempted `npx vitest run src/app/api/questions/__tests__/route.test.ts` but it failed to run because `vitest` was not available via the registry (npm returned `403`), so the unit test runner could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06204d933c832e82f4e8222303448a)