### PR TITLE
require a display name during onboarding

### DIFF
--- a/src/app/api/onboarding/save-interests/__tests__/route.test.ts
+++ b/src/app/api/onboarding/save-interests/__tests__/route.test.ts
@@ -2,11 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   getSessionMock,
+  getUserOnboardingProfileMock,
   markOnboardingCompleteMock,
   refreshSessionOnboardingClaimMock,
   saveDeclaredInterestsMock,
 } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
+  getUserOnboardingProfileMock: vi.fn(),
   markOnboardingCompleteMock: vi.fn(),
   refreshSessionOnboardingClaimMock: vi.fn(),
   saveDeclaredInterestsMock: vi.fn(),
@@ -18,6 +20,7 @@ vi.mock('@/server/auth/session', () => ({
 }))
 
 vi.mock('@/server/db/queries/users', () => ({
+  getUserOnboardingProfile: getUserOnboardingProfileMock,
   markOnboardingComplete: markOnboardingCompleteMock,
   saveDeclaredInterests: saveDeclaredInterestsMock,
 }))
@@ -36,6 +39,11 @@ describe('POST /api/onboarding/save-interests', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     getSessionMock.mockResolvedValue({ userId: 'user-invitee' })
+    getUserOnboardingProfileMock.mockResolvedValue({
+      id: 'user-invitee',
+      displayName: 'Morgan Lee',
+      onboardingComplete: false,
+    })
     saveDeclaredInterestsMock.mockResolvedValue(undefined)
     markOnboardingCompleteMock.mockResolvedValue(undefined)
     refreshSessionOnboardingClaimMock.mockResolvedValue(true)
@@ -144,6 +152,11 @@ describe('POST /api/onboarding/save-interests', () => {
     for (const choice of choices) {
       vi.clearAllMocks()
       getSessionMock.mockResolvedValue({ userId: 'user-jaime' })
+      getUserOnboardingProfileMock.mockResolvedValue({
+        id: 'user-jaime',
+        displayName: 'Jaime',
+        onboardingComplete: false,
+      })
       saveDeclaredInterestsMock.mockResolvedValue(undefined)
       markOnboardingCompleteMock.mockResolvedValue(undefined)
       refreshSessionOnboardingClaimMock.mockResolvedValue(true)
@@ -202,6 +215,40 @@ describe('POST /api/onboarding/save-interests', () => {
 
     expect(response.status).toBe(400)
     expect(body.error).toBe('invalid_request')
+    expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()
+    expect(markOnboardingCompleteMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to complete onboarding when displayName is still null', async () => {
+    getUserOnboardingProfileMock.mockResolvedValue({
+      id: 'user-invitee',
+      displayName: null,
+      onboardingComplete: false,
+    })
+
+    const response = await POST(
+      jsonRequest([{ domain: 'Sondheim', broadCategory: 'Theater' }])
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('display_name_required')
+    expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()
+    expect(markOnboardingCompleteMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to complete onboarding when displayName is whitespace only', async () => {
+    getUserOnboardingProfileMock.mockResolvedValue({
+      id: 'user-invitee',
+      displayName: '   ',
+      onboardingComplete: false,
+    })
+
+    const response = await POST(
+      jsonRequest([{ domain: 'Sondheim', broadCategory: 'Theater' }])
+    )
+
+    expect(response.status).toBe(409)
     expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()
     expect(markOnboardingCompleteMock).not.toHaveBeenCalled()
   })

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -8,6 +8,7 @@ import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { logTelemetry } from '@/server/telemetry';
 import {
   type DeclaredInterestInput,
+  getUserOnboardingProfile,
   markOnboardingComplete,
   saveDeclaredInterests,
 } from '@/server/db/queries/users';
@@ -82,6 +83,17 @@ export async function POST(request: Request) {
     return NextResponse.json(
       { error: 'invalid_request', message: 'Save 1 to 5 interests, or skip invite suggestions. Domains must be 2 to 100 characters.' },
       { status: 400 },
+    );
+  }
+
+  const profile = await getUserOnboardingProfile(session.userId);
+  if (!profile?.displayName?.trim()) {
+    return NextResponse.json(
+      {
+        error: 'display_name_required',
+        message: 'Choose a display name before finishing onboarding.',
+      },
+      { status: 409 },
     );
   }
 

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -8,6 +8,7 @@ import { COUNTRIES } from '@/lib/onboarding/countries'
 import { US_STATES } from '@/lib/onboarding/us-regions'
 
 type CurrentStep =
+  | 'display-name'
   | 'invite-suggestions'
   | 'background'
   | 'warmup'
@@ -35,7 +36,12 @@ export type PreSeededInterest = ProposedInterest
 type OnboardingFlowProps = {
   preSeededInterests: PreSeededInterest[]
   inviterName?: string | null
+  inviteeDisplayName?: string | null
+  initialDisplayName?: string | null
 }
+
+const DISPLAY_NAME_MIN = 2
+const DISPLAY_NAME_MAX = 30
 
 type CanonicalSuggestion = {
   original: string
@@ -170,11 +176,22 @@ function StepHeader({ title, subtitle }: { title: string; subtitle: string }) {
 export default function OnboardingFlow({
   preSeededInterests,
   inviterName,
+  inviteeDisplayName,
+  initialDisplayName,
 }: OnboardingFlowProps) {
   const router = useRouter()
-  const [currentStep, setCurrentStep] = useState<CurrentStep>(() =>
-    preSeededInterests.length > 0 ? 'invite-suggestions' : 'background'
+  const hasInitialDisplayName = Boolean(initialDisplayName?.trim())
+  const [currentStep, setCurrentStep] = useState<CurrentStep>(() => {
+    if (!hasInitialDisplayName) return 'display-name'
+    return preSeededInterests.length > 0 ? 'invite-suggestions' : 'background'
+  })
+  const [displayName, setDisplayName] = useState<string>(() =>
+    (initialDisplayName ?? inviteeDisplayName ?? '')
+      .trim()
+      .slice(0, DISPLAY_NAME_MAX)
   )
+  const [isSavingDisplayName, setIsSavingDisplayName] = useState(false)
+  const [displayNameError, setDisplayNameError] = useState<string | null>(null)
   const [birthYear, setBirthYear] = useState('')
   const [grewUpCountry, setGrewUpCountry] = useState('')
   const [grewUpRegion, setGrewUpRegion] = useState('')
@@ -431,6 +448,46 @@ export default function OnboardingFlow({
     }
   }
 
+  async function submitDisplayName() {
+    const trimmed = displayName.trim().replace(/\s+/g, ' ')
+    if (trimmed.length < DISPLAY_NAME_MIN || trimmed.length > DISPLAY_NAME_MAX) {
+      setDisplayNameError(
+        `Pick something between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters.`
+      )
+      return
+    }
+
+    setDisplayNameError(null)
+    setIsSavingDisplayName(true)
+
+    try {
+      const response = await fetch('/api/account', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: trimmed }),
+      })
+      const data = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        setDisplayNameError(
+          typeof data?.error === 'string'
+            ? data.error
+            : "We couldn't save that name. Try again."
+        )
+        return
+      }
+
+      setDisplayName(trimmed)
+      setCurrentStep(
+        inviteInterests.length > 0 ? 'invite-suggestions' : 'background'
+      )
+    } catch {
+      setDisplayNameError("We couldn't save that name. Try again.")
+    } finally {
+      setIsSavingDisplayName(false)
+    }
+  }
+
   function keepInviteInterests() {
     setError(null)
     const toSave = inviteInterests
@@ -563,6 +620,59 @@ export default function OnboardingFlow({
         <ProgressDots currentStep={currentStep} />
 
         <div className="mt-9 flex flex-1 flex-col">
+          {currentStep === 'display-name' ? (
+            <div className="flex flex-1 flex-col justify-center gap-8">
+              <StepHeader
+                title="What should we call you?"
+                subtitle={
+                  inviteeDisplayName?.trim()
+                    ? `${displayInviterName} added you as "${inviteeDisplayName.trim()}". Keep it or change it — ${DISPLAY_NAME_MIN} to ${DISPLAY_NAME_MAX} characters.`
+                    : `This is how you'll appear to friends. ${DISPLAY_NAME_MIN} to ${DISPLAY_NAME_MAX} characters.`
+                }
+              />
+
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  if (!isSavingDisplayName) void submitDisplayName()
+                }}
+              >
+                <label className="block">
+                  <span className="text-sm font-medium">Your name</span>
+                  <input
+                    type="text"
+                    className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
+                    placeholder="Your name"
+                    autoFocus
+                    autoComplete="name"
+                    maxLength={DISPLAY_NAME_MAX}
+                    value={displayName}
+                    onChange={(e) => {
+                      setDisplayName(e.target.value.slice(0, DISPLAY_NAME_MAX))
+                      if (displayNameError) setDisplayNameError(null)
+                    }}
+                  />
+                </label>
+
+                {displayNameError ? (
+                  <p className="text-destructive text-sm">{displayNameError}</p>
+                ) : null}
+
+                <button
+                  type="submit"
+                  className="btn-primary h-12 w-full"
+                  disabled={
+                    isSavingDisplayName ||
+                    displayName.trim().length < DISPLAY_NAME_MIN
+                  }
+                >
+                  {isSavingDisplayName ? 'Saving...' : 'Continue'}
+                </button>
+              </form>
+            </div>
+          ) : null}
+
           {currentStep === 'invite-suggestions' ? (
             <div className="flex flex-1 flex-col justify-center gap-8">
               <StepHeader

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -13,23 +13,22 @@ describe('OnboardingFlow invited-interest copy', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         inviterName="Alex Inviter"
+        initialDisplayName="Returning User"
         preSeededInterests={[
           { domain: 'Sondheim', broadCategory: 'Theater', rationale: null },
         ]}
       />
     )
 
-    expect(html).toContain('Alex Inviter left a few ideas for you:')
+    expect(html).toContain('Alex Inviter suggested these for you.')
     expect(html).toContain('Sondheim')
-    expect(html).toContain(
-      'They&#x27;re just a starting point — keep, edit, or ignore them before anything is saved.'
-    )
   })
 
   it("renders Josh as Jaime's inviter with all three suggested interests", () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         inviterName="Josh"
+        initialDisplayName="Returning User"
         preSeededInterests={[
           { domain: 'Sondheim', broadCategory: 'Theater', rationale: null },
           { domain: 'Jazz', broadCategory: 'Music', rationale: null },
@@ -38,7 +37,7 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('Josh left a few ideas for you:')
+    expect(html).toContain('Josh suggested these for you.')
     expect(html).toContain('Sondheim')
     expect(html).toContain('Jazz')
     expect(html).toContain('Poetry')
@@ -48,41 +47,73 @@ describe('OnboardingFlow invited-interest copy', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         inviterName={null}
+        initialDisplayName="Returning User"
         preSeededInterests={[
           { domain: 'Jazz', broadCategory: 'Music', rationale: null },
         ]}
       />
     )
 
-    expect(html).toContain('A friend left a few ideas for you:')
+    expect(html).toContain('A friend suggested these for you.')
   })
 
   it('still renders regular onboarding with no invite', () => {
     const html = renderToStaticMarkup(
-      <OnboardingFlow preSeededInterests={[]} />
+      <OnboardingFlow preSeededInterests={[]} initialDisplayName="Returning User" />
     )
 
-    expect(html).toContain('The trivia you wish you were asked.')
-    expect(html).not.toContain('left a few ideas for you:')
+    expect(html).toContain('Welcome to Joshing')
+    expect(html).not.toContain('suggested these for you.')
   })
 })
 
-describe('OnboardingFlow Add Friend regression copy', () => {
-  it('renders the invite skip affordance without changing regular onboarding', () => {
-    const invitedHtml = renderToStaticMarkup(
+describe('OnboardingFlow display-name gate', () => {
+  it('renders the name step first when no displayName is set', () => {
+    const html = renderToStaticMarkup(
       <OnboardingFlow
-        inviterName="Alex Inviter"
         preSeededInterests={[
-          { domain: 'Jazz', broadCategory: 'Music', rationale: null },
+          { domain: 'Sondheim', broadCategory: 'Theater', rationale: null },
         ]}
+        inviterName="Alex Inviter"
       />
     )
-    const regularHtml = renderToStaticMarkup(
-      <OnboardingFlow preSeededInterests={[]} />
+
+    expect(html).toContain('What should we call you?')
+    expect(html).not.toContain('suggested these for you.')
+  })
+
+  it('prefills the input with the invitee name from the invitation', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        preSeededInterests={[]}
+        inviterName="Alex Inviter"
+        inviteeDisplayName="Morgan Lee"
+      />
     )
 
-    expect(invitedHtml).toContain('Skip these ideas')
-    expect(regularHtml).not.toContain('Skip these ideas')
-    expect(regularHtml).toContain('The trivia you wish you were asked.')
+    expect(html).toContain('What should we call you?')
+    expect(html).toContain('value="Morgan Lee"')
+    expect(html).toContain('Alex Inviter')
+  })
+
+  it('uses the generic subtitle when no inviteeDisplayName is provided', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow preSeededInterests={[]} inviterName={null} />
+    )
+
+    expect(html).toContain('What should we call you?')
+    expect(html).toContain("This is how you&#x27;ll appear to friends.")
+  })
+
+  it('skips the name step when the user already has a displayName', () => {
+    const html = renderToStaticMarkup(
+      <OnboardingFlow
+        preSeededInterests={[]}
+        initialDisplayName="Existing Name"
+      />
+    )
+
+    expect(html).not.toContain('What should we call you?')
+    expect(html).toContain('Welcome to Joshing')
   })
 })

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -47,5 +47,12 @@ export default async function OnboardingPage() {
     rationale: interest.description ?? null,
   }));
 
-  return <OnboardingFlow preSeededInterests={preSeededInterests} inviterName={seeded.inviterName} />;
+  return (
+    <OnboardingFlow
+      preSeededInterests={preSeededInterests}
+      inviterName={seeded.inviterName}
+      inviteeDisplayName={seeded.inviteeDisplayName}
+      initialDisplayName={user.displayName}
+    />
+  );
 }

--- a/src/server/db/queries/__tests__/users-preseeded.test.ts
+++ b/src/server/db/queries/__tests__/users-preseeded.test.ts
@@ -2,7 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { dbMock, state } = vi.hoisted(() => {
   const state = {
-    row: undefined as { preSeededInterests: unknown; inviterName: string | null } | undefined,
+    row: undefined as
+      | {
+          preSeededInterests: unknown
+          inviterName: string | null
+          inviteeDisplayName: string | null
+        }
+      | undefined,
   }
 
   const limited = {
@@ -34,6 +40,7 @@ vi.mock('@/server/db', () => ({
     preSeededInterests: 'friendInvitations.preSeededInterests',
     inviterUserId: 'friendInvitations.inviterUserId',
     inviteeUserId: 'friendInvitations.inviteeUserId',
+    inviteeDisplayName: 'friendInvitations.inviteeDisplayName',
     acceptedAt: 'friendInvitations.acceptedAt',
   },
   users: {
@@ -53,11 +60,13 @@ describe('getPreSeededInterestsForUser', () => {
   it('loads inviter display name with accepted invite interests', async () => {
     state.row = {
       inviterName: '  Alex   Inviter  ',
+      inviteeDisplayName: '  Morgan   Lee  ',
       preSeededInterests: [{ label: ' Sondheim ', broadCategory: 'Theater' }],
     }
 
     await expect(getPreSeededInterestsForUser('user-invitee')).resolves.toEqual({
       inviterName: 'Alex Inviter',
+      inviteeDisplayName: 'Morgan Lee',
       interests: [{ label: 'Sondheim', description: null, broadCategory: 'Theater' }],
     })
   })
@@ -65,11 +74,13 @@ describe('getPreSeededInterestsForUser', () => {
   it('returns a null inviter name when unavailable so UI can use friend fallback', async () => {
     state.row = {
       inviterName: '   ',
+      inviteeDisplayName: null,
       preSeededInterests: ['Jazz'],
     }
 
     await expect(getPreSeededInterestsForUser('user-invitee')).resolves.toEqual({
       inviterName: null,
+      inviteeDisplayName: null,
       interests: [{ label: 'Jazz' }],
     })
   })
@@ -77,6 +88,7 @@ describe('getPreSeededInterestsForUser', () => {
   it('keeps non-invite onboarding empty', async () => {
     await expect(getPreSeededInterestsForUser('user-no-invite')).resolves.toEqual({
       inviterName: null,
+      inviteeDisplayName: null,
       interests: [],
     })
   })

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -21,6 +21,7 @@ export type PreSeededInterest = {
 export type PreSeededInterestsForUser = {
   interests: PreSeededInterest[];
   inviterName: string | null;
+  inviteeDisplayName: string | null;
 };
 
 function normalizeDeclaredInterest(interest: DeclaredInterestInput): DeclaredInterestInput | null {
@@ -176,7 +177,7 @@ export const getUserOnboardingProfile = cache(async (userId: string) => {
   return user ?? null;
 });
 
-function normalizeInviterName(value: string | null | undefined) {
+function normalizePersonName(value: string | null | undefined) {
   const normalized = value?.trim().replace(/\s+/g, ' ');
   return normalized ? normalized.slice(0, 80) : null;
 }
@@ -186,6 +187,7 @@ export async function getPreSeededInterestsForUser(userId: string): Promise<PreS
     .select({
       preSeededInterests: friendInvitations.preSeededInterests,
       inviterName: users.displayName,
+      inviteeDisplayName: friendInvitations.inviteeDisplayName,
     })
     .from(friendInvitations)
     .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
@@ -195,6 +197,7 @@ export async function getPreSeededInterestsForUser(userId: string): Promise<PreS
 
   return {
     interests: parsePreSeededInterests(invitation?.preSeededInterests),
-    inviterName: normalizeInviterName(invitation?.inviterName),
+    inviterName: normalizePersonName(invitation?.inviterName),
+    inviteeDisplayName: normalizePersonName(invitation?.inviteeDisplayName),
   };
 }


### PR DESCRIPTION
New users were created with displayName=null and could finish onboarding
without ever picking one, leaving them showing up as "Player XXXX" to
friends. Add a "What should we call you?" step at the start of
onboarding, prefilled from FriendInvitation.inviteeDisplayName (the name
the inviter typed when creating the invite) so most users just tap
Continue. Defensive server gate in /api/onboarding/save-interests
refuses to flip onboardingComplete when displayName is still null.

https://claude.ai/code/session_01Ni2xoVFTr63CEJ4Yg9jJbP