### PR TITLE
Fade answered question region with a tinted background bar

### DIFF
--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -237,7 +237,12 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
         className="absolute inset-y-0 left-0 w-[2px]"
         style={{ backgroundColor: categoryColor }}
       />
-      <div className="p-[14px]">
+      <div
+        className="px-[14px] pt-[14px] pb-[12px]"
+        style={{
+          backgroundColor: 'color-mix(in srgb, var(--ink) 5%, var(--cream))',
+        }}
+      >
         <div className="flex items-center gap-3">
           <AnsweredAvatarStack
             pairedFriend={item.pairedFriend}
@@ -301,10 +306,10 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
             {item.personalMessage}
           </p>
         ) : null}
+      </div>
 
-        <div className="mt-3 border-t border-[var(--border-light)] pt-3">
-          <AnsweredResult item={item} recheckAction={recheckAction} />
-        </div>
+      <div className="px-[14px] py-[12px]">
+        <AnsweredResult item={item} recheckAction={recheckAction} />
       </div>
     </article>
   )


### PR DESCRIPTION
Splits the AnsweredByYouCard body so the top half (avatars, category,
question text, optional personal message) sits on a subtly tinted bar
while the result section keeps the normal cream background. Makes
already-answered questions recede visually so the answer/result is what
pops, without sacrificing legibility.

https://claude.ai/code/session_01E4Wo4gFXP5iiwhgGgDfFhY