### PR TITLE
daily-five: mix vetted user-authored questions into the Daily 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "start": "next start",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",
+    "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/scripts/question-vetting.smoke.mjs
+++ b/scripts/question-vetting.smoke.mjs
@@ -1,0 +1,24 @@
+import assert from 'node:assert/strict';
+
+import { verdictToPublicStatus } from '../src/server/llm/vet-verdict.ts';
+
+const approved = verdictToPublicStatus({ status: 'approved', score: 0.82, reason: 'specific and verifiable' });
+assert.equal(approved.publicStatus, 'eligible_pending');
+assert.equal(approved.publicEligibilityScore, 0.82);
+assert.equal(approved.publicEligibilityReason, 'specific and verifiable');
+
+const rejected = verdictToPublicStatus({ status: 'rejected', score: 0.12, reason: 'factual: wrong answer' });
+assert.equal(rejected.publicStatus, 'rejected');
+assert.equal(rejected.publicEligibilityScore, 0.12);
+assert.equal(rejected.publicEligibilityReason, 'factual: wrong answer');
+
+const needsReview = verdictToPublicStatus({ status: 'needs_review', score: null, reason: 'llm_error' });
+assert.equal(needsReview.publicStatus, 'not_scored');
+assert.equal(needsReview.publicEligibilityScore, null);
+assert.equal(needsReview.publicEligibilityReason, 'llm_error');
+
+const needsReviewWithScore = verdictToPublicStatus({ status: 'needs_review', score: 0.6, reason: 'unverifiable: niche claim' });
+assert.equal(needsReviewWithScore.publicStatus, 'not_scored');
+assert.equal(needsReviewWithScore.publicEligibilityScore, 0.6);
+
+console.log('question-vetting.smoke: ok');

--- a/src/app/api/cron/vet-questions/route.ts
+++ b/src/app/api/cron/vet-questions/route.ts
@@ -1,0 +1,98 @@
+import { and, eq, isNull } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+
+import { db, questions } from '@/server/db';
+import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
+
+export const dynamic = 'force-dynamic';
+export const maxDuration = 300;
+
+const BATCH_SIZE = 25;
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
+  if (!secret) return true;
+  const authHeader = request.headers.get('authorization');
+  return authHeader === `Bearer ${secret}`;
+}
+
+/**
+ * Sweeps `Question` rows that are still at `publicStatus = 'not_scored'`
+ * (the default) and re-runs the Haiku vetter. The submit route also vets
+ * inline; this cron catches the cases where the inline call hit a Haiku
+ * error or returned `factual: 'unknown'`.
+ */
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const pending = await db
+    .select({
+      id: questions.id,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+      acceptedAlternatives: questions.acceptedAlternatives,
+      factualExplanation: questions.factualExplanation,
+      broadCategory: questions.broadCategory,
+      canonicalSubcategory: questions.canonicalSubcategory,
+    })
+    .from(questions)
+    .where(and(
+      eq(questions.publicStatus, 'not_scored'),
+      eq(questions.visibility, 'public'),
+      isNull(questions.deletedAt),
+    ))
+    .limit(BATCH_SIZE);
+
+  const results = {
+    scanned: pending.length,
+    approved: 0,
+    rejected: 0,
+    deferred: 0,
+    failed: 0,
+  };
+
+  for (const row of pending) {
+    try {
+      const verdict = await vetQuestion({
+        questionText: row.questionText,
+        answer: row.answerText,
+        alternateAnswers: row.acceptedAlternatives ?? [],
+        explanation: row.factualExplanation,
+        broadCategory: row.broadCategory,
+        canonicalSubcategory: row.canonicalSubcategory,
+      });
+      const scoring = verdictToPublicStatus(verdict);
+
+      // Skip the update when we'd just re-write 'not_scored' with the same
+      // null score — the row was already in that state and nothing changed.
+      // Storing the reason still helps observability, so write when reason
+      // moved.
+      const noChange = scoring.publicStatus === 'not_scored' && scoring.publicEligibilityScore === null;
+      if (!noChange) {
+        await db
+          .update(questions)
+          .set({
+            publicStatus: scoring.publicStatus,
+            publicEligibilityScore: scoring.publicEligibilityScore,
+            publicEligibilityReason: scoring.publicEligibilityReason,
+            updatedAt: new Date(),
+          })
+          .where(eq(questions.id, row.id));
+      }
+
+      if (scoring.publicStatus === 'eligible_pending') results.approved += 1;
+      else if (scoring.publicStatus === 'rejected') results.rejected += 1;
+      else results.deferred += 1;
+    } catch (error) {
+      results.failed += 1;
+      console.warn('[cron/vet-questions] question failed', {
+        questionId: row.id,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  return NextResponse.json(results);
+}

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -18,6 +18,7 @@ import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { type QueueSlot } from '@/server/daily/types';
 import { asQueueSlots } from '@/server/daily/catchup';
+import { resolveDailyBasePoints } from '@/server/daily/types';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { suggestAnswer } from '@/lib/llm';
 import { computeAnswerState } from '@/server/answer-state';
@@ -121,24 +122,76 @@ export async function POST(request: NextRequest) {
     if (slot.answered || slot.skipped) {
       return dailyAnswerErrorResponse(400, 'invalid_state', 'That question is already closed.');
     }
-    if (!slot.generated_question_id) {
+    if (!slot.generated_question_id && !slot.question_id) {
       return dailyAnswerErrorResponse(400, 'invalid_state', 'That Daily Five slot is not ready yet.');
     }
 
-    const [question] = await db
-      .select()
-      .from(generatedQuestions)
-      .where(and(
-        eq(generatedQuestions.id, slot.generated_question_id),
-        eq(generatedQuestions.userId, session.userId),
-      ))
-      .limit(1);
+    // The Daily 5 mixes two slot shapes — bot-generated questions live in
+    // `generatedQuestions`, while vetted user-authored questions live in the
+    // canonical `questions` table and are picked into a `source: 'friend'`
+    // slot. Normalise both into a single shape so the rest of the route
+    // (grading, mastery, propagation) doesn't care which pool we're in.
+    type DailyAnswerQuestion = {
+      generatedId: string | null;
+      canonicalId: string | null;
+      questionText: string;
+      answer: string;
+      explainer: string | null;
+      canonicalSubcategory: string;
+      broadCategory: string | null;
+      basePoints: number;
+    };
 
-    if (!question) {
-      return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
+    let question: DailyAnswerQuestion;
+    if (slot.generated_question_id) {
+      const [row] = await db
+        .select()
+        .from(generatedQuestions)
+        .where(and(
+          eq(generatedQuestions.id, slot.generated_question_id),
+          eq(generatedQuestions.userId, session.userId),
+        ))
+        .limit(1);
+      if (!row) {
+        return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
+      }
+      question = {
+        generatedId: row.id,
+        canonicalId: null,
+        questionText: row.questionText,
+        answer: await resolveCanonicalAnswer(row),
+        explainer: row.explainer,
+        canonicalSubcategory: row.canonicalSubcategory,
+        broadCategory: row.broadCategory,
+        basePoints: Math.round(row.basePoints),
+      };
+    } else {
+      const [row] = await db
+        .select()
+        .from(questions)
+        .where(eq(questions.id, slot.question_id!))
+        .limit(1);
+      if (!row || row.deletedAt) {
+        return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
+      }
+      const explainer = row.explainerFull
+        ?? row.explainerBrief
+        ?? row.factualExplanation
+        ?? null;
+      const difficulty = row.calibratedDifficulty ?? row.llmDifficulty ?? row.difficultyEstimate ?? null;
+      question = {
+        generatedId: null,
+        canonicalId: row.id,
+        questionText: row.questionText,
+        answer: row.answerText,
+        explainer,
+        canonicalSubcategory: row.canonicalSubcategory ?? slot.domain,
+        broadCategory: row.broadCategory,
+        basePoints: resolveDailyBasePoints(difficulty),
+      };
     }
 
-    const canonicalAnswer = await resolveCanonicalAnswer(question);
+    const canonicalAnswer = question.answer;
 
     const grade = parsed.gaveUp
       ? { result: 'wrong' as const, consolation: null }
@@ -153,43 +206,64 @@ export async function POST(request: NextRequest) {
     const answerState = isCorrect ? 'correct' : 'incorrect';
     const quip = parsed.gaveUp ? null : selectQuip({ isCorrect, surface: 'daily', friendResult: null });
 
-    // Promote the bot question to a canonical row BEFORE writing the mastery
-    // event so cross-surface dedup can key on the canonical Question.id
-    // (F2.1). If persistence fails the route still records the answer in the
+    // For bot slots: promote the generated question to a canonical row
+    // BEFORE writing the mastery event so cross-surface dedup can key on
+    // Question.id (F2.1). For friend slots: the canonical row already
+    // exists, so skip the promotion and read author metadata directly.
+    // If persistence fails the route still records the answer in the
     // queue and the user-visible result is unaffected; only mastery /
     // friend-feed propagation are skipped for this attempt.
-    let canonicalQuestionId: string | null = null;
+    let canonicalQuestionId: string | null = question.canonicalId;
     let persistedCreatorId: string | null = null;
     let persistedDomainForCreator: string | null = null;
     let persistedInsideJoke: string | null = null;
-    let persistAttempt = 0;
-    while (persistAttempt < 2 && canonicalQuestionId === null) {
-      persistAttempt += 1;
-      try {
-        const persisted = await persistGeneratedQuestion(question.id, slot.domain);
-        canonicalQuestionId = persisted.questionId;
-        const [persistedQuestion] = await db
-          .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category, insideJoke: questions.insideJoke })
-          .from(questions)
-          .where(eq(questions.id, persisted.questionId))
-          .limit(1);
-        persistedCreatorId = persistedQuestion?.creatorId ?? null;
-        persistedDomainForCreator =
-          persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category || null;
-        persistedInsideJoke = persistedQuestion?.insideJoke ?? null;
-      } catch (error) {
-        const finalAttempt = persistAttempt >= 2;
-        console.warn(
-          finalAttempt
-            ? '[daily/answer] persistGeneratedQuestion failed after retry; canonical id will be backfilled later'
-            : '[daily/answer] persistGeneratedQuestion failed; retrying once',
-          {
-            generatedQuestionId: question.id,
-            attempt: persistAttempt,
-            error: error instanceof Error ? error.message : String(error),
-          },
-        );
+
+    if (question.generatedId) {
+      let persistAttempt = 0;
+      while (persistAttempt < 2 && canonicalQuestionId === null) {
+        persistAttempt += 1;
+        try {
+          const persisted = await persistGeneratedQuestion(question.generatedId, slot.domain);
+          canonicalQuestionId = persisted.questionId;
+          const [persistedQuestion] = await db
+            .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category, insideJoke: questions.insideJoke })
+            .from(questions)
+            .where(eq(questions.id, persisted.questionId))
+            .limit(1);
+          persistedCreatorId = persistedQuestion?.creatorId ?? null;
+          persistedDomainForCreator =
+            persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category || null;
+          persistedInsideJoke = persistedQuestion?.insideJoke ?? null;
+        } catch (error) {
+          const finalAttempt = persistAttempt >= 2;
+          console.warn(
+            finalAttempt
+              ? '[daily/answer] persistGeneratedQuestion failed after retry; canonical id will be backfilled later'
+              : '[daily/answer] persistGeneratedQuestion failed; retrying once',
+            {
+              generatedQuestionId: question.generatedId,
+              attempt: persistAttempt,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
       }
+    } else if (question.canonicalId) {
+      const [canonicalRow] = await db
+        .select({
+          creatorId: questions.creatorId,
+          domain: questions.canonicalSubcategory,
+          broadCategory: questions.broadCategory,
+          category: questions.category,
+          insideJoke: questions.insideJoke,
+        })
+        .from(questions)
+        .where(eq(questions.id, question.canonicalId))
+        .limit(1);
+      persistedCreatorId = canonicalRow?.creatorId ?? null;
+      persistedDomainForCreator =
+        canonicalRow?.domain || canonicalRow?.broadCategory || canonicalRow?.category || null;
+      persistedInsideJoke = canonicalRow?.insideJoke ?? null;
     }
 
     // Compute answer_state against masteryEvents history so first_correct
@@ -204,7 +278,7 @@ export async function POST(request: NextRequest) {
       isCorrect ? 'correct' : 'wrong',
       priorAnswers,
     );
-    const basePoints = Math.round(question.basePoints);
+    const basePoints = question.basePoints;
     const uncheckedPointsAwarded =
       masteryAnswerState === 'first_correct'
         ? basePoints
@@ -232,7 +306,7 @@ export async function POST(request: NextRequest) {
         console.warn('[daily/answer] bot question domain not in player KB; skipping mastery write', {
           userId: session.userId,
           domain: question.canonicalSubcategory,
-          generatedQuestionId: question.id,
+          generatedQuestionId: question.generatedId,
         });
       }
     }
@@ -253,7 +327,7 @@ export async function POST(request: NextRequest) {
         submitted_answer: parsed.gaveUp ? '' : parsed.submittedAnswer,
         awarded_points: pointsAwarded,
         reveal_canonical_answer: canonicalAnswer,
-        reveal_explainer: question.explainer,
+        reveal_explainer: question.explainer ?? undefined,
         reveal_inside_joke: insideJokeForViewer,
         reveal_quip: grade.consolation,
         quip,
@@ -270,7 +344,7 @@ export async function POST(request: NextRequest) {
       try {
         masteryDelta = await writeMasteryEvent({
           userId: session.userId,
-          questionId: question.id,
+          questionId: question.generatedId ?? question.canonicalId ?? canonicalQuestionId ?? `${queue.id}:${parsed.slotIndex}`,
           domain: question.canonicalSubcategory,
           answerState: masteryAnswerState,
           pointsAwarded,
@@ -295,6 +369,7 @@ export async function POST(request: NextRequest) {
     });
 
     if (canonicalQuestionId && !parsed.gaveUp) {
+      const propagationKey = question.generatedId ?? question.canonicalId ?? canonicalQuestionId;
       try {
         if (isCorrect && persistedCreatorId && persistedCreatorId !== session.userId && persistedDomainForCreator) {
           void promoteDeclaredToDemonstrated({
@@ -311,7 +386,7 @@ export async function POST(request: NextRequest) {
             answererUserId: session.userId,
             questionId: canonicalQuestionId,
             domain: persistedDomainForCreator,
-            sourceId: `daily:${question.id}:${session.userId}`,
+            sourceId: `daily:${propagationKey}:${session.userId}`,
             scope: 'daily/answer',
           });
         }
@@ -323,11 +398,11 @@ export async function POST(request: NextRequest) {
           session.userId,
           canonicalQuestionId,
           isCorrect ? 'correct' : 'incorrect',
-          `daily:${question.id}:${session.userId}`,
+          `daily:${propagationKey}:${session.userId}`,
         );
       } catch (error) {
         console.warn('[daily/answer] feed propagation failed', {
-          generatedQuestionId: question.id,
+          generatedQuestionId: question.generatedId,
           canonicalQuestionId,
           error: error instanceof Error ? error.message : String(error),
         });

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion, generateInsideJoke } from '@/lib/llm';
+import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
 import { getSession } from '@/server/auth/session';
 import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
@@ -134,6 +135,26 @@ export async function POST(request: NextRequest) {
     broadCategory: questionFields.broadCategory,
     canonicalSubcategory: questionFields.canonicalSubcategory,
   });
+  // Haiku-vet for the shared Daily 5 pool — approved questions become eligible
+  // to surface in other users' games (prioritised by friends + friends-of-
+  // friends). Failure is non-fatal: we leave publicStatus at 'not_scored'
+  // and the /api/cron/vet-questions sweep will retry.
+  const verdict = await vetQuestion({
+    questionText: questionFields.text,
+    answer: questionFields.correctAnswer,
+    alternateAnswers: questionFields.alternateAnswers,
+    explanation: questionFields.explanation ?? null,
+    broadCategory: questionFields.broadCategory,
+    canonicalSubcategory: questionFields.canonicalSubcategory,
+  });
+  const publicScoring = verdictToPublicStatus(verdict);
+  console.info('[questions/vet]', {
+    userId: session.userId,
+    verdictStatus: verdict.status,
+    overallScore: publicScoring.publicEligibilityScore,
+    publicStatus: publicScoring.publicStatus,
+  });
+
   const categorizedQuestionFields = {
     ...questionFields,
     difficulty: difficultyAssessment.difficulty,
@@ -153,7 +174,13 @@ export async function POST(request: NextRequest) {
     }
   }
 
-  const created = await createQuestion({ authorId: session.userId, ...categorizedQuestionFields });
+  const created = await createQuestion({
+    authorId: session.userId,
+    ...categorizedQuestionFields,
+    publicStatus: publicScoring.publicStatus,
+    publicEligibilityScore: publicScoring.publicEligibilityScore,
+    publicEligibilityReason: publicScoring.publicEligibilityReason,
+  });
   console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: categorizedQuestionFields.verified, category: categorizedQuestionFields.category, canonicalSubcategory: categorizedQuestionFields.canonicalSubcategory, difficultyTier: difficultyAssessment.tier });
   const feedShare = {
     requested: shareToFeed,

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1,9 +1,12 @@
 import {
   createDailyQueueItem,
+  createDailyQueueItemFromAuthored,
   getKnowledgeBase,
   getTodaysDailyQueue,
+  pickEligibleAuthoredQuestions,
 } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
 import { generateDailyQuestionsFromKnowledgeBase } from '@/server/daily/generate-questions';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 
@@ -41,15 +44,33 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     );
   }
 
-  const generated = await generateDailyQuestionsFromKnowledgeBase(userId, DAILY_QUEUE_SIZE);
-  if (generated.length === 0) {
+  // Prefer vetted user-authored questions, prioritised by friends-of-friends,
+  // then top up the remaining slots with LLM-generated questions. The
+  // QueueSlot schema already supports both bot and friend sources
+  // (src/server/daily/types.ts), so this is a picker change — no slot-shape
+  // migration required.
+  const socialGraph = await getFriendAndFoFUserIds(userId);
+  const authored = await pickEligibleAuthoredQuestions(userId, socialGraph, DAILY_QUEUE_SIZE);
+
+  const remaining = DAILY_QUEUE_SIZE - authored.length;
+  const generated = remaining > 0
+    ? await generateDailyQuestionsFromKnowledgeBase(userId, remaining)
+    : [];
+
+  if (authored.length === 0 && generated.length === 0) {
     throw new DailyQueueFillError(
       'generation_failed',
       "Today's Daily Five is taking longer than usual.",
     );
   }
 
-  for (const [index, question] of generated.slice(0, DAILY_QUEUE_SIZE).entries()) {
-    await createDailyQueueItem(userId, question.id, index);
+  let position = 0;
+  for (const pick of authored) {
+    await createDailyQueueItemFromAuthored(userId, pick, position);
+    position += 1;
+  }
+  for (const question of generated.slice(0, DAILY_QUEUE_SIZE - position)) {
+    await createDailyQueueItem(userId, question.id, position);
+    position += 1;
   }
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -11,6 +11,7 @@ import {
   playerMastery,
   questions as canonicalQuestions,
   userDomainExclusions,
+  users,
 } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
@@ -494,6 +495,197 @@ export async function createDailyQueueItem(
       .set({ usedInQueue: true })
       .where(eq(generatedQuestions.id, generatedQuestionId));
 
+    return updated;
+  });
+}
+
+export type AuthoredPick = {
+  id: string;
+  creatorId: string | null;
+  questionText: string;
+  answerText: string;
+  alternateAnswers: string[];
+  factualExplanation: string | null;
+  canonicalSubcategory: string;
+  broadCategory: string | null;
+  category: string;
+  difficultyEstimate: 'accessible' | 'moderate' | 'specialist' | null;
+  authorName: string | null;
+  authorNote: string | null;
+};
+
+/**
+ * Returns up to `limit` vetted user-authored questions for the viewer's
+ * Daily 5, ranked by social tier: direct friends first, then friends-of-
+ * friends, then everyone else. The orchestrator tops up the remaining
+ * slots with LLM-generated questions.
+ *
+ * "Vetted" means publicStatus = 'eligible_pending' (set by the Haiku
+ * vetter in src/server/llm/vet-question.ts). The viewer is never offered
+ * their own question, deleted questions, or questions that have already
+ * appeared in any of their past daily queues.
+ */
+export async function pickEligibleAuthoredQuestions(
+  viewerUserId: string,
+  socialGraph: { direct: Set<string>; extended: Set<string> },
+  limit: number,
+): Promise<AuthoredPick[]> {
+  if (limit <= 0) return [];
+
+  // Collect every question id the viewer has already seen on any past daily
+  // queue. The graph is small per user (5 slots/day) so a Node-side scan is
+  // simpler than a JSONB containment subquery and dodges driver portability
+  // questions. Indexed via DailyQueue_user_id_idx.
+  const pastQueues = await db
+    .select({ slots: dailyQueues.slots })
+    .from(dailyQueues)
+    .where(eq(dailyQueues.userId, viewerUserId));
+  const seenQuestionIds = new Set<string>();
+  for (const row of pastQueues) {
+    for (const slot of asQueueSlots(row.slots)) {
+      if (slot.question_id) seenQuestionIds.add(slot.question_id);
+    }
+  }
+
+  // Pull a generous over-fetch so the in-memory tier sort has something to
+  // work with even when most of the recent pool came from the viewer's own
+  // FoF cluster. The DB-side ORDER BY is only the score+recency tiebreak.
+  const overFetch = Math.max(limit * 6, 30);
+  const candidates = await db
+    .select({
+      id: canonicalQuestions.id,
+      creatorId: canonicalQuestions.creatorId,
+      questionText: canonicalQuestions.questionText,
+      answerText: canonicalQuestions.answerText,
+      alternateAnswers: canonicalQuestions.acceptedAlternatives,
+      factualExplanation: canonicalQuestions.factualExplanation,
+      canonicalSubcategory: canonicalQuestions.canonicalSubcategory,
+      broadCategory: canonicalQuestions.broadCategory,
+      category: canonicalQuestions.category,
+      difficultyEstimate: canonicalQuestions.difficultyEstimate,
+      creatorNote: canonicalQuestions.creatorNote,
+      publicEligibilityScore: canonicalQuestions.publicEligibilityScore,
+      createdAt: canonicalQuestions.createdAt,
+    })
+    .from(canonicalQuestions)
+    .where(and(
+      eq(canonicalQuestions.publicStatus, 'eligible_pending'),
+      eq(canonicalQuestions.visibility, 'public'),
+      isNotNull(canonicalQuestions.creatorId),
+      isNotNull(canonicalQuestions.canonicalSubcategory),
+      isNull(canonicalQuestions.deletedAt),
+    ))
+    .orderBy(
+      desc(canonicalQuestions.publicEligibilityScore),
+      desc(canonicalQuestions.createdAt),
+    )
+    .limit(overFetch);
+
+  const tierOf = (creatorId: string | null): number => {
+    if (!creatorId) return 3;
+    if (socialGraph.direct.has(creatorId)) return 0;
+    if (socialGraph.extended.has(creatorId)) return 1;
+    return 2;
+  };
+
+  const filtered = candidates
+    .filter((row) => row.creatorId && row.creatorId !== viewerUserId)
+    .filter((row) => !seenQuestionIds.has(row.id))
+    .filter((row) => row.canonicalSubcategory && !isGenericSubcategory(row.canonicalSubcategory))
+    .map((row) => ({
+      row,
+      tier: tierOf(row.creatorId),
+      score: row.publicEligibilityScore ?? 0,
+      createdAt: row.createdAt?.getTime() ?? 0,
+    }))
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+      if (a.score !== b.score) return b.score - a.score;
+      return b.createdAt - a.createdAt;
+    })
+    .slice(0, limit);
+
+  if (filtered.length === 0) return [];
+
+  // Hydrate author display names in one shot.
+  const authorIds = [...new Set(filtered.map((c) => c.row.creatorId).filter((id): id is string => Boolean(id)))];
+  const authorRows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(inArray(users.id, authorIds));
+  const nameById = new Map(authorRows.map((u) => [u.id, u.displayName] as const));
+
+  return filtered.map(({ row }) => ({
+    id: row.id,
+    creatorId: row.creatorId,
+    questionText: row.questionText,
+    answerText: row.answerText,
+    alternateAnswers: row.alternateAnswers ?? [],
+    factualExplanation: row.factualExplanation,
+    canonicalSubcategory: row.canonicalSubcategory ?? '',
+    broadCategory: row.broadCategory,
+    category: String(row.category ?? ''),
+    difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
+    authorName: row.creatorId ? nameById.get(row.creatorId) ?? null : null,
+    authorNote: row.creatorNote ?? null,
+  } satisfies AuthoredPick));
+}
+
+/**
+ * Inserts a vetted user-authored question into the viewer's daily queue
+ * as a `source: 'friend'` slot. Counterpart to `createDailyQueueItem`,
+ * which only handles bot-generated questions. The QueueSlot schema
+ * already supports both shapes (src/server/daily/types.ts).
+ */
+export async function createDailyQueueItemFromAuthored(
+  userId: string,
+  authored: AuthoredPick,
+  position: number,
+): Promise<DailyQueueRow> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+
+  const slot: QueueSlot = {
+    slot_index: position,
+    source: 'friend',
+    question_id: authored.id,
+    author_id: authored.creatorId ?? undefined,
+    author_name: authored.authorName,
+    author_note: authored.authorNote,
+    domain: authored.canonicalSubcategory,
+    broad_category: authored.broadCategory,
+    category: authored.category || null,
+    question_text: authored.questionText,
+    difficulty_estimate: authored.difficultyEstimate ?? undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.userId, userId), eq(dailyQueues.queueDate, assignmentDateStr)))
+      .limit(1);
+
+    if (!existing) {
+      const [created] = await tx
+        .insert(dailyQueues)
+        .values({
+          userId,
+          queueDate: assignmentDateStr,
+          slots: [slot],
+        })
+        .returning();
+      return created;
+    }
+
+    const slots = asQueueSlots(existing.slots).filter((item) => item.slot_index !== position);
+    const nextSlots = [...slots, slot].sort((a, b) => a.slot_index - b.slot_index);
+    const [updated] = await tx
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, existing.id))
+      .returning();
     return updated;
   });
 }

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -162,3 +162,62 @@ export async function areFriends(userAId: string, userBId: string): Promise<bool
   const friendship = await getFriendship(userAId, userBId);
   return friendship?.status === 'active';
 }
+
+/**
+ * Returns the viewer's 1st-degree friend ids and 2nd-degree (friends of
+ * friends) ids, with FoF de-duplicated against direct friends and the
+ * viewer themselves. Used by the Daily 5 picker to rank eligible
+ * user-authored questions: direct friends first, then FoF, then everyone
+ * else.
+ *
+ * The friend graph is small and uncached, so we run two normal queries
+ * rather than a recursive CTE — the second pass is bounded by
+ * `directIds.length` which is itself indexed via the existing
+ * Friendship_userAId_status_idx / Friendship_userBId_status_idx pair.
+ */
+export async function getFriendAndFoFUserIds(userId: string): Promise<{
+  direct: Set<string>;
+  extended: Set<string>;
+}> {
+  const directRows = await db
+    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
+    .from(friendships)
+    .where(and(
+      eq(friendships.status, 'active'),
+      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
+    ));
+
+  const direct = new Set<string>();
+  for (const row of directRows) {
+    const friendId = row.userAId === userId ? row.userBId : row.userAId;
+    direct.add(friendId);
+  }
+
+  if (direct.size === 0) {
+    return { direct, extended: new Set<string>() };
+  }
+
+  const directList = [...direct];
+  const fofRows = await db
+    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
+    .from(friendships)
+    .where(and(
+      eq(friendships.status, 'active'),
+      or(
+        inArray(friendships.userAId, directList),
+        inArray(friendships.userBId, directList),
+      ),
+    ));
+
+  const extended = new Set<string>();
+  for (const row of fofRows) {
+    if (directList.includes(row.userAId) && row.userBId !== userId && !direct.has(row.userBId)) {
+      extended.add(row.userBId);
+    }
+    if (directList.includes(row.userBId) && row.userAId !== userId && !direct.has(row.userAId)) {
+      extended.add(row.userAId);
+    }
+  }
+
+  return { direct, extended };
+}

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -366,6 +366,9 @@ export async function createQuestion(params: {
   verified: boolean;
   llmSuggestedAnswer?: string | null;
   critiqueIterations: number;
+  publicStatus?: 'not_scored' | 'eligible_pending' | 'rejected' | 'opted_out' | 'migrated';
+  publicEligibilityScore?: number | null;
+  publicEligibilityReason?: string | null;
 }): Promise<{ id: string }> {
   await ensureQuestionSurfacePriorityColumn();
 
@@ -390,6 +393,9 @@ export async function createQuestion(params: {
     questionType: 'factual',
     visibility: 'public',
     status: params.verified ? 'verified' : 'unverified',
+    ...(params.publicStatus !== undefined ? { publicStatus: params.publicStatus } : {}),
+    ...(params.publicEligibilityScore !== undefined ? { publicEligibilityScore: params.publicEligibilityScore } : {}),
+    ...(params.publicEligibilityReason !== undefined ? { publicEligibilityReason: params.publicEligibilityReason } : {}),
   } satisfies Partial<typeof questions.$inferInsert>;
 
   const createWithValues = async (values: typeof questions.$inferInsert) => {

--- a/src/server/llm/vet-question.ts
+++ b/src/server/llm/vet-question.ts
@@ -1,0 +1,155 @@
+/**
+ * LLM vetting for user-authored questions. A single Haiku pass checks
+ * factual correctness, quality, safety, and answer-not-in-question, and
+ * returns a verdict the caller can map onto Question.publicStatus.
+ *
+ * Approved (publicStatus = 'eligible_pending') questions are eligible to
+ * appear in any user's Daily 5; the daily orchestrator prioritises ones
+ * authored by the viewer's friends and friends-of-friends.
+ *
+ * On Haiku error or `factual = 'unknown'` we leave the question at the
+ * default 'not_scored' so a nightly sweep can retry — auto-approving on
+ * uncertainty would let bad questions reach strangers.
+ */
+
+import {
+  HAIKU_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+} from '@/lib/llm';
+
+export { verdictToPublicStatus } from '@/server/llm/vet-verdict';
+export type { VetVerdict } from '@/server/llm/vet-verdict';
+import type { VetVerdict } from '@/server/llm/vet-verdict';
+
+export type VetQuestionInput = {
+  questionText: string;
+  answer: string;
+  alternateAnswers?: string[];
+  explanation?: string | null;
+  broadCategory?: string | null;
+  canonicalSubcategory?: string | null;
+};
+
+const QUALITY_APPROVAL_THRESHOLD = 0.5;
+
+const SYSTEM_PROMPT = `You are a strict reviewer for a personal trivia game. A user has submitted a question that may be shown to other players (including strangers). Decide whether it is safe and good enough to enter the shared question pool.
+
+Evaluate four independent dimensions and return JSON only.
+
+1. factual: "pass" | "fail" | "unknown"
+   - "pass" — the stated answer is correct and the question is unambiguous.
+   - "fail" — the stated answer is wrong, or the question has multiple equally-valid answers and the given one isn't clearly "the" answer.
+   - "unknown" — you genuinely cannot verify the fact (extremely niche, recent, or personal).
+
+2. quality: number 0..1
+   - Specific, well-formed, interesting trivia → high.
+   - Vague, low-effort, opinion-based, gibberish, or extremely well-known → low.
+
+3. safety: "pass" | "fail"
+   - "fail" for slurs, harassment, sexual content involving minors, doxxing, or content targeting a private individual.
+   - Ordinary edgy humour is fine; this is a friend game.
+
+4. answer_leaked: boolean
+   - true if the question text contains the answer or near-paraphrase.
+
+Also emit:
+- overall_score: number 0..1 — your composite confidence the question belongs in a shared pool.
+- reason: short single sentence explaining the verdict (≤ 140 chars), human-readable, no markdown.
+
+Return only valid JSON with keys: factual, quality, safety, answer_leaked, overall_score, reason. No prose outside the object.`;
+
+function buildUserMessage(input: VetQuestionInput): string {
+  const lines = [
+    `Question: ${input.questionText}`,
+    `Stated answer: ${input.answer}`,
+  ];
+  if (input.alternateAnswers && input.alternateAnswers.length > 0) {
+    lines.push(`Accepted alternates: ${input.alternateAnswers.join(' | ')}`);
+  }
+  if (input.explanation) {
+    lines.push(`Author explanation: ${input.explanation}`);
+  }
+  if (input.canonicalSubcategory) {
+    lines.push(`Categorised as: ${input.canonicalSubcategory}${input.broadCategory ? ` (${input.broadCategory})` : ''}`);
+  }
+  lines.push('Vet this submission. Return JSON only.');
+  return lines.join('\n');
+}
+
+function clamp01(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return fallback;
+  return Math.max(0, Math.min(1, value));
+}
+
+function trimmed(value: unknown, fallback: string): string {
+  if (typeof value !== 'string') return fallback;
+  const t = value.trim();
+  return t.length > 0 ? t.slice(0, 240) : fallback;
+}
+
+function asFactual(value: unknown): 'pass' | 'fail' | 'unknown' | null {
+  return value === 'pass' || value === 'fail' || value === 'unknown' ? value : null;
+}
+
+function asPassFail(value: unknown): 'pass' | 'fail' | null {
+  return value === 'pass' || value === 'fail' ? value : null;
+}
+
+export async function vetQuestion(input: VetQuestionInput): Promise<VetVerdict> {
+  const client = getAnthropicClient();
+  if (!client) {
+    return { status: 'needs_review', score: null, reason: 'llm_disabled' };
+  }
+
+  let response;
+  try {
+    response = await loggedMessagesCreate(client, 'vet-question', {
+      model: HAIKU_MODEL,
+      max_tokens: 400,
+      temperature: 0,
+      system: [{ type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } }],
+      messages: [{ role: 'user', content: buildUserMessage(input) }],
+    });
+  } catch (error) {
+    console.warn('[vetQuestion] request_failed', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return { status: 'needs_review', score: null, reason: 'llm_error' };
+  }
+
+  const parsed = parseJsonObject(extractTextContent(response.content));
+  if (!parsed) {
+    return { status: 'needs_review', score: null, reason: 'invalid_llm_json' };
+  }
+
+  const factual = asFactual(parsed.factual);
+  const safety = asPassFail(parsed.safety);
+  if (!factual || !safety) {
+    return { status: 'needs_review', score: null, reason: 'missing_fields' };
+  }
+
+  const quality = clamp01(parsed.quality, 0);
+  const overall = clamp01(parsed.overall_score, quality);
+  const answerLeaked = parsed.answer_leaked === true;
+  const reason = trimmed(parsed.reason, 'vetted');
+
+  // Hard rejects first.
+  if (factual === 'fail') return { status: 'rejected', score: overall, reason: `factual: ${reason}` };
+  if (safety === 'fail') return { status: 'rejected', score: overall, reason: `safety: ${reason}` };
+  if (answerLeaked) return { status: 'rejected', score: overall, reason: `answer in question: ${reason}` };
+  if (quality < QUALITY_APPROVAL_THRESHOLD) {
+    return { status: 'rejected', score: overall, reason: `quality ${quality.toFixed(2)}: ${reason}` };
+  }
+
+  // Cannot verify the fact, but no other red flags — let a human (or a later
+  // sweep) decide. Better to under-show than to push wrong trivia to strangers.
+  if (factual === 'unknown') {
+    return { status: 'needs_review', score: overall, reason: `unverifiable: ${reason}` };
+  }
+
+  return { status: 'approved', score: overall, reason };
+}
+

--- a/src/server/llm/vet-verdict.ts
+++ b/src/server/llm/vet-verdict.ts
@@ -1,0 +1,38 @@
+/**
+ * Pure mapping from a Haiku vetting verdict to the Question table's
+ * publicStatus / publicEligibilityScore / publicEligibilityReason columns.
+ * Lives separate from vet-question.ts so it can be smoke-tested without
+ * pulling in the Anthropic SDK.
+ */
+
+export type VetVerdict =
+  | { status: 'approved'; score: number; reason: string }
+  | { status: 'rejected'; score: number; reason: string }
+  | { status: 'needs_review'; score: number | null; reason: string };
+
+export function verdictToPublicStatus(verdict: VetVerdict): {
+  publicStatus: 'eligible_pending' | 'rejected' | 'not_scored';
+  publicEligibilityScore: number | null;
+  publicEligibilityReason: string;
+} {
+  switch (verdict.status) {
+    case 'approved':
+      return {
+        publicStatus: 'eligible_pending',
+        publicEligibilityScore: verdict.score,
+        publicEligibilityReason: verdict.reason,
+      };
+    case 'rejected':
+      return {
+        publicStatus: 'rejected',
+        publicEligibilityScore: verdict.score,
+        publicEligibilityReason: verdict.reason,
+      };
+    case 'needs_review':
+      return {
+        publicStatus: 'not_scored',
+        publicEligibilityScore: verdict.score,
+        publicEligibilityReason: verdict.reason,
+      };
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,10 @@
     {
       "path": "/api/cron/weekly-ceremony",
       "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/vet-questions",
+      "schedule": "0 * * * *"
     }
   ]
 }


### PR DESCRIPTION
The Daily 5 was 100% LLM-generated even though the QueueSlot schema already supports source: 'friend' | 'bot' | 'community' and the Question table already has publicStatus / publicEligibilityScore / publicEligibilityReason columns. This wires those rails up:

- vet-question: a Haiku pass on each submitted question that checks factual correctness, quality, safety, and answer-not-in-question, and maps the verdict onto publicStatus = eligible_pending | rejected | not_scored. Runs inline on POST /api/questions; a new hourly cron at /api/cron/vet-questions retries any rows left at not_scored.
- friends-of-friends: getFriendAndFoFUserIds() resolves the viewer's direct friends and 2nd-degree contacts in two indexed queries.
- daily picker: pickEligibleAuthoredQuestions() pulls vetted questions ranked by (direct friend > FoF > everyone else), excluding the viewer's own questions and anything they've already seen.
- queue orchestrator: fills as many of the 5 slots as possible from the authored pool, then tops up with LLM-generated questions. Surfaces user-authored content immediately while ensuring 5 questions every day even when the authored pool is empty.
- daily/answer route: branches on slot.generated_question_id vs slot.question_id to load the question from the right table; mastery, author credit, and feed propagation flow through both paths.

No schema migration — every column the feature needs already exists.