### PR TITLE
catch-up: move "Not interested" to question card, rename Skip to "I give up"

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -146,6 +146,18 @@ export default function DailyCatchupPage() {
               </div>
             ) : null}
             <GameplayChatThread messages={messages} />
+            {currentItem ? (
+              <div className="mt-1 pl-0.5">
+                <button
+                  type="button"
+                  className="text-xs text-[var(--text-muted)] underline underline-offset-4 disabled:opacity-50"
+                  disabled={submitting || isResolvingTurn}
+                  onClick={() => setConfirmingDismiss(true)}
+                >
+                  Not interested
+                </button>
+              </div>
+            ) : null}
           </>
         )}
       </section>
@@ -173,22 +185,14 @@ export default function DailyCatchupPage() {
               {submitting ? '...' : 'Send'}
             </button>
           </div>
-          <div className="mt-2 flex items-center justify-between gap-3">
+          <div className="mt-2 flex items-center gap-3">
             <button
               type="button"
-              className="text-xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)] underline-offset-4 hover:underline"
+              className="text-xs font-medium uppercase tracking-[0.08em] text-[var(--text-muted)] underline-offset-4 hover:underline disabled:opacity-50"
               disabled={submitting || isResolvingTurn}
               onClick={skipCurrent}
             >
-              Skip
-            </button>
-            <button
-              type="button"
-              className="text-xs text-[var(--text-muted)] underline underline-offset-4"
-              disabled={submitting || isResolvingTurn}
-              onClick={() => setConfirmingDismiss(true)}
-            >
-              Not interested
+              I give up
             </button>
           </div>
         </form>

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -42,7 +42,7 @@ export type ChatMessage =
       kind: 'result';
       assignmentId: string;
       questionText: string;
-      result: 'correct' | 'wrong' | 'expired';
+      result: 'correct' | 'wrong' | 'expired' | 'gave_up';
       submitted: string;
       /** Canonical answer when wrong */
       correctAnswer: string | null;
@@ -538,7 +538,7 @@ function ResultRow({
   pointsLabel,
   recheckAction,
 }: {
-  result: 'correct' | 'wrong' | 'expired';
+  result: 'correct' | 'wrong' | 'expired' | 'gave_up';
   submitted: string;
   questionText: string;
   correctAnswer: string | null;
@@ -558,6 +558,7 @@ function ResultRow({
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
   const expired = result === 'expired';
   const correct = result === 'correct';
+  const gaveUp = result === 'gave_up';
   const copy = CORRECT_COPY[copyVariant % 4];
   const requestRecheck = useCallback(async () => {
     if (!recheckAction || recheckState === 'submitting') return;
@@ -583,10 +584,15 @@ function ResultRow({
         background: 'color-mix(in srgb, var(--success) 9%, var(--surface-2))',
         border: '1px solid color-mix(in srgb, var(--success) 30%, var(--border))',
       }
-      : {
-        background: 'color-mix(in srgb, #b42318 7%, var(--surface-2))',
-        border: '1px solid color-mix(in srgb, #b42318 24%, var(--border))',
-      };
+      : gaveUp
+        ? {
+          background: 'var(--surface-2)',
+          border: '1px solid var(--border)',
+        }
+        : {
+          background: 'color-mix(in srgb, #b42318 7%, var(--surface-2))',
+          border: '1px solid color-mix(in srgb, #b42318 24%, var(--border))',
+        };
 
   return (
     <div className="flex flex-col gap-0 pt-0.5" style={{ alignItems: 'flex-start', maxWidth: '88%' }}>
@@ -613,6 +619,17 @@ function ResultRow({
               {copy.subLabel}
             </p>
             {relationalFeedbackLine ? <RelationalFeedbackFade text={relationalFeedbackLine} /> : null}
+          </>
+        ) : gaveUp ? (
+          <>
+            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--text-muted)' }}>
+              Here&rsquo;s the answer.
+            </p>
+            {correctAnswer ? (
+              <p style={{ marginTop: '8px', fontSize: '0.9rem', color: 'var(--text)' }}>
+                <span style={{ fontWeight: 600 }}>Answer:</span> {correctAnswer}
+              </p>
+            ) : null}
           </>
         ) : (
           <>

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -149,14 +149,32 @@ export function useCatchupFlow() {
   }, []);
 
   const skipCurrent = useCallback(() => {
-    if (!currentItem || submitting) return;
-    resultPostedItemIdsRef.current.add(currentItem.dailyQueueItemId);
+    if (!currentItem || submitting || isResolvingTurn) return;
+    const item = currentItem;
+    resultPostedItemIdsRef.current.add(item.dailyQueueItemId);
+    setIsResolvingTurn(true);
     setMessages((existing) => [
       ...existing,
-      { id: newMessageId(), kind: 'system', text: 'Skipped for now.' },
+      {
+        id: newMessageId(),
+        kind: 'result',
+        assignmentId: item.dailyQueueItemId,
+        questionText: item.questionText,
+        result: 'gave_up',
+        submitted: '',
+        correctAnswer: item.correctAnswer,
+        consolation: null,
+        breadcrumb: null,
+        copyVariant: item.queueAge,
+        creatorName: 'Joshing',
+        canonicalSubcategory: item.domain,
+      },
     ]);
-    advancePast(currentItem.dailyQueueItemId);
-  }, [advancePast, currentItem, submitting]);
+    window.setTimeout(() => {
+      advancePast(item.dailyQueueItemId);
+      setIsResolvingTurn(false);
+    }, 1200);
+  }, [advancePast, currentItem, isResolvingTurn, submitting]);
 
   const dismissCurrent = useCallback(async (reason: 'not_interested' | 'too_old' | 'unclear' = 'not_interested') => {
     if (!currentItem || submitting) return;


### PR DESCRIPTION
- "Not interested" now sits under the question card rather than the form,
  so the dismiss affordance is anchored to the question it refers to.
- "Skip" becomes "I give up" and reveals the correct answer (via a new
  gave_up result variant) before advancing, instead of silently skipping.