### PR TITLE
perf: measurement plan — LLM, proxy, and DB pool instrumentation

### DIFF
--- a/src/app/api/questions/suggest/route.ts
+++ b/src/app/api/questions/suggest/route.ts
@@ -4,6 +4,7 @@ import {
   ANTHROPIC_MODEL,
   extractTextContent,
   getAnthropicClient,
+  loggedMessagesCreate,
   parseJsonObject,
 } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
@@ -42,7 +43,7 @@ Up to 3 alternate accepted answers (common variations, abbreviations, or alterna
 A brief educational explanation (2-3 sentences) that would help someone learn if they got it wrong.
 Respond in JSON only: { "correctAnswer": "...", "alternateAnswers": ["...", "..."], "explanation": "..." }`;
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'questions-suggest', {
       model: ANTHROPIC_MODEL,
       max_tokens: 500,
       temperature: 0,

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -131,6 +131,43 @@ function logFallback(scope: string, reason: string, extra?: Record<string, unkno
   console.warn(`[LLM] ${scope} fallback: ${reason}`, extra ?? {});
 }
 
+/**
+ * Wraps Anthropic.messages.create with structured logging of duration, token
+ * usage, and cache hits/writes. Use everywhere a request is made instead of
+ * calling client.messages.create directly, so the prompt-caching configuration
+ * can be observed in production. `scope` should be a short stable label like
+ * 'grade' or 'categorize'.
+ */
+export async function loggedMessagesCreate(
+  client: Anthropic,
+  scope: string,
+  params: Anthropic.MessageCreateParamsNonStreaming,
+): Promise<Anthropic.Message> {
+  const startedAt = Date.now();
+  try {
+    const response = await client.messages.create(params);
+    const usage = response.usage;
+    console.info('[llm]', {
+      scope,
+      model: params.model,
+      duration_ms: Date.now() - startedAt,
+      input_tokens: usage.input_tokens,
+      output_tokens: usage.output_tokens,
+      cache_read_tokens: usage.cache_read_input_tokens ?? 0,
+      cache_create_tokens: usage.cache_creation_input_tokens ?? 0,
+    });
+    return response;
+  } catch (error) {
+    console.warn('[llm] error', {
+      scope,
+      model: params.model,
+      duration_ms: Date.now() - startedAt,
+      ...summarizeError(error),
+    });
+    throw error;
+  }
+}
+
 function clampConfidence(value: unknown, fallback: number): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) {
     return fallback;
@@ -420,7 +457,7 @@ Return only valid JSON with keys: result, confidence, reason, consolation. No ex
       return fallbackGrading();
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'grade', {
       model: GRADING_MODEL,
       max_tokens: 300,
       temperature: 0,
@@ -504,7 +541,7 @@ Categorize this question. Return JSON only.`;
       return fallbackCategorization(questionText, answerText);
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'categorize', {
       model: ANTHROPIC_MODEL,
       max_tokens: 300,
       temperature: 0,
@@ -548,7 +585,7 @@ Broad category: ${broadCategory}
 Current subcategory (too broad): ${subcategory}
 Return JSON only.`;
 
-      const refinementResponse = await client.messages.create({
+      const refinementResponse = await loggedMessagesCreate(client, 'categorize-refine', {
         model: ANTHROPIC_MODEL,
         max_tokens: 120,
         temperature: 0,
@@ -618,7 +655,7 @@ Write brief and full explainers. Return JSON only.`;
       return fallbackExplainer(canonicalAnswer);
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'explainer', {
       model: ANTHROPIC_MODEL,
       max_tokens: 800,
       temperature: 0.7,
@@ -673,7 +710,7 @@ Write 2–3 sentences of factual explanation.`;
       return fallbackFactualReflectionExplanation(canonicalAnswer);
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'reflection-explainer', {
       model: ANTHROPIC_MODEL,
       max_tokens: 400,
       temperature: 0.45,
@@ -740,7 +777,7 @@ Suggest a canonical answer and classify the question type. Return JSON only.`;
       return fallbackSuggestion();
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'suggest-answer', {
       model: ANTHROPIC_MODEL,
       max_tokens: 600,
       temperature: 0,
@@ -827,7 +864,7 @@ Suggest specific topic tags. Return JSON only.`;
     const client = getAnthropicClient();
     if (!client) return { tags: [] };
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'suggest-tags', {
       model: ANTHROPIC_MODEL,
       max_tokens: 150,
       temperature: 0,
@@ -880,7 +917,7 @@ Return JSON only.`;
     const client = getAnthropicClient();
     if (!client) return null;
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'resolve-subcategory', {
       model: ANTHROPIC_MODEL,
       max_tokens: 120,
       temperature: 0,
@@ -928,7 +965,7 @@ No explanation outside the JSON.`;
       return { cleaned_text: questionText, confidence: 'high' };
     }
 
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'clean-question', {
       model: ANTHROPIC_MODEL,
       max_tokens: 200,
       temperature: 0,

--- a/src/lib/questions/categorization.ts
+++ b/src/lib/questions/categorization.ts
@@ -1,4 +1,4 @@
-import { extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { extractTextContent, getAnthropicClient, loggedMessagesCreate, parseJsonObject } from '@/lib/llm';
 import { getKnowledgeBase } from '@/server/db/queries/daily';
 
 const RECONCILE_MODEL = 'claude-haiku-4-5';
@@ -49,7 +49,7 @@ ${existingDomains.map((d) => `- ${d}`).join('\n')}`;
       setTimeout(() => reject(new Error('reconcile timeout')), RECONCILE_TIMEOUT_MS),
     );
 
-    const responsePromise = client.messages.create({
+    const responsePromise = loggedMessagesCreate(client, 'reconcile-subcategory', {
       model: RECONCILE_MODEL,
       max_tokens: 256,
       temperature: 0,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -4,6 +4,11 @@ import { readSessionClaims } from '@/server/auth/session'
 
 const SESSION_COOKIE_NAME = 'joshing_session'
 
+function tagTiming(response: NextResponse, startedAt: number): NextResponse {
+  response.headers.set('Server-Timing', `proxy;dur=${Date.now() - startedAt}`)
+  return response
+}
+
 /**
  * Edge proxy: defense-in-depth JWT gate plus onboarding/login routing for
  * authenticated page requests. Reads `inv` and `onb` directly from the JWT
@@ -12,12 +17,16 @@ const SESSION_COOKIE_NAME = 'joshing_session'
  * /api/auth/refresh-onboarding-claim, which does a single DB read and
  * re-mints the cookie.
  *
+ * Every response is tagged with a Server-Timing header so middleware cost
+ * shows up in the DevTools Network panel and on Vercel function logs.
+ *
  * Route handlers MUST keep their own `getSession()` checks — this is an
  * additional fence, not a replacement.
  */
 export async function middleware(request: NextRequest) {
+  const startedAt = Date.now()
   if (request.method === 'OPTIONS') {
-    return new NextResponse(null, { status: 200 })
+    return tagTiming(new NextResponse(null, { status: 200 }), startedAt)
   }
 
   const { pathname, search } = request.nextUrl
@@ -30,37 +39,43 @@ export async function middleware(request: NextRequest) {
 
   if (!claims) {
     if (isApi) {
-      return NextResponse.json(
-        { error: 'unauthenticated', message: 'Sign in required.' },
-        { status: 401 },
+      return tagTiming(
+        NextResponse.json(
+          { error: 'unauthenticated', message: 'Sign in required.' },
+          { status: 401 },
+        ),
+        startedAt,
       )
     }
-    if (isLoginPage || isInvitePage) return NextResponse.next()
+    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt)
     const loginUrl = new URL('/login', request.url)
     loginUrl.searchParams.set('next', pathname + search)
-    return NextResponse.redirect(loginUrl)
+    return tagTiming(NextResponse.redirect(loginUrl), startedAt)
   }
 
   // Legacy session: valid JWT but no `inv` claim. Trigger graceful refresh.
   if (!claims.invitationAccepted) {
     if (isApi) {
-      return NextResponse.json(
-        {
-          error: 'session_refresh_required',
-          message: 'Session needs to be refreshed.',
-        },
-        { status: 401 },
+      return tagTiming(
+        NextResponse.json(
+          {
+            error: 'session_refresh_required',
+            message: 'Session needs to be refreshed.',
+          },
+          { status: 401 },
+        ),
+        startedAt,
       )
     }
-    if (isLoginPage || isInvitePage) return NextResponse.next()
+    if (isLoginPage || isInvitePage) return tagTiming(NextResponse.next(), startedAt)
     const refreshUrl = new URL('/api/auth/refresh-session', request.url)
     refreshUrl.searchParams.set('next', pathname + search)
-    return NextResponse.redirect(refreshUrl)
+    return tagTiming(NextResponse.redirect(refreshUrl), startedAt)
   }
 
   // Authenticated with valid invitation. API requests pass through; page
   // requests get the onboarding/login routing pass.
-  if (isApi) return NextResponse.next()
+  if (isApi) return tagTiming(NextResponse.next(), startedAt)
 
   const isOnboardingPage = pathname === '/onboarding'
   const isAllowedOnboardingPath =
@@ -71,9 +86,9 @@ export async function middleware(request: NextRequest) {
 
   if (claims.onboardingComplete) {
     if (isLoginPage || isOnboardingPage) {
-      return NextResponse.redirect(new URL('/', request.url))
+      return tagTiming(NextResponse.redirect(new URL('/', request.url)), startedAt)
     }
-    return NextResponse.next()
+    return tagTiming(NextResponse.next(), startedAt)
   }
 
   // claims.onboardingComplete is false: either the user genuinely hasn't
@@ -81,14 +96,14 @@ export async function middleware(request: NextRequest) {
   // their JWT is missing the field. Allow onboarding/auth paths through and
   // route everything else to the refresh endpoint, which does one DB read,
   // re-mints the JWT if needed, and bounces back. Steady-state is JWT-only.
-  if (isAllowedOnboardingPath) return NextResponse.next()
+  if (isAllowedOnboardingPath) return tagTiming(NextResponse.next(), startedAt)
 
   const refreshUrl = new URL(
     '/api/auth/refresh-onboarding-claim',
     request.url,
   )
   refreshUrl.searchParams.set('next', pathname + search)
-  return NextResponse.redirect(refreshUrl)
+  return tagTiming(NextResponse.redirect(refreshUrl), startedAt)
 }
 
 /**

--- a/src/server/daily/generate-breadcrumb.ts
+++ b/src/server/daily/generate-breadcrumb.ts
@@ -1,4 +1,4 @@
-import { extractTextContent, getAnthropicClient } from '@/lib/llm';
+import { extractTextContent, getAnthropicClient, loggedMessagesCreate } from '@/lib/llm';
 
 const BREADCRUMB_MODEL = 'claude-haiku-4-5';
 const BREADCRUMB_TIMEOUT_MS = 3000;
@@ -64,7 +64,7 @@ export async function generateBreadcrumb(params: GenerateBreadcrumbParams): Prom
     ? 'The user got it right.'
     : `The user answered "${params.submittedAnswer}" instead of the correct answer "${params.correctAnswer}".`;
 
-  const request = client.messages.create({
+  const request = loggedMessagesCreate(client, 'breadcrumb', {
     model: BREADCRUMB_MODEL,
     max_tokens: 120,
     temperature: 0.55,

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -2,6 +2,7 @@ import {
   ANTHROPIC_MODEL,
   extractTextContent,
   getAnthropicClient,
+  loggedMessagesCreate,
   parseJsonObject,
 } from '@/lib/llm';
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
@@ -221,7 +222,7 @@ async function callLlmOnce(
   const client = getAnthropicClient();
   if (!client) return [];
 
-  const response = await client.messages.create({
+  const response = await loggedMessagesCreate(client, 'generate-questions', {
     model: ANTHROPIC_MODEL,
     max_tokens: 2000,
     temperature: 0.8,

--- a/src/server/db/index.ts
+++ b/src/server/db/index.ts
@@ -27,4 +27,26 @@ globalForDb.pool = pool;
 
 export const db = drizzle(pool, { schema });
 
+// Periodic pool-saturation logger. Logs only when there's actual contention
+// (a request was waiting on a connection) or the pool is near its cap, so
+// the log stays quiet during normal operation and screams when the
+// 5-connection ceiling is biting. unref() prevents the interval from keeping
+// the Node process alive in scripts/tests, and the global cache prevents
+// dev-mode hot-reload from spawning duplicates.
+const globalForPoolLogger = globalThis as unknown as {
+  __joshingPoolLogger?: NodeJS.Timeout;
+};
+if (!globalForPoolLogger.__joshingPoolLogger) {
+  const timer = setInterval(() => {
+    const total = pool.totalCount;
+    const idle = pool.idleCount;
+    const waiting = pool.waitingCount;
+    if (waiting > 0 || total >= 4) {
+      console.info('[db-pool]', { total, idle, waiting, max: 5 });
+    }
+  }, 30_000);
+  timer.unref();
+  globalForPoolLogger.__joshingPoolLogger = timer;
+}
+
 export * from './schema';

--- a/src/server/llm/critique.ts
+++ b/src/server/llm/critique.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, loggedMessagesCreate, parseJsonObject } from '@/lib/llm';
 
 export type CritiqueResult =
   | { ok: true }
@@ -63,7 +63,7 @@ Reformulations should preserve the author's apparent intent while fixing the iss
 
   try {
     const response = await Promise.race([
-      client.messages.create({
+      loggedMessagesCreate(client, 'critique', {
         model: ANTHROPIC_MODEL,
         max_tokens: 700,
         temperature: 0.2,

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -3,6 +3,7 @@ import {
   HAIKU_MODEL,
   extractTextContent,
   getAnthropicClient,
+  loggedMessagesCreate,
   parseJsonObject,
 } from '@/lib/llm';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
@@ -225,7 +226,7 @@ Propose candidate interests. Return JSON array only.`;
   const client = getAnthropicClient();
   if (!client) return fallbackInterests(cleanAnswers);
 
-  const response = await client.messages.create({
+  const response = await loggedMessagesCreate(client, 'interests-suggest', {
     model: ANTHROPIC_MODEL,
     max_tokens: 1600,
     temperature: 0.65,
@@ -285,7 +286,7 @@ Avoid broad categories like "Music", "Literature", "History". Prefer forms like 
 Never return "Other" as broadCategory; use "General Knowledge" only when no precise top-level bucket applies.
 Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation": "..." }`;
 
-  const response = await client.messages.create({
+  const response = await loggedMessagesCreate(client, 'interests-canonicalize', {
     model: CANONICALIZE_MODEL,
     max_tokens: 260,
     temperature: 0.2,

--- a/src/server/llm/recheck.ts
+++ b/src/server/llm/recheck.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, loggedMessagesCreate, parseJsonObject } from '@/lib/llm';
 
 export type AnswerRecheckDecision = 'accept' | 'reject' | 'needs_human';
 
@@ -88,7 +88,7 @@ Question type: ${params.questionType}
 Should this challenged answer count? Return JSON only.`;
 
   try {
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'recheck', {
       model: ANTHROPIC_MODEL,
       max_tokens: 400,
       temperature: 0,

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -16,7 +16,7 @@ import {
   questions,
   skippedDailyQuestions,
 } from '@/server/db';
-import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, loggedMessagesCreate, parseJsonObject } from '@/lib/llm';
 import { pgErrorCode, pgErrorMessage } from '@/server/db/pg-error';
 import { effectiveTier, resolveTier } from '@/server/mastery/tiers';
 import type { MasteryTier } from '@/types/db';
@@ -491,7 +491,7 @@ If no merges are needed: { "merges": [] }`;
 
   let response;
   try {
-    response = await client.messages.create({
+    response = await loggedMessagesCreate(client, 'ceremony-narrative', {
       model: ANTHROPIC_MODEL,
       max_tokens: 1200,
       temperature: 0,

--- a/src/server/profile/multitudes.ts
+++ b/src/server/profile/multitudes.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { loggedMessagesCreate } from '@/lib/llm';
 import type { MasteryTier } from '@/types/db';
 import type { PortraitState } from '@/server/profile/portrait';
 
@@ -89,7 +90,7 @@ export async function generateMultitudesCopy(input: {
   });
 
   try {
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'multitudes', {
       model: MODEL,
       system: SYSTEM_PROMPT,
       max_tokens: 120,

--- a/src/server/questions/llm-difficulty.ts
+++ b/src/server/questions/llm-difficulty.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, parseJsonObject } from '@/lib/llm';
+import { ANTHROPIC_MODEL, extractTextContent, getAnthropicClient, loggedMessagesCreate, parseJsonObject } from '@/lib/llm';
 import { DIFFICULTY_COPY, type QuestionDifficultyTier } from '@/lib/questions/difficulty-copy';
 
 export { DIFFICULTY_COPY };
@@ -68,7 +68,7 @@ Use this domain-relative scale:
 Respond in JSON only: { "tier": "establishing" | "solid" | "skilled" | "master" }`;
 
   try {
-    const response = await client.messages.create({
+    const response = await loggedMessagesCreate(client, 'difficulty', {
       model: ANTHROPIC_MODEL,
       max_tokens: 120,
       temperature: 0,


### PR DESCRIPTION
## Summary

Audit Section 8 — instrument the three things we currently can't measure: how often prompt caching actually hits, how much time the proxy spends per request, and whether the 5-connection DB pool ever saturates. Three independent commits, one PR.

### 1. LLM call instrumentation (`f3b97b1`)

Add a `loggedMessagesCreate(client, scope, params)` wrapper in `src/lib/llm.ts` that records this per call:

```
[llm] { scope, model, duration_ms, input_tokens, output_tokens,
        cache_read_tokens, cache_create_tokens }
```

The `cache_read_tokens` / `cache_create_tokens` fields verify whether the prompt-caching shipped in `018b61a` is actually hitting in production — without this we have no way to tell a cold read from a cache hit.

Wraps **15 call sites** across `lib/llm.ts`, `lib/questions/categorization.ts`, `server/llm/*`, `server/daily/*`, `server/profile/multitudes.ts`, `server/questions/llm-difficulty.ts`, `server/mastery/ceremony.ts`, and `app/api/questions/suggest/route.ts`. Each gets a stable `scope` label (`grade`, `categorize`, `breadcrumb`, `multitudes`, etc.) for filtering and aggregation.

### 2. Server-Timing header from the edge proxy (`7d22a08`)

`src/proxy.ts` runs on every authenticated page navigation. Adding `Server-Timing: proxy;dur=…` to every response surfaces that cost in DevTools Network panel and Vercel function logs — quick way to catch a future regression that reintroduces something slow in middleware.

Implementation is a tiny `tagTiming(response, startedAt)` helper applied at every return site.

### 3. DB pool saturation logger (`7d43840`)

The pool is intentionally capped at 5 (per CLAUDE.md, commit `2aafbb1`) due to Supabase PgBouncer session-mode constraints. We currently have **no signal** for whether real production traffic ever hits that ceiling — the audit's Section 7 flagged this as the #1 architectural risk for scale.

Adds a `setInterval` in `src/server/db/index.ts` (30s, `unref()`'d, deduped via `globalThis` to survive dev-mode hot reload) that logs `[db-pool] { total, idle, waiting, max }` only when there's actual contention (`waitingCount > 0`) or the pool is at 80%+ capacity (`total >= 4`). The conditional keeps the log silent during quiet periods so a saturation event is unmistakable when it shows up.

If `[db-pool]` starts firing on a given route, that's the signal that the next move is either (a) reducing per-request DB work, (b) pushing some reads to a cache tier, or (c) revisiting PgBouncer config.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean.
- [x] `npm run lint` — no new violations on any touched file.
- [x] `npx vitest run` — no new failures vs. `dev2`; pre-existing failures reproduce identically.
- [ ] Manual: run `npm run dev`, log in, answer one Daily Five question. Server logs should show `[llm] scope=grade …` lines and possibly `[llm] scope=breadcrumb …`. After a second question on the same topic, the second `[llm] scope=grade` line should have `cache_read_tokens > 0` (confirming caching).
- [ ] Manual: load `/` and inspect any response in DevTools → Network → Headers. Expect a `Server-Timing: proxy;dur=N` header with `N` in single-digit ms.
- [ ] Manual: under any kind of load (or k6/autocannon on `POST /api/daily/answer` with a fixture user with 20+ friends), watch logs for `[db-pool]`. Expect quiet otherwise.

## What this unlocks

Once a week or so of data is in, you'll be able to answer:

- **Is prompt caching paying off?** → `cache_read_tokens / (input_tokens + cache_read_tokens)` per scope.
- **Where's LLM latency spent?** → p50/p95 `duration_ms` per scope.
- **Is the DB pool the actual bottleneck?** → frequency and route attribution of `[db-pool]` lines.
- **Is the proxy ever slow?** → distribution of `Server-Timing: proxy;dur` from real users.

That data is what should drive the bigger architectural calls (Redis cache layer, PgBouncer config, edge runtime adoption) — instead of guessing.

https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH)_