### PR TITLE
exclude viewer-authored questions from the home feed

### DIFF
--- a/src/server/db/queries/__tests__/feed.test.ts
+++ b/src/server/db/queries/__tests__/feed.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const { dbMock, state } = vi.hoisted(() => {
   type Predicate =
     | { op: 'eq'; column: string; value: unknown }
+    | { op: 'ne'; column: string; value: unknown }
     | { op: 'and'; predicates: Array<Predicate | undefined> }
     | { op: 'or'; predicates: Array<Predicate | undefined> }
     | { op: 'inArray'; column: string; values: readonly unknown[] }
@@ -29,6 +30,7 @@ const { dbMock, state } = vi.hoisted(() => {
     visibility: string;
     deletedAt: Date | null;
     canonicalSubcategory: string | null;
+    creatorId?: string | null;
   };
 
   const state = {
@@ -47,6 +49,11 @@ const { dbMock, state } = vi.hoisted(() => {
     switch (predicate.op) {
       case 'eq':
         return columnValue(predicate.column, feedItem, question) === predicate.value;
+      case 'ne': {
+        const v = columnValue(predicate.column, feedItem, question);
+        // SQL: `x != y` is NULL when x is NULL, which is falsy in WHERE.
+        return v != null && v !== predicate.value;
+      }
       case 'and':
         return predicate.predicates.every((part) => evaluate(part, feedItem, question));
       case 'or':
@@ -105,7 +112,10 @@ vi.mock('drizzle-orm', () => ({
   ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
   notInArray: vi.fn((column, values) => ({ op: 'notInArray', column, values })),
   or: vi.fn((...predicates) => ({ op: 'or', predicates })),
-  sql: vi.fn(() => ({ op: 'sql' })),
+  sql: Object.assign(
+    vi.fn(() => ({ op: 'sql', as: (alias: string) => ({ op: 'sql', alias }) })),
+    { raw: vi.fn((value: unknown) => ({ op: 'sql', value })) },
+  ),
 }));
 
 vi.mock('@/server/db', () => ({
@@ -132,6 +142,7 @@ vi.mock('@/server/db', () => ({
     visibility: 'questions.visibility',
     deletedAt: 'questions.deletedAt',
     canonicalSubcategory: 'questions.canonicalSubcategory',
+    creatorId: 'questions.creatorId',
   },
   users: { id: 'users.id', displayName: 'users.displayName' },
 }));
@@ -306,6 +317,63 @@ describe('getFeedForUser feed visibility', () => {
     const result = await getFeedForUser('recipient-1', { limit: 1 });
 
     expect(result.items[0]).toEqual(expect.objectContaining({ id: 'feed-direct-priority' }));
+  });
+
+  it('excludes feed items for questions the viewer authored', async () => {
+    state.questionRows = [
+      // Viewer is the author — must be filtered out
+      { id: 'question-own', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music', creatorId: 'recipient-1' },
+      // Authored by someone else — should remain visible
+      { id: 'question-friend', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music', creatorId: 'author-2' },
+      // System-generated (no author) — should remain visible
+      { id: 'question-system', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music', creatorId: null },
+    ];
+    state.feedRows = [
+      {
+        id: 'feed-self-authored',
+        recipientUserId: 'recipient-1',
+        questionId: 'question-own',
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:00:00.000Z'),
+        personalMessage: null,
+        state: 'active',
+        isPinned: false,
+        joshingGameId: null,
+      },
+      {
+        id: 'feed-friend-authored',
+        recipientUserId: 'recipient-1',
+        questionId: 'question-friend',
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:01:00.000Z'),
+        personalMessage: null,
+        state: 'active',
+        isPinned: false,
+        joshingGameId: null,
+      },
+      {
+        id: 'feed-system-authored',
+        recipientUserId: 'recipient-1',
+        questionId: 'question-system',
+        sourceType: 'direct_sent',
+        sourceUserId: 'sender-1',
+        sourceResult: null,
+        sourceEventAt: new Date('2026-05-14T12:02:00.000Z'),
+        personalMessage: null,
+        state: 'active',
+        isPinned: false,
+        joshingGameId: null,
+      },
+    ];
+
+    const result = await getFeedForUser('recipient-1');
+
+    expect(result.items.map((item) => item.id).sort()).toEqual(['feed-friend-authored', 'feed-system-authored']);
+    expect(result.totalCount).toBe(2);
   });
 
   it('applies the from-friends URL filter', async () => {

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -306,6 +306,14 @@ function visibleQuestionPredicate(dismissedDomains: string[]) {
   return and(...predicates);
 }
 
+// Exclude items where the viewer authored the underlying question — they
+// already know the answer, so it shouldn't surface as a "question to answer"
+// card in their feed. Nullable creatorId (system-generated questions) stays
+// visible.
+function viewerNotAuthorPredicate(userId: string) {
+  return or(isNull(questions.creatorId), ne(questions.creatorId, userId));
+}
+
 async function fetchVisibleFeedItems(
   userId: string,
   dismissedDomains: string[],
@@ -324,6 +332,7 @@ async function fetchVisibleFeedItems(
       feedFilterPredicate(options.filter),
       inArray(feedItems.state, VISIBLE_FEED_STATES),
       visibleQuestionPredicate(dismissedDomains),
+      viewerNotAuthorPredicate(userId),
       cursorPredicate,
     ))
     .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
@@ -350,6 +359,7 @@ async function fetchVisibleFeedItems(
         feedFilterPredicate(options.filter),
         inArray(feedItems.state, VISIBLE_FEED_STATES),
         visibleQuestionPredicate(dismissedDomains),
+        viewerNotAuthorPredicate(userId),
         cursorPredicate,
       ))
       .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
@@ -381,6 +391,7 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
         feedFilterPredicate(filter),
         inArray(feedItems.state, VISIBLE_FEED_STATES),
         visibleQuestionPredicate(dismissedDomains),
+        viewerNotAuthorPredicate(userId),
       )),
   ]);
 

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -7,7 +7,7 @@
  * to hydrate <FeedList /> with the first page (no client round-trip).
  */
 
-import { and, count, eq, inArray, or } from 'drizzle-orm';
+import { and, count, eq, inArray, isNull, ne, or } from 'drizzle-orm';
 
 import { db, feedItems, friendships, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
@@ -167,20 +167,24 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
     db
       .select({ value: count() })
       .from(feedItems)
+      .innerJoin(questions, eq(feedItems.questionId, questions.id))
       .where(and(
         eq(feedItems.recipientUserId, viewerUserId),
         visibleSourcePredicate,
         feedFilterSourcePredicate(filter),
+        or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
       ))
       .then((rows) => rows[0]?.value ?? 0),
     db
       .select({ value: count() })
       .from(feedItems)
+      .innerJoin(questions, eq(feedItems.questionId, questions.id))
       .where(and(
         eq(feedItems.recipientUserId, viewerUserId),
         visibleSourcePredicate,
         feedFilterSourcePredicate(filter),
         inArray(feedItems.state, ['active', 'skipped']),
+        or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
       ))
       .then((rows) => rows[0]?.value ?? 0),
   ]);


### PR DESCRIPTION
The home feed was surfacing questions the viewer themselves had created
(rendered as the "You" + "New question" variant of FeedCard). Those
shouldn't appear: the viewer already knows the answer, so the card is
not "a question they can answer".

Add a viewerNotAuthorPredicate to the feed query and apply it to the
paginated read, the totalCount, and the meta count queries so the empty-
state hints stay consistent. Nullable creatorId (system-generated
questions) stays visible via or(isNull, ne).