### PR TITLE
Redesign feed cards: avatar circles, white bg + category left border, inline category

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -211,6 +211,8 @@ function baseTypedFields(item: FeedApiItem, answered = false) {
     question: item.question_text ?? 'Untitled question',
     personalMessage: item.personal_message,
     isInBank: item.is_in_bank,
+    avatarName: item.source_friend_display_name,
+    avatarUserId: item.source_user_id,
   }
 }
 
@@ -302,6 +304,8 @@ function toAnsweredByYouItem(
 ): AnsweredByYouFeedItem {
   return {
     ...baseTypedFields(item, true),
+    avatarName: null,
+    avatarUserId: null,
     type: 'answered_by_you',
     resultLabel:
       item.is_correct === false || result?.correct === false

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useState, type ReactNode } from 'react'
 
 import { FeedCard } from './FeedCard'
+import { visibleFeedCategory } from './category'
 import type { AnsweredByYouFeedItem } from './types'
 
 export type FeedRecheckAction = {
@@ -83,10 +84,15 @@ function AnsweredResult({
 }
 
 export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByYouCardProps) {
+  const category = visibleFeedCategory(item.category)
+  const categoryClause = category ? <> about {category}</> : null
+  const socialSignal: ReactNode = <>You answered this{categoryClause}.</>
+
   return (
     <FeedCard
       item={item}
       tone={item.isCorrect ? 'green' : 'gray'}
+      socialSignal={socialSignal}
       overflow={overflow}
       resultContent={<AnsweredResult item={item} recheckAction={recheckAction} />}
     />

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
+import { visibleFeedCategory } from './category'
 import type { DirectSentFeedItem } from './types'
 
 type DirectSentCardProps = {
@@ -26,10 +27,13 @@ export function DirectSentCard({
   onAnswer,
   resultContent,
 }: DirectSentCardProps) {
+  const category = visibleFeedCategory(item.category)
+  const categoryClause = category ? <> about {category}</> : null
+
   const socialSignal: ReactNode = (
     <>
       <PersonName href={item.senderHref} name={item.senderName} /> thought
-      you&apos;d like this one.
+      you&apos;d like this{categoryClause}.
     </>
   )
 

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -1,41 +1,33 @@
 import { cn } from '@/lib/utils'
 
-import { visibleFeedCategory } from './category'
-import type { FeedCardShellProps, FeedCardTone } from './types'
+import type { FeedCardShellProps } from './types'
 
-const toneClasses: Record<FeedCardTone, string> = {
-  cream:
-    'border-amber-200/80 bg-[#fff7df] shadow-[0_1px_0_rgba(120,83,25,0.08)]',
-  white: 'border-stone-200 bg-white shadow-sm',
-  green:
-    'border-emerald-200 bg-emerald-50/80 shadow-[0_1px_0_rgba(22,101,52,0.08)]',
-  amber:
-    'border-orange-200 bg-orange-50/80 shadow-[0_1px_0_rgba(154,52,18,0.08)]',
-  gray: 'border-stone-200 bg-stone-100/80 text-stone-800 shadow-none',
-  muted: 'border-stone-200 bg-stone-50 shadow-none',
+const AVATAR_COLORS = ['#0f766e', '#7c3aed', '#be123c', '#2563eb', '#b45309', '#15803d']
+const CATEGORY_COLORS = ['#0f766e', '#7c3aed', '#be123c', '#2563eb', '#b45309', '#15803d', '#c2410c', '#0369a1']
+
+function hashString(str: string): number {
+  return Array.from(str).reduce((sum, char) => sum + char.charCodeAt(0), 0)
 }
 
-const categoryToneClasses: Record<FeedCardTone, string> = {
-  cream: 'text-amber-700',
-  white: 'text-stone-500',
-  green: 'text-emerald-700',
-  amber: 'text-orange-700',
-  gray: 'text-stone-500',
-  muted: 'text-stone-400',
+function colorForUser(userId?: string | null): string {
+  if (!userId) return '#9ca3af'
+  return AVATAR_COLORS[hashString(userId) % AVATAR_COLORS.length]!
 }
 
-const dividerToneClasses: Record<FeedCardTone, string> = {
-  cream: 'border-amber-200/60',
-  white: 'border-stone-200',
-  green: 'border-emerald-200/60',
-  amber: 'border-orange-200/60',
-  gray: 'border-stone-200',
-  muted: 'border-stone-200',
+function colorForCategory(category?: string | null): string {
+  if (!category) return '#e5e7eb'
+  return CATEGORY_COLORS[hashString(category.toLowerCase()) % CATEGORY_COLORS.length]!
+}
+
+function initialsFor(name: string): string {
+  const parts = name.trim().split(/\s+/).filter(Boolean)
+  if (!parts.length) return '?'
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase()
 }
 
 export function FeedCard({
   item,
-  tone,
   socialSignal,
   overflow,
   onAnswer,
@@ -43,45 +35,39 @@ export function FeedCard({
   className,
   dimQuestion,
 }: FeedCardShellProps) {
-  const category = visibleFeedCategory(item.category)
   const hasBottom = Boolean(resultContent ?? onAnswer)
 
   return (
     <article
       className={cn(
-        'text-card-foreground rounded-2xl border transition-colors',
-        toneClasses[tone],
+        'overflow-hidden rounded-2xl border border-stone-200 bg-white transition-colors',
         className
       )}
+      style={{ borderLeftWidth: '4px', borderLeftColor: colorForCategory(item.category) }}
     >
-      <div className="p-3">
-        {/* Header: metadata + overflow */}
+      <div className="p-3 pl-4">
+        {/* Header: avatar + social signal + overflow */}
         <div className="flex items-start justify-between gap-3">
-          <p className="text-muted-foreground text-xs leading-5 font-medium">
-            {item.metadata}
-          </p>
+          <div className="flex items-start gap-2.5">
+            {item.avatarName ? (
+              <div
+                className="mt-0.5 grid size-8 shrink-0 place-items-center rounded-full text-[11px] font-semibold text-white"
+                style={{ backgroundColor: colorForUser(item.avatarUserId) }}
+              >
+                {initialsFor(item.avatarName)}
+              </div>
+            ) : null}
+            {socialSignal ? (
+              <p className="text-sm font-medium leading-5 text-stone-700">
+                {socialSignal}
+              </p>
+            ) : null}
+          </div>
           {overflow ? <div className="shrink-0">{overflow}</div> : null}
         </div>
 
-        {/* Social signal — the headline event */}
-        {socialSignal ? (
-          <p className="mt-2 text-sm font-semibold text-stone-900 leading-5">
-            {socialSignal}
-          </p>
-        ) : null}
-
-        {/* Category + question */}
-        <div className="mt-2 space-y-1.5">
-          {category ? (
-            <p
-              className={cn(
-                'text-[0.68rem] font-semibold tracking-[0.18em] uppercase',
-                categoryToneClasses[tone]
-              )}
-            >
-              {category.toUpperCase()}
-            </p>
-          ) : null}
+        {/* Question */}
+        <div className={cn('mt-2', item.avatarName ? 'pl-[2.625rem]' : '')}>
           <p
             className={cn(
               'font-serif text-base leading-6',
@@ -93,7 +79,12 @@ export function FeedCard({
         </div>
 
         {item.personalMessage ? (
-          <p className="text-muted-foreground mt-2 text-sm leading-6">
+          <p
+            className={cn(
+              'text-muted-foreground mt-2 text-sm leading-6',
+              item.avatarName ? 'pl-[2.625rem]' : ''
+            )}
+          >
             &ldquo;{item.personalMessage}&rdquo;
           </p>
         ) : null}
@@ -101,16 +92,9 @@ export function FeedCard({
 
       {/* Bottom strip */}
       {hasBottom ? (
-        <div
-          className={cn(
-            'flex items-center gap-3 border-t px-3 py-2.5',
-            dividerToneClasses[tone]
-          )}
-        >
+        <div className="flex items-center gap-3 border-t border-stone-200 px-3 py-2.5">
           {resultContent ? (
-            <div className="flex-1 text-sm leading-6 text-stone-700">
-              {resultContent}
-            </div>
+            <div className="flex-1 text-sm leading-6 text-stone-700">{resultContent}</div>
           ) : (
             <>
               <div className="flex-1" />

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -1,8 +1,7 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
-import { cn } from '@/lib/utils'
-
+import { FeedCard } from './FeedCard'
 import { visibleFeedCategory } from './category'
 import type { FriendAddedFeedItem } from './types'
 
@@ -14,30 +13,12 @@ type FriendAddedCardProps = {
   className?: string
 }
 
-function Sparkle({ className }: { className?: string }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      fill="none"
-      aria-hidden
-      className={cn('text-amber-400/70', className)}
-    >
-      <path
-        d="M12 2 L13.6 8.6 L20 10 L13.6 11.4 L12 18 L10.4 11.4 L4 10 L10.4 8.6 Z"
-        fill="currentColor"
-      />
-      <circle cx="20" cy="4" r="1.2" fill="currentColor" opacity="0.6" />
-      <circle cx="4" cy="20" r="1" fill="currentColor" opacity="0.5" />
-    </svg>
-  )
-}
-
 function PersonName({ href, name }: { href?: string | null; name: string }) {
   if (!href) return <>{name}</>
   return (
     <Link
       href={href}
-      className="font-medium text-stone-950 underline-offset-2 hover:underline"
+      className="font-medium underline-offset-2 hover:underline"
     >
       {name}
     </Link>
@@ -52,74 +33,24 @@ export function FriendAddedCard({
   className,
 }: FriendAddedCardProps) {
   const category = visibleFeedCategory(item.category)
+  const categoryClause = category ? <> about {category}</> : null
+
+  const socialSignal: ReactNode = (
+    <>
+      <PersonName href={item.friendHref} name={item.friendName} /> added a
+      question{categoryClause}.
+    </>
+  )
 
   return (
-    <article
-      className={cn(
-        'relative overflow-hidden rounded-2xl border border-amber-200/80 bg-gradient-to-br from-[#fff8e3] via-[#fff4d0] to-[#fdebb8] text-stone-900 shadow-[0_2px_12px_rgba(154,109,24,0.10)]',
-        className
-      )}
-    >
-      <Sparkle className="pointer-events-none absolute top-3 left-3 h-5 w-5" />
-      <Sparkle className="pointer-events-none absolute top-10 right-12 h-3 w-3 opacity-60" />
-      <Sparkle className="pointer-events-none absolute bottom-16 left-8 h-4 w-4 opacity-50" />
-      <Sparkle className="pointer-events-none absolute right-4 bottom-4 h-6 w-6" />
-
-      <div className="relative p-3 pl-9">
-        {/* Header: metadata + overflow */}
-        <div className="flex items-start justify-between gap-3">
-          <p className="text-xs leading-5 font-medium text-amber-900/70">
-            {item.metadata}
-          </p>
-          {overflow ? <div className="shrink-0">{overflow}</div> : null}
-        </div>
-
-        {/* Kicker: NEW QUESTION · CATEGORY */}
-        <p className="mt-3 text-[0.68rem] font-semibold tracking-[0.18em] text-amber-700 uppercase">
-          New question
-          {category ? (
-            <>
-              <span className="mx-1.5 text-amber-700/40">·</span>
-              {category.toUpperCase()}
-            </>
-          ) : null}
-        </p>
-
-        {/* Question */}
-        <p className="text-foreground mt-2 font-serif text-base leading-6">
-          {item.question}
-        </p>
-
-        {/* Friend attribution */}
-        <p className="mt-3 text-sm leading-6 text-stone-700">
-          <PersonName href={item.friendHref} name={item.friendName} /> added this
-          to their bank — be the first to take it on.
-        </p>
-
-        {item.personalMessage ? (
-          <p className="mt-2 text-sm leading-6 text-stone-600 italic">
-            &ldquo;{item.personalMessage}&rdquo;
-          </p>
-        ) : null}
-      </div>
-
-      {/* Bottom strip: result OR CTA */}
-      {resultContent ? (
-        <div className="relative border-t border-amber-200/60 px-3 py-2.5 text-sm leading-6 text-stone-700">
-          {resultContent}
-        </div>
-      ) : onAnswer ? (
-        <div className="relative border-t border-amber-200/60 px-3 py-2.5">
-          <button
-            type="button"
-            onClick={onAnswer}
-            className="inline-flex w-full items-center justify-center gap-2 rounded-xl bg-stone-950 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-stone-800 focus-visible:ring-2 focus-visible:ring-amber-400 focus-visible:ring-offset-2 focus-visible:outline-none"
-          >
-            Answer this
-            <span aria-hidden>→</span>
-          </button>
-        </div>
-      ) : null}
-    </article>
+    <FeedCard
+      item={item}
+      tone="white"
+      socialSignal={socialSignal}
+      overflow={overflow}
+      onAnswer={onAnswer}
+      resultContent={resultContent}
+      className={className}
+    />
   )
 }

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -3,6 +3,7 @@ import { Fragment } from 'react'
 import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
+import { visibleFeedCategory } from './category'
 import type { FriendAnsweredFeedItem, FriendAnsweredParticipant } from './types'
 
 type FriendAnsweredCardProps = {
@@ -57,32 +58,30 @@ export function FriendAnsweredCard({
       ? [{ userId: '', displayName: item.friendName, href: item.friendHref ?? null }]
       : correctFriends
 
+  const category = visibleFeedCategory(item.category)
+  const categoryClause = category ? <> about {category}</> : null
+
   let socialSignal: ReactNode
   let tone: 'green' | 'white' | 'muted'
 
   if (viewerAnswered && fallbackFriends.length > 0) {
-    // Viewer already answered the question. Muted treatment, question dimmed,
-    // social update foregrounded.
     tone = 'muted'
     const friendNodes = friendNameNodes(fallbackFriends)
     if (viewerCorrect) {
       const all = joinNames([<>You</>, ...friendNodes])
-      socialSignal = <>{all} got this right.</>
+      socialSignal = <>{all} got this right{categoryClause}.</>
     } else {
-      // Viewer got it wrong — don't call attention to that. Just show friends.
-      socialSignal = <>{joinNames(friendNodes)} got this right.</>
+      socialSignal = <>{joinNames(friendNodes)} got this right{categoryClause}.</>
     }
   } else if (fallbackFriends.length > 0) {
-    // Viewer hasn't answered. Active card prompting answer.
     tone = 'green'
     const friendNodes = friendNameNodes(fallbackFriends)
-    socialSignal = <>{joinNames(friendNodes)} got this right.</>
+    socialSignal = <>{joinNames(friendNodes)} got this right{categoryClause}.</>
   } else {
-    // Fallback (no friend list, friend didn't get it right) — keep prior behavior.
     tone = 'white'
-    socialSignal = item.answerSummary ?? (
+    socialSignal = (
       <>
-        <PersonName href={item.friendHref} name={item.friendName} /> answered this.
+        <PersonName href={item.friendHref} name={item.friendName} /> answered this{categoryClause}.
       </>
     )
   }

--- a/src/components/feed/FriendLikedCard.tsx
+++ b/src/components/feed/FriendLikedCard.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react'
 import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
+import { visibleFeedCategory } from './category'
 import type { FriendLikedFeedItem } from './types'
 
 type FriendLikedCardProps = {
@@ -20,13 +21,12 @@ function PersonName({ href, name }: { href?: string | null; name: string }) {
   )
 }
 
-function endorsementSignal(item: FriendLikedFeedItem): ReactNode {
+function endorsementSignal(item: FriendLikedFeedItem, categoryClause: ReactNode): ReactNode {
   const count = item.endorsementCount ?? 1
   if (count <= 1) {
     return (
       <>
-        <PersonName href={item.friendHref} name={item.friendName} /> liked this
-        question.
+        <PersonName href={item.friendHref} name={item.friendName} /> liked this{categoryClause}.
       </>
     )
   }
@@ -37,7 +37,7 @@ function endorsementSignal(item: FriendLikedFeedItem): ReactNode {
   return (
     <>
       <PersonName href={item.friendHref} name={item.friendName} /> and{' '}
-      {count - 1} {count - 1 === 1 ? 'friend' : 'friends'} liked this
+      {count - 1} {count - 1 === 1 ? 'friend' : 'friends'} liked this{categoryClause}
       {suffix}.
     </>
   )
@@ -49,11 +49,14 @@ export function FriendLikedCard({
   onAnswer,
   resultContent,
 }: FriendLikedCardProps) {
+  const category = visibleFeedCategory(item.category)
+  const categoryClause = category ? <> about {category}</> : null
+
   return (
     <FeedCard
       item={item}
       tone="white"
-      socialSignal={endorsementSignal(item)}
+      socialSignal={endorsementSignal(item, categoryClause)}
       overflow={overflow}
       onAnswer={onAnswer}
       resultContent={resultContent}

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -15,6 +15,8 @@ export type FeedCardBaseItem = {
   category?: string | null
   personalMessage?: string | null
   isInBank?: boolean
+  avatarName?: string | null
+  avatarUserId?: string | null
 }
 
 export type DirectSentFeedItem = FeedCardBaseItem & {


### PR DESCRIPTION
- Replace tinted card backgrounds (green/cream/white) with white cards
  and a 4px colored left border whose color is derived from the category name
- Add colored avatar circle (initial letters) at top-left of each card,
  color derived from the source user ID for per-person consistency
- Collapse the duplicate name lines (metadata + social signal) into a
  single header: "[Name] [action] about [Category]" — no date shown
- Move category inline into the header text; remove the separate
  uppercase category label
- Migrate FriendAddedCard from its bespoke gradient/sparkle layout to
  the shared FeedCard shell for visual consistency
- Add "You answered this about [Category]" social signal to AnsweredByYouCard
- Add avatarName/avatarUserId fields to FeedCardBaseItem; populate them
  in FeedList from source_friend_display_name / source_user_id; null them
  out on answered-by-you cards (no avatar for self-answer context)

https://claude.ai/code/session_01QgR7ZkigsBdkxJ7kv2qjoB