### PR TITLE
Stop serving general/bucket-level questions in daily queue and catchup

### DIFF
--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -5,6 +5,7 @@ import { getTodaysDailyQueue } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { type QueueSlot } from '@/server/daily/types';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,11 +13,18 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+// Drop slots whose domain is a bucket-level label. Older queues built before
+// the upstream guard could contain "general"/"general knowledge" slots; we
+// suppress them here so the user never sees a general question.
+function filterNonGenericSlots(slots: QueueSlot[]): QueueSlot[] {
+  return slots.filter((slot) => !isGenericSubcategory(slot.domain));
+}
+
 function serializeQueue(queue: NonNullable<Awaited<ReturnType<typeof getTodaysDailyQueue>>>, difficultyMode: string) {
   return {
     queue_id: queue.id,
     queue_date: queue.queueDate,
-    slots: asQueueSlots(queue.slots),
+    slots: filterNonGenericSlots(asQueueSlots(queue.slots)),
     difficulty_mode: difficultyMode,
   };
 }

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -15,6 +15,7 @@ import { getKnowledgeBase, getRecentDailyQuestionTexts } from '@/server/db/queri
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { resolveDailyBasePoints } from './types';
 
 export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
@@ -187,6 +188,15 @@ function parseQuestions(raw: string): LlmQuestion[] {
     if (isGenericCanonicalAnswer(answer)) {
       continue;
     }
+    // Reject LLM responses that pick a bucket-level subcategory ("general",
+    // "general knowledge", "trivia", etc.) — those questions are not tied
+    // to any of the user's declared/demonstrated domains and must not be
+    // served. This is the upstream guard on the generated_questions write
+    // boundary; the LLM is told to use the exact domain it was given, so
+    // anything generic here is a prompt violation we discard.
+    if (isGenericSubcategory(canonical)) {
+      continue;
+    }
     result.push({
       canonical_subcategory: canonical,
       broad_category: broad,
@@ -306,6 +316,14 @@ export async function generateDailyQuestions(
       question.canonical_subcategory,
       userId,
     ).catch(() => ({ canonicalDomain: question.canonical_subcategory, reconciled: false }));
+
+    if (isGenericSubcategory(canonicalDomain)) {
+      console.warn('[daily/generate-questions] skipping question with generic canonical subcategory', {
+        proposed: question.canonical_subcategory,
+        reconciled: canonicalDomain,
+      });
+      continue;
+    }
 
     const basePoints = resolveDailyBasePoints(question.difficulty_estimate);
     const [row] = await db

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -27,6 +27,7 @@ import {
   dedupeCatchUpItems,
   orderCatchUpItems,
 } from '@/server/play/catch-up-turn-sequencing';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 function asQueueSlotDifficulty(
   value: string | null | undefined,
@@ -227,6 +228,11 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
       const queueDate = String(queue.queueDate);
       const expiresAt = catchUpExpiresAt(queueDate);
       const domain = slot.domain || question.canonicalSubcategory;
+      // Suppress catchup items whose domain is a bucket-level label
+      // ("general", "general knowledge", "trivia", etc.). These would
+      // otherwise replay an earlier generation that slipped past the
+      // upstream guard.
+      if (isGenericSubcategory(domain)) return null;
       return {
         dailyQueueItemId: dailyQueueItemId(queue.id, slot.slot_index),
         queueId: queue.id,


### PR DESCRIPTION
The LLM in generateDailyQuestions can return canonical_subcategory values
like "general"/"general knowledge"/"trivia" even though the prompt says to
use the exact provided domain. parseQuestions filtered generic answers
(isGenericCanonicalAnswer) but had no equivalent check on the subcategory,
and reconcileProposedDomain passes the LLM's value through unchanged when
nothing matches the user's existing domains. The generic label then lands
in generated_questions, gets copied into a daily-queue slot's domain, and
is served to the user. The only existing isGenericSubcategory guard lived
on the downstream persistGeneratedQuestion path (post-correct-answer feed
propagation) — never on the upstream generated_questions write boundary.

Fix at three points:

- src/server/daily/generate-questions.ts (parseQuestions): reject LLM
  questions whose canonical_subcategory is a forbidden bucket label.
  This is the root-cause guard — generic-labeled questions never reach
  generated_questions.
- src/server/daily/generate-questions.ts (generateDailyQuestions): after
  reconcileProposedDomain, skip persisting if the reconciled domain is
  generic. Defense in depth in case reconciliation collapses to a bucket.
- src/server/db/queries/daily.ts (getCatchupQuestions) and
  src/app/api/daily/queue/route.ts (serializeQueue): filter out any
  slots whose stored domain is generic, so the user immediately stops
  seeing general questions left over in existing queues.