### PR TITLE
push profile sub-page back link below the sticky nav

### DIFF
--- a/src/app/account/notifications/page.tsx
+++ b/src/app/account/notifications/page.tsx
@@ -29,7 +29,7 @@ export default async function NotificationsSettingsPage() {
   if (!state) redirect('/login');
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-28">
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
       <Link
         href="/account"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"

--- a/src/components/account/StubPage.tsx
+++ b/src/components/account/StubPage.tsx
@@ -3,7 +3,7 @@ import { ChevronLeft } from 'lucide-react';
 
 export function StubPage({ title, description }: { title: string; description: string }) {
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-28">
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
       <Link
         href="/account"
         className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"


### PR DESCRIPTION
The "Back" link at the top of each /account sub-page was rendering
crammed against (and partly behind) the sticky nav, so it read as
hidden until the page was pulled down. Increase the top padding on
<main> from py-6 to pt-10 so the back link sits clearly below the
nav. Fix lives in StubPage (covers 7 pages) and in the notifications
page (which inlines the back link instead of using StubPage).