### PR TITLE
perf: defer author-credit chain off the answer hot path

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -11,8 +11,7 @@ import {
   questions,
 } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
-import { creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
-import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
+import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
@@ -266,39 +265,16 @@ export async function POST(request: NextRequest) {
             questionId: canonicalQuestionId,
           });
 
-          // Author credit: windowed scheme, Moderate/Specialist only (PRD §8.32).
-          // We need the canonical question row to get difficulty and counts.
-          const [canonicalQ] = await db
-            .select({ calibratedDifficulty: questions.calibratedDifficulty, llmDifficulty: questions.llmDifficulty, correctCount: questions.correctCount, askedCount: questions.askedCount })
-            .from(questions)
-            .where(eq(questions.id, canonicalQuestionId))
-            .limit(1);
-          if (canonicalQ) {
-            const existingCredits = await countAuthorCreditEvents(canonicalQuestionId, persistedCreatorId);
-            const authorAward = creatorMasteryAwardForNthCorrect(
-              canonicalQ.correctCount,
-              canonicalQ.askedCount,
-              existingCredits + 1,
-              canonicalQ.calibratedDifficulty ?? canonicalQ.llmDifficulty,
-            );
-            if (authorAward.awardedPoints > 0) {
-              await writeMasteryEvent({
-                userId: persistedCreatorId,
-                questionId: canonicalQuestionId,
-                domain: persistedDomainForCreator,
-                pointsAwarded: authorAward.awardedPoints,
-                sourceType: 'author_credit',
-                sourceId: `daily:${question.id}:${session.userId}`,
-                broadCategory: undefined,
-                eventQuestionId: canonicalQuestionId,
-                basePoints: authorAward.basePoints,
-                weight: authorAward.weight,
-                answeredByUserId: session.userId,
-              }).catch((err) => {
-                console.warn('[daily/answer] author_credit write failed', err);
-              });
-            }
-          }
+          // Author credit (PRD §8.32): off the user's hot path — three queries
+          // the answerer never sees in their response.
+          void awardAuthorCredit({
+            creatorUserId: persistedCreatorId,
+            answererUserId: session.userId,
+            questionId: canonicalQuestionId,
+            domain: persistedDomainForCreator,
+            sourceId: `daily:${question.id}:${session.userId}`,
+            scope: 'daily/answer',
+          });
         }
 
         // Fan-out runs after the response is sent: the user-visible reveal does

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -9,8 +9,7 @@ import { getCatchupQuestions } from '@/server/db/queries/daily';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
-import { creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
-import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
+import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
@@ -185,38 +184,15 @@ export async function POST(request: NextRequest) {
           questionId: canonicalQuestionId,
         });
 
-        // Author credit: windowed scheme, Moderate/Specialist only (PRD §8.32).
-        const [canonicalQ] = await db
-          .select({ calibratedDifficulty: questions.calibratedDifficulty, llmDifficulty: questions.llmDifficulty, correctCount: questions.correctCount, askedCount: questions.askedCount })
-          .from(questions)
-          .where(eq(questions.id, canonicalQuestionId))
-          .limit(1);
-        if (canonicalQ) {
-          const existingCredits = await countAuthorCreditEvents(canonicalQuestionId, persistedCreatorId);
-          const authorAward = creatorMasteryAwardForNthCorrect(
-            canonicalQ.correctCount,
-            canonicalQ.askedCount,
-            existingCredits + 1,
-            canonicalQ.calibratedDifficulty ?? canonicalQ.llmDifficulty,
-          );
-          if (authorAward.awardedPoints > 0) {
-            await writeMasteryEvent({
-              userId: persistedCreatorId,
-              questionId: canonicalQuestionId,
-              domain: persistedDomainForCreator,
-              pointsAwarded: authorAward.awardedPoints,
-              sourceType: 'author_credit',
-              sourceId: `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
-              broadCategory: undefined,
-              eventQuestionId: canonicalQuestionId,
-              basePoints: authorAward.basePoints,
-              weight: authorAward.weight,
-              answeredByUserId: session.userId,
-            }).catch((err) => {
-              console.warn('[daily/catchup/answer] author_credit write failed', err);
-            });
-          }
-        }
+        // Author credit (PRD §8.32): off the user's hot path.
+        void awardAuthorCredit({
+          creatorUserId: persistedCreatorId,
+          answererUserId: session.userId,
+          questionId: canonicalQuestionId,
+          domain: persistedDomainForCreator,
+          sourceId: `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
+          scope: 'daily/catchup/answer',
+        });
       }
 
       void createFeedItemsForFriendsFromAnswer(

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -5,8 +5,8 @@ import { gradeAnswer, selectQuip } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
 import { promptCreatorNoteAfterWrongAnswer } from '@/server/creator-notes';
 import { db, feedItems, playerMastery, questions, users } from '@/server/db';
-import { getBasePoints, creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
-import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
+import { getBasePoints } from '@/server/mastery/scoring';
+import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
@@ -165,31 +165,23 @@ export async function POST(request: NextRequest, context: RouteContext) {
       questionId: question.id,
     });
 
-    // Author credit: windowed scheme, Moderate/Specialist only (PRD §8.32).
-    const existingCredits = await countAuthorCreditEvents(question.id, question.creatorId);
-    const authorAward = creatorMasteryAwardForNthCorrect(
-      question.correctCount,
-      question.askedCount,
-      existingCredits + 1,
-      question.calibratedDifficulty ?? question.llmDifficulty,
-    );
-    if (authorAward.awardedPoints > 0) {
-      await writeMasteryEvent({
-        userId: question.creatorId,
-        questionId: question.id,
-        domain,
-        pointsAwarded: authorAward.awardedPoints,
-        sourceType: 'author_credit',
-        sourceId: feedItemId,
-        broadCategory: question.broadCategory,
-        eventQuestionId: question.id,
-        basePoints: authorAward.basePoints,
-        weight: authorAward.weight,
-        answeredByUserId: session.userId,
-      }).catch((err) => {
-        console.warn('[feed/answer] author_credit write failed', err);
-      });
-    }
+    // Author credit (PRD §8.32): off the user's hot path. We pass the
+    // question row we already loaded so the helper doesn't re-fetch it.
+    void awardAuthorCredit({
+      creatorUserId: question.creatorId,
+      answererUserId: session.userId,
+      questionId: question.id,
+      domain,
+      sourceId: feedItemId,
+      broadCategory: question.broadCategory,
+      questionStats: {
+        correctCount: question.correctCount,
+        askedCount: question.askedCount,
+        calibratedDifficulty: question.calibratedDifficulty,
+        llmDifficulty: question.llmDifficulty,
+      },
+      scope: 'feed/answer',
+    });
   }
 
   // Only correct Feed answers are eligible to become public/social friend Feed cards.

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -5,8 +5,8 @@ import { gradeAnswer, selectQuip } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
 import { promptCreatorNoteAfterWrongAnswer } from '@/server/creator-notes';
 import { db, playerMastery, questions } from '@/server/db';
-import { getBasePoints, creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
-import { countAuthorCreditEvents } from '@/server/mastery/author-credit';
+import { getBasePoints } from '@/server/mastery/scoring';
+import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
@@ -139,30 +139,23 @@ export async function POST(request: NextRequest, context: RouteContext) {
       questionId: question.id,
     });
 
-    const existingCredits = await countAuthorCreditEvents(question.id, question.creatorId);
-    const authorAward = creatorMasteryAwardForNthCorrect(
-      question.correctCount,
-      question.askedCount,
-      existingCredits + 1,
-      question.calibratedDifficulty ?? question.llmDifficulty,
-    );
-    if (authorAward.awardedPoints > 0) {
-      await writeMasteryEvent({
-        userId: question.creatorId,
-        questionId: question.id,
-        domain,
-        pointsAwarded: authorAward.awardedPoints,
-        sourceType: 'author_credit',
-        sourceId,
-        broadCategory: question.broadCategory,
-        eventQuestionId: question.id,
-        basePoints: authorAward.basePoints,
-        weight: authorAward.weight,
-        answeredByUserId: session.userId,
-      }).catch((err) => {
-        console.warn('[questions/answer] author_credit write failed', err);
-      });
-    }
+    // Author credit (PRD §8.32): off the user's hot path. Pass the loaded
+    // question row so the helper doesn't re-fetch.
+    void awardAuthorCredit({
+      creatorUserId: question.creatorId,
+      answererUserId: session.userId,
+      questionId: question.id,
+      domain,
+      sourceId,
+      broadCategory: question.broadCategory,
+      questionStats: {
+        correctCount: question.correctCount,
+        askedCount: question.askedCount,
+        calibratedDifficulty: question.calibratedDifficulty,
+        llmDifficulty: question.llmDifficulty,
+      },
+      scope: 'questions/answer',
+    });
   }
 
   if (isCorrect) {

--- a/src/server/mastery/author-credit.ts
+++ b/src/server/mastery/author-credit.ts
@@ -5,7 +5,9 @@
 
 import { and, count, eq } from 'drizzle-orm';
 
-import { db, masteryEvents } from '@/server/db';
+import { db, masteryEvents, questions } from '@/server/db';
+import { creatorMasteryAwardForNthCorrect } from '@/server/mastery/scoring';
+import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 
 /**
  * Count existing author_credit mastery events for a given question+author pair.
@@ -23,4 +25,87 @@ export async function countAuthorCreditEvents(questionId: string, authorId: stri
     ));
 
   return row?.value ?? 0;
+}
+
+type QuestionStats = {
+  correctCount: number;
+  askedCount: number;
+  calibratedDifficulty: typeof questions.$inferSelect['calibratedDifficulty'];
+  llmDifficulty: typeof questions.$inferSelect['llmDifficulty'];
+};
+
+export type AwardAuthorCreditParams = {
+  creatorUserId: string;
+  answererUserId: string;
+  questionId: string;
+  domain: string;
+  sourceId: string;
+  broadCategory?: string | null;
+  /**
+   * Pre-fetched stats from the canonical Question row. Pass when the caller
+   * already has the row loaded (feed/[id]/answer, questions/[id]/answer);
+   * omit to have the helper fetch them itself (daily/answer, catchup/answer,
+   * which only have a generated_question id pre-persist).
+   */
+  questionStats?: QuestionStats;
+  /** Short label for log lines, e.g. 'daily/answer'. */
+  scope: string;
+};
+
+/**
+ * Compute and persist the author-credit mastery event for a correct answer.
+ *
+ * Designed to be called via `void awardAuthorCredit(...)` from every answer
+ * route — the caller's HTTP response should never wait on this. All errors
+ * are swallowed and logged; the answerer's own mastery write is unaffected.
+ *
+ * Pattern A callers (daily/answer, daily/catchup/answer) only have the
+ * canonical question id at this point, so the helper fetches the stats row
+ * itself. Pattern B callers (feed/[id]/answer, questions/[id]/answer)
+ * already have the row in memory and pass it via `questionStats` so we
+ * don't re-fetch.
+ */
+export async function awardAuthorCredit(params: AwardAuthorCreditParams): Promise<void> {
+  try {
+    let stats = params.questionStats;
+    if (!stats) {
+      const [row] = await db
+        .select({
+          correctCount: questions.correctCount,
+          askedCount: questions.askedCount,
+          calibratedDifficulty: questions.calibratedDifficulty,
+          llmDifficulty: questions.llmDifficulty,
+        })
+        .from(questions)
+        .where(eq(questions.id, params.questionId))
+        .limit(1);
+      if (!row) return;
+      stats = row;
+    }
+
+    const existingCredits = await countAuthorCreditEvents(params.questionId, params.creatorUserId);
+    const authorAward = creatorMasteryAwardForNthCorrect(
+      stats.correctCount,
+      stats.askedCount,
+      existingCredits + 1,
+      stats.calibratedDifficulty ?? stats.llmDifficulty,
+    );
+    if (authorAward.awardedPoints <= 0) return;
+
+    await writeMasteryEvent({
+      userId: params.creatorUserId,
+      questionId: params.questionId,
+      domain: params.domain,
+      pointsAwarded: authorAward.awardedPoints,
+      sourceType: 'author_credit',
+      sourceId: params.sourceId,
+      broadCategory: params.broadCategory ?? undefined,
+      eventQuestionId: params.questionId,
+      basePoints: authorAward.basePoints,
+      weight: authorAward.weight,
+      answeredByUserId: params.answererUserId,
+    });
+  } catch (err) {
+    console.warn(`[${params.scope}] author_credit failed`, err);
+  }
 }


### PR DESCRIPTION
## Summary

Re-audit item #1 — defer the author-credit chain off the answer hot path. Mirrors the friend-feed fan-out deferral from commit `4e8ac51`.

Every answer route had an inline author-credit chain awaited after the user's own mastery write:

```ts
// Pattern A (daily/answer, daily/catchup/answer):
const [canonicalQ] = await db.select({...}).from(questions).limit(1);  // 1 query
const existingCredits = await countAuthorCreditEvents(...);              // 1 query
const authorAward = creatorMasteryAwardForNthCorrect(...);
if (authorAward.awardedPoints > 0) {
  await writeMasteryEvent({...});                                        // 1 query
}

// Pattern B (feed/answer, questions/answer): same but skips the first SELECT
// because question row is already in memory.
```

…all awaited before the response returned, even though the answerer never sees any of these results in the API response. With the pool capped at 5 and 1–3 sequential queries per correct answer, this was ~100–300ms on the critical path for every correct answer where author ≠ answerer.

### Change

- **New helper** `awardAuthorCredit()` in `src/server/mastery/author-credit.ts` that runs the whole chain with its own `try/catch` — safe to fire via `void awardAuthorCredit(...)`. Accepts optional pre-fetched `questionStats` so Pattern-B callers that already loaded the row don't re-fetch.
- **Four answer routes** converted from awaited inline chain to `void awardAuthorCredit({...})`:
  - `src/app/api/daily/answer/route.ts`
  - `src/app/api/daily/catchup/answer/route.ts`
  - `src/app/api/feed/[feedItemId]/answer/route.ts`
  - `src/app/api/questions/[id]/answer/route.ts`
- Dropped now-unused imports (`creatorMasteryAwardForNthCorrect`, `countAuthorCreditEvents`) from the four routes.

### What stays the same

- The author still receives credit; it just arrives 50–200ms after the answerer's response settles instead of blocking it.
- The author-credit business logic (PRD §8.32 windowed scheme) is unchanged — just relocated.
- `joshing-games/[id]/answer/route.ts` is intentionally untouched. It doesn't use the author-credit chain (joshing-game completion handles credit differently).

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` clean.
- [x] `npm run lint` — no new violations on any touched file.
- [x] `npx vitest run src/app/api/daily src/app/api/feed src/app/api/questions src/server/mastery` — same pre-existing failures as on `dev2` (vi.mock hoisting issue + searchParams mock issue), none new.
- [ ] Manual: answer one Daily Five question correctly on a question authored by a friend. Confirm in DB:
  - `POST /api/daily/answer` returns within ~600ms (down from ~900ms baseline).
  - Within a few seconds, `MASTERY_EVENTS` has a new `author_credit` row for the question's creator (visible via `SELECT * FROM "MASTERY_EVENTS" WHERE source_type = 'author_credit' AND user_id = '<creator>' ORDER BY created_at DESC LIMIT 5`).
- [ ] Monitor `[llm]` and `[db-pool]` logs from PR #301 — verify author-credit DB queries no longer correlate with elevated `Server-Timing: proxy;dur` values on `/api/daily/answer`.

https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH

---
_Generated by [Claude Code](https://claude.ai/code/session_01YLNB6eKXD8GhPtNobgs1RH)_