### PR TITLE
Add domain visibility controls to knowledge portrait

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -30,6 +30,7 @@ type DomainMastery = {
   isDeclaredInterest: boolean;
   isDemonstrated: boolean;
   territoryType?: 'declared' | 'demonstrated';
+  isHidden?: boolean;
 };
 
 type KnowledgeResponse = {
@@ -105,6 +106,7 @@ function toPortraitEntry(domain: DomainMastery): PortraitEntry {
     totalMasteryPoints: Math.max(domain.points, domain.isDeclaredInterest ? 1 : 0),
     tier: asTier(domain.tier),
     authoredAnsweredCount: domain.questionsAnswered,
+    isHidden: Boolean(domain.isHidden),
   };
 }
 
@@ -170,6 +172,10 @@ function KnowledgePageContent() {
   const [reinstating, setReinstating] = useState<string | null>(null);
   const [questionToast, setQuestionToast] = useState<string | null>(null);
   const [askFriendDomain, setAskFriendDomain] = useState<string | null>(null);
+  const [editMode, setEditMode] = useState(false);
+  const [hiddenOverrides, setHiddenOverrides] = useState<Record<string, boolean>>({});
+  const [hidePending, setHidePending] = useState<string | null>(null);
+  const [hideError, setHideError] = useState<string | null>(null);
 
   const loadKnowledge = async () => {
     const response = await fetch('/api/knowledge', { cache: 'no-store', credentials: 'include' });
@@ -240,7 +246,29 @@ function KnowledgePageContent() {
     [data],
   );
 
-  const portraitEntries = useMemo(() => sortedDomains.map(toPortraitEntry), [sortedDomains]);
+  const isDomainHidden = useMemo(() => {
+    return (domain: DomainMastery) => {
+      const override = hiddenOverrides[domain.displayName];
+      if (typeof override === 'boolean') return override;
+      return Boolean(domain.isHidden);
+    };
+  }, [hiddenOverrides]);
+
+  const annotatedDomains = useMemo(
+    () => sortedDomains.map((domain) => ({ ...domain, isHidden: isDomainHidden(domain) })),
+    [sortedDomains, isDomainHidden],
+  );
+  const visibleDomains = useMemo(
+    () => annotatedDomains.filter((domain) => !domain.isHidden),
+    [annotatedDomains],
+  );
+  const hiddenCount = annotatedDomains.length - visibleDomains.length;
+
+  const portraitEntries = useMemo(
+    () => (editMode ? annotatedDomains : visibleDomains).map(toPortraitEntry),
+    [annotatedDomains, visibleDomains, editMode],
+  );
+  const sharePortraitEntries = useMemo(() => visibleDomains.map(toPortraitEntry), [visibleDomains]);
   const declaredSlots = useMemo(() => {
     if (!data) return [];
     const byKey = new Map(data.pageData.allDomains.map((domain) => [domainKey(domain.domain), domain]));
@@ -255,15 +283,43 @@ function KnowledgePageContent() {
       .sort((a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName));
   }, [data, declaredKeys]);
 
-  const topCardDomains = useMemo(() => sortedDomains.filter((domain) => domain.points > 0).slice(0, 5), [sortedDomains]);
+  const topCardDomains = useMemo(() => visibleDomains.filter((domain) => domain.points > 0).slice(0, 5), [visibleDomains]);
   const expandingDomains = data?.pageData.expandingDomains ?? [];
   const showShareNotice = (message: string) => {
     setQuestionToast(message);
     window.setTimeout(() => setQuestionToast(null), 2200);
   };
-  const yourMind = data ? displayMind(sortedDomains, data.pageData.declaredInterests) : '';
+  const yourMind = data ? displayMind(visibleDomains, data.pageData.declaredInterests) : '';
   const displayName = 'You';
-  const hasAnything = sortedDomains.length > 0;
+  const hasAnything = annotatedDomains.length > 0;
+
+  const toggleDomainHidden = async (canonicalSubcategory: string, nextHidden: boolean) => {
+    setHideError(null);
+    setHidePending(canonicalSubcategory);
+    setHiddenOverrides((current) => ({ ...current, [canonicalSubcategory]: nextHidden }));
+    try {
+      const response = await fetch(`/api/knowledge/${encodeURIComponent(canonicalSubcategory)}`, {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ visibility: nextHidden ? 'private' : 'public' }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => null) as { message?: string } | null;
+        throw new Error(body?.message ?? 'Could not save that change.');
+      }
+    } catch (caught) {
+      setHiddenOverrides((current) => {
+        const next = { ...current };
+        delete next[canonicalSubcategory];
+        return next;
+      });
+      setHideError(caught instanceof Error ? caught.message : 'Could not save that change.');
+      window.setTimeout(() => setHideError(null), 3200);
+    } finally {
+      setHidePending((current) => (current === canonicalSubcategory ? null : current));
+    }
+  };
 
   // openInterestModal is always triggered from within manage-interests, so closing returns there.
   const openInterestModal = (slotIndex: number, currentDomain: string | null) => {
@@ -437,8 +493,8 @@ function KnowledgePageContent() {
             iconKey: domain.iconKey,
             broadCategory: domain.broadCategory,
           }))}
-          overflowCount={Math.max(0, sortedDomains.filter((domain) => domain.points > 0).length - topCardDomains.length)}
-          tierSignature={`${formatNumber(data.mastery.totalPoints)} knowledge points across ${sortedDomains.length} territories`}
+          overflowCount={Math.max(0, visibleDomains.filter((domain) => domain.points > 0).length - topCardDomains.length)}
+          tierSignature={`${formatNumber(data.mastery.totalPoints)} knowledge points across ${visibleDomains.length} territories`}
           rarestTerritory={null}
           rarestTerritorySolo={false}
           shareText={`My Joshing knowledge portrait: ${topCardDomains.map((domain) => domain.displayName).join(', ')}`}
@@ -454,18 +510,57 @@ function KnowledgePageContent() {
 
       {hasAnything && (
         <section className="bg-white border border-[var(--border-warm)] p-4" aria-label="Knowledge progression">
-          <div className="mb-2">
-            <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">YOUR KNOWLEDGE</p>
-            <p className="mt-[0.15rem] text-[10px] [font-variant:small-caps] text-[var(--text-muted-warm)] tracking-[0.06em] font-[var(--font-neutral)]">SEE HOW YOUR KNOWLEDGE IS BUILDING -&gt;</p>
+          <div className="mb-2 flex items-start justify-between gap-3">
+            <div>
+              <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">YOUR KNOWLEDGE</p>
+              <p className="mt-[0.15rem] text-[10px] [font-variant:small-caps] text-[var(--text-muted-warm)] tracking-[0.06em] font-[var(--font-neutral)]">
+                {editMode ? 'TAP A CIRCLE TO HIDE OR SHOW IT' : 'SEE HOW YOUR KNOWLEDGE IS BUILDING ->'}
+              </p>
+            </div>
+            <button
+              type="button"
+              onClick={() => setEditMode((current) => !current)}
+              className="shrink-0 min-h-8 border border-[var(--border-warm)] bg-white text-[var(--ink)] px-3 text-[0.7rem] uppercase tracking-[0.08em] cursor-pointer"
+              aria-pressed={editMode}
+            >
+              {editMode ? 'Done' : 'Edit'}
+            </button>
           </div>
 
-          <div id="portrait-circles-section">
-            <PortraitCircles entries={portraitEntries} />
-            <div className="mt-5 flex justify-center">
-              <button type="button" className="px-8 py-[11px] border-[1.5px] border-[#0e0e0e] bg-[#0e0e0e] text-[#faf8f2] font-['Courier_New',monospace] text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
-                Share portrait
+          {editMode ? (
+            <p className="m-0 mb-2 text-[0.78rem] text-[var(--text-muted-warm)] leading-[1.5]">
+              Tap a circle to hide it from friends. Hidden circles stay visible to you here while editing.
+            </p>
+          ) : hiddenCount > 0 ? (
+            <p className="m-0 mb-2 text-[0.78rem] text-[var(--text-muted-warm)]">
+              {hiddenCount} hidden from friends —{' '}
+              <button
+                type="button"
+                className="underline bg-transparent border-none p-0 text-[var(--text-muted-warm)] cursor-pointer"
+                onClick={() => setEditMode(true)}
+              >
+                Edit to show
               </button>
-            </div>
+            </p>
+          ) : null}
+
+          <div id="portrait-circles-section">
+            <PortraitCircles
+              entries={portraitEntries}
+              editMode={editMode}
+              onToggleHidden={(canonical, nextHidden) => void toggleDomainHidden(canonical, nextHidden)}
+              pendingDomain={hidePending}
+            />
+            {hideError ? (
+              <p className="mt-3 text-[0.78rem] text-[#8b1a0e] border border-[#c0392b]/40 p-2">{hideError}</p>
+            ) : null}
+            {!editMode ? (
+              <div className="mt-5 flex justify-center">
+                <button type="button" className="px-8 py-[11px] border-[1.5px] border-[#0e0e0e] bg-[#0e0e0e] text-[#faf8f2] font-['Courier_New',monospace] text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
+                  Share portrait
+                </button>
+              </div>
+            ) : null}
           </div>
         </section>
       )}
@@ -538,7 +633,7 @@ function KnowledgePageContent() {
       </section>
 
       {shareModalOpen && (
-        <SharePortraitModal entries={portraitEntries} playerDisplayName={displayName} onClose={() => setShareModalOpen(false)} />
+        <SharePortraitModal entries={sharePortraitEntries} playerDisplayName={displayName} onClose={() => setShareModalOpen(false)} />
       )}
 
       {askFriendDomain ? (

--- a/src/app/users/[id]/knowledge/page.tsx
+++ b/src/app/users/[id]/knowledge/page.tsx
@@ -51,12 +51,16 @@ export default async function FriendKnowledgePage({
   const portrait = await getFriendPortraitData(id, session.userId)
   if (!portrait) notFound()
 
+  const isOwner = portrait.visibility === 'self'
   const [mastery, pageData] = await Promise.all([
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
   ])
 
-  const sortedDomains = [...pageData.allDomains].sort(
+  const visibleDomains = isOwner
+    ? pageData.allDomains
+    : pageData.allDomains.filter((domain) => !domain.isHidden)
+  const sortedDomains = [...visibleDomains].sort(
     (a, b) =>
       b.points - a.points || a.displayName.localeCompare(b.displayName),
   )
@@ -67,8 +71,11 @@ export default async function FriendKnowledgePage({
   ).length
   const hasKnowledge = sortedDomains.length > 0
   const mindStatement = buildMindStatement(portrait.user.displayName, topDomains)
+  const visibleTotalPoints = isOwner
+    ? mastery.totalPoints
+    : sortedDomains.reduce((sum, domain) => sum + domain.points, 0)
   const tierSignature = `${new Intl.NumberFormat().format(
-    Math.round(mastery.totalPoints),
+    Math.round(visibleTotalPoints),
   )} knowledge points across ${sortedDomains.length} territories`
   const friendFirstName = firstName(portrait.user.displayName)
 

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -16,10 +16,14 @@ export type PortraitEntry = {
   totalMasteryPoints: number
   tier: PortraitTier
   authoredAnsweredCount: number
+  isHidden?: boolean
 }
 
 type PortraitCirclesProps = {
   entries: PortraitEntry[]
+  editMode?: boolean
+  onToggleHidden?: (canonicalSubcategory: string, nextHidden: boolean) => void
+  pendingDomain?: string | null
 }
 
 const TIER_ORDER: PortraitTier[] = [
@@ -176,6 +180,9 @@ export function PortraitDomainCircle({
   circleScale = 1,
   selected = false,
   circleSlotSize,
+  editMode = false,
+  onToggleHidden,
+  pending = false,
 }: {
   entry: PortraitEntry
   maxPointsForTier: number
@@ -184,6 +191,9 @@ export function PortraitDomainCircle({
   circleScale?: number
   selected?: boolean
   circleSlotSize?: number
+  editMode?: boolean
+  onToggleHidden?: (canonicalSubcategory: string, nextHidden: boolean) => void
+  pending?: boolean
 }) {
   const broadCategory = normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge'
   const dc = getPortraitDomainColor(broadCategory)
@@ -194,22 +204,55 @@ export function PortraitDomainCircle({
       maxPointsForTier
     ) * circleScale
   )
-  const opacity = forceFullOpacity
+  const baseOpacity = forceFullOpacity
     ? 1
     : getPortraitCircleOpacity(entry.totalMasteryPoints, maxPointsForTier)
+  const isHidden = Boolean(entry.isHidden)
+  const dimForHidden = editMode && isHidden
+  const opacity = dimForHidden ? baseOpacity * 0.35 : baseOpacity
   const labelOpacity =
-    0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5
+    (0.5 + (entry.totalMasteryPoints / Math.max(maxPointsForTier, 1)) * 0.5) *
+    (dimForHidden ? 0.5 : 1)
   const showMasteryCount =
     showCount &&
     entry.tier !== 'establishing' &&
     entry.authoredAnsweredCount > 0
   const resolvedCircleSlotSize = Math.max(circleSlotSize ?? size, size)
 
+  const handleClick = () => {
+    if (!editMode || !onToggleHidden || pending) return
+    onToggleHidden(entry.canonicalSubcategory, !isHidden)
+  }
+
+  const interactive = editMode && Boolean(onToggleHidden)
+
   return (
     <div
+      role={interactive ? 'button' : undefined}
+      tabIndex={interactive ? 0 : undefined}
+      aria-pressed={interactive ? isHidden : undefined}
+      aria-label={
+        interactive
+          ? `${isHidden ? 'Show' : 'Hide'} ${entry.canonicalSubcategory} ${isHidden ? 'on your portrait' : 'from friends'}`
+          : undefined
+      }
+      onClick={interactive ? handleClick : undefined}
+      onKeyDown={
+        interactive
+          ? (event) => {
+              if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault()
+                handleClick()
+              }
+            }
+          : undefined
+      }
       style={{
         ...circleItemStyle,
         width: Math.max(90, resolvedCircleSlotSize + 8),
+        cursor: interactive ? (pending ? 'wait' : 'pointer') : undefined,
+        userSelect: interactive ? 'none' : undefined,
+        opacity: pending ? 0.6 : 1,
       }}
     >
       <div
@@ -231,6 +274,7 @@ export function PortraitDomainCircle({
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
+              filter: dimForHidden ? 'grayscale(0.6)' : undefined,
             }}
           >
             {showMasteryCount && (
@@ -273,6 +317,31 @@ export function PortraitDomainCircle({
               </span>
             </div>
           )}
+          {editMode && (
+            <div
+              aria-hidden
+              style={{
+                position: 'absolute',
+                top: -4,
+                right: -4,
+                width: 22,
+                height: 22,
+                borderRadius: '50%',
+                background: isHidden ? '#faf8f2' : '#1a1208',
+                color: isHidden ? '#1a1208' : '#faf8f2',
+                border: `1.5px solid ${isHidden ? '#1a1208' : '#1a1208'}`,
+                display: 'grid',
+                placeItems: 'center',
+                fontSize: 12,
+                fontWeight: 700,
+                fontFamily: 'Georgia, "Times New Roman", serif',
+                lineHeight: 1,
+                boxShadow: '0 1px 3px rgba(0,0,0,0.18)',
+              }}
+            >
+              {isHidden ? '+' : '×'}
+            </div>
+          )}
         </div>
       </div>
       <span
@@ -285,6 +354,7 @@ export function PortraitDomainCircle({
           maxWidth: 90,
           wordWrap: 'break-word',
           opacity: labelOpacity,
+          textDecoration: dimForHidden ? 'line-through' : undefined,
         }}
       >
         {entry.canonicalSubcategory}
@@ -306,7 +376,7 @@ function getPortraitEntryCircleSize(
   )
 }
 
-export function PortraitCircles({ entries }: PortraitCirclesProps) {
+export function PortraitCircles({ entries, editMode = false, onToggleHidden, pendingDomain = null }: PortraitCirclesProps) {
   const [sortMode, setSortMode] = useState<SortMode>('domain')
 
   const validEntries = useMemo(
@@ -452,6 +522,9 @@ export function PortraitCircles({ entries }: PortraitCirclesProps) {
                     entry={entry}
                     maxPointsForTier={maxPointsByTier[entry.tier] ?? 1}
                     circleSlotSize={circleSlotSize}
+                    editMode={editMode}
+                    onToggleHidden={onToggleHidden}
+                    pending={pendingDomain === entry.canonicalSubcategory}
                   />
                 ))}
               </div>

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -36,6 +36,7 @@ export type DomainMastery = {
   isDeclaredInterest: boolean;
   isDemonstrated: boolean;
   territoryType: 'declared' | 'demonstrated';
+  isHidden: boolean;
 };
 
 export type ExpandingDomain = {
@@ -357,6 +358,7 @@ function toDomainMasteryRow(
   },
   masteryByDomain: Map<string, typeof playerMastery.$inferSelect>,
   statsByDomain: Map<string, AnswerStats>,
+  hiddenDomainKeys: Set<string>,
 ): DomainMastery {
   const domain = knowledgeDomain.domain;
   const row = masteryByDomain.get(domainKey(domain));
@@ -384,11 +386,12 @@ function toDomainMasteryRow(
     isDeclaredInterest: knowledgeDomain.isDeclared,
     isDemonstrated: knowledgeDomain.isDemonstrated,
     territoryType,
+    isHidden: hiddenDomainKeys.has(domainKey(domain)),
   };
 }
 
 export async function getUserMasteryOverview(userId: string): Promise<MasteryOverview> {
-  const [declaredRows, masteryRows, eventRows, recentRows] = await Promise.all([
+  const [declaredRows, masteryRows, eventRows, recentRows, hiddenDomainKeys] = await Promise.all([
     getActiveDeclaredInterests(userId),
     getPlayerMasteryRows(userId, true),
     db
@@ -417,6 +420,7 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
       .where(eq(masteryEvents.userId, userId))
       .orderBy(desc(masteryEvents.createdAt))
       .limit(10),
+    getHiddenDomainKeys(userId),
   ]);
 
   const totalPoints = masteryRows.reduce((sum, row) => sum + Number(row.totalPoints ?? 0), 0);
@@ -485,7 +489,7 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
   }
 
   const domains = [...knowledgeDomainNames.values()]
-    .map((knowledgeDomain) => toDomainMasteryRow(knowledgeDomain, masteryByDomain, statsByDomain))
+    .map((knowledgeDomain) => toDomainMasteryRow(knowledgeDomain, masteryByDomain, statsByDomain, hiddenDomainKeys))
     .sort((a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName));
 
   return {
@@ -506,7 +510,7 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
 }
 
 export async function getKnowledgePageData(userId: string): Promise<KnowledgePageData> {
-  const [declaredRows, masteryRows, eventRows] = await Promise.all([
+  const [declaredRows, masteryRows, eventRows, hiddenDomainKeys] = await Promise.all([
     getActiveDeclaredInterests(userId),
     getPlayerMasteryRows(userId, true),
     db
@@ -520,6 +524,7 @@ export async function getKnowledgePageData(userId: string): Promise<KnowledgePag
       })
       .from(masteryEvents)
       .where(eq(masteryEvents.userId, userId)),
+    getHiddenDomainKeys(userId),
   ]);
 
   const statsByDomain = new Map<string, AnswerStats>();
@@ -588,7 +593,7 @@ export async function getKnowledgePageData(userId: string): Promise<KnowledgePag
   }
 
   const allDomains = [...knowledgeDomainNames.values()]
-    .map((knowledgeDomain) => toDomainMasteryRow(knowledgeDomain, masteryByDomain, statsByDomain))
+    .map((knowledgeDomain) => toDomainMasteryRow(knowledgeDomain, masteryByDomain, statsByDomain, hiddenDomainKeys))
     .sort((a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName));
 
   return {
@@ -786,6 +791,27 @@ export async function getDomainDetail(userId: string, domain: string): Promise<D
     })),
     questionHistory,
   };
+}
+
+export async function getHiddenDomainKeys(userId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      domain: profileDomainVisibility.domain,
+      canonicalSubcategory: profileDomainVisibility.canonicalSubcategory,
+      visibility: profileDomainVisibility.visibility,
+      isVisible: profileDomainVisibility.isVisible,
+    })
+    .from(profileDomainVisibility)
+    .where(eq(profileDomainVisibility.userId, userId));
+
+  const hidden = new Set<string>();
+  for (const row of rows) {
+    const isHidden = row.visibility === 'private' || row.isVisible === false;
+    if (!isHidden) continue;
+    const label = row.domain ?? row.canonicalSubcategory;
+    if (label) hidden.add(domainKey(label));
+  }
+  return hidden;
 }
 
 export async function setDomainVisibility(


### PR DESCRIPTION
## Summary
Adds the ability for users to hide specific knowledge domains from their shared portrait while keeping them visible in their personal view. This includes an edit mode toggle, visual indicators for hidden domains, and API integration to persist visibility preferences.

## Key Changes

- **Domain visibility state management**: Added `isHidden` field to `DomainMastery` type and integrated with existing `profileDomainVisibility` table via new `getHiddenDomainKeys()` query
- **Edit mode UI**: Added toggle button to enter/exit edit mode on the knowledge page, with contextual help text and visual feedback
- **Interactive portrait circles**: Enhanced `PortraitDomainCircle` component to support click-to-toggle hiding in edit mode, with visual indicators (× and + badges) and accessibility features (keyboard support, ARIA labels)
- **Visibility filtering**: Separated portrait display into `annotatedDomains` (all domains with visibility state), `visibleDomains` (filtered for sharing), and `portraitEntries` (shown based on edit mode)
- **API integration**: Added `toggleDomainHidden()` function to PATCH `/api/knowledge/{domain}` with visibility state, including error handling and optimistic UI updates
- **Share modal isolation**: Uses `sharePortraitEntries` (visible-only) instead of all entries to ensure shared portraits respect privacy settings
- **Friend view filtering**: Updated friend knowledge page to filter hidden domains unless viewing own profile (`isOwner` check)
- **Visual feedback**: Dimmed appearance (grayscale, reduced opacity, strikethrough text) for hidden domains in edit mode; error toast for failed visibility changes

## Implementation Details

- Hidden domain state is tracked locally in `hiddenOverrides` with optimistic updates; reverts on API failure
- Pending state prevents duplicate requests while visibility change is in flight
- Edit mode shows all domains but visually distinguishes hidden ones; normal view only shows public domains
- Accessibility: circles become interactive buttons with proper ARIA attributes when in edit mode
- Friend portrait respects owner's visibility preferences; owner always sees all their domains

https://claude.ai/code/session_01JUMuq7gih5UWRstE24qqsL