### PR TITLE
perf: SSR homepage cards + prompt-cache the remaining LLM calls

### DIFF
--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -1,33 +1,10 @@
-import { and, count, eq, inArray, or } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { db, feedItems, friendships, questions, users } from '@/server/db';
-import { checkBankedQuestions } from '@/server/db/queries/bank';
-import { getDismissedDomains, getFeedForUser, type CollapsedFeedItem, type FeedCursor, type FeedFilter } from '@/server/db/queries/feed';
-import { DIRECT_SENT_FEED_SOURCE_TYPE, socialFeedDomainLabel, visibleFeedSourcePredicate } from '@/server/feed/visibility';
+import { type FeedCursor, type FeedFilter } from '@/server/db/queries/feed';
+import { decodeFeedCursor, getFeedPagePayload } from '@/server/feed/get-feed-page';
 
 export const dynamic = 'force-dynamic';
-
-const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
-
-const feedQuestionSelectColumns = {
-  id: questions.id,
-  questionText: questions.questionText,
-  answerText: questions.answerText,
-  creatorId: questions.creatorId,
-  explainerBrief: questions.explainerBrief,
-  factualExplanation: questions.factualExplanation,
-  canonicalSubcategory: questions.canonicalSubcategory,
-  broadCategory: questions.broadCategory,
-  category: questions.category,
-};
-
-async function selectFeedQuestions(questionIds: string[]) {
-  return questionIds.length
-    ? db.select(feedQuestionSelectColumns).from(questions).where(inArray(questions.id, questionIds))
-    : Promise.resolve([]);
-}
 
 const DEFAULT_PAGE_LIMIT = 20;
 const MAX_PAGE_LIMIT = 50;
@@ -35,32 +12,6 @@ const MAX_PAGE_LIMIT = 50;
 type ParsedPagination =
   | { limit: number; cursor: FeedCursor | null; filter: FeedFilter }
   | { error: string };
-
-function encodeCursor(cursor: FeedCursor | null): string | null {
-  if (!cursor) return null;
-
-  return Buffer.from(JSON.stringify({
-    source_event_at: cursor.sourceEventAt.toISOString(),
-    id: cursor.id,
-  })).toString('base64url');
-}
-
-function decodeCursor(value: string): FeedCursor | null {
-  try {
-    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as {
-      source_event_at?: unknown;
-      id?: unknown;
-    };
-    if (typeof parsed.source_event_at !== 'string' || typeof parsed.id !== 'string') return null;
-
-    const sourceEventAt = new Date(parsed.source_event_at);
-    if (Number.isNaN(sourceEventAt.getTime()) || parsed.id.trim().length === 0) return null;
-
-    return { sourceEventAt, id: parsed.id };
-  } catch {
-    return null;
-  }
-}
 
 function parsePagination(request: NextRequest): ParsedPagination {
   const limitParam = request.nextUrl.searchParams.get('limit');
@@ -71,7 +22,7 @@ function parsePagination(request: NextRequest): ParsedPagination {
   const limit = Number.isFinite(parsedLimit)
     ? Math.min(Math.max(parsedLimit, 1), MAX_PAGE_LIMIT)
     : DEFAULT_PAGE_LIMIT;
-  const cursor = cursorParam ? decodeCursor(cursorParam) : null;
+  const cursor = cursorParam ? decodeFeedCursor(cursorParam) : null;
 
   if (cursorParam && !cursor) return { error: 'invalid_cursor' };
   if (filterParam !== 'all' && filterParam !== 'sent-to-me' && filterParam !== 'from-friends') {
@@ -81,71 +32,6 @@ function parsePagination(request: NextRequest): ParsedPagination {
   return { limit, cursor, filter: filterParam };
 }
 
-type UserDisplay = { displayName: string | null; slug?: string | null };
-
-function humanizeSlug(slug: string | null | undefined): string | null {
-  const trimmed = slug?.trim();
-  if (!trimmed) return null;
-  const parts = trimmed.split(/[-_]+/).filter(Boolean);
-  if (parts.length === 0) return null;
-  return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
-}
-
-function displayName(user: UserDisplay | null | undefined, fallback = 'A friend') {
-  const name = user?.displayName?.trim();
-  if (name) return name;
-  const fromSlug = humanizeSlug(user?.slug);
-  if (fromSlug) return fromSlug;
-  return fallback;
-}
-
-function authoredSharedAttribution(sourceName: string, domain: string | null): string {
-  return domain ? `${sourceName} shared a question — ${domain}` : `${sourceName} shared a question`;
-}
-
-function directSentAttribution(sourceName: string, domain: string | null): string {
-  return domain ? `${sourceName} sent you a question — ${domain}` : `${sourceName} sent you a question`;
-}
-
-function feedFilterSourcePredicate(filter: FeedFilter) {
-  if (filter === 'sent-to-me') return eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE);
-  if (filter === 'from-friends') {
-    return inArray(feedItems.sourceType, ['friend_answered', 'authored_shared', 'thumbs_upped']);
-  }
-  return undefined;
-}
-
-function feedCardType(item: CollapsedFeedItem): 'direct_sent' | 'friend_answered' | 'friend_added' | 'friend_liked' | 'answered_by_you' {
-  if (item.state === 'answered') return 'answered_by_you';
-  if (item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE) return 'direct_sent';
-  if (item.sourceType === 'authored_shared') return 'friend_added';
-  if (item.sourceType === 'thumbs_upped') return 'friend_liked';
-  return 'friend_answered';
-}
-
-function friendAnsweredAttribution(
-  item: CollapsedFeedItem,
-  userById: Map<string, UserDisplay>,
-  domain: string | null,
-  authorName: string,
-): string {
-  const results = item.friendResults;
-  if (!results || results.length === 0) {
-    const name = displayName(userById.get(item.sourceUserId));
-    return domain ? `${name} knew ${authorName}’s question — ${domain}` : `${name} knew ${authorName}’s question`;
-  }
-
-  if (results.length === 1) {
-    const { displayName: answererName } = results[0];
-    return domain
-      ? `Common ground in ${domain}: ${answererName} knew ${authorName}’s question`
-      : `${answererName} and ${authorName} share this one`;
-  }
-
-  const names = results.slice(0, 3).map(({ displayName: answererName }) => answererName).join(' · ');
-  return domain ? `Common ground in ${domain}: ${names}` : `${names} share this one`;
-}
-
 export async function GET(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -153,155 +39,30 @@ export async function GET(request: NextRequest) {
   const pagination = parsePagination(request);
   if ('error' in pagination) return NextResponse.json({ error: pagination.error }, { status: 400 });
 
-  const { limit, cursor, filter } = pagination;
+  const payload = await getFeedPagePayload(session.userId, pagination);
 
-  const [feedPage, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
-    getFeedForUser(session.userId, { limit, cursor, filter }),
-    db
-      .select({ value: count() })
-      .from(friendships)
-      .where(and(
-        eq(friendships.status, 'active'),
-        or(eq(friendships.userAId, session.userId), eq(friendships.userBId, session.userId)),
-      ))
-      .then((rows) => rows[0]?.value ?? 0),
-    getDismissedDomains(session.userId),
-    db
-      .select({ value: count() })
-      .from(feedItems)
-      .where(and(
-        eq(feedItems.recipientUserId, session.userId),
-        visibleSourcePredicate,
-        feedFilterSourcePredicate(filter),
-      ))
-      .then((rows) => rows[0]?.value ?? 0),
-    db
-      .select({ value: count() })
-      .from(feedItems)
-      .where(and(
-        eq(feedItems.recipientUserId, session.userId),
-        visibleSourcePredicate,
-        feedFilterSourcePredicate(filter),
-        inArray(feedItems.state, ['active', 'skipped']),
-      ))
-      .then((rows) => rows[0]?.value ?? 0),
-  ]);
-
-  const activeItemCount = feedPage.totalCount;
-  const feed = feedPage.items;
-  const pageItemCount = feedPage.items.length;
-  const nextCursor = encodeCursor(feedPage.nextCursor);
-  const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
   const verboseFeedDebug = process.env.FEED_DEBUG_VERBOSE === 'true';
-
   console.info('[feed/get]', {
     userId: session.userId,
-    limit,
-    filter,
-    cursorPresent: Boolean(cursor),
-    friendCount,
-    dismissedDomainCount: dismissedDomains.length,
-    totalItemCount,
-    preFilterActiveCount,
-    activeItemCount: feedPage.totalCount,
-    pageItemCount: feedPage.items.length,
-    hasMore: feedPage.hasMore,
+    limit: pagination.limit,
+    filter: pagination.filter,
+    cursorPresent: Boolean(pagination.cursor),
+    friendCount: payload.meta.has_friends ? 'positive' : 0,
+    dismissedDomainCount: payload.meta.has_dismissed_domains ? 'positive' : 0,
+    totalItemCount: payload.meta.total_item_count,
+    preFilterActiveCount: payload.meta.pre_filter_active_count,
+    activeItemCount: payload.meta.active_item_count,
+    pageItemCount: payload.meta.page_item_count,
+    hasMore: payload.meta.has_more,
     ...(verboseFeedDebug
       ? {
-          feedItemPreview: feedPage.items.map((item) => ({
+          feedItemPreview: payload.items.map((item) => ({
             id: item.id,
-            sourceType: item.sourceType,
+            sourceType: item.source_type,
           })),
         }
       : {}),
   });
 
-  const [questionRows, bankedById] = await Promise.all([
-    selectFeedQuestions(questionIds),
-    checkBankedQuestions(session.userId, questionIds),
-  ]);
-
-  const questionById = new Map(questionRows.map((q) => [q.id, q]));
-  const userIds = [...new Set([
-    ...feed.map((item) => item.sourceUserId),
-    ...questionRows.map((question) => question.creatorId).filter((id): id is string => Boolean(id)),
-  ])];
-  const userRows = userIds.length
-    ? await db.select({ id: users.id, displayName: users.displayName, slug: users.slug }).from(users).where(inArray(users.id, userIds))
-    : [];
-  const userById = new Map(userRows.map((u) => [u.id, u]));
-
-  return NextResponse.json({
-    viewer_user_id: session.userId,
-    meta: {
-      has_friends: friendCount > 0,
-      has_dismissed_domains: dismissedDomains.length > 0,
-      total_item_count: totalItemCount,
-      active_item_count: activeItemCount,
-      pre_filter_active_count: preFilterActiveCount,
-      page_item_count: pageItemCount,
-      limit,
-      cursor: cursor ? encodeCursor(cursor) : null,
-      next_cursor: nextCursor,
-      has_more: feedPage.hasMore,
-      filter,
-    },
-    next_cursor: nextCursor,
-    has_more: feedPage.hasMore,
-    items: feed.map((item) => {
-      const question = item.questionId ? questionById.get(item.questionId) : undefined;
-      const sourceUser = userById.get(item.sourceUserId);
-      const sourceName = displayName(sourceUser);
-      const authorName = displayName(question?.creatorId ? userById.get(question.creatorId) : null, 'the author');
-      const domain = socialFeedDomainLabel(question);
-      const cardType = feedCardType(item);
-      // Fall back to viewer's mastery-event answer status when answerResult is null
-      // (legacy feed items answered before the answerResult column was added).
-      const answerResult = item.answerResult ?? item.viewerAnswerStatus?.result ?? null;
-      const awardedPoints = typeof item.pointsAwarded === 'number' ? item.pointsAwarded : null;
-
-      return {
-        id: item.id,
-        kind: 'question',
-        card_type: cardType,
-        type: cardType,
-        question_id: item.questionId,
-        joshing_game_id: item.joshingGameId,
-        source_type: item.sourceType,
-        source_user_id: item.sourceUserId,
-        source_result: item.sourceResult ?? null,
-        source_friend_display_name: sourceName,
-        source_profile_href: `/users/${encodeURIComponent(item.sourceUserId)}`,
-        source_attribution: item.sourceType === 'authored_shared'
-          ? authoredSharedAttribution(sourceName, domain)
-          : item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE
-            ? directSentAttribution(sourceName, domain)
-            : friendAnsweredAttribution(item, userById, domain, authorName),
-        friend_results: item.friendResults ?? null,
-        viewer_answer_status: item.viewerAnswerStatus ?? null,
-        endorsement_count: item.thumbsUpCount ?? null,
-        additional_endorsers: item.additionalEndorsers ?? null,
-        source_event_at: item.sourceEventAt,
-        personal_message: item.personalMessage,
-        state: item.state,
-        is_pinned: item.isPinned,
-        question_text: question?.questionText ?? null,
-        verified: true,
-        is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
-        explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
-        domain_pill: domain,
-        broad_category: question?.broadCategory ?? null,
-        game_title: null,
-        difficulty: null,
-        answer_result: answerResult,
-        is_correct: answerResult === null ? null : answerResult === 'correct',
-        correct_answer: cardType === 'answered_by_you' ? question?.answerText ?? null : null,
-        submitted_answer: cardType === 'answered_by_you' ? item.submittedAnswer ?? null : null,
-        awarded_points: cardType === 'answered_by_you' ? awardedPoints : null,
-        mastery_delta: cardType === 'answered_by_you' ? item.masteryDelta ?? null : null,
-        unverified_answer: false,
-        viewer_is_author: question?.creatorId ? question.creatorId === session.userId : false,
-      };
-    }),
-  });
+  return NextResponse.json(payload);
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,22 @@
+import { Suspense } from 'react'
 import Link from 'next/link'
 import FeedList from '@/components/FeedList'
-import TodaysFiveCard from '@/components/TodaysFiveCard'
+import TodaysFiveCard, {
+  type DailyPreferences,
+  type DailyStatus,
+} from '@/components/TodaysFiveCard'
 import { getSession } from '@/server/auth/session'
-import { getCatchupQuestions } from '@/server/db/queries/daily'
+import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types'
+import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
+import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
+import { getCeremonyBanner } from '@/server/db/queries/ceremony'
+import { getFeedPagePayload } from '@/server/feed/get-feed-page'
+import { getNextDailyResetBoundary } from '@/lib/games/timezone'
+
+const FEED_PAGE_SIZE = 20
 
 export default async function Home() {
   const session = await getSession()
-  const catchupItems = session ? await getCatchupQuestions(session.userId) : []
-  const catchupCount = catchupItems.length
-  const expiringCount = catchupItems.filter((item) => item.expiresSoon).length
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24 md:py-10">
@@ -19,20 +27,122 @@ export default async function Home() {
           </h1>
         </div>
         <div className="w-full space-y-3">
-          <TodaysFiveCard />
-          <MissedQuestionsCard
-            count={catchupCount}
-            expiringCount={expiringCount}
-          />
+          {session ? (
+            <Suspense fallback={<CardSkeleton minHeight="9rem" />}>
+              <TodaysFiveSection userId={session.userId} />
+            </Suspense>
+          ) : (
+            <TodaysFiveCard />
+          )}
+          {session ? (
+            <Suspense fallback={null}>
+              <MissedQuestionsSection userId={session.userId} />
+            </Suspense>
+          ) : null}
           <div>
             <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
               What&apos;s happening
             </p>
-            <FeedList pageSize={20} infinite />
+            {session ? (
+              <Suspense fallback={<FeedSkeleton />}>
+                <FeedSection userId={session.userId} />
+              </Suspense>
+            ) : (
+              <FeedList pageSize={FEED_PAGE_SIZE} infinite />
+            )}
           </div>
         </div>
       </section>
     </main>
+  )
+}
+
+async function TodaysFiveSection({ userId }: { userId: string }) {
+  const [queue, preferences] = await Promise.all([
+    getTodaysDailyQueue(userId),
+    getDailyPreferences(userId),
+  ])
+
+  const status = buildDailyStatusSnapshot(queue)
+  const cardPreferences: DailyPreferences = {
+    difficulty: preferences.difficulty,
+    domainMode: preferences.domainMode,
+    selectedDomains: preferences.selectedDomains,
+  }
+
+  return (
+    <TodaysFiveCard
+      initialStatus={status}
+      initialPreferences={cardPreferences}
+    />
+  )
+}
+
+async function MissedQuestionsSection({ userId }: { userId: string }) {
+  const catchupItems = await getCatchupQuestions(userId)
+  const count = catchupItems.length
+  if (count === 0) return null
+  const expiringCount = catchupItems.filter((item) => item.expiresSoon).length
+  return <MissedQuestionsCard count={count} expiringCount={expiringCount} />
+}
+
+async function FeedSection({ userId }: { userId: string }) {
+  const [feedPage, banner] = await Promise.all([
+    getFeedPagePayload(userId, { limit: FEED_PAGE_SIZE, cursor: null, filter: 'all' }),
+    getCeremonyBanner(userId),
+  ])
+
+  return (
+    <FeedList
+      pageSize={FEED_PAGE_SIZE}
+      infinite
+      initialPage={feedPage}
+      initialBanner={banner ? { id: banner.id, firedAt: banner.firedAt.toISOString() } : null}
+    />
+  )
+}
+
+function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDailyQueue>>): DailyStatus {
+  const nextRoundAt = getNextDailyResetBoundary().toISOString()
+  if (!queue) {
+    return {
+      questionsRemaining: DAILY_QUEUE_SIZE,
+      questionsAnswered: 0,
+      isComplete: false,
+      nextRoundAt,
+      queueId: null,
+    }
+  }
+
+  const slots: QueueSlot[] = Array.isArray(queue.slots) ? (queue.slots as QueueSlot[]) : []
+  const answered = slots.filter((slot) => slot.answered).length
+  const questionsAnswered = Math.min(answered, DAILY_QUEUE_SIZE)
+  const questionsRemaining = Math.max(DAILY_QUEUE_SIZE - questionsAnswered, 0)
+  const isComplete = questionsAnswered >= DAILY_QUEUE_SIZE
+  return {
+    questionsRemaining,
+    questionsAnswered,
+    isComplete,
+    nextRoundAt,
+    queueId: queue.id,
+  }
+}
+
+function CardSkeleton({ minHeight }: { minHeight: string }) {
+  return (
+    <div
+      className="bg-card rounded-lg border p-4"
+      style={{ minHeight }}
+      aria-hidden="true"
+    />
+  )
+}
+
+function FeedSkeleton() {
+  return (
+    <div className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
+      Loading feed…
+    </div>
   )
 }
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -405,6 +405,15 @@ function toAnsweredByYouItem(
 type FeedListProps = {
   pageSize?: number
   infinite?: boolean
+  /**
+   * Server-rendered first page. When supplied, the initial client fetch is
+   * skipped — items, cursor, and meta are seeded from this prop so the user
+   * sees the feed on first paint with no client round-trip. Subsequent filter
+   * changes and infinite-scroll pages still fetch via /api/feed.
+   */
+  initialPage?: FeedResponse | null
+  /** Server-rendered ceremony banner; same rationale as initialPage. */
+  initialBanner?: CeremonyBanner | null
 }
 
 type QuestionCardState = 'unanswered' | 'answered'
@@ -428,6 +437,8 @@ function FeedListLoading() {
 function FeedListContent({
   pageSize = 20,
   infinite = false,
+  initialPage = null,
+  initialBanner = null,
 }: FeedListProps) {
   const searchParams = useSearchParams()
   const initialFilterParam =
@@ -436,21 +447,39 @@ function FeedListContent({
     initialFilterParam === 'sent-to-me' || initialFilterParam === 'from-friends'
       ? initialFilterParam
       : 'all'
+  // initialPage is only valid for the 'all' filter (that's what the server
+  // pre-fetches). If the URL pins a different filter, fall back to client fetch.
+  const initialPageMatchesFilter = initialPage !== null && initialFilter === 'all'
   const [feedFilter, setFeedFilter] = useState<FeedFilter>(initialFilter)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
-  const [items, setItems] = useState<FeedApiItem[]>([])
-  const [nextCursor, setNextCursor] = useState<string | null>(null)
-  const [hasMore, setHasMore] = useState(false)
-  const [loadingInitial, setLoadingInitial] = useState(true)
+  const [items, setItems] = useState<FeedApiItem[]>(
+    initialPageMatchesFilter ? initialPage!.items : []
+  )
+  const [nextCursor, setNextCursor] = useState<string | null>(
+    initialPageMatchesFilter
+      ? initialPage!.next_cursor ?? initialPage!.meta?.next_cursor ?? null
+      : null
+  )
+  const [hasMore, setHasMore] = useState(
+    initialPageMatchesFilter
+      ? Boolean(initialPage!.has_more ?? initialPage!.meta?.has_more)
+      : false
+  )
+  const [loadingInitial, setLoadingInitial] = useState(!initialPageMatchesFilter)
   const [loadingMore, setLoadingMore] = useState(false)
-  const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(null)
+  const [feedMeta, setFeedMeta] = useState<FeedMeta | null>(
+    initialPageMatchesFilter ? initialPage!.meta ?? null : null
+  )
   const [results, setResults] = useState<Record<string, ResultState>>({})
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({})
   const [answerSheetId, setAnswerSheetId] = useState<string | null>(null)
   const [feedbackSheetId, setFeedbackSheetId] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
-  const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(null)
+  const [ceremonyBanner, setCeremonyBanner] = useState<CeremonyBanner | null>(initialBanner)
+  // True for the very first render path when we already have server-rendered
+  // data; the initial-fetch useEffect skips its work once.
+  const skipInitialFetchRef = useRef(initialPageMatchesFilter)
 
   const loadFeed = useCallback(
     async (cursor?: string | null) => {
@@ -514,6 +543,10 @@ function FeedListContent({
   )
 
   useEffect(() => {
+    if (skipInitialFetchRef.current) {
+      skipInitialFetchRef.current = false
+      return
+    }
     const timer = window.setTimeout(() => {
       void loadFeed()
     }, 0)

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -2,9 +2,9 @@
 
 import Link from 'next/link'
 import { CheckCircle2, Clock, MessageCircleQuestion, Settings } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 
-type DailyStatus = {
+export type DailyStatus = {
   questionsRemaining: number
   questionsAnswered: number
   isComplete: boolean
@@ -12,10 +12,17 @@ type DailyStatus = {
   queueId: string | null
 }
 
-type DailyPreferences = {
+export type DailyPreferences = {
   difficulty: 'normal' | 'moderate' | 'challenging' | 'ridiculous' | 'adaptive'
   domainMode: 'random' | 'custom'
   selectedDomains: string[]
+}
+
+type TodaysFiveCardProps = {
+  /** When supplied, the initial /api/daily/status fetch is skipped. */
+  initialStatus?: DailyStatus | null
+  /** When supplied, the initial /api/daily/preferences fetch is skipped. */
+  initialPreferences?: DailyPreferences | null
 }
 
 const DIFFICULTY_LABELS: Record<string, string> = {
@@ -60,14 +67,23 @@ function formatCountdown(targetIso: string, nowMs: number): string {
   return `${totalMinutes}m`
 }
 
-export default function TodaysFiveCard() {
-  const [status, setStatus] = useState<DailyStatus | null>(null)
-  const [preferences, setPreferences] = useState<DailyPreferences | null>(null)
+export default function TodaysFiveCard({
+  initialStatus = null,
+  initialPreferences = null,
+}: TodaysFiveCardProps = {}) {
+  const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
+  const [preferences, setPreferences] = useState<DailyPreferences | null>(initialPreferences)
   const [nowMs, setNowMs] = useState(() => Date.now())
   const [resetting, setResetting] = useState(false)
   const [resetError, setResetError] = useState<string | null>(null)
+  // Skip the initial /api/daily/* fetch when the server already provided both.
+  const skipInitialFetchRef = useRef(initialStatus !== null && initialPreferences !== null)
 
   useEffect(() => {
+    if (skipInitialFetchRef.current) {
+      skipInitialFetchRef.current = false
+      return
+    }
     let cancelled = false
 
     async function loadStatus() {

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -508,7 +508,7 @@ Categorize this question. Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 300,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -552,7 +552,7 @@ Return JSON only.`;
         model: ANTHROPIC_MODEL,
         max_tokens: 120,
         temperature: 0,
-        system: refinementPrompt,
+        system: [{ type: 'text', text: refinementPrompt, cache_control: { type: 'ephemeral' } }],
         messages: [{ role: 'user', content: refinementMessage }],
       });
 
@@ -622,7 +622,7 @@ Write brief and full explainers. Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 800,
       temperature: 0.7,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -677,7 +677,7 @@ Write 2–3 sentences of factual explanation.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 400,
       temperature: 0.45,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -744,7 +744,7 @@ Suggest a canonical answer and classify the question type. Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 600,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -831,7 +831,7 @@ Suggest specific topic tags. Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 150,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -884,7 +884,7 @@ Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 120,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 
@@ -932,7 +932,7 @@ No explanation outside the JSON.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 200,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 

--- a/src/server/daily/generate-breadcrumb.ts
+++ b/src/server/daily/generate-breadcrumb.ts
@@ -68,7 +68,11 @@ export async function generateBreadcrumb(params: GenerateBreadcrumbParams): Prom
     model: BREADCRUMB_MODEL,
     max_tokens: 120,
     temperature: 0.55,
-    system: 'You write tiny contextual breadcrumbs for a warm trivia chat. Return plain text only, no markdown.',
+    system: [{
+      type: 'text',
+      text: 'You write tiny contextual breadcrumbs for a warm trivia chat. Return plain text only, no markdown.',
+      cache_control: { type: 'ephemeral' },
+    }],
     messages: [
       {
         role: 'user',

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -1,0 +1,276 @@
+/**
+ * Server-side feed page builder.
+ *
+ * This is the single source of truth for the shape returned to clients on
+ * /api/feed. The HTTP handler at src/app/api/feed/route.ts is a thin wrapper
+ * around getFeedPagePayload; the homepage server component calls it directly
+ * to hydrate <FeedList /> with the first page (no client round-trip).
+ */
+
+import { and, count, eq, inArray, or } from 'drizzle-orm';
+
+import { db, feedItems, friendships, questions, users } from '@/server/db';
+import { checkBankedQuestions } from '@/server/db/queries/bank';
+import {
+  getDismissedDomains,
+  getFeedForUser,
+  type CollapsedFeedItem,
+  type FeedCursor,
+  type FeedFilter,
+} from '@/server/db/queries/feed';
+import {
+  DIRECT_SENT_FEED_SOURCE_TYPE,
+  socialFeedDomainLabel,
+  visibleFeedSourcePredicate,
+} from '@/server/feed/visibility';
+
+const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
+
+const feedQuestionSelectColumns = {
+  id: questions.id,
+  questionText: questions.questionText,
+  answerText: questions.answerText,
+  creatorId: questions.creatorId,
+  explainerBrief: questions.explainerBrief,
+  factualExplanation: questions.factualExplanation,
+  canonicalSubcategory: questions.canonicalSubcategory,
+  broadCategory: questions.broadCategory,
+  category: questions.category,
+};
+
+async function selectFeedQuestions(questionIds: string[]) {
+  return questionIds.length
+    ? db.select(feedQuestionSelectColumns).from(questions).where(inArray(questions.id, questionIds))
+    : Promise.resolve([]);
+}
+
+export function encodeFeedCursor(cursor: FeedCursor | null): string | null {
+  if (!cursor) return null;
+  return Buffer.from(JSON.stringify({
+    source_event_at: cursor.sourceEventAt.toISOString(),
+    id: cursor.id,
+  })).toString('base64url');
+}
+
+export function decodeFeedCursor(value: string): FeedCursor | null {
+  try {
+    const parsed = JSON.parse(Buffer.from(value, 'base64url').toString('utf8')) as {
+      source_event_at?: unknown;
+      id?: unknown;
+    };
+    if (typeof parsed.source_event_at !== 'string' || typeof parsed.id !== 'string') return null;
+
+    const sourceEventAt = new Date(parsed.source_event_at);
+    if (Number.isNaN(sourceEventAt.getTime()) || parsed.id.trim().length === 0) return null;
+
+    return { sourceEventAt, id: parsed.id };
+  } catch {
+    return null;
+  }
+}
+
+type UserDisplay = { displayName: string | null; slug?: string | null };
+
+function humanizeSlug(slug: string | null | undefined): string | null {
+  const trimmed = slug?.trim();
+  if (!trimmed) return null;
+  const parts = trimmed.split(/[-_]+/).filter(Boolean);
+  if (parts.length === 0) return null;
+  return parts.map((part) => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+}
+
+function displayName(user: UserDisplay | null | undefined, fallback = 'A friend') {
+  const name = user?.displayName?.trim();
+  if (name) return name;
+  const fromSlug = humanizeSlug(user?.slug);
+  if (fromSlug) return fromSlug;
+  return fallback;
+}
+
+function authoredSharedAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} shared a question — ${domain}` : `${sourceName} shared a question`;
+}
+
+function directSentAttribution(sourceName: string, domain: string | null): string {
+  return domain ? `${sourceName} sent you a question — ${domain}` : `${sourceName} sent you a question`;
+}
+
+function feedFilterSourcePredicate(filter: FeedFilter) {
+  if (filter === 'sent-to-me') return eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE);
+  if (filter === 'from-friends') {
+    return inArray(feedItems.sourceType, ['friend_answered', 'authored_shared', 'thumbs_upped']);
+  }
+  return undefined;
+}
+
+function feedCardType(item: CollapsedFeedItem): 'direct_sent' | 'friend_answered' | 'friend_added' | 'friend_liked' | 'answered_by_you' {
+  if (item.state === 'answered') return 'answered_by_you';
+  if (item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE) return 'direct_sent';
+  if (item.sourceType === 'authored_shared') return 'friend_added';
+  if (item.sourceType === 'thumbs_upped') return 'friend_liked';
+  return 'friend_answered';
+}
+
+function friendAnsweredAttribution(
+  item: CollapsedFeedItem,
+  userById: Map<string, UserDisplay>,
+  domain: string | null,
+  authorName: string,
+): string {
+  const results = item.friendResults;
+  if (!results || results.length === 0) {
+    const name = displayName(userById.get(item.sourceUserId));
+    return domain ? `${name} knew ${authorName}’s question — ${domain}` : `${name} knew ${authorName}’s question`;
+  }
+
+  if (results.length === 1) {
+    const { displayName: answererName } = results[0];
+    return domain
+      ? `Common ground in ${domain}: ${answererName} knew ${authorName}’s question`
+      : `${answererName} and ${authorName} share this one`;
+  }
+
+  const names = results.slice(0, 3).map(({ displayName: answererName }) => answererName).join(' · ');
+  return domain ? `Common ground in ${domain}: ${names}` : `${names} share this one`;
+}
+
+export type FeedPageOptions = {
+  limit: number;
+  cursor: FeedCursor | null;
+  filter: FeedFilter;
+};
+
+export type FeedPagePayload = Awaited<ReturnType<typeof getFeedPagePayload>>;
+
+export async function getFeedPagePayload(viewerUserId: string, options: FeedPageOptions) {
+  const { limit, cursor, filter } = options;
+
+  const [feedPage, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
+    getFeedForUser(viewerUserId, { limit, cursor, filter }),
+    db
+      .select({ value: count() })
+      .from(friendships)
+      .where(and(
+        eq(friendships.status, 'active'),
+        or(eq(friendships.userAId, viewerUserId), eq(friendships.userBId, viewerUserId)),
+      ))
+      .then((rows) => rows[0]?.value ?? 0),
+    getDismissedDomains(viewerUserId),
+    db
+      .select({ value: count() })
+      .from(feedItems)
+      .where(and(
+        eq(feedItems.recipientUserId, viewerUserId),
+        visibleSourcePredicate,
+        feedFilterSourcePredicate(filter),
+      ))
+      .then((rows) => rows[0]?.value ?? 0),
+    db
+      .select({ value: count() })
+      .from(feedItems)
+      .where(and(
+        eq(feedItems.recipientUserId, viewerUserId),
+        visibleSourcePredicate,
+        feedFilterSourcePredicate(filter),
+        inArray(feedItems.state, ['active', 'skipped']),
+      ))
+      .then((rows) => rows[0]?.value ?? 0),
+  ]);
+
+  const activeItemCount = feedPage.totalCount;
+  const feed = feedPage.items;
+  const pageItemCount = feedPage.items.length;
+  const nextCursor = encodeFeedCursor(feedPage.nextCursor);
+  const questionIds = feed.map((item) => item.questionId).filter((id): id is string => Boolean(id));
+
+  const [questionRows, bankedById] = await Promise.all([
+    selectFeedQuestions(questionIds),
+    checkBankedQuestions(viewerUserId, questionIds),
+  ]);
+
+  const questionById = new Map(questionRows.map((q) => [q.id, q]));
+  const userIds = [...new Set([
+    ...feed.map((item) => item.sourceUserId),
+    ...questionRows.map((question) => question.creatorId).filter((id): id is string => Boolean(id)),
+  ])];
+  const userRows = userIds.length
+    ? await db.select({ id: users.id, displayName: users.displayName, slug: users.slug }).from(users).where(inArray(users.id, userIds))
+    : [];
+  const userById = new Map(userRows.map((u) => [u.id, u]));
+
+  return {
+    viewer_user_id: viewerUserId,
+    meta: {
+      has_friends: friendCount > 0,
+      has_dismissed_domains: dismissedDomains.length > 0,
+      total_item_count: totalItemCount,
+      active_item_count: activeItemCount,
+      pre_filter_active_count: preFilterActiveCount,
+      page_item_count: pageItemCount,
+      limit,
+      cursor: cursor ? encodeFeedCursor(cursor) : null,
+      next_cursor: nextCursor,
+      has_more: feedPage.hasMore,
+      filter,
+    },
+    next_cursor: nextCursor,
+    has_more: feedPage.hasMore,
+    items: feed.map((item) => {
+      const question = item.questionId ? questionById.get(item.questionId) : undefined;
+      const sourceUser = userById.get(item.sourceUserId);
+      const sourceName = displayName(sourceUser);
+      const authorName = displayName(question?.creatorId ? userById.get(question.creatorId) : null, 'the author');
+      const domain = socialFeedDomainLabel(question);
+      const cardType = feedCardType(item);
+      // Fall back to viewer's mastery-event answer status when answerResult is null
+      // (legacy feed items answered before the answerResult column was added).
+      const answerResult = item.answerResult ?? item.viewerAnswerStatus?.result ?? null;
+      const awardedPoints = typeof item.pointsAwarded === 'number' ? item.pointsAwarded : null;
+
+      return {
+        id: item.id,
+        kind: 'question' as const,
+        card_type: cardType,
+        type: cardType,
+        question_id: item.questionId,
+        joshing_game_id: item.joshingGameId,
+        source_type: item.sourceType,
+        source_user_id: item.sourceUserId,
+        source_result: item.sourceResult ?? null,
+        source_friend_display_name: sourceName,
+        source_profile_href: `/users/${encodeURIComponent(item.sourceUserId)}`,
+        source_attribution: item.sourceType === 'authored_shared'
+          ? authoredSharedAttribution(sourceName, domain)
+          : item.sourceType === DIRECT_SENT_FEED_SOURCE_TYPE
+            ? directSentAttribution(sourceName, domain)
+            : friendAnsweredAttribution(item, userById, domain, authorName),
+        friend_results: item.friendResults ?? null,
+        viewer_answer_status: item.viewerAnswerStatus ?? null,
+        endorsement_count: item.thumbsUpCount ?? null,
+        additional_endorsers: item.additionalEndorsers ?? null,
+        source_event_at: item.sourceEventAt instanceof Date
+          ? item.sourceEventAt.toISOString()
+          : item.sourceEventAt,
+        personal_message: item.personalMessage,
+        state: item.state,
+        is_pinned: item.isPinned,
+        question_text: question?.questionText ?? null,
+        verified: true,
+        is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
+        explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
+        domain_pill: domain,
+        broad_category: question?.broadCategory ?? null,
+        game_title: null,
+        difficulty: null,
+        answer_result: answerResult,
+        is_correct: answerResult === null ? null : answerResult === 'correct',
+        correct_answer: cardType === 'answered_by_you' ? question?.answerText ?? null : null,
+        submitted_answer: cardType === 'answered_by_you' ? item.submittedAnswer ?? null : null,
+        awarded_points: cardType === 'answered_by_you' ? awardedPoints : null,
+        mastery_delta: cardType === 'answered_by_you' ? item.masteryDelta ?? null : null,
+        unverified_answer: false,
+        viewer_is_author: question?.creatorId ? question.creatorId === viewerUserId : false,
+      };
+    }),
+  };
+}

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -229,7 +229,7 @@ Propose candidate interests. Return JSON array only.`;
     model: ANTHROPIC_MODEL,
     max_tokens: 1600,
     temperature: 0.65,
-    system: systemPrompt,
+    system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
     messages: [{ role: 'user', content: userMessage }],
   });
 
@@ -289,7 +289,7 @@ Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation
     model: CANONICALIZE_MODEL,
     max_tokens: 260,
     temperature: 0.2,
-    system: systemPrompt,
+    system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
     messages: [{ role: 'user', content: cleanInput }],
   });
 

--- a/src/server/llm/recheck.ts
+++ b/src/server/llm/recheck.ts
@@ -92,7 +92,7 @@ Should this challenged answer count? Return JSON only.`;
       model: ANTHROPIC_MODEL,
       max_tokens: 400,
       temperature: 0,
-      system: systemPrompt,
+      system: [{ type: 'text', text: systemPrompt, cache_control: { type: 'ephemeral' } }],
       messages: [{ role: 'user', content: userMessage }],
     });
 


### PR DESCRIPTION
## Summary

Two more items from the performance audit — the homepage SSR-then-CSR waterfall (#4) and prompt caching on the remaining LLM system prompts (#5).

### 1. SSR the homepage cards instead of CSR fetch waterfall (6373795)

The homepage previously rendered an empty shell, then fired four sequential client requests (`/api/daily/status`, `/api/daily/preferences`, `/api/feed`, `/api/ceremony/banner`) before showing populated content — ~3 RTTs added to LCP for every authenticated load.

- **New helper `src/server/feed/get-feed-page.ts`** extracts the `/api/feed` GET body into `getFeedPagePayload(userId, options)` returning the same JSON shape. The route handler is now ~70 lines (down from ~310) and is a thin wrapper.
- **`src/app/page.tsx`** is now a streaming server component. Each card is an async section wrapped in `<Suspense>`, fetching its data in parallel server-side and passing it as initial props.
- **`TodaysFiveCard`** accepts optional `initialStatus` / `initialPreferences`.
- **`FeedList`** accepts optional `initialPage` / `initialBanner`. Filter switches and infinite scroll still hit `/api/feed`.
- Unauthenticated `/` and `/feed` keep their existing client-fetch behavior (no props passed).

### 2. Enable prompt caching on the remaining LLM system prompts (018b61a)

`gradeAnswerWithLLM` already had `cache_control: { type: 'ephemeral' }` on its system prompt. Added the same to **11 other** static system prompts:

- `lib/llm.ts`: `categorizeQuestion` (main + refinement), `generateExplainer`, `generateFactualReflectionExplanation`, `suggestAnswer`, `suggestTags`, `resolveCanonicalSubcategoryWithLLM`, `cleanQuestion`
- `server/daily/generate-breadcrumb.ts`
- `server/llm/interests.ts` (two call sites)
- `server/llm/recheck.ts`

Question-creation alone fires `suggestAnswer` + `cleanQuestion` + `categorizeQuestion` per save; steady-state cost of those system prompts drops to a cache-read price (~10x cheaper) and TTFT should improve ~30–60%. `critique.ts` is intentionally skipped — its system prompt is one sentence and the bulk of the prompt is in the dynamic user message.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean.
- [x] `npm run lint` — no new violations on any touched file.
- [x] `npx vitest run` — no new test failures vs. `dev2`. (9 pre-existing failures reproduce identically on the base branch.)
- [ ] Manual: load `/` while signed in, check DevTools Network panel. Expected: zero client requests to `/api/daily/status`, `/api/daily/preferences`, `/api/feed`, `/api/ceremony/banner` on first load. Click a feed filter button and confirm `/api/feed?filter=…` fires as before. Scroll the feed to confirm cursor-based pagination still hits `/api/feed`.
- [ ] Manual: load `/feed` and unauthenticated `/`. Both should still work via the client-fetch fallback paths.
- [ ] Optional: hit the question-creation flow (Quick Add) twice in a row and check the Anthropic console for prompt cache hits on the second call.

https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH)_