### PR TITLE
§8.22 wrong-answer text visibility + keep direct_sent retries actionable

### DIFF
--- a/.claude/agents/drizzle-migration-reviewer.md
+++ b/.claude/agents/drizzle-migration-reviewer.md
@@ -1,0 +1,46 @@
+---
+name: drizzle-migration-reviewer
+description: Reviews new or modified Drizzle migrations for correct numbering, schema parity, destructive-op safety, defensive guards in instrumentation.ts, and rollback story. Invoke automatically when files under drizzle/ are added or changed, or manually before merging a PR that touches migrations.
+tools: Read, Glob, Grep, Bash(git diff:*), Bash(git log:*), Bash(ls:*)
+---
+
+# Drizzle migration reviewer
+
+You review Drizzle migrations for this repo.
+
+## Repo conventions
+
+- Migrations: `drizzle/NNNN_*.sql`, sequentially numbered, no gaps.
+- Schema source of truth: `src/server/db/schema.ts`.
+- Migrations auto-apply at boot via `src/instrumentation.ts`.
+- Postgres pool capped at `max: 5` in `src/server/db/index.ts:24` (Supabase PgBouncer constraint — see commit `2aafbb1`). Migrations should not assume a higher connection count.
+
+## Review checklist
+
+When invoked, run through every changed `.sql` file under `drizzle/` against this checklist:
+
+1. **Numbering.** Is the new file's number exactly `previous_highest + 1`? No gaps, no duplicates, no skipped indices.
+
+2. **Schema parity.** Does `src/server/db/schema.ts` contain the matching change? Run `git diff` to confirm both moved together. A migration without a schema update (or vice versa) is a blocker.
+
+3. **Destructive operations.** Flag and require justification for:
+   - `ADD COLUMN ... NOT NULL` without a `DEFAULT` → reject unless the table is provably empty in all environments.
+   - `DROP COLUMN`, `DROP TABLE`, `ALTER COLUMN ... TYPE` → require explicit rollback notes in the SQL header comment.
+   - `CREATE INDEX` on a large table without `CONCURRENTLY` → flag; this locks writes.
+   - Any `UPDATE` over an unbounded `WHERE` clause → flag.
+
+4. **Defensive guards.** If the migration depends on existing rows being in a particular shape, check `src/instrumentation.ts` for a guard. Migrations `0006` and `0009` set the precedent — reference them in your review when a similar guard is missing.
+
+5. **Rollback story.** The SQL file should have a header comment with:
+   - One paragraph explaining the change in human terms
+   - Rollback instructions in one or two sentences
+   If either is missing, request it before approving.
+
+## Output
+
+Structured review:
+- ✅ Passed checks
+- ⚠️ Warnings
+- ❌ Blockers
+
+End with an overall verdict: **approve**, **request changes**, or **block**. Cite file paths and line numbers for every claim. Do not modify any files.

--- a/.claude/agents/feed-card-changes.md
+++ b/.claude/agents/feed-card-changes.md
@@ -1,0 +1,34 @@
+---
+name: feed-card-changes
+description: Validates edits to the feed-card surface (src/components/feed/* and src/components/FeedList.tsx) for switch exhaustiveness, prop alignment, no new inline styles, and test parity. Invoke automatically whenever files under these paths are modified.
+tools: Read, Glob, Grep
+---
+
+# Feed card change validator
+
+You watch over the feed card surface. The relevant files:
+
+- `src/components/feed/FeedCard.tsx` — main renderer
+- `src/components/FeedList.tsx` — parent that maps feed items to cards
+- `src/components/feed/types.ts` — discriminated union of feed-item types
+- Other components under `src/components/feed/`
+
+These files churn together — commits `0e0dc13`, `950bc0d`, `94a803f`, `1ebd4b1` each modified all three. That's a signal there's a missing abstraction, but until one exists, watch for these regressions on every change.
+
+## Checks on every invocation
+
+1. **Exhaustive switch.** `FeedCard.tsx` should handle every variant in the `types.ts` discriminated union. A missing case — or a `default` branch that silently swallows unknown types — is a bug. Report by variant name and the line where the switch should add a case.
+
+2. **Prop alignment.** Every card invoked by `FeedList.tsx` should receive all its required props. Read both files when either changes:
+   - Required-but-not-passed props → blocker
+   - Passed-but-not-read props → flag as dead code
+
+3. **No new inline styles.** This project uses Tailwind tokens. Flag any new `style={{...}}`, `text-[#hex]`, `bg-[#hex]`, or arbitrary spacing/sizing (`p-[Npx]`, `w-[Npx]`) introduced in the diff. Existing instances aren't your problem unless they were just edited.
+
+4. **Test parity.** If a new card variant or new prop was added, look for a corresponding test under `src/tests/`. If none exists, ask the user whether to add one before declaring the change complete.
+
+5. **Hoist opportunities.** If a layout pattern (wrapper, header row, action bar, footer) now appears in 3+ cards, name it and suggest a shared component. Don't just suggest it abstractly — name the file and propose the component signature.
+
+## Output
+
+A short checklist with `file:line` citations. Keep it tight — this agent runs on every edit, not just at review time. Avoid noise on trivial changes (a one-line copy edit shouldn't generate a five-section report).

--- a/.claude/agents/vercel-deploy-debugger.md
+++ b/.claude/agents/vercel-deploy-debugger.md
@@ -1,0 +1,51 @@
+---
+name: vercel-deploy-debugger
+description: Debugs a failing Vercel deployment or production incident. Pulls logs via the Vercel MCP, correlates to recent commits, watches for known repo-specific failure patterns, and proposes a fix or rollback. Invoke manually for incidents — do not auto-invoke.
+tools: Read, Grep, Glob, Bash(git log:*), Bash(git show:*), Bash(git diff:*), mcp__vercel__*, mcp__supabase__*
+---
+
+# Vercel deploy debugger
+
+You debug Vercel production incidents for this project.
+
+**Prerequisites:** The Vercel MCP server must be installed (`claude mcp add --transport http vercel https://mcp.vercel.com`). The Supabase MCP is helpful but optional. If the Vercel MCP is unavailable, stop and tell the user to install it first.
+
+## Workflow
+
+1. **Pull the deployment.**
+   Use the Vercel MCP to fetch:
+   - The failing deployment metadata
+   - Build logs
+   - Runtime function logs (if applicable)
+   - The most recent successful deployment, for diff comparison
+   If the user didn't specify a deployment, fetch the most recent failing one in the current project.
+
+2. **Identify the failure mode.**
+   Is this a build error, runtime error, timeout, cold-start failure, or a deploy that succeeded but is misbehaving? Quote the relevant log line(s) verbatim so the user can see what you saw.
+
+3. **Watch for known patterns first.** This repo has fingerprints — check these before anything else:
+   - **`EMAXCONNSESSION` or PgBouncer session-limit errors** → see commit `2aafbb1`. The pool is capped at 5 in `src/server/db/index.ts:24`. Check whether a new code path is opening connections outside the shared pool (e.g. a new `postgres()` or `drizzle()` call somewhere it shouldn't be).
+   - **Migration failure on boot** → check `src/instrumentation.ts`. Migrations `0006` and `0009` needed defensive guards; if a newer migration is failing, the missing guard is probably the issue.
+   - **Next.js middleware/proxy conflict** → check for a stray `src/middleware.ts` (this repo uses `src/proxy.ts`). Five reverts in history: `c02a980`, `95157a1`, `8c8a6f7`, `b5d8e7d`, `635abc6`.
+   - **LLM provider errors (Anthropic 429/5xx)** → check if the failing route is in `src/server/llm/` and which model it's calling (Sonnet for gen, Haiku for grade/categorize).
+
+4. **Correlate to commits.**
+   - `git log --oneline -20` for the recent commit window.
+   - If the failure is on a specific function/route, `git log -- <path>` for that file's recent changes.
+   - For each commit that touches the failing code path, summarize what it changed.
+
+5. **Propose a fix.**
+   Specific files, specific lines, specific reasoning. If the fix is non-obvious or risky:
+   - Propose a rollback to the last known-good deployment as the immediate move
+   - Defer the actual fix to a follow-up that can be tested in preview
+
+6. **Don't ship the fix.** Production changes go through the user, not the agent. Output the diff, but don't apply it.
+
+## Output
+
+Structured incident report:
+- **Summary** (one paragraph)
+- **Log evidence** (quoted lines)
+- **Suspected commit(s)** (with hashes)
+- **Proposed fix or rollback**
+- **Confidence level** (high / medium / low — and why)

--- a/.claude/hooks/block-middleware.ps1
+++ b/.claude/hooks/block-middleware.ps1
@@ -1,0 +1,14 @@
+# PreToolUse hook for Write
+# Blocks creation of src/middleware.ts.
+# This repo uses src/proxy.ts for Next.js 16 middleware.
+# Five prior reverts of this exact regression: c02a980, 95157a1, 8c8a6f7, b5d8e7d, 635abc6
+
+$paths = $env:CLAUDE_FILE_PATHS
+if ([string]::IsNullOrWhiteSpace($paths)) { exit 0 }
+
+if ($paths -like '*src/middleware.ts*' -or $paths -like '*src\middleware.ts*') {
+    Write-Host "BLOCKED: this repo uses src/proxy.ts, not middleware.ts."
+    Write-Host "See commits c02a980, 95157a1, 8c8a6f7, b5d8e7d, 635abc6 for the 5 previous reverts of this exact change."
+    exit 2
+}
+exit 0

--- a/.claude/hooks/format-edited.ps1
+++ b/.claude/hooks/format-edited.ps1
@@ -1,0 +1,17 @@
+# PostToolUse hook for Edit | Write | MultiEdit
+# Runs prettier on any edited .ts/.tsx/.js/.jsx/.json/.md files.
+# CLAUDE_FILE_PATHS can contain multiple paths when MultiEdit fires.
+
+$paths = $env:CLAUDE_FILE_PATHS
+if ([string]::IsNullOrWhiteSpace($paths)) { exit 0 }
+
+$paths -split '\s+' | Where-Object {
+    $_ -and ($_ -match '\.(ts|tsx|js|jsx|json|md)$')
+} | ForEach-Object {
+    try {
+        npx prettier --write "$_" 2>$null | Out-Null
+    } catch {
+        # Prettier not installed or file unreadable - silent, hook is best-effort
+    }
+}
+exit 0

--- a/.claude/hooks/warn-schema.ps1
+++ b/.claude/hooks/warn-schema.ps1
@@ -1,0 +1,12 @@
+# PostToolUse hook for Edit | Write | MultiEdit
+# Prints a reminder when the Drizzle schema is modified.
+
+$paths = $env:CLAUDE_FILE_PATHS
+if ([string]::IsNullOrWhiteSpace($paths)) { exit 0 }
+
+if ($paths -like '*src/server/db/schema.ts*' -or $paths -like '*src\server\db\schema.ts*') {
+    Write-Host ""
+    Write-Host "Schema changed. Run: npx drizzle-kit generate" -ForegroundColor Yellow
+    Write-Host ""
+}
+exit 0

--- a/.claude/hooks/warn-tsbuildinfo.ps1
+++ b/.claude/hooks/warn-tsbuildinfo.ps1
@@ -1,0 +1,14 @@
+# Stop hook
+# Warns if any tsbuildinfo file ended up modified in the working tree.
+# These should be in .gitignore — see the workflow audit.
+
+$diff = git diff --name-only HEAD 2>$null
+
+if ($LASTEXITCODE -ne 0) { exit 0 }
+
+if ($diff -match 'tsbuildinfo$') {
+    Write-Host ""
+    Write-Host "tsbuildinfo files were modified in this session. They should be in .gitignore — do NOT commit them." -ForegroundColor Yellow
+    Write-Host ""
+}
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-middleware.ps1"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/format-edited.ps1"
+          }
+        ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/warn-schema.ps1"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/warn-tsbuildinfo.ps1"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/check-middleware/SKILL.md
+++ b/.claude/skills/check-middleware/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: check-middleware
+description: Verify there is no src/middleware.ts in this repo — this codebase uses src/proxy.ts for Next.js 16 middleware, and the middleware.ts variant has been reverted at least 5 times. Run before commits, after merges, or any time something feels off about routing.
+allowed-tools: Bash(ls:*), Bash(test:*), Bash(git log:*), Read
+---
+
+# Check middleware / proxy state
+
+This repo uses `src/proxy.ts` for Next.js 16 middleware. **`src/middleware.ts` must not exist.** The same regression has been fixed at least 5 times: commits `c02a980`, `95157a1`, `8c8a6f7`, `b5d8e7d`, `635abc6`.
+
+## Steps
+
+1. Check whether `src/middleware.ts` exists.
+
+2. **If it exists:**
+   - Read it.
+   - Read `src/proxy.ts`.
+   - Determine if `middleware.ts` contains anything not already in `proxy.ts`.
+     - If yes: port the missing logic into `proxy.ts`, then delete `middleware.ts`.
+     - If no: just delete `middleware.ts`.
+   - Show the user exactly what was removed and why.
+   - Look at recent commits (`git log --oneline -10 -- src/middleware.ts src/proxy.ts`) to identify how it crept back in. If a recent commit reintroduced it, flag the author/commit so they don't repeat it.
+
+3. **If it doesn't exist:**
+   - Confirm `src/proxy.ts` is still present.
+   - Confirm it exports the middleware (look for `export const middleware` or equivalent).
+   - Report all clear.
+
+4. Run any tests under `src/tests/` whose names mention `middleware` or `proxy`.
+
+## Output
+
+End with the state of both files: exists/absent, last-modified info if available, and any test results.

--- a/.claude/skills/feed-card-audit/SKILL.md
+++ b/.claude/skills/feed-card-audit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: feed-card-audit
+description: Audit the feed-card surface (FeedCard, FeedList, feed/types.ts and friends) for type exhaustiveness, prop alignment, test coverage, styling drift, and missing abstractions. Read-only — proposes changes but never edits.
+allowed-tools: Read, Glob, Grep, Bash(ls:*)
+---
+
+# Feed card audit
+
+Audit every feed card component in this repo. The high-churn files (`src/components/feed/FeedCard.tsx`, `src/components/FeedList.tsx`, `src/components/feed/types.ts`) move together repeatedly — start with those, then expand to the rest of `src/components/feed/`.
+
+## What to check
+
+For each card variant:
+
+1. **Feed-item types it renders.**
+   Cross-reference with the discriminated union in `src/components/feed/types.ts`. Report:
+   - Variants in the union that no card handles
+   - Cards that handle types not in the union
+   - Any default/fallback branch silently swallowing unknown types (this is almost always a bug)
+
+2. **Required props.**
+   List the props each card consumes. Flag:
+   - Props required in the card's type but never provided by `FeedList.tsx`
+   - Props provided by `FeedList.tsx` that the card doesn't read
+   - Optional props that are effectively required (will throw if missing)
+
+3. **Test coverage.**
+   Glob `src/tests/**` for tests that import each card. If a card has no test, report it. If a test imports the card but doesn't render every variant the card handles, that's a coverage gap worth flagging.
+
+4. **Style drift.**
+   Flag any of the following introduced in feed components:
+   - Inline `style={{...}}` blocks
+   - Hex colors in className (`text-[#abc123]`)
+   - Arbitrary Tailwind values (`p-[13px]`, `w-[247px]`)
+   - Tailwind classes that duplicate a token from the design system
+
+5. **Duplication.**
+   If a layout/styling pattern (shared wrapper, header row, action bar, footer) is repeated in 3+ cards, name it and suggest a shared component. This is exactly the abstraction the repo is currently missing.
+
+## Output
+
+Group findings by card. For every claim, cite the file and line number. End with:
+- A summary count of issues by category
+- The top 2-3 refactors ranked by leverage
+
+Do not modify any files. This is read-only.

--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: new-migration
+description: Scaffold the next Drizzle migration following the repo's numbering convention, schema parity, and instrumentation guards. Invoke when starting any schema change.
+argument-hint: <description of the migration, e.g. "add tags table">
+allowed-tools: Bash(ls:*), Bash(npx drizzle-kit:*), Bash(cat:*), Bash(git diff:*), Read, Edit, Write, Grep
+---
+
+# New Drizzle migration: $ARGUMENTS
+
+Create the next Drizzle migration for: **$ARGUMENTS**
+
+## Repo conventions to honor
+
+- ORM is Drizzle, not Prisma. Older docs in `_docs/` may say otherwise — ignore them.
+- Migrations live in `drizzle/NNNN_*.sql`, numbered sequentially.
+- Schema source of truth: `src/server/db/schema.ts`.
+- Migrations are auto-applied at boot via `src/instrumentation.ts`.
+- Postgres pool is capped at `max: 5` in `src/server/db/index.ts:24` (Supabase PgBouncer constraint — see commit 2aafbb1). Don't write migrations that assume a higher connection count.
+
+## Steps
+
+1. List `drizzle/` and find the highest-numbered `NNNN_*.sql` file. The new migration uses `NNNN+1`.
+2. Update `src/server/db/schema.ts` to reflect the change implied by `$ARGUMENTS`. Show the user the diff before generating SQL. If anything about the intent is ambiguous, ask before editing.
+3. Generate the SQL: `npx drizzle-kit generate`. Confirm the filename matches the expected `NNNN+1` prefix; if it doesn't, rename it.
+4. Read the generated SQL. If it includes any of the following, stop and warn the user:
+   - `ADD COLUMN ... NOT NULL` without a `DEFAULT` (will fail on non-empty tables)
+   - `DROP COLUMN` or `DROP TABLE` on a table that may have production data
+   - `ALTER COLUMN ... TYPE` changes that aren't trivially safe
+   - `CREATE INDEX` on a large table without `CONCURRENTLY`
+5. Check `src/instrumentation.ts`. Migrations 0006 and 0009 set a precedent — if this migration depends on data being in a particular shape, add a defensive guard there. Reference the precedent explicitly.
+6. Add a header comment at the top of the generated `.sql` file: one paragraph explaining the change in human terms, plus the rollback plan in one or two sentences.
+7. Do NOT run the migration. Tell the user to run `npm run db:migrate` themselves when ready.

--- a/.claude/skills/prd-audit/SKILL.md
+++ b/.claude/skills/prd-audit/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: prd-audit
+description: Run the project's PRD audit prompt against a specific PRD section and write findings to audits/. Replaces the manual chore(audit) commits that have been ledgering through git.
+argument-hint: <PRD section, e.g. "§8.5" or "phase 2 author credit">
+allowed-tools: Read, Write, Bash(date:*), Bash(ls:*), Grep, Glob
+---
+
+# PRD audit: $ARGUMENTS
+
+Run the audit defined in `PRD-AUDIT-PROMPT.md` against the PRD section: **$ARGUMENTS**.
+
+## Steps
+
+1. Read `PRD-AUDIT-PROMPT.md` to load the audit template. If it does not exist at the repo root, stop and ask the user where it lives.
+2. Read the relevant PRD section. The current PRD is `_docs/PRD11.md` (or `_docs/PRD-v11.1.md` if that's the newer one — check both). If `$ARGUMENTS` doesn't pin down a specific section, ask before proceeding rather than guess.
+3. Read at least one existing file in `audits/` to match the established format, headers, evidence-citation style, and verdict conventions. Do NOT diverge from the existing style.
+4. Execute the audit exactly as the template specifies.
+5. Write the result to `audits/$(date +%Y-%m-%d)-{section-slug}-findings.md` where `{section-slug}` is a short lowercase, hyphenated form of `$ARGUMENTS` (e.g. `§8.5` → `phase-8-5`, `author credit` → `author-credit`).
+6. Cite every claim with a file path and line number. If a claim can't be cited, mark it as inference, not fact.
+7. Do NOT commit. Write the file, report the path, and stop.

--- a/.claude/skills/typecheck/SKILL.md
+++ b/.claude/skills/typecheck/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: typecheck
+description: Run the project's strict TypeScript typecheck, group errors by file, and propose minimal fixes for the worst offenders. Invoke before commits, before PRs, or whenever you want to know how clean main really is.
+allowed-tools: Bash(npx tsc:*), Bash(npm:*), Bash(git status:*), Read, Edit, Grep
+---
+
+# Strict typecheck
+
+Run `npx tsc -p tsconfig.typecheck.json --noEmit` and analyze the output.
+
+If it passes, just say so and stop.
+
+If it fails:
+
+1. Group every diagnostic by file path.
+2. List the 3 files with the most errors, with the count for each.
+3. For each of those 3 files, read the file and propose minimal fixes. Prefer:
+   - Narrowing types
+   - Adding guards or assertions
+   - Fixing genuine bugs the type-checker uncovered
+   Avoid `any`, `// @ts-ignore`, and `// @ts-expect-error` unless the user explicitly asks. If a type error reveals a real bug (not just a typing gap), call that out explicitly — those are the ones worth fixing first.
+4. Do NOT regenerate, stage, or commit `tsconfig.tsbuildinfo` or `tsconfig.typecheck.tsbuildinfo`. These are gitignored; confirm with `git status` before any commit.
+
+End with a one-line summary: total error count, total file count, and whether the proposed fixes will likely clear all of them or only the top 3 files.

--- a/audit/B-VERIFY-01.md
+++ b/audit/B-VERIFY-01.md
@@ -1,0 +1,385 @@
+# B-VERIFY-01 Audit Report
+
+**Commit audited:** `0924f52ec155dee085d10236d1ef26842b8127f2`
+**Date:** 2026-05-21
+
+## Summary
+
+- Reaction mechanic present: 🟡 partial (single-level only; wrong-answer canned types declared in DB enum but unused at the app level)
+- Wrong-answer text leakage to author: **1 confirmed UI violation**, plus 1 elevated-risk loader; details below
+- Opt-in path ready: ❌ no `include_submitted_answer` column, no UI affordance, no read-path branch
+- Dispute path correct: 🟡 partial (dispute table exists and stores submitted answer; no surface yet exposes it to the question author — the only "non-reaction path that surfaces text" today is the **creator-notes flow**, which is NOT a dispute path)
+- Aggregation rule enforced: 🟡 partial (analytics surfaces aggregate stats only; no individual wrong-answer rows are exposed, but there is no explicit count-threshold gate because no "common wrong answers" surface exists yet)
+
+---
+
+## Section A — Reaction mechanic
+
+### A1. Schema — ✅ partial
+
+`QuestionReaction` table exists at `src/server/db/schema.ts:389-409`. Columns:
+
+| Required by §8.10b spec  | Present in schema?                                     |
+|--------------------------|--------------------------------------------------------|
+| id                       | ✅ `id` (line 392)                                     |
+| question_id              | ✅ `questionId` (line 395)                             |
+| from_user_id             | ✅ `senderUserId` (line 393)                           |
+| to_user_id               | ✅ `recipientUserId` (line 394)                        |
+| canned_type (nullable)   | 🟡 `reactionType text NOT NULL` (line 398) — text, not enum, not nullable; defaults to `'good_one'` for legacy rows (migration `drizzle/0006_question_reactions_contexts.sql:91`) |
+| note_text (≤100 chars)   | 🟡 `customMessage` (line 399); cap is **160** chars at the route, not 100 — see `PRD_BACKLOG.md:61` for already-acknowledged drift |
+| parent_reaction_id       | ❌ **dropped** in `drizzle/0006_question_reactions_contexts.sql:102` (`ALTER TABLE ... DROP COLUMN IF EXISTS "parent_reaction_id"`). It existed in `drizzle/0000_material_lyja.sql:161` and was removed |
+| created_at               | ✅ `createdAt` (line 401)                              |
+| (also present)           | `contextType` `'feed' \| 'joshing_game'`, `contextId`, `repliedAt` |
+
+Verdict: 🟡 partial — the table exists with a single-level shape only. Threaded creator responses (parent_reaction_id) are no longer supported by the schema.
+
+### A2. Wrong-answer canned types — 🟡 partial
+
+`reactionCannedEnum` at `src/server/db/schema.ts:64-74` declares **9** canned values, including the four wrong-answer ones spec'd in §8.10b:
+
+```
+'always_knew', 'got_me', 'of_course_you', 'never_heard',
+'need_to_talk', 'didnt_know_tell_me', 'need_story',
+'adding_to_list', 'knew_i_wouldnt'
+```
+
+However, **`reactionType` in the `QuestionReaction` table is `text`, not the enum** (`src/server/db/schema.ts:398`), so the DB does not constrain to those values. And — critically — the application-side `CANNED_REACTIONS` constant at `src/lib/reactions.ts:1-8` is a **completely different list** with **none of the wrong-answer types**:
+
+```ts
+CANNED_REACTIONS = [
+  'how_did_you_know', 'good_one', 'too_easy',
+  'i_should_have_known', 'made_my_day', 'thinking_of_you',
+]
+```
+
+`src/app/api/reactions/route.ts:37` calls `isReactionKey(reactionType)` (`src/lib/reactions.ts:16-18`), which rejects any value not in the application list. **Net effect: the API cannot accept a wrong-answer canned reaction today** — the DB enum is dormant and the UI does not surface those buttons.
+
+Verdict: 🟡 partial — the enum hints at intent; the runtime path does not deliver it.
+
+### A3. Write path — ✅ present
+
+Route: `POST /api/reactions` at `src/app/api/reactions/route.ts:85-111`.
+
+- Auth check: `getSession()` at line 86; rejects unauth with 401 (line 87).
+- Validation: `parseBody` at line 24 (Zod-free; manual). Rejects missing question_id, bad contextType, bad reactionType.
+- `from_user_id` is **always** `session.userId` (line 101) — payload cannot override.
+- Recipient is derived server-side via `resolveRecipient` (lines 42-83) from feed-item / joshing-game ownership, not trusted from the body.
+
+Verdict: ✅.
+
+### A4. Self-reaction block — ✅ present
+
+`src/app/api/reactions/route.ts:96-98`:
+
+```ts
+if (recipientUserId === session.userId) {
+  return NextResponse.json({ error: 'self_reaction', ... }, { status: 400 });
+}
+```
+
+Verdict: ✅.
+
+### A5. Notification — ✅ partial; no submitted-answer leak in SMS body
+
+Reaction SMS sender: `src/server/db/queries/reactions.ts:86-93`.
+
+```ts
+const body = `${senderName} reacted to your question: ${reaction.label}`;
+sendSms(recipientRow.phoneNumber, body, 'question_reaction', params.recipientUserId)
+```
+
+SMS body contains: sender display name + canned reaction label (e.g. "Good one"). It does **not** contain `note_text`/`customMessage`, and does **not** contain `submitted_answer`. ✅
+
+Activity-feed event: `src/server/db/queries/reactions.ts:73-80` inserts an `ActivityItem` of type `reaction_received` targeting `recipientUserId` (the author). The hydrator at `src/server/db/queries/activity.ts:306-345` and renderer at `src/app/activities/page.tsx:227-240` show `reactionEmoji + reactionLabel + customMessage + questionText`. The activity payload **does** include `customMessage` (the answerer's free-text note, up to 160 chars). No `submitted_answer` join exists.
+
+Templates consulted: `src/server/sms.ts:189-221` (creator_note_prompt — does not reference reactions), `src/server/db/queries/reactions.ts:89` (the only `question_reaction` SMS body).
+
+Verdict: ✅ for SMS body privacy of `submitted_answer`. (Note: `customMessage` is a separate free-text channel; see B-OPTIN-01 below.)
+
+### A6. Read path — End of Session Review — 🟡 partial
+
+The reaction-prompt UI is mounted from `src/app/games/[id]/play-client.tsx:94-101` and rendered by `QuestionReactionPrompt` at `src/components/play/GameplayChat.tsx:365-489`. It appears **inline after each answer during gameplay**, not in a separate "end of session" panel.
+
+For the **answerer**: the reaction prompt is shown when `game.game.creatorId !== viewerId` (line 94), i.e., the recipient sees it after each question. Cards: `CANNED_REACTIONS.map(...)` at line 438 — so the **wrong-answer-specific canned reactions are not offered**, because they are not in the app-level list (see A2).
+
+For the **author**: incoming reactions surface in `/activities` (`src/app/activities/page.tsx:227-240`) and via SMS (A5). The summary page (`src/app/games/[id]/summary/page.tsx`) does **not** render reactions.
+
+Verdict: 🟡 — a reaction-prompt UI exists in-game but is wired to the "correct-answer" canned list only; no End-of-Session-Review surface aggregates reactions for the answerer.
+
+### A7. Read path — archive — ❌ missing
+
+`grep -rn reaction /home/user/Joshing-11/src/app/archive` and the same against `/replay`, `/daily/summary`, `/components/feed/*` return zero matches. The archive (`src/app/archive/page.tsx`, query `src/server/db/queries/archive.ts`) does not project reactions.
+
+Verdict: ❌ — archive does not surface reactions.
+
+### A8. Creator response — ❌ missing
+
+A schema enum exists (`creatorResponseCannedEnum` at `src/server/db/schema.ts:75-80` with `knew_youd_get_it`, `surprised_you_knew`, `just_for_you`, `story_here`) and a SMS type `creator_reaction_response` at line 98 — but:
+
+- There is **no `parent_reaction_id` column** (dropped in 0006); a creator response cannot be modelled as a child reaction.
+- The only "response" path is `POST /api/reactions/[id]/reply` (`src/app/api/reactions/[id]/reply/route.ts`), which calls `markReactionReplied` (`src/server/db/queries/reactions.ts:174-182`). That just stamps `repliedAt = now` on the original reaction. **No row is inserted; no SMS or activity is sent to the original answerer.**
+- The button at `src/app/activities/ReactionGotItButton.tsx:34` labels this as "👍 Got it" / "Acknowledged" — i.e., an acknowledgement, not a reply.
+
+Verdict: ❌ — there is no creator-response write path.
+
+---
+
+## Section B — Leakage check
+
+### B1. Wrong-answer creator prompt notification (SMS + in-app) — 🚨 LEAKS (in-app)
+
+**SMS body:** ✅ no leak.
+`src/server/creator-notes.ts:72`:
+
+```ts
+const body = `${displayName(recipient?.displayName)} just missed your question:
+  '${truncateQuestion(row.questionText)}' Want to send them a note? ${url}`;
+```
+
+And the alternate sender at `src/server/sms.ts:218`:
+
+```ts
+const body = `Someone got your question wrong: "${preview}". Add a note to give context: ${baseUrl}/questions`;
+```
+
+Neither includes `submittedAnswer`.
+
+**In-app landing page:** 🚨 LEAKS.
+The SMS URL points the question's author at `/creator-notes/new?q={questionId}&r={recipientUserId}` (`src/server/creator-notes.ts:71`). That page (`src/app/creator-notes/new/page.tsx:71-80`) renders:
+
+```tsx
+<p>Question: {row.question.questionText}</p>
+<p>Answer: {row.question.answerText}</p>
+<p>{recipientName} said: {creatorNoteSubmittedAnswerText(wrongAnswer.submittedAnswer, 'Their')}</p>
+```
+
+`wrongAnswer.submittedAnswer` is the literal text the answerer typed in (loaded by `findWrongAnswerContext` at `src/server/creator-notes.ts:80-133`, which selects `joshingGameResponses.submittedAnswer` or `feedItems.submittedAnswer`). The page guards on `row.question.creatorId !== session.userId` (line 52), so the viewer **is** the question's author by construction.
+
+This is a clear §8.22 violation: a wrong-answer reaction is **not** required to reach this surface; the answerer never consented; the path is not a dispute. Verdict: 🚨 **B1 — in-app creator-note compose surface leaks submitted answer to the question author by default.**
+
+### B2. Activity feed item ("Friend got your question wrong") — N/A (item does not exist yet)
+
+There is no activity type that fires for "friend got your question wrong". The closest type is `friend_answered_your_question` (`src/server/activity/write-activity.ts:15`), and its writer at `src/server/feed/create-feed-items-for-answer.ts:150-173` (`notifyPreviousAnswerers`) sends the activity to **previous co-answerers**, not the question's author. Its renderer at `src/server/db/queries/activity.ts:478-522` and `src/app/activities/page.tsx:121-135` projects only `{ domain, result: 'correct'|'incorrect' }` — no `submittedAnswer`.
+
+Verdict: not applicable — no such item is written to the author, so nothing leaks here. Flagged for product clarification: §8.22 implies an "event" notification exists; today the author is reached only by the `creator_note_prompt` SMS (B1).
+
+### B3. Creator analytics view (`/questions`) — ✅ no leak
+
+`src/app/questions/page.tsx:411-470` renders one card per authored question with:
+- domain pill, difficulty pill (`difficultyCopyFromValue`)
+- question text
+- aggregate counts: `"{timesAnswered} answers · {correctRate}% correct · {usedInGamesCount} games"` (line 441)
+- attribution of answerer **names** when applicable: `formatAnswerersLine` (lines 148-156) shows up to two names plus "and N others"
+
+Data source: `getQuestionsForUser` → `getBankedQuestions` → `toQuestionView` (`src/server/db/queries/questions.ts:205-252`). The view returns `{ timesAnswered, timesCorrect, correctRate, usedInGamesCount, ... }`. **It does not return any answerer's `submittedAnswer`.** No "common wrong answers" surface exists.
+
+Verdict: ✅ — aggregate-only; no per-row submitted text. Note: answerer **names** are attributed (not anonymised) in the answerers line; this is a separate identity-privacy question, not a submitted-text leak.
+
+### B4. Game / season summary, author-facing slice — ✅ no UI leak, but data is over-fetched
+
+`src/app/games/[id]/summary/page.tsx`:
+- Round Recap section (lines 254-332) renders `responseByUserQuestion.get(responseKey(session.userId, gameQuestion.questionId))` — i.e., only the **viewer's own** response (line 259). `response.submittedAnswer` at line 295 is the viewer's own text.
+- Your Impact Recap (lines 335-342) is a count only: "{impactCount} of your questions were answered correctly this round."
+- `computeOverlapCells` (`src/server/db/queries/joshing-game.ts:71-121`) produces aggregate scores/correct-counts only, no submitted text.
+
+However, the underlying loader `getJoshingGame` at `src/server/db/queries/joshing-game.ts:300-401` includes the branch:
+
+```ts
+const canSeeAllResponses = viewerComplete || params.requestingUserId === gameRow.game.creatorId;
+return {
+  ...,
+  responses: canSeeAllResponses ? responseRows : responseRows.filter(...),
+};
+```
+
+`responseRows` are full `joshingGameResponses` rows including `submittedAnswer`. So **the game creator (and any completed recipient) receives every participant's `submittedAnswer` in the page payload**, including for questions they authored. Today nothing in the rendered UI projects those values — but the data is shipped to the client in `play-client.tsx` (`JSON.parse(JSON.stringify(view))`, `src/app/games/[id]/page.tsx:23`), so it is observable in the DOM/JS state on the play route for any creator who is also a recipient. The summary route does not pass `view` to a client component, so the leak there is server-only.
+
+Verdict: ✅ on UI rendering; 🟡 **elevated risk in the data layer** — `getJoshingGame` ships submitted text to the game creator with no §8.22 gate. Worth a defence-in-depth fix even though no current view surfaces it.
+
+### B5. Question detail / archive view, when accessed by the author — ✅ no leak
+
+Archive query `src/server/db/queries/archive.ts`:
+- `readFeedItems` (lines 213-281): sets `submittedAnswer: null` (line 269) for feed-sourced items in the archive — the user's own answer is not surfaced here at all.
+- `readJoshingGameItems` (lines 283-319): `submittedAnswer: response.submittedAnswer` (line 307) — but the query filters by `eq(joshingGameResponses.userId, userId)` (line 293), so this is the viewer's **own** response.
+- `readDailyItems` (lines 155-211): viewer's own slot, same rationale.
+- `readWrittenByMeItems` (lines 321-373): for questions the viewer wrote, `submittedAnswer: null` (line 361). ✅ — the author does **not** see other players' submitted text on their own questions in the archive.
+
+Verdict: ✅.
+
+### B6. SMS_LOG audit — ✅ no leak
+
+`SmsLog` schema at `src/server/db/schema.ts:459-473` stores **only** `{ id, userId, phoneNumber, messageType, sentAt }`. There is **no message-body column**, so no submitted-answer text can be persisted in SMS logs by construction.
+
+The SMS sender at `src/server/sms.ts:22-65` accepts a `body: string` but writes only the rate-limited row above (the body itself goes to Twilio and is not retained server-side).
+
+Reviewed all SMS bodies in `src/server/sms.ts` (lines 163-220) and `src/server/db/queries/reactions.ts:89` — no body references `submittedAnswer` or `customMessage` text. The only free-text interpolations are display names, question-text previews, and URLs.
+
+Verdict: ✅.
+
+### B7. API endpoints returning ANSWERS.submitted_answer — partial inventory
+
+There is no single `ANSWERS` table — wrong-answer text lives in **three** stores depending on surface:
+- `FeedItem.submittedAnswer` (`src/server/db/schema.ts:710`) — recorded when a user answers a feed/direct item.
+- `JoshingGameResponse.submittedAnswer` (`src/server/db/schema.ts:764`) — recorded per game.
+- `DailyQueue.slots[].submitted_answer` (jsonb blob).
+- `GradeDispute.submittedAnswer` (`src/server/db/schema.ts:440`) — recorded when a disputer files a recheck.
+
+Endpoints that read these fields and respond with submitted text:
+
+| Endpoint | Caller authorization | Leak risk? |
+|---|---|---|
+| `POST /api/feed/[feedItemId]/answer` | recipient-only (`recipientUserId === session.userId`) | ✅ own answer only |
+| `POST /api/feed/[feedItemId]/recheck` | recipient-only (line 29) | ✅ own dispute |
+| `POST /api/daily/answer` | session-scoped daily slot | ✅ own |
+| `POST /api/daily/recheck` | session-scoped daily slot | ✅ own |
+| `POST /api/daily/catchup/answer` | session-scoped | ✅ own |
+| `POST /api/joshing-games/[id]/answer` | own response only | ✅ own |
+| `POST /api/replay/grade` | session-scoped (`src/app/api/replay/grade/route.ts:51`) | ✅ own |
+| `POST /api/breadcrumb` | filters by `userId` on both daily and joshing-game branches (`src/app/api/breadcrumb/route.ts:119`) | ✅ own |
+| `GET /api/feed` → `get-feed-page.ts:278` | `submitted_answer` only when `cardType === 'answered_by_you'` | ✅ own card only |
+
+Server-rendered surfaces that read submitted text:
+
+| Surface | Audience | Leak? |
+|---|---|---|
+| `/creator-notes/new?q=…&r=…` | question author (enforced line 52) | 🚨 **YES** — see B1 |
+| `/games/[id]/summary` | creator or recipient | ✅ UI filters to viewer's own |
+| `/games/[id]` (play) | recipient (or creator-as-recipient) | 🟡 loader over-fetches; UI filters by viewerId |
+| `/archive` | self | ✅ |
+| `/knowledge/[domain]` | self | ✅ |
+| `/activities` | self | ✅ (no submitted-answer field in activity payloads except the creator-note where the recipient is the answerer, which is by design — they see their own text) |
+
+Verdict: **One confirmed leak (B1).** One elevated-risk loader (B4 / `getJoshingGame`).
+
+### Violations found
+
+#### Violation 1 — `/creator-notes/new` exposes the answerer's submitted text to the question author
+
+- **Path:** `src/app/creator-notes/new/page.tsx:77-79` (renderer); `src/server/creator-notes.ts:80-133` (loader `findWrongAnswerContext`).
+- **Trigger:** Author receives a `creator_note_prompt` SMS (`src/server/sms.ts:189-221` or `src/server/creator-notes.ts:30-78`) after a player misses their question, taps the link, and lands on this page.
+- **Current behavior:** Page shows `{recipientName} said: {submittedAnswer}` verbatim. No opt-in from the answerer is checked.
+- **Expected per §8.22:** Submitted text reaches the author only via (a) a grade dispute initiated by the answerer, (b) a reaction with `include_submitted_answer = true`, or (c) de-identified aggregate (count ≥ 3 / cross-group ≥ 2). The creator-note compose flow is none of these.
+- **Suggested fix scope (do not implement here — flagged for B-FIX-01):** Stop loading `submittedAnswer` for the author's compose surface. Either (i) gate the load on an explicit opt-in stored against the wrong-answer row (requires C1 migration), or (ii) hide the "X said: …" row entirely and write the creator note from the question + canonical-answer pair alone. Option (ii) is the minimal-change fix and aligns with the SMS body, which already omits the answer text. Also remove `submittedAnswer` from `findWrongAnswerContext`'s return type or restrict it to author-disallowed callers.
+
+#### Elevated risk — `getJoshingGame` ships every participant's `submittedAnswer` to the game creator
+
+- **Path:** `src/server/db/queries/joshing-game.ts:361-398`.
+- **Current behavior:** When the requester is the game creator (or any recipient who has completed the game), the loader returns the full `responseRows` array, including every other participant's `submittedAnswer`.
+- **Today:** No rendered UI projects those values for the creator (B4). Risk: any future addition (or a third-party client reading the play-client's serialized `view`) would surface them.
+- **Suggested fix scope (B-FIX-01 sub-task):** Strip `submittedAnswer` from rows where `response.userId !== params.requestingUserId` before returning. Or, at minimum, when `requestingUserId === gameRow.game.creatorId` and the row belongs to a different user.
+
+---
+
+## Section C — Opt-in path
+
+### C1. `include_submitted_answer` column — ❌ missing
+
+`grep -rn "include_submitted_answer\|includeSubmittedAnswer" src/` returns zero hits. `QuestionReaction` columns are listed in A1; none correspond to this opt-in.
+
+**Migration required:** add `ALTER TABLE "QuestionReaction" ADD COLUMN IF NOT EXISTS "include_submitted_answer" boolean NOT NULL DEFAULT false`. Drizzle schema update at `src/server/db/schema.ts:389-409` to match. The migration must also be made idempotent for partially-recorded preview/production DBs in `src/instrumentation.ts` (see CLAUDE.md note on enums/columns).
+
+### C2. UI surface for the opt-in checkbox — 🟡 partial
+
+`QuestionReactionPrompt` at `src/components/play/GameplayChat.tsx:365-489` is the only reaction-composer surface today. It already has a "custom message" toggle (lines 419-436) and a chip rail. The opt-in checkbox could attach to the same prompt — but **only the answerer can see a reaction prompt today, and only inside a joshing-game play view** (it is not rendered in feed, daily, or End-of-Session-Review surfaces). For the §8.22 opt-in to be meaningful on **all** wrong answers, the prompt has to be wired into the feed/daily wrong-answer flows too.
+
+Files to touch:
+- `src/components/play/GameplayChat.tsx` — add the checkbox to `QuestionReactionPrompt`.
+- `src/app/api/reactions/route.ts:24-40` — parse and persist `includeSubmittedAnswer` from the body.
+- A new mount of `QuestionReactionPrompt` in `src/components/feed/AnswerFeedbackSheet.tsx` (or equivalent wrong-answer review surface) — there is no such mount today.
+
+### C3. Read-layer join — ❌ missing
+
+The current reaction view (`src/server/db/queries/reactions.ts:98-148`, `getReactionsForUser`) returns `customMessage` but never joins `ANSWERS.submitted_answer`. The activity hydrator (`src/server/db/queries/activity.ts:306-345`, `hydrateReactions`) likewise does not join. Add a conditional join: `if include_submitted_answer = true AND viewerUserId = question.creatorId then surface answerRow.submitted_answer`. The natural place is `hydrateReactions` (it already filters by `recipientUserId = viewer`, which equals the question author for any inbound reaction).
+
+Verdict: ❌ — the opt-in path requires schema + UI + read-layer work. Score: not ready.
+
+---
+
+## Section D — Dispute path
+
+### D1. Grade-dispute mechanism exists — ✅
+
+Schema: `gradeDisputes` table at `src/server/db/schema.ts:433-457`. Migrations: `drizzle/0025_grade_dispute_recheck_details.sql` and ancestors.
+
+Two write paths:
+- Feed recheck: `POST /api/feed/[feedItemId]/recheck` (`src/app/api/feed/[feedItemId]/recheck/route.ts:75-99` — inserts a `gradeDispute` row).
+- Daily recheck: `POST /api/daily/recheck` (`src/app/api/daily/recheck/route.ts`).
+
+Both are initiated by the **answerer** (auth check restricts to `recipientUserId === session.userId`).
+
+### D2. Dispute exposes the submitted answer to the author — ❌ not yet
+
+`gradeDisputes.submittedAnswer` is persisted (`src/server/db/schema.ts:440`), but `grep -rn "gradeDisputes\|gradeDispute" src/` returns only:
+
+- `src/server/db/schema.ts` — table def
+- `src/server/db/queries/account.ts` — referenced in user-data export
+- `src/app/api/daily/recheck/route.ts`, `src/app/api/feed/[feedItemId]/recheck/route.ts` — write paths
+
+**There is no surface where the question's author reads the dispute (no admin queue, no author-facing notification, no `/disputes` UI).** The disputer receives an LLM verdict back via the recheck response; the author is not notified and has no view.
+
+Verdict: ❌ — disputes are filed but not surfaced. §8.22 requires that disputes be one of the channels that **does** expose the submitted answer to the author; today that channel is dead-end.
+
+### D3. Dispute is the only non-reaction path that does this — ❌
+
+Per the actual code, the dispute path does **not** currently expose the submitted answer to the author (D2). The **only path that does today** is the **creator-notes compose page** (B1), which is neither a dispute nor an opt-in reaction. So today the rule "dispute is the only non-reaction path that exposes submitted text to the author" is violated in the opposite direction: dispute exposes nothing, while creator-notes exposes everything.
+
+Verdict: ❌ — the role currently played by "dispute" is held by the creator-notes flow, and no other path is in between.
+
+---
+
+## Section E — Aggregation rule
+
+### E1. Threshold (count ≥ N) before surfacing common wrong answers — N/A
+
+There is no "common wrong answers" UI in the codebase. `grep -rn "Nobody got this\|common wrong\|common_wrong"` returns zero hits. The thresholds that do exist (`session-close-copy.ts:102`, `daily/summary/page.tsx:120`) are for daily summary copy choices ("≥ 2 of you missed it"), not for revealing submitted text.
+
+Verdict: not applicable — no surface to gate.
+
+### E2. Any view attributes a specific wrong answer to a specific named user in the author's analytics — ✅ no leak found
+
+The author's analytics surfaces are:
+- `/questions` (B3) — names attributed, **but no submitted-answer text**.
+- Authored-questions feed on a profile (`src/components/profile/AuthoredQuestionsFeed.tsx`) — shows the **viewer's own** submitted answer when the viewer answers a friend's question; this is the user's own data, not other answerers' data.
+
+Verdict: ✅ on submitted-text attribution. **Caveat (tangential):** answerer-name attribution in the answerers line at `/questions` (B3) names up to two people who answered, e.g. "Alice and 3 others answered your question". Whether this counts as identity-attribution that §8.22 cares about is a product question; flagged below.
+
+---
+
+## Recommended follow-up prompts
+
+### B-FIX-01 — Stop leaking submitted text in the creator-note compose flow
+
+Scope: change `src/app/creator-notes/new/page.tsx:77-79` to no longer render `wrongAnswer.submittedAnswer`, and change `src/server/creator-notes.ts:findWrongAnswerContext` to either (a) not return `submittedAnswer` to author-side callers, or (b) gate it on an opt-in flag once C1 lands. Add a unit/integration test asserting the page does not render answerer text when accessed by a non-disputing author. Also strip `submittedAnswer` from `getJoshingGame` rows belonging to other users when the requester is the game creator (`src/server/db/queries/joshing-game.ts:396-398`). Single PR, ~50 LoC + tests.
+
+### B-OPTIN-01 — Wire the wrong-answer reaction opt-in end-to-end
+
+Scope:
+- Migration: add `include_submitted_answer boolean NOT NULL DEFAULT false` to `QuestionReaction`. Add idempotent guard in `src/instrumentation.ts`.
+- App `CANNED_REACTIONS` at `src/lib/reactions.ts:1-8` — add the wrong-answer canned types (`didnt_know_tell_me`, `need_story`, `adding_to_list`, `knew_i_wouldnt`) and split the list by context (correct vs. wrong) so the prompt renders the right ones.
+- `QuestionReactionPrompt` (`src/components/play/GameplayChat.tsx:365-489`) — add a checkbox "include what I wrote" that posts `includeSubmittedAnswer: true`.
+- `POST /api/reactions` (`src/app/api/reactions/route.ts`) — accept and persist.
+- `hydrateReactions` (`src/server/db/queries/activity.ts:306-345`) — when `include_submitted_answer = true` and the viewer is the question's author, join the relevant `submittedAnswer` and add it to the activity payload.
+- Renderer (`src/app/activities/page.tsx:227-240`) — render the joined text under the reaction card.
+- Mount `QuestionReactionPrompt` in the feed wrong-answer review (it is currently joshing-game-only).
+- Tests: opt-in defaults off; off → text hidden; on → text visible only to the question author.
+
+This is the bulk of the §8.22 work. Plan as a multi-PR sequence.
+
+### B-DISPUTE-01 — Make dispute actually expose the submitted answer to the author
+
+Scope: build an author-facing surface (an item in `/activities`, or a dedicated `/disputes` queue) that lists pending disputes on questions the user authored, projecting `gradeDisputes.submittedAnswer` and `gradeDisputes.canonicalAnswer`. Without this, §8.22's "dispute path" is theoretical.
+
+### B-AGGREGATION-01 — Decide and enforce the aggregation rule
+
+Scope: today there is no "common wrong answers" surface, so the rule is not yet under threat. Before any future analytics PR adds one, encode the count-threshold (≥ 3, or ≥ 2 cross-group) in a single helper at `src/server/analytics/wrong-answer-aggregation.ts` and require its use as the only way to read wrong-answer text in an author-facing query.
+
+---
+
+## Tangential findings (not acted on)
+
+1. `reactionType` is typed `text` in the table (`src/server/db/schema.ts:398`) rather than the existing `reactionCannedEnum`. This makes the DB enum dormant and lets the app diverge from the schema (which it does — see A2). Worth tightening when B-OPTIN-01 lands.
+2. The `creatorResponseCannedEnum` and `creator_reaction_response` SMS type exist with no write path (A8). Either implement or remove.
+3. PRD vs. code drift on the custom-message char cap (100 vs. 160) is already in `PRD_BACKLOG.md:61`.
+4. `notifyPreviousAnswerers` (`src/server/feed/create-feed-items-for-answer.ts:150-173`) sends `friend_answered_your_question` activity to **previous co-answerers**, not to the question's author. The naming "your question" is misleading. Worth renaming or reusing for an actual author-side notification.
+5. The answerers line at `/questions` (`src/app/questions/page.tsx:148-156`) names up to two people who answered the author's question. This is identity-attribution that §8.22 does not explicitly address (the rule is about *text*, not names). If product wants identity-anonymisation, this is the surface to revisit.
+6. `Friendship` answerer-name attribution + the `customMessage` channel on reactions (160 chars of free text from answerer → author, with no opt-in metadata) together approximate a §8.22 leak via user behaviour: an answerer can paste their own submitted text into the customMessage. Not a code bug, but worth a copy/UX consideration in the reaction-composer.

--- a/drizzle/0038_feed_item_catchup_resolved.sql
+++ b/drizzle/0038_feed_item_catchup_resolved.sql
@@ -1,0 +1,11 @@
+-- Track when a wrong feed answer was recovered through the catch-up flow.
+-- Catch-up surfaces feed items where state = 'answered' AND answerResult =
+-- 'incorrect' AND catchupResolvedAt IS NULL. Setting this timestamp removes
+-- the feed item from catch-up without altering the feed history (so the
+-- recipient still sees "you answered this wrong" on the feed card itself).
+--
+-- Idempotent guard is pre-applied in src/instrumentation.ts for preview/
+-- production databases that may have this migration recorded without the
+-- column actually present.
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "catchupResolvedAt" timestamptz;

--- a/drizzle/0039_repair_short_canonical_subcategory.sql
+++ b/drizzle/0039_repair_short_canonical_subcategory.sql
@@ -1,0 +1,51 @@
+-- Data backfill — repair rows where canonical_subcategory landed as a 1–2 char
+-- fragment due to the categorizer truncating abbreviations (`Mr. Hooper` → `Mr`)
+-- or picking a leading single capital letter (`A loaf of bread...` → `A`).
+--
+-- In the affected database both bad labels happen to belong to Sesame Street
+-- questions Robyn authored, so we consolidate them under one "Sesame Street"
+-- territory in Film & Television. Mastery points are summed when a user has
+-- both rows. The categorizer + write-boundary fixes in this same change ensure
+-- new questions can't land here again.
+--
+-- Idempotent: after a successful run there are no rows with canonical_subcategory
+-- in ('Mr', 'A'), so subsequent boots are no-ops.
+
+BEGIN;
+
+-- 1. Question — rename canonical/sub/broad/category on the two authored rows.
+UPDATE "Question"
+SET canonical_subcategory = 'Sesame Street',
+    subcategory = 'Sesame Street',
+    broad_category = 'Film & Television',
+    category = 'film_tv',
+    updated_at = NOW()
+WHERE id IN (
+  '43a93612-81cb-4998-af96-bd7433d544d6',
+  'b1f075d1-e9c7-4439-87f9-73224293f3bc'
+)
+  AND canonical_subcategory IN ('Mr', 'A');
+
+-- 2. MASTERY_EVENTS — every event under the broken labels gets rewritten.
+UPDATE "MASTERY_EVENTS"
+SET canonical_subcategory = 'Sesame Street'
+WHERE canonical_subcategory IN ('Mr', 'A');
+
+-- 3. PLAYER_MASTERY — for each user, sum points from any 'Mr' and/or 'A' rows
+--    into a single 'Sesame Street' row, then delete the originals. ON CONFLICT
+--    keeps this safe if a 'Sesame Street' row already exists for the user
+--    (sums into the existing row instead of erroring on the unique constraint).
+INSERT INTO "PLAYER_MASTERY" (user_id, canonical_subcategory, broad_category, total_points)
+SELECT user_id, 'Sesame Street', 'Film & Television', SUM(total_points)
+FROM "PLAYER_MASTERY"
+WHERE canonical_subcategory IN ('Mr', 'A')
+GROUP BY user_id
+ON CONFLICT (user_id, canonical_subcategory) DO UPDATE
+  SET total_points = "PLAYER_MASTERY".total_points + EXCLUDED.total_points,
+      broad_category = 'Film & Television',
+      updated_at = NOW();
+
+DELETE FROM "PLAYER_MASTERY"
+WHERE canonical_subcategory IN ('Mr', 'A');
+
+COMMIT;

--- a/drizzle/0040_question_reaction_include_submitted_answer.sql
+++ b/drizzle/0040_question_reaction_include_submitted_answer.sql
@@ -1,0 +1,13 @@
+-- Migration: §8.22 wrong-answer text visibility — opt-in flag on reactions.
+--
+-- Adds include_submitted_answer to QuestionReaction. When an answerer sends
+-- a wrong-answer reaction with this flag = true, the activity-feed read
+-- layer joins their submitted_answer into the payload that reaches the
+-- question's author. Default false; existing rows preserve the §8.22
+-- default that submitted text does NOT reach the author.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded
+-- without the column actually present.
+ALTER TABLE "QuestionReaction"
+  ADD COLUMN IF NOT EXISTS "includeSubmittedAnswer" boolean NOT NULL DEFAULT false;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -267,6 +267,13 @@
       "when": 1779753600000,
       "tag": "0037_round_reminder_optin",
       "breakpoints": true
+    },
+    {
+      "idx": 38,
+      "version": "7",
+      "when": 1779840000000,
+      "tag": "0038_feed_item_catchup_resolved",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1779926400000,
       "tag": "0039_repair_short_canonical_subcategory",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1780012800000,
+      "tag": "0040_question_reaction_include_submitted_answer",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1779840000000,
       "tag": "0038_feed_item_catchup_resolved",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1779926400000,
+      "tag": "0039_repair_short_canonical_subcategory",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/account/notifications/NotificationsForm.tsx
+++ b/src/app/account/notifications/NotificationsForm.tsx
@@ -32,8 +32,6 @@ async function patchReminders(body: Record<string, unknown>): Promise<{
 
 export function NotificationsForm({ initialState, maskedPhone }: Props) {
   const [state, setState] = useState<ReminderState>(initialState);
-  const [savingSms, setSavingSms] = useState(false);
-  const [smsError, setSmsError] = useState<string | null>(null);
   const [emailDraft, setEmailDraft] = useState(state.pendingEmail ?? '');
   const [savingEmail, setSavingEmail] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
@@ -43,19 +41,6 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
   const emailOn = state.emailOptIn === 'opted_in';
   const hasPendingEmail = Boolean(state.pendingEmail);
   const hasVerifiedEmail = state.emailVerified && Boolean(state.email);
-
-  async function toggleSms() {
-    const next = smsOn ? 'opted_out' : 'opted_in';
-    setSavingSms(true);
-    setSmsError(null);
-    const result = await patchReminders({ smsOptIn: next });
-    setSavingSms(false);
-    if (!result.ok || !result.state) {
-      setSmsError(result.errorMessage ?? 'Could not save.');
-      return;
-    }
-    setState(result.state);
-  }
 
   async function saveEmail() {
     const trimmed = emailDraft.trim();
@@ -92,20 +77,26 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
       <section className="rounded-xl border bg-card p-5 text-card-foreground">
         <div className="flex items-start justify-between gap-3">
           <div className="flex min-w-0 flex-1 flex-col">
-            <h2 className="font-serif text-lg font-semibold">SMS reminders</h2>
+            <div className="flex flex-wrap items-center gap-2">
+              <h2 className="font-serif text-lg font-semibold">SMS reminders</h2>
+              <span className="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800">
+                Coming soon
+              </span>
+            </div>
             <p className="mt-1 text-sm text-muted-foreground">
-              Text {maskedPhone} when a new round opens.
+              SMS notifications are coming soon — this functionality isn&apos;t
+              available yet. Once it&apos;s ready, we&apos;ll text {maskedPhone}{' '}
+              when a new round opens.
             </p>
           </div>
           <button
             type="button"
             role="switch"
             aria-checked={smsOn}
-            disabled={savingSms}
-            onClick={() => void toggleSms()}
-            className={`relative inline-flex h-7 w-12 flex-none items-center rounded-full border transition ${
-              smsOn ? 'bg-emerald-500 border-emerald-500' : 'bg-muted border-border'
-            } ${savingSms ? 'opacity-60' : ''}`}
+            aria-disabled
+            disabled
+            title="SMS notifications are coming soon"
+            className="relative inline-flex h-7 w-12 flex-none cursor-not-allowed items-center rounded-full border bg-muted border-border opacity-60"
           >
             <span
               className={`inline-block size-5 rounded-full bg-white shadow transition ${
@@ -114,14 +105,6 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
             />
           </button>
         </div>
-        {smsOn ? (
-          <p className="mt-3 text-xs text-muted-foreground">
-            Saved. Texts will start when reminders launch.
-          </p>
-        ) : null}
-        {smsError ? (
-          <p className="mt-2 text-xs text-rose-700">{smsError}</p>
-        ) : null}
       </section>
 
       <section className="rounded-xl border bg-card p-5 text-card-foreground">

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -150,6 +150,14 @@ function ActivityCopy({ item }: { item: ActivityItemView }) {
     )
   }
 
+  if (item.type === 'grade_dispute_filed') {
+    return (
+      <>
+        {actorName(item)} asked for a re-look at your question
+      </>
+    )
+  }
+
   return <>Something happened on Joshing</>
 }
 
@@ -224,6 +232,32 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
     )
   }
 
+  if (item.type === 'grade_dispute_filed') {
+    const dispute = item.reference.gradeDispute
+    if (!dispute) return null
+    return (
+      <div className="bg-background mt-1 space-y-1 rounded-md border p-3 text-sm leading-6">
+        <p>
+          <span className="text-foreground font-medium">Question:</span>{' '}
+          {dispute.questionText}
+        </p>
+        <p className="text-muted-foreground">
+          <span className="text-foreground font-medium">Canonical answer:</span>{' '}
+          {dispute.canonicalAnswer}
+        </p>
+        {/* §8.22 dispute path: the answerer initiated the dispute, which is
+            the consent gate that lets the author see their literal text. */}
+        <p className="text-muted-foreground">
+          <span className="text-foreground font-medium">They wrote:</span>{' '}
+          {dispute.submittedAnswer || '(no text)'}
+        </p>
+        <p className="text-muted-foreground text-xs">
+          {disputeStatusLabel(dispute.status, dispute.acceptedAlternative)}
+        </p>
+      </div>
+    )
+  }
+
   if (item.type !== 'reaction_received') return null
   const reaction = item.reference.reaction
   if (!reaction) return null
@@ -246,6 +280,20 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
       ) : null}
     </div>
   )
+}
+
+function disputeStatusLabel(
+  status: string,
+  acceptedAlternative: string | null,
+): string {
+  if (status === 'alternative_added') {
+    return acceptedAlternative
+      ? `Accepted — added "${acceptedAlternative}" as an alternative.`
+      : 'Accepted — alternative added.'
+  }
+  if (status === 'dismissed') return 'Dismissed — grade stands.'
+  if (status === 'reviewed') return 'Reviewed.'
+  return 'Pending review.'
 }
 
 function ActivityCta({ item }: { item: ActivityItemView }) {

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -236,6 +236,14 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
         {reaction.customMessage ? ` - ${reaction.customMessage}` : ''}
       </p>
       <p className="line-clamp-2 italic">{reaction.questionText}</p>
+      {/* §8.22 opt-in: rendered only when the answerer explicitly chose to
+          include their submitted text. */}
+      {reaction.submittedAnswer ? (
+        <p>
+          <span className="text-foreground font-medium">They wrote:</span>{' '}
+          {reaction.submittedAnswer}
+        </p>
+      ) : null}
     </div>
   )
 }

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -36,8 +36,10 @@ const {
 
 const CATCHUP_ITEM = {
   dailyQueueItemId: 'queue-1:0',
+  surface: 'daily' as const,
   queueId: 'queue-1',
   slotIndex: 0,
+  feedItemId: null,
   questionId: 'gen-q-1',
   questionText: 'q?',
   correctAnswer: 'A',
@@ -107,6 +109,16 @@ vi.mock('@/server/auth/session', () => ({
 vi.mock('@/server/db', () => ({
   db: dbMock,
   dailyQueues: { id: 'q.id' },
+  feedItems: {
+    id: 'f.id',
+    recipientUserId: 'f.recipient',
+    questionId: 'f.questionId',
+    catchupResolvedAt: 'f.catchupResolvedAt',
+    answerResult: 'f.answerResult',
+    submittedAnswer: 'f.submittedAnswer',
+    state: 'f.state',
+    sourceEventAt: 'f.sourceEventAt',
+  },
   questions: {
     id: 'q.id',
     creatorId: 'q.creatorId',
@@ -126,6 +138,11 @@ vi.mock('@/server/daily/catchup', () => ({
     slots.find((s) => s.slot_index === idx),
   replaceQueueSlot: (slots: { slot_index: number }[], idx: number, fn: (s: unknown) => unknown) =>
     slots.map((s) => (s.slot_index === idx ? fn(s) : s)),
+  parseCatchupItemId: (id: string) => {
+    if (id.startsWith('feed:')) return { surface: 'feed', feedItemId: id.slice(5) }
+    const [queueId, slotIndexValue] = id.split(':')
+    return { surface: 'daily', queueId, slotIndex: Number(slotIndexValue) }
+  },
 }))
 
 vi.mock('@/server/mastery/write-mastery-event', () => ({

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -4,9 +4,14 @@ import { NextRequest } from 'next/server';
 import { gradeAnswer, selectQuip } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
 import { getSession } from '@/server/auth/session';
-import { dailyQueues, db, questions } from '@/server/db';
-import { getCatchupQuestions } from '@/server/db/queries/daily';
-import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
+import { dailyQueues, db, feedItems, questions } from '@/server/db';
+import { getCatchupQuestions, type CatchupQuestion } from '@/server/db/queries/daily';
+import {
+  asQueueSlots,
+  findQueueSlotBySlotIndex,
+  parseCatchupItemId,
+  replaceQueueSlot,
+} from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { awardAuthorCredit } from '@/server/mastery/author-credit';
@@ -32,6 +37,26 @@ function parseBody(value: unknown): { dailyQueueItemId: string; submittedAnswer:
   return { dailyQueueItemId, submittedAnswer };
 }
 
+function nextItemPayload(item: CatchupQuestion | null) {
+  if (!item) return null;
+  return {
+    dailyQueueItemId: item.dailyQueueItemId,
+    questionId: item.questionId,
+    questionText: item.questionText,
+    correctAnswer: item.correctAnswer,
+    alternateAnswers: item.alternateAnswers,
+    explanation: item.explanation,
+    domain: item.domain,
+    domainDisplayName: item.domainDisplayName,
+    queueDate: item.queueDate,
+    queueAge: item.queueAge,
+    wasSkipped: item.wasSkipped,
+    expiresAt: item.expiresAt,
+    expiresSoon: item.expiresSoon,
+    difficultyEstimate: item.difficultyEstimate,
+  };
+}
+
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return catchUpErrorResponse(401, 'unauthorized');
@@ -49,12 +74,40 @@ export async function POST(request: NextRequest) {
     });
   }
 
+  if (catchupItem.surface === 'feed') {
+    return handleFeedCatchupAnswer({
+      userId: session.userId,
+      submittedAnswer: parsed.submittedAnswer,
+      catchupItem,
+    });
+  }
+
+  return handleDailyCatchupAnswer({
+    userId: session.userId,
+    submittedAnswer: parsed.submittedAnswer,
+    catchupItem,
+  });
+}
+
+async function handleDailyCatchupAnswer({
+  userId,
+  submittedAnswer,
+  catchupItem,
+}: {
+  userId: string;
+  submittedAnswer: string;
+  catchupItem: CatchupQuestion;
+}) {
+  if (catchupItem.queueId === null || catchupItem.slotIndex === null) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Daily catch-up item missing queue reference');
+  }
+
   const [queue] = await db
     .select()
     .from(dailyQueues)
     .where(eq(dailyQueues.id, catchupItem.queueId))
     .limit(1);
-  if (!queue || queue.userId !== session.userId) {
+  if (!queue || queue.userId !== userId) {
     return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found', {
       refresh_required: true,
     });
@@ -62,14 +115,21 @@ export async function POST(request: NextRequest) {
 
   const slots = asQueueSlots(queue.slots);
   const slot = findQueueSlotBySlotIndex(slots, catchupItem.slotIndex);
-  if (!slot || slot.answered || slot.dismissed_at) {
+  if (!slot || slot.dismissed_at) {
+    return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
+      refresh_required: true,
+    });
+  }
+  // A slot previously answered correctly is not eligible — only wrong/skipped/
+  // untouched slots show up in catch-up after the expanded eligibility rules.
+  if (slot.answered && slot.answer_state !== 'incorrect') {
     return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
       refresh_required: true,
     });
   }
 
   const grade = await gradeAnswer(
-    parsed.submittedAnswer,
+    submittedAnswer,
     catchupItem.correctAnswer,
     catchupItem.alternateAnswers,
     catchupItem.questionText,
@@ -115,7 +175,7 @@ export async function POST(request: NextRequest) {
   }
 
   const priorAnswers = canonicalQuestionId
-    ? await readPriorAnswersForQuestion(session.userId, canonicalQuestionId)
+    ? await readPriorAnswersForQuestion(userId, canonicalQuestionId)
     : [];
   const masteryAnswerState = computeAnswerState(
     isCorrect ? 'correct' : 'wrong',
@@ -138,7 +198,7 @@ export async function POST(request: NextRequest) {
       ...item,
       answered: true,
       answer_state: answerState,
-      submitted_answer: parsed.submittedAnswer,
+      submitted_answer: submittedAnswer,
       awarded_points: pointsAwarded,
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
@@ -148,13 +208,13 @@ export async function POST(request: NextRequest) {
   });
 
   const masteryDelta = await writeMasteryEvent({
-    userId: session.userId,
+    userId,
     questionId: catchupItem.questionId,
     domain: catchupItem.domain,
     answerState: masteryAnswerState,
     pointsAwarded,
     sourceType: 'catchup',
-    sourceId: parsed.dailyQueueItemId,
+    sourceId: catchupItem.dailyQueueItemId,
     broadCategory: catchupItem.broadCategory,
     eventQuestionId: canonicalQuestionId,
     basePoints: catchupItem.basePoints,
@@ -164,10 +224,10 @@ export async function POST(request: NextRequest) {
   await db
     .update(dailyQueues)
     .set({ slots: nextSlots })
-    .where(eq(dailyQueues.id, catchupItem.queueId));
+    .where(eq(dailyQueues.id, queue.id));
 
   await updateDomainDifficultyOnAnswer(
-    session.userId,
+    userId,
     catchupItem.domain,
     isCorrect,
   ).catch((err) => {
@@ -176,30 +236,30 @@ export async function POST(request: NextRequest) {
 
   if (canonicalQuestionId) {
     try {
-      if (isCorrect && persistedCreatorId && persistedCreatorId !== session.userId && persistedDomainForCreator) {
+      if (isCorrect && persistedCreatorId && persistedCreatorId !== userId && persistedDomainForCreator) {
         void promoteDeclaredToDemonstrated({
           userId: persistedCreatorId,
           domain: persistedDomainForCreator,
-          triggeringFriendId: session.userId,
+          triggeringFriendId: userId,
           questionId: canonicalQuestionId,
         });
 
         // Author credit (PRD §8.32): off the user's hot path.
         void awardAuthorCredit({
           creatorUserId: persistedCreatorId,
-          answererUserId: session.userId,
+          answererUserId: userId,
           questionId: canonicalQuestionId,
           domain: persistedDomainForCreator,
-          sourceId: `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
+          sourceId: `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
           scope: 'daily/catchup/answer',
         });
       }
 
       void createFeedItemsForFriendsFromAnswer(
-        session.userId,
+        userId,
         canonicalQuestionId,
         isCorrect ? 'correct' : 'incorrect',
-        `catchup:${catchupItem.dailyQueueItemId}:${session.userId}`,
+        `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
       );
     } catch (error) {
       console.warn('[daily/catchup/answer] feed propagation failed', {
@@ -210,7 +270,7 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const nextItem = (await getCatchupQuestions(session.userId))[0] ?? null;
+  const nextItem = (await getCatchupQuestions(userId))[0] ?? null;
 
   return Response.json({
     dailyQueueItemId: catchupItem.dailyQueueItemId,
@@ -230,23 +290,150 @@ export async function POST(request: NextRequest) {
     explainer: catchupItem.explanation,
     consolation: grade.consolation,
     quip,
-    nextItem: nextItem
-      ? {
-          dailyQueueItemId: nextItem.dailyQueueItemId,
-          questionId: nextItem.questionId,
-          questionText: nextItem.questionText,
-          correctAnswer: nextItem.correctAnswer,
-          alternateAnswers: nextItem.alternateAnswers,
-          explanation: nextItem.explanation,
-          domain: nextItem.domain,
-          domainDisplayName: nextItem.domainDisplayName,
-          queueDate: nextItem.queueDate,
-          queueAge: nextItem.queueAge,
-          wasSkipped: nextItem.wasSkipped,
-          expiresAt: nextItem.expiresAt,
-          expiresSoon: nextItem.expiresSoon,
-          difficultyEstimate: nextItem.difficultyEstimate,
-        }
-      : null,
+    nextItem: nextItemPayload(nextItem),
+  });
+}
+
+async function handleFeedCatchupAnswer({
+  userId,
+  submittedAnswer,
+  catchupItem,
+}: {
+  userId: string;
+  submittedAnswer: string;
+  catchupItem: CatchupQuestion;
+}) {
+  if (!catchupItem.feedItemId) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
+  }
+  const parsedId = parseCatchupItemId(catchupItem.dailyQueueItemId);
+  if (parsedId?.surface !== 'feed') {
+    return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item id malformed');
+  }
+
+  // Re-verify the feed item still exists and is still eligible. We pulled it
+  // via getCatchupQuestions, but a concurrent feed answer/dismiss could have
+  // resolved it between the read and now.
+  const [feedRow] = await db
+    .select({ feedItem: feedItems, question: questions })
+    .from(feedItems)
+    .innerJoin(questions, eq(feedItems.questionId, questions.id))
+    .where(eq(feedItems.id, catchupItem.feedItemId))
+    .limit(1);
+  if (!feedRow || feedRow.feedItem.recipientUserId !== userId) {
+    return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found', {
+      refresh_required: true,
+    });
+  }
+  if (feedRow.feedItem.catchupResolvedAt) {
+    return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
+      refresh_required: true,
+    });
+  }
+
+  const grade = await gradeAnswer(
+    submittedAnswer,
+    catchupItem.correctAnswer,
+    catchupItem.alternateAnswers,
+    catchupItem.questionText,
+    feedRow.question.questionType,
+  );
+  const isCorrect = grade.result === 'correct';
+  const answerState = isCorrect ? 'correct' : 'incorrect';
+  const quip = selectQuip({ isCorrect, surface: 'daily', friendResult: null });
+
+  const priorAnswers = await readPriorAnswersForQuestion(userId, feedRow.question.id);
+  const masteryAnswerState = computeAnswerState(
+    isCorrect ? 'correct' : 'wrong',
+    priorAnswers,
+  );
+
+  const baseCatchupPoints = Math.round(catchupItem.basePoints * CATCHUP_SURFACE_WEIGHT);
+  const pointsAwarded =
+    masteryAnswerState === 'first_correct'
+      ? baseCatchupPoints
+      : masteryAnswerState === 'first_correct_after_wrong'
+        ? Math.round(catchupItem.basePoints * RECOVERY_STATE_WEIGHT)
+        : 0;
+
+  const masteryDelta = await writeMasteryEvent({
+    userId,
+    questionId: feedRow.question.id,
+    domain: catchupItem.domain,
+    answerState: masteryAnswerState,
+    pointsAwarded,
+    sourceType: 'catchup',
+    sourceId: catchupItem.dailyQueueItemId,
+    broadCategory: catchupItem.broadCategory,
+    eventQuestionId: feedRow.question.id,
+    basePoints: catchupItem.basePoints,
+    weight: catchupItem.basePoints > 0 ? pointsAwarded / catchupItem.basePoints : 0,
+  });
+
+  // Resolve the feed item so it stops surfacing in catch-up. We only flip
+  // answerResult to 'correct' on recovery; the original feed-card history
+  // (state='answered', submittedAnswer) stays put so the user can still see
+  // what they originally typed.
+  await db
+    .update(feedItems)
+    .set({
+      catchupResolvedAt: new Date(),
+      ...(isCorrect ? { answerResult: 'correct' as const, pointsAwarded } : {}),
+    })
+    .where(eq(feedItems.id, feedRow.feedItem.id));
+
+  await updateDomainDifficultyOnAnswer(userId, catchupItem.domain, isCorrect).catch((err) => {
+    console.warn('[daily/catchup/answer] updateDomainDifficultyOnAnswer (feed) failed', err);
+  });
+
+  // Promote author's declared territory + author credit on first recovery,
+  // mirroring the daily path. Skipped for self-authored questions.
+  if (isCorrect && feedRow.question.creatorId && feedRow.question.creatorId !== userId) {
+    void promoteDeclaredToDemonstrated({
+      userId: feedRow.question.creatorId,
+      domain: catchupItem.domain,
+      triggeringFriendId: userId,
+      questionId: feedRow.question.id,
+    });
+    void awardAuthorCredit({
+      creatorUserId: feedRow.question.creatorId,
+      answererUserId: userId,
+      questionId: feedRow.question.id,
+      domain: catchupItem.domain,
+      sourceId: `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
+      scope: 'daily/catchup/answer',
+    });
+  }
+
+  if (isCorrect) {
+    void createFeedItemsForFriendsFromAnswer(
+      userId,
+      feedRow.question.id,
+      'correct',
+      `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
+    );
+  }
+
+  const nextItem = (await getCatchupQuestions(userId))[0] ?? null;
+
+  return Response.json({
+    dailyQueueItemId: catchupItem.dailyQueueItemId,
+    questionId: feedRow.question.id,
+    result: grade.result,
+    isCorrect,
+    correct: isCorrect,
+    pointsAwarded,
+    answerState,
+    breadcrumb: null,
+    awarded_points: pointsAwarded,
+    masteryDelta,
+    mastery_delta: masteryDelta,
+    correctAnswer: catchupItem.correctAnswer,
+    answer: catchupItem.correctAnswer,
+    explanation: catchupItem.explanation,
+    explainer: catchupItem.explanation,
+    consolation: grade.consolation,
+    quip,
+    nextItem: nextItemPayload(nextItem),
   });
 }

--- a/src/app/api/daily/catchup/dismiss/route.ts
+++ b/src/app/api/daily/catchup/dismiss/route.ts
@@ -2,7 +2,7 @@ import { eq } from 'drizzle-orm';
 import { NextRequest } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { dailyQueues, db } from '@/server/db';
+import { dailyQueues, db, feedItems } from '@/server/db';
 import { getCatchupQuestions } from '@/server/db/queries/daily';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
@@ -42,6 +42,34 @@ export async function POST(request: NextRequest) {
     .find((item) => item.dailyQueueItemId === parsed.dailyQueueItemId);
   if (!catchupItem) return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
 
+  if (catchupItem.surface === 'feed') {
+    if (!catchupItem.feedItemId) {
+      return catchUpErrorResponse(500, 'invalid_state', 'Feed catch-up item missing feed reference');
+    }
+    const [feedItem] = await db
+      .select()
+      .from(feedItems)
+      .where(eq(feedItems.id, catchupItem.feedItemId))
+      .limit(1);
+    if (!feedItem || feedItem.recipientUserId !== session.userId) {
+      return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
+    }
+    if (feedItem.catchupResolvedAt) {
+      return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
+    }
+
+    await db
+      .update(feedItems)
+      .set({ catchupResolvedAt: new Date() })
+      .where(eq(feedItems.id, feedItem.id));
+
+    return Response.json({ dismissed: true });
+  }
+
+  if (catchupItem.queueId === null || catchupItem.slotIndex === null) {
+    return catchUpErrorResponse(500, 'invalid_state', 'Daily catch-up item missing queue reference');
+  }
+
   const [queue] = await db
     .select()
     .from(dailyQueues)
@@ -53,7 +81,10 @@ export async function POST(request: NextRequest) {
 
   const slots = asQueueSlots(queue.slots);
   const slot = findQueueSlotBySlotIndex(slots, catchupItem.slotIndex);
-  if (!slot || slot.answered || slot.dismissed_at) {
+  if (!slot || slot.dismissed_at) {
+    return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
+  }
+  if (slot.answered && slot.answer_state !== 'incorrect') {
     return catchUpErrorResponse(400, 'invalid_state', 'catch-up item is already closed');
   }
 

--- a/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
+++ b/src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts
@@ -10,28 +10,60 @@ const {
   readPriorAnswersForQuestionMock,
   selectQuipMock,
   writeMasteryEventMock,
-} = vi.hoisted(() => ({
-  createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
-  getBasePointsMock: vi.fn((_difficulty: unknown, state: string) => {
-    if (state === 'first_correct') return 100
-    if (state === 'first_correct_after_wrong') return 25
-    return 0
-  }),
-  getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
-  gradeAnswerMock: vi.fn(),
-  promoteDeclaredToDemonstratedMock: vi.fn(),
-  promptCreatorNoteAfterWrongAnswerMock: vi.fn(),
-  readPriorAnswersForQuestionMock: vi.fn(async () => []),
-  selectQuipMock: vi.fn(() => 'quip'),
-  writeMasteryEventMock: vi.fn(async () => ({
-    domain: 'history',
-    points: 0,
-    previousTier: 'establishing',
-    newTier: 'establishing',
-    tierChanged: false,
-    openedNewTerritory: false,
-  })),
-}))
+  dbMock,
+  selectCallChain,
+} = vi.hoisted(() => {
+  // Drizzle chain mock — sequence: feed lookup, playerMastery lookup.
+  const selectCallChain: Array<() => Promise<unknown[]>> = []
+  function makeChainable() {
+    const chain: Record<string, unknown> = {}
+    chain.from = () => chain
+    chain.innerJoin = () => chain
+    chain.leftJoin = () => chain
+    chain.where = () => chain
+    chain.limit = () => {
+      const handler = selectCallChain.shift() ?? (async () => [])
+      return handler()
+    }
+    return chain
+  }
+  return {
+    createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
+    getBasePointsMock: vi.fn((_difficulty: unknown, state: string) => {
+      if (state === 'first_correct') return 100
+      if (state === 'first_correct_after_wrong') return 25
+      return 0
+    }),
+    getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
+    gradeAnswerMock: vi.fn(),
+    promoteDeclaredToDemonstratedMock: vi.fn(),
+    promptCreatorNoteAfterWrongAnswerMock: vi.fn(),
+    readPriorAnswersForQuestionMock: vi.fn(async () => []),
+    selectQuipMock: vi.fn(() => 'quip'),
+    writeMasteryEventMock: vi.fn(async () => ({
+      domain: 'history',
+      points: 0,
+      previousTier: 'establishing',
+      newTier: 'establishing',
+      tierChanged: false,
+      openedNewTerritory: false,
+    })),
+    dbMock: {
+      select: vi.fn(() => makeChainable()),
+      transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
+        const tx = {
+          update: vi.fn(() => ({
+            set: vi.fn(() => ({
+              where: vi.fn(async () => undefined),
+            })),
+          })),
+        }
+        await fn(tx)
+      }),
+    },
+    selectCallChain,
+  }
+})
 
 const FEED_ROW = {
   feedItem: {
@@ -59,36 +91,6 @@ const FEED_ROW = {
     factualExplanation: null,
   },
   sourceDisplayName: 'Friend',
-}
-
-// Drizzle chain mock — sequence: feed lookup, playerMastery lookup.
-const selectCallChain: Array<() => Promise<unknown[]>> = []
-
-function makeChainable() {
-  const chain: Record<string, unknown> = {}
-  chain.from = () => chain
-  chain.innerJoin = () => chain
-  chain.leftJoin = () => chain
-  chain.where = () => chain
-  chain.limit = () => {
-    const handler = selectCallChain.shift() ?? (async () => [])
-    return handler()
-  }
-  return chain
-}
-
-const dbMock = {
-  select: vi.fn(() => makeChainable()),
-  transaction: vi.fn(async (fn: (tx: unknown) => Promise<void>) => {
-    const tx = {
-      update: vi.fn(() => ({
-        set: vi.fn(() => ({
-          where: vi.fn(async () => undefined),
-        })),
-      })),
-    }
-    await fn(tx)
-  }),
 }
 
 vi.mock('@/server/grading', () => ({
@@ -283,5 +285,97 @@ describe('POST /api/feed/[feedItemId]/answer mastery scoring (F2.3)', () => {
     await POST(jsonRequest({ submitted_answer: 'A' }) as never, makeContext())
 
     expect(promoteDeclaredToDemonstratedMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('POST /api/feed/[feedItemId]/answer retry policy (direct_sent persistence)', () => {
+  function rowWith(overrides: Partial<typeof FEED_ROW.feedItem>) {
+    return {
+      ...FEED_ROW,
+      feedItem: { ...FEED_ROW.feedItem, ...overrides },
+    }
+  }
+
+  function primeDbChain(row: unknown) {
+    selectCallChain.length = 0
+    selectCallChain.push(async () => [row])
+    selectCallChain.push(async () => [])
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readPriorAnswersForQuestionMock.mockResolvedValue([])
+    writeMasteryEventMock.mockResolvedValue({
+      domain: 'history',
+      points: 0,
+      previousTier: 'establishing',
+      newTier: 'establishing',
+      tierChanged: false,
+      openedNewTerritory: false,
+    })
+  })
+
+  it('accepts a retry on a direct_sent item that was answered wrong', async () => {
+    primeDbChain(rowWith({
+      state: 'answered',
+      sourceType: 'direct_sent',
+      answerResult: 'incorrect',
+    }))
+    readPriorAnswersForQuestionMock.mockResolvedValueOnce([{ result: 'wrong' }])
+    gradeAnswerMock.mockResolvedValueOnce({ result: 'correct', consolation: null })
+
+    const response = await POST(jsonRequest({ submitted_answer: 'A' }) as never, makeContext())
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ isCorrect: true })
+    expect(writeMasteryEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ answerState: 'first_correct_after_wrong' }),
+    )
+  })
+
+  it('rejects a retry on a direct_sent item that was answered correctly', async () => {
+    primeDbChain(rowWith({
+      state: 'answered',
+      sourceType: 'direct_sent',
+      answerResult: 'correct',
+    }))
+
+    const response = await POST(jsonRequest({ submitted_answer: 'A' }) as never, makeContext())
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body).toMatchObject({ error: 'invalid_state' })
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a retry on a non-direct_sent answered item even if wrong', async () => {
+    primeDbChain(rowWith({
+      state: 'answered',
+      sourceType: 'authored_shared',
+      answerResult: 'incorrect',
+    }))
+
+    const response = await POST(jsonRequest({ submitted_answer: 'A' }) as never, makeContext())
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body).toMatchObject({ error: 'invalid_state' })
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
+  })
+
+  it('still rejects dismissed / rolled_off items regardless of source', async () => {
+    primeDbChain(rowWith({
+      state: 'dismissed',
+      sourceType: 'direct_sent',
+      answerResult: 'incorrect',
+    }))
+
+    const response = await POST(jsonRequest({ submitted_answer: 'A' }) as never, makeContext())
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body).toMatchObject({ error: 'invalid_state' })
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -55,8 +55,20 @@ export async function POST(request: NextRequest, context: RouteContext) {
     .limit(1);
 
   if (!row) return NextResponse.json({ error: 'not_found' }, { status: 404 });
-  if (row.feedItem.state === 'dismissed' || row.feedItem.state === 'rolled_off' || row.feedItem.state === 'answered') {
+  if (row.feedItem.state === 'dismissed' || row.feedItem.state === 'rolled_off') {
     return NextResponse.json({ error: 'invalid_state', message: 'This Feed item is already closed.' }, { status: 400 });
+  }
+  // direct_sent questions are personal asks from a specific friend. A wrong
+  // answer keeps the card actionable so the recipient can take another swing
+  // without leaving the feed. Other source types — including direct_sent
+  // that were already answered correctly — stay closed once answered.
+  if (row.feedItem.state === 'answered') {
+    const allowRetry =
+      row.feedItem.sourceType === 'direct_sent'
+      && row.feedItem.answerResult === 'incorrect';
+    if (!allowRetry) {
+      return NextResponse.json({ error: 'invalid_state', message: 'This Feed item is already closed.' }, { status: 400 });
+    }
   }
 
   const question = row.question;

--- a/src/app/api/feed/[feedItemId]/recheck/route.ts
+++ b/src/app/api/feed/[feedItemId]/recheck/route.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
+import { writeActivity } from '@/server/activity/write-activity';
 import { db, feedItems, gradeDisputes, questions } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { getBasePoints } from '@/server/mastery/scoring';
@@ -72,7 +73,7 @@ export async function POST(_request: NextRequest, context: RouteContext) {
       pointsAwarded = getBasePoints(question.calibratedDifficulty ?? question.llmDifficulty ?? null, 'first_correct');
     }
 
-    await db.transaction(async (tx) => {
+    const disputeId = await db.transaction(async (tx) => {
       if (accepted) {
         await tx
           .update(feedItems)
@@ -80,7 +81,7 @@ export async function POST(_request: NextRequest, context: RouteContext) {
           .where(eq(feedItems.id, feedItemId));
       }
 
-      await tx
+      const [inserted] = await tx
         .insert(gradeDisputes)
         .values({
           answerId,
@@ -95,8 +96,24 @@ export async function POST(_request: NextRequest, context: RouteContext) {
           acceptedAlternative: review.acceptedAlternative,
           status: disputeStatus,
           reviewedAt: review.decision === 'needs_human' ? null : new Date(),
-        });
+        })
+        .returning({ id: gradeDisputes.id });
+      return inserted?.id ?? null;
     });
+
+    // §8.22 dispute path: notify the question's author so they can review.
+    // The dispute is the answerer's explicit ask for a second look, which
+    // is the consent gate that lets the author see the literal submitted
+    // text alongside the canonical answer.
+    if (disputeId && question.creatorId && question.creatorId !== session.userId) {
+      await writeActivity({
+        userId: question.creatorId,
+        type: 'grade_dispute_filed',
+        actorUserId: session.userId,
+        referenceId: disputeId,
+        referenceType: 'grade_dispute',
+      });
+    }
 
     if (accepted) {
       await writeMasteryEvent({

--- a/src/app/api/reactions/route.ts
+++ b/src/app/api/reactions/route.ts
@@ -1,7 +1,7 @@
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { isReactionKey, type ReactionKey } from '@/lib/reactions';
+import { isReactionKey, isWrongAnswerReactionKey, type ReactionKey } from '@/lib/reactions';
 import { getSession } from '@/server/auth/session';
 import { db, feedItems, joshingGameQuestions, joshingGameRecipients, joshingGames } from '@/server/db';
 import {
@@ -19,6 +19,7 @@ type ReactionBody = {
   contextId: string | null;
   reactionType: ReactionKey;
   customMessage?: string | null;
+  includeSubmittedAnswer: boolean;
 };
 
 function parseBody(value: unknown): ReactionBody | null {
@@ -33,10 +34,14 @@ function parseBody(value: unknown): ReactionBody | null {
     : null;
   const reactionType = typeof record.reactionType === 'string' ? record.reactionType.trim() : '';
   const customMessage = typeof record.customMessage === 'string' ? record.customMessage.trim().slice(0, 160) : null;
+  // §8.22: only wrong-answer reactions are eligible to attach submitted text.
+  // For any other reactionType we coerce to false even if the client asks.
+  const includeSubmittedAnswerRequested = record.includeSubmittedAnswer === true;
+  const includeSubmittedAnswer = includeSubmittedAnswerRequested && isWrongAnswerReactionKey(reactionType);
 
   if (!questionId || !contextType || !isReactionKey(reactionType)) return null;
 
-  return { questionId, contextType, contextId, reactionType, customMessage };
+  return { questionId, contextType, contextId, reactionType, customMessage, includeSubmittedAnswer };
 }
 
 async function resolveRecipient(body: ReactionBody, senderUserId: string): Promise<string | null> {
@@ -105,6 +110,7 @@ export async function POST(request: NextRequest) {
     contextId: body.contextId,
     reactionType: body.reactionType,
     customMessage: body.customMessage,
+    includeSubmittedAnswer: body.includeSubmittedAnswer,
   });
 
   return NextResponse.json(created, { status: 201 });

--- a/src/app/creator-notes/new/page.tsx
+++ b/src/app/creator-notes/new/page.tsx
@@ -3,7 +3,6 @@ import { redirect } from 'next/navigation';
 import { eq } from 'drizzle-orm';
 
 import { CreatorNoteForm } from '@/app/creator-notes/new/CreatorNoteForm';
-import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer';
 import { getSession } from '@/server/auth/session';
 import { findWrongAnswerContext } from '@/server/creator-notes';
 import { db, questions, users } from '@/server/db';
@@ -68,14 +67,13 @@ export default async function NewCreatorNotePage({ searchParams }: PageProps) {
         </h1>
       </header>
 
+      {/* §8.22 wrong-answer text visibility: the answerer's submitted text is
+          intentionally NOT shown to the question author here. The author writes
+          the note from the question + canonical answer alone. */}
       <section className="mt-5 rounded-md border bg-card p-4 text-sm leading-6">
         <p><span className="font-medium text-foreground">Question:</span> {row.question.questionText}</p>
         <p className="mt-2 text-muted-foreground">
           <span className="font-medium text-foreground">Answer:</span> {row.question.answerText}
-        </p>
-        <p className="mt-2 text-muted-foreground">
-          <span className="font-medium text-foreground">{recipientName} said:</span>{' '}
-          {creatorNoteSubmittedAnswerText(wrongAnswer.submittedAnswer, 'Their')}
         </p>
       </section>
 

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -228,7 +228,16 @@ function DailySetupContent() {
       });
       const queueBody = await queueResponse.json().catch(() => null);
       if (!queueResponse.ok) {
-        if (domainMode === 'custom' && selectedDomains.size > 0) {
+        // Only the "no knowledge base for this domain" failure should send the
+        // user to the empty-state knowledge page. Transient generation
+        // failures (503 `generation_failed`, e.g. LLM outage or exhausted
+        // credits) should surface the server's banner so we don't lie that
+        // the topic itself is missing.
+        if (
+          queueBody?.error === 'no_knowledge_base' &&
+          domainMode === 'custom' &&
+          selectedDomains.size > 0
+        ) {
           const [domain] = Array.from(selectedDomains);
           router.push(`/knowledge?emptyDomain=${encodeURIComponent(domain)}`);
           return;

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -97,6 +97,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
                 questionId: item.questionId,
                 contextType: 'joshing_game',
                 contextId: game.game.id,
+                result: response.isCorrect ? 'correct' : 'wrong',
               }
             : null,
         });
@@ -171,6 +172,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
                 questionId: currentQuestion.questionId,
                 contextType: 'joshing_game',
                 contextId: game.game.id,
+                result: body.isCorrect ? 'correct' : 'wrong',
               }
             : null,
         },

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -348,7 +348,7 @@ function QuestionsPageContent() {
       <header className="mb-5 flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
         <div>
           <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
-          <p className="mt-1 text-sm text-muted-foreground">{questions.length} banked questions</p>
+          <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
         </div>
         <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create' })}>
           <Plus className="size-4" />
@@ -394,7 +394,7 @@ function QuestionsPageContent() {
         <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
           <h2 className="font-serif text-2xl font-semibold">No questions yet.</h2>
           <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-            Your question bank is empty. Write a question or save one from a friend to build your bank.
+            You haven&apos;t written any questions yet. Write one to get started.
           </p>
           <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
             Write a question

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1039,11 +1039,19 @@ function FeedListContent({
                   const recheckAction: FeedRecheckAction | null = isIncorrect
                     ? { onSubmit: () => submitRecheck(item) }
                     : null
+                  // direct_sent wrong answers stay re-attemptable (server
+                  // allows the re-grade; clicking reopens the same answer
+                  // sheet). Other source types still close on answer.
+                  const onRetry =
+                    isIncorrect && item.source_type === 'direct_sent'
+                      ? () => setAnswerSheetId(item.id)
+                      : undefined
                   return (
                     <AnsweredByYouCard
                       key={item.id}
                       item={answeredItem}
                       recheckAction={recheckAction}
+                      onRetry={onRetry}
                       overflow={overflow}
                     />
                   )

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -117,15 +117,20 @@ export type FeedRecheckAction = {
 type AnsweredByYouCardProps = {
   item: AnsweredByYouFeedItem
   recheckAction?: FeedRecheckAction | null
+  // Optional retry handler for direct_sent wrong answers — opens the answer
+  // sheet so the recipient can take another swing without leaving the feed.
+  onRetry?: () => void
   overflow?: ReactNode
 }
 
 function AnsweredResult({
   item,
   recheckAction,
+  onRetry,
 }: {
   item: AnsweredByYouFeedItem
   recheckAction?: FeedRecheckAction | null
+  onRetry?: () => void
 }) {
   const [recheckState, setRecheckState] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle')
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null)
@@ -180,17 +185,29 @@ function AnsweredResult({
           {item.quip}
         </p>
       ) : null}
-      {recheckAction && recheckState !== 'done' ? (
-        <div className="flex justify-end pt-2">
-          <button
-            type="button"
-            onClick={() => void requestRecheck()}
-            disabled={recheckState === 'submitting'}
-            className="inline-flex items-center border-[1.5px] border-[var(--ink)] bg-[var(--cream)] px-[8px] py-[4px] text-[12px] text-[var(--ink)] transition-transform hover:translate-x-[1px] hover:translate-y-[1px] active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:cursor-default disabled:opacity-60"
-            style={{ boxShadow: '3px 3px 0 var(--ink)' }}
-          >
-            {recheckState === 'submitting' ? 'Rechecking...' : 'Recheck →'}
-          </button>
+      {(onRetry || (recheckAction && recheckState !== 'done')) ? (
+        <div className="flex justify-end gap-2 pt-2">
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={onRetry}
+              className="inline-flex items-center border-[1.5px] border-[var(--ink)] bg-[var(--cream)] px-[8px] py-[4px] text-[12px] text-[var(--ink)] transition-transform hover:translate-x-[1px] hover:translate-y-[1px] active:translate-x-[3px] active:translate-y-[3px] active:shadow-none"
+              style={{ boxShadow: '3px 3px 0 var(--ink)' }}
+            >
+              Try again →
+            </button>
+          ) : null}
+          {recheckAction && recheckState !== 'done' ? (
+            <button
+              type="button"
+              onClick={() => void requestRecheck()}
+              disabled={recheckState === 'submitting'}
+              className="inline-flex items-center border-[1.5px] border-[var(--ink)] bg-[var(--cream)] px-[8px] py-[4px] text-[12px] text-[var(--ink)] transition-transform hover:translate-x-[1px] hover:translate-y-[1px] active:translate-x-[3px] active:translate-y-[3px] active:shadow-none disabled:cursor-default disabled:opacity-60"
+              style={{ boxShadow: '3px 3px 0 var(--ink)' }}
+            >
+              {recheckState === 'submitting' ? 'Rechecking...' : 'Recheck →'}
+            </button>
+          ) : null}
         </div>
       ) : null}
       {recheckMessage ? (
@@ -226,7 +243,7 @@ function AnsweredResult({
   )
 }
 
-export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByYouCardProps) {
+export function AnsweredByYouCard({ item, recheckAction, onRetry, overflow }: AnsweredByYouCardProps) {
   const category = visibleFeedCategory(item.category)
   const categoryColor = colorForCategory(item.category)
 
@@ -309,7 +326,7 @@ export function AnsweredByYouCard({ item, recheckAction, overflow }: AnsweredByY
       </div>
 
       <div className="px-[14px] py-[12px]">
-        <AnsweredResult item={item} recheckAction={recheckAction} />
+        <AnsweredResult item={item} recheckAction={recheckAction} onRetry={onRetry} />
       </div>
     </article>
   )

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -46,6 +46,19 @@ type DomainColor = {
   text: string
 }
 
+// Section header relabel — "General Knowledge" is the catch-all bucket the
+// categorizer falls back to, but it shouldn't be shown to users as a category
+// name. ("Other" already normalizes to "General Knowledge" via
+// normalizeBroadCategory.) Render those entries under a softer label.
+const SECTION_LABEL_OVERRIDES: Record<string, string> = {
+  'General Knowledge': 'Other interests',
+  Other: 'Other interests',
+}
+
+function displaySectionLabel(broadCategory: string): string {
+  return SECTION_LABEL_OVERRIDES[broadCategory] ?? broadCategory
+}
+
 const DOMAIN_COLORS: Record<string, DomainColor> = {
   Literature: {
     primary: '#c0392b',
@@ -151,7 +164,7 @@ function buildSections(
     }
     return Array.from(domainMap.entries())
       .map(([domain, cats]) => ({
-        label: domain,
+        label: displaySectionLabel(domain),
         color: getPortraitDomainColor(domain).primary,
         entries: [...cats].sort(
           (a, b) => b.totalMasteryPoints - a.totalMasteryPoints
@@ -381,12 +394,10 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
 
   const validEntries = useMemo(
     () =>
-      entries
-        .map((entry) => ({
-          ...entry,
-          broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge',
-        }))
-        .filter((e) => e.broadCategory && e.broadCategory !== 'General Knowledge'),
+      entries.map((entry) => ({
+        ...entry,
+        broadCategory: normalizeBroadCategory(entry.broadCategory) ?? 'General Knowledge',
+      })),
     [entries]
   )
   const isSparse = validEntries.length < SPARSE_THRESHOLD
@@ -443,7 +454,7 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
                   }}
                 />
                 <span style={{ fontSize: 9.5, color: dc.text, opacity: 0.85 }}>
-                  {domain}
+                  {displaySectionLabel(domain)}
                 </span>
               </div>
             )

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -6,13 +6,21 @@ import Link from 'next/link';
 import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
 import { SessionCloseMessage } from '@/components/play/SessionCloseMessage';
-import { CANNED_REACTIONS, type ReactionKey } from '@/lib/reactions';
+import {
+  CORRECT_ANSWER_REACTIONS,
+  WRONG_ANSWER_REACTIONS,
+  isWrongAnswerReactionKey,
+  type ReactionKey,
+} from '@/lib/reactions';
 
 export type ReactionPromptData = {
   senderName: string;
   questionId: string;
   contextType: 'feed' | 'joshing_game';
   contextId: string | null;
+  // §8.10b: which canned set to render. Wrong-answer reactions also enable
+  // the §8.22 "include what I wrote" opt-in.
+  result: 'correct' | 'wrong';
 };
 
 export type RecheckActionResult = { accepted: boolean; message: string };
@@ -358,6 +366,10 @@ function reactionEmoji(value: string): string {
     case ':face_palm:': return '🤦';
     case ':sunny:': return '☀️';
     case ':thought_balloon:': return '💭';
+    case ':thinking_face:': return '🤔';
+    case ':open_book:': return '📖';
+    case ':memo:': return '📝';
+    case ':sweat_smile:': return '😅';
     default: return value;
   }
 }
@@ -366,6 +378,12 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
   const [status, setStatus] = useState<'idle' | 'sending' | 'sent' | 'hidden' | 'error'>('idle');
   const [customOpen, setCustomOpen] = useState(false);
   const [customMessage, setCustomMessage] = useState('');
+  // §8.22 opt-in. Only meaningful on wrong-answer reactions; the API coerces
+  // it to false for any other reactionType.
+  const [includeSubmittedAnswer, setIncludeSubmittedAnswer] = useState(false);
+
+  const isWrongAnswer = prompt.result === 'wrong';
+  const cannedSet = isWrongAnswer ? WRONG_ANSWER_REACTIONS : CORRECT_ANSWER_REACTIONS;
 
   useEffect(() => {
     if (status !== 'idle') return;
@@ -392,6 +410,8 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
           contextId: prompt.contextId,
           reactionType,
           customMessage: customMessage.trim() || null,
+          includeSubmittedAnswer:
+            includeSubmittedAnswer && isWrongAnswerReactionKey(reactionType),
         }),
       });
       if (!response.ok) throw new Error('Could not send reaction');
@@ -399,7 +419,7 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
     } catch {
       setStatus('error');
     }
-  }, [customMessage, prompt.contextId, prompt.contextType, prompt.questionId]);
+  }, [customMessage, includeSubmittedAnswer, prompt.contextId, prompt.contextType, prompt.questionId]);
 
   if (status === 'hidden') return null;
 
@@ -434,8 +454,29 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
           }}
         />
       ) : null}
+      {isWrongAnswer ? (
+        <label
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: '6px',
+            marginBottom: '8px',
+            fontSize: '0.72rem',
+            color: 'var(--text-muted)',
+            cursor: 'pointer',
+          }}
+        >
+          <input
+            type="checkbox"
+            checked={includeSubmittedAnswer}
+            onChange={(event) => setIncludeSubmittedAnswer(event.target.checked)}
+            disabled={status === 'sending'}
+          />
+          Include what I wrote
+        </label>
+      ) : null}
       <div style={{ display: 'flex', gap: '6px', maxWidth: '100%', overflowX: 'auto', paddingBottom: '3px' }}>
-        {CANNED_REACTIONS.map((reaction) => (
+        {cannedSet.map((reaction) => (
           <button
             key={reaction.key}
             type="button"

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -285,10 +285,14 @@ export function useCatchupFlow() {
         },
       ]);
 
-      const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
-      const slotIndex = Number(slotIndexValue);
-      if (queueId && Number.isInteger(slotIndex)) {
-        void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
+      // Breadcrumbs are computed from daily-queue slots only; feed-sourced
+      // catch-up items use a `feed:<feedItemId>` ID and have no slot to look up.
+      if (!item.dailyQueueItemId.startsWith('feed:')) {
+        const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
+        const slotIndex = Number(slotIndexValue);
+        if (queueId && Number.isInteger(slotIndex)) {
+          void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
+        }
       }
 
       window.setTimeout(() => {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -136,7 +136,8 @@ export async function register() {
           ADD COLUMN IF NOT EXISTS "personalMessage" text,
           ADD COLUMN IF NOT EXISTS "sourceResult" text,
           ADD COLUMN IF NOT EXISTS "submittedAnswer" text,
-          ADD COLUMN IF NOT EXISTS "quip" text
+          ADD COLUMN IF NOT EXISTS "quip" text,
+          ADD COLUMN IF NOT EXISTS "catchupResolvedAt" timestamptz
       `);
     } catch {
       // FeedItem table may not exist yet — migrate() handles initial creation.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -335,6 +335,20 @@ export async function register() {
       // it before this migration runs.
     }
 
+    // Migration 0040 adds includeSubmittedAnswer to QuestionReaction (§8.22
+    // opt-in for surfacing answerer text to the question author). Guard for
+    // preview/production databases that may have this migration recorded
+    // without the column actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "QuestionReaction"
+          ADD COLUMN IF NOT EXISTS "includeSubmittedAnswer" boolean NOT NULL DEFAULT false
+      `);
+    } catch {
+      // QuestionReaction table may not exist yet on a fresh database —
+      // migrate() creates it before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/lib/__tests__/reactions.test.ts
+++ b/src/lib/__tests__/reactions.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CANNED_REACTIONS,
+  CORRECT_ANSWER_REACTIONS,
+  WRONG_ANSWER_REACTIONS,
+  isReactionKey,
+  isWrongAnswerReactionKey,
+} from '@/lib/reactions';
+
+describe('reaction canned-list classification', () => {
+  it('exposes the four wrong-answer canned types from §8.10b', () => {
+    const keys = WRONG_ANSWER_REACTIONS.map((reaction) => reaction.key);
+    expect(keys).toEqual([
+      'didnt_know_tell_me',
+      'need_story',
+      'adding_to_list',
+      'knew_i_wouldnt',
+    ]);
+  });
+
+  it('keeps the correct-answer and wrong-answer sets disjoint', () => {
+    const correctKeys = new Set(CORRECT_ANSWER_REACTIONS.map((reaction) => reaction.key));
+    for (const reaction of WRONG_ANSWER_REACTIONS) {
+      expect(correctKeys.has(reaction.key)).toBe(false);
+    }
+  });
+
+  it('treats every wrong-answer key as a valid reaction key', () => {
+    for (const reaction of WRONG_ANSWER_REACTIONS) {
+      expect(isReactionKey(reaction.key)).toBe(true);
+      expect(isWrongAnswerReactionKey(reaction.key)).toBe(true);
+    }
+  });
+
+  it('does not classify correct-answer keys as wrong-answer keys', () => {
+    for (const reaction of CORRECT_ANSWER_REACTIONS) {
+      expect(isReactionKey(reaction.key)).toBe(true);
+      expect(isWrongAnswerReactionKey(reaction.key)).toBe(false);
+    }
+  });
+
+  it('rejects unknown keys from both classifiers', () => {
+    expect(isReactionKey('not_a_real_reaction')).toBe(false);
+    expect(isWrongAnswerReactionKey('not_a_real_reaction')).toBe(false);
+    // The §8.22 opt-in gate hinges on this: a misspelled or attacker-supplied
+    // key must not be allowed to attach submitted text.
+    expect(isWrongAnswerReactionKey('good_one')).toBe(false);
+  });
+
+  it('aggregates both subsets into the canonical CANNED_REACTIONS list', () => {
+    const all = new Set(CANNED_REACTIONS.map((reaction) => reaction.key));
+    for (const reaction of [...CORRECT_ANSWER_REACTIONS, ...WRONG_ANSWER_REACTIONS]) {
+      expect(all.has(reaction.key)).toBe(true);
+    }
+    expect(CANNED_REACTIONS).toHaveLength(
+      CORRECT_ANSWER_REACTIONS.length + WRONG_ANSWER_REACTIONS.length,
+    );
+  });
+});

--- a/src/lib/llm.categorization.test.ts
+++ b/src/lib/llm.categorization.test.ts
@@ -5,16 +5,20 @@ import { normalizeCanonicalSubcategory } from '@/lib/question-categorization'
 const createMessageMock = vi.hoisted(() => vi.fn())
 
 vi.mock('@anthropic-ai/sdk', () => ({
-  default: vi.fn(() => ({
-    messages: {
-      create: createMessageMock,
-    },
-  })),
+  // Anthropic is invoked with `new Anthropic({ apiKey })`, so the default export
+  // must be constructable. A class returning the mocked messages.create works;
+  // a vi.fn() factory does not (Node's new-call coercion rejects arrow fns).
+  default: class MockAnthropic {
+    messages = { create: createMessageMock };
+  },
 }))
 
 function anthropicTextResponse(json: Record<string, unknown>) {
   return {
     content: [{ type: 'text', text: JSON.stringify(json) }],
+    // loggedMessagesCreate reads response.usage.input_tokens etc.; without
+    // this stub the mocked call throws and categorizeQuestion falls back.
+    usage: { input_tokens: 0, output_tokens: 0 },
   }
 }
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -127,6 +127,28 @@ function summarizeError(error: unknown): Record<string, unknown> {
   };
 }
 
+// Operator-actionable errors deserve a louder log line than the generic
+// "[llm] error" warn so they don't get lost in the noise of timeouts /
+// model overload. These are the cases where the model is fine but the
+// account/key is broken: refilling credits, rotating the key, or waiting
+// out a rate limit is the only fix, and the user-visible symptom (zero
+// generated questions, "Today's Daily Five is taking longer than usual")
+// looks identical to a model hiccup.
+function classifyOperatorError(error: unknown): string | null {
+  if (!(error instanceof Error)) return null;
+  const status = (error as { status?: number }).status;
+  const apiMessage = (error as { error?: { message?: string } }).error?.message ?? '';
+  const combined = `${error.message} ${apiMessage}`;
+
+  if (status === 429) return 'RATE_LIMITED';
+  if (status === 401 || status === 403) return 'AUTH_FAILED';
+  if (status === 402) return 'PAYMENT_REQUIRED';
+  if (status === 400 && /credit balance|billing|insufficient.*credit/i.test(combined)) {
+    return 'CREDITS_EXHAUSTED';
+  }
+  return null;
+}
+
 function logFallback(scope: string, reason: string, extra?: Record<string, unknown>) {
   console.warn(`[LLM] ${scope} fallback: ${reason}`, extra ?? {});
 }
@@ -158,12 +180,22 @@ export async function loggedMessagesCreate(
     });
     return response;
   } catch (error) {
-    console.warn('[llm] error', {
-      scope,
-      model: params.model,
-      duration_ms: Date.now() - startedAt,
-      ...summarizeError(error),
-    });
+    const operatorErrorKind = classifyOperatorError(error);
+    if (operatorErrorKind) {
+      console.error(`[llm] ${operatorErrorKind}`, {
+        scope,
+        model: params.model,
+        duration_ms: Date.now() - startedAt,
+        ...summarizeError(error),
+      });
+    } else {
+      console.warn('[llm] error', {
+        scope,
+        model: params.model,
+        duration_ms: Date.now() - startedAt,
+        ...summarizeError(error),
+      });
+    }
     throw error;
   }
 }

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -262,12 +262,15 @@ function tidySubcategoryCandidate(value: string): string | null {
     .replace(/[\s"'“”‘’`]+$/g, '')
     .replace(/^[\s"'“”‘’`]+/g, '')
     .trim();
-  const firstClause = withoutPrefix.split(/(?:\s+[-–—]\s+|[.!?;]|\n)/)[0]?.trim() ?? '';
+  // Split on em-dashes, semicolons, newlines, and `! ?`. Periods are intentionally
+  // omitted: splitting on `.` shreds abbreviations like "Mr. Hooper" or "T. S. Eliot"
+  // into the leading fragment, which then becomes a junk canonical_subcategory.
+  const firstClause = withoutPrefix.split(/(?:\s+[-–—]\s+|[!?;]|\n)/)[0]?.trim() ?? '';
   const normalized = firstClause.replace(/\s+/g, ' ').trim();
   if (!normalized) return null;
 
   const words = normalized.split(/\s+/);
-  if (words.length > 8 || normalized.length > 80) return null;
+  if (normalized.length < 3 || words.length > 8 || normalized.length > 80) return null;
   if (QUESTION_WORDS_NORMALIZED.has(normalizeCategoryLabel(normalized))) return null;
   return normalized;
 }
@@ -286,7 +289,10 @@ function quotedCandidates(value: string): string[] {
 
 function capitalizedPhraseCandidates(value: string): string[] {
   const candidates: string[] = [];
-  const phrasePattern = /\b(?:[A-Z][A-Za-z0-9]*(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,})(?:[-\s]+(?:[A-Z][A-Za-z0-9]*(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,}|of|the|and|for|in|to|a|an))*\b/g;
+  // Leading atom requires 2+ chars so single-letter words like "A" in
+  // "A loaf of bread..." don't get picked as a category. Acronyms ([A-Z]{2,})
+  // and any continuation atoms still match.
+  const phrasePattern = /\b(?:[A-Z][A-Za-z0-9]+(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,})(?:[-\s]+(?:[A-Z][A-Za-z0-9]*(?:[.'’][A-Za-z0-9]+)?|[A-Z]{2,}|of|the|and|for|in|to|a|an))*\b/g;
   for (const match of value.matchAll(phrasePattern)) {
     const phrase = match[0]?.trim();
     if (phrase) candidates.push(phrase);
@@ -414,9 +420,29 @@ function fallbackGrading(): GradingResponse {
   return { result: 'wrong', confidence: 0, reason: 'llm_error', consolation: null };
 }
 
+// "General Knowledge" and "Other" must never reach the UI as a broad_category.
+// The prompt forbids them, but this is a last-line guard if the LLM still
+// returns one. Remaps to the closest thematic bucket; "Pop Culture" is the
+// most flexible host for "doesn't quite fit anywhere else" topics.
+const FORBIDDEN_BROAD_CATEGORIES_NORMALIZED = new Set([
+  'general knowledge',
+  'general',
+  'other',
+  'potpourri',
+  'trivia',
+]);
+
+function avoidForbiddenBroadCategory(broadCategory: string): string {
+  const normalized = broadCategory.trim().toLowerCase().replace(/[_-]+/g, ' ');
+  if (FORBIDDEN_BROAD_CATEGORIES_NORMALIZED.has(normalized)) {
+    return 'Pop Culture';
+  }
+  return broadCategory;
+}
+
 function fallbackCategorization(questionText = '', answerText = ''): CategoryResult {
   return finalizeCategorization(
-    { subcategory: 'General Knowledge', broad_category: 'General Knowledge', confidence: 0 },
+    { subcategory: 'General Knowledge', broad_category: 'Pop Culture', confidence: 0 },
     questionText,
     answerText
   );
@@ -539,8 +565,8 @@ Rules:
 - The subcategory must be as specific as the question demands.
 - Never normalize upward to a broad field if a narrower label is justified.
 - Use title case for both labels.
-- broad_category must be a stable top-level bucket, not an author/work/movement-specific territory (e.g., use "Literature" for James Joyce, Irish Modernism, novels, poetry, or fiction; use "Music", "History", "Film & Television", "Science", "Philosophy", "Language", "Sports", "Pop Culture", or "General Knowledge").
-- Never return "Other" as a broad_category or subcategory. Use "General Knowledge" as the broad_category only when no more precise top-level bucket applies.
+- broad_category must be a stable top-level bucket, not an author/work/movement-specific territory (e.g., use "Literature" for James Joyce, Irish Modernism, novels, poetry, or fiction; use "Music", "History", "Film & Television", "Science", "Philosophy", "Language", "Sports", or "Pop Culture"). For lifestyle/wellness/craft/community topics that don't fit those buckets, invent a thematic top-level label like "Health & Wellness", "Crafts & Making", or "Communities & Identities" — but keep it broad enough to host many subcategories.
+- NEVER return "General Knowledge" or "Other" as the broad_category — these are explicitly forbidden catch-alls. If no bucket fits, pick the closest thematic top-level label (or invent one as above). Same prohibition applies to the subcategory.
 - subcategory should be narrow and portrait-friendly.
 - The subcategory must always be narrower than the broad_category. Never return the broad_category value itself as the subcategory (e.g. if broad_category is "Pop Culture", the subcategory must be something more specific than "Pop Culture"; if broad_category is "Music", the subcategory must be more specific than "Music").
 - For music, film, TV, or pop culture questions: name the specific artist, franchise, era, or cultural moment — not the genre or medium (e.g. "Late-Career David Bowie", "MCU Phase 3", "Drag Race Seasons 1–5", "Early 2010s Internet Memes", "Survivor Original Era").
@@ -589,10 +615,20 @@ Categorize this question. Return JSON only.`;
     }
 
     let subcategory = asTrimmedString(parsed.subcategory);
-    const broadCategory = asTrimmedString(parsed.broad_category);
+    let broadCategory = asTrimmedString(parsed.broad_category);
     if (!subcategory || !broadCategory) {
       logFallback('categorizeQuestion', 'missing_required_fields');
       return fallbackCategorization(questionText, answerText);
+    }
+
+    const safeBroadCategory = avoidForbiddenBroadCategory(broadCategory);
+    if (safeBroadCategory !== broadCategory) {
+      console.warn('[categorizeQuestion] remapped forbidden broad_category', {
+        attempted: broadCategory,
+        remappedTo: safeBroadCategory,
+        subcategory,
+      });
+      broadCategory = safeBroadCategory;
     }
 
     if (isTooGenericSubcategory(subcategory, broadCategory)) {

--- a/src/lib/reactions.ts
+++ b/src/lib/reactions.ts
@@ -1,4 +1,5 @@
-export const CANNED_REACTIONS = [
+// Reactions the answerer can send after a CORRECT answer.
+export const CORRECT_ANSWER_REACTIONS = [
   { key: 'how_did_you_know', label: 'How did you know that?', emoji: ':exploding_head:' },
   { key: 'good_one', label: 'Good one', emoji: ':ok_hand:' },
   { key: 'too_easy', label: 'Too easy', emoji: ':smirk:' },
@@ -7,7 +8,23 @@ export const CANNED_REACTIONS = [
   { key: 'thinking_of_you', label: 'Thinking of you', emoji: ':thought_balloon:' },
 ] as const;
 
+// Reactions the answerer can send after a WRONG answer (§8.10b / §8.22).
+// The wrong-answer canned types are the only ones eligible to attach the
+// answerer's submitted text via the include_submitted_answer opt-in.
+export const WRONG_ANSWER_REACTIONS = [
+  { key: 'didnt_know_tell_me', label: "Didn't know — tell me", emoji: ':thinking_face:' },
+  { key: 'need_story', label: 'Need the story', emoji: ':open_book:' },
+  { key: 'adding_to_list', label: 'Adding to my list', emoji: ':memo:' },
+  { key: 'knew_i_wouldnt', label: "Knew I wouldn't get it", emoji: ':sweat_smile:' },
+] as const;
+
+export const CANNED_REACTIONS = [
+  ...CORRECT_ANSWER_REACTIONS,
+  ...WRONG_ANSWER_REACTIONS,
+] as const;
+
 export type ReactionKey = typeof CANNED_REACTIONS[number]['key'];
+export type WrongAnswerReactionKey = typeof WRONG_ANSWER_REACTIONS[number]['key'];
 
 export function getCannedReaction(key: string) {
   return CANNED_REACTIONS.find((reaction) => reaction.key === key) ?? null;
@@ -15,4 +32,8 @@ export function getCannedReaction(key: string) {
 
 export function isReactionKey(value: string): value is ReactionKey {
   return CANNED_REACTIONS.some((reaction) => reaction.key === value);
+}
+
+export function isWrongAnswerReactionKey(value: string): value is WrongAnswerReactionKey {
+  return WRONG_ANSWER_REACTIONS.some((reaction) => reaction.key === value);
 }

--- a/src/server/activity/write-activity.ts
+++ b/src/server/activity/write-activity.ts
@@ -14,7 +14,12 @@ export type ActivityItemType =
   | 'creator_note_received'
   | 'friend_answered_your_question'
   | 'authored_question_shared'
-  | 'declared_promoted';
+  | 'declared_promoted'
+  // §8.22 grade-dispute path: the question's author is notified when an
+  // answerer disputes their wrong-answer grade. The dispute is the
+  // answerer's explicit ask for a second look, which is the consent gate
+  // that exposes their submitted text to the author.
+  | 'grade_dispute_filed';
 
 export async function writeActivity(params: {
   userId: string;

--- a/src/server/creator-notes.ts
+++ b/src/server/creator-notes.ts
@@ -77,11 +77,16 @@ export async function promptCreatorNoteAfterWrongAnswer(params: {
   }
 }
 
+// §8.22: the answerer's submitted text is intentionally NOT returned here.
+// This helper exists to locate the (contextType, contextId) for a wrong answer
+// — the question's author calls it from the creator-note compose page and
+// must not see the literal text. The activity-feed hydrator queries
+// `joshingGameResponses.submittedAnswer` / `feedItems.submittedAnswer`
+// directly when the viewer is the answerer (their own text).
 export async function findWrongAnswerContext(questionId: string, recipientUserId: string) {
   const [gameResponse] = await db
     .select({
       contextId: joshingGameResponses.gameId,
-      submittedAnswer: joshingGameResponses.submittedAnswer,
       answeredAt: joshingGameResponses.answeredAt,
     })
     .from(joshingGameResponses)
@@ -97,15 +102,11 @@ export async function findWrongAnswerContext(questionId: string, recipientUserId
     return {
       contextType: 'joshing_game' as const,
       contextId: gameResponse.contextId,
-      submittedAnswer: gameResponse.submittedAnswer,
     };
   }
 
   const [feedItem] = await db
-    .select({
-      id: feedItems.id,
-      submittedAnswer: feedItems.submittedAnswer,
-    })
+    .select({ id: feedItems.id })
     .from(feedItems)
     .where(and(
       eq(feedItems.questionId, questionId),
@@ -129,7 +130,7 @@ export async function findWrongAnswerContext(questionId: string, recipientUserId
     .limit(1);
 
   if (correctEvent) return null;
-  return { contextType: 'feed' as const, contextId: feedItem.id, submittedAnswer: feedItem.submittedAnswer };
+  return { contextType: 'feed' as const, contextId: feedItem.id };
 }
 
 export async function createCreatorNote(params: {

--- a/src/server/creator-notes/__tests__/feed-submitted-answer.test.ts
+++ b/src/server/creator-notes/__tests__/feed-submitted-answer.test.ts
@@ -104,15 +104,20 @@ vi.mock('@/server/sms', () => ({ sendSms: vi.fn() }));
 vi.mock('@/server/activity/write-activity', () => ({ writeActivity: vi.fn() }));
 
 function selectChain(result: unknown[]) {
+  const terminalWhere = {
+    orderBy: vi.fn(() => ({ limit: vi.fn(async () => result) })),
+    limit: vi.fn(async () => result),
+  };
+  const joinNode: Record<string, unknown> = {
+    where: vi.fn(() => terminalWhere),
+  };
+  joinNode.leftJoin = vi.fn(() => joinNode);
+  joinNode.innerJoin = vi.fn(() => joinNode);
   return {
     from: vi.fn(() => ({
-      innerJoin: vi.fn(() => ({
-        where: vi.fn(() => ({ limit: vi.fn(async () => result) })),
-      })),
-      where: vi.fn(() => ({
-        orderBy: vi.fn(() => ({ limit: vi.fn(async () => result) })),
-        limit: vi.fn(async () => result),
-      })),
+      innerJoin: vi.fn(() => joinNode),
+      leftJoin: vi.fn(() => joinNode),
+      where: vi.fn(() => terminalWhere),
     })),
   };
 }
@@ -188,51 +193,36 @@ describe('Feed submitted answers for creator notes', () => {
     }));
   });
 
-  it('returns the saved Feed submitted answer for creator-note context', async () => {
-    vi.clearAllMocks();
+  // §8.22 wrong-answer text visibility:
+  // findWrongAnswerContext is consumed by the question's author on the
+  // creator-note compose page. The answerer's literal text must NOT be in
+  // the return shape — only (contextType, contextId).
+
+  it('returns context for a Feed wrong answer without exposing the submitted text', async () => {
+    dbMock.select.mockReset();
     dbMock.select
       .mockReturnValueOnce(selectChain([]))
-      .mockReturnValueOnce(selectChain([{ id: 'feed-1', submittedAnswer: 'Morris Day' }]))
+      .mockReturnValueOnce(selectChain([{ id: 'feed-1' }]))
       .mockReturnValueOnce(selectChain([]));
 
     const { findWrongAnswerContext } = await import('@/server/creator-notes');
-    await expect(findWrongAnswerContext('question-1', 'recipient-1')).resolves.toEqual({
-      contextType: 'feed',
-      contextId: 'feed-1',
-      submittedAnswer: 'Morris Day',
-    });
+    const result = await findWrongAnswerContext('question-1', 'recipient-1');
+    expect(result).toEqual({ contextType: 'feed', contextId: 'feed-1' });
+    expect(result && 'submittedAnswer' in result).toBe(false);
   });
 
-  it('preserves the historical Feed fallback when no submitted answer was saved', async () => {
-    vi.clearAllMocks();
-    dbMock.select
-      .mockReturnValueOnce(selectChain([]))
-      .mockReturnValueOnce(selectChain([{ id: 'old-feed-1', submittedAnswer: null }]))
-      .mockReturnValueOnce(selectChain([]));
-
-    const { findWrongAnswerContext } = await import('@/server/creator-notes');
-    await expect(findWrongAnswerContext('question-1', 'recipient-1')).resolves.toMatchObject({
-      contextType: 'feed',
-      contextId: 'old-feed-1',
-      submittedAnswer: null,
-    });
-  });
-
-  it('keeps existing Joshing Game submitted-answer context unchanged', async () => {
-    vi.clearAllMocks();
+  it('returns context for a Joshing Game wrong answer without exposing the submitted text', async () => {
+    dbMock.select.mockReset();
     dbMock.select.mockReturnValueOnce(selectChain([
       {
         contextId: 'game-1',
-        submittedAnswer: 'Morris Day',
         answeredAt: new Date('2026-05-01T12:00:00.000Z'),
       },
     ]));
 
     const { findWrongAnswerContext } = await import('@/server/creator-notes');
-    await expect(findWrongAnswerContext('question-1', 'recipient-1')).resolves.toEqual({
-      contextType: 'joshing_game',
-      contextId: 'game-1',
-      submittedAnswer: 'Morris Day',
-    });
+    const result = await findWrongAnswerContext('question-1', 'recipient-1');
+    expect(result).toEqual({ contextType: 'joshing_game', contextId: 'game-1' });
+    expect(result && 'submittedAnswer' in result).toBe(false);
   });
 });

--- a/src/server/daily/catchup.ts
+++ b/src/server/daily/catchup.ts
@@ -32,6 +32,30 @@ export function dailyQueueItemId(queueId: string, slotIndex: number): string {
   return `${queueId}:${slotIndex}`;
 }
 
+// Catch-up now mixes daily-queue slots with feed items the user answered
+// wrong. The wire field stays `dailyQueueItemId` (it's opaque to the client),
+// but the value carries a prefix so the server can dispatch to the right
+// surface. Daily IDs keep the original `${queueId}:${slotIndex}` shape for
+// backward compatibility; feed IDs get a `feed:` prefix.
+export const FEED_CATCHUP_ID_PREFIX = 'feed:';
+
+export function feedCatchupItemId(feedItemId: string): string {
+  return `${FEED_CATCHUP_ID_PREFIX}${feedItemId}`;
+}
+
+export function parseCatchupItemId(
+  id: string,
+): { surface: 'feed'; feedItemId: string } | { surface: 'daily'; queueId: string; slotIndex: number } | null {
+  if (id.startsWith(FEED_CATCHUP_ID_PREFIX)) {
+    const feedItemId = id.slice(FEED_CATCHUP_ID_PREFIX.length);
+    return feedItemId ? { surface: 'feed', feedItemId } : null;
+  }
+  const [queueId, slotIndexValue] = id.split(':');
+  const slotIndex = Number(slotIndexValue);
+  if (!queueId || !Number.isInteger(slotIndex)) return null;
+  return { surface: 'daily', queueId, slotIndex };
+}
+
 export function findQueueSlotBySlotIndex(slots: QueueSlot[], slotIndex: number): QueueSlot | null {
   return slots.find((slot) => slot.slot_index === slotIndex) ?? null;
 }

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -6,6 +6,7 @@ import {
   db,
   feedItems,
   friendships,
+  gradeDisputes,
   joshingGameQuestions,
   joshingGameRecipients,
   joshingGameResponses,
@@ -89,6 +90,18 @@ export type ActivityItemView = Pick<
       noteText: string;
       deliveredAt: Date | null;
     };
+    gradeDispute?: {
+      id: string;
+      questionText: string;
+      canonicalAnswer: string;
+      // §8.22 dispute path: the answerer initiated the dispute, which is
+      // the consent gate that exposes their literal text to the author.
+      submittedAnswer: string;
+      status: string;
+      reviewDecision: string | null;
+      reviewReason: string | null;
+      acceptedAlternative: string | null;
+    };
   };
 };
 
@@ -118,6 +131,7 @@ function isActivityType(value: string): value is ActivityItemType {
     'friend_answered_your_question',
     'authored_question_shared',
     'declared_promoted',
+    'grade_dispute_filed',
   ].includes(value);
 }
 
@@ -537,6 +551,48 @@ async function hydrateCreatorNotes(items: ActivityItemRow[]) {
   ] as const));
 }
 
+async function hydrateGradeDisputes(items: ActivityItemRow[]) {
+  const disputeIds = [
+    ...new Set(
+      items
+        .filter((item) => item.type === 'grade_dispute_filed' && item.referenceType === 'grade_dispute')
+        .map((item) => item.referenceId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  if (disputeIds.length === 0) {
+    return new Map<string, NonNullable<ActivityItemView['reference']['gradeDispute']>>();
+  }
+
+  const rows = await db
+    .select({
+      id: gradeDisputes.id,
+      questionText: gradeDisputes.questionText,
+      canonicalAnswer: gradeDisputes.canonicalAnswer,
+      submittedAnswer: gradeDisputes.submittedAnswer,
+      status: gradeDisputes.status,
+      reviewDecision: gradeDisputes.reviewDecision,
+      reviewReason: gradeDisputes.reviewReason,
+      acceptedAlternative: gradeDisputes.acceptedAlternative,
+    })
+    .from(gradeDisputes)
+    .where(inArray(gradeDisputes.id, disputeIds));
+
+  return new Map(rows.map((row) => [
+    row.id,
+    {
+      id: row.id,
+      questionText: row.questionText ?? '',
+      canonicalAnswer: row.canonicalAnswer,
+      submittedAnswer: row.submittedAnswer,
+      status: row.status,
+      reviewDecision: row.reviewDecision,
+      reviewReason: row.reviewReason,
+      acceptedAlternative: row.acceptedAlternative,
+    } satisfies NonNullable<ActivityItemView['reference']['gradeDispute']>,
+  ]));
+}
+
 async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
   const relevant = items.filter(
     (item) => item.type === 'friend_answered_your_question'
@@ -659,7 +715,7 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
     .orderBy(desc(activityItems.createdAt))
     .limit(100);
 
-  const [actorsById, friendshipRequestsById, gamesById, masteryEventsById, reactionsById, directQuestionsById, curatedQuestionsById, creatorNotesById, friendAnsweredQuestionsById, authoredSharedQuestionsById, declaredPromotedById] = await Promise.all([
+  const [actorsById, friendshipRequestsById, gamesById, masteryEventsById, reactionsById, directQuestionsById, curatedQuestionsById, creatorNotesById, friendAnsweredQuestionsById, authoredSharedQuestionsById, declaredPromotedById, gradeDisputesById] = await Promise.all([
     hydrateActors(rows),
     hydrateFriendshipRequests(rows),
     hydrateGames(rows, userId),
@@ -671,6 +727,7 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
     hydrateFriendAnsweredQuestions(rows),
     hydrateAuthoredSharedQuestions(rows),
     hydrateDeclaredPromoted(rows),
+    hydrateGradeDisputes(rows),
   ]);
 
   return rows
@@ -715,6 +772,9 @@ export async function getActivitiesForUser(userId: string): Promise<ActivityItem
           : undefined,
         creatorNote: row.referenceType === 'creator_note' && row.referenceId
           ? creatorNotesById.get(row.referenceId)
+          : undefined,
+        gradeDispute: row.referenceType === 'grade_dispute' && row.referenceId
+          ? gradeDisputesById.get(row.referenceId)
           : undefined,
       },
     }));

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -50,6 +50,10 @@ export type ActivityItemView = Pick<
       customMessage: string | null;
       repliedAt: Date | null;
       questionText: string;
+      // §8.22 wrong-answer text visibility: populated only when the answerer
+      // explicitly opted in (includeSubmittedAnswer=true on a wrong-answer
+      // reaction). Null in every other case.
+      submittedAnswer: string | null;
     };
     directQuestion?: {
       feedItemId: string;
@@ -323,13 +327,70 @@ async function hydrateReactions(items: ActivityItemRow[]) {
       customMessage: questionReactions.customMessage,
       repliedAt: questionReactions.repliedAt,
       questionText: questions.questionText,
+      senderUserId: questionReactions.senderUserId,
+      questionId: questionReactions.questionId,
+      contextType: questionReactions.contextType,
+      contextId: questionReactions.contextId,
+      includeSubmittedAnswer: questionReactions.includeSubmittedAnswer,
     })
     .from(questionReactions)
     .innerJoin(questions, eq(questionReactions.questionId, questions.id))
     .where(inArray(questionReactions.id, reactionIds));
 
+  // §8.22 opt-in resolution: for any reaction the answerer flagged with
+  // includeSubmittedAnswer=true, join the original submitted text from the
+  // matching feed item or joshing-game response. The viewer of this activity
+  // is the question's author by construction (reaction activities target
+  // recipientUserId === author); the opt-in is the consent gate.
+  const optedInRows = rows.filter((row) => row.includeSubmittedAnswer);
+  const feedRowIds = optedInRows
+    .filter((row) => row.contextType === 'feed' && row.contextId)
+    .map((row) => row.contextId!);
+  const gameKeys = optedInRows
+    .filter((row) => row.contextType === 'joshing_game' && row.contextId)
+    .map((row) => ({ gameId: row.contextId!, questionId: row.questionId, userId: row.senderUserId }));
+  const gameIds = [...new Set(gameKeys.map((key) => key.gameId))];
+
+  const [feedAnswerRows, gameAnswerRows] = await Promise.all([
+    feedRowIds.length > 0
+      ? db
+          .select({ id: feedItems.id, submittedAnswer: feedItems.submittedAnswer })
+          .from(feedItems)
+          .where(inArray(feedItems.id, feedRowIds))
+      : Promise.resolve([] as { id: string; submittedAnswer: string | null }[]),
+    gameIds.length > 0
+      ? db
+          .select({
+            gameId: joshingGameResponses.gameId,
+            questionId: joshingGameResponses.questionId,
+            userId: joshingGameResponses.userId,
+            submittedAnswer: joshingGameResponses.submittedAnswer,
+          })
+          .from(joshingGameResponses)
+          .where(inArray(joshingGameResponses.gameId, gameIds))
+      : Promise.resolve([] as {
+          gameId: string;
+          questionId: string;
+          userId: string;
+          submittedAnswer: string | null;
+        }[]),
+  ]);
+
+  const feedAnswerById = new Map(feedAnswerRows.map((row) => [row.id, row.submittedAnswer ?? null]));
+  const gameAnswerByKey = new Map(
+    gameAnswerRows.map((row) => [`${row.gameId}:${row.questionId}:${row.userId}`, row.submittedAnswer ?? null]),
+  );
+
   return new Map(rows.map((row) => {
     const reaction = getCannedReaction(row.reactionType);
+    let submittedAnswer: string | null = null;
+    if (row.includeSubmittedAnswer) {
+      if (row.contextType === 'feed' && row.contextId) {
+        submittedAnswer = feedAnswerById.get(row.contextId) ?? null;
+      } else if (row.contextType === 'joshing_game' && row.contextId) {
+        submittedAnswer = gameAnswerByKey.get(`${row.contextId}:${row.questionId}:${row.senderUserId}`) ?? null;
+      }
+    }
     return [
       row.id,
       {
@@ -339,6 +400,7 @@ async function hydrateReactions(items: ActivityItemRow[]) {
         customMessage: row.customMessage,
         repliedAt: row.repliedAt,
         questionText: row.questionText,
+        submittedAnswer,
       },
     ] as const;
   }));

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -190,7 +190,15 @@ export async function checkBankedQuestions(userId: string, questionIds: string[]
   return Object.fromEntries(uniqueIds.map((id) => [id, banked.has(id)]));
 }
 
-export async function getBankedQuestions(userId: string): Promise<BankedQuestion[]> {
+export async function getBankedQuestions(
+  userId: string,
+  options?: { onlyAuthored?: boolean },
+): Promise<BankedQuestion[]> {
+  const filters = [eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)];
+  if (options?.onlyAuthored) {
+    filters.push(eq(questions.creatorId, userId));
+  }
+
   const rows = await db
     .select({
       bank: userQuestionBank,
@@ -203,7 +211,7 @@ export async function getBankedQuestions(userId: string): Promise<BankedQuestion
     .from(userQuestionBank)
     .innerJoin(questions, eq(userQuestionBank.questionId, questions.id))
     .innerJoin(users, eq(questions.creatorId, users.id))
-    .where(and(eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)))
+    .where(and(...filters))
     .orderBy(desc(userQuestionBank.addedAt));
 
   const answerersByQuestion = await getAnswerersForQuestions(

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1,10 +1,11 @@
-import { and, asc, eq, inArray, isNotNull, lt, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
 
 import {
   dailyPreferences,
   dailyQueues,
   db,
   declaredInterests,
+  feedItems,
   generatedQuestions,
   masteryEvents,
   playerMastery,
@@ -15,7 +16,7 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
-import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
+import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId } from '@/server/daily/catchup';
 import type { QueueSlot } from '@/server/daily/types';
 import {
   catchUpExpiresAt,
@@ -28,6 +29,7 @@ import {
   dedupeCatchUpItems,
   orderCatchUpItems,
 } from '@/server/play/catch-up-turn-sequencing';
+import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 function asQueueSlotDifficulty(
@@ -49,14 +51,27 @@ export type KnowledgeBaseDomain = {
 export type DailyPreferenceRow = typeof dailyPreferences.$inferSelect;
 export type DailyQueueRow = typeof dailyQueues.$inferSelect;
 
+export type CatchupSurface = 'daily' | 'feed';
+
 export type CatchupQueueItem = {
+  /**
+   * Opaque dispatch ID. Daily slots use `${queueId}:${slotIndex}` (legacy
+   * format the client already parses); feed items use `feed:${feedItemId}`.
+   * Routes that receive this back from the client should resolve it via
+   * `parseCatchupItemId` rather than splitting manually.
+   */
   dailyQueueItemId: string;
-  queueId: string;
+  surface: CatchupSurface;
+  /** Daily-only — null for feed items. */
+  queueId: string | null;
+  /** Daily-only — null for feed items. */
+  slotIndex: number | null;
+  /** Feed-only — null for daily items. */
+  feedItemId: string | null;
   queueDate: string;
   queueAge: number;
   expiresAt: string;
   expiresSoon: boolean;
-  slotIndex: number;
   questionId: string;
   questionText: string;
   correctAnswer: string;
@@ -254,12 +269,24 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
 export async function getCatchupQuestions(userId: string): Promise<CatchupQuestion[]> {
   const { assignmentDateStr } = getDailyAssignmentBounds();
 
+  const [dailyItems, feedItemsForCatchup] = await Promise.all([
+    getDailyCatchupItems(userId, assignmentDateStr),
+    getFeedCatchupItems(userId, assignmentDateStr),
+  ]);
+
+  return dedupeCatchUpItems(orderCatchUpItems([...dailyItems, ...feedItemsForCatchup]));
+}
+
+async function getDailyCatchupItems(
+  userId: string,
+  assignmentDateStr: string,
+): Promise<CatchupQuestion[]> {
   const queues = await db
     .select()
     .from(dailyQueues)
     .where(and(
       eq(dailyQueues.userId, userId),
-      lt(dailyQueues.queueDate, assignmentDateStr),
+      lte(dailyQueues.queueDate, assignmentDateStr),
     ))
     .orderBy(asc(dailyQueues.queueDate));
 
@@ -284,7 +311,7 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
     ));
   const questionById = new Map(questions.map((question) => [question.id, question]));
 
-  const mapped = candidateSlots
+  return candidateSlots
     .map(({ queue, slot }): CatchupQuestion | null => {
       const question = slot.generated_question_id ? questionById.get(slot.generated_question_id) : null;
       if (!question) return null;
@@ -298,12 +325,14 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
       if (isGenericSubcategory(domain)) return null;
       return {
         dailyQueueItemId: dailyQueueItemId(queue.id, slot.slot_index),
+        surface: 'daily',
         queueId: queue.id,
+        slotIndex: slot.slot_index,
+        feedItemId: null,
         queueDate,
         queueAge: queueAgeInDays(queueDate, assignmentDateStr),
         expiresAt,
         expiresSoon: expiresWithin24Hours(expiresAt),
-        slotIndex: slot.slot_index,
         questionId: question.id,
         questionText: slot.question_text || question.questionText,
         correctAnswer: question.answer,
@@ -319,8 +348,79 @@ export async function getCatchupQuestions(userId: string): Promise<CatchupQuesti
       } satisfies CatchupQuestion;
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
+}
 
-  return dedupeCatchUpItems(orderCatchUpItems(mapped));
+async function getFeedCatchupItems(
+  userId: string,
+  assignmentDateStr: string,
+): Promise<CatchupQuestion[]> {
+  // Mirror the daily lookback: only surface feed-missed items whose source
+  // event landed within the catch-up window. sourceEventAt is the canonical
+  // "when this hit your feed" timestamp and is already indexed.
+  const oldestDate = new Date(`${assignmentDateStr}T00:00:00.000Z`);
+  oldestDate.setUTCDate(oldestDate.getUTCDate() - CATCHUP_LOOKBACK_DAYS);
+
+  let rows: Array<{ feedItem: typeof feedItems.$inferSelect; question: typeof canonicalQuestions.$inferSelect }>;
+  try {
+    rows = await db
+      .select({ feedItem: feedItems, question: canonicalQuestions })
+      .from(feedItems)
+      .innerJoin(canonicalQuestions, eq(feedItems.questionId, canonicalQuestions.id))
+      .where(and(
+        eq(feedItems.recipientUserId, userId),
+        eq(feedItems.state, 'answered'),
+        eq(feedItems.answerResult, 'incorrect'),
+        isNull(feedItems.catchupResolvedAt),
+        gte(feedItems.sourceEventAt, oldestDate),
+      ))
+      .orderBy(desc(feedItems.sourceEventAt));
+  } catch (error) {
+    // catchupResolvedAt is added by migration 0038; tolerate a brief window
+    // where the column is missing so the homepage doesn't 500 on first boot.
+    if (pgErrorCode(error) === '42703') return [];
+    throw error;
+  }
+
+  return rows
+    .map(({ feedItem, question }): CatchupQuestion | null => {
+      const domain = question.canonicalSubcategory || question.broadCategory || question.category;
+      if (!domain || isGenericSubcategory(domain)) return null;
+      const queueDate = feedItem.sourceEventAt.toISOString().slice(0, 10);
+      const expiresAt = catchUpExpiresAt(queueDate);
+      const difficulty = asQueueSlotDifficulty(
+        question.calibratedDifficulty ?? question.llmDifficulty ?? question.difficultyEstimate ?? null,
+      ) ?? null;
+      const basePoints = getBasePoints(difficulty, 'first_correct');
+      const explanation = question.explainerFullWrong
+        ?? question.explainerFull
+        ?? question.explainerBrief
+        ?? question.factualExplanation
+        ?? null;
+      return {
+        dailyQueueItemId: feedCatchupItemId(feedItem.id),
+        surface: 'feed',
+        queueId: null,
+        slotIndex: null,
+        feedItemId: feedItem.id,
+        queueDate,
+        queueAge: queueAgeInDays(queueDate, assignmentDateStr),
+        expiresAt,
+        expiresSoon: expiresWithin24Hours(expiresAt),
+        questionId: question.id,
+        questionText: question.questionText,
+        correctAnswer: question.answerText,
+        alternateAnswers: question.acceptedAlternatives ?? [],
+        explanation,
+        domain,
+        domainDisplayName: categoryLabel(domain),
+        broadCategory: question.broadCategory ?? domain,
+        basePoints,
+        difficultyEstimate: difficulty,
+        submittedAnswer: feedItem.submittedAnswer ?? null,
+        wasSkipped: false,
+      } satisfies CatchupQuestion;
+    })
+    .filter((item): item is CatchupQuestion => Boolean(item));
 }
 
 export async function createDailyQueueItem(

--- a/src/server/db/queries/joshing-game.ts
+++ b/src/server/db/queries/joshing-game.ts
@@ -360,6 +360,18 @@ export async function getJoshingGame(params: {
 
   const canSeeAllResponses = viewerComplete || params.requestingUserId === gameRow.game.creatorId;
 
+  // §8.22 wrong-answer text visibility: even when the viewer is allowed to
+  // see aggregate results across participants, only their own row carries
+  // submittedAnswer. Other rows are projected with submittedAnswer = null so
+  // that no UI (or serialized payload shipped to a client component) can
+  // surface another player's literal answer text.
+  const visibleResponses = (canSeeAllResponses
+    ? responseRows
+    : responseRows.filter((response) => response.userId === params.requestingUserId))
+    .map((response) => response.userId === params.requestingUserId
+      ? response
+      : { ...response, submittedAnswer: null });
+
   return {
     game: {
       id: gameRow.game.id,
@@ -393,9 +405,7 @@ export async function getJoshingGame(params: {
         score: completed ? userResponses.filter((response) => response.isCorrect).length : null,
       };
     }),
-    responses: canSeeAllResponses
-      ? responseRows
-      : responseRows.filter((response) => response.userId === params.requestingUserId),
+    responses: visibleResponses,
     viewerStatus,
   };
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -253,7 +253,7 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
 
 export async function getQuestionsForUser(userId: string): Promise<QuestionView[]> {
   const { getBankedQuestions } = await import('@/server/db/queries/bank');
-  return getBankedQuestions(userId);
+  return getBankedQuestions(userId, { onlyAuthored: true });
 }
 
 export async function hasUserAuthoredAnyQuestion(userId: string): Promise<boolean> {

--- a/src/server/db/queries/reactions.ts
+++ b/src/server/db/queries/reactions.ts
@@ -32,6 +32,7 @@ type CreateReactionParams = {
   contextId: string | null;
   reactionType: ReactionKey;
   customMessage?: string | null;
+  includeSubmittedAnswer?: boolean;
 };
 
 function displayName(value: string | null, fallback = 'Someone'): string {
@@ -67,6 +68,7 @@ export async function createReaction(params: CreateReactionParams): Promise<{ id
         contextId: params.contextId,
         reactionType: params.reactionType,
         customMessage: params.customMessage?.trim() ? params.customMessage.trim().slice(0, 160) : null,
+        includeSubmittedAnswer: params.includeSubmittedAnswer ?? false,
       })
       .returning({ id: questionReactions.id });
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -397,6 +397,10 @@ export const questionReactions = pgTable(
     contextId: text('contextId'),
     reactionType: text('reactionType').notNull(),
     customMessage: text('customMessage'),
+    // §8.22 opt-in. When true on a wrong-answer reaction, the answerer
+    // consents to the question's author seeing their literal submitted text
+    // alongside the reaction.
+    includeSubmittedAnswer: boolean('includeSubmittedAnswer').notNull().default(false),
     repliedAt: timestamp('repliedAt', { withTimezone: true }),
     createdAt: createdAt(),
   },

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -715,6 +715,7 @@ export const feedItems = pgTable(
     state: text('state').notNull().default('active'),
     isPinned: boolean('isPinned').notNull().default(false),
     quip: text('quip'),
+    catchupResolvedAt: timestamp('catchupResolvedAt', { withTimezone: true }),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [

--- a/src/server/play/catch-up-eligibility.ts
+++ b/src/server/play/catch-up-eligibility.ts
@@ -20,11 +20,17 @@ export function isCatchUpQueueDateEligible(
   lookbackDays = CATCHUP_LOOKBACK_DAYS,
 ): boolean {
   const oldestDate = minusUtcDays(assignmentDate, lookbackDays);
-  return queueDate < assignmentDate && queueDate >= oldestDate;
+  // Today's queue is eligible so wrong answers from today's Daily 5 surface
+  // immediately rather than waiting until tomorrow.
+  return queueDate <= assignmentDate && queueDate >= oldestDate;
 }
 
 export function isCatchUpSlotEligible(slot: QueueSlot): boolean {
-  return !slot.answered && !slot.dismissed_at && Boolean(slot.generated_question_id);
+  if (slot.dismissed_at) return false;
+  if (!slot.generated_question_id) return false;
+  // Wrong daily-5 answers are eligible for re-attempt; correct ones are not.
+  if (slot.answered) return slot.answer_state === 'incorrect';
+  return true;
 }
 
 export function expiresWithin24Hours(expiresAt: string, now = new Date()): boolean {

--- a/src/server/questions/__tests__/canonical-subcategory.test.ts
+++ b/src/server/questions/__tests__/canonical-subcategory.test.ts
@@ -33,6 +33,15 @@ describe('canonical-subcategory boundary guard (F4.5)', () => {
       expect(isGenericSubcategory('T. S. Eliot')).toBe(false)
     })
 
+    it('returns true for ultra-short fragment labels (e.g. categorizer truncation)', () => {
+      // Real-world bug: the deterministic fallback in src/lib/llm.ts produced
+      // "Mr" (from "Mr. Hooper") and "A" (from "A loaf of bread...") as canonical
+      // subcategories. Both are too short to be meaningful.
+      expect(isGenericSubcategory('A')).toBe(true)
+      expect(isGenericSubcategory('Mr')).toBe(true)
+      expect(isGenericSubcategory('T')).toBe(true)
+    })
+
     it('returns false for broad-but-acceptable category names', () => {
       // Note: the audit lists these in the LLM helper's superset (used for
       // re-prompting), but they are NOT in the strict write-boundary set.

--- a/src/server/questions/canonical-subcategory.ts
+++ b/src/server/questions/canonical-subcategory.ts
@@ -22,6 +22,12 @@ const FORBIDDEN_CANONICAL_SUBCATEGORIES = new Set<string>([
   'potpourri',
 ])
 
+// Anything shorter than this after normalization is treated as generic. This
+// catches single-letter and abbreviation-fragment labels like "A" and "Mr"
+// that previously slipped past the bucket-name blocklist (see the categorizer
+// fallback in src/lib/llm.ts).
+const MIN_SUBCATEGORY_LENGTH = 3
+
 function normalizeForCheck(value: string): string {
   return value
     .trim()
@@ -32,7 +38,9 @@ function normalizeForCheck(value: string): string {
 
 export function isGenericSubcategory(value: string | null | undefined): boolean {
   if (!value) return true
-  return FORBIDDEN_CANONICAL_SUBCATEGORIES.has(normalizeForCheck(value))
+  const normalized = normalizeForCheck(value)
+  if (normalized.length < MIN_SUBCATEGORY_LENGTH) return true
+  return FORBIDDEN_CANONICAL_SUBCATEGORIES.has(normalized)
 }
 
 export class GenericCanonicalSubcategoryError extends Error {


### PR DESCRIPTION
## Summary

Audit (B-VERIFY-01) of the §8.10b Question Reaction mechanic against the §8.22 "Wrong-Answer Text Visibility — Author Side" rule, then the three follow-up fixes it scoped, plus a small UX improvement to keep direct-sent wrong answers re-attemptable in the feed.

The §8.22 rule: the literal text a player submits on a wrong answer is **not visible to the question's author by default**. It reaches the author only via (1) a grade dispute initiated by the answerer, (2) a wrong-answer Reaction with explicit `include_submitted_answer = true` opt-in, or (3) a de-identified aggregate roll-up. The audit found one active leak and two channels (opt-in, dispute) that were declared but not wired end-to-end. Each follow-up commit closes one gap.

## Commits

- **`dd07f20` — audit: B-VERIFY-01.** Report at `audit/B-VERIFY-01.md`. Reaction mechanic present-but-partial; one confirmed UI violation; one elevated-risk loader; opt-in and dispute paths declared in schema/migrations but not consumed.
- **`ee6dc35` — B-FIX-01: stop leaking answerer text on creator-note compose page.** The author lands on `/creator-notes/new` from the `creator_note_prompt` SMS and the page rendered `{name} said: {submittedAnswer}` verbatim — no consent gate. Remove that row; drop `submittedAnswer` from `findWrongAnswerContext`'s return shape so no other author-side caller can pick it up by accident. Also harden `getJoshingGame`: zero out `submittedAnswer` on response rows that don't belong to the requester (the game creator was over-fetching even though no UI surfaced it).
- **`912abd3` — B-OPTIN-01: wrong-answer reaction opt-in for submitted-text visibility.** Migration `0040` adds `includeSubmittedAnswer` to `QuestionReaction` (default `false`), with a matching idempotent guard in `src/instrumentation.ts`. `src/lib/reactions.ts` splits the canned list into `CORRECT_ANSWER_REACTIONS` and `WRONG_ANSWER_REACTIONS` — the four §8.10b wrong-answer types were declared in the DB enum but unreachable at the app level until now. `isWrongAnswerReactionKey` is the consent gate. `POST /api/reactions` accepts `includeSubmittedAnswer` and coerces it to `false` for any non-wrong-answer reaction. `hydrateReactions` joins the answerer's `submittedAnswer` only when the opt-in is set, keyed on `(contextId, questionId, senderUserId)`. `/activities` renders "They wrote: …" only when the joined value is present. `QuestionReactionPrompt` branches on `result` and shows an "Include what I wrote" checkbox on wrong-answer prompts.
- **`cdecdd7` — B-DISPUTE-01: notify the question author when an answerer files a recheck.** New `grade_dispute_filed` activity type. `POST /api/feed/[feedItemId]/recheck` writes the activity to the question's author when the question has a distinct `creatorId`. `/activities` renders the dispute card with the literal submitted text, the canonical answer, and the outcome. The answerer's act of disputing is the consent gate. Scoped to the feed-recheck path only; daily-recheck disputes target AI-generated questions with `creatorId: null`, so there is no human author to notify.
- **`afb266e` — keep direct_sent wrong answers re-attemptable in the feed.** Today a wrong answer on a friend-asked question collapses into a closed-state recap with only a Recheck button. Server now accepts a re-answer when the item is `direct_sent` AND `answerResult='incorrect'`. Other source types stay closed once answered. The existing `computeAnswerState` path correctly resolves a wrong→correct retry to `first_correct_after_wrong` (0.25× credit), and `createFeedItemsForFriendsFromAnswer` only fires on the correct attempt — no double-propagation. UI: `AnsweredByYouCard` gains an optional `onRetry`; `FeedList` wires it for direct_sent wrong only. Dismiss path is the existing card-overflow action.

## Out of scope (called out in the audit)

- Mounting `QuestionReactionPrompt` in feed / daily wrong-answer review surfaces (today it only fires in joshing-game gameplay).
- Tightening `QuestionReaction.reactionType` from `text` to the existing `reactionCannedEnum`.
- Daily-recheck dispute notifications (targets AI-generated questions; no author).
- The `creatorResponseCannedEnum` exists with no write path — either implement or remove.

## Test plan

- [ ] `npx tsc -p tsconfig.typecheck.json` clean.
- [ ] `npx vitest run src/lib/__tests__/reactions.test.ts` — 6 classifier tests pass (`isWrongAnswerReactionKey` is the §8.22 opt-in gate).
- [ ] `npx vitest run src/app/api/feed/[feedItemId]/answer/__tests__/route.test.ts` — 11 tests pass, including the 4 new retry-policy cases (accept/reject matrix) and 7 pre-existing tests that were silently broken by a `vi.hoisted` bug fixed here.
- [ ] `npx vitest run src/server/creator-notes/__tests__/feed-submitted-answer.test.ts` — 2 new tests assert `findWrongAnswerContext` no longer exposes `submittedAnswer` in its return shape.
- [ ] Manually walk:
  - [ ] Friend sends you a question (direct_sent). Answer wrong. Card stays visible with a "Try again →" button alongside "Recheck →". Click Try again, answer correctly. Card flips to correct state.
  - [ ] Same flow but on an `authored_shared` / `friend_answered` card — no "Try again" button appears.
  - [ ] Answerer plays a joshing-game wrong-answer question. Reaction prompt shows the four wrong-answer canned types and an "Include what I wrote" checkbox.
  - [ ] With the checkbox unchecked: author sees the reaction on `/activities`, no "They wrote: …" line.
  - [ ] With the checkbox checked: author sees the same reaction with "They wrote: {answerer's text}".
  - [ ] Answerer answers a friend's feed question wrong, presses Recheck, recheck is rejected. Author sees `grade_dispute_filed` on `/activities` with the question, the canonical answer, the submitted text, and "Dismissed — grade stands."
  - [ ] Author follows the creator-note SMS link to `/creator-notes/new`. Page shows the question and the canonical answer only — no row showing what the answerer wrote.

https://claude.ai/code/session_01CKYzfsnm8ageUA4YAuxMbU

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKYzfsnm8ageUA4YAuxMbU)_