### PR TITLE
Fix database connection pooling for Next.js dev mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,12 @@
 # =============================================================
 
 # ── Database (Supabase — used as Postgres only) ───────────────
-# Pooled connection (PgBouncer, port 6543) — used by Prisma at runtime
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/DATABASE?pgbouncer=true&connection_limit=1"
+# Pooled connection (PgBouncer, port 6543) — used by Drizzle at runtime.
+# Note: pgbouncer=true and connection_limit are Prisma-only params; pg ignores
+# them. Pool size is controlled via max: 5 in src/server/db/index.ts instead.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/DATABASE?pgbouncer=true"
 
-# Direct connection (port 5432) — used by Prisma Migrate
+# Direct connection (port 5432) — used by Drizzle migrations (instrumentation.ts)
 DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
 
 # ── Anthropic ─────────────────────────────────────────────────

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -5,12 +5,26 @@ import * as schema from './schema';
 
 const connectionString = process.env.DATABASE_URL;
 
-
 if (!connectionString) {
   throw new Error('DATABASE_URL is required to initialize the database client.');
 }
 
-export const pool = new Pool({ connectionString });
+// Singleton prevents a new Pool from being allocated on every hot-reload in
+// Next.js dev mode. Without this, each reload leaks idle connections that
+// count against PgBouncer's session-mode pool_size limit.
+const globalForDb = globalThis as unknown as { pool: Pool | undefined };
+
+export const pool =
+  globalForDb.pool ??
+  new Pool({
+    connectionString,
+    // Cap well below PgBouncer's session-mode pool_size (15) so that
+    // multiple Next.js worker processes don't jointly exhaust the limit.
+    max: 5,
+  });
+
+globalForDb.pool = pool;
+
 export const db = drizzle(pool, { schema });
 
 export * from './schema';


### PR DESCRIPTION
## Summary
Implement a singleton pattern for the database connection pool to prevent connection leaks during Next.js hot-reloads in development mode. This prevents exhausting PgBouncer's session-mode pool limits when multiple pool instances are created on each file change.

## Key Changes
- **Database pool singleton**: Use `globalThis` to store a single Pool instance that persists across hot-reloads, preventing new Pool allocations on every dev mode reload
- **Connection pool size limit**: Cap the pool size to 5 connections (well below PgBouncer's session-mode limit of 15) to account for multiple Next.js worker processes
- **Updated environment documentation**: Clarified that `pgbouncer` and `connection_limit` parameters are Prisma-specific and ignored by the `pg` driver; pool sizing is now controlled in code instead

## Implementation Details
- The pool is stored on a typed `globalForDb` object attached to `globalThis`, following Next.js best practices for singleton patterns in dev mode
- Pool configuration now explicitly sets `max: 5` to prevent connection exhaustion when multiple Next.js processes share a PgBouncer instance
- Updated `.env.example` to reflect the migration from Prisma to Drizzle and clarify which connection string is used for runtime vs. migrations

https://claude.ai/code/session_01QB173iXP1EYzN6HLGYYvgn