### PR TITLE
Hide create FAB on the friends page

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -35,7 +35,8 @@ export function Nav() {
   const hidesNewGameShortcut =
     pathname.startsWith('/daily') ||
     pathname === '/replay' ||
-    pathname.startsWith('/games/');
+    pathname.startsWith('/games/') ||
+    pathname === '/friends';
   const showNewGameShortcut = !hidesNewGameShortcut;
 
   const loadCurrentUser = useCallback(async () => {


### PR DESCRIPTION
The friends page already has its own inline "Add friend" card, so the
floating create shortcut just duplicates the affordance.