### PR TITLE
Strip non-numeric characters from phone input in LoginPanel

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -136,7 +136,7 @@ export default function LoginPanel() {
             className="h-11 w-full rounded-md border bg-background px-3 text-base outline-none ring-offset-background focus:ring-2 focus:ring-ring"
             placeholder="555-123-4567"
             value={phone}
-            onChange={(event) => setPhone(event.target.value)}
+            onChange={(event) => setPhone(event.target.value.replace(/\D/g, ''))}
             disabled={loading}
           />
           <button


### PR DESCRIPTION
## Summary
Updated the phone number input field in the LoginPanel to automatically remove non-numeric characters as the user types, ensuring only digits are stored in the phone state.

## Changes
- Modified the `onChange` handler for the phone input field to filter out non-numeric characters using `.replace(/\D/g, '')`, keeping only digits (0-9)

## Implementation Details
This change improves the user experience by:
- Allowing users to paste or type phone numbers with formatting characters (dashes, spaces, parentheses, etc.)
- Automatically cleaning the input to store only the numeric digits
- Maintaining a consistent phone number format in the application state without requiring manual user intervention

https://claude.ai/code/session_01NvTFNRSZpZMBiUXVjzn5FB