### PR TITLE
Add authenticated friend profile route

### DIFF
--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -1,0 +1,93 @@
+import React from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getFriendPortraitDataMock, getSessionMock, notFoundMock } = vi.hoisted(
+  () => ({
+    getFriendPortraitDataMock: vi.fn(),
+    getSessionMock: vi.fn(),
+    notFoundMock: vi.fn(() => {
+      throw new Error('NEXT_NOT_FOUND')
+    }),
+  })
+)
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={typeof href === 'string' ? href : String(href)} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: notFoundMock,
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/profile/friend', () => ({
+  getFriendPortraitData: getFriendPortraitDataMock,
+}))
+
+import UserProfilePage from '@/app/users/[id]/page'
+
+describe('/users/[id] friend profile page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ userId: 'viewer-1' })
+    getFriendPortraitDataMock.mockResolvedValue({
+      user: {
+        id: 'friend-1',
+        displayName: 'Frances Friend',
+        memberSince: new Date('2026-01-01T00:00:00.000Z'),
+      },
+      visibility: 'friend',
+      friendship: {
+        id: 'friendship-1',
+        formedAt: new Date('2026-02-01T00:00:00.000Z'),
+      },
+      interests: [
+        { domain: 'Jazz piano', broadCategory: 'Music', shared: true },
+        { domain: 'Roman roads', broadCategory: 'History', shared: false },
+      ],
+      sharedInterests: ['Jazz piano'],
+    })
+  })
+
+  it('renders the active friend portrait shell', async () => {
+    const element = await UserProfilePage({
+      params: Promise.resolve({ id: 'friend-1' }),
+    })
+    const html = renderToStaticMarkup(element)
+
+    expect(getFriendPortraitDataMock).toHaveBeenCalledWith(
+      'friend-1',
+      'viewer-1'
+    )
+    expect(html).toContain('Friend profile')
+    expect(html).toContain('Frances Friend')
+    expect(html).toContain('Jazz piano')
+    expect(html).toContain('shared')
+    expect(html).toContain('href="/friends"')
+  })
+
+  it('handles unauthenticated and unavailable profiles with notFound', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    await expect(
+      UserProfilePage({ params: Promise.resolve({ id: 'friend-1' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND')
+
+    getSessionMock.mockResolvedValueOnce({ userId: 'viewer-1' })
+    getFriendPortraitDataMock.mockResolvedValueOnce(null)
+    await expect(
+      UserProfilePage({ params: Promise.resolve({ id: 'stranger-1' }) })
+    ).rejects.toThrow('NEXT_NOT_FOUND')
+  })
+})

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,0 +1,113 @@
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+
+import { getSession } from '@/server/auth/session'
+import { getFriendPortraitData } from '@/server/profile/friend'
+
+type UserProfilePageProps = {
+  params: Promise<{ id: string }>
+}
+
+function formatMemberSince(value: Date) {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    year: 'numeric',
+  }).format(value)
+}
+
+export default async function UserProfilePage({
+  params,
+}: UserProfilePageProps) {
+  const session = await getSession()
+  if (!session) notFound()
+
+  const { id } = await params
+  const portrait = await getFriendPortraitData(id, session.userId)
+  if (!portrait) notFound()
+
+  const sharedInterests = portrait.sharedInterests
+  const hasInterests = portrait.interests.length > 0
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
+      <div className="mb-5">
+        <Link
+          href="/friends"
+          className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
+        >
+          ← Friends
+        </Link>
+      </div>
+
+      <section className="bg-card text-card-foreground rounded-3xl border p-5 shadow-sm">
+        <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+          {portrait.visibility === 'self' ? 'Your profile' : 'Friend profile'}
+        </p>
+        <div className="mt-4 flex items-start gap-4">
+          <div className="bg-primary/10 text-primary flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl font-serif text-3xl font-semibold">
+            {portrait.user.displayName.slice(0, 1).toUpperCase() || 'J'}
+          </div>
+          <div className="min-w-0">
+            <h1 className="text-foreground font-serif text-3xl font-semibold">
+              {portrait.user.displayName}
+            </h1>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              On Joshing since {formatMemberSince(portrait.user.memberSince)}.
+            </p>
+            {portrait.friendship?.formedAt ? (
+              <p className="text-muted-foreground mt-1 text-sm leading-6">
+                Friends since {formatMemberSince(portrait.friendship.formedAt)}.
+              </p>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-card text-card-foreground mt-5 rounded-2xl border p-4 shadow-sm">
+        <div className="mb-4">
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+            Portrait
+          </p>
+          <h2 className="mt-1 font-serif text-xl font-semibold">
+            Interests and common ground
+          </h2>
+        </div>
+
+        {sharedInterests.length > 0 ? (
+          <div className="bg-primary/5 border-primary/10 mb-4 rounded-xl border p-3">
+            <p className="text-sm font-medium">
+              You share {sharedInterests.slice(0, 3).join(', ')}
+              {sharedInterests.length > 3
+                ? `, +${sharedInterests.length - 3} more`
+                : ''}
+              .
+            </p>
+          </div>
+        ) : null}
+
+        {hasInterests ? (
+          <div className="flex flex-wrap gap-2">
+            {portrait.interests.map((interest) => (
+              <span
+                key={interest.domain}
+                className={
+                  interest.shared
+                    ? 'bg-primary/10 text-foreground border-primary/20 rounded-full border px-3 py-1 text-sm font-medium'
+                    : 'bg-muted text-foreground rounded-full px-3 py-1 text-sm font-medium'
+                }
+              >
+                {interest.domain}
+                {interest.shared ? ' · shared' : ''}
+              </span>
+            ))}
+          </div>
+        ) : (
+          <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
+            This portrait will fill in as they declare interests and answer
+            questions.
+          </p>
+        )}
+      </section>
+    </main>
+  )
+}

--- a/src/server/profile/__tests__/friend.test.ts
+++ b/src/server/profile/__tests__/friend.test.ts
@@ -1,161 +1,121 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  getPortraitDataMock,
-  answerFindManyMock,
-  userFindManyMock,
-} = vi.hoisted(() => ({
-  getPortraitDataMock: vi.fn(),
-  answerFindManyMock: vi.fn(),
-  userFindManyMock: vi.fn(),
-}));
+const { dbMock, getFriendshipMock, getUserByIdMock, state } = vi.hoisted(() => {
+  const state = {
+    interestRows: [] as Array<{
+      userId: string
+      domain: string
+      broadCategory: string | null
+    }>,
+  }
 
-vi.mock('@/server/profile/portrait', () => ({
-  getPortraitData: getPortraitDataMock,
-}));
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          orderBy: vi.fn(async () => state.interestRows),
+        })),
+      })),
+    })),
+  }
 
-import { getFriendPortraitData } from '@/server/profile/friend';
+  return {
+    dbMock,
+    getFriendshipMock: vi.fn(),
+    getUserByIdMock: vi.fn(),
+    state,
+  }
+})
 
-describe('friend portrait data shaping', () => {
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  declaredInterests: {
+    userId: 'declaredInterests.userId',
+    domain: 'declaredInterests.domain',
+    broadCategory: 'declaredInterests.broadCategory',
+    isActive: 'declaredInterests.isActive',
+  },
+}))
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendship: getFriendshipMock,
+}))
+
+vi.mock('@/server/db/queries/users', () => ({
+  getUserById: getUserByIdMock,
+}))
+
+import { getFriendPortraitData } from '@/server/profile/friend'
+
+describe('friend portrait data', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-  });
+    vi.clearAllMocks()
+    state.interestRows = []
+    getUserByIdMock.mockResolvedValue({
+      id: 'friend-1',
+      displayName: 'Frances Friend',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    getFriendshipMock.mockResolvedValue({
+      id: 'friendship-1',
+      status: 'active',
+      formedAt: new Date('2026-02-01T00:00:00.000Z'),
+    })
+  })
 
-  it('limits visitor_unexplored to 50 categories and maps overlap counters', async () => {
-    const ownerCategories = [
-      {
-        canonical_subcategory: 'Late Tchaikovsky',
-        broad_category: 'Music',
-        declared_score: 5,
-        proven_score: 4,
-        proven_score_catchup: 0,
-        question_count: 0,
-        answer_count: 0,
-        difficulty_breakdown: {
-          declared: { accessible: 0, moderate: 0, specialist: 1 },
-          proven: { accessible: 0, moderate: 1, specialist: 0 },
-        },
+  it('returns a minimal friend portrait for active friends', async () => {
+    state.interestRows = [
+      { userId: 'friend-1', domain: 'Jazz piano', broadCategory: 'Music' },
+      { userId: 'friend-1', domain: 'Roman roads', broadCategory: 'History' },
+      { userId: 'viewer-1', domain: 'Jazz piano', broadCategory: 'Music' },
+    ]
+
+    await expect(
+      getFriendPortraitData('friend-1', 'viewer-1')
+    ).resolves.toEqual({
+      user: {
+        id: 'friend-1',
+        displayName: 'Frances Friend',
+        memberSince: new Date('2026-01-01T00:00:00.000Z'),
       },
-    ];
-
-    const viewerCategories = Array.from({ length: 55 }, (_, index) => ({
-      canonical_subcategory: `Viewer category ${index + 1}`,
-      broad_category: 'History',
-      declared_score: 1,
-      proven_score: 1,
-      proven_score_catchup: 0,
-      question_count: 0,
-      answer_count: 0,
-      difficulty_breakdown: {
-        declared: { accessible: 1, moderate: 0, specialist: 0 },
-        proven: { accessible: 0, moderate: 1, specialist: 0 },
+      visibility: 'friend',
+      friendship: {
+        id: 'friendship-1',
+        formedAt: new Date('2026-02-01T00:00:00.000Z'),
       },
-    }));
+      interests: [
+        { domain: 'Jazz piano', broadCategory: 'Music', shared: true },
+        { domain: 'Roman roads', broadCategory: 'History', shared: false },
+      ],
+      sharedInterests: ['Jazz piano'],
+    })
+  })
 
-    getPortraitDataMock
-      .mockResolvedValueOnce({ categories: ownerCategories, max_declared_score: 5, max_proven_score: 4 })
-      .mockResolvedValueOnce({ categories: viewerCategories, max_declared_score: 1, max_proven_score: 1 });
+  it('returns null for missing users and non-active friendships', async () => {
+    getUserByIdMock.mockResolvedValueOnce(null)
+    await expect(
+      getFriendPortraitData('missing-user', 'viewer-1')
+    ).resolves.toBeNull()
 
-    answerFindManyMock.mockResolvedValueOnce([
-      { result: 'correct', question: { canonical_subcategory: 'Late Tchaikovsky' } },
-      { result: 'wrong', question: { canonical_subcategory: 'Late Tchaikovsky' } },
-    ]);
-    userFindManyMock.mockReset();
+    getUserByIdMock.mockResolvedValueOnce({
+      id: 'stranger-1',
+      displayName: 'Stranger',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+    getFriendshipMock.mockResolvedValueOnce({
+      id: 'friendship-2',
+      status: 'pending',
+    })
 
-    const result = await getFriendPortraitData('owner-1', 'viewer-1');
-
-    expect(result.categories).toHaveLength(1);
-    expect(result.categories[0].visitor_overlap).toEqual({
-      has_played_here: true,
-      has_correct_here: true,
-      questions_answered: 2,
-      questions_correct: 1,
-      overlap_top_peer_name: null,
-    });
-    expect(result.visitor_unexplored).toHaveLength(50);
-    expect(result.visitor_unexplored[0].canonical_subcategory).toBe('Viewer category 1');
-    expect(result.visitor_unexplored[49].canonical_subcategory).toBe('Viewer category 50');
-  });
-
-  it('keeps friend overlap behavior neutral when the viewer has no answer history in owner categories', async () => {
-    getPortraitDataMock
-      .mockResolvedValueOnce({
-        categories: [
-          {
-            canonical_subcategory: 'Roman legal codification',
-            broad_category: 'History',
-            declared_score: 4,
-            proven_score: 2,
-            proven_score_catchup: 0,
-            question_count: 0,
-            answer_count: 0,
-            difficulty_breakdown: {
-              declared: { accessible: 0, moderate: 1, specialist: 1 },
-              proven: { accessible: 1, moderate: 0, specialist: 0 },
-            },
-          },
-          {
-            canonical_subcategory: 'Byzantine hymnography',
-            broad_category: 'Music',
-            declared_score: 3,
-            proven_score: 2,
-            proven_score_catchup: 0,
-            question_count: 0,
-            answer_count: 0,
-            difficulty_breakdown: {
-              declared: { accessible: 1, moderate: 0, specialist: 1 },
-              proven: { accessible: 1, moderate: 0, specialist: 0 },
-            },
-          },
-        ],
-        max_declared_score: 4,
-        max_proven_score: 2,
-      })
-      .mockResolvedValueOnce({
-        categories: [
-          {
-            canonical_subcategory: 'Byzantine hymnography',
-            broad_category: 'Music',
-            declared_score: 2,
-            proven_score: 1,
-            proven_score_catchup: 0,
-            question_count: 0,
-            answer_count: 0,
-            difficulty_breakdown: {
-              declared: { accessible: 1, moderate: 0, specialist: 0 },
-              proven: { accessible: 1, moderate: 0, specialist: 0 },
-            },
-          },
-        ],
-        max_declared_score: 2,
-        max_proven_score: 1,
-      });
-
-    answerFindManyMock.mockResolvedValueOnce([]);
-    const result = await getFriendPortraitData('owner-2', 'viewer-2');
-
-    expect(result.categories).toEqual([
-      expect.objectContaining({
-        canonical_subcategory: 'Roman legal codification',
-        visitor_overlap: {
-          has_played_here: false,
-          has_correct_here: false,
-          questions_answered: 0,
-          questions_correct: 0,
-          overlap_top_peer_name: null,
-        },
-      }),
-      expect.objectContaining({
-        canonical_subcategory: 'Byzantine hymnography',
-        visitor_overlap: {
-          has_played_here: false,
-          has_correct_here: false,
-          questions_answered: 0,
-          questions_correct: 0,
-          overlap_top_peer_name: null,
-        },
-      }),
-    ]);
-    expect(result.visitor_unexplored).toEqual([]);
-  });
-});
+    await expect(
+      getFriendPortraitData('stranger-1', 'viewer-1')
+    ).resolves.toBeNull()
+  })
+})

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -1,6 +1,103 @@
-export async function getFriendPortraitData(userId: string, viewerId: string) {
-  // TODO Phase 8: port to Drizzle when friend profiles are built
-  void userId;
-  void viewerId;
-  return null as any;
+import { and, asc, eq, inArray } from 'drizzle-orm'
+
+import { db, declaredInterests } from '@/server/db'
+import { getFriendship } from '@/server/db/queries/friends'
+import { getUserById } from '@/server/db/queries/users'
+
+type FriendProfileVisibility = 'self' | 'friend'
+
+export type FriendPortraitInterest = {
+  domain: string
+  broadCategory: string | null
+  shared: boolean
+}
+
+export type FriendPortraitData = {
+  user: {
+    id: string
+    displayName: string
+    memberSince: Date
+  }
+  visibility: FriendProfileVisibility
+  friendship: {
+    id: string
+    formedAt: Date | null
+  } | null
+  interests: FriendPortraitInterest[]
+  sharedInterests: string[]
+}
+
+function profileDisplayName(name: string | null, fallback = 'Joshing friend') {
+  return name?.trim() || fallback
+}
+
+export async function getFriendPortraitData(
+  userId: string,
+  viewerId: string
+): Promise<FriendPortraitData | null> {
+  const normalizedUserId = userId.trim()
+  const normalizedViewerId = viewerId.trim()
+  if (!normalizedUserId || !normalizedViewerId) return null
+
+  const viewedUser = await getUserById(normalizedUserId)
+  if (!viewedUser) return null
+
+  const isSelf = normalizedUserId === normalizedViewerId
+  const friendship = isSelf
+    ? null
+    : await getFriendship(normalizedViewerId, normalizedUserId)
+
+  if (!isSelf && friendship?.status !== 'active') return null
+
+  const visibleUserIds = isSelf
+    ? [normalizedUserId]
+    : [normalizedUserId, normalizedViewerId]
+
+  const interestRows = await db
+    .select({
+      userId: declaredInterests.userId,
+      domain: declaredInterests.domain,
+      broadCategory: declaredInterests.broadCategory,
+    })
+    .from(declaredInterests)
+    .where(
+      and(
+        eq(declaredInterests.isActive, true),
+        inArray(declaredInterests.userId, visibleUserIds)
+      )
+    )
+    .orderBy(asc(declaredInterests.domain))
+
+  const viewerInterests = new Set(
+    interestRows
+      .filter((interest) => interest.userId === normalizedViewerId)
+      .map((interest) => interest.domain)
+  )
+
+  const interests = interestRows
+    .filter((interest) => interest.userId === normalizedUserId)
+    .map((interest) => ({
+      domain: interest.domain,
+      broadCategory: interest.broadCategory,
+      shared: !isSelf && viewerInterests.has(interest.domain),
+    }))
+
+  return {
+    user: {
+      id: viewedUser.id,
+      displayName: profileDisplayName(viewedUser.displayName),
+      memberSince: viewedUser.createdAt,
+    },
+    visibility: isSelf ? 'self' : 'friend',
+    friendship: friendship
+      ? {
+          id: friendship.id,
+          formedAt: friendship.formedAt,
+        }
+      : null,
+    interests,
+    sharedInterests: interests
+      .filter((interest) => interest.shared)
+      .map((interest) => interest.domain),
+  }
 }


### PR DESCRIPTION
### Motivation
- Friends listing and Feed metadata link to `/users/[id]` but there was no App Router page to render an individual friend profile, leaving links pointing to a missing route.
- Provide a small, safe profile surface so friend names in the Feed and FriendsList resolve to a valid destination without rebuilding the full profile system.

### Description
- Added an App Router page at `src/app/users/[id]/page.tsx` that requires a session, returns `notFound()` for unauthenticated or unavailable profiles, and renders a minimal portrait shell (name, member/friend dates, interests, shared-interest badges).
- Implemented `getFriendPortraitData` in `src/server/profile/friend.ts` to verify the target user exists, allow self-view, require an active friendship for other viewers, and return declared interests and shared interests via a small Drizzle query.
- Left Feed and FriendsList behavior unchanged; Feed already emits `source_profile_href: /users/<id>` and FriendsList links to `/users/${friend.id}` so links now resolve to the new page.
- Added unit tests for the helper and page at `src/server/profile/__tests__/friend.test.ts` and `src/app/users/[id]/__tests__/page.test.tsx` to assert expected portrait shape and auth/visibility handling.

### Testing
- Ran targeted lint on the new files with `npx eslint src/app/users/[id]/page.tsx src/server/profile/friend.ts` which passed for the modified files.
- Type-checked the project with `npx tsc --noEmit` which completed successfully.
- Attempted to run the new Vitest tests with `npx vitest run ...`, but the run was blocked because `vitest` is not installed locally and registry access returned `403 Forbidden` so tests could not be executed in this environment.
- A full `npm run lint` was also run and failed due to existing unrelated repo-wide lint errors outside the scope of these changes, but the targeted checks above passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06536b8808832e932353893d43dbbc)