### PR TITLE
Promote author byline on review card + record surface dispositions

### DIFF
--- a/PRD-11.1-MASTER-ALIGNMENT-AUDIT.md
+++ b/PRD-11.1-MASTER-ALIGNMENT-AUDIT.md
@@ -443,3 +443,40 @@ Files requested by the prompt but not found in `/workspace`:
 - `CLAUDE.md`
 - `AGENTS.md`
 
+---
+
+## 14. Surfaces & Copy Disposition (2026-05-18)
+
+Resolutions for brief-referenced surfaces flagged as "missing in code." Group-game-adjacent items are withdrawn now that group games are out of Phase 1 (parallel to the declared-territory visual withdrawal in commit `629cedb`).
+
+### Withdrawn
+
+| Item | Reason |
+|---|---|
+| Standout moments / "only you got this" | No peer set without group games — no referent to be the standout against. |
+| Game Summary "Group Story" section | Group-game artifact. |
+| Friend Play | Group-game artifact. |
+| Challenge Worlds | Group-game-adjacent feature; not on Phase 1 roadmap. |
+| Share-card emoji grid (Wordle-style) | Numeric highlights in `ShareCard.tsx` stay on-brand; no plan to add an emoji grid. |
+
+### Resolved (already in code)
+
+| Item | Where |
+|---|---|
+| "common ground +" sub-label rotation | `src/components/play/GameplayChat.tsx:87-90` — four-step rotation (`common ground`, `+`, `++`, `+++`). |
+| Accepted-variant near-miss feedback | Handled by the consolation line for in-ballpark wrong answers: `src/lib/llm.ts:446-450`, surfaced via `gradeAnswer` in `src/server/grading.ts`. Accepted alternatives are silently correct; no separate "near-miss" UI state. |
+| Next-questions countdown | `src/components/TodaysFiveCard.tsx:164` — time-to-next-round countdown satisfies the brief. No per-session "X of 5" indicator planned. |
+
+### Removed
+
+| Item | Where |
+|---|---|
+| "Now it's in yours too." wrong-reveal variant | Removed from the `wrongHeadline` rotation in `src/components/play/GameplayChat.tsx` — read as conciliatory ownership-transfer rather than honest miss feedback. Rotation dropped from 4 to 3 variants. |
+
+### Author identity (Top 10 items 3, 7, 11, 14) — Phase 1 status
+
+| Surface | Status | Reference |
+|---|---|---|
+| In-session question card byline | ✅ Promoted — `0.86rem / weight 600` serif name with `0.55rem` mono "FROM" label | `src/components/play/GameplayChat.tsx:178-198`; commit `70399ba`. |
+| End-of-session review card byline | ✅ Promoted — same in-session pattern when `creatorNote` exists; system questions retain "JOSHING BOT · DOMAIN" | `src/app/daily/summary/page.tsx` (this PR). |
+

--- a/PRD-AUDIT.md
+++ b/PRD-AUDIT.md
@@ -538,3 +538,32 @@ Production launch blockers right now: the hardcoded OTP bypass, failing producti
 
 Smallest launchable fix set: remove `000000` OTP bypass, make `npm run build` pass in the deployment environment, wire `/feed` to `FeedList`, enforce friend-only recipients server-side for Joshing Games, require the PRD onboarding warmup threshold and load pre-seeded interests, complete or explicitly defer friend profiles/invites, remove spider/streak surfacing if PRD remains authoritative, and update `.env.example` to match `env-check.ts`.
 
+---
+
+## SECTION 13 - Surfaces & Copy Disposition (2026-05-18)
+
+Resolutions for brief-referenced surfaces flagged as "missing in code." Group-game-adjacent items are withdrawn now that group games are out of Phase 1 (parallel to the declared-territory visual withdrawal in commit `629cedb`). See `PRD-11.1-MASTER-ALIGNMENT-AUDIT.md` §14 for the same disposition with additional context.
+
+### Withdrawn (Phase 1)
+
+- **Standout moments / "only you got this"** — no peer set without group games.
+- **Game Summary "Group Story" section** — group-game artifact.
+- **Friend Play** — group-game artifact.
+- **Challenge Worlds** — group-game-adjacent feature; not on Phase 1 roadmap.
+- **Share-card emoji grid (Wordle-style)** — numeric highlights in `ShareCard.tsx` stay on-brand.
+
+### Resolved (already implemented)
+
+- **"common ground +" sub-label rotation** — `src/components/play/GameplayChat.tsx:87-90`.
+- **Accepted-variant near-miss** — handled by the consolation line for in-ballpark wrong answers (`src/lib/llm.ts:446-450`); accepted alternatives are silently correct.
+- **Next-questions countdown** — time-to-next-round in `src/components/TodaysFiveCard.tsx:164`.
+
+### Removed
+
+- **"Now it's in yours too." wrong-reveal variant** — dropped from the `wrongHeadline` rotation in `src/components/play/GameplayChat.tsx` (4 → 3 variants).
+
+### Author identity (Top 10 items 3, 7, 11, 14)
+
+- **In-session question card** — ✅ author promoted; `0.86rem / weight 600` serif name with `0.55rem` mono "FROM" label (commit `70399ba`).
+- **End-of-session review card** — ✅ author promoted to same in-session pattern when `creatorNote` exists (this PR). System questions retain "JOSHING BOT · DOMAIN".
+

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -404,8 +404,41 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
               : 'WRONG'}
         </span>
         <p className="pt-1" style={{ ...monoStyle, color: 'var(--text-muted)' }}>
-          JOSHING BOT · {question.domainDisplayName.toUpperCase()}
+          {question.creatorNote ? null : `JOSHING BOT · ${question.domainDisplayName.toUpperCase()}`}
         </p>
+        {question.creatorNote ? (
+          <p
+            className="pt-1"
+            style={{
+              fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+              fontSize: '0.86rem',
+              color: 'var(--text)',
+              lineHeight: 1.3,
+              opacity: 0.92,
+            }}
+          >
+            <span
+              style={{
+                ...monoStyle,
+                fontSize: '0.55rem',
+                color: 'var(--text-muted)',
+                marginRight: '6px',
+              }}
+            >
+              FROM
+            </span>
+            <span style={{ fontWeight: 600 }}>{question.creatorNote.authorName}</span>
+            <span
+              style={{
+                ...monoStyle,
+                color: 'var(--text-muted)',
+                marginLeft: '8px',
+              }}
+            >
+              · {question.domainDisplayName.toUpperCase()}
+            </span>
+          </p>
+        ) : null}
       </div>
 
       <button


### PR DESCRIPTION
## Summary
Follow-up to #310. Promotes the question author from a creator-note prefix to a load-bearing byline on the end-of-session review card, matching the in-session treatment. Also records Phase 1 dispositions in both audit files for the brief-referenced surfaces that don't exist in code.

## Code
- `src/app/daily/summary/page.tsx` — when `creatorNote` exists, replaces the `JOSHING BOT · DOMAIN` mono line with the in-session byline pattern: `0.55rem` mono "FROM" label + `0.86rem` weight-600 serif author name + mono domain tag. System questions retain the existing `JOSHING BOT · DOMAIN` treatment.
- Closes Top 10 items 11 & 14 on review-card author prominence.

## Docs
- `PRD-11.1-MASTER-ALIGNMENT-AUDIT.md` §14 and `PRD-AUDIT.md` SECTION 13 record:
  - **Withdrawn** (group-game-adjacent): standout moments / "only you got this", Group Story, Friend Play, Challenge Worlds, share-card emoji grid.
  - **Resolved** (already in code): "common ground +" sub-label, accepted-variant near-miss (handled via the consolation line for in-ballpark wrong answers), next-questions countdown (time-based countdown in `TodaysFiveCard`).
  - **Removed**: "Now it's in yours too." wrong-reveal variant (already merged in #310).
- Parallels the `629cedb` declared-territory-visual withdrawal pattern.

## Test plan
- [ ] Open the daily summary and confirm friend-authored questions show the new byline; system questions still show `JOSHING BOT · DOMAIN`.
- [ ] Confirm the "A note from {authorName}:" block still renders inline below the question text.
- [ ] Visually compare byline weight/size with the in-session question card — should match.

https://claude.ai/code/session_0156HfEb2xdmzi4274UcsxSf

---
_Generated by [Claude Code](https://claude.ai/code/session_0156HfEb2xdmzi4274UcsxSf)_