### PR TITLE
fix: prevent PgBouncer EMAXCONNSESSION by capping pool connections

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,12 @@
 # =============================================================
 
 # ── Database (Supabase — used as Postgres only) ───────────────
-# Pooled connection (PgBouncer, port 6543) — used by Prisma at runtime
-DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/DATABASE?pgbouncer=true&connection_limit=1"
+# Pooled connection (PgBouncer, port 6543) — used by Drizzle at runtime.
+# Note: pgbouncer=true and connection_limit are Prisma-only params; pg ignores
+# them. Pool size is controlled via max: 5 in src/server/db/index.ts instead.
+DATABASE_URL="postgresql://USER:PASSWORD@HOST:6543/DATABASE?pgbouncer=true"
 
-# Direct connection (port 5432) — used by Prisma Migrate
+# Direct connection (port 5432) — used by Drizzle migrations (instrumentation.ts)
 DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
 
 # ── Anthropic ─────────────────────────────────────────────────

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -5,12 +5,26 @@ import * as schema from './schema';
 
 const connectionString = process.env.DATABASE_URL;
 
-
 if (!connectionString) {
   throw new Error('DATABASE_URL is required to initialize the database client.');
 }
 
-export const pool = new Pool({ connectionString });
+// Singleton prevents a new Pool from being allocated on every hot-reload in
+// Next.js dev mode. Without this, each reload leaks idle connections that
+// count against PgBouncer's session-mode pool_size limit.
+const globalForDb = globalThis as unknown as { pool: Pool | undefined };
+
+export const pool =
+  globalForDb.pool ??
+  new Pool({
+    connectionString,
+    // Cap well below PgBouncer's session-mode pool_size (15) so that
+    // multiple Next.js worker processes don't jointly exhaust the limit.
+    max: 5,
+  });
+
+globalForDb.pool = pool;
+
 export const db = drizzle(pool, { schema });
 
 export * from './schema';


### PR DESCRIPTION
pg.Pool defaulted to max:10 connections per process and had no singleton guard, so Next.js dev hot-reloads would silently allocate a new pool on each reload, leaking idle sessions against PgBouncer's session-mode pool_size limit of 15.

Two changes:
- Add a globalThis singleton so the same Pool instance is reused across hot-reloads in the same Node.js process.
- Set max:5 so that even with multiple Next.js workers the combined connection count stays well under the PgBouncer limit.

Also clarify .env.example: connection_limit=1 in the URL is a Prisma-only parameter that pg silently ignores; pool sizing must be set in code instead.

https://claude.ai/code/session_01QB173iXP1EYzN6HLGYYvgn