### PR TITLE
encode onboardingComplete in JWT; remove auth/me thrash

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -70,11 +70,85 @@ describe('proxy (invitation gate)', () => {
         userId: 'u1',
         sessionId: 's1',
         invitationAccepted: true,
+        onboardingComplete: true,
       })
       const res = await proxy(
         makeRequest('/api/feed', { cookie: 'valid.jwt' }),
       )
       expect(res.status).toBe(200)
+    })
+
+    it('passes onboarded users through to the requested page', async () => {
+      readSessionClaimsMock.mockResolvedValueOnce({
+        userId: 'u1',
+        sessionId: 's1',
+        invitationAccepted: true,
+        onboardingComplete: true,
+      })
+      const res = await proxy(
+        makeRequest('/knowledge', { cookie: 'valid.jwt' }),
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-middleware-next')).toBe('1')
+    })
+
+    it('redirects an onboarded user away from /login', async () => {
+      readSessionClaimsMock.mockResolvedValueOnce({
+        userId: 'u1',
+        sessionId: 's1',
+        invitationAccepted: true,
+        onboardingComplete: true,
+      })
+      const res = await proxy(makeRequest('/login', { cookie: 'valid.jwt' }))
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toMatch(/\/$/)
+    })
+
+    it('redirects an onboarded user away from /onboarding', async () => {
+      readSessionClaimsMock.mockResolvedValueOnce({
+        userId: 'u1',
+        sessionId: 's1',
+        invitationAccepted: true,
+        onboardingComplete: true,
+      })
+      const res = await proxy(
+        makeRequest('/onboarding', { cookie: 'valid.jwt' }),
+      )
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toMatch(/\/$/)
+    })
+  })
+
+  describe('authenticated but onboarding not yet complete', () => {
+    it('lets the user reach /onboarding without bouncing', async () => {
+      readSessionClaimsMock.mockResolvedValueOnce({
+        userId: 'u1',
+        sessionId: 's1',
+        invitationAccepted: true,
+        onboardingComplete: false,
+      })
+      const res = await proxy(
+        makeRequest('/onboarding', { cookie: 'valid.jwt' }),
+      )
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-middleware-next')).toBe('1')
+    })
+
+    it('redirects any other page to the onboarding-claim refresh endpoint with a next param', async () => {
+      readSessionClaimsMock.mockResolvedValueOnce({
+        userId: 'u1',
+        sessionId: 's1',
+        invitationAccepted: true,
+        onboardingComplete: false,
+      })
+      const res = await proxy(
+        makeRequest('/knowledge', { cookie: 'valid.jwt' }),
+      )
+      expect(res.status).toBe(307)
+      expect(res.headers.get('location')).toContain(
+        '/api/auth/refresh-onboarding-claim',
+      )
+      expect(res.headers.get('location')).toContain('next=%2Fknowledge')
     })
   })
 
@@ -84,6 +158,7 @@ describe('proxy (invitation gate)', () => {
         userId: 'u1',
         sessionId: 's1',
         invitationAccepted: false,
+        onboardingComplete: false,
       })
       const res = await proxy(
         makeRequest('/knowledge', { cookie: 'legacy.jwt' }),
@@ -100,6 +175,7 @@ describe('proxy (invitation gate)', () => {
         userId: 'u1',
         sessionId: 's1',
         invitationAccepted: false,
+        onboardingComplete: false,
       })
       const res = await proxy(
         makeRequest('/api/feed', { cookie: 'legacy.jwt' }),

--- a/src/app/api/auth/refresh-onboarding-claim/__tests__/route.test.ts
+++ b/src/app/api/auth/refresh-onboarding-claim/__tests__/route.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  getSessionMock,
+  getUserOnboardingProfileMock,
+  refreshSessionOnboardingClaimMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getUserOnboardingProfileMock: vi.fn(),
+  refreshSessionOnboardingClaimMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+  refreshSessionOnboardingClaim: refreshSessionOnboardingClaimMock,
+}))
+
+vi.mock('@/server/db/queries/users', () => ({
+  getUserOnboardingProfile: getUserOnboardingProfileMock,
+}))
+
+import { GET } from '@/app/api/auth/refresh-onboarding-claim/route'
+
+function makeRequest(query = '') {
+  return new Request(
+    `http://localhost/api/auth/refresh-onboarding-claim${query}`,
+    { method: 'GET' },
+  )
+}
+
+describe('GET /api/auth/refresh-onboarding-claim', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockReset()
+    getUserOnboardingProfileMock.mockReset()
+    refreshSessionOnboardingClaimMock.mockReset()
+  })
+
+  it('redirects to /login when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const res = await GET(makeRequest('?next=/knowledge'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toMatch(/\/login$/)
+    expect(refreshSessionOnboardingClaimMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /login when the user row is missing', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce(null)
+    const res = await GET(makeRequest('?next=/knowledge'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toMatch(/\/login$/)
+    expect(refreshSessionOnboardingClaimMock).not.toHaveBeenCalled()
+  })
+
+  it('redirects to /onboarding when the user has not finished onboarding', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: false,
+    })
+    const res = await GET(makeRequest('?next=/knowledge'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toMatch(/\/onboarding$/)
+    expect(refreshSessionOnboardingClaimMock).not.toHaveBeenCalled()
+  })
+
+  it('re-mints the session and redirects to next when the user has finished onboarding', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: true,
+    })
+    refreshSessionOnboardingClaimMock.mockResolvedValueOnce(true)
+    const res = await GET(makeRequest('?next=/knowledge'))
+    expect(refreshSessionOnboardingClaimMock).toHaveBeenCalled()
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toContain('/knowledge')
+  })
+
+  it('bounces to /login when refresh helper fails (cookie disappeared)', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: true,
+    })
+    refreshSessionOnboardingClaimMock.mockResolvedValueOnce(false)
+    const res = await GET(makeRequest('?next=/knowledge'))
+    expect(res.status).toBe(307)
+    expect(res.headers.get('location')).toMatch(/\/login$/)
+  })
+
+  it('rejects open-redirect attempts via the next param', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: true,
+    })
+    refreshSessionOnboardingClaimMock.mockResolvedValueOnce(true)
+    const res = await GET(makeRequest('?next=//evil.example.com/steal'))
+    const location = res.headers.get('location') ?? ''
+    expect(location).not.toContain('evil.example.com')
+    expect(location).toMatch(/localhost\/$/)
+  })
+
+  it('rejects absolute-URL next params', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: true,
+    })
+    refreshSessionOnboardingClaimMock.mockResolvedValueOnce(true)
+    const res = await GET(makeRequest('?next=https://evil.example.com'))
+    const location = res.headers.get('location') ?? ''
+    expect(location).not.toContain('evil.example.com')
+  })
+
+  it('defaults to / when next param is missing', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: true,
+    })
+    refreshSessionOnboardingClaimMock.mockResolvedValueOnce(true)
+    const res = await GET(makeRequest())
+    expect(res.headers.get('location')).toMatch(/localhost\/$/)
+  })
+})

--- a/src/app/api/auth/refresh-onboarding-claim/route.ts
+++ b/src/app/api/auth/refresh-onboarding-claim/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server'
+
+import {
+  getSession,
+  refreshSessionOnboardingClaim,
+} from '@/server/auth/session'
+import { getUserOnboardingProfile } from '@/server/db/queries/users'
+
+/**
+ * Graceful migration endpoint for sessions issued before the `onb` JWT
+ * claim existed. The edge proxy redirects authenticated page requests here
+ * when `claims.onboardingComplete` is false; this handler does one DB read
+ * to discover the actual state, re-mints the cookie if the user already
+ * finished onboarding, then 302s back to the original path. After the
+ * single refresh the steady-state path is JWT-only.
+ */
+
+function safeNextPath(rawNext: string | null): string {
+  if (!rawNext) return '/'
+  // Only allow same-origin relative paths.
+  if (!rawNext.startsWith('/') || rawNext.startsWith('//')) return '/'
+  return rawNext
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url)
+  const next = safeNextPath(url.searchParams.get('next'))
+
+  const session = await getSession()
+  if (!session) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  const user = await getUserOnboardingProfile(session.userId)
+  if (!user) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  if (!user.onboardingComplete) {
+    return NextResponse.redirect(new URL('/onboarding', request.url))
+  }
+
+  const refreshed = await refreshSessionOnboardingClaim()
+  if (!refreshed) {
+    return NextResponse.redirect(new URL('/login', request.url))
+  }
+
+  return NextResponse.redirect(new URL(next, request.url))
+}

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -139,6 +139,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
       expect(body.invitation).toEqual({ accepted: false })
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
+        onboardingComplete: false,
       })
       expect(acceptFriendInvitationMock).not.toHaveBeenCalled()
     })
@@ -156,6 +157,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
       expect(body.invitation).toEqual({ accepted: false })
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
+        onboardingComplete: false,
       })
       expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
     })
@@ -182,6 +184,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
       })
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
+        onboardingComplete: false,
       })
     })
 
@@ -203,6 +206,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
       expect(response.status).toBe(200)
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
+        onboardingComplete: false,
       })
     })
   })
@@ -324,6 +328,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
       })
       expect(createSessionMock).toHaveBeenCalledWith('user-2', {
         invitationAccepted: true,
+        onboardingComplete: false,
       })
     })
 

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -137,7 +137,10 @@ export async function POST(request: Request) {
         })
       }
 
-      await createSession(existingUser.id, { invitationAccepted: true })
+      await createSession(existingUser.id, {
+        invitationAccepted: true,
+        onboardingComplete: false,
+      })
 
       return NextResponse.json({
         user: {
@@ -183,7 +186,10 @@ export async function POST(request: Request) {
       return invitationRejection()
     }
 
-    await createSession(user.id, { invitationAccepted: true })
+    await createSession(user.id, {
+      invitationAccepted: true,
+      onboardingComplete: false,
+    })
 
     return NextResponse.json({
       user: {

--- a/src/app/api/onboarding/save-interests/__tests__/route.test.ts
+++ b/src/app/api/onboarding/save-interests/__tests__/route.test.ts
@@ -3,15 +3,18 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   getSessionMock,
   markOnboardingCompleteMock,
+  refreshSessionOnboardingClaimMock,
   saveDeclaredInterestsMock,
 } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   markOnboardingCompleteMock: vi.fn(),
+  refreshSessionOnboardingClaimMock: vi.fn(),
   saveDeclaredInterestsMock: vi.fn(),
 }))
 
 vi.mock('@/server/auth/session', () => ({
   getSession: getSessionMock,
+  refreshSessionOnboardingClaim: refreshSessionOnboardingClaimMock,
 }))
 
 vi.mock('@/server/db/queries/users', () => ({
@@ -35,6 +38,7 @@ describe('POST /api/onboarding/save-interests', () => {
     getSessionMock.mockResolvedValue({ userId: 'user-invitee' })
     saveDeclaredInterestsMock.mockResolvedValue(undefined)
     markOnboardingCompleteMock.mockResolvedValue(undefined)
+    refreshSessionOnboardingClaimMock.mockResolvedValue(true)
   })
 
   it('accept all saves selected invited interests', async () => {
@@ -142,6 +146,7 @@ describe('POST /api/onboarding/save-interests', () => {
       getSessionMock.mockResolvedValue({ userId: 'user-jaime' })
       saveDeclaredInterestsMock.mockResolvedValue(undefined)
       markOnboardingCompleteMock.mockResolvedValue(undefined)
+      refreshSessionOnboardingClaimMock.mockResolvedValue(true)
 
       const response = await POST(
         jsonRequest(choice.interests, {
@@ -176,6 +181,19 @@ describe('POST /api/onboarding/save-interests', () => {
     expect(response.status).toBe(400)
     expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()
     expect(markOnboardingCompleteMock).not.toHaveBeenCalled()
+  })
+
+  it('re-mints the session cookie so the next request sees onboardingComplete=true', async () => {
+    const response = await POST(
+      jsonRequest([{ domain: 'Sondheim', broadCategory: 'Theater' }])
+    )
+
+    expect(response.status).toBe(200)
+    expect(markOnboardingCompleteMock).toHaveBeenCalledWith('user-invitee')
+    expect(refreshSessionOnboardingClaimMock).toHaveBeenCalledTimes(1)
+    const markOrder = markOnboardingCompleteMock.mock.invocationCallOrder[0]
+    const refreshOrder = refreshSessionOnboardingClaimMock.mock.invocationCallOrder[0]
+    expect(refreshOrder).toBeGreaterThan(markOrder)
   })
 
   it('does not silently save rejected interests from an empty non-invite selection', async () => {

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server';
 
-import { getSession } from '@/server/auth/session';
+import {
+  getSession,
+  refreshSessionOnboardingClaim,
+} from '@/server/auth/session';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { logTelemetry } from '@/server/telemetry';
 import {
@@ -85,6 +88,7 @@ export async function POST(request: Request) {
   try {
     await saveDeclaredInterests(session.userId, interests);
     await markOnboardingComplete(session.userId);
+    await refreshSessionOnboardingClaim();
 
     if (telemetry.inviteInterestCount > 0) {
       const event = telemetry.inviteSelectedCount === 0

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Caveat, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
+import { getUserOnboardingProfile } from '@/server/db/queries/users';
 
 
 // Intentional product choice (2026-05-16): Montserrat is the body font.
@@ -41,13 +42,17 @@ export default async function RootLayout({
 }) {
   const sessionToken = await getSessionToken()
   const claims = await readSessionClaims(sessionToken)
+  const profile = claims ? await getUserOnboardingProfile(claims.userId) : null
   return (
     <html
       lang="en"
       className={`font-sans ${caveat.variable} ${playfair.variable}`}
     >
       <body className={montserrat.className}>
-        <Nav initialUserId={claims?.userId ?? null} />
+        <Nav
+          initialUserId={claims?.userId ?? null}
+          initialDisplayName={profile?.displayName ?? null}
+        />
         {children}
       </body>
     </html>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,17 +1,10 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { Brain, Home, Menu, Pencil, Plus, Rss, User, X } from 'lucide-react';
 import { CreateChooser } from '@/components/CreateChooser';
-
-type MeResponse = {
-  user?: {
-    id?: string | null;
-    display_name?: string | null;
-  };
-};
 
 const navItems = [
   { href: '/', label: 'Home', Icon: Home },
@@ -28,10 +21,16 @@ function initialsFor(name: string): string {
   return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase();
 }
 
-export function Nav({ initialUserId = null }: { initialUserId?: string | null }) {
+export function Nav({
+  initialUserId = null,
+  initialDisplayName = null,
+}: {
+  initialUserId?: string | null;
+  initialDisplayName?: string | null;
+}) {
   const pathname = usePathname();
-  const [accountInitials, setAccountInitials] = useState<string | null>(null);
-  const [currentUserId, setCurrentUserId] = useState<string | null>(initialUserId);
+  const accountInitials = initialDisplayName ? initialsFor(initialDisplayName) || null : null;
+  const currentUserId = initialUserId;
   const [menuOpen, setMenuOpen] = useState(false);
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
   const isOtherUserProfilePath = (() => {
@@ -48,34 +47,6 @@ export function Nav({ initialUserId = null }: { initialUserId?: string | null })
     pathname === '/friends' ||
     isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;
-
-  const loadCurrentUser = useCallback(async () => {
-    try {
-      const response = await fetch('/api/auth/me', { cache: 'no-store', credentials: 'include' });
-      if (!response.ok) {
-        setAccountInitials(null);
-        setCurrentUserId(null);
-        return;
-      }
-      const body = await response.json().catch(() => null) as MeResponse | null;
-      const initials = body?.user?.display_name ? initialsFor(body.user.display_name) : '';
-      setAccountInitials(initials || null);
-      setCurrentUserId(body?.user?.id ?? null);
-    } catch {
-      setAccountInitials(null);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (pathname === '/onboarding') return;
-
-    const initialTimer = window.setTimeout(() => {
-      void loadCurrentUser();
-    }, 0);
-    return () => {
-      window.clearTimeout(initialTimer);
-    };
-  }, [loadCurrentUser, pathname]);
 
   if (pathname === '/onboarding') {
     return null;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,35 +4,13 @@ import { readSessionClaims } from '@/server/auth/session'
 
 const SESSION_COOKIE_NAME = 'joshing_session'
 
-type AuthMeResponse = {
-  user?: {
-    onboardingComplete?: boolean
-  }
-}
-
-async function getAuthenticatedUser(
-  request: NextRequest,
-): Promise<AuthMeResponse['user'] | null> {
-  const response = await fetch(new URL('/api/auth/me', request.url), {
-    headers: {
-      cookie: request.headers.get('cookie') ?? '',
-    },
-    cache: 'no-store',
-  }).catch(() => null)
-
-  if (!response?.ok) return null
-
-  const data = (await response
-    .json()
-    .catch(() => null)) as AuthMeResponse | null
-  return data?.user ?? null
-}
-
 /**
- * Combined edge proxy:
- *  1. Defense-in-depth JWT gate (edge-safe, only verifies signature + `inv` claim).
- *  2. Onboarding/login routing for authenticated page requests (calls
- *     `/api/auth/me` in the Node runtime to read onboarding state).
+ * Edge proxy: defense-in-depth JWT gate plus onboarding/login routing for
+ * authenticated page requests. Reads `inv` and `onb` directly from the JWT
+ * so no DB lookup or self-fetch happens on the steady-state path. Legacy
+ * sessions missing `onb` are redirected once to
+ * /api/auth/refresh-onboarding-claim, which does a single DB read and
+ * re-mints the cookie.
  *
  * Route handlers MUST keep their own `getSession()` checks — this is an
  * additional fence, not a replacement.
@@ -91,31 +69,26 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith('/api/onboarding/') ||
     pathname.startsWith('/api/auth/')
 
-  const user = await getAuthenticatedUser(request)
-
-  if (!user) {
-    if (isLoginPage || isInvitePage) return NextResponse.next()
-    const loginUrl = request.nextUrl.clone()
-    loginUrl.pathname = '/login'
-    loginUrl.search = ''
-    return NextResponse.redirect(loginUrl)
+  if (claims.onboardingComplete) {
+    if (isLoginPage || isOnboardingPage) {
+      return NextResponse.redirect(new URL('/', request.url))
+    }
+    return NextResponse.next()
   }
 
-  if (!user.onboardingComplete && !isAllowedOnboardingPath) {
-    const onboardingUrl = request.nextUrl.clone()
-    onboardingUrl.pathname = '/onboarding'
-    onboardingUrl.search = ''
-    return NextResponse.redirect(onboardingUrl)
-  }
+  // claims.onboardingComplete is false: either the user genuinely hasn't
+  // finished onboarding, or they did so before the `onb` claim existed and
+  // their JWT is missing the field. Allow onboarding/auth paths through and
+  // route everything else to the refresh endpoint, which does one DB read,
+  // re-mints the JWT if needed, and bounces back. Steady-state is JWT-only.
+  if (isAllowedOnboardingPath) return NextResponse.next()
 
-  if (user.onboardingComplete && (isLoginPage || isOnboardingPage)) {
-    const homeUrl = request.nextUrl.clone()
-    homeUrl.pathname = '/'
-    homeUrl.search = ''
-    return NextResponse.redirect(homeUrl)
-  }
-
-  return NextResponse.next()
+  const refreshUrl = new URL(
+    '/api/auth/refresh-onboarding-claim',
+    request.url,
+  )
+  refreshUrl.searchParams.set('next', pathname + search)
+  return NextResponse.redirect(refreshUrl)
 }
 
 /**

--- a/src/server/auth/__tests__/session.test.ts
+++ b/src/server/auth/__tests__/session.test.ts
@@ -1,0 +1,214 @@
+import { SignJWT } from 'jose'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { cookieStoreMock, dbUpdateSpy, selectChainMock } = vi.hoisted(() => {
+  const cookieStoreMock = {
+    get: vi.fn<(name: string) => { value: string } | undefined>(),
+    set: vi.fn(),
+    delete: vi.fn(),
+  }
+  const selectChainMock = vi.fn<() => Promise<Array<{ id: string; expiresAt: Date }>>>(
+    async () => [],
+  )
+  const dbUpdateSpy = vi.fn(async () => undefined)
+  return { cookieStoreMock, dbUpdateSpy, selectChainMock }
+})
+
+vi.mock('next/headers', () => ({
+  cookies: async () => cookieStoreMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: () => selectChainMock(),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => dbUpdateSpy(),
+      }),
+    }),
+    insert: () => ({
+      values: async () => undefined,
+    }),
+    delete: () => ({
+      where: async () => undefined,
+    }),
+  },
+  userSessions: {
+    id: 'userSessions.id',
+    userId: 'userSessions.userId',
+    token: 'userSessions.token',
+    expiresAt: 'userSessions.expiresAt',
+  },
+}))
+
+import {
+  readSessionClaims,
+  refreshSessionOnboardingClaim,
+} from '@/server/auth/session'
+
+const SECRET = 'test-secret-for-session-tests'
+
+// Mirror session.ts's getJwtSecret(): a non-empty base64-decodable string is
+// used as raw bytes. Buffer.from(_, 'base64') will return a non-empty buffer
+// for any non-empty input, so we must decode the same way the module does.
+function secretBytes(): Uint8Array {
+  const decoded = Buffer.from(SECRET, 'base64')
+  if (decoded.length > 0) return new Uint8Array(decoded)
+  return new TextEncoder().encode(SECRET)
+}
+
+async function mintJwt(opts: {
+  sub: string
+  sid: string
+  inv?: boolean
+  onb?: boolean
+  expiresIn?: string
+}) {
+  const payload: Record<string, unknown> = { sid: opts.sid }
+  if (opts.inv !== undefined) payload.inv = opts.inv
+  if (opts.onb !== undefined) payload.onb = opts.onb
+  return new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(opts.sub)
+    .setIssuedAt()
+    .setExpirationTime(opts.expiresIn ?? '90d')
+    .sign(secretBytes())
+}
+
+describe('readSessionClaims', () => {
+  const originalSecret = process.env.JWT_SECRET
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = SECRET
+    cookieStoreMock.get.mockReset()
+    cookieStoreMock.set.mockReset()
+    selectChainMock.mockReset()
+    dbUpdateSpy.mockReset()
+  })
+
+  afterEach(() => {
+    process.env.JWT_SECRET = originalSecret
+  })
+
+  it('returns null for an empty token', async () => {
+    expect(await readSessionClaims(null)).toBeNull()
+    expect(await readSessionClaims('')).toBeNull()
+  })
+
+  it('exposes onboardingComplete=true when the JWT carries onb', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1', inv: true, onb: true })
+    const claims = await readSessionClaims(token)
+    expect(claims).toEqual({
+      userId: 'u1',
+      sessionId: 's1',
+      invitationAccepted: true,
+      onboardingComplete: true,
+    })
+  })
+
+  it('defaults onboardingComplete to false when the claim is absent', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1', inv: true })
+    const claims = await readSessionClaims(token)
+    expect(claims?.onboardingComplete).toBe(false)
+    expect(claims?.invitationAccepted).toBe(true)
+  })
+
+  it('returns null for a tampered token', async () => {
+    const claims = await readSessionClaims('not.a.jwt')
+    expect(claims).toBeNull()
+  })
+})
+
+describe('refreshSessionOnboardingClaim', () => {
+  const originalSecret = process.env.JWT_SECRET
+
+  beforeEach(() => {
+    process.env.JWT_SECRET = SECRET
+    cookieStoreMock.get.mockReset()
+    cookieStoreMock.set.mockReset()
+    selectChainMock.mockReset()
+    dbUpdateSpy.mockReset()
+  })
+
+  afterEach(() => {
+    process.env.JWT_SECRET = originalSecret
+  })
+
+  it('returns false when there is no session cookie', async () => {
+    cookieStoreMock.get.mockReturnValue(undefined)
+    expect(await refreshSessionOnboardingClaim()).toBe(false)
+    expect(cookieStoreMock.set).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the cookie is not a valid JWT', async () => {
+    cookieStoreMock.get.mockReturnValue({ value: 'garbage' })
+    expect(await refreshSessionOnboardingClaim()).toBe(false)
+    expect(cookieStoreMock.set).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the underlying DB session has expired', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1', inv: true })
+    cookieStoreMock.get.mockReturnValue({ value: token })
+    selectChainMock.mockResolvedValueOnce([
+      { id: 'row-1', expiresAt: new Date(Date.now() - 1000) },
+    ])
+    expect(await refreshSessionOnboardingClaim()).toBe(false)
+    expect(cookieStoreMock.set).not.toHaveBeenCalled()
+  })
+
+  it('returns false when the DB row is missing', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1', inv: true })
+    cookieStoreMock.get.mockReturnValue({ value: token })
+    selectChainMock.mockResolvedValueOnce([])
+    expect(await refreshSessionOnboardingClaim()).toBe(false)
+    expect(cookieStoreMock.set).not.toHaveBeenCalled()
+  })
+
+  it('re-signs the JWT with onb=true while preserving inv, and resets the cookie', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1', inv: true })
+    cookieStoreMock.get.mockReturnValue({ value: token })
+    selectChainMock.mockResolvedValueOnce([
+      { id: 'row-1', expiresAt: new Date(Date.now() + 86_400_000) },
+    ])
+
+    expect(await refreshSessionOnboardingClaim()).toBe(true)
+    expect(dbUpdateSpy).toHaveBeenCalledTimes(1)
+    expect(cookieStoreMock.set).toHaveBeenCalledTimes(1)
+
+    const [name, newToken, opts] = cookieStoreMock.set.mock.calls[0]!
+    expect(name).toBe('joshing_session')
+    expect(typeof newToken).toBe('string')
+    expect(opts).toMatchObject({
+      httpOnly: true,
+      sameSite: 'lax',
+      path: '/',
+    })
+
+    const claims = await readSessionClaims(newToken as string)
+    expect(claims?.userId).toBe('u1')
+    expect(claims?.sessionId).toBe('s1')
+    expect(claims?.invitationAccepted).toBe(true)
+    expect(claims?.onboardingComplete).toBe(true)
+  })
+
+  it('does not flip inv to true on a legacy (inv=false) session', async () => {
+    const token = await mintJwt({ sub: 'u1', sid: 's1' })
+    cookieStoreMock.get.mockReturnValue({ value: token })
+    selectChainMock.mockResolvedValueOnce([
+      { id: 'row-1', expiresAt: new Date(Date.now() + 86_400_000) },
+    ])
+
+    expect(await refreshSessionOnboardingClaim()).toBe(true)
+
+    const newToken = cookieStoreMock.set.mock.calls[0]?.[1] as string
+    const claims = await readSessionClaims(newToken)
+    expect(claims?.invitationAccepted).toBe(false)
+    expect(claims?.onboardingComplete).toBe(true)
+  })
+})

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -28,6 +28,14 @@ type SessionJwtPayload = {
    * /api/auth/refresh-session.
    */
   inv?: boolean;
+  /**
+   * Set to true when the user has completed onboarding. Middleware reads
+   * this directly from the JWT to decide whether to redirect to /onboarding,
+   * avoiding a per-navigation DB read. Sessions issued before this claim
+   * existed omit the field and are refreshed via
+   * /api/auth/refresh-onboarding-claim on first need.
+   */
+  onb?: boolean;
 };
 
 export type Session = {
@@ -39,6 +47,7 @@ export type SessionJwtClaims = {
   userId: string;
   sessionId: string;
   invitationAccepted: boolean;
+  onboardingComplete: boolean;
 };
 
 function readConfiguredSessionSecret(): string | null {
@@ -88,7 +97,7 @@ function getJwtSecret(): Uint8Array {
  */
 export async function createSession(
   userId: string,
-  options: { invitationAccepted: true },
+  options: { invitationAccepted: true; onboardingComplete: boolean },
 ): Promise<string> {
   const sessionId = randomBytes(24).toString('hex');
   const expiresAt = new Date();
@@ -97,6 +106,7 @@ export async function createSession(
   const payload: SessionJwtPayload = {
     sid: sessionId,
     inv: options.invitationAccepted,
+    onb: options.onboardingComplete,
   };
 
   const token = await new SignJWT(payload)
@@ -132,12 +142,13 @@ export async function readSessionClaims(
 
   try {
     const verified = await jwtVerify<SessionJwtPayload>(token, getJwtSecret());
-    const { sub, sid, inv } = verified.payload;
+    const { sub, sid, inv, onb } = verified.payload;
     if (!sub || typeof sid !== 'string') return null;
     return {
       userId: sub,
       sessionId: sid,
       invitationAccepted: inv === true,
+      onboardingComplete: onb === true,
     };
   } catch {
     return null;
@@ -159,6 +170,7 @@ export async function refreshSessionInvitationClaim(): Promise<boolean> {
 
   let userId: string;
   let sessionId: string;
+  let onb: boolean;
   try {
     const verified = await jwtVerify<SessionJwtPayload>(
       existingToken,
@@ -169,6 +181,7 @@ export async function refreshSessionInvitationClaim(): Promise<boolean> {
     }
     userId = verified.payload.sub;
     sessionId = verified.payload.sid;
+    onb = verified.payload.onb === true;
   } catch {
     return false;
   }
@@ -181,7 +194,72 @@ export async function refreshSessionInvitationClaim(): Promise<boolean> {
 
   if (!existingRow || existingRow.expiresAt < new Date()) return false;
 
-  const payload: SessionJwtPayload = { sid: sessionId, inv: true };
+  const payload: SessionJwtPayload = { sid: sessionId, inv: true, onb };
+  const newToken = await new SignJWT(payload)
+    .setProtectedHeader({ alg: 'HS256' })
+    .setSubject(userId)
+    .setIssuedAt()
+    .setExpirationTime(`${SESSION_DAYS}d`)
+    .sign(getJwtSecret());
+
+  await db
+    .update(userSessions)
+    .set({ token: newToken })
+    .where(eq(userSessions.id, existingRow.id));
+
+  cookieStore.set(SESSION_COOKIE_NAME, newToken, {
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    maxAge: SESSION_DAYS * 24 * 60 * 60,
+    path: '/',
+  });
+
+  return true;
+}
+
+/**
+ * Re-sign the current session JWT with `onb: true`. Used by
+ * /api/auth/refresh-onboarding-claim to upgrade sessions that completed
+ * onboarding before the JWT claim existed, and by the onboarding-complete
+ * flow so the very next request sees the new state without a DB lookup.
+ *
+ * The existing `inv` value is preserved so this never downgrades the
+ * invitation gate. The DB row's `token` column is updated to match the new
+ * JWT so `validateSessionToken` continues to find the row.
+ */
+export async function refreshSessionOnboardingClaim(): Promise<boolean> {
+  const cookieStore = await cookies();
+  const existingToken = cookieStore.get(SESSION_COOKIE_NAME)?.value;
+  if (!existingToken) return false;
+
+  let userId: string;
+  let sessionId: string;
+  let inv: boolean;
+  try {
+    const verified = await jwtVerify<SessionJwtPayload>(
+      existingToken,
+      getJwtSecret(),
+    );
+    if (!verified.payload.sub || typeof verified.payload.sid !== 'string') {
+      return false;
+    }
+    userId = verified.payload.sub;
+    sessionId = verified.payload.sid;
+    inv = verified.payload.inv === true;
+  } catch {
+    return false;
+  }
+
+  const [existingRow] = await db
+    .select({ id: userSessions.id, expiresAt: userSessions.expiresAt })
+    .from(userSessions)
+    .where(eq(userSessions.token, existingToken))
+    .limit(1);
+
+  if (!existingRow || existingRow.expiresAt < new Date()) return false;
+
+  const payload: SessionJwtPayload = { sid: sessionId, inv, onb: true };
   const newToken = await new SignJWT(payload)
     .setProtectedHeader({ alg: 'HS256' })
     .setSubject(userId)

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -1,5 +1,6 @@
 import type { InferSelectModel } from 'drizzle-orm';
 import { and, desc, eq, isNotNull } from 'drizzle-orm';
+import { cache } from 'react';
 
 import { db, declaredInterests, friendInvitations, users } from '@/server/db';
 
@@ -155,7 +156,10 @@ export async function markOnboardingComplete(userId: string) {
     .where(eq(users.id, userId));
 }
 
-export async function getUserOnboardingProfile(userId: string) {
+// React.cache dedupes calls within a single server request, so the root
+// layout's lookup is shared with any other server component (e.g. the
+// onboarding page) that asks for the same profile during the same render.
+export const getUserOnboardingProfile = cache(async (userId: string) => {
   const [user] = await db
     .select({
       id: users.id,
@@ -170,7 +174,7 @@ export async function getUserOnboardingProfile(userId: string) {
     .limit(1);
 
   return user ?? null;
-}
+});
 
 function normalizeInviterName(value: string | null | undefined) {
   const normalized = value?.trim().replace(/\s+/g, ' ');


### PR DESCRIPTION
Every authenticated page navigation used to fire two duplicate
getUserOnboardingProfile reads:

 - src/proxy.ts self-fetched /api/auth/me to learn onboardingComplete.
 - src/components/Nav.tsx refetched /api/auth/me on every pathname
   change to recompute account initials.

That cost 2 DB reads, 1 HTTP self-fetch hop, and ~1.5 RTT on every
navigation. After this change both become zero on the steady-state
path:

 1. Add an `onb` claim to the session JWT (mirrors the existing `inv`
    claim, including its legacy-refresh escape hatch). The proxy now
    reads claims.onboardingComplete instead of self-fetching. Sessions
    issued before this claim are redirected once to a new
    /api/auth/refresh-onboarding-claim endpoint, which does one DB
    read, re-signs the cookie if needed, and bounces back.
    POST /api/onboarding/save-interests re-mints the cookie on
    completion so the very next request sees onb=true without a DB
    read.

 2. Server-render initials by passing initialDisplayName through the
    root layout. getUserOnboardingProfile is wrapped in React.cache so
    layouts and pages share a single fetch per request, and Nav.tsx
    becomes prop-driven — its /api/auth/me fetch (and the useEffect
    that ran it on every navigation) are gone.

Adds tests for refreshSessionOnboardingClaim,
/api/auth/refresh-onboarding-claim, and the new proxy branches;
updates the verify-otp and save-interests tests for the new option
shape and the post-mark re-mint.

https://claude.ai/code/session_01UkXDLQ86s62UR4PBAicivz