### PR TITLE
Show a status footer on already-answered FriendAnsweredCard

### DIFF
--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -11,10 +11,11 @@ type FeedCardProps = {
   item: FeedCardBaseItem
   overflow?: ReactNode
   onAnswer?: () => void
+  footer?: ReactNode
   className?: string
 }
 
-export function FeedCard({ item, overflow, onAnswer, className }: FeedCardProps) {
+export function FeedCard({ item, overflow, onAnswer, footer, className }: FeedCardProps) {
   const categoryColor = colorForCategory(item.category)
   const visibleCategory = visibleFeedCategory(item.category)
   const onDark = isDarkColor(categoryColor)
@@ -198,6 +199,8 @@ export function FeedCard({ item, overflow, onAnswer, className }: FeedCardProps)
               Answer →
             </button>
           </div>
+        ) : footer ? (
+          <div className="mt-3">{footer}</div>
         ) : null}
       </div>
     </article>

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -9,23 +9,51 @@ type FriendAnsweredCardProps = {
   onAnswer?: () => void
 }
 
+function viewerAnsweredFooterText(
+  viewerResult: 'correct' | 'incorrect',
+  friendName: string,
+  friendCorrect: boolean | null | undefined,
+): string {
+  if (viewerResult === 'correct') {
+    if (friendCorrect === true) return 'You both had it'
+    if (friendCorrect === false) return `You knew this · ${friendName} didn’t`
+    return `You answered · ${friendName} answered`
+  }
+  if (friendCorrect === true) return `${friendName} knew this · you missed it`
+  if (friendCorrect === false) return 'Neither of you got this one'
+  return `You missed this · ${friendName} answered`
+}
+
 export function FriendAnsweredCard({
   item,
   overflow,
   onAnswer,
 }: FriendAnsweredCardProps) {
-  const viewerAnswered =
-    item.viewerResult !== null && item.viewerResult !== undefined
+  const viewerResult = item.viewerResult ?? null
+  const viewerAnswered = viewerResult !== null
   const merged: FriendAnsweredFeedItem = {
     ...item,
     avatarName: item.avatarName ?? item.friendName,
     authorHref: item.authorHref ?? item.friendHref ?? null,
   }
+  const footer = viewerResult ? (
+    <p
+      className="text-right text-[12px] italic leading-tight"
+      style={{
+        fontFamily: 'var(--font-literata)',
+        color: 'var(--ink)',
+        opacity: 0.7,
+      }}
+    >
+      {viewerAnsweredFooterText(viewerResult, item.friendName, item.friendCorrect)}
+    </p>
+  ) : undefined
   return (
     <FeedCard
       item={merged}
       overflow={overflow}
       onAnswer={viewerAnswered ? undefined : onAnswer}
+      footer={footer}
     />
   )
 }

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -247,6 +247,51 @@ describe('Feed answered states', () => {
   })
 })
 
+describe('FriendAnsweredCard viewer-already-answered footer', () => {
+  it('renders a "you both had it" status when viewer and friend were both correct', () => {
+    const rendered = html(
+      <FriendAnsweredCard
+        item={{
+          ...feedCardPreviewFixtures.friendAnsweredRight,
+          viewerResult: 'correct',
+          friendCorrect: true,
+        }}
+        onAnswer={() => undefined}
+      />
+    )
+    expect(rendered).toContain('You both had it')
+    expect(rendered).not.toContain('Answer →')
+  })
+
+  it('renders a "you missed it" status when viewer was wrong and friend was right', () => {
+    const rendered = html(
+      <FriendAnsweredCard
+        item={{
+          ...feedCardPreviewFixtures.friendAnsweredRight,
+          viewerResult: 'incorrect',
+          friendCorrect: true,
+        }}
+        onAnswer={() => undefined}
+      />
+    )
+    expect(rendered).toContain('Noah knew this')
+    expect(rendered).toContain('you missed it')
+    expect(rendered).not.toContain('Answer →')
+  })
+
+  it('omits the status footer when the viewer has not answered yet', () => {
+    const rendered = html(
+      <FriendAnsweredCard
+        item={feedCardPreviewFixtures.friendAnsweredRight}
+        onAnswer={() => undefined}
+      />
+    )
+    expect(rendered).toContain('Answer →')
+    expect(rendered).not.toContain('You both had it')
+    expect(rendered).not.toContain('you missed it')
+  })
+})
+
 describe('Authored-by-viewer card', () => {
   it('renders a "New question" eyebrow with the italic category', () => {
     const rendered = html(


### PR DESCRIPTION
FriendAnsweredCard previously hid the "Answer →" button when the viewer
had already answered the underlying question, but rendered nothing in
its place. The card looked indistinguishable from an unanswered one
minus the button, leaving viewers unable to tell whether they had
answered or still needed to. Add a small italic status row summarizing
the viewer's and friend's results (e.g. "You both had it", "Noah knew
this · you missed it") via a new footer slot on FeedCard.