### PR TITLE
Fix feed prerender Suspense boundary

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import {
@@ -296,7 +296,23 @@ type FeedListProps = {
 
 type QuestionCardState = 'unanswered' | 'answering' | 'answered' | 'reacted'
 
-export default function FeedList({
+export default function FeedList(props: FeedListProps) {
+  return (
+    <Suspense fallback={<FeedListLoading />}>
+      <FeedListContent {...props} />
+    </Suspense>
+  )
+}
+
+function FeedListLoading() {
+  return (
+    <div className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
+      Loading feed…
+    </div>
+  )
+}
+
+function FeedListContent({
   pageSize = 20,
   infinite = false,
 }: FeedListProps) {


### PR DESCRIPTION
### Motivation
- The `/feed` page failed prerendering because `useSearchParams()` was used outside of a `Suspense` boundary, triggering Next.js CSR bailout errors during build. 
- Isolate client-only search-param usage so the page can be prerendered without hitting the Next.js missing-suspense error.

### Description
- Updated `src/components/FeedList.tsx` to import `Suspense` and wrap the feed in a `Suspense` boundary so `useSearchParams()` is executed inside a client-only subtree. 
- Moved the search-param-dependent logic into a new `FeedListContent` function and added a minimal `FeedListLoading` fallback component to display while the boundary resolves. 
- No other behavior changes to feed fetching or rendering were made.

### Testing
- Ran `npm run build`, which failed early in the environment due to a Google Fonts fetch error (`Failed to fetch Montserrat from Google Fonts`) before the prerendering step could complete. 
- Ran `npm run lint`, which reported existing lint errors in unrelated files; the changes to `src/components/FeedList.tsx` did not introduce new lint failures specific to this file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065d795504832eb856be2ebac1aaed)