### PR TITLE
Add validation to prevent questions that contain their own answers

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -5,6 +5,7 @@ import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, norm
 import { categorizeQuestion } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
+import { textContainsAnswer } from '@/server/questions/self-answering';
 import { db, questions } from '@/server/db';
 import {
   deleteQuestion,
@@ -107,14 +108,41 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Question has been used in a game and cannot be edited.' }, { status: 409 });
   }
 
+  const effectiveText = values.text ?? existing.text;
+  const effectiveAnswer = values.correctAnswer ?? existing.correctAnswer;
+  const effectiveAlternates = values.alternateAnswers ?? existing.alternateAnswers ?? [];
+  if (
+    (values.text !== undefined || values.correctAnswer !== undefined || values.alternateAnswers !== undefined)
+    && textContainsAnswer(effectiveText, effectiveAnswer, effectiveAlternates)
+  ) {
+    return NextResponse.json(
+      {
+        error: 'answer_in_question',
+        message: 'Your question appears to contain its own answer. Rephrase the question so it does not reveal the answer.',
+      },
+      { status: 400 },
+    );
+  }
+
   const shouldRecategorize = values.text !== undefined || values.correctAnswer !== undefined;
   if (shouldRecategorize) {
-    const categorization = await categorizeQuestion(
-      values.text ?? existing.text,
-      values.correctAnswer ?? existing.correctAnswer,
-    );
+    const categorization = await categorizeQuestion(effectiveText, effectiveAnswer);
     const category = normalizeBroadQuestionCategoryOrDefault(categorization.broad_category);
     const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
+    if (textContainsAnswer(canonicalSubcategory, effectiveAnswer, effectiveAlternates)) {
+      console.warn('[questions/patch] rejected category that leaks answer', {
+        subcategory: canonicalSubcategory,
+        answer: effectiveAnswer,
+      });
+      return NextResponse.json(
+        {
+          error: 'category_leaks_answer',
+          message:
+            "This question's category would give away the answer. Try rephrasing the question so a different category fits.",
+        },
+        { status: 422 },
+      );
+    }
     values.category = category;
     values.broadCategory = broadCategoryDisplayName(category);
     values.canonicalSubcategory = canonicalSubcategory;

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -60,6 +60,16 @@ export async function POST(request: NextRequest) {
     },
   });
   if (errors.length > 0) {
+    if (errors.includes('answerInQuestion')) {
+      return NextResponse.json(
+        {
+          error: 'answer_in_question',
+          fields: errors,
+          message: 'Your question appears to contain its own answer. Rephrase the question so it does not reveal the answer.',
+        },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
 

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -20,6 +20,7 @@ import { openKBDomain } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
 import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
+import { textContainsAnswer } from '@/server/questions/self-answering';
 import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
@@ -93,6 +94,20 @@ export async function POST(request: NextRequest) {
         error: 'category_too_generic',
         message:
           "We couldn't pin a specific category for this question. Try rephrasing with a more specific topic.",
+      },
+      { status: 422 },
+    );
+  }
+  if (textContainsAnswer(normalizedSubcategory, value.correctAnswer, value.alternateAnswers)) {
+    console.warn('[questions/create] rejected category that leaks answer', {
+      subcategory: normalizedSubcategory,
+      answer: value.correctAnswer,
+    });
+    return NextResponse.json(
+      {
+        error: 'category_leaks_answer',
+        message:
+          "This question's category would give away the answer. Try rephrasing the question so a different category fits.",
       },
       { status: 422 },
     );

--- a/src/server/llm/critique.ts
+++ b/src/server/llm/critique.ts
@@ -47,6 +47,7 @@ A question is NOT OK if:
 - It asks for an opinion or preference
 - It contains factual errors or false premises
 - It is so broad that a correct answer could be any of dozens of things
+- It contains or telegraphs its own answer ("What is the capital of France, which is Paris?" — self-answering; "Who wrote the 1922 poem 'The Waste Land' by T. S. Eliot?" — names the author it is asking for)
 
 Question to review: ${JSON.stringify(questionText)}
 
@@ -58,6 +59,7 @@ Issue descriptions should be short (under 12 words each), specific, and helpful.
 - "Multiple Tchaikovsky symphonies could be the answer."
 - "Asks for opinion rather than fact."
 - "Date range is too broad to have a single answer."
+- "Question reveals its own answer."
 
 Reformulations should preserve the author's apparent intent while fixing the issue. Provide 2-4 reformulations, ordered most to least faithful to the original.`;
 

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -103,6 +103,86 @@ describe('create question payload categorization', () => {
     expect(result.errors).toEqual([]);
     expect(result.value.sendToFriendIds).toEqual([]);
   });
+
+  describe('answer-in-question guard', () => {
+    it('rejects when the answer appears verbatim in the question', () => {
+      const result = readCreateQuestionPayload({
+        text: 'What is the capital of France, which is Paris?',
+        correctAnswer: 'Paris',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).toContain('answerInQuestion');
+    });
+
+    it('rejects multi-word answers that appear in the question', () => {
+      const result = readCreateQuestionPayload({
+        text: "Who wrote The Waste Land, the 1922 poem?",
+        correctAnswer: 'The Waste Land',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).toContain('answerInQuestion');
+    });
+
+    it('rejects when an alternate answer leaks into the question', () => {
+      const result = readCreateQuestionPayload({
+        text: 'Which US state is also nicknamed the Empire State?',
+        correctAnswer: 'New York',
+        alternateAnswers: ['Empire State'],
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).toContain('answerInQuestion');
+    });
+
+    it('is case- and punctuation-insensitive', () => {
+      const result = readCreateQuestionPayload({
+        text: 'In 1969, who took "one small step" on the moon?',
+        correctAnswer: 'one small step',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).toContain('answerInQuestion');
+    });
+
+    it('does not trigger on partial word overlap', () => {
+      const result = readCreateQuestionPayload({
+        text: 'Which French city served as the setting for the Burning of Notre-Dame?',
+        correctAnswer: 'Paris',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).not.toContain('answerInQuestion');
+    });
+
+    it('does not flag short answers like "no"', () => {
+      const result = readCreateQuestionPayload({
+        text: 'Is there snow on Mount Everest year-round?',
+        correctAnswer: 'No',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).not.toContain('answerInQuestion');
+    });
+
+    it('does not trigger on answers that are only a substring of a question word', () => {
+      const result = readCreateQuestionPayload({
+        text: 'What country is famous for hosting the Cannes Film Festival?',
+        correctAnswer: 'an',
+        verified: true,
+        critiqueIterations: 0,
+      });
+
+      expect(result.errors).not.toContain('answerInQuestion');
+    });
+  });
 });
 
 describe('normalizeCanonicalSubcategory', () => {

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 
 import { normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
+import { textContainsAnswer } from '@/server/questions/self-answering';
 
 describe('create question payload categorization', () => {
   const basePayload = {
@@ -182,6 +183,26 @@ describe('create question payload categorization', () => {
 
       expect(result.errors).not.toContain('answerInQuestion');
     });
+  });
+});
+
+describe('textContainsAnswer (category leak guard)', () => {
+  it('flags when a category equals the answer', () => {
+    expect(textContainsAnswer('Paradise Lost', 'Paradise Lost')).toBe(true);
+    expect(textContainsAnswer('paradise lost', 'Paradise Lost')).toBe(true);
+  });
+
+  it('flags when a category contains the answer as a token', () => {
+    expect(textContainsAnswer('John Milton', 'Milton')).toBe(true);
+  });
+
+  it('does not flag when the category is broader than the answer', () => {
+    expect(textContainsAnswer('British Poetry', 'Paradise Lost')).toBe(false);
+    expect(textContainsAnswer('17th Century Literature', 'John Milton')).toBe(false);
+  });
+
+  it('flags via an alternate answer', () => {
+    expect(textContainsAnswer('Empire State', 'New York', ['Empire State'])).toBe(true);
   });
 });
 

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -1,3 +1,5 @@
+import { questionContainsAnswer } from '@/server/questions/self-answering';
+
 function readBoolean(value: unknown): boolean {
   if (value === true) return true;
   if (typeof value !== 'string') return false;
@@ -64,6 +66,9 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   if (verified === null) errors.push('verified');
   if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
   if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
+  if (text && correctAnswer && questionContainsAnswer(text, correctAnswer, alternateAnswers)) {
+    errors.push('answerInQuestion');
+  }
 
   return {
     value: {

--- a/src/server/questions/self-answering.ts
+++ b/src/server/questions/self-answering.ts
@@ -1,0 +1,32 @@
+const MIN_ANSWER_TOKEN_LENGTH = 3;
+const COMBINING_DIACRITICS = /[̀-ͯ]/g;
+
+function normalize(value: string): string {
+  return value
+    .normalize('NFKD')
+    .replace(COMBINING_DIACRITICS, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    .replace(/\s+/g, ' ');
+}
+
+function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string): boolean {
+  const normalizedAnswer = normalize(candidate);
+  if (!normalizedAnswer || normalizedAnswer.length < MIN_ANSWER_TOKEN_LENGTH) return false;
+  return ` ${normalizedQuestion} `.includes(` ${normalizedAnswer} `);
+}
+
+export function questionContainsAnswer(
+  questionText: string,
+  answer: string,
+  alternateAnswers: readonly string[] = [],
+): boolean {
+  const normalizedQuestion = normalize(questionText);
+  if (!normalizedQuestion) return false;
+  if (answerLeaksIntoQuestion(normalizedQuestion, answer)) return true;
+  for (const alt of alternateAnswers) {
+    if (answerLeaksIntoQuestion(normalizedQuestion, alt)) return true;
+  }
+  return false;
+}

--- a/src/server/questions/self-answering.ts
+++ b/src/server/questions/self-answering.ts
@@ -17,16 +17,18 @@ function answerLeaksIntoQuestion(normalizedQuestion: string, candidate: string):
   return ` ${normalizedQuestion} `.includes(` ${normalizedAnswer} `);
 }
 
-export function questionContainsAnswer(
-  questionText: string,
+export function textContainsAnswer(
+  text: string,
   answer: string,
   alternateAnswers: readonly string[] = [],
 ): boolean {
-  const normalizedQuestion = normalize(questionText);
-  if (!normalizedQuestion) return false;
-  if (answerLeaksIntoQuestion(normalizedQuestion, answer)) return true;
+  const normalizedText = normalize(text);
+  if (!normalizedText) return false;
+  if (answerLeaksIntoQuestion(normalizedText, answer)) return true;
   for (const alt of alternateAnswers) {
-    if (answerLeaksIntoQuestion(normalizedQuestion, alt)) return true;
+    if (answerLeaksIntoQuestion(normalizedText, alt)) return true;
   }
   return false;
 }
+
+export const questionContainsAnswer = textContainsAnswer;


### PR DESCRIPTION
## Summary
Adds a new validation guard to prevent questions from being created when they contain or telegraph their own answer. This improves question quality by catching self-answering questions before they're submitted.

## Key Changes
- **New module `src/server/questions/self-answering.ts`**: Implements `questionContainsAnswer()` function that detects when a question text contains the correct answer or any alternate answers. The detection is case- and punctuation-insensitive, uses word-boundary matching to avoid false positives on partial word overlaps, and filters out very short answers (< 3 tokens) to prevent noise.
- **Updated `src/server/questions/create-payload.ts`**: Integrated the new validation check into `readCreateQuestionPayload()` to add `'answerInQuestion'` error when detected.
- **Updated `src/app/api/questions/route.ts`**: Added specific error response handling for `answerInQuestion` errors with a user-friendly message guiding users to rephrase their questions.
- **Updated `src/server/llm/critique.ts`**: Enhanced the LLM critique prompt to include self-answering as a criterion for rejection, with concrete examples.
- **Test coverage in `src/server/questions/__tests__/create-payload.test.ts`**: Added comprehensive test suite covering:
  - Single-word answers appearing verbatim
  - Multi-word answers appearing verbatim
  - Alternate answers leaking into the question
  - Case- and punctuation-insensitive matching
  - Negative cases: partial word overlaps, short answers like "no", substring matches

## Implementation Details
The `normalize()` function in `self-answering.ts` handles Unicode normalization (NFKD), removes combining diacritics, lowercases, strips punctuation, and normalizes whitespace. Word-boundary detection uses space-padding (`" ${question} "` and `" ${answer} "`) to ensure answers match complete words, not substrings within words. The `MIN_ANSWER_TOKEN_LENGTH` threshold of 3 prevents false positives on common short words.

https://claude.ai/code/session_017iyX59ijJXrX5LAyyP4sEL