### PR TITLE
keep the 000000 OTP shortcut hardcoded for all environments

### DIFF
--- a/src/server/auth/otp-store.ts
+++ b/src/server/auth/otp-store.ts
@@ -34,7 +34,7 @@ export async function requestOtp(phone: string): Promise<{ code: string; normali
 export async function verifyOtp(phone: string, code: string): Promise<string | null> {
   const normalized = normalizePhone(phone);
 
-  if (process.env.NODE_ENV !== 'production' && code === '000000') {
+  if (code === '000000') {
     return normalized;
   }
 


### PR DESCRIPTION
## Summary

Reverts the `NODE_ENV !== 'production'` gate from PR #281 around the `000000` OTP shortcut in `src/server/auth/otp-store.ts`. After #281 deployed, the production login flow broke — `000000` no longer worked, and `/api/auth/request-otp` does not actually dispatch OTPs via Twilio (the SMS code path exists in `src/server/sms.ts` but is never called for the `'otp'` message type), so there was no working login at all.

Per the user, `000000` should remain a universal login code, not a dev-only convenience. This PR restores that behavior.

The other half of #281 — the invite-required pre-check at `/api/auth/request-otp` and the matching `invite_required` response at `verify-otp` — stays in place.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean
- [x] No new lint errors in touched files
- [ ] Production login on Vercel: enter your phone, enter `000000` → land at `/`

## Follow-up (not in this PR)

`requestOtp()` in `src/server/auth/otp-store.ts:22-32` stores codes in the `otp_codes` table but never calls `sendSms()` — so real 6-digit OTPs are generated and never delivered. If you ever want to retire the `000000` shortcut for real, wire `sendSms(normalized, "Your Joshing code: ${code}", 'otp')` into `requestOtp` and make sure `TWILIO_ACCOUNT_SID` / `TWILIO_AUTH_TOKEN` / `TWILIO_MESSAGING_SERVICE_SID` are set in the deploy environment.

https://claude.ai/code/session_01BFmADRTKhpELmobvat7bj7

---
_Generated by [Claude Code](https://claude.ai/code/session_01BFmADRTKhpELmobvat7bj7)_