### PR TITLE
Add zero-activity silence check to fireCeremony

### DIFF
--- a/src/app/api/cron/biweekly-ceremony/route.ts
+++ b/src/app/api/cron/biweekly-ceremony/route.ts
@@ -46,6 +46,7 @@ export async function GET(request: NextRequest) {
 
   let fired = 0;
   let skipped = 0;
+  let skippedNoActivity = 0;
 
   for (const user of onboardedUsers) {
     const accountAgeDays = daysBetweenNewYorkDates(user.createdAt, today);
@@ -67,9 +68,13 @@ export async function GET(request: NextRequest) {
       continue;
     }
 
-    await fireCeremony(user.id);
-    fired += 1;
+    const ceremonyId = await fireCeremony(user.id);
+    if (ceremonyId) {
+      fired += 1;
+    } else {
+      skippedNoActivity += 1;
+    }
   }
 
-  return NextResponse.json({ fired, skipped });
+  return NextResponse.json({ fired, skipped, skippedNoActivity });
 }

--- a/src/server/ceremony/__tests__/fire-ceremony.test.ts
+++ b/src/server/ceremony/__tests__/fire-ceremony.test.ts
@@ -8,49 +8,56 @@ const {
   insertReturningMock,
   userLookupMock,
   existingCeremonyLookupMock,
-} = vi.hoisted(() => ({
-  computeBeatsMock: vi.fn(async () => ({
-    cycleStart: '2026-05-01',
-    cycleEnd: '2026-05-15',
-    beat1: null,
-    beat2: null,
-    beat3: null,
-    beat4: null,
-    beat5: null,
-  })),
-  runDomainMergesForUserMock: vi.fn(async () => ({ mergesApplied: 0, details: [] })),
-  sendSmsMock: vi.fn(async () => undefined),
-  writeActivityMock: vi.fn(async () => undefined),
-  insertReturningMock: vi.fn(async () => [{ id: 'cer-1' }]),
-  userLookupMock: vi.fn(async () => [
-    { phoneNumber: '+15551234567', smsOptIn: 'opted_in' },
-  ]),
-  existingCeremonyLookupMock: vi.fn(async () => []),
-}))
-
-// The route's two distinct select() shapes:
-//   1) findExistingCeremony: select({id}).from(biweeklyCeremonies).where(and(...)).limit(1)
-//   2) user lookup: select({phoneNumber, smsOptIn}).from(users).where(eq(...)).limit(1)
-// Dispatch sequentially via a queue.
-const selectChain: Array<() => Promise<unknown[]>> = []
-
-const dbMock = {
-  select: vi.fn(() => {
-    const handler = selectChain.shift() ?? (async () => [])
-    return {
-      from: () => ({
-        where: () => ({
-          limit: handler,
+  selectChain,
+  dbMock,
+} = vi.hoisted(() => {
+  const insertReturningMock = vi.fn(async () => [{ id: 'cer-1' }])
+  const selectChain: Array<() => Promise<unknown[]>> = []
+  const dbMock = {
+    select: vi.fn(() => {
+      const handler = selectChain.shift() ?? (async () => [])
+      return {
+        from: () => ({
+          where: () => ({
+            limit: handler,
+          }),
         }),
-      }),
-    }
-  }),
-  insert: vi.fn(() => ({
-    values: vi.fn(() => ({
-      returning: () => insertReturningMock(),
+      }
+    }),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({
+        returning: () => insertReturningMock(),
+      })),
     })),
-  })),
-}
+  }
+  return {
+    computeBeatsMock: vi.fn(async () => ({
+      cycleStart: '2026-05-01',
+      cycleEnd: '2026-05-15',
+      beat1: null,
+      beat2: null,
+      beat3: null,
+      beat4: null,
+      beat5: null,
+    })),
+    runDomainMergesForUserMock: vi.fn(async () => ({ mergesApplied: 0, details: [] })),
+    sendSmsMock: vi.fn(async () => undefined),
+    writeActivityMock: vi.fn(async () => undefined),
+    insertReturningMock,
+    userLookupMock: vi.fn(async () => [
+      { phoneNumber: '+15551234567', smsOptIn: 'opted_in' },
+    ]),
+    existingCeremonyLookupMock: vi.fn(async () => []),
+    selectChain,
+    dbMock,
+  }
+})
+
+// The route's distinct select() shapes:
+//   1) findExistingCeremony: select({id}).from(biweeklyCeremonies).where(and(...)).limit(1)
+//   2) hasMasteryEventInCycle: select({id}).from(masteryEvents).where(and(...)).limit(1)
+//   3) user lookup: select({phoneNumber, smsOptIn}).from(users).where(eq(...)).limit(1)
+// Dispatch sequentially via a queue.
 
 vi.mock('@/server/activity/write-activity', () => ({
   writeActivity: writeActivityMock,
@@ -58,11 +65,13 @@ vi.mock('@/server/activity/write-activity', () => ({
 
 vi.mock('@/server/ceremony/compute-beats', () => ({
   computeBeats: computeBeatsMock,
+  beatsPayloadSchema: { parse: (value: unknown) => value },
 }))
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
   biweeklyCeremonies: { id: 'b.id', userId: 'b.uid', cycleStart: 'b.cs', cycleEnd: 'b.ce' },
+  masteryEvents: { id: 'm.id', userId: 'm.uid', createdAt: 'm.created' },
   users: { id: 'u.id', phoneNumber: 'u.phone', smsOptIn: 'u.opt' },
 }))
 
@@ -77,6 +86,10 @@ vi.mock('@/server/sms', () => ({
 import { fireCeremony } from '@/server/ceremony/fire-ceremony'
 
 function pushExistingLookup(rows: unknown[]) {
+  selectChain.push(async () => rows)
+}
+
+function pushMasteryLookup(rows: unknown[]) {
   selectChain.push(async () => rows)
 }
 
@@ -107,6 +120,7 @@ describe('fireCeremony (F3.3 idempotency)', () => {
 
   it('on first fire: computes beats, inserts row, writes activity, sends SMS', async () => {
     pushExistingLookup([]) // no prior
+    pushMasteryLookup([{ id: 'me-1' }]) // has activity in cycle
     pushUserLookup()
 
     const result = await fireCeremony('user-1')
@@ -123,6 +137,7 @@ describe('fireCeremony (F3.3 idempotency)', () => {
 
   it('on concurrent unique-violation: returns the racing winner id, skips activity + SMS', async () => {
     pushExistingLookup([]) // pre-check: nothing yet
+    pushMasteryLookup([{ id: 'me-1' }]) // has activity in cycle
     insertReturningMock.mockRejectedValueOnce(new Error('duplicate key value violates unique constraint'))
     // post-failure lookup: another transaction wrote 'racing-winner'
     pushExistingLookup([{ id: 'racing-winner' }])
@@ -136,6 +151,7 @@ describe('fireCeremony (F3.3 idempotency)', () => {
 
   it('skips SMS when user has opted out', async () => {
     pushExistingLookup([])
+    pushMasteryLookup([{ id: 'me-1' }])
     selectChain.push(async () => [{ phoneNumber: '+15551234567', smsOptIn: 'opted_out' }])
 
     await fireCeremony('user-1')
@@ -145,9 +161,32 @@ describe('fireCeremony (F3.3 idempotency)', () => {
 
   it('rethrows non-duplicate insert failures', async () => {
     pushExistingLookup([])
+    pushMasteryLookup([{ id: 'me-1' }])
     insertReturningMock.mockRejectedValueOnce(new Error('unrelated db failure'))
     pushExistingLookup([]) // post-failure lookup still finds nothing
 
     await expect(fireCeremony('user-1')).rejects.toThrow('unrelated db failure')
+  })
+})
+
+describe('fireCeremony (§8.1.31 eligibility — zero-activity silence)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    selectChain.length = 0
+    insertReturningMock.mockResolvedValue([{ id: 'cer-1' }])
+  })
+
+  it('returns null and does no work when the user has zero mastery events in the cycle', async () => {
+    pushExistingLookup([]) // no prior ceremony
+    pushMasteryLookup([]) // zero activity in cycle window
+
+    const result = await fireCeremony('user-1')
+
+    expect(result).toBeNull()
+    expect(runDomainMergesForUserMock).not.toHaveBeenCalled()
+    expect(computeBeatsMock).not.toHaveBeenCalled()
+    expect(writeActivityMock).not.toHaveBeenCalled()
+    expect(sendSmsMock).not.toHaveBeenCalled()
+    expect(dbMock.insert).not.toHaveBeenCalled()
   })
 })

--- a/src/server/ceremony/fire-ceremony.ts
+++ b/src/server/ceremony/fire-ceremony.ts
@@ -1,8 +1,8 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, gte, lte } from 'drizzle-orm';
 
 import { writeActivity } from '@/server/activity/write-activity';
 import { beatsPayloadSchema, computeBeats } from '@/server/ceremony/compute-beats';
-import { biweeklyCeremonies, db, users } from '@/server/db';
+import { biweeklyCeremonies, db, masteryEvents, users } from '@/server/db';
 import { runDomainMergesForUser } from '@/server/mastery/ceremony';
 import { sendSms } from '@/server/sms';
 
@@ -31,7 +31,24 @@ async function findExistingCeremony(
   return row?.id ?? null;
 }
 
-export async function fireCeremony(userId: string): Promise<string> {
+async function hasMasteryEventInCycle(
+  userId: string,
+  cycleStart: Date,
+  cycleEnd: Date,
+): Promise<boolean> {
+  const [row] = await db
+    .select({ id: masteryEvents.id })
+    .from(masteryEvents)
+    .where(and(
+      eq(masteryEvents.userId, userId),
+      gte(masteryEvents.createdAt, cycleStart),
+      lte(masteryEvents.createdAt, cycleEnd),
+    ))
+    .limit(1);
+  return Boolean(row);
+}
+
+export async function fireCeremony(userId: string): Promise<string | null> {
   const cycleEnd = new Date();
   const cycleStart = new Date(cycleEnd);
   cycleStart.setDate(cycleStart.getDate() - 14);
@@ -45,6 +62,13 @@ export async function fireCeremony(userId: string): Promise<string> {
   // the common case.
   const existingId = await findExistingCeremony(userId, cycleStartIso, cycleEndIso);
   if (existingId) return existingId;
+
+  // PRD §8.1.31 eligibility: a ceremony is the climax of activity, not a
+  // scheduled empty notification. Users with zero mastery events in the
+  // cycle window receive silence — no ceremony row, no activity item,
+  // no SMS.
+  const hasActivity = await hasMasteryEventInCycle(userId, cycleStart, cycleEnd);
+  if (!hasActivity) return null;
 
   const mergeResult = await runDomainMergesForUser(userId);
   const beatsPayload = await computeBeats(userId, cycleStart, cycleEnd);


### PR DESCRIPTION
## Summary
Implements PRD §8.1.31 eligibility requirement: users with zero mastery events in the ceremony cycle window now receive silence (no ceremony row, activity item, or SMS) instead of an empty ceremony notification.

## Changes
- **fireCeremony logic**: Added `hasMasteryEventInCycle()` helper that queries `masteryEvents` table within the cycle date range. Returns `null` instead of creating a ceremony when user has zero activity.
- **Return type**: Changed `fireCeremony()` return type from `Promise<string>` to `Promise<string | null>` to signal when a ceremony was skipped due to inactivity.
- **Cron endpoint**: Updated `biweekly-ceremony` route to track `skippedNoActivity` separately and include it in the response JSON.
- **Test coverage**: Added comprehensive test suite covering the zero-activity silence behavior, including verification that no downstream work (merges, beats computation, activity writes, SMS) occurs when a user has no activity.

## Implementation Details
- The `hasMasteryEventInCycle()` check runs after the idempotency check (`findExistingCeremony`) but before any expensive operations (domain merges, beats computation).
- Uses Drizzle `gte` and `lte` operators to query mastery events within the cycle window.
- Test infrastructure refactored to use a `selectChain` queue pattern, allowing sequential dispatch of multiple `select()` calls with different return values.

https://claude.ai/code/session_018kjftkVgQinxAcpgRH9mYg