### PR TITLE
Remove invitation acceptance gate for existing users

### DIFF
--- a/src/app/api/auth/refresh-session/__tests__/route.test.ts
+++ b/src/app/api/auth/refresh-session/__tests__/route.test.ts
@@ -1,25 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const {
-  destroySessionMock,
-  getSessionMock,
-  hasAcceptedInvitationForUserMock,
-  refreshSessionInvitationClaimMock,
-} = vi.hoisted(() => ({
-  destroySessionMock: vi.fn(async () => undefined),
-  getSessionMock: vi.fn(),
-  hasAcceptedInvitationForUserMock: vi.fn(),
-  refreshSessionInvitationClaimMock: vi.fn(),
-}))
+const { getSessionMock, refreshSessionInvitationClaimMock } = vi.hoisted(
+  () => ({
+    getSessionMock: vi.fn(),
+    refreshSessionInvitationClaimMock: vi.fn(),
+  }),
+)
 
 vi.mock('@/server/auth/session', () => ({
-  destroySession: destroySessionMock,
   getSession: getSessionMock,
   refreshSessionInvitationClaim: refreshSessionInvitationClaimMock,
-}))
-
-vi.mock('@/server/friends/invitations', () => ({
-  hasAcceptedInvitationForUser: hasAcceptedInvitationForUserMock,
 }))
 
 import { GET } from '@/app/api/auth/refresh-session/route'
@@ -34,10 +24,7 @@ describe('GET /api/auth/refresh-session', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockReset()
-    hasAcceptedInvitationForUserMock.mockReset()
     refreshSessionInvitationClaimMock.mockReset()
-    destroySessionMock.mockReset()
-    destroySessionMock.mockResolvedValue(undefined)
   })
 
   it('redirects to /login when there is no session', async () => {
@@ -47,20 +34,8 @@ describe('GET /api/auth/refresh-session', () => {
     expect(res.headers.get('location')).toMatch(/\/login$/)
   })
 
-  it('destroys session and bounces to /login?reason=no_invitation when user has no accepted invitation', async () => {
+  it('re-signs the session and redirects to the next path for any valid session', async () => {
     getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(false)
-    const res = await GET(makeRequest('?next=/feed'))
-    expect(destroySessionMock).toHaveBeenCalled()
-    expect(res.status).toBe(307)
-    expect(res.headers.get('location')).toContain(
-      '/login?reason=no_invitation',
-    )
-  })
-
-  it('re-signs the session and redirects to the next path when invitation is accepted', async () => {
-    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     refreshSessionInvitationClaimMock.mockResolvedValueOnce(true)
     const res = await GET(makeRequest('?next=/knowledge'))
     expect(refreshSessionInvitationClaimMock).toHaveBeenCalled()
@@ -70,7 +45,6 @@ describe('GET /api/auth/refresh-session', () => {
 
   it('rejects open-redirect attempts via the next param', async () => {
     getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     refreshSessionInvitationClaimMock.mockResolvedValueOnce(true)
     const res = await GET(makeRequest('?next=//evil.example.com/steal'))
     expect(res.status).toBe(307)
@@ -82,7 +56,6 @@ describe('GET /api/auth/refresh-session', () => {
 
   it('rejects absolute-URL next params', async () => {
     getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     refreshSessionInvitationClaimMock.mockResolvedValueOnce(true)
     const res = await GET(makeRequest('?next=https://evil.example.com'))
     const location = res.headers.get('location') ?? ''
@@ -91,7 +64,6 @@ describe('GET /api/auth/refresh-session', () => {
 
   it('bounces to /login when refresh helper fails (cookie disappeared)', async () => {
     getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     refreshSessionInvitationClaimMock.mockResolvedValueOnce(false)
     const res = await GET(makeRequest('?next=/feed'))
     expect(res.status).toBe(307)
@@ -100,7 +72,6 @@ describe('GET /api/auth/refresh-session', () => {
 
   it('defaults to / when next param is missing', async () => {
     getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     refreshSessionInvitationClaimMock.mockResolvedValueOnce(true)
     const res = await GET(makeRequest())
     expect(res.headers.get('location')).toMatch(/localhost\/$/)

--- a/src/app/api/auth/refresh-session/route.ts
+++ b/src/app/api/auth/refresh-session/route.ts
@@ -1,23 +1,18 @@
 import { NextResponse } from 'next/server'
 
 import {
-  destroySession,
   getSession,
   refreshSessionInvitationClaim,
 } from '@/server/auth/session'
-import { hasAcceptedInvitationForUser } from '@/server/friends/invitations'
 
 /**
  * Graceful migration endpoint for sessions issued before the `inv` JWT
  * claim existed. Middleware redirects legacy sessions here; this handler
  * runs in the Node runtime, so DB calls are fine.
  *
- * - Session has prior accepted invitation -> re-sign JWT with `inv: true`
- *   and redirect to the original URL.
- * - Session has no prior accepted invitation -> destroy session and
- *   bounce to /login with reason=no_invitation. This catches legacy
- *   orphan accounts that existed before the F1.1/F1.2 gate was added.
- * - No session at all -> bounce to /login.
+ * Any valid session is re-signed with `inv: true` — established users
+ * (including legacy accounts created before the invitation gate existed)
+ * keep their session.
  */
 
 function safeNextPath(rawNext: string | null): string {
@@ -35,14 +30,6 @@ export async function GET(request: Request) {
   const session = await getSession()
   if (!session) {
     const loginUrl = new URL('/login', request.url)
-    return NextResponse.redirect(loginUrl)
-  }
-
-  const hasInvitation = await hasAcceptedInvitationForUser(session.userId)
-  if (!hasInvitation) {
-    await destroySession()
-    const loginUrl = new URL('/login', request.url)
-    loginUrl.searchParams.set('reason', 'no_invitation')
     return NextResponse.redirect(loginUrl)
   }
 

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -3,43 +3,48 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   acceptFriendInvitationMock,
   createSessionMock,
+  dbMock,
   findUserSelectMock,
   hasAcceptedInvitationForUserMock,
   getValidInvitationForPhoneMock,
   provisionUserInsertMock,
   verifyOtpMock,
 } = vi.hoisted(() => {
+  const findUserSelectMock = vi.fn(
+    async () => [] as Array<Record<string, unknown>>
+  )
+  const provisionUserInsertMock = vi.fn(
+    async () => [] as Array<Record<string, unknown>>
+  )
+  const dbMock = {
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        onConflictDoNothing: vi.fn(() => ({
+          returning: vi.fn(() => provisionUserInsertMock()),
+        })),
+      })),
+    })),
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => findUserSelectMock()),
+        })),
+      })),
+    })),
+  }
   return {
     acceptFriendInvitationMock: vi.fn(),
     createSessionMock: vi.fn(async () => 'session-token'),
-    findUserSelectMock: vi.fn(async () => [] as Array<Record<string, unknown>>),
+    dbMock,
+    findUserSelectMock,
     hasAcceptedInvitationForUserMock: vi.fn(async () => false),
     getValidInvitationForPhoneMock: vi.fn(async () => null as unknown),
-    provisionUserInsertMock: vi.fn(
-      async () => [] as Array<Record<string, unknown>>
-    ),
+    provisionUserInsertMock,
     verifyOtpMock: vi.fn(async (phone: string, code: string) =>
       code === '000000' ? phone : null
     ),
   }
 })
-
-const dbMock = {
-  insert: vi.fn(() => ({
-    values: vi.fn(() => ({
-      onConflictDoNothing: vi.fn(() => ({
-        returning: vi.fn(() => provisionUserInsertMock()),
-      })),
-    })),
-  })),
-  select: vi.fn(() => ({
-    from: vi.fn(() => ({
-      where: vi.fn(() => ({
-        limit: vi.fn(() => findUserSelectMock()),
-      })),
-    })),
-  })),
-}
 
 vi.mock('@/server/auth', () => ({
   verifyOtp: verifyOtpMock,
@@ -123,7 +128,6 @@ describe('/api/auth/verify-otp invitation gate', () => {
   describe('re-login (existing user)', () => {
     it('allows re-login with no token when the user has a prior accepted invitation', async () => {
       findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
-      hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
 
       const response = await POST(
         jsonRequest({ phone: '+15551234567', code: '000000' })
@@ -133,28 +137,30 @@ describe('/api/auth/verify-otp invitation gate', () => {
       expect(response.status).toBe(200)
       expect(body.user.id).toBe('user-1')
       expect(body.invitation).toEqual({ accepted: false })
-      expect(createSessionMock).toHaveBeenCalledWith('user-1')
+      expect(createSessionMock).toHaveBeenCalledWith('user-1', {
+        invitationAccepted: true,
+      })
       expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
     })
 
-    it('rejects re-login with no token when the user has no prior accepted invitation', async () => {
+    it('allows re-login with no token even when the user has no prior accepted invitation (legacy/grandfathered account)', async () => {
       findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
-      hasAcceptedInvitationForUserMock.mockResolvedValueOnce(false)
 
       const response = await POST(
         jsonRequest({ phone: '+15551234567', code: '000000' })
       )
       const body = await response.json()
 
-      expect(response.status).toBe(400)
-      expect(body).toEqual({
-        error: 'invalid_invitation',
-        message: 'This invitation could not be accepted.',
+      expect(response.status).toBe(200)
+      expect(body.user.id).toBe('user-1')
+      expect(body.invitation).toEqual({ accepted: false })
+      expect(createSessionMock).toHaveBeenCalledWith('user-1', {
+        invitationAccepted: true,
       })
-      expect(createSessionMock).not.toHaveBeenCalled()
+      expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
     })
 
-    it('allows re-login when accepting a new invitation, even without prior history', async () => {
+    it('allows re-login when accepting a new invitation', async () => {
       findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
       acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
 
@@ -174,16 +180,17 @@ describe('/api/auth/verify-otp invitation gate', () => {
         inviteeUserId: 'user-1',
         verifiedPhone: '+15551234567',
       })
-      expect(createSessionMock).toHaveBeenCalledWith('user-1')
+      expect(createSessionMock).toHaveBeenCalledWith('user-1', {
+        invitationAccepted: true,
+      })
     })
 
-    it('falls back to prior-invitation check when a supplied token fails to accept', async () => {
+    it('still logs in when a supplied invitation token fails to accept', async () => {
       findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
       acceptFriendInvitationMock.mockResolvedValueOnce({
         accepted: false,
         reason: 'expired',
       })
-      hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
 
       const response = await POST(
         jsonRequest({
@@ -194,29 +201,9 @@ describe('/api/auth/verify-otp invitation gate', () => {
       )
 
       expect(response.status).toBe(200)
-      expect(createSessionMock).toHaveBeenCalledWith('user-1')
-    })
-
-    it('rejects when supplied token fails AND there is no prior invitation', async () => {
-      findUserSelectMock.mockResolvedValueOnce([EXISTING_USER])
-      acceptFriendInvitationMock.mockResolvedValueOnce({
-        accepted: false,
-        reason: 'phone_mismatch',
+      expect(createSessionMock).toHaveBeenCalledWith('user-1', {
+        invitationAccepted: true,
       })
-      hasAcceptedInvitationForUserMock.mockResolvedValueOnce(false)
-
-      const response = await POST(
-        jsonRequest({
-          phone: '+15551234567',
-          code: '000000',
-          invitationToken: 'invite-token',
-        })
-      )
-      const body = await response.json()
-
-      expect(response.status).toBe(400)
-      expect(body.error).toBe('invalid_invitation')
-      expect(createSessionMock).not.toHaveBeenCalled()
     })
   })
 
@@ -335,7 +322,9 @@ describe('/api/auth/verify-otp invitation gate', () => {
         inviteeUserId: 'user-2',
         verifiedPhone: '+15559876543',
       })
-      expect(createSessionMock).toHaveBeenCalledWith('user-2')
+      expect(createSessionMock).toHaveBeenCalledWith('user-2', {
+        invitationAccepted: true,
+      })
     })
 
     it('rejects new signup when accept races and fails after provisioning', async () => {

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -7,7 +7,6 @@ import { db, users } from '@/server/db'
 import {
   acceptFriendInvitation,
   getValidInvitationForPhone,
-  hasAcceptedInvitationForUser,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
 } from '@/server/friends/invitations'
 
@@ -111,9 +110,8 @@ export async function POST(request: Request) {
 
     const existingUser = await findUserByPhone(normalizedPhone)
 
-    // Re-login path: user already exists. Allow if they have a prior accepted
-    // invitation OR they're accepting one now. New invitation acceptance is
-    // optional here — a returning user without a token should still log in.
+    // Re-login path: any existing user can re-authenticate after OTP. The
+    // invitation gate only applies to new-account creation below.
     if (existingUser) {
       let invitationResult: { accepted: boolean } = { accepted: false }
 
@@ -123,21 +121,6 @@ export async function POST(request: Request) {
           inviteeUserId: existingUser.id,
           verifiedPhone: normalizedPhone,
         })
-
-        if (!invitationResult.accepted) {
-          // The token they sent didn't accept. Fall through to the
-          // prior-invitation check — if they have history, the token failure
-          // shouldn't block re-login.
-        }
-      }
-
-      if (!invitationResult.accepted) {
-        const hasPrior = await hasAcceptedInvitationForUser(existingUser.id)
-        if (!hasPrior) {
-          // User row exists but no invitation ever accepted (e.g. legacy
-          // orphan from before this gate). Reject.
-          return invitationRejection()
-        }
       }
 
       await createSession(existingUser.id, { invitationAccepted: true })

--- a/src/app/onboarding/__tests__/page.test.ts
+++ b/src/app/onboarding/__tests__/page.test.ts
@@ -4,13 +4,11 @@ const {
   getSessionMock,
   getUserOnboardingProfileMock,
   getPreSeededInterestsForUserMock,
-  hasAcceptedInvitationForUserMock,
   redirectMock,
 } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   getUserOnboardingProfileMock: vi.fn(),
   getPreSeededInterestsForUserMock: vi.fn(),
-  hasAcceptedInvitationForUserMock: vi.fn(),
   redirectMock: vi.fn((target: string) => {
     // Mirror Next.js: redirect() throws to short-circuit rendering.
     throw new Error(`__REDIRECT__:${target}`)
@@ -28,10 +26,6 @@ vi.mock('@/server/auth/session', () => ({
 vi.mock('@/server/db/queries/users', () => ({
   getUserOnboardingProfile: getUserOnboardingProfileMock,
   getPreSeededInterestsForUser: getPreSeededInterestsForUserMock,
-}))
-
-vi.mock('@/server/friends/invitations', () => ({
-  hasAcceptedInvitationForUser: hasAcceptedInvitationForUserMock,
 }))
 
 // Stub the client component import so this test stays server-side.
@@ -59,7 +53,6 @@ describe('OnboardingPage guard', () => {
     getSessionMock.mockReset()
     getUserOnboardingProfileMock.mockReset()
     getPreSeededInterestsForUserMock.mockReset()
-    hasAcceptedInvitationForUserMock.mockReset()
     getPreSeededInterestsForUserMock.mockResolvedValue({
       inviterName: 'Someone',
       interests: [],
@@ -70,7 +63,6 @@ describe('OnboardingPage guard', () => {
     getSessionMock.mockResolvedValueOnce(null)
     const result = await callPage()
     expect(result).toEqual({ redirected: true, target: '/login' })
-    expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
   })
 
   it('redirects to /login when the user row is missing', async () => {
@@ -78,22 +70,6 @@ describe('OnboardingPage guard', () => {
     getUserOnboardingProfileMock.mockResolvedValueOnce(null)
     const result = await callPage()
     expect(result).toEqual({ redirected: true, target: '/login' })
-    expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
-  })
-
-  it('redirects to /login?reason=no_invitation when the user has no accepted invitation', async () => {
-    getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
-    getUserOnboardingProfileMock.mockResolvedValueOnce({
-      id: 'u1',
-      onboardingComplete: false,
-    })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(false)
-    const result = await callPage()
-    expect(result).toEqual({
-      redirected: true,
-      target: '/login?reason=no_invitation',
-    })
-    expect(getPreSeededInterestsForUserMock).not.toHaveBeenCalled()
   })
 
   it('redirects already-onboarded users to /', async () => {
@@ -102,18 +78,16 @@ describe('OnboardingPage guard', () => {
       id: 'u1',
       onboardingComplete: true,
     })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     const result = await callPage()
     expect(result).toEqual({ redirected: true, target: '/' })
   })
 
-  it('renders OnboardingFlow when session + invitation + not-yet-onboarded', async () => {
+  it('renders OnboardingFlow when session present and not-yet-onboarded', async () => {
     getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
     getUserOnboardingProfileMock.mockResolvedValueOnce({
       id: 'u1',
       onboardingComplete: false,
     })
-    hasAcceptedInvitationForUserMock.mockResolvedValueOnce(true)
     const result = await callPage()
     expect(result).toEqual({ redirected: false })
     expect(getPreSeededInterestsForUserMock).toHaveBeenCalledWith('u1')

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -2,7 +2,6 @@ import { redirect } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { getPreSeededInterestsForUser, getUserOnboardingProfile } from '@/server/db/queries/users';
-import { hasAcceptedInvitationForUser } from '@/server/friends/invitations';
 
 import OnboardingFlow, { type PreSeededInterest } from './OnboardingFlow';
 
@@ -16,15 +15,6 @@ export default async function OnboardingPage() {
   const user = await getUserOnboardingProfile(session.userId);
   if (!user) {
     redirect('/login');
-  }
-
-  // Belt-and-suspenders: middleware enforces this app-wide, but the
-  // onboarding page is the last natural choke-point before full access.
-  // If we ever ship a code path that mints a session without verifying
-  // invitation acceptance, this check catches it.
-  const hasInvitation = await hasAcceptedInvitationForUser(session.userId);
-  if (!hasInvitation) {
-    redirect('/login?reason=no_invitation');
   }
 
   if (user.onboardingComplete) {


### PR DESCRIPTION
## Summary
This PR removes the invitation acceptance requirement for existing users during re-authentication and session refresh. The invitation gate now only applies to new account creation, allowing legacy accounts and returning users to log in without prior invitation history.

## Key Changes

- **verify-otp route**: Removed the fallback check for prior invitation acceptance when re-authenticating existing users. Any user with a valid phone number can now re-login regardless of invitation history.

- **refresh-session route**: Removed the invitation acceptance validation that was bouncing users to `/login?reason=no_invitation`. All valid sessions are now re-signed and allowed to continue.

- **onboarding page**: Removed the belt-and-suspenders invitation check that was guarding access to the onboarding flow. The middleware-level enforcement is now the sole gate.

- **Test updates**: Updated test cases to reflect the new behavior:
  - Changed "rejects re-login with no token when user has no prior invitation" to "allows re-login... (legacy/grandfathered account)"
  - Removed tests that expected rejection based on missing invitation history
  - Simplified test descriptions to reflect that invitation acceptance is no longer required for existing users
  - Removed mocks for `hasAcceptedInvitationForUser` and `destroySession` where no longer needed

## Implementation Details

The invitation acceptance gate is now scoped to new account creation only (the `provisionUser` path in verify-otp). Existing users can re-authenticate freely, and the `invitationAccepted: true` flag is always passed to `createSession` for consistency. This maintains the invitation system for new signups while removing friction for returning users, including those who may have been created before the invitation gate was implemented.

https://claude.ai/code/session_012crpwHaAXgXmdGRU4hXjSX