### PR TITLE
Add confirmation toast when hiding feed categories

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -593,7 +593,7 @@ function KnowledgePageContent() {
       </section>
 
       {dismissedDomains.length > 0 && (
-        <section className="bg-white border border-[var(--border-warm)] p-4" aria-label="Dismissed domains">
+        <section id="focused-feed" className="bg-white border border-[var(--border-warm)] p-4 scroll-mt-4" aria-label="Dismissed domains">
           <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">FOCUSED FEED</p>
           <p className="mt-[0.15rem] text-[10px] [font-variant:small-caps] text-[var(--text-muted-warm)] tracking-[0.06em] font-[var(--font-neutral)]">DOMAINS YOU&rsquo;VE HIDDEN FROM YOUR FEED — RE-OPEN ANY TIME</p>
           <div className="mt-3 flex flex-col gap-2">

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -527,6 +527,7 @@ function FeedListContent({
   const [feedbackSheetId, setFeedbackSheetId] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [hideToast, setHideToast] = useState<{ category: string } | null>(null)
   const [ceremonyStatus, setCeremonyStatus] = useState<CeremonyStatus | null>(initialCeremonyStatus)
   // True for the very first render path when we already have server-rendered
   // data; the initial-fetch useEffect skips its work once.
@@ -667,6 +668,7 @@ function FeedListContent({
 
   const hideCategory = useCallback(async (item: FeedApiItem) => {
     if (!item.domain_pill) return
+    const category = item.domain_pill
     setBusyId(item.id)
     setError(null)
     try {
@@ -674,17 +676,21 @@ function FeedListContent({
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify({ domain: item.domain_pill }),
+        body: JSON.stringify({ domain: category }),
       })
       if (!response.ok) {
         const body = await response.json().catch(() => null)
         throw new Error(body?.message ?? 'Could not hide that category.')
       }
       setItems((current) =>
-        current.filter(
-          (currentItem) => currentItem.domain_pill !== item.domain_pill
-        )
+        current.filter((currentItem) => currentItem.domain_pill !== category)
       )
+      setHideToast({ category })
+      window.setTimeout(() => {
+        setHideToast((current) =>
+          current?.category === category ? null : current
+        )
+      }, 4500)
     } catch (caught) {
       setError(
         caught instanceof Error
@@ -961,6 +967,22 @@ function FeedListContent({
         ))}
       </nav>
       <CeremonyTopOfFeed status={ceremonyStatus} />
+
+      {hideToast ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-muted-foreground mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed px-3 py-2 text-sm italic"
+        >
+          <span>Hidden questions about {hideToast.category}.</span>
+          <Link
+            href="/knowledge#focused-feed"
+            className="text-foreground text-xs font-medium not-italic underline-offset-4 hover:underline"
+          >
+            Manage on your knowledge page →
+          </Link>
+        </div>
+      ) : null}
 
       {items.length === 0 ? (
         <section className="flex min-h-48 flex-col items-center justify-center gap-3 py-12 text-center">

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -45,7 +45,7 @@ export function getFeedOverflowMenuLabels({
 }) {
   const visibleCategory = visibleFeedCategory(category)
   return [
-    ...(visibleCategory ? ['Hide this category'] : []),
+    ...(visibleCategory ? [`Hide questions about ${visibleCategory}`] : []),
     `Hide questions from ${sourceName || 'this person'}`,
     ...(hasQuestion && !isInBank ? ['Add to bank'] : []),
     ...(hasQuestion ? ['Send to friend'] : []),
@@ -167,7 +167,7 @@ export function FeedOverflowMenu({
                 disabled={disabled}
                 onClick={wrapAction(onHideCategory)}
               >
-                Hide this category
+                Hide questions about {visibleCategory}
               </MenuButton>
             ) : null}
             <MenuButton disabled={disabled} onClick={wrapAction(onHidePerson)}>

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -128,7 +128,7 @@ export function FriendAddedCard({
                 onClick={onHideCategory}
                 className="font-medium text-[#1d4ed8] hover:underline"
               >
-                Hide this category
+                Hide questions about {visibleCategory}
               </button>
             </>
           ) : null}

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -349,7 +349,7 @@ describe('Feed card category and overflow affordances', () => {
         isInBank: true,
       })
     ).toEqual([
-      'Hide this category',
+      'Hide questions about Literature',
       'Hide questions from Maya',
       'Send to friend',
       'Report',


### PR DESCRIPTION
## Summary
Adds a dismissible toast notification that appears when users hide a feed category, confirming the action and providing a link to manage hidden categories on the knowledge page.

## Key Changes
- **FeedList.tsx**: 
  - Added `hideToast` state to track which category was just hidden
  - Modified `hideCategory` callback to set the toast with a 4.5-second auto-dismiss timer
  - Rendered a new toast UI with category name and link to knowledge page's "Focused Feed" section
  - Toast includes accessible markup (`role="status"`, `aria-live="polite"`)

- **FeedActions.tsx & FriendAddedCard.tsx**: 
  - Updated menu labels and button text from generic "Hide this category" to specific "Hide questions about {category}" for better clarity

- **knowledge/page.tsx**: 
  - Added `id="focused-feed"` and `scroll-mt-4` to the dismissed domains section to enable smooth anchor linking from the toast

- **FeedCards.test.tsx**: 
  - Updated test expectation to match new label text

## Implementation Details
- Toast auto-dismisses after 4.5 seconds but respects newer dismissals (won't reappear if user hides another category while one is showing)
- Uses a dashed border style consistent with the design system
- Provides direct navigation to the knowledge page where users can re-enable hidden categories

https://claude.ai/code/session_01SQnEkpN9wvK7QXmhry82ck