### PR TITLE
replace group progress recap with overlap map on game summary

### DIFF
--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -6,6 +6,7 @@ import { and, eq, inArray, sql } from 'drizzle-orm';
 import { QuestionRatingButtons } from '@/components/games/QuestionRatingButtons';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
+import { OverlapMap } from '@/components/OverlapMap';
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay';
 import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 import MasteryMoment from '@/components/review/MasteryMoment';
@@ -13,8 +14,11 @@ import { getSession } from '@/server/auth/session';
 import { getDeliveredCreatorNotesForQuestions } from '@/server/creator-notes';
 import { db, masteryEvents, playerMastery } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
-import { getJoshingGame, type JoshingGameView } from '@/server/db/queries/joshing-game';
+import { computeOverlapCells, getJoshingGame, type JoshingGameView } from '@/server/db/queries/joshing-game';
 import { resolveTier } from '@/server/mastery/tiers';
+
+const CREATOR_COLOR = '#c0392b';
+const RECIPIENT_COLOR = '#1a6b8a';
 
 type PageProps = {
   params: Promise<{ id: string }>;
@@ -57,10 +61,6 @@ function explanationFor(question: JoshingGameView['questions'][number]['question
     ?? question.explainerBrief
     ?? question.factualExplanation
     ?? 'No explanation available.';
-}
-
-function truncate(value: string, max = 48) {
-  return value.length > max ? `${value.slice(0, max - 1)}...` : value;
 }
 
 function responseKey(userId: string, questionId: string) {
@@ -179,7 +179,19 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
       .map((response) => response.questionId),
   );
   const impactCount = authoredQuestionsAnsweredCorrectly.size;
-  const showGroupProgress = view.recipients.length > 1;
+
+  // TODO: multi-recipient overlap visualization is a separate decision
+  // (force-directed web vs. per-recipient strip) — out of scope here.
+  const singleRecipient = view.recipients.length === 1 ? view.recipients[0] : null;
+  const overlapCells = singleRecipient
+    ? computeOverlapCells(view, view.game.creatorId, singleRecipient.userId)
+    : [];
+  const overlapPlayers = singleRecipient
+    ? ([
+        { id: view.creator.id, name: view.creator.displayName, color: CREATOR_COLOR },
+        { id: singleRecipient.userId, name: singleRecipient.displayName, color: RECIPIENT_COLOR },
+      ] as const)
+    : null;
 
   return (
     <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
@@ -329,55 +341,13 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
         </p>
       </section>
 
-      {showGroupProgress ? (
-        <section className="card mt-4 p-5">
-          <h2 style={titleStyle}>Group Progress Recap</h2>
-          {viewerHasPlayed || isCreator ? (
-            <>
-              <p style={{ ...monoStyle, marginTop: '14px', color: 'var(--text-muted)' }}>How Everyone Did</p>
-              <div className="mt-3 space-y-2">
-                {view.recipients.map((recipient) => (
-                  <div key={recipient.userId} className="flex items-center justify-between rounded-md border p-3 text-sm">
-                    <span>{recipient.displayName}</span>
-                    <span>
-                      {recipient.score ?? view.responses.filter((response) => response.userId === recipient.userId && response.isCorrect).length}/{questionCount}
-                      {recipient.completedAt ? ' done' : ''}
-                    </span>
-                  </div>
-                ))}
-              </div>
-              <div className="mt-5 overflow-x-auto">
-                <table className="w-full min-w-[560px] border-collapse text-sm">
-                  <thead>
-                    <tr>
-                      <th className="border-b p-2 text-left">Question</th>
-                      {view.recipients.map((recipient) => (
-                        <th key={recipient.userId} className="border-b p-2 text-center">{recipient.displayName}</th>
-                      ))}
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {view.questions.map((gameQuestion) => (
-                      <tr key={gameQuestion.questionId}>
-                        <td className="border-b p-2">{truncate(gameQuestion.question.questionText)}</td>
-                        {view.recipients.map((recipient) => {
-                          const response = responseByUserQuestion.get(responseKey(recipient.userId, gameQuestion.questionId));
-                          return (
-                            <td key={recipient.userId} className="border-b p-2 text-center">
-                              {response ? (response.isCorrect ? 'Y' : 'N') : '-'}
-                            </td>
-                          );
-                        })}
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </>
-          ) : (
-            <p className="mt-3 text-sm text-muted-foreground">Play to unlock results.</p>
-          )}
-        </section>
+      {overlapPlayers ? (
+        <div className="mt-6">
+          <OverlapMap
+            players={[overlapPlayers[0], overlapPlayers[1]]}
+            cells={overlapCells}
+          />
+        </div>
       ) : null}
 
       <Link className="btn-ghost mt-4" href="/feed">Back to Feed</Link>

--- a/src/components/OverlapMap.tsx
+++ b/src/components/OverlapMap.tsx
@@ -1,0 +1,322 @@
+import type { CSSProperties, ReactElement } from 'react';
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
+
+export type OverlapMapPlayer = { id: string; name: string; color: string };
+
+export type OverlapMapCell = {
+  broadCategory: string;
+  canonicalSubcategory: string;
+  aScore: number;
+  bScore: number;
+  aCorrect: number;
+  bCorrect: number;
+  sharedCorrect: number;
+};
+
+export type OverlapMapProps = {
+  players: [OverlapMapPlayer, OverlapMapPlayer];
+  cells: OverlapMapCell[];
+};
+
+const MIN_DIAMETER = 22;
+const MAX_DIAMETER = 56;
+const CIRCLE_OPACITY = 0.72;
+
+const INK = '#1a1a1a';
+const CREAM = '#faf8f2';
+const MUTED_INK = '#5a5448';
+
+const cardStyle: CSSProperties = {
+  background: CREAM,
+  border: `2px solid ${INK}`,
+  boxShadow: `6px 6px 0 ${INK}`,
+  borderRadius: 0,
+  padding: '24px 22px 22px',
+  color: INK,
+};
+
+const monoLabel: CSSProperties = {
+  fontFamily: 'var(--font-mono)',
+  fontSize: '0.62rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.18em',
+  color: INK,
+};
+
+const monoMuted: CSSProperties = {
+  ...monoLabel,
+  color: MUTED_INK,
+};
+
+const courierHeader: CSSProperties = {
+  fontFamily: '"Courier New", ui-monospace, monospace',
+  fontSize: '0.72rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.22em',
+  color: INK,
+};
+
+const italicSerif: CSSProperties = {
+  fontFamily: 'var(--font-display, "Playfair Display"), Georgia, serif',
+  fontStyle: 'italic',
+};
+
+function overlapRatioOf(cell: OverlapMapCell): number {
+  const denom = Math.max(cell.aCorrect, cell.bCorrect);
+  if (denom <= 0) return 0;
+  return cell.sharedCorrect / denom;
+}
+
+function CategoryItem({
+  cell,
+  players,
+  maxScore,
+}: {
+  cell: OverlapMapCell;
+  players: [OverlapMapPlayer, OverlapMapPlayer];
+  maxScore: number;
+}): ReactElement {
+  const dA = MIN_DIAMETER + (cell.aScore / maxScore) * (MAX_DIAMETER - MIN_DIAMETER);
+  const dB = MIN_DIAMETER + (cell.bScore / maxScore) * (MAX_DIAMETER - MIN_DIAMETER);
+  const rA = dA / 2;
+  const rB = dB / 2;
+  const overlapRatio = overlapRatioOf(cell);
+  const centerGap = (rA + rB) * (1 - overlapRatio * 0.85);
+  const svgWidth = rA + centerGap + rB;
+  const svgHeight = Math.max(dA, dB);
+  const cxA = rA;
+  const cxB = rA + centerGap;
+  const cy = svgHeight / 2;
+  const sharedPct = Math.round(overlapRatio * 100);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        gap: '8px',
+        minWidth: '120px',
+        maxWidth: '160px',
+        padding: '4px 6px',
+      }}
+    >
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        role="img"
+        aria-label={`${players[0].name} and ${players[1].name} share ${sharedPct} percent of ${cell.canonicalSubcategory}`}
+      >
+        <circle cx={cxA} cy={cy} r={rA} fill={players[0].color} opacity={CIRCLE_OPACITY} />
+        <circle cx={cxB} cy={cy} r={rB} fill={players[1].color} opacity={CIRCLE_OPACITY} />
+      </svg>
+      <p
+        style={{
+          ...italicSerif,
+          fontSize: '0.95rem',
+          textAlign: 'center',
+          lineHeight: 1.15,
+          color: INK,
+          margin: 0,
+        }}
+      >
+        {cell.canonicalSubcategory}
+      </p>
+      <p style={{ ...monoMuted, margin: 0 }}>{sharedPct}% shared</p>
+    </div>
+  );
+}
+
+export function OverlapMap({ players, cells }: OverlapMapProps): ReactElement | null {
+  const totalA = cells.reduce((sum, cell) => sum + cell.aScore, 0);
+  const totalB = cells.reduce((sum, cell) => sum + cell.bScore, 0);
+  if (cells.length === 0 || totalA === 0 || totalB === 0) return null;
+
+  const visible = cells.filter((cell) => cell.sharedCorrect > 0 && overlapRatioOf(cell) > 0);
+
+  const grouped = new Map<string, OverlapMapCell[]>();
+  for (const cell of visible) {
+    const list = grouped.get(cell.broadCategory) ?? [];
+    list.push(cell);
+    grouped.set(cell.broadCategory, list);
+  }
+
+  const maxScore = visible.length === 0
+    ? 1
+    : Math.max(1, ...visible.flatMap((cell) => [cell.aScore, cell.bScore]));
+
+  const strongest = visible.reduce<OverlapMapCell | null>((best, cell) => {
+    const ratio = overlapRatioOf(cell);
+    const score = ratio * (cell.aScore + cell.bScore);
+    if (!best) return cell;
+    const bestRatio = overlapRatioOf(best);
+    const bestScore = bestRatio * (best.aScore + best.bScore);
+    return score > bestScore ? cell : best;
+  }, null);
+
+  const headline = (
+    <h2
+      style={{
+        ...italicSerif,
+        fontSize: '1.65rem',
+        lineHeight: 1.1,
+        margin: 0,
+        color: INK,
+      }}
+    >
+      <span style={{ fontStyle: 'normal', fontFamily: 'var(--font-neutral), system-ui, sans-serif' }}>
+        Where you&apos;ve met
+      </span>
+      <br />
+      <span>so far.</span>
+    </h2>
+  );
+
+  const legend = (
+    <div
+      style={{
+        display: 'flex',
+        flexWrap: 'wrap',
+        gap: '14px',
+        marginTop: '14px',
+        paddingTop: '12px',
+        borderTop: `1px solid ${INK}`,
+      }}
+    >
+      {players.map((player) => (
+        <span
+          key={player.id}
+          style={{
+            ...monoLabel,
+            display: 'inline-flex',
+            alignItems: 'center',
+            gap: '8px',
+          }}
+        >
+          <span
+            aria-hidden
+            style={{
+              display: 'inline-block',
+              width: '12px',
+              height: '12px',
+              borderRadius: '50%',
+              background: player.color,
+              border: `1.5px solid ${INK}`,
+            }}
+          />
+          {player.name}
+        </span>
+      ))}
+    </div>
+  );
+
+  if (visible.length === 0) {
+    return (
+      <section style={cardStyle}>
+        {headline}
+        {legend}
+        <p
+          style={{
+            ...italicSerif,
+            fontSize: '0.95rem',
+            color: MUTED_INK,
+            marginTop: '20px',
+            marginBottom: 0,
+          }}
+        >
+          You haven&apos;t answered the same question correctly yet. Keep playing.
+        </p>
+      </section>
+    );
+  }
+
+  const groupEntries = [...grouped.entries()].sort(([a], [b]) => a.localeCompare(b));
+
+  return (
+    <section style={cardStyle}>
+      {headline}
+      {legend}
+
+      <div style={{ marginTop: '22px', display: 'flex', flexDirection: 'column', gap: '22px' }}>
+        {groupEntries.map(([broad, items]) => {
+          const domainColor = getPortraitDomainColor(broad).primary;
+          return (
+            <div key={broad}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: '10px', marginBottom: '12px' }}>
+                <span
+                  aria-hidden
+                  style={{
+                    display: 'inline-block',
+                    width: '10px',
+                    height: '10px',
+                    background: domainColor,
+                    border: `1.5px solid ${INK}`,
+                  }}
+                />
+                <span style={courierHeader}>{broad}</span>
+              </div>
+              <div
+                style={{
+                  display: 'flex',
+                  flexWrap: 'wrap',
+                  gap: '14px',
+                  rowGap: '18px',
+                }}
+              >
+                {items
+                  .slice()
+                  .sort((a, b) => b.sharedCorrect - a.sharedCorrect || a.canonicalSubcategory.localeCompare(b.canonicalSubcategory))
+                  .map((cell) => (
+                    <CategoryItem
+                      key={cell.canonicalSubcategory}
+                      cell={cell}
+                      players={players}
+                      maxScore={maxScore}
+                    />
+                  ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {strongest ? (
+        <div
+          style={{
+            marginTop: '24px',
+            padding: '16px 18px',
+            background: CREAM,
+            border: `2px solid ${INK}`,
+            boxShadow: `4px 4px 0 ${INK}`,
+          }}
+        >
+          <p style={{ ...monoLabel, margin: 0 }}>Your strongest overlap</p>
+          <p
+            style={{
+              ...italicSerif,
+              fontSize: '1.35rem',
+              margin: '6px 0 0',
+              color: INK,
+            }}
+          >
+            {strongest.canonicalSubcategory}
+          </p>
+        </div>
+      ) : null}
+
+      <p
+        style={{
+          ...italicSerif,
+          fontSize: '0.78rem',
+          color: MUTED_INK,
+          marginTop: '14px',
+          marginBottom: 0,
+          lineHeight: 1.4,
+        }}
+      >
+        Categories where neither of you has answered correctly together are hidden. They&apos;ll appear when you do.
+      </p>
+    </section>
+  );
+}

--- a/src/server/db/queries/joshing-game.ts
+++ b/src/server/db/queries/joshing-game.ts
@@ -46,6 +46,110 @@ export type JoshingGameView = {
   viewerStatus: 'not_started' | 'in_progress' | 'complete';
 };
 
+export type OverlapAggregateCell = {
+  broadCategory: string;
+  canonicalSubcategory: string;
+  aScore: number;
+  bScore: number;
+  aCorrect: number;
+  bCorrect: number;
+  sharedCorrect: number;
+};
+
+const DIFFICULTY_WEIGHT: Record<string, number> = {
+  accessible: 1,
+  moderate: 2,
+  specialist: 3,
+};
+
+function difficultyWeight(question: QuestionRow): number {
+  const level = question.calibratedDifficulty ?? question.llmDifficulty ?? question.difficultyEstimate ?? null;
+  if (!level) return 1;
+  return DIFFICULTY_WEIGHT[level] ?? 1;
+}
+
+export function computeOverlapCells(
+  view: JoshingGameView,
+  creatorId: string,
+  recipientId: string,
+): OverlapAggregateCell[] {
+  const responseIndex = new Map<string, JoshingGameResponseRow>();
+  for (const response of view.responses) {
+    responseIndex.set(`${response.userId}:${response.questionId}`, response);
+  }
+
+  const cells = new Map<string, OverlapAggregateCell>();
+  for (const gameQuestion of view.questions) {
+    const question = gameQuestion.question;
+    const canonical = question.canonicalSubcategory || question.broadCategory || question.category || 'General';
+    const broad = question.broadCategory || question.category || canonical;
+    const weight = difficultyWeight(question);
+
+    let cell = cells.get(canonical);
+    if (!cell) {
+      cell = {
+        broadCategory: broad,
+        canonicalSubcategory: canonical,
+        aScore: 0,
+        bScore: 0,
+        aCorrect: 0,
+        bCorrect: 0,
+        sharedCorrect: 0,
+      };
+      cells.set(canonical, cell);
+    }
+
+    if (question.creatorId === creatorId) cell.aScore += weight;
+    if (question.creatorId === recipientId) cell.bScore += weight;
+
+    const aResponse = responseIndex.get(`${creatorId}:${question.id}`);
+    const bResponse = responseIndex.get(`${recipientId}:${question.id}`);
+    const aCorrect = Boolean(aResponse?.isCorrect);
+    const bCorrect = Boolean(bResponse?.isCorrect);
+    if (aCorrect) {
+      cell.aScore += weight;
+      cell.aCorrect += 1;
+    }
+    if (bCorrect) {
+      cell.bScore += weight;
+      cell.bCorrect += 1;
+    }
+    if (aCorrect && bCorrect) cell.sharedCorrect += 1;
+  }
+
+  return [...cells.values()];
+}
+
+export async function getGameOverlapAggregates(gameId: string): Promise<{
+  creatorId: string;
+  recipientId: string | null;
+  recipientCount: number;
+  cells: OverlapAggregateCell[];
+} | null> {
+  const [gameRow] = await db
+    .select({ id: joshingGames.id, creatorId: joshingGames.creatorId })
+    .from(joshingGames)
+    .where(eq(joshingGames.id, gameId))
+    .limit(1);
+  if (!gameRow) return null;
+
+  const view = await getJoshingGame({ gameId, requestingUserId: gameRow.creatorId });
+  if (!view) return null;
+
+  const recipientCount = view.recipients.length;
+  const recipientId = recipientCount === 1 ? view.recipients[0].userId : null;
+  const cells = recipientId
+    ? computeOverlapCells(view, view.game.creatorId, recipientId)
+    : [];
+
+  return {
+    creatorId: view.game.creatorId,
+    recipientId,
+    recipientCount,
+    cells,
+  };
+}
+
 type PriorAnswerResult = 'correct' | 'wrong' | 'expired';
 
 export class JoshingGameValidationError extends Error {


### PR DESCRIPTION
Introduces an OverlapMap component that visualizes shared knowledge
territory between a creator and a single recipient as overlapping
circles per canonical subcategory. Categories with no shared correct
answers are filtered out. Renders only for 1-recipient Joshing games;
multi-recipient surfacing is deferred.