### PR TITLE
add replacement question on skip so daily five always reaches 5

### DIFF
--- a/src/app/api/daily/skip/route.ts
+++ b/src/app/api/daily/skip/route.ts
@@ -3,7 +3,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, skippedDailyQuestions } from '@/server/db';
-import { DAILY_SKIP_LIMIT, type QueueSlot } from '@/server/daily/types';
+import { DAILY_QUEUE_SIZE, DAILY_SKIP_LIMIT, type QueueSlot } from '@/server/daily/types';
+import { generateDailyQuestionsFromKnowledgeBase } from '@/server/daily/generate-questions';
+import { createDailyQueueItem } from '@/server/db/queries/daily';
 
 export const dynamic = 'force-dynamic';
 
@@ -78,9 +80,43 @@ export async function POST(request: NextRequest) {
       .where(eq(dailyQueues.id, queue.id));
   });
 
+  const answeredCount = nextSlots.filter((item) => item.answered).length;
+  const pendingCount = nextSlots.filter((item) => !item.answered && !item.skipped).length;
+  const needsReplacement = answeredCount + pendingCount < DAILY_QUEUE_SIZE;
+
+  let finalSlots: QueueSlot[] = nextSlots;
+  let replacementAdded = false;
+
+  if (needsReplacement) {
+    try {
+      const [generated] = await generateDailyQuestionsFromKnowledgeBase(session.userId, 1);
+      if (generated) {
+        const maxSlotIndex = nextSlots.reduce(
+          (max, item) => (item.slot_index > max ? item.slot_index : max),
+          -1,
+        );
+        const updatedQueue = await createDailyQueueItem(
+          session.userId,
+          generated.id,
+          maxSlotIndex + 1,
+        );
+        finalSlots = Array.isArray(updatedQueue.slots)
+          ? (updatedQueue.slots as QueueSlot[])
+          : nextSlots;
+        replacementAdded = true;
+      }
+    } catch (error) {
+      console.error('[daily/skip] replacement generation failed', error);
+    }
+  }
+
   return NextResponse.json({
     skipped: true,
     skip_count: currentSkipCount + 1,
     skip_limit: DAILY_SKIP_LIMIT,
+    replacement_added: replacementAdded,
+    queue_id: queue.id,
+    queue_date: queue.queueDate,
+    slots: finalSlots,
   });
 }

--- a/src/app/api/daily/status/route.ts
+++ b/src/app/api/daily/status/route.ts
@@ -43,9 +43,8 @@ export async function GET() {
 
   const slots = asQueueSlots(queue.slots);
   const answered = slots.filter((slot) => slot.answered).length;
-  const skipped = slots.filter((slot) => slot.skipped).length;
-  const total = slots.length || DAILY_QUEUE_SIZE;
-  const questionsAnswered = Math.min(answered + skipped, DAILY_QUEUE_SIZE);
+  const total = DAILY_QUEUE_SIZE;
+  const questionsAnswered = Math.min(answered, DAILY_QUEUE_SIZE);
   const questionsRemaining = Math.max(DAILY_QUEUE_SIZE - questionsAnswered, 0);
   const isComplete = questionsAnswered >= DAILY_QUEUE_SIZE;
 

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -241,7 +241,7 @@ export default function DailyPage() {
 
   const actualCurrentSlot = useMemo(() => currentPendingSlot(queue?.slots ?? []), [queue?.slots]);
   const currentSlot = pausedAfterSlotIndex === null ? actualCurrentSlot : null;
-  const completedCount = queue?.slots.filter((slot) => slot.answered || slot.skipped).length ?? 0;
+  const completedCount = queue?.slots.filter((slot) => slot.answered).length ?? 0;
   const allDone = Boolean(queue && queue.slots.length > 0 && !actualCurrentSlot);
 
 
@@ -256,18 +256,21 @@ export default function DailyPage() {
         credentials: 'include',
         body: JSON.stringify({ queue_id: queue.queue_id, slot_index: currentSlot.slot_index }),
       });
+      const body = await response.json().catch(() => null);
       if (!response.ok) {
-        const body = await response.json().catch(() => null);
         throw new Error(body?.message ?? 'Could not skip that question.');
       }
-      setQueue((existing) => existing
-        ? {
-            ...existing,
-            slots: existing.slots.map((slot) =>
-              slot.slot_index === currentSlot.slot_index ? { ...slot, skipped: true } : slot
-            ),
-          }
-        : existing);
+      const nextSlots = Array.isArray(body?.slots) ? (body.slots as QueueSlot[]) : null;
+      setQueue((existing) => {
+        if (!existing) return existing;
+        if (nextSlots) return { ...existing, slots: nextSlots };
+        return {
+          ...existing,
+          slots: existing.slots.map((slot) =>
+            slot.slot_index === currentSlot.slot_index ? { ...slot, skipped: true } : slot
+          ),
+        };
+      });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not skip that question.');
     } finally {
@@ -436,9 +439,11 @@ export default function DailyPage() {
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
-    for (const slot of queue?.slots ?? []) {
+    let position = 1;
+    for (const slot of [...(queue?.slots ?? [])].sort((a, b) => a.slot_index - b.slot_index)) {
       if (!slot.answered) continue;
-      map[slot.slot_index + 1] = slot.answer_state === 'correct' ? 'correct' : 'wrong';
+      map[position] = slot.answer_state === 'correct' ? 'correct' : 'wrong';
+      position += 1;
     }
     return map;
   }, [queue?.slots]);
@@ -517,8 +522,8 @@ export default function DailyPage() {
           </div>
         </div>
         <GeometricProgress
-          total={queue?.slots.length || DAILY_QUEUE_SIZE}
-          current={(currentSlot?.slot_index ?? completedCount) + 1}
+          total={DAILY_QUEUE_SIZE}
+          current={Math.min(completedCount + 1, DAILY_QUEUE_SIZE)}
           results={results}
         />
       </header>


### PR DESCRIPTION
Skipping a question previously counted as 'answered' on the home card
and left no pending slot, so resuming a round with a skip jumped
straight to the summary. Now each successful skip generates a fresh
question and appends it to the queue, and the status count tracks
only actually-answered slots.

https://claude.ai/code/session_01JDFqoiZnBYeXQwffhVPs4m