### PR TITLE
Add "Show me the answer" on Daily Five

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -72,21 +72,23 @@ async function resolveCanonicalAnswer(question: typeof generatedQuestions.$infer
   return repairedAnswer;
 }
 
-function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string } | null {
+function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string; gaveUp: boolean } | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   const record = value as Record<string, unknown>;
   const queueId = typeof record.queue_id === 'string' ? record.queue_id : null;
   const slotIndex = typeof record.slot_index === 'number' && Number.isInteger(record.slot_index)
     ? record.slot_index
     : null;
+  const gaveUp = record.gave_up === true;
   const submittedAnswer = typeof record.submitted_answer === 'string'
     ? record.submitted_answer.trim()
     : typeof record.answer === 'string'
       ? record.answer.trim()
-      : null;
+      : '';
 
-  if (!queueId || slotIndex === null || !submittedAnswer) return null;
-  return { queueId, slotIndex, submittedAnswer };
+  if (!queueId || slotIndex === null) return null;
+  if (!gaveUp && !submittedAnswer) return null;
+  return { queueId, slotIndex, submittedAnswer, gaveUp };
 }
 
 export async function POST(request: NextRequest) {
@@ -138,24 +140,28 @@ export async function POST(request: NextRequest) {
 
     const canonicalAnswer = await resolveCanonicalAnswer(question);
 
-    const grade = await gradeAnswer(
-      parsed.submittedAnswer,
-      canonicalAnswer,
-      [],
-      question.questionText,
-      'factual',
-    );
+    const grade = parsed.gaveUp
+      ? { result: 'wrong' as const, consolation: null }
+      : await gradeAnswer(
+          parsed.submittedAnswer,
+          canonicalAnswer,
+          [],
+          question.questionText,
+          'factual',
+        );
     const isCorrect = grade.result === 'correct';
     const answerState = isCorrect ? 'correct' : 'incorrect';
-    const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-    const breadcrumb = await generateBreadcrumb({
-      questionId: question.id,
-      questionText: question.questionText,
-      correctAnswer: canonicalAnswer,
-      submittedAnswer: parsed.submittedAnswer,
-      isCorrect,
-      domain: question.canonicalSubcategory,
-    }).catch(() => null);
+    const quip = parsed.gaveUp ? null : selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+    const breadcrumb = parsed.gaveUp
+      ? null
+      : await generateBreadcrumb({
+          questionId: question.id,
+          questionText: question.questionText,
+          correctAnswer: canonicalAnswer,
+          submittedAnswer: parsed.submittedAnswer,
+          isCorrect,
+          domain: question.canonicalSubcategory,
+        }).catch(() => null);
 
     // Promote the bot question to a canonical row BEFORE writing the mastery
     // event so cross-surface dedup can key on the canonical Question.id
@@ -220,7 +226,7 @@ export async function POST(request: NextRequest) {
         ...item,
         answered: true,
         answer_state: answerState,
-        submitted_answer: parsed.submittedAnswer,
+        submitted_answer: parsed.gaveUp ? '' : parsed.submittedAnswer,
         awarded_points: pointsAwarded,
         reveal_canonical_answer: canonicalAnswer,
         reveal_explainer: question.explainer,
@@ -262,7 +268,7 @@ export async function POST(request: NextRequest) {
       console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
     });
 
-    if (canonicalQuestionId) {
+    if (canonicalQuestionId && !parsed.gaveUp) {
       try {
         if (isCorrect && persistedCreatorId && persistedCreatorId !== session.userId && persistedDomainForCreator) {
           void promoteDeclaredToDemonstrated({
@@ -324,6 +330,7 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       isCorrect,
+      gaveUp: parsed.gaveUp,
       explanation: question.explainer,
       pointsAwarded,
       answerState,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -24,6 +24,7 @@ type QueueResponse = {
 type AnswerResponse = {
   isCorrect?: boolean;
   correct?: boolean;
+  gaveUp?: boolean;
   explanation?: string;
   explainer?: string;
   pointsAwarded?: number;
@@ -365,6 +366,7 @@ export default function DailyPage() {
     const rows: ChatMessage[] = [];
     for (const slot of queue.slots) {
       if (slot.answered) {
+        const gaveUp = slot.answer_state === 'incorrect' && !slot.submitted_answer;
         rows.push({
           id: `q-${slot.slot_index}`,
           kind: 'question',
@@ -381,7 +383,7 @@ export default function DailyPage() {
           kind: 'result',
           assignmentId: String(slot.slot_index),
           questionText: slot.question_text,
-          result: slot.answer_state === 'correct' ? 'correct' : 'wrong',
+          result: slot.answer_state === 'correct' ? 'correct' : gaveUp ? 'gave_up' : 'wrong',
           submitted: slot.submitted_answer ?? '',
           correctAnswer: slot.answer_state === 'correct' ? null : slot.reveal_canonical_answer ?? null,
           consolation: slot.reveal_quip ?? null,
@@ -389,7 +391,7 @@ export default function DailyPage() {
           copyVariant: slot.slot_index,
           creatorName: slot.source === 'friend' ? (slot.author_name ?? null) : null,
           canonicalSubcategory: slot.domain,
-          recheckAction: slot.answer_state === 'incorrect' && !slot.recheck_status
+          recheckAction: slot.answer_state === 'incorrect' && !gaveUp && !slot.recheck_status
             ? { onSubmit: () => requestRecheck(slot.slot_index) }
             : null,
         });
@@ -433,7 +435,6 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [allDone, currentSlot?.slot_index, queue, requestRecheck, submitting, answer]);
 
   const results = useMemo(() => {
@@ -445,9 +446,8 @@ export default function DailyPage() {
     return map;
   }, [queue?.slots]);
 
-  const submitAnswer = useCallback(async () => {
-    if (!queue || !currentSlot || submitting || !answer.trim()) return;
-    const submittedAnswer = answer.trim();
+  const postAnswer = useCallback(async (opts: { submittedAnswer: string; gaveUp: boolean }) => {
+    if (!queue || !currentSlot || submitting) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -458,7 +458,8 @@ export default function DailyPage() {
         body: JSON.stringify({
           queue_id: queue.queue_id,
           slot_index: currentSlot.slot_index,
-          submitted_answer: submittedAnswer,
+          submitted_answer: opts.submittedAnswer,
+          gave_up: opts.gaveUp,
         }),
       });
       if (!response.ok) {
@@ -481,12 +482,12 @@ export default function DailyPage() {
                     ...slot,
                     answered: true,
                     answer_state: isCorrect ? 'correct' : 'incorrect',
-                    submitted_answer: submittedAnswer,
+                    submitted_answer: opts.gaveUp ? '' : opts.submittedAnswer,
                     awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                     reveal_canonical_answer: body.correctAnswer ?? body.answer,
                     reveal_explainer: body.explanation ?? body.explainer,
                     reveal_breadcrumb: body.breadcrumb ?? null,
-                    reveal_quip: body.consolation ?? body.quip ?? null,
+                    reveal_quip: opts.gaveUp ? null : body.consolation ?? body.quip ?? null,
                   }
                 : slot
             ),
@@ -500,7 +501,17 @@ export default function DailyPage() {
     } finally {
       setSubmitting(false);
     }
-  }, [answer, currentSlot, queue, submitting]);
+  }, [currentSlot, queue, submitting]);
+
+  const submitAnswer = useCallback(async () => {
+    const trimmed = answer.trim();
+    if (!trimmed) return;
+    await postAnswer({ submittedAnswer: trimmed, gaveUp: false });
+  }, [answer, postAnswer]);
+
+  const giveUpCurrent = useCallback(async () => {
+    await postAnswer({ submittedAnswer: '', gaveUp: true });
+  }, [postAnswer]);
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-lg flex-col px-0">
@@ -573,14 +584,24 @@ export default function DailyPage() {
               {submitting ? '...' : 'Send'}
             </button>
           </div>
-          <button
-            type="button"
-            className="mt-2 text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
-            disabled={submitting}
-            onClick={() => setShowUnfamiliarDialog(true)}
-          >
-            Not familiar with this topic
-          </button>
+          <div className="mt-2 flex items-center justify-between gap-3">
+            <button
+              type="button"
+              className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
+              disabled={submitting}
+              onClick={() => setShowUnfamiliarDialog(true)}
+            >
+              Not familiar with this topic
+            </button>
+            <button
+              type="button"
+              className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
+              disabled={submitting}
+              onClick={() => void giveUpCurrent()}
+            >
+              Show me the answer
+            </button>
+          </div>
         </form>
       ) : null}
 


### PR DESCRIPTION
## Summary
- New "Show me the answer" link on the Daily Five answer form (`src/app/daily/page.tsx`), opposite the existing "Not familiar with this topic" link.
- `/api/daily/answer` accepts an optional `gave_up: true` flag. When set: skip LLM grading + breadcrumb generation, mark the slot answered + incorrect, reveal the canonical answer, award 0 points, and skip friend-feed propagation so giving up isn't broadcast.
- The result renders via the existing `gave_up` styling in `GameplayChat.tsx` — a muted card with the canonical answer, no user bubble and no recheck affordance.

## Test plan
- [ ] Tap "Show me the answer" on a pending Daily Five slot → the canonical answer reveals in a muted card, 0 points, no user bubble, no recheck button
- [ ] After giving up, the next pending slot appears
- [ ] After giving up, the summary screen counts the slot as incorrect (not skipped)
- [ ] Refresh mid-round: gave-up slots persist as the gave_up card after reload
- [ ] Friend feed: confirm no "answered incorrectly" feed item is created when a user gives up
- [ ] Existing flow (typed answer, "Not familiar with this topic") still works


---
_Generated by [Claude Code](https://claude.ai/code/session_01W1jP5zNVeCwaLDHpaVLnkr)_