### PR TITLE
Add support for authored/shared question comparisons in feed

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -130,13 +130,23 @@ function formatEventTime(value: string) {
 
 function comparisonCopy(
   playerCorrect: boolean | null,
-  friendResults: FriendResult[] | null
+  friendResults: FriendResult[] | null,
+  sourceType?: string,
+  sourceFriendName?: string
 ): string {
   const primaryFriend = friendResults?.[0]
-  const friendName = primaryFriend?.displayName ?? 'They'
+  const friendIsAuthor =
+    !primaryFriend &&
+    (sourceType === 'direct_sent' || sourceType === 'authored_shared')
+  const friendName =
+    primaryFriend?.displayName ?? sourceFriendName ?? 'They'
   const friendCorrect = primaryFriend?.result === 'correct'
 
   if (playerCorrect === null) return 'You have already answered this question.'
+  if (friendIsAuthor) {
+    if (playerCorrect) return `You and ${friendName} have that in common.`
+    return `${friendName} knows this one. You might next time.`
+  }
   if (playerCorrect && friendCorrect) return 'You both had it.'
   if (playerCorrect && !friendCorrect)
     return `You found a connection ${friendName} missed.`
@@ -273,8 +283,18 @@ function toAnsweredByYouItem(
         ? 'Reviewed privately'
         : 'You answered',
     answerSummary: result
-      ? comparisonCopy(result.correct, item.friend_results)
-      : comparisonCopy(item.is_correct, item.friend_results),
+      ? comparisonCopy(
+          result.correct,
+          item.friend_results,
+          item.source_type,
+          item.source_friend_display_name
+        )
+      : comparisonCopy(
+          item.is_correct,
+          item.friend_results,
+          item.source_type,
+          item.source_friend_display_name
+        ),
     correctAnswer: result?.answer || item.correct_answer,
     submittedAnswer: item.submitted_answer || undefined,
     isCorrect: result?.correct ?? item.is_correct,


### PR DESCRIPTION
## Summary
Updated the feed comparison logic to properly handle questions that were authored or shared by friends, displaying personalized comparison messages when the friend is the question author rather than just a respondent.

## Key Changes
- Extended `comparisonCopy()` function to accept `sourceType` and `sourceFriendName` parameters to identify when a friend authored or shared a question
- Added logic to detect when a friend is the question author (`sourceType === 'direct_sent'` or `sourceType === 'authored_shared'`)
- Implemented new comparison messages for authored/shared questions:
  - If player answered correctly: "You and [friendName] have that in common."
  - If player answered incorrectly: "[friendName] knows this one. You might next time."
- Updated `toAnsweredByYouItem()` to pass `source_type` and `source_friend_display_name` from the item data to the `comparisonCopy()` function

## Implementation Details
- The friend is considered the author when there are no friend results in the comparison AND the source type indicates the question was authored or directly sent by them
- Falls back to using `sourceFriendName` when the primary friend data is unavailable, ensuring the correct friend name is displayed in authored question scenarios

https://claude.ai/code/session_01XJKzXc7v3iHqiNeg6n7RL9