### PR TITLE
Add points diagnostic dev tool for inspecting mastery events

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import {
+  BarChart3,
   Code2,
   FlaskConical,
   Loader2,
@@ -253,6 +254,12 @@ export default function AccountPage() {
             title="View staging flags"
             subtitle="See feature flag status"
             href="/dev/flags"
+          />
+          <SettingsRow
+            icon={BarChart3}
+            title="Points diagnostic"
+            subtitle="Inspect a user's mastery events and where points came from"
+            href="/dev/points-diagnostic"
           />
         </SettingsGroup>
 

--- a/src/app/api/dev/points-diagnostic/route.ts
+++ b/src/app/api/dev/points-diagnostic/route.ts
@@ -1,0 +1,123 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  CATEGORY_VALUES,
+  DIFFICULTY_VALUES,
+  MAX_LIMIT,
+  SOURCE_TYPE_VALUES,
+  loadPointsDiagnostic,
+  resolveUserByQuery,
+  summarize,
+  type PointsDiagnosticRow,
+} from '@/server/db/queries/points-diagnostic';
+
+export const dynamic = 'force-dynamic';
+
+export function isDevDiagnosticEnabled(): boolean {
+  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
+  if (process.env.NODE_ENV !== 'production') return true;
+  // Vercel preview deploys run with NODE_ENV='production' but VERCEL_ENV='preview'.
+  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
+}
+
+const querySchema = z.object({
+  user: z.string().trim().min(1).optional(),
+  category: z.enum(CATEGORY_VALUES).optional(),
+  difficulty: z.enum(DIFFICULTY_VALUES).optional(),
+  sourceType: z.enum(SOURCE_TYPE_VALUES).optional(),
+  from: z.string().datetime().optional(),
+  to: z.string().datetime().optional(),
+  limit: z.coerce.number().int().min(1).max(MAX_LIMIT).optional(),
+  format: z.enum(['json', 'csv']).optional(),
+});
+
+function csvEscape(value: unknown): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (/[",\r\n]/.test(str)) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+const CSV_COLUMNS: Array<{ key: keyof PointsDiagnosticRow; label: string }> = [
+  { key: 'createdAt', label: 'created_at' },
+  { key: 'sourceType', label: 'source_type' },
+  { key: 'answerState', label: 'answer_state' },
+  { key: 'sessionContext', label: 'session_context' },
+  { key: 'questionId', label: 'question_id' },
+  { key: 'questionTextSnippet', label: 'question_text' },
+  { key: 'category', label: 'category' },
+  { key: 'broadCategory', label: 'broad_category' },
+  { key: 'canonicalSubcategory', label: 'question_canonical_subcategory' },
+  { key: 'eventCanonicalSubcategory', label: 'event_canonical_subcategory' },
+  { key: 'difficulty', label: 'difficulty' },
+  { key: 'correctRate', label: 'correct_rate' },
+  { key: 'basePoints', label: 'base_points' },
+  { key: 'weight', label: 'weight' },
+  { key: 'awardedPoints', label: 'awarded_points' },
+  { key: 'answeredByUserId', label: 'answered_by_user_id' },
+  { key: 'answeredByDisplayName', label: 'answered_by_display_name' },
+  { key: 'masteryEventId', label: 'mastery_event_id' },
+];
+
+function rowsToCsv(rows: PointsDiagnosticRow[]): string {
+  const header = CSV_COLUMNS.map((c) => csvEscape(c.label)).join(',');
+  const body = rows
+    .map((row) => CSV_COLUMNS.map((c) => csvEscape(row[c.key])).join(','))
+    .join('\n');
+  return body ? `${header}\n${body}\n` : `${header}\n`;
+}
+
+export async function GET(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  if (!isDevDiagnosticEnabled()) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  const params = Object.fromEntries(request.nextUrl.searchParams.entries());
+  const parsed = querySchema.safeParse(params);
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'invalid_params', issues: parsed.error.issues }, { status: 400 });
+  }
+  const q = parsed.data;
+
+  if (!q.user) {
+    return NextResponse.json({ error: 'missing_user' }, { status: 400 });
+  }
+
+  const resolution = await resolveUserByQuery(q.user);
+  if (!resolution.match) {
+    return NextResponse.json(
+      { error: 'user_not_found', nearMatches: resolution.nearMatches },
+      { status: 404 },
+    );
+  }
+
+  const rows = await loadPointsDiagnostic(resolution.match.id, {
+    category: q.category,
+    difficulty: q.difficulty,
+    sourceType: q.sourceType,
+    from: q.from ? new Date(q.from) : undefined,
+    to: q.to ? new Date(q.to) : undefined,
+    limit: q.limit,
+  });
+
+  if (q.format === 'csv') {
+    const filename = `points-diagnostic-${resolution.match.id}.csv`;
+    return new NextResponse(rowsToCsv(rows), {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+      },
+    });
+  }
+
+  return NextResponse.json({
+    user: resolution.match,
+    summary: summarize(rows),
+    rows,
+  });
+}

--- a/src/app/dev/points-diagnostic/PointsDiagnosticTable.tsx
+++ b/src/app/dev/points-diagnostic/PointsDiagnosticTable.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+
+import type { PointsDiagnosticRow } from '@/server/db/queries/points-diagnostic';
+
+type SortKey =
+  | 'createdAt'
+  | 'sourceType'
+  | 'answerState'
+  | 'sessionContext'
+  | 'questionTextSnippet'
+  | 'category'
+  | 'canonicalSubcategory'
+  | 'difficulty'
+  | 'correctRate'
+  | 'basePoints'
+  | 'weight'
+  | 'awardedPoints'
+  | 'answeredByDisplayName';
+
+type SortDir = 'asc' | 'desc';
+
+type Column = {
+  key: SortKey;
+  label: string;
+  align?: 'left' | 'right';
+};
+
+const COLUMNS: Column[] = [
+  { key: 'createdAt', label: 'answered_at' },
+  { key: 'sourceType', label: 'source' },
+  { key: 'answerState', label: 'answer_state' },
+  { key: 'sessionContext', label: 'context' },
+  { key: 'questionTextSnippet', label: 'question' },
+  { key: 'category', label: 'category' },
+  { key: 'canonicalSubcategory', label: 'subcategory' },
+  { key: 'difficulty', label: 'difficulty' },
+  { key: 'correctRate', label: 'correct_rate', align: 'right' },
+  { key: 'basePoints', label: 'base', align: 'right' },
+  { key: 'weight', label: 'weight', align: 'right' },
+  { key: 'awardedPoints', label: 'awarded', align: 'right' },
+  { key: 'answeredByDisplayName', label: 'answerer' },
+];
+
+const POSITIVE_SOURCES = new Set(['live_correct', 'catchup_correct']);
+const AUTHORING_SOURCES = new Set(['authored', 'author_credit', 'curator_credit']);
+const META_SOURCES = new Set(['domain_merged', 'declared_promoted']);
+
+function sourceColor(sourceType: string, answerState: string | null): string {
+  if (answerState === 'incorrect') return '#a02500';
+  if (POSITIVE_SOURCES.has(sourceType)) return '#0a7d2a';
+  if (AUTHORING_SOURCES.has(sourceType)) return '#1e40af';
+  if (META_SOURCES.has(sourceType)) return '#7c00a0';
+  return '#444';
+}
+
+function fmtTimestamp(value: string): string {
+  return value.replace('T', ' ').replace(/\.\d+Z$/, 'Z');
+}
+
+function fmtNumber(value: number, digits = 2): string {
+  if (Number.isInteger(value)) return value.toString();
+  return value.toFixed(digits);
+}
+
+function fmtRate(value: number | null): string {
+  if (value === null) return '—';
+  return `${Math.round(value * 100)}%`;
+}
+
+function compareValues(a: unknown, b: unknown): number {
+  // Nulls sort last regardless of direction (we flip the final result for desc).
+  const aNull = a === null || a === undefined;
+  const bNull = b === null || b === undefined;
+  if (aNull && bNull) return 0;
+  if (aNull) return 1;
+  if (bNull) return -1;
+  if (typeof a === 'number' && typeof b === 'number') return a - b;
+  return String(a).localeCompare(String(b));
+}
+
+export function PointsDiagnosticTable({ rows }: { rows: PointsDiagnosticRow[] }) {
+  const [sortKey, setSortKey] = useState<SortKey>('createdAt');
+  const [sortDir, setSortDir] = useState<SortDir>('desc');
+
+  const sorted = useMemo(() => {
+    const copy = [...rows];
+    copy.sort((a, b) => {
+      const base = compareValues(a[sortKey], b[sortKey]);
+      if (base !== 0) return sortDir === 'asc' ? base : -base;
+      // Stable tiebreaker by id so re-sorts are deterministic.
+      return a.masteryEventId.localeCompare(b.masteryEventId);
+    });
+    return copy;
+  }, [rows, sortKey, sortDir]);
+
+  function clickHeader(key: SortKey) {
+    if (key === sortKey) {
+      setSortDir((d) => (d === 'asc' ? 'desc' : 'asc'));
+    } else {
+      setSortKey(key);
+      setSortDir(key === 'createdAt' ? 'desc' : 'asc');
+    }
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p style={{ color: '#666', fontSize: '13px', padding: '12px 0' }}>
+        No mastery events match the current filters.
+      </p>
+    );
+  }
+
+  return (
+    <div style={{ overflowX: 'auto' }}>
+      <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: '12px' }}>
+        <thead>
+          <tr style={{ background: '#f4f4f4' }}>
+            {COLUMNS.map((col) => {
+              const active = col.key === sortKey;
+              const arrow = active ? (sortDir === 'asc' ? ' ↑' : ' ↓') : '';
+              return (
+                <th
+                  key={col.key}
+                  style={{
+                    padding: '6px 8px',
+                    textAlign: col.align ?? 'left',
+                    fontSize: '11px',
+                    whiteSpace: 'nowrap',
+                    borderBottom: '1px solid #ddd',
+                  }}
+                >
+                  <button
+                    type="button"
+                    onClick={() => clickHeader(col.key)}
+                    style={{
+                      background: 'none',
+                      border: 'none',
+                      padding: 0,
+                      cursor: 'pointer',
+                      font: 'inherit',
+                      fontWeight: active ? 'bold' : 'normal',
+                      color: active ? '#000' : '#444',
+                    }}
+                  >
+                    {col.label}{arrow}
+                  </button>
+                </th>
+              );
+            })}
+          </tr>
+        </thead>
+        <tbody>
+          {sorted.map((row) => (
+            <tr key={row.masteryEventId} style={{ verticalAlign: 'top', borderBottom: '1px solid #f0f0f0' }}>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {fmtTimestamp(row.createdAt)}
+              </td>
+              <td
+                style={{
+                  padding: '4px 8px',
+                  fontFamily: 'monospace',
+                  fontSize: '11px',
+                  color: sourceColor(row.sourceType, row.answerState),
+                  fontWeight: 'bold',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {row.sourceType}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {row.answerState ?? '—'}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {row.sessionContext ?? '—'}
+              </td>
+              <td style={{ padding: '4px 8px', fontSize: '12px', maxWidth: '420px' }}>
+                <div>{row.questionTextSnippet ?? <em style={{ color: '#999' }}>(no question)</em>}</div>
+                {row.questionId && (
+                  <div style={{ fontFamily: 'monospace', fontSize: '10px', color: '#888' }}>
+                    q={row.questionId.slice(0, 8)}…
+                  </div>
+                )}
+              </td>
+              <td style={{ padding: '4px 8px', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {row.category ?? '—'}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px' }}>
+                {row.canonicalSubcategory ?? row.eventCanonicalSubcategory ?? '—'}
+              </td>
+              <td style={{ padding: '4px 8px', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {row.difficulty ?? '—'}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', textAlign: 'right' }}>
+                {fmtRate(row.correctRate)}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', textAlign: 'right' }}>
+                {row.basePoints}
+              </td>
+              <td style={{ padding: '4px 8px', fontFamily: 'monospace', fontSize: '11px', textAlign: 'right' }}>
+                {fmtNumber(row.weight)}
+              </td>
+              <td
+                style={{
+                  padding: '4px 8px',
+                  fontFamily: 'monospace',
+                  fontSize: '12px',
+                  textAlign: 'right',
+                  fontWeight: 'bold',
+                  color: row.awardedPoints > 0 ? '#0a7d2a' : row.awardedPoints < 0 ? '#a02500' : '#444',
+                }}
+              >
+                {fmtNumber(row.awardedPoints)}
+              </td>
+              <td style={{ padding: '4px 8px', fontSize: '11px', whiteSpace: 'nowrap' }}>
+                {row.answeredByDisplayName ?? (row.answeredByUserId ? <span style={{ fontFamily: 'monospace', color: '#888' }}>{row.answeredByUserId.slice(0, 8)}…</span> : '—')}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/app/dev/points-diagnostic/page.tsx
+++ b/src/app/dev/points-diagnostic/page.tsx
@@ -1,0 +1,304 @@
+import { notFound, redirect } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import {
+  CATEGORY_VALUES,
+  DIFFICULTY_VALUES,
+  MAX_LIMIT,
+  SOURCE_TYPE_VALUES,
+  loadPointsDiagnostic,
+  resolveUserByQuery,
+  summarize,
+  type Category,
+  type DifficultyEstimate,
+  type MasterySourceType,
+  type UserMatch,
+} from '@/server/db/queries/points-diagnostic';
+
+import { PointsDiagnosticTable } from './PointsDiagnosticTable';
+
+export const dynamic = 'force-dynamic';
+
+type SearchParams = {
+  user?: string;
+  category?: string;
+  difficulty?: string;
+  sourceType?: string;
+  from?: string;
+  to?: string;
+  limit?: string;
+};
+
+type PageProps = {
+  searchParams: Promise<SearchParams>;
+};
+
+function isDevDiagnosticEnabled(): boolean {
+  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
+  if (process.env.NODE_ENV !== 'production') return true;
+  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
+}
+
+function asCategory(value: string | undefined): Category | undefined {
+  return value && (CATEGORY_VALUES as readonly string[]).includes(value) ? (value as Category) : undefined;
+}
+
+function asDifficulty(value: string | undefined): DifficultyEstimate | undefined {
+  return value && (DIFFICULTY_VALUES as readonly string[]).includes(value)
+    ? (value as DifficultyEstimate)
+    : undefined;
+}
+
+function asSourceType(value: string | undefined): MasterySourceType | undefined {
+  return value && (SOURCE_TYPE_VALUES as readonly string[]).includes(value)
+    ? (value as MasterySourceType)
+    : undefined;
+}
+
+function parseDate(value: string | undefined): Date | undefined {
+  if (!value) return undefined;
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? undefined : d;
+}
+
+function parseLimit(value: string | undefined): number | undefined {
+  if (!value) return undefined;
+  const n = Number(value);
+  if (!Number.isFinite(n)) return undefined;
+  return Math.min(Math.max(Math.trunc(n), 1), MAX_LIMIT);
+}
+
+function userLabel(user: UserMatch): string {
+  return user.displayName || user.phoneNumber || user.id;
+}
+
+const SUMMARY_BOX: React.CSSProperties = {
+  padding: '8px 12px',
+  background: '#fafafa',
+  border: '1px solid #eee',
+  fontFamily: 'monospace',
+  fontSize: '12px',
+};
+
+const INPUT_STYLE: React.CSSProperties = {
+  padding: '2px 6px',
+  fontFamily: 'monospace',
+  fontSize: '12px',
+};
+
+const LABEL_STYLE: React.CSSProperties = {
+  display: 'inline-flex',
+  flexDirection: 'column',
+  fontSize: '11px',
+  color: '#444',
+  marginRight: '12px',
+  marginBottom: '6px',
+};
+
+export default async function PointsDiagnosticPage({ searchParams }: PageProps) {
+  if (!isDevDiagnosticEnabled()) notFound();
+
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const params = await searchParams;
+  const userQuery = params.user?.trim() || null;
+  const category = asCategory(params.category);
+  const difficulty = asDifficulty(params.difficulty);
+  const sourceType = asSourceType(params.sourceType);
+  const from = parseDate(params.from);
+  const to = parseDate(params.to);
+  const limit = parseLimit(params.limit);
+
+  const resolution = userQuery ? await resolveUserByQuery(userQuery) : { match: null, nearMatches: [] };
+  const target = resolution.match;
+
+  const rows = target
+    ? await loadPointsDiagnostic(target.id, { category, difficulty, sourceType, from, to, limit })
+    : [];
+  const summary = summarize(rows);
+
+  const csvHref = (() => {
+    if (!target) return null;
+    const usp = new URLSearchParams();
+    usp.set('user', target.id);
+    usp.set('format', 'csv');
+    if (category) usp.set('category', category);
+    if (difficulty) usp.set('difficulty', difficulty);
+    if (sourceType) usp.set('sourceType', sourceType);
+    if (params.from) usp.set('from', params.from);
+    if (params.to) usp.set('to', params.to);
+    if (limit) usp.set('limit', String(limit));
+    return `/api/dev/points-diagnostic?${usp.toString()}`;
+  })();
+
+  const correctDenominator = summary.correctCount + summary.incorrectCount;
+  const pctCorrect = correctDenominator > 0
+    ? `${Math.round((summary.correctCount / correctDenominator) * 100)}%`
+    : '—';
+
+  return (
+    <main style={{ padding: '16px', maxWidth: '1600px', margin: '0 auto', fontFamily: 'system-ui, sans-serif' }}>
+      <h1 style={{ fontFamily: 'monospace', fontSize: '18px', marginBottom: '4px' }}>
+        Points diagnostic
+      </h1>
+      <p style={{ color: '#666', fontSize: '12px', marginTop: '0' }}>
+        Every <code>MASTERY_EVENTS</code> row for a given user — live answers, catchup, author credit, and meta
+        events. Click column headers to sort. This is a diagnostic, not product UI.
+      </p>
+
+      <form method="get" style={{ marginTop: '12px', padding: '12px', border: '1px solid #ddd', background: '#fff' }}>
+        <div style={{ marginBottom: '10px' }}>
+          <label style={LABEL_STYLE}>
+            <span>user (id / display name / phone / email)</span>
+            <input
+              name="user"
+              defaultValue={userQuery ?? ''}
+              style={{ ...INPUT_STYLE, width: '320px' }}
+              placeholder="Jane Smith"
+            />
+          </label>
+          <button type="submit" style={{ padding: '4px 12px', fontSize: '12px' }}>Look up</button>
+        </div>
+
+        <div style={{ display: 'flex', flexWrap: 'wrap' }}>
+          <label style={LABEL_STYLE}>
+            <span>category</span>
+            <select name="category" defaultValue={category ?? ''} style={INPUT_STYLE}>
+              <option value="">(any)</option>
+              {CATEGORY_VALUES.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </label>
+
+          <label style={LABEL_STYLE}>
+            <span>difficulty</span>
+            <select name="difficulty" defaultValue={difficulty ?? ''} style={INPUT_STYLE}>
+              <option value="">(any)</option>
+              {DIFFICULTY_VALUES.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </label>
+
+          <label style={LABEL_STYLE}>
+            <span>source type</span>
+            <select name="sourceType" defaultValue={sourceType ?? ''} style={INPUT_STYLE}>
+              <option value="">(any)</option>
+              {SOURCE_TYPE_VALUES.map((v) => (
+                <option key={v} value={v}>{v}</option>
+              ))}
+            </select>
+          </label>
+
+          <label style={LABEL_STYLE}>
+            <span>from (ISO date)</span>
+            <input
+              name="from"
+              defaultValue={params.from ?? ''}
+              style={{ ...INPUT_STYLE, width: '200px' }}
+              placeholder="2025-01-01T00:00:00Z"
+            />
+          </label>
+
+          <label style={LABEL_STYLE}>
+            <span>to (ISO date)</span>
+            <input
+              name="to"
+              defaultValue={params.to ?? ''}
+              style={{ ...INPUT_STYLE, width: '200px' }}
+              placeholder="2026-01-01T00:00:00Z"
+            />
+          </label>
+
+          <label style={LABEL_STYLE}>
+            <span>limit (max {MAX_LIMIT})</span>
+            <input
+              name="limit"
+              defaultValue={limit ? String(limit) : ''}
+              style={{ ...INPUT_STYLE, width: '80px' }}
+              placeholder="500"
+            />
+          </label>
+        </div>
+      </form>
+
+      {!target && resolution.nearMatches.length > 0 && (
+        <section style={{ marginTop: '16px', ...SUMMARY_BOX, background: '#fffbe6', borderColor: '#c8b900' }}>
+          <strong>Multiple matches — pick one:</strong>
+          <ul style={{ marginTop: '6px', listStyle: 'none', padding: 0 }}>
+            {resolution.nearMatches.map((match) => (
+              <li key={match.id} style={{ marginTop: '4px' }}>
+                <a href={`/dev/points-diagnostic?user=${encodeURIComponent(match.id)}`}>
+                  {userLabel(match)}
+                </a>
+                <span style={{ color: '#666' }}>
+                  {' · '}id={match.id}
+                  {' · '}phone={match.phoneNumber}
+                  {match.email ? ` · email=${match.email}` : ''}
+                </span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {!target && userQuery && resolution.nearMatches.length === 0 && (
+        <section style={{ marginTop: '16px', ...SUMMARY_BOX, background: '#ffefef', borderColor: '#a02500', color: '#a02500' }}>
+          No user matched <code>{userQuery}</code>. Try an exact id, partial display name, phone, or email.
+        </section>
+      )}
+
+      {!target && !userQuery && (
+        <section style={{ marginTop: '16px', ...SUMMARY_BOX }}>
+          Enter a user id, display name, phone number, or email above to load their mastery events.
+        </section>
+      )}
+
+      {target && (
+        <>
+          <section style={{ marginTop: '16px', ...SUMMARY_BOX }}>
+            <div>
+              <strong>{userLabel(target)}</strong>
+              {' · '}id={target.id}
+              {' · '}phone={target.phoneNumber}
+              {target.email ? ` · email=${target.email}` : ''}
+            </div>
+            <div style={{ marginTop: '6px' }}>
+              events={summary.eventCount}
+              {' · '}awarded_points_total={summary.totalAwardedPoints}
+              {' · '}correct={summary.correctCount}
+              {' · '}incorrect={summary.incorrectCount}
+              {' · '}%correct={pctCorrect}
+              {' · '}unique_questions={summary.uniqueQuestions}
+            </div>
+            {csvHref && (
+              <div style={{ marginTop: '8px' }}>
+                <a
+                  href={csvHref}
+                  download
+                  style={{
+                    display: 'inline-block',
+                    padding: '4px 10px',
+                    border: '1px solid #444',
+                    background: '#fff',
+                    color: '#000',
+                    textDecoration: 'none',
+                    fontSize: '11px',
+                  }}
+                >
+                  Download CSV ({summary.eventCount} rows)
+                </a>
+              </div>
+            )}
+          </section>
+
+          <section style={{ marginTop: '16px' }}>
+            <PointsDiagnosticTable rows={rows} />
+          </section>
+        </>
+      )}
+    </main>
+  );
+}

--- a/src/server/db/queries/points-diagnostic.ts
+++ b/src/server/db/queries/points-diagnostic.ts
@@ -1,0 +1,213 @@
+import { and, asc, desc, eq, gte, ilike, lte, or, sql } from 'drizzle-orm';
+
+import {
+  categoryEnum,
+  db,
+  difficultyEstimateEnum,
+  masterySourceTypeEnum,
+  masteryEvents,
+  questions,
+  users,
+} from '@/server/db';
+
+export type Category = (typeof categoryEnum.enumValues)[number];
+export type DifficultyEstimate = (typeof difficultyEstimateEnum.enumValues)[number];
+export type MasterySourceType = (typeof masterySourceTypeEnum.enumValues)[number];
+
+export const CATEGORY_VALUES = categoryEnum.enumValues;
+export const DIFFICULTY_VALUES = difficultyEstimateEnum.enumValues;
+export const SOURCE_TYPE_VALUES = masterySourceTypeEnum.enumValues;
+
+export type PointsDiagnosticFilters = {
+  category?: Category;
+  difficulty?: DifficultyEstimate;
+  sourceType?: MasterySourceType;
+  from?: Date;
+  to?: Date;
+  limit?: number;
+};
+
+export const DEFAULT_LIMIT = 500;
+export const MAX_LIMIT = 2000;
+
+export type PointsDiagnosticRow = {
+  masteryEventId: string;
+  createdAt: string;
+  sourceType: MasterySourceType;
+  answerState: string | null;
+  sessionContext: string | null;
+  basePoints: number;
+  weight: number;
+  awardedPoints: number;
+  eventCanonicalSubcategory: string;
+  questionId: string | null;
+  questionTextSnippet: string | null;
+  category: Category | null;
+  broadCategory: string | null;
+  canonicalSubcategory: string | null;
+  difficulty: DifficultyEstimate | null;
+  correctRate: number | null;
+  answeredByUserId: string | null;
+  answeredByDisplayName: string | null;
+};
+
+export type UserMatch = {
+  id: string;
+  displayName: string | null;
+  phoneNumber: string;
+  email: string | null;
+};
+
+export type UserResolution = {
+  match: UserMatch | null;
+  nearMatches: UserMatch[];
+};
+
+export type PointsDiagnosticSummary = {
+  eventCount: number;
+  totalAwardedPoints: number;
+  correctCount: number;
+  incorrectCount: number;
+  uniqueQuestions: number;
+};
+
+function snippet(text: string | null | undefined, max = 140): string | null {
+  if (!text) return null;
+  const trimmed = text.trim();
+  return trimmed.length <= max ? trimmed : `${trimmed.slice(0, max - 1)}…`;
+}
+
+export async function resolveUserByQuery(query: string): Promise<UserResolution> {
+  const trimmed = query.trim();
+  if (!trimmed) return { match: null, nearMatches: [] };
+
+  const byId = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      phoneNumber: users.phoneNumber,
+      email: users.email,
+    })
+    .from(users)
+    .where(eq(users.id, trimmed))
+    .limit(1);
+  if (byId.length > 0) return { match: byId[0]!, nearMatches: [] };
+
+  const candidates = await db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+      phoneNumber: users.phoneNumber,
+      email: users.email,
+    })
+    .from(users)
+    .where(
+      or(
+        ilike(users.displayName, `%${trimmed}%`),
+        eq(users.phoneNumber, trimmed),
+        ilike(users.email, `%${trimmed}%`),
+      ),
+    )
+    .orderBy(asc(users.displayName))
+    .limit(10);
+
+  if (candidates.length === 0) return { match: null, nearMatches: [] };
+  if (candidates.length === 1) return { match: candidates[0]!, nearMatches: [] };
+  return { match: null, nearMatches: candidates };
+}
+
+export async function loadPointsDiagnostic(
+  userId: string,
+  filters: PointsDiagnosticFilters,
+): Promise<PointsDiagnosticRow[]> {
+  const limit = Math.min(Math.max(filters.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
+
+  const predicates = [eq(masteryEvents.userId, userId)];
+  if (filters.sourceType) predicates.push(eq(masteryEvents.sourceType, filters.sourceType));
+  if (filters.from) predicates.push(gte(masteryEvents.createdAt, filters.from));
+  if (filters.to) predicates.push(lte(masteryEvents.createdAt, filters.to));
+  if (filters.category) predicates.push(eq(questions.category, filters.category));
+  if (filters.difficulty) {
+    // Effective difficulty = calibratedDifficulty if set, else difficultyEstimate.
+    predicates.push(
+      sql`COALESCE(${questions.calibratedDifficulty}, ${questions.difficultyEstimate}) = ${filters.difficulty}`,
+    );
+  }
+
+  const rows = await db
+    .select({
+      masteryEventId: masteryEvents.id,
+      createdAt: masteryEvents.createdAt,
+      sourceType: masteryEvents.sourceType,
+      answerState: masteryEvents.answerState,
+      sessionContext: masteryEvents.sessionContext,
+      basePoints: masteryEvents.basePoints,
+      weight: masteryEvents.weight,
+      awardedPoints: masteryEvents.awardedPoints,
+      eventCanonicalSubcategory: masteryEvents.canonicalSubcategory,
+      questionId: masteryEvents.questionId,
+      questionText: questions.questionText,
+      category: questions.category,
+      broadCategory: questions.broadCategory,
+      questionCanonicalSubcategory: questions.canonicalSubcategory,
+      calibratedDifficulty: questions.calibratedDifficulty,
+      difficultyEstimate: questions.difficultyEstimate,
+      correctRate: questions.correctRate,
+      answeredByUserId: masteryEvents.answeredByUserId,
+      answeredByDisplayName: users.displayName,
+    })
+    .from(masteryEvents)
+    .leftJoin(questions, eq(masteryEvents.questionId, questions.id))
+    .leftJoin(users, eq(masteryEvents.answeredByUserId, users.id))
+    .where(and(...predicates))
+    .orderBy(desc(masteryEvents.createdAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    masteryEventId: row.masteryEventId,
+    createdAt: row.createdAt.toISOString(),
+    sourceType: row.sourceType,
+    answerState: row.answerState,
+    sessionContext: row.sessionContext,
+    basePoints: row.basePoints ?? 0,
+    weight: Number(row.weight ?? 0),
+    awardedPoints: Number(row.awardedPoints ?? 0),
+    eventCanonicalSubcategory: row.eventCanonicalSubcategory,
+    questionId: row.questionId,
+    questionTextSnippet: snippet(row.questionText),
+    category: row.category,
+    broadCategory: row.broadCategory,
+    canonicalSubcategory: row.questionCanonicalSubcategory,
+    difficulty: row.calibratedDifficulty ?? row.difficultyEstimate,
+    correctRate: row.correctRate,
+    answeredByUserId: row.answeredByUserId,
+    answeredByDisplayName: row.answeredByDisplayName,
+  }));
+}
+
+export function summarize(rows: PointsDiagnosticRow[]): PointsDiagnosticSummary {
+  const uniqueQuestionIds = new Set<string>();
+  let total = 0;
+  let correct = 0;
+  let incorrect = 0;
+  for (const r of rows) {
+    total += r.awardedPoints;
+    if (r.questionId) uniqueQuestionIds.add(r.questionId);
+    if (
+      r.answerState === 'first_correct' ||
+      r.answerState === 'first_correct_after_wrong' ||
+      r.answerState === 'repeat_correct'
+    ) {
+      correct++;
+    } else if (r.answerState === 'incorrect') {
+      incorrect++;
+    }
+  }
+  return {
+    eventCount: rows.length,
+    totalAwardedPoints: Math.round(total * 100) / 100,
+    correctCount: correct,
+    incorrectCount: incorrect,
+    uniqueQuestions: uniqueQuestionIds.size,
+  };
+}


### PR DESCRIPTION
Adds /dev/points-diagnostic, a developer-only page that shows every
MASTERY_EVENTS row for a chosen user — the per-question award trail
behind PLAYER_MASTERY totals. Includes filters (category, difficulty,
source type, date range), summary stats (total awarded, %correct,
unique questions), sortable columns, and a CSV export. Gated behind
the same NODE_ENV / VERCEL_ENV check as the existing friend-coverage
diagnostic so it 404s in production. Reached via a new "Points
diagnostic" row in the account page's Developer Tools section.