### PR TITLE
Redesign Friends page with tabs and reduced button clutter

### DIFF
--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -3,33 +3,19 @@
 import AddFriendInvite from '@/components/AddFriendInvite'
 import FriendsList from '@/components/FriendsList'
 
-function openAddFriend() {
-  window.dispatchEvent(new CustomEvent('friend-invitations:create-new'))
-  window.scrollTo({ top: 0, behavior: 'smooth' })
-}
-
 export default function FriendsHubPage() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
-      <header className="mb-5 flex items-start justify-between gap-4 border-b pb-4">
-        <div>
-          <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
-            Joshing
-          </p>
-          <h1 className="text-foreground font-serif text-3xl font-semibold">
-            Friends
-          </h1>
-          <p className="text-muted-foreground mt-2 text-sm leading-6">
-            Invite your people, answer warm notes, and keep your circle close.
-          </p>
-        </div>
-        <button
-          type="button"
-          className="btn-primary min-h-11 shrink-0 rounded-full px-5"
-          onClick={openAddFriend}
-        >
-          Add friend
-        </button>
+      <header className="mb-5 border-b pb-4">
+        <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
+          Joshing
+        </p>
+        <h1 className="text-foreground font-serif text-3xl font-semibold">
+          Friends
+        </h1>
+        <p className="text-muted-foreground mt-2 text-sm leading-6">
+          Invite your people, answer warm notes, and keep your circle close.
+        </p>
       </header>
 
       <AddFriendInvite />

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link'
 import PeopleYouInvited from '@/components/PeopleYouInvited'
 import { useCallback, useEffect, useState } from 'react'
 
+type Tab = 'friends' | 'requests' | 'sent'
+
 type Friend = {
   id: string
   displayName: string
@@ -34,11 +36,6 @@ function previewInterests(interests: string[]) {
   return remainder > 0 ? `${visible}, +${remainder} more` : visible
 }
 
-function openAddFriend() {
-  window.dispatchEvent(new CustomEvent('friend-invitations:create-new'))
-  window.scrollTo({ top: 0, behavior: 'smooth' })
-}
-
 export default function FriendsList() {
   const [friends, setFriends] = useState<Friend[]>([])
   const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>(
@@ -47,6 +44,7 @@ export default function FriendsList() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [pendingRequest, setPendingRequest] = useState<string | null>(null)
+  const [activeTab, setActiveTab] = useState<Tab>('friends')
 
   const loadFriends = useCallback(async () => {
     setError(null)
@@ -116,177 +114,185 @@ export default function FriendsList() {
     }
   }
 
-  const hasNoRelationships =
-    !loading && !error && friends.length === 0 && incomingRequests.length === 0
-
   return (
     <div className="space-y-5">
-      {hasNoRelationships ? (
-        <section className="bg-card text-card-foreground rounded-2xl border p-5 text-center shadow-sm">
-          <h2 className="font-serif text-2xl font-semibold">
-            Joshing gets better when your people are here.
-          </h2>
-          <p className="text-muted-foreground mt-2 text-sm leading-6">
-            Invite someone you already trade facts, recommendations, and inside
-            jokes with.
-          </p>
-          <button
-            type="button"
-            className="btn-primary mt-4 min-h-12 w-full rounded-full sm:w-auto sm:px-6"
-            onClick={openAddFriend}
-          >
-            Add friend
-          </button>
+      {/* Tab bar */}
+      <div className="flex border-b">
+        <button
+          type="button"
+          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === 'friends'
+              ? 'border-b-2 border-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('friends')}
+        >
+          Friends
+        </button>
+        <button
+          type="button"
+          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === 'requests'
+              ? 'border-b-2 border-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('requests')}
+        >
+          Requests
+          {incomingRequests.length > 0 ? (
+            <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-xs leading-none">
+              {incomingRequests.length}
+            </span>
+          ) : null}
+        </button>
+        <button
+          type="button"
+          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === 'sent'
+              ? 'border-b-2 border-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('sent')}
+        >
+          Sent
+        </button>
+      </div>
+
+      {/* Friends tab */}
+      {activeTab === 'friends' ? (
+        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+          {error ? (
+            <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
+          ) : null}
+
+          {loading ? (
+            <p className="text-muted-foreground text-sm">Loading friends…</p>
+          ) : friends.length > 0 ? (
+            <div className="space-y-3">
+              {friends.map((friend) => {
+                const interests = previewInterests(friend.declaredInterests)
+                const sharedInterest = friend.sharedInterests[0]
+
+                return (
+                  <Link
+                    key={friend.id}
+                    href={`/users/${friend.id}`}
+                    className="bg-background hover:border-foreground/30 block rounded-xl border p-3 transition hover:shadow-sm"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-foreground font-medium">
+                          {friend.displayName}
+                        </h3>
+                        {interests ? (
+                          <p className="text-muted-foreground mt-1 text-sm leading-6">
+                            Into {interests}
+                          </p>
+                        ) : (
+                          <p className="text-muted-foreground mt-1 text-sm leading-6">
+                            Interests will appear here as they declare them.
+                          </p>
+                        )}
+                      </div>
+                      {sharedInterest ? (
+                        <span className="bg-muted text-foreground shrink-0 rounded-full px-3 py-1 text-xs font-medium">
+                          Shared: {sharedInterest}
+                        </span>
+                      ) : null}
+                    </div>
+                  </Link>
+                )
+              })}
+            </div>
+          ) : (
+            <div className="py-2 text-center">
+              <h2 className="font-serif text-xl font-semibold">
+                Joshing gets better when your people are here.
+              </h2>
+              <p className="text-muted-foreground mt-2 text-sm leading-6">
+                Invite someone you already trade facts, recommendations, and
+                inside jokes with.
+              </p>
+            </div>
+          )}
         </section>
       ) : null}
 
-      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-        <div className="mb-4 flex items-start justify-between gap-3">
-          <div>
-            <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-              Requests
-            </p>
-            <h2 className="mt-1 font-serif text-xl font-semibold">
-              Invitations from friends
-            </h2>
-          </div>
-          <button
-            type="button"
-            className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
-            onClick={() => void loadFriends()}
-          >
-            Refresh
-          </button>
-        </div>
-
-        {loading ? (
-          <p className="text-muted-foreground text-sm">Loading requests…</p>
-        ) : incomingRequests.length > 0 ? (
-          <div className="space-y-3">
-            {incomingRequests.map((request) => (
-              <article
-                key={request.id}
-                className="bg-background rounded-xl border p-3"
-              >
-                <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                  <div>
-                    <h3 className="text-foreground font-medium">
-                      {request.requesterName}
-                    </h3>
-                    {request.suggestedInterests.length > 0 ? (
-                      <div className="mt-3 flex flex-wrap gap-2">
-                        {request.suggestedInterests.map((interest) => (
-                          <span
-                            key={interest}
-                            className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
-                          >
-                            {interest}
-                          </span>
-                        ))}
-                      </div>
-                    ) : (
-                      <p className="text-muted-foreground mt-1 text-sm">
-                        No ideas attached — just a friendly hello.
-                      </p>
-                    )}
-                  </div>
-
-                  <div className="grid grid-cols-2 gap-2 sm:min-w-48">
-                    <button
-                      type="button"
-                      className="btn-primary min-h-11 rounded-full"
-                      disabled={Boolean(pendingRequest)}
-                      onClick={() => void updateRequest(request.id, 'accept')}
-                    >
-                      {pendingRequest === `${request.id}:accept`
-                        ? 'Accepting…'
-                        : 'Accept'}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-ghost min-h-11 rounded-full"
-                      disabled={Boolean(pendingRequest)}
-                      onClick={() => void updateRequest(request.id, 'ignore')}
-                    >
-                      {pendingRequest === `${request.id}:ignore`
-                        ? 'Setting aside…'
-                        : 'Not now'}
-                    </button>
-                  </div>
-                </div>
-              </article>
-            ))}
-          </div>
-        ) : (
-          <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
-            No incoming requests right now.
-          </p>
-        )}
-      </section>
-
-      <PeopleYouInvited />
-
-      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-        <div className="mb-4">
-          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-            Friends
-          </p>
-          <h2 className="mt-1 font-serif text-xl font-semibold">
-            Active friends
-          </h2>
-        </div>
-
-        {error ? (
-          <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
-        ) : null}
-
-        {loading ? (
-          <p className="text-muted-foreground text-sm">Loading friends…</p>
-        ) : friends.length > 0 ? (
-          <div className="space-y-3">
-            {friends.map((friend) => {
-              const interests = previewInterests(friend.declaredInterests)
-              const sharedInterest = friend.sharedInterests[0]
-
-              return (
-                <Link
-                  key={friend.id}
-                  href={`/users/${friend.id}`}
-                  className="bg-background hover:border-foreground/30 block rounded-xl border p-3 transition hover:shadow-sm"
+      {/* Requests tab */}
+      {activeTab === 'requests' ? (
+        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+          {loading ? (
+            <p className="text-muted-foreground text-sm">Loading requests…</p>
+          ) : incomingRequests.length > 0 ? (
+            <div className="space-y-3">
+              {incomingRequests.map((request) => (
+                <article
+                  key={request.id}
+                  className="bg-background rounded-xl border p-3"
                 >
-                  <div className="flex items-start justify-between gap-3">
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                     <div>
                       <h3 className="text-foreground font-medium">
-                        {friend.displayName}
+                        {request.requesterName}
                       </h3>
-                      {interests ? (
-                        <p className="text-muted-foreground mt-1 text-sm leading-6">
-                          Into {interests}
-                        </p>
+                      {request.suggestedInterests.length > 0 ? (
+                        <div className="mt-3 flex flex-wrap gap-2">
+                          {request.suggestedInterests.map((interest) => (
+                            <span
+                              key={interest}
+                              className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
+                            >
+                              {interest}
+                            </span>
+                          ))}
+                        </div>
                       ) : (
-                        <p className="text-muted-foreground mt-1 text-sm leading-6">
-                          Interests will appear here as they declare them.
+                        <p className="text-muted-foreground mt-1 text-sm">
+                          No ideas attached — just a friendly hello.
                         </p>
                       )}
                     </div>
-                    {sharedInterest ? (
-                      <span className="bg-muted text-foreground shrink-0 rounded-full px-3 py-1 text-xs font-medium">
-                        Shared: {sharedInterest}
-                      </span>
-                    ) : null}
+
+                    <div className="grid grid-cols-2 gap-2 sm:min-w-48">
+                      <button
+                        type="button"
+                        className="btn-primary min-h-11 rounded-full"
+                        disabled={Boolean(pendingRequest)}
+                        onClick={() =>
+                          void updateRequest(request.id, 'accept')
+                        }
+                      >
+                        {pendingRequest === `${request.id}:accept`
+                          ? 'Accepting…'
+                          : 'Accept'}
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-ghost min-h-11 rounded-full"
+                        disabled={Boolean(pendingRequest)}
+                        onClick={() =>
+                          void updateRequest(request.id, 'ignore')
+                        }
+                      >
+                        {pendingRequest === `${request.id}:ignore`
+                          ? 'Setting aside…'
+                          : 'Not now'}
+                      </button>
+                    </div>
                   </div>
-                </Link>
-              )
-            })}
-          </div>
-        ) : (
-          <div className="bg-muted rounded-xl px-3 py-2">
-            <p className="text-muted-foreground text-sm">
-              No active friends yet.
+                </article>
+              ))}
+            </div>
+          ) : (
+            <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
+              No incoming requests right now.
             </p>
-          </div>
-        )}
-      </section>
+          )}
+        </section>
+      ) : null}
+
+      {/* Sent tab */}
+      {activeTab === 'sent' ? <PeopleYouInvited /> : null}
     </div>
   )
 }

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -172,143 +172,122 @@ export default function PeopleYouInvited() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  if (loading) {
-    return (
-      <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
-        <h2 className="font-serif text-xl font-semibold">
-          People you thought of
-        </h2>
-        <p className="text-muted-foreground mt-2 text-sm">Loading invites…</p>
-      </section>
-    )
-  }
-
-  if (!loading && invites.length === 0 && !error) return null
-
   return (
-    <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 shadow-sm">
-      <div className="mb-4 flex items-start justify-between gap-3">
-        <div>
-          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-            Notes sent
-          </p>
-          <h2 className="mt-1 font-serif text-xl font-semibold">
-            People you thought of
-          </h2>
-        </div>
-        <button
-          type="button"
-          className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
-          onClick={() => void loadInvites()}
-        >
-          Refresh
-        </button>
-      </div>
-
+    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
       {error ? (
         <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
       ) : null}
 
-      <div className="space-y-3">
-        {invites.map((invite) => {
-          const canMessage =
-            invite.status === 'pending' &&
-            invite.message &&
-            invite.inviteePhoneForActions
+      {loading ? (
+        <p className="text-muted-foreground text-sm">Loading invites…</p>
+      ) : invites.length === 0 ? (
+        <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
+          No notes sent yet.
+        </p>
+      ) : (
+        <div className="space-y-3">
+          {invites.map((invite) => {
+            const canMessage =
+              invite.status === 'pending' &&
+              invite.message &&
+              invite.inviteePhoneForActions
 
-          return (
-            <article
-              key={invite.id}
-              className="bg-background rounded-xl border p-3"
-            >
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <h3 className="text-foreground font-medium">
-                    {invite.inviteeDisplayName}
-                  </h3>
-                  <p className="text-muted-foreground mt-1 text-sm">
-                    {invite.inviteePhoneMasked}
+            return (
+              <article
+                key={invite.id}
+                className="bg-background rounded-xl border p-3"
+              >
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-foreground font-medium">
+                      {invite.inviteeDisplayName}
+                    </h3>
+                    <p className="text-muted-foreground mt-1 text-sm">
+                      {invite.inviteePhoneMasked}
+                    </p>
+                  </div>
+                  <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
+                    {STATUS_COPY[invite.status]}
+                  </span>
+                </div>
+
+                {invite.suggestedInterests.length > 0 ? (
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {invite.suggestedInterests.map((interest) => (
+                      <span
+                        key={interest}
+                        className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
+                      >
+                        {interest}
+                      </span>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
+                    No ideas attached to this note.
                   </p>
-                </div>
-                <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
-                  {STATUS_COPY[invite.status]}
-                </span>
-              </div>
+                )}
 
-              {invite.suggestedInterests.length > 0 ? (
-                <div className="mt-3 flex flex-wrap gap-2">
-                  {invite.suggestedInterests.map((interest) => (
-                    <span
-                      key={interest}
-                      className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
+                <p className="text-muted-foreground mt-3 text-sm">
+                  {statusDetail(invite)}
+                </p>
+
+                {invite.status === 'accepted' ? (
+                  <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
+                    They accepted your note — now you can trade questions more
+                    easily.
+                  </p>
+                ) : null}
+
+                {invite.status === 'expired' ? (
+                  <div className="mt-3">
+                    <button
+                      type="button"
+                      className="btn-ghost min-h-11 w-full rounded-full"
+                      onClick={() => createNewInvite(invite)}
                     >
-                      {interest}
-                    </span>
-                  ))}
-                </div>
-              ) : (
-                <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
-                  No ideas attached to this note.
-                </p>
-              )}
+                      Write a fresh note
+                    </button>
+                  </div>
+                ) : null}
 
-              <p className="text-muted-foreground mt-3 text-sm">
-                {statusDetail(invite)}
-              </p>
-
-              {invite.status === 'accepted' ? (
-                <p className="bg-muted text-muted-foreground mt-3 rounded-lg px-3 py-2 text-sm">
-                  They accepted your note — now you can trade questions more
-                  easily.
-                </p>
-              ) : null}
-
-              {invite.status === 'expired' ? (
-                <div className="mt-3">
-                  <button
-                    type="button"
-                    className="btn-ghost min-h-11 w-full rounded-full"
-                    onClick={() => createNewInvite(invite)}
-                  >
-                    Write a fresh note
-                  </button>
-                </div>
-              ) : null}
-
-              {canMessage ? (
-                <div className="mt-3 grid gap-2 sm:grid-cols-3">
-                  <button
-                    type="button"
-                    className="btn-primary min-h-11 rounded-full sm:col-span-1"
-                    onClick={() => copyInvite(invite)}
-                  >
-                    {copyingId === invite.id ? 'Copied ✓' : 'Copy message'}
-                  </button>
-                  <a
-                    className="btn-ghost min-h-11 rounded-full sm:col-span-1"
-                    href={buildSmsHref(
-                      invite.inviteePhoneForActions!,
-                      invite.message!
-                    )}
-                  >
-                    Open Messages
-                  </a>
-                  <button
-                    type="button"
-                    className="text-muted-foreground min-h-11 rounded-full border px-4 text-sm font-medium"
-                    onClick={() => cancelInvite(invite)}
-                    disabled={cancellingId === invite.id}
-                  >
-                    {cancellingId === invite.id
-                      ? 'Setting aside…'
-                      : 'Set aside'}
-                  </button>
-                </div>
-              ) : null}
-            </article>
-          )
-        })}
-      </div>
+                {canMessage ? (
+                  <div className="mt-3 space-y-2">
+                    <a
+                      className="btn-primary flex min-h-11 w-full items-center justify-center rounded-full"
+                      href={buildSmsHref(
+                        invite.inviteePhoneForActions!,
+                        invite.message!
+                      )}
+                    >
+                      Send message
+                    </a>
+                    <div className="flex justify-center gap-6">
+                      <button
+                        type="button"
+                        className="text-muted-foreground text-sm"
+                        onClick={() => copyInvite(invite)}
+                      >
+                        {copyingId === invite.id ? 'Copied ✓' : 'Copy instead'}
+                      </button>
+                      <button
+                        type="button"
+                        className="text-muted-foreground text-sm"
+                        onClick={() => cancelInvite(invite)}
+                        disabled={cancellingId === invite.id}
+                      >
+                        {cancellingId === invite.id
+                          ? 'Setting aside…'
+                          : 'Set aside'}
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </article>
+            )
+          })}
+        </div>
+      )}
     </section>
   )
 }


### PR DESCRIPTION
- Remove duplicate 'Add friend' button from page header; inline card is the sole CTA
- Replace stacked sections with Friends / Requests / Sent tab bar
- Requests tab shows a count badge when there are pending invitations
- Remove Refresh buttons from both list sections
- Consolidate 3-button send row in Sent tab to 1 primary CTA + 2 text links

https://claude.ai/code/session_01RJEKtLxpoQE19S2UM3m3md