### PR TITLE
Condense feed answer display: green card, points pill, no explanation

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -280,6 +280,7 @@ function toAnsweredByYouItem(
     isCorrect: result?.correct ?? item.is_correct,
     awardedPoints: result?.awardedPoints ?? item.awarded_points,
     explanation: result?.explanation ?? item.explanation,
+    quip: result?.quip ?? null,
     unverifiedAnswer: item.unverified_answer,
   }
 }

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -43,20 +43,23 @@ function AnsweredResult({
   const markerClass = item.isCorrect ? 'text-emerald-700' : 'text-stone-500'
 
   return (
-    <div className="w-full space-y-1">
+    <div className="w-full space-y-1.5">
       <div className="flex items-start justify-between gap-3">
         <p className="text-sm font-medium text-stone-800">
           <span className={markerClass}>{marker}</span>{' '}
           {item.answerSummary ?? 'You answered this question.'}
         </p>
         {item.isCorrect && typeof item.awardedPoints === 'number' ? (
-          <span className="shrink-0 text-xs font-semibold text-emerald-700">
+          <span className="shrink-0 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">
             +{item.awardedPoints} pts
           </span>
         ) : null}
       </div>
-      {item.correctAnswer ? (
+      {!item.isCorrect && item.correctAnswer ? (
         <p className="text-sm text-stone-500 italic">{item.correctAnswer}</p>
+      ) : null}
+      {!item.isCorrect && item.quip ? (
+        <p className="text-sm text-stone-500">{item.quip}</p>
       ) : null}
       {recheckAction && recheckState !== 'done' ? (
         <div className="pt-1">
@@ -83,7 +86,7 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
   return (
     <FeedCard
       item={item}
-      tone="gray"
+      tone={item.isCorrect ? 'green' : 'gray'}
       overflow={overflow}
       resultContent={<AnsweredResult item={item} recheckAction={recheckAction} />}
     />

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -54,6 +54,7 @@ export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   isCorrect?: boolean | null
   awardedPoints?: number | null
   explanation?: string | null
+  quip?: string | null
   unverifiedAnswer?: boolean
 }
 


### PR DESCRIPTION
## Summary

- Correct answers now render with a **green card** (uses the existing `green` FeedCard tone) and a rounded **+N pts pill badge**
- Wrong answers stay gray, show the correct answer and quip (if any) — long factual explanation removed for both
- Wires `quip` from the answer API response through `ResultState` → `toAnsweredByYouItem` → `AnsweredByYouFeedItem` so it renders in the result strip for wrong answers

## Files changed

- `src/components/feed/AnsweredByYouCard.tsx` — green/gray tone, pill badge, conditional correct answer + quip
- `src/components/feed/types.ts` — adds `quip?: string | null` to `AnsweredByYouFeedItem`
- `src/components/FeedList.tsx` — passes `quip` through `toAnsweredByYouItem`

https://claude.ai/code/session_019FtNLZKfBCUoEwFB8ncKzy

---
_Generated by [Claude Code](https://claude.ai/code/session_019FtNLZKfBCUoEwFB8ncKzy)_