### PR TITLE
remove outer card wrapper from Friends tab

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -158,7 +158,7 @@ export default function FriendsList() {
 
       {/* Friends tab */}
       {activeTab === 'friends' ? (
-        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <section>
           {error ? (
             <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
           ) : null}


### PR DESCRIPTION
The Friends tab had a card-styled section wrapping individual friend
Link cards, producing a visible box-in-box. Drop the outer styling so
only the per-friend cards render.