### PR TITLE
Fix feed visibility: stop throwing when all category fallbacks are generic

### DIFF
--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 
 import { db, generatedQuestions, questions } from '@/server/db';
 import {
-  assertSpecificCanonicalSubcategory,
+  GenericCanonicalSubcategoryError,
   isGenericSubcategory,
 } from '@/server/questions/canonical-subcategory';
 
@@ -38,17 +38,22 @@ export async function persistGeneratedQuestion(generatedQuestionId: string, slot
       throw new Error(`Generated question not found: ${generatedQuestionId}`);
     }
 
-    // F4.5: refuse to persist a question whose canonical_subcategory is a
-    // generic bucket. Prefer the canonical subcategory; fall back to the
-    // broad category if it's specific; otherwise throw before the INSERT.
+    // F4.5: prefer a specific canonical subcategory; fall back through broad
+    // category and slot domain. If all three are generic labels, use whatever
+    // is non-null rather than throwing — persisting with a generic label is
+    // far better than failing to persist at all, which would silently block
+    // feed propagation for every correct daily answer.
     const desiredCanonical = !isGenericSubcategory(generated.canonicalSubcategory)
       ? generated.canonicalSubcategory!
       : !isGenericSubcategory(generated.broadCategory)
         ? generated.broadCategory!
         : !isGenericSubcategory(slotDomain)
           ? slotDomain!
-          : generated.canonicalSubcategory || generated.broadCategory;
-    assertSpecificCanonicalSubcategory(desiredCanonical);
+          : slotDomain ?? generated.canonicalSubcategory ?? generated.broadCategory;
+
+    if (!desiredCanonical) {
+      throw new GenericCanonicalSubcategoryError(desiredCanonical);
+    }
 
     const [created] = await db
       .insert(questions)


### PR DESCRIPTION
persistGeneratedQuestion threw GenericCanonicalSubcategoryError whenever
canonicalSubcategory, broadCategory, and slotDomain were all generic labels
(e.g. 'general knowledge'). This left canonicalQuestionId null in both the
daily and catchup answer routes, causing the if (canonicalQuestionId) guard
to skip createFeedItemsForFriendsFromAnswer entirely — so correct daily
answers never created feed items for friends.

The previous fix (8abe522) added slotDomain as a third fallback but still
called assertSpecificCanonicalSubcategory, which threw when slotDomain was
itself generic (likely because the queue builder derived it from the same
question metadata).

Change: drop the assertion on the last-resort path and only throw when
there is truly nothing at all to use as a canonical subcategory. Persisting
with a generic label is far better than failing to persist and silently
blocking all feed propagation for the user's correct answers.

https://claude.ai/code/session_019DvHhAqxGji787iyz3sEa3