### PR TITLE
Improve give-up UX with pending state and refined answer display

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -171,6 +171,7 @@ export default function DailyPage() {
   const [pausedAfterSlotIndex, setPausedAfterSlotIndex] = useState<number | null>(null);
   const [showUnfamiliarDialog, setShowUnfamiliarDialog] = useState(false);
   const [excludingDomain, setExcludingDomain] = useState(false);
+  const [pendingGiveUp, setPendingGiveUp] = useState(false);
 
   const loadQueue = useCallback(async () => {
     setLoading(true);
@@ -378,6 +379,8 @@ export default function DailyPage() {
         });
         if (slot.submitted_answer) {
           rows.push({ id: `u-${slot.slot_index}`, kind: 'user', text: slot.submitted_answer });
+        } else if (gaveUp) {
+          rows.push({ id: `u-${slot.slot_index}`, kind: 'user', text: 'show me the answer' });
         }
         rows.push({
           id: `r-${slot.slot_index}`,
@@ -419,6 +422,9 @@ export default function DailyPage() {
         if (submitting && answer.trim()) {
           rows.push({ id: 'u-pending', kind: 'user', text: answer.trim() });
           rows.push({ id: 'grading', kind: 'typing' });
+        } else if (pendingGiveUp) {
+          rows.push({ id: 'u-pending-giveup', kind: 'user', text: 'show me the answer' });
+          rows.push({ id: 'grading', kind: 'typing' });
         }
         break;
       }
@@ -436,7 +442,7 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  }, [allDone, currentSlot?.slot_index, queue, requestRecheck, submitting, answer]);
+  }, [allDone, currentSlot?.slot_index, queue, requestRecheck, submitting, answer, pendingGiveUp]);
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
@@ -544,7 +550,12 @@ export default function DailyPage() {
   }, [answer, postAnswer]);
 
   const giveUpCurrent = useCallback(async () => {
-    await postAnswer({ submittedAnswer: '', gaveUp: true });
+    setPendingGiveUp(true);
+    try {
+      await postAnswer({ submittedAnswer: '', gaveUp: true });
+    } finally {
+      setPendingGiveUp(false);
+    }
   }, [postAnswer]);
 
   return (

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -629,12 +629,26 @@ function ResultRow({
           </>
         ) : gaveUp ? (
           <>
-            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--text-muted)' }}>
-              Here&rsquo;s the answer.
+            <p
+              style={{
+                fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+                fontSize: '0.82rem',
+                color: 'var(--text-muted)',
+              }}
+            >
+              <span style={{ color: 'var(--text-muted)', marginRight: '6px' }}>—</span>
+              For the record.
             </p>
             {correctAnswer ? (
-              <p style={{ marginTop: '8px', fontSize: '0.9rem', color: 'var(--text)' }}>
-                <span style={{ fontWeight: 600 }}>Answer:</span> {correctAnswer}
+              <p
+                style={{
+                  marginTop: '6px',
+                  fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+                  fontSize: '0.95rem',
+                  color: 'var(--text)',
+                }}
+              >
+                {correctAnswer}
               </p>
             ) : null}
           </>

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -182,6 +182,7 @@ export function useCatchupFlow() {
     setIsResolvingTurn(true);
     setMessages((existing) => [
       ...existing,
+      { id: newMessageId(), kind: 'user', text: 'i give up' },
       {
         id: newMessageId(),
         kind: 'result',


### PR DESCRIPTION
## Summary
Enhances the user experience when giving up on a puzzle by adding visual feedback during the give-up action and refining how the correct answer is displayed in the chat interface.

## Key Changes

- **Added pending give-up state tracking** (`pendingGiveUp`) in `DailyPage` to show typing indicator while the give-up request is being processed, improving perceived responsiveness
- **Updated give-up flow** in `useCatchupFlow` to include a user message ("i give up") in the chat history for better context
- **Refined answer reveal UI** in `GameplayChat`:
  - Changed header text from "Here's the answer." to "For the record." with an em-dash prefix
  - Removed "Answer:" label and bold formatting from the answer text itself
  - Adjusted typography (font family, sizing, spacing) for a more elegant presentation
  - Reduced margin-top from 8px to 6px for tighter spacing

## Implementation Details

- The `pendingGiveUp` state is properly managed with try/finally to ensure cleanup even if the API call fails
- The dependency array in the `rows` useMemo was updated to include `pendingGiveUp` to ensure proper re-rendering
- Typography changes maintain consistency with the serif font stack already in use for the answer reveal section

https://claude.ai/code/session_01Fq1839ZMXqQonXxTU6PpQQ