### PR TITLE
de-emphasize question text on "you answered" feed cards

### DIFF
--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -257,8 +257,12 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
         </div>
 
         <p
-          className="mt-3 text-[16px] leading-snug text-[var(--ink)]"
-          style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          className="mt-3 text-[16px] leading-snug"
+          style={{
+            fontFamily: 'Georgia, "Times New Roman", serif',
+            color: 'var(--ink)',
+            opacity: 0.65,
+          }}
         >
           &ldquo;{item.question}&rdquo;
         </p>


### PR DESCRIPTION
Reduces the opacity of already-answered question text to match the
muted treatment used by sibling text in the same card, so completed
items recede instead of competing with actionable feed entries.