### PR TITLE
Keep feed filters on current page

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import Link from 'next/link'
-import { useSearchParams } from 'next/navigation'
+import { usePathname, useSearchParams } from 'next/navigation'
 import {
   AnsweredByYouCard,
   AnswerForm,
@@ -316,6 +316,7 @@ function FeedListContent({
   pageSize = 20,
   infinite = false,
 }: FeedListProps) {
+  const pathname = usePathname()
   const searchParams = useSearchParams()
   const feedFilterParam =
     searchParams.get('filter') ?? searchParams.get('feed_filter') ?? 'all'
@@ -643,13 +644,23 @@ function FeedListContent({
     { value: 'from-friends', label: 'From friends' },
   ]
 
+  const feedFilterHref = useCallback(
+    (filter: FeedFilter) => {
+      const params = new URLSearchParams(searchParams.toString())
+      params.set('filter', filter)
+      params.delete('feed_filter')
+      return `${pathname}?${params.toString()}`
+    },
+    [pathname, searchParams]
+  )
+
   return (
     <>
       <nav className="mb-4 flex flex-wrap gap-2" aria-label="Feed filters">
         {filterOptions.map((option) => (
           <Link
             key={option.value}
-            href={`/feed?filter=${option.value}`}
+            href={feedFilterHref(option.value)}
             aria-current={feedFilter === option.value ? 'page' : undefined}
             className={
               feedFilter === option.value


### PR DESCRIPTION
### Motivation
- Clicking the Feed filter tabs on the homepage navigated to `/feed` instead of staying on the current page, which breaks the intended in-place tab behavior.
- The UI should preserve the current pathname while updating the `filter` query param so tabs work on `/` and on the dedicated `/feed` page.

### Description
- Import `usePathname` from `next/navigation` and read the current `pathname` in `FeedList`.
- Add a `feedFilterHref` helper that builds a URL from the current `pathname` and `searchParams`, sets `filter`, and removes legacy `feed_filter`.
- Replace the hard-coded `href={`/feed?filter=${...}`}` links with `href={feedFilterHref(...)} ` so selecting a tab updates the query on the current page.

### Testing
- Ran `npx eslint src/components/FeedList.tsx`, which succeeded for the modified file. 
- Ran `npx tsc --noEmit --pretty false`, which completed without errors. 
- Ran `npm run lint`, which failed due to pre-existing lint issues in unrelated files and not because of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a067485d5a4832eba3b4fa774feaa8f)