### PR TITLE
perf: composite index on MASTERY_EVENTS for viewer-status lookups

### DIFF
--- a/drizzle/0035_mastery_events_viewer_status_idx.sql
+++ b/drizzle/0035_mastery_events_viewer_status_idx.sql
@@ -1,0 +1,21 @@
+-- Migration: composite index on MASTERY_EVENTS (user_id, answered_by_user_id, question_id).
+--
+-- The two hot paths that filter on all three columns are:
+--   1. getViewerAnswerStatusForQuestions (src/server/db/queries/feed.ts:478) —
+--      called on every feed render to determine the viewer's prior result on
+--      each question shown.
+--   2. The archive timeline reader (src/server/db/queries/archive.ts:241) —
+--      called whenever a user opens /archive.
+--
+-- Before this index, Postgres had to bitmap-AND two single-column index scans
+-- (user_id + answered_by_user_id, then intersect with question_id IN (...)).
+-- The composite turns it into a single index lookup keyed on the leading
+-- prefix (user_id, answered_by_user_id) with the question_id check served by
+-- the third column.
+--
+-- IF NOT EXISTS keeps the migration idempotent if it has already been applied
+-- out-of-band (e.g. via a CONCURRENTLY one-liner against a large production
+-- table to avoid the brief write lock that a non-concurrent CREATE INDEX takes
+-- inside the migration transaction).
+CREATE INDEX IF NOT EXISTS "MASTERY_EVENTS_user_id_answered_by_user_id_question_id_idx"
+  ON "MASTERY_EVENTS" ("user_id", "answered_by_user_id", "question_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -246,6 +246,13 @@
       "when": 1778952386715,
       "tag": "0034_territory_type_enum",
       "breakpoints": true
+    },
+    {
+      "idx": 35,
+      "version": "7",
+      "when": 1779580800000,
+      "tag": "0035_mastery_events_viewer_status_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -362,6 +362,17 @@ export const masteryEvents = pgTable(
     index('MASTERY_EVENTS_canonical_subcategory_idx').on(table.canonicalSubcategory),
     index('MASTERY_EVENTS_question_id_idx').on(table.questionId),
     index('MASTERY_EVENTS_answered_by_user_id_idx').on(table.answeredByUserId),
+    // Composite covers the hot viewer-status lookup at
+    // src/server/db/queries/feed.ts:478 (getViewerAnswerStatusForQuestions,
+    // called on every feed render) and the archive timeline reader at
+    // src/server/db/queries/archive.ts:241 — both filter on userId +
+    // answeredByUserId and then by question. Single-column indexes were forcing
+    // bitmap-AND merges of two separate scans.
+    index('MASTERY_EVENTS_user_id_answered_by_user_id_question_id_idx').on(
+      table.userId,
+      table.answeredByUserId,
+      table.questionId,
+    ),
   ],
 );
 


### PR DESCRIPTION
## Summary

Audit item #6 — composite index on `MASTERY_EVENTS` for the viewer-status hot path.

`getViewerAnswerStatusForQuestions` (`src/server/db/queries/feed.ts:478`) is called on every feed render to look up the viewer's prior result for each question shown. It filters on `(userId, answeredByUserId, questionId IN […])` but the table only had three single-column indexes on those fields, forcing Postgres to bitmap-AND two scans. The archive timeline reader at `src/server/db/queries/archive.ts:241` hits the same `(userId, answeredByUserId, …)` prefix on every `/archive` open.

Adds a three-column composite on `(user_id, answered_by_user_id, question_id)` so both lookups become a single index seek.

### Scope notes

- Uses `CREATE INDEX IF NOT EXISTS` (no `CONCURRENTLY`), matching this repo's existing migration convention. The brief write lock during deploy is acceptable for a moderate table. For a large production `MASTERY_EVENTS`, the index can be pre-created out-of-band with `CREATE INDEX CONCURRENTLY` and this migration will then skip via the `IF NOT EXISTS` guard.
- The other index candidates flagged in the audit (`Question.createdAt`, `Question.deletedAt` partial, `FeedItem(recipientUserId, createdAt)`) were verified against the actual query patterns and would **not** be exercised by any current hot query — existing composites already cover them. Skipped to keep write amplification down.
- Audit item #7 (bound the breadcrumb cache) was already shipped in `60268bf` (the breadcrumb-decoupling PR) with `BREADCRUMB_CACHE_MAX = 500` and LRU eviction, so nothing to do there.

### Files

- `drizzle/0035_mastery_events_viewer_status_idx.sql` — new SQL migration.
- `drizzle/meta/_journal.json` — journal entry for idx=35.
- `src/server/db/schema.ts` — declares the new index on the `masteryEvents` table.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean.
- [x] `npm run lint` — no new violations.
- [x] `npx vitest run` — no new failures vs. `dev2` (pre-existing failures reproduce identically).
- [ ] After deploy: `EXPLAIN ANALYZE` the `getViewerAnswerStatusForQuestions` query against a representative user. Should show `Index Scan using MASTERY_EVENTS_user_id_answered_by_user_id_question_id_idx` instead of a `BitmapAnd` of two single-column scans.
- [ ] Monitor `pg_stat_user_indexes` for `MASTERY_EVENTS_user_id_answered_by_user_id_question_id_idx` — `idx_scan` should grow steadily; the now-redundant single-column indexes should not (they still serve other narrower queries, so keep them).

https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH)_