### PR TITLE
add /feed/debug/friend-coverage diagnostic to triage missing friend daily-5 answers

### DIFF
--- a/src/app/api/feed/friend-coverage/route.ts
+++ b/src/app/api/feed/friend-coverage/route.ts
@@ -1,0 +1,352 @@
+import { and, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import {
+  db,
+  feedDismissedDomains,
+  feedItems,
+  friendships,
+  masteryEvents,
+  questionFeedback,
+  questionRatings,
+  questions,
+  users,
+} from '@/server/db';
+import { isCorrectAnswerFeedEligible } from '@/server/feed/visibility';
+
+export const dynamic = 'force-dynamic';
+
+export type FriendCoverageDiagnosis =
+  | 'visible'
+  | 'friendship_inactive'
+  | 'eligibility_failed'
+  | 'friend_thumbs_down'
+  | 'domain_dismissed_by_viewer'
+  | 'no_feed_item_written'
+  | 'feed_item_state_hidden'
+  | 'source_result_wrong'
+  | 'rolled_off'
+  | 'question_now_private_or_deleted';
+
+export type FriendCoverageEventRow = {
+  masteryEventId: string;
+  masteryAnswerId: string | null;
+  masterySourceType: 'live_correct' | 'catchup_correct';
+  masteryAnswerState: string | null;
+  answeredAt: string;
+  questionId: string | null;
+  questionTextSnippet: string | null;
+  questionVisibility: string | null;
+  questionSource: string | null;
+  questionDeletedAt: string | null;
+  questionCreatorId: string | null;
+  questionCanonicalSubcategory: string | null;
+  questionBroadCategory: string | null;
+  eligibilityWouldPass: boolean;
+  friendThumbsDown: boolean;
+  viewerDomainDismissed: boolean;
+  feedItem: {
+    id: string;
+    state: string;
+    sourceType: string;
+    sourceResult: 'correct' | 'incorrect' | null;
+    sourceEventAt: string;
+    sourceAnswerId: string | null;
+    isPinned: boolean;
+    createdAt: string;
+  } | null;
+  diagnosis: FriendCoverageDiagnosis;
+};
+
+export type FriendCoverageFriendBlock = {
+  friendUserId: string;
+  friendDisplayName: string | null;
+  friendPhoneNumber: string | null;
+  friendshipId: string | null;
+  friendshipStatus: string | null;
+  recentCorrectAnswers: FriendCoverageEventRow[];
+  note: string | null;
+};
+
+export type FriendCoverageResponse = {
+  viewerUserId: string;
+  friendQuery: string | null;
+  limit: number;
+  summary: {
+    totalFriendshipsForViewer: number;
+    activeFriendCount: number;
+    viewerActiveFeedItemCount: number;
+    rolloffCap: number;
+  };
+  friends: FriendCoverageFriendBlock[];
+};
+
+const VISIBLE_FEED_STATES = new Set(['active', 'skipped', 'answered']);
+const ACTION_REQUIRED_FEED_STATES = ['active', 'skipped'] as const;
+const ROLLOFF_CAP = 50;
+
+function isFeedDebugEnabled() {
+  return process.env.NODE_ENV !== 'production' || process.env.FEED_DEBUG_ENABLED === 'true';
+}
+
+function snippet(text: string | null | undefined, max = 120): string | null {
+  if (!text) return null;
+  const trimmed = text.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+function isoOrNull(value: Date | string | null | undefined): string | null {
+  if (!value) return null;
+  if (value instanceof Date) return value.toISOString();
+  return value;
+}
+
+export async function loadFriendCoverage(
+  viewerUserId: string,
+  friendQuery: string | null,
+  limit: number,
+): Promise<FriendCoverageResponse> {
+  const allFriendships = await db
+    .select({
+      friendshipId: friendships.id,
+      status: friendships.status,
+      userAId: friendships.userAId,
+      userBId: friendships.userBId,
+    })
+    .from(friendships)
+    .where(or(
+      eq(friendships.userAId, viewerUserId),
+      eq(friendships.userBId, viewerUserId),
+    ));
+
+  const friendshipByOtherUserId = new Map<string, { friendshipId: string; status: string }>();
+  for (const row of allFriendships) {
+    const otherId = row.userAId === viewerUserId ? row.userBId : row.userAId;
+    friendshipByOtherUserId.set(otherId, { friendshipId: row.friendshipId, status: row.status });
+  }
+
+  const activeFriendCount = allFriendships.filter((row) => row.status === 'active').length;
+
+  const viewerActiveFeedItemCount = await db
+    .select({ value: sql<number>`COUNT(*)::int`.as('value') })
+    .from(feedItems)
+    .where(and(
+      eq(feedItems.recipientUserId, viewerUserId),
+      eq(feedItems.isPinned, false),
+      inArray(feedItems.state, ACTION_REQUIRED_FEED_STATES),
+    ))
+    .then((rows) => rows[0]?.value ?? 0);
+
+  const summary = {
+    totalFriendshipsForViewer: allFriendships.length,
+    activeFriendCount,
+    viewerActiveFeedItemCount,
+    rolloffCap: ROLLOFF_CAP,
+  };
+
+  const otherIds = [...friendshipByOtherUserId.keys()];
+  if (otherIds.length === 0) {
+    return { viewerUserId, friendQuery, limit, summary, friends: [] };
+  }
+
+  const friendFilters = [inArray(users.id, otherIds)];
+  if (friendQuery) {
+    friendFilters.push(or(
+      eq(users.id, friendQuery),
+      eq(users.phoneNumber, friendQuery),
+      ilike(users.displayName, `%${friendQuery}%`),
+    )!);
+  }
+
+  const friendRows = await db
+    .select({ id: users.id, displayName: users.displayName, phoneNumber: users.phoneNumber })
+    .from(users)
+    .where(and(...friendFilters));
+
+  if (friendRows.length === 0) {
+    return { viewerUserId, friendQuery, limit, summary, friends: [] };
+  }
+
+  const viewerDismissedDomains = new Set(
+    (await db
+      .select({ canonicalSubcategory: feedDismissedDomains.canonicalSubcategory })
+      .from(feedDismissedDomains)
+      .where(and(
+        eq(feedDismissedDomains.userId, viewerUserId),
+        isNull(feedDismissedDomains.reinstatedAt),
+      )))
+      .map((row) => row.canonicalSubcategory),
+  );
+
+  const friends: FriendCoverageFriendBlock[] = [];
+
+  for (const friend of friendRows) {
+    const friendship = friendshipByOtherUserId.get(friend.id) ?? null;
+
+    const events = await db
+      .select({
+        masteryEventId: masteryEvents.id,
+        masteryAnswerId: masteryEvents.answerId,
+        masterySourceType: masteryEvents.sourceType,
+        masteryAnswerState: masteryEvents.answerState,
+        answeredAt: masteryEvents.createdAt,
+        questionId: questions.id,
+        questionText: questions.questionText,
+        questionVisibility: questions.visibility,
+        questionSource: questions.source,
+        questionDeletedAt: questions.deletedAt,
+        questionCreatorId: questions.creatorId,
+        questionCanonicalSubcategory: questions.canonicalSubcategory,
+        questionBroadCategory: questions.broadCategory,
+      })
+      .from(masteryEvents)
+      .leftJoin(questions, eq(masteryEvents.questionId, questions.id))
+      .where(and(
+        eq(masteryEvents.answeredByUserId, friend.id),
+        inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+        inArray(masteryEvents.answerState, ['first_correct', 'first_correct_after_wrong', 'repeat_correct']),
+      ))
+      .orderBy(desc(masteryEvents.createdAt))
+      .limit(limit);
+
+    const rows: FriendCoverageEventRow[] = [];
+
+    for (const event of events) {
+      const questionPayload = event.questionId ? {
+        creatorId: event.questionCreatorId,
+        source: event.questionSource as 'authored' | 'daily_generated',
+        visibility: event.questionVisibility as 'public' | 'private',
+        deletedAt: event.questionDeletedAt,
+      } : null;
+
+      const eligibilityWouldPass = questionPayload
+        ? isCorrectAnswerFeedEligible({
+          answerIsCorrect: true,
+          answererUserId: friend.id,
+          question: questionPayload,
+          hasVisibleSocialContext: true,
+        })
+        : false;
+
+      const [thumbsDownFeedback] = event.questionId ? await db
+        .select({ id: questionFeedback.id })
+        .from(questionFeedback)
+        .where(and(
+          eq(questionFeedback.userId, friend.id),
+          eq(questionFeedback.questionId, event.questionId),
+          eq(questionFeedback.signal, 'thumbs_down'),
+        ))
+        .limit(1) : [];
+
+      const [thumbsDownRating] = event.questionId && !thumbsDownFeedback ? await db
+        .select({ id: questionRatings.id })
+        .from(questionRatings)
+        .where(and(
+          eq(questionRatings.userId, friend.id),
+          eq(questionRatings.questionId, event.questionId),
+          eq(questionRatings.rating, 'down'),
+        ))
+        .limit(1) : [];
+
+      const friendThumbsDown = Boolean(thumbsDownFeedback || thumbsDownRating);
+
+      const viewerDomainDismissed = Boolean(
+        event.questionCanonicalSubcategory && viewerDismissedDomains.has(event.questionCanonicalSubcategory),
+      );
+
+      const feedItemRow = event.questionId ? await db
+        .select()
+        .from(feedItems)
+        .where(and(
+          eq(feedItems.recipientUserId, viewerUserId),
+          eq(feedItems.questionId, event.questionId),
+          eq(feedItems.sourceUserId, friend.id),
+        ))
+        .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
+        .limit(1)
+        .then((rs) => rs[0] ?? null) : null;
+
+      let diagnosis: FriendCoverageDiagnosis;
+      if (!friendship || friendship.status !== 'active') {
+        diagnosis = 'friendship_inactive';
+      } else if (!eligibilityWouldPass) {
+        diagnosis = 'eligibility_failed';
+      } else if (friendThumbsDown) {
+        diagnosis = 'friend_thumbs_down';
+      } else if (!feedItemRow) {
+        diagnosis = viewerDomainDismissed ? 'domain_dismissed_by_viewer' : 'no_feed_item_written';
+      } else if (feedItemRow.sourceResult !== 'correct') {
+        diagnosis = 'source_result_wrong';
+      } else if (feedItemRow.state === 'rolled_off') {
+        diagnosis = 'rolled_off';
+      } else if (!VISIBLE_FEED_STATES.has(feedItemRow.state)) {
+        diagnosis = 'feed_item_state_hidden';
+      } else if (questionPayload && ((questionPayload.visibility as string) !== 'public' || questionPayload.deletedAt)) {
+        diagnosis = 'question_now_private_or_deleted';
+      } else if (viewerDomainDismissed) {
+        // Read-side filter excludes dismissed-domain rows even if the row exists.
+        diagnosis = 'domain_dismissed_by_viewer';
+      } else {
+        diagnosis = 'visible';
+      }
+
+      rows.push({
+        masteryEventId: event.masteryEventId,
+        masteryAnswerId: event.masteryAnswerId,
+        masterySourceType: event.masterySourceType as 'live_correct' | 'catchup_correct',
+        masteryAnswerState: event.masteryAnswerState,
+        answeredAt: isoOrNull(event.answeredAt) ?? '',
+        questionId: event.questionId,
+        questionTextSnippet: snippet(event.questionText),
+        questionVisibility: event.questionVisibility,
+        questionSource: event.questionSource,
+        questionDeletedAt: isoOrNull(event.questionDeletedAt),
+        questionCreatorId: event.questionCreatorId,
+        questionCanonicalSubcategory: event.questionCanonicalSubcategory,
+        questionBroadCategory: event.questionBroadCategory,
+        eligibilityWouldPass,
+        friendThumbsDown,
+        viewerDomainDismissed,
+        feedItem: feedItemRow ? {
+          id: feedItemRow.id,
+          state: feedItemRow.state,
+          sourceType: feedItemRow.sourceType,
+          sourceResult: feedItemRow.sourceResult,
+          sourceEventAt: isoOrNull(feedItemRow.sourceEventAt) ?? '',
+          sourceAnswerId: feedItemRow.sourceAnswerId,
+          isPinned: feedItemRow.isPinned,
+          createdAt: isoOrNull(feedItemRow.createdAt) ?? '',
+        } : null,
+        diagnosis,
+      });
+    }
+
+    friends.push({
+      friendUserId: friend.id,
+      friendDisplayName: friend.displayName,
+      friendPhoneNumber: friend.phoneNumber,
+      friendshipId: friendship?.friendshipId ?? null,
+      friendshipStatus: friendship?.status ?? null,
+      recentCorrectAnswers: rows,
+      note: rows.length === 0 ? 'No recent correct daily/catchup answers found in masteryEvents.' : null,
+    });
+  }
+
+  return { viewerUserId, friendQuery, limit, summary, friends };
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  if (!isFeedDebugEnabled()) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  const friendQuery = request.nextUrl.searchParams.get('friend')?.trim() || null;
+  const rawLimit = Number(request.nextUrl.searchParams.get('limit') ?? '25');
+  const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : 25, 1), 100);
+
+  const payload = await loadFriendCoverage(session.userId, friendQuery, limit);
+  return NextResponse.json(payload);
+}
+
+export const __test_only_isFeedDebugEnabled = isFeedDebugEnabled;

--- a/src/app/feed/debug/friend-coverage/page.tsx
+++ b/src/app/feed/debug/friend-coverage/page.tsx
@@ -1,0 +1,194 @@
+import { notFound, redirect } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import {
+  loadFriendCoverage,
+  type FriendCoverageDiagnosis,
+  type FriendCoverageEventRow,
+  type FriendCoverageFriendBlock,
+} from '@/app/api/feed/friend-coverage/route';
+
+export const dynamic = 'force-dynamic';
+
+type PageProps = {
+  searchParams: Promise<{ friend?: string; limit?: string }>;
+};
+
+function isFeedDebugEnabled() {
+  return process.env.NODE_ENV !== 'production' || process.env.FEED_DEBUG_ENABLED === 'true';
+}
+
+const DIAGNOSIS_COLORS: Record<FriendCoverageDiagnosis, string> = {
+  visible: '#0a7d2a',
+  friendship_inactive: '#a07e00',
+  eligibility_failed: '#a02500',
+  friend_thumbs_down: '#7c00a0',
+  domain_dismissed_by_viewer: '#7c00a0',
+  no_feed_item_written: '#a02500',
+  feed_item_state_hidden: '#7c00a0',
+  source_result_wrong: '#a02500',
+  rolled_off: '#7c00a0',
+  question_now_private_or_deleted: '#a07e00',
+};
+
+function fmtTimestamp(value: string | null): string {
+  if (!value) return '—';
+  return value.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+}
+
+function fmtBool(value: boolean): string {
+  return value ? 'YES' : 'no';
+}
+
+function EventRow({ row }: { row: FriendCoverageEventRow }) {
+  const color = DIAGNOSIS_COLORS[row.diagnosis] ?? '#000';
+  return (
+    <tr style={{ verticalAlign: 'top' }}>
+      <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+        {fmtTimestamp(row.answeredAt)}
+      </td>
+      <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px' }}>
+        {row.masterySourceType}
+      </td>
+      <td style={{ padding: '4px 8px', fontSize: '12px', maxWidth: '380px' }}>
+        <div>{row.questionTextSnippet ?? <em>(question missing)</em>}</div>
+        <div style={{ fontFamily: 'monospace', fontSize: '10px', color: '#666' }}>
+          q={row.questionId ?? 'null'} domain={row.questionCanonicalSubcategory ?? row.questionBroadCategory ?? 'null'} visibility={row.questionVisibility ?? 'null'} source={row.questionSource ?? 'null'} deletedAt={row.questionDeletedAt ?? 'null'} creator={row.questionCreatorId ?? 'null'}
+        </div>
+      </td>
+      <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+        elig={fmtBool(row.eligibilityWouldPass)}<br />
+        thumbsDown={fmtBool(row.friendThumbsDown)}<br />
+        dismissed={fmtBool(row.viewerDomainDismissed)}
+      </td>
+      <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+        {row.feedItem ? (
+          <>
+            id={row.feedItem.id.slice(0, 8)}…<br />
+            state={row.feedItem.state}<br />
+            sourceResult={row.feedItem.sourceResult ?? 'null'}<br />
+            sourceEventAt={fmtTimestamp(row.feedItem.sourceEventAt)}<br />
+            sourceAnswerId={row.feedItem.sourceAnswerId ?? 'null'}<br />
+            isPinned={fmtBool(row.feedItem.isPinned)}
+          </>
+        ) : (
+          <span style={{ color: '#a02500' }}>no row</span>
+        )}
+      </td>
+      <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '12px', fontWeight: 'bold', color, whiteSpace: 'nowrap' }}>
+        {row.diagnosis}
+      </td>
+    </tr>
+  );
+}
+
+function FriendBlock({ block }: { block: FriendCoverageFriendBlock }) {
+  return (
+    <details open style={{ marginBottom: '16px', border: '1px solid #ddd', padding: '8px' }}>
+      <summary style={{ cursor: 'pointer', fontFamily: 'monospace', fontSize: '13px' }}>
+        <strong>{block.friendDisplayName ?? '(no display name)'}</strong>
+        {' · '}id={block.friendUserId}
+        {' · '}phone={block.friendPhoneNumber ?? '—'}
+        {' · '}friendship={block.friendshipStatus ?? '(none)'}
+        {' · '}rows={block.recentCorrectAnswers.length}
+      </summary>
+
+      {block.note && <p style={{ color: '#666', fontSize: '12px', marginTop: '8px' }}>{block.note}</p>}
+
+      {block.recentCorrectAnswers.length > 0 && (
+        <table style={{ width: '100%', marginTop: '8px', borderCollapse: 'collapse' }}>
+          <thead>
+            <tr style={{ background: '#f4f4f4' }}>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>answered_at</th>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>source</th>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>question</th>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>gates</th>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>feedItem</th>
+              <th style={{ padding: '4px 8px', textAlign: 'left', fontSize: '11px' }}>diagnosis</th>
+            </tr>
+          </thead>
+          <tbody>
+            {block.recentCorrectAnswers.map((row) => (
+              <EventRow key={row.masteryEventId} row={row} />
+            ))}
+          </tbody>
+        </table>
+      )}
+    </details>
+  );
+}
+
+export default async function FriendCoverageDebugPage({ searchParams }: PageProps) {
+  if (!isFeedDebugEnabled()) notFound();
+
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const params = await searchParams;
+  const friendQuery = params.friend?.trim() || null;
+  const rawLimit = Number(params.limit ?? '25');
+  const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? Math.trunc(rawLimit) : 25, 1), 100);
+
+  const data = await loadFriendCoverage(session.userId, friendQuery, limit);
+
+  const diagnosisCounts = data.friends
+    .flatMap((f) => f.recentCorrectAnswers)
+    .reduce<Record<string, number>>((acc, row) => {
+      acc[row.diagnosis] = (acc[row.diagnosis] ?? 0) + 1;
+      return acc;
+    }, {});
+
+  return (
+    <main style={{ padding: '16px', maxWidth: '1400px', margin: '0 auto', fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ fontFamily: 'monospace', fontSize: '18px' }}>Feed friend-coverage diagnostic</h1>
+      <p style={{ color: '#666', fontSize: '12px', marginTop: '4px' }}>
+        For each friend, the most recent <code>limit</code> correct daily / catchup mastery events, and whether each one is visible in your feed (and if not, why). This is a diagnostic, not product UI.
+      </p>
+
+      <form method="get" style={{ marginTop: '12px', fontSize: '12px' }}>
+        <label>
+          friend name/phone/id:{' '}
+          <input name="friend" defaultValue={friendQuery ?? ''} style={{ padding: '2px 6px', fontFamily: 'monospace' }} />
+        </label>
+        {' '}
+        <label>
+          limit:{' '}
+          <input name="limit" defaultValue={String(limit)} style={{ padding: '2px 6px', width: '60px', fontFamily: 'monospace' }} />
+        </label>
+        {' '}
+        <button type="submit" style={{ padding: '3px 10px' }}>Run</button>
+      </form>
+
+      <section style={{ marginTop: '16px', padding: '8px 12px', background: '#fafafa', border: '1px solid #eee', fontFamily: 'monospace', fontSize: '12px' }}>
+        <div>viewer={data.viewerUserId}</div>
+        <div>friendQuery={data.friendQuery ?? '(all)'} limit={data.limit}</div>
+        <div>
+          friendships={data.summary.totalFriendshipsForViewer}
+          {' · '}active={data.summary.activeFriendCount}
+          {' · '}viewerActiveFeedItems={data.summary.viewerActiveFeedItemCount}/{data.summary.rolloffCap}
+          {data.summary.viewerActiveFeedItemCount >= data.summary.rolloffCap && (
+            <strong style={{ color: '#a02500' }}>{' '}— rolloff is in play</strong>
+          )}
+        </div>
+        <div style={{ marginTop: '6px' }}>
+          diagnosis counts:{' '}
+          {Object.keys(diagnosisCounts).length === 0
+            ? '(none)'
+            : Object.entries(diagnosisCounts).map(([k, v]) => (
+              <span key={k} style={{ marginRight: '12px', color: DIAGNOSIS_COLORS[k as FriendCoverageDiagnosis] ?? '#000' }}>
+                {k}={v}
+              </span>
+            ))}
+        </div>
+      </section>
+
+      <section style={{ marginTop: '16px' }}>
+        {data.friends.length === 0 ? (
+          <p style={{ color: '#666', fontSize: '13px' }}>No friends matched.</p>
+        ) : (
+          data.friends.map((block) => <FriendBlock key={block.friendUserId} block={block} />)
+        )}
+      </section>
+    </main>
+  );
+}


### PR DESCRIPTION
For each of the viewer's friends, lists their recent correct daily/catchup
mastery events and tags each with the reason it is (or isn't) visible in the
viewer's feed: friendship_inactive, eligibility_failed, friend_thumbs_down,
domain_dismissed_by_viewer, no_feed_item_written, feed_item_state_hidden,
source_result_wrong, rolled_off, question_now_private_or_deleted, visible.

Gated by FEED_DEBUG_ENABLED=true in production (same flag as /api/feed/debug).
JSON endpoint at /api/feed/friend-coverage and a thin SSR page at
/feed/debug/friend-coverage that renders one table per friend.