### PR TITLE
Add close button and safe area insets to daily pages

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useState, type FormEvent } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { X } from 'lucide-react';
 
 import { GameplayChatThread } from '@/components/play/GameplayChat';
 import { useCatchupFlow } from '@/components/play/useCatchupFlow';
@@ -55,13 +57,22 @@ export default function DailyCatchupPage() {
           backdropFilter: 'blur(8px)',
         }}
       >
-        <nav className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
-          <button type="button" onClick={() => router.push('/')} className="underline-offset-4 hover:underline">
-            Home
-          </button>
-          <span className="px-1.5">/</span>
-          <span>Catch up</span>
-        </nav>
+        <div className="flex items-center justify-between gap-3">
+          <nav className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
+            <button type="button" onClick={() => router.push('/')} className="underline-offset-4 hover:underline">
+              Home
+            </button>
+            <span className="px-1.5">/</span>
+            <span>Catch up</span>
+          </nav>
+          <Link
+            href="/"
+            aria-label="Close"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+          >
+            <X className="size-5" strokeWidth={1.9} />
+          </Link>
+        </div>
         <div className="mt-2 flex items-end justify-between gap-3">
           <div>
             <p className="text-xs font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">Catch up</p>
@@ -79,7 +90,14 @@ export default function DailyCatchupPage() {
         </div>
       </header>
 
-      <section className="flex-1 overflow-y-auto px-4 py-4" style={{ paddingBottom: currentItem ? '190px' : '48px' }}>
+      <section
+        className="flex-1 overflow-y-auto px-4 py-4"
+        style={{
+          paddingBottom: currentItem
+            ? 'calc(130px + env(safe-area-inset-bottom))'
+            : 'calc(24px + env(safe-area-inset-bottom))',
+        }}
+      >
         {loading ? (
           <p className="text-sm text-[var(--text-muted)]">Loading catch-up...</p>
         ) : error ? (
@@ -164,11 +182,12 @@ export default function DailyCatchupPage() {
 
       {currentItem && !loading && !completed ? (
         <form
-          className="fixed inset-x-0 bottom-16 z-30 mx-auto max-w-lg border-t px-4 py-3 md:bottom-0"
+          className="fixed inset-x-0 bottom-0 z-30 mx-auto max-w-lg border-t px-4 py-3"
           style={{
             borderColor: 'var(--border)',
             background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
             backdropFilter: 'blur(8px)',
+            paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
           }}
           onSubmit={(event) => void handleSubmit(event)}
         >

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { X } from 'lucide-react';
 
 import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
@@ -661,16 +663,25 @@ export default function DailyPage() {
             <h1 className="font-serif text-xl font-semibold text-[var(--text)]">Today&apos;s five</h1>
           </div>
         </div>
-        <GeometricProgress
-          total={DAILY_QUEUE_SIZE}
-          current={Math.min(completedCount + 1, DAILY_QUEUE_SIZE)}
-          results={results}
-        />
+        <div className="flex items-center gap-2">
+          <GeometricProgress
+            total={DAILY_QUEUE_SIZE}
+            current={Math.min(completedCount + 1, DAILY_QUEUE_SIZE)}
+            results={results}
+          />
+          <Link
+            href="/"
+            aria-label="Close"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+          >
+            <X className="size-5" strokeWidth={1.9} />
+          </Link>
+        </div>
       </header>
 
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
-        style={{ paddingBottom: "calc(140px + env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: "calc(24px + env(safe-area-inset-bottom))" }}
       >
         {loading ? (
           <p className="text-sm text-[var(--text-muted)]">Loading today...</p>
@@ -690,6 +701,7 @@ export default function DailyPage() {
             borderColor: 'var(--border)',
             background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
             backdropFilter: 'blur(6px)',
+            paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
           }}
           onSubmit={(event) => {
             event.preventDefault();

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -54,7 +54,7 @@ export function Nav({
     isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;
 
-  if (pathname === '/onboarding') {
+  if (pathname === '/onboarding' || pathname.startsWith('/daily')) {
     return null;
   }
 


### PR DESCRIPTION
## Summary
Improves the UX of the daily challenge and catch-up pages by adding close buttons and properly accounting for safe area insets on mobile devices.

## Key Changes
- **Close buttons**: Added an X icon button (using lucide-react) to both `/daily` and `/daily/catchup` pages that navigates back to home. Styled with hover and focus states matching the design system.
- **Safe area insets**: Updated padding calculations in the form and section elements to use `env(safe-area-inset-bottom)` for proper spacing on devices with notches or home indicators (e.g., iPhone).
- **Layout adjustments**:
  - Wrapped the progress indicator and close button in a flex container on the daily page
  - Restructured the catch-up page header to use flexbox for alignment
  - Adjusted form positioning from `bottom-16` to `bottom-0` on catch-up page (now handled by safe area padding)
  - Updated section padding calculations to account for form height and safe area insets
- **Navigation**: Hidden the main Nav component when on `/daily/*` routes (alongside existing `/onboarding` check)

## Implementation Details
- Close buttons use `Link` from `next/link` for client-side navigation
- Safe area insets use CSS `env()` function for responsive mobile support
- Form padding now includes `calc(0.75rem + env(safe-area-inset-bottom))` for proper spacing
- Section padding adjusted from fixed values to dynamic calculations based on content state

https://claude.ai/code/session_01KaaTprFoAveEJyKLhDvzQn