### PR TITLE
add Delete action for set-aside friend invitations in the Sent tab

### DIFF
--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -7,6 +7,7 @@ import { db, friendInvitations, users } from '@/server/db'
 import {
   cancelFriendInvitation,
   createFriendInvitation,
+  deleteFriendInvitation,
   listOutgoingFriendInvitations,
   type OutgoingFriendInvitation,
 } from '@/server/friends/invitations'
@@ -417,6 +418,7 @@ export async function DELETE(request: Request) {
   > | null
   const invitationId =
     typeof body?.invitationId === 'string' ? body.invitationId.trim() : ''
+  const permanent = body?.permanent === true
 
   if (!invitationId) {
     return NextResponse.json(
@@ -426,6 +428,34 @@ export async function DELETE(request: Request) {
   }
 
   try {
+    if (permanent) {
+      const deleted = await deleteFriendInvitation({
+        invitationId,
+        inviterUserId: session.userId,
+      })
+
+      if (!deleted) {
+        return NextResponse.json(
+          {
+            error: 'not_found',
+            message: 'Set-aside invitation was not found.',
+          },
+          { status: 404 }
+        )
+      }
+
+      logTelemetry('add_friend_invite_deleted', {
+        inviter_user_id: session.userId,
+        invitation_id: deleted.id,
+      })
+
+      return NextResponse.json({
+        ok: true,
+        invitationId: deleted.id,
+        status: 'deleted',
+      })
+    }
+
     const invitation = await cancelFriendInvitation({
       invitationId,
       inviterUserId: session.userId,

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -76,6 +76,7 @@ export default function PeopleYouInvited() {
   const [error, setError] = useState<string | null>(null)
   const [copyingId, setCopyingId] = useState<string | null>(null)
   const [cancellingId, setCancellingId] = useState<string | null>(null)
+  const [deletingId, setDeletingId] = useState<string | null>(null)
 
   const loadInvites = useCallback(async () => {
     setError(null)
@@ -158,6 +159,35 @@ export default function PeopleYouInvited() {
       )
     } finally {
       setCancellingId(null)
+    }
+  }
+
+  async function deleteInvite(invite: OutgoingInvite) {
+    setDeletingId(invite.id)
+    setError(null)
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ invitationId: invite.id, permanent: true }),
+      })
+      const body = (await response.json().catch(() => null)) as {
+        message?: string
+      } | null
+
+      if (!response.ok) {
+        throw new Error(body?.message ?? 'Could not delete this.')
+      }
+
+      await loadInvites()
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : 'Could not delete this.'
+      )
+    } finally {
+      setDeletingId(null)
     }
   }
 
@@ -266,6 +296,19 @@ export default function PeopleYouInvited() {
                       onClick={() => createNewInvite(invite)}
                     >
                       Write a fresh note
+                    </button>
+                  </div>
+                ) : null}
+
+                {invite.status === 'cancelled' ? (
+                  <div className="mt-3 flex justify-end">
+                    <button
+                      type="button"
+                      className="text-muted-foreground text-sm"
+                      onClick={() => deleteInvite(invite)}
+                      disabled={deletingId === invite.id}
+                    >
+                      {deletingId === invite.id ? 'Deleting…' : 'Delete'}
                     </button>
                   </div>
                 ) : null}

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -400,6 +400,27 @@ export async function cancelFriendInvitation({
   return invitation ?? null
 }
 
+export async function deleteFriendInvitation({
+  invitationId,
+  inviterUserId,
+}: {
+  invitationId: string
+  inviterUserId: string
+}): Promise<FriendInvitation | null> {
+  const [invitation] = await db
+    .delete(friendInvitations)
+    .where(
+      and(
+        eq(friendInvitations.id, invitationId),
+        eq(friendInvitations.inviterUserId, inviterUserId),
+        isNotNull(friendInvitations.cancelledAt)
+      )
+    )
+    .returning()
+
+  return invitation ?? null
+}
+
 export async function markInvitationAccepted({
   invitationId,
   inviteeUserId,

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -4,6 +4,7 @@ export type TelemetryEventName =
   | 'add_friend_started'
   | 'add_friend_invite_created'
   | 'add_friend_invite_cancelled'
+  | 'add_friend_invite_deleted'
   | 'add_friend_invite_rate_limited'
   | 'add_friend_message_copied'
   | 'add_friend_sms_handoff_opened'


### PR DESCRIPTION
Set-aside (cancelled) invites previously had no follow-up action on
their card. Adds a Delete button that hard-deletes the FriendInvitation
row, guarded server-side by an isNotNull(cancelledAt) check so pending
or accepted invites can never be deleted through this path.

https://claude.ai/code/session_01Wa7gyUvhgS64tBYDrR1re7