### PR TITLE
Highlight new territory discoveries in answer feedback

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -69,6 +69,7 @@ const {
       previousTier: 'establishing',
       newTier: 'establishing',
       tierChanged: false,
+      openedNewTerritory: false,
     })),
     dbState,
   }
@@ -189,6 +190,7 @@ describe('POST /api/daily/answer mastery scoring (F2.1)', () => {
       previousTier: 'establishing',
       newTier: 'establishing',
       tierChanged: false,
+      openedNewTerritory: false,
     })
   })
 

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -30,6 +30,7 @@ const {
     previousTier: 'establishing',
     newTier: 'establishing',
     tierChanged: false,
+    openedNewTerritory: false,
   })),
 }))
 
@@ -195,6 +196,7 @@ describe('POST /api/daily/catchup/answer mastery scoring (F2.2)', () => {
       previousTier: 'establishing',
       newTier: 'establishing',
       tierChanged: false,
+      openedNewTerritory: false,
     })
   })
 

--- a/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
+++ b/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
@@ -29,6 +29,7 @@ const {
     previousTier: 'establishing',
     newTier: 'establishing',
     tierChanged: false,
+    openedNewTerritory: false,
   })),
 }))
 
@@ -177,6 +178,7 @@ describe('POST /api/feed/[feedItemId]/answer mastery scoring (F2.3)', () => {
       previousTier: 'establishing',
       newTier: 'establishing',
       tierChanged: false,
+      openedNewTerritory: false,
     })
   })
 

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -117,6 +117,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       previousTier,
       newTier: previousTier,
       tierChanged: false,
+      openedNewTerritory: false,
     };
   });
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -364,6 +364,12 @@ function normalizeMasteryDelta(
   return { previousTier, newTier, tierChanged }
 }
 
+function pickOpenedNewTerritory(raw: unknown): boolean {
+  if (!raw || typeof raw !== 'object') return false
+  const r = raw as Record<string, unknown>
+  return r.openedNewTerritory === true
+}
+
 function pickBroadCategory(
   raw: unknown,
   item: FeedApiItem
@@ -1132,6 +1138,7 @@ function FeedListContent({
             submittedAnswer={result.submittedAnswer}
             explanation={result.explanation}
             quip={result.quip}
+            openedNewTerritory={pickOpenedNewTerritory(result.masteryDelta)}
             questionId={sheetItem.question_id}
             feedItemId={sheetItem.id}
             onClose={() => setFeedbackSheetId(null)}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
-import { Check, X } from 'lucide-react'
+import { Check, Sparkles, X } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
 import { visibleFeedCategory } from './category'
@@ -15,6 +15,7 @@ type AnswerFeedbackSheetProps = {
   submittedAnswer: string
   explanation: string | null
   quip: string | null
+  openedNewTerritory?: boolean
   questionId: string
   feedItemId: string
   onClose: () => void
@@ -31,11 +32,13 @@ export function AnswerFeedbackSheet({
   submittedAnswer,
   explanation,
   quip,
+  openedNewTerritory = false,
   questionId,
   feedItemId,
   onClose,
 }: AnswerFeedbackSheetProps) {
   const visibleCategory = visibleFeedCategory(category)
+  const showNewTerritory = openedNewTerritory && isCorrect
   const [bankState, setBankState] = useState<BankState>('idle')
   const hasAutoSavedRef = useRef(false)
 
@@ -98,9 +101,22 @@ export function AnswerFeedbackSheet({
         onClick={onClose}
         aria-label="Dismiss"
       />
-      <div className="relative flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-white shadow-2xl">
+      <div
+        className={
+          showNewTerritory
+            ? 'relative flex max-h-[90vh] w-full max-w-lg flex-col overflow-hidden rounded-t-3xl bg-white shadow-2xl ring-2 ring-amber-400/60'
+            : 'relative flex max-h-[90vh] w-full max-w-lg flex-col rounded-t-3xl bg-white shadow-2xl'
+        }
+      >
         <div className="flex items-center justify-between px-5 pt-5 pb-2">
-          {visibleCategory ? (
+          {showNewTerritory ? (
+            <p className="inline-flex items-center gap-1.5 text-[0.68rem] font-semibold tracking-[0.18em] uppercase text-amber-700">
+              <Sparkles className="size-3.5" aria-hidden />
+              <span>
+                New territory{visibleCategory ? <span className="text-amber-700/70"> · {visibleCategory.toUpperCase()}</span> : null}
+              </span>
+            </p>
+          ) : visibleCategory ? (
             <p className="text-[0.68rem] font-semibold tracking-[0.18em] uppercase text-stone-500">
               {visibleCategory.toUpperCase()}
             </p>
@@ -144,6 +160,26 @@ export function AnswerFeedbackSheet({
               </span>
             ) : null}
           </div>
+
+          {showNewTerritory ? (
+            <div className="mb-3 flex items-start gap-3 rounded-2xl border border-amber-300/70 bg-amber-50 px-4 py-3">
+              <span
+                className="mt-0.5 inline-flex size-7 shrink-0 items-center justify-center rounded-full bg-amber-100 text-amber-700"
+                aria-hidden
+              >
+                <Sparkles className="size-4" />
+              </span>
+              <div className="min-w-0">
+                <p className="font-serif text-[15px] leading-snug font-semibold text-amber-900">
+                  You opened new territory
+                  {visibleCategory ? <> in {visibleCategory}</> : null}.
+                </p>
+                <p className="mt-0.5 text-[12px] text-amber-800/80">
+                  First time you&rsquo;ve gotten a question right here. It&rsquo;s on your map now.
+                </p>
+              </div>
+            </div>
+          ) : null}
 
           <p className="pb-3 font-serif text-lg leading-7 text-stone-950">
             {question}

--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -29,6 +29,7 @@ export type MasteryEventWriteResult = {
   previousTier: MasteryTier;
   newTier: MasteryTier;
   tierChanged: boolean;
+  openedNewTerritory: boolean;
 };
 
 async function readAuthorCredit(userId: string, domain: string) {
@@ -87,6 +88,7 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
     ? effectiveTier(nextTotalPoints, authorCredit.points, authorCredit.distinctQuestions)
     : previousTier;
   const tierChanged = previousTier !== nextTier;
+  const openedNewTerritory = !existing && params.pointsAwarded > 0;
 
   await db.transaction(async (tx) => {
     await tx.execute(sql`
@@ -165,5 +167,6 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
     previousTier,
     newTier: nextTier,
     tierChanged,
+    openedNewTerritory,
   };
 }


### PR DESCRIPTION
When a correct answer creates a player's first PlayerMastery row in a
domain, surface it: the answer-result sheet now shows an amber
"✦ New territory" header pill and a celebratory banner above the
question, so first-time discoveries are unmistakable instead of being
collapsed into the standard "Correct!" reveal.

Plumbing: writeMasteryEvent returns openedNewTerritory (set when no
prior PlayerMastery row existed and points were awarded), which flows
through the existing masteryDelta payload to FeedList and into
AnswerFeedbackSheet.