### PR TITLE
Register feed answered-card migration (0031)

### DIFF
--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -218,6 +218,13 @@
       "when": 1778714200000,
       "tag": "0030_apply_general_knowledge_category",
       "breakpoints": true
+    },
+    {
+      "idx": 31,
+      "version": "7",
+      "when": 1778806800000,
+      "tag": "0031_feed_answered_card_data",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
### Motivation
- A runtime query failed with `column FeedItem.answerResult does not exist` because the migration that adds answered-card columns to `FeedItem` was not registered in the Drizzle journal, preventing the schema update from being discovered and applied.

### Description
- Add a journal entry for `0031_feed_answered_card_data` to `drizzle/meta/_journal.json` so the migration will be run by `drizzle-kit migrate` in environments that have not yet applied it.
- The referenced migration `drizzle/0031_feed_answered_card_data.sql` adds `FeedItem.answerResult`, `FeedItem.pointsAwarded`, and `FeedItem.masteryDelta`, restoring the missing columns the feed API expects.

### Testing
- Ran `npm exec tsc -- --noEmit`, which succeeded with no type-errors reported.
- Ran `npm run build`, which failed due to Next/Turbopack being unable to fetch the Google Font `Montserrat` from `fonts.googleapis.com` in this environment, and not due to the migration change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0672d914b4832eb579e24e0c6efc94)