### PR TITLE
show more interest chips per side in Common Ground

### DIFF
--- a/src/components/profile/SharedInterestsOverlap.tsx
+++ b/src/components/profile/SharedInterestsOverlap.tsx
@@ -9,8 +9,8 @@ type SharedInterestsOverlapProps = {
   friendFirstName: string
 }
 
-const MAX_CHIPS_PER_SIDE = 5
-const MAX_SHARED_CHIPS = 6
+const MAX_CHIPS_PER_SIDE = 8
+const MAX_SHARED_CHIPS = 10
 
 export function SharedInterestsOverlap({
   viewerSoloInterests,


### PR DESCRIPTION
Raise the per-side cap from 5 to 8 and the shared middle cap from 6
to 10 so more of each user's declared interests are visible without
expanding. The full set of interests is still used to compute overlap
in src/server/profile/friend.ts; this only changes how many chips
render before the +N more / Show all overflow kicks in.