### PR TITLE
scope /questions to only show questions you've written

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -348,7 +348,7 @@ function QuestionsPageContent() {
       <header className="mb-5 flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
-          <p className="mt-1 text-sm text-muted-foreground">{questions.length} banked questions</p>
+          <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
         </div>
         <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create' })}>
           <Plus className="size-4" />
@@ -394,7 +394,7 @@ function QuestionsPageContent() {
         <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
           <h2 className="font-serif text-2xl font-semibold">No questions yet.</h2>
           <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-            Your question bank is empty. Write a question or save one from a friend to build your bank.
+            You haven&apos;t written any questions yet. Write one to get started.
           </p>
           <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
             Write a question

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -190,7 +190,15 @@ export async function checkBankedQuestions(userId: string, questionIds: string[]
   return Object.fromEntries(uniqueIds.map((id) => [id, banked.has(id)]));
 }
 
-export async function getBankedQuestions(userId: string): Promise<BankedQuestion[]> {
+export async function getBankedQuestions(
+  userId: string,
+  options?: { onlyAuthored?: boolean },
+): Promise<BankedQuestion[]> {
+  const filters = [eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)];
+  if (options?.onlyAuthored) {
+    filters.push(eq(questions.creatorId, userId));
+  }
+
   const rows = await db
     .select({
       bank: userQuestionBank,
@@ -203,7 +211,7 @@ export async function getBankedQuestions(userId: string): Promise<BankedQuestion
     .from(userQuestionBank)
     .innerJoin(questions, eq(userQuestionBank.questionId, questions.id))
     .innerJoin(users, eq(questions.creatorId, users.id))
-    .where(and(eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)))
+    .where(and(...filters))
     .orderBy(desc(userQuestionBank.addedAt));
 
   const answerersByQuestion = await getAnswerersForQuestions(

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -253,7 +253,7 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
 
 export async function getQuestionsForUser(userId: string): Promise<QuestionView[]> {
   const { getBankedQuestions } = await import('@/server/db/queries/bank');
-  return getBankedQuestions(userId);
+  return getBankedQuestions(userId, { onlyAuthored: true });
 }
 
 export async function hasUserAuthoredAnyQuestion(userId: string): Promise<boolean> {


### PR DESCRIPTION
The page header says "Your Questions" but it was surfacing the full
question bank — authored questions and questions saved from friends.
Filter the /questions data fetch to only return questions where the
viewer is the creator, and update the subtitle and empty-state copy so
they no longer talk about the "bank" or saving from a friend. The
separate /api/bank endpoint still returns the full bank.