### PR TITLE
Restore missed questions card on homepage

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -27,9 +27,10 @@ export default async function Home() {
         </div>
         <div className="w-full space-y-3">
           <TodaysFiveCard />
-          {catchupCount > 0 ? (
-            <CatchupCard count={catchupCount} expiringCount={expiringCount} />
-          ) : null}
+          <MissedQuestionsCard
+            count={catchupCount}
+            expiringCount={expiringCount}
+          />
           <div className="bg-card text-card-foreground rounded-lg border p-4">
             <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
               What&apos;s happening
@@ -42,7 +43,7 @@ export default async function Home() {
   )
 }
 
-function CatchupCard({
+function MissedQuestionsCard({
   count,
   expiringCount,
 }: {
@@ -62,11 +63,18 @@ function CatchupCard({
           : undefined
       }
     >
-      <p className="text-foreground text-sm font-semibold">
-        {count} {count === 1 ? 'question' : 'questions'} you missed
+      <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+        Play missed questions
+      </p>
+      <p className="text-foreground mt-2 text-sm font-semibold">
+        {count > 0
+          ? `${count} ${count === 1 ? 'question' : 'questions'} you missed`
+          : 'No missed questions right now'}
       </p>
       <p className="text-muted-foreground mt-1 text-sm leading-6">
-        Catch up - 0.25x points
+        {count > 0
+          ? 'Catch up - 0.25x points'
+          : 'When you miss or skip daily questions, they will appear here for review.'}
       </p>
       {expiringCount > 0 ? (
         <p
@@ -80,7 +88,7 @@ function CatchupCard({
         href="/daily/catchup"
         className="btn-ghost mt-4 min-h-11 w-full justify-center"
       >
-        Catch up →
+        {count > 0 ? 'Catch up →' : 'Review missed questions'}
       </Link>
     </div>
   )


### PR DESCRIPTION
### Motivation
- The homepage previously displayed a persistent “missed questions” / catch-up entry immediately under the Daily card, but that section was removed in a refactor and the entry point disappeared for zero-count users; restore the affordance so users can always find missed-question review. 

### Description
- Always render a `MissedQuestionsCard` directly beneath `TodaysFiveCard` in `src/app/page.tsx` instead of conditionally rendering the prior `CatchupCard`. 
- Rename and adjust the component copy and behavior: `MissedQuestionsCard` replaces `CatchupCard`, preserves the expiring-soon styling and `/daily/catchup` link, and adds an empty-state message and alternate button label when `count === 0`. 
- No other pages or APIs were changed; this is a UI-only change in `src/app/page.tsx`.

### Testing
- Ran `npx eslint src/app/page.tsx` which passed for the modified file. 
- Ran `npx tsc --noEmit` which passed (no type errors introduced). 
- Ran `npm run lint` which failed due to pre-existing lint errors elsewhere in the repo and not from this change. 
- Ran `npm run build` which failed in this environment because Next.js could not fetch the Google Font during the build (external network/font fetch issue), unrelated to the UI change. 
- Started the dev server and checked the root with `curl -I http://localhost:3000/`, which returned a redirect to `/login` (expected for an anonymous session).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a066cea9188832ea4bca0d066ef3d6b)