### PR TITLE
require invite to log in — reject before sending OTP, and gate the 000000 dev shortcut to non-production

### DIFF
--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -1,6 +1,12 @@
+import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 import { isUsPhoneNumber, normalizePhone, requestOtp } from '@/server/auth';
+import { db, users } from '@/server/db';
+import {
+  hasValidPendingInvitationForPhone,
+  INVITE_REQUIRED_MESSAGE,
+} from '@/server/friends/invitations';
 
 export async function POST(request: Request) {
   try {
@@ -22,6 +28,23 @@ export async function POST(request: Request) {
     }
 
     const phone = normalizePhone(rawPhone);
+
+    const [existingUser] = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.phoneNumber, phone))
+      .limit(1);
+
+    if (!existingUser) {
+      const hasInvite = await hasValidPendingInvitationForPhone(phone);
+      if (!hasInvite) {
+        return NextResponse.json(
+          { error: 'invite_required', message: INVITE_REQUIRED_MESSAGE },
+          { status: 403 },
+        );
+      }
+    }
+
     const { code } = await requestOtp(phone);
 
     return NextResponse.json({

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -8,6 +8,7 @@ import {
   acceptFriendInvitation,
   getValidInvitationForPhone,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
+  INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations'
 
 type VerifyOtpBody = {
@@ -68,6 +69,16 @@ function invitationRejection() {
       message: INVITATION_ACCEPTANCE_ERROR_MESSAGE,
     },
     { status: 400 }
+  )
+}
+
+function inviteRequiredRejection() {
+  return NextResponse.json(
+    {
+      error: 'invite_required',
+      message: INVITE_REQUIRED_MESSAGE,
+    },
+    { status: 403 }
   )
 }
 
@@ -142,7 +153,7 @@ export async function POST(request: Request) {
 
     // New-user path: invitation is a hard precondition.
     if (!hasUsableToken) {
-      return invitationRejection()
+      return inviteRequiredRejection()
     }
 
     // Pre-validate the invitation read-only so we don't provision a user

--- a/src/server/auth/otp-store.ts
+++ b/src/server/auth/otp-store.ts
@@ -34,7 +34,7 @@ export async function requestOtp(phone: string): Promise<{ code: string; normali
 export async function verifyOtp(phone: string, code: string): Promise<string | null> {
   const normalized = normalizePhone(phone);
 
-  if (code === '000000') {
+  if (process.env.NODE_ENV !== 'production' && code === '000000') {
     return normalized;
   }
 

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -9,6 +9,9 @@ import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
 export const INVITATION_ACCEPTANCE_ERROR_MESSAGE =
   'This invitation could not be accepted.'
 
+export const INVITE_REQUIRED_MESSAGE =
+  "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite."
+
 const DEFAULT_INVITATION_TTL_MS = 1000 * 60 * 60 * 24 * 14
 
 export type FriendInvitation = typeof friendInvitations.$inferSelect
@@ -240,6 +243,28 @@ export async function hasAcceptedInvitationForUser(
       and(
         eq(friendInvitations.inviteeUserId, inviteeUserId),
         isNotNull(friendInvitations.acceptedAt)
+      )
+    )
+    .limit(1)
+
+  return !!row
+}
+
+export async function hasValidPendingInvitationForPhone(
+  phoneNumber: string,
+  now: Date = new Date()
+): Promise<boolean> {
+  if (!phoneNumber) return false
+
+  const [row] = await db
+    .select({ id: friendInvitations.id })
+    .from(friendInvitations)
+    .where(
+      and(
+        eq(friendInvitations.inviteePhone, phoneNumber),
+        isNull(friendInvitations.acceptedAt),
+        isNull(friendInvitations.cancelledAt),
+        gt(friendInvitations.expiresAt, now)
       )
     )
     .limit(1)


### PR DESCRIPTION
Two related fixes to the phone+OTP login flow:

1. otp-store.ts: the `000000` code accepted any phone in any environment,
   including production. Combined with the existing-user re-login path
   skipping the invitation check, this meant anyone could log into any
   account by guessing a phone number. Gate behind NODE_ENV !== 'production'.

2. request-otp now pre-checks for an existing user or a valid pending
   invitation and returns `invite_required` with a clear "ask a friend"
   message before sending an OTP — no SMS wasted, no misleading
   "invitation could not be accepted" after the user has typed a code.
   The same `invite_required` response is also returned at verify-otp's
   new-user-no-token branch for defense-in-depth.