### PR TITLE
Add friend search and recent recipients to question form

### DIFF
--- a/src/app/api/users/recent/route.ts
+++ b/src/app/api/users/recent/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getRecentDirectSendRecipients } from '@/server/db/queries/friends';
+
+export const dynamic = 'force-dynamic';
+
+function displayName(name: string | null, fallback: string): string {
+  return name?.trim() || fallback;
+}
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const rows = await getRecentDirectSendRecipients(session.userId, 3);
+
+  return NextResponse.json(
+    rows.map((user) => ({
+      id: user.id,
+      displayName: displayName(user.displayName, user.phoneNumber),
+    })),
+  );
+}

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Search, X } from 'lucide-react';
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
 
 export type QuestionFormValues = {
@@ -65,6 +66,8 @@ type State = {
   friends: FriendOption[];
   friendsLoading: boolean;
   sendToFriendIds: string[];
+  recentFriendIds: string[];
+  friendSearch: string;
 };
 
 type Action =
@@ -86,6 +89,8 @@ type Action =
   | { type: 'SHARE_TO_FEED'; value: boolean }
   | { type: 'FRIENDS_LOADING'; value: boolean }
   | { type: 'FRIENDS_LOADED'; friends: FriendOption[] }
+  | { type: 'RECENTS_LOADED'; ids: string[] }
+  | { type: 'FRIEND_SEARCH'; value: string }
   | { type: 'TOGGLE_FRIEND'; id: string };
 
 function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecificMode = false): State {
@@ -110,6 +115,8 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     friends: [],
     friendsLoading: false,
     sendToFriendIds: initialValues?.sendToFriendIds ?? [],
+    recentFriendIds: [],
+    friendSearch: '',
   };
 }
 
@@ -156,10 +163,12 @@ function reducer(state: State, action: Action): State {
     }
     case 'SUBMITTING': return { ...state, stage: 'SUBMITTING', error: null };
     case 'DONE': return { ...state, stage: 'DONE' };
-    case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, shareToFeed: action.value ? false : state.shareToFeed, sendToFriendIds: [] };
+    case 'SPECIFIC_MODE': return { ...state, specificMode: action.value, shareToFeed: action.value ? false : state.shareToFeed, sendToFriendIds: [], friendSearch: '' };
     case 'SHARE_TO_FEED': return { ...state, shareToFeed: action.value, specificMode: action.value ? false : state.specificMode, sendToFriendIds: action.value ? [] : state.sendToFriendIds };
     case 'FRIENDS_LOADING': return { ...state, friendsLoading: action.value };
     case 'FRIENDS_LOADED': return { ...state, friends: action.friends, friendsLoading: false };
+    case 'RECENTS_LOADED': return { ...state, recentFriendIds: action.ids };
+    case 'FRIEND_SEARCH': return { ...state, friendSearch: action.value };
     case 'TOGGLE_FRIEND': {
       const selected = state.sendToFriendIds.includes(action.id);
       return { ...state, sendToFriendIds: selected ? state.sendToFriendIds.filter((id) => id !== action.id) : [...state.sendToFriendIds, action.id] };
@@ -249,6 +258,25 @@ export function QuestionForm({
   }, [state.stage]);
 
   const alternateAnswers = useMemo(() => alternateAnswersFrom(state.alternateText), [state.alternateText]);
+  const friendsById = useMemo(() => {
+    const map = new Map<string, FriendOption>();
+    for (const friend of state.friends) map.set(friend.id, friend);
+    return map;
+  }, [state.friends]);
+  const recents = useMemo(() => {
+    const result: FriendOption[] = [];
+    for (const id of state.recentFriendIds) {
+      const friend = friendsById.get(id);
+      if (friend) result.push(friend);
+      if (result.length >= 3) break;
+    }
+    return result;
+  }, [state.recentFriendIds, friendsById]);
+  const filteredFriends = useMemo(() => {
+    const query = state.friendSearch.trim().toLowerCase();
+    if (!query) return state.friends;
+    return state.friends.filter((friend) => friend.displayName.toLowerCase().includes(query));
+  }, [state.friends, state.friendSearch]);
   const showDestinations = mode === 'create';
   const verified = computedVerified(state);
   const submitDisabled = state.stage === 'SUBMITTING';
@@ -258,11 +286,18 @@ export function QuestionForm({
     if (state.friends.length > 0 || state.friendsLoading) return;
     dispatch({ type: 'FRIENDS_LOADING', value: true });
     try {
-      const response = await fetch('/api/users', { cache: 'no-store', credentials: 'include' });
-      const body = await response.json().catch(() => null) as FriendOption[] | null;
-      dispatch({ type: 'FRIENDS_LOADED', friends: response.ok && Array.isArray(body) ? body : [] });
+      const [friendsResponse, recentsResponse] = await Promise.all([
+        fetch('/api/users', { cache: 'no-store', credentials: 'include' }),
+        fetch('/api/users/recent', { cache: 'no-store', credentials: 'include' }),
+      ]);
+      const friendsBody = await friendsResponse.json().catch(() => null) as FriendOption[] | null;
+      dispatch({ type: 'FRIENDS_LOADED', friends: friendsResponse.ok && Array.isArray(friendsBody) ? friendsBody : [] });
+      const recentsBody = await recentsResponse.json().catch(() => null) as FriendOption[] | null;
+      const recentIds = recentsResponse.ok && Array.isArray(recentsBody) ? recentsBody.map((friend) => friend.id) : [];
+      dispatch({ type: 'RECENTS_LOADED', ids: recentIds });
     } catch {
       dispatch({ type: 'FRIENDS_LOADED', friends: [] });
+      dispatch({ type: 'RECENTS_LOADED', ids: [] });
     }
   }
 
@@ -521,14 +556,94 @@ export function QuestionForm({
               <label className="mb-2 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.shareToFeed} onChange={(event) => toggleShareToFeed(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Share with all friends</span></label>
               <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.specificMode} onChange={(event) => toggleSpecificMode(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING'} /><span className="text-foreground">Send to specific friends only</span></label>
               {state.specificMode ? (
-                <div className="mt-1">
-                  {state.friendsLoading ? <p className="text-xs text-muted-foreground">Loading friends...</p> : state.friends.length === 0 ? <p className="text-xs text-muted-foreground">No friends found.</p> : (
+                <div className="mt-1 space-y-3">
+                  {state.sendToFriendIds.length > 0 ? (
                     <div className="flex flex-wrap gap-2">
-                      {state.friends.map((friend) => {
-                        const selected = state.sendToFriendIds.includes(friend.id);
-                        return <button key={friend.id} type="button" onClick={() => dispatch({ type: 'TOGGLE_FRIEND', id: friend.id })} className={['rounded-full border px-3 py-1 text-sm transition', selected ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-muted'].join(' ')}>{friend.displayName}</button>;
+                      {state.sendToFriendIds.map((id) => {
+                        const friend = friendsById.get(id);
+                        if (!friend) return null;
+                        return (
+                          <span key={id} className="inline-flex items-center gap-1 rounded-full border border-primary bg-primary py-1 pl-3 pr-1 text-sm text-primary-foreground">
+                            {friend.displayName}
+                            <button
+                              type="button"
+                              onClick={() => dispatch({ type: 'TOGGLE_FRIEND', id })}
+                              aria-label={`Remove ${friend.displayName}`}
+                              className="inline-flex size-5 items-center justify-center rounded-full hover:bg-primary-foreground/20"
+                            >
+                              <X className="size-3" />
+                            </button>
+                          </span>
+                        );
                       })}
                     </div>
+                  ) : null}
+
+                  {state.friendsLoading ? (
+                    <p className="text-xs text-muted-foreground">Loading friends...</p>
+                  ) : state.friends.length === 0 ? (
+                    <p className="text-xs text-muted-foreground">No friends found.</p>
+                  ) : (
+                    <>
+                      {state.friendSearch.trim() === '' && recents.length > 0 ? (
+                        <div>
+                          <p className="mb-2 text-xs uppercase tracking-[0.1em] text-muted-foreground">Recents</p>
+                          <div className="flex flex-wrap gap-2">
+                            {recents.map((friend) => {
+                              const selected = state.sendToFriendIds.includes(friend.id);
+                              return (
+                                <button
+                                  key={friend.id}
+                                  type="button"
+                                  onClick={() => dispatch({ type: 'TOGGLE_FRIEND', id: friend.id })}
+                                  aria-pressed={selected}
+                                  className={['rounded-full border px-3 py-1 text-sm transition', selected ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background hover:bg-muted'].join(' ')}
+                                >
+                                  {friend.displayName}
+                                </button>
+                              );
+                            })}
+                          </div>
+                        </div>
+                      ) : null}
+
+                      <label className="relative block">
+                        <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+                        <input
+                          type="text"
+                          aria-label="Search friends"
+                          value={state.friendSearch}
+                          onChange={(event) => dispatch({ type: 'FRIEND_SEARCH', value: event.target.value })}
+                          placeholder="Search friends..."
+                          className="h-10 w-full rounded-md border bg-background pl-9 pr-3 text-sm outline-none focus:border-primary"
+                          disabled={state.stage === 'SUBMITTING'}
+                        />
+                      </label>
+
+                      <div className="max-h-64 overflow-y-auto rounded-md border">
+                        {filteredFriends.length === 0 ? (
+                          <p className="p-3 text-xs text-muted-foreground">No friends match &ldquo;{state.friendSearch.trim()}&rdquo;.</p>
+                        ) : (
+                          filteredFriends.map((friend) => {
+                            const selected = state.sendToFriendIds.includes(friend.id);
+                            return (
+                              <button
+                                key={friend.id}
+                                type="button"
+                                onClick={() => dispatch({ type: 'TOGGLE_FRIEND', id: friend.id })}
+                                aria-pressed={selected}
+                                className="flex w-full items-center gap-3 border-b px-3 py-2 text-left text-sm last:border-b-0 hover:bg-muted/60"
+                              >
+                                <span className={['inline-flex size-4 items-center justify-center rounded-sm border', selected ? 'border-primary bg-primary text-primary-foreground' : 'border-border bg-background'].join(' ')}>
+                                  {selected ? <span aria-hidden className="text-[10px] leading-none">✓</span> : null}
+                                </span>
+                                <span>{friend.displayName}</span>
+                              </button>
+                            );
+                          })
+                        )}
+                      </div>
+                    </>
                   )}
                 </div>
               ) : null}

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -1,6 +1,7 @@
-import { and, asc, eq, inArray, ne, or } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, or } from 'drizzle-orm';
 
-import { db, declaredInterests, friendships, users } from '@/server/db';
+import { db, declaredInterests, feedItems, friendships, users } from '@/server/db';
+import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 export type User = typeof users.$inferSelect;
 export type Friendship = typeof friendships.$inferSelect;
@@ -59,6 +60,40 @@ export async function getFriends(userId: string): Promise<User[]> {
     .from(users)
     .where(inArray(users.id, friendIds))
     .orderBy(asc(users.displayName), asc(users.phoneNumber));
+}
+
+export async function getRecentDirectSendRecipients(userId: string, limit = 3): Promise<User[]> {
+  if (limit <= 0) return [];
+
+  const recentRows = await db
+    .select({ recipientUserId: feedItems.recipientUserId })
+    .from(feedItems)
+    .where(and(
+      eq(feedItems.sourceUserId, userId),
+      eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
+    ))
+    .orderBy(desc(feedItems.sourceEventAt))
+    .limit(50);
+
+  const orderedDistinctIds: string[] = [];
+  const seen = new Set<string>();
+  for (const row of recentRows) {
+    if (seen.has(row.recipientUserId)) continue;
+    seen.add(row.recipientUserId);
+    orderedDistinctIds.push(row.recipientUserId);
+    if (orderedDistinctIds.length >= limit) break;
+  }
+  if (orderedDistinctIds.length === 0) return [];
+
+  const friends = await getFriends(userId);
+  const friendsById = new Map(friends.map((friend) => [friend.id, friend] as const));
+
+  const result: User[] = [];
+  for (const id of orderedDistinctIds) {
+    const friend = friendsById.get(id);
+    if (friend) result.push(friend);
+  }
+  return result;
 }
 
 export async function getFriendsHub(userId: string): Promise<FriendsHub> {


### PR DESCRIPTION
## Summary
Enhanced the question form's friend selection UI with search functionality and a "recents" section showing recently messaged friends. This improves the UX when sending questions to specific friends by reducing the need to scroll through a full friend list.

## Key Changes
- **New API endpoint** (`/api/users/recent`): Returns up to 3 most recent direct message recipients for the current user, queried from `feedItems` table ordered by recency
- **Database query helper** (`getRecentDirectSendRecipients`): Fetches recent direct send recipients from feed history, filtering to only friends and deduplicating while preserving order
- **Enhanced friend selection UI**:
  - Added search input with icon to filter friends by display name
  - Shows "Recents" section (up to 3 friends) when search is empty
  - Displays filtered results in a scrollable list with checkboxes
  - Selected friends now shown as removable chips at the top
  - Improved visual hierarchy and accessibility with proper ARIA labels
- **State management**: Added `recentFriendIds` and `friendSearch` to reducer state, with corresponding actions and memoized selectors for recents and filtered friends
- **Parallel loading**: Friends and recent recipients are now fetched concurrently via `Promise.all`

## Implementation Details
- Recent recipients are determined by querying `feedItems` where `sourceType` is `DIRECT_SENT_FEED_SOURCE_TYPE`, ordered by `sourceEventAt` descending
- The recents section only appears when the search field is empty, preventing confusion with search results
- Friend search is case-insensitive and matches against `displayName`
- Selected friends are displayed as removable chips with an X button, improving clarity over the previous button-based approach
- The filtered friends list is scrollable (max-height: 16rem) to handle large friend lists

https://claude.ai/code/session_01UNbNJTpLXuZ6arsSyKpAaL