### PR TITLE
decouple breadcrumb generation from answer response

### DIFF
--- a/src/app/api/breadcrumb/__tests__/route.test.ts
+++ b/src/app/api/breadcrumb/__tests__/route.test.ts
@@ -1,0 +1,228 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  dbMock,
+  generateBreadcrumbMock,
+  getSessionMock,
+  selectCallChain,
+  updateSetSpy,
+} = vi.hoisted(() => {
+  const selectCallChain: Array<() => Promise<unknown[]>> = []
+  const updateSetSpy = vi.fn(async () => undefined)
+
+  function makeChainable(): Record<string, unknown> {
+    const chain: Record<string, unknown> = {}
+    chain.from = () => chain
+    chain.innerJoin = () => chain
+    chain.where = () => chain
+    chain.limit = () => {
+      const handler = selectCallChain.shift() ?? (async () => [])
+      return handler()
+    }
+    return chain
+  }
+
+  const dbMock = {
+    select: vi.fn(() => makeChainable()),
+    update: vi.fn(() => ({
+      set: vi.fn((updates: unknown) => ({
+        where: vi.fn(async () => {
+          await updateSetSpy(updates)
+        }),
+      })),
+    })),
+  }
+
+  return {
+    dbMock,
+    generateBreadcrumbMock: vi.fn(),
+    getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
+    selectCallChain,
+    updateSetSpy,
+  }
+})
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  dailyQueues: { id: 'q.id', userId: 'q.userId' },
+  joshingGames: { id: 'g.id', creatorId: 'g.creatorId' },
+  joshingGameRecipients: { id: 'r.id', gameId: 'r.gameId', userId: 'r.userId' },
+  joshingGameResponses: {
+    id: 'jr.id',
+    gameId: 'jr.gameId',
+    questionId: 'jr.questionId',
+    userId: 'jr.userId',
+  },
+  questions: {
+    id: 'q.id',
+    canonicalSubcategory: 'q.cs',
+    broadCategory: 'q.bc',
+    category: 'q.c',
+  },
+}))
+
+vi.mock('@/server/daily/generate-breadcrumb', () => ({
+  generateBreadcrumb: generateBreadcrumbMock,
+}))
+
+vi.mock('@/server/daily/catchup', () => ({
+  asQueueSlots: (value: unknown) => (Array.isArray(value) ? value : []),
+  findQueueSlotBySlotIndex: (slots: { slot_index: number }[], idx: number) =>
+    slots.find((s) => s.slot_index === idx) ?? null,
+  replaceQueueSlot: (slots: { slot_index: number }[], idx: number, fn: (s: unknown) => unknown) =>
+    slots.map((s) => (s.slot_index === idx ? fn(s) : s)),
+}))
+
+import { POST } from '@/app/api/breadcrumb/route'
+
+function jsonRequest(body: unknown) {
+  return new Request('http://localhost/api/breadcrumb', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/breadcrumb', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectCallChain.length = 0
+    generateBreadcrumbMock.mockReset()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSessionMock.mockResolvedValueOnce(null as never)
+    const res = await POST(jsonRequest({ source: 'daily', queueId: 'q-1', slotIndex: 0 }) as never)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 on invalid body shape', async () => {
+    const res = await POST(jsonRequest({ source: 'unknown' }) as never)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error).toBe('validation')
+  })
+
+  describe('daily', () => {
+    it('returns null breadcrumb for gaveUp (no submitted answer + incorrect)', async () => {
+      selectCallChain.push(async () => [{
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [{
+          slot_index: 0,
+          source: 'bot',
+          domain: 'history',
+          question_text: 'q?',
+          answered: true,
+          answer_state: 'incorrect',
+          submitted_answer: '',
+        }],
+      }])
+
+      const res = await POST(jsonRequest({ source: 'daily', queueId: 'queue-1', slotIndex: 0 }) as never)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ breadcrumb: null })
+      expect(generateBreadcrumbMock).not.toHaveBeenCalled()
+    })
+
+    it('returns existing breadcrumb without calling LLM when slot already has one', async () => {
+      selectCallChain.push(async () => [{
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [{
+          slot_index: 0,
+          source: 'bot',
+          domain: 'history',
+          question_text: 'q?',
+          answered: true,
+          answer_state: 'correct',
+          submitted_answer: 'A',
+          reveal_canonical_answer: 'A',
+          reveal_breadcrumb: 'cached crumb',
+        }],
+      }])
+
+      const res = await POST(jsonRequest({ source: 'daily', queueId: 'queue-1', slotIndex: 0 }) as never)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ breadcrumb: 'cached crumb' })
+      expect(generateBreadcrumbMock).not.toHaveBeenCalled()
+    })
+
+    it('generates, persists to slot, and returns breadcrumb for a fresh answer', async () => {
+      selectCallChain.push(async () => [{
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [{
+          slot_index: 0,
+          source: 'bot',
+          generated_question_id: 'gen-q-1',
+          domain: 'history',
+          question_text: 'q?',
+          answered: true,
+          answer_state: 'correct',
+          submitted_answer: 'A',
+          reveal_canonical_answer: 'A',
+        }],
+      }])
+      generateBreadcrumbMock.mockResolvedValueOnce('fresh crumb')
+
+      const res = await POST(jsonRequest({ source: 'daily', queueId: 'queue-1', slotIndex: 0 }) as never)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ breadcrumb: 'fresh crumb' })
+      expect(generateBreadcrumbMock).toHaveBeenCalledWith(expect.objectContaining({
+        questionId: 'gen-q-1',
+        isCorrect: true,
+        domain: 'history',
+        correctAnswer: 'A',
+        submittedAnswer: 'A',
+      }))
+      expect(updateSetSpy).toHaveBeenCalledWith(expect.objectContaining({
+        slots: expect.arrayContaining([expect.objectContaining({ reveal_breadcrumb: 'fresh crumb' })]),
+      }))
+    })
+
+    it('returns null without persisting when generator times out', async () => {
+      selectCallChain.push(async () => [{
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [{
+          slot_index: 0,
+          source: 'bot',
+          domain: 'history',
+          question_text: 'q?',
+          answered: true,
+          answer_state: 'correct',
+          submitted_answer: 'A',
+          reveal_canonical_answer: 'A',
+        }],
+      }])
+      generateBreadcrumbMock.mockResolvedValueOnce(null)
+
+      const res = await POST(jsonRequest({ source: 'daily', queueId: 'queue-1', slotIndex: 0 }) as never)
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ breadcrumb: null })
+      expect(updateSetSpy).not.toHaveBeenCalled()
+    })
+
+    it('rejects unanswered slots', async () => {
+      selectCallChain.push(async () => [{
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [{
+          slot_index: 0,
+          source: 'bot',
+          domain: 'history',
+          question_text: 'q?',
+          answered: false,
+        }],
+      }])
+
+      const res = await POST(jsonRequest({ source: 'daily', queueId: 'queue-1', slotIndex: 0 }) as never)
+      expect(res.status).toBe(400)
+      expect(generateBreadcrumbMock).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/src/app/api/breadcrumb/route.ts
+++ b/src/app/api/breadcrumb/route.ts
@@ -1,0 +1,162 @@
+import { and, eq } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
+import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
+import {
+  dailyQueues,
+  db,
+  joshingGameRecipients,
+  joshingGameResponses,
+  joshingGames,
+  questions,
+} from '@/server/db';
+
+export const dynamic = 'force-dynamic';
+
+const dailyBodySchema = z.object({
+  source: z.literal('daily'),
+  queueId: z.string().min(1),
+  slotIndex: z.number().int().nonnegative(),
+});
+
+const joshingGameBodySchema = z.object({
+  source: z.literal('joshing_game'),
+  gameId: z.string().min(1),
+  questionId: z.string().min(1),
+});
+
+const bodySchema = z.discriminatedUnion('source', [dailyBodySchema, joshingGameBodySchema]);
+
+type ParsedBody = z.infer<typeof bodySchema>;
+
+function errorResponse(status: number, error: string, message: string) {
+  return NextResponse.json({ error, message, breadcrumb: null }, { status });
+}
+
+async function handleDaily(userId: string, body: z.infer<typeof dailyBodySchema>) {
+  const [queue] = await db
+    .select()
+    .from(dailyQueues)
+    .where(and(eq(dailyQueues.id, body.queueId), eq(dailyQueues.userId, userId)))
+    .limit(1);
+  if (!queue) return errorResponse(404, 'not_found', 'Queue not found.');
+
+  const slots = asQueueSlots(queue.slots);
+  const slot = findQueueSlotBySlotIndex(slots, body.slotIndex);
+  if (!slot) return errorResponse(404, 'not_found', 'Slot not found.');
+  if (!slot.answered) return errorResponse(400, 'invalid_state', 'Slot is not answered yet.');
+
+  if (slot.reveal_breadcrumb) {
+    return NextResponse.json({ breadcrumb: slot.reveal_breadcrumb });
+  }
+
+  const isCorrect = slot.answer_state === 'correct';
+  const correctAnswer = slot.reveal_canonical_answer ?? '';
+  const submittedAnswer = slot.submitted_answer ?? '';
+
+  // Mirrors the gaveUp short-circuit in src/app/api/daily/answer/route.ts —
+  // no breadcrumb when the player gave up.
+  if (!isCorrect && !submittedAnswer) {
+    return NextResponse.json({ breadcrumb: null });
+  }
+
+  const breadcrumb = await generateBreadcrumb({
+    questionId: slot.generated_question_id ?? slot.question_id,
+    questionText: slot.question_text,
+    correctAnswer,
+    submittedAnswer,
+    isCorrect,
+    domain: slot.domain,
+  }).catch(() => null);
+
+  if (breadcrumb) {
+    const nextSlots = replaceQueueSlot(slots, body.slotIndex, (item) => ({
+      ...item,
+      reveal_breadcrumb: breadcrumb,
+    }));
+    await db
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, queue.id))
+      .catch((err) => {
+        console.warn('[breadcrumb] failed to persist breadcrumb to slot', err);
+      });
+  }
+
+  return NextResponse.json({ breadcrumb });
+}
+
+async function handleJoshingGame(userId: string, body: z.infer<typeof joshingGameBodySchema>) {
+  const [game] = await db
+    .select({ creatorId: joshingGames.creatorId })
+    .from(joshingGames)
+    .where(eq(joshingGames.id, body.gameId))
+    .limit(1);
+  if (!game) return errorResponse(404, 'not_found', 'Game not found.');
+
+  if (game.creatorId !== userId) {
+    const [recipient] = await db
+      .select({ id: joshingGameRecipients.id })
+      .from(joshingGameRecipients)
+      .where(and(eq(joshingGameRecipients.gameId, body.gameId), eq(joshingGameRecipients.userId, userId)))
+      .limit(1);
+    if (!recipient) return errorResponse(403, 'forbidden', 'Not a participant of this game.');
+  }
+
+  const [row] = await db
+    .select({
+      response: joshingGameResponses,
+      question: questions,
+    })
+    .from(joshingGameResponses)
+    .innerJoin(questions, eq(joshingGameResponses.questionId, questions.id))
+    .where(and(
+      eq(joshingGameResponses.gameId, body.gameId),
+      eq(joshingGameResponses.questionId, body.questionId),
+      eq(joshingGameResponses.userId, userId),
+    ))
+    .limit(1);
+
+  if (!row) return errorResponse(404, 'not_found', 'No answer recorded for that question.');
+  if (row.response.isCorrect === null) {
+    return NextResponse.json({ breadcrumb: null });
+  }
+
+  const isCorrect = Boolean(row.response.isCorrect);
+  const submittedAnswer = row.response.submittedAnswer ?? '';
+  if (!isCorrect && !submittedAnswer) {
+    return NextResponse.json({ breadcrumb: null });
+  }
+  const domain = row.question.canonicalSubcategory || row.question.broadCategory || row.question.category;
+
+  const breadcrumb = await generateBreadcrumb({
+    questionId: row.question.id,
+    questionText: row.question.questionText,
+    correctAnswer: row.question.answerText,
+    submittedAnswer,
+    isCorrect,
+    domain,
+  }).catch(() => null);
+
+  return NextResponse.json({ breadcrumb });
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session) return errorResponse(401, 'unauthorized', 'Please sign in.');
+
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return errorResponse(400, 'validation', 'Invalid breadcrumb request.');
+
+    const body: ParsedBody = parsed.data;
+    if (body.source === 'daily') return handleDaily(session.userId, body);
+    return handleJoshingGame(session.userId, body);
+  } catch (error) {
+    console.error('[breadcrumb] unexpected failure', error);
+    return errorResponse(500, 'unexpected', 'Could not generate a breadcrumb.');
+  }
+}

--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   createFeedItemsForFriendsFromAnswerMock,
-  generateBreadcrumbMock,
   getSessionMock,
   gradeAnswerMock,
   persistGeneratedQuestionMock,
@@ -53,7 +52,6 @@ const {
 
   return {
     createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
-    generateBreadcrumbMock: vi.fn(async () => null),
     getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
     gradeAnswerMock: vi.fn(),
     persistGeneratedQuestionMock: vi.fn(async () => ({
@@ -123,10 +121,6 @@ vi.mock('@/server/db', () => ({
     broadCategory: 'q.bc',
     category: 'q.c',
   },
-}))
-
-vi.mock('@/server/daily/generate-breadcrumb', () => ({
-  generateBreadcrumb: generateBreadcrumbMock,
 }))
 
 vi.mock('@/server/mastery/write-mastery-event', () => ({

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -10,7 +10,6 @@ import {
   generatedQuestions,
   questions,
 } from '@/server/db';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
 import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
@@ -152,16 +151,6 @@ export async function POST(request: NextRequest) {
     const isCorrect = grade.result === 'correct';
     const answerState = isCorrect ? 'correct' : 'incorrect';
     const quip = parsed.gaveUp ? null : selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-    const breadcrumb = parsed.gaveUp
-      ? null
-      : await generateBreadcrumb({
-          questionId: question.id,
-          questionText: question.questionText,
-          correctAnswer: canonicalAnswer,
-          submittedAnswer: parsed.submittedAnswer,
-          isCorrect,
-          domain: question.canonicalSubcategory,
-        }).catch(() => null);
 
     // Promote the bot question to a canonical row BEFORE writing the mastery
     // event so cross-surface dedup can key on the canonical Question.id
@@ -230,7 +219,6 @@ export async function POST(request: NextRequest) {
         awarded_points: pointsAwarded,
         reveal_canonical_answer: canonicalAnswer,
         reveal_explainer: question.explainer,
-        reveal_breadcrumb: breadcrumb,
         reveal_quip: grade.consolation,
         quip,
       } satisfies QueueSlot;
@@ -337,7 +325,7 @@ export async function POST(request: NextRequest) {
       explanation: question.explainer,
       pointsAwarded,
       answerState,
-      breadcrumb,
+      breadcrumb: null,
       masteryDelta,
       correctAnswer: canonicalAnswer,
       consolation: grade.consolation,

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   createFeedItemsForFriendsFromAnswerMock,
-  generateBreadcrumbMock,
   getCatchupQuestionsMock,
   getSessionMock,
   gradeAnswerMock,
@@ -14,7 +13,6 @@ const {
   writeMasteryEventMock,
 } = vi.hoisted(() => ({
   createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
-  generateBreadcrumbMock: vi.fn(async () => null),
   getCatchupQuestionsMock: vi.fn(),
   getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
   gradeAnswerMock: vi.fn(),
@@ -127,10 +125,6 @@ vi.mock('@/server/daily/catchup', () => ({
     slots.find((s) => s.slot_index === idx),
   replaceQueueSlot: (slots: { slot_index: number }[], idx: number, fn: (s: unknown) => unknown) =>
     slots.map((s) => (s.slot_index === idx ? fn(s) : s)),
-}))
-
-vi.mock('@/server/daily/generate-breadcrumb', () => ({
-  generateBreadcrumb: generateBreadcrumbMock,
 }))
 
 vi.mock('@/server/mastery/write-mastery-event', () => ({

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -7,7 +7,6 @@ import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, questions } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
@@ -80,14 +79,6 @@ export async function POST(request: NextRequest) {
   const isCorrect = grade.result === 'correct';
   const answerState = isCorrect ? 'correct' : 'incorrect';
   const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
-  const breadcrumb = await generateBreadcrumb({
-    questionId: catchupItem.questionId,
-    questionText: catchupItem.questionText,
-    correctAnswer: catchupItem.correctAnswer,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain: catchupItem.domain,
-  }).catch(() => null);
 
   // Promote the bot question to a canonical row BEFORE writing the mastery
   // event so cross-surface dedup can key on the canonical Question.id
@@ -152,7 +143,6 @@ export async function POST(request: NextRequest) {
       awarded_points: pointsAwarded,
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
-      reveal_breadcrumb: breadcrumb,
       reveal_quip: grade.consolation,
       quip,
     } satisfies QueueSlot;
@@ -254,7 +244,7 @@ export async function POST(request: NextRequest) {
     correct: isCorrect,
     pointsAwarded,
     answerState,
-    breadcrumb,
+    breadcrumb: null,
     awarded_points: pointsAwarded,
     masteryDelta,
     mastery_delta: masteryDelta,

--- a/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
+++ b/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   createFeedItemsForFriendsFromAnswerMock,
-  generateBreadcrumbMock,
   getBasePointsMock,
   getSessionMock,
   gradeAnswerMock,
@@ -13,7 +12,6 @@ const {
   writeMasteryEventMock,
 } = vi.hoisted(() => ({
   createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
-  generateBreadcrumbMock: vi.fn(async () => null),
   getBasePointsMock: vi.fn((_difficulty: unknown, state: string) => {
     if (state === 'first_correct') return 100
     if (state === 'first_correct_after_wrong') return 25
@@ -121,10 +119,6 @@ vi.mock('@/server/db', () => ({
     correctCount: 'q.correctCount',
   },
   users: { id: 'u.id', displayName: 'u.display' },
-}))
-
-vi.mock('@/server/daily/generate-breadcrumb', () => ({
-  generateBreadcrumb: generateBreadcrumbMock,
 }))
 
 vi.mock('@/server/mastery/scoring', () => ({

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -5,7 +5,6 @@ import { gradeAnswer, selectQuip } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
 import { promptCreatorNoteAfterWrongAnswer } from '@/server/creator-notes';
 import { db, feedItems, playerMastery, questions, users } from '@/server/db';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { getBasePoints, creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
 import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
@@ -95,14 +94,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
     : 0;
   const pointsAwarded = basePoints;
   const awardsMasteryCredit = pointsAwarded > 0;
-  const breadcrumb = await generateBreadcrumb({
-    questionId: question.id,
-    questionText: question.questionText,
-    correctAnswer: question.answerText,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain,
-  }).catch(() => null);
   const masteryDelta = await writeMasteryEvent({
     userId: session.userId,
     questionId: question.id,
@@ -230,7 +221,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     explanation,
     pointsAwarded,
     answerState,
-    breadcrumb,
+    breadcrumb: null,
     masteryDelta,
     correctAnswer: question.answerText,
     quip,

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -6,7 +6,6 @@ import { selectQuip, type FriendResult } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
 import { promptCreatorNoteAfterWrongAnswer } from '@/server/creator-notes';
 import { db, feedItems, joshingGameResponses, users } from '@/server/db';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import {
   checkJoshingGameCompletion,
   getJoshingGame,
@@ -101,16 +100,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
     const domain = answeredQuestion
       ? answeredQuestion.question.canonicalSubcategory || answeredQuestion.question.broadCategory || answeredQuestion.question.category
       : 'General Knowledge';
-    const breadcrumb = answeredQuestion
-      ? await generateBreadcrumb({
-          questionId: answeredQuestion.questionId,
-          questionText: answeredQuestion.question.questionText,
-          correctAnswer,
-          submittedAnswer: parsed.submittedAnswer,
-          isCorrect: grade.isCorrect,
-          domain,
-        }).catch(() => null)
-      : null;
 
     if (grade.isCorrect && answeredQuestion?.question.creatorId && answeredQuestion.question.creatorId !== session.userId) {
       void promoteDeclaredToDemonstrated({
@@ -212,7 +201,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       ...grade,
       correctAnswer,
       answerState: grade.answerState,
-      breadcrumb,
+      breadcrumb: null,
       viewerStatus: freshView.viewerStatus,
       quip,
     });

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -5,7 +5,6 @@ import { gradeAnswer, selectQuip } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
 import { promptCreatorNoteAfterWrongAnswer } from '@/server/creator-notes';
 import { db, playerMastery, questions } from '@/server/db';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { getBasePoints, creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
 import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
@@ -84,14 +83,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
     : 0;
   const pointsAwarded = basePoints;
   const awardsMasteryCredit = pointsAwarded > 0;
-  const breadcrumb = await generateBreadcrumb({
-    questionId: question.id,
-    questionText: question.questionText,
-    correctAnswer: question.answerText,
-    submittedAnswer: parsed.submittedAnswer,
-    isCorrect,
-    domain,
-  }).catch(() => null);
   const sourceId = `profile:${question.id}:${session.userId}`;
   const masteryDelta = await writeMasteryEvent({
     userId: session.userId,
@@ -197,7 +188,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     explanation: question.explainerFull ?? question.explainerBrief ?? question.factualExplanation,
     pointsAwarded,
     answerState,
-    breadcrumb,
+    breadcrumb: null,
     masteryDelta,
     correctAnswer: question.answerText,
     quip,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -449,6 +449,33 @@ export default function DailyPage() {
     return map;
   }, [queue?.slots]);
 
+  const fetchBreadcrumb = useCallback(async (queueId: string, slotIndex: number) => {
+    try {
+      const response = await fetch('/api/breadcrumb', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ source: 'daily', queueId, slotIndex }),
+      });
+      if (!response.ok) return;
+      const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
+      const breadcrumb = body?.breadcrumb ?? null;
+      if (!breadcrumb) return;
+      setQueue((existing) => existing && existing.queue_id === queueId
+        ? {
+            ...existing,
+            slots: existing.slots.map((slot) =>
+              slot.slot_index === slotIndex
+                ? { ...slot, reveal_breadcrumb: breadcrumb }
+                : slot,
+            ),
+          }
+        : existing);
+    } catch {
+      // Breadcrumb is purely additive context; failure is silently ignored.
+    }
+  }, []);
+
   const postAnswer = useCallback(async (opts: { submittedAnswer: string; gaveUp: boolean }) => {
     if (!queue || !currentSlot || submitting) return;
     setSubmitting(true);
@@ -489,7 +516,7 @@ export default function DailyPage() {
                     awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
                     reveal_canonical_answer: body.correctAnswer ?? body.answer,
                     reveal_explainer: body.explanation ?? body.explainer,
-                    reveal_breadcrumb: body.breadcrumb ?? null,
+                    reveal_breadcrumb: null,
                     reveal_quip: opts.gaveUp ? null : body.consolation ?? body.quip ?? null,
                   }
                 : slot
@@ -499,12 +526,16 @@ export default function DailyPage() {
       setPausedAfterSlotIndex(currentSlot.slot_index);
       window.setTimeout(() => setPausedAfterSlotIndex(null), 850);
       setAnswer('');
+
+      if (!opts.gaveUp) {
+        void fetchBreadcrumb(queue.queue_id, currentSlot.slot_index);
+      }
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not record that answer.');
     } finally {
       setSubmitting(false);
     }
-  }, [currentSlot, queue, submitting]);
+  }, [currentSlot, fetchBreadcrumb, queue, submitting]);
 
   const submitAnswer = useCallback(async () => {
     const trimmed = answer.trim();

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -1,9 +1,36 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+
+async function fetchJoshingGameBreadcrumb(
+  gameId: string,
+  questionId: string,
+  messageId: string,
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
+): Promise<void> {
+  try {
+    const response = await fetch('/api/breadcrumb', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ source: 'joshing_game', gameId, questionId }),
+    });
+    if (!response.ok) return;
+    const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
+    const breadcrumb = body?.breadcrumb ?? null;
+    if (!breadcrumb) return;
+    setMessages((existing) => existing.map((message) =>
+      message.id === messageId && message.kind === 'result'
+        ? { ...message, breadcrumb }
+        : message,
+    ));
+  } catch {
+    // Breadcrumb is purely additive context; failure is silently ignored.
+  }
+}
 import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 import type { JoshingGameView, QuestionRow } from '@/server/db/queries/joshing-game';
 
@@ -122,10 +149,11 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
       setAnsweredIds(nextAnswered);
       const nextQuestion = orderedQuestions.find((question) => !nextAnswered.has(question.questionId));
       setPausingAfterAnswer(true);
+      const resultMessageId = `result-${currentQuestion.questionId}`;
       setMessages((current) => [
         ...current,
         {
-          id: `result-${currentQuestion.questionId}`,
+          id: resultMessageId,
           kind: 'result',
           assignmentId: currentQuestion.questionId,
           questionText: currentQuestion.question.questionText,
@@ -133,7 +161,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
           submitted,
           correctAnswer: body.isCorrect ? null : body.correctAnswer ?? currentQuestion.question.answerText,
           consolation: null,
-          breadcrumb: body.breadcrumb ?? null,
+          breadcrumb: null,
           copyVariant: currentQuestion.position,
           creatorName: game.creator.displayName,
           canonicalSubcategory: currentQuestion.question.canonicalSubcategory,
@@ -147,6 +175,8 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
             : null,
         },
       ]);
+
+      void fetchJoshingGameBreadcrumb(game.game.id, currentQuestion.questionId, resultMessageId, setMessages);
 
       nextQuestionTimerRef.current = window.setTimeout(() => {
         setPausingAfterAnswer(false);

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -109,7 +109,6 @@ type AnswerResponse = {
   correctAnswer?: string
   explanation?: string | null
   quip?: string | null
-  breadcrumb?: string | null
   pointsAwarded?: number | null
   masteryDelta?: unknown | null
 }
@@ -120,7 +119,6 @@ type ResultState = {
   submittedAnswer: string
   explanation: string | null
   quip: string | null
-  breadcrumb: string | null
   awardedPoints: number | null
   masteryDelta: unknown | null
 }
@@ -702,7 +700,6 @@ function FeedListContent({
             submittedAnswer,
             explanation: body.explanation ?? null,
             quip: body.quip ?? null,
-            breadcrumb: body.breadcrumb ?? null,
             awardedPoints: body.pointsAwarded ?? null,
             masteryDelta: body.masteryDelta ?? null,
           },

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 
 import { newMessageId, type ChatMessage } from '@/components/play/GameplayChat';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
@@ -62,6 +62,33 @@ function formatQuestionSubhead(item: CatchupQueueItem): string {
   const date = new Date(`${item.queueDate}T12:00:00.000Z`);
   if (Number.isNaN(date.getTime())) return 'FROM EARLIER';
   return `FROM ${new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date).toUpperCase()}`;
+}
+
+async function fetchBreadcrumbForCatchupMessage(
+  queueId: string,
+  slotIndex: number,
+  messageId: string,
+  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
+): Promise<void> {
+  try {
+    const response = await fetch('/api/breadcrumb', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ source: 'daily', queueId, slotIndex }),
+    });
+    if (!response.ok) return;
+    const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
+    const breadcrumb = body?.breadcrumb ?? null;
+    if (!breadcrumb) return;
+    setMessages((existing) => existing.map((message) =>
+      message.id === messageId && message.kind === 'result'
+        ? { ...message, breadcrumb }
+        : message,
+    ));
+  } catch {
+    // Breadcrumb is purely additive context; failure is silently ignored.
+  }
 }
 
 function questionMessage(item: CatchupQueueItem): ChatMessage {
@@ -229,6 +256,7 @@ export function useCatchupFlow() {
       const data = raw as CatchupAnswerResponse;
       const isCorrect = Boolean(data.isCorrect ?? data.correct ?? data.result === 'correct');
       const pointsAwarded = Number(data.pointsAwarded ?? data.awarded_points ?? 0);
+      const resultMessageId = newMessageId();
       resultPostedItemIdsRef.current.add(item.dailyQueueItemId);
       setStats((existing) => ({
         answered: existing.answered + 1,
@@ -239,7 +267,7 @@ export function useCatchupFlow() {
         ...existing,
         { id: newMessageId(), kind: 'user', text: trimmedAnswer },
         {
-          id: newMessageId(),
+          id: resultMessageId,
           kind: 'result',
           assignmentId: item.dailyQueueItemId,
           questionText: item.questionText,
@@ -247,7 +275,7 @@ export function useCatchupFlow() {
           submitted: trimmedAnswer,
           correctAnswer: isCorrect ? null : data.correctAnswer ?? data.answer ?? item.correctAnswer,
           consolation: data.consolation ?? data.quip ?? null,
-          breadcrumb: data.breadcrumb ?? null,
+          breadcrumb: null,
           copyVariant: item.queueAge,
           creatorName: 'Joshing',
           canonicalSubcategory: item.domain,
@@ -255,6 +283,12 @@ export function useCatchupFlow() {
           pointsLabel: 'Catch-up - 0.25x points',
         },
       ]);
+
+      const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
+      const slotIndex = Number(slotIndexValue);
+      if (queueId && Number.isInteger(slotIndex)) {
+        void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
+      }
 
       window.setTimeout(() => {
         advancePast(item.dailyQueueItemId);

--- a/src/server/daily/generate-breadcrumb.ts
+++ b/src/server/daily/generate-breadcrumb.ts
@@ -12,11 +12,22 @@ type GenerateBreadcrumbParams = {
   domain: string;
 };
 
+const BREADCRUMB_CACHE_MAX = 500;
 const breadcrumbCache = new Map<string, string | null>();
 
 function cacheKey(params: GenerateBreadcrumbParams): string {
   const questionKey = params.questionId?.trim() || params.questionText.trim().toLowerCase();
   return `${questionKey}:${params.isCorrect ? 'correct' : 'wrong'}`;
+}
+
+function setCacheEntry(key: string, value: string | null): void {
+  if (breadcrumbCache.has(key)) breadcrumbCache.delete(key);
+  breadcrumbCache.set(key, value);
+  while (breadcrumbCache.size > BREADCRUMB_CACHE_MAX) {
+    const oldest = breadcrumbCache.keys().next().value;
+    if (oldest === undefined) break;
+    breadcrumbCache.delete(oldest);
+  }
 }
 
 function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T | null> {
@@ -45,7 +56,7 @@ export async function generateBreadcrumb(params: GenerateBreadcrumbParams): Prom
 
   const client = getAnthropicClient();
   if (!client) {
-    breadcrumbCache.set(key, null);
+    setCacheEntry(key, null);
     return null;
   }
 
@@ -73,6 +84,6 @@ Correct answer: ${params.correctAnswer}`,
 
   const response = await withTimeout(request, BREADCRUMB_TIMEOUT_MS);
   const text = response ? cleanBreadcrumb(extractTextContent(response.content)) : null;
-  breadcrumbCache.set(key, text);
+  setCacheEntry(key, text);
   return text;
 }


### PR DESCRIPTION
The five answer routes (daily, daily/catchup, feed/[id], questions/[id],
joshing-games/[id]) used to await generateBreadcrumb() in series with
gradeAnswer(), adding up to 3s of Haiku latency to the response. The
breadcrumb is purely additive context shown in the reveal card; users
read the reveal for ~2-3s, so fetching it separately after the answer
returns cuts perceived latency to ~300ms while still rendering the
breadcrumb in time.

- New POST /api/breadcrumb (Zod-validated) supports daily slots and
  joshing-game responses. For daily, it re-reads the slot, generates,
  and persists reveal_breadcrumb back so re-renders skip the LLM call.
  Mirrors the gaveUp short-circuit from daily/answer.
- Bounds breadcrumbCache at 500 entries with FIFO eviction.
- daily/page, useCatchupFlow, joshing-game play-client fire the new
  endpoint after the answer settles and patch the breadcrumb into the
  already-rendered card.
- FeedList stored breadcrumb in state but never rendered it; the field
  is gone now along with the dead AnswerResponse type entry.