### PR TITLE
add INVITE_THROTTLE_DISABLED env-var bypass for invite throttle

### DIFF
--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -44,6 +44,8 @@ function rateLimitKey(userId: string, phone: string) {
 }
 
 function checkInviteRateLimit(userId: string, phone: string, now = new Date()) {
+  if (process.env.INVITE_THROTTLE_DISABLED === '1') return null
+
   const nowMs = now.getTime()
   const userAttempts = pruneWindow(
     inviteAttemptsByUser.get(userId) ?? [],


### PR DESCRIPTION
When set to "1", checkInviteRateLimit short-circuits to null so all
same-phone / cancelled / ignored / per-window throttles become no-ops.
Lets phase-one testing send/resend/cancel invites freely without
removing the production throttle.