### PR TITLE
fix friend feed: DROP NOT NULL on Question.creator_id at boot (real root cause)

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -80,6 +80,14 @@ export async function register() {
     // pieces present, "my questions" reads can fail before migrate() repairs them.
     // Add the columns, foreign key, and unique index idempotently before migrate().
     try {
+      // 0018 also drops NOT NULL on creator_id so daily_generated questions
+      // (which have no human author) can be persisted with creator_id=null.
+      // If that statement didn't take effect on a partially-recorded migration,
+      // every persistGeneratedQuestion call fails with 23502 and friend-feed
+      // propagation silently drops for the rest of time. Re-apply it idempotently.
+      await db.execute(sql`
+        ALTER TABLE "Question" ALTER COLUMN "creator_id" DROP NOT NULL
+      `);
       await db.execute(sql`
         ALTER TABLE "Question"
           ADD COLUMN IF NOT EXISTS "generated_question_id" text,

--- a/src/server/feed/backfill-missing-feed-items.ts
+++ b/src/server/feed/backfill-missing-feed-items.ts
@@ -14,40 +14,40 @@ export type BackfillResult = {
   errors: Array<{ masteryEventId: string; error: string }>;
 };
 
-// Postgres drivers (postgres-js, pg) attach the actual failure reason to
-// the error object as own properties — but the property naming differs by
-// driver/version (`code`, `severity_local`, `column_name` vs `column`, etc).
-// Rather than guess the right names, dump every own property on the error
-// so the diagnostic UI shows whatever the driver actually attached. Falls
-// back to truncated `.message` only when the error has no own properties.
+// Postgres drivers (postgres-js, pg) and drizzle wrappers attach the actual
+// failure reason to the error object — but the property naming differs by
+// version. Rather than guess, walk every own property on the error (and on
+// `cause` if present) and emit non-noisy primitives. Returns one line per
+// call site so the diagnostic UI shows whatever the driver actually wrote.
 function describeError(error: unknown): string {
-  if (!(error instanceof Error)) return String(error);
-  const e = error as Error & Record<string, unknown>;
-  const skip = new Set(['message', 'stack', 'name', 'query', 'sql', 'parameters', 'params']);
-  const parts: string[] = [];
-  for (const key of Object.getOwnPropertyNames(e)) {
-    if (skip.has(key)) continue;
-    const value = e[key];
-    if (value === undefined || value === null) continue;
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      const stringValue = String(value);
-      parts.push(`${key}=${stringValue.length > 200 ? `${stringValue.slice(0, 200)}…` : stringValue}`);
-    } else if (typeof value === 'object') {
-      // Nested error info from pg/postgres-js (e.g. `cause`, `originalError`).
-      try {
-        const json = JSON.stringify(value);
-        if (json && json !== '{}') {
-          parts.push(`${key}=${json.length > 200 ? `${json.slice(0, 200)}…` : json}`);
-        }
-      } catch {
-        // ignore non-serializable
+  const skip = new Set(['stack', 'name', 'query', 'sql', 'parameters', 'params']);
+  const lines: string[] = [];
+
+  const collect = (label: string, obj: unknown) => {
+    if (!obj || typeof obj !== 'object') return;
+    const record = obj as Record<string, unknown>;
+    const parts: string[] = [];
+    for (const key of Object.getOwnPropertyNames(record)) {
+      if (skip.has(key)) continue;
+      const value = record[key];
+      if (value === undefined || value === null) continue;
+      if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+        const stringValue = String(value);
+        parts.push(`${key}=${stringValue.length > 400 ? `${stringValue.slice(0, 400)}…` : stringValue}`);
       }
     }
+    if (parts.length > 0) lines.push(`${label}: ${parts.join(' · ')}`);
+  };
+
+  if (error instanceof Error) {
+    collect('error', error);
+    const cause = (error as Error & { cause?: unknown }).cause;
+    if (cause) collect('cause', cause);
+  } else {
+    return String(error);
   }
-  // Always include a snippet of message so we can tell which query failed.
-  const messageSnippet = e.message.length > 120 ? `${e.message.slice(0, 120)}…` : e.message;
-  parts.push(`message=${messageSnippet}`);
-  return parts.join(' · ');
+
+  return lines.join(' || ');
 }
 
 // Extracts the generated question id from a synthesized `answer_id`


### PR DESCRIPTION
## TL;DR — actual root cause of the friend-feed bug

After three rounds of diagnostic improvements, the postgres error finally surfaced:

```
code=23502 (NOT NULL violation)
detail=Failing row contains (uuid, null, null, null, "In the TNG episode...")
```

Migration `0018_daily_generated_and_player_mastery_territory.sql` has three statements:

```sql
ALTER TABLE "Question" ALTER COLUMN "creator_id" DROP NOT NULL;
ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "generated_question_id" text;
ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source" text DEFAULT 'authored' NOT NULL;
```

`instrumentation.ts:82-87` already pre-applies the two `ADD COLUMN` statements as idempotent guards (added in earlier hotfixes for partially-recorded migrations). **It never pre-applied the `DROP NOT NULL`.** On any database where 0018 is marked applied in `__drizzle_migrations` but that one statement didn't take effect, every `persistGeneratedQuestion` call has been failing with `23502` ever since — `daily_generated` questions have no human author, so drizzle passes `creator_id = null`, and Postgres rejects it.

That's why six prior rounds of fixes to `createFeedItemsForFriendsFromAnswer` and the daily-answer route never helped: the bug wasn't in the feed code. The canonical question never got into the `Question` table at all, `MASTERY_EVENTS.question_id` stayed null, and propagation silently collapsed.

The "3 nulls before question_text" pattern in the failing row decodes exactly: ADD-COLUMN columns sit at the *end* of `pg_attribute` order, so positions 2-4 are the original 0000 layout — `creator_id` (null — the violation), `source_question_id` (null, fine), `source_creator_id` (null, fine) — then `question_text` at position 5.

## Change

One line of DDL added to the existing 0018 pre-apply block in `instrumentation.ts`:

```sql
ALTER TABLE "Question" ALTER COLUMN "creator_id" DROP NOT NULL
```

Idempotent — running it on a DB where the constraint is already dropped is a no-op. Any partially-recorded database self-heals at next boot.

(Also keeps the diagnostic improvements from earlier this thread; those were what made this finding possible.)

## Test plan
- [ ] Merge, wait for preview deploy. Boot logs should show migration pre-apply running without error.
- [ ] Reload `/feed/debug/friend-coverage?friend=Joshua%20P`, click **Dry run**. Now expect `scanned=15 · updated=15 · parseFailures=0 · persistFailures=0 · alreadyHadConflict=0` (no errors).
- [ ] Click **Run backfill**. Expect `propagated=15` and the dry-run errors box to disappear.
- [ ] Reload `/feed` — Joshua P's previously-missing TNG/Shakespeare/Hamlet/etc answers should now be in your feed.
- [ ] Reload `/feed/debug/friend-coverage` — every `(question missing)` row should resolve to a real question and the diagnoses flip to `visible` (or to a legitimate hidden state).
- [ ] Have Joshua P answer a fresh daily-5 question; confirm the feed item appears without backfill (forward fix now actually works).


---
_Generated by [Claude Code](https://claude.ai/code/session_015YKibKeKBr8HoDBB2foZL8)_