### PR TITLE
Add Lately feed to activities page with moment bucketing

### DIFF
--- a/src/app/activities/__tests__/creator-note-subcopy.test.tsx
+++ b/src/app/activities/__tests__/creator-note-subcopy.test.tsx
@@ -12,6 +12,8 @@ vi.mock('@/app/activities/MarkActivitiesRead', () => ({ MarkActivitiesRead: () =
 vi.mock('@/app/activities/ReactionGotItButton', () => ({ ReactionGotItButton: () => null }));
 vi.mock('@/server/auth/session', () => ({ getSession: vi.fn() }));
 vi.mock('@/server/db/queries/activity', () => ({ getActivitiesForUser: vi.fn() }));
+vi.mock('@/server/db/queries/lately', () => ({ getLatelyMoments: vi.fn() }));
+vi.mock('@/server/db/queries/users', () => ({ getUserById: vi.fn() }));
 vi.mock('next/navigation', () => ({ redirect: vi.fn() }));
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -5,12 +5,27 @@ import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton'
 import { FriendRequestActions } from '@/app/activities/FriendRequestActions'
 import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead'
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton'
+import { DayDivider } from '@/components/lately/DayDivider'
+import { LatelyFeed } from '@/components/lately/LatelyFeed'
+import {
+  CREAM,
+  FH,
+  FM,
+  FS,
+  HILITE,
+  INK,
+  INK2,
+  INK3,
+  RULE,
+} from '@/components/lately/tokens'
 import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer'
 import { getSession } from '@/server/auth/session'
 import {
   getActivitiesForUser,
   type ActivityItemView,
 } from '@/server/db/queries/activity'
+import { getLatelyMoments } from '@/server/db/queries/lately'
+import { getUserById } from '@/server/db/queries/users'
 
 function formatActivityTime(value: Date) {
   return new Intl.DateTimeFormat(undefined, {
@@ -392,59 +407,150 @@ export default async function ActivitiesPage() {
   const session = await getSession()
   if (!session) redirect('/login')
 
-  const items = await getActivitiesForUser(session.userId)
+  const [items, moments, viewer] = await Promise.all([
+    getActivitiesForUser(session.userId),
+    getLatelyMoments(session.userId),
+    getUserById(session.userId),
+  ])
+  const tz = viewer?.timezone ?? 'America/New_York'
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
-      <MarkActivitiesRead />
-      <header className="mb-5 border-b pb-4">
-        <p className="text-muted-foreground text-xs tracking-[0.1em] uppercase">
-          Notes
-        </p>
-        <h1 className="text-foreground font-serif text-2xl font-semibold">
-          Recent notes
-        </h1>
-      </header>
+    <main
+      style={{
+        background: CREAM,
+        color: INK,
+        minHeight: '100dvh',
+      }}
+    >
+      <div
+        style={{
+          maxWidth: 420,
+          margin: '0 auto',
+          padding: '18px 20px 100px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <MarkActivitiesRead />
 
-      {items.length === 0 ? (
-        <section className="flex flex-1 items-center justify-center py-16 text-center">
-          <p className="text-muted-foreground max-w-sm text-sm">
-            Nothing here yet. Play some questions and send a Joshing Game.
-          </p>
-        </section>
-      ) : (
-        <section className="space-y-3 pb-8">
-          {items.map((item) => (
-            <article
-              key={item.id}
-              id={
-                item.type === 'friend_request'
-                  ? `friendship-${item.referenceId}`
-                  : undefined
-              }
-              className={[
-                'bg-card text-card-foreground rounded-lg border p-4 transition',
-                isUnread(item)
-                  ? 'border-l-primary border-l-[3px]'
-                  : 'border-l-transparent opacity-75',
-              ].join(' ')}
+        <div style={{ marginBottom: 6 }}>
+          <h1
+            style={{
+              fontSize: 52,
+              fontFamily: FS,
+              fontWeight: 400,
+              fontStyle: 'italic',
+              lineHeight: 1,
+              margin: 0,
+              letterSpacing: -1.5,
+              position: 'relative',
+              display: 'inline-block',
+            }}
+          >
+            Lately.
+            <span
+              aria-hidden
+              style={{
+                position: 'absolute',
+                left: 0,
+                right: '30%',
+                bottom: 4,
+                height: 8,
+                background: HILITE,
+                zIndex: -1,
+                opacity: 0.85,
+              }}
+            />
+          </h1>
+        </div>
+        <div
+          style={{
+            fontSize: 13,
+            color: INK2,
+            fontStyle: 'italic',
+            lineHeight: 1.5,
+            marginBottom: 4,
+          }}
+        >
+          Moments of connection from across your games.
+        </div>
+        <div
+          style={{
+            fontFamily: FH,
+            fontSize: 18,
+            color: INK2,
+            marginTop: 6,
+            marginLeft: 2,
+            transform: 'rotate(-1deg)',
+            display: 'inline-block',
+          }}
+        >
+          — the people who get you, getting you.
+        </div>
+
+        <LatelyFeed moments={moments} tz={tz} />
+
+        {items.length > 0 ? (
+          <>
+            <DayDivider label="EARLIER ACTIVITY" />
+            <section className="space-y-3 pb-8">
+              {items.map((item) => (
+                <article
+                  key={item.id}
+                  id={
+                    item.type === 'friend_request'
+                      ? `friendship-${item.referenceId}`
+                      : undefined
+                  }
+                  className={[
+                    'bg-card text-card-foreground rounded-lg border p-4 transition',
+                    isUnread(item)
+                      ? 'border-l-primary border-l-[3px]'
+                      : 'border-l-transparent opacity-75',
+                  ].join(' ')}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div>
+                      <p className="text-base leading-7">
+                        <ActivityCopy item={item} />
+                      </p>
+                      <ActivitySubcopy item={item} />
+                      <p className="text-muted-foreground mt-1 text-xs">
+                        {formatActivityTime(item.createdAt)}
+                      </p>
+                    </div>
+                    <ActivityCta item={item} />
+                  </div>
+                </article>
+              ))}
+            </section>
+          </>
+        ) : null}
+
+        {moments.length > 0 || items.length > 0 ? (
+          <div
+            style={{
+              marginTop: 36,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 12,
+            }}
+          >
+            <div style={{ width: 40, height: 1, background: RULE }} />
+            <div
+              style={{
+                fontSize: 9,
+                fontFamily: FM,
+                color: INK3,
+                letterSpacing: 3,
+              }}
             >
-              <div className="flex items-start justify-between gap-4">
-                <div>
-                  <p className="text-base leading-7">
-                    <ActivityCopy item={item} />
-                  </p>
-                  <ActivitySubcopy item={item} />
-                  <p className="text-muted-foreground mt-1 text-xs">
-                    {formatActivityTime(item.createdAt)}
-                  </p>
-                </div>
-                <ActivityCta item={item} />
-              </div>
-            </article>
-          ))}
-        </section>
-      )}
+              END OF FEED
+            </div>
+            <div style={{ width: 40, height: 1, background: RULE }} />
+          </div>
+        ) : null}
+      </div>
     </main>
   )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,12 +1,10 @@
 import type { Metadata } from 'next'
-import { Montserrat, Playfair_Display } from 'next/font/google'
+import { Caveat, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
 import { getBellBadgeCount } from '@/server/db/queries/activity';
-
-// Caveat removed — was preloaded but unused. Re-add when a handwriting register lands in UI.
 
 // Intentional product choice (2026-05-16): Montserrat is the body font.
 // PRD §typography spec'd Inter, but Montserrat ships. Update PRD to reflect this.
@@ -23,6 +21,13 @@ const playfair = Playfair_Display({
   subsets: ['latin'],
   style: ['italic'],
   variable: '--font-display',
+  display: 'swap',
+})
+
+// Handwritten register for the Lately flourish on /activities. Used sparingly.
+const caveat = Caveat({
+  subsets: ['latin'],
+  variable: '--font-caveat',
   display: 'swap',
 })
 
@@ -47,7 +52,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${playfair.variable}`}
+      className={`font-sans ${playfair.variable} ${caveat.variable}`}
     >
       <body className={montserrat.className}>
         <Nav

--- a/src/components/lately/DayDivider.tsx
+++ b/src/components/lately/DayDivider.tsx
@@ -1,0 +1,28 @@
+import { FM, INK3, RULE } from './tokens';
+
+export function DayDivider({ label }: { label: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 14,
+        margin: '28px 0 18px',
+      }}
+    >
+      <div style={{ flex: 1, height: 1, background: RULE }} />
+      <div
+        style={{
+          fontSize: 10,
+          fontFamily: FM,
+          color: INK3,
+          letterSpacing: 3,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        {label}
+      </div>
+      <div style={{ flex: 1, height: 1, background: RULE }} />
+    </div>
+  );
+}

--- a/src/components/lately/LatelyFeed.tsx
+++ b/src/components/lately/LatelyFeed.tsx
@@ -1,0 +1,56 @@
+import { Fragment } from 'react';
+
+import { assignCaption, bucketMoments, formatMomentTime } from '@/lib/lately';
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+import { DayDivider } from './DayDivider';
+import { MomentRow } from './MomentRow';
+import { FS, INK2 } from './tokens';
+
+type Props = {
+  moments: LatelyMoment[];
+  tz: string;
+};
+
+export function LatelyFeed({ moments, tz }: Props) {
+  if (moments.length === 0) {
+    return (
+      <div
+        style={{
+          fontFamily: FS,
+          fontStyle: 'italic',
+          fontSize: 16,
+          color: INK2,
+          textAlign: 'center',
+          paddingTop: 40,
+        }}
+      >
+        No moments yet. They&rsquo;ll appear here once you and your friends start
+        answering each other&rsquo;s questions.
+      </div>
+    );
+  }
+
+  const buckets = bucketMoments(moments, tz);
+  const featuredId = moments[0]?.momentId;
+
+  return (
+    <>
+      {buckets.map((bucket) => (
+        <Fragment key={bucket.label}>
+          <DayDivider label={bucket.label} />
+          {bucket.items.map((moment) => (
+            <MomentRow
+              key={moment.momentId}
+              moment={moment}
+              caption={assignCaption(moment.momentId, moment.dir, moment.friendFirstName)}
+              footnoteTime={formatMomentTime(moment.answeredAt, bucket.label, tz)}
+              featured={moment.momentId === featuredId}
+              defaultOpen={moment.momentId === featuredId}
+            />
+          ))}
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/src/components/lately/MomentRow.tsx
+++ b/src/components/lately/MomentRow.tsx
@@ -1,0 +1,189 @@
+'use client';
+
+import Link from 'next/link';
+import { useState, type MouseEvent } from 'react';
+
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+import { CREAM, FI, FM, FS, INK, INK2, INK3, PAPER, RULE } from './tokens';
+
+type Props = {
+  moment: LatelyMoment;
+  caption: string;
+  footnoteTime: string;
+  featured?: boolean;
+  defaultOpen?: boolean;
+};
+
+export function MomentRow({
+  moment,
+  caption,
+  footnoteTime,
+  featured = false,
+  defaultOpen = false,
+}: Props) {
+  const [open, setOpen] = useState(defaultOpen);
+  const theyGotYou = moment.dir === 'they_got_you';
+
+  function handleSend(e: MouseEvent) {
+    e.stopPropagation();
+    console.log({
+      momentId: moment.momentId,
+      questionId: moment.questionId,
+      friendId: moment.friendId,
+      dir: moment.dir,
+    });
+  }
+
+  function handleFriendClick(e: MouseEvent) {
+    e.stopPropagation();
+  }
+
+  const nameLink = (
+    <Link
+      href={`/users/${moment.friendId}`}
+      onClick={handleFriendClick}
+      style={{
+        color: INK,
+        textDecoration: 'underline',
+        textDecorationColor: INK,
+        textUnderlineOffset: 4,
+        textDecorationThickness: 1.5,
+        cursor: 'pointer',
+      }}
+    >
+      {moment.friendName}
+    </Link>
+  );
+
+  const categorySpan = (
+    <span style={{ fontFamily: FI, fontStyle: 'italic', fontWeight: 500 }}>
+      {moment.category}
+    </span>
+  );
+
+  return (
+    <div
+      onClick={() => setOpen((v) => !v)}
+      style={{
+        background: PAPER,
+        border: `1.5px solid ${featured ? INK : RULE}`,
+        boxShadow: featured ? `3px 3px 0 ${INK2}` : 'none',
+        padding: featured ? '18px 20px 16px' : '14px 18px 12px',
+        marginBottom: 14,
+        cursor: 'pointer',
+        transition: 'border-color 120ms ease',
+      }}
+    >
+      <div
+        style={{
+          fontSize: 9,
+          fontFamily: FM,
+          color: INK3,
+          letterSpacing: 2.5,
+          marginBottom: 8,
+        }}
+      >
+        {caption}
+      </div>
+
+      <div
+        style={{
+          fontSize: featured ? 22 : 17,
+          fontFamily: FS,
+          fontWeight: 500,
+          color: INK,
+          lineHeight: 1.35,
+          letterSpacing: -0.2,
+          marginBottom: open ? 14 : 12,
+        }}
+      >
+        {theyGotYou ? (
+          <>{nameLink} got you on {categorySpan}.</>
+        ) : (
+          <>You got {nameLink} on {categorySpan}.</>
+        )}
+      </div>
+
+      {open ? (
+        <>
+          <div
+            style={{
+              borderLeft: `2px solid ${INK}`,
+              paddingLeft: 12,
+              marginBottom: 14,
+            }}
+          >
+            <div
+              style={{
+                fontSize: featured ? 14 : 13,
+                fontFamily: FI,
+                fontStyle: 'italic',
+                color: INK2,
+                lineHeight: 1.55,
+              }}
+            >
+              &ldquo;{moment.questionText}&rdquo;
+            </div>
+          </div>
+
+          <div onClick={(e) => e.stopPropagation()} style={{ marginBottom: 14 }}>
+            <button
+              type="button"
+              onClick={handleSend}
+              style={{
+                background: CREAM,
+                border: `1.5px solid ${INK}`,
+                color: INK,
+                fontFamily: FM,
+                fontSize: 10,
+                letterSpacing: 2,
+                padding: '8px 14px',
+                cursor: 'pointer',
+                boxShadow: `2px 2px 0 ${INK2}`,
+              }}
+            >
+              SEND TO A FRIEND →
+            </button>
+          </div>
+        </>
+      ) : null}
+
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 10,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 10,
+            fontSize: 9,
+            fontFamily: FM,
+            color: INK3,
+            letterSpacing: 2,
+          }}
+        >
+          <span>{moment.gameTitle.toUpperCase()}</span>
+          <span style={{ opacity: 0.5 }}>·</span>
+          <span>{footnoteTime}</span>
+        </div>
+        <div
+          style={{
+            fontSize: 9,
+            fontFamily: FM,
+            color: INK2,
+            letterSpacing: 2,
+            fontWeight: 600,
+          }}
+        >
+          {open ? '− QUESTION' : '+ QUESTION'}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/lately/tokens.ts
+++ b/src/components/lately/tokens.ts
@@ -1,0 +1,16 @@
+export const INK = '#1a1a2e';
+export const INK2 = '#3a3a4e';
+export const INK3 = '#8a8a9a';
+export const CREAM = '#faf8f2';
+export const PAPER = '#fffdf7';
+export const RULE = '#d8d4c8';
+export const HILITE = '#f5d76e';
+
+// Body font intentionally uses the project default (Montserrat via next/font);
+// CSS var resolves to it. The mockup spec'd Inter — project decision to keep
+// Montserrat (see CLAUDE.md + intentional comment in src/app/layout.tsx).
+export const FF = 'var(--font-sans-body), -apple-system, system-ui, sans-serif';
+export const FM = '"Courier New", ui-monospace, monospace';
+export const FS = 'var(--font-display), Georgia, serif';
+export const FI = 'Georgia, var(--font-display), serif';
+export const FH = 'var(--font-caveat), "Caveat", cursive';

--- a/src/lib/__tests__/lately.test.ts
+++ b/src/lib/__tests__/lately.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import { assignCaption, bucketMoments, formatMomentTime } from '@/lib/lately';
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+function moment(overrides: Partial<LatelyMoment> & { answeredAt: Date }): LatelyMoment {
+  return {
+    momentId: 'm-1',
+    dir: 'they_got_you',
+    friendId: 'u-1',
+    friendName: 'Robyn',
+    friendFirstName: 'Robyn',
+    questionId: 'q-1',
+    questionText: 'q?',
+    category: 'a category',
+    gameId: 'g-1',
+    gameTitle: 'asterisk',
+    ...overrides,
+  };
+}
+
+describe('assignCaption', () => {
+  it('returns a caption from the they_got_you pool when dir is they_got_you', () => {
+    const pool = new Set([
+      'THEY KNEW YOU',
+      'ROBYN GOT IT',
+      'THEY SAW IT',
+      'A MATCH',
+      'ON YOUR FREQUENCY',
+    ]);
+    const caption = assignCaption('any-id', 'they_got_you', 'Robyn');
+    expect(pool.has(caption)).toBe(true);
+  });
+
+  it('returns a caption from the you_got_them pool when dir is you_got_them', () => {
+    const pool = new Set([
+      'YOU KNEW THEM',
+      'YOU SAW IT',
+      'YOU NAILED IT',
+      'A MATCH',
+      'ON THEIR FREQUENCY',
+    ]);
+    const caption = assignCaption('any-id', 'you_got_them', 'Robyn');
+    expect(pool.has(caption)).toBe(true);
+  });
+
+  it('is deterministic across calls', () => {
+    expect(assignCaption('stable-id', 'they_got_you', 'Robyn'))
+      .toBe(assignCaption('stable-id', 'they_got_you', 'Robyn'));
+  });
+
+  it('substitutes the friend first name (uppercase) into the {NAME} slot', () => {
+    // Find an id that lands on the {NAME} template (pool index 1).
+    let id = 'x';
+    for (let i = 0; i < 200; i++) {
+      const c = assignCaption(`probe-${i}`, 'they_got_you', 'jamie');
+      if (c === 'JAMIE GOT IT') {
+        id = `probe-${i}`;
+        break;
+      }
+    }
+    expect(assignCaption(id, 'they_got_you', 'jamie')).toBe('JAMIE GOT IT');
+  });
+});
+
+describe('bucketMoments', () => {
+  const tz = 'America/New_York';
+  const now = new Date('2026-05-23T20:00:00.000Z'); // 4pm ET
+
+  it('places same-day moments in TODAY', () => {
+    const m = moment({ answeredAt: new Date('2026-05-23T18:14:00.000Z') });
+    const buckets = bucketMoments([m], tz, now);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].label).toBe('TODAY');
+    expect(buckets[0].items).toEqual([m]);
+  });
+
+  it('places previous-day moments in YESTERDAY', () => {
+    const m = moment({ momentId: 'm-2', answeredAt: new Date('2026-05-22T20:00:00.000Z') });
+    const buckets = bucketMoments([m], tz, now);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].label).toBe('YESTERDAY');
+  });
+
+  it('places 2–7-day-old moments in EARLIER THIS WEEK', () => {
+    const m = moment({ momentId: 'm-3', answeredAt: new Date('2026-05-19T20:00:00.000Z') });
+    const buckets = bucketMoments([m], tz, now);
+    expect(buckets).toHaveLength(1);
+    expect(buckets[0].label).toBe('EARLIER THIS WEEK');
+  });
+
+  it('drops moments older than 7 days', () => {
+    const m = moment({ momentId: 'm-4', answeredAt: new Date('2026-05-10T20:00:00.000Z') });
+    const buckets = bucketMoments([m], tz, now);
+    expect(buckets).toHaveLength(0);
+  });
+
+  it('orders buckets TODAY → YESTERDAY → EARLIER and only includes buckets with items', () => {
+    const today = moment({ momentId: 't', answeredAt: new Date('2026-05-23T18:00:00.000Z') });
+    const earlier = moment({ momentId: 'e', answeredAt: new Date('2026-05-20T18:00:00.000Z') });
+    const buckets = bucketMoments([today, earlier], tz, now);
+    expect(buckets.map((b) => b.label)).toEqual(['TODAY', 'EARLIER THIS WEEK']);
+  });
+});
+
+describe('formatMomentTime', () => {
+  const tz = 'America/New_York';
+
+  it('renders 12-hour time for TODAY', () => {
+    const out = formatMomentTime(new Date('2026-05-23T18:14:00.000Z'), 'TODAY', tz);
+    expect(out).toMatch(/2:14\s?PM/);
+  });
+
+  it('renders weekday + 24-hour time for EARLIER THIS WEEK', () => {
+    const out = formatMomentTime(new Date('2026-05-19T13:20:00.000Z'), 'EARLIER THIS WEEK', tz);
+    expect(out).toMatch(/^TUE\s+9:20$/);
+  });
+});

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -1,0 +1,119 @@
+import type { LatelyDirection, LatelyMoment } from '@/server/db/queries/lately';
+
+export type LatelyBucketLabel = 'TODAY' | 'YESTERDAY' | 'EARLIER THIS WEEK';
+
+export type LatelyBucket = {
+  label: LatelyBucketLabel;
+  items: LatelyMoment[];
+};
+
+const THEY_GOT_YOU_POOL: ReadonlyArray<string> = [
+  'THEY KNEW YOU',
+  '{NAME} GOT IT',
+  'THEY SAW IT',
+  'A MATCH',
+  'ON YOUR FREQUENCY',
+];
+
+const YOU_GOT_THEM_POOL: ReadonlyArray<string> = [
+  'YOU KNEW THEM',
+  'YOU SAW IT',
+  'YOU NAILED IT',
+  'A MATCH',
+  'ON THEIR FREQUENCY',
+];
+
+function djb2(input: string): number {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i++) {
+    hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
+  }
+  return hash >>> 0;
+}
+
+export function assignCaption(
+  momentId: string,
+  dir: LatelyDirection,
+  friendFirstName: string,
+): string {
+  const pool = dir === 'they_got_you' ? THEY_GOT_YOU_POOL : YOU_GOT_THEM_POOL;
+  const template = pool[djb2(momentId) % pool.length];
+  return template.replace('{NAME}', friendFirstName.toUpperCase());
+}
+
+function ymdInZone(date: Date, tz: string): string {
+  // en-CA gives ISO-style YYYY-MM-DD reliably.
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function addDays(ymd: string, delta: number): string {
+  const [y, m, d] = ymd.split('-').map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + delta);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(dt.getUTCDate()).padStart(2, '0');
+  return `${yy}-${mm}-${dd}`;
+}
+
+export function bucketMoments(
+  moments: LatelyMoment[],
+  tz: string,
+  now: Date = new Date(),
+): LatelyBucket[] {
+  const today = ymdInZone(now, tz);
+  const yesterday = addDays(today, -1);
+  const sevenAgo = addDays(today, -7);
+
+  const todayItems: LatelyMoment[] = [];
+  const yesterdayItems: LatelyMoment[] = [];
+  const earlierItems: LatelyMoment[] = [];
+
+  for (const m of moments) {
+    const ymd = ymdInZone(m.answeredAt, tz);
+    if (ymd === today) todayItems.push(m);
+    else if (ymd === yesterday) yesterdayItems.push(m);
+    else if (ymd > sevenAgo && ymd < yesterday) earlierItems.push(m);
+    // anything older than 7 days is dropped per spec
+  }
+
+  const buckets: LatelyBucket[] = [];
+  if (todayItems.length) buckets.push({ label: 'TODAY', items: todayItems });
+  if (yesterdayItems.length) buckets.push({ label: 'YESTERDAY', items: yesterdayItems });
+  if (earlierItems.length) buckets.push({ label: 'EARLIER THIS WEEK', items: earlierItems });
+  return buckets;
+}
+
+export function formatMomentTime(
+  answeredAt: Date,
+  bucket: LatelyBucketLabel,
+  tz: string,
+): string {
+  if (bucket === 'EARLIER THIS WEEK') {
+    const weekday = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      weekday: 'short',
+    }).format(answeredAt).toUpperCase();
+    const parts = new Intl.DateTimeFormat('en-US', {
+      timeZone: tz,
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: false,
+    }).formatToParts(answeredAt);
+    const hour = parts.find((p) => p.type === 'hour')?.value ?? '';
+    const minute = parts.find((p) => p.type === 'minute')?.value ?? '';
+    const unpaddedHour = String(parseInt(hour, 10));
+    return `${weekday} ${unpaddedHour}:${minute}`;
+  }
+  return new Intl.DateTimeFormat('en-US', {
+    timeZone: tz,
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  }).format(answeredAt);
+}

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -1,0 +1,113 @@
+import { and, desc, eq, gte, ne, or, sql } from 'drizzle-orm';
+
+import {
+  db,
+  joshingGameResponses,
+  joshingGames,
+  questions,
+  users,
+} from '@/server/db';
+
+export type LatelyDirection = 'they_got_you' | 'you_got_them';
+
+export type LatelyMoment = {
+  momentId: string;
+  dir: LatelyDirection;
+  friendId: string;
+  friendName: string;
+  friendFirstName: string;
+  questionId: string;
+  questionText: string;
+  category: string;
+  gameId: string;
+  gameTitle: string;
+  answeredAt: Date;
+};
+
+const CATEGORY_ENUM_PRETTY: Record<string, string> = {
+  music: 'music',
+  literature: 'literature',
+  history: 'history',
+  film_tv: 'film & TV',
+  sport: 'sport',
+  science: 'science',
+  philosophy: 'philosophy',
+  pop_culture: 'pop culture',
+  language: 'language',
+  general_knowledge: 'general knowledge',
+};
+
+function prettifyCategory(canonical: string | null, coarse: string | null): string {
+  const trimmed = canonical?.trim();
+  if (trimmed) return trimmed;
+  if (coarse && CATEGORY_ENUM_PRETTY[coarse]) return CATEGORY_ENUM_PRETTY[coarse];
+  return 'something';
+}
+
+function firstName(displayName: string | null, fallback: string): string {
+  const trimmed = displayName?.trim();
+  if (!trimmed) return fallback;
+  const head = trimmed.split(/\s+/)[0];
+  return head || fallback;
+}
+
+export async function getLatelyMoments(userId: string): Promise<LatelyMoment[]> {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+
+  const friendIdExpr = sql<string>`CASE WHEN ${questions.creatorId} = ${userId} THEN ${joshingGameResponses.userId} ELSE ${questions.creatorId} END`;
+
+  const rows = await db
+    .select({
+      momentId: joshingGameResponses.id,
+      creatorId: questions.creatorId,
+      responderId: joshingGameResponses.userId,
+      friendId: friendIdExpr,
+      friendDisplayName: users.displayName,
+      questionId: questions.id,
+      questionText: questions.questionText,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      category: questions.category,
+      gameId: joshingGames.id,
+      gameTitle: joshingGames.title,
+      answeredAt: joshingGameResponses.answeredAt,
+    })
+    .from(joshingGameResponses)
+    .innerJoin(questions, eq(questions.id, joshingGameResponses.questionId))
+    .innerJoin(joshingGames, eq(joshingGames.id, joshingGameResponses.gameId))
+    .innerJoin(users, eq(users.id, friendIdExpr))
+    .where(
+      and(
+        eq(joshingGameResponses.isCorrect, true),
+        gte(joshingGameResponses.answeredAt, thirtyDaysAgo),
+        or(
+          and(eq(questions.creatorId, userId), ne(joshingGameResponses.userId, userId)),
+          and(eq(joshingGameResponses.userId, userId), ne(questions.creatorId, userId)),
+        ),
+      ),
+    )
+    .orderBy(desc(joshingGameResponses.answeredAt))
+    .limit(200);
+
+  const moments: LatelyMoment[] = [];
+  for (const row of rows) {
+    if (!row.answeredAt) continue;
+    if (!row.friendId) continue;
+    const dir: LatelyDirection =
+      row.creatorId === userId ? 'they_got_you' : 'you_got_them';
+    const friendName = row.friendDisplayName?.trim() || 'A friend';
+    moments.push({
+      momentId: row.momentId,
+      dir,
+      friendId: row.friendId,
+      friendName,
+      friendFirstName: firstName(row.friendDisplayName, friendName),
+      questionId: row.questionId,
+      questionText: row.questionText,
+      category: prettifyCategory(row.canonicalSubcategory, row.category),
+      gameId: row.gameId,
+      gameTitle: row.gameTitle,
+      answeredAt: row.answeredAt,
+    });
+  }
+  return moments;
+}


### PR DESCRIPTION
## Summary
Introduces a new "Lately" feed feature to the activities page that displays recent moments of connection between the user and their friends. The feed shows correct answers from the past 30 days, organized by time buckets (Today, Yesterday, Earlier This Week), with expandable moment cards that reveal the original question and a "send to friend" action.

## Key Changes

- **New Lately query layer** (`src/server/db/queries/lately.ts`): Fetches correct answers from the past 30 days where the user either answered a friend's question correctly or a friend answered theirs correctly. Includes logic to prettify category names and extract friend first names.

- **Moment bucketing and formatting** (`src/lib/lately.ts`): 
  - `bucketMoments()` organizes moments into time-based buckets (TODAY, YESTERDAY, EARLIER THIS WEEK) using timezone-aware date comparisons
  - `assignCaption()` deterministically assigns captions to moments using a hash-based pool selection
  - `formatMomentTime()` formats timestamps appropriately per bucket (12-hour for today, weekday + 24-hour for earlier)

- **Lately UI components**:
  - `LatelyFeed`: Main feed component that renders bucketed moments with the first moment featured
  - `MomentRow`: Expandable card showing moment summary, with collapsible question text and send-to-friend button
  - `DayDivider`: Visual separator between time buckets
  - `tokens.ts`: Design system color and font tokens for the Lately feature

- **Activities page refactor** (`src/app/activities/page.tsx`):
  - Fetches moments and user timezone alongside existing activity items
  - Replaced Tailwind-based layout with inline styles using design tokens
  - Reorganized to show Lately feed prominently at top, with earlier activity below a divider
  - Updated header to "Lately." with tagline and visual styling

- **Tests** (`src/lib/__tests__/lately.test.ts`): Comprehensive test coverage for caption assignment, moment bucketing, and time formatting with timezone handling.

- **Font addition** (`src/app/layout.tsx`): Re-enabled Caveat font import (was previously removed as unused; now used in Lately handwriting-style elements).

## Notable Implementation Details

- Moments older than 7 days are dropped per spec
- Caption assignment uses DJB2 hash for deterministic but varied output
- Timezone-aware date bucketing handles edge cases around midnight
- First moment in feed is featured (larger, with shadow) and expanded by default
- "Send to friend" button is a placeholder console.log pending backend integration

https://claude.ai/code/session_011USGcaqeBuMEKRfQ3MyPJy