### PR TITLE
Reframe friend-answered cards around the viewer's own answered question

### DIFF
--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -13,9 +13,19 @@ type FeedCardProps = {
   onAnswer?: () => void
   footer?: ReactNode
   className?: string
+  headerContent?: ReactNode
+  dimQuestion?: boolean
 }
 
-export function FeedCard({ item, overflow, onAnswer, footer, className }: FeedCardProps) {
+export function FeedCard({
+  item,
+  overflow,
+  onAnswer,
+  footer,
+  className,
+  headerContent,
+  dimQuestion,
+}: FeedCardProps) {
   const categoryColor = colorForCategory(item.category)
   const visibleCategory = visibleFeedCategory(item.category)
   const onDark = isDarkColor(categoryColor)
@@ -128,31 +138,37 @@ export function FeedCard({ item, overflow, onAnswer, footer, className }: FeedCa
           </div>
 
           <div className="min-w-0 flex-1">
-            {item.authorHref ? (
-              <Link
-                href={item.authorHref}
-                className="block truncate text-[16px] leading-tight text-[var(--ink)] underline underline-offset-2"
-                style={{ textDecorationColor: 'rgb(0 0 0 / 0.35)' }}
-              >
-                {authorName}
-              </Link>
+            {headerContent ? (
+              headerContent
             ) : (
-              <span className="block truncate text-[16px] leading-tight text-[var(--ink)]">
-                {authorName}
-              </span>
+              <>
+                {item.authorHref ? (
+                  <Link
+                    href={item.authorHref}
+                    className="block truncate text-[16px] leading-tight text-[var(--ink)] underline underline-offset-2"
+                    style={{ textDecorationColor: 'rgb(0 0 0 / 0.35)' }}
+                  >
+                    {authorName}
+                  </Link>
+                ) : (
+                  <span className="block truncate text-[16px] leading-tight text-[var(--ink)]">
+                    {authorName}
+                  </span>
+                )}
+                {visibleCategory ? (
+                  <p
+                    className="mt-0.5 truncate text-[12px] italic leading-tight"
+                    style={{
+                      fontFamily: 'var(--font-literata)',
+                      color: 'var(--ink)',
+                      opacity: 0.7,
+                    }}
+                  >
+                    {visibleCategory}
+                  </p>
+                ) : null}
+              </>
             )}
-            {visibleCategory ? (
-              <p
-                className="mt-0.5 truncate text-[12px] italic leading-tight"
-                style={{
-                  fontFamily: 'var(--font-literata)',
-                  color: 'var(--ink)',
-                  opacity: 0.7,
-                }}
-              >
-                {visibleCategory}
-              </p>
-            ) : null}
           </div>
 
           <div className="flex shrink-0 items-center gap-2">
@@ -169,8 +185,14 @@ export function FeedCard({ item, overflow, onAnswer, footer, className }: FeedCa
         </div>
 
         <p
-          className="mt-3 line-clamp-4 text-[17px] leading-snug text-[var(--ink)]"
-          style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          className={cn(
+            'mt-3 line-clamp-4 leading-snug text-[var(--ink)]',
+            dimQuestion ? 'text-[14px]' : 'text-[17px]',
+          )}
+          style={{
+            fontFamily: 'Georgia, "Times New Roman", serif',
+            ...(dimQuestion ? { opacity: 0.65 } : null),
+          }}
         >
           {item.question}
         </p>

--- a/src/components/feed/FriendAnsweredCard.tsx
+++ b/src/components/feed/FriendAnsweredCard.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react'
+import Link from 'next/link'
 
 import { FeedCard } from './FeedCard'
+import { visibleFeedCategory } from './category'
 import type { FriendAnsweredFeedItem } from './types'
 
 type FriendAnsweredCardProps = {
@@ -13,15 +15,28 @@ function viewerAnsweredFooterText(
   viewerResult: 'correct' | 'incorrect',
   friendName: string,
   friendCorrect: boolean | null | undefined,
+  visibleCategory: string | null,
 ): string {
   if (viewerResult === 'correct') {
-    if (friendCorrect === true) return 'You both had it'
+    if (friendCorrect === true) {
+      return visibleCategory
+        ? `You both know some ${visibleCategory}.`
+        : 'You both got this one.'
+    }
     if (friendCorrect === false) return `You knew this · ${friendName} didn’t`
     return `You answered · ${friendName} answered`
   }
   if (friendCorrect === true) return `${friendName} knew this · you missed it`
   if (friendCorrect === false) return 'Neither of you got this one'
   return `You missed this · ${friendName} answered`
+}
+
+function viewerAnsweredHeaderVerb(
+  friendCorrect: boolean | null | undefined,
+): string {
+  if (friendCorrect === true) return 'got'
+  if (friendCorrect === false) return 'missed'
+  return 'answered'
 }
 
 export function FriendAnsweredCard({
@@ -36,6 +51,7 @@ export function FriendAnsweredCard({
     avatarName: item.avatarName ?? item.friendName,
     authorHref: item.authorHref ?? item.friendHref ?? null,
   }
+  const visibleCategory = visibleFeedCategory(item.category)
   const footer = viewerResult ? (
     <p
       className="text-right text-[12px] italic leading-tight"
@@ -45,15 +61,42 @@ export function FriendAnsweredCard({
         opacity: 0.7,
       }}
     >
-      {viewerAnsweredFooterText(viewerResult, item.friendName, item.friendCorrect)}
+      {viewerAnsweredFooterText(
+        viewerResult,
+        item.friendName,
+        item.friendCorrect,
+        visibleCategory,
+      )}
     </p>
   ) : undefined
+
+  const headerContent = viewerAnswered ? (
+    <p className="text-[16px] leading-tight text-[var(--ink)]">
+      {merged.authorHref ? (
+        <Link
+          href={merged.authorHref}
+          className="underline underline-offset-2"
+          style={{ textDecorationColor: 'rgb(0 0 0 / 0.35)' }}
+        >
+          {item.friendName}
+        </Link>
+      ) : (
+        <span>{item.friendName}</span>
+      )}
+      {` ${viewerAnsweredHeaderVerb(item.friendCorrect)} your${
+        visibleCategory ? ` ${visibleCategory}` : ''
+      } question`}
+    </p>
+  ) : undefined
+
   return (
     <FeedCard
       item={merged}
       overflow={overflow}
       onAnswer={viewerAnswered ? undefined : onAnswer}
       footer={footer}
+      headerContent={headerContent}
+      dimQuestion={viewerAnswered}
     />
   )
 }

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -248,7 +248,7 @@ describe('Feed answered states', () => {
 })
 
 describe('FriendAnsweredCard viewer-already-answered footer', () => {
-  it('renders a "you both had it" status when viewer and friend were both correct', () => {
+  it('reframes the header around the viewer when both were correct and uses warm footer copy', () => {
     const rendered = html(
       <FriendAnsweredCard
         item={{
@@ -259,11 +259,13 @@ describe('FriendAnsweredCard viewer-already-answered footer', () => {
         onAnswer={() => undefined}
       />
     )
-    expect(rendered).toContain('You both had it')
+    expect(rendered).toContain('got your Science question')
+    expect(rendered).toContain('You both know some Science.')
+    expect(rendered).not.toContain('You both had it')
     expect(rendered).not.toContain('Answer →')
   })
 
-  it('renders a "you missed it" status when viewer was wrong and friend was right', () => {
+  it('renders a "missed your … question" header and "you missed it" footer when viewer was wrong and friend was right', () => {
     const rendered = html(
       <FriendAnsweredCard
         item={{
@@ -274,12 +276,14 @@ describe('FriendAnsweredCard viewer-already-answered footer', () => {
         onAnswer={() => undefined}
       />
     )
+    // Friend was right, so from the viewer's perspective the friend "got" their question.
+    expect(rendered).toContain('got your Science question')
     expect(rendered).toContain('Noah knew this')
     expect(rendered).toContain('you missed it')
     expect(rendered).not.toContain('Answer →')
   })
 
-  it('omits the status footer when the viewer has not answered yet', () => {
+  it('omits the status footer and the reframed header when the viewer has not answered yet', () => {
     const rendered = html(
       <FriendAnsweredCard
         item={feedCardPreviewFixtures.friendAnsweredRight}
@@ -288,7 +292,9 @@ describe('FriendAnsweredCard viewer-already-answered footer', () => {
     )
     expect(rendered).toContain('Answer →')
     expect(rendered).not.toContain('You both had it')
+    expect(rendered).not.toContain('You both know some')
     expect(rendered).not.toContain('you missed it')
+    expect(rendered).not.toContain('got your Science question')
   })
 })
 


### PR DESCRIPTION
When a friend answers a question the viewer has already answered, the
card now reads as a social outcome about a familiar prompt rather than
a fresh question. The header becomes "Robyn got/missed your <category>
question", the question body renders smaller and dimmed for context,
and the both-correct footer swaps to warmer copy ("You both know some
Wagner's Ring Cycle.").

FeedCard gains two additive optional props (headerContent, dimQuestion)
so the chrome — avatar, accent bar, timestamp, overflow, footer slot —
stays centralized.

https://claude.ai/code/session_01P7KAFsnRgJojaFHpNBDmvg