### PR TITLE
Integrate typed Feed cards into FeedList

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -239,6 +239,7 @@ export async function GET(request: NextRequest) {
         source_user_id: item.sourceUserId,
         source_result: item.sourceResult ?? null,
         source_friend_display_name: sourceName,
+        source_profile_href: `/users/${encodeURIComponent(item.sourceUserId)}`,
         source_attribution: item.sourceType === AUTHORED_SHARED_FEED_SOURCE_TYPE
           ? authoredSharedAttribution(sourceName, domain)
           : item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -7,6 +7,7 @@ import {
   AnsweredByYouCard,
   AnswerForm,
   DirectSentCard,
+  FeedOverflowMenu,
   FriendAddedCard,
   FriendAnsweredCard,
   FriendLikedCard,
@@ -43,6 +44,7 @@ type FeedApiItem = {
   source_type: string
   source_user_id: string
   source_friend_display_name: string
+  source_profile_href?: string | null
   source_attribution: string
   source_result: 'correct' | 'incorrect' | null
   friend_results: FriendResult[] | null
@@ -61,6 +63,7 @@ type FeedApiItem = {
   correct_answer: string | null
   submitted_answer: string | null
   awarded_points: number | null
+  pointsAwarded?: number | null
   mastery_delta: unknown | null
   unverified_answer: boolean
 }
@@ -103,6 +106,10 @@ type AnswerResponse = {
   quip?: string | null
   consolation?: string | null
   breadcrumb?: string | null
+  pointsAwarded?: number | null
+  awarded_points?: number | null
+  masteryDelta?: unknown | null
+  mastery_delta?: unknown | null
 }
 
 type ResultState = {
@@ -111,6 +118,8 @@ type ResultState = {
   explanation: string | null
   quip: string | null
   breadcrumb: string | null
+  awardedPoints: number | null
+  masteryDelta: unknown | null
 }
 
 function formatEventTime(value: string) {
@@ -139,15 +148,56 @@ function comparisonCopy(
   return 'This one is still waiting for common ground.'
 }
 
-function feedMetadata(item: FeedApiItem) {
-  const time = formatEventTime(item.source_event_at)
-  return time ? `${item.source_attribution} · ${time}` : item.source_attribution
+function profileHref(userId?: string | null) {
+  return userId ? `/users/${encodeURIComponent(userId)}` : null
 }
 
-function baseTypedFields(item: FeedApiItem) {
+function FeedPersonLink({
+  href,
+  name,
+}: {
+  href?: string | null
+  name: string
+}) {
+  if (!href) return <>{name}</>
+  return (
+    <Link href={href} className="underline-offset-2 hover:underline">
+      {name}
+    </Link>
+  )
+}
+
+function feedMetadata(item: FeedApiItem, answered = false) {
+  const time = formatEventTime(item.source_event_at)
+  const source = (
+    <span>
+      <FeedPersonLink
+        href={item.source_profile_href ?? profileHref(item.source_user_id)}
+        name={item.source_friend_display_name}
+      />{' '}
+      {item.source_type === 'direct_sent'
+        ? 'sent this to you'
+        : item.source_type === 'authored_shared'
+          ? 'shared this'
+          : item.source_type === 'thumbs_upped'
+            ? 'liked this'
+            : 'answered this'}
+    </span>
+  )
+
+  return (
+    <span>
+      {source}
+      {time ? <> · {time}</> : null}
+      {answered ? <> · You answered</> : null}
+    </span>
+  )
+}
+
+function baseTypedFields(item: FeedApiItem, answered = false) {
   return {
     id: item.id,
-    metadata: feedMetadata(item),
+    metadata: feedMetadata(item, answered),
     category: item.domain_pill,
     question: item.question_text ?? 'Untitled question',
     personalMessage: item.personal_message,
@@ -174,6 +224,7 @@ function toTypedFeedItem(item: FeedApiItem) {
       ...base,
       type: 'direct_sent' as const,
       senderName: item.source_friend_display_name,
+      senderHref: item.source_profile_href ?? profileHref(item.source_user_id),
     } satisfies DirectSentFeedItem
   }
 
@@ -182,6 +233,7 @@ function toTypedFeedItem(item: FeedApiItem) {
       ...base,
       type: 'friend_added' as const,
       friendName: item.source_friend_display_name,
+      friendHref: item.source_profile_href ?? profileHref(item.source_user_id),
     } satisfies FriendAddedFeedItem
   }
 
@@ -190,6 +242,7 @@ function toTypedFeedItem(item: FeedApiItem) {
       ...base,
       type: 'friend_liked' as const,
       friendName: item.source_friend_display_name,
+      friendHref: item.source_profile_href ?? profileHref(item.source_user_id),
     } satisfies FriendLikedFeedItem
   }
 
@@ -198,6 +251,9 @@ function toTypedFeedItem(item: FeedApiItem) {
     type: 'friend_answered' as const,
     friendName:
       item.friend_results?.[0]?.displayName ?? item.source_friend_display_name,
+    friendHref: profileHref(
+      item.friend_results?.[0]?.userId ?? item.source_user_id
+    ),
     friendCorrect:
       item.friend_results?.[0]?.result === 'correct' ||
       item.source_result === 'correct',
@@ -210,13 +266,21 @@ function toAnsweredByYouItem(
   result?: ResultState
 ): AnsweredByYouFeedItem {
   return {
-    ...baseTypedFields(item),
+    ...baseTypedFields(item, true),
     type: 'answered_by_you',
     resultLabel:
-      item.is_correct === false ? 'Answered by you · Not quite' : 'Answered by you',
+      item.is_correct === false || result?.correct === false
+        ? 'Reviewed privately'
+        : 'You answered',
     answerSummary: result
       ? comparisonCopy(result.correct, item.friend_results)
       : comparisonCopy(item.is_correct, item.friend_results),
+    correctAnswer: result?.answer || item.correct_answer,
+    submittedAnswer: item.submitted_answer || undefined,
+    isCorrect: result?.correct ?? item.is_correct,
+    awardedPoints: result?.awardedPoints ?? item.awarded_points,
+    explanation: result?.explanation ?? item.explanation,
+    unverifiedAnswer: item.unverified_answer,
   }
 }
 
@@ -386,27 +450,88 @@ export default function FeedList({
     setItems((current) => current.filter((item) => item.id !== itemId))
   }, [])
 
-  const updateState = useCallback(
-    async (itemId: string, state: 'skipped' | 'dismissed') => {
-      setBusyId(itemId)
+  const hideCategory = useCallback(async (item: FeedApiItem) => {
+    if (!item.domain_pill) return
+    setBusyId(item.id)
+    setError(null)
+    try {
+      const response = await fetch('/api/feed/dismiss-domain', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain: item.domain_pill }),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => null)
+        throw new Error(body?.message ?? 'Could not hide that category.')
+      }
+      setItems((current) =>
+        current.filter(
+          (currentItem) => currentItem.domain_pill !== item.domain_pill
+        )
+      )
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : 'Could not hide that category.'
+      )
+    } finally {
+      setBusyId(null)
+    }
+  }, [])
+
+  const hidePerson = useCallback(async (item: FeedApiItem) => {
+    setBusyId(item.id)
+    setError(null)
+    try {
+      const response = await fetch(`/api/feed/${item.id}/state`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ state: 'dismissed' }),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => null)
+        throw new Error(
+          body?.message ?? 'Could not hide questions from that person.'
+        )
+      }
+      setItems((current) =>
+        current.filter(
+          (currentItem) => currentItem.source_user_id !== item.source_user_id
+        )
+      )
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : 'Could not hide questions from that person.'
+      )
+    } finally {
+      setBusyId(null)
+    }
+  }, [])
+
+  const reportItem = useCallback(
+    async (item: FeedApiItem) => {
+      setBusyId(item.id)
       setError(null)
       try {
-        const response = await fetch(`/api/feed/${itemId}/state`, {
-          method: 'PATCH',
-          headers: { 'content-type': 'application/json' },
+        const response = await fetch(`/api/feed/${item.id}/thumbsdown`, {
+          method: 'POST',
           credentials: 'include',
-          body: JSON.stringify({ state }),
         })
         if (!response.ok) {
           const body = await response.json().catch(() => null)
-          throw new Error(body?.message ?? 'Could not update that Feed item.')
+          throw new Error(body?.message ?? 'Could not report that question.')
         }
-        removeItem(itemId)
+        removeItem(item.id)
       } catch (caught) {
         setError(
           caught instanceof Error
             ? caught.message
-            : 'Could not update that Feed item.'
+            : 'Could not report that question.'
         )
       } finally {
         setBusyId(null)
@@ -450,8 +575,33 @@ export default function FeedList({
             explanation: body.explanation ?? null,
             quip: body.quip ?? body.consolation ?? null,
             breadcrumb: body.breadcrumb ?? null,
+            awardedPoints: body.pointsAwarded ?? body.awarded_points ?? null,
+            masteryDelta: body.masteryDelta ?? body.mastery_delta ?? null,
           },
         }))
+        setItems((current) =>
+          current.map((currentItem) =>
+            currentItem.id === item.id
+              ? {
+                  ...currentItem,
+                  state: 'answered',
+                  card_type: 'answered_by_you',
+                  type: 'answered_by_you',
+                  submitted_answer: submitted,
+                  answer_result: Boolean(body.correct ?? body.isCorrect)
+                    ? 'correct'
+                    : 'incorrect',
+                  is_correct: Boolean(body.correct ?? body.isCorrect),
+                  correct_answer: body.answer ?? body.correctAnswer ?? '',
+                  awarded_points:
+                    body.pointsAwarded ?? body.awarded_points ?? null,
+                  mastery_delta:
+                    body.masteryDelta ?? body.mastery_delta ?? null,
+                  explanation: body.explanation ?? currentItem.explanation,
+                }
+              : currentItem
+          )
+        )
         setCardStates((s) => ({ ...s, [item.id]: 'answered' }))
       } catch (caught) {
         setError(
@@ -466,8 +616,30 @@ export default function FeedList({
     [answers]
   )
 
+  const filterOptions: Array<{ value: FeedFilter; label: string }> = [
+    { value: 'all', label: 'All' },
+    { value: 'sent-to-me', label: 'Sent to me' },
+    { value: 'from-friends', label: 'From friends' },
+  ]
+
   return (
     <>
+      <nav className="mb-4 flex flex-wrap gap-2" aria-label="Feed filters">
+        {filterOptions.map((option) => (
+          <Link
+            key={option.value}
+            href={`/feed?filter=${option.value}`}
+            aria-current={feedFilter === option.value ? 'page' : undefined}
+            className={
+              feedFilter === option.value
+                ? 'rounded-full bg-stone-950 px-3 py-1.5 text-sm font-medium text-white'
+                : 'rounded-full border border-stone-300 bg-white px-3 py-1.5 text-sm font-medium text-stone-700 hover:bg-stone-50'
+            }
+          >
+            {option.label}
+          </Link>
+        ))}
+      </nav>
       {ceremonyBanner ? (
         <Link
           href={`/ceremony/${ceremonyBanner.id}`}
@@ -521,6 +693,26 @@ export default function FeedList({
                 : null
             const typedItem = toTypedFeedItem(item)
             const isBusy = busyId === item.id
+            const overflow = (
+              <FeedOverflowMenu
+                sourceName={item.source_friend_display_name}
+                category={item.domain_pill}
+                question={
+                  item.question_id && item.question_text
+                    ? {
+                        id: item.question_id,
+                        text: item.question_text,
+                        domain: item.domain_pill,
+                      }
+                    : null
+                }
+                isInBank={item.is_in_bank}
+                disabled={isBusy}
+                onHideCategory={() => void hideCategory(item)}
+                onHidePerson={() => void hidePerson(item)}
+                onReport={() => void reportItem(item)}
+              />
+            )
             const answerActions =
               cardState === 'answering' ? (
                 <AnswerForm
@@ -545,52 +737,14 @@ export default function FeedList({
                       [item.id]: 'answering',
                     }))
                   }
-                  onDismiss={() => void updateState(item.id, 'dismissed')}
+                  overflow={overflow}
                   disabled={isBusy}
                 />
               ) : null
 
-            const answeredDetails = result || cardState === 'answered' ? (
-              <div className="rounded-xl bg-white/60 p-3 text-sm leading-6 text-stone-700">
-                <p className="font-medium text-stone-900">
-                  {comparisonCopy(result?.correct ?? item.is_correct, item.friend_results)}
-                </p>
-                {item.submitted_answer || answers[item.id] ? (
-                  <p className="mt-1">Your answer: {item.submitted_answer || answers[item.id]}</p>
-                ) : null}
-                {(result?.answer || item.correct_answer) &&
-                (result?.correct === false || item.is_correct === false) ? (
-                  <p className="mt-1">
-                    Answer: {result?.answer || item.correct_answer}
-                  </p>
-                ) : null}
-                {typeof item.awarded_points === 'number' ? (
-                  <p className="mt-1">Points: +{item.awarded_points}</p>
-                ) : null}
-                {item.unverified_answer ? (
-                  <p className="text-muted-foreground mt-1">This answer is still unverified.</p>
-                ) : null}
-                {result?.explanation || item.explanation ? (
-                  <p className="text-muted-foreground mt-1">
-                    {result?.explanation || item.explanation}
-                  </p>
-                ) : null}
-                {result?.quip ? (
-                  <p className="text-muted-foreground mt-1">{result.quip}</p>
-                ) : null}
-                {result?.breadcrumb ? (
-                  <p className="text-muted-foreground mt-2 italic">
-                    {result.breadcrumb}
-                  </p>
-                ) : null}
-              </div>
-            ) : null
-
             if (answeredByYouItem) {
               return (
-                <AnsweredByYouCard key={item.id} item={answeredByYouItem}>
-                  {answeredDetails}
-                </AnsweredByYouCard>
+                <AnsweredByYouCard key={item.id} item={answeredByYouItem} />
               )
             }
 

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -9,6 +9,78 @@ type AnsweredByYouCardProps = {
   children?: ReactNode
 }
 
+function FeedProgressCircles({
+  correct,
+}: {
+  correct: boolean | null | undefined
+}) {
+  return (
+    <div
+      className="flex items-center gap-1.5"
+      aria-label="Feed answer progress"
+    >
+      {Array.from({ length: 5 }, (_, index) => {
+        const active = index === 0
+        const className = active
+          ? correct
+            ? 'bg-emerald-600 border-emerald-600'
+            : 'bg-stone-400 border-stone-400'
+          : 'border-stone-300 bg-white/70'
+        return (
+          <span
+            key={index}
+            aria-hidden
+            className={`size-2.5 rounded-full border ${className}`}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+function AnsweredDetails({ item }: { item: AnsweredByYouFeedItem }) {
+  return (
+    <div className="rounded-xl bg-white/65 p-3 text-sm leading-6 text-stone-700">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <p className="font-medium text-stone-900">
+          {item.answerSummary ?? 'You answered this question.'}
+        </p>
+        <FeedProgressCircles correct={item.isCorrect} />
+      </div>
+      {item.submittedAnswer ? (
+        <p className="mt-2">
+          <span className="font-medium text-stone-900">Your answer:</span>{' '}
+          {item.submittedAnswer}
+        </p>
+      ) : null}
+      {item.correctAnswer ? (
+        <p className="mt-1">
+          <span className="font-medium text-stone-900">Correct answer:</span>{' '}
+          {item.correctAnswer}
+        </p>
+      ) : null}
+      {item.isCorrect && typeof item.awardedPoints === 'number' ? (
+        <p className="mt-2 inline-flex rounded-full bg-emerald-100 px-3 py-1 font-medium text-emerald-900">
+          +{item.awardedPoints} points
+        </p>
+      ) : null}
+      {item.isCorrect === false ? (
+        <p className="mt-2 rounded-lg bg-stone-100 px-3 py-2 text-stone-700">
+          Added to your missed questions — you can try again for review later.
+        </p>
+      ) : null}
+      {item.unverifiedAnswer ? (
+        <p className="text-muted-foreground mt-2">
+          This answer is still unverified.
+        </p>
+      ) : null}
+      {item.explanation ? (
+        <p className="text-muted-foreground mt-2">{item.explanation}</p>
+      ) : null}
+    </div>
+  )
+}
+
 export function AnsweredByYouCard({
   item,
   actions,
@@ -18,10 +90,10 @@ export function AnsweredByYouCard({
     <FeedCard
       item={item}
       tone="gray"
-      eyebrow={<span>{item.resultLabel ?? 'Answered'}</span>}
+      eyebrow={<span>{item.resultLabel ?? 'You answered'}</span>}
       actions={actions}
     >
-      {children ?? (item.answerSummary ? <p>{item.answerSummary}</p> : null)}
+      {children ?? <AnsweredDetails item={item} />}
     </FeedCard>
   )
 }

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
 import type { DirectSentFeedItem } from './types'
@@ -7,6 +8,18 @@ type DirectSentCardProps = {
   item: DirectSentFeedItem
   actions?: ReactNode
   children?: ReactNode
+}
+
+function PersonName({ href, name }: { href?: string | null; name: string }) {
+  if (!href) return <>{name}</>
+  return (
+    <Link
+      href={href}
+      className="font-medium underline-offset-2 hover:underline"
+    >
+      {name}
+    </Link>
+  )
 }
 
 export function DirectSentCard({
@@ -21,7 +34,12 @@ export function DirectSentCard({
       eyebrow={<span>For you</span>}
       actions={actions}
     >
-      {children ?? <p>{item.senderName} thought you would like this one.</p>}
+      {children ?? (
+        <p>
+          <PersonName href={item.senderHref} name={item.senderName} /> thought
+          you would like this one.
+        </p>
+      )}
     </FeedCard>
   )
 }

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -1,19 +1,166 @@
 'use client'
 
-import { MoreHorizontal } from 'lucide-react'
+import { Flag, MoreHorizontal, X } from 'lucide-react'
+import { type ReactNode, useState } from 'react'
 
+import { AddToBankAction } from '@/components/AddToBankAction'
+import { SendQuestionAction } from '@/components/SendQuestionAction'
 import { Button } from '@/components/ui/button'
+import { visibleFeedCategory } from './category'
+
+export type FeedOverflowQuestion = {
+  id: string
+  text: string
+  domain?: string | null
+}
+
+export type FeedOverflowMenuProps = {
+  sourceName: string
+  category?: string | null
+  question?: FeedOverflowQuestion | null
+  isInBank?: boolean
+  disabled?: boolean
+  onHideCategory?: () => void
+  onHidePerson?: () => void
+  onReport?: () => void
+  children?: ReactNode
+}
+
+function MenuButton({
+  children,
+  disabled,
+  onClick,
+}: {
+  children: ReactNode
+  disabled?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <button
+      type="button"
+      disabled={disabled}
+      onClick={onClick}
+      className="text-foreground hover:bg-muted flex min-h-10 w-full items-center rounded-xl px-3 text-left text-sm transition disabled:cursor-not-allowed disabled:opacity-50"
+    >
+      {children}
+    </button>
+  )
+}
+
+export function FeedOverflowMenu({
+  sourceName,
+  category,
+  question,
+  isInBank = false,
+  disabled = false,
+  onHideCategory,
+  onHidePerson,
+  onReport,
+  children,
+}: FeedOverflowMenuProps) {
+  const [open, setOpen] = useState(false)
+  const visibleCategory = visibleFeedCategory(category)
+
+  const wrapAction = (action?: () => void) => {
+    if (!action) return undefined
+    return () => {
+      action()
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        aria-label="More Feed actions"
+        aria-expanded={open}
+        disabled={disabled}
+        onClick={() => setOpen((current) => !current)}
+        className="flex size-9 items-center justify-center rounded-lg border border-stone-300 bg-white/70 text-stone-700 transition hover:bg-white disabled:opacity-50"
+      >
+        <MoreHorizontal className="size-4" />
+      </button>
+      {open ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
+          <button
+            className="absolute inset-0 cursor-default sm:hidden"
+            type="button"
+            aria-label="Close Feed actions"
+            onClick={() => setOpen(false)}
+          />
+          <div className="bg-background relative w-full max-w-md rounded-3xl border p-2 shadow-2xl sm:w-72 sm:rounded-2xl sm:shadow-xl">
+            <div className="flex items-center justify-between px-3 py-2 sm:hidden">
+              <p className="text-foreground text-sm font-medium">
+                More actions
+              </p>
+              <button
+                type="button"
+                aria-label="Close menu"
+                onClick={() => setOpen(false)}
+                className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-11 items-center justify-center rounded-full"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            {visibleCategory ? (
+              <MenuButton
+                disabled={disabled}
+                onClick={wrapAction(onHideCategory)}
+              >
+                Hide this category
+              </MenuButton>
+            ) : null}
+            <MenuButton disabled={disabled} onClick={wrapAction(onHidePerson)}>
+              Hide questions from {sourceName || 'this person'}
+            </MenuButton>
+            {question && !isInBank ? (
+              <AddToBankAction
+                questionId={question.id}
+                initialInBank={false}
+                contextType="feed"
+                label="Add to bank"
+                className="hover:bg-muted flex min-h-10 w-full justify-start rounded-xl border-0 px-3 text-left text-sm"
+              />
+            ) : null}
+            {question ? (
+              <SendQuestionAction
+                question={{
+                  id: question.id,
+                  text: question.text,
+                  domain: question.domain ?? '',
+                }}
+                label="Send to friend"
+                className="text-foreground hover:bg-muted flex min-h-10 w-full items-center rounded-xl px-3 text-left text-sm transition"
+              />
+            ) : null}
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={wrapAction(onReport)}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-10 w-full items-center gap-2 rounded-xl px-3 text-left text-sm transition disabled:opacity-50"
+            >
+              <Flag className="size-4" />
+              Report
+            </button>
+            {children}
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
 
 export type UnansweredFeedActionsProps = {
   onAnswer: () => void
   disabled?: boolean
-  onDismiss?: () => void
+  overflow: ReactNode
 }
 
 export function UnansweredFeedActions({
   onAnswer,
   disabled = false,
-  onDismiss,
+  overflow,
 }: UnansweredFeedActionsProps) {
   return (
     <div className="flex items-center gap-2">
@@ -25,29 +172,7 @@ export function UnansweredFeedActions({
       >
         Answer
       </Button>
-      <div className="relative">
-        <details className="group">
-          <summary className="flex size-8 cursor-pointer list-none items-center justify-center rounded-lg border border-stone-300 bg-white/70 text-stone-700 transition hover:bg-white [&::-webkit-details-marker]:hidden">
-            <MoreHorizontal className="size-4" aria-label="More options" />
-          </summary>
-          <div className="absolute right-0 z-10 mt-2 min-w-32 rounded-lg border border-stone-200 bg-white p-2 shadow-lg">
-            {onDismiss ? (
-              <button
-                type="button"
-                onClick={onDismiss}
-                disabled={disabled}
-                className="w-full rounded-md px-2 py-1.5 text-left text-sm font-medium text-sky-700 hover:bg-sky-50 disabled:opacity-50"
-              >
-                Dismiss
-              </button>
-            ) : (
-              <p className="text-muted-foreground px-2 py-1.5 text-sm">
-                More soon
-              </p>
-            )}
-          </div>
-        </details>
-      </div>
+      {overflow}
     </div>
   )
 }

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
 import type { FriendAddedFeedItem } from './types'
@@ -7,6 +8,18 @@ type FriendAddedCardProps = {
   item: FriendAddedFeedItem
   actions?: ReactNode
   children?: ReactNode
+}
+
+function PersonName({ href, name }: { href?: string | null; name: string }) {
+  if (!href) return <>{name}</>
+  return (
+    <Link
+      href={href}
+      className="font-medium underline-offset-2 hover:underline"
+    >
+      {name}
+    </Link>
+  )
 }
 
 export function FriendAddedCard({
@@ -21,7 +34,12 @@ export function FriendAddedCard({
       eyebrow={<span>New question</span>}
       actions={actions}
     >
-      {children ?? <p>{item.friendName} added a question to their bank.</p>}
+      {children ?? (
+        <p>
+          <PersonName href={item.friendHref} name={item.friendName} /> added a
+          question to their bank.
+        </p>
+      )}
     </FeedCard>
   )
 }

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
 import type { FriendAnsweredFeedItem } from './types'
@@ -7,6 +8,18 @@ type FriendAnsweredCardProps = {
   item: FriendAnsweredFeedItem
   actions?: ReactNode
   children?: ReactNode
+}
+
+function PersonName({ href, name }: { href?: string | null; name: string }) {
+  if (!href) return <>{name}</>
+  return (
+    <Link
+      href={href}
+      className="font-medium underline-offset-2 hover:underline"
+    >
+      {name}
+    </Link>
+  )
 }
 
 export function FriendAnsweredCard({
@@ -23,11 +36,15 @@ export function FriendAnsweredCard({
       eyebrow={<span>Friend answered</span>}
       actions={actions}
     >
-      {children ?? (
-        <p>
-          {item.answerSummary ?? `${item.friendName} answered this question.`}
-        </p>
-      )}
+      {children ??
+        (item.answerSummary ? (
+          <p>{item.answerSummary}</p>
+        ) : (
+          <p>
+            <PersonName href={item.friendHref} name={item.friendName} />{' '}
+            answered this question.
+          </p>
+        ))}
     </FeedCard>
   )
 }

--- a/src/components/feed/FriendLikedCard.tsx
+++ b/src/components/feed/FriendLikedCard.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
 import type { FriendLikedFeedItem } from './types'
@@ -7,6 +8,18 @@ type FriendLikedCardProps = {
   item: FriendLikedFeedItem
   actions?: ReactNode
   children?: ReactNode
+}
+
+function PersonName({ href, name }: { href?: string | null; name: string }) {
+  if (!href) return <>{name}</>
+  return (
+    <Link
+      href={href}
+      className="font-medium underline-offset-2 hover:underline"
+    >
+      {name}
+    </Link>
+  )
 }
 
 export function FriendLikedCard({
@@ -21,7 +34,12 @@ export function FriendLikedCard({
       eyebrow={<span>Friend liked</span>}
       actions={actions}
     >
-      {children ?? <p>{item.friendName} liked this question.</p>}
+      {children ?? (
+        <p>
+          <PersonName href={item.friendHref} name={item.friendName} /> liked
+          this question.
+        </p>
+      )}
     </FeedCard>
   )
 }

--- a/src/components/feed/index.ts
+++ b/src/components/feed/index.ts
@@ -1,4 +1,4 @@
-export { AnswerForm, UnansweredFeedActions } from './FeedActions'
+export { AnswerForm, FeedOverflowMenu, UnansweredFeedActions } from './FeedActions'
 export { AnsweredByYouCard } from './AnsweredByYouCard'
 export { DirectSentCard } from './DirectSentCard'
 export { FeedCard } from './FeedCard'

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -10,7 +10,7 @@ export type FeedCardActionState =
 
 export type FeedCardBaseItem = {
   id: string
-  metadata: string
+  metadata: ReactNode
   question: string
   category?: string | null
   personalMessage?: string | null
@@ -19,11 +19,13 @@ export type FeedCardBaseItem = {
 export type DirectSentFeedItem = FeedCardBaseItem & {
   type: 'direct_sent'
   senderName: string
+  senderHref?: string | null
 }
 
 export type FriendAnsweredFeedItem = FeedCardBaseItem & {
   type: 'friend_answered'
   friendName: string
+  friendHref?: string | null
   friendCorrect?: boolean | null
   answerSummary?: string | null
 }
@@ -31,17 +33,25 @@ export type FriendAnsweredFeedItem = FeedCardBaseItem & {
 export type FriendAddedFeedItem = FeedCardBaseItem & {
   type: 'friend_added'
   friendName: string
+  friendHref?: string | null
 }
 
 export type FriendLikedFeedItem = FeedCardBaseItem & {
   type: 'friend_liked'
   friendName: string
+  friendHref?: string | null
 }
 
 export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   type: 'answered_by_you'
   resultLabel?: string | null
   answerSummary?: string | null
+  correctAnswer?: string | null
+  submittedAnswer?: string | null
+  isCorrect?: boolean | null
+  awardedPoints?: number | null
+  explanation?: string | null
+  unverifiedAnswer?: boolean
 }
 
 export type TypedFeedItem =


### PR DESCRIPTION
### Motivation
- Replace untyped/cluttered Feed rendering with typed/discriminated Feed card components and surface friend/profile metadata so the Feed can render presentational cards and interactions consistently.
- Support product requirements: URL-persisted filters, inline answer expansion and submission, answered-by-you rendering that shows correct answers/points/progress, and a simple overflow menu with the specified actions.

### Description
- Feed API: include `source_profile_href` in `/api/feed` payload so cards can link friend names (server-side change in `src/app/api/feed/route.ts`).
- Types: extended typed feed item shapes in `src/components/feed/types.ts` to carry profile hrefs and answered-card fields used by UI cards.
- FeedList orchestration: updated `src/components/FeedList.tsx` to load typed Feed items, add URL-backed filters (`?filter=all|sent-to-me|from-friends`), persist filter selection in links, manage card state, submit inline answers to `/api/feed/[feedItemId]/answer`, and locally convert items to answered-by-you on success while preserving grading/points/mastery fields.
- Presentational cards: added/updated feed card components in `src/components/feed/*` (AnsweredByYouCard, DirectSentCard, FriendAddedCard, FriendAnsweredCard, FriendLikedCard) to render metadata, linked friend names, correct answer, explanation, points, and progress circles for answered-by-you items.
- Unanswered actions & overflow: replaced old actions with a compact `Answer` button plus a ⋯ overflow (`FeedOverflowMenu`) exposing Hide this category, Hide questions from this person, Add to bank (if not banked), Send to friend, and Report; Skip/React are omitted (implemented in `src/components/feed/FeedActions.tsx`).
- Category hiding / person hiding / reporting: implemented optimistic UI handlers in `FeedList` calling `/api/feed/dismiss-domain`, `/api/feed/:id/state` and `/api/feed/:id/thumbsdown` and removing/transforming items locally.
- UX details: unanswered cards only show `Answer` + overflow (no Skip or other chips), inline answer form expands in-place, answered-by-you cards always show the correct answer and use calm private copy for wrong answers (no red wrong state), and progress circles + points are shown for correct answers.

### Testing
- Typecheck: ran `npx tsc --noEmit` on the repo; targeted type errors introduced by changes were addressed and typecheck completed (success for modified files).
- Linting: ran `npx eslint` against changed Feed files; targeted lint checks for updated files passed, while a repo-wide `npm run lint` surfaced pre-existing unrelated lint issues outside the scope of these changes.
- Build / tests: attempted `npm run build` but the Next/font fetch for Google Fonts failed in this environment (network/fetch limitation); running unit tests with `vitest` was blocked by environment/npm registry access (403), so automated test runs for feed API tests could not be completed here.

If you want, I can split follow-ups into smaller PRs (e.g., overflow menu + types, answered-card UI, FeedList orchestration) or address the remaining CI/build blockers (Google Fonts/network and repo lint noise).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0650188a90832eafab69b043f41d52)