### PR TITLE
wrong reveal: now-it's-in-yours-too + named sub-label + promoted breadcrumb (audit 4.1, 4.2, 4.3)

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -675,6 +675,9 @@ function ResultRow({
                 <span style={{ fontWeight: 600 }}>Answer:</span> {correctAnswer}
               </p>
             ) : null}
+            <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '4px' }}>
+              Now it&rsquo;s in yours too
+            </p>
             {consolation ? (
               <p style={{ marginTop: '8px', fontSize: '0.88rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
                 {consolation}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -324,6 +324,8 @@ function UserRow({ text }: { text: string }) {
 
 function BreadcrumbLine({ text, creatorName }: { text: string; creatorName: string | null }) {
   const author = creatorName?.trim() ?? null;
+  const isBot = author?.toLowerCase() === 'joshing';
+  const showAuthor = author && !isBot;
   return (
     <div
       style={{
@@ -332,15 +334,25 @@ function BreadcrumbLine({ text, creatorName }: { text: string; creatorName: stri
         paddingLeft: '8px',
       }}
     >
-      {author ? (
-        <p style={{ ...monoStyle, fontSize: '0.5rem', color: 'var(--text-muted)' }}>FROM [{author}]</p>
+      {showAuthor ? (
+        <p
+          style={{
+            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+            fontSize: '0.7rem',
+            fontStyle: 'italic',
+            color: 'var(--text-muted)',
+          }}
+        >
+          From {firstNameFrom(author!)}.
+        </p>
       ) : null}
       <p
         style={{
-          marginTop: author ? '2px' : '0',
-          fontSize: '0.78rem',
+          marginTop: showAuthor ? '2px' : '0',
+          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+          fontSize: '0.92rem',
           fontStyle: 'italic',
-          color: 'color-mix(in srgb, var(--text-muted) 78%, var(--text))',
+          color: 'color-mix(in srgb, var(--text-muted) 50%, var(--text))',
           lineHeight: 1.35,
         }}
       >

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -110,6 +110,26 @@ const monoStyle: CSSProperties = {
   letterSpacing: '0.06em',
 };
 
+const WRONG_NAMED_SUBLABEL: Array<(name: string) => string> = [
+  (name) => `${name}’s world includes this`,
+  (name) => `${name} carries this one`,
+  (name) => `${name} thought you might`,
+];
+
+function firstNameFrom(creatorName: string): string {
+  const trimmed = creatorName.trim();
+  const space = trimmed.indexOf(' ');
+  return space === -1 ? trimmed : trimmed.slice(0, space);
+}
+
+function wrongNamedSubLabel(creatorName: string | null, variant: number): string | null {
+  if (!creatorName) return null;
+  if (creatorName.trim().toLowerCase() === 'joshing') return null;
+  const firstName = firstNameFrom(creatorName);
+  if (!firstName) return null;
+  return WRONG_NAMED_SUBLABEL[variant % WRONG_NAMED_SUBLABEL.length]!(firstName);
+}
+
 function SystemRow({ text }: { text: string }) {
   return (
     <div className="flex justify-center py-0.5">
@@ -678,6 +698,14 @@ function ResultRow({
             <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '4px' }}>
               Now it&rsquo;s in yours too
             </p>
+            {(() => {
+              const namedSubLabel = wrongNamedSubLabel(creatorName, copyVariant);
+              return namedSubLabel ? (
+                <p style={{ ...monoStyle, fontSize: '0.6rem', color: 'var(--text-muted)', marginTop: '4px' }}>
+                  {namedSubLabel}
+                </p>
+              ) : null;
+            })()}
             {consolation ? (
               <p style={{ marginTop: '8px', fontSize: '0.88rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
                 {consolation}


### PR DESCRIPTION
## Summary

Phase-1 frontend rebuild of the wrong-answer reveal. Implements the three open sub-items from audit Top-10 #4 ("Wrong-answer rebuild" in `audits/2026-05-18-learning-and-shared-knowledge.md`). All edits are in `src/components/play/GameplayChat.tsx`. No schema, API, or data-shape changes.

The new wrong reveal reads:

> ✕ Not this time — here's the answer.
> **Answer:** Bucephalus
> NOW IT'S IN YOURS TOO
> SARAH'S WORLD INCLUDES THIS
> _consolation if any_
>
> _From Sarah._
> _"In the Iliad, Alexander's horse Bucephalus was tamed when Alexander noticed it was afraid of its own shadow."_

Bot-authored (`Joshing`) wrong reveals omit the named sub-label and the breadcrumb's author line — `NOW IT'S IN YOURS TOO` and the breadcrumb body still render.

## Three commits

1. **`wrong reveal: add "now it's in yours too" sub-label`** (4.1)
   New mono small-caps line under the `Answer:` line and above the consolation quip. Wrong reveals only — `gave_up` and `expired` unchanged. Style mirrors the correct-side sub-label rotation for visual symmetry.

2. **`wrong reveal: add named sub-label rotation crediting the author`** (4.2)
   New `WRONG_NAMED_SUBLABEL` rotation keyed off `copyVariant`:
   - `{name}'s world includes this`
   - `{name} carries this one`
   - `{name} thought you might`
   
   Renders only when `creatorName` is non-empty AND not the `Joshing` bot. New `firstNameFrom()` helper splits on the first space.

3. **`BreadcrumbLine: promote typography to editorial register`** (4.3)
   - Body: `0.78rem → 0.92rem`, switch from default font to Literata italic, lighten the muted-mix from 78% to 50% so the larger size doesn't read gray-on-cream too soft.
   - Author line: replace mono `FROM [{author}]` at 0.5rem with Literata italic `From {firstName}.` at 0.7rem, matching the question-bubble author treatment. Suppressed when creator is the `Joshing` bot.
   - Border-left rule, placement, and breadcrumb generation (`generate-breadcrumb.ts`, `/api/breadcrumb`) untouched.

## What does NOT change

- The `insideJoke` / "Between us friends" gold card — kept distinct from the breadcrumb (verified with product before starting; they're separate surfaces serving different purposes).
- Correct-side `CORRECT_COPY` rotation.
- `wrongHeadline()` rotation.
- `gave_up` and `expired` result branches.
- `recheckAccepted` success treatment.

## Test plan

- [ ] Visual: trigger a wrong reveal on a question with a non-bot author — verify the stack order is Headline → Answer → NOW IT'S IN YOURS TOO → named sub-label → consolation → recheck → breadcrumb.
- [ ] Visual: trigger a wrong reveal on a Joshing-authored question — verify NO named sub-label and NO `From X.` on the breadcrumb (NOW IT'S IN YOURS TOO still appears; breadcrumb body still renders).
- [ ] Visual: trigger a `gave_up` reveal — verify the new sub-labels do NOT appear (existing `— For the record.` treatment unchanged).
- [ ] Visual: trigger `expired` — same as gave_up, no new sub-labels.
- [ ] Visual on 360px viewport: confirm the longer stack still fits comfortably.
- [ ] Rotate `copyVariant` to verify each of the three named sub-label variants renders.

## Followups (intentionally not in this PR)

- **Difficulty gating on variant 2 (`thought you might`)** — could read patronising on Specialist questions. Result-row payload doesn't carry difficulty today; adding it is a small backend touch and was deferred.
- **Recheck success → re-tint bubble** — the audit's other piece of #17 (turning the bubble green on recheck-accepted rather than just showing a green box under the button). Separate change.

https://claude.ai/code/session_013Wif6naFj19U2vE7RSScD8

---
_Generated by [Claude Code](https://claude.ai/code/session_013Wif6naFj19U2vE7RSScD8)_