### PR TITLE
Add friend management UI and stranger profile views

### DIFF
--- a/src/app/api/friend-requests/[friendshipId]/__tests__/route.test.ts
+++ b/src/app/api/friend-requests/[friendshipId]/__tests__/route.test.ts
@@ -1,9 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { acceptPendingFriendshipRequestMock, getSessionMock, ignorePendingFriendshipRequestMock } = vi.hoisted(() => ({
+const {
+  acceptPendingFriendshipRequestMock,
+  cancelPendingFriendshipRequestMock,
+  getSessionMock,
+  ignorePendingFriendshipRequestMock,
+  removeFriendshipMock,
+} = vi.hoisted(() => ({
   acceptPendingFriendshipRequestMock: vi.fn(),
+  cancelPendingFriendshipRequestMock: vi.fn(),
   getSessionMock: vi.fn(),
   ignorePendingFriendshipRequestMock: vi.fn(),
+  removeFriendshipMock: vi.fn(),
 }))
 
 vi.mock('@/server/auth/session', () => ({
@@ -12,11 +20,15 @@ vi.mock('@/server/auth/session', () => ({
 
 vi.mock('@/server/friends/friendships', () => ({
   acceptPendingFriendshipRequest: acceptPendingFriendshipRequestMock,
+  cancelPendingFriendshipRequest: cancelPendingFriendshipRequestMock,
   ignorePendingFriendshipRequest: ignorePendingFriendshipRequestMock,
+  removeFriendship: removeFriendshipMock,
 }))
 
 import { POST as acceptRequest } from '@/app/api/friend-requests/[friendshipId]/accept/route'
+import { POST as cancelRequest } from '@/app/api/friend-requests/[friendshipId]/cancel/route'
 import { POST as ignoreRequest } from '@/app/api/friend-requests/[friendshipId]/ignore/route'
+import { POST as removeRequest } from '@/app/api/friend-requests/[friendshipId]/remove/route'
 
 const context = { params: Promise.resolve({ friendshipId: 'friendship-1' }) }
 const request = new Request('https://joshing.example/api/friend-requests/friendship-1/accept', { method: 'POST' })
@@ -53,5 +65,59 @@ describe('friend request action routes', () => {
       userId: 'recipient-user',
     })
     expect(body.friendship).toEqual({ id: 'friendship-1', status: 'declined' })
+  })
+
+  it('cancel marks the requester’s pending request as cancelled', async () => {
+    cancelPendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'cancelled' })
+
+    const response = await cancelRequest(request, context)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(cancelPendingFriendshipRequestMock).toHaveBeenCalledWith({
+      friendshipId: 'friendship-1',
+      userId: 'recipient-user',
+    })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'cancelled' })
+  })
+
+  it('cancel returns 404 when nothing matches', async () => {
+    cancelPendingFriendshipRequestMock.mockResolvedValueOnce(null)
+
+    const response = await cancelRequest(request, context)
+    expect(response.status).toBe(404)
+  })
+
+  it('remove marks an active friendship as removed', async () => {
+    removeFriendshipMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'removed' })
+
+    const response = await removeRequest(request, context)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(removeFriendshipMock).toHaveBeenCalledWith({
+      friendshipId: 'friendship-1',
+      userId: 'recipient-user',
+    })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'removed' })
+  })
+
+  it('remove returns 404 when no active friendship matches', async () => {
+    removeFriendshipMock.mockResolvedValueOnce(null)
+
+    const response = await removeRequest(request, context)
+    expect(response.status).toBe(404)
+  })
+
+  it('cancel requires auth', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await cancelRequest(request, context)
+    expect(response.status).toBe(401)
+  })
+
+  it('remove requires auth', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await removeRequest(request, context)
+    expect(response.status).toBe(401)
   })
 })

--- a/src/app/api/friend-requests/[friendshipId]/cancel/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/cancel/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { cancelPendingFriendshipRequest } from '@/server/friends/friendships'
+import { logTelemetry } from '@/server/telemetry'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ friendshipId: string }> }
+) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { friendshipId } = await params
+  const friendship = await cancelPendingFriendshipRequest({
+    friendshipId,
+    userId: session.userId,
+  })
+
+  if (!friendship) {
+    return NextResponse.json(
+      { error: 'not_found', message: 'No pending friend request was found.' },
+      { status: 404 }
+    )
+  }
+
+  logTelemetry('friend_request_cancelled', {
+    friendship_id: friendship.id,
+    user_id: session.userId,
+  })
+
+  return NextResponse.json({
+    ok: true,
+    friendship: { id: friendship.id, status: friendship.status },
+  })
+}

--- a/src/app/api/friend-requests/[friendshipId]/remove/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/remove/route.ts
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { removeFriendship } from '@/server/friends/friendships'
+import { logTelemetry } from '@/server/telemetry'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(
+  _request: Request,
+  { params }: { params: Promise<{ friendshipId: string }> }
+) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const { friendshipId } = await params
+  const friendship = await removeFriendship({
+    friendshipId,
+    userId: session.userId,
+  })
+
+  if (!friendship) {
+    return NextResponse.json(
+      { error: 'not_found', message: 'No active friendship was found.' },
+      { status: 404 }
+    )
+  }
+
+  logTelemetry('friendship_removed', {
+    friendship_id: friendship.id,
+    user_id: session.userId,
+  })
+
+  return NextResponse.json({
+    ok: true,
+    friendship: { id: friendship.id, status: friendship.status },
+  })
+}

--- a/src/app/api/friend-requests/__tests__/route.test.ts
+++ b/src/app/api/friend-requests/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  createOrReusePendingFriendshipRequestMock,
+  getSessionMock,
+  getUserByIdMock,
+} = vi.hoisted(() => ({
+  createOrReusePendingFriendshipRequestMock: vi.fn(),
+  getSessionMock: vi.fn(),
+  getUserByIdMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/friends/friendships', () => ({
+  createOrReusePendingFriendshipRequest: createOrReusePendingFriendshipRequestMock,
+}))
+
+vi.mock('@/server/db/queries/users', () => ({
+  getUserById: getUserByIdMock,
+}))
+
+import { POST as createFriendRequest } from '@/app/api/friend-requests/route'
+
+function buildRequest(body: unknown) {
+  return new Request('https://joshing.example/api/friend-requests', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('POST /api/friend-requests', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ userId: 'viewer-user' })
+    getUserByIdMock.mockResolvedValue({ id: 'invitee-user' })
+    createOrReusePendingFriendshipRequestMock.mockResolvedValue({
+      friendship: { id: 'friendship-1', status: 'pending' },
+      state: 'created',
+    })
+  })
+
+  it('creates a friendship request via the shared helper', async () => {
+    const response = await createFriendRequest(
+      buildRequest({ inviteeUserId: 'invitee-user' })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(createOrReusePendingFriendshipRequestMock).toHaveBeenCalledWith({
+      inviterUserId: 'viewer-user',
+      inviteeUserId: 'invitee-user',
+    })
+    expect(body).toMatchObject({
+      ok: true,
+      state: 'created',
+      friendship: { id: 'friendship-1', status: 'pending' },
+    })
+  })
+
+  it('rejects unauthenticated callers', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await createFriendRequest(
+      buildRequest({ inviteeUserId: 'invitee-user' })
+    )
+    expect(response.status).toBe(401)
+  })
+
+  it('rejects missing inviteeUserId', async () => {
+    const response = await createFriendRequest(buildRequest({}))
+    expect(response.status).toBe(400)
+  })
+
+  it('rejects self-requests', async () => {
+    const response = await createFriendRequest(
+      buildRequest({ inviteeUserId: 'viewer-user' })
+    )
+    expect(response.status).toBe(400)
+  })
+
+  it('returns 404 when the invitee does not exist', async () => {
+    getUserByIdMock.mockResolvedValueOnce(null)
+    const response = await createFriendRequest(
+      buildRequest({ inviteeUserId: 'missing-user' })
+    )
+    expect(response.status).toBe(404)
+  })
+})

--- a/src/app/api/friend-requests/route.ts
+++ b/src/app/api/friend-requests/route.ts
@@ -1,0 +1,62 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getSession } from '@/server/auth/session'
+import { getUserById } from '@/server/db/queries/users'
+import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
+import { logTelemetry } from '@/server/telemetry'
+
+export const dynamic = 'force-dynamic'
+
+const bodySchema = z.object({
+  inviteeUserId: z.string().min(1),
+})
+
+export async function POST(request: Request) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const json = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'Missing inviteeUserId.' },
+      { status: 400 }
+    )
+  }
+
+  const { inviteeUserId } = parsed.data
+  if (inviteeUserId === session.userId) {
+    return NextResponse.json(
+      { error: 'self_request', message: 'You cannot friend yourself.' },
+      { status: 400 }
+    )
+  }
+
+  const invitee = await getUserById(inviteeUserId)
+  if (!invitee) {
+    return NextResponse.json(
+      { error: 'not_found', message: 'No such user.' },
+      { status: 404 }
+    )
+  }
+
+  const { friendship, state } = await createOrReusePendingFriendshipRequest({
+    inviterUserId: session.userId,
+    inviteeUserId,
+  })
+
+  logTelemetry('friend_request_from_profile', {
+    inviter_user_id: session.userId,
+    invitee_user_id: inviteeUserId,
+    friendship_id: friendship.id,
+    state,
+  })
+
+  return NextResponse.json({
+    ok: true,
+    state,
+    friendship: { id: friendship.id, status: friendship.status },
+  })
+}

--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -34,6 +34,14 @@ vi.mock('next/link', () => ({
 
 vi.mock('next/navigation', () => ({
   notFound: notFoundMock,
+  useRouter: () => ({
+    refresh: vi.fn(),
+    push: vi.fn(),
+    replace: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    prefetch: vi.fn(),
+  }),
 }))
 
 vi.mock('@/server/auth/session', () => ({
@@ -130,6 +138,8 @@ describe('/users/[id] friend profile page', () => {
       sharedInterests: ['Jazz piano'],
       viewerSoloInterests: ['Bauhaus design'],
       friendSoloInterests: ['Roman roads'],
+      mutualFriends: [],
+      mutualFriendsOverflow: 0,
     })
     getUserMasteryOverviewMock.mockResolvedValue({
       totalPoints: 0,

--- a/src/app/users/[id]/knowledge/page.tsx
+++ b/src/app/users/[id]/knowledge/page.tsx
@@ -50,6 +50,7 @@ export default async function FriendKnowledgePage({
   const { id } = await params
   const portrait = await getFriendPortraitData(id, session.userId)
   if (!portrait) notFound()
+  if (portrait.visibility === 'stranger') notFound()
 
   const isOwner = portrait.visibility === 'self'
   const [mastery, pageData] = await Promise.all([

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation'
 
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard'
 import { AuthoredQuestionsFeed } from '@/components/profile/AuthoredQuestionsFeed'
+import { MutualFriendsSection } from '@/components/profile/MutualFriendsSection'
+import { ProfileFriendButton } from '@/components/profile/ProfileFriendButton'
 import { SharedInterestsOverlap } from '@/components/profile/SharedInterestsOverlap'
 import { getSession } from '@/server/auth/session'
 import {
@@ -59,6 +61,67 @@ export default async function UserProfilePage({
   const portrait = await getFriendPortraitData(id, session.userId)
   if (!portrait) notFound()
 
+  const isSelf = portrait.visibility === 'self'
+  const isStranger = portrait.visibility === 'stranger'
+  const friendFirstName = firstName(portrait.user.displayName)
+
+  const profileLabel = isSelf
+    ? 'Your profile'
+    : isStranger
+      ? 'Joshing member'
+      : 'Friend profile'
+
+  if (isStranger) {
+    return (
+      <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
+        <div className="mb-5">
+          <Link
+            href="/friends"
+            className="text-muted-foreground text-sm font-medium underline-offset-4 hover:underline"
+          >
+            ← Friends
+          </Link>
+        </div>
+
+        <section className="bg-card text-card-foreground rounded-3xl border p-5 shadow-sm">
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+            {profileLabel}
+          </p>
+          <div className="mt-4 flex items-start gap-4">
+            <div className="bg-primary/10 text-primary flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl font-serif text-3xl font-semibold">
+              {portrait.user.displayName.slice(0, 1).toUpperCase() || 'J'}
+            </div>
+            <div className="min-w-0">
+              <h1 className="text-foreground font-serif text-3xl font-semibold">
+                {portrait.user.displayName}
+              </h1>
+              <p className="text-muted-foreground mt-2 text-sm leading-6">
+                On Joshing since {formatMemberSince(portrait.user.memberSince)}.
+              </p>
+              <ProfileFriendButton
+                targetUserId={portrait.user.id}
+                friendship={portrait.friendship}
+                targetDisplayName={portrait.user.displayName}
+              />
+            </div>
+          </div>
+        </section>
+
+        <MutualFriendsSection
+          friends={portrait.mutualFriends}
+          overflowCount={portrait.mutualFriendsOverflow}
+          visibility="stranger"
+          friendFirstName={friendFirstName}
+        />
+
+        <p className="text-muted-foreground mt-6 text-sm">
+          Become friends to see {friendFirstName}’s knowledge portrait,
+          interests, and authored questions.
+        </p>
+      </main>
+    )
+  }
+
   const [mastery, pageData, authoredQuestions] = await Promise.all([
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
@@ -81,8 +144,6 @@ export default async function UserProfilePage({
   const tierSignature = `${new Intl.NumberFormat().format(
     Math.round(mastery.totalPoints),
   )} knowledge points across ${sortedDomains.length} territories`
-  const friendFirstName = firstName(portrait.user.displayName)
-  const isSelf = portrait.visibility === 'self'
 
   const authoredItems = authoredQuestions.map((question) => ({
     id: question.id,
@@ -105,7 +166,7 @@ export default async function UserProfilePage({
 
       <section className="bg-card text-card-foreground rounded-3xl border p-5 shadow-sm">
         <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-          {isSelf ? 'Your profile' : 'Friend profile'}
+          {profileLabel}
         </p>
         <div className="mt-4 flex items-start gap-4">
           <div className="bg-primary/10 text-primary flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl font-serif text-3xl font-semibold">
@@ -123,17 +184,32 @@ export default async function UserProfilePage({
                 Friends since {formatMemberSince(portrait.friendship.formedAt)}.
               </p>
             ) : null}
+            {!isSelf ? (
+              <ProfileFriendButton
+                targetUserId={portrait.user.id}
+                friendship={portrait.friendship}
+                targetDisplayName={portrait.user.displayName}
+              />
+            ) : null}
           </div>
         </div>
       </section>
 
       {!isSelf ? (
-        <SharedInterestsOverlap
-          viewerSoloInterests={portrait.viewerSoloInterests}
-          friendSoloInterests={portrait.friendSoloInterests}
-          sharedInterests={portrait.sharedInterests}
-          friendFirstName={friendFirstName}
-        />
+        <>
+          <SharedInterestsOverlap
+            viewerSoloInterests={portrait.viewerSoloInterests}
+            friendSoloInterests={portrait.friendSoloInterests}
+            sharedInterests={portrait.sharedInterests}
+            friendFirstName={friendFirstName}
+          />
+          <MutualFriendsSection
+            friends={portrait.mutualFriends}
+            overflowCount={portrait.mutualFriendsOverflow}
+            visibility="friend"
+            friendFirstName={friendFirstName}
+          />
+        </>
       ) : null}
 
       <section className="mt-5" aria-label="Knowledge portrait">

--- a/src/components/profile/MutualFriendsSection.tsx
+++ b/src/components/profile/MutualFriendsSection.tsx
@@ -1,0 +1,67 @@
+import Link from 'next/link'
+
+type MutualFriend = {
+  id: string
+  displayName: string
+}
+
+type MutualFriendsSectionProps = {
+  friends: MutualFriend[]
+  overflowCount: number
+  visibility: 'friend' | 'stranger'
+  friendFirstName: string
+}
+
+export function MutualFriendsSection({
+  friends,
+  overflowCount,
+  visibility,
+  friendFirstName,
+}: MutualFriendsSectionProps) {
+  if (friends.length === 0) {
+    if (visibility === 'friend') return null
+    return (
+      <section className="mt-5" aria-label="Mutual friends">
+        <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+          Mutual friends
+        </p>
+        <p className="text-muted-foreground mt-2 text-sm">
+          No mutual friends yet.
+        </p>
+      </section>
+    )
+  }
+
+  const heading =
+    visibility === 'stranger'
+      ? `You both know`
+      : `Friends you and ${friendFirstName} share`
+
+  return (
+    <section className="mt-5" aria-label="Mutual friends">
+      <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+        Mutual friends
+      </p>
+      <h2 className="mt-1 font-serif text-xl font-semibold">{heading}</h2>
+      <ul className="mt-3 flex flex-wrap gap-2">
+        {friends.map((friend) => (
+          <li key={friend.id}>
+            <Link
+              href={`/users/${friend.id}`}
+              className="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center rounded-full px-3 py-1 text-sm font-medium"
+            >
+              {friend.displayName}
+            </Link>
+          </li>
+        ))}
+        {overflowCount > 0 ? (
+          <li>
+            <span className="text-muted-foreground inline-flex items-center rounded-full px-3 py-1 text-sm">
+              +{overflowCount} more
+            </span>
+          </li>
+        ) : null}
+      </ul>
+    </section>
+  )
+}

--- a/src/components/profile/ProfileFriendButton.tsx
+++ b/src/components/profile/ProfileFriendButton.tsx
@@ -1,0 +1,162 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+type FriendshipShape = {
+  id: string
+  status: string
+  viewerIsRequester: boolean
+} | null
+
+type ProfileFriendButtonProps = {
+  targetUserId: string
+  friendship: FriendshipShape
+  targetDisplayName: string
+}
+
+type Action =
+  | 'create'
+  | 'accept'
+  | 'ignore'
+  | 'cancel'
+  | 'remove'
+
+export function ProfileFriendButton({
+  targetUserId,
+  friendship,
+  targetDisplayName,
+}: ProfileFriendButtonProps) {
+  const router = useRouter()
+  const [pendingAction, setPendingAction] = useState<Action | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function run(action: Action, request: () => Promise<Response>) {
+    if (pendingAction) return
+    setPendingAction(action)
+    setError(null)
+    try {
+      const response = await request()
+      if (!response.ok) {
+        setError('Something went wrong. Please try again.')
+        return
+      }
+      router.refresh()
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  const createRequest = () =>
+    run('create', () =>
+      fetch('/api/friend-requests', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ inviteeUserId: targetUserId }),
+      })
+    )
+
+  const accept = () => {
+    if (!friendship) return
+    return run('accept', () =>
+      fetch(`/api/friend-requests/${friendship.id}/accept`, { method: 'POST' })
+    )
+  }
+
+  const ignore = () => {
+    if (!friendship) return
+    return run('ignore', () =>
+      fetch(`/api/friend-requests/${friendship.id}/ignore`, { method: 'POST' })
+    )
+  }
+
+  const cancel = () => {
+    if (!friendship) return
+    return run('cancel', () =>
+      fetch(`/api/friend-requests/${friendship.id}/cancel`, { method: 'POST' })
+    )
+  }
+
+  const remove = () => {
+    if (!friendship) return
+    const confirmed = window.confirm(
+      `Remove ${targetDisplayName} from your friends?`
+    )
+    if (!confirmed) return
+    return run('remove', () =>
+      fetch(`/api/friend-requests/${friendship.id}/remove`, { method: 'POST' })
+    )
+  }
+
+  const status = friendship?.status ?? null
+  const isPending = status === 'pending'
+  const isActive = status === 'active'
+  const viewerIsRequester = friendship?.viewerIsRequester ?? false
+
+  return (
+    <div className="mt-4 flex flex-col gap-2">
+      <div className="flex flex-wrap items-center gap-2">
+        {isActive ? (
+          <>
+            <Button size="sm" variant="secondary" disabled>
+              Friends ✓
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={remove}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'remove' ? 'Removing…' : 'Unfriend'}
+            </Button>
+          </>
+        ) : isPending && viewerIsRequester ? (
+          <>
+            <Button size="sm" variant="secondary" disabled>
+              Request sent
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={cancel}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'cancel' ? 'Cancelling…' : 'Cancel'}
+            </Button>
+          </>
+        ) : isPending && !viewerIsRequester ? (
+          <>
+            <Button
+              size="sm"
+              onClick={accept}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'accept' ? 'Joining…' : 'Accept'}
+            </Button>
+            <Button
+              size="sm"
+              variant="ghost"
+              onClick={ignore}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'ignore' ? 'Setting aside…' : 'Not now'}
+            </Button>
+          </>
+        ) : (
+          <Button
+            size="sm"
+            onClick={createRequest}
+            disabled={pendingAction !== null}
+          >
+            {pendingAction === 'create' ? 'Sending…' : 'Add friend'}
+          </Button>
+        )}
+      </div>
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+    </div>
+  )
+}

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -187,6 +187,63 @@ export async function ignorePendingFriendshipRequest({
   return friendship ?? null
 }
 
+export async function cancelPendingFriendshipRequest({
+  friendshipId,
+  userId,
+  now = new Date(),
+}: {
+  friendshipId: string
+  userId: string
+  now?: Date
+}): Promise<typeof friendships.$inferSelect | null> {
+  const [friendship] = await db
+    .update(friendships)
+    .set({
+      status: 'cancelled',
+      removedAt: now,
+      removedByUserId: userId,
+    })
+    .where(
+      and(
+        eq(friendships.id, friendshipId),
+        eq(friendships.status, 'pending'),
+        eq(friendships.requestedByUserId, userId),
+        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
+      )
+    )
+    .returning()
+
+  return friendship ?? null
+}
+
+export async function removeFriendship({
+  friendshipId,
+  userId,
+  now = new Date(),
+}: {
+  friendshipId: string
+  userId: string
+  now?: Date
+}): Promise<typeof friendships.$inferSelect | null> {
+  const [friendship] = await db
+    .update(friendships)
+    .set({
+      status: 'removed',
+      removedAt: now,
+      removedByUserId: userId,
+    })
+    .where(
+      and(
+        eq(friendships.id, friendshipId),
+        eq(friendships.status, 'active'),
+        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
+      )
+    )
+    .returning()
+
+  return friendship ?? null
+}
+
 export async function upsertInvitationFriendship(
   writer: FriendshipWriter,
   {

--- a/src/server/profile/__tests__/friend.test.ts
+++ b/src/server/profile/__tests__/friend.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { dbMock, getFriendshipMock, getUserByIdMock, state } = vi.hoisted(() => {
+const { dbMock, getFriendshipMock, getFriendsMock, getUserByIdMock, state } = vi.hoisted(() => {
   const state = {
     interestRows: [] as Array<{
       userId: string
@@ -22,6 +22,7 @@ const { dbMock, getFriendshipMock, getUserByIdMock, state } = vi.hoisted(() => {
   return {
     dbMock,
     getFriendshipMock: vi.fn(),
+    getFriendsMock: vi.fn(),
     getUserByIdMock: vi.fn(),
     state,
   }
@@ -46,6 +47,7 @@ vi.mock('@/server/db', () => ({
 
 vi.mock('@/server/db/queries/friends', () => ({
   getFriendship: getFriendshipMock,
+  getFriends: getFriendsMock,
 }))
 
 vi.mock('@/server/db/queries/users', () => ({
@@ -68,7 +70,9 @@ describe('friend portrait data', () => {
       id: 'friendship-1',
       status: 'active',
       formedAt: new Date('2026-02-01T00:00:00.000Z'),
+      requestedByUserId: 'viewer-1',
     })
+    getFriendsMock.mockResolvedValue([])
   })
 
   it('returns a minimal friend portrait for active friends', async () => {
@@ -89,7 +93,10 @@ describe('friend portrait data', () => {
       visibility: 'friend',
       friendship: {
         id: 'friendship-1',
+        status: 'active',
         formedAt: new Date('2026-02-01T00:00:00.000Z'),
+        requestedByUserId: 'viewer-1',
+        viewerIsRequester: true,
       },
       interests: [
         { domain: 'Jazz piano', broadCategory: 'Music', shared: true },
@@ -98,6 +105,8 @@ describe('friend portrait data', () => {
       sharedInterests: ['Jazz piano'],
       viewerSoloInterests: [],
       friendSoloInterests: ['Roman roads'],
+      mutualFriends: [],
+      mutualFriendsOverflow: 0,
     })
   })
 
@@ -114,12 +123,14 @@ describe('friend portrait data', () => {
     expect(portrait?.user.displayName).toBe('+15550101010')
   })
 
-  it('returns null for missing users and non-active friendships', async () => {
+  it('returns null for missing users', async () => {
     getUserByIdMock.mockResolvedValueOnce(null)
     await expect(
       getFriendPortraitData('missing-user', 'viewer-1')
     ).resolves.toBeNull()
+  })
 
+  it('returns a stranger portrait when no active friendship exists', async () => {
     getUserByIdMock.mockResolvedValueOnce({
       id: 'stranger-1',
       displayName: 'Stranger',
@@ -129,10 +140,63 @@ describe('friend portrait data', () => {
     getFriendshipMock.mockResolvedValueOnce({
       id: 'friendship-2',
       status: 'pending',
+      formedAt: null,
+      requestedByUserId: 'viewer-1',
     })
 
-    await expect(
-      getFriendPortraitData('stranger-1', 'viewer-1')
-    ).resolves.toBeNull()
+    const portrait = await getFriendPortraitData('stranger-1', 'viewer-1')
+
+    expect(portrait?.visibility).toBe('stranger')
+    expect(portrait?.friendship).toEqual({
+      id: 'friendship-2',
+      status: 'pending',
+      formedAt: null,
+      requestedByUserId: 'viewer-1',
+      viewerIsRequester: true,
+    })
+    expect(portrait?.interests).toEqual([])
+    expect(portrait?.sharedInterests).toEqual([])
+    expect(portrait?.viewerSoloInterests).toEqual([])
+    expect(portrait?.friendSoloInterests).toEqual([])
+  })
+
+  it('returns a stranger portrait with no friendship row at all', async () => {
+    getUserByIdMock.mockResolvedValueOnce({
+      id: 'stranger-2',
+      displayName: 'Unconnected',
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      phoneNumber: '+15550101012',
+    })
+    getFriendshipMock.mockResolvedValueOnce(null)
+
+    const portrait = await getFriendPortraitData('stranger-2', 'viewer-1')
+
+    expect(portrait?.visibility).toBe('stranger')
+    expect(portrait?.friendship).toBeNull()
+  })
+
+  it('returns mutual friends for non-self views', async () => {
+    getFriendsMock.mockImplementation(async (userId: string) => {
+      if (userId === 'viewer-1') {
+        return [
+          { id: 'mutual-1', displayName: 'Mona Mutual', phoneNumber: null },
+          { id: 'viewer-only', displayName: 'Vera', phoneNumber: null },
+        ]
+      }
+      if (userId === 'friend-1') {
+        return [
+          { id: 'mutual-1', displayName: 'Mona Mutual', phoneNumber: null },
+          { id: 'friend-only', displayName: 'Fiona', phoneNumber: null },
+        ]
+      }
+      return []
+    })
+
+    const portrait = await getFriendPortraitData('friend-1', 'viewer-1')
+
+    expect(portrait?.mutualFriends).toEqual([
+      { id: 'mutual-1', displayName: 'Mona Mutual' },
+    ])
+    expect(portrait?.mutualFriendsOverflow).toBe(0)
   })
 })

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -1,15 +1,30 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
 
 import { db, declaredInterests } from '@/server/db'
-import { getFriendship } from '@/server/db/queries/friends'
+import { getFriends, getFriendship } from '@/server/db/queries/friends'
 import { getUserById } from '@/server/db/queries/users'
 
-type FriendProfileVisibility = 'self' | 'friend'
+type FriendProfileVisibility = 'self' | 'friend' | 'stranger'
+
+const MUTUAL_FRIENDS_LIMIT = 24
 
 export type FriendPortraitInterest = {
   domain: string
   broadCategory: string | null
   shared: boolean
+}
+
+export type FriendPortraitMutualFriend = {
+  id: string
+  displayName: string
+}
+
+export type FriendPortraitFriendship = {
+  id: string
+  status: string
+  formedAt: Date | null
+  requestedByUserId: string
+  viewerIsRequester: boolean
 }
 
 export type FriendPortraitData = {
@@ -19,14 +34,13 @@ export type FriendPortraitData = {
     memberSince: Date
   }
   visibility: FriendProfileVisibility
-  friendship: {
-    id: string
-    formedAt: Date | null
-  } | null
+  friendship: FriendPortraitFriendship | null
   interests: FriendPortraitInterest[]
   sharedInterests: string[]
   viewerSoloInterests: string[]
   friendSoloInterests: string[]
+  mutualFriends: FriendPortraitMutualFriend[]
+  mutualFriendsOverflow: number
 }
 
 function profileDisplayName(
@@ -52,11 +66,18 @@ export async function getFriendPortraitData(
     ? null
     : await getFriendship(normalizedViewerId, normalizedUserId)
 
-  if (!isSelf && friendship?.status !== 'active') return null
+  const isActiveFriend = !isSelf && friendship?.status === 'active'
+  const visibility: FriendProfileVisibility = isSelf
+    ? 'self'
+    : isActiveFriend
+      ? 'friend'
+      : 'stranger'
 
-  const visibleUserIds = isSelf
+  const interestOwnerIds = isSelf
     ? [normalizedUserId]
-    : [normalizedUserId, normalizedViewerId]
+    : isActiveFriend
+      ? [normalizedUserId, normalizedViewerId]
+      : [normalizedViewerId]
 
   const interestRows = await db
     .select({
@@ -68,7 +89,7 @@ export async function getFriendPortraitData(
     .where(
       and(
         eq(declaredInterests.isActive, true),
-        inArray(declaredInterests.userId, visibleUserIds)
+        inArray(declaredInterests.userId, interestOwnerIds)
       )
     )
     .orderBy(asc(declaredInterests.domain))
@@ -84,18 +105,47 @@ export async function getFriendPortraitData(
     .map((interest) => ({
       domain: interest.domain,
       broadCategory: interest.broadCategory,
-      shared: !isSelf && viewerInterests.has(interest.domain),
+      shared: isActiveFriend && viewerInterests.has(interest.domain),
     }))
 
   const friendInterestDomains = new Set(interests.map((i) => i.domain))
-  const viewerSoloInterests = isSelf
-    ? []
-    : Array.from(viewerInterests)
+  const viewerSoloInterests = isActiveFriend
+    ? Array.from(viewerInterests)
         .filter((domain) => !friendInterestDomains.has(domain))
         .sort((a, b) => a.localeCompare(b))
-  const friendSoloInterests = interests
-    .filter((interest) => !interest.shared)
-    .map((interest) => interest.domain)
+    : []
+  const friendSoloInterests = isActiveFriend
+    ? interests.filter((interest) => !interest.shared).map((i) => i.domain)
+    : []
+
+  let mutualFriends: FriendPortraitMutualFriend[] = []
+  let mutualFriendsOverflow = 0
+  if (!isSelf) {
+    const [viewerFriends, viewedUserFriends] = await Promise.all([
+      getFriends(normalizedViewerId),
+      getFriends(normalizedUserId),
+    ])
+    const viewerFriendIds = new Set(viewerFriends.map((u) => u.id))
+    const mutuals = viewedUserFriends
+      .filter((user) => viewerFriendIds.has(user.id))
+      .map((user) => ({
+        id: user.id,
+        displayName: profileDisplayName(user.displayName, user.phoneNumber),
+      }))
+      .sort((a, b) => a.displayName.localeCompare(b.displayName))
+    mutualFriends = mutuals.slice(0, MUTUAL_FRIENDS_LIMIT)
+    mutualFriendsOverflow = Math.max(0, mutuals.length - mutualFriends.length)
+  }
+
+  const portraitFriendship: FriendPortraitFriendship | null = friendship
+    ? {
+        id: friendship.id,
+        status: friendship.status,
+        formedAt: friendship.formedAt,
+        requestedByUserId: friendship.requestedByUserId,
+        viewerIsRequester: friendship.requestedByUserId === normalizedViewerId,
+      }
+    : null
 
   return {
     user: {
@@ -106,18 +156,15 @@ export async function getFriendPortraitData(
       ),
       memberSince: viewedUser.createdAt,
     },
-    visibility: isSelf ? 'self' : 'friend',
-    friendship: friendship
-      ? {
-          id: friendship.id,
-          formedAt: friendship.formedAt,
-        }
-      : null,
+    visibility,
+    friendship: portraitFriendship,
     interests,
     sharedInterests: interests
       .filter((interest) => interest.shared)
       .map((interest) => interest.domain),
     viewerSoloInterests,
     friendSoloInterests,
+    mutualFriends,
+    mutualFriendsOverflow,
   }
 }

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -19,6 +19,9 @@ export type TelemetryEventName =
   | 'friend_request_reinvite_after_ignore_limited'
   | 'friend_request_accepted'
   | 'friend_request_ignored'
+  | 'friend_request_from_profile'
+  | 'friend_request_cancelled'
+  | 'friendship_removed'
 
 type TelemetryValue = string | number | boolean | null | undefined
 export type TelemetryMetadata = Record<string, TelemetryValue>


### PR DESCRIPTION
## Summary
Adds comprehensive friend management capabilities to user profiles, including the ability to send/accept/cancel/remove friend requests, and introduces a new "stranger" profile visibility level for users without active friendships. Users can now see mutual friends and manage their friendship status directly from profile pages.

## Key Changes

- **New `ProfileFriendButton` component** (`src/components/profile/ProfileFriendButton.tsx`): Interactive button that displays contextual actions based on friendship status:
  - "Add friend" for strangers
  - "Accept"/"Not now" for incoming requests
  - "Request sent"/"Cancel" for outgoing requests
  - "Friends ✓"/"Unfriend" for active friendships
  - Handles loading states and error messaging

- **New `MutualFriendsSection` component** (`src/components/profile/MutualFriendsSection.tsx`): Displays up to 24 mutual friends with overflow count, with different messaging for friend vs. stranger contexts

- **Expanded profile visibility model**: Changed from binary (self/friend) to three-tier (self/friend/stranger):
  - Strangers can now view limited profiles with mutual friends and pending friendship status
  - Interests are only visible to active friends or self
  - Profile data no longer returns `null` for non-active friendships

- **New API endpoints**:
  - `POST /api/friend-requests` — Create new friend request
  - `POST /api/friend-requests/[id]/cancel` — Cancel outgoing request
  - `POST /api/friend-requests/[id]/remove` — Remove active friendship
  - All endpoints include proper auth checks and validation

- **Backend friendship operations** (`src/server/friends/friendships.ts`):
  - `cancelPendingFriendshipRequest()` — Allows requester to cancel pending request
  - `removeFriendship()` — Allows either party to remove active friendship

- **Enhanced portrait data** (`src/server/profile/friend.ts`):
  - Added `mutualFriends` and `mutualFriendsOverflow` fields
  - Expanded `FriendPortraitFriendship` type to include `status`, `requestedByUserId`, and `viewerIsRequester`
  - Mutual friends fetched via new `getFriends()` query helper
  - Visibility logic now supports 'stranger' state

- **Updated user profile page** (`src/app/users/[id]/page.tsx`):
  - Renders dedicated stranger profile layout with mutual friends and friend request button
  - Integrates `ProfileFriendButton` and `MutualFriendsSection` for both friend and stranger views
  - Maintains existing friend profile layout with new components

- **Telemetry events**: Added tracking for `friend_request_from_profile`, `friend_request_cancelled`, and `friendship_removed`

- **Comprehensive test coverage**: Added tests for new API endpoints and updated existing profile tests to cover stranger visibility and mutual friends logic

## Implementation Details

- Friend request button uses optimistic UI patterns with `pendingAction` state to prevent double-submission
- Mutual friends limited to 24 with overflow count to prevent excessive data transfer
- Stranger profiles show only the viewer's solo interests (not the stranger's interests)
- All friendship mutations properly validate user authorization and friendship state
- Profile data queries now fetch mutual friends in parallel for performance

https://claude.ai/code/session_01XDdLsBxomx3zPFXpZTabWN