### PR TITLE
Move "Add friend" button to Friends page header

### DIFF
--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -229,26 +229,7 @@ export default function AddFriendInvite() {
   }
 
   if (!expanded) {
-    return (
-      <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-sm">
-        <p className="text-foreground text-sm font-medium">
-          Bring a friend into Joshing.
-        </p>
-        <p className="text-muted-foreground mt-1 text-sm leading-6">
-          Send a warm note with just a few ideas they can keep, edit, or ignore.
-        </p>
-        <button
-          type="button"
-          className="btn-primary mt-4 min-h-12 w-full rounded-full"
-          onClick={() => {
-            sendTelemetry('add_friend_started', { source: 'inline_card' })
-            setExpanded(true)
-          }}
-        >
-          Add friend
-        </button>
-      </section>
-    )
+    return null
   }
 
   return (

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -4,18 +4,25 @@ import AddFriendInvite from '@/components/AddFriendInvite'
 import FriendsList from '@/components/FriendsList'
 
 export default function FriendsHubPage() {
+  function openAddFriend() {
+    window.dispatchEvent(
+      new CustomEvent('friend-invitations:create-new', { detail: {} })
+    )
+  }
+
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
-      <header className="mb-5 border-b pb-4">
-        <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
-          Joshing
-        </p>
+      <header className="mb-5 flex items-center justify-between gap-4 border-b pb-4">
         <h1 className="text-foreground font-serif text-3xl font-semibold">
           Friends
         </h1>
-        <p className="text-muted-foreground mt-2 text-sm leading-6">
-          Invite your people, answer warm notes, and keep your circle close.
-        </p>
+        <button
+          type="button"
+          className="btn-primary min-h-10 shrink-0 rounded-full px-4 text-sm"
+          onClick={openAddFriend}
+        >
+          Add friend
+        </button>
       </header>
 
       <AddFriendInvite />

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -26,7 +26,9 @@ describe('Friends page QA surface', () => {
 
     expect(html).toContain('Friends')
     expect(html).toContain('Add friend')
-    expect(html).toContain('Bring a friend into Joshing.')
+    expect(html).not.toContain('Joshing</p>')
+    expect(html).not.toContain('Invite your people')
+    expect(html).not.toContain('Send a warm note')
     expect(html).not.toMatch(forbiddenGamificationCopy)
   })
 


### PR DESCRIPTION
## Summary
Refactored the "Add friend" invite flow by moving the call-to-action button from an inline card component to the Friends page header, and updated the AddFriendInvite component to only render the expanded form.

## Changes
- **AddFriendInvite.tsx**: Removed the collapsed card UI (heading, description, and button) and now returns `null` when not expanded, leaving only the expanded form logic
- **FriendsHubPage.tsx**: 
  - Added `openAddFriend()` function that dispatches a custom event to trigger the invite form
  - Restructured header layout to flex with space-between alignment
  - Moved "Add friend" button from AddFriendInvite component to the page header
  - Removed the "Joshing" branding text and descriptive copy from the header
- **FriendsHubPage.test.tsx**: Updated test assertions to reflect removed copy and verify the new button placement

## Implementation Details
The refactor uses a custom event (`friend-invitations:create-new`) to communicate between the header button and the AddFriendInvite component, decoupling the UI layout from the form logic. This allows the invite form to be triggered from the header while keeping the form component focused on its expanded state.

https://claude.ai/code/session_01RJ4zMGPgV9sBXteyhgAD4S