### PR TITLE
Finalize Feed surface audit polish

### DIFF
--- a/src/app/feed/page.tsx
+++ b/src/app/feed/page.tsx
@@ -9,7 +9,7 @@ export default function FeedPage() {
             Feed
           </h1>
           <p className="text-muted-foreground mt-3 max-w-xl text-base leading-7">
-            Questions your friends thought you&apos;d like
+            Questions your friends thought you&apos;d like.
           </p>
         </div>
         <FeedList />

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -180,7 +180,7 @@ function feedMetadata(item: FeedApiItem, answered = false) {
       {item.source_type === 'direct_sent'
         ? 'sent this to you'
         : item.source_type === 'authored_shared'
-          ? 'shared this'
+          ? 'wrote this'
           : item.source_type === 'thumbs_upped'
             ? 'liked this'
             : 'answered this'}
@@ -624,7 +624,7 @@ export default function FeedList({
   const filterOptions: Array<{ value: FeedFilter; label: string }> = [
     { value: 'all', label: 'All' },
     { value: 'sent-to-me', label: 'Sent to me' },
-    { value: 'from-friends', label: 'From friends only' },
+    { value: 'from-friends', label: 'From friends' },
   ]
 
   return (

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -1,5 +1,7 @@
 import type { ReactNode } from 'react'
 
+import { GeometricProgress } from '@/components/play/GeometricProgress'
+
 import { FeedCard } from './FeedCard'
 import type { AnsweredByYouFeedItem } from './types'
 
@@ -15,25 +17,12 @@ function FeedProgressCircles({
   correct: boolean | null | undefined
 }) {
   return (
-    <div
-      className="flex items-center gap-1.5"
-      aria-label="Feed answer progress"
-    >
-      {Array.from({ length: 5 }, (_, index) => {
-        const active = index === 0
-        const className = active
-          ? correct
-            ? 'bg-emerald-600 border-emerald-600'
-            : 'bg-stone-400 border-stone-400'
-          : 'border-stone-300 bg-white/70'
-        return (
-          <span
-            key={index}
-            aria-hidden
-            className={`size-2.5 rounded-full border ${className}`}
-          />
-        )
-      })}
+    <div aria-label="Feed answer progress">
+      <GeometricProgress
+        total={5}
+        current={1}
+        results={{ 1: correct ? 'correct' : 'expired' }}
+      />
     </div>
   )
 }
@@ -70,9 +59,7 @@ function AnsweredDetails({ item }: { item: AnsweredByYouFeedItem }) {
         </p>
       ) : null}
       {item.unverifiedAnswer ? (
-        <p className="text-muted-foreground mt-2">
-          This answer is still unverified.
-        </p>
+        <p className="text-muted-foreground mt-2">LLM answer — unverified.</p>
       ) : null}
       {item.explanation ? (
         <p className="text-muted-foreground mt-2">{item.explanation}</p>

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -14,6 +14,14 @@ const toneClasses: Record<FeedCardTone, string> = {
   gray: 'border-stone-200 bg-stone-100/80 text-stone-800 shadow-none',
 }
 
+const categoryToneClasses: Record<FeedCardTone, string> = {
+  cream: 'text-amber-700',
+  white: 'text-stone-500',
+  green: 'text-emerald-700',
+  amber: 'text-orange-700',
+  gray: 'text-stone-500',
+}
+
 export function FeedCard({
   item,
   tone,
@@ -42,7 +50,12 @@ export function FeedCard({
 
         <div className="space-y-2">
           {category ? (
-            <p className="text-[0.68rem] font-semibold tracking-[0.18em] text-stone-500 uppercase">
+            <p
+              className={cn(
+                'text-[0.68rem] font-semibold tracking-[0.18em] uppercase',
+                categoryToneClasses[tone]
+              )}
+            >
               {category.toUpperCase()}
             </p>
           ) : null}

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -172,7 +172,7 @@ describe('Feed answered states', () => {
       />
     )
 
-    expect(rendered).toContain('This answer is still unverified.')
+    expect(rendered).toContain('LLM answer — unverified.')
     expect(rendered).toContain('Explanation is pending verification')
   })
 })


### PR DESCRIPTION
### Motivation
- Perform a final verification/hardening pass on the Feed surface after the refactor to ensure UI copy, filters, typed card mapping, card styling, overflow behavior, and answer persistence meet product requirements. 
- Make small, contained fixes for discovered polish issues without changing architecture or gameplay mechanics.

### Description
- Fixed Feed page subhead punctuation to the exact required sentence: `Questions your friends thought you'd like.` (updated `src/app/feed/page.tsx`).
- Normalized filter label to the exact text `From friends` and ensured URL-driven filters remain `?filter=all|sent-to-me|from-friends` (updated `src/components/FeedList.tsx`).
- Adjusted authored/shared attribution copy to `wrote this` for authored/shared items so answered-by-you cards preserve correct source context (updated `src/components/FeedList.tsx`).
- Made category labels inherit a subtle tone color tied to the card accent and preserved uppercase/letterspaced sans treatment (updated `src/components/feed/FeedCard.tsx`).
- Reused existing gameplay progress component for answered-by-you cards to keep visual language consistent and non-red for wrong answers (updated `src/components/feed/AnsweredByYouCard.tsx`).
- Reworded the unverified-answer note to the calm required copy `LLM answer — unverified.` and updated the corresponding test fixture expectation (updated `src/components/feed/AnsweredByYouCard.tsx` and `src/components/feed/__tests__/FeedCards.test.tsx`).
- Committed changes as `Polish feed surface audit findings` touching the five files above.

### Testing
- Ran `npx eslint src/app/feed/page.tsx src/components/FeedList.tsx src/components/feed/AnsweredByYouCard.tsx src/components/feed/FeedCard.tsx src/components/feed/__tests__/FeedCards.test.tsx` and validated the targeted files pass lint checks (local ESLint run for those files succeeded).
- Ran typecheck with `npx tsc -p tsconfig.typecheck.json --noEmit` and it passed.
- Executed the smoke script `npm run smoke:daily-catchup` which completed successfully in this environment.
- Performed targeted grep/inspection for forbidden strings and confirmed matches are limited to tests/fixtures or intentional comments rather than user-facing Feed UI.
- Known environmental / repo-level blockers: `npm run lint` across the entire repo fails due to pre-existing lint issues outside the Feed surface, `npm run build` is blocked by a network/font fetch error for Google Fonts in this environment, and running `vitest` was blocked by registry policy (`403 Forbidden`) in this environment; these issues are unrelated to the small Feed fixes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065bd6149c832ebbf514dc646c97f8)