### PR TITLE
catch-up: include wrong/skipped answers from today + the feed

### DIFF
--- a/drizzle/0038_feed_item_catchup_resolved.sql
+++ b/drizzle/0038_feed_item_catchup_resolved.sql
@@ -1,0 +1,11 @@
+-- Track when a wrong feed answer was recovered through the catch-up flow.
+-- Catch-up surfaces feed items where state = 'answered' AND answerResult =
+-- 'incorrect' AND catchupResolvedAt IS NULL. Setting this timestamp removes
+-- the feed item from catch-up without altering the feed history (so the
+-- recipient still sees "you answered this wrong" on the feed card itself).
+--
+-- Idempotent guard is pre-applied in src/instrumentation.ts for preview/
+-- production databases that may have this migration recorded without the
+-- column actually present.
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "catchupResolvedAt" timestamptz;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1779753600000,
       "tag": "0037_round_reminder_optin",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0038_feed_item_catchup_resolved",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -36,8 +36,10 @@ const {
 
 const CATCHUP_ITEM = {
   dailyQueueItemId: 'queue-1:0',
+  surface: 'daily' as const,
   queueId: 'queue-1',
   slotIndex: 0,
+  feedItemId: null,
   questionId: 'gen-q-1',
   questionText: 'q?',
   correctAnswer: 'A',
@@ -107,6 +109,16 @@ vi.mock('@/server/auth/session', () => ({
 vi.mock('@/server/db', () => ({
   db: dbMock,
   dailyQueues: { id: 'q.id' },
+  feedItems: {
+    id: 'f.id',
+    recipientUserId: 'f.recipient',
+    questionId: 'f.questionId',
+    catchupResolvedAt: 'f.catchupResolvedAt',
+    answerResult: 'f.answerResult',
+    submittedAnswer: 'f.submittedAnswer',
+    state: 'f.state',
+    sourceEventAt: 'f.sourceEventAt',
+  },
   questions: {
     id: 'q.id',
     creatorId: 'q.creatorId',
@@ -126,6 +138,11 @@ vi.mock('@/server/daily/catchup', () => ({
     slots.find((s) => s.slot_index === idx),
   replaceQueueSlot: (slots: { slot_index: number }[], idx: number, fn: (s: unknown) => unknown) =>
     slots.map((s) => (s.slot_index === idx ? fn(s) : s)),
+  parseCatchupItemId: (id: string) => {
+    if (id.startsWith('feed:')) return { surface: 'feed', feedItemId: id.slice(5) }
+    const [queueId, slotIndexValue] = id.split(':')
+    return { surface: 'daily', queueId, slotIndex: Number(slotIndexValue) }
+  },
 }))
 
 vi.mock('@/server/mastery/write-mastery-event', () => ({

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -4,9 +4,14 @@ import { NextRequest } from 'next/server';
 import { gradeAnswer, selectQuip } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
 import { getSession } from '@/server/auth/session';
-import { dailyQueues, db, questions } from '@/server/db';
-import { getCatchupQuestions } from '@/server/db/queries/daily';
-import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
+import { dailyQueues, db, feedItems, questions } from '@/server/db';
+import { getCatchupQuestions, type CatchupQuestion } from '@/server/db/queries/daily';
+import {
+  asQueueSlots,
+  findQueueSlotBySlotIndex,
+  parseCatchupItemId,
+  replaceQueueSlot,
+} from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { awardAuthorCredit } from '@/server/mastery/author-credit';
@@ -32,6 +37,26 @@ function parseBody(value: unknown): { dailyQueueItemId: string; submittedAnswer:
   return { dailyQueueItemId, submittedAnswer };
 }
 
+function nextItemPayload(item: CatchupQuestion | null) {
+  if (!item) return null;
+  return {
+    dailyQueueItemId: item.dailyQueueItemId,
+    questionId: item.questionId,
+    questionText: item.questionText,
+    correctAnswer: item.correctAnswer,
+    alternateAnswers: item.alternateAnswers,
+    explanation: item.explanation,
+    domain: item.domain,
+    domainDisplayName: item.domainDisplayName,
+    queueDate: item.queueDate,
+    queueAge: item.queueAge,
+    wasSkipped: item.wasSkipped,
+    expiresAt: item.expiresAt,
+    expiresSoon: item.expiresSoon,
+    difficultyEstimate: item.difficultyEstimate,
+  };
+}
+
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return catchUpErrorResponse(401, 'unauthorized');
@@ -49,12 +74,40 @@ export async function POST(request: NextRequest) {
     });
   }
 
+  if (catchupItem.surface === 'feed') {
+    return handleFeedCatchupAnswer({
+      userId: session.userId,
+      submittedAnswer: parsed.submittedAnswer,
+      catchupItem,
+    });
+  }
+
+  return handleDailyCatchupAnswer({
+    userId: session.userId,
+    submittedAnswer: parsed.submittedAnswer,
+    catchupItem,
+  });
+}
+
+async function handleDailyCatchupAnswer({
+  userId,
+  submittedAnswer,
+  catchupItem,
+}: {
+  userId: string;
+  submittedAnswer: string;
+  catchupItem: CatchupQuestion;
+}) {
+  if (catchupItem.queueId === null || catchupItem.slotIndex === null) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Daily catch-up item missing queue reference');
+  }
+
   const [queue] = await db
     .select()
     .from(dailyQueues)
     .where(eq(dailyQueues.id, catchupItem.queueId))
     .limit(1);
-  if (!queue || queue.userId !== session.userId) {
+  if (!queue || queue.userId !== userId) {
     return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found', {
       refresh_required: true,
     });
@@ -62,14 +115,21 @@ export async function POST(request: NextRequest) {
 
   const slots = asQueueSlots(queue.slots);
   const slot = findQueueSlotBySlotIndex(slots, catchupItem.slotIndex);
-  if (!slot || slot.answered || slot.dismissed_at) {
+  if (!slot || slot.dismissed_at) {
+    return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
+      refresh_required: true,
+    });
+  }
+  // A slot previously answered correctly is not eligible — only wrong/skipped/
+  // untouched slots show up in catch-up after the expanded eligibility rules.
+  if (slot.answered && slot.answer_state !== 'incorrect') {
     return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
       refresh_required: true,
     });
   }
 
   const grade = await gradeAnswer(
-    parsed.submittedAnswer,
+    submittedAnswer,
     catchupItem.correctAnswer,
     catchupItem.alternateAnswers,
     catchupItem.questionText,
@@ -115,7 +175,7 @@ export async function POST(request: NextRequest) {
   }
 
   const priorAnswers = canonicalQuestionId
-    ? await readPriorAnswersForQuestion(session.userId, canonicalQuestionId)
+    ? await readPriorAnswersForQuestion(userId, canonicalQuestionId)
     : [];
   const masteryAnswerState = computeAnswerState(
     isCorrect ? 'correct' : 'wrong',
@@ -138,7 +198,7 @@ export async function POST(request: NextRequest) {
       ...item,
       answered: true,
       answer_state: answerState,
-      submitted_answer: parsed.submittedAnswer,
+      submitted_answer: submittedAnswer,
       awarded_points: pointsAwarded,
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
@@ -148,13 +208,13 @@ export async function POST(request: NextRequest) {
   });
 
   const masteryDelta = await writeMasteryEvent({
-    userId: session.userId,
+    userId,
     questionId: catchupItem.questionId,
     domain: catchupItem.domain,
     answerState: masteryAnswerState,
     pointsAwarded,
     sourceType: 'catchup',
-    sourceId: parsed.dailyQueueItemId,
+    sourceId: catchupItem.dailyQueueItemId,
     broadCategory: catchupItem.broadCategory,
     eventQuestionId: canonicalQuestionId,
     basePoints: catchupItem.basePoints,
@@ -164,10 +224,10 @@ export async function POST(request: NextRequest) {
   await db
     .update(dailyQueues)
     .set({ slots: nextSlots })
-    .where(eq(dailyQueues.id, catchupItem.queueId));
+    .where(eq(dailyQueues.id, queue.id));
 
   await updateDomainDifficultyOnAnswer(
-    session.userId,
+    userId,
     catchupItem.domain,
     isCorrect,
   ).catch((err) => {
@@ -176,30 +236,30 @@ export async function POST(request: NextRequest) {
 
   if (canonicalQuestionId) {
     try {
-      if (isCorrect && persistedCreatorId && persistedCreatorId !== session.userId && persistedDomainForCreator) {
+      if (isCorrect && persistedCreatorId && persistedCreatorId !== userId && persistedDomainForCreator) {
         void promoteDeclaredToDemonstrated({
           userId: persistedCreatorId,
           domain: persistedDomainForCreator,
-          triggeringFriendId: session.userId,
+          triggeringFriendId: userId,
           questionId: canonicalQuestionId,
         });
 
         // Author credit (PRD §8.32): off the user's hot path.
         void awardAuthorCredit({
           creatorUserId: persistedCreatorId,
-          answererUserId: session.userId,
+          answererUserId: userId,
           questionId: canonicalQuestionId,
           domain: persistedDomainForCreator,
-          sourceId: `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
+          sourceId: `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
           scope: 'daily/catchup/answer',
         });
       }
 
       void createFeedItemsForFriendsFromAnswer(
-        session.userId,
+        userId,
         canonicalQuestionId,
         isCorrect ? 'correct' : 'incorrect',
-        `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
+        `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
       );
     } catch (error) {
       console.warn('[daily/catchup/answer] feed propagation failed', {
@@ -210,7 +270,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const nextItem = (await getCatchupQuestions(session.userId))[0] ?? null;
+  const nextItem = (await getCatchupQuestions(userId))[0] ?? null;
 
   return Response.json({
     dailyQueueItemId: catchupItem.dailyQueueItemId,
@@ -230,23 +290,150 @@ export async function POST(request: NextRequest) {
     explainer: catchupItem.explanation,
     consolation: grade.consolation,
     quip,
-    nextItem: nextItem
-      ? {
-          dailyQueueItemId: nextItem.dailyQueueItemId,
-          questionId: nextItem.questionId,
-          questionText: nextItem.questionText,
-          correctAnswer: nextItem.correctAnswer,
-          alternateAnswers: nextItem.alternateAnswers,
-          explanation: nextItem.explanation,
-          domain: nextItem.domain,
-          domainDisplayName: nextItem.domainDisplayName,
-          queueDate: nextItem.queueDate,
-          queueAge: nextItem.queueAge,
-          wasSkipped: nextItem.wasSkipped,
-          expiresAt: nextItem.expiresAt,
-          expiresSoon: nextItem.expiresSoon,
-          difficultyEstimate: nextItem.difficultyEstimate,
-        }
-      : null,
+    nextItem: nextItemPayload(nextItem),
+  });
+}
+
+async function handleFeedCatchupAnswer({
+  userId,
+  submittedAnswer,
+  catchupItem,
+}: {
+  userId: string;
+  submittedAnswer: string;
+  catchupItem: CatchupQuestion;
+}) {
+  if (!catchupItem.feedItemId) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
+  }
+  const parsedId = parseCatchupItemId(catchupItem.dailyQueueItemId);
+  if (parsedId?.surface !== 'feed') {
+    return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item id malformed');
+  }
+
+  // Re-verify the feed item still exists and is still eligible. We pulled it
+  // via getCatchupQuestions, but a concurrent feed answer/dismiss could have
+  // resolved it between the read and now.
+  const [feedRow] = await db
+    .select({ feedItem: feedItems, question: questions })
+    .from(feedItems)
+    .innerJoin(questions, eq(feedItems.questionId, questions.id))
+    .where(eq(feedItems.id, catchupItem.feedItemId))
+    .limit(1);
+  if (!feedRow || feedRow.feedItem.recipientUserId !== userId) {
+    return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found', {
+      refresh_required: true,
+    });
+  }
+  if (feedRow.feedItem.catchupResolvedAt) {
+    return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
+      refresh_required: true,
+    });
+  }
+
+  const grade = await gradeAnswer(
+    submittedAnswer,
+    catchupItem.correctAnswer,
+    catchupItem.alternateAnswers,
+    catchupItem.questionText,
+    feedRow.question.questionType,
+  );
+  const isCorrect = grade.result === 'correct';
+  const answerState = isCorrect ? 'correct' : 'incorrect';
+  const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+
+  const priorAnswers = await readPriorAnswersForQuestion(userId, feedRow.question.id);
+  const masteryAnswerState = computeAnswerState(
+    isCorrect ? 'correct' : 'wrong',
+    priorAnswers,
+  );
+
+  const baseCatchupPoints = Math.round(catchupItem.basePoints * CATCHUP_SURFACE_WEIGHT);
+  const pointsAwarded =
+    masteryAnswerState === 'first_correct'
+      ? baseCatchupPoints
+      : masteryAnswerState === 'first_correct_after_wrong'
+        ? Math.round(catchupItem.basePoints * RECOVERY_STATE_WEIGHT)
+        : 0;
+
+  const masteryDelta = await writeMasteryEvent({
+    userId,
+    questionId: feedRow.question.id,
+    domain: catchupItem.domain,
+    answerState: masteryAnswerState,
+    pointsAwarded,
+    sourceType: 'catchup',
+    sourceId: catchupItem.dailyQueueItemId,
+    broadCategory: catchupItem.broadCategory,
+    eventQuestionId: feedRow.question.id,
+    basePoints: catchupItem.basePoints,
+    weight: catchupItem.basePoints > 0 ? pointsAwarded / catchupItem.basePoints : 0,
+  });
+
+  // Resolve the feed item so it stops surfacing in catch-up. We only flip
+  // answerResult to 'correct' on recovery; the original feed-card history
+  // (state='answered', submittedAnswer) stays put so the user can still see
+  // what they originally typed.
+  await db
+    .update(feedItems)
+    .set({
+      catchupResolvedAt: new Date(),
+      ...(isCorrect ? { answerResult: 'correct' as const, pointsAwarded } : {}),
+    })
+    .where(eq(feedItems.id, feedRow.feedItem.id));
+
+  await updateDomainDifficultyOnAnswer(userId, catchupItem.domain, isCorrect).catch((err) => {
+    console.warn('[daily/catchup/answer] updateDomainDifficultyOnAnswer (feed) failed', err);
+  });
+
+  // Promote author's declared territory + author credit on first recovery,
+  // mirroring the daily path. Skipped for self-authored questions.
+  if (isCorrect && feedRow.question.creatorId && feedRow.question.creatorId !== userId) {
+    void promoteDeclaredToDemonstrated({
+      userId: feedRow.question.creatorId,
+      domain: catchupItem.domain,
+      triggeringFriendId: userId,
+      questionId: feedRow.question.id,
+    });
+    void awardAuthorCredit({
+      creatorUserId: feedRow.question.creatorId,
+      answererUserId: userId,
+      questionId: feedRow.question.id,
+      domain: catchupItem.domain,
+      sourceId: `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
+      scope: 'daily/catchup/answer',
+    });
+  }
+
+  if (isCorrect) {
+    void createFeedItemsForFriendsFromAnswer(
+      userId,
+      feedRow.question.id,
+      'correct',
+      `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
+    );
+  }
+
+  const nextItem = (await getCatchupQuestions(userId))[0] ?? null;
+
+  return Response.json({
+    dailyQueueItemId: catchupItem.dailyQueueItemId,
+    questionId: feedRow.question.id,
+    result: grade.result,
+    isCorrect,
+    correct: isCorrect,
+    pointsAwarded,
+    answerState,
+    breadcrumb: null,
+    awarded_points: pointsAwarded,
+    masteryDelta,
+    mastery_delta: masteryDelta,
+    correctAnswer: catchupItem.correctAnswer,
+    answer: catchupItem.correctAnswer,
+    explanation: catchupItem.explanation,
+    explainer: catchupItem.explanation,
+    consolation: grade.consolation,
+    quip,
+    nextItem: nextItemPayload(nextItem),
   });
 }

--- a/src/app/api/daily/catchup/dismiss/route.ts
+++ b/src/app/api/daily/catchup/dismiss/route.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { NextRequest } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { dailyQueues, db } from '@/server/db';
+import { dailyQueues, db, feedItems } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
@@ -42,6 +42,34 @@ export async function POST(request: NextRequest) {
     .find((item) => item.dailyQueueItemId === parsed.dailyQueueItemId);
   if (!catchupItem) return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
 
+  if (catchupItem.surface === 'feed') {
+    if (!catchupItem.feedItemId) {
+      return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
+    }
+    const [feedItem] = await db
+      .select()
+      .from(feedItems)
+      .where(eq(feedItems.id, catchupItem.feedItemId))
+      .limit(1);
+    if (!feedItem || feedItem.recipientUserId !== session.userId) {
+      return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
+    }
+    if (feedItem.catchupResolvedAt) {
+      return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
+    }
+
+    await db
+      .update(feedItems)
+      .set({ catchupResolvedAt: new Date() })
+      .where(eq(feedItems.id, feedItem.id));
+
+    return Response.json({ dismissed: true });
+  }
+
+  if (catchupItem.queueId === null || catchupItem.slotIndex === null) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Daily catch-up item missing queue reference');
+  }
+
   const [queue] = await db
     .select()
     .from(dailyQueues)
@@ -53,7 +81,10 @@ export async function POST(request: NextRequest) {
 
   const slots = asQueueSlots(queue.slots);
   const slot = findQueueSlotBySlotIndex(slots, catchupItem.slotIndex);
-  if (!slot || slot.answered || slot.dismissed_at) {
+  if (!slot || slot.dismissed_at) {
+    return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
+  }
+  if (slot.answered && slot.answer_state !== 'incorrect') {
     return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
   }
 

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -285,10 +285,14 @@ export function useCatchupFlow() {
         },
       ]);
 
-      const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
-      const slotIndex = Number(slotIndexValue);
-      if (queueId && Number.isInteger(slotIndex)) {
-        void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
+      // Breadcrumbs are computed from daily-queue slots only; feed-sourced
+      // catch-up items use a `feed:<feedItemId>` ID and have no slot to look up.
+      if (!item.dailyQueueItemId.startsWith('feed:')) {
+        const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
+        const slotIndex = Number(slotIndexValue);
+        if (queueId && Number.isInteger(slotIndex)) {
+          void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
+        }
       }
 
       window.setTimeout(() => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -136,7 +136,8 @@ export async function register() {
           ADD COLUMN IF NOT EXISTS "personalMessage" text,
           ADD COLUMN IF NOT EXISTS "sourceResult" text,
           ADD COLUMN IF NOT EXISTS "submittedAnswer" text,
-          ADD COLUMN IF NOT EXISTS "quip" text
+          ADD COLUMN IF NOT EXISTS "quip" text,
+          ADD COLUMN IF NOT EXISTS "catchupResolvedAt" timestamptz
       `);
     } catch {
       // FeedItem table may not exist yet — migrate() handles initial creation.

--- a/src/server/daily/catchup.ts
+++ b/src/server/daily/catchup.ts
@@ -32,6 +32,30 @@ export function dailyQueueItemId(queueId: string, slotIndex: number): string {
   return `${queueId}:${slotIndex}`;
 }
 
+// Catch-up now mixes daily-queue slots with feed items the user answered
+// wrong. The wire field stays `dailyQueueItemId` (it's opaque to the client),
+// but the value carries a prefix so the server can dispatch to the right
+// surface. Daily IDs keep the original `${queueId}:${slotIndex}` shape for
+// backward compatibility; feed IDs get a `feed:` prefix.
+export const FEED_CATCHUP_ID_PREFIX = 'feed:';
+
+export function feedCatchupItemId(feedItemId: string): string {
+  return `${FEED_CATCHUP_ID_PREFIX}${feedItemId}`;
+}
+
+export function parseCatchupItemId(
+  id: string,
+): { surface: 'feed'; feedItemId: string } | { surface: 'daily'; queueId: string; slotIndex: number } | null {
+  if (id.startsWith(FEED_CATCHUP_ID_PREFIX)) {
+    const feedItemId = id.slice(FEED_CATCHUP_ID_PREFIX.length);
+    return feedItemId ? { surface: 'feed', feedItemId } : null;
+  }
+  const [queueId, slotIndexValue] = id.split(':');
+  const slotIndex = Number(slotIndexValue);
+  if (!queueId || !Number.isInteger(slotIndex)) return null;
+  return { surface: 'daily', queueId, slotIndex };
+}
+
 export function findQueueSlotBySlotIndex(slots: QueueSlot[], slotIndex: number): QueueSlot | null {
   return slots.find((slot) => slot.slot_index === slotIndex) ?? null;
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1,10 +1,11 @@
-import { and, asc, eq, inArray, isNotNull, lt, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 
 import {
   dailyPreferences,
   dailyQueues,
   db,
   declaredInterests,
+  feedItems,
   generatedQuestions,
   masteryEvents,
   playerMastery,
@@ -15,7 +16,7 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
-import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
+import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId } from '@/server/daily/catchup';
 import type { QueueSlot } from '@/server/daily/types';
 import {
   catchUpExpiresAt,
@@ -28,6 +29,7 @@ import {
   dedupeCatchUpItems,
   orderCatchUpItems,
 } from '@/server/play/catch-up-turn-sequencing';
+import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 function asQueueSlotDifficulty(
@@ -49,14 +51,27 @@ export type KnowledgeBaseDomain = {
 export type DailyPreferenceRow = typeof dailyPreferences.$inferSelect;
 export type DailyQueueRow = typeof dailyQueues.$inferSelect;
 
+export type CatchupSurface = 'daily' | 'feed';
+
 export type CatchupQueueItem = {
+  /**
+   * Opaque dispatch ID. Daily slots use `${queueId}:${slotIndex}` (legacy
+   * format the client already parses); feed items use `feed:${feedItemId}`.
+   * Routes that receive this back from the client should resolve it via
+   * `parseCatchupItemId` rather than splitting manually.
+   */
   dailyQueueItemId: string;
-  queueId: string;
+  surface: CatchupSurface;
+  /** Daily-only — null for feed items. */
+  queueId: string | null;
+  /** Daily-only — null for feed items. */
+  slotIndex: number | null;
+  /** Feed-only — null for daily items. */
+  feedItemId: string | null;
   queueDate: string;
   queueAge: number;
   expiresAt: string;
   expiresSoon: boolean;
-  slotIndex: number;
   questionId: string;
   questionText: string;
   correctAnswer: string;
@@ -254,12 +269,24 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
 export async function getCatchupQuestions(userId: string): Promise<CatchupQuestion[]> {
   const { assignmentDateStr } = getDailyAssignmentBounds();
 
+  const [dailyItems, feedItemsForCatchup] = await Promise.all([
+    getDailyCatchupItems(userId, assignmentDateStr),
+    getFeedCatchupItems(userId, assignmentDateStr),
+  ]);
+
+  return dedupeCatchUpItems(orderCatchUpItems([...dailyItems, ...feedItemsForCatchup]));
+}
+
+async function getDailyCatchupItems(
+  userId: string,
+  assignmentDateStr: string,
+): Promise<CatchupQuestion[]> {
   const queues = await db
     .select()
     .from(dailyQueues)
     .where(and(
       eq(dailyQueues.userId, userId),
-      lt(dailyQueues.queueDate, assignmentDateStr),
+      lte(dailyQueues.queueDate, assignmentDateStr),
     ))
     .orderBy(asc(dailyQueues.queueDate));
 
@@ -284,7 +311,7 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
     ));
   const questionById = new Map(questions.map((question) => [question.id, question]));
 
-  const mapped = candidateSlots
+  return candidateSlots
     .map(({ queue, slot }): CatchupQuestion | null => {
       const question = slot.generated_question_id ? questionById.get(slot.generated_question_id) : null;
       if (!question) return null;
@@ -298,12 +325,14 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
       if (isGenericSubcategory(domain)) return null;
       return {
         dailyQueueItemId: dailyQueueItemId(queue.id, slot.slot_index),
+        surface: 'daily',
         queueId: queue.id,
+        slotIndex: slot.slot_index,
+        feedItemId: null,
         queueDate,
         queueAge: queueAgeInDays(queueDate, assignmentDateStr),
         expiresAt,
         expiresSoon: expiresWithin24Hours(expiresAt),
-        slotIndex: slot.slot_index,
         questionId: question.id,
         questionText: slot.question_text || question.questionText,
         correctAnswer: question.answer,
@@ -319,8 +348,79 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
       } satisfies CatchupQuestion;
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
+}
 
-  return dedupeCatchUpItems(orderCatchUpItems(mapped));
+async function getFeedCatchupItems(
+  userId: string,
+  assignmentDateStr: string,
+): Promise<CatchupQuestion[]> {
+  // Mirror the daily lookback: only surface feed-missed items whose source
+  // event landed within the catch-up window. sourceEventAt is the canonical
+  // "when this hit your feed" timestamp and is already indexed.
+  const oldestDate = new Date(`${assignmentDateStr}T00:00:00.000Z`);
+  oldestDate.setUTCDate(oldestDate.getUTCDate() - CATCHUP_LOOKBACK_DAYS);
+
+  let rows: Array<{ feedItem: typeof feedItems.$inferSelect; question: typeof canonicalQuestions.$inferSelect }>;
+  try {
+    rows = await db
+      .select({ feedItem: feedItems, question: canonicalQuestions })
+      .from(feedItems)
+      .innerJoin(canonicalQuestions, eq(feedItems.questionId, canonicalQuestions.id))
+      .where(and(
+        eq(feedItems.recipientUserId, userId),
+        eq(feedItems.state, 'answered'),
+        eq(feedItems.answerResult, 'incorrect'),
+        isNull(feedItems.catchupResolvedAt),
+        gte(feedItems.sourceEventAt, oldestDate),
+      ))
+      .orderBy(desc(feedItems.sourceEventAt));
+  } catch (error) {
+    // catchupResolvedAt is added by migration 0038; tolerate a brief window
+    // where the column is missing so the homepage doesn't 500 on first boot.
+    if (pgErrorCode(error) === '42703') return [];
+    throw error;
+  }
+
+  return rows
+    .map(({ feedItem, question }): CatchupQuestion | null => {
+      const domain = question.canonicalSubcategory || question.broadCategory || question.category;
+      if (!domain || isGenericSubcategory(domain)) return null;
+      const queueDate = feedItem.sourceEventAt.toISOString().slice(0, 10);
+      const expiresAt = catchUpExpiresAt(queueDate);
+      const difficulty = asQueueSlotDifficulty(
+        question.calibratedDifficulty ?? question.llmDifficulty ?? question.difficultyEstimate ?? null,
+      ) ?? null;
+      const basePoints = getBasePoints(difficulty, 'first_correct');
+      const explanation = question.explainerFullWrong
+        ?? question.explainerFull
+        ?? question.explainerBrief
+        ?? question.factualExplanation
+        ?? null;
+      return {
+        dailyQueueItemId: feedCatchupItemId(feedItem.id),
+        surface: 'feed',
+        queueId: null,
+        slotIndex: null,
+        feedItemId: feedItem.id,
+        queueDate,
+        queueAge: queueAgeInDays(queueDate, assignmentDateStr),
+        expiresAt,
+        expiresSoon: expiresWithin24Hours(expiresAt),
+        questionId: question.id,
+        questionText: question.questionText,
+        correctAnswer: question.answerText,
+        alternateAnswers: question.acceptedAlternatives ?? [],
+        explanation,
+        domain,
+        domainDisplayName: categoryLabel(domain),
+        broadCategory: question.broadCategory ?? domain,
+        basePoints,
+        difficultyEstimate: difficulty,
+        submittedAnswer: feedItem.submittedAnswer ?? null,
+        wasSkipped: false,
+      } satisfies CatchupQuestion;
+    })
+    .filter((item): item is CatchupQuestion => Boolean(item));
 }
 
 export async function createDailyQueueItem(

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -715,6 +715,7 @@ export const feedItems = pgTable(
     state: text('state').notNull().default('active'),
     isPinned: boolean('isPinned').notNull().default(false),
     quip: text('quip'),
+    catchupResolvedAt: timestamp('catchupResolvedAt', { withTimezone: true }),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/server/play/catch-up-eligibility.ts
+++ b/src/server/play/catch-up-eligibility.ts
@@ -20,11 +20,17 @@ export function isCatchUpQueueDateEligible(
   lookbackDays = CATCHUP_LOOKBACK_DAYS,
 ): boolean {
   const oldestDate = minusUtcDays(assignmentDate, lookbackDays);
-  return queueDate < assignmentDate && queueDate >= oldestDate;
+  // Today's queue is eligible so wrong answers from today's Daily 5 surface
+  // immediately rather than waiting until tomorrow.
+  return queueDate <= assignmentDate && queueDate >= oldestDate;
 }
 
 export function isCatchUpSlotEligible(slot: QueueSlot): boolean {
-  return !slot.answered && !slot.dismissed_at && Boolean(slot.generated_question_id);
+  if (slot.dismissed_at) return false;
+  if (!slot.generated_question_id) return false;
+  // Wrong daily-5 answers are eligible for re-attempt; correct ones are not.
+  if (slot.answered) return slot.answer_state === 'incorrect';
+  return true;
 }
 
 export function expiresWithin24Hours(expiresAt: string, now = new Date()): boolean {


### PR DESCRIPTION
The homepage "Reinforce what you learned" card was hidden whenever
getCatchupQuestions returned 0, which it always did unless the user had
a skipped/untouched slot from a *past* Daily 5. Today's wrongs and feed
wrongs never qualified, so the card vanished for the very cases users
think of as "the ones I missed."

Expand eligibility on three axes:
- queueDate <= today (was <): today's Daily 5 wrongs surface immediately
- include slots with answer_state='incorrect' (was: skipped/untouched only)
- union in FeedItem rows where state='answered' AND answerResult='incorrect'
  AND catchupResolvedAt IS NULL, within the same 7-day lookback

Feed items dispatch via a `feed:<feedItemId>` prefix on dailyQueueItemId
(the wire field stays opaque). Recovering a feed-miss through catch-up
writes a mastery event (recovery handling already lives in
computeAnswerState/getBasePoints), updates the FeedItem in place
(catchupResolvedAt + answerResult flip if correct), and propagates to
friend feeds — same shape as the daily path.

New column FeedItem.catchupResolvedAt (migration 0038) with an idempotent
guard in instrumentation.ts so partially-recorded preview/production
databases keep booting. The client breadcrumb fetch in useCatchupFlow
now skips feed-prefixed IDs since breadcrumbs are slot-derived.

https://claude.ai/code/session_01An4UWRfTNpLSEAKt6BKSQc