### PR TITLE
color player chat bubbles blue in-game

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,6 +88,8 @@
     --text: var(--foreground);
     --text-muted: var(--muted-foreground);
     --accent-contrast: var(--primary-foreground);
+    --user-bubble: oklch(0.62 0.18 250);
+    --user-bubble-foreground: oklch(0.99 0 0);
     --success: #178245;
     --danger: var(--destructive);
     --wrong: var(--destructive);
@@ -126,6 +128,8 @@
     --muted-foreground: oklch(0.708 0 0);
     --accent: oklch(0.269 0 0);
     --accent-foreground: oklch(0.985 0 0);
+    --user-bubble: oklch(0.58 0.18 250);
+    --user-bubble-foreground: oklch(0.99 0 0);
     --destructive: oklch(0.704 0.191 22.216);
     --border: oklch(1 0 0 / 10%);
     --input: oklch(1 0 0 / 15%);

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -283,11 +283,11 @@ function UserRow({ text }: { text: string }) {
       <div
         style={{
           maxWidth: '88%',
-          background: 'var(--accent)',
+          background: 'var(--user-bubble)',
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
           padding: '10px 14px',
           fontSize: '0.9rem',
-          color: 'var(--accent-foreground)',
+          color: 'var(--user-bubble-foreground)',
         }}
       >
         {text}


### PR DESCRIPTION
player answer bubbles previously shared --accent with question bubbles,
making them visually indistinguishable. introduce --user-bubble /
--user-bubble-foreground tokens (light + dark) and apply them in UserRow
so the player's own messages stand out, iMessage-style.

https://claude.ai/code/session_01YN3DQkiwz9kGznTPHgwHvd