### PR TITLE
Extract MyQuestionCard component from questions page

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 
-import { Lock, MoreHorizontal, Pencil, Plus, Search, Trash2, X } from 'lucide-react';
+import { Plus, Search, X } from 'lucide-react';
 import { useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useId, useMemo, useRef, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
-import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
-import { SendQuestionAction } from '@/components/SendQuestionAction';
+import { MyQuestionCard } from '@/components/questions/MyQuestionCard';
 import type { QuestionView } from '@/server/db/queries/questions';
 
 type SortMode = 'newest' | 'most_answered' | 'hardest' | 'easiest';
@@ -46,113 +45,6 @@ function isNoQuestionsResponse(response: Response, body: QuestionsApiResponse | 
   return response.status === 204
     || response.status === 404
     || NO_QUESTIONS_PATTERNS.some((pattern) => pattern.test(apiMessage));
-}
-
-const DOMAIN_COLORS: Record<string, string> = {
-  music: '#7c3aed',
-  literature: '#0f766e',
-  history: '#b45309',
-  film_tv: '#be123c',
-  sport: '#15803d',
-  science: '#2563eb',
-  philosophy: '#6d28d9',
-  pop_culture: '#db2777',
-  language: '#0369a1',
-  general_knowledge: '#64748b',
-};
-
-function CardOverflowMenu({
-  inUse,
-  onEdit,
-  onDelete,
-}: {
-  inUse: boolean;
-  onEdit: () => void;
-  onDelete: () => void;
-}) {
-  const [open, setOpen] = useState(false);
-  const menuId = useId();
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const handleClickOutside = (event: MouseEvent) => {
-      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
-    };
-    const handleKey = (event: globalThis.KeyboardEvent) => {
-      if (event.key === 'Escape') setOpen(false);
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    document.addEventListener('keydown', handleKey);
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-      document.removeEventListener('keydown', handleKey);
-    };
-  }, [open]);
-
-  const lockedTitle = 'Used in a game — cannot be edited';
-
-  return (
-    <div className="relative ml-auto" ref={containerRef}>
-      <button
-        type="button"
-        aria-label="More actions"
-        aria-haspopup="menu"
-        aria-expanded={open}
-        aria-controls={open ? menuId : undefined}
-        onClick={() => setOpen((current) => !current)}
-        className="-mr-1 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
-      >
-        <MoreHorizontal className="size-4" />
-      </button>
-      {open ? (
-        <div
-          id={menuId}
-          role="menu"
-          className="absolute right-0 top-full z-30 mt-1 w-44 rounded-md border bg-background p-1 shadow-md"
-        >
-          <button
-            type="button"
-            role="menuitem"
-            disabled={inUse}
-            title={inUse ? lockedTitle : undefined}
-            onClick={() => {
-              setOpen(false);
-              onEdit();
-            }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {inUse ? <Lock className="size-4" /> : <Pencil className="size-4" />}
-            Edit
-          </button>
-          <button
-            type="button"
-            role="menuitem"
-            disabled={inUse}
-            title={inUse ? lockedTitle : undefined}
-            onClick={() => {
-              setOpen(false);
-              onDelete();
-            }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
-          >
-            {inUse ? <Lock className="size-4" /> : <Trash2 className="size-4" />}
-            Delete
-          </button>
-        </div>
-      ) : null}
-    </div>
-  );
-}
-
-function formatAnswerersLine(answerers: { names: string[]; total: number }): string | null {
-  const { names, total } = answerers;
-  if (total <= 0 || names.length === 0) return null;
-  const [first, second] = names;
-  if (total === 1) return `${first} answered your question`;
-  if (total === 2 && second) return `${first} and ${second} answered your question`;
-  const others = total - 1;
-  return `${first} and ${others} ${others === 1 ? 'other' : 'others'} answered your question`;
 }
 
 function initialValues(question: QuestionView): QuestionFormValues {
@@ -409,64 +301,19 @@ function QuestionsPageContent() {
         </section>
       ) : (
         <section className="space-y-3">
-          {filteredQuestions.map((question) => {
-            const inUse = question.usedInGamesCount > 0;
-            const color = DOMAIN_COLORS[question.category] ?? '#64748b';
-            const deleting = removingId === question.id;
-            const difficultyLabel = difficultyCopyFromValue(question.difficulty) ?? 'Unrated';
-
-            return (
-              <article
-                key={question.id}
-                className={`rounded-lg border bg-card p-4 text-card-foreground transition duration-200 ${deleting ? 'scale-[0.98] opacity-0' : 'opacity-100'}`}
-              >
-                <div className="mb-3 flex flex-wrap items-center gap-2">
-                  <span
-                    className="rounded-full px-2.5 py-1 text-xs font-medium text-white"
-                    style={{ backgroundColor: color }}
-                  >
-                    {question.domainDisplayName}
-                  </span>
-                  <span className="rounded-full bg-muted px-2.5 py-1 text-xs font-medium text-muted-foreground" aria-label={`LLM-rated difficulty: ${difficultyLabel}`}>
-                    {difficultyLabel}
-                  </span>
-                  <CardOverflowMenu
-                    inUse={inUse}
-                    onEdit={() => setDrawer({ mode: 'edit', question })}
-                    onDelete={() => setConfirmingId(question.id)}
-                  />
-                </div>
-                <p className="line-clamp-2 text-base font-medium leading-7">{question.text}</p>
-                <p className="mt-4 text-sm text-muted-foreground">
-                  {question.timesAnswered} answers · {question.correctRate}% correct · {question.usedInGamesCount} games
-                </p>
-                {question.isOwnAuthored && question.answerers ? (() => {
-                  const line = formatAnswerersLine(question.answerers);
-                  return line ? <p className="mt-1 text-sm text-muted-foreground">{line}</p> : null;
-                })() : null}
-                {cardError[question.id] ? <p className="mt-3 text-sm text-destructive">{cardError[question.id]}</p> : null}
-                <div className="mt-4 flex items-center gap-2">
-                  {confirmingId === question.id ? (
-                    <>
-                      <span className="mr-auto text-sm font-medium">Delete this question?</span>
-                      <button className="rounded-md border border-destructive px-3 py-2 text-sm text-destructive" type="button" onClick={() => void confirmDelete(question)}>
-                        Confirm
-                      </button>
-                      <button className="rounded-md border px-3 py-2 text-sm" type="button" onClick={() => setConfirmingId(null)}>
-                        Cancel
-                      </button>
-                    </>
-                  ) : (
-                    <div className="ml-auto">
-                      <SendQuestionAction
-                        question={{ id: question.id, text: question.text, domain: question.domainDisplayName }}
-                      />
-                    </div>
-                  )}
-                </div>
-              </article>
-            );
-          })}
+          {filteredQuestions.map((question) => (
+            <MyQuestionCard
+              key={question.id}
+              question={question}
+              confirming={confirmingId === question.id}
+              cardError={cardError[question.id]}
+              deleting={removingId === question.id}
+              onEdit={() => setDrawer({ mode: 'edit', question })}
+              onDeleteRequest={() => setConfirmingId(question.id)}
+              onConfirmDelete={() => void confirmDelete(question)}
+              onCancelConfirm={() => setConfirmingId(null)}
+            />
+          ))}
         </section>
       )}
 

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -57,24 +57,30 @@ export function FeedCard({
             </div>
 
             <div className="min-w-0 flex-1">
-              <p
-                className="text-[11px] uppercase leading-none tracking-[0.08em]"
-                style={{ color: 'var(--ink)', opacity: 0.7 }}
-              >
-                New question
-              </p>
-              {visibleCategory ? (
-                <p
-                  className="mt-1 truncate text-[12px] italic leading-tight"
-                  style={{
-                    fontFamily: 'var(--font-literata)',
-                    color: 'var(--ink)',
-                    opacity: 0.7,
-                  }}
-                >
-                  {visibleCategory}
-                </p>
-              ) : null}
+              {headerContent ? (
+                headerContent
+              ) : (
+                <>
+                  <p
+                    className="text-[11px] uppercase leading-none tracking-[0.08em]"
+                    style={{ color: 'var(--ink)', opacity: 0.7 }}
+                  >
+                    New question
+                  </p>
+                  {visibleCategory ? (
+                    <p
+                      className="mt-1 truncate text-[12px] italic leading-tight"
+                      style={{
+                        fontFamily: 'var(--font-literata)',
+                        color: 'var(--ink)',
+                        opacity: 0.7,
+                      }}
+                    >
+                      {visibleCategory}
+                    </p>
+                  ) : null}
+                </>
+              )}
             </div>
 
             <div className="flex shrink-0 items-center gap-2">
@@ -109,6 +115,8 @@ export function FeedCard({
               {item.personalMessage}
             </p>
           ) : null}
+
+          {footer ? <div className="mt-3">{footer}</div> : null}
         </div>
       </article>
     )

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -1,0 +1,236 @@
+'use client';
+
+import { Lock, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
+import { useEffect, useId, useRef, useState } from 'react';
+
+import { FeedCard } from '@/components/feed/FeedCard';
+import { visibleFeedCategory } from '@/components/feed/category';
+import type { FeedCardBaseItem } from '@/components/feed/types';
+import { SendQuestionAction } from '@/components/SendQuestionAction';
+import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
+import type { QuestionView } from '@/server/db/queries/questions';
+
+type MyQuestionCardProps = {
+  question: QuestionView;
+  confirming: boolean;
+  cardError?: string;
+  deleting: boolean;
+  onEdit: () => void;
+  onDeleteRequest: () => void;
+  onConfirmDelete: () => void;
+  onCancelConfirm: () => void;
+};
+
+export function MyQuestionCard({
+  question,
+  confirming,
+  cardError,
+  deleting,
+  onEdit,
+  onDeleteRequest,
+  onConfirmDelete,
+  onCancelConfirm,
+}: MyQuestionCardProps) {
+  const inUse = question.usedInGamesCount > 0;
+  const difficultyLabel = difficultyCopyFromValue(question.difficulty) ?? 'Unrated';
+  const visibleCategory = visibleFeedCategory(question.domainDisplayName);
+  const answerersLine = question.isOwnAuthored && question.answerers
+    ? formatAnswerersLine(question.answerers)
+    : null;
+
+  const item: FeedCardBaseItem = {
+    id: question.id,
+    metadata: null,
+    question: question.text,
+    category: question.domainDisplayName,
+    viewerIsAuthor: true,
+  };
+
+  return (
+    <FeedCard
+      item={item}
+      className={`transition duration-200 ${deleting ? 'scale-[0.98] opacity-0' : 'opacity-100'}`}
+      overflow={
+        <CardOverflowMenu
+          inUse={inUse}
+          onEdit={onEdit}
+          onDelete={onDeleteRequest}
+        />
+      }
+      headerContent={
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          {visibleCategory ? (
+            <span
+              className="truncate text-[12px] italic leading-tight"
+              style={{
+                fontFamily: 'var(--font-literata)',
+                color: 'var(--ink)',
+                opacity: 0.7,
+              }}
+            >
+              {visibleCategory}
+            </span>
+          ) : null}
+          <span
+            className="rounded-full bg-[rgba(0,0,0,0.06)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+            style={{ color: 'var(--ink)', opacity: 0.7 }}
+            aria-label={`LLM-rated difficulty: ${difficultyLabel}`}
+          >
+            {difficultyLabel}
+          </span>
+        </div>
+      }
+      footer={
+        <>
+          <p
+            className="text-[13px] leading-snug"
+            style={{ color: 'var(--ink)', opacity: 0.65 }}
+          >
+            {question.timesAnswered} answers · {question.correctRate}% correct · {question.usedInGamesCount} games
+          </p>
+          {answerersLine ? (
+            <p
+              className="mt-1 text-[13px] leading-snug"
+              style={{ color: 'var(--ink)', opacity: 0.65 }}
+            >
+              {answerersLine}
+            </p>
+          ) : null}
+          {cardError ? (
+            <p className="mt-2 text-[13px] text-destructive">{cardError}</p>
+          ) : null}
+          <div className="mt-3 flex items-center gap-2">
+            {confirming ? (
+              <>
+                <span
+                  className="mr-auto text-[13px] font-medium"
+                  style={{ color: 'var(--ink)' }}
+                >
+                  Delete this question?
+                </span>
+                <button
+                  className="rounded-md border border-destructive px-3 py-2 text-sm text-destructive"
+                  type="button"
+                  onClick={onConfirmDelete}
+                >
+                  Confirm
+                </button>
+                <button
+                  className="rounded-md border px-3 py-2 text-sm"
+                  type="button"
+                  onClick={onCancelConfirm}
+                >
+                  Cancel
+                </button>
+              </>
+            ) : (
+              <div className="ml-auto">
+                <SendQuestionAction
+                  question={{
+                    id: question.id,
+                    text: question.text,
+                    domain: question.domainDisplayName,
+                  }}
+                />
+              </div>
+            )}
+          </div>
+        </>
+      }
+    />
+  );
+}
+
+function CardOverflowMenu({
+  inUse,
+  onEdit,
+  onDelete,
+}: {
+  inUse: boolean;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const menuId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    };
+    const handleKey = (event: globalThis.KeyboardEvent) => {
+      if (event.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('keydown', handleKey);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKey);
+    };
+  }, [open]);
+
+  const lockedTitle = 'Used in a game — cannot be edited';
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        onClick={() => setOpen((current) => !current)}
+        className="-mr-1 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <MoreHorizontal className="size-4" />
+      </button>
+      {open ? (
+        <div
+          id={menuId}
+          role="menu"
+          className="absolute right-0 top-full z-30 mt-1 w-44 rounded-md border bg-background p-1 shadow-md"
+        >
+          <button
+            type="button"
+            role="menuitem"
+            disabled={inUse}
+            title={inUse ? lockedTitle : undefined}
+            onClick={() => {
+              setOpen(false);
+              onEdit();
+            }}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {inUse ? <Lock className="size-4" /> : <Pencil className="size-4" />}
+            Edit
+          </button>
+          <button
+            type="button"
+            role="menuitem"
+            disabled={inUse}
+            title={inUse ? lockedTitle : undefined}
+            onClick={() => {
+              setOpen(false);
+              onDelete();
+            }}
+            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {inUse ? <Lock className="size-4" /> : <Trash2 className="size-4" />}
+            Delete
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function formatAnswerersLine(answerers: { names: string[]; total: number }): string | null {
+  const { names, total } = answerers;
+  if (total <= 0 || names.length === 0) return null;
+  const [first, second] = names;
+  if (total === 1) return `${first} answered your question`;
+  if (total === 2 && second) return `${first} and ${second} answered your question`;
+  const others = total - 1;
+  return `${first} and ${others} ${others === 1 ? 'other' : 'others'} answered your question`;
+}


### PR DESCRIPTION
## Summary
Refactored the question card rendering logic from the questions page into a dedicated `MyQuestionCard` component. This improves code organization, reusability, and maintainability by extracting card-specific UI and behavior into a separate, composable component.

## Key Changes
- **New component:** Created `src/components/questions/MyQuestionCard.tsx` that encapsulates all question card rendering, including:
  - Card overflow menu (edit/delete actions)
  - Difficulty and category display
  - Answer statistics and answerer attribution
  - Delete confirmation UI
  - Send question action
  - Deletion animation state

- **Updated FeedCard:** Modified `src/components/feed/FeedCard.tsx` to support optional `headerContent` and `footer` props, allowing customization of card header and footer sections while maintaining default behavior for feed items

- **Simplified questions page:** Refactored `src/app/questions/page.tsx` to:
  - Remove inline card rendering logic
  - Remove `CardOverflowMenu` and `formatAnswerersLine` helper functions (now in MyQuestionCard)
  - Remove unused imports (`Lock`, `MoreHorizontal`, `Pencil`, `Trash2`, `useId`, `useRef`)
  - Replace card rendering with `MyQuestionCard` component calls, passing state and callbacks as props

## Implementation Details
- `MyQuestionCard` uses the existing `FeedCard` component as its base, leveraging the shared card styling and structure
- The component accepts all necessary state (`confirming`, `deleting`, `cardError`) and callbacks (`onEdit`, `onDeleteRequest`, `onConfirmDelete`, `onCancelConfirm`) as props, keeping it fully controlled and testable
- Maintains all existing functionality including locked state for questions used in games, answer statistics display, and delete confirmation flow

https://claude.ai/code/session_01SMH46DcNrHhqqRb2qe7peZ