### PR TITLE
show prominent confirmation when a recheck is accepted

### DIFF
--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -129,18 +129,22 @@ function AnsweredResult({
 }) {
   const [recheckState, setRecheckState] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle')
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null)
+  const [recheckAccepted, setRecheckAccepted] = useState(false)
 
   const requestRecheck = useCallback(async () => {
     if (!recheckAction || recheckState === 'submitting') return
     setRecheckState('submitting')
     setRecheckMessage(null)
+    setRecheckAccepted(false)
     try {
       const outcome = await recheckAction.onSubmit()
       setRecheckState('done')
       setRecheckMessage(outcome.message)
+      setRecheckAccepted(outcome.accepted)
     } catch {
       setRecheckState('error')
       setRecheckMessage('Could not recheck that answer.')
+      setRecheckAccepted(false)
     }
   }, [recheckAction, recheckState])
 
@@ -190,15 +194,33 @@ function AnsweredResult({
         </div>
       ) : null}
       {recheckMessage ? (
-        <p
-          className="text-[11px]"
-          style={{
-            color: recheckState === 'error' ? '#b91c1c' : 'var(--ink)',
-            opacity: recheckState === 'error' ? 1 : 0.6,
-          }}
-        >
-          {recheckMessage}
-        </p>
+        recheckAccepted ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="mt-2 flex items-center gap-2 rounded-md border px-3 py-2 text-[13px] font-medium"
+            style={{
+              backgroundColor: 'color-mix(in srgb, #047857 10%, var(--cream))',
+              borderColor: 'color-mix(in srgb, #047857 35%, var(--border-warm))',
+              color: '#065f46',
+            }}
+          >
+            <span aria-hidden className="text-[15px] leading-none">✓</span>
+            <span>{recheckMessage}</span>
+          </div>
+        ) : (
+          <p
+            role="status"
+            aria-live="polite"
+            className="text-[11px]"
+            style={{
+              color: recheckState === 'error' ? '#b91c1c' : 'var(--ink)',
+              opacity: recheckState === 'error' ? 1 : 0.6,
+            }}
+          >
+            {recheckMessage}
+          </p>
+        )
       ) : null}
     </div>
   )

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -567,6 +567,7 @@ function ResultRow({
 }) {
   const [recheckState, setRecheckState] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
+  const [recheckAccepted, setRecheckAccepted] = useState(false);
   const expired = result === 'expired';
   const correct = result === 'correct';
   const gaveUp = result === 'gave_up';
@@ -575,13 +576,16 @@ function ResultRow({
     if (!recheckAction || recheckState === 'submitting') return;
     setRecheckState('submitting');
     setRecheckMessage(null);
+    setRecheckAccepted(false);
     try {
       const outcome = await recheckAction.onSubmit();
       setRecheckState('done');
       setRecheckMessage(outcome.message);
+      setRecheckAccepted(outcome.accepted);
     } catch {
       setRecheckState('error');
       setRecheckMessage('Could not recheck that answer.');
+      setRecheckAccepted(false);
     }
   }, [recheckAction, recheckState]);
 
@@ -694,9 +698,33 @@ function ResultRow({
                   {recheckState === 'submitting' ? 'Rechecking...' : 'Recheck my answer'}
                 </button>
                 {recheckMessage ? (
-                  <p style={{ marginTop: '6px', fontSize: '0.78rem', color: recheckState === 'error' ? 'var(--danger)' : 'var(--text-muted)', lineHeight: 1.35 }}>
-                    {recheckMessage}
-                  </p>
+                  recheckAccepted ? (
+                    <div
+                      role="status"
+                      aria-live="polite"
+                      style={{
+                        marginTop: '8px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        borderRadius: 'var(--radius-md)',
+                        border: '1px solid color-mix(in srgb, var(--success) 35%, var(--border))',
+                        background: 'color-mix(in srgb, var(--success) 12%, var(--surface))',
+                        color: '#065f46',
+                        padding: '8px 12px',
+                        fontSize: '0.85rem',
+                        fontWeight: 500,
+                        lineHeight: 1.35,
+                      }}
+                    >
+                      <span aria-hidden style={{ fontSize: '1rem', lineHeight: 1 }}>✓</span>
+                      <span>{recheckMessage}</span>
+                    </div>
+                  ) : (
+                    <p role="status" aria-live="polite" style={{ marginTop: '6px', fontSize: '0.78rem', color: recheckState === 'error' ? 'var(--danger)' : 'var(--text-muted)', lineHeight: 1.35 }}>
+                      {recheckMessage}
+                    </p>
+                  )
                 ) : null}
               </div>
             ) : null}


### PR DESCRIPTION
The previous accepted-recheck feedback was an 11px, 60%-opacity line that
was easy to miss next to the much-bolder Recheck button, so users
weren't sure their answer had actually been re-credited. Render a green
✓ pill with the points-awarded message in both the feed card and the
gameplay/daily result row, while keeping the dim text for
rejected/needs-human/error outcomes.