### PR TITLE
Centralize mastery tier labels to single source of truth

### DIFF
--- a/src/app/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/ceremony/[ceremonyId]/page.tsx
@@ -6,6 +6,7 @@ import { Check, Share2, X } from 'lucide-react';
 
 import { ShareCard } from '@/components/ShareCard';
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
 import type { MasteryTier } from '@/types/db';
 
 type Beat1 = { domain: string; fromTier: MasteryTier; toTier: MasteryTier }[];
@@ -49,13 +50,6 @@ type BeatView =
   | { id: 4; content: Beat4 }
   | { id: 5; content: Beat5 }
   | { id: '5-friend'; content: Beat5FriendFallback };
-
-const TIER_LABEL: Record<MasteryTier, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
-};
 
 function joinList(values: string[]) {
   if (values.length <= 2) return values.join(' and ');
@@ -154,7 +148,7 @@ function Beat({ beat, mode }: { beat: BeatView; mode?: CeremonyMode }) {
               <div>
                 <p className="font-serif text-xl font-semibold text-stone-50">{crossing.domain}</p>
                 <p className="mt-1 text-xs uppercase tracking-[0.16em] text-stone-400">
-                  {TIER_LABEL[crossing.fromTier]} {'->'} {TIER_LABEL[crossing.toTier]}
+                  {KNOWLEDGE_TIER_LABEL[crossing.fromTier]} {'->'} {KNOWLEDGE_TIER_LABEL[crossing.toTier]}
                 </p>
               </div>
             </div>

--- a/src/app/knowledge/[domain]/page.tsx
+++ b/src/app/knowledge/[domain]/page.tsx
@@ -8,6 +8,7 @@ import { DomainVisibilityToggle, type DomainVisibility } from '@/components/know
 import { TierProgressBar } from '@/components/progression/TierProgressBar';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
 import type { MasteryTier } from '@/types/db';
 
 type MasteryEvent = {
@@ -47,13 +48,6 @@ type DomainDetail = {
   visibility: DomainVisibility;
   recentEvents: MasteryEvent[];
   questionHistory: QuestionAnswer[];
-};
-
-const TIER_LABEL: Record<MasteryTier, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
 };
 
 const VISIBILITY_HELP: Record<DomainVisibility, string> = {
@@ -191,7 +185,7 @@ export default function DomainDetailPage() {
 
       <section className="mb-5 rounded-lg border bg-card p-5 text-card-foreground">
         <p className="text-xs uppercase tracking-[0.12em] text-muted-foreground">Current tier</p>
-        <h2 className="mt-2 font-serif text-4xl font-semibold">{TIER_LABEL[tier]}</h2>
+        <h2 className="mt-2 font-serif text-4xl font-semibold">{KNOWLEDGE_TIER_LABEL[tier]}</h2>
         <div className="mt-5">
           <TierProgressBar
             tier={tier}
@@ -202,7 +196,7 @@ export default function DomainDetailPage() {
         <p className="mt-3 text-sm text-muted-foreground">
           {formatNumber(detail.points)} points
           {detail.nextTier && detail.pointsToNextTier !== null
-            ? ` · ${formatNumber(detail.pointsToNextTier)} to ${TIER_LABEL[asTier(detail.nextTier)]}`
+            ? ` · ${formatNumber(detail.pointsToNextTier)} to ${KNOWLEDGE_TIER_LABEL[asTier(detail.nextTier)]}`
             : ' · Top tier reached'}
         </p>
       </section>

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -1,5 +1,6 @@
 import { forwardRef, type CSSProperties } from 'react';
 
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
 import type { MasteryTier } from '@/types/db';
 
 type ShareCardSize = 'square' | 'portrait';
@@ -24,13 +25,6 @@ export type ShareCardProps = {
   cycleStart: string;
   cycleEnd: string;
   size?: ShareCardSize;
-};
-
-const TIER_LABEL: Record<MasteryTier, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
 };
 
 const TIER_POINTS: Record<MasteryTier, number> = {
@@ -58,7 +52,7 @@ function buildHighlights(payload: ShareCardBeatsPayload): string[] {
   const highlights: string[] = [];
   const mastered = payload.beat1?.[0];
   if (mastered) {
-    highlights.push(`Crossed into ${TIER_LABEL[mastered.toTier]} in ${mastered.domain}`);
+    highlights.push(`Crossed into ${KNOWLEDGE_TIER_LABEL[mastered.toTier]} in ${mastered.domain}`);
   }
 
   const discovered = payload.beat2?.friendMediated[0] ?? payload.beat2?.authored[0] ?? payload.beat2?.promoted[0];

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -4,20 +4,16 @@ import { useCallback, useState, type ReactNode } from 'react'
 
 import { KnowledgeCircle } from '@/components/knowledge/CategoryCircles'
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy'
+import type { MasteryTier } from '@/types/db'
 
 import { visibleFeedCategory } from './category'
 import type { AnsweredByYouFeedItem, AnsweredByYouPairedFriend } from './types'
 import { colorForCategory, colorForUser, initialsFor, isDarkColor } from './visual'
 
-const TIER_LABEL: Record<string, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
-}
-
 function tierLabel(tier: string): string {
-  return TIER_LABEL[tier.toLowerCase()] ?? tier
+  const normalized = tier.toLowerCase() as MasteryTier
+  return KNOWLEDGE_TIER_LABEL[normalized] ?? tier
 }
 
 function KnowledgeGainIndicator({ item }: { item: AnsweredByYouFeedItem }) {

--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -4,15 +4,9 @@ import {
 } from '@/components/icons/domain-icons'
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy'
 import type { MasteryTier } from '@/types/db'
 import type { CSSProperties } from 'react'
-
-const TIER_LABEL: Record<MasteryTier, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
-}
 
 type DomainCircleProps = {
   diameter: number
@@ -159,7 +153,7 @@ export function DomainCircle({
       </div>
       <p style={nameStyle}>{canonicalSubcategory}</p>
       {showTierLabel && currentTier && (
-        <p style={tierStyle}>{TIER_LABEL[currentTier]}</p>
+        <p style={tierStyle}>{KNOWLEDGE_TIER_LABEL[currentTier]}</p>
       )}
       {showYourQs > 0 && (
         <div

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -6,8 +6,10 @@ import {
   type CircleSizingTier,
 } from '@/lib/knowledge/circle-sizing'
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy'
+import type { MasteryTier } from '@/types/db'
 
-type PortraitTier = 'establishing' | 'familiar' | 'solid' | 'mastery'
+type PortraitTier = MasteryTier
 type SortMode = 'domain' | 'mastery'
 
 export type PortraitEntry = {
@@ -32,13 +34,6 @@ const TIER_ORDER: PortraitTier[] = [
   'familiar',
   'establishing',
 ]
-
-const TIER_DISPLAY: Record<PortraitTier, string> = {
-  establishing: 'Establishing',
-  familiar: 'Familiar',
-  solid: 'Solid',
-  mastery: 'Mastery',
-}
 
 type DomainColor = {
   primary: string
@@ -177,7 +172,7 @@ function buildSections(
       })
   }
   return TIER_ORDER.map((tier) => ({
-    label: TIER_DISPLAY[tier],
+    label: KNOWLEDGE_TIER_LABEL[tier],
     color: '#6b5535',
     entries: entries
       .filter((e) => e.tier === tier)
@@ -475,7 +470,7 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
                 }}
               />
               <span style={{ fontSize: 9.5, color: '#8b7355' }}>
-                {TIER_DISPLAY[tier]}
+                {KNOWLEDGE_TIER_LABEL[tier]}
               </span>
             </div>
           ))}

--- a/src/components/knowledge/ProgressionLandscape.tsx
+++ b/src/components/knowledge/ProgressionLandscape.tsx
@@ -3,17 +3,11 @@
 import { Fragment, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
 import { DomainCircle } from '@/components/knowledge/DomainCircle';
 import { getDomainCircleSize } from '@/lib/knowledge/circle-sizing';
+import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
 import type { MasteryTier } from '@/types/db';
 
 const TIERS = ['establishing', 'familiar', 'solid', 'mastery'] as const;
 type Tier = (typeof TIERS)[number];
-
-const TIER_LABEL: Record<Tier, string> = {
-  establishing: 'ESTABLISHING',
-  familiar: 'FAMILIAR',
-  solid: 'SOLID',
-  mastery: 'MASTERY',
-};
 
 const GHOST_CIRCLE_DIAMETER = 18;
 const GHOST_CIRCLE_DIAMETER_MOBILE = 15;
@@ -219,7 +213,7 @@ export function ProgressionLandscape({
               }}
               style={{ ...colHeaderStyle, borderRight: i < 3 ? '1px solid #e8e2d6' : undefined }}
             >
-              {TIER_LABEL[tier]}
+              {KNOWLEDGE_TIER_LABEL[tier].toUpperCase()}
             </div>
           ))}
 

--- a/src/lib/questions/difficulty-copy.ts
+++ b/src/lib/questions/difficulty-copy.ts
@@ -18,7 +18,7 @@ const TIER_COPY: Record<QuestionDifficultyTier, string> = {
 
 const ESTIMATE_COPY: Record<DifficultyEstimateValue, string> = {
   accessible: 'Establishing',
-  moderate: 'Solid',
+  moderate: 'Familiar',
   specialist: 'Mastery',
 };
 

--- a/src/lib/questions/difficulty-tier.ts
+++ b/src/lib/questions/difficulty-tier.ts
@@ -2,7 +2,7 @@ import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 
 /**
  * Maps the LLM's persisted `difficulty_estimate` to the tier vocabulary used
- * elsewhere in the app: Establishing / Solid / Mastery.
+ * elsewhere in the app: Establishing / Familiar / Mastery.
  */
 export function difficultyEstimateToTierLabel(
   difficulty: string | null | undefined,


### PR DESCRIPTION
## Summary
Consolidates duplicate mastery tier label definitions across multiple components and pages into a single centralized constant `KNOWLEDGE_TIER_LABEL` from `@/server/profile/knowledge-tier-copy`. This eliminates code duplication and ensures consistent tier naming throughout the application.

## Key Changes
- **Removed duplicate `TIER_LABEL`/`TIER_DISPLAY` definitions** from:
  - `src/components/knowledge/PortraitCircles.tsx`
  - `src/app/knowledge/[domain]/page.tsx`
  - `src/components/feed/AnsweredByYouCard.tsx`
  - `src/app/ceremony/[ceremonyId]/page.tsx`
  - `src/components/ShareCard.tsx`
  - `src/components/knowledge/DomainCircle.tsx`
  - `src/components/knowledge/ProgressionLandscape.tsx`

- **Updated all references** to use the centralized `KNOWLEDGE_TIER_LABEL` constant
- **Improved type safety** in `PortraitCircles.tsx` by changing `PortraitTier` type from a string union to use the `MasteryTier` type from the database schema
- **Fixed difficulty estimate mapping** in `src/lib/questions/difficulty-copy.ts`: changed "moderate" estimate to map to "Familiar" instead of "Solid" for consistency with tier vocabulary
- **Updated documentation** in `src/lib/questions/difficulty-tier.ts` to reflect correct tier labels

## Implementation Details
- All components now import `KNOWLEDGE_TIER_LABEL` from the server-side copy module
- The `ProgressionLandscape` component applies `.toUpperCase()` to the centralized label to maintain its uppercase display style
- Type consistency improved by leveraging the existing `MasteryTier` type definition rather than local string unions

https://claude.ai/code/session_01WCVifn2NC3NxMqPxCuFhuw