### PR TITLE
Reduce wrong answer headline variants from 4 to 3

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -91,12 +91,10 @@ const CORRECT_COPY: Array<{ headline: string; subLabel: string }> = [
 ];
 
 function wrongHeadline(variant: number): string {
-  switch (variant % 4) {
+  switch (variant % 3) {
     case 0: return 'Not this time — here\u2019s the answer.';
     case 1: return 'You\u2019ll know this one next time.';
-    case 2:
-      return 'Now it’s in yours too.';
-    case 3: return 'Close, but not quite.';
+    case 2: return 'Close, but not quite.';
     default: return 'Not this time — here\u2019s the answer.';
   }
 }


### PR DESCRIPTION
## Summary
Simplified the `wrongHeadline()` function in GameplayChat to cycle through 3 headline variants instead of 4, removing one of the incorrect answer messages.

## Changes
- Changed the modulo operation from `variant % 4` to `variant % 3`
- Removed the case for "Now it's in yours too." (previously case 2)
- Consolidated remaining cases: "Not this time — here's the answer." (case 0), "You'll know this one next time." (case 1), and "Close, but not quite." (case 2)

## Details
This reduces the variety of feedback messages shown to players when they answer incorrectly. The function will now cycle through a smaller set of three distinct messages rather than four.

https://claude.ai/code/session_0156HfEb2xdmzi4274UcsxSf