### PR TITLE
Add round-open reminder opt-in UI and API

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,9 @@
       "Bash(Select-Object Name)",
       "Bash(mkdir -p C:/Users/rpala/Desktop/dev/joshing-11/audits)",
       "Bash(git push *)",
-      "Bash(npx eslint *)"
+      "Bash(npx eslint *)",
+      "Read(//root/.claude/plans/**)",
+      "Bash(mkdir -p /root/.claude/plans)"
     ]
   }
 }

--- a/drizzle/0037_round_reminder_optin.sql
+++ b/drizzle/0037_round_reminder_optin.sql
@@ -1,0 +1,21 @@
+-- Migration: opt-in plumbing for round-open reminders.
+-- Phase 1 stores user preferences and a dismissal timestamp; no message is
+-- sent yet. Phase 2 will add EmailVerificationToken + EmailLog tables and
+-- wire the cron to actually deliver.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded
+-- without the columns actually present.
+CREATE TYPE "public"."EmailOptIn" AS ENUM('opted_in', 'opted_out', 'not_asked');
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "email_opt_in" "public"."EmailOptIn" NOT NULL DEFAULT 'not_asked';
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "email_verified" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "reminder_prompt_dismissed_at" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "pending_email" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -260,6 +260,13 @@
       "when": 1779667200000,
       "tag": "0036_domain_exclusion_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 37,
+      "version": "7",
+      "when": 1779753600000,
+      "tag": "0037_round_reminder_optin",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/account/notifications/NotificationsForm.tsx
+++ b/src/app/account/notifications/NotificationsForm.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { ReminderState } from '@/server/db/queries/account';
+
+type Props = {
+  initialState: ReminderState;
+  maskedPhone: string;
+};
+
+async function patchReminders(body: Record<string, unknown>): Promise<{
+  ok: boolean;
+  state: ReminderState | null;
+  errorMessage: string | null;
+}> {
+  const response = await fetch('/api/account/reminders', {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json().catch(() => null)) as {
+    state?: ReminderState;
+    message?: string;
+  } | null;
+  if (!response.ok) {
+    return { ok: false, state: null, errorMessage: json?.message ?? 'Could not save.' };
+  }
+  return { ok: true, state: json?.state ?? null, errorMessage: null };
+}
+
+export function NotificationsForm({ initialState, maskedPhone }: Props) {
+  const [state, setState] = useState<ReminderState>(initialState);
+  const [savingSms, setSavingSms] = useState(false);
+  const [smsError, setSmsError] = useState<string | null>(null);
+  const [emailDraft, setEmailDraft] = useState(state.pendingEmail ?? '');
+  const [savingEmail, setSavingEmail] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [savingEmailToggle, setSavingEmailToggle] = useState(false);
+
+  const smsOn = state.smsOptIn === 'opted_in';
+  const emailOn = state.emailOptIn === 'opted_in';
+  const hasPendingEmail = Boolean(state.pendingEmail);
+  const hasVerifiedEmail = state.emailVerified && Boolean(state.email);
+
+  async function toggleSms() {
+    const next = smsOn ? 'opted_out' : 'opted_in';
+    setSavingSms(true);
+    setSmsError(null);
+    const result = await patchReminders({ smsOptIn: next });
+    setSavingSms(false);
+    if (!result.ok || !result.state) {
+      setSmsError(result.errorMessage ?? 'Could not save.');
+      return;
+    }
+    setState(result.state);
+  }
+
+  async function saveEmail() {
+    const trimmed = emailDraft.trim();
+    if (!trimmed) {
+      setEmailError('Please enter an email address.');
+      return;
+    }
+    setSavingEmail(true);
+    setEmailError(null);
+    const result = await patchReminders({ pendingEmail: trimmed });
+    setSavingEmail(false);
+    if (!result.ok || !result.state) {
+      setEmailError(result.errorMessage ?? 'Could not save.');
+      return;
+    }
+    setState(result.state);
+  }
+
+  async function toggleEmail() {
+    const next = emailOn ? 'opted_out' : 'opted_in';
+    setSavingEmailToggle(true);
+    setEmailError(null);
+    const result = await patchReminders({ emailOptIn: next });
+    setSavingEmailToggle(false);
+    if (!result.ok || !result.state) {
+      setEmailError(result.errorMessage ?? 'Could not save.');
+      return;
+    }
+    setState(result.state);
+  }
+
+  return (
+    <div className="mt-8 space-y-6">
+      <section className="rounded-xl border bg-card p-5 text-card-foreground">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-serif text-lg font-semibold">SMS reminders</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Text {maskedPhone} when a new round opens.
+            </p>
+          </div>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={smsOn}
+            disabled={savingSms}
+            onClick={() => void toggleSms()}
+            className={`relative inline-flex h-7 w-12 flex-none items-center rounded-full border transition ${
+              smsOn ? 'bg-emerald-500 border-emerald-500' : 'bg-muted border-border'
+            } ${savingSms ? 'opacity-60' : ''}`}
+          >
+            <span
+              className={`inline-block size-5 rounded-full bg-white shadow transition ${
+                smsOn ? 'translate-x-6' : 'translate-x-1'
+              }`}
+            />
+          </button>
+        </div>
+        {smsOn ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Saved. Texts will start when reminders launch.
+          </p>
+        ) : null}
+        {smsError ? (
+          <p className="mt-2 text-xs text-rose-700">{smsError}</p>
+        ) : null}
+      </section>
+
+      <section className="rounded-xl border bg-card p-5 text-card-foreground">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex min-w-0 flex-1 flex-col">
+            <h2 className="font-serif text-lg font-semibold">Email reminders</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {hasVerifiedEmail
+                ? `Email ${state.email} when a new round opens.`
+                : 'Add an email address to enable email reminders.'}
+            </p>
+          </div>
+          {hasVerifiedEmail ? (
+            <button
+              type="button"
+              role="switch"
+              aria-checked={emailOn}
+              disabled={savingEmailToggle}
+              onClick={() => void toggleEmail()}
+              className={`relative inline-flex h-7 w-12 flex-none items-center rounded-full border transition ${
+                emailOn ? 'bg-emerald-500 border-emerald-500' : 'bg-muted border-border'
+              } ${savingEmailToggle ? 'opacity-60' : ''}`}
+            >
+              <span
+                className={`inline-block size-5 rounded-full bg-white shadow transition ${
+                  emailOn ? 'translate-x-6' : 'translate-x-1'
+                }`}
+              />
+            </button>
+          ) : null}
+        </div>
+
+        {!hasVerifiedEmail ? (
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <input
+              type="email"
+              inputMode="email"
+              autoComplete="email"
+              placeholder="you@example.com"
+              value={emailDraft}
+              disabled={savingEmail}
+              onChange={(event) => {
+                setEmailDraft(event.target.value);
+                setEmailError(null);
+              }}
+              className="bg-background flex-1 rounded-lg border px-3 py-2 text-sm"
+            />
+            <button
+              type="button"
+              className="btn-primary text-sm"
+              onClick={() => void saveEmail()}
+              disabled={savingEmail}
+            >
+              {savingEmail ? 'Saving…' : hasPendingEmail ? 'Update' : 'Save'}
+            </button>
+          </div>
+        ) : null}
+
+        {hasPendingEmail && !hasVerifiedEmail ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Awaiting verification (coming soon). We saved {state.pendingEmail} and
+            will email a confirmation link once email reminders launch.
+          </p>
+        ) : null}
+        {hasVerifiedEmail && emailOn ? (
+          <p className="mt-3 text-xs text-muted-foreground">
+            Saved. Emails will start when reminders launch.
+          </p>
+        ) : null}
+        {emailError ? (
+          <p className="mt-2 text-xs text-rose-700">{emailError}</p>
+        ) : null}
+      </section>
+
+      <p className="text-xs text-muted-foreground">
+        Reminders aren&apos;t sending yet — we&apos;re collecting preferences while
+        we finish setting up message delivery.
+      </p>
+    </div>
+  );
+}

--- a/src/app/account/notifications/page.tsx
+++ b/src/app/account/notifications/page.tsx
@@ -1,10 +1,54 @@
-import { StubPage } from '@/components/account/StubPage';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { ChevronLeft } from 'lucide-react';
 
-export default function NotificationsSettingsPage() {
+import { getSession } from '@/server/auth/session';
+import { getReminderState } from '@/server/db/queries/account';
+import { NotificationsForm } from './NotificationsForm';
+
+export const dynamic = 'force-dynamic';
+
+function maskPhone(value: string): string {
+  const digits = value.replace(/\D/g, '');
+  if (digits.length < 4) return value;
+  const last = digits.slice(-4);
+  if (digits.length === 11 && digits.startsWith('1')) {
+    return `(•••) •••-${last}`;
+  }
+  if (digits.length === 10) {
+    return `(•••) •••-${last}`;
+  }
+  return `••• ${last}`;
+}
+
+export default async function NotificationsSettingsPage() {
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const state = await getReminderState(session.userId);
+  if (!state) redirect('/login');
+
   return (
-    <StubPage
-      title="SMS & notifications"
-      description="Manage how you get updates."
-    />
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-28">
+      <Link
+        href="/account"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Back
+      </Link>
+      <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
+        SMS &amp; notifications
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        We&apos;ll only message you when a new round opens. One per day, max. You can
+        turn it off here any time.
+      </p>
+
+      <NotificationsForm
+        initialState={state}
+        maskedPhone={maskPhone(state.phoneNumber)}
+      />
+    </main>
   );
 }

--- a/src/app/api/account/reminders/route.ts
+++ b/src/app/api/account/reminders/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  getReminderState,
+  updateReminderPreferences,
+} from '@/server/db/queries/account';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z
+  .object({
+    smsOptIn: z.enum(['opted_in', 'opted_out']).optional(),
+    emailOptIn: z.enum(['opted_in', 'opted_out']).optional(),
+    pendingEmail: z.string().trim().email().optional(),
+    dismissed: z.literal(true).optional(),
+  })
+  .refine(
+    (b) =>
+      b.smsOptIn !== undefined ||
+      b.emailOptIn !== undefined ||
+      b.pendingEmail !== undefined ||
+      b.dismissed === true,
+    'must specify at least one change',
+  );
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const state = await getReminderState(session.userId);
+  if (!state) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  return NextResponse.json({ state });
+}
+
+export async function PATCH(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const json = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'No reminder changes provided.' },
+      { status: 400 },
+    );
+  }
+
+  const result = await updateReminderPreferences(session.userId, parsed.data);
+  if (!result.ok) {
+    if (result.reason === 'not_found') {
+      return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+    }
+    if (result.reason === 'email_not_verified') {
+      return NextResponse.json(
+        {
+          error: 'email_not_verified',
+          message: 'Verify your email before enabling email reminders.',
+        },
+        { status: 409 },
+      );
+    }
+    if (result.reason === 'phone_not_verified') {
+      return NextResponse.json(
+        {
+          error: 'phone_not_verified',
+          message: 'Verify your phone number before enabling SMS reminders.',
+        },
+        { status: 409 },
+      );
+    }
+  }
+
+  return NextResponse.json({ state: result.ok ? result.state : null });
+}

--- a/src/app/daily/summary/RoundReminderCard.tsx
+++ b/src/app/daily/summary/RoundReminderCard.tsx
@@ -1,0 +1,182 @@
+'use client'
+
+import Link from 'next/link'
+import { type CSSProperties, useState } from 'react'
+
+type CardState =
+  | { kind: 'idle' }
+  | { kind: 'sms-saving' }
+  | { kind: 'sms-confirmed' }
+  | { kind: 'email-form'; value: string; error: string | null; saving: boolean }
+  | { kind: 'email-saved'; email: string }
+  | { kind: 'dismissing' }
+  | { kind: 'hidden' }
+
+const titleStyle: CSSProperties = {
+  fontFamily: 'var(--font-neutral), system-ui, sans-serif',
+  fontSize: '1.05rem',
+  fontWeight: 600,
+  color: '#111111',
+  textTransform: 'uppercase',
+  letterSpacing: '0.05em',
+}
+
+async function patchReminders(body: Record<string, unknown>): Promise<boolean> {
+  const response = await fetch('/api/account/reminders', {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+  return response.ok
+}
+
+export function RoundReminderCard() {
+  const [state, setState] = useState<CardState>({ kind: 'idle' })
+
+  if (state.kind === 'hidden') return null
+
+  if (state.kind === 'sms-confirmed') {
+    return (
+      <section className="card mt-5 px-5 py-4">
+        <h2 style={titleStyle}>Reminders</h2>
+        <p className="text-foreground mt-2 text-sm leading-6">
+          We&apos;ve saved your preference. Texts will start when reminders launch.
+        </p>
+        <p className="text-muted-foreground mt-2 text-xs">
+          <Link href="/account/notifications" className="underline underline-offset-2">
+            Manage in settings
+          </Link>
+        </p>
+      </section>
+    )
+  }
+
+  if (state.kind === 'email-saved') {
+    return (
+      <section className="card mt-5 px-5 py-4">
+        <h2 style={titleStyle}>Reminders</h2>
+        <p className="text-foreground mt-2 text-sm leading-6">
+          Got it — we&apos;ll verify {state.email} and email you once reminders launch.
+        </p>
+        <p className="text-muted-foreground mt-2 text-xs">
+          <Link href="/account/notifications" className="underline underline-offset-2">
+            Manage in settings
+          </Link>
+        </p>
+      </section>
+    )
+  }
+
+  if (state.kind === 'email-form') {
+    return (
+      <section className="card mt-5 px-5 py-4">
+        <h2 style={titleStyle}>Email me when the next round opens</h2>
+        <form
+          className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start"
+          onSubmit={async (event) => {
+            event.preventDefault()
+            const trimmed = state.value.trim()
+            if (!trimmed) {
+              setState({ ...state, error: 'Please enter an email address.' })
+              return
+            }
+            setState({ ...state, saving: true, error: null })
+            const ok = await patchReminders({ pendingEmail: trimmed })
+            if (!ok) {
+              setState({ ...state, saving: false, error: 'Could not save. Try again.' })
+              return
+            }
+            setState({ kind: 'email-saved', email: trimmed })
+          }}
+        >
+          <input
+            type="email"
+            inputMode="email"
+            autoComplete="email"
+            required
+            placeholder="you@example.com"
+            value={state.value}
+            disabled={state.saving}
+            onChange={(event) =>
+              setState({ ...state, value: event.target.value, error: null })
+            }
+            className="bg-background flex-1 rounded-lg border px-3 py-2 text-sm"
+          />
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              className="btn-primary text-sm"
+              disabled={state.saving}
+            >
+              {state.saving ? 'Saving…' : 'Save'}
+            </button>
+            <button
+              type="button"
+              className="btn-ghost text-sm"
+              disabled={state.saving}
+              onClick={() => setState({ kind: 'idle' })}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+        {state.error ? (
+          <p className="mt-2 text-xs text-rose-700">{state.error}</p>
+        ) : null}
+        <p className="text-muted-foreground mt-3 text-xs leading-5">
+          We&apos;ll send a confirmation email once email reminders launch.
+        </p>
+      </section>
+    )
+  }
+
+  const sendingSms = state.kind === 'sms-saving'
+  const dismissing = state.kind === 'dismissing'
+  const busy = sendingSms || dismissing
+
+  return (
+    <section className="card mt-5 px-5 py-4">
+      <h2 style={titleStyle}>Want a reminder when tomorrow&apos;s round opens?</h2>
+      <p className="text-foreground mt-2 text-sm leading-6">
+        One message a day, max. You can turn it off any time.
+      </p>
+      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
+        <button
+          type="button"
+          className="btn-primary text-sm sm:flex-1"
+          disabled={busy}
+          onClick={async () => {
+            setState({ kind: 'sms-saving' })
+            const ok = await patchReminders({ smsOptIn: 'opted_in' })
+            setState(ok ? { kind: 'sms-confirmed' } : { kind: 'idle' })
+          }}
+        >
+          {sendingSms ? 'Saving…' : 'Yes, text me'}
+        </button>
+        <button
+          type="button"
+          className="btn-ghost text-sm sm:flex-1"
+          disabled={busy}
+          onClick={() =>
+            setState({ kind: 'email-form', value: '', error: null, saving: false })
+          }
+        >
+          Use email instead
+        </button>
+        <button
+          type="button"
+          className="btn-ghost text-sm sm:flex-1"
+          disabled={busy}
+          onClick={async () => {
+            setState({ kind: 'dismissing' })
+            const ok = await patchReminders({ dismissed: true })
+            setState(ok ? { kind: 'hidden' } : { kind: 'idle' })
+          }}
+        >
+          {dismissing ? 'Saving…' : 'No thanks'}
+        </button>
+      </div>
+    </section>
+  )
+}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -21,6 +21,7 @@ import type {
   DailySummaryView,
   QuestionRecap,
 } from '@/server/db/queries/daily-summary'
+import { RoundReminderCard } from './RoundReminderCard'
 
 type FeedbackSignal = 'thumbs_up' | 'thumbs_down'
 
@@ -266,6 +267,8 @@ export default function DailySummaryPage() {
           ))}
         </div>
       </section>
+
+      {summary.reminderPromptState === 'show' ? <RoundReminderCard /> : null}
 
       <section className="card mt-5 px-5 py-4">
         <h2 style={titleStyle}>Tomorrow</h2>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -295,6 +295,45 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0037 adds the EmailOptIn enum and four columns on User for the
+    // round-open reminder opt-in (email_opt_in, email_verified, pending_email,
+    // reminder_prompt_dismissed_at). If a preview/production database has this
+    // migration recorded without the pieces present, the daily summary query
+    // and PATCH /api/account/reminders fail before migrate() can repair them.
+    try {
+      await db.execute(sql`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM pg_type t
+            JOIN pg_namespace n ON n.oid = t.typnamespace
+            WHERE t.typname = 'EmailOptIn' AND n.nspname = 'public'
+          ) THEN
+            CREATE TYPE "public"."EmailOptIn" AS ENUM('opted_in', 'opted_out', 'not_asked');
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "email_opt_in" "public"."EmailOptIn" NOT NULL DEFAULT 'not_asked'
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "email_verified" boolean NOT NULL DEFAULT false
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "pending_email" text
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "reminder_prompt_dismissed_at" timestamptz
+      `);
+    } catch {
+      // User table may not exist yet on a fresh database — migrate() creates
+      // it before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -82,6 +82,92 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
   };
 }
 
+export type ReminderOptInState = 'opted_in' | 'opted_out' | 'not_asked';
+
+export type ReminderState = {
+  smsOptIn: ReminderOptInState;
+  emailOptIn: ReminderOptInState;
+  emailVerified: boolean;
+  email: string | null;
+  pendingEmail: string | null;
+  phoneNumber: string;
+  reminderPromptDismissedAt: string | null;
+};
+
+export async function getReminderState(userId: string): Promise<ReminderState | null> {
+  const [row] = await db
+    .select({
+      smsOptIn: users.smsOptIn,
+      emailOptIn: users.emailOptIn,
+      emailVerified: users.emailVerified,
+      email: users.email,
+      pendingEmail: users.pendingEmail,
+      phoneNumber: users.phoneNumber,
+      reminderPromptDismissedAt: users.reminderPromptDismissedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) return null;
+
+  return {
+    smsOptIn: row.smsOptIn,
+    emailOptIn: row.emailOptIn,
+    emailVerified: row.emailVerified,
+    email: row.email,
+    pendingEmail: row.pendingEmail,
+    phoneNumber: row.phoneNumber,
+    reminderPromptDismissedAt: row.reminderPromptDismissedAt?.toISOString() ?? null,
+  };
+}
+
+export type ReminderPreferenceUpdate = {
+  smsOptIn?: 'opted_in' | 'opted_out';
+  emailOptIn?: 'opted_in' | 'opted_out';
+  pendingEmail?: string;
+  dismissed?: true;
+};
+
+export type ReminderPreferenceResult =
+  | { ok: true; state: ReminderState }
+  | { ok: false; reason: 'not_found' | 'email_not_verified' | 'phone_not_verified' };
+
+export async function updateReminderPreferences(
+  userId: string,
+  patch: ReminderPreferenceUpdate,
+): Promise<ReminderPreferenceResult> {
+  const [current] = await db
+    .select({
+      phoneVerified: users.phoneVerified,
+      emailVerified: users.emailVerified,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!current) return { ok: false, reason: 'not_found' };
+
+  if (patch.smsOptIn === 'opted_in' && !current.phoneVerified) {
+    return { ok: false, reason: 'phone_not_verified' };
+  }
+  if (patch.emailOptIn === 'opted_in' && !current.emailVerified) {
+    return { ok: false, reason: 'email_not_verified' };
+  }
+
+  const set: Record<string, unknown> = { updatedAt: new Date() };
+  if (patch.smsOptIn !== undefined) set.smsOptIn = patch.smsOptIn;
+  if (patch.emailOptIn !== undefined) set.emailOptIn = patch.emailOptIn;
+  if (patch.pendingEmail !== undefined) set.pendingEmail = patch.pendingEmail;
+  if (patch.dismissed === true) set.reminderPromptDismissedAt = new Date();
+
+  await db.update(users).set(set).where(eq(users.id, userId));
+
+  const state = await getReminderState(userId);
+  if (!state) return { ok: false, reason: 'not_found' };
+  return { ok: true, state };
+}
+
 export async function updateDisplayName(params: {
   userId: string;
   displayName: string;

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, lt, sql } from 'drizzle-orm';
+import { and, eq, inArray, lt, ne, sql } from 'drizzle-orm';
 
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 import {
@@ -7,6 +7,7 @@ import {
   generatedQuestions,
   masteryEvents,
   playerMastery,
+  users,
 } from '@/server/db';
 import { resolveTier } from '@/server/mastery/tiers';
 import { getDeliveredCreatorNotesForQuestions, type DeliveredCreatorNote } from '@/server/creator-notes';
@@ -30,6 +31,8 @@ export type DailySummaryView = {
   newTerritory: string[];
   tierCrossings: TierCrossing[];
   recentFriendBridge: RecentFriendBridge | null;
+  isFirstCompletedRound: boolean;
+  reminderPromptState: 'show' | 'hidden';
 };
 
 export type RecentFriendBridge = {
@@ -231,6 +234,8 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const gainedDomains = [...touchedDomains].filter((domain) => (pointsByDomain.get(domain) ?? 0) > 0);
 
   const recentFriendBridge = await getRecentFriendBridge(userId);
+  const { isFirstCompletedRound, reminderPromptState } =
+    await computeReminderPromptState(userId, dateString, totalAnswered);
 
   return {
     date: dateString,
@@ -254,6 +259,64 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     newTerritory,
     tierCrossings,
     recentFriendBridge,
+    isFirstCompletedRound,
+    reminderPromptState,
+  };
+}
+
+async function computeReminderPromptState(
+  userId: string,
+  todayString: string,
+  todayAnswered: number,
+): Promise<{ isFirstCompletedRound: boolean; reminderPromptState: 'show' | 'hidden' }> {
+  // Today must have at least one answered slot to count as "completed".
+  if (todayAnswered <= 0) {
+    return { isFirstCompletedRound: false, reminderPromptState: 'hidden' };
+  }
+
+  // Did the user complete any earlier daily queue? A queue counts as completed
+  // when any of its slots has answered=true. We only need to know whether such
+  // a row exists for any prior date, not how many.
+  const [prior] = await db
+    .select({ id: dailyQueues.id })
+    .from(dailyQueues)
+    .where(and(
+      eq(dailyQueues.userId, userId),
+      ne(dailyQueues.queueDate, todayString),
+      sql`EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${dailyQueues.slots}) slot
+        WHERE (slot->>'answered')::boolean IS TRUE
+      )`,
+    ))
+    .limit(1);
+
+  const isFirstCompletedRound = !prior;
+  if (!isFirstCompletedRound) {
+    return { isFirstCompletedRound: false, reminderPromptState: 'hidden' };
+  }
+
+  const [user] = await db
+    .select({
+      smsOptIn: users.smsOptIn,
+      emailOptIn: users.emailOptIn,
+      reminderPromptDismissedAt: users.reminderPromptDismissedAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user) {
+    return { isFirstCompletedRound: true, reminderPromptState: 'hidden' };
+  }
+
+  const show =
+    user.smsOptIn === 'not_asked' &&
+    user.emailOptIn === 'not_asked' &&
+    user.reminderPromptDismissedAt === null;
+
+  return {
+    isFirstCompletedRound: true,
+    reminderPromptState: show ? 'show' : 'hidden',
   };
 }
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -116,6 +116,7 @@ export const answerStateEnum = pgEnum('AnswerState', [
   'incorrect',
 ]);
 export const smsOptInEnum = pgEnum('SmsOptIn', ['opted_in', 'opted_out', 'not_asked']);
+export const emailOptInEnum = pgEnum('EmailOptIn', ['opted_in', 'opted_out', 'not_asked']);
 export const themePreferenceEnum = pgEnum('ThemePreference', [
   'quiet_atelier',
   'sunday_margins',
@@ -155,6 +156,10 @@ export const users = pgTable(
     subscriptionPlan: subscriptionPlanEnum('subscription_plan').notNull().default('free'),
     smsOptIn: smsOptInEnum('sms_opt_in').notNull().default('not_asked'),
     smsReminderTime: integer('sms_reminder_time'),
+    emailOptIn: emailOptInEnum('email_opt_in').notNull().default('not_asked'),
+    emailVerified: boolean('email_verified').notNull().default(false),
+    pendingEmail: text('pending_email'),
+    reminderPromptDismissedAt: timestamp('reminder_prompt_dismissed_at', { withTimezone: true }),
     portraitVisibility: portraitVisibilityEnum('portrait_visibility').notNull().default('public'),
     knowledgeCardShareToken: text('knowledge_card_share_token'),
     knowledgeCardShareExpiresAt: timestamp('knowledge_card_share_expires_at', { withTimezone: true }),


### PR DESCRIPTION
## Summary
Implements the preference collection phase for round-open reminders. Users can now opt into SMS or email notifications when a new round opens, with preferences stored in the database. No messages are sent yet — this is phase 1 of the feature, collecting user preferences and dismissal state.

## Key Changes

- **Database schema & migration (0037):** Added `EmailOptIn` enum and four new columns to `User` table:
  - `email_opt_in` (opted_in/opted_out/not_asked)
  - `email_verified` (boolean)
  - `pending_email` (text, for unverified email addresses)
  - `reminder_prompt_dismissed_at` (timestamp for dismissal tracking)
  - Pre-applied idempotent guards in `src/instrumentation.ts` for preview/production databases

- **API endpoint (`PATCH /api/account/reminders`):** New route handler that:
  - Validates reminder preference updates with Zod
  - Enforces phone/email verification before opt-in
  - Returns updated `ReminderState` on success
  - Handles GET to retrieve current state

- **Query helpers (`src/server/db/queries/account.ts`):**
  - `getReminderState()` — fetches user's reminder preferences
  - `updateReminderPreferences()` — updates preferences with verification checks
  - Type exports: `ReminderState`, `ReminderOptInState`, `ReminderPreferenceUpdate`

- **Settings page (`/account/notifications`):** 
  - Replaced stub with full `NotificationsForm` component
  - Displays SMS toggle with masked phone number
  - Email section with input for unverified addresses or toggle for verified
  - Shows pending verification status and confirmation messages
  - Phone number masking utility function

- **Daily summary integration:**
  - `RoundReminderCard` component shown on first completed round
  - Stateful card with SMS quick-opt, email form, or dismiss options
  - Computed `reminderPromptState` in `getDailySummary()` to determine visibility
  - Only shows if user hasn't opted in/out and hasn't dismissed

- **Client-side components:**
  - `NotificationsForm` — full settings page form with error handling
  - `RoundReminderCard` — inline card on daily summary with state machine (idle → sms-saving → sms-confirmed, etc.)
  - Both handle API calls with loading states and error messages

## Implementation Details

- Reminder prompt only appears on first completed round (when `answered > 0` for the first time)
- Prompt is hidden if user has already made a choice or explicitly dismissed it
- Email opt-in requires verified email; SMS opt-in requires verified phone
- Pending email addresses are stored but reminders won't send until verification (phase 2)
- All API inputs validated with Zod; no exceptions
- Uses existing session auth pattern for user identification

https://claude.ai/code/session_01GYh8szZEeAkCdzwq9ECWYa