### PR TITLE
show answer feedback popup before returning to feed

### DIFF
--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -221,9 +221,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
     });
   }
 
+  const explanation = isCorrect
+    ? (question.explainerFullCorrect ?? question.explainerFull ?? question.explainerBrief ?? question.factualExplanation)
+    : (question.explainerFullWrong ?? question.explainerFull ?? question.explainerBrief ?? question.factualExplanation);
+
   return NextResponse.json({
     isCorrect,
-    explanation: question.explainerFull ?? question.explainerBrief ?? question.factualExplanation,
+    explanation,
     pointsAwarded,
     answerState,
     breadcrumb,

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link'
 import { useSearchParams } from 'next/navigation'
 import {
   AnsweredByYouCard,
+  AnswerFeedbackSheet,
   AnswerSheet,
   DirectSentCard,
   FeedOverflowMenu,
@@ -116,6 +117,7 @@ type AnswerResponse = {
 type ResultState = {
   correct: boolean
   answer: string
+  submittedAnswer: string
   explanation: string | null
   quip: string | null
   breadcrumb: string | null
@@ -447,6 +449,7 @@ function FeedListContent({
   const [results, setResults] = useState<Record<string, ResultState>>({})
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({})
   const [answerSheetId, setAnswerSheetId] = useState<string | null>(null)
+  const [feedbackSheetId, setFeedbackSheetId] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(null)
@@ -696,6 +699,7 @@ function FeedListContent({
           [item.id]: {
             correct: isCorrect,
             answer: body.correctAnswer ?? '',
+            submittedAnswer,
             explanation: body.explanation ?? null,
             quip: body.quip ?? null,
             breadcrumb: body.breadcrumb ?? null,
@@ -724,6 +728,7 @@ function FeedListContent({
         )
         setCardStates((s) => ({ ...s, [item.id]: 'answered' }))
         setAnswerSheetId(null)
+        setFeedbackSheetId(item.id)
       } catch (caught) {
         setError(
           caught instanceof Error
@@ -962,6 +967,27 @@ function FeedListContent({
             onSubmit={(answer) => void submitAnswer(sheetItem, answer)}
             onClose={() => setAnswerSheetId(null)}
             loading={busyId === sheetItem.id}
+          />
+        )
+      })() : null}
+
+      {feedbackSheetId ? (() => {
+        const sheetItem = items.find((item) => item.id === feedbackSheetId)
+        const result = results[feedbackSheetId]
+        if (!sheetItem || !result || !sheetItem.question_id) return null
+        return (
+          <AnswerFeedbackSheet
+            question={sheetItem.question_text ?? ''}
+            category={sheetItem.domain_pill}
+            isCorrect={result.correct}
+            pointsAwarded={result.awardedPoints}
+            correctAnswer={result.answer}
+            submittedAnswer={result.submittedAnswer}
+            explanation={result.explanation}
+            quip={result.quip}
+            questionId={sheetItem.question_id}
+            feedItemId={sheetItem.id}
+            onClose={() => setFeedbackSheetId(null)}
           />
         )
       })() : null}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -1,0 +1,233 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import { Check, X } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
+import { visibleFeedCategory } from './category'
+
+type AnswerFeedbackSheetProps = {
+  question: string
+  category?: string | null
+  isCorrect: boolean
+  pointsAwarded: number | null
+  correctAnswer: string
+  submittedAnswer: string
+  explanation: string | null
+  quip: string | null
+  questionId: string
+  feedItemId: string
+  onClose: () => void
+}
+
+type BankState = 'idle' | 'saving' | 'saved' | 'undoing' | 'undone' | 'error'
+
+export function AnswerFeedbackSheet({
+  question,
+  category,
+  isCorrect,
+  pointsAwarded,
+  correctAnswer,
+  submittedAnswer,
+  explanation,
+  quip,
+  questionId,
+  feedItemId,
+  onClose,
+}: AnswerFeedbackSheetProps) {
+  const visibleCategory = visibleFeedCategory(category)
+  const [bankState, setBankState] = useState<BankState>('idle')
+  const hasAutoSavedRef = useRef(false)
+
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [onClose])
+
+  useEffect(() => {
+    if (isCorrect || hasAutoSavedRef.current) return
+    hasAutoSavedRef.current = true
+    setBankState('saving')
+    void (async () => {
+      try {
+        const response = await fetch('/api/bank', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            questionId,
+            contextType: 'feed',
+            contextId: feedItemId,
+          }),
+        })
+        if (!response.ok) throw new Error('save failed')
+        setBankState('saved')
+      } catch {
+        setBankState('error')
+      }
+    })()
+  }, [isCorrect, questionId, feedItemId])
+
+  const handleUndo = async () => {
+    if (bankState !== 'saved') return
+    setBankState('undoing')
+    try {
+      const response = await fetch('/api/bank', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ questionId }),
+      })
+      if (!response.ok) throw new Error('undo failed')
+      setBankState('undone')
+    } catch {
+      setBankState('error')
+    }
+  }
+
+  const points = typeof pointsAwarded === 'number' ? pointsAwarded : 0
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-end justify-center">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-label="Dismiss"
+      />
+      <div className="relative flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-white shadow-2xl">
+        <div className="flex items-center justify-between px-5 pt-5 pb-2">
+          {visibleCategory ? (
+            <p className="text-[0.68rem] font-semibold tracking-[0.18em] uppercase text-stone-500">
+              {visibleCategory.toUpperCase()}
+            </p>
+          ) : (
+            <div />
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex size-8 items-center justify-center rounded-full text-stone-400 transition hover:bg-stone-100 hover:text-stone-700"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 pb-2">
+          <div className="flex items-center gap-3 pb-3">
+            <span
+              className={
+                isCorrect
+                  ? 'inline-flex size-9 items-center justify-center rounded-full bg-emerald-100 text-emerald-700'
+                  : 'inline-flex size-9 items-center justify-center rounded-full bg-stone-100 text-stone-700'
+              }
+              aria-hidden
+            >
+              {isCorrect ? <Check className="size-5" /> : <X className="size-5" />}
+            </span>
+            <p
+              className={
+                isCorrect
+                  ? 'text-lg font-semibold text-emerald-700'
+                  : 'text-lg font-semibold text-stone-800'
+              }
+            >
+              {isCorrect ? 'Correct!' : 'Not quite'}
+            </p>
+            {isCorrect && points > 0 ? (
+              <span className="ml-auto inline-flex items-center rounded-full bg-emerald-600 px-3 py-1 text-sm font-semibold text-white">
+                +{points} {points === 1 ? 'pt' : 'pts'}
+              </span>
+            ) : null}
+          </div>
+
+          <p className="pb-3 font-serif text-lg leading-7 text-stone-950">
+            {question}
+          </p>
+
+          <div className="space-y-1.5 pb-3">
+            <p
+              className="text-[13px] italic"
+              style={{
+                fontFamily: 'var(--font-literata)',
+                color: 'var(--ink)',
+                opacity: 0.7,
+              }}
+            >
+              Your answer: {submittedAnswer}
+            </p>
+            {!isCorrect && correctAnswer ? (
+              <p
+                className="text-[13px] italic"
+                style={{
+                  fontFamily: 'var(--font-literata)',
+                  color: 'var(--ink)',
+                  opacity: 0.85,
+                }}
+              >
+                Correct answer: {correctAnswer}
+              </p>
+            ) : null}
+            {!isCorrect && quip ? (
+              <p
+                className="text-[13px]"
+                style={{ color: 'var(--ink)', opacity: 0.6 }}
+              >
+                {quip}
+              </p>
+            ) : null}
+          </div>
+
+          {explanation ? (
+            <div className="rounded-2xl bg-stone-50 p-4">
+              <p className="font-serif text-[15px] leading-7 text-stone-800">
+                {explanation}
+              </p>
+            </div>
+          ) : null}
+
+          {!isCorrect ? (
+            <div className="pt-3 text-[12px] text-stone-600">
+              {bankState === 'saving' ? (
+                <span>Saving to your practice bank…</span>
+              ) : null}
+              {bankState === 'saved' ? (
+                <span>
+                  Saved to your practice bank ·{' '}
+                  <button
+                    type="button"
+                    onClick={() => void handleUndo()}
+                    className="font-semibold text-stone-800 underline underline-offset-2 hover:text-stone-950"
+                  >
+                    Undo
+                  </button>
+                </span>
+              ) : null}
+              {bankState === 'undoing' ? <span>Undoing…</span> : null}
+              {bankState === 'undone' ? (
+                <span className="text-stone-500">Removed from your practice bank.</span>
+              ) : null}
+              {bankState === 'error' ? (
+                <span className="text-red-700">Could not update your practice bank.</span>
+              ) : null}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="px-5 pt-2 pb-8">
+          <Button
+            type="button"
+            onClick={onClose}
+            className="w-full bg-stone-950 text-white hover:bg-stone-800"
+          >
+            Done
+          </Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/feed/index.ts
+++ b/src/components/feed/index.ts
@@ -1,6 +1,7 @@
 export { FeedOverflowMenu, getFeedOverflowMenuLabels } from './FeedActions'
 export { AnsweredByYouCard, type FeedRecheckAction } from './AnsweredByYouCard'
 export { AnswerSheet } from './AnswerSheet'
+export { AnswerFeedbackSheet } from './AnswerFeedbackSheet'
 export { DirectSentCard } from './DirectSentCard'
 export { FeedCard } from './FeedCard'
 export { FriendAddedCard } from './FriendAddedCard'


### PR DESCRIPTION
After submitting an answer the bottom sheet used to close immediately,
giving no acknowledgement of right/wrong, points, or the long explanation.
Now the sheet morphs into a feedback view that shows correctness, points
awarded, the user's answer, the correct answer (when wrong), the quip,
and the full explainer. Wrong answers are auto-added to the practice
bank with an Undo so they're queued for later play.

Also prefer explainerFullCorrect / explainerFullWrong over the generic
explainerFull so the conditional explainer copy actually gets surfaced.