### PR TITLE
Tighten friend profile display fallback

### DIFF
--- a/src/server/profile/__tests__/friend.test.ts
+++ b/src/server/profile/__tests__/friend.test.ts
@@ -62,6 +62,7 @@ describe('friend portrait data', () => {
       id: 'friend-1',
       displayName: 'Frances Friend',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      phoneNumber: '+15550101010',
     })
     getFriendshipMock.mockResolvedValue({
       id: 'friendship-1',
@@ -98,6 +99,19 @@ describe('friend portrait data', () => {
     })
   })
 
+  it('falls back to the verified phone number when a friend has no display name yet', async () => {
+    getUserByIdMock.mockResolvedValueOnce({
+      id: 'friend-1',
+      displayName: null,
+      phoneNumber: '+15550101010',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    })
+
+    const portrait = await getFriendPortraitData('friend-1', 'viewer-1')
+
+    expect(portrait?.user.displayName).toBe('+15550101010')
+  })
+
   it('returns null for missing users and non-active friendships', async () => {
     getUserByIdMock.mockResolvedValueOnce(null)
     await expect(
@@ -108,6 +122,7 @@ describe('friend portrait data', () => {
       id: 'stranger-1',
       displayName: 'Stranger',
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      phoneNumber: '+15550101011',
     })
     getFriendshipMock.mockResolvedValueOnce({
       id: 'friendship-2',

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -27,8 +27,11 @@ export type FriendPortraitData = {
   sharedInterests: string[]
 }
 
-function profileDisplayName(name: string | null, fallback = 'Joshing friend') {
-  return name?.trim() || fallback
+function profileDisplayName(
+  name: string | null,
+  fallback: string | null = 'Joshing friend'
+) {
+  return name?.trim() || fallback?.trim() || 'Joshing friend'
 }
 
 export async function getFriendPortraitData(
@@ -85,7 +88,10 @@ export async function getFriendPortraitData(
   return {
     user: {
       id: viewedUser.id,
-      displayName: profileDisplayName(viewedUser.displayName),
+      displayName: profileDisplayName(
+        viewedUser.displayName,
+        viewedUser.phoneNumber
+      ),
       memberSince: viewedUser.createdAt,
     },
     visibility: isSelf ? 'self' : 'friend',


### PR DESCRIPTION
### Motivation

- Ensure links to individual friend profiles (which target `/users/[id]`) render a usable display name even when a friend has not set `displayName` so Feed metadata can safely link to a visible page. 

### Description

- Update `src/server/profile/friend.ts` to make `profileDisplayName` accept a `fallback` (nullable) and prefer the viewed user’s verified `phoneNumber` when `displayName` is empty before falling back to the generic label. 
- Use the phone-number fallback when composing the returned `FriendPortraitData.user.displayName`. 
- Add a unit test in `src/server/profile/__tests__/friend.test.ts` that verifies the portrait falls back to `phoneNumber` when `displayName` is null. 
- Kept the existing `/users/[id]` page at `src/app/users/[id]/page.tsx` and preserved `FriendsList` linking to `/users/${friend.id}` so the friends hub continues to work.

### Testing

- Ran lint: `./node_modules/.bin/eslint src/server/profile/friend.ts src/app/users/[id]/page.tsx src/components/FriendsList.tsx --max-warnings=0` and it passed. 
- Type-checked with `./node_modules/.bin/tsc --noEmit` and it passed. 
- Attempted `npm run build` but it was blocked by `next/font` failing to fetch Google Fonts in this environment. 
- Attempted running the related `vitest` tests but the run was blocked by inability to fetch `vitest` from the registry (403); the new unit test was added and committed regardless.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0654e49044832e8edc3abaeb9f91b7)