### PR TITLE
Reframe home catch-up card as a learning prompt

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -65,13 +65,10 @@ function MissedQuestionsCard({
       }
     >
       <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-        Play missed questions
+        Reinforce what you learned
       </p>
       <p className="text-foreground mt-2 text-sm font-semibold">
-        {count === 1 ? '1 question you missed' : `${count} questions you missed`}
-      </p>
-      <p className="text-muted-foreground mt-1 text-sm leading-6">
-        Catch up - 0.25x points
+        {count === 1 ? '1 question to revisit' : `${count} questions to revisit`}
       </p>
       {expiringCount > 0 ? (
         <p


### PR DESCRIPTION
Rename the header from "Play missed questions" to "Reinforce what you
learned", drop the "Catch up - 0.25x points" sub-line, and rephrase the
count from "you missed" to "to revisit" so the card reads as a learning
nudge rather than a points opportunity. Card collapses from three body
lines to two; the expiry warning and Catch up button are unchanged.

https://claude.ai/code/session_01P3zesvTNscpsMUTUxrWTQm