### PR TITLE
Propagate correct answers from public daily-generated questions to friends' feed

### DIFF
--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -9,6 +9,7 @@ import {
 
 const publicQuestion = {
   creatorId: 'author-1',
+  source: 'authored' as const,
   visibility: 'public' as const,
   deletedAt: null,
 };
@@ -29,6 +30,20 @@ describe('correct-answer social feed eligibility', () => {
       hasVisibleSocialContext: true,
     })).toBe(true);
     expect(isMainFeedSourceVisible('friend_answered', 'correct')).toBe(true);
+  });
+
+  it('allows public daily-generated questions without an author to propagate correct friend answers', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: {
+        creatorId: null,
+        source: 'daily_generated' as const,
+        visibility: 'public' as const,
+        deletedAt: null,
+      },
+      hasVisibleSocialContext: true,
+    })).toBe(true);
   });
 
   it('rejects a correct answer by the author', () => {

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -55,7 +55,14 @@ async function _createFeedItemsForFriendsFromAnswer(
   if (thumbsDown || ratingDown) return;
 
   const [question] = await db
-    .select({ creatorId: questions.creatorId, visibility: questions.visibility, deletedAt: questions.deletedAt, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
+    .select({
+      creatorId: questions.creatorId,
+      source: questions.source,
+      visibility: questions.visibility,
+      deletedAt: questions.deletedAt,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+    })
     .from(questions)
     .where(eq(questions.id, questionId))
     .limit(1);

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -31,13 +31,13 @@ export const QUESTION_SHARING_FEED_SOURCE_VISIBILITY = [
 
 const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown', 'general', 'general knowledge']);
 
-type QuestionLike = Pick<typeof questions.$inferSelect, 'creatorId' | 'visibility' | 'canonicalSubcategory' | 'broadCategory' | 'category' | 'deletedAt'>;
+type QuestionLike = Pick<typeof questions.$inferSelect, 'creatorId' | 'source' | 'visibility' | 'canonicalSubcategory' | 'broadCategory' | 'category' | 'deletedAt'>;
 type FeedItemsVisibilityColumns = Pick<typeof feedItems, 'sourceType' | 'sourceResult'>;
 
 export type FeedEventEligibilityInput = {
   answerIsCorrect: boolean;
   answererUserId: string;
-  question: Pick<QuestionLike, 'creatorId' | 'visibility' | 'deletedAt'> | null | undefined;
+  question: Pick<QuestionLike, 'creatorId' | 'source' | 'visibility' | 'deletedAt'> | null | undefined;
   hasVisibleSocialContext: boolean;
 };
 
@@ -47,6 +47,7 @@ export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): b
   if (!input.question) return false;
   if (input.question.deletedAt) return false;
   if (input.question.visibility !== 'public') return false;
+  if (input.question.source === 'daily_generated') return true;
   if (!input.question.creatorId) return false;
   return input.answererUserId !== input.question.creatorId;
 }


### PR DESCRIPTION
### Motivation
- Correct answers to `daily_generated` questions persisted with `creatorId: null` were being suppressed by the social-feed eligibility gate that required an authored creator. 
- The intent is to let public, non-deleted, daily-generated questions surface successful friend activity in the main feed while preserving the rule that prevents an author from amplifying their own answers.

### Description
- Allow `daily_generated` questions to pass `isCorrectAnswerFeedEligible` even when `creatorId` is null by checking `question.source === 'daily_generated'` early. (modified `src/server/feed/visibility.ts`)
- Include `questions.source` in the query used when creating friend feed items so the eligibility function receives the `source` field. (modified `src/server/feed/create-feed-items-for-answer.ts`)
- Add a focused regression test to cover public `daily_generated` questions without an author. (modified `src/server/feed/__tests__/visibility.test.ts`)
- Extend the local `QuestionLike` typing to include `source` so the new field is typed end-to-end. (modified `src/server/feed/visibility.ts`)

### Testing
- Ran `npx eslint src/server/feed/visibility.ts src/server/feed/create-feed-items-for-answer.ts src/server/feed/__tests__/visibility.test.ts` against the changed files and it succeeded. 
- Ran `npx tsc -p tsconfig.typecheck.json --noEmit` and type checks passed. 
- Attempted `npx vitest run src/server/feed/__tests__/visibility.test.ts`, but the test runner could not be fetched locally (`vitest` not installed via npx due to registry access returning 403), so the unit test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06fa2b3140832eb96936a67aa9987a)