### PR TITLE
fix invitation links generated from preview deployments routing to those preview URLs

### DIFF
--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -156,6 +156,13 @@ function getBaseUrl(request: Request): string {
   const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL
   if (configured) return configured.replace(/\/$/, '')
 
+  // On Vercel, prefer the project's stable production hostname over the
+  // request host so invites created from a preview deployment still link
+  // to production. VERCEL_PROJECT_PRODUCTION_URL is auto-injected on every
+  // deployment and contains the hostname only (no scheme).
+  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  if (vercelProd) return `https://${vercelProd.replace(/\/$/, '')}`
+
   const host =
     request.headers.get('x-forwarded-host') ?? request.headers.get('host')
   const protocol = request.headers.get('x-forwarded-proto') ?? 'https'


### PR DESCRIPTION
Prefer Vercel's VERCEL_PROJECT_PRODUCTION_URL over the request Host when
NEXT_PUBLIC_APP_URL is unset, so invites created while browsing a preview
deployment still link to production.

https://claude.ai/code/session_01EipNCVNteYgSwhM2eQQfad