### PR TITLE
add "Pick from contacts" picker to friend invite form

### DIFF
--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -73,6 +73,10 @@ export default function AddFriendInvite() {
   const [error, setError] = useState<string | null>(null)
   const [copyLabel, setCopyLabel] = useState('Copy message')
   const [submitting, setSubmitting] = useState(false)
+  const [contactsSupported, setContactsSupported] = useState<boolean | null>(
+    null
+  )
+  const [isIos, setIsIos] = useState(false)
   const messageRef = useRef<HTMLTextAreaElement | null>(null)
 
   const trimmedName = name.trim()
@@ -110,6 +114,66 @@ export default function AddFriendInvite() {
     return () =>
       window.removeEventListener('friend-invitations:create-new', prefillInvite)
   }, [])
+
+  useEffect(() => {
+    void (async () => {
+      const ios = /iPad|iPhone|iPod/.test(navigator.userAgent)
+      if (!('contacts' in navigator) || !('ContactsManager' in window)) {
+        setIsIos(ios)
+        setContactsSupported(false)
+        return
+      }
+      try {
+        const props = await navigator.contacts!.getProperties()
+        setIsIos(ios)
+        setContactsSupported(props.includes('name') && props.includes('tel'))
+      } catch {
+        setIsIos(ios)
+        setContactsSupported(false)
+      }
+    })()
+  }, [])
+
+  async function pickContact() {
+    sendTelemetry('contact_picker_opened', {})
+    try {
+      const results = await navigator.contacts!.select(['name', 'tel'], {
+        multiple: false,
+      })
+      if (!results.length) {
+        sendTelemetry('contact_picker_cancelled', {})
+        return
+      }
+      const contact = results[0]
+      const pickedName = (contact.name ?? [])
+        .filter(Boolean)
+        .join(' ')
+        .trim()
+      const pickedTel =
+        (contact.tel ?? []).find(looksLikeUsMobileNumber) ?? null
+      if (!pickedTel) {
+        setError(
+          'That contact has no US mobile number. Try another, or type one in.'
+        )
+        sendTelemetry('contact_picker_no_us_tel', {
+          had_name: Boolean(pickedName),
+        })
+        return
+      }
+      if (pickedName) setName(pickedName)
+      setPhone(pickedTel)
+      setError(null)
+      sendTelemetry('contact_picker_selected', {
+        had_name: Boolean(pickedName),
+        tel_count: contact.tel?.length ?? 0,
+      })
+    } catch (err) {
+      setError('Could not open contacts. You can type the number instead.')
+      sendTelemetry('contact_picker_error', {
+        message: err instanceof Error ? err.message : 'unknown',
+      })
+    }
+  }
 
   function resetFlow() {
     setExpanded(false)
@@ -245,6 +309,16 @@ export default function AddFriendInvite() {
             </h2>
           </div>
 
+          {contactsSupported ? (
+            <button
+              type="button"
+              onClick={pickContact}
+              className="btn-ghost min-h-11 w-full rounded-full text-sm"
+            >
+              Pick from contacts
+            </button>
+          ) : null}
+
           <div className="space-y-4">
             <label className="text-foreground block text-sm font-medium">
               Name
@@ -277,6 +351,12 @@ export default function AddFriendInvite() {
                 enterKeyHint="next"
               />
             </label>
+            {isIos ? (
+              <p className="text-muted-foreground text-xs leading-5">
+                Tip: tap the name or phone field and use the suggestion above
+                your keyboard to pull from Contacts.
+              </p>
+            ) : null}
           </div>
 
           {error ? (

--- a/src/types/contacts.d.ts
+++ b/src/types/contacts.d.ts
@@ -1,0 +1,22 @@
+interface ContactInfo {
+  name?: string[]
+  tel?: string[]
+}
+
+interface ContactsManager {
+  select(
+    props: Array<'name' | 'tel' | 'email' | 'address' | 'icon'>,
+    options?: { multiple?: boolean }
+  ): Promise<ContactInfo[]>
+  getProperties(): Promise<
+    Array<'name' | 'tel' | 'email' | 'address' | 'icon'>
+  >
+}
+
+interface Navigator {
+  contacts?: ContactsManager
+}
+
+interface Window {
+  ContactsManager?: unknown
+}


### PR DESCRIPTION
On Android Chrome/Edge, where the Contact Picker API is available,
users can now pick a friend from their phone's address book in one
tap instead of typing the name and number. iOS gets a small hint
under the phone input pointing at the keyboard's QuickType bar,
which already surfaces contacts via the existing autocomplete
attributes. Desktop is unchanged.

Feature-detected via getProperties() so the button only appears
when 'name' and 'tel' are both supported. All client-side; server
validation in /api/friend-invitations remains authoritative.

https://claude.ai/code/session_01LUCvgYfJoaGHXRHfBYyyKs