### PR TITLE
feat(P0-A): add user handles

### DIFF
--- a/drizzle/0045_user_handle.sql
+++ b/drizzle/0045_user_handle.sql
@@ -1,0 +1,22 @@
+-- Migration: introduce per-user public handle.
+--
+-- Required for invite links (/invite/<handle>/<token>) and exact-handle
+-- search. Nullable for now: a follow-up migration will tighten to NOT NULL
+-- once backfill is complete and signup is gated on entering a handle.
+-- The unique-lower index prevents 'Robyn' and 'robyn' from coexisting.
+--
+-- handle_last_changed_at gates the 30-day rate limit on handle changes
+-- (PATCH /api/account/handle). NULL on freshly-backfilled rows is treated
+-- as 'never changed', so the first user-initiated change is always allowed.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded
+-- without the columns actually present.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "handle" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_handle_lower"
+  ON "User" (LOWER("handle")) WHERE "handle" IS NOT NULL;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "handle_last_changed_at" timestamptz;

--- a/drizzle/0046_user_avatar_color.sql
+++ b/drizzle/0046_user_avatar_color.sql
@@ -1,0 +1,16 @@
+-- Migration: persist a deterministic avatar color per user.
+--
+-- Today src/components/feed/visual.ts derives avatar color on the fly from
+-- a hash of the user id. Persisting it gives future avatar-customization
+-- UI a place to write, and lets us render the chip without recomputing the
+-- hash on every page load.
+--
+-- The backfill script must use the existing colorForUser() helper so that
+-- already-rendered avatars don't visibly change color when this column
+-- starts being read.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded
+-- without the column actually present.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "avatar_color" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1780444800000,
       "tag": "0045_user_handle",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1780531200000,
+      "tag": "0046_user_avatar_color",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1780358400000,
       "tag": "0044_user_last_activity_bell_opened_at",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1780444800000,
+      "tag": "0045_user_handle",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-avatar-colors.ts
+++ b/scripts/backfill-avatar-colors.ts
@@ -1,0 +1,56 @@
+// One-shot script: populate users.avatar_color for every row that still has
+// NULL. Uses the existing colorForUser() so the persisted value matches what
+// the runtime helper has been computing — users won't see their avatar color
+// change when downstream callers start reading the column.
+//
+// Idempotent: skips rows that already have a color.
+//
+// Usage:
+//   npx tsx scripts/backfill-avatar-colors.ts            # dry-run
+//   npx tsx scripts/backfill-avatar-colors.ts --apply    # actually write
+
+import 'dotenv/config';
+
+import { eq, isNull } from 'drizzle-orm';
+
+import { colorForUser } from '../src/components/feed/visual';
+import { db, pool, users } from '../src/server/db';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+
+async function main() {
+  console.log(`[backfill-avatar-colors] ${APPLY ? 'APPLY' : 'DRY RUN'} mode\n`);
+
+  const candidates = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(isNull(users.avatarColor));
+
+  console.log(`[backfill-avatar-colors] ${candidates.length} users without an avatar color.`);
+
+  let updated = 0;
+
+  for (const user of candidates) {
+    const color = colorForUser(user.id);
+    console.log(`[backfill-avatar-colors] ${user.id} → ${color}`);
+    if (APPLY) {
+      await db
+        .update(users)
+        .set({ avatarColor: color, updatedAt: new Date() })
+        .where(eq(users.id, user.id));
+      updated++;
+    }
+  }
+
+  console.log(`\n[backfill-avatar-colors] done. updated=${updated}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-avatar-colors] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/scripts/backfill-user-handles.ts
+++ b/scripts/backfill-user-handles.ts
@@ -1,0 +1,109 @@
+// One-shot script: assign a handle to every user that doesn't have one yet.
+//
+// Strategy:
+//   1. Sanitize the user's displayName into the [a-z0-9_]+ allowed set.
+//   2. Truncate to 15 chars, append a 4-char random hex suffix (20 char cap).
+//   3. If the result collides (rare), retry with a fresh suffix up to 5 times.
+//   4. After 5 collisions, fall back to `user_<first 8 of UUID>`.
+//
+// Idempotent: skips rows where handle is already set. Safe to re-run.
+//
+// Usage:
+//   npx tsx scripts/backfill-user-handles.ts            # dry-run
+//   npx tsx scripts/backfill-user-handles.ts --apply    # actually write
+
+import 'dotenv/config';
+
+import { randomBytes } from 'crypto';
+import { eq, isNull } from 'drizzle-orm';
+
+import { db, pool, users } from '../src/server/db';
+import {
+  isReservedHandle,
+  isValidHandleFormat,
+  sanitizeForHandle,
+} from '../src/server/lib/handle-validation';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+
+function fourCharSuffix(): string {
+  return randomBytes(2).toString('hex');
+}
+
+function fallbackHandle(userId: string): string {
+  const slug = userId.replace(/-/g, '').slice(0, 8).toLowerCase();
+  return `user_${slug}`;
+}
+
+async function pickHandleForUser(userId: string, displayName: string | null): Promise<string> {
+  const base = sanitizeForHandle(displayName ?? '');
+
+  for (let attempt = 0; attempt < 5; attempt++) {
+    if (!base) break;
+    const suffix = fourCharSuffix();
+    const trimmedBase = base.slice(0, 15);
+    const candidate = `${trimmedBase}${suffix}`.toLowerCase();
+    if (!isValidHandleFormat(candidate)) continue;
+    if (isReservedHandle(candidate)) continue;
+
+    const taken = await db
+      .select({ id: users.id })
+      .from(users)
+      .where(eq(users.handle, candidate))
+      .limit(1);
+
+    if (taken.length === 0) return candidate;
+  }
+
+  return fallbackHandle(userId);
+}
+
+async function main() {
+  console.log(`[backfill-user-handles] ${APPLY ? 'APPLY' : 'DRY RUN'} mode\n`);
+
+  const candidates = await db
+    .select({ id: users.id, displayName: users.displayName, handle: users.handle })
+    .from(users)
+    .where(isNull(users.handle));
+
+  console.log(`[backfill-user-handles] ${candidates.length} users without a handle.`);
+
+  let assigned = 0;
+  let skipped = 0;
+  let fallbacks = 0;
+
+  for (const user of candidates) {
+    const chosen = await pickHandleForUser(user.id, user.displayName);
+    if (chosen.startsWith('user_')) fallbacks++;
+
+    console.log(`[backfill-user-handles] ${user.id} (${user.displayName ?? '—'}) → ${chosen}`);
+
+    if (APPLY) {
+      try {
+        await db
+          .update(users)
+          .set({ handle: chosen, updatedAt: new Date() })
+          .where(eq(users.id, user.id));
+        assigned++;
+      } catch (err) {
+        console.warn(
+          `[backfill-user-handles]   collision on ${chosen}:`,
+          err instanceof Error ? err.message : err,
+        );
+        skipped++;
+      }
+    }
+  }
+
+  console.log(`\n[backfill-user-handles] done. assigned=${assigned}, fallback=${fallbacks}, skipped=${skipped}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-user-handles] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -183,6 +183,9 @@ export default function AccountPage() {
         </div>
         <div className="flex min-w-0 flex-1 flex-col">
           <h1 className="font-serif text-4xl font-semibold leading-tight">{profile.displayName}</h1>
+          {profile.handle ? (
+            <p className="mt-1 text-sm text-muted-foreground">@{profile.handle}</p>
+          ) : null}
           <p className="mt-2 text-base text-muted-foreground">{profile.bio}</p>
           <p className="mt-3 inline-flex items-center gap-2 text-sm text-muted-foreground">
             <PhoneIcon className="size-4" />

--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -19,6 +19,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { SettingsGroup, SettingsRow } from '@/components/account/SettingsRow';
+import { colorForUser, initialsFor } from '@/components/feed/visual';
 import type { UserProfile } from '@/server/db/queries/account';
 
 type AccountResponse = {
@@ -26,20 +27,7 @@ type AccountResponse = {
   error?: string;
 };
 
-const AVATAR_COLORS = ['#0f766e', '#7c3aed', '#be123c', '#2563eb', '#b45309', '#15803d'];
 const APP_VERSION = 'v1.0.0';
-
-function initialsFor(name: string): string {
-  const parts = name.trim().split(/\s+/).filter(Boolean);
-  if (parts.length === 0) return '?';
-  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase();
-  return `${parts[0]![0] ?? ''}${parts[parts.length - 1]![0] ?? ''}`.toUpperCase();
-}
-
-function colorForUser(userId: string): string {
-  const hash = Array.from(userId).reduce((sum, char) => sum + char.charCodeAt(0), 0);
-  return AVATAR_COLORS[hash % AVATAR_COLORS.length]!;
-}
 
 function memberSince(value: string): string {
   const date = new Date(value);

--- a/src/app/api/account/handle/route.ts
+++ b/src/app/api/account/handle/route.ts
@@ -1,0 +1,89 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { getHandleChangeStatus, updateHandle } from '@/server/db/queries/account';
+import {
+  isReservedHandle,
+  isValidHandleFormat,
+  normalizeHandle,
+  validateHandle,
+} from '@/server/lib/handle-validation';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  handle: z.string().trim().min(3).max(20),
+});
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const status = await getHandleChangeStatus(session.userId);
+  if (!status) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  return NextResponse.json({
+    handle: status.handle,
+    handleLastChangedAt: status.handleLastChangedAt?.toISOString() ?? null,
+  });
+}
+
+export async function PATCH(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const json = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'Handle must be 3–20 characters.' },
+      { status: 400 },
+    );
+  }
+
+  const normalized = normalizeHandle(parsed.data.handle);
+  if (!isValidHandleFormat(normalized)) {
+    return NextResponse.json(
+      {
+        error: 'invalid_format',
+        message: 'Handle must start with a letter and use only lowercase letters, numbers, and underscores.',
+      },
+      { status: 400 },
+    );
+  }
+  if (isReservedHandle(normalized)) {
+    return NextResponse.json(
+      { error: 'reserved', message: 'That handle is reserved.' },
+      { status: 400 },
+    );
+  }
+
+  const verdict = await validateHandle(normalized, { excludeUserId: session.userId });
+  if (!verdict.ok) {
+    if (verdict.reason === 'taken') {
+      return NextResponse.json(
+        { error: 'taken', message: 'That handle is already taken.' },
+        { status: 409 },
+      );
+    }
+    return NextResponse.json(
+      { error: verdict.reason, message: 'That handle is not available.' },
+      { status: 400 },
+    );
+  }
+
+  const result = await updateHandle({ userId: session.userId, handle: normalized });
+  if (!result.ok) {
+    return NextResponse.json(
+      {
+        error: 'rate_limited',
+        message: 'You can change your handle once every 30 days.',
+        retryAfter: result.retryAfter.toISOString(),
+      },
+      { status: 429 },
+    );
+  }
+
+  return NextResponse.json({ ok: true, handle: result.handle });
+}

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -1,6 +1,9 @@
+import { randomUUID } from 'node:crypto'
+
 import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
+import { colorForUser } from '@/components/feed/visual'
 import { verifyOtp } from '@/server/auth'
 import { createSession } from '@/server/auth/session'
 import { db, users } from '@/server/db'
@@ -46,9 +49,13 @@ async function findUserByPhone(
 async function provisionUserForPhone(
   phoneNumber: string
 ): Promise<AuthUser> {
+  // Pre-generate the id so we can persist a deterministic avatar_color in the
+  // same insert (colorForUser hashes the id). Without this, avatar_color
+  // would be NULL until the next signup backfill.
+  const id = randomUUID()
   const [created] = await db
     .insert(users)
-    .values({ phoneNumber })
+    .values({ id, phoneNumber, avatarColor: colorForUser(id) })
     .onConflictDoNothing({ target: users.phoneNumber })
     .returning(USER_SELECTION)
 

--- a/src/app/api/handle/check/route.ts
+++ b/src/app/api/handle/check/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+import {
+  isReservedHandle,
+  isValidHandleFormat,
+  normalizeHandle,
+  validateHandle,
+} from '@/server/lib/handle-validation';
+
+export const dynamic = 'force-dynamic';
+
+// Public (no auth) so the signup handle picker can hit it before login.
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const raw = url.searchParams.get('handle') ?? '';
+  const normalized = normalizeHandle(raw);
+
+  if (!isValidHandleFormat(normalized)) {
+    return NextResponse.json({ available: false, reason: 'format' as const });
+  }
+  if (isReservedHandle(normalized)) {
+    return NextResponse.json({ available: false, reason: 'reserved' as const });
+  }
+
+  const result = await validateHandle(normalized);
+  if (result.ok) {
+    return NextResponse.json({ available: true });
+  }
+  return NextResponse.json({ available: false, reason: result.reason });
+}

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -9,6 +9,7 @@ import { US_STATES } from '@/lib/onboarding/us-regions'
 
 type CurrentStep =
   | 'display-name'
+  | 'handle'
   | 'invite-suggestions'
   | 'background'
   | 'warmup'
@@ -38,10 +39,22 @@ type OnboardingFlowProps = {
   inviterName?: string | null
   inviteeDisplayName?: string | null
   initialDisplayName?: string | null
+  initialHandle?: string | null
 }
 
 const DISPLAY_NAME_MIN = 2
 const DISPLAY_NAME_MAX = 30
+const HANDLE_MIN = 3
+const HANDLE_MAX = 20
+const HANDLE_FORMAT = /^[a-z][a-z0-9_]{2,19}$/
+
+function sanitizeForHandle(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '')
+    .replace(/^[^a-z]+/, '')
+    .slice(0, HANDLE_MAX)
+}
 
 type CanonicalSuggestion = {
   original: string
@@ -178,11 +191,14 @@ export default function OnboardingFlow({
   inviterName,
   inviteeDisplayName,
   initialDisplayName,
+  initialHandle,
 }: OnboardingFlowProps) {
   const router = useRouter()
   const hasInitialDisplayName = Boolean(initialDisplayName?.trim())
+  const hasInitialHandle = Boolean(initialHandle?.trim())
   const [currentStep, setCurrentStep] = useState<CurrentStep>(() => {
     if (!hasInitialDisplayName) return 'display-name'
+    if (!hasInitialHandle) return 'handle'
     return preSeededInterests.length > 0 ? 'invite-suggestions' : 'background'
   })
   const [displayName, setDisplayName] = useState<string>(() =>
@@ -192,6 +208,20 @@ export default function OnboardingFlow({
   )
   const [isSavingDisplayName, setIsSavingDisplayName] = useState(false)
   const [displayNameError, setDisplayNameError] = useState<string | null>(null)
+  const [handle, setHandle] = useState<string>(() => {
+    const seed = initialHandle?.trim()
+    if (seed) return seed.toLowerCase().slice(0, HANDLE_MAX)
+    return sanitizeForHandle(initialDisplayName ?? inviteeDisplayName ?? '')
+  })
+  const [handleTouched, setHandleTouched] = useState(false)
+  const [handleStatus, setHandleStatus] = useState<
+    | { state: 'idle' }
+    | { state: 'checking' }
+    | { state: 'available' }
+    | { state: 'unavailable'; reason: 'format' | 'reserved' | 'taken' }
+  >({ state: 'idle' })
+  const [isSavingHandle, setIsSavingHandle] = useState(false)
+  const [handleError, setHandleError] = useState<string | null>(null)
   const [birthYear, setBirthYear] = useState('')
   const [grewUpCountry, setGrewUpCountry] = useState('')
   const [grewUpRegion, setGrewUpRegion] = useState('')
@@ -263,6 +293,62 @@ export default function OnboardingFlow({
     ],
     [inviteInterests, proposedInterests]
   )
+
+  useEffect(() => {
+    if (currentStep !== 'handle') return
+
+    const candidate = handle.trim().toLowerCase()
+    const controller = new AbortController()
+
+    const immediate = window.setTimeout(() => {
+      if (candidate.length < HANDLE_MIN) {
+        setHandleStatus({ state: 'idle' })
+        return
+      }
+      if (!HANDLE_FORMAT.test(candidate)) {
+        setHandleStatus({ state: 'unavailable', reason: 'format' })
+        return
+      }
+      setHandleStatus({ state: 'checking' })
+    }, 0)
+
+    const debounced = window.setTimeout(async () => {
+      if (
+        candidate.length < HANDLE_MIN ||
+        !HANDLE_FORMAT.test(candidate)
+      ) {
+        return
+      }
+      try {
+        const response = await fetch(
+          `/api/handle/check?handle=${encodeURIComponent(candidate)}`,
+          { signal: controller.signal },
+        )
+        const data = await response.json().catch(() => ({}))
+        if (!response.ok) return
+        if (data?.available === true) {
+          setHandleStatus({ state: 'available' })
+        } else if (typeof data?.reason === 'string') {
+          setHandleStatus({
+            state: 'unavailable',
+            reason: data.reason as 'format' | 'reserved' | 'taken',
+          })
+        }
+      } catch (fetchError) {
+        if (
+          !(fetchError instanceof DOMException && fetchError.name === 'AbortError')
+        ) {
+          setHandleStatus({ state: 'idle' })
+        }
+      }
+    }, 300)
+
+    return () => {
+      controller.abort()
+      window.clearTimeout(immediate)
+      window.clearTimeout(debounced)
+    }
+  }, [currentStep, handle])
 
   useEffect(() => {
     if (!isLoading || currentStep !== 'warmup') return
@@ -478,13 +564,56 @@ export default function OnboardingFlow({
       }
 
       setDisplayName(trimmed)
-      setCurrentStep(
-        inviteInterests.length > 0 ? 'invite-suggestions' : 'background'
-      )
+      if (!handle && !hasInitialHandle) {
+        setHandle(sanitizeForHandle(trimmed))
+      }
+      setCurrentStep(hasInitialHandle ? nextStepAfterHandle() : 'handle')
     } catch {
       setDisplayNameError("We couldn't save that name. Try again.")
     } finally {
       setIsSavingDisplayName(false)
+    }
+  }
+
+  function nextStepAfterHandle(): CurrentStep {
+    return inviteInterests.length > 0 ? 'invite-suggestions' : 'background'
+  }
+
+  async function submitHandle() {
+    const candidate = handle.trim().toLowerCase()
+    if (!HANDLE_FORMAT.test(candidate)) {
+      setHandleError(
+        'Handle must be 3–20 characters, start with a letter, and use only lowercase letters, numbers, and underscores.'
+      )
+      return
+    }
+
+    setIsSavingHandle(true)
+    setHandleError(null)
+
+    try {
+      const response = await fetch('/api/account/handle', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ handle: candidate }),
+      })
+      const data = await response.json().catch(() => ({}))
+
+      if (!response.ok) {
+        setHandleError(
+          typeof data?.message === 'string'
+            ? data.message
+            : "We couldn't save that handle. Try again."
+        )
+        return
+      }
+
+      setHandle(candidate)
+      setCurrentStep(nextStepAfterHandle())
+    } catch {
+      setHandleError("We couldn't save that handle. Try again.")
+    } finally {
+      setIsSavingHandle(false)
     }
   }
 
@@ -668,6 +797,92 @@ export default function OnboardingFlow({
                   }
                 >
                   {isSavingDisplayName ? 'Saving...' : 'Continue'}
+                </button>
+              </form>
+            </div>
+          ) : null}
+
+          {currentStep === 'handle' ? (
+            <div className="flex flex-1 flex-col justify-center gap-8">
+              <StepHeader
+                title="Pick your handle"
+                subtitle={`This is your @ on Joshing — friends use it to find you. ${HANDLE_MIN}–${HANDLE_MAX} characters, lowercase letters, numbers, and underscores. Starts with a letter.`}
+              />
+
+              <form
+                className="space-y-4"
+                onSubmit={(event) => {
+                  event.preventDefault()
+                  if (!isSavingHandle) void submitHandle()
+                }}
+              >
+                <label className="block">
+                  <span className="text-sm font-medium">Your handle</span>
+                  <div className="mt-2 flex items-center gap-2">
+                    <span className="text-muted-foreground text-base">@</span>
+                    <input
+                      type="text"
+                      className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
+                      placeholder="yourhandle"
+                      autoFocus
+                      autoCapitalize="none"
+                      autoCorrect="off"
+                      spellCheck={false}
+                      maxLength={HANDLE_MAX}
+                      value={handle}
+                      onChange={(e) => {
+                        setHandleTouched(true)
+                        setHandle(
+                          e.target.value
+                            .toLowerCase()
+                            .replace(/[^a-z0-9_]/g, '')
+                            .slice(0, HANDLE_MAX),
+                        )
+                        if (handleError) setHandleError(null)
+                      }}
+                    />
+                  </div>
+                </label>
+
+                {handleTouched && handle.length >= HANDLE_MIN ? (
+                  <p
+                    className={`text-sm ${
+                      handleStatus.state === 'available'
+                        ? 'text-emerald-600'
+                        : handleStatus.state === 'unavailable'
+                          ? 'text-destructive'
+                          : 'text-muted-foreground'
+                    }`}
+                  >
+                    {handleStatus.state === 'checking'
+                      ? 'Checking…'
+                      : handleStatus.state === 'available'
+                        ? `@${handle} is available.`
+                        : handleStatus.state === 'unavailable'
+                          ? handleStatus.reason === 'taken'
+                            ? 'That handle is already taken.'
+                            : handleStatus.reason === 'reserved'
+                              ? 'That handle is reserved.'
+                              : 'Use only lowercase letters, numbers, and underscores. Start with a letter.'
+                          : null}
+                  </p>
+                ) : null}
+
+                {handleError ? (
+                  <p className="text-destructive text-sm">{handleError}</p>
+                ) : null}
+
+                <button
+                  type="submit"
+                  className="btn-primary h-12 w-full"
+                  disabled={
+                    isSavingHandle ||
+                    handle.length < HANDLE_MIN ||
+                    handleStatus.state === 'checking' ||
+                    handleStatus.state === 'unavailable'
+                  }
+                >
+                  {isSavingHandle ? 'Saving…' : 'Continue'}
                 </button>
               </form>
             </div>

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -53,6 +53,7 @@ export default async function OnboardingPage() {
       inviterName={seeded.inviterName}
       inviteeDisplayName={seeded.inviteeDisplayName}
       initialDisplayName={user.displayName}
+      initialHandle={user.handle}
     />
   );
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -95,6 +95,11 @@ export default async function UserProfilePage({
               <h1 className="text-foreground font-serif text-3xl font-semibold">
                 {portrait.user.displayName}
               </h1>
+              {portrait.user.handle ? (
+                <p className="text-muted-foreground mt-1 text-sm">
+                  @{portrait.user.handle}
+                </p>
+              ) : null}
               <p className="text-muted-foreground mt-2 text-sm leading-6">
                 On Joshing since {formatMemberSince(portrait.user.memberSince)}.
               </p>
@@ -176,6 +181,11 @@ export default async function UserProfilePage({
             <h1 className="text-foreground font-serif text-3xl font-semibold">
               {portrait.user.displayName}
             </h1>
+            {portrait.user.handle ? (
+              <p className="text-muted-foreground mt-1 text-sm">
+                @{portrait.user.handle}
+              </p>
+            ) : null}
             <p className="text-muted-foreground mt-2 text-sm leading-6">
               On Joshing since {formatMemberSince(portrait.user.memberSince)}.
             </p>

--- a/src/components/AvatarChip.tsx
+++ b/src/components/AvatarChip.tsx
@@ -1,0 +1,47 @@
+// Initials chip with deterministic background color. Designed to be dropped
+// into friends lists, request rows, and search results so the visual variety
+// in the friends surfaces (`[SA]`, `[RO]`) actually renders with distinct
+// colors per user.
+//
+// Color comes from the persisted users.avatar_color when available, falling
+// back to colorForUser() so this works for any caller that hasn't (or can't)
+// load the column. initialsFor() is the same helper the feed cards use.
+
+import { AVATAR_COLORS, colorForUser, initialsFor, isDarkColor } from '@/components/feed/visual'
+
+type Size = 'sm' | 'md' | 'lg'
+
+const SIZE_CLASSES: Record<Size, string> = {
+  sm: 'h-7 w-7 text-[10px]',
+  md: 'h-9 w-9 text-xs',
+  lg: 'h-12 w-12 text-sm',
+}
+
+function normalizeColor(color: string | null | undefined, userId: string): string {
+  if (color && (AVATAR_COLORS as readonly string[]).includes(color)) return color
+  return colorForUser(userId)
+}
+
+type AvatarChipProps = {
+  displayName: string
+  userId: string
+  color?: string | null
+  size?: Size
+}
+
+export function AvatarChip({ displayName, userId, color, size = 'md' }: AvatarChipProps) {
+  const bg = normalizeColor(color, userId)
+  const onDark = isDarkColor(bg)
+  return (
+    <div
+      aria-hidden
+      className={`grid shrink-0 place-items-center rounded-full font-semibold ${SIZE_CLASSES[size]}`}
+      style={{
+        backgroundColor: bg,
+        color: onDark ? 'var(--cream, #fff)' : 'var(--ink, #111)',
+      }}
+    >
+      {initialsFor(displayName)}
+    </div>
+  )
+}

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -5,7 +5,7 @@ import PeopleYouInvited from '@/components/PeopleYouInvited'
 import { formatRelativeTime } from '@/components/feed/visual'
 import { useCallback, useEffect, useState } from 'react'
 
-type Tab = 'friends' | 'requests' | 'sent'
+type Tab = 'friends' | 'invitations' | 'sent'
 
 type Friend = {
   id: string
@@ -132,13 +132,13 @@ export default function FriendsList() {
         <button
           type="button"
           className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'requests'
+            activeTab === 'invitations'
               ? 'border-b-2 border-foreground text-foreground'
               : 'text-muted-foreground hover:text-foreground'
           }`}
-          onClick={() => setActiveTab('requests')}
+          onClick={() => setActiveTab('invitations')}
         >
-          Requests
+          Invitations
           {incomingRequests.length > 0 ? (
             <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-xs leading-none">
               {incomingRequests.length}
@@ -226,11 +226,11 @@ export default function FriendsList() {
         </section>
       ) : null}
 
-      {/* Requests tab */}
-      {activeTab === 'requests' ? (
+      {/* Invitations tab */}
+      {activeTab === 'invitations' ? (
         <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
           {loading ? (
-            <p className="text-muted-foreground text-sm">Loading requests…</p>
+            <p className="text-muted-foreground text-sm">Loading invitations…</p>
           ) : incomingRequests.length > 0 ? (
             <div className="space-y-3">
               {incomingRequests.map((request) => (
@@ -293,7 +293,7 @@ export default function FriendsList() {
             </div>
           ) : (
             <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
-              No incoming requests right now.
+              No incoming invitations right now.
             </p>
           )}
         </section>

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -32,11 +32,11 @@ describe('Friends page QA surface', () => {
     expect(html).not.toMatch(forbiddenGamificationCopy)
   })
 
-  it('renders the Friends / Requests / Sent tab bar with the friends tab active by default', () => {
+  it('renders the Friends / Invitations / Sent tab bar with the friends tab active by default', () => {
     const html = renderToStaticMarkup(<FriendsList />)
 
     expect(html).toContain('Friends')
-    expect(html).toContain('Requests')
+    expect(html).toContain('Invitations')
     expect(html).toContain('Sent')
     expect(html).toContain('Loading friends')
     expect(html).not.toMatch(forbiddenGamificationCopy)

--- a/src/components/feed/visual.ts
+++ b/src/components/feed/visual.ts
@@ -9,7 +9,7 @@ const CATEGORY_COLORS = [
   '#0369a1',
 ] as const
 
-const AVATAR_COLORS = [
+export const AVATAR_COLORS = [
   '#0f766e',
   '#7c3aed',
   '#be123c',
@@ -17,6 +17,8 @@ const AVATAR_COLORS = [
   '#b45309',
   '#15803d',
 ] as const
+
+export type AvatarColor = (typeof AVATAR_COLORS)[number]
 
 function hashString(str: string): number {
   return Array.from(str).reduce((sum, char) => sum + char.charCodeAt(0), 0)

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -538,6 +538,21 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0046 adds the nullable User.avatar_color column. The value
+    // is computed at signup via colorForUser(id) so the persisted color
+    // matches what the runtime helper already renders. Guard for
+    // preview/production databases that may have the migration recorded
+    // without the column actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "avatar_color" text
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -516,6 +516,28 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0045 introduces the public-facing User.handle plus the
+    // handle_last_changed_at rate-limit anchor. Guard for preview/production
+    // databases that may have this migration recorded without the column
+    // or unique-lower index actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "handle" text
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "handle_last_changed_at" timestamp with time zone
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_handle_lower"
+          ON "User" (LOWER("handle")) WHERE "handle" IS NOT NULL
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -11,10 +11,13 @@ import { formatBio } from '@/server/profile/bio';
 export type UserProfile = {
   id: string;
   displayName: string;
+  handle: string | null;
   phoneNumber: string;
   createdAt: string;
   bio: string;
 };
+
+export const HANDLE_CHANGE_COOLDOWN_DAYS = 30;
 
 function formatPhoneNumber(value: string): string {
   const digits = value.replace(/\D/g, '');
@@ -39,6 +42,7 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
     .select({
       id: users.id,
       displayName: users.displayName,
+      handle: users.handle,
       phoneNumber: users.phoneNumber,
       createdAt: users.createdAt,
     })
@@ -76,6 +80,7 @@ export async function getUserProfile(userId: string): Promise<UserProfile | null
   return {
     id: user.id,
     displayName: user.displayName?.trim() || fallbackDisplayName(user.phoneNumber),
+    handle: user.handle?.trim() ? user.handle.trim() : null,
     phoneNumber: formatPhoneNumber(user.phoneNumber),
     createdAt: user.createdAt.toISOString(),
     bio,
@@ -183,6 +188,79 @@ export async function updateDisplayName(params: {
     .set({ displayName, updatedAt: new Date() })
     .where(eq(users.id, params.userId));
 
+  return { ok: true };
+}
+
+export type HandleChangeStatus = {
+  handle: string | null;
+  handleLastChangedAt: Date | null;
+};
+
+export async function getHandleChangeStatus(userId: string): Promise<HandleChangeStatus | null> {
+  const [row] = await db
+    .select({ handle: users.handle, handleLastChangedAt: users.handleLastChangedAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) return null;
+  return { handle: row.handle, handleLastChangedAt: row.handleLastChangedAt };
+}
+
+export type UpdateHandleResult =
+  | { ok: true; handle: string }
+  | { ok: false; reason: 'rate_limited'; retryAfter: Date };
+
+// Writes a new handle, stamping handleLastChangedAt to now. Rate-limit: a
+// successful change locks the user out of further changes for
+// HANDLE_CHANGE_COOLDOWN_DAYS. Callers must validate format/reserved/taken
+// upstream (see src/server/lib/handle-validation.ts).
+export async function updateHandle(params: {
+  userId: string;
+  handle: string;
+}): Promise<UpdateHandleResult> {
+  const handle = params.handle.trim().toLowerCase();
+  const now = new Date();
+
+  const status = await getHandleChangeStatus(params.userId);
+  if (status?.handleLastChangedAt) {
+    const elapsedMs = now.getTime() - status.handleLastChangedAt.getTime();
+    const cooldownMs = HANDLE_CHANGE_COOLDOWN_DAYS * 24 * 60 * 60 * 1000;
+    if (elapsedMs < cooldownMs) {
+      const retryAfter = new Date(status.handleLastChangedAt.getTime() + cooldownMs);
+      return { ok: false, reason: 'rate_limited', retryAfter };
+    }
+  }
+
+  await db
+    .update(users)
+    .set({ handle, handleLastChangedAt: now, updatedAt: now })
+    .where(eq(users.id, params.userId));
+
+  return { ok: true, handle };
+}
+
+// Initial assignment (no rate-limit gate) — used by the onboarding handle
+// picker and the backfill script. Returns ok:false if the handle was claimed
+// by another user between validation and write (race).
+export async function assignInitialHandle(params: {
+  userId: string;
+  handle: string;
+}): Promise<{ ok: boolean }> {
+  const handle = params.handle.trim().toLowerCase();
+  const now = new Date();
+
+  try {
+    await db
+      .update(users)
+      .set({ handle, updatedAt: now })
+      .where(eq(users.id, params.userId));
+  } catch (err) {
+    if (err instanceof Error && /unique/i.test(err.message)) {
+      return { ok: false };
+    }
+    throw err;
+  }
   return { ok: true };
 }
 

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -186,6 +186,7 @@ export const getUserOnboardingProfile = cache(async (userId: string) => {
       id: users.id,
       phoneNumber: users.phoneNumber,
       displayName: users.displayName,
+      handle: users.handle,
       timezone: users.timezone,
       preferredTheme: users.preferredTheme,
       onboardingComplete: users.onboardingComplete,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -167,6 +167,7 @@ export const users = pgTable(
     slug: text('slug'),
     handle: text('handle'),
     handleLastChangedAt: timestamp('handle_last_changed_at', { withTimezone: true }),
+    avatarColor: text('avatar_color'),
     authorProfilePublic: boolean('authorProfilePublic').notNull().default(true),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
     birthYear: integer('birth_year'),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -165,6 +165,8 @@ export const users = pgTable(
     knowledgeCardShareToken: text('knowledge_card_share_token'),
     knowledgeCardShareExpiresAt: timestamp('knowledge_card_share_expires_at', { withTimezone: true }),
     slug: text('slug'),
+    handle: text('handle'),
+    handleLastChangedAt: timestamp('handle_last_changed_at', { withTimezone: true }),
     authorProfilePublic: boolean('authorProfilePublic').notNull().default(true),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
     birthYear: integer('birth_year'),

--- a/src/server/lib/handle-validation.ts
+++ b/src/server/lib/handle-validation.ts
@@ -1,0 +1,112 @@
+// Public-handle validation. Used by:
+//   - GET /api/handle/check (signup picker, debounced live validation)
+//   - PATCH /api/account/handle (authenticated handle change)
+//   - scripts/backfill-user-handles.ts (one-shot backfill)
+//
+// Format and reserved list are enumerated below — top-level routes are
+// snapshotted as a constant rather than computed at runtime so the list
+// stays deterministic across builds.
+
+import { sql } from 'drizzle-orm';
+
+import { db, users } from '@/server/db';
+
+// Enumerated from src/app/ top-level directories (2026-05-23 audit). Anything
+// that resolves to a top-level route must NOT be claimable as a handle.
+const ROUTE_RESERVED = [
+  'account',
+  'activities',
+  'api',
+  'archive',
+  'ceremony',
+  'creator-notes',
+  'daily',
+  'dev',
+  'feed',
+  'friends',
+  'games',
+  'invite',
+  'knowledge',
+  'login',
+  'new-game',
+  'onboarding',
+  'questions',
+  'replay',
+  'share',
+  'users',
+] as const;
+
+const NAME_RESERVED = [
+  'admin',
+  'joshing',
+  'system',
+  'api',
+  'account',
+  'friends',
+  'invite',
+  'me',
+  'support',
+] as const;
+
+const RESERVED = new Set<string>([
+  ...ROUTE_RESERVED.map((entry) => entry.toLowerCase()),
+  ...NAME_RESERVED.map((entry) => entry.toLowerCase()),
+]);
+
+// Must start with a letter, then 2–19 chars of [a-z0-9_]. Total length 3–20.
+// Lowercase only; callers normalize before validating.
+const FORMAT = /^[a-z][a-z0-9_]{2,19}$/;
+
+export type HandleValidationResult =
+  | { ok: true }
+  | { ok: false; reason: 'format' | 'reserved' | 'taken' };
+
+export function isValidHandleFormat(handle: string): boolean {
+  return FORMAT.test(handle);
+}
+
+export function isReservedHandle(handle: string): boolean {
+  return RESERVED.has(handle.toLowerCase());
+}
+
+export function normalizeHandle(raw: string): string {
+  return raw.trim().toLowerCase();
+}
+
+// Strip non-[a-z0-9_], lowercase, ensure leading letter. Returns null when
+// nothing usable remains — caller must fall back to a uuid-derived handle.
+export function sanitizeForHandle(input: string): string | null {
+  const stripped = input
+    .toLowerCase()
+    .replace(/[^a-z0-9_]/g, '')
+    .replace(/^[^a-z]+/, '');
+
+  if (!stripped) return null;
+  return stripped.slice(0, 16);
+}
+
+export async function isHandleTaken(handle: string, excludeUserId?: string): Promise<boolean> {
+  const normalized = normalizeHandle(handle);
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(sql`LOWER(${users.handle}) = ${normalized}`)
+    .limit(1);
+
+  if (rows.length === 0) return false;
+  if (excludeUserId && rows[0]?.id === excludeUserId) return false;
+  return true;
+}
+
+export async function validateHandle(
+  raw: string,
+  options: { excludeUserId?: string } = {},
+): Promise<HandleValidationResult> {
+  const normalized = normalizeHandle(raw);
+  if (!isValidHandleFormat(normalized)) return { ok: false, reason: 'format' };
+  if (isReservedHandle(normalized)) return { ok: false, reason: 'reserved' };
+  if (await isHandleTaken(normalized, options.excludeUserId)) {
+    return { ok: false, reason: 'taken' };
+  }
+  return { ok: true };
+}

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -31,6 +31,7 @@ export type FriendPortraitData = {
   user: {
     id: string
     displayName: string
+    handle: string | null
     memberSince: Date
   }
   visibility: FriendProfileVisibility
@@ -154,6 +155,7 @@ export async function getFriendPortraitData(
         viewedUser.displayName,
         viewedUser.phoneNumber
       ),
+      handle: viewedUser.handle?.trim() ? viewedUser.handle.trim() : null,
       memberSince: viewedUser.createdAt,
     },
     visibility,


### PR DESCRIPTION
Introduces a per-user public @handle backed by the new "User"."handle"
column with a case-insensitive unique-lower index. Handle is required to
become useful for invite links (/invite/<handle>/<token>) and exact-handle
search in subsequent B-Friends work.

- Migration 0045 adds nullable handle + handle_last_changed_at; instrumentation
  guards mirror the column add and unique-lower index.
- src/server/lib/handle-validation.ts is the single validator (format +
  reserved list snapshot of current top-level routes + name reservations).
- GET /api/handle/check is public so the signup picker can hit it pre-login;
  PATCH /api/account/handle is authenticated and rate-limited to once per 30
  days via users.handle_last_changed_at.
- Onboarding gains a 'handle' step after display-name, with debounced live
  validation against /api/handle/check.
- @handle renders beneath displayName on /account and /users/[id] in all
  visibility modes when set.
- scripts/backfill-user-handles.ts is the one-shot script for existing rows
  (sanitized displayName + 4-char hex suffix, with fallback to user_<uuid8>).