### PR TITLE
Implement thumbs-down confirmation UI and session close messaging v11.1

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -8,6 +8,7 @@ import {
   dailyQueues,
   db,
   generatedQuestions,
+  playerMastery,
   questions,
 } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
@@ -201,12 +202,38 @@ export async function POST(request: NextRequest) {
       priorAnswers,
     );
     const basePoints = Math.round(question.basePoints);
-    const pointsAwarded =
+    const uncheckedPointsAwarded =
       masteryAnswerState === 'first_correct'
         ? basePoints
         : masteryAnswerState === 'first_correct_after_wrong'
           ? Math.round(basePoints * RECOVERY_STATE_WEIGHT)
           : 0;
+
+    // PRD §8.4.3 — LLM-generated Daily Five questions can only deepen mastery
+    // in existing Knowledge base domains; they cannot open new ones. For a
+    // bot-source question whose domain isn't in the player's playerMastery,
+    // skip the mastery event and award 0 points rather than letting
+    // ON CONFLICT DO UPDATE silently insert a ghost domain row.
+    let skipMasteryForUnknownDomain = false;
+    if (slot.source === 'bot' && uncheckedPointsAwarded > 0) {
+      const [existingDomain] = await db
+        .select({ canonicalSubcategory: playerMastery.canonicalSubcategory })
+        .from(playerMastery)
+        .where(and(
+          eq(playerMastery.userId, session.userId),
+          eq(playerMastery.canonicalSubcategory, question.canonicalSubcategory),
+        ))
+        .limit(1);
+      if (!existingDomain) {
+        skipMasteryForUnknownDomain = true;
+        console.warn('[daily/answer] bot question domain not in player KB; skipping mastery write', {
+          userId: session.userId,
+          domain: question.canonicalSubcategory,
+          generatedQuestionId: question.id,
+        });
+      }
+    }
+    const pointsAwarded = skipMasteryForUnknownDomain ? 0 : uncheckedPointsAwarded;
 
     const nextSlots = slots.map((item) => {
       if (item.slot_index !== parsed.slotIndex) return item;
@@ -229,22 +256,24 @@ export async function POST(request: NextRequest) {
       .where(eq(dailyQueues.id, queue.id));
 
     let masteryDelta = null;
-    try {
-      masteryDelta = await writeMasteryEvent({
-        userId: session.userId,
-        questionId: question.id,
-        domain: question.canonicalSubcategory,
-        answerState: masteryAnswerState,
-        pointsAwarded,
-        sourceType: 'daily',
-        sourceId: `${queue.id}:${parsed.slotIndex}`,
-        broadCategory: question.broadCategory,
-        eventQuestionId: canonicalQuestionId,
-        basePoints,
-        weight: pointsAwarded > 0 ? pointsAwarded / basePoints : 0,
-      });
-    } catch (error) {
-      console.warn('[daily/answer] writeMasteryEvent failed', error);
+    if (!skipMasteryForUnknownDomain) {
+      try {
+        masteryDelta = await writeMasteryEvent({
+          userId: session.userId,
+          questionId: question.id,
+          domain: question.canonicalSubcategory,
+          answerState: masteryAnswerState,
+          pointsAwarded,
+          sourceType: 'daily',
+          sourceId: `${queue.id}:${parsed.slotIndex}`,
+          broadCategory: question.broadCategory,
+          eventQuestionId: canonicalQuestionId,
+          basePoints,
+          weight: pointsAwarded > 0 ? pointsAwarded / basePoints : 0,
+        });
+      } catch (error) {
+        console.warn('[daily/answer] writeMasteryEvent failed', error);
+      }
     }
 
     await updateDomainDifficultyOnAnswer(

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -7,6 +7,7 @@ import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionR
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
 
 function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' | 'warning' }> {
   const tier = difficultyEstimateToTierLabel(slot.difficulty_estimate);
@@ -66,16 +67,22 @@ function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {
   return slots.find((slot) => !slot.answered && !slot.skipped) ?? null;
 }
 
-function sessionCloseCopy(slots: QueueSlot[]): string {
-  if (slots.length > 0 && slots.every((slot) => slot.skipped)) return "We'll come back to these.";
-  const answered = slots.filter((slot) => slot.answered);
-  if (answered.length > 0 && answered.every((slot) => slot.answer_state === 'correct')) {
-    return 'Five for five. See you tomorrow.';
+function sessionCloseLines(slots: QueueSlot[]): { scoreLine: string; interpretiveLine: string | null } {
+  if (slots.length > 0 && slots.every((slot) => slot.skipped)) {
+    return { scoreLine: "We'll come back to these.", interpretiveLine: null };
   }
-  if (answered.length > 0 && answered.every((slot) => slot.answer_state === 'incorrect')) {
-    return 'Tough round. The map grows anyway.';
-  }
-  return "That's today's round. See you tomorrow.";
+  // PRD §8.1.13 (v11.1) — score line + interpretive line. Tier-crossing and
+  // new-demonstrated-domain interpretive cases need server-side mastery delta
+  // plumbing that doesn't exist on the daily page yet; for now we only
+  // populate the slot fields needed for the slot-derived priority levels
+  // (sweep, wipeout, streaks, all-wrong-in-domain).
+  const summaries: SessionSlotSummary[] = slots
+    .filter((slot) => slot.answered)
+    .map((slot) => ({
+      domain: slot.domain ?? null,
+      answer_state: slot.answer_state ?? null,
+    }));
+  return buildSessionCloseLines(summaries);
 }
 
 function UnfamiliarDialog({
@@ -431,10 +438,12 @@ export default function DailyPage() {
     }
 
     if (allDone) {
+      const { scoreLine, interpretiveLine } = sessionCloseLines(queue.slots);
       rows.push({
         id: 'session-close',
         kind: 'session_close',
-        text: sessionCloseCopy(queue.slots),
+        scoreLine,
+        interpretiveLine,
         summaryHref: '/daily/summary',
       });
     }

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -129,6 +129,51 @@ function profileHref(userId?: string | null) {
   return userId ? `/users/${encodeURIComponent(userId)}` : null
 }
 
+/**
+ * PRD §8.2.10 — transient confirmation line that replaces a feed card after
+ * a thumbs-down (or its undo). Auto-dismisses on a 4s timer set by the
+ * caller; tap-to-dismiss-early is wired to onDismiss.
+ */
+function ThumbsdownConfirmRow({
+  phase,
+  onDismiss,
+  onUndo,
+  disabled,
+}: {
+  phase: 'removed' | 'restored'
+  onDismiss: () => void
+  onUndo: () => void
+  disabled?: boolean
+}) {
+  const message =
+    phase === 'removed'
+      ? "Removed from your feed. Won't pass to your friends."
+      : 'Restored. This may pass to your friends.'
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      onClick={onDismiss}
+      className="text-muted-foreground flex items-center justify-between gap-3 rounded-lg border border-dashed px-3 py-2 text-sm italic"
+    >
+      <span>{message}</span>
+      {phase === 'removed' ? (
+        <button
+          type="button"
+          disabled={disabled}
+          onClick={(event) => {
+            event.stopPropagation()
+            onUndo()
+          }}
+          className="text-foreground text-xs font-medium underline-offset-4 hover:underline disabled:opacity-50"
+        >
+          Undo
+        </button>
+      ) : null}
+    </div>
+  )
+}
+
 function FeedPersonLink({
   href,
   name,
@@ -464,6 +509,12 @@ function FeedListContent({
   )
   const [results, setResults] = useState<Record<string, ResultState>>({})
   const [cardStates, setCardStates] = useState<Record<string, QuestionCardState>>({})
+  // PRD §8.2.10 — after a thumbs-down or its undo, replace the card with a
+  // transient inline confirmation line for ~4s. Tracks the per-item phase.
+  const [thumbsdownConfirm, setThumbsdownConfirm] = useState<
+    Record<string, 'removed' | 'restored'>
+  >({})
+  const thumbsdownTimersRef = useRef<Record<string, number>>({})
   const [answerSheetId, setAnswerSheetId] = useState<string | null>(null)
   const [feedbackSheetId, setFeedbackSheetId] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
@@ -571,7 +622,7 @@ function FeedListContent({
     if (loadingInitial) return 'Loading your Feed...'
     if (error) return error
     if (!feedMeta?.has_friends)
-      return 'When friends recognize each other’s questions, those moments will appear here.'
+      return 'When your friends play, their questions will show up here.'
     // pre_filter_active_count > 0 means items exist in active/skipped state but are hidden by domain filters
     if (
       feedMeta.has_dismissed_domains &&
@@ -579,10 +630,11 @@ function FeedListContent({
     ) {
       return "You've focused your Feed. You can re-open domains from your Knowledge page."
     }
-    if (feedMeta.total_item_count > 0)
-      return "You're caught up. Answer questions to reveal more common ground."
-    return 'Answer questions to reveal common ground.'
+    if (feedMeta.total_item_count > 0) return "You're caught up."
+    return 'Quiet today. Check back when your friends have played.'
   }, [error, feedMeta, loadingInitial])
+
+  const showInviteFriendCta = !loadingInitial && !error && feedMeta && !feedMeta.has_friends
 
   const emptyDiagnostics = useMemo(() => {
     if (process.env.NODE_ENV === 'production' || !feedMeta) return null
@@ -668,6 +720,47 @@ function FeedListContent({
     }
   }, [])
 
+  const clearThumbsdownTimer = useCallback((itemId: string) => {
+    const timer = thumbsdownTimersRef.current[itemId]
+    if (timer) {
+      window.clearTimeout(timer)
+      delete thumbsdownTimersRef.current[itemId]
+    }
+  }, [])
+
+  const dismissThumbsdownConfirm = useCallback(
+    (itemId: string) => {
+      clearThumbsdownTimer(itemId)
+      const phase = thumbsdownConfirm[itemId]
+      setThumbsdownConfirm((current) => {
+        const next = { ...current }
+        delete next[itemId]
+        return next
+      })
+      if (phase === 'removed') {
+        removeItem(itemId)
+      }
+    },
+    [clearThumbsdownTimer, removeItem, thumbsdownConfirm]
+  )
+
+  useEffect(() => {
+    return () => {
+      Object.values(thumbsdownTimersRef.current).forEach((t) => window.clearTimeout(t))
+      thumbsdownTimersRef.current = {}
+    }
+  }, [])
+
+  const scheduleThumbsdownAutoDismiss = useCallback(
+    (itemId: string) => {
+      clearThumbsdownTimer(itemId)
+      thumbsdownTimersRef.current[itemId] = window.setTimeout(() => {
+        dismissThumbsdownConfirm(itemId)
+      }, 4000)
+    },
+    [clearThumbsdownTimer, dismissThumbsdownConfirm]
+  )
+
   const reportItem = useCallback(
     async (item: FeedApiItem) => {
       setBusyId(item.id)
@@ -681,7 +774,8 @@ function FeedListContent({
           const body = await response.json().catch(() => null)
           throw new Error(body?.message ?? 'Could not report that question.')
         }
-        removeItem(item.id)
+        setThumbsdownConfirm((current) => ({ ...current, [item.id]: 'removed' }))
+        scheduleThumbsdownAutoDismiss(item.id)
       } catch (caught) {
         setError(
           caught instanceof Error
@@ -692,7 +786,34 @@ function FeedListContent({
         setBusyId(null)
       }
     },
-    [removeItem]
+    [scheduleThumbsdownAutoDismiss]
+  )
+
+  const undoThumbsdown = useCallback(
+    async (itemId: string) => {
+      setBusyId(itemId)
+      setError(null)
+      try {
+        const response = await fetch(`/api/feed/${itemId}/thumbsdown`, {
+          method: 'DELETE',
+          credentials: 'include',
+        })
+        if (!response.ok) {
+          const body = await response.json().catch(() => null)
+          throw new Error(body?.message ?? 'Could not undo that.')
+        }
+        clearThumbsdownTimer(itemId)
+        setThumbsdownConfirm((current) => ({ ...current, [itemId]: 'restored' }))
+        scheduleThumbsdownAutoDismiss(itemId)
+      } catch (caught) {
+        setError(
+          caught instanceof Error ? caught.message : 'Could not undo that.'
+        )
+      } finally {
+        setBusyId(null)
+      }
+    },
+    [clearThumbsdownTimer, scheduleThumbsdownAutoDismiss]
   )
 
   const submitAnswer = useCallback(
@@ -843,6 +964,14 @@ function FeedListContent({
           >
             {emptyCopy}
           </p>
+          {showInviteFriendCta ? (
+            <Link
+              href="/friends"
+              className="text-primary text-sm font-medium underline-offset-4 hover:underline"
+            >
+              Invite a friend
+            </Link>
+          ) : null}
           {emptyDiagnostics ? (
             <p className="bg-muted text-muted-foreground max-w-xl rounded px-3 py-2 font-mono text-xs break-words">
               {emptyDiagnostics}
@@ -863,6 +992,19 @@ function FeedListContent({
                   (item.state === 'answered' ? 'answered' : 'unanswered')
                 const isAnswered = cardState === 'answered'
                 const isBusy = busyId === item.id
+                const confirmPhase = thumbsdownConfirm[item.id]
+
+                if (confirmPhase) {
+                  return (
+                    <ThumbsdownConfirmRow
+                      key={item.id}
+                      phase={confirmPhase}
+                      onDismiss={() => dismissThumbsdownConfirm(item.id)}
+                      onUndo={() => void undoThumbsdown(item.id)}
+                      disabled={isBusy}
+                    />
+                  )
+                }
 
                 const overflow = (
                   <FeedOverflowMenu

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -74,7 +74,7 @@ export type ChatMessage =
       roundsRemaining: number;
       nextRoundOpensAt: string | null;
     }
-  | { id: string; kind: 'session_close'; text: string; summaryHref?: string }
+  | { id: string; kind: 'session_close'; scoreLine: string; interpretiveLine: string | null; summaryHref?: string }
   | {
       id: string;
       kind: 'bonus_offer';
@@ -712,7 +712,15 @@ function ResultRow({
   );
 }
 
-function SessionCloseRow({ text, summaryHref }: { text: string; summaryHref?: string }) {
+function SessionCloseRow({
+  scoreLine,
+  interpretiveLine,
+  summaryHref,
+}: {
+  scoreLine: string;
+  interpretiveLine: string | null;
+  summaryHref?: string;
+}) {
   return (
     <div
       className="mt-4"
@@ -725,7 +733,7 @@ function SessionCloseRow({ text, summaryHref }: { text: string; summaryHref?: st
         padding: '14px 16px',
       }}
     >
-      <SessionCloseMessage closeCopy={text} />
+      <SessionCloseMessage scoreLine={scoreLine} interpretiveLine={interpretiveLine} />
       {summaryHref ? (
         <div className="pt-3">
           <Link href={summaryHref} className="btn-primary inline-flex">
@@ -928,7 +936,14 @@ export function GameplayChatThread({
               />
             );
           case 'session_close':
-            return <SessionCloseRow key={m.id} text={m.text} summaryHref={m.summaryHref} />;
+            return (
+              <SessionCloseRow
+                key={m.id}
+                scoreLine={m.scoreLine}
+                interpretiveLine={m.interpretiveLine}
+                summaryHref={m.summaryHref}
+              />
+            );
           case 'bonus_offer':
             return (
               <BonusOfferRow

--- a/src/components/play/SessionCloseMessage.tsx
+++ b/src/components/play/SessionCloseMessage.tsx
@@ -1,15 +1,42 @@
+'use client';
+
 import Link from 'next/link';
+import { useEffect, useState } from 'react';
 
 type SessionCloseMessageProps = {
-  closeCopy: string;
+  /** PRD §8.1.13 Layer 1 — score-based line, always present. */
+  scoreLine: string;
+  /** PRD §8.1.13 Layer 2 — interpretive line, appears ~300ms after Layer 1. */
+  interpretiveLine?: string | null;
   reviewLink?: string;
   knowledgeLink?: string;
 };
 
-export function SessionCloseMessage({ closeCopy, reviewLink, knowledgeLink }: SessionCloseMessageProps) {
+export function SessionCloseMessage({
+  scoreLine,
+  interpretiveLine,
+  reviewLink,
+  knowledgeLink,
+}: SessionCloseMessageProps) {
+  const [showInterpretive, setShowInterpretive] = useState(false);
+
+  useEffect(() => {
+    if (!interpretiveLine) return;
+    const timer = window.setTimeout(() => setShowInterpretive(true), 300);
+    return () => window.clearTimeout(timer);
+  }, [interpretiveLine]);
+
   return (
     <>
-      <p className="text-[1.22rem] text-[var(--text)] leading-relaxed">{closeCopy}</p>
+      <p className="text-[1.22rem] text-[var(--text)] leading-relaxed">{scoreLine}</p>
+      {interpretiveLine ? (
+        <p
+          className="mt-1 text-[1.05rem] text-[var(--text-muted)] leading-relaxed"
+          style={{ opacity: showInterpretive ? 1 : 0, transition: 'opacity 0.25s ease' }}
+        >
+          {interpretiveLine}
+        </p>
+      ) : null}
       {reviewLink ? (
         <div className="pt-2">
           <Link href={reviewLink} className="btn-primary inline-flex">

--- a/src/server/mastery/__tests__/session-close-copy.test.ts
+++ b/src/server/mastery/__tests__/session-close-copy.test.ts
@@ -1,44 +1,103 @@
 import { describe, expect, it } from 'vitest';
-import type { CategoryGainsDeltaRow } from '@/server/mastery/category-gains-types';
-import { buildSessionCloseCopy } from '@/server/mastery/session-close-copy';
+import {
+  buildScoreLine,
+  buildInterpretiveLine,
+  buildSessionCloseLines,
+  type SessionSlotSummary,
+} from '@/server/mastery/session-close-copy';
 
-function row(partial: Pick<CategoryGainsDeltaRow, 'subcategory' | 'points_earned'>): CategoryGainsDeltaRow {
-  return {
-    ...partial,
-    points_from_answers: 0,
-    points_from_catchup: 0,
-    points_from_author_credit: 0,
-    points_from_authored: 0,
-    total: 0,
-    current_tier: 'establishing',
-    next_tier: 'familiar',
-    progress_pct: 0,
-    tier_crossed: false,
-    new_tier: null,
-  };
+function slot(partial: Partial<SessionSlotSummary> & { answer_state: SessionSlotSummary['answer_state'] }): SessionSlotSummary {
+  return { domain: 'History', ...partial };
 }
 
-describe('buildSessionCloseCopy', () => {
-  it('omits domains when no movement', () => {
-    expect(buildSessionCloseCopy([row({ subcategory: 'History', points_earned: 0 })])).toBe(
-      'Done for today. Your next 5 questions arrive tomorrow at noon.',
-    );
+describe('buildScoreLine', () => {
+  it('5/5 is Untouched', () => {
+    expect(buildScoreLine(5)).toBe('Untouched.');
+  });
+  it('4/5 is Strong', () => {
+    expect(buildScoreLine(4)).toBe('Strong.');
+  });
+  it('3/5 is Solid', () => {
+    expect(buildScoreLine(3)).toBe('Solid.');
+  });
+  it('2/5 is Working ground', () => {
+    expect(buildScoreLine(2)).toBe('Working ground.');
+  });
+  it('1/5 and 0/5 share the same line', () => {
+    expect(buildScoreLine(1)).toBe("Tomorrow's another five.");
+    expect(buildScoreLine(0)).toBe("Tomorrow's another five.");
+  });
+});
+
+describe('buildInterpretiveLine', () => {
+  it('returns null when nothing qualifies (mixed 2/5 with no streak or domain wipe)', () => {
+    const slots: SessionSlotSummary[] = [
+      slot({ answer_state: 'correct', domain: 'A' }),
+      slot({ answer_state: 'incorrect', domain: 'B' }),
+      slot({ answer_state: 'correct', domain: 'C' }),
+      slot({ answer_state: 'incorrect', domain: 'D' }),
+      slot({ answer_state: 'incorrect', domain: 'E' }),
+    ];
+    expect(buildInterpretiveLine(slots)).toBeNull();
   });
 
-  it('names one top domain', () => {
-    expect(buildSessionCloseCopy([row({ subcategory: 'Film & TV', points_earned: 2 })])).toBe(
-      "Done for today. You're building in Film & TV. Your next 5 questions arrive tomorrow at noon.",
-    );
+  it('returns Clean sweep for 5/5', () => {
+    const slots = Array.from({ length: 5 }, (_, i) => slot({ answer_state: 'correct', domain: `D${i}` }));
+    expect(buildInterpretiveLine(slots)).toBe('Clean sweep.');
   });
 
-  it('names top two domains by points', () => {
-    const copy = buildSessionCloseCopy([
-      row({ subcategory: 'Alpha', points_earned: 5 }),
-      row({ subcategory: 'Beta', points_earned: 3 }),
-      row({ subcategory: 'Gamma', points_earned: 1 }),
-    ]);
-    expect(copy).toBe(
-      "Done for today. You're building in Alpha and Beta. Your next 5 questions arrive tomorrow at noon.",
-    );
+  it('returns wipeout for 0/5', () => {
+    const slots = Array.from({ length: 5 }, (_, i) => slot({ answer_state: 'incorrect', domain: `D${i}` }));
+    expect(buildInterpretiveLine(slots)).toBe('Every one of them. Tomorrow.');
+  });
+
+  it('returns streak copy for 3 in a row', () => {
+    const slots: SessionSlotSummary[] = [
+      slot({ answer_state: 'incorrect', domain: 'A' }),
+      slot({ answer_state: 'correct', domain: 'B' }),
+      slot({ answer_state: 'correct', domain: 'C' }),
+      slot({ answer_state: 'correct', domain: 'D' }),
+      slot({ answer_state: 'incorrect', domain: 'E' }),
+    ];
+    expect(buildInterpretiveLine(slots)).toBe('Three in a row at one point.');
+  });
+
+  it('returns domain-deep-look copy when all answers in one domain are wrong', () => {
+    const slots: SessionSlotSummary[] = [
+      slot({ answer_state: 'correct', domain: 'A' }),
+      slot({ answer_state: 'incorrect', domain: 'Late Tchaikovsky' }),
+      slot({ answer_state: 'incorrect', domain: 'Late Tchaikovsky' }),
+      slot({ answer_state: 'correct', domain: 'A' }),
+      slot({ answer_state: 'correct', domain: 'A' }),
+    ];
+    expect(buildInterpretiveLine(slots)).toBe('Late Tchaikovsky is worth a deeper look.');
+  });
+
+  it('prioritizes tier crossing over slot-derived signals', () => {
+    const slots: SessionSlotSummary[] = Array.from({ length: 5 }, (_, i) => slot({
+      answer_state: 'correct',
+      domain: `D${i}`,
+    }));
+    slots[0] = { ...slots[0], tier_crossed: true, new_tier: 'familiar', domain: 'Late Tchaikovsky' };
+    expect(buildInterpretiveLine(slots)).toBe('You moved to Familiar in Late Tchaikovsky.');
+  });
+
+  it('prioritizes new demonstrated domain over slot-derived signals', () => {
+    const slots: SessionSlotSummary[] = Array.from({ length: 5 }, (_, i) => slot({
+      answer_state: 'correct',
+      domain: `D${i}`,
+    }));
+    slots[2] = { ...slots[2], is_first_in_new_demonstrated_domain: true, domain: 'Geology' };
+    expect(buildInterpretiveLine(slots)).toBe('New ground: Geology is yours now.');
+  });
+});
+
+describe('buildSessionCloseLines', () => {
+  it('produces both layers', () => {
+    const slots: SessionSlotSummary[] = Array.from({ length: 5 }, (_, i) => slot({ answer_state: 'correct', domain: `D${i}` }));
+    expect(buildSessionCloseLines(slots)).toEqual({
+      scoreLine: 'Untouched.',
+      interpretiveLine: 'Clean sweep.',
+    });
   });
 });

--- a/src/server/mastery/session-close-copy.ts
+++ b/src/server/mastery/session-close-copy.ts
@@ -1,34 +1,117 @@
-import type { CategoryGainsDeltaRow } from '@/server/mastery/category-gains-types';
+/**
+ * PRD §8.1.13 (v11.1) — Session Close Messaging is two layers:
+ *   Layer 1: score-based line (always present)
+ *   Layer 2: interpretive line (highest-priority match only, may be omitted)
+ *
+ * The interpretive line appears ~300ms after Layer 1; that delay is enforced
+ * by the renderer (SessionCloseMessage), not here.
+ *
+ * Priority order for Layer 2 (highest first):
+ *   1. tier crossing
+ *   2. first correct in a new demonstrated domain
+ *   3. 5/5 sweep
+ *   4. 0/5 wipeout
+ *   5. 3+ correct in a row
+ *   6. all wrong in a single domain
+ * If nothing qualifies, Layer 2 is null.
+ */
 
-/** PRD §8.38 — end-of-session line after daily play; domain lines mirror CategoryGainsDisplay (movement = points_earned > 0). */
-export const DEFAULT_SESSION_CLOSE_COPY = 'Done for today. Your next 5 questions arrive tomorrow at noon.';
-
-export type SessionCloseDomainRow = {
-  canonical_subcategory: string;
-  points_earned: number;
+export type SessionSlotSummary = {
+  domain: string | null;
+  answer_state: 'correct' | 'incorrect' | null;
+  /** Server-side mastery delta for this slot; populated when available. */
+  tier_crossed?: boolean;
+  new_tier?: string | null;
+  /** True iff this answer opened the first demonstrated point in this domain. */
+  is_first_in_new_demonstrated_domain?: boolean;
 };
 
-export function buildSessionCloseCopyFromDomains(rows: SessionCloseDomainRow[] | null | undefined): string {
-  const withMovement = (rows ?? []).filter((row) => row.points_earned > 0);
-  if (withMovement.length === 0) {
-    return DEFAULT_SESSION_CLOSE_COPY;
-  }
+export type SessionCloseLines = {
+  scoreLine: string;
+  interpretiveLine: string | null;
+};
 
-  const sorted = [...withMovement].sort(
-    (a, b) => b.points_earned - a.points_earned || a.canonical_subcategory.localeCompare(b.canonical_subcategory),
-  );
-  const top = sorted.slice(0, 2).map((row) => row.canonical_subcategory);
-  if (top.length === 1) {
-    return `Done for today. You're building in ${top[0]}. Your next 5 questions arrive tomorrow at noon.`;
-  }
-  return `Done for today. You're building in ${top[0]} and ${top[1]}. Your next 5 questions arrive tomorrow at noon.`;
+function tierDisplay(tier: string | null | undefined): string | null {
+  if (!tier) return null;
+  return tier.charAt(0).toUpperCase() + tier.slice(1);
 }
 
-export function buildSessionCloseCopy(deltas: CategoryGainsDeltaRow[] | null | undefined): string {
-  return buildSessionCloseCopyFromDomains(
-    (deltas ?? []).map((row) => ({
-      canonical_subcategory: row.subcategory,
-      points_earned: row.points_earned,
-    })),
-  );
+export function buildScoreLine(correctCount: number): string {
+  if (correctCount >= 5) return 'Untouched.';
+  if (correctCount === 4) return 'Strong.';
+  if (correctCount === 3) return 'Solid.';
+  if (correctCount === 2) return 'Working ground.';
+  return "Tomorrow's another five.";
+}
+
+export function buildInterpretiveLine(slots: SessionSlotSummary[]): string | null {
+  const answered = slots.filter((s) => s.answer_state === 'correct' || s.answer_state === 'incorrect');
+  if (answered.length === 0) return null;
+
+  // 1. Tier crossing
+  const tierCrossing = answered.find((s) => s.tier_crossed && s.new_tier && s.domain);
+  if (tierCrossing) {
+    return `You moved to ${tierDisplay(tierCrossing.new_tier)} in ${tierCrossing.domain}.`;
+  }
+
+  // 2. First correct in a new demonstrated domain
+  const newDomain = answered.find((s) => s.is_first_in_new_demonstrated_domain && s.domain);
+  if (newDomain) {
+    return `New ground: ${newDomain.domain} is yours now.`;
+  }
+
+  const correctCount = answered.filter((s) => s.answer_state === 'correct').length;
+  const wrongCount = answered.length - correctCount;
+
+  // 3. 5/5 sweep
+  if (answered.length >= 5 && correctCount === answered.length) {
+    return 'Clean sweep.';
+  }
+
+  // 4. 0/5 wipeout
+  if (answered.length >= 5 && correctCount === 0) {
+    return 'Every one of them. Tomorrow.';
+  }
+
+  // 5. 3+ correct in a row
+  let maxStreak = 0;
+  let currentStreak = 0;
+  for (const slot of slots) {
+    if (slot.answer_state === 'correct') {
+      currentStreak += 1;
+      if (currentStreak > maxStreak) maxStreak = currentStreak;
+    } else if (slot.answer_state === 'incorrect') {
+      currentStreak = 0;
+    }
+  }
+  if (maxStreak >= 3) {
+    return `${maxStreak === 3 ? 'Three' : maxStreak === 4 ? 'Four' : 'Five'} in a row at one point.`;
+  }
+
+  // 6. All wrong in a single domain (a domain with 2+ slots, all incorrect)
+  if (wrongCount > 0) {
+    const byDomain = new Map<string, { correct: number; incorrect: number }>();
+    for (const slot of answered) {
+      if (!slot.domain) continue;
+      const counts = byDomain.get(slot.domain) ?? { correct: 0, incorrect: 0 };
+      if (slot.answer_state === 'correct') counts.correct += 1;
+      else counts.incorrect += 1;
+      byDomain.set(slot.domain, counts);
+    }
+    for (const [domain, counts] of byDomain.entries()) {
+      if (counts.incorrect >= 2 && counts.correct === 0) {
+        return `${domain} is worth a deeper look.`;
+      }
+    }
+  }
+
+  return null;
+}
+
+export function buildSessionCloseLines(slots: SessionSlotSummary[]): SessionCloseLines {
+  const correctCount = slots.filter((s) => s.answer_state === 'correct').length;
+  return {
+    scoreLine: buildScoreLine(correctCount),
+    interpretiveLine: buildInterpretiveLine(slots),
+  };
 }


### PR DESCRIPTION
## Summary
This PR implements two major UX improvements: (1) a transient confirmation line that replaces feed cards after thumbs-down actions with undo capability, and (2) a two-layer session close messaging system with score-based and interpretive lines per PRD §8.1.13 (v11.1) and §8.2.10.

## Key Changes

### Feed Thumbs-Down Confirmation (PRD §8.2.10)
- Added `ThumbsdownConfirmRow` component that displays a transient confirmation message when a feed item is removed or restored via thumbs-down
- Implemented state tracking (`thumbsdownConfirm`) and auto-dismiss timers (4s) with manual dismiss-on-tap
- Added `undoThumbsdown` callback to support DELETE `/api/feed/{itemId}/thumbsdown` endpoint
- Confirmation line replaces the card during the transient state and auto-removes the item on final dismiss
- Properly handles timer cleanup on component unmount and when dismissing early

### Session Close Messaging (PRD §8.1.13 v11.1)
- Refactored `session-close-copy.ts` to implement two-layer messaging:
  - **Layer 1 (scoreLine):** Score-based line always present (5/5 → "Untouched.", 4/5 → "Strong.", etc.)
  - **Layer 2 (interpretiveLine):** Interpretive line with priority-ordered matching (tier crossing > new domain > sweep > wipeout > streaks > domain wipeout)
- Updated `SessionCloseMessage` component to render both layers with 300ms stagger (Layer 2 fades in after Layer 1)
- Replaced old domain-based copy generation with slot-based analysis
- Updated daily page and gameplay chat to use new `buildSessionCloseLines()` API

### Bot-Generated Question Domain Validation (PRD §8.4.3)
- Added guard in `/api/daily/answer` to prevent LLM-generated questions from opening new domains in player mastery
- Bot-source questions now skip mastery writes and award 0 points if the domain isn't already in the player's knowledge base
- Includes console warning for debugging

### Empty Feed State Improvements
- Updated empty feed messaging ("When your friends play, their questions will show up here.")
- Added "Invite a friend" CTA link when feed is empty and user has no friends
- Simplified caught-up messaging ("You're caught up.")

## Implementation Details
- Thumbs-down timers stored in `useRef` to persist across renders and enable cleanup on unmount
- Session close interpretive line matching follows strict priority order with early returns
- Streak detection uses linear scan to find max consecutive correct answers
- Domain wipeout detection requires 2+ incorrect answers in a single domain with 0 correct
- All new messaging copy is data-driven from slot answer states rather than hardcoded domain lists

https://claude.ai/code/session_01Ehd2uHq6QydtEXLexU28vp