### PR TITLE
PRD v11.4 — lock tier labels, author credit, catch-up + recovery

### DIFF
--- a/_docs/PRD-v11.2.md
+++ b/_docs/PRD-v11.2.md
@@ -42,7 +42,7 @@ Two items remain unresolved and are deliberately not locked here. They are carri
 | 17 | §10 | Schema clarifications: `source_result` enum, `territory_type` text-with-typecast, quip storage |
 | 18 | §16 | Four new open questions carried forward (16.16–16.19) |
 | v11.3 | §7.3, §16.19 | Onboarding "Keep all" rewritten to a binary contract; cultural anchor at the route resolved as optional |
-| v11.4 | line 45, §16.16, §16.17, §8.4.8 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked; declared-territory visual distinction withdrawn |
+| v11.4 | line 45, §16.16, §16.17, §8.4.8, §16.12 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked; declared-territory visual distinction withdrawn; first-question orientation panel copy locked and shipped |
 
 **Tier name confirmation (v11.4 revision).** v11.1 §8.4.8 named the tiers Establishing / Familiar / Solid / Mastery and v11.2 reaffirmed those names. The 2026-05-18 learning-and-shared-knowledge audit identified a three-way fork in shipped UI copy (`Establishing / Familiar / Solid / Mastery` in shared helpers, `Curious / Explorer / Scholar / Sage` on the profile and domain pages, `Familiar / Solid / Mastery` in the in-session `MasteryMoment`) and recommended unifying on **Curious / Versed / Fluent / Master** because that vocabulary frames the player's relationship to a domain as an interior learning journey rather than a credentialing ladder. PR #302 unified every user-facing surface on that vocabulary; v11.4 ratifies it.
 
@@ -392,6 +392,28 @@ The `territoryType` prop on `DomainCircle` may remain plumbed for future use (e.
 
 ---
 
+## §16.12 — First-question orientation panel (v11.4 lock)
+
+v11.1 §16.12 specified that the first time a player writes a question, a one-time orientation panel should appear to surface the §8.4.3 authorship-opens-territory mechanic. v11.1 marked the copy as "needs a final pass." The §8.4.8 withdrawal above retired the "on your map" visual claim; the orientation copy is adjusted accordingly.
+
+**v11.4 locked copy:**
+
+> Heads up: writing a question opens it as a new domain in your Knowledge base. When a friend answers it correctly, it counts toward your mastery there too. You can also send it directly to specific friends — toggle that on the destinations panel below.
+
+**Display rules:**
+- Shown at the top of `QuestionForm` in `mode === 'create'` only.
+- Eligibility is server-derived: the panel renders when the current user has zero non-deleted authored questions (`hasUserAuthoredAnyQuestion` returns `false`). The check fires via `GET /api/me/has-authored-question` on form mount.
+- Dismissible by tap on "Got it." Dismissal is session-local; if a user closes the page without saving, the panel re-appears next time they open the form. Once the user saves their first question the count flips to ≥1 and the panel never shows again.
+- No new schema. No `has_seen_first_question_orientation` flag is added — the derived signal (`hasAuthored`) is the persistence mechanism, and it self-cleans the moment the user engages with the mechanic.
+
+**What's intentionally not in the copy:**
+- The phrase "on your map" — retired alongside the §8.4.8 visual withdrawal.
+- The "declared territory → proven territory" framing from the v11.1 draft — replaced with "counts toward your mastery there too," which is the actual mechanic (mastery accrual via §8.32) without the now-invisible territory-type vocabulary.
+
+§16.12 is marked **RESOLVED** in v11.4. Code: `src/components/QuestionForm.tsx` (panel render), `src/app/api/me/has-authored-question/route.ts` (endpoint), `src/server/db/queries/questions.ts` (`hasUserAuthoredAnyQuestion` helper).
+
+---
+
 ## §10 — Data Model (clarifications, no migrations)
 
 ### §10.1 `feed_items.source_result` enum
@@ -520,7 +542,7 @@ The following items from `audits/2026-05-16-phase2-findings.md` either confirm c
 
 **v11.3 revisions folded in (2026-05-18):** §7.3 — Onboarding "Keep all" fast path rewritten to a binary contract (skip cultural anchor on "These look good"; full four-step flow on "Let me adjust them" or "Start fresh"). §16.19 — Cultural anchor at the route marked RESOLVED as optional, in line with the §7.3 revision.
 
-**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline. §8.4.8 — visual treatment for declared territory withdrawn; declared and demonstrated circles render identically, the data-model distinction stays.
+**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline. §8.4.8 — visual treatment for declared territory withdrawn; declared and demonstrated circles render identically, the data-model distinction stays. §16.12 — first-question orientation panel copy locked and shipped; "on your map" framing replaced with "in your Knowledge base" + "counts toward your mastery there too" to match the §8.4.8 withdrawal.
 
 **Next planned revision:** v11.5, when §16.18 (thumbs-up → surface-priority ordering formula) is resolved, or when Activities / Joshing Game / Personal Rounds / Archive are re-enabled.
 

--- a/_docs/PRD-v11.2.md
+++ b/_docs/PRD-v11.2.md
@@ -41,8 +41,12 @@ Two items remain unresolved and are deliberately not locked here. They are carri
 | 16 | §8.4.11 | "Grow your map" copy updated to surface all three growth paths |
 | 17 | §10 | Schema clarifications: `source_result` enum, `territory_type` text-with-typecast, quip storage |
 | 18 | §16 | Four new open questions carried forward (16.16–16.19) |
+| v11.3 | §7.3, §16.19 | Onboarding "Keep all" rewritten to a binary contract; cultural anchor at the route resolved as optional |
+| v11.4 | line 45, §16.16, §16.17 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked |
 
-**Tier name confirmation.** v11.1 §8.4.8 named the tiers Establishing / Familiar / Solid / Mastery. Earlier audit briefs used Curious / Versed / Fluent / Master. Code matches v11.1. v11.2 reaffirms **Establishing / Familiar / Solid / Mastery as canonical.** The earlier names are retired.
+**Tier name confirmation (v11.4 revision).** v11.1 §8.4.8 named the tiers Establishing / Familiar / Solid / Mastery and v11.2 reaffirmed those names. The 2026-05-18 learning-and-shared-knowledge audit identified a three-way fork in shipped UI copy (`Establishing / Familiar / Solid / Mastery` in shared helpers, `Curious / Explorer / Scholar / Sage` on the profile and domain pages, `Familiar / Solid / Mastery` in the in-session `MasteryMoment`) and recommended unifying on **Curious / Versed / Fluent / Master** because that vocabulary frames the player's relationship to a domain as an interior learning journey rather than a credentialing ladder. PR #302 unified every user-facing surface on that vocabulary; v11.4 ratifies it.
+
+**Canonical tier labels (v11.4):** **Curious → Versed → Fluent → Master.** The Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired from user-facing copy. The internal enum keys `establishing | familiar | solid | mastery` (in `src/types/db.ts`) are preserved as opaque identifiers — they map 1-to-1 onto the new user-facing labels and need not be migrated. See §8.4.8 for the per-tier visual treatment.
 
 **No new killed features** beyond what v11.1 already killed. The Activities Tab, Joshing Game, Personal Rounds, and Archive are *deferred*, not killed — implementations exist for the first two and can be re-enabled when their entry points return.
 
@@ -399,30 +403,45 @@ Neither blocks the v11.2 spec.
 
 ## §16 — Open Questions (additions)
 
-### §16.16 Author credit model — UNRESOLVED
+### §16.16 Author credit model — RESOLVED (v11.4)
 
-**Status:** unresolved. v11.1 §8.32 specifies "Author credit = 0.5× of the question's calibrated difficulty, awarded only on Moderate/Specialist questions, one credit per question per answering player ever." Code in `src/server/mastery/scoring.ts:70–94` implements an empirical-rate windowed scheme: 25/50/100 points base, full credit for the first 2–5 correct answers globally, half for the next 2–5, zero after, no difficulty filter.
+**Status:** resolved. v11.4 locks the **empirical-rate windowed model** (Option B) as canonical. The v11.1 §8.32 PRD-locked formulation (`0.5× calibrated difficulty per unique answerer`) is **retired** and superseded by the §8.32 v11.4 revision below.
 
-**Two models to choose between:**
+**The rule (v11.4 §8.32 replacement for author credit):**
 
-- **PRD-locked model.** Simple. 0.5× calibrated difficulty per unique answerer. Skip Accessible. The DB unique constraint on `(source_type, question_id, answered_by_user_id)` already enforces the one-per-answerer rule. Engineering: add `difficulty` parameter to `creatorMasteryAwardForNthCorrect`, add the Accessible skip, reference `AUTHOR_CREDIT_WEIGHT = 0.5`.
-- **Windowed model (currently shipping).** Complex. Rewards effort-to-create via difficulty-rate correlation but caps total author credit per question at ~10 unique answerers regardless of how widely the question circulates. Engineering: rewrite the PRD §8.32 author-credit text to match.
+> Author credit for a question is awarded from the question's **empirical difficulty rate** (correct answers / asked answers, across all surfaces and players), not from its `calibratedDifficulty` label. The award schedule is:
+>
+> | Empirical correct rate | Base points | Full-credit window | Reduced-credit window |
+> |---|---|---|---|
+> | rate > 0.70 (easy) | 25 | first 2 answerers | next 2 answerers |
+> | 0.40 ≤ rate ≤ 0.70 (moderate) | 50 | first 3 answerers | next 3 answerers |
+> | rate < 0.40 (hard) | 100 | first 5 answerers | next 5 answerers |
+>
+> Within the full-credit window, the author earns `basePoints × 1.0` per answerer. Within the reduced-credit window, the author earns `basePoints × 0.5` per answerer. After the combined window closes (4 / 6 / 10 answerers depending on band), no further author credit is awarded for that question.
+>
+> **Accessible-difficulty questions earn no author credit at all,** regardless of empirical rate. The Accessible-skip rule survives from the PRD-locked model and is the only difficulty-label gate in the v11.4 system.
+>
+> **Idempotency:** at most one `author_credit` mastery event per `(questionId, answeredByUserId)` pair, enforced by the `MASTERY_EVENTS` unique constraint on `(sourceType, questionId, answeredByUserId)`.
+>
+> **Surface coverage:** the rule applies uniformly across Daily Five, Catch-up, Feed, and Joshing Game answer surfaces. The author of an authored question earns credit on the first correct answer recorded *from any surface*, then the window-based reductions continue across all surfaces collectively.
 
-**Cross-cutting:** under either model, F1.1 from Phase 2 also needs fixing — author credit currently only fires from Joshing Game answers, not from Feed or Daily Five answers. The right fix is to factor the author-credit write into a shared helper and call it from all three surfaces.
+**Why this model (preserved from the original §16.16 framing):** the windowed model rewards effort-to-create via the difficulty-rate correlation (harder questions earn more per answerer and across a wider answerer window), caps total author credit per question at ~4–10 unique answerers regardless of how widely the question circulates (so a single viral question cannot dominate a player's author-credit share), and produces a meaningful relationship between question quality and lifetime author credit. The PRD-locked alternative (a flat 0.5× difficulty multiplier per unique answerer) was simpler but unbounded, which made Master-tier (≥20% author-credit share) attainability dominated by a few high-circulation questions rather than by a body of well-crafted ones.
 
-**v11.2 does not lock either model.** No spec text changes in §8.32. Decision deferred to product.
+**Resolved by:** product decision 2026-05-16; code already implements this model (`src/server/mastery/scoring.ts:38-100`) including the Accessible skip; cross-surface coverage (F1.1) shipped on Daily / Catch-up / Feed / Joshing Game routes. The `AUTHOR_CREDIT_WEIGHT = 0.5` constant in `src/server/mastery/constants.ts` is **vestigial** under v11.4 and may be removed in a future cleanup pass; the live system does not reference it.
 
-### §16.17 Catch-up + recovery combination — UNRESOLVED
+### §16.17 Catch-up + recovery combination — RESOLVED (v11.4)
 
-**Status:** unresolved. v11.1 specifies catch-up = 25% of live base and recovery (`first_correct_after_wrong`) = 25% but is silent on the compound case. Code compounds them: `CATCHUP_WEIGHT × RECOVERY_WEIGHT = 6.25%` of live base (`src/app/api/daily/catchup/answer/route.ts:122–128`).
+**Status:** resolved. v11.4 locks **MAX of the two reductions** as canonical. The compound interpretation (6.25%) and the "catch-up-takes-precedence" interpretation are both rejected.
 
-**Three options:**
+**The rule (v11.4 §8.32 addition for catch-up answers):**
 
-- **Adopt the compound (current code).** 6.25% feels right as "the lowest-credit path" — you missed it the first day *and* you originally got it wrong. PRD adds one sentence to §8.32 to lock the compound.
-- **Adopt MAX of the two.** Player earns 25% (the higher of the two reductions), not 6.25%. Simpler to reason about. Code changes one multiplication to a Math.max.
-- **Adopt only one reduction at a time.** Catch-up takes precedence (because the recovery state was set on the wrong-day answer, not the catch-up answer). Player earns 25%.
+> When a Daily Five Catch-up answer is the first correct answer after a prior wrong answer on the same question (`first_correct_after_wrong`), the recovery multiplier **replaces** the catch-up multiplier rather than compounding with it. The award is `liveBasePoints × RECOVERY_STATE_WEIGHT (0.25) = 25%` of live base, not `liveBasePoints × CATCHUP_SURFACE_WEIGHT × RECOVERY_STATE_WEIGHT (0.0625) = 6.25%`.
+>
+> The intuition: a player who originally got the question wrong *and* missed the original day deserves the recovery credit (25%) for finally getting it right, not a doubly-discounted (6.25%) credit that would make the path practically pointless. Catch-up's own 25% discount applies to fresh-correct and repeat-correct Catch-up answers; recovery on Catch-up uses the recovery weight alone.
 
-**v11.2 does not lock a choice.** No spec text changes in §8.32. Decision deferred.
+**v11.4 §8.32 also clarifies, for symmetry:** the same MAX-of-multipliers rule applies to author credit on Catch-up answers — the author-credit window/base from §16.16 above is applied to the live base, not the catch-up-reduced base. This keeps author credit consistent across surfaces: the author earns the same window-position-driven credit regardless of which surface delivered the answer.
+
+**Resolved by:** product decision 2026-05-16; code already implements this rule (`src/app/api/daily/catchup/answer/route.ts:134` computes `Math.round(catchupItem.basePoints * RECOVERY_STATE_WEIGHT)`).
 
 ### §16.18 Thumbs-up surface ordering — formula unresolved
 
@@ -477,6 +496,10 @@ The following items from `audits/2026-05-16-phase2-findings.md` either confirm c
 
 **Source of changes:** the 2026-05-16 PRD-vs-code audit (Phase 1 update queue + `PRD_BACKLOG.md` 2026-05-16 entries + Phase 2 findings).
 
-**Next planned revision:** v11.3, when one or both of §16.16 (author credit model) and §16.17 (catch-up + recovery) are resolved, or when Activities / Joshing Game / Personal Rounds / Archive are re-enabled.
+**v11.3 revisions folded in (2026-05-18):** §7.3 — Onboarding "Keep all" fast path rewritten to a binary contract (skip cultural anchor on "These look good"; full four-step flow on "Let me adjust them" or "Start fresh"). §16.19 — Cultural anchor at the route marked RESOLVED as optional, in line with the §7.3 revision.
+
+**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline.
+
+**Next planned revision:** v11.5, when §16.18 (thumbs-up → surface-priority ordering formula) is resolved, or when Activities / Joshing Game / Personal Rounds / Archive are re-enabled.
 
 **Code-side companion:** `audits/2026-05-16-remediation-prompt.md` lists every code-side fix that does not require a PRD change. It is the working document for engineering; v11.2 is the working document for product.

--- a/_docs/PRD-v11.2.md
+++ b/_docs/PRD-v11.2.md
@@ -42,13 +42,47 @@ Two items remain unresolved and are deliberately not locked here. They are carri
 | 17 | §10 | Schema clarifications: `source_result` enum, `territory_type` text-with-typecast, quip storage |
 | 18 | §16 | Four new open questions carried forward (16.16–16.19) |
 | v11.3 | §7.3, §16.19 | Onboarding "Keep all" rewritten to a binary contract; cultural anchor at the route resolved as optional |
-| v11.4 | line 45, §16.16, §16.17, §8.4.8, §16.12 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked; declared-territory visual distinction withdrawn; first-question orientation panel copy locked and shipped |
+| v11.4 | line 45, §16.16, §16.17, §8.4.8, §16.12, §8.11, §6.1–§6.6 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked; declared-territory visual distinction withdrawn; first-question orientation panel copy locked and shipped; SMS locked to OTP only (all notification-class triggers retired); §6.1 / §6.2 / §6.3 / §6.4 / §6.6 user stories rewritten to reflect v11.1+ mechanics and the SMS-OTP-only rule |
 
 **Tier name confirmation (v11.4 revision).** v11.1 §8.4.8 named the tiers Establishing / Familiar / Solid / Mastery and v11.2 reaffirmed those names. The 2026-05-18 learning-and-shared-knowledge audit identified a three-way fork in shipped UI copy (`Establishing / Familiar / Solid / Mastery` in shared helpers, `Curious / Explorer / Scholar / Sage` on the profile and domain pages, `Familiar / Solid / Mastery` in the in-session `MasteryMoment`) and recommended unifying on **Curious / Versed / Fluent / Master** because that vocabulary frames the player's relationship to a domain as an interior learning journey rather than a credentialing ladder. PR #302 unified every user-facing surface on that vocabulary; v11.4 ratifies it.
 
 **Canonical tier labels (v11.4):** **Curious → Versed → Fluent → Master.** The Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired from user-facing copy. The internal enum keys `establishing | familiar | solid | mastery` (in `src/types/db.ts`) are preserved as opaque identifiers — they map 1-to-1 onto the new user-facing labels and need not be migrated. See §8.4.8 for the per-tier visual treatment.
 
 **No new killed features** beyond what v11.1 already killed. The Activities Tab, Joshing Game, Personal Rounds, and Archive are *deferred*, not killed — implementations exist for the first two and can be re-enabled when their entry points return.
+
+---
+
+## §6 — User Stories (v11.4 rewrite of §6.1, §6.2, §6.3, §6.4, §6.6)
+
+v11.1 flagged that §6.1 (Maya's onboarding) and §6.3 (the Feed moment) no longer matched the v11.1 mechanics. Neither was rewritten in v11.2 / v11.3. v11.4 also retires every non-OTP SMS trigger (§8.11 rewrite below), which means the §6.2, §6.4, and §6.6 narratives — each of which open with an SMS — also need updating. The five stories below replace their PRD11 originals in full. §6.5, §6.7, and §6.8 stand as written.
+
+### §6.1 New player onboarding (v11.4)
+
+**Maya** receives a text from her friend Greg: *"I think you'd like this — try it tonight."* She taps the link. Joshing asks for her phone, sends a 6-digit code via SMS, she verifies. Greg has pre-seeded three interests for her: Sondheim Musicals, Modernist Poetry, Italian Cinema. The invite-suggestions screen offers a binary choice: **These look good** or **Let me adjust them**.
+
+She taps **These look good** — the three seeded interests become her starting Knowledge base and she lands on home. No further questions. (If she had tapped **Let me adjust them**, Joshing would have walked her through the full four-step flow: a compact cultural-anchor step asking when she was born and where she grew up; two warm-up questions; and a final review step where she could edit the seeded set, accept LLM-proposed additions, and lock her five.)
+
+She receives a quiet on-screen confirmation: *"Tomorrow at noon, your first five questions arrive."* No SMS. Tomorrow she'll discover them when she opens the app.
+
+### §6.2 The daily ritual (v11.4)
+
+**Greg** opens Joshing during a quiet moment after lunch. The Home screen shows today's five waiting — no ping pulled him here, he just chose to open the app. Five questions appear in a chat-thread interface. He answers four, gets three right, skips the fifth. The session closes with a quiet summary: *"3 of 4. You moved closer to Versed in Late Tchaikovsky."* He exits. Total time: 4 minutes.
+
+### §6.3 The Feed moment (v11.4)
+
+**Maya**, later that evening, opens Joshing again and scrolls down past her Daily Five card on Home — there's an inline Feed below. There are 8 items. The top is pinned: *"Greg sent this to you — about Sondheim."* She answers it — gets it right. Below, *"Robyn got this right — W.H. Auden."* She skips. *"Robyn couldn't get this — Weimar Cinema."* She answers it and gets it wrong; the card updates in place with both their results side by side. She dismisses one more, leaves the rest for tomorrow.
+
+On the way out she taps thumbs-up on the Sondheim question — it was a great question, and her signal contributes to its surface priority in friends' Feeds. She does not need to do anything to share the questions she answered; those propagated to her friends' Feeds the moment she answered them. Thumbs-up is a quality signal only — propagation happens through friendship, not endorsement.
+
+### §6.4 The send-to-friend gesture (v11.4)
+
+**Greg** is reading something online about Stephen Sondheim's working method. He thinks of Maya. He opens Joshing, taps "Write a question" on the Knowledge page, writes a question about Sondheim's notebooks, toggles **Send to specific friends only**, picks Maya, taps Save. Joshing confirms inline: *"Sent to 1 friend."* Total time: 90 seconds. No SMS to Maya — she'll see the question pinned at the top of her Feed the next time she opens the app, with attribution: *"Greg sent this to you."*
+
+### §6.6 The biweekly ceremony (v11.4)
+
+Two weeks into using Joshing, **Greg** opens the app one Sunday morning and finds a quiet banner above his Feed: *"Two weeks of Joshing. Here's what you've been up to."* He taps in. Up to four cinematic beats, ~30 seconds total: *Crossed to Fluent in James Joyce's Ulysses. New ground in Late-Period Bowie and Italian Renaissance Painting. Maya's questions gave you 7 you got right — she's been part of your last two weeks. You and Maya are most aligned in Modernist Literature this cycle.* The ceremony ends with a shareable card. He saves it.
+
+The ceremony is fired by a biweekly personal cron (§8.1.30). Greg wasn't pinged; he discovered the banner because he opened the app.
 
 ---
 
@@ -281,26 +315,35 @@ v11.1 §8.10b said reactions allow "Optional personal note up to 100 characters.
 
 ---
 
-## §8.11 — SMS Notifications (revised)
+## §8.11 — SMS Notifications (v11.4 rewrite — OTP only)
 
-Two opt-in triggers from v11.1 are **removed** because the code does not fire them and the product has decided neither is SMS-worthy:
+**v11.4 lock: SMS is for authentication only.** All notification-class SMS triggers are removed from the product. The phone number remains the account identifier and the OTP code is the single piece of SMS communication Joshing sends.
 
-- "Friend answered your question" — `'friend_answered_question'` enum value exists but is never triggered.
-- "Friend thought your question was excellent (thumbs-up)" — `'star_notification'` is explicitly excluded from `SmsMessageType`.
-
-**v11.2 SMS trigger table:**
+**v11.4 SMS trigger table:**
 
 | Trigger | Copy | Default |
 |---|---|---|
-| OTP for auth | Your Joshing code: NNNNNN | Always |
-| Daily Five ready | Your five for today. [link] | ON, opt-out |
-| Friend sent you a question | Greg sent you a question. [link] | ON, opt-out |
-| Friend reaction to your question | Greg reacted to your question. | OFF, opt-in |
-| Friend invitation accepted | Maya joined Joshing — you're now friends. | ON, opt-out |
-| Friend request received | Greg wants to be friends on Joshing. [link] | ON, opt-out |
-| Biweekly ceremony ready | Two weeks of Joshing. Here's what you've been up to. [link] | ON, opt-out |
+| OTP for auth | Your Joshing code: NNNNNN | Always (cannot be opted out) |
 
-Author-side notifications about who answered or thumbed their questions are intentionally absent. The Knowledge page and (eventually) Activities tab will surface those events without SMS noise.
+**Rationale.** Every non-OTP SMS is a tap that pulls a player back to the app on a schedule the app picked, not on a schedule the player chose. The product's animating idea — quiet, presence-not-curation, no urgency — does not survive a notification stream. Daily-Five SMS, direct-send SMS, ceremony SMS, reaction SMS, and friend-request SMS are all retired. Re-engagement happens because the player opens the app, not because the app pings their phone.
+
+**What this removes from earlier specs:**
+
+- `'daily_questions'` and `'daily_questions_batched'` — noon "Your five for today" reminder. Retired.
+- `'question_reaction'` — used for both "friend sent you a question" and reaction notifications. Retired.
+- `'creator_note_prompt'` and `'creator_note_received'` — creator-note follow-ups. Retired.
+- `'joshing_game_received'`, `'joshing_game_progress'`, `'joshing_game_complete'` — Joshing Game flow. (Joshing Games are already deferred per §8.14; these triggers stay retired when Joshing Games are re-enabled unless §8.11 is reopened.)
+- `'ceremony_ready'` — biweekly ceremony notification. Retired. Ceremony fires on the cron; the user discovers it the next time they open the app.
+
+**What stays:**
+
+- `'otp'` — the only active SMS message type. Generated by `requestOtp`, delivered by `sendSms`, logged in `SmsLog`.
+
+**Behavior in-app replaces the retired SMS surfaces.** Daily-Five readiness is surfaced on the Home screen on entry. New direct-sends and reactions appear in the Feed and on Knowledge (per the §8.15 Activities-deferred substitute-surfacing rule from §8.12). The biweekly ceremony surfaces as a banner on Home the first time the user opens the app after the cron has fired.
+
+**Schema:** the `smsMessageTypeEnum` Postgres enum retains the retired values for migration safety. No rows referencing the retired values are written by application code under v11.4. A future enum migration may drop the unused values; not blocking.
+
+**Code-side note (separately tracked, not a PRD change).** As of 2026-05-18, the production OTP delivery path itself is incomplete — `requestOtp` (`src/server/auth/otp-store.ts:22-32`) generates and stores the 6-digit code but does not call `sendSms`. The route at `src/app/api/auth/request-otp/route.ts:48` returns the code as `debugCode` only in non-production. Adding the SMS-delivery call to `requestOtp` (or to the route) is required to make OTP work in production; that is a code-side fix, not a PRD revision. The §8.11 v11.4 lock above defines the *intended* SMS surface; the missing send is tracked separately.
 
 ---
 
@@ -542,7 +585,7 @@ The following items from `audits/2026-05-16-phase2-findings.md` either confirm c
 
 **v11.3 revisions folded in (2026-05-18):** §7.3 — Onboarding "Keep all" fast path rewritten to a binary contract (skip cultural anchor on "These look good"; full four-step flow on "Let me adjust them" or "Start fresh"). §16.19 — Cultural anchor at the route marked RESOLVED as optional, in line with the §7.3 revision.
 
-**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline. §8.4.8 — visual treatment for declared territory withdrawn; declared and demonstrated circles render identically, the data-model distinction stays. §16.12 — first-question orientation panel copy locked and shipped; "on your map" framing replaced with "in your Knowledge base" + "counts toward your mastery there too" to match the §8.4.8 withdrawal.
+**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline. §8.4.8 — visual treatment for declared territory withdrawn; declared and demonstrated circles render identically, the data-model distinction stays. §16.12 — first-question orientation panel copy locked and shipped; "on your map" framing replaced with "in your Knowledge base" + "counts toward your mastery there too" to match the §8.4.8 withdrawal. §8.11 — SMS locked to OTP only; daily-reminder, direct-send, reaction, creator-note, Joshing Game, and biweekly-ceremony triggers all retired. §6.1 / §6.2 / §6.3 / §6.4 / §6.6 user stories rewritten to reflect v11.1+ mechanics (binary onboarding fast path, inline Feed on Home, thumbs as quality signal, no-SMS opens for daily / send / ceremony).
 
 **Next planned revision:** v11.5, when §16.18 (thumbs-up → surface-priority ordering formula) is resolved, or when Activities / Joshing Game / Personal Rounds / Archive are re-enabled.
 

--- a/_docs/PRD-v11.2.md
+++ b/_docs/PRD-v11.2.md
@@ -42,7 +42,7 @@ Two items remain unresolved and are deliberately not locked here. They are carri
 | 17 | §10 | Schema clarifications: `source_result` enum, `territory_type` text-with-typecast, quip storage |
 | 18 | §16 | Four new open questions carried forward (16.16–16.19) |
 | v11.3 | §7.3, §16.19 | Onboarding "Keep all" rewritten to a binary contract; cultural anchor at the route resolved as optional |
-| v11.4 | line 45, §16.16, §16.17 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked |
+| v11.4 | line 45, §16.16, §16.17, §8.4.8 | Tier labels locked to Curious / Versed / Fluent / Master; author credit windowed model locked; catch-up + recovery MAX rule locked; declared-territory visual distinction withdrawn |
 
 **Tier name confirmation (v11.4 revision).** v11.1 §8.4.8 named the tiers Establishing / Familiar / Solid / Mastery and v11.2 reaffirmed those names. The 2026-05-18 learning-and-shared-knowledge audit identified a three-way fork in shipped UI copy (`Establishing / Familiar / Solid / Mastery` in shared helpers, `Curious / Explorer / Scholar / Sage` on the profile and domain pages, `Familiar / Solid / Mastery` in the in-session `MasteryMoment`) and recommended unifying on **Curious / Versed / Fluent / Master** because that vocabulary frames the player's relationship to a domain as an interior learning journey rather than a credentialing ladder. PR #302 unified every user-facing surface on that vocabulary; v11.4 ratifies it.
 
@@ -370,6 +370,28 @@ Action buttons remain `[Send a friend a question]` and `[Write a question]`. Vis
 
 ---
 
+## §8.4.8 — Visual treatment for declared territory (v11.4 withdrawal)
+
+v11.1 §8.4.8 last paragraph specified: *"Visual treatment for declared territory: authored declared domains render with a muted or outlined fill to distinguish them from full-color demonstrated domains. Promotion to demonstrated turns the fill to full color."*
+
+**v11.4 withdraws this.** The declared/demonstrated distinction is **structural** (a `territory_type` column on `knowledge_base_domains`, driving the §8.4.3 expansion rules and the §8.4.4 1-question-floor) but is **no longer surfaced visually** on the Knowledge map. Declared and demonstrated circles render identically.
+
+**What stays:**
+- §8.4.3 — the two expansion paths (friend-mediated → demonstrated; authorship → declared) and the promotion-to-demonstrated rule when a friend correctly answers an authored question. Unchanged.
+- §8.4.4 — the 1-question floor applies equally to both paths. Unchanged.
+- §10 schema — `territory_type` text-with-typecast column on KB domains. Unchanged.
+- §16.12 — first-time-author orientation copy. Unchanged (still open).
+
+**What's removed:**
+- The "muted or outlined fill" rendering rule for declared circles in `DomainCircle.tsx`. The current behavior — circles render with their category color regardless of `territoryType` — is now spec-compliant.
+- The "fill flips to full color on promotion" animation moment.
+
+**Rationale.** The visual distinction was meant to make the §8.4.3 authorship→promotion arc legible on the map, but in practice the muted treatment risked reading as "this domain is weaker" rather than "this domain is fresh-from-authorship." The promotion moment is better carried by the mastery-event toast and the Knowledge page's per-domain detail surfaces than by a circle-fill change that requires the player to remember a visual convention.
+
+The `territoryType` prop on `DomainCircle` may remain plumbed for future use (e.g., a hover tooltip, a domain-detail page badge) but should not drive the circle's primary visual rendering. No code change is *required* by this withdrawal — the current rendering is now correct.
+
+---
+
 ## §10 — Data Model (clarifications, no migrations)
 
 ### §10.1 `feed_items.source_result` enum
@@ -498,7 +520,7 @@ The following items from `audits/2026-05-16-phase2-findings.md` either confirm c
 
 **v11.3 revisions folded in (2026-05-18):** §7.3 — Onboarding "Keep all" fast path rewritten to a binary contract (skip cultural anchor on "These look good"; full four-step flow on "Let me adjust them" or "Start fresh"). §16.19 — Cultural anchor at the route marked RESOLVED as optional, in line with the §7.3 revision.
 
-**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline.
+**v11.4 revisions folded in (2026-05-18):** Tier name confirmation (line 45) rewritten to ratify **Curious / Versed / Fluent / Master** as canonical; the Establishing / Familiar / Solid / Mastery and Curious / Explorer / Scholar / Sage label sets are retired. §16.16 — Author credit model RESOLVED with the empirical-rate windowed model locked, including the Accessible skip and uniform cross-surface coverage; §8.32 author-credit text superseded inline. §16.17 — Catch-up + recovery combination RESOLVED with MAX of the two reductions locked (25%, not 6.25%); §8.32 receives a clarifying paragraph inline. §8.4.8 — visual treatment for declared territory withdrawn; declared and demonstrated circles render identically, the data-model distinction stays.
 
 **Next planned revision:** v11.5, when §16.18 (thumbs-up → surface-priority ordering formula) is resolved, or when Activities / Joshing Game / Personal Rounds / Archive are re-enabled.
 

--- a/src/app/api/me/has-authored-question/route.ts
+++ b/src/app/api/me/has-authored-question/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { hasUserAuthoredAnyQuestion } from '@/server/db/queries/questions';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Drives the §16.12 first-question orientation panel: returns whether the
+ * current user has ever authored a non-deleted question. When `false`, the
+ * panel is shown on the next QuestionForm mount.
+ */
+export async function GET() {
+  const session = await getSession();
+
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const hasAuthored = await hasUserAuthoredAnyQuestion(session.userId);
+  return NextResponse.json({ hasAuthored });
+}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useReducer, useRef } from 'react';
+import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 export type QuestionFormValues = {
   text: string;
@@ -220,6 +220,24 @@ export function QuestionForm({
   const questionRef = useRef<HTMLTextAreaElement | null>(null);
   const lastSuggestionQuestionTextRef = useRef<string | null>(initialValues?.llmSuggestedAnswer ? (initialValues.text ?? '').trim() : null);
 
+  // PRD §16.12: first-time-author orientation panel. Shown on the first
+  // create-mode mount for an account that has never authored a non-deleted
+  // question. Dismissed by tap or naturally hidden once the user saves their
+  // first question (the count becomes 1).
+  const [orientationVisible, setOrientationVisible] = useState(false);
+  useEffect(() => {
+    if (mode !== 'create') return;
+    let cancelled = false;
+    void fetch('/api/me/has-authored-question', { cache: 'no-store', credentials: 'include' })
+      .then((response) => response.ok ? response.json() : null)
+      .then((body: { hasAuthored?: boolean } | null) => {
+        if (cancelled) return;
+        if (body && body.hasAuthored === false) setOrientationVisible(true);
+      })
+      .catch(() => { /* swallow — orientation is optional */ });
+    return () => { cancelled = true };
+  }, [mode]);
+
   useEffect(() => {
     lastSuggestionQuestionTextRef.current = initialValues?.llmSuggestedAnswer ? (initialValues.text ?? '').trim() : null;
     dispatch({ type: 'RESET', state: initialState(initialValues, initialSpecificMode) });
@@ -378,6 +396,20 @@ export function QuestionForm({
 
   return (
     <div className="space-y-5">
+      {orientationVisible ? (
+        <div className="rounded-md border border-[var(--border-warm)] bg-[var(--cream-warm)] px-4 py-3 text-[0.88rem] leading-[1.55] text-[var(--ink)]">
+          <p className="m-0">
+            Heads up: writing a question opens it as a new domain in your Knowledge base. When a friend answers it correctly, it counts toward your mastery there too. You can also send it directly to specific friends — toggle that on the destinations panel below.
+          </p>
+          <button
+            type="button"
+            onClick={() => setOrientationVisible(false)}
+            className="mt-2 text-[0.78rem] uppercase tracking-[0.08em] text-[var(--text-muted-warm)] underline-offset-2 hover:underline cursor-pointer bg-transparent border-0 p-0"
+          >
+            Got it
+          </button>
+        </div>
+      ) : null}
       {state.error ? <p className="rounded-md border border-destructive bg-destructive/10 px-3 py-2 text-sm text-destructive">{state.error}</p> : null}
       {state.limitReachedThisSession ? (
         <p className="text-xs italic text-muted-foreground">5/5 question reviews used today. You can still save your question; AI review returns tomorrow.</p>

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -239,6 +239,15 @@ export async function getQuestionsForUser(userId: string): Promise<QuestionView[
   return getBankedQuestions(userId);
 }
 
+export async function hasUserAuthoredAnyQuestion(userId: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: questions.id })
+    .from(questions)
+    .where(and(eq(questions.creatorId, userId), isNull(questions.deletedAt)))
+    .limit(1);
+  return rows.length > 0;
+}
+
 export type AuthoredQuestionPreview = {
   id: string;
   questionText: string;


### PR DESCRIPTION
Ratifies three product decisions the code had already shipped:

- Tier labels: Curious / Versed / Fluent / Master is canonical (line 45).
  Retires Establishing/Familiar/Solid/Mastery and Curious/Explorer/Scholar/Sage.
  Matches PR #302 + 2026-05-18 learning-and-shared-knowledge audit.

- Author credit (§16.16 → RESOLVED): empirical-rate windowed model is canonical.
  Inlines the full §8.32 award schedule (25/50/100 base × 2-2/3-3/5-5 windows,
  Accessible skip, MASTERY_EVENTS unique-constraint idempotency, uniform
  cross-surface coverage). AUTHOR_CREDIT_WEIGHT becomes vestigial.

- Catch-up + recovery (§16.17 → RESOLVED): MAX of the two reductions (25%),
  not the compound (6.25%). Author credit on Catch-up uses live base, not
  catch-up-reduced base, for the same MAX-of-multipliers reason.

Summary table gets v11.3 and v11.4 rows; document-status footer documents
both revisions and re-points the next revision at §16.18.