### PR TITLE
perf: Montserrat font swap + omit-null pass on /api/feed

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,6 +11,7 @@ import { getUserOnboardingProfile } from '@/server/db/queries/users';
 const montserrat = Montserrat({
   subsets: ['latin'],
   variable: '--font-sans-body',
+  display: 'swap',
 })
 
 // F5.1: handwriting register (Personal Record, annotations, signature-style microcopy).

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -42,26 +42,29 @@ type FeedApiItem = {
   source_friend_display_name: string
   source_profile_href?: string | null
   source_attribution: string
-  source_result: 'correct' | 'incorrect' | null
-  friend_results: FriendResult[] | null
+  // Fields the server omits when null (see compactNulls in get-feed-page.ts).
+  // Optional + nullable here because the client also constructs FeedApiItem
+  // values locally (after answer submit) and sometimes writes null explicitly.
+  source_result?: 'correct' | 'incorrect' | null
+  friend_results?: FriendResult[] | null
   viewer_answer_status?: { result: 'correct' | 'incorrect' } | null
   endorsement_count?: number | null
   additional_endorsers?: Array<{ userId: string; displayName: string }> | null
   source_event_at: string
-  personal_message: string | null
+  personal_message?: string | null
   state: string
   is_pinned: boolean
-  question_text: string | null
+  question_text?: string | null
   is_in_bank: boolean
-  domain_pill: string | null
+  domain_pill?: string | null
   broad_category?: string | null
-  explanation: string | null
-  answer_result: 'correct' | 'incorrect' | null
-  is_correct: boolean | null
-  correct_answer: string | null
-  submitted_answer: string | null
-  awarded_points: number | null
-  mastery_delta: unknown | null
+  explanation?: string | null
+  answer_result?: 'correct' | 'incorrect' | null
+  is_correct?: boolean | null
+  correct_answer?: string | null
+  submitted_answer?: string | null
+  awarded_points?: number | null
+  mastery_delta?: unknown | null
   viewer_is_author?: boolean
 }
 
@@ -367,14 +370,14 @@ function toAnsweredByYouItem(
     answerSummary: result
       ? comparisonCopy(
           result.correct,
-          item.friend_results,
+          item.friend_results ?? null,
           item.source_type,
           item.source_friend_display_name,
           item.source_user_id
         )
       : comparisonCopy(
-          item.is_correct,
-          item.friend_results,
+          item.is_correct ?? null,
+          item.friend_results ?? null,
           item.source_type,
           item.source_friend_display_name,
           item.source_user_id

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -134,6 +134,14 @@ function friendAnsweredAttribution(
   return domain ? `Common ground in ${domain}: ${names}` : `${names} share this one`;
 }
 
+function compactNulls<T extends Record<string, unknown>>(obj: T): T {
+  const result: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(obj)) {
+    if (value !== null) result[key] = value;
+  }
+  return result as T;
+}
+
 export type FeedPageOptions = {
   limit: number;
   cursor: FeedCursor | null;
@@ -227,7 +235,13 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
       const answerResult = item.answerResult ?? item.viewerAnswerStatus?.result ?? null;
       const awardedPoints = typeof item.pointsAwarded === 'number' ? item.pointsAwarded : null;
 
-      return {
+      // compactNulls strips `"field":null` from the wire; the client treats
+      // absent fields and null fields identically (verified by grep:
+      // no `=== null` checks on these fields, only `??`, optional chaining,
+      // and truthy checks). Card-discriminated fields are the bulk of the
+      // saving — `joshing_game_id`, `endorsement_count`, `correct_answer`
+      // etc. are null on 4 of 5 card types each.
+      return compactNulls({
         id: item.id,
         kind: 'question' as const,
         card_type: cardType,
@@ -265,7 +279,7 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         awarded_points: cardType === 'answered_by_you' ? awardedPoints : null,
         mastery_delta: cardType === 'answered_by_you' ? item.masteryDelta ?? null : null,
         viewer_is_author: question?.creatorId ? question.creatorId === viewerUserId : false,
-      };
+      });
     }),
   };
 }


### PR DESCRIPTION
## Summary

Two quick wins from the audit, on a single PR for review economy.

### 1. `display: 'swap'` on Montserrat (commit `e2f1509`)

`src/app/layout.tsx`. Caveat and Playfair_Display already had `display: 'swap'`; Montserrat (the body font, used everywhere) was the only Google font import without it. Without `display: 'swap'`, the browser blocks text rendering until Montserrat downloads (FOIT — flash of invisible text), adding 200–400ms to perceived LCP on cold loads. With swap, text renders immediately in the system fallback and reflows to Montserrat when ready.

### 2. Omit null fields from `/api/feed` payload (commit `bf929cb`)

Follow-up to PR #299. Adds a small `compactNulls()` helper in `src/server/feed/get-feed-page.ts` that strips `"field":null` entries from each item. The client already handles undefined and null identically on these fields (verified by grep: zero `=== null` checks anywhere — only `??`, optional chaining, and truthy/falsy patterns).

Biggest wins are the card-discriminated fields that are null on most items:

| Field | Null on |
|---|---|
| `joshing_game_id` | Every non-game item |
| `friend_results` | 4 of 5 card types |
| `viewer_answer_status` | Items the viewer hasn't answered |
| `endorsement_count`, `additional_endorsers` | 4 of 5 card types |
| `correct_answer`, `submitted_answer`, `awarded_points`, `mastery_delta` | 4 of 5 card types |
| `personal_message` | Items without a sent note |

A typical `friend_answered` card sheds ~9 null fields × ~22 chars each = ~200 bytes. For a 20-item page, **~4KB shaved before Brotli**.

Type-honesty: `FeedApiItem` in `FeedList.tsx` now marks these as `T | null | undefined` (the client still constructs `FeedApiItem` values locally after answer submission and sometimes writes null explicitly). Two call sites passing `item.field` to `comparisonCopy()` got `?? null` to satisfy its narrower `T | null` contract.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean.
- [x] `npm run lint` — no new violations on any touched file.
- [x] `npx vitest run src/app/api/feed src/components/FeedList src/server/feed src/app` — same 15 pre-existing failures as on `dev2`, none new.
- [ ] Manual: load `/` while signed in, inspect `/api/feed` response in DevTools. Confirm that `friend_answered` items no longer ship `endorsement_count`, `joshing_game_id`, `correct_answer` etc. as `null`.
- [ ] Manual: WebPageTest before/after on `/` for an authenticated user. LCP should improve by 100–300ms from the font swap alone.

## What's left after this PR

This closes the last two single-PR items from the audit. Remaining work is bigger conversations: measurement plan instrumentation (Server-Timing, pool stats, LLM token+latency logs), `instrumentation.ts` guard cleanup, and the architectural questions around the DB pool cap / caching layer / `force-dynamic` everywhere.

https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH)_