### PR TITLE
Simplify interests preview to show first 5 items

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -31,9 +31,7 @@ type RequestAction = 'accept' | 'ignore'
 
 function previewInterests(interests: string[]) {
   if (interests.length === 0) return null
-  const visible = interests.slice(0, 3).join(', ')
-  const remainder = interests.length - 3
-  return remainder > 0 ? `${visible}, +${remainder} more` : visible
+  return interests.slice(0, 5).join(', ')
 }
 
 export default function FriendsList() {


### PR DESCRIPTION
## Summary
Simplified the `previewInterests` function to display the first 5 interests without showing a "+X more" indicator.

## Changes
- Removed the logic that calculated and displayed the count of remaining interests
- Changed the preview limit from 3 to 5 interests
- Simplified the return statement to directly join the first 5 items

## Implementation Details
The function now takes a straightforward approach by displaying up to 5 interests separated by commas, without indicating how many additional interests exist beyond the preview. This provides a cleaner UI while still showing more context about a user's interests.

https://claude.ai/code/session_01YMBf4FS9ezZBnMSY4eMhSD