### PR TITLE
Refactor Feed cards and answered persistence

### DIFF
--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -157,13 +157,16 @@ export async function POST(request: NextRequest, context: RouteContext) {
     });
   }
 
-  // Propagate this answer to the answering user's friends' Feeds
-  await createFeedItemsForFriendsFromAnswer(
-    session.userId,
-    question.id,
-    isCorrect ? 'correct' : 'incorrect',
-    `feed:${feedItemId}:${session.userId}`,
-  );
+  // Only correct answers may create public/social friend Feed cards.
+  // Wrong answers persist privately on this FeedItem as answered_by_you.
+  if (isCorrect) {
+    await createFeedItemsForFriendsFromAnswer(
+      session.userId,
+      question.id,
+      'correct',
+      `feed:${feedItemId}:${session.userId}`,
+    );
+  }
 
   if (!isCorrect) {
     void promptCreatorNoteAfterWrongAnswer({

--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -31,7 +31,20 @@ const { checkBankedQuestionsMock, dbMock, getDismissedDomainsMock, getFeedForUse
             calibratedDifficulty: null,
             llmDifficulty: null,
             difficultyEstimate: null,
+            answerText: 'Correct answer',
+            explainerFull: 'A stored full explanation.',
           }]);
+        }
+        if ((selection as { answerId?: unknown })?.answerId) {
+          return thenable([{
+            answerId: 'feed:feed-answered-1:question-1:recipient-1',
+            answerState: 'incorrect',
+            awardedPoints: 0,
+            basePoints: 0,
+          }]);
+        }
+        if ((selection as { canonicalSubcategory?: unknown; totalPoints?: unknown; tier?: unknown })?.canonicalSubcategory) {
+          return thenable([{ canonicalSubcategory: 'Music', totalPoints: 12, tier: 'familiar' }]);
         }
         if ((selection as { id?: unknown; displayName?: unknown })?.id && (selection as { id?: unknown; displayName?: unknown })?.displayName) {
           return thenable([
@@ -66,11 +79,25 @@ vi.mock('@/server/db', () => ({
   feedItems: {
     recipientUserId: 'feedItems.recipientUserId',
     state: 'feedItems.state',
+    sourceType: 'feedItems.sourceType',
+    sourceResult: 'feedItems.sourceResult',
   },
   friendships: {
     status: 'friendships.status',
     userAId: 'friendships.userAId',
     userBId: 'friendships.userBId',
+  },
+  masteryEvents: {
+    answerId: 'masteryEvents.answerId',
+    answerState: 'masteryEvents.answerState',
+    awardedPoints: 'masteryEvents.awardedPoints',
+    basePoints: 'masteryEvents.basePoints',
+  },
+  playerMastery: {
+    userId: 'playerMastery.userId',
+    canonicalSubcategory: 'playerMastery.canonicalSubcategory',
+    totalPoints: 'playerMastery.totalPoints',
+    tier: 'playerMastery.tier',
   },
   questions: 'questions',
   users: {
@@ -99,6 +126,8 @@ describe('GET /api/feed', () => {
         personalMessage: 'Try this one.',
         state: 'active',
         isPinned: true,
+        submittedAnswer: null,
+        quip: null,
       }],
       nextCursor: null,
       hasMore: false,
@@ -114,6 +143,8 @@ describe('GET /api/feed', () => {
     expect(body.items).toEqual([
       expect.objectContaining({
         id: 'feed-direct-1',
+        card_type: 'direct_sent',
+        type: 'direct_sent',
         source_type: 'direct_sent',
         state: 'active',
         is_pinned: true,
@@ -123,5 +154,64 @@ describe('GET /api/feed', () => {
       }),
     ]);
     expect(body.meta.active_item_count).toBe(1);
+  });
+
+  it('passes the Feed filter query param to the feed query', async () => {
+    const response = await GET(new Request('https://joshing.example/api/feed?filter=sent-to-me') as never);
+
+    expect(response.status).toBe(200);
+    expect(getFeedForUserMock).toHaveBeenCalledWith('recipient-1', expect.objectContaining({ filter: 'sent-to-me' }));
+  });
+
+  it('returns durable answered_by_you card data for answered Feed items', async () => {
+    getFeedForUserMock.mockResolvedValueOnce({
+      items: [{
+        id: 'feed-answered-1',
+        questionId: 'question-1',
+        joshingGameId: null,
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:00:00.000Z'),
+        personalMessage: 'Try this one.',
+        state: 'answered',
+        isPinned: true,
+        submittedAnswer: 'My wrong answer',
+        quip: 'Not quite.',
+      }],
+      nextCursor: null,
+      hasMore: false,
+      totalCount: 1,
+    });
+
+    const response = await GET(new Request('https://joshing.example/api/feed') as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.items[0]).toEqual(expect.objectContaining({
+      card_type: 'answered_by_you',
+      type: 'answered_by_you',
+      state: 'answered',
+      is_pinned: false,
+      original_source: expect.objectContaining({ source_type: 'direct_sent' }),
+      answered_by_you: expect.objectContaining({
+        correct: false,
+        answer_state: 'incorrect',
+        correct_answer: 'Correct answer',
+        submitted_answer: 'My wrong answer',
+        awarded_points: 0,
+        explanation: 'A stored full explanation.',
+        quip: 'Not quite.',
+      }),
+      mastery_progress: expect.objectContaining({ domain: 'Music', total_points: 12, tier: 'familiar' }),
+    }));
+  });
+
+  it('rejects unsupported Feed filters', async () => {
+    const response = await GET(new Request('https://joshing.example/api/feed?filter=hidden-categories') as never);
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toBe('invalid_filter');
   });
 });

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -2,10 +2,10 @@ import { and, count, eq, inArray, or } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { db, feedItems, friendships, questions, users } from '@/server/db';
+import { db, feedItems, friendships, masteryEvents, playerMastery, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
-import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem, type FeedCursor } from '@/server/db/queries/feed';
-import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, socialFeedDomainLabel, visibleFeedSourcePredicate } from '@/server/feed/visibility';
+import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem, type FeedCursor, type FeedFilter } from '@/server/db/queries/feed';
+import { AUTHORED_SHARED_FEED_SOURCE_TYPE, DIRECT_SENT_FEED_SOURCE_TYPE, SOCIAL_FEED_SOURCE_TYPE, THUMBS_UPPED_FEED_SOURCE_TYPE, socialFeedDomainLabel, visibleFeedSourcePredicate } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,8 +15,22 @@ const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 50;
 
 type ParsedPagination =
-  | { limit: number; cursor: FeedCursor | null }
+  | { limit: number; cursor: FeedCursor | null; filter: FeedFilter }
   | { error: string };
+
+type FeedCardType = 'direct_sent' | 'friend_answered' | 'friend_added' | 'friend_liked' | 'answered_by_you';
+
+type AnsweredResult = {
+  correct: boolean | null;
+  answer_state: string | null;
+  correct_answer: string | null;
+  submitted_answer: string | null;
+  awarded_points: number | null;
+  base_points: number | null;
+  explanation: string | null;
+  quip: string | null;
+  unverified_answer: boolean;
+};
 
 function encodeCursor(cursor: FeedCursor | null): string | null {
   if (!cursor) return null;
@@ -47,6 +61,7 @@ function decodeCursor(value: string): FeedCursor | null {
 function parsePagination(request: NextRequest): ParsedPagination {
   const limitParam = request.nextUrl.searchParams.get('limit');
   const cursorParam = request.nextUrl.searchParams.get('cursor');
+  const filterParam = request.nextUrl.searchParams.get('filter') ?? 'all';
   const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : DEFAULT_PAGE_LIMIT;
 
   const limit = Number.isFinite(parsedLimit)
@@ -55,8 +70,9 @@ function parsePagination(request: NextRequest): ParsedPagination {
   const cursor = cursorParam ? decodeCursor(cursorParam) : null;
 
   if (cursorParam && !cursor) return { error: 'invalid_cursor' };
+  if (!['all', 'sent-to-me', 'from-friends'].includes(filterParam)) return { error: 'invalid_filter' };
 
-  return { limit, cursor };
+  return { limit, cursor, filter: filterParam as FeedFilter };
 }
 
 function displayName(name: string | null, fallback = 'A friend') {
@@ -69,6 +85,45 @@ function authoredSharedAttribution(sourceName: string, domain: string | null): s
 
 function directSentAttribution(sourceName: string, domain: string | null): string {
   return domain ? `${sourceName} sent you a question — ${domain}` : `${sourceName} sent you a question`;
+}
+
+function cardTypeForItem(item: CollapsedFeedItem): FeedCardType {
+  if (item.state === 'answered') return 'answered_by_you';
+  if (item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE) return 'direct_sent';
+  if (item.sourceType === SOCIAL_FEED_SOURCE_TYPE && item.sourceResult === 'correct') return 'friend_answered';
+  if (item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE) return 'friend_added';
+  if (item.sourceType === THUMBS_UPPED_FEED_SOURCE_TYPE) return 'friend_liked';
+  return 'friend_answered';
+}
+
+function answerIdForFeedItem(item: CollapsedFeedItem, viewerUserId: string): string | null {
+  if (item.state !== 'answered' || !item.questionId) return null;
+  return `feed:${item.id}:${item.questionId}:${viewerUserId}`;
+}
+
+function answeredResultForItem(params: {
+  item: CollapsedFeedItem;
+  answerEvent: { answerState: string | null; awardedPoints: number; basePoints: number } | undefined;
+  question: { answerText?: string | null; explainerFull?: string | null; explainerBrief?: string | null; factualExplanation?: string | null; verified?: boolean | null } | undefined;
+}): AnsweredResult | null {
+  const { item, answerEvent, question } = params;
+  if (item.state !== 'answered') return null;
+
+  return {
+    correct: answerEvent?.answerState ? answerEvent.answerState !== 'incorrect' : null,
+    answer_state: answerEvent?.answerState ?? null,
+    correct_answer: question?.answerText ?? null,
+    submitted_answer: item.submittedAnswer ?? null,
+    awarded_points: typeof answerEvent?.awardedPoints === 'number' ? answerEvent.awardedPoints : null,
+    base_points: typeof answerEvent?.basePoints === 'number' ? answerEvent.basePoints : null,
+    explanation: question?.explainerFull ?? question?.explainerBrief ?? question?.factualExplanation ?? null,
+    quip: item.quip ?? null,
+    unverified_answer: question?.verified === false,
+  };
+}
+
+function friendLikedAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} liked a question — ${domain}` : `${sourceName} liked a question`;
 }
 
 function friendAnsweredAttribution(
@@ -101,10 +156,10 @@ export async function GET(request: NextRequest) {
   const pagination = parsePagination(request);
   if ('error' in pagination) return NextResponse.json({ error: pagination.error }, { status: 400 });
 
-  const { limit, cursor } = pagination;
+  const { limit, cursor, filter } = pagination;
 
   const [feedPage, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
-    getFeedForUser(session.userId, { limit, cursor }),
+    getFeedForUser(session.userId, { limit, cursor, filter }),
     db
       .select({ value: count() })
       .from(friendships)
@@ -143,6 +198,7 @@ export async function GET(request: NextRequest) {
   console.info('[feed/get]', {
     userId: session.userId,
     limit,
+    filter,
     cursorPresent: Boolean(cursor),
     friendCount,
     dismissedDomainCount: dismissedDomains.length,
@@ -168,6 +224,25 @@ export async function GET(request: NextRequest) {
     checkBankedQuestions(session.userId, questionIds),
   ]);
 
+  const answerIdsByFeedItemId = new Map(
+    feed
+      .map((item) => [item.id, answerIdForFeedItem(item, session.userId)] as const)
+      .filter((entry): entry is readonly [string, string] => Boolean(entry[1])),
+  );
+  const answerIds = [...answerIdsByFeedItemId.values()];
+  const answerEventRows = answerIds.length
+    ? await db
+      .select({
+        answerId: masteryEvents.answerId,
+        answerState: masteryEvents.answerState,
+        awardedPoints: masteryEvents.awardedPoints,
+        basePoints: masteryEvents.basePoints,
+      })
+      .from(masteryEvents)
+      .where(inArray(masteryEvents.answerId, answerIds))
+    : [];
+  const answerEventByAnswerId = new Map(answerEventRows.map((event) => [event.answerId, event]));
+
   const questionById = new Map(questionRows.map((q) => [q.id, q]));
   const userIds = [...new Set([
     ...feed.map((item) => item.sourceUserId),
@@ -177,6 +252,18 @@ export async function GET(request: NextRequest) {
     ? await db.select({ id: users.id, displayName: users.displayName }).from(users).where(inArray(users.id, userIds))
     : [];
   const userById = new Map(userRows.map((u) => [u.id, u]));
+  const masteryDomains = [...new Set(questionRows.map((question) => question.canonicalSubcategory ?? question.broadCategory ?? question.category).filter((domain): domain is string => Boolean(domain)))];
+  const masteryRows = masteryDomains.length
+    ? await db
+      .select({
+        canonicalSubcategory: playerMastery.canonicalSubcategory,
+        totalPoints: playerMastery.totalPoints,
+        tier: playerMastery.tier,
+      })
+      .from(playerMastery)
+      .where(and(eq(playerMastery.userId, session.userId), inArray(playerMastery.canonicalSubcategory, masteryDomains)))
+    : [];
+  const masteryByDomain = new Map(masteryRows.map((row) => [row.canonicalSubcategory, row]));
 
   return NextResponse.json({
     viewer_user_id: session.userId,
@@ -188,6 +275,7 @@ export async function GET(request: NextRequest) {
       pre_filter_active_count: preFilterActiveCount,
       page_item_count: pageItemCount,
       limit,
+      filter,
       cursor: cursor ? encodeCursor(cursor) : null,
       next_cursor: nextCursor,
       has_more: feedPage.hasMore,
@@ -200,10 +288,21 @@ export async function GET(request: NextRequest) {
       const sourceName = displayName(sourceUser?.displayName ?? null);
       const authorName = displayName(question?.creatorId ? userById.get(question.creatorId)?.displayName ?? null : null, 'the author');
       const domain = socialFeedDomainLabel(question);
+      const rawDomain = question?.canonicalSubcategory ?? question?.broadCategory ?? question?.category ?? null;
+      const answerId = answerIdsByFeedItemId.get(item.id) ?? null;
+      const answeredResult = answeredResultForItem({
+        item,
+        answerEvent: answerId ? answerEventByAnswerId.get(answerId) : undefined,
+        question,
+      });
+      const cardType = cardTypeForItem(item);
+      const masteryProgress = rawDomain ? masteryByDomain.get(rawDomain) : undefined;
 
       return {
         id: item.id,
         kind: 'question',
+        card_type: cardType,
+        type: cardType,
         question_id: item.questionId,
         joshing_game_id: item.joshingGameId,
         source_type: item.sourceType,
@@ -214,12 +313,14 @@ export async function GET(request: NextRequest) {
           ? authoredSharedAttribution(sourceName, domain)
           : item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE
             ? directSentAttribution(sourceName, domain)
-            : friendAnsweredAttribution(item, userById, domain, authorName),
+            : item.sourceType === THUMBS_UPPED_FEED_SOURCE_TYPE
+              ? friendLikedAttribution(sourceName, domain)
+              : friendAnsweredAttribution(item, userById, domain, authorName),
         friend_results: item.friendResults ?? null,
         source_event_at: item.sourceEventAt,
         personal_message: item.personalMessage,
         state: item.state,
-        is_pinned: item.isPinned,
+        is_pinned: item.state === 'answered' ? false : item.isPinned,
         question_text: question?.questionText ?? null,
         verified: question?.verified ?? true,
         is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
@@ -227,6 +328,20 @@ export async function GET(request: NextRequest) {
         domain_pill: domain,
         game_title: null,
         difficulty: question?.calibratedDifficulty ?? question?.llmDifficulty ?? question?.difficultyEstimate ?? null,
+        answered_by_you: answeredResult,
+        answer_result: answeredResult,
+        original_source: {
+          source_type: item.sourceType,
+          source_user_id: item.sourceUserId,
+          source_result: item.sourceResult ?? null,
+          source_event_at: item.sourceEventAt,
+          personal_message: item.personalMessage,
+        },
+        mastery_progress: masteryProgress ? {
+          domain: masteryProgress.canonicalSubcategory,
+          total_points: masteryProgress.totalPoints,
+          tier: masteryProgress.tier,
+        } : null,
       };
     }),
   });

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -15,9 +15,25 @@ type FriendResult = {
   result: 'correct' | 'incorrect' | null;
 };
 
+type AnsweredByYouPayload = {
+  correct: boolean | null;
+  answer_state: string | null;
+  correct_answer: string | null;
+  submitted_answer: string | null;
+  awarded_points: number | null;
+  base_points: number | null;
+  explanation: string | null;
+  quip: string | null;
+  unverified_answer: boolean;
+};
+
+type FeedCardType = 'direct_sent' | 'friend_answered' | 'friend_added' | 'friend_liked' | 'answered_by_you';
+
 type FeedApiItem = {
   id: string;
   kind: 'question';
+  card_type?: FeedCardType;
+  type?: FeedCardType;
   question_id: string | null;
   source_type: string;
   source_user_id: string;
@@ -34,6 +50,8 @@ type FeedApiItem = {
   is_in_bank: boolean;
   domain_pill: string | null;
   difficulty: string | null;
+  answered_by_you?: AnsweredByYouPayload | null;
+  answer_result?: AnsweredByYouPayload | null;
 };
 
 type FeedMeta = {
@@ -79,7 +97,21 @@ type ResultState = {
   explanation: string | null;
   quip: string | null;
   breadcrumb: string | null;
+  submittedAnswer?: string | null;
 };
+
+function resultFromAnsweredPayload(payload: AnsweredByYouPayload | null | undefined): ResultState | null {
+  if (!payload) return null;
+
+  return {
+    correct: payload.correct ?? (payload.answer_state ? payload.answer_state !== 'incorrect' : false),
+    answer: payload.correct_answer ?? '',
+    explanation: payload.explanation ?? null,
+    quip: payload.quip ?? null,
+    breadcrumb: null,
+    submittedAnswer: payload.submitted_answer,
+  };
+}
 
 function formatEventTime(value: string) {
   const date = new Date(value);
@@ -144,6 +176,22 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
       setViewerId(body.viewer_user_id);
       setFeedMeta(body.meta ?? null);
       setItems((current) => (isNextPage ? [...current, ...body.items] : body.items));
+      setResults((current) => {
+        const hydrated = Object.fromEntries(
+          body.items
+            .map((item) => [item.id, resultFromAnsweredPayload(item.answered_by_you ?? item.answer_result)] as const)
+            .filter((entry): entry is readonly [string, ResultState] => Boolean(entry[1])),
+        );
+        return isNextPage ? { ...current, ...hydrated } : hydrated;
+      });
+      setCardStates((current) => {
+        const hydrated = Object.fromEntries(
+          body.items
+            .filter((item) => (item.card_type ?? item.type) === 'answered_by_you' || item.state === 'answered')
+            .map((item) => [item.id, 'answered' as QuestionCardState]),
+        );
+        return isNextPage ? { ...current, ...hydrated } : hydrated;
+      });
       setNextCursor(body.next_cursor ?? body.meta?.next_cursor ?? null);
       setHasMore(Boolean(body.has_more ?? body.meta?.has_more));
 
@@ -341,7 +389,7 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
         <section className="space-y-3 pb-8">
           {visibleItems.map((item) => {
             const result = results[item.id];
-            const cardState = cardStates[item.id] ?? (item.state === 'answered' ? 'answered' : 'unanswered');
+            const cardState = cardStates[item.id] ?? ((item.card_type ?? item.type) === 'answered_by_you' || item.state === 'answered' ? 'answered' : 'unanswered');
             const toast = toasts[item.id];
 
 
@@ -409,6 +457,7 @@ export default function FeedList({ pageSize = 20, infinite = false }: FeedListPr
                         ? comparisonCopy(result.correct, item.friend_results)
                         : result.correct ? 'This one connected.' : 'Not quite.'}
                     </p>
+                    {result.submittedAnswer ? <p className="mt-1">You answered: {result.submittedAnswer}</p> : null}
                     {!result.correct ? <p className="mt-1">Answer: {result.answer}</p> : null}
                     {result.explanation ? <p className="mt-1 text-muted-foreground">{result.explanation}</p> : null}
                     {result.quip ? <p className="mt-1 text-muted-foreground">{result.quip}</p> : null}

--- a/src/server/db/queries/__tests__/feed.test.ts
+++ b/src/server/db/queries/__tests__/feed.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { dbMock, state } = vi.hoisted(() => {
   type Predicate =
@@ -22,6 +22,8 @@ const { dbMock, state } = vi.hoisted(() => {
     state: string;
     isPinned: boolean;
     joshingGameId: string | null;
+    submittedAnswer?: string | null;
+    quip?: string | null;
   };
 
   type QuestionRow = {
@@ -141,6 +143,11 @@ vi.mock('@/server/db/pg-error', () => ({ pgErrorCode: vi.fn(() => null) }));
 import { getFeedForUser } from '@/server/db/queries/feed';
 
 describe('getFeedForUser feed visibility', () => {
+  beforeEach(() => {
+    state.feedRows = [];
+    state.questionRows = [];
+  });
+
   it('returns an active pinned direct_sent feed item', async () => {
     const sourceEventAt = new Date('2026-05-14T12:00:00.000Z');
     state.questionRows = [{ id: 'question-1', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' }];
@@ -168,6 +175,100 @@ describe('getFeedForUser feed visibility', () => {
         isPinned: true,
       }),
     ]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('keeps answered direct_sent items visible even if they were pinned before answer', async () => {
+    const sourceEventAt = new Date('2026-05-14T12:00:00.000Z');
+    state.questionRows = [{ id: 'question-1', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' }];
+    state.feedRows = [{
+      id: 'feed-answered-1',
+      recipientUserId: 'recipient-1',
+      questionId: 'question-1',
+      sourceType: 'direct_sent',
+      sourceUserId: 'sender-1',
+      sourceResult: null,
+      sourceEventAt,
+      personalMessage: 'Try this one.',
+      state: 'answered',
+      isPinned: true,
+      joshingGameId: null,
+      submittedAnswer: 'wrong guess',
+      quip: 'Not quite.',
+    }];
+
+    const result = await getFeedForUser('recipient-1');
+
+    expect(result.items).toEqual([
+      expect.objectContaining({
+        id: 'feed-answered-1',
+        sourceType: 'direct_sent',
+        state: 'answered',
+        isPinned: true,
+      }),
+    ]);
+    expect(result.totalCount).toBe(1);
+  });
+
+  it('filters out incorrect public friend_answered items', async () => {
+    state.questionRows = [{ id: 'question-1', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' }];
+    state.feedRows = [{
+      id: 'feed-wrong-friend-1',
+      recipientUserId: 'recipient-1',
+      questionId: 'question-1',
+      sourceType: 'friend_answered',
+      sourceUserId: 'friend-1',
+      sourceResult: 'incorrect',
+      sourceEventAt: new Date('2026-05-14T12:00:00.000Z'),
+      personalMessage: null,
+      state: 'active',
+      isPinned: false,
+      joshingGameId: null,
+    }];
+
+    const result = await getFeedForUser('recipient-1');
+
+    expect(result.items).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it('applies the sent-to-me Feed filter', async () => {
+    state.questionRows = [
+      { id: 'question-direct', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' },
+      { id: 'question-friend', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' },
+    ];
+    state.feedRows = [
+      {
+        id: 'feed-direct-1',
+        recipientUserId: 'recipient-1',
+        questionId: 'question-direct',
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:00:00.000Z'),
+        personalMessage: null,
+        state: 'active',
+        isPinned: false,
+        joshingGameId: null,
+      },
+      {
+        id: 'feed-friend-1',
+        recipientUserId: 'recipient-1',
+        questionId: 'question-friend',
+        sourceType: 'authored_shared',
+        sourceUserId: 'friend-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T11:00:00.000Z'),
+        personalMessage: null,
+        state: 'active',
+        isPinned: false,
+        joshingGameId: null,
+      },
+    ];
+
+    const result = await getFeedForUser('recipient-1', { filter: 'sent-to-me' });
+
+    expect(result.items.map((item) => item.id)).toEqual(['feed-direct-1']);
     expect(result.totalCount).toBe(1);
   });
 });

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,7 +1,14 @@
 import { and, count, desc, eq, inArray, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
-import { isVisibleFriendAnsweredSource, visibleFeedSourcePredicate } from '@/server/feed/visibility';
+import {
+  AUTHORED_SHARED_FEED_SOURCE_TYPE,
+  DIRECT_SENT_FEED_SOURCE_TYPE,
+  isVisibleFriendAnsweredSource,
+  SOCIAL_FEED_SOURCE_TYPE,
+  THUMBS_UPPED_FEED_SOURCE_TYPE,
+  visibleFeedSourcePredicate,
+} from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -18,7 +25,8 @@ export type CollapsedFeedItem = FeedItem & {
   additionalEndorsers?: Array<{ userId: string; displayName: string }>;
 };
 
-const VISIBLE_FEED_STATES = ['active', 'skipped'] as const;
+const VISIBLE_FEED_STATES = ['active', 'skipped', 'answered'] as const;
+const ACTION_REQUIRED_FEED_STATES = ['active', 'skipped'] as const;
 const BLOCKING_FEED_STATES = ['active', 'skipped', 'dismissed'] as const;
 
 const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
@@ -171,7 +179,7 @@ export async function dismissDomain(userId: string, canonicalSubcategory: string
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
     .where(and(
       eq(feedItems.recipientUserId, userId),
-      inArray(feedItems.state, VISIBLE_FEED_STATES),
+      inArray(feedItems.state, ACTION_REQUIRED_FEED_STATES),
       eq(questions.canonicalSubcategory, canonicalSubcategory),
     ));
 
@@ -199,9 +207,12 @@ export type FeedCursor = {
   id: string;
 };
 
+export type FeedFilter = 'all' | 'sent-to-me' | 'from-friends';
+
 type FeedForUserOptions = {
   limit?: number;
   cursor?: FeedCursor | null;
+  filter?: FeedFilter;
 };
 
 export type PaginatedFeedResult = {
@@ -231,6 +242,23 @@ function feedCursorPredicate(cursor: FeedCursor | null | undefined) {
   );
 }
 
+function pinnedPagePredicate(pinned: boolean | undefined) {
+  if (pinned) return eq(feedItems.isPinned, true);
+  return or(eq(feedItems.isPinned, false), eq(feedItems.state, 'answered'));
+}
+
+function feedFilterPredicate(filter: FeedFilter | undefined) {
+  if (filter === 'sent-to-me') return eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE);
+  if (filter === 'from-friends') {
+    return or(
+      eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+      eq(feedItems.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
+      eq(feedItems.sourceType, THUMBS_UPPED_FEED_SOURCE_TYPE),
+    );
+  }
+  return undefined;
+}
+
 function visibleQuestionPredicate(dismissedDomains: string[]) {
   const predicates = [
     eq(questions.visibility, 'public'),
@@ -250,7 +278,7 @@ function visibleQuestionPredicate(dismissedDomains: string[]) {
 async function fetchVisibleFeedItems(
   userId: string,
   dismissedDomains: string[],
-  options: { limit: number; cursor?: FeedCursor | null; pinned?: boolean },
+  options: { limit: number; cursor?: FeedCursor | null; pinned?: boolean; filter?: FeedFilter },
 ): Promise<FeedItem[]> {
   const cursorPredicate = options.pinned ? undefined : feedCursorPredicate(options.cursor);
 
@@ -260,9 +288,10 @@ async function fetchVisibleFeedItems(
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
     .where(and(
       eq(feedItems.recipientUserId, userId),
-      eq(feedItems.isPinned, options.pinned ?? false),
+      pinnedPagePredicate(options.pinned),
       visibleSourcePredicate,
-      inArray(feedItems.state, VISIBLE_FEED_STATES),
+      inArray(feedItems.state, options.pinned ? ACTION_REQUIRED_FEED_STATES : VISIBLE_FEED_STATES),
+      feedFilterPredicate(options.filter),
       visibleQuestionPredicate(dismissedDomains),
       cursorPredicate,
     ))
@@ -275,14 +304,15 @@ async function fetchVisibleFeedItems(
 export async function getFeedForUser(userId: string, options: FeedForUserOptions = {}): Promise<PaginatedFeedResult> {
   const dismissedDomains = await getDismissedDomains(userId);
   const limit = normalizeFeedLimit(options.limit);
+  const filter = options.filter ?? 'all';
   const isFirstPage = !options.cursor;
 
   // Pinned items are deliberately returned only on the first page, ahead of the chronological feed.
   const [pinned, nonPinnedRaw, countRows] = await Promise.all([
     isFirstPage
-      ? fetchVisibleFeedItems(userId, dismissedDomains, { limit, pinned: true })
+      ? fetchVisibleFeedItems(userId, dismissedDomains, { limit, pinned: true, filter })
       : Promise.resolve([]),
-    fetchVisibleFeedItems(userId, dismissedDomains, { limit: limit + 1, cursor: options.cursor, pinned: false }),
+    fetchVisibleFeedItems(userId, dismissedDomains, { limit: limit + 1, cursor: options.cursor, pinned: false, filter }),
     db
       .select({ value: count() })
       .from(feedItems)
@@ -291,6 +321,7 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
         eq(feedItems.recipientUserId, userId),
         visibleSourcePredicate,
         inArray(feedItems.state, VISIBLE_FEED_STATES),
+        feedFilterPredicate(filter),
         visibleQuestionPredicate(dismissedDomains),
       )),
   ]);
@@ -333,10 +364,10 @@ export async function rollOffOldItems(userId: string): Promise<number> {
     .where(and(
       eq(feedItems.recipientUserId, userId),
       eq(feedItems.isPinned, false),
-      inArray(feedItems.state, VISIBLE_FEED_STATES),
+      inArray(feedItems.state, ACTION_REQUIRED_FEED_STATES),
     ))
     .orderBy(desc(feedItems.sourceEventAt))
-    .offset(25);
+    .offset(50);
 
   if (overflow.length === 0) return 0;
 
@@ -355,7 +386,7 @@ export async function userHasQuestionInVisibleFeed(userId: string, questionId: s
     .where(and(
       eq(feedItems.recipientUserId, userId),
       eq(feedItems.questionId, questionId),
-      inArray(feedItems.state, VISIBLE_FEED_STATES),
+      inArray(feedItems.state, ACTION_REQUIRED_FEED_STATES),
     ))
     .limit(1);
 

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -5,10 +5,12 @@ import type { feedItems, questions } from '@/server/db';
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
 export const AUTHORED_SHARED_FEED_SOURCE_TYPE = 'authored_shared' as const;
 export const DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent' as const;
+export const THUMBS_UPPED_FEED_SOURCE_TYPE = 'thumbs_upped' as const;
 
 export const ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES = [
   AUTHORED_SHARED_FEED_SOURCE_TYPE,
   DIRECT_SENT_FEED_SOURCE_TYPE,
+  THUMBS_UPPED_FEED_SOURCE_TYPE,
 ] as const;
 
 export const RESULT_GATED_MAIN_FEED_SOURCE_TYPES = {
@@ -18,6 +20,7 @@ export const RESULT_GATED_MAIN_FEED_SOURCE_TYPES = {
 export const QUESTION_SHARING_FEED_SOURCE_VISIBILITY = [
   { sourceType: AUTHORED_SHARED_FEED_SOURCE_TYPE, sourceResult: null, visible: true, reason: null },
   { sourceType: DIRECT_SENT_FEED_SOURCE_TYPE, sourceResult: null, visible: true, reason: null },
+  { sourceType: THUMBS_UPPED_FEED_SOURCE_TYPE, sourceResult: null, visible: true, reason: null },
   { sourceType: SOCIAL_FEED_SOURCE_TYPE, sourceResult: 'correct', visible: true, reason: null },
   {
     sourceType: SOCIAL_FEED_SOURCE_TYPE,
@@ -63,6 +66,7 @@ export function visibleFeedSourcePredicate(feedItemColumns: FeedItemsVisibilityC
   return or(
     eq(feedItemColumns.sourceType, AUTHORED_SHARED_FEED_SOURCE_TYPE),
     eq(feedItemColumns.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
+    eq(feedItemColumns.sourceType, THUMBS_UPPED_FEED_SOURCE_TYPE),
     and(
       eq(feedItemColumns.sourceType, SOCIAL_FEED_SOURCE_TYPE),
       eq(feedItemColumns.sourceResult, 'correct'),


### PR DESCRIPTION
### Motivation
- Represent Feed cards as explicit typed variants (discriminated union) so UI and API can render different card types consistently. 
- Ensure answered-by-you cards persist and return durable data (submitted answer, correctness, stored explanation, points/mastery) instead of relying on ephemeral client state. 
- Provide URL-filter support and expand visibility/rolloff rules to surface direct-sent unanswered items and increase the visible feed cap. 
- Make wrong-answer privacy explicit so incorrect answers never generate public/social friend Feed cards.

### Description
- API: extended `/api/feed` to return typed card discriminants (`card_type`/`type`) and an `answered_by_you` payload reconstructed from `FeedItem`, `MASTERY_EVENTS`, question rows, and `playerMastery` progress; added `filter` query param handling. (`src/app/api/feed/route.ts`)
- Queries: included `answered` in visible feed states, separated `ACTION_REQUIRED_FEED_STATES` from visible states, added `pinnedPagePredicate` and `feedFilterPredicate`, and increased action-required rolloff offset from `25` to `50`. (`src/server/db/queries/feed.ts`)
- Visibility: added legacy `thumbs_upped` as a visible source mapped to `friend_liked` and preserved gating of `friend_answered` to successful answers only. (`src/server/feed/visibility.ts`)
- Answer route: made propagation explicit so only correct answers produce friend-facing feed items while wrong answers persist privately on the answering user's `FeedItem`. (`src/app/api/feed/[feedItemId]/answer/route.ts`)
- Client: hydrated Feed client state from the API `answered_by_you` payload so answered cards render after refresh (including submitted answer preview and explanation) and treated answered items as not action-pinned. (`src/components/FeedList.tsx`)
- Tests: expanded and updated Feed API / query tests to cover typed cards, filters, durable answered cards, pinned-answered visibility, and incorrect-friend suppression. (`src/app/api/feed/__tests__/route.test.ts`, `src/server/db/queries/__tests__/feed.test.ts`)

### Testing
- Type check: ran `npx tsc --noEmit` and it completed successfully.  
- Targeted lint: ran `npx eslint` against the modified Feed files and the targeted test files (as listed in the PR) and checks for those files completed without errors; a full repo `npm run lint` still reports unrelated pre-existing issues outside the touched Feed files.  
- Unit tests: updated Feed tests were added and validate the new API shapes locally, however running `vitest` in this environment was blocked by registry access (`403 Forbidden`), so full automated test execution was not possible here.  
- Commit: changes were staged and committed for review; reviewers can run the full test matrix locally or in CI (`npx vitest run`, `npm run lint`) to finish verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0639778924832eab6c33116e286f01)