### PR TITLE
Update vet-questions cron schedule to 7 AM UTC

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -10,7 +10,7 @@
     },
     {
       "path": "/api/cron/vet-questions",
-      "schedule": "0 * * * *"
+      "schedule": "0 7 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
Updates the scheduled execution time for the vet-questions cron job from hourly (every hour at minute 0) to daily at 7 AM UTC.

## Changes
- Modified `vercel.json` cron schedule for `/api/cron/vet-questions` endpoint
  - Changed from `"0 * * * *"` (hourly at :00) to `"0 7 * * *"` (daily at 07:00 UTC)

## Details
This change reduces the frequency of the vet-questions cron job from running 24 times per day to once daily, executing at 7 AM UTC. This is likely a cost or load optimization measure.

https://claude.ai/code/session_016CR7uuTPLNRHVseNXHpYoM