### PR TITLE
auto-enable friend-coverage diagnostic on Vercel preview deploys

### DIFF
--- a/src/app/api/feed/friend-coverage/route.ts
+++ b/src/app/api/feed/friend-coverage/route.ts
@@ -87,7 +87,11 @@ const ACTION_REQUIRED_FEED_STATES = ['active', 'skipped'] as const;
 const ROLLOFF_CAP = 50;
 
 function isFeedDebugEnabled() {
-  return process.env.NODE_ENV !== 'production' || process.env.FEED_DEBUG_ENABLED === 'true';
+  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
+  if (process.env.NODE_ENV !== 'production') return true;
+  // Vercel preview deploys run with NODE_ENV='production' but VERCEL_ENV='preview'.
+  // Auto-enable there so the route is reachable without flipping a flag for every preview.
+  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
 }
 
 function snippet(text: string | null | undefined, max = 120): string | null {

--- a/src/app/feed/debug/friend-coverage/page.tsx
+++ b/src/app/feed/debug/friend-coverage/page.tsx
@@ -15,7 +15,9 @@ type PageProps = {
 };
 
 function isFeedDebugEnabled() {
-  return process.env.NODE_ENV !== 'production' || process.env.FEED_DEBUG_ENABLED === 'true';
+  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
+  if (process.env.NODE_ENV !== 'production') return true;
+  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
 }
 
 const DIAGNOSIS_COLORS: Record<FriendCoverageDiagnosis, string> = {


### PR DESCRIPTION
## Summary

Follow-up to #270. You hit the `/feed/debug/friend-coverage` URL on a `dev2` preview deploy and got a 404 even though the route had merged. The Vercel runtime log confirmed the route was reached and gated: preview deploys run with `NODE_ENV='production'` (so the original gate failed) and `FEED_DEBUG_ENABLED` wasn't set, so `notFound()` fired.

This loosens `isFeedDebugEnabled()` in both `src/app/api/feed/friend-coverage/route.ts` and `src/app/feed/debug/friend-coverage/page.tsx` to also enable when `VERCEL_ENV` is set and is not `'production'`. That covers every Vercel preview without flipping a flag for each one. Production still requires `FEED_DEBUG_ENABLED=true`. The page is session-gated by `getSession()` so only signed-in users see their own data either way.

## Test plan

- [ ] On a preview deploy of this branch (or after merge to `dev2`), `/feed/debug/friend-coverage` returns the diagnostic page instead of 404
- [ ] On the production deploy (no `FEED_DEBUG_ENABLED`), the URL still 404s
- [ ] `npx tsc -p tsconfig.typecheck.json` clean
- [ ] `npm run lint` clean for the two changed files

https://claude.ai/code/session_01Foc5dZFxppN8eyayreEpAJ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Foc5dZFxppN8eyayreEpAJ)_