### PR TITLE
style friend names as links and rephrase feed social signals around shared knowledge

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import {
@@ -130,33 +130,6 @@ function formatEventTime(value: string) {
   }).format(date)
 }
 
-function comparisonCopy(
-  playerCorrect: boolean | null,
-  friendResults: FriendResult[] | null,
-  sourceType?: string,
-  sourceFriendName?: string
-): string {
-  const primaryFriend = friendResults?.[0]
-  const friendIsAuthor =
-    !primaryFriend &&
-    (sourceType === 'direct_sent' || sourceType === 'authored_shared')
-  const friendName =
-    primaryFriend?.displayName ?? sourceFriendName ?? 'They'
-  const friendCorrect = primaryFriend?.result === 'correct'
-
-  if (playerCorrect === null) return 'You have already answered this question.'
-  if (friendIsAuthor) {
-    if (playerCorrect) return `You and ${friendName} have that in common.`
-    return `${friendName} knows this one. You might next time.`
-  }
-  if (playerCorrect && friendCorrect) return 'You both had it.'
-  if (playerCorrect && !friendCorrect)
-    return `You found a connection ${friendName} missed.`
-  if (!playerCorrect && friendCorrect)
-    return `${friendName} recognized this one. You might next time.`
-  return 'This one is still waiting for common ground.'
-}
-
 function profileHref(userId?: string | null) {
   return userId ? `/users/${encodeURIComponent(userId)}` : null
 }
@@ -170,10 +143,47 @@ function FeedPersonLink({
 }) {
   if (!href) return <>{name}</>
   return (
-    <Link href={href} className="underline-offset-2 hover:underline">
+    <Link
+      href={href}
+      className="font-semibold text-stone-900 underline decoration-stone-300 underline-offset-2 hover:decoration-stone-700"
+    >
       {name}
     </Link>
   )
+}
+
+function comparisonCopy(
+  playerCorrect: boolean | null,
+  friendResults: FriendResult[] | null,
+  sourceType?: string,
+  sourceFriendName?: string,
+  sourceUserId?: string | null
+): ReactNode {
+  const primaryFriend = friendResults?.[0]
+  const friendIsAuthor =
+    !primaryFriend &&
+    (sourceType === 'direct_sent' || sourceType === 'authored_shared')
+  const friendName =
+    primaryFriend?.displayName ?? sourceFriendName ?? 'They'
+  const friendUserId = primaryFriend?.userId ?? sourceUserId ?? null
+  const friendNode = (
+    <FeedPersonLink href={profileHref(friendUserId)} name={friendName} />
+  )
+  const friendCorrect = primaryFriend?.result === 'correct'
+
+  if (playerCorrect === null) return 'You have already answered this question.'
+  if (friendIsAuthor) {
+    if (playerCorrect)
+      return <>You and {friendNode} have that in common.</>
+    return <>{friendNode} knows this one. You might next time.</>
+  }
+  if (playerCorrect && friendCorrect)
+    return <>You and {friendNode} share this knowledge.</>
+  if (playerCorrect && !friendCorrect)
+    return <>You found a connection {friendNode} missed.</>
+  if (!playerCorrect && friendCorrect)
+    return <>{friendNode} has knowledge to share. You might next time.</>
+  return 'This one is still waiting for common ground.'
 }
 
 function feedMetadata(item: FeedApiItem, answered = false) {
@@ -316,13 +326,15 @@ function toAnsweredByYouItem(
           result.correct,
           item.friend_results,
           item.source_type,
-          item.source_friend_display_name
+          item.source_friend_display_name,
+          item.source_user_id
         )
       : comparisonCopy(
           item.is_correct,
           item.friend_results,
           item.source_type,
-          item.source_friend_display_name
+          item.source_friend_display_name,
+          item.source_user_id
         ),
     correctAnswer: result?.answer || item.correct_answer,
     submittedAnswer: item.submitted_answer || undefined,

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -42,11 +42,14 @@ function AnsweredResult({
 
   const marker = item.isCorrect ? '✓' : '✗'
   const markerClass = item.isCorrect ? 'text-emerald-700' : 'text-stone-500'
+  const summaryClass = item.isCorrect
+    ? 'text-sm font-medium text-emerald-700'
+    : 'text-sm font-medium text-stone-800'
 
   return (
     <div className="w-full space-y-1.5">
       <div className="flex items-start justify-between gap-3">
-        <p className="text-sm font-medium text-stone-800">
+        <p className={summaryClass}>
           <span className={markerClass}>{marker}</span>{' '}
           {item.answerSummary ?? 'You answered this question.'}
         </p>

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -16,7 +16,10 @@ type FriendAnsweredCardProps = {
 function PersonName({ href, name }: { href?: string | null; name: string }) {
   if (!href) return <>{name}</>
   return (
-    <Link href={href} className="font-medium underline-offset-2 hover:underline">
+    <Link
+      href={href}
+      className="font-semibold text-stone-900 underline decoration-stone-300 underline-offset-2 hover:decoration-stone-700"
+    >
       {name}
     </Link>
   )
@@ -68,15 +71,34 @@ export function FriendAnsweredCard({
     tone = 'muted'
     const friendNodes = friendNameNodes(fallbackFriends)
     if (viewerCorrect) {
-      const all = joinNames([<>You</>, ...friendNodes])
-      socialSignal = <>{all} got this right{categoryClause}.</>
+      socialSignal = (
+        <>
+          You and {joinNames(friendNodes)}{' '}
+          <span className="text-emerald-700">share this knowledge</span>
+          {categoryClause}.
+        </>
+      )
     } else {
-      socialSignal = <>{joinNames(friendNodes)} got this right{categoryClause}.</>
+      const verb = fallbackFriends.length === 1 ? 'has' : 'have'
+      socialSignal = (
+        <>
+          {joinNames(friendNodes)}{' '}
+          <span className="text-emerald-700">{verb} knowledge to share</span>
+          {categoryClause}.
+        </>
+      )
     }
   } else if (fallbackFriends.length > 0) {
     tone = 'green'
     const friendNodes = friendNameNodes(fallbackFriends)
-    socialSignal = <>{joinNames(friendNodes)} got this right{categoryClause}.</>
+    const verb = fallbackFriends.length === 1 ? 'has' : 'have'
+    socialSignal = (
+      <>
+        {joinNames(friendNodes)}{' '}
+        <span className="text-emerald-700">{verb} knowledge to share</span>
+        {categoryClause}.
+      </>
+    )
   } else {
     tone = 'white'
     socialSignal = (

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -36,7 +36,7 @@ export type FriendAnsweredFeedItem = FeedCardBaseItem & {
   friendName: string
   friendHref?: string | null
   friendCorrect?: boolean | null
-  answerSummary?: string | null
+  answerSummary?: ReactNode
   // Friends who got this question right, in order of recency.
   correctFriends?: FriendAnsweredParticipant[]
   // Viewer's own status on the underlying question, regardless of feed-item state.
@@ -60,7 +60,7 @@ export type FriendLikedFeedItem = FeedCardBaseItem & {
 export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   type: 'answered_by_you'
   resultLabel?: string | null
-  answerSummary?: string | null
+  answerSummary?: ReactNode
   correctAnswer?: string | null
   submittedAnswer?: string | null
   isCorrect?: boolean | null


### PR DESCRIPTION
In the What's Happening feed, friend names now render with a persistent
underline so they read as profile links rather than plain text, the
success phrase is highlighted in emerald, and the copy shifts from
test-style "got this right" to sharing-style "has knowledge to share" /
"share this knowledge". The answered-by-you summary also greens up when
correct and routes the friend name through a real link.