### PR TITLE
embed friend knowledge portrait on profile, hide create FAB there

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import { Caveat, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
+import { getSessionToken, readSessionClaims } from '@/server/auth/session';
 
 
 // Intentional product choice (2026-05-16): Montserrat is the body font.
@@ -33,18 +34,20 @@ export const metadata: Metadata = {
   description: 'A daily knowledge game',
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode
 }) {
+  const sessionToken = await getSessionToken()
+  const claims = await readSessionClaims(sessionToken)
   return (
     <html
       lang="en"
       className={`font-sans ${caveat.variable} ${playfair.variable}`}
     >
       <body className={montserrat.className}>
-        <Nav />
+        <Nav initialUserId={claims?.userId ?? null} />
         {children}
       </body>
     </html>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
+import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard'
 import { AuthoredQuestionsFeed } from '@/components/profile/AuthoredQuestionsFeed'
 import { SharedInterestsOverlap } from '@/components/profile/SharedInterestsOverlap'
 import { getSession } from '@/server/auth/session'
@@ -10,7 +11,10 @@ import {
 } from '@/server/db/queries/knowledge'
 import { getAuthoredQuestionsForUser } from '@/server/db/queries/questions'
 import { getFriendPortraitData } from '@/server/profile/friend'
-import { topPointPositiveDomains } from '@/server/profile/knowledge-view'
+import {
+  toKnowledgeCardDomain,
+  topPointPositiveDomains,
+} from '@/server/profile/knowledge-view'
 
 type UserProfilePageProps = {
   params: Promise<{ id: string }>
@@ -70,6 +74,9 @@ export default async function UserProfilePage({
       b.points - a.points || a.displayName.localeCompare(b.displayName),
   )
   const topDomains = topPointPositiveDomains(sortedDomains, 5)
+  const totalPointPositiveDomains = sortedDomains.filter(
+    (domain) => domain.points > 0,
+  ).length
   const mindStatement = buildMindStatement(portrait.user.displayName, topDomains)
   const tierSignature = `${new Intl.NumberFormat().format(
     Math.round(mastery.totalPoints),
@@ -129,21 +136,46 @@ export default async function UserProfilePage({
         />
       ) : null}
 
-      <section className="mt-5" aria-label="Knowledge map">
+      <section className="mt-5" aria-label="Knowledge portrait">
         <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-          Knowledge map
+          Knowledge portrait
         </p>
-        <h2 className="mt-1 font-serif text-xl font-semibold">
-          {mindStatement}
-        </h2>
-        <p className="text-muted-foreground mt-2 text-sm leading-6">
-          {tierSignature}.
-        </p>
+        {!isSelf && topDomains.length > 0 ? (
+          <div className="mt-3">
+            <KnowledgeCard
+              playerDisplayName={portrait.user.displayName}
+              portraitStatement={mindStatement}
+              domains={topDomains.map(toKnowledgeCardDomain)}
+              overflowCount={Math.max(
+                0,
+                totalPointPositiveDomains - topDomains.length,
+              )}
+              tierSignature={tierSignature}
+              rarestTerritory={null}
+              rarestTerritorySolo={false}
+              shareText=""
+              shareCardToken=""
+              shareCardExpiresAt=""
+              readOnly
+            />
+          </div>
+        ) : (
+          <>
+            <h2 className="mt-1 font-serif text-xl font-semibold">
+              {mindStatement}
+            </h2>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              {tierSignature}.
+            </p>
+          </>
+        )}
         <Link
           href={`/users/${portrait.user.id}/knowledge`}
           className="mt-3 inline-flex text-sm font-semibold text-stone-950 underline-offset-4 hover:underline"
         >
-          View {friendFirstName}&rsquo;s full knowledge map →
+          {isSelf
+            ? 'View your full knowledge portrait →'
+            : `View ${friendFirstName}’s full knowledge portrait →`}
         </Link>
       </section>
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -28,10 +28,10 @@ function initialsFor(name: string): string {
   return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase();
 }
 
-export function Nav() {
+export function Nav({ initialUserId = null }: { initialUserId?: string | null }) {
   const pathname = usePathname();
   const [accountInitials, setAccountInitials] = useState<string | null>(null);
-  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(initialUserId);
   const [menuOpen, setMenuOpen] = useState(false);
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
   const isOtherUserProfilePath = (() => {
@@ -63,7 +63,6 @@ export function Nav() {
       setCurrentUserId(body?.user?.id ?? null);
     } catch {
       setAccountInitials(null);
-      setCurrentUserId(null);
     }
   }, []);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -8,6 +8,7 @@ import { CreateChooser } from '@/components/CreateChooser';
 
 type MeResponse = {
   user?: {
+    id?: string | null;
     display_name?: string | null;
   };
 };
@@ -30,13 +31,22 @@ function initialsFor(name: string): string {
 export function Nav() {
   const pathname = usePathname();
   const [accountInitials, setAccountInitials] = useState<string | null>(null);
+  const [currentUserId, setCurrentUserId] = useState<string | null>(null);
   const [menuOpen, setMenuOpen] = useState(false);
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
+  const isOtherUserProfilePath = (() => {
+    if (!pathname.startsWith('/users/')) return false;
+    const rest = pathname.slice('/users/'.length);
+    const profileId = rest.split('/')[0] ?? '';
+    if (!profileId) return false;
+    return profileId !== currentUserId;
+  })();
   const hidesNewGameShortcut =
     pathname.startsWith('/daily') ||
     pathname === '/replay' ||
     pathname.startsWith('/games/') ||
-    pathname === '/friends';
+    pathname === '/friends' ||
+    isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;
 
   const loadCurrentUser = useCallback(async () => {
@@ -44,13 +54,16 @@ export function Nav() {
       const response = await fetch('/api/auth/me', { cache: 'no-store', credentials: 'include' });
       if (!response.ok) {
         setAccountInitials(null);
+        setCurrentUserId(null);
         return;
       }
       const body = await response.json().catch(() => null) as MeResponse | null;
       const initials = body?.user?.display_name ? initialsFor(body.user.display_name) : '';
       setAccountInitials(initials || null);
+      setCurrentUserId(body?.user?.id ?? null);
     } catch {
       setAccountInitials(null);
+      setCurrentUserId(null);
     }
   }, []);
 


### PR DESCRIPTION
On another user's profile page, render the top-5 KnowledgeCard inline so
visitors immediately see what their friend has been building around,
keeping the link out to the full portrait. The compact mind-statement
view stays for self-profile.

Hide the floating create button on other users' profile routes — those
pages are for reading someone else's portrait, not creating new content.
Nav now reads the current user's id from /api/auth/me to scope the hide
to non-self /users/[id] paths.