### PR TITLE
Fix daily correct answers not appearing in friends' social feed

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -205,7 +205,7 @@ describe('POST /api/daily/answer mastery scoring (F2.1)', () => {
     const res = await POST(jsonRequest(VALID_BODY) as never)
     expect(res.status).toBe(200)
 
-    expect(persistGeneratedQuestionMock).toHaveBeenCalledWith('gen-q-1')
+    expect(persistGeneratedQuestionMock).toHaveBeenCalledWith('gen-q-1', 'history')
     expect(readPriorAnswersForQuestionMock).toHaveBeenCalledWith(
       'user-1',
       'canonical-q-1',

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -167,7 +167,7 @@ export async function POST(request: NextRequest) {
     let persistedCreatorId: string | null = null;
     let persistedDomainForCreator: string | null = null;
     try {
-      const persisted = await persistGeneratedQuestion(question.id);
+      const persisted = await persistGeneratedQuestion(question.id, slot.domain);
       canonicalQuestionId = persisted.questionId;
       const [persistedQuestion] = await db
         .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -210,7 +210,7 @@ describe('POST /api/daily/catchup/answer mastery scoring (F2.2)', () => {
 
     await POST(jsonRequest(VALID_BODY) as never)
 
-    expect(persistGeneratedQuestionMock).toHaveBeenCalledWith('gen-q-1')
+    expect(persistGeneratedQuestionMock).toHaveBeenCalledWith('gen-q-1', 'history')
     expect(readPriorAnswersForQuestionMock).toHaveBeenCalledWith('user-1', 'canonical-q-1')
     expect(writeMasteryEventMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -94,7 +94,7 @@ export async function POST(request: NextRequest) {
   let persistedCreatorId: string | null = null;
   let persistedDomainForCreator: string | null = null;
   try {
-    const persisted = await persistGeneratedQuestion(catchupItem.questionId);
+    const persisted = await persistGeneratedQuestion(catchupItem.questionId, catchupItem.domain);
     canonicalQuestionId = persisted.questionId;
     const [persistedQuestion] = await db
       .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -16,7 +16,7 @@ function asDifficulty(value: string): 'accessible' | 'moderate' | 'specialist' |
   return null;
 }
 
-export async function persistGeneratedQuestion(generatedQuestionId: string): Promise<PersistGeneratedQuestionResult> {
+export async function persistGeneratedQuestion(generatedQuestionId: string, slotDomain?: string): Promise<PersistGeneratedQuestionResult> {
   try {
     const [existing] = await db
       .select({ id: questions.id })
@@ -45,7 +45,9 @@ export async function persistGeneratedQuestion(generatedQuestionId: string): Pro
       ? generated.canonicalSubcategory!
       : !isGenericSubcategory(generated.broadCategory)
         ? generated.broadCategory!
-        : generated.canonicalSubcategory || generated.broadCategory;
+        : !isGenericSubcategory(slotDomain)
+          ? slotDomain!
+          : generated.canonicalSubcategory || generated.broadCategory;
     assertSpecificCanonicalSubcategory(desiredCanonical);
 
     const [created] = await db


### PR DESCRIPTION
When a generated question had null/generic canonicalSubcategory and broadCategory,
persistGeneratedQuestion threw GenericCanonicalSubcategoryError. The route caught
this silently and left canonicalQuestionId null, so createFeedItemsForFriendsFromAnswer
was never called. QueueSlot.domain is always a reliable, specific value set by the
queue builder — pass it as a fallback so persistence succeeds and feed items are created.

https://claude.ai/code/session_014cT49mNdiULiyDYPDaUVUr