### PR TITLE
Redesign "you answered" and "you created" feed cards

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -227,6 +227,7 @@ function baseTypedFields(item: FeedApiItem, answered = false) {
     avatarUserId: item.source_user_id,
     authorHref: item.source_profile_href ?? profileHref(item.source_user_id),
     timestamp: formatRelativeTime(item.source_event_at),
+    viewerIsAuthor: item.viewer_is_author === true,
   }
 }
 
@@ -338,6 +339,27 @@ function pickBroadCategory(
   return item.broad_category ?? null
 }
 
+function pickPairedFriend(
+  item: FeedApiItem
+): { displayName: string; userId: string | null } | null {
+  const primary = item.friend_results?.[0]
+  if (primary?.displayName) {
+    return { displayName: primary.displayName, userId: primary.userId ?? null }
+  }
+  if (
+    item.source_type === 'direct_sent' ||
+    item.source_type === 'authored_shared'
+  ) {
+    if (item.source_friend_display_name) {
+      return {
+        displayName: item.source_friend_display_name,
+        userId: item.source_user_id ?? null,
+      }
+    }
+  }
+  return null
+}
+
 function toAnsweredByYouItem(
   item: FeedApiItem,
   result?: ResultState
@@ -376,6 +398,7 @@ function toAnsweredByYouItem(
     unverifiedAnswer: item.unverified_answer,
     broadCategory: pickBroadCategory(masteryDeltaRaw, item),
     masteryDelta: normalizeMasteryDelta(masteryDeltaRaw),
+    pairedFriend: pickPairedFriend(item),
   }
 }
 

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -6,8 +6,8 @@ import { KnowledgeCircle } from '@/components/knowledge/CategoryCircles'
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
 
 import { visibleFeedCategory } from './category'
-import type { AnsweredByYouFeedItem } from './types'
-import { colorForCategory } from './visual'
+import type { AnsweredByYouFeedItem, AnsweredByYouPairedFriend } from './types'
+import { colorForCategory, colorForUser, initialsFor, isDarkColor } from './visual'
 
 const TIER_LABEL: Record<string, string> = {
   establishing: 'Establishing',
@@ -54,6 +54,62 @@ function KnowledgeGainIndicator({ item }: { item: AnsweredByYouFeedItem }) {
   )
 }
 
+function AvatarDisc({
+  initials,
+  bg,
+  size = 28,
+  ring = false,
+}: {
+  initials: string
+  bg: string
+  size?: number
+  ring?: boolean
+}) {
+  const onDark = isDarkColor(bg)
+  return (
+    <div
+      aria-hidden
+      className="grid shrink-0 place-items-center rounded-full text-[10px] font-semibold"
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: bg,
+        color: onDark ? 'var(--cream)' : 'var(--ink)',
+        boxShadow: ring ? '0 0 0 2px var(--cream)' : undefined,
+      }}
+    >
+      {initials}
+    </div>
+  )
+}
+
+function AnsweredAvatarStack({
+  pairedFriend,
+  categoryColor,
+}: {
+  pairedFriend?: AnsweredByYouPairedFriend | null
+  categoryColor: string
+}) {
+  const viewerInitials = 'You'
+  if (!pairedFriend) {
+    return (
+      <AvatarDisc initials={viewerInitials} bg={categoryColor} size={32} />
+    )
+  }
+  const friendColor = colorForUser(pairedFriend.userId)
+  const friendInitials = initialsFor(pairedFriend.displayName)
+  return (
+    <div className="relative shrink-0" style={{ width: 44, height: 28 }}>
+      <div className="absolute left-0 top-0">
+        <AvatarDisc initials={viewerInitials} bg={categoryColor} size={28} />
+      </div>
+      <div className="absolute left-[16px] top-0">
+        <AvatarDisc initials={friendInitials} bg={friendColor} size={28} ring />
+      </div>
+    </div>
+  )
+}
+
 export type FeedRecheckAction = {
   onSubmit: () => Promise<{ accepted: boolean; message: string }>
 }
@@ -88,41 +144,59 @@ function AnsweredResult({
     }
   }, [recheckAction, recheckState])
 
-  const marker = item.isCorrect ? '✓' : '✗'
-  const markerClass = item.isCorrect ? 'text-emerald-700' : 'text-stone-500'
   const summaryClass = item.isCorrect
-    ? 'text-sm font-medium text-emerald-700'
-    : 'text-sm font-medium text-stone-800'
+    ? 'text-[14px] font-medium text-emerald-700'
+    : 'text-[14px] font-medium text-stone-800'
 
   return (
     <div className="w-full space-y-1.5">
       <div className="flex items-start justify-between gap-3">
         <p className={summaryClass}>
-          <span className={markerClass}>{marker}</span>{' '}
           {item.answerSummary ?? 'You answered this question.'}
         </p>
         {item.isCorrect ? <KnowledgeGainIndicator item={item} /> : null}
       </div>
       {!item.isCorrect && item.correctAnswer ? (
-        <p className="text-sm text-stone-500 italic">{item.correctAnswer}</p>
+        <p
+          className="text-[13px] italic"
+          style={{
+            fontFamily: 'var(--font-literata)',
+            color: 'var(--ink)',
+            opacity: 0.7,
+          }}
+        >
+          {item.correctAnswer}
+        </p>
       ) : null}
       {!item.isCorrect && item.quip ? (
-        <p className="text-sm text-stone-500">{item.quip}</p>
+        <p
+          className="text-[13px]"
+          style={{ color: 'var(--ink)', opacity: 0.6 }}
+        >
+          {item.quip}
+        </p>
       ) : null}
       {recheckAction && recheckState !== 'done' ? (
-        <div className="pt-1">
+        <div className="flex justify-end pt-2">
           <button
             type="button"
             onClick={() => void requestRecheck()}
             disabled={recheckState === 'submitting'}
-            className="rounded-full border border-stone-300 bg-white px-3 py-1 font-mono text-xs uppercase tracking-wide text-stone-600 hover:bg-stone-50 disabled:cursor-default disabled:opacity-60"
+            className="inline-flex items-center border-[1.5px] border-[var(--ink)] bg-[var(--cream)] px-[8px] py-[4px] text-[12px] text-[var(--ink)] transition-transform hover:translate-x-[1px] hover:translate-y-[1px] active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:cursor-default disabled:opacity-60"
+            style={{ boxShadow: '3px 3px 0 var(--ink)' }}
           >
-            {recheckState === 'submitting' ? 'Rechecking...' : 'Recheck my answer'}
+            {recheckState === 'submitting' ? 'Rechecking...' : 'Recheck →'}
           </button>
         </div>
       ) : null}
       {recheckMessage ? (
-        <p className={`text-xs ${recheckState === 'error' ? 'text-red-600' : 'text-stone-500'}`}>
+        <p
+          className="text-[11px]"
+          style={{
+            color: recheckState === 'error' ? '#b91c1c' : 'var(--ink)',
+            opacity: recheckState === 'error' ? 1 : 0.6,
+          }}
+        >
           {recheckMessage}
         </p>
       ) : null}
@@ -135,47 +209,73 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
   const categoryColor = colorForCategory(item.category)
 
   return (
-    <article
-      className="relative overflow-hidden rounded-2xl border border-[var(--border-warm)] bg-[var(--cream)]"
-    >
+    <article className="relative overflow-hidden rounded-2xl border border-[var(--border-warm)] bg-[var(--cream)]">
       <span
         aria-hidden
         className="absolute inset-y-0 left-0 w-[2px]"
         style={{ backgroundColor: categoryColor }}
       />
       <div className="p-[14px]">
-        <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-3">
+          <AnsweredAvatarStack
+            pairedFriend={item.pairedFriend}
+            categoryColor={categoryColor}
+          />
+
           <div className="min-w-0 flex-1">
             <p
-              className="text-[11px] uppercase tracking-[0.08em]"
-              style={{ color: 'var(--ink)', opacity: 0.6 }}
+              className="text-[11px] uppercase leading-none tracking-[0.08em]"
+              style={{ color: 'var(--ink)', opacity: 0.7 }}
             >
               You answered
-              {category ? (
-                <>
-                  {' · '}
-                  <span
-                    className="normal-case italic"
-                    style={{ fontFamily: 'var(--font-literata)' }}
-                  >
-                    {category}
-                  </span>
-                </>
-              ) : null}
             </p>
-            <p
-              className="mt-2 text-[15px] leading-snug"
-              style={{
-                fontFamily: 'Georgia, "Times New Roman", serif',
-                color: 'var(--ink)',
-                opacity: 0.65,
-              }}
-            >
-              {item.question}
-            </p>
+            {category ? (
+              <p
+                className="mt-1 truncate text-[12px] italic leading-tight"
+                style={{
+                  fontFamily: 'var(--font-literata)',
+                  color: 'var(--ink)',
+                  opacity: 0.7,
+                }}
+              >
+                {category}
+              </p>
+            ) : null}
           </div>
-          {overflow ? <div className="shrink-0">{overflow}</div> : null}
+
+          <div className="flex shrink-0 items-center gap-2">
+            {item.timestamp ? (
+              <span
+                className="text-[11px] leading-none"
+                style={{ color: 'var(--ink)', opacity: 0.6 }}
+              >
+                {item.timestamp}
+              </span>
+            ) : null}
+            {overflow ? overflow : null}
+          </div>
         </div>
+
+        <p
+          className="mt-3 text-[16px] leading-snug text-[var(--ink)]"
+          style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+        >
+          &ldquo;{item.question}&rdquo;
+        </p>
+
+        {item.personalMessage ? (
+          <p
+            className="mt-2 text-[13px] italic leading-snug"
+            style={{
+              fontFamily: 'var(--font-literata)',
+              color: 'var(--ink)',
+              opacity: 0.65,
+            }}
+          >
+            {item.personalMessage}
+          </p>
+        ) : null}
+
         <div className="mt-3 border-t border-[var(--border-light)] pt-3">
           <AnsweredResult item={item} recheckAction={recheckAction} />
         </div>

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -18,9 +18,90 @@ export function FeedCard({ item, overflow, onAnswer, className }: FeedCardProps)
   const categoryColor = colorForCategory(item.category)
   const visibleCategory = visibleFeedCategory(item.category)
   const onDark = isDarkColor(categoryColor)
-  const initialsColor = onDark ? 'var(--cream)' : 'var(--ink)'
+  const fgOnCategory = onDark ? 'var(--cream)' : 'var(--ink)'
   const authorName = item.avatarName ?? 'Someone'
-  const initials = initialsFor(authorName)
+
+  if (item.viewerIsAuthor) {
+    return (
+      <article
+        className={cn(
+          'relative overflow-hidden rounded-2xl border border-[var(--border-warm)] bg-[var(--cream)]',
+          className,
+        )}
+      >
+        <span
+          aria-hidden
+          className="absolute inset-y-0 left-0 w-[2px]"
+          style={{ backgroundColor: categoryColor }}
+        />
+
+        <div className="p-[14px]">
+          <div className="flex items-center gap-3">
+            <div
+              aria-hidden
+              className="grid size-9 shrink-0 place-items-center rounded-full text-[11px] font-semibold"
+              style={{ backgroundColor: categoryColor, color: fgOnCategory }}
+            >
+              You
+            </div>
+
+            <div className="min-w-0 flex-1">
+              <p
+                className="text-[11px] uppercase leading-none tracking-[0.08em]"
+                style={{ color: 'var(--ink)', opacity: 0.7 }}
+              >
+                New question
+              </p>
+              {visibleCategory ? (
+                <p
+                  className="mt-1 truncate text-[12px] italic leading-tight"
+                  style={{
+                    fontFamily: 'var(--font-literata)',
+                    color: 'var(--ink)',
+                    opacity: 0.7,
+                  }}
+                >
+                  {visibleCategory}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex shrink-0 items-center gap-2">
+              {item.timestamp ? (
+                <span
+                  className="text-[11px] leading-none"
+                  style={{ color: 'var(--ink)', opacity: 0.6 }}
+                >
+                  {item.timestamp}
+                </span>
+              ) : null}
+              {overflow ? overflow : null}
+            </div>
+          </div>
+
+          <p
+            className="mt-3 line-clamp-4 text-[17px] leading-snug text-[var(--ink)]"
+            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          >
+            &ldquo;{item.question}&rdquo;
+          </p>
+
+          {item.personalMessage ? (
+            <p
+              className="mt-2 text-[13px] italic leading-snug"
+              style={{
+                fontFamily: 'var(--font-literata)',
+                color: 'var(--ink)',
+                opacity: 0.65,
+              }}
+            >
+              {item.personalMessage}
+            </p>
+          ) : null}
+        </div>
+      </article>
+    )
+  }
 
   return (
     <article
@@ -40,9 +121,9 @@ export function FeedCard({ item, overflow, onAnswer, className }: FeedCardProps)
           <div
             aria-hidden
             className="grid size-9 shrink-0 place-items-center rounded-full text-[12px] font-semibold tracking-wide"
-            style={{ backgroundColor: categoryColor, color: initialsColor }}
+            style={{ backgroundColor: categoryColor, color: fgOnCategory }}
           >
-            {initials}
+            {initialsFor(authorName)}
           </div>
 
           <div className="min-w-0 flex-1">

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -64,6 +64,7 @@ describe('Feed card preview fixtures', () => {
       'missingSuppressedCategory',
       'alreadyBankedItem',
       'unverifiedAnsweredExplanationNote',
+      'authoredByViewerUnanswered',
     ])
   })
 
@@ -197,6 +198,84 @@ describe('Feed answered states', () => {
     expect(rendered).not.toContain('text-red')
     expect(rendered).not.toContain('destructive')
     expect(rendered).not.toContain('+ Knowledge')
+  })
+
+  it('reintroduces the personal-message line that the previous redesign dropped', () => {
+    const rendered = html(
+      <AnsweredByYouCard item={feedCardPreviewFixtures.answeredByYouWrong} />
+    )
+    expect(rendered).toContain('I always confuse this one with the Spanish capital.')
+  })
+
+  it('renders the "You answered" eyebrow with the italic category', () => {
+    const rendered = html(
+      <AnsweredByYouCard item={feedCardPreviewFixtures.answeredByYouCorrect} />
+    )
+    expect(rendered).toContain('You answered')
+    expect(rendered).toContain('Sports')
+  })
+
+  it('renders an overlapping pair of avatars when a paired friend is present', () => {
+    const rendered = html(
+      <AnsweredByYouCard item={feedCardPreviewFixtures.answeredByYouCorrect} />
+    )
+    // Viewer disc shows "You", friend disc shows initials "JP" (Joshua P).
+    expect(rendered).toContain('>You<')
+    expect(rendered).toContain('>JP<')
+  })
+
+  it('falls back to a single avatar disc when no paired friend is set', () => {
+    const rendered = html(
+      <AnsweredByYouCard
+        item={feedCardPreviewFixtures.unverifiedAnsweredExplanationNote}
+      />
+    )
+    // Only the viewer disc renders; no paired-friend initials.
+    expect(rendered).toContain('>You<')
+  })
+
+  it('uses the Joshing offset-shadow recheck button on wrong answers', () => {
+    const recheckAction = { onSubmit: async () => ({ accepted: false, message: '' }) }
+    const rendered = html(
+      <AnsweredByYouCard
+        item={feedCardPreviewFixtures.answeredByYouWrong}
+        recheckAction={recheckAction}
+      />
+    )
+    expect(rendered).toContain('Recheck →')
+    expect(rendered).toContain('3px 3px 0 var(--ink)')
+  })
+})
+
+describe('Authored-by-viewer card', () => {
+  it('renders a "New question" eyebrow with the italic category', () => {
+    const rendered = html(
+      <FriendAddedCard
+        item={feedCardPreviewFixtures.authoredByViewerUnanswered}
+      />
+    )
+    expect(rendered).toContain('New question')
+    expect(rendered).toContain('Detroit Techno')
+  })
+
+  it('renders the identity slot as plain text "You" with no profile link', () => {
+    const rendered = html(
+      <FriendAddedCard
+        item={feedCardPreviewFixtures.authoredByViewerUnanswered}
+      />
+    )
+    expect(rendered).toContain('>You<')
+    expect(rendered).not.toMatch(/<a[^>]*>You<\/a>/)
+  })
+
+  it('hides the Answer button on authored cards even if onAnswer is provided', () => {
+    const rendered = html(
+      <FriendAddedCard
+        item={feedCardPreviewFixtures.authoredByViewerUnanswered}
+        onAnswer={() => undefined}
+      />
+    )
+    expect(rendered).not.toContain('Answer →')
   })
 })
 

--- a/src/components/feed/mock-feed-items.ts
+++ b/src/components/feed/mock-feed-items.ts
@@ -93,6 +93,8 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
       newTier: 'solid',
       tierChanged: true,
     },
+    timestamp: '6d ago',
+    pairedFriend: { displayName: 'Joshua P', userId: 'user-joshua' },
   },
   {
     type: 'answered_by_you',
@@ -106,6 +108,9 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
     correctAnswer: 'Lisbon',
     isCorrect: false,
     awardedPoints: 0,
+    personalMessage: 'I always confuse this one with the Spanish capital.',
+    timestamp: '6d ago',
+    pairedFriend: { displayName: 'Maya', userId: 'user-maya' },
   },
   {
     type: 'friend_added',
@@ -154,6 +159,22 @@ export const mockTypedFeedItems: TypedFeedItem[] = [
       newTier: 'familiar',
       tierChanged: false,
     },
+    timestamp: '12d ago',
+    pairedFriend: null,
+  },
+  {
+    type: 'friend_added',
+    id: 'mock-authored-by-viewer-unanswered',
+    friendName: 'You',
+    friendHref: null,
+    metadata: 'You wrote a question · May 7',
+    category: 'Detroit Techno',
+    question: 'What Belleville trio helped define the first wave of Detroit techno?',
+    avatarName: 'You',
+    avatarUserId: 'viewer',
+    authorHref: null,
+    timestamp: '1h ago',
+    viewerIsAuthor: true,
   },
 ]
 
@@ -168,4 +189,5 @@ export const feedCardPreviewFixtures = {
   missingSuppressedCategory: mockTypedFeedItems[7],
   alreadyBankedItem: mockTypedFeedItems[8],
   unverifiedAnsweredExplanationNote: mockTypedFeedItems[9],
+  authoredByViewerUnanswered: mockTypedFeedItems[10],
 } satisfies Record<string, TypedFeedItem>

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -11,6 +11,7 @@ export type FeedCardBaseItem = {
   avatarUserId?: string | null
   authorHref?: string | null
   timestamp?: string | null
+  viewerIsAuthor?: boolean
 }
 
 export type DirectSentFeedItem = FeedCardBaseItem & {
@@ -57,6 +58,11 @@ export type AnsweredByYouMasteryDelta = {
   tierChanged: boolean
 }
 
+export type AnsweredByYouPairedFriend = {
+  displayName: string
+  userId: string | null
+}
+
 export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   type: 'answered_by_you'
   resultLabel?: string | null
@@ -70,6 +76,7 @@ export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   unverifiedAnswer?: boolean
   broadCategory?: string | null
   masteryDelta?: AnsweredByYouMasteryDelta | null
+  pairedFriend?: AnsweredByYouPairedFriend | null
 }
 
 export type TypedFeedItem =

--- a/src/components/feed/visual.ts
+++ b/src/components/feed/visual.ts
@@ -9,6 +9,15 @@ const CATEGORY_COLORS = [
   '#0369a1',
 ] as const
 
+const AVATAR_COLORS = [
+  '#0f766e',
+  '#7c3aed',
+  '#be123c',
+  '#2563eb',
+  '#b45309',
+  '#15803d',
+] as const
+
 function hashString(str: string): number {
   return Array.from(str).reduce((sum, char) => sum + char.charCodeAt(0), 0)
 }
@@ -18,6 +27,11 @@ export function colorForCategory(category?: string | null): string {
   return CATEGORY_COLORS[
     hashString(category.toLowerCase()) % CATEGORY_COLORS.length
   ]!
+}
+
+export function colorForUser(userId?: string | null): string {
+  if (!userId) return '#9ca3af'
+  return AVATAR_COLORS[hashString(userId) % AVATAR_COLORS.length]!
 }
 
 export function isDarkColor(hex: string): boolean {


### PR DESCRIPTION
## Summary

- **"You answered" card** (`AnsweredByYouCard`): new shell that rhymes with the redesigned unanswered card. Header is overlapping avatars (your "You" disc in the category color + the paired friend's initials in their user color, ringed in cream) + "YOU ANSWERED" eyebrow + italic Playfair category + relative timestamp + ⋯ menu. Question wrapped in curly quotes at full opacity. Recheck button restyled as a smaller Joshing offset-shadow button so a mixed feed reads Answer → as primary and Recheck → as secondary. **Personal-message rendering reintroduced** — this was a regression from the prior commit on this branch, now fixed.
- **"You created" card**: `FeedCard` branches on a new `viewerIsAuthor` flag → single category-colored "You" disc, "NEW QUESTION" eyebrow + italic category, curly-quoted question, no Answer button, no footer (quietest treatment per design call).
- **Plumbing**: `viewerIsAuthor` added to `FeedCardBaseItem`; `pairedFriend` added to `AnsweredByYouFeedItem`. `FeedList` populates both — `viewer_is_author` flows through `baseTypedFields`, `pairedFriend` is derived from `friend_results[0]` with a `direct_sent` / `authored_shared` fallback to the source friend name. `colorForUser` helper restored in `visual.ts` for the friend disc.

## Test plan

- [x] `npx vitest run src/components/feed/` — 22/22 pass (8 new assertions covering: personal-message regression fix, "YOU ANSWERED" eyebrow + italic category, overlapping vs single avatar branches, Joshing offset-shadow recheck button, and the authored card's eyebrow + non-link "You" identity + hidden Answer button even when `onAnswer` is provided)
- [x] `npx tsc -p tsconfig.typecheck.json` — clean for touched files
- [x] `npx eslint src/components/feed/ src/components/FeedList.tsx` — clean
- [ ] Manual eyeball at 375px viewport — confirm spine + avatar(s) + eyebrow + italic category + timestamp + ⋯ line up; overlapping avatars use correct per-user and category colors; "Recheck →" reads visually subordinate to "Answer →"; personal message renders in italic; authored card ends at the question with no orphaned footer space.

## Notes for review

- Defaults that are easy to flip if the design wants them:
  - Eyebrow tinted with the category color (today: INK at 70% opacity).
  - Sparkle ornaments on the answered card (skipped for now — they read more "launch event" than editorial).
  - Curly-quoted questions rolled out to the unanswered cards too (today: self-state only, matching the inspiration scope).

https://claude.ai/code/session_014iLQxDuX2YKsgK8mwUDBy5

---
_Generated by [Claude Code](https://claude.ai/code/session_014iLQxDuX2YKsgK8mwUDBy5)_