### PR TITLE
Show who answered user's banked questions

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -145,6 +145,16 @@ function CardOverflowMenu({
   );
 }
 
+function formatAnswerersLine(answerers: { names: string[]; total: number }): string | null {
+  const { names, total } = answerers;
+  if (total <= 0 || names.length === 0) return null;
+  const [first, second] = names;
+  if (total === 1) return `${first} answered your question`;
+  if (total === 2 && second) return `${first} and ${second} answered your question`;
+  const others = total - 1;
+  return `${first} and ${others} ${others === 1 ? 'other' : 'others'} answered your question`;
+}
+
 function initialValues(question: QuestionView): QuestionFormValues {
   return {
     text: question.text,
@@ -430,6 +440,10 @@ function QuestionsPageContent() {
                 <p className="mt-4 text-sm text-muted-foreground">
                   {question.timesAnswered} answers · {question.correctRate}% correct · {question.usedInGamesCount} games
                 </p>
+                {question.isOwnAuthored && question.answerers ? (() => {
+                  const line = formatAnswerersLine(question.answerers);
+                  return line ? <p className="mt-1 text-sm text-muted-foreground">{line}</p> : null;
+                })() : null}
                 {cardError[question.id] ? <p className="mt-3 text-sm text-destructive">{cardError[question.id]}</p> : null}
                 <div className="mt-4 flex items-center gap-2">
                   {confirmingId === question.id ? (

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, inArray, isNull } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import { writeActivity } from '@/server/activity/write-activity';
-import { db, questions, userQuestionBank, users } from '@/server/db';
+import { db, feedItems, joshingGameResponses, questions, userQuestionBank, users } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { bankQuestionSelectColumns, type QuestionView, toQuestionView } from '@/server/db/queries/questions';
 
@@ -21,6 +21,81 @@ function questionDomain(question: typeof questions.$inferSelect): string {
 
 function displayName(value: string | null): string {
   return value?.trim() || 'A friend';
+}
+
+function shortAnswererName(value: string | null): string {
+  const trimmed = value?.trim();
+  if (!trimmed) return 'A friend';
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return parts[0];
+  const initial = parts[1].charAt(0).toUpperCase();
+  return initial ? `${parts[0]} ${initial}` : parts[0];
+}
+
+async function getAnswerersForQuestions(
+  questionIds: string[],
+  viewerUserId: string,
+): Promise<Map<string, { names: string[]; total: number }>> {
+  if (questionIds.length === 0) return new Map();
+
+  const [gameRows, feedRows] = await Promise.all([
+    db
+      .select({
+        questionId: joshingGameResponses.questionId,
+        userId: joshingGameResponses.userId,
+        displayName: users.displayName,
+        answeredAt: sql<Date>`max(${joshingGameResponses.answeredAt})`.as('answered_at'),
+      })
+      .from(joshingGameResponses)
+      .innerJoin(users, eq(joshingGameResponses.userId, users.id))
+      .where(and(
+        inArray(joshingGameResponses.questionId, questionIds),
+        ne(joshingGameResponses.userId, viewerUserId),
+        sql`${joshingGameResponses.answeredAt} is not null`,
+      ))
+      .groupBy(joshingGameResponses.questionId, joshingGameResponses.userId, users.displayName),
+    db
+      .select({
+        questionId: feedItems.questionId,
+        userId: feedItems.recipientUserId,
+        displayName: users.displayName,
+        answeredAt: sql<Date>`max(${feedItems.sourceEventAt})`.as('answered_at'),
+      })
+      .from(feedItems)
+      .innerJoin(users, eq(feedItems.recipientUserId, users.id))
+      .where(and(
+        inArray(feedItems.questionId, questionIds),
+        ne(feedItems.recipientUserId, viewerUserId),
+        sql`${feedItems.answerResult} is not null`,
+        isNull(feedItems.joshingGameId),
+      ))
+      .groupBy(feedItems.questionId, feedItems.recipientUserId, users.displayName),
+  ]);
+
+  const byQuestion = new Map<string, Map<string, { displayName: string | null; answeredAt: number }>>();
+  for (const row of [...gameRows, ...feedRows]) {
+    if (!row.questionId || !row.userId) continue;
+    const answeredAt = row.answeredAt ? new Date(row.answeredAt).getTime() : 0;
+    let perUser = byQuestion.get(row.questionId);
+    if (!perUser) {
+      perUser = new Map();
+      byQuestion.set(row.questionId, perUser);
+    }
+    const existing = perUser.get(row.userId);
+    if (!existing || answeredAt > existing.answeredAt) {
+      perUser.set(row.userId, { displayName: row.displayName, answeredAt });
+    }
+  }
+
+  const result = new Map<string, { names: string[]; total: number }>();
+  for (const [questionId, perUser] of byQuestion) {
+    const sorted = [...perUser.values()].sort((a, b) => b.answeredAt - a.answeredAt);
+    result.set(questionId, {
+      names: sorted.slice(0, 2).map((entry) => shortAnswererName(entry.displayName)),
+      total: sorted.length,
+    });
+  }
+  return result;
 }
 
 export async function addToBank(params: {
@@ -131,8 +206,14 @@ export async function getBankedQuestions(userId: string): Promise<BankedQuestion
     .where(and(eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)))
     .orderBy(desc(userQuestionBank.addedAt));
 
+  const answerersByQuestion = await getAnswerersForQuestions(
+    rows.map((row) => row.question.id),
+    userId,
+  );
+
   return Promise.all(rows.map(async (row) => {
     const view = await toQuestionView(row.question);
+    const answerers = answerersByQuestion.get(row.question.id);
     return {
       ...view,
       bankEntryId: row.bank.id,
@@ -140,6 +221,7 @@ export async function getBankedQuestions(userId: string): Promise<BankedQuestion
       isInBank: true,
       isOwnAuthored: row.question.creatorId === userId,
       authorName: row.question.creatorId === userId ? 'You' : displayName(row.author.displayName),
+      answerers: answerers && answerers.total > 0 ? answerers : undefined,
     };
   }));
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -56,6 +56,7 @@ export type QuestionView = {
   verified: boolean;
   llmSuggestedAnswer: string | null;
   critiqueIterations: number;
+  answerers?: { names: string[]; total: number };
 };
 
 export type QuestionMutationResult = { ok: boolean; reason?: 'not_found' | 'in_use' };


### PR DESCRIPTION
## Summary
Add functionality to display the names of users who answered a question that the current user has banked. This provides feedback to question authors about engagement with their questions.

## Key Changes
- **New query function `getAnswerersForQuestions()`** in `src/server/db/queries/bank.ts`:
  - Fetches answerers from both `joshingGameResponses` and `feedItems` tables
  - Excludes the question author (viewer) from results
  - Returns up to 2 most recent answerer names plus total count per question
  - Uses `shortAnswererName()` helper to format names (first name + last initial for brevity)

- **Updated `getBankedQuestions()`** to include answerer data:
  - Calls `getAnswerersForQuestions()` for all banked questions in a single batch query
  - Adds `answerers` field to returned question view when data exists

- **UI display in `src/app/questions/page.tsx`**:
  - New `formatAnswerersLine()` helper generates human-readable text (e.g., "Alice and 3 others answered your question")
  - Displays answerer information below question stats for author-owned questions only

- **Type updates** in `src/server/db/queries/questions.ts`:
  - Added optional `answerers` field to `QuestionView` type

## Implementation Details
- Queries combine results from two sources (game responses and feed items) to capture all answer attempts
- Deduplicates answerers by user ID, keeping the most recent answer timestamp
- Limits display to 2 names to avoid UI clutter while showing total count
- Only shown for questions authored by the current user

https://claude.ai/code/session_01FrKbn1d3AHe5616YyK4kKX