### PR TITLE
fix: remove src/middleware.ts to resolve Next.js proxy conflict

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { proxy as middleware, config } from './proxy'


### PR DESCRIPTION
Next.js 16 does not allow both middleware.ts and proxy.ts to coexist.
The middleware.ts file was a thin re-export of proxy.ts; deleting it
lets Next.js pick up proxy.ts as the sole edge handler.

https://claude.ai/code/session_018RGnoJ8kMbH1dPvVCcj14s