### PR TITLE
Replace +X pts pill on feed cards with knowledge-gain circle

### DIFF
--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -121,6 +121,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     });
     return {
       domain,
+      broadCategory: question.broadCategory ?? null,
       points: pointsAwarded,
       previousTier,
       newTier: previousTier,

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -290,6 +290,7 @@ export async function GET(request: NextRequest) {
         is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
         explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
         domain_pill: domain,
+        broad_category: question?.broadCategory ?? null,
         game_title: null,
         difficulty: null,
         answer_result: answerResult,

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -111,6 +111,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     });
     return {
       domain,
+      broadCategory: question.broadCategory ?? null,
       points: pointsAwarded,
       previousTier,
       newTier: previousTier,

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -59,6 +59,7 @@ type FeedApiItem = {
   verified: boolean
   is_in_bank: boolean
   domain_pill: string | null
+  broad_category?: string | null
   difficulty: string | null
   explanation: string | null
   answer_result: 'correct' | 'incorrect' | null
@@ -308,10 +309,37 @@ function toTypedFeedItem(item: FeedApiItem) {
   } satisfies FriendAnsweredFeedItem
 }
 
+function normalizeMasteryDelta(
+  raw: unknown
+): AnsweredByYouFeedItem['masteryDelta'] {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  const previousTier = typeof r.previousTier === 'string' ? r.previousTier : null
+  const newTier = typeof r.newTier === 'string' ? r.newTier : null
+  if (!previousTier || !newTier) return null
+  const tierChanged =
+    typeof r.tierChanged === 'boolean' ? r.tierChanged : previousTier !== newTier
+  return { previousTier, newTier, tierChanged }
+}
+
+function pickBroadCategory(
+  raw: unknown,
+  item: FeedApiItem
+): string | null {
+  if (raw && typeof raw === 'object') {
+    const r = raw as Record<string, unknown>
+    if (typeof r.broadCategory === 'string' && r.broadCategory.length > 0) {
+      return r.broadCategory
+    }
+  }
+  return item.broad_category ?? null
+}
+
 function toAnsweredByYouItem(
   item: FeedApiItem,
   result?: ResultState
 ): AnsweredByYouFeedItem {
+  const masteryDeltaRaw = result?.masteryDelta ?? item.mastery_delta
   return {
     ...baseTypedFields(item, true),
     avatarName: null,
@@ -343,6 +371,8 @@ function toAnsweredByYouItem(
     explanation: result?.explanation ?? item.explanation,
     quip: result?.quip ?? null,
     unverifiedAnswer: item.unverified_answer,
+    broadCategory: pickBroadCategory(masteryDeltaRaw, item),
+    masteryDelta: normalizeMasteryDelta(masteryDeltaRaw),
   }
 }
 

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -2,9 +2,57 @@
 
 import { useCallback, useState, type ReactNode } from 'react'
 
+import { KnowledgeCircle } from '@/components/knowledge/CategoryCircles'
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+
 import { FeedCard } from './FeedCard'
 import { visibleFeedCategory } from './category'
 import type { AnsweredByYouFeedItem } from './types'
+
+const TIER_LABEL: Record<string, string> = {
+  establishing: 'Establishing',
+  familiar: 'Familiar',
+  solid: 'Solid',
+  mastery: 'Mastery',
+}
+
+function tierLabel(tier: string): string {
+  return TIER_LABEL[tier.toLowerCase()] ?? tier
+}
+
+function KnowledgeGainIndicator({ item }: { item: AnsweredByYouFeedItem }) {
+  const broad = item.broadCategory ?? item.category ?? 'General'
+  const tooltipArea = visibleFeedCategory(item.category) ?? broad
+  const dc = getPortraitDomainColor(broad)
+  const tierChanged = Boolean(item.masteryDelta?.tierChanged)
+  const tierLine = tierChanged && item.masteryDelta
+    ? `${tierLabel(item.masteryDelta.previousTier)} → ${tierLabel(item.masteryDelta.newTier)}`
+    : null
+
+  return (
+    <div
+      className="flex shrink-0 flex-col items-end gap-1"
+      title={`+ Knowledge in ${tooltipArea}`}
+      aria-label={`Knowledge gained in ${tooltipArea}${tierLine ? `, ${tierLine}` : ''}`}
+    >
+      <KnowledgeCircle
+        broadCategory={broad}
+        pointsAfter={1}
+        maxPoints={1}
+        animate
+        size={28}
+      />
+      {tierLine ? (
+        <span
+          className="font-mono text-[9px] uppercase tracking-[0.1em]"
+          style={{ color: dc.primary }}
+        >
+          {tierLine}
+        </span>
+      ) : null}
+    </div>
+  )
+}
 
 export type FeedRecheckAction = {
   onSubmit: () => Promise<{ accepted: boolean; message: string }>
@@ -53,11 +101,7 @@ function AnsweredResult({
           <span className={markerClass}>{marker}</span>{' '}
           {item.answerSummary ?? 'You answered this question.'}
         </p>
-        {item.isCorrect && typeof item.awardedPoints === 'number' ? (
-          <span className="shrink-0 rounded-full bg-emerald-100 px-2.5 py-0.5 text-xs font-semibold text-emerald-700">
-            +{item.awardedPoints} pts
-          </span>
-        ) : null}
+        {item.isCorrect ? <KnowledgeGainIndicator item={item} /> : null}
       </div>
       {!item.isCorrect && item.correctAnswer ? (
         <p className="text-sm text-stone-500 italic">{item.correctAnswer}</p>

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -139,10 +139,30 @@ describe('Feed answered states', () => {
 
     expect(rendered).toContain('You both had it')
     expect(rendered).toContain('Barcelona')
-    expect(rendered).toContain('+5 pts')
   })
 
-  it('wrong answers show correct answer and avoid red Feed styling', () => {
+  it('shows the knowledge-gain circle (no raw points pill) on a correct answer that crosses a tier', () => {
+    const rendered = html(
+      <AnsweredByYouCard item={feedCardPreviewFixtures.answeredByYouCorrect} />
+    )
+
+    expect(rendered).not.toContain('+5 pts')
+    expect(rendered).toContain('+ Knowledge in Sports')
+    expect(rendered).toContain('Familiar → Solid')
+  })
+
+  it('correct answers without a tier change show the circle but no tier subtitle', () => {
+    const rendered = html(
+      <AnsweredByYouCard
+        item={feedCardPreviewFixtures.unverifiedAnsweredExplanationNote}
+      />
+    )
+
+    expect(rendered).toContain('+ Knowledge in Film')
+    expect(rendered).not.toMatch(/→/)
+  })
+
+  it('wrong answers show correct answer, avoid red Feed styling, and skip the knowledge circle', () => {
     const rendered = html(
       <AnsweredByYouCard item={feedCardPreviewFixtures.answeredByYouWrong} />
     )
@@ -151,6 +171,7 @@ describe('Feed answered states', () => {
     expect(rendered).not.toContain('bg-red')
     expect(rendered).not.toContain('text-red')
     expect(rendered).not.toContain('destructive')
+    expect(rendered).not.toContain('+ Knowledge')
   })
 })
 

--- a/src/components/feed/mock-feed-items.ts
+++ b/src/components/feed/mock-feed-items.ts
@@ -55,6 +55,7 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
     id: 'mock-answered-by-you-correct',
     metadata: 'You answered · May 7',
     category: 'Sports',
+    broadCategory: 'Sports',
     question: 'Which city hosted the 1992 Summer Olympics?',
     resultLabel: 'You answered',
     answerSummary: 'You both had it.',
@@ -62,6 +63,11 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
     correctAnswer: 'Barcelona',
     isCorrect: true,
     awardedPoints: 5,
+    masteryDelta: {
+      previousTier: 'familiar',
+      newTier: 'solid',
+      tierChanged: true,
+    },
   },
   {
     type: 'answered_by_you',
@@ -98,6 +104,7 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
     id: 'mock-unverified-answered-note',
     metadata: 'You answered · May 5',
     category: 'Film',
+    broadCategory: 'Film & Television',
     question: 'Which editor cut Raging Bull?',
     resultLabel: 'You answered',
     answerSummary: 'You answered this question.',
@@ -107,6 +114,11 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
     awardedPoints: 3,
     explanation: 'Explanation is pending verification by the question author.',
     unverifiedAnswer: true,
+    masteryDelta: {
+      previousTier: 'familiar',
+      newTier: 'familiar',
+      tierChanged: false,
+    },
   },
 ]
 

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -57,6 +57,12 @@ export type FriendLikedFeedItem = FeedCardBaseItem & {
   additionalEndorsers?: Array<{ userId: string; displayName: string }> | null
 }
 
+export type AnsweredByYouMasteryDelta = {
+  previousTier: string
+  newTier: string
+  tierChanged: boolean
+}
+
 export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   type: 'answered_by_you'
   resultLabel?: string | null
@@ -68,6 +74,8 @@ export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   explanation?: string | null
   quip?: string | null
   unverifiedAnswer?: boolean
+  broadCategory?: string | null
+  masteryDelta?: AnsweredByYouMasteryDelta | null
 }
 
 export type TypedFeedItem =

--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -24,6 +24,7 @@ export type WriteMasteryEventParams = {
 
 export type MasteryEventWriteResult = {
   domain: string;
+  broadCategory: string | null;
   points: number;
   previousTier: MasteryTier;
   newTier: MasteryTier;
@@ -159,6 +160,7 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
 
   return {
     domain: params.domain,
+    broadCategory: broadCategory ?? null,
     points: params.pointsAwarded,
     previousTier,
     newTier: nextTier,


### PR DESCRIPTION
On AnsweredByYouCard, the prominent green "+X pts" badge is replaced by a
small domain-colored KnowledgeCircle that pops in when the answer is
correct. The circle reuses the same visual grammar as the post-game
knowledge summary, so a correct feed answer reads as growth in that area
rather than a raw point tally. When the answer crosses a tier
threshold, a quiet "Previous → Next" line surfaces below the circle in
the domain color; otherwise the indicator stays silent.

To support coloring the circle without an extra client-side lookup,
broadCategory is now threaded through the mastery write result, the
feed API response, and the AnsweredByYouFeedItem type.

https://claude.ai/code/session_01Ad78ExcfA8QMrYdiTDitZs