### PR TITLE
make the homepage feed an actionable inbox

### DIFF
--- a/src/server/db/queries/__tests__/feed.test.ts
+++ b/src/server/db/queries/__tests__/feed.test.ts
@@ -9,6 +9,7 @@ const { dbMock, state } = vi.hoisted(() => {
     | { op: 'inArray'; column: string; values: readonly unknown[] }
     | { op: 'isNull'; column: string }
     | { op: 'notInArray'; column: string; values: readonly unknown[] }
+    | { op: 'notExists' }
     | { op: 'lt'; column: string; value: unknown };
 
   type FeedRow = {
@@ -64,6 +65,11 @@ const { dbMock, state } = vi.hoisted(() => {
         return columnValue(predicate.column, feedItem, question) == null;
       case 'notInArray':
         return !predicate.values.includes(columnValue(predicate.column, feedItem, question));
+      case 'notExists':
+        // The tests don't model the masteryEvents table; treat the
+        // viewer-not-already-answered subquery as always passing so the
+        // existing visibility cases continue to drive what's exercised here.
+        return true;
       case 'lt':
         return String(columnValue(predicate.column, feedItem, question)) < String(predicate.value);
     }
@@ -110,6 +116,7 @@ vi.mock('drizzle-orm', () => ({
   isNull: vi.fn((column) => ({ op: 'isNull', column })),
   lt: vi.fn((column, value) => ({ op: 'lt', column, value })),
   ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  notExists: vi.fn(() => ({ op: 'notExists' })),
   notInArray: vi.fn((column, values) => ({ op: 'notInArray', column, values })),
   or: vi.fn((...predicates) => ({ op: 'or', predicates })),
   sql: Object.assign(
@@ -187,7 +194,11 @@ describe('getFeedForUser feed visibility', () => {
     expect(result.totalCount).toBe(1);
   });
 
-  it('keeps answered direct_sent items visible without pinned priority', async () => {
+  it('hides answered items from the actionable inbox query', async () => {
+    // The homepage feed is an inbox of things the viewer can still act on.
+    // Once a feed item is in state='answered' the server stops returning it;
+    // the client keeps the just-answered card in local React state for the
+    // current page session and it disappears on the next load.
     const sourceEventAt = new Date('2026-05-14T12:00:00.000Z');
     state.questionRows = [{ id: 'question-1', visibility: 'public', deletedAt: null, canonicalSubcategory: 'Music' }];
     state.feedRows = [{
@@ -206,15 +217,8 @@ describe('getFeedForUser feed visibility', () => {
 
     const result = await getFeedForUser('recipient-1');
 
-    expect(result.items).toEqual([
-      expect.objectContaining({
-        id: 'feed-answered-1',
-        sourceType: 'direct_sent',
-        state: 'answered',
-        isPinned: true,
-      }),
-    ]);
-    expect(result.totalCount).toBe(1);
+    expect(result.items).toEqual([]);
+    expect(result.totalCount).toBe(0);
   });
 
 

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,4 +1,4 @@
-import { and, count, desc, eq, inArray, isNull, lt, ne, notInArray, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, lt, ne, notExists, notInArray, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
 import { isVisibleFriendAnsweredSource, visibleFeedSourcePredicate } from '@/server/feed/visibility';
@@ -26,6 +26,10 @@ export type CollapsedFeedItem = FeedItem & {
 const VISIBLE_FEED_STATES = ['active', 'skipped', 'answered'] as const;
 const ACTION_REQUIRED_FEED_STATES = ['active', 'skipped'] as const;
 const BLOCKING_FEED_STATES = ['active', 'skipped', 'dismissed'] as const;
+// Homepage feed inbox: only items the viewer can still act on.
+// Answered cards stay in the client's local React state for the current
+// page session (see FeedList.submitAnswer) and disappear on next load.
+const ACTIONABLE_FEED_STATES = ACTION_REQUIRED_FEED_STATES;
 
 const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
 
@@ -272,9 +276,26 @@ function feedPinnedPredicate(pinned: boolean | undefined) {
     return and(eq(feedItems.isPinned, true), inArray(feedItems.state, ACTION_REQUIRED_FEED_STATES));
   }
 
+  return eq(feedItems.isPinned, false);
+}
+
+// Hide non-direct_sent items for questions the viewer has already answered
+// elsewhere (joshing game, catchup, an earlier feed card). direct_sent stays
+// — a friend addressed it to them specifically, and the server allows
+// re-grade on direct_sent so the card stays useful.
+function viewerNotAlreadyAnsweredPredicate(userId: string) {
   return or(
-    eq(feedItems.isPinned, false),
-    eq(feedItems.state, 'answered'),
+    eq(feedItems.sourceType, 'direct_sent'),
+    notExists(
+      db
+        .select({ id: masteryEvents.id })
+        .from(masteryEvents)
+        .where(and(
+          eq(masteryEvents.userId, userId),
+          eq(masteryEvents.answeredByUserId, userId),
+          eq(masteryEvents.questionId, feedItems.questionId),
+        )),
+    ),
   );
 }
 
@@ -330,9 +351,10 @@ async function fetchVisibleFeedItems(
       feedPinnedPredicate(options.pinned),
       visibleSourcePredicate,
       feedFilterPredicate(options.filter),
-      inArray(feedItems.state, VISIBLE_FEED_STATES),
+      inArray(feedItems.state, ACTIONABLE_FEED_STATES),
       visibleQuestionPredicate(dismissedDomains),
       viewerNotAuthorPredicate(userId),
+      viewerNotAlreadyAnsweredPredicate(userId),
       cursorPredicate,
     ))
     .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
@@ -357,9 +379,10 @@ async function fetchVisibleFeedItems(
         feedPinnedPredicate(options.pinned),
         visibleSourcePredicate,
         feedFilterPredicate(options.filter),
-        inArray(feedItems.state, VISIBLE_FEED_STATES),
+        inArray(feedItems.state, ACTIONABLE_FEED_STATES),
         visibleQuestionPredicate(dismissedDomains),
         viewerNotAuthorPredicate(userId),
+        viewerNotAlreadyAnsweredPredicate(userId),
         cursorPredicate,
       ))
       .orderBy(desc(feedItems.sourceEventAt), desc(feedItems.id))
@@ -389,9 +412,10 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
         eq(feedItems.recipientUserId, userId),
         visibleSourcePredicate,
         feedFilterPredicate(filter),
-        inArray(feedItems.state, VISIBLE_FEED_STATES),
+        inArray(feedItems.state, ACTIONABLE_FEED_STATES),
         visibleQuestionPredicate(dismissedDomains),
         viewerNotAuthorPredicate(userId),
+        viewerNotAlreadyAnsweredPredicate(userId),
       )),
   ]);
 

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -7,9 +7,9 @@
  * to hydrate <FeedList /> with the first page (no client round-trip).
  */
 
-import { and, count, eq, inArray, isNull, ne, or } from 'drizzle-orm';
+import { and, count, eq, inArray, isNull, ne, notExists, or } from 'drizzle-orm';
 
-import { db, feedItems, friendships, questions, users } from '@/server/db';
+import { db, feedItems, friendships, masteryEvents, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import {
   getDismissedDomains,
@@ -185,6 +185,21 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         feedFilterSourcePredicate(filter),
         inArray(feedItems.state, ['active', 'skipped']),
         or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
+        // Match the visibility rule applied in getFeedForUser so this
+        // diagnostic count reflects what the user actually sees.
+        or(
+          eq(feedItems.sourceType, 'direct_sent'),
+          notExists(
+            db
+              .select({ id: masteryEvents.id })
+              .from(masteryEvents)
+              .where(and(
+                eq(masteryEvents.userId, viewerUserId),
+                eq(masteryEvents.answeredByUserId, viewerUserId),
+                eq(masteryEvents.questionId, feedItems.questionId),
+              )),
+          ),
+        ),
       ))
       .then((rows) => rows[0]?.value ?? 0),
   ]);


### PR DESCRIPTION
The "From your friends" feed was duplicating Activity by surfacing both already-answered cards (answered_by_you) and friend-activity cards for questions the viewer had already answered elsewhere. Per request, the feed should now only show items the viewer can still answer or act on.

- Drop state='answered' from the feed query (ACTIONABLE_FEED_STATES). The just-answered card stays in FeedList's local React state for the current page session and disappears on the next load — no schema or session-timestamp plumbing needed.
- For non-direct_sent items, hide questions the viewer has already answered via mastery events (joshing, catchup, an earlier feed card). direct_sent stays visible regardless since the friend addressed it specifically and re-grade is allowed.
- Drop the answered carve-out from feedPinnedPredicate.
- Mirror the new visibility rule in the preFilterActiveCount query so the empty-state diagnostic stays accurate.