### PR TITLE
Color Today's Five dots by per-slot outcome

### DIFF
--- a/src/app/api/daily/status/route.ts
+++ b/src/app/api/daily/status/route.ts
@@ -12,6 +12,22 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+type SlotOutcome = 'correct' | 'incorrect' | 'skipped' | 'unanswered';
+
+function buildSlotOutcomes(slots: QueueSlot[]): SlotOutcome[] {
+  const outcomes: SlotOutcome[] = Array.from({ length: DAILY_QUEUE_SIZE }, () => 'unanswered');
+  for (const slot of slots) {
+    const idx = slot.slot_index;
+    if (!Number.isInteger(idx) || idx < 0 || idx >= DAILY_QUEUE_SIZE) continue;
+    if (slot.answered) {
+      outcomes[idx] = slot.answer_state === 'incorrect' ? 'incorrect' : 'correct';
+    } else if (slot.skipped) {
+      outcomes[idx] = 'skipped';
+    }
+  }
+  return outcomes;
+}
+
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
@@ -33,6 +49,7 @@ export async function GET() {
       complete: false,
       queue_id: null,
       queue_date: null,
+      slotOutcomes: buildSlotOutcomes([]),
       preferences: {
         selected_domains: preferences.selectedDomains,
         difficulty_preference: preferences.difficulty,
@@ -58,6 +75,7 @@ export async function GET() {
     complete: isComplete,
     queue_id: queue.id,
     queue_date: queue.queueDate,
+    slotOutcomes: buildSlotOutcomes(slots),
     preferences: {
       selected_domains: preferences.selectedDomains,
       difficulty_preference: preferences.difficulty,

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import FeedList from '@/components/FeedList'
 import TodaysFiveCard, {
   type DailyPreferences,
   type DailyStatus,
+  type SlotOutcome,
 } from '@/components/TodaysFiveCard'
 import { getSession } from '@/server/auth/session'
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types'
@@ -107,6 +108,20 @@ async function FeedSection({ userId }: { userId: string }) {
   )
 }
 
+function buildSlotOutcomes(slots: QueueSlot[]): SlotOutcome[] {
+  const outcomes: SlotOutcome[] = Array.from({ length: DAILY_QUEUE_SIZE }, () => 'unanswered')
+  for (const slot of slots) {
+    const idx = slot.slot_index
+    if (!Number.isInteger(idx) || idx < 0 || idx >= DAILY_QUEUE_SIZE) continue
+    if (slot.answered) {
+      outcomes[idx] = slot.answer_state === 'incorrect' ? 'incorrect' : 'correct'
+    } else if (slot.skipped) {
+      outcomes[idx] = 'skipped'
+    }
+  }
+  return outcomes
+}
+
 function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDailyQueue>>): DailyStatus {
   const nextRoundAt = getNextDailyResetBoundary().toISOString()
   if (!queue) {
@@ -116,6 +131,7 @@ function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDail
       isComplete: false,
       nextRoundAt,
       queueId: null,
+      slotOutcomes: buildSlotOutcomes([]),
     }
   }
 
@@ -130,6 +146,7 @@ function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDail
     isComplete,
     nextRoundAt,
     queueId: queue.id,
+    slotOutcomes: buildSlotOutcomes(slots),
   }
 }
 

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -4,12 +4,15 @@ import Link from 'next/link'
 import { CheckCircle2, Clock, MessageCircleQuestion, Settings } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 
+export type SlotOutcome = 'correct' | 'incorrect' | 'skipped' | 'unanswered'
+
 export type DailyStatus = {
   questionsRemaining: number
   questionsAnswered: number
   isComplete: boolean
   nextRoundAt: string
   queueId: string | null
+  slotOutcomes: SlotOutcome[]
 }
 
 export type DailyPreferences = {
@@ -48,6 +51,25 @@ const FALLBACK_STATUS: DailyStatus = {
   isComplete: false,
   nextRoundAt: new Date().toISOString(),
   queueId: null,
+  slotOutcomes: ['unanswered', 'unanswered', 'unanswered', 'unanswered', 'unanswered'],
+}
+
+const VALID_OUTCOMES: ReadonlySet<SlotOutcome> = new Set<SlotOutcome>([
+  'correct',
+  'incorrect',
+  'skipped',
+  'unanswered',
+])
+
+function normalizeSlotOutcomes(value: unknown): SlotOutcome[] {
+  const fallback: SlotOutcome[] = ['unanswered', 'unanswered', 'unanswered', 'unanswered', 'unanswered']
+  if (!Array.isArray(value)) return fallback
+  return fallback.map((unanswered, index) => {
+    const candidate = value[index]
+    return typeof candidate === 'string' && VALID_OUTCOMES.has(candidate as SlotOutcome)
+      ? (candidate as SlotOutcome)
+      : unanswered
+  })
 }
 
 function formatCountdown(targetIso: string, nowMs: number): string {
@@ -117,6 +139,7 @@ export default function TodaysFiveCard({
               ? body.nextRoundAt
               : FALLBACK_STATUS.nextRoundAt,
           queueId: typeof body.queue_id === 'string' ? body.queue_id : null,
+          slotOutcomes: normalizeSlotOutcomes(body.slotOutcomes),
         })
         if (prefsResponse.ok) {
           const prefsBody = await prefsResponse.json()
@@ -228,19 +251,38 @@ export default function TodaysFiveCard({
             aria-label={`${answered} of 5 answered`}
           >
             {Array.from({ length: 5 }, (_, index) => {
-              const filled = index < answered
+              const outcome = effectiveStatus.slotOutcomes[index] ?? 'unanswered'
+              const isFilled = outcome !== 'unanswered'
+              const background =
+                outcome === 'correct'
+                  ? 'var(--success)'
+                  : outcome === 'incorrect'
+                    ? 'var(--destructive)'
+                    : outcome === 'skipped'
+                      ? 'color-mix(in srgb, var(--foreground) 35%, transparent)'
+                      : 'transparent'
+              const label =
+                outcome === 'correct'
+                  ? 'Correct'
+                  : outcome === 'incorrect'
+                    ? 'Wrong'
+                    : outcome === 'skipped'
+                      ? 'Skipped'
+                      : 'Not answered'
               return (
                 <span
                   key={index}
                   className="block rounded-full"
+                  aria-label={label}
+                  title={label}
                   style={{
-                    width: filled ? 9 : 8,
-                    height: filled ? 9 : 8,
-                    background: filled ? 'var(--foreground)' : 'transparent',
-                    border: filled
+                    width: isFilled ? 9 : 8,
+                    height: isFilled ? 9 : 8,
+                    background,
+                    border: isFilled
                       ? 'none'
                       : '1px solid color-mix(in srgb, var(--foreground) 35%, transparent)',
-                    opacity: filled ? 0.85 : 0.7,
+                    opacity: isFilled ? 0.95 : 0.7,
                   }}
                 />
               )


### PR DESCRIPTION
Each dot now reflects the slot it represents: green for correct, red for wrong, grey-filled for skipped, outlined for not-yet-answered. The status endpoint and server snapshot now emit a slotOutcomes array so the card can render the colors without a second roundtrip.