### PR TITLE
Remove REVIEWING stage from question form workflow

### DIFF
--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -32,7 +32,7 @@ type SuggestionResponse = {
 
 type FriendOption = { id: string; displayName: string };
 
-type Stage = 'WRITING' | 'CRITIQUING' | 'CRITIQUED' | 'ANSWERING' | 'REVIEWING' | 'SUBMITTING' | 'DONE';
+type Stage = 'WRITING' | 'CRITIQUING' | 'CRITIQUED' | 'ANSWERING' | 'SUBMITTING' | 'DONE';
 
 type Props = {
   mode?: 'create' | 'edit';
@@ -80,8 +80,6 @@ type Action =
   | { type: 'START_SUGGESTION' }
   | { type: 'SUGGESTION_RESULT'; questionText: string; suggestion: SuggestionResponse }
   | { type: 'SUGGESTION_ERROR'; questionText?: string; value: string | null }
-  | { type: 'REVIEW' }
-  | { type: 'BACK_TO_EDIT' }
   | { type: 'SUBMITTING' }
   | { type: 'DONE' }
   | { type: 'SPECIFIC_MODE'; value: boolean }
@@ -156,8 +154,6 @@ function reducer(state: State, action: Action): State {
       }
       return { ...state, suggesting: false, suggestionError: action.value };
     }
-    case 'REVIEW': return { ...state, stage: 'REVIEWING', error: null };
-    case 'BACK_TO_EDIT': return { ...state, stage: 'ANSWERING' };
     case 'SUBMITTING': return { ...state, stage: 'SUBMITTING', error: null };
     case 'DONE': return { ...state, stage: 'DONE' };
     case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, shareToFeed: action.value ? false : state.shareToFeed, sendToFriendIds: [] };
@@ -354,15 +350,6 @@ export function QuestionForm({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, state.stage, state.questionText, state.suggesting, state.llmSuggestedAnswer]);
 
-  function review() {
-    const validationError = validate(state);
-    if (validationError) {
-      dispatch({ type: 'ERROR', value: validationError });
-      return;
-    }
-    dispatch({ type: 'REVIEW' });
-  }
-
   async function finalSave() {
     const validationError = validate(state);
     if (validationError) {
@@ -392,7 +379,7 @@ export function QuestionForm({
 
   const critique = state.critiqueResult;
   const counter = remainingCopy(state);
-  const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' || mode === 'edit';
+  const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'SUBMITTING' || mode === 'edit';
 
   return (
     <div className="space-y-5">
@@ -428,7 +415,7 @@ export function QuestionForm({
           required
           className="w-full rounded-md border bg-background px-3 py-2 text-base outline-none focus:border-primary"
           placeholder="What is the name of Alexander the Great's horse?"
-          readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'}
+          readOnly={state.stage === 'SUBMITTING'}
         />
         <div className="mt-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
           <span>{state.stage === 'CRITIQUING' ? 'Reviewing your question...' : null}</span>
@@ -469,7 +456,7 @@ export function QuestionForm({
 
       {canShowAnswering ? (
         <>
-          {state.stage !== 'REVIEWING' && state.stage !== 'SUBMITTING' && (counter || state.suggesting || state.suggestionError) ? (
+          {state.stage !== 'SUBMITTING' && (counter || state.suggesting || state.suggestionError) ? (
             <div className="flex flex-wrap items-center gap-3">
               {state.suggesting ? <span className="text-sm text-muted-foreground">Suggesting answer...</span> : null}
               {counter ? <span className="text-xs text-muted-foreground">{counter}</span> : null}
@@ -485,7 +472,7 @@ export function QuestionForm({
               onChange={(event) => dispatch({ type: 'FIELD', field: 'userAnswer', value: event.target.value.slice(0, 200) })}
               maxLength={200}
               required
-              readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'}
+              readOnly={state.stage === 'SUBMITTING'}
               className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary"
               placeholder="Bucephalus"
             />
@@ -493,14 +480,20 @@ export function QuestionForm({
 
           <div>
             <label htmlFor="alternate-answers" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Alternate answers</label>
-            <input id="alternate-answers" value={state.alternateText} onChange={(event) => dispatch({ type: 'FIELD', field: 'alternateText', value: event.target.value })} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Accepted variations, separated by commas" />
+            <input id="alternate-answers" value={state.alternateText} onChange={(event) => dispatch({ type: 'FIELD', field: 'alternateText', value: event.target.value })} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Accepted variations, separated by commas" />
             <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/5 alternates</p>
           </div>
 
           <div>
             <label htmlFor="explanation" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Explanation</label>
-            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={4} maxLength={500} readOnly={state.stage === 'REVIEWING' || state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="A short note that helps someone learn if they miss it." />
+            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={4} maxLength={500} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="A short note that helps someone learn if they miss it." />
             <p className="mt-1 text-right text-xs text-muted-foreground">{state.explanation.length}/500</p>
+          </div>
+
+          <div>
+            <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Creator note</label>
+            <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Optional context for recipients" />
+            <p className="mt-1 text-right text-xs text-muted-foreground">{state.creatorNote.length}/200</p>
           </div>
 
           <div className="rounded-md border bg-muted/30 p-3">
@@ -508,24 +501,17 @@ export function QuestionForm({
             <p className="mt-1 text-sm text-muted-foreground">Joshing will read the question and answer when you save, then use the LLM to choose the broad category, precise domain, and difficulty.</p>
           </div>
 
-          {state.stage === 'REVIEWING' && state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (
+          {state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (
             <div className="rounded-md border bg-muted/40 p-3 text-sm">
               <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">LLM suggestion</p>
               <p className="mt-1 line-through decoration-amber-500">{state.llmSuggestedAnswer}</p>
             </div>
           ) : null}
 
-          {state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' ? (
-            <>
-              <div>
-                <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Creator note</label>
-                <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Optional context for recipients" />
-                <p className="mt-1 text-right text-xs text-muted-foreground">{state.creatorNote.length}/200</p>
-              </div>
-              <p className={verified ? 'text-sm text-emerald-700' : 'text-sm text-amber-700'}>
-                {verified ? '✓ Verified — matches LLM suggestion' : "⚠ Unverified — your answer differs from the LLM's suggestion. Recipients will see this."}
-              </p>
-            </>
+          {state.llmSuggestedAnswer ? (
+            <p className={verified ? 'text-sm text-emerald-700' : 'text-sm text-amber-700'}>
+              {verified ? '✓ Verified — matches LLM suggestion' : "⚠ Unverified — your answer differs from the LLM's suggestion. Recipients will see this."}
+            </p>
           ) : null}
 
           {showDestinations ? (
@@ -551,14 +537,7 @@ export function QuestionForm({
           ) : null}
 
           <div className="flex flex-wrap items-center gap-3 pt-2">
-            {state.stage === 'REVIEWING' || state.stage === 'SUBMITTING' ? (
-              <>
-                <button type="button" onClick={() => dispatch({ type: 'BACK_TO_EDIT' })} className="btn-ghost" disabled={submitDisabled}>Back to edit</button>
-                <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">{submitDisabled ? loadingLabel : resolvedSubmitLabel}</button>
-              </>
-            ) : (
-              <button type="button" onClick={review} className="btn-primary">Review</button>
-            )}
+            <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">{submitDisabled ? loadingLabel : resolvedSubmitLabel}</button>
             {onCancel ? <button type="button" onClick={onCancel} className="btn-ghost" disabled={submitDisabled}>Cancel</button> : null}
           </div>
         </>


### PR DESCRIPTION
## Summary
Simplifies the question form submission workflow by removing the intermediate `REVIEWING` stage. The form now transitions directly from `ANSWERING` to `SUBMITTING`, eliminating the separate review step and consolidating the creator note field into the main form.

## Key Changes
- **Removed `REVIEWING` stage** from the `Stage` type and all related logic
- **Removed review actions** (`REVIEW` and `BACK_TO_EDIT`) from the action dispatcher and reducer
- **Removed `review()` function** that validated and dispatched the review action
- **Consolidated creator note field** into the main answering section (always visible when `canShowAnswering` is true) instead of only appearing in the reviewing stage
- **Simplified field readOnly logic** to only check for `SUBMITTING` stage instead of both `REVIEWING` and `SUBMITTING`
- **Simplified LLM suggestion display** to show whenever an LLM suggestion exists and differs from the user's answer, rather than only in the reviewing stage
- **Simplified verification message display** to show whenever an LLM suggestion exists, rather than only in reviewing/submitting stages
- **Removed "Back to edit" button** and replaced the two-button review flow with a single submit button

## Implementation Details
The workflow now follows a linear progression: `WRITING` → `CRITIQUING` → `CRITIQUED` → `ANSWERING` → `SUBMITTING` → `DONE`. Users can now provide all information (question, answer, alternates, explanation, and creator note) in a single form before submission, with the LLM suggestion and verification status visible throughout the answering phase.

https://claude.ai/code/session_01H2jWJTebYEErfX8XR69o3S