### PR TITLE
Refactor daily summary layout and fix circle sizing

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -222,23 +222,10 @@ export default function DailySummaryPage() {
         <p className="text-muted-foreground mt-1 text-sm">
           {formatDate(summary.date)}
         </p>
-      </header>
-
-      <section
-        className="mt-5 rounded-md border px-5 py-5"
-        style={{
-          background: 'color-mix(in srgb, var(--success) 10%, var(--surface))',
-          borderColor: 'color-mix(in srgb, var(--success) 22%, var(--border))',
-        }}
-      >
-        <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>Total</p>
-        <p className="mt-2 font-mono text-5xl leading-none font-bold text-[#111111]">
-          +{Math.round(summary.pointsEarned)}
-        </p>
         <p
           style={{
             ...monoStyle,
-            marginTop: '12px',
+            marginTop: '8px',
             color: 'var(--text-muted)',
           }}
         >
@@ -248,9 +235,9 @@ export default function DailySummaryPage() {
           {summary.totalCorrect}/{summary.questions.length} correct
           {summary.totalSkipped > 0 ? ` · ${summary.totalSkipped} skipped` : ''}
         </p>
-      </section>
+      </header>
 
-      <section className="card mt-4 px-5 py-4">
+      <section className="card mt-5 px-5 py-4">
         <h2 style={titleStyle}>Your Growth Recap</h2>
         <CategoryGainsDisplay
           roundItems={growthCircleItems}

--- a/src/components/knowledge/CategoryCircles.tsx
+++ b/src/components/knowledge/CategoryCircles.tsx
@@ -75,6 +75,7 @@ export function KnowledgeCircle({
 }) {
   const dc = getPortraitDomainColor(broadCategory);
   const resolvedSize = size ?? getCircleSize(pointsAfter, maxPoints);
+  const slotSize = size ?? MAX_SIZE;
   const finalOpacity = getCircleOpacity(pointsAfter, maxPoints);
   const [opacity, setOpacity] = useState(animate ? MIN_OPACITY : finalOpacity);
   const rafRef = useRef<number | null>(null);
@@ -123,8 +124,8 @@ export function KnowledgeCircle({
   return (
     <div
       style={{
-        width: resolvedSize,
-        height: resolvedSize,
+        width: slotSize,
+        height: slotSize,
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',


### PR DESCRIPTION
## Summary
This PR refactors the daily summary page layout and fixes a sizing issue in the KnowledgeCircle component.

## Key Changes

**Daily Summary Page (`src/app/daily/summary/page.tsx`)**
- Moved the points earned display section from a dedicated styled section into the header
- Removed the custom-styled "Total" section with success color background
- Consolidated the summary information (points, correct answers, skipped count) into the header area
- Adjusted spacing: changed marginTop from 12px to 8px for better visual hierarchy
- Updated the "Your Growth Recap" section margin from mt-4 to mt-5 for consistent spacing

**Knowledge Circle Component (`src/components/knowledge/CategoryCircles.tsx`)**
- Fixed circle sizing logic by introducing `slotSize` variable that preserves the slot dimensions
- Changed the container's width and height from using `resolvedSize` (which can be animated) to `slotSize` (which remains constant)
- This ensures the component maintains a fixed layout space while the inner circle can animate independently

## Implementation Details
The KnowledgeCircle fix prevents layout shift during animations by separating the container size (slotSize) from the animated circle size (resolvedSize). The daily summary refactor simplifies the visual hierarchy by integrating the points display directly into the header rather than as a separate highlighted section.

https://claude.ai/code/session_01DCJNiccA3JDfpfHFqduSMp