### PR TITLE
clearer signal when Daily Five fails because the LLM is broken

### DIFF
--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -228,7 +228,16 @@ function DailySetupContent() {
       });
       const queueBody = await queueResponse.json().catch(() => null);
       if (!queueResponse.ok) {
-        if (domainMode === 'custom' && selectedDomains.size > 0) {
+        // Only the "no knowledge base for this domain" failure should send the
+        // user to the empty-state knowledge page. Transient generation
+        // failures (503 `generation_failed`, e.g. LLM outage or exhausted
+        // credits) should surface the server's banner so we don't lie that
+        // the topic itself is missing.
+        if (
+          queueBody?.error === 'no_knowledge_base' &&
+          domainMode === 'custom' &&
+          selectedDomains.size > 0
+        ) {
           const [domain] = Array.from(selectedDomains);
           router.push(`/knowledge?emptyDomain=${encodeURIComponent(domain)}`);
           return;

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -127,6 +127,28 @@ function summarizeError(error: unknown): Record<string, unknown> {
   };
 }
 
+// Operator-actionable errors deserve a louder log line than the generic
+// "[llm] error" warn so they don't get lost in the noise of timeouts /
+// model overload. These are the cases where the model is fine but the
+// account/key is broken: refilling credits, rotating the key, or waiting
+// out a rate limit is the only fix, and the user-visible symptom (zero
+// generated questions, "Today's Daily Five is taking longer than usual")
+// looks identical to a model hiccup.
+function classifyOperatorError(error: unknown): string | null {
+  if (!(error instanceof Error)) return null;
+  const status = (error as { status?: number }).status;
+  const apiMessage = (error as { error?: { message?: string } }).error?.message ?? '';
+  const combined = `${error.message} ${apiMessage}`;
+
+  if (status === 429) return 'RATE_LIMITED';
+  if (status === 401 || status === 403) return 'AUTH_FAILED';
+  if (status === 402) return 'PAYMENT_REQUIRED';
+  if (status === 400 && /credit balance|billing|insufficient.*credit/i.test(combined)) {
+    return 'CREDITS_EXHAUSTED';
+  }
+  return null;
+}
+
 function logFallback(scope: string, reason: string, extra?: Record<string, unknown>) {
   console.warn(`[LLM] ${scope} fallback: ${reason}`, extra ?? {});
 }
@@ -158,12 +180,22 @@ export async function loggedMessagesCreate(
     });
     return response;
   } catch (error) {
-    console.warn('[llm] error', {
-      scope,
-      model: params.model,
-      duration_ms: Date.now() - startedAt,
-      ...summarizeError(error),
-    });
+    const operatorErrorKind = classifyOperatorError(error);
+    if (operatorErrorKind) {
+      console.error(`[llm] ${operatorErrorKind}`, {
+        scope,
+        model: params.model,
+        duration_ms: Date.now() - startedAt,
+        ...summarizeError(error),
+      });
+    } else {
+      console.warn('[llm] error', {
+        scope,
+        model: params.model,
+        duration_ms: Date.now() - startedAt,
+        ...summarizeError(error),
+      });
+    }
     throw error;
   }
 }


### PR DESCRIPTION
The "out of Anthropic credits" failure mode was disguised twice over.
On Random mode the user got "Today's Daily Five is taking longer than
usual" — fine, but on Custom mode the setup page redirected to
/knowledge?emptyDomain=X for ANY queue POST failure, telling the user
"We don't have X questions yet" when the real problem was the LLM call
throwing. Restrict that redirect to the no_knowledge_base 409; let
generation_failed 503 surface the banner like Random mode does.

Server side, billing/auth/rate-limit errors from Anthropic were logged
at the same warn level as a transient model hiccup, so they got lost.
Classify status 401/402/403/429 and "credit balance" 400s and log them
at console.error with a distinct tag (RATE_LIMITED / AUTH_FAILED /
PAYMENT_REQUIRED / CREDITS_EXHAUSTED) so the operator can grep them
out of Vercel logs.

https://claude.ai/code/session_01MNa1mZDjM13gt1AJho5va7