### PR TITLE
Move 'Not familiar' under the question and add a 3-level scope slider

### DIFF
--- a/drizzle/0036_domain_exclusion_scope.sql
+++ b/drizzle/0036_domain_exclusion_scope.sql
@@ -1,0 +1,19 @@
+-- Migration: scope-aware USER_DOMAIN_EXCLUSIONS so users can exclude a single
+-- subcategory ("Pee-wee's Playhouse"), a broader category ("Saturday morning
+-- cartoons"), or a top-level category enum value ("film_tv"). The familiarity
+-- slider in the daily client writes one of these scopes per click.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded without
+-- the column actually present.
+CREATE TYPE "public"."DomainExclusionScope" AS ENUM('subcategory', 'broad_category', 'category');
+--> statement-breakpoint
+ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+  ADD COLUMN IF NOT EXISTS "scope" "public"."DomainExclusionScope" NOT NULL DEFAULT 'subcategory';
+--> statement-breakpoint
+ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+  DROP CONSTRAINT IF EXISTS "USER_DOMAIN_EXCLUSIONS_user_id_canonical_subcategory_key";
+--> statement-breakpoint
+ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+  ADD CONSTRAINT "USER_DOMAIN_EXCLUSIONS_user_id_scope_canonical_subcategory_key"
+  UNIQUE ("user_id", "scope", "canonical_subcategory");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -253,6 +253,13 @@
       "when": 1779580800000,
       "tag": "0035_mastery_events_viewer_status_idx",
       "breakpoints": true
+    },
+    {
+      "idx": 36,
+      "version": "7",
+      "when": 1779667200000,
+      "tag": "0036_domain_exclusion_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/users/domain-exclusions/route.ts
+++ b/src/app/api/users/domain-exclusions/route.ts
@@ -1,31 +1,52 @@
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { db, userDomainExclusions } from '@/server/db';
 
 export const dynamic = 'force-dynamic';
 
-function parseDomain(value: unknown): string | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const domain = (value as Record<string, unknown>).canonical_subcategory;
-  return typeof domain === 'string' && domain.trim() ? domain.trim().replace(/\s+/g, ' ') : null;
+const exclusionPayloadSchema = z.object({
+  canonical_subcategory: z
+    .string()
+    .trim()
+    .min(1)
+    .transform((value) => value.replace(/\s+/g, ' ')),
+  scope: z.enum(['subcategory', 'broad_category', 'category']).default('subcategory'),
+});
+
+async function parsePayload(request: NextRequest) {
+  const body = await request.json().catch(() => null);
+  const parsed = exclusionPayloadSchema.safeParse(body);
+  return parsed.success ? parsed.data : null;
 }
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const domain = parseDomain(await request.json().catch(() => null));
-  if (!domain) {
-    return NextResponse.json({ error: 'validation', message: 'canonical_subcategory is required' }, { status: 400 });
+  const payload = await parsePayload(request);
+  if (!payload) {
+    return NextResponse.json(
+      { error: 'validation', message: 'canonical_subcategory is required' },
+      { status: 400 },
+    );
   }
 
   await db
     .insert(userDomainExclusions)
-    .values({ userId: session.userId, canonicalSubcategory: domain })
+    .values({
+      userId: session.userId,
+      canonicalSubcategory: payload.canonical_subcategory,
+      scope: payload.scope,
+    })
     .onConflictDoNothing({
-      target: [userDomainExclusions.userId, userDomainExclusions.canonicalSubcategory],
+      target: [
+        userDomainExclusions.userId,
+        userDomainExclusions.scope,
+        userDomainExclusions.canonicalSubcategory,
+      ],
     });
 
   return NextResponse.json({ ok: true });
@@ -35,16 +56,20 @@ export async function DELETE(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const domain = parseDomain(await request.json().catch(() => null));
-  if (!domain) {
-    return NextResponse.json({ error: 'validation', message: 'canonical_subcategory is required' }, { status: 400 });
+  const payload = await parsePayload(request);
+  if (!payload) {
+    return NextResponse.json(
+      { error: 'validation', message: 'canonical_subcategory is required' },
+      { status: 400 },
+    );
   }
 
   await db
     .delete(userDomainExclusions)
     .where(and(
       eq(userDomainExclusions.userId, session.userId),
-      eq(userDomainExclusions.canonicalSubcategory, domain),
+      eq(userDomainExclusions.scope, payload.scope),
+      eq(userDomainExclusions.canonicalSubcategory, payload.canonical_subcategory),
     ));
 
   return NextResponse.json({ ok: true });

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -6,8 +6,26 @@ import { useRouter } from 'next/navigation';
 import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
+import { categoryLabel } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
+
+type ExclusionScope = 'subcategory' | 'broad_category' | 'category';
+
+type ExclusionTick = { scope: ExclusionScope; label: string; value: string };
+
+function buildExclusionTicks(slot: QueueSlot): ExclusionTick[] {
+  const ticks: ExclusionTick[] = [
+    { scope: 'subcategory', label: slot.domain, value: slot.domain },
+  ];
+  if (slot.broad_category && slot.broad_category.trim()) {
+    ticks.push({ scope: 'broad_category', label: slot.broad_category, value: slot.broad_category });
+  }
+  if (slot.category && slot.category.trim()) {
+    ticks.push({ scope: 'category', label: categoryLabel(slot.category), value: slot.category });
+  }
+  return ticks;
+}
 
 function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' | 'warning' }> {
   const tier = difficultyEstimateToTierLabel(slot.difficulty_estimate);
@@ -86,18 +104,23 @@ function sessionCloseLines(slots: QueueSlot[]): { scoreLine: string; interpretiv
 }
 
 function UnfamiliarDialog({
-  domain,
+  ticks,
   busy,
   onExclude,
   onSkipOnly,
   onCancel,
 }: {
-  domain: string;
+  ticks: ExclusionTick[];
   busy: boolean;
-  onExclude: () => void;
+  onExclude: (tick: ExclusionTick) => void;
   onSkipOnly: () => void;
   onCancel: () => void;
 }) {
+  const [tickIndex, setTickIndex] = useState(0);
+  const maxIndex = Math.max(0, ticks.length - 1);
+  const safeIndex = Math.min(tickIndex, maxIndex);
+  const selected = ticks[safeIndex] ?? ticks[0];
+
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel(); };
     window.addEventListener('keydown', handleKey);
@@ -127,22 +150,58 @@ function UnfamiliarDialog({
           border: '1px solid var(--border)',
           borderRadius: 'var(--radius-lg)',
           padding: '1.5rem',
-          maxWidth: '22rem',
+          maxWidth: '24rem',
           width: '100%',
         }}
       >
         <p id="unfamiliar-dialog-title" className="text-sm font-semibold text-[var(--text)]">
-          Not familiar with &ldquo;{domain}&rdquo;?
+          How familiar are you with this?
         </p>
         <p className="mt-1 text-sm text-[var(--text-muted)]">
-          Remove it from your daily topics so you won&rsquo;t see these questions again.
+          Slide to the scope you&rsquo;d like to skip going forward.
         </p>
+
+        {ticks.length > 1 ? (
+          <div className="mt-5">
+            <input
+              type="range"
+              min={0}
+              max={maxIndex}
+              step={1}
+              value={safeIndex}
+              onChange={(event) => setTickIndex(Number(event.target.value))}
+              aria-label="Unfamiliarity scope"
+              style={{ width: '100%' }}
+            />
+            <div className="mt-2 flex justify-between gap-1 text-[0.65rem] uppercase tracking-[0.06em] text-[var(--text-muted)]">
+              {ticks.map((tick, i) => (
+                <span
+                  key={`${tick.scope}-${i}`}
+                  style={{
+                    flex: '1 1 0',
+                    textAlign: i === 0 ? 'left' : i === ticks.length - 1 ? 'right' : 'center',
+                    color: i === safeIndex ? 'var(--text)' : 'var(--text-muted)',
+                    fontWeight: i === safeIndex ? 600 : 400,
+                  }}
+                >
+                  {tick.label}
+                </span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        <p className="mt-4 text-sm text-[var(--text-muted)]">
+          We&rsquo;ll stop sending you questions about{' '}
+          <span className="font-semibold text-[var(--text)]">{selected?.label ?? ''}</span>.
+        </p>
+
         <div className="mt-4 flex flex-col gap-2">
           <button
             type="button"
             className="btn-primary w-full"
-            disabled={busy}
-            onClick={onExclude}
+            disabled={busy || !selected}
+            onClick={() => { if (selected) onExclude(selected); }}
           >
             {busy ? '...' : 'Remove from my topics'}
           </button>
@@ -287,34 +346,47 @@ export default function DailyPage() {
     }
   }, [currentSlot, queue, submitting]);
 
-  const excludeDomainAndSkip = useCallback(async () => {
+  const excludeDomainAndSkip = useCallback(async (tick: ExclusionTick) => {
     if (!currentSlot) return;
-    const domain = currentSlot.domain;
     setExcludingDomain(true);
     try {
-      const prefsResponse = await fetch('/api/daily/preferences', { credentials: 'include' });
-      if (prefsResponse.ok) {
-        const prefsBody = await prefsResponse.json().catch(() => null) as {
-          preferences: { domainMode: string; selectedDomains: string[] };
-          domains: Array<{ domain: string }>;
-        } | null;
-        if (prefsBody) {
-          const { preferences, domains } = prefsBody;
-          const allDomains = domains.map((d) => d.domain);
-          const base = preferences.domainMode === 'custom' ? preferences.selectedDomains : allDomains;
-          const nextDomains = base.filter((d) => d !== domain);
-          if (nextDomains.length > 0) {
-            await fetch('/api/daily/preferences', {
-              method: 'PATCH',
-              headers: { 'content-type': 'application/json' },
-              credentials: 'include',
-              body: JSON.stringify({ domainMode: 'custom', selectedDomains: nextDomains }),
-            });
+      await fetch('/api/users/domain-exclusions', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ canonical_subcategory: tick.value, scope: tick.scope }),
+      });
+      // Subcategory exclusions also need to drop the domain from the user's
+      // selectedDomains list in Custom mode so today's queue rebuild can't
+      // re-pull it; broader scopes are filtered out by getKnowledgeBase via
+      // userDomainExclusions and don't touch selectedDomains.
+      if (tick.scope === 'subcategory') {
+        try {
+          const prefsResponse = await fetch('/api/daily/preferences', { credentials: 'include' });
+          if (prefsResponse.ok) {
+            const prefsBody = await prefsResponse.json().catch(() => null) as {
+              preferences: { domainMode: string; selectedDomains: string[] };
+              domains: Array<{ domain: string }>;
+            } | null;
+            if (prefsBody && prefsBody.preferences.domainMode === 'custom') {
+              const nextDomains = prefsBody.preferences.selectedDomains.filter((d) => d !== tick.value);
+              if (nextDomains.length > 0 && nextDomains.length !== prefsBody.preferences.selectedDomains.length) {
+                await fetch('/api/daily/preferences', {
+                  method: 'PATCH',
+                  headers: { 'content-type': 'application/json' },
+                  credentials: 'include',
+                  body: JSON.stringify({ domainMode: 'custom', selectedDomains: nextDomains }),
+                });
+              }
+            }
           }
+        } catch {
+          // preferences sync is best-effort; the exclusion write above already
+          // ensures future queue builds skip this domain.
         }
       }
     } catch {
-      // preference update is best-effort; skip regardless
+      // exclusion is best-effort; still skip the slot so the user can move on
     } finally {
       setExcludingDomain(false);
     }
@@ -425,6 +497,9 @@ export default function DailyPage() {
           creatorName: null,
           isNew: true,
           badges: questionBadges(slot),
+          onDismiss: () => setShowUnfamiliarDialog(true),
+          dismissLabel: 'Not familiar with this topic',
+          dismissImmediate: false,
         });
         if (submitting && answer.trim()) {
           rows.push({ id: 'u-pending', kind: 'user', text: answer.trim() });
@@ -631,15 +706,7 @@ export default function DailyPage() {
               {submitting ? '...' : 'Send'}
             </button>
           </div>
-          <div className="mt-2 flex items-center justify-between gap-3">
-            <button
-              type="button"
-              className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
-              disabled={submitting}
-              onClick={() => setShowUnfamiliarDialog(true)}
-            >
-              Not familiar with this topic
-            </button>
+          <div className="mt-2 flex items-center justify-end gap-3">
             <button
               type="button"
               className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
@@ -654,9 +721,9 @@ export default function DailyPage() {
 
       {showUnfamiliarDialog && currentSlot ? (
         <UnfamiliarDialog
-          domain={currentSlot.domain}
+          ticks={buildExclusionTicks(currentSlot)}
           busy={excludingDomain || submitting}
-          onExclude={() => void excludeDomainAndSkip()}
+          onExclude={(tick) => void excludeDomainAndSkip(tick)}
           onSkipOnly={() => { setShowUnfamiliarDialog(false); void skipCurrent(); }}
           onCancel={() => setShowUnfamiliarDialog(false)}
         />

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -32,6 +32,8 @@ export type ChatMessage =
       isNew?: boolean;
       onDismiss?: () => void;
       dismissLabel?: string;
+      /** When false, the dismiss button calls onDismiss but does not flip into the "Skipped" inline state — used when the click opens a dialog instead of completing the action. Defaults to true to preserve legacy behavior. */
+      dismissImmediate?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
     }
@@ -133,6 +135,7 @@ function QuestionRow({
   isNew = false,
   onDismiss,
   dismissLabel = "Skip - don't show again",
+  dismissImmediate = true,
 }: {
   subhead?: string | null;
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -141,6 +144,7 @@ function QuestionRow({
   isNew?: boolean;
   onDismiss?: () => void;
   dismissLabel?: string;
+  dismissImmediate?: boolean;
 }) {
   const [dismissed, setDismissed] = useState(false);
   const [visible, setVisible] = useState(!isNew);
@@ -153,9 +157,9 @@ function QuestionRow({
   }, []);
 
   const handleDismiss = useCallback(() => {
-    setDismissed(true);
+    if (dismissImmediate) setDismissed(true);
     onDismiss?.();
-  }, [onDismiss]);
+  }, [onDismiss, dismissImmediate]);
 
   return (
     <div
@@ -894,6 +898,7 @@ export function GameplayChatThread({
                 isNew={m.isNew}
                 onDismiss={m.onDismiss}
                 dismissLabel={m.dismissLabel}
+                dismissImmediate={m.dismissImmediate}
                 subhead={m.subhead}
                 badges={m.badges}
               />

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -245,6 +245,56 @@ export async function register() {
       // will create both User and FeedDismissedDomain in normal migration order.
     }
 
+    // Migration 0036 adds a DomainExclusionScope enum, a NOT NULL scope column
+    // with default on USER_DOMAIN_EXCLUSIONS, and replaces the unique constraint
+    // to include scope. If a preview/production database has this migration
+    // recorded without these pieces present, the exclusion writes used by the
+    // daily familiarity slider fail before migrate() can repair them. Apply each
+    // piece idempotently outside the migrator transaction.
+    try {
+      await db.execute(sql`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t
+            JOIN pg_namespace n ON n.oid = t.typnamespace
+            WHERE t.typname = 'DomainExclusionScope' AND n.nspname = 'public'
+          ) THEN
+            CREATE TYPE "public"."DomainExclusionScope" AS ENUM('subcategory', 'broad_category', 'category');
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+          ADD COLUMN IF NOT EXISTS "scope" "public"."DomainExclusionScope" NOT NULL DEFAULT 'subcategory'
+      `);
+      await db.execute(sql`
+        ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+          DROP CONSTRAINT IF EXISTS "USER_DOMAIN_EXCLUSIONS_user_id_canonical_subcategory_key"
+      `);
+      await db.execute(sql`
+        DO $$
+        DECLARE
+          exclusions_table regclass := to_regclass('public."USER_DOMAIN_EXCLUSIONS"');
+        BEGIN
+          IF exclusions_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'USER_DOMAIN_EXCLUSIONS_user_id_scope_canonical_subcategory_key'
+                AND conrelid = exclusions_table
+            )
+          THEN
+            ALTER TABLE "USER_DOMAIN_EXCLUSIONS"
+              ADD CONSTRAINT "USER_DOMAIN_EXCLUSIONS_user_id_scope_canonical_subcategory_key"
+              UNIQUE ("user_id", "scope", "canonical_subcategory");
+          END IF;
+        END $$
+      `);
+    } catch {
+      // USER_DOMAIN_EXCLUSIONS may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -30,6 +30,10 @@ export const queueSlotSchema = z.object({
   /** Optional creator note — only ever set for friend questions. */
   author_note: z.string().nullish(),
   domain: z.string(),
+  /** Free-text broader topic for this slot (e.g. "Saturday morning cartoons"). Optional — populated for newly built slots. */
+  broad_category: z.string().nullish(),
+  /** Top-level category enum value (e.g. "film_tv"). Optional — populated for newly built slots from canonical Question rows. */
+  category: z.string().nullish(),
   question_text: z.string(),
   /** LLM-rated objective difficulty for this question, surfaced as a badge in the UI. */
   difficulty_estimate: z.enum(['accessible', 'moderate', 'specialist']).optional(),

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -8,12 +8,13 @@ import {
   generatedQuestions,
   masteryEvents,
   playerMastery,
+  questions as canonicalQuestions,
   userDomainExclusions,
 } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
-import { categoryLabel } from '@/lib/questions-types';
+import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
 import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
 import type { QueueSlot } from '@/server/daily/types';
 import {
@@ -76,18 +77,74 @@ function normalizeDomain(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
 }
 
-async function getExcludedKnowledgeDomains(userId: string): Promise<Set<string>> {
+type ScopedExclusions = {
+  subcategories: Set<string>;
+  broadCategories: Set<string>;
+};
+
+async function getExcludedKnowledgeDomains(userId: string): Promise<ScopedExclusions> {
+  let rows: { domain: string; scope: 'subcategory' | 'broad_category' | 'category' }[];
   try {
-    const rows = await db
-      .select({ domain: userDomainExclusions.canonicalSubcategory })
+    rows = await db
+      .select({
+        domain: userDomainExclusions.canonicalSubcategory,
+        scope: userDomainExclusions.scope,
+      })
       .from(userDomainExclusions)
       .where(eq(userDomainExclusions.userId, userId));
-
-    return new Set(rows.map((row) => normalizeDomain(row.domain).toLowerCase()).filter(Boolean));
   } catch (error) {
-    if (pgErrorCode(error) === '42P01') return new Set();
-    throw error;
+    if (pgErrorCode(error) === '42P01') return { subcategories: new Set(), broadCategories: new Set() };
+    // 42703 = scope column missing on a database where the additive migration
+    // hasn't landed yet. Fall back to a scope='subcategory' read so the feature
+    // degrades to its pre-migration behavior instead of failing.
+    if (pgErrorCode(error) === '42703') {
+      const legacy = await db
+        .select({ domain: userDomainExclusions.canonicalSubcategory })
+        .from(userDomainExclusions)
+        .where(eq(userDomainExclusions.userId, userId));
+      rows = legacy.map((row) => ({ domain: row.domain, scope: 'subcategory' as const }));
+    } else {
+      throw error;
+    }
   }
+
+  const subcategories = new Set<string>();
+  const broadCategories = new Set<string>();
+  const categoryEnums: string[] = [];
+
+  for (const row of rows) {
+    const value = normalizeDomain(row.domain);
+    if (!value) continue;
+    if (row.scope === 'subcategory') subcategories.add(value.toLowerCase());
+    else if (row.scope === 'broad_category') broadCategories.add(value.toLowerCase());
+    else if (row.scope === 'category') categoryEnums.push(value);
+  }
+
+  // Category-scope exclusions name a top-level Category enum value (e.g.
+  // 'film_tv'). The knowledge base only carries subcategory + broadCategory,
+  // so we map each excluded category to the set of broadCategory strings it
+  // covers in the canonical Question table and merge those into the
+  // broadCategories filter.
+  if (categoryEnums.length > 0) {
+    try {
+      const knownCategories = categoryEnums.filter((value): value is typeof CATEGORIES[number] =>
+        (CATEGORIES as readonly string[]).includes(value),
+      );
+      if (knownCategories.length > 0) {
+        const expanded = await db
+          .select({ broadCategory: canonicalQuestions.broadCategory })
+          .from(canonicalQuestions)
+          .where(inArray(canonicalQuestions.category, knownCategories));
+        for (const row of expanded) {
+          if (row.broadCategory) broadCategories.add(row.broadCategory.toLowerCase());
+        }
+      }
+    } catch (error) {
+      if (pgErrorCode(error) !== '42P01' && pgErrorCode(error) !== '42703') throw error;
+    }
+  }
+
+  return { subcategories, broadCategories };
 }
 
 async function getPlayerMasteryKnowledgeRows(userId: string) {
@@ -128,13 +185,19 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     getExcludedKnowledgeDomains(userId),
   ]);
 
+  const isExcluded = (domain: string, broadCategory: string | null): boolean => {
+    if (excludedDomains.subcategories.has(domain.toLowerCase())) return true;
+    if (broadCategory && excludedDomains.broadCategories.has(broadCategory.toLowerCase())) return true;
+    return false;
+  };
+
   const domainsByKey = new Map<string, KnowledgeBaseDomain>();
 
   for (const row of masteryRows) {
     const domain = normalizeDomain(row.domain);
     if (!domain) continue;
     const key = domain.toLowerCase();
-    if (excludedDomains.has(key)) continue;
+    if (isExcluded(domain, row.broadCategory)) continue;
     domainsByKey.set(key, {
       domain,
       broadCategory: row.broadCategory,
@@ -149,7 +212,7 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     const domain = normalizeDomain(row.domain);
     if (!domain) continue;
     const key = domain.toLowerCase();
-    if (excludedDomains.has(key)) continue;
+    if (isExcluded(domain, row.broadCategory)) continue;
     const existing = domainsByKey.get(key);
     domainsByKey.set(key, {
       domain: existing?.domain ?? domain,
@@ -285,6 +348,8 @@ export async function createDailyQueueItem(
     source: 'bot',
     generated_question_id: question.id,
     domain: question.canonicalSubcategory,
+    broad_category: question.broadCategory,
+    category: null,
     question_text: question.questionText,
     difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate),
     answered: false,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -124,6 +124,11 @@ export const themePreferenceEnum = pgEnum('ThemePreference', [
 export const subscriptionPlanEnum = pgEnum('SubscriptionPlan', ['free', 'plus_monthly', 'plus_yearly']);
 export const portraitVisibilityEnum = pgEnum('PortraitVisibility', ['public', 'private']);
 export const masteryTierEnum = pgEnum('MasteryTier', ['establishing', 'familiar', 'solid', 'mastery']);
+export const domainExclusionScopeEnum = pgEnum('DomainExclusionScope', [
+  'subcategory',
+  'broad_category',
+  'category',
+]);
 export const masterySourceTypeEnum = pgEnum('MasterySourceType', [
   'live_correct',
   'authored',
@@ -598,11 +603,13 @@ export const userDomainExclusions = pgTable(
     id: id(),
     userId: text('user_id').notNull().references(() => users.id),
     canonicalSubcategory: text('canonical_subcategory').notNull(),
+    scope: domainExclusionScopeEnum('scope').notNull().default('subcategory'),
     excludedAt: timestamp('excluded_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
-    unique('USER_DOMAIN_EXCLUSIONS_user_id_canonical_subcategory_key').on(
+    unique('USER_DOMAIN_EXCLUSIONS_user_id_scope_canonical_subcategory_key').on(
       table.userId,
+      table.scope,
       table.canonicalSubcategory,
     ),
   ],


### PR DESCRIPTION
The familiarity affordance lived in the sticky footer next to the answer
input, attached to the wrong moment of the interaction. Moves it under
the question card by reusing QuestionRow's existing dismiss slot.

Clicking it now opens a slider dialog with three ticks scoped to the
current question — subcategory ("Pee-wee's Playhouse"), broad category
("Saturday morning cartoons"), and top-level Category enum ("Film & TV").
The chosen tick writes to USER_DOMAIN_EXCLUSIONS with a new `scope`
column so future queue builds filter at the right granularity instead of
treating every exclusion as subcategory-level.

Backend changes:
- New DomainExclusionScope enum + scope column on USER_DOMAIN_EXCLUSIONS
  with unique constraint widened to (user_id, scope, canonical_subcategory).
- getKnowledgeBase reads exclusions grouped by scope; category-scoped
  rows are expanded to broad_category strings via a Question lookup so
  the knowledge base filter actually honors top-level exclusions.
- broad_category and category are surfaced on QueueSlot so the client
  can label the slider ticks.
- Idempotent guard in instrumentation.ts for preview/prod DBs that
  record the migration without the column present.