### PR TITLE
Reframe Lately copy around shared knowledge

### DIFF
--- a/src/components/lately/MomentRow.tsx
+++ b/src/components/lately/MomentRow.tsx
@@ -23,7 +23,6 @@ export function MomentRow({
   defaultOpen = false,
 }: Props) {
   const [open, setOpen] = useState(defaultOpen);
-  const theyGotYou = moment.dir === 'they_got_you';
 
   function handleSend(e: MouseEvent) {
     e.stopPropagation();
@@ -98,11 +97,7 @@ export function MomentRow({
           marginBottom: open ? 14 : 12,
         }}
       >
-        {theyGotYou ? (
-          <>{nameLink} got you on {categorySpan}.</>
-        ) : (
-          <>You got {nameLink} on {categorySpan}.</>
-        )}
+        <>You and {nameLink} both know {categorySpan}.</>
       </div>
 
       {open ? (

--- a/src/lib/__tests__/lately.test.ts
+++ b/src/lib/__tests__/lately.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 
-import { assignCaption, bucketMoments, formatMomentTime } from '@/lib/lately';
+import {
+  assignCaption,
+  bucketMoments,
+  formatMomentTime,
+  SHARED_CAPTIONS,
+} from '@/lib/lately';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 
 function moment(overrides: Partial<LatelyMoment> & { answeredAt: Date }): LatelyMoment {
@@ -20,28 +25,17 @@ function moment(overrides: Partial<LatelyMoment> & { answeredAt: Date }): Lately
 }
 
 describe('assignCaption', () => {
-  it('returns a caption from the they_got_you pool when dir is they_got_you', () => {
-    const pool = new Set([
-      'THEY KNEW YOU',
-      'ROBYN GOT IT',
-      'THEY SAW IT',
-      'A MATCH',
-      'ON YOUR FREQUENCY',
-    ]);
-    const caption = assignCaption('any-id', 'they_got_you', 'Robyn');
-    expect(pool.has(caption)).toBe(true);
+  const pool = new Set<string>(SHARED_CAPTIONS);
+
+  it('returns a caption from the shared pool regardless of direction', () => {
+    expect(pool.has(assignCaption('any-id', 'they_got_you', 'Robyn'))).toBe(true);
+    expect(pool.has(assignCaption('any-id', 'you_got_them', 'Robyn'))).toBe(true);
   });
 
-  it('returns a caption from the you_got_them pool when dir is you_got_them', () => {
-    const pool = new Set([
-      'YOU KNEW THEM',
-      'YOU SAW IT',
-      'YOU NAILED IT',
-      'A MATCH',
-      'ON THEIR FREQUENCY',
-    ]);
-    const caption = assignCaption('any-id', 'you_got_them', 'Robyn');
-    expect(pool.has(caption)).toBe(true);
+  it('returns the same caption for both directions given the same momentId', () => {
+    const a = assignCaption('stable-id', 'they_got_you', 'Robyn');
+    const b = assignCaption('stable-id', 'you_got_them', 'Jamie');
+    expect(a).toBe(b);
   });
 
   it('is deterministic across calls', () => {
@@ -49,17 +43,12 @@ describe('assignCaption', () => {
       .toBe(assignCaption('stable-id', 'they_got_you', 'Robyn'));
   });
 
-  it('substitutes the friend first name (uppercase) into the {NAME} slot', () => {
-    // Find an id that lands on the {NAME} template (pool index 1).
-    let id = 'x';
-    for (let i = 0; i < 200; i++) {
-      const c = assignCaption(`probe-${i}`, 'they_got_you', 'jamie');
-      if (c === 'JAMIE GOT IT') {
-        id = `probe-${i}`;
-        break;
-      }
+  it('distributes across the pool over many ids', () => {
+    const seen = new Set<string>();
+    for (let i = 0; i < 20; i++) {
+      seen.add(assignCaption(`probe-${i}`, 'they_got_you', 'Robyn'));
     }
-    expect(assignCaption(id, 'they_got_you', 'jamie')).toBe('JAMIE GOT IT');
+    expect(seen.size).toBeGreaterThanOrEqual(3);
   });
 });
 

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -7,21 +7,15 @@ export type LatelyBucket = {
   items: LatelyMoment[];
 };
 
-const THEY_GOT_YOU_POOL: ReadonlyArray<string> = [
-  'THEY KNEW YOU',
-  '{NAME} GOT IT',
-  'THEY SAW IT',
+export const SHARED_CAPTIONS = [
+  'SHARED FREQUENCY',
+  'BOTH OF YOU',
+  'COMMON GROUND',
   'A MATCH',
-  'ON YOUR FREQUENCY',
-];
-
-const YOU_GOT_THEM_POOL: ReadonlyArray<string> = [
-  'YOU KNEW THEM',
-  'YOU SAW IT',
-  'YOU NAILED IT',
-  'A MATCH',
-  'ON THEIR FREQUENCY',
-];
+  'ON THE SAME WAVELENGTH',
+  'TWO MINDS, ONE ANSWER',
+  'A SHARED CORNER',
+] as const;
 
 function djb2(input: string): number {
   let hash = 5381;
@@ -33,12 +27,10 @@ function djb2(input: string): number {
 
 export function assignCaption(
   momentId: string,
-  dir: LatelyDirection,
-  friendFirstName: string,
+  _dir: LatelyDirection,
+  _friendFirstName: string,
 ): string {
-  const pool = dir === 'they_got_you' ? THEY_GOT_YOU_POOL : YOU_GOT_THEM_POOL;
-  const template = pool[djb2(momentId) % pool.length];
-  return template.replace('{NAME}', friendFirstName.toUpperCase());
+  return SHARED_CAPTIONS[djb2(momentId) % SHARED_CAPTIONS.length];
 }
 
 function ymdInZone(date: Date, tz: string): string {


### PR DESCRIPTION
## Summary
- Every moment row now reads `You and {Friend} both know {category}.` regardless of who authored vs who answered — the connection is the headline, not the win/loss.
- Caption pool collapses from two direction-specific lists into a single shared-knowledge pool: `SHARED FREQUENCY`, `BOTH OF YOU`, `COMMON GROUND`, `A MATCH`, `ON THE SAME WAVELENGTH`, `TWO MINDS, ONE ANSWER`, `A SHARED CORNER`.
- `dir` is still carried on the moment and on the `SEND TO A FRIEND` payload so the (out-of-scope) send flow can still use directionality.

## Test plan
- [x] `npx vitest run src/lib/__tests__/lately.test.ts` — 11/11 pass (caption pool membership, determinism, distribution).
- [x] `npx tsc -p tsconfig.typecheck.json` — clean.
- [ ] Visit `/activities` on a logged-in account with recent cross-author correct answers; confirm sentence reads `You and {Friend} both know {category}.` and captions come from the new pool.
- [ ] Confirm captions are stable across reloads.
- [ ] Confirm `SEND TO A FRIEND →` still logs the payload with `dir` intact.

https://claude.ai/code/session_011USGcaqeBuMEKRfQ3MyPJy

---
_Generated by [Claude Code](https://claude.ai/code/session_011USGcaqeBuMEKRfQ3MyPJy)_