### PR TITLE
Build typed Feed card system and Feed page shell

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -5,14 +5,11 @@ export default function FeedPage() {
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24 md:py-10">
       <section className="space-y-6">
         <div>
-          <p className="text-muted-foreground text-xs font-medium tracking-[0.12em] uppercase">
+          <h1 className="text-foreground text-4xl leading-tight font-semibold tracking-[-0.02em] md:text-5xl">
             Feed
-          </p>
-          <h1 className="text-foreground mt-3 font-serif text-4xl leading-tight font-semibold md:text-5xl">
-            What&apos;s happening
           </h1>
-          <p className="text-muted-foreground mt-4 max-w-xl text-base leading-7">
-            Keep up with the moments where your friends recognize each other&apos;s questions.
+          <p className="text-muted-foreground mt-3 max-w-xl text-base leading-7">
+            Questions your friends thought you&apos;d like.
           </p>
         </div>
         <FeedList />

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,209 +1,336 @@
-'use client';
+'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
-import { Send, SkipForward, X } from 'lucide-react';
-
-import { AddToBankAction } from '@/components/AddToBankAction';
-import { SendQuestionAction } from '@/components/SendQuestionAction';
-import { QuestionReactionPrompt } from '@/components/play/GameplayChat';
-import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import Link from 'next/link'
+import {
+  AnsweredByYouCard,
+  AnswerForm,
+  DirectSentCard,
+  FriendAddedCard,
+  FriendAnsweredCard,
+  FriendLikedCard,
+  UnansweredFeedActions,
+  type AnsweredByYouFeedItem,
+  type DirectSentFeedItem,
+  type FriendAddedFeedItem,
+  type FriendAnsweredFeedItem,
+  type FriendLikedFeedItem,
+} from '@/components/feed'
 
 type FriendResult = {
-  userId: string;
-  displayName: string;
-  result: 'correct' | 'incorrect' | null;
-};
-
-type FeedApiItem = {
-  id: string;
-  kind: 'question';
-  question_id: string | null;
-  source_type: string;
-  source_user_id: string;
-  source_friend_display_name: string;
-  source_attribution: string;
-  source_result: 'correct' | 'incorrect' | null;
-  friend_results: FriendResult[] | null;
-  source_event_at: string;
-  personal_message: string | null;
-  state: string;
-  is_pinned: boolean;
-  question_text: string | null;
-  verified: boolean;
-  is_in_bank: boolean;
-  domain_pill: string | null;
-  difficulty: string | null;
-};
-
-type FeedMeta = {
-  has_friends: boolean;
-  has_dismissed_domains: boolean;
-  total_item_count: number;
-  active_item_count: number;
-  pre_filter_active_count: number;
-  page_item_count?: number;
-  limit?: number;
-  cursor?: string | null;
-  next_cursor?: string | null;
-  has_more?: boolean;
-};
-
-type FeedResponse = {
-  viewer_user_id: string;
-  meta?: FeedMeta;
-  next_cursor?: string | null;
-  has_more?: boolean;
-  items: FeedApiItem[];
-};
-
-type CeremonyBanner = {
-  id: string;
-  firedAt: string;
-};
-
-type AnswerResponse = {
-  correct?: boolean;
-  isCorrect?: boolean;
-  answer?: string;
-  correctAnswer?: string;
-  explanation?: string | null;
-  quip?: string | null;
-  consolation?: string | null;
-  breadcrumb?: string | null;
-};
-
-type ResultState = {
-  correct: boolean;
-  answer: string;
-  explanation: string | null;
-  quip: string | null;
-  breadcrumb: string | null;
-};
-
-function formatEventTime(value: string) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) return '';
-  return new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' }).format(date);
+  userId: string
+  displayName: string
+  result: 'correct' | 'incorrect' | null
 }
 
-function comparisonCopy(playerCorrect: boolean, friendResults: FriendResult[] | null): string {
-  const primaryFriend = friendResults?.[0];
-  const friendName = primaryFriend?.displayName ?? 'They';
-  const friendCorrect = primaryFriend?.result === 'correct';
+type FeedApiItem = {
+  id: string
+  kind: 'question'
+  question_id: string | null
+  source_type: string
+  source_user_id: string
+  source_friend_display_name: string
+  source_attribution: string
+  source_result: 'correct' | 'incorrect' | null
+  friend_results: FriendResult[] | null
+  source_event_at: string
+  personal_message: string | null
+  state: string
+  is_pinned: boolean
+  question_text: string | null
+  verified: boolean
+  is_in_bank: boolean
+  domain_pill: string | null
+  difficulty: string | null
+}
 
-  if (playerCorrect && friendCorrect) return 'You both had it.';
-  if (playerCorrect && !friendCorrect) return `You found a connection ${friendName} missed.`;
-  if (!playerCorrect && friendCorrect) return `${friendName} recognized this one. You might next time.`;
-  return 'This one is still waiting for common ground.';
+type FeedMeta = {
+  has_friends: boolean
+  has_dismissed_domains: boolean
+  total_item_count: number
+  active_item_count: number
+  pre_filter_active_count: number
+  page_item_count?: number
+  limit?: number
+  cursor?: string | null
+  next_cursor?: string | null
+  has_more?: boolean
+}
+
+type FeedResponse = {
+  viewer_user_id: string
+  meta?: FeedMeta
+  next_cursor?: string | null
+  has_more?: boolean
+  items: FeedApiItem[]
+}
+
+type CeremonyBanner = {
+  id: string
+  firedAt: string
+}
+
+type AnswerResponse = {
+  correct?: boolean
+  isCorrect?: boolean
+  answer?: string
+  correctAnswer?: string
+  explanation?: string | null
+  quip?: string | null
+  consolation?: string | null
+  breadcrumb?: string | null
+}
+
+type ResultState = {
+  correct: boolean
+  answer: string
+  explanation: string | null
+  quip: string | null
+  breadcrumb: string | null
+}
+
+function formatEventTime(value: string) {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return ''
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date)
+}
+
+function comparisonCopy(
+  playerCorrect: boolean,
+  friendResults: FriendResult[] | null
+): string {
+  const primaryFriend = friendResults?.[0]
+  const friendName = primaryFriend?.displayName ?? 'They'
+  const friendCorrect = primaryFriend?.result === 'correct'
+
+  if (playerCorrect && friendCorrect) return 'You both had it.'
+  if (playerCorrect && !friendCorrect)
+    return `You found a connection ${friendName} missed.`
+  if (!playerCorrect && friendCorrect)
+    return `${friendName} recognized this one. You might next time.`
+  return 'This one is still waiting for common ground.'
+}
+
+function feedMetadata(item: FeedApiItem) {
+  const time = formatEventTime(item.source_event_at)
+  return time ? `${item.source_attribution} · ${time}` : item.source_attribution
+}
+
+function baseTypedFields(item: FeedApiItem) {
+  return {
+    id: item.id,
+    metadata: feedMetadata(item),
+    category: item.domain_pill,
+    question: item.question_text ?? 'Untitled question',
+    personalMessage: item.personal_message,
+  }
+}
+
+function friendAnsweredSummary(item: FeedApiItem) {
+  const primaryFriend = item.friend_results?.[0]
+  const friendName =
+    primaryFriend?.displayName ?? item.source_friend_display_name
+
+  if (primaryFriend?.result === 'correct' || item.source_result === 'correct') {
+    return `${friendName} recognized this one. See if you share the same common ground.`
+  }
+
+  return `${friendName} answered this question.`
+}
+
+function toTypedFeedItem(item: FeedApiItem) {
+  const base = baseTypedFields(item)
+
+  if (item.source_type === 'direct_sent') {
+    return {
+      ...base,
+      type: 'direct_sent' as const,
+      senderName: item.source_friend_display_name,
+    } satisfies DirectSentFeedItem
+  }
+
+  if (item.source_type === 'authored_shared') {
+    return {
+      ...base,
+      type: 'friend_added' as const,
+      friendName: item.source_friend_display_name,
+    } satisfies FriendAddedFeedItem
+  }
+
+  if (item.source_type === 'thumbs_upped') {
+    return {
+      ...base,
+      type: 'friend_liked' as const,
+      friendName: item.source_friend_display_name,
+    } satisfies FriendLikedFeedItem
+  }
+
+  return {
+    ...base,
+    type: 'friend_answered' as const,
+    friendName:
+      item.friend_results?.[0]?.displayName ?? item.source_friend_display_name,
+    friendCorrect:
+      item.friend_results?.[0]?.result === 'correct' ||
+      item.source_result === 'correct',
+    answerSummary: friendAnsweredSummary(item),
+  } satisfies FriendAnsweredFeedItem
+}
+
+function toAnsweredByYouItem(
+  item: FeedApiItem,
+  result?: ResultState
+): AnsweredByYouFeedItem {
+  return {
+    ...baseTypedFields(item),
+    type: 'answered_by_you',
+    resultLabel: 'Answered by you',
+    answerSummary: result
+      ? comparisonCopy(result.correct, item.friend_results)
+      : 'You have already answered this question.',
+  }
 }
 
 type FeedListProps = {
-  pageSize?: number;
-  infinite?: boolean;
-};
+  pageSize?: number
+  infinite?: boolean
+}
 
-type QuestionCardState = 'unanswered' | 'answered' | 'reacted';
+type QuestionCardState = 'unanswered' | 'answering' | 'answered' | 'reacted'
 
-export default function FeedList({ pageSize = 20, infinite = false }: FeedListProps) {
-  const sentinelRef = useRef<HTMLDivElement | null>(null);
-  const [items, setItems] = useState<FeedApiItem[]>([]);
-  const [nextCursor, setNextCursor] = useState<string | null>(null);
-  const [hasMore, setHasMore] = useState(false);
-  const [loadingInitial, setLoadingInitial] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
-  const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null);
-  const [viewerId, setViewerId] = useState<string | null>(null);
-  const [answers, setAnswers] = useState<Record<string, string>>({});
-  const [results, setResults] = useState<Record<string, ResultState>>({});
-  const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({});
-  const [toasts, setToasts] = useState<Record<string, string>>({});
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(null);
+export default function FeedList({
+  pageSize = 20,
+  infinite = false,
+}: FeedListProps) {
+  const sentinelRef = useRef<HTMLDivElement | null>(null)
+  const [items, setItems] = useState<FeedApiItem[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [hasMore, setHasMore] = useState(false)
+  const [loadingInitial, setLoadingInitial] = useState(true)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null)
+  const [answers, setAnswers] = useState<Record<string, string>>({})
+  const [results, setResults] = useState<Record<string, ResultState>>({})
+  const [cardStates, setCardStates] = useState<
+    Record<string, QuestionCardState>
+  >({})
+  const [busyId, setBusyId] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(
+    null
+  )
 
-  const loadFeed = useCallback(async (cursor?: string | null) => {
-    const isNextPage = Boolean(cursor);
-    if (isNextPage) setLoadingMore(true);
-    else setLoadingInitial(true);
-    setError(null);
+  const loadFeed = useCallback(
+    async (cursor?: string | null) => {
+      const isNextPage = Boolean(cursor)
+      if (isNextPage) setLoadingMore(true)
+      else setLoadingInitial(true)
+      setError(null)
 
-    try {
-      const search = new URLSearchParams({ limit: String(pageSize) });
-      if (cursor) search.set('cursor', cursor);
+      try {
+        const search = new URLSearchParams({ limit: String(pageSize) })
+        if (cursor) search.set('cursor', cursor)
 
-      const response = await fetch(`/api/feed?${search.toString()}`, { cache: 'no-store', credentials: 'include' });
-      const body = await response.json().catch(() => null) as FeedResponse | { message?: string; error?: string } | null;
-      if (!response.ok || !body || !('items' in body)) {
-        const message = (body as { message?: string; error?: string } | null)?.message
-          ?? (body as { message?: string; error?: string } | null)?.error
-          ?? 'Could not load your Feed.';
-        throw new Error(message);
+        const response = await fetch(`/api/feed?${search.toString()}`, {
+          cache: 'no-store',
+          credentials: 'include',
+        })
+        const body = (await response.json().catch(() => null)) as
+          | FeedResponse
+          | { message?: string; error?: string }
+          | null
+        if (!response.ok || !body || !('items' in body)) {
+          const message =
+            (body as { message?: string; error?: string } | null)?.message ??
+            (body as { message?: string; error?: string } | null)?.error ??
+            'Could not load your Feed.'
+          throw new Error(message)
+        }
+
+        setFeedMeta(body.meta ?? null)
+        setItems((current) =>
+          isNextPage ? [...current, ...body.items] : body.items
+        )
+        setNextCursor(body.next_cursor ?? body.meta?.next_cursor ?? null)
+        setHasMore(Boolean(body.has_more ?? body.meta?.has_more))
+
+        if (!isNextPage) {
+          const bannerResponse = await fetch('/api/ceremony/banner', {
+            cache: 'no-store',
+            credentials: 'include',
+          })
+          const bannerBody = (await bannerResponse
+            .json()
+            .catch(() => null)) as { ceremony?: CeremonyBanner | null } | null
+          setCeremonyBanner(
+            bannerResponse.ok ? (bannerBody?.ceremony ?? null) : null
+          )
+        }
+      } catch (caught) {
+        setError(
+          caught instanceof Error ? caught.message : 'Could not load your Feed.'
+        )
+      } finally {
+        setLoadingInitial(false)
+        setLoadingMore(false)
       }
-
-      setViewerId(body.viewer_user_id);
-      setFeedMeta(body.meta ?? null);
-      setItems((current) => (isNextPage ? [...current, ...body.items] : body.items));
-      setNextCursor(body.next_cursor ?? body.meta?.next_cursor ?? null);
-      setHasMore(Boolean(body.has_more ?? body.meta?.has_more));
-
-      if (!isNextPage) {
-        const bannerResponse = await fetch('/api/ceremony/banner', { cache: 'no-store', credentials: 'include' });
-        const bannerBody = await bannerResponse.json().catch(() => null) as { ceremony?: CeremonyBanner | null } | null;
-        setCeremonyBanner(bannerResponse.ok ? bannerBody?.ceremony ?? null : null);
-      }
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not load your Feed.');
-    } finally {
-      setLoadingInitial(false);
-      setLoadingMore(false);
-    }
-  }, [pageSize]);
+    },
+    [pageSize]
+  )
 
   useEffect(() => {
     const timer = window.setTimeout(() => {
-      void loadFeed();
-    }, 0);
-    return () => window.clearTimeout(timer);
-  }, [loadFeed]);
+      void loadFeed()
+    }, 0)
+    return () => window.clearTimeout(timer)
+  }, [loadFeed])
 
-  const visibleItems = items;
+  const visibleItems = items
 
   useEffect(() => {
-    if (!infinite || !hasMore || loadingInitial || loadingMore || !nextCursor) return;
+    if (!infinite || !hasMore || loadingInitial || loadingMore || !nextCursor)
+      return
 
-    const sentinelNode = sentinelRef.current;
-    if (!sentinelNode) return;
+    const sentinelNode = sentinelRef.current
+    if (!sentinelNode) return
 
-    if (!('IntersectionObserver' in window)) return;
+    if (!('IntersectionObserver' in window)) return
 
     const observer = new IntersectionObserver(
       (entries) => {
         if (entries.some((entry) => entry.isIntersecting)) {
-          void loadFeed(nextCursor);
+          void loadFeed(nextCursor)
         }
       },
-      { rootMargin: '320px 0px' },
-    );
+      { rootMargin: '320px 0px' }
+    )
 
-    observer.observe(sentinelNode);
-    return () => observer.disconnect();
-  }, [hasMore, infinite, loadFeed, loadingInitial, loadingMore, nextCursor]);
+    observer.observe(sentinelNode)
+    return () => observer.disconnect()
+  }, [hasMore, infinite, loadFeed, loadingInitial, loadingMore, nextCursor])
 
   const emptyCopy = useMemo(() => {
-    if (loadingInitial) return 'Loading your Feed...';
-    if (error) return error;
-    if (!feedMeta?.has_friends) return "When friends recognize each other’s questions, those moments will appear here.";
+    if (loadingInitial) return 'Loading your Feed...'
+    if (error) return error
+    if (!feedMeta?.has_friends)
+      return 'When friends recognize each other’s questions, those moments will appear here.'
     // pre_filter_active_count > 0 means items exist in active/skipped state but are hidden by domain filters
-    if (feedMeta.has_dismissed_domains && feedMeta.pre_filter_active_count > 0) {
-      return "You've focused your Feed. You can re-open domains from your Knowledge page.";
+    if (
+      feedMeta.has_dismissed_domains &&
+      feedMeta.pre_filter_active_count > 0
+    ) {
+      return "You've focused your Feed. You can re-open domains from your Knowledge page."
     }
-    if (feedMeta.total_item_count > 0) return "You're caught up. Answer questions to reveal more common ground.";
-    return "Answer questions to reveal common ground.";
-  }, [error, feedMeta, loadingInitial]);
+    if (feedMeta.total_item_count > 0)
+      return "You're caught up. Answer questions to reveal more common ground."
+    return 'Answer questions to reveal common ground.'
+  }, [error, feedMeta, loadingInitial])
 
   const emptyDiagnostics = useMemo(() => {
-    if (process.env.NODE_ENV === 'production' || !feedMeta) return null;
+    if (process.env.NODE_ENV === 'production' || !feedMeta) return null
 
     return [
       `has_friends=${String(feedMeta.has_friends)}`,
@@ -216,96 +343,92 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
       `cursor=${feedMeta.cursor ?? 'none'}`,
       `next_cursor=${nextCursor ?? 'none'}`,
       `has_more=${String(hasMore)}`,
-    ].join(' · ');
-  }, [feedMeta, hasMore, items.length, nextCursor, pageSize]);
-
-  const showToast = useCallback((itemId: string, message: string) => {
-    setToasts((t) => ({ ...t, [itemId]: message }));
-    setTimeout(() => setToasts((t) => { const next = { ...t }; delete next[itemId]; return next; }), 3000);
-  }, []);
+    ].join(' · ')
+  }, [feedMeta, hasMore, items.length, nextCursor, pageSize])
 
   const removeItem = useCallback((itemId: string) => {
-    setItems((current) => current.filter((item) => item.id !== itemId));
-  }, []);
+    setItems((current) => current.filter((item) => item.id !== itemId))
+  }, [])
 
-  const updateState = useCallback(async (itemId: string, state: 'skipped' | 'dismissed') => {
-    setBusyId(itemId);
-    setError(null);
-    try {
-      const response = await fetch(`/api/feed/${itemId}/state`, {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ state }),
-      });
-      if (!response.ok) {
-        const body = await response.json().catch(() => null);
-        throw new Error(body?.message ?? 'Could not update that Feed item.');
+  const updateState = useCallback(
+    async (itemId: string, state: 'skipped' | 'dismissed') => {
+      setBusyId(itemId)
+      setError(null)
+      try {
+        const response = await fetch(`/api/feed/${itemId}/state`, {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ state }),
+        })
+        if (!response.ok) {
+          const body = await response.json().catch(() => null)
+          throw new Error(body?.message ?? 'Could not update that Feed item.')
+        }
+        removeItem(itemId)
+      } catch (caught) {
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : 'Could not update that Feed item.'
+        )
+      } finally {
+        setBusyId(null)
       }
-      removeItem(itemId);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not update that Feed item.');
-    } finally {
-      setBusyId(null);
-    }
-  }, [removeItem]);
+    },
+    [removeItem]
+  )
 
-  const dismissDomain = useCallback(async (itemId: string, domain: string) => {
-    setBusyId(itemId);
-    try {
-      const response = await fetch('/api/feed/dismiss-domain', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ domain }),
-      });
-      if (!response.ok) {
-        const body = await response.json().catch(() => null);
-        throw new Error(body?.message ?? 'Could not dismiss domain.');
+  const submitAnswer = useCallback(
+    async (item: FeedApiItem) => {
+      const submitted = answers[item.id]?.trim()
+      if (!submitted) return
+      setBusyId(item.id)
+      setError(null)
+      try {
+        const response = await fetch(`/api/feed/${item.id}/answer`, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ submitted_answer: submitted }),
+        })
+        const body = (await response.json().catch(() => null)) as
+          | AnswerResponse
+          | { message?: string }
+          | null
+        if (
+          !response.ok ||
+          !body ||
+          !('correct' in body || 'isCorrect' in body)
+        ) {
+          throw new Error(
+            (body as { message?: string } | null)?.message ??
+              'Could not submit that answer.'
+          )
+        }
+        setResults((current) => ({
+          ...current,
+          [item.id]: {
+            correct: Boolean(body.correct ?? body.isCorrect),
+            answer: body.answer ?? body.correctAnswer ?? '',
+            explanation: body.explanation ?? null,
+            quip: body.quip ?? body.consolation ?? null,
+            breadcrumb: body.breadcrumb ?? null,
+          },
+        }))
+        setCardStates((s) => ({ ...s, [item.id]: 'answered' }))
+      } catch (caught) {
+        setError(
+          caught instanceof Error
+            ? caught.message
+            : 'Could not submit that answer.'
+        )
+      } finally {
+        setBusyId(null)
       }
-      // Remove all items with this domain from local state
-      setItems((current) => current.filter((item) => item.domain_pill !== domain));
-      showToast(itemId, `Got it. No more ${domain} questions.`);
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not dismiss domain.');
-    } finally {
-      setBusyId(null);
-    }
-  }, [showToast]);
-
-  const submitAnswer = useCallback(async (item: FeedApiItem) => {
-    const submitted = answers[item.id]?.trim();
-    if (!submitted) return;
-    setBusyId(item.id);
-    setError(null);
-    try {
-      const response = await fetch(`/api/feed/${item.id}/answer`, {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ submitted_answer: submitted }),
-      });
-      const body = await response.json().catch(() => null) as AnswerResponse | { message?: string } | null;
-      if (!response.ok || !body || !('correct' in body || 'isCorrect' in body)) {
-        throw new Error((body as { message?: string } | null)?.message ?? 'Could not submit that answer.');
-      }
-      setResults((current) => ({
-        ...current,
-        [item.id]: {
-          correct: Boolean(body.correct ?? body.isCorrect),
-          answer: body.answer ?? body.correctAnswer ?? '',
-          explanation: body.explanation ?? null,
-          quip: body.quip ?? body.consolation ?? null,
-          breadcrumb: body.breadcrumb ?? null,
-        },
-      }));
-      setCardStates((s) => ({ ...s, [item.id]: 'answered' }));
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not submit that answer.');
-    } finally {
-      setBusyId(null);
-    }
-  }, [answers]);
+    },
+    [answers]
+  )
 
   return (
     <>
@@ -315,10 +438,14 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
           className="mb-4 block rounded-lg border border-amber-300 bg-amber-50 px-4 py-4 text-stone-950 shadow-sm"
         >
           <div className="flex items-start gap-3">
-            <span className="mt-0.5 text-lg" aria-hidden>✦</span>
+            <span className="mt-0.5 text-lg" aria-hidden>
+              ✦
+            </span>
             <div>
               <p className="font-medium">Your two-week reflection is ready</p>
-              <p className="mt-1 text-sm text-stone-700">See what you&rsquo;ve been up to {'->'}</p>
+              <p className="mt-1 text-sm text-stone-700">
+                See what you&rsquo;ve been up to {'->'}
+              </p>
             </div>
           </div>
         </Link>
@@ -326,9 +453,17 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
 
       {visibleItems.length === 0 ? (
         <section className="flex min-h-48 flex-col items-center justify-center gap-3 py-12 text-center">
-          <p className={error ? 'text-sm text-destructive' : 'text-sm text-muted-foreground'}>{emptyCopy}</p>
+          <p
+            className={
+              error
+                ? 'text-destructive text-sm'
+                : 'text-muted-foreground text-sm'
+            }
+          >
+            {emptyCopy}
+          </p>
           {emptyDiagnostics ? (
-            <p className="max-w-xl break-words rounded bg-muted px-3 py-2 font-mono text-xs text-muted-foreground">
+            <p className="bg-muted text-muted-foreground max-w-xl rounded px-3 py-2 font-mono text-xs break-words">
               {emptyDiagnostics}
             </p>
           ) : null}
@@ -340,191 +475,126 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
       ) : (
         <section className="space-y-3 pb-8">
           {visibleItems.map((item) => {
-            const result = results[item.id];
-            const cardState = cardStates[item.id] ?? (item.state === 'answered' ? 'answered' : 'unanswered');
-            const toast = toasts[item.id];
+            const result = results[item.id]
+            const cardState =
+              cardStates[item.id] ??
+              (item.state === 'answered' ? 'answered' : 'unanswered')
+            const answeredByYouItem =
+              cardState === 'answered'
+                ? toAnsweredByYouItem(item, result)
+                : null
+            const typedItem = toTypedFeedItem(item)
+            const isBusy = busyId === item.id
+            const answerActions =
+              cardState === 'answering' ? (
+                <AnswerForm
+                  value={answers[item.id] ?? ''}
+                  onChange={(value) =>
+                    setAnswers((current) => ({ ...current, [item.id]: value }))
+                  }
+                  onSubmit={() => void submitAnswer(item)}
+                  onCancel={() =>
+                    setCardStates((state) => ({
+                      ...state,
+                      [item.id]: 'unanswered',
+                    }))
+                  }
+                  disabled={isBusy}
+                />
+              ) : cardState === 'unanswered' ? (
+                <UnansweredFeedActions
+                  onAnswer={() =>
+                    setCardStates((state) => ({
+                      ...state,
+                      [item.id]: 'answering',
+                    }))
+                  }
+                  onDismiss={() => void updateState(item.id, 'dismissed')}
+                  disabled={isBusy}
+                />
+              ) : null
 
+            const answeredDetails = result ? (
+              <div className="rounded-xl bg-white/60 p-3 text-sm leading-6 text-stone-700">
+                <p className="font-medium text-stone-900">
+                  {comparisonCopy(result.correct, item.friend_results)}
+                </p>
+                {!result.correct && result.answer ? (
+                  <p className="mt-1">Answer: {result.answer}</p>
+                ) : null}
+                {result.explanation ? (
+                  <p className="text-muted-foreground mt-1">
+                    {result.explanation}
+                  </p>
+                ) : null}
+                {result.quip ? (
+                  <p className="text-muted-foreground mt-1">{result.quip}</p>
+                ) : null}
+                {result.breadcrumb ? (
+                  <p className="text-muted-foreground mt-2 italic">
+                    {result.breadcrumb}
+                  </p>
+                ) : null}
+              </div>
+            ) : null
+
+            if (answeredByYouItem) {
+              return (
+                <AnsweredByYouCard key={item.id} item={answeredByYouItem}>
+                  {answeredDetails}
+                </AnsweredByYouCard>
+              )
+            }
+
+            if (typedItem.type === 'direct_sent') {
+              return (
+                <DirectSentCard
+                  key={item.id}
+                  item={typedItem}
+                  actions={answerActions}
+                />
+              )
+            }
+
+            if (typedItem.type === 'friend_added') {
+              return (
+                <FriendAddedCard
+                  key={item.id}
+                  item={typedItem}
+                  actions={answerActions}
+                />
+              )
+            }
+
+            if (typedItem.type === 'friend_liked') {
+              return (
+                <FriendLikedCard
+                  key={item.id}
+                  item={typedItem}
+                  actions={answerActions}
+                />
+              )
+            }
 
             return (
-              <article
+              <FriendAnsweredCard
                 key={item.id}
-                className="rounded-lg border bg-card p-4 text-card-foreground"
-              >
-                {/* Header row */}
-                <div className="mb-3 flex flex-wrap items-center gap-2">
-                  {item.is_pinned ? (
-                    <span className="rounded-full bg-primary px-2.5 py-1 text-xs text-primary-foreground">Pinned</span>
-                  ) : null}
-                  {item.domain_pill ? (
-                    <span className="rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground">
-                      {item.domain_pill}
-                    </span>
-                  ) : null}
-                  {!item.verified ? (
-                    <button
-                      type="button"
-                      className="rounded-full border px-2.5 py-1 text-xs text-muted-foreground"
-                      title="The author wrote their own answer instead of using the LLM's suggestion. The answer may not be standard."
-                      onClick={() => showToast(item.id, "The author wrote their own answer instead of using the LLM's suggestion. The answer may not be standard.")}
-                    >
-                      ⚠ unverified
-                    </button>
-                  ) : null}
-                  {item.difficulty ? (
-                    <span className={[
-                      'rounded-full px-2.5 py-1 text-xs font-medium',
-                      item.difficulty === 'specialist' ? 'bg-rose-100 text-rose-700'
-                      : item.difficulty === 'moderate' ? 'bg-amber-100 text-amber-700'
-                      : 'bg-sky-100 text-sky-700',
-                    ].join(' ')}>
-                      {difficultyCopyFromEstimate(item.difficulty) ?? 'Unrated'}
-                    </span>
-                  ) : null}
-                  <span className="ml-auto text-xs text-muted-foreground">{formatEventTime(item.source_event_at)}</span>
-                </div>
-
-                {/* Question text */}
-                <p className="text-base leading-7 text-foreground">{item.question_text}</p>
-
-                {/* Attribution line */}
-                <div className="mt-2 flex items-center gap-1.5">
-                  <p className="text-sm font-medium text-foreground">{item.source_attribution}</p>
-                </div>
-                {item.personal_message ? (
-                  <p className="mt-1 text-sm italic text-muted-foreground">&ldquo;{item.personal_message}&rdquo;</p>
-                ) : null}
-
-                {/* Toast */}
-                {toast ? (
-                  <p className="mt-2 text-sm text-muted-foreground">{toast}</p>
-                ) : null}
-
-
-                {/* State 2 — Answered */}
-                {cardState === 'answered' && result ? (
-                  <div className="mt-4 rounded-md bg-muted p-3 text-sm">
-                    {/* Comparison copy */}
-                    <p className="font-medium">
-                      {item.source_type === 'friend_answered'
-                        ? comparisonCopy(result.correct, item.friend_results)
-                        : result.correct ? 'This one connected.' : 'Not quite.'}
-                    </p>
-                    {!result.correct ? <p className="mt-1">Answer: {result.answer}</p> : null}
-                    {result.explanation ? <p className="mt-1 text-muted-foreground">{result.explanation}</p> : null}
-                    {result.quip ? <p className="mt-1 text-muted-foreground">{result.quip}</p> : null}
-                    {result.breadcrumb ? <p className="mt-2 text-muted-foreground italic">{result.breadcrumb}</p> : null}
-
-                    {/* Post-answer actions */}
-                    <div className="mt-3 flex flex-wrap gap-2">
-                      {item.question_id ? (
-                        <SendQuestionAction
-                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill ?? '' }}
-                          label="Send to friend"
-                          className="inline-flex h-9 items-center gap-2 rounded-md border px-3 text-sm hover:bg-muted"
-                        />
-                      ) : null}
-                      {item.question_id ? (
-                        <AddToBankAction
-                          questionId={item.question_id}
-                          initialInBank={item.is_in_bank}
-                          contextType="feed"
-                          contextId={item.id}
-                          label=""
-                          className="inline-flex size-9 items-center justify-center rounded-md border px-0"
-                          onChange={(inBank) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, is_in_bank: inBank } : row))}
-                        />
-                      ) : null}
-                      {item.question_id && viewerId && item.source_user_id !== viewerId ? (
-                        <QuestionReactionPrompt
-                          prompt={{
-                            senderName: item.source_friend_display_name,
-                            questionId: item.question_id,
-                            contextType: 'feed',
-                            contextId: item.id,
-                          }}
-                        />
-                      ) : null}
-                    </div>
-                  </div>
-                ) : cardState === 'unanswered' ? (
-                  /* State 1 — Unanswered */
-                  <form
-                    className="mt-4 flex flex-col gap-3 sm:flex-row"
-                    onSubmit={(event) => {
-                      event.preventDefault();
-                      void submitAnswer(item);
-                    }}
-                  >
-                    <input
-                      className="min-h-11 flex-1 rounded-md border bg-background px-3 text-base outline-none"
-                      value={answers[item.id] ?? ''}
-                      onChange={(event) => setAnswers((current) => ({ ...current, [item.id]: event.target.value }))}
-                      placeholder="Your answer..."
-                      disabled={busyId === item.id}
-                    />
-                    <div className="flex flex-wrap gap-2">
-                      <button className="btn-primary inline-flex h-11 items-center gap-2" type="submit" disabled={busyId === item.id || !answers[item.id]?.trim()}>
-                        <Send className="size-4" />
-                        Send
-                      </button>
-                      <button
-                        className="inline-flex h-11 w-11 items-center justify-center rounded-md border"
-                        type="button"
-                        onClick={() => void updateState(item.id, 'skipped')}
-                        disabled={busyId === item.id}
-                        title="Skip"
-                      >
-                        <SkipForward className="size-4" />
-                      </button>
-                      <button
-                        className="inline-flex h-11 w-11 items-center justify-center rounded-md border"
-                        type="button"
-                        onClick={() => void updateState(item.id, 'dismissed')}
-                        disabled={busyId === item.id}
-                        title="Dismiss"
-                      >
-                        <X className="size-4" />
-                      </button>
-                      <button
-                        className="inline-flex h-11 items-center gap-1.5 rounded-md border px-3 text-sm text-muted-foreground"
-                        type="button"
-                        onClick={() => item.domain_pill ? void dismissDomain(item.id, item.domain_pill) : undefined}
-                        disabled={busyId === item.id || !item.domain_pill}
-                        title={item.domain_pill ? `Not my focus: ${item.domain_pill}` : 'No category to focus'}
-                      >
-                        Not my focus
-                      </button>
-                      {item.question_id ? (
-                        <SendQuestionAction
-                          question={{ id: item.question_id, text: item.question_text ?? '', domain: item.domain_pill ?? '' }}
-                          label=""
-                          className="inline-flex h-11 w-11 items-center justify-center rounded-md border hover:bg-muted"
-                        />
-                      ) : null}
-                      {item.question_id ? (
-                        <AddToBankAction
-                          questionId={item.question_id}
-                          initialInBank={item.is_in_bank}
-                          contextType="feed"
-                          contextId={item.id}
-                          label=""
-                          className="inline-flex h-11 w-11 items-center justify-center rounded-md border px-0"
-                          onChange={(inBank) => setItems((current) => current.map((row) => row.id === item.id ? { ...row, is_in_bank: inBank } : row))}
-                        />
-                      ) : null}
-                    </div>
-                  </form>
-                ) : null}
-              </article>
-            );
+                item={typedItem}
+                actions={answerActions}
+              />
+            )
           })}
         </section>
       )}
       {infinite && hasMore ? (
         <div ref={sentinelRef} className="py-4 text-center" aria-live="polite">
-          {loadingMore ? <p className="text-muted-foreground text-sm">Loading more Feed...</p> : null}
+          {loadingMore ? (
+            <p className="text-muted-foreground text-sm">
+              Loading more Feed...
+            </p>
+          ) : null}
         </div>
       ) : null}
     </>
-  );
+  )
 }

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+import { FeedCard } from './FeedCard'
+import type { AnsweredByYouFeedItem } from './types'
+
+type AnsweredByYouCardProps = {
+  item: AnsweredByYouFeedItem
+  actions?: ReactNode
+  children?: ReactNode
+}
+
+export function AnsweredByYouCard({
+  item,
+  actions,
+  children,
+}: AnsweredByYouCardProps) {
+  return (
+    <FeedCard
+      item={item}
+      tone="gray"
+      eyebrow={<span>{item.resultLabel ?? 'Answered'}</span>}
+      actions={actions}
+    >
+      {children ?? (item.answerSummary ? <p>{item.answerSummary}</p> : null)}
+    </FeedCard>
+  )
+}

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+import { FeedCard } from './FeedCard'
+import type { DirectSentFeedItem } from './types'
+
+type DirectSentCardProps = {
+  item: DirectSentFeedItem
+  actions?: ReactNode
+  children?: ReactNode
+}
+
+export function DirectSentCard({
+  item,
+  actions,
+  children,
+}: DirectSentCardProps) {
+  return (
+    <FeedCard
+      item={item}
+      tone="cream"
+      eyebrow={<span>For you</span>}
+      actions={actions}
+    >
+      {children ?? <p>{item.senderName} thought you would like this one.</p>}
+    </FeedCard>
+  )
+}

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -1,0 +1,104 @@
+'use client'
+
+import { MoreHorizontal } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+
+export type UnansweredFeedActionsProps = {
+  onAnswer: () => void
+  disabled?: boolean
+  onDismiss?: () => void
+}
+
+export function UnansweredFeedActions({
+  onAnswer,
+  disabled = false,
+  onDismiss,
+}: UnansweredFeedActionsProps) {
+  return (
+    <div className="flex items-center gap-2">
+      <Button
+        type="button"
+        onClick={onAnswer}
+        disabled={disabled}
+        className="bg-stone-950 text-white hover:bg-stone-800"
+      >
+        Answer
+      </Button>
+      <div className="relative">
+        <details className="group">
+          <summary className="flex size-8 cursor-pointer list-none items-center justify-center rounded-lg border border-stone-300 bg-white/70 text-stone-700 transition hover:bg-white [&::-webkit-details-marker]:hidden">
+            <MoreHorizontal className="size-4" aria-label="More options" />
+          </summary>
+          <div className="absolute right-0 z-10 mt-2 min-w-32 rounded-lg border border-stone-200 bg-white p-2 shadow-lg">
+            {onDismiss ? (
+              <button
+                type="button"
+                onClick={onDismiss}
+                disabled={disabled}
+                className="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium text-sky-700 hover:bg-sky-50 disabled:opacity-50"
+              >
+                Dismiss
+              </button>
+            ) : (
+              <p className="text-muted-foreground px-2 py-1.5 text-sm">
+                More soon
+              </p>
+            )}
+          </div>
+        </details>
+      </div>
+    </div>
+  )
+}
+
+export type AnswerFormProps = {
+  value: string
+  onChange: (value: string) => void
+  onSubmit: () => void
+  onCancel: () => void
+  disabled?: boolean
+}
+
+export function AnswerForm({
+  value,
+  onChange,
+  onSubmit,
+  onCancel,
+  disabled = false,
+}: AnswerFormProps) {
+  return (
+    <form
+      className="flex flex-col gap-3 sm:flex-row"
+      onSubmit={(event) => {
+        event.preventDefault()
+        onSubmit()
+      }}
+    >
+      <input
+        className="min-h-11 flex-1 rounded-lg border border-stone-300 bg-white px-3 text-base outline-none focus:border-stone-500 focus:ring-2 focus:ring-stone-200"
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder="Your answer..."
+        disabled={disabled}
+      />
+      <div className="flex items-center gap-2">
+        <Button
+          type="submit"
+          disabled={disabled || !value.trim()}
+          className="bg-stone-950 text-white hover:bg-stone-800"
+        >
+          Submit answer
+        </Button>
+        <button
+          type="button"
+          onClick={onCancel}
+          disabled={disabled}
+          className="px-2 text-sm font-medium text-sky-700 hover:underline disabled:opacity-50"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -1,0 +1,69 @@
+import { cn } from '@/lib/utils'
+
+import { visibleFeedCategory } from './category'
+import type { FeedCardShellProps, FeedCardTone } from './types'
+
+const toneClasses: Record<FeedCardTone, string> = {
+  cream:
+    'border-amber-200/80 bg-[#fff7df] shadow-[0_1px_0_rgba(120,83,25,0.08)]',
+  white: 'border-stone-200 bg-white shadow-sm',
+  green:
+    'border-emerald-200 bg-emerald-50/80 shadow-[0_1px_0_rgba(22,101,52,0.08)]',
+  amber:
+    'border-orange-200 bg-orange-50/80 shadow-[0_1px_0_rgba(154,52,18,0.08)]',
+  gray: 'border-stone-200 bg-stone-100/80 text-stone-800 shadow-none',
+}
+
+export function FeedCard({
+  item,
+  tone,
+  eyebrow,
+  children,
+  actions,
+  className,
+}: FeedCardShellProps) {
+  const category = visibleFeedCategory(item.category)
+
+  return (
+    <article
+      className={cn(
+        'text-card-foreground rounded-2xl border p-4 transition-colors sm:p-5',
+        toneClasses[tone],
+        className
+      )}
+    >
+      <div className="space-y-3">
+        <div className="text-muted-foreground flex items-start justify-between gap-3 text-xs leading-5 font-medium">
+          <p>{item.metadata}</p>
+          {eyebrow ? (
+            <div className="shrink-0 text-right">{eyebrow}</div>
+          ) : null}
+        </div>
+
+        <div className="space-y-2">
+          {category ? (
+            <p className="text-[0.68rem] font-semibold tracking-[0.18em] text-stone-500 uppercase">
+              {category}
+            </p>
+          ) : null}
+          <p className="text-foreground font-serif text-xl leading-8 sm:text-2xl sm:leading-9">
+            {item.question}
+          </p>
+        </div>
+
+        {item.personalMessage ? (
+          <p className="text-muted-foreground text-sm leading-6">
+            &ldquo;{item.personalMessage}&rdquo;
+          </p>
+        ) : null}
+
+        {children ? (
+          <div className="pt-1 text-sm leading-6 text-stone-700">
+            {children}
+          </div>
+        ) : null}
+        {actions ? <div className="pt-2">{actions}</div> : null}
+      </div>
+    </article>
+  )
+}

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+import { FeedCard } from './FeedCard'
+import type { FriendAddedFeedItem } from './types'
+
+type FriendAddedCardProps = {
+  item: FriendAddedFeedItem
+  actions?: ReactNode
+  children?: ReactNode
+}
+
+export function FriendAddedCard({
+  item,
+  actions,
+  children,
+}: FriendAddedCardProps) {
+  return (
+    <FeedCard
+      item={item}
+      tone="amber"
+      eyebrow={<span>New question</span>}
+      actions={actions}
+    >
+      {children ?? <p>{item.friendName} added a question to their bank.</p>}
+    </FeedCard>
+  )
+}

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode } from 'react'
+
+import { FeedCard } from './FeedCard'
+import type { FriendAnsweredFeedItem } from './types'
+
+type FriendAnsweredCardProps = {
+  item: FriendAnsweredFeedItem
+  actions?: ReactNode
+  children?: ReactNode
+}
+
+export function FriendAnsweredCard({
+  item,
+  actions,
+  children,
+}: FriendAnsweredCardProps) {
+  const tone = item.friendCorrect ? 'green' : 'white'
+
+  return (
+    <FeedCard
+      item={item}
+      tone={tone}
+      eyebrow={<span>Friend answered</span>}
+      actions={actions}
+    >
+      {children ?? (
+        <p>
+          {item.answerSummary ?? `${item.friendName} answered this question.`}
+        </p>
+      )}
+    </FeedCard>
+  )
+}

--- a/src/components/feed/FriendLikedCard.tsx
+++ b/src/components/feed/FriendLikedCard.tsx
@@ -1,0 +1,27 @@
+import type { ReactNode } from 'react'
+
+import { FeedCard } from './FeedCard'
+import type { FriendLikedFeedItem } from './types'
+
+type FriendLikedCardProps = {
+  item: FriendLikedFeedItem
+  actions?: ReactNode
+  children?: ReactNode
+}
+
+export function FriendLikedCard({
+  item,
+  actions,
+  children,
+}: FriendLikedCardProps) {
+  return (
+    <FeedCard
+      item={item}
+      tone="white"
+      eyebrow={<span>Friend liked</span>}
+      actions={actions}
+    >
+      {children ?? <p>{item.friendName} liked this question.</p>}
+    </FeedCard>
+  )
+}

--- a/src/components/feed/category.ts
+++ b/src/components/feed/category.ts
@@ -1,0 +1,15 @@
+const SUPPRESSED_CATEGORY_LABELS = new Set([
+  'other',
+  'uncategorized',
+  'general',
+  'general knowledge',
+])
+
+export function visibleFeedCategory(category?: string | null) {
+  const trimmed = category?.trim()
+  if (!trimmed) return null
+
+  if (SUPPRESSED_CATEGORY_LABELS.has(trimmed.toLowerCase())) return null
+
+  return trimmed
+}

--- a/src/components/feed/index.ts
+++ b/src/components/feed/index.ts
@@ -1,0 +1,20 @@
+export { AnswerForm, UnansweredFeedActions } from './FeedActions'
+export { AnsweredByYouCard } from './AnsweredByYouCard'
+export { DirectSentCard } from './DirectSentCard'
+export { FeedCard } from './FeedCard'
+export { FriendAddedCard } from './FriendAddedCard'
+export { FriendAnsweredCard } from './FriendAnsweredCard'
+export { FriendLikedCard } from './FriendLikedCard'
+export { mockTypedFeedItems } from './mock-feed-items'
+export { visibleFeedCategory } from './category'
+export type {
+  AnsweredByYouFeedItem,
+  DirectSentFeedItem,
+  FeedCardBaseItem,
+  FeedCardShellProps,
+  FeedCardTone,
+  FriendAddedFeedItem,
+  FriendAnsweredFeedItem,
+  FriendLikedFeedItem,
+  TypedFeedItem,
+} from './types'

--- a/src/components/feed/mock-feed-items.ts
+++ b/src/components/feed/mock-feed-items.ts
@@ -1,0 +1,50 @@
+import type { TypedFeedItem } from './types'
+
+export const mockTypedFeedItems: TypedFeedItem[] = [
+  {
+    type: 'direct_sent',
+    id: 'mock-direct-sent',
+    senderName: 'Maya',
+    metadata: 'Maya sent this · Today',
+    category: 'Food & Drink',
+    question: 'Which fermented tea is often kept alive by a SCOBY?',
+    personalMessage: 'This felt like your kind of kitchen lore.',
+  },
+  {
+    type: 'friend_answered',
+    id: 'mock-friend-answered',
+    friendName: 'Noah',
+    friendCorrect: true,
+    metadata: 'Noah got this right · Yesterday',
+    category: 'Science',
+    question: 'What kind of celestial object is a magnetar?',
+    answerSummary:
+      'A pale green shell marks correct friend answers as common ground.',
+  },
+  {
+    type: 'friend_added',
+    id: 'mock-friend-added',
+    friendName: 'Ari',
+    metadata: 'Ari wrote a question · May 9',
+    category: 'History',
+    question: 'What treaty formally ended World War I for Germany?',
+  },
+  {
+    type: 'friend_liked',
+    id: 'mock-friend-liked',
+    friendName: 'Sam',
+    metadata: 'Sam liked this · May 8',
+    category: null,
+    question: 'Which instrument family does the oboe belong to?',
+  },
+  {
+    type: 'answered_by_you',
+    id: 'mock-answered-by-you',
+    metadata: 'You answered · May 7',
+    category: 'General Knowledge',
+    question: 'Which city hosted the 1992 Summer Olympics?',
+    resultLabel: 'Answered by you',
+    answerSummary:
+      'Muted gray is reserved for questions you have already answered.',
+  },
+]

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -1,0 +1,61 @@
+import type { ReactNode } from 'react'
+
+export type FeedCardTone = 'cream' | 'white' | 'green' | 'amber' | 'gray'
+
+export type FeedCardActionState =
+  | 'unanswered'
+  | 'answering'
+  | 'answered'
+  | 'seen'
+
+export type FeedCardBaseItem = {
+  id: string
+  metadata: string
+  question: string
+  category?: string | null
+  personalMessage?: string | null
+}
+
+export type DirectSentFeedItem = FeedCardBaseItem & {
+  type: 'direct_sent'
+  senderName: string
+}
+
+export type FriendAnsweredFeedItem = FeedCardBaseItem & {
+  type: 'friend_answered'
+  friendName: string
+  friendCorrect?: boolean | null
+  answerSummary?: string | null
+}
+
+export type FriendAddedFeedItem = FeedCardBaseItem & {
+  type: 'friend_added'
+  friendName: string
+}
+
+export type FriendLikedFeedItem = FeedCardBaseItem & {
+  type: 'friend_liked'
+  friendName: string
+}
+
+export type AnsweredByYouFeedItem = FeedCardBaseItem & {
+  type: 'answered_by_you'
+  resultLabel?: string | null
+  answerSummary?: string | null
+}
+
+export type TypedFeedItem =
+  | DirectSentFeedItem
+  | FriendAnsweredFeedItem
+  | FriendAddedFeedItem
+  | FriendLikedFeedItem
+  | AnsweredByYouFeedItem
+
+export type FeedCardShellProps = {
+  item: FeedCardBaseItem
+  tone: FeedCardTone
+  eyebrow?: ReactNode
+  children?: ReactNode
+  actions?: ReactNode
+  className?: string
+}


### PR DESCRIPTION
### Motivation
- Replace the old generic Feed card UI with a typed, presentation-focused card system that maps backend feed rows to explicit variants and simplifies the action surface.
- Provide a visual Feed page shell with the requested sans header/subhead copy and prepare components for a future API integration using typed fixtures.

### Description
- Added a shared `FeedCard` base and typed variants `DirectSentCard`, `FriendAnsweredCard`, `FriendAddedCard`, `FriendLikedCard`, and `AnsweredByYouCard` under `src/components/feed/` with tone-driven color classes and the shared layout (metadata, optional uppercase category label, serif question text, personal message, and action region). 
- Introduced typed feed model and mocks in `src/components/feed/types.ts` and `src/components/feed/mock-feed-items.ts`, plus a category suppression helper `visibleFeedCategory` to omit `Other`, `Uncategorized`, `General`, and `General Knowledge` categories.
- Replaced the old inline, cluttered action row in `FeedList` with a compact `Answer` + `⋯` collapsed shell and an expandable `AnswerForm` (`src/components/feed/FeedActions.tsx`), and adapted `src/components/FeedList.tsx` to convert API rows into the new typed variants and render the new shells.
- Updated the Feed page copy and typography to the visual shell requested in `src/app/feed/page.tsx` and kept all card labels/metadata in the app sans while using serif only for question text.

### Testing
- Ran targeted lint on the new feed files with `npx eslint src/app/feed/page.tsx src/components/FeedList.tsx src/components/feed --ext .ts,.tsx`, which passed for the touched feed surface.
- Ran typecheck with `npx tsc -p tsconfig.typecheck.json --noEmit`, which completed successfully for the changes.
- Ran repository lint `npm run lint` which surfaced pre-existing, unrelated lint errors elsewhere in the repo and did not pass; these are outside the scope of this UI-focused change.

Components are ready to be wired to the real Feed API in a follow-up integration prompt.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0639863978832ea803f8d4091dba6b)