### PR TITLE
Remove env gate on points-diagnostic so prod deploys can reach it

### DIFF
--- a/src/app/api/dev/points-diagnostic/route.ts
+++ b/src/app/api/dev/points-diagnostic/route.ts
@@ -15,13 +15,6 @@ import {
 
 export const dynamic = 'force-dynamic';
 
-export function isDevDiagnosticEnabled(): boolean {
-  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
-  if (process.env.NODE_ENV !== 'production') return true;
-  // Vercel preview deploys run with NODE_ENV='production' but VERCEL_ENV='preview'.
-  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
-}
-
 const querySchema = z.object({
   user: z.string().trim().min(1).optional(),
   category: z.enum(CATEGORY_VALUES).optional(),
@@ -74,7 +67,6 @@ function rowsToCsv(rows: PointsDiagnosticRow[]): string {
 export async function GET(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-  if (!isDevDiagnosticEnabled()) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
   const params = Object.fromEntries(request.nextUrl.searchParams.entries());
   const parsed = querySchema.safeParse(params);

--- a/src/app/dev/points-diagnostic/page.tsx
+++ b/src/app/dev/points-diagnostic/page.tsx
@@ -1,4 +1,4 @@
-import { notFound, redirect } from 'next/navigation';
+import { redirect } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import {
@@ -32,12 +32,6 @@ type SearchParams = {
 type PageProps = {
   searchParams: Promise<SearchParams>;
 };
-
-function isDevDiagnosticEnabled(): boolean {
-  if (process.env.FEED_DEBUG_ENABLED === 'true') return true;
-  if (process.env.NODE_ENV !== 'production') return true;
-  return process.env.VERCEL_ENV !== undefined && process.env.VERCEL_ENV !== 'production';
-}
 
 function asCategory(value: string | undefined): Category | undefined {
   return value && (CATEGORY_VALUES as readonly string[]).includes(value) ? (value as Category) : undefined;
@@ -96,8 +90,6 @@ const LABEL_STYLE: React.CSSProperties = {
 };
 
 export default async function PointsDiagnosticPage({ searchParams }: PageProps) {
-  if (!isDevDiagnosticEnabled()) notFound();
-
   const session = await getSession();
   if (!session) redirect('/login');
 


### PR DESCRIPTION
The page and API route were 404ing on production Vercel deployments
because isDevDiagnosticEnabled() required VERCEL_ENV!=='production' or
FEED_DEBUG_ENABLED=true. Drop the gate; the session check still keeps
the page behind login, matching the other /dev/* surfaces.

https://claude.ai/code/session_01G2T3yjBLoHBA2fMSxJboka