### PR TITLE
Add Recently Expanding Domains section to knowledge page

### DIFF
--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -44,6 +44,7 @@ export function RecentlyExpanding({ domains, playerDisplayName = 'Josh', onNotic
         @keyframes recentExpansionIn {
           to { opacity: 1; transform: translateY(0); }
         }
+        [data-expanding-row="true"] { grid-template-columns: 44px minmax(0, 1fr) minmax(112px, auto) minmax(86px, 112px); }
         @media (hover: hover) {
           button[data-expanding-share="true"] { transition: border-color 160ms ease, background-color 160ms ease, transform 160ms ease; }
           button[data-expanding-share="true"]:hover { border-color: #c9bea9; background: #f8f3eb; transform: translateY(-1px); }
@@ -282,7 +283,6 @@ const rowsStyle: CSSProperties = {
 const rowStyle: CSSProperties = {
   minHeight: 62,
   display: 'grid',
-  gridTemplateColumns: '44px minmax(0, 1fr) minmax(112px, auto) minmax(86px, 112px)',
   alignItems: 'center',
   columnGap: '0.75rem',
   padding: '0.54rem 0',


### PR DESCRIPTION
## Summary
This PR adds a new "Recently Expanding" section to the knowledge page that highlights domains where users have made recent progress, showing their weekly discovery counts and progression toward the next mastery tier.

## Key Changes
- **Backend**: Added `getRecentlyExpandingDomains()` query function that identifies domains with correct answers in the past 7 days, sorted by weekly discovery count (limited to top 8)
- **API**: Updated `/api/knowledge` endpoint to include `recentlyExpanding` data in the response
- **Frontend**: 
  - Added new "Recently Expanding" section that displays when there are expanding domains
  - Implemented share functionality for expanding domains (native share API with clipboard fallback)
  - Created styled domain cards showing domain name, current tier, next tier progression, and weekly discovery count
  - Added color-coded circular avatars using domain colors from `getPortraitDomainColor()`
  - Imported `Share2` icon from lucide-react for the share button
- **Types**: Added `RecentlyExpandingDomain` type to both frontend and backend for type safety

## Implementation Details
- The section only renders when there are expanding domains to display
- Weekly correct answer counts are calculated from `masteryEvents` table filtered to the past 7 days
- Domains are sorted by discovery count in descending order
- The share button uses the Web Share API when available, falling back to clipboard copy with visual feedback
- Tier progression logic shows the next tier level (Establishing → Familiar → Solid → Mastery)
- Styling follows the existing design system with serif typography and earth-tone color palette

https://claude.ai/code/session_012g1CAQo2GvrrosFrpUFNsn