### PR TITLE
Add friend activity bridge and improve daily summary UX

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -267,16 +267,50 @@ export default function DailySummaryPage() {
         </div>
       </section>
 
+      <section className="card mt-5 px-5 py-4">
+        <h2 style={titleStyle}>Tomorrow</h2>
+        <p className="text-foreground mt-2 text-sm leading-6">
+          Five new at noon.
+        </p>
+      </section>
+
+      {summary.recentFriendBridge ? (
+        <section className="card mt-5 px-5 py-4">
+          <h2 style={titleStyle}>Meanwhile</h2>
+          <p className="text-foreground mt-2 text-sm leading-6">
+            {bridgeSentence(summary.recentFriendBridge)}
+          </p>
+          <Link className="btn-ghost mt-3" href="/#feed">
+            See what they&apos;re up to →
+          </Link>
+        </section>
+      ) : null}
+
       <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-        <Link className="btn-primary sm:flex-1" href="/knowledge">
-          See your knowledge map
-        </Link>
-        <Link className="btn-ghost sm:flex-1" href="/">
+        <Link className="btn-primary sm:flex-1" href="/">
           Back home
+        </Link>
+        <Link className="btn-ghost sm:flex-1" href="/knowledge">
+          See your knowledge map
         </Link>
       </div>
     </main>
   )
+}
+
+function bridgeSentence(bridge: NonNullable<DailySummaryView['recentFriendBridge']>): string {
+  const { friendName, cardType, domainDisplayName } = bridge
+  const domain = domainDisplayName?.trim() || 'something new'
+  switch (cardType) {
+    case 'friend_answered':
+      return `${friendName} answered ${domain}.`
+    case 'friend_liked':
+      return `${friendName} liked a question about ${domain}.`
+    case 'friend_added':
+      return `${friendName} just joined.`
+    default:
+      return `${friendName} is around today.`
+  }
 }
 
 function InterpretiveLine({ text }: { text: string }) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -40,7 +40,7 @@ export default async function Home() {
               <MissedQuestionsSection userId={session.userId} />
             </Suspense>
           ) : null}
-          <div>
+          <div id="feed">
             <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
               What&apos;s happening
             </p>

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link'
 import { CheckCircle2, Clock, MessageCircleQuestion, Settings } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export type SlotOutcome = 'correct' | 'incorrect' | 'skipped' | 'unanswered'
 
@@ -72,30 +72,12 @@ function normalizeSlotOutcomes(value: unknown): SlotOutcome[] {
   })
 }
 
-function formatCountdown(targetIso: string, nowMs: number): string {
-  const targetMs = Date.parse(targetIso)
-  if (!Number.isFinite(targetMs)) return 'any second now'
-
-  const remainingMs = targetMs - nowMs
-  if (remainingMs < 60_000) return 'any second now'
-
-  const totalMinutes = Math.ceil(remainingMs / 60_000)
-  if (totalMinutes > 60) {
-    const hours = Math.floor(totalMinutes / 60)
-    const minutes = totalMinutes % 60
-    return `${hours}h ${minutes}m`
-  }
-
-  return `${totalMinutes}m`
-}
-
 export default function TodaysFiveCard({
   initialStatus = null,
   initialPreferences = null,
 }: TodaysFiveCardProps = {}) {
   const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
   const [preferences, setPreferences] = useState<DailyPreferences | null>(initialPreferences)
-  const [nowMs, setNowMs] = useState(() => Date.now())
   const [resetting, setResetting] = useState(false)
   const [resetError, setResetError] = useState<string | null>(null)
   // Skip the initial /api/daily/* fetch when the server already provided both.
@@ -164,11 +146,6 @@ export default function TodaysFiveCard({
     }
   }, [])
 
-  useEffect(() => {
-    const timer = window.setInterval(() => setNowMs(Date.now()), 60_000)
-    return () => window.clearInterval(timer)
-  }, [])
-
   const effectiveStatus = status ?? FALLBACK_STATUS
   const answered = Math.max(0, Math.min(effectiveStatus.questionsAnswered, 5))
   const isComplete =
@@ -178,16 +155,15 @@ export default function TodaysFiveCard({
     ? '/daily/summary'
     : '/daily'
   const actionLabel = isComplete
-    ? 'See your recap'
+    ? "See today's recap →"
     : hasStartedRound
       ? 'Resume round'
       : 'Play now'
-  const subtext = useMemo(() => {
-    if (isComplete) {
-      return `Done for today. Next round in ${formatCountdown(effectiveStatus.nextRoundAt, nowMs)}.`
-    }
-    return answered > 0 ? `${answered} of 5 answered` : 'Ready when you are'
-  }, [answered, effectiveStatus.nextRoundAt, isComplete, nowMs])
+  const subtext = isComplete
+    ? 'Today done · Five new at noon tomorrow'
+    : answered > 0
+      ? `${answered} of 5 answered`
+      : 'Ready when you are'
 
   const resetForToday = async () => {
     if (resetting) return

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, lt, sql } from 'drizzle-orm';
 
+import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 import {
   dailyQueues,
   db,
@@ -11,8 +12,11 @@ import { resolveTier } from '@/server/mastery/tiers';
 import { getDeliveredCreatorNotesForQuestions, type DeliveredCreatorNote } from '@/server/creator-notes';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { getFeedPagePayload } from '@/server/feed/get-feed-page';
 import type { QueueSlot } from '@/server/daily/types';
 import type { MasteryTier } from '@/types/db';
+
+const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export type DailySummaryView = {
   date: string;
@@ -25,6 +29,13 @@ export type DailySummaryView = {
   domainGains: DomainGain[];
   newTerritory: string[];
   tierCrossings: TierCrossing[];
+  recentFriendBridge: RecentFriendBridge | null;
+};
+
+export type RecentFriendBridge = {
+  friendName: string;
+  cardType: string;
+  domainDisplayName: string | null;
 };
 
 export type QuestionRecap = {
@@ -219,6 +230,8 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const pointsEarned = [...pointsByDomain.values()].reduce((sum, points) => sum + points, 0);
   const gainedDomains = [...touchedDomains].filter((domain) => (pointsByDomain.get(domain) ?? 0) > 0);
 
+  const recentFriendBridge = await getRecentFriendBridge(userId);
+
   return {
     date: dateString,
     totalAnswered,
@@ -240,5 +253,25 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
       .sort((a, b) => b.pointsGained - a.pointsGained || a.displayName.localeCompare(b.displayName)),
     newTerritory,
     tierCrossings,
+    recentFriendBridge,
   };
+}
+
+async function getRecentFriendBridge(userId: string): Promise<RecentFriendBridge | null> {
+  const mostRecentReset = new Date(getNextDailyResetBoundary().getTime() - ONE_DAY_MS);
+  const page = await getFeedPagePayload(userId, { limit: 5, cursor: null, filter: 'all' });
+  for (const item of page.items) {
+    if (item.card_type === 'answered_by_you') continue;
+    const eventAtRaw = typeof item.source_event_at === 'string' ? item.source_event_at : null;
+    if (!eventAtRaw) continue;
+    const eventAt = new Date(eventAtRaw);
+    if (Number.isNaN(eventAt.getTime())) continue;
+    if (eventAt < mostRecentReset) continue;
+    return {
+      friendName: item.source_friend_display_name ?? 'A friend',
+      cardType: item.card_type,
+      domainDisplayName: item.domain_pill ?? null,
+    };
+  }
+  return null;
 }


### PR DESCRIPTION
## Summary
Enhances the daily summary page with a new "Meanwhile" section showing recent friend activity, adds a "Tomorrow" teaser section, and improves button labeling and countdown display logic.

## Key Changes

- **New friend activity bridge**: Added `getRecentFriendBridge()` query that fetches the most recent friend activity from the feed (answered, liked, or joined) since the last daily reset, displayed in a new "Meanwhile" section on the summary page
- **Tomorrow teaser section**: Added a new "Tomorrow" section on the daily summary page indicating "Five new at noon"
- **Improved button UX**: 
  - Swapped primary/ghost button order on summary page (home button now primary)
  - Updated "See your recap" label to "See today's recap →" with arrow indicator
- **Simplified countdown logic**: Removed real-time countdown timer and `formatCountdown()` function; replaced with static "Today done · Five new at noon tomorrow" message when daily is complete
- **Feed anchor**: Added `id="feed"` to the feed section on home page to support the "See what they're up to →" link from the summary page
- **Code cleanup**: Removed unused `useMemo` and `useEffect` hooks from `TodaysFiveCard` component

## Implementation Details

- The `getRecentFriendBridge()` function filters feed items to find the most recent activity after the last daily reset boundary, skipping self-authored items
- The `bridgeSentence()` helper generates contextual messages based on card type (friend_answered, friend_liked, friend_added)
- Removed the 60-second interval timer that was updating countdown display, simplifying state management

https://claude.ai/code/session_017mggwyB8knMWbYCnRVV9dz