### PR TITLE
fix: remove middleware.ts to resolve Next.js 16 proxy conflict

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,1 +1,0 @@
-export { middleware, config } from '@/proxy'


### PR DESCRIPTION
Next.js 16.1.6 requires using proxy.ts exclusively — having both
middleware.ts and proxy.ts in src/ causes a build error. middleware.ts
was only re-exporting from proxy.ts, so removing it is safe.

https://claude.ai/code/session_01ELgfCBhky635mC9iMao6eP