### PR TITLE
Add privacy & discoverability settings UI and schema foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - **LLM calls:** centralized under `src/server/llm/` (and `src/lib/llm.ts`).
 - **Anthropic model split:** Sonnet (`claude-sonnet-4-6`) for generation; Haiku (`claude-haiku-4-5-20251001`) for grading and categorization. Don't swap these without measuring quality and cost.
 - **`_salvaged/`** is excluded from TypeScript (`tsconfig.json`) and ESLint (`eslint.config.mjs`). **Never edit anything inside it.**
+- **`PHONE_HASH_SALT`** is required in production (enforced at boot in `src/instrumentation.ts`). Used by `src/server/lib/phone-hashing.ts` and the client-side hashing path B-Friends-4 will add. Rotating it invalidates every `ContactHash` row and every persisted `User.phone_hash`.
 
 ## Further reading
 - Architecture overview: `_docs/ARCHITECTURAL-DECISIONS.md` (may contain stale claims — treat as background, not gospel).

--- a/drizzle/0048_friends_privacy_foundation.sql
+++ b/drizzle/0048_friends_privacy_foundation.sql
@@ -1,0 +1,91 @@
+-- Migration: schema foundation for the friends/privacy work (B-Friends-1).
+--
+-- Adds three independent pieces in one file:
+--
+--   1. Discoverability flags on User (default FALSE). Nothing reads them
+--      yet; B-Friends-3 / B-Friends-4 will. Privacy & visibility page goes
+--      live as part of this work.
+--   2. ContactHash table — stores SHA-256 hashes of a user's E.164 phone
+--      contacts so B-Friends-4 can match against User.phone_hash without
+--      the server ever seeing the raw numbers. Cascades on User delete.
+--   3. Friendship extension — personalNote (≤160), expiresAt, resolvedAt.
+--      The existing pending-friendship mechanism gains a freeform note,
+--      a 30-day expiry, and a resolved-at timestamp. B-Friends-2 wires
+--      the lifecycle endpoints. Two CHECK constraints (note length and
+--      "users distinct") plus two partial indexes for the expiry cron
+--      and the post-resolution decay GC.
+--
+-- Idempotent guards mirroring this migration also land in
+-- src/instrumentation.ts so preview/production databases that may have the
+-- migration recorded without the columns/constraints actually present can
+-- still boot.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "discoverable_by_contacts" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "discoverable_by_mutual_friends" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ContactHash" (
+  "userId"     text NOT NULL,
+  "phoneHash"  text NOT NULL,
+  "uploadedAt" timestamptz NOT NULL DEFAULT NOW(),
+  PRIMARY KEY ("userId", "phoneHash")
+);
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'ContactHash_userId_User_id_fk'
+      AND conrelid = to_regclass('public."ContactHash"')
+  ) THEN
+    ALTER TABLE "ContactHash"
+      ADD CONSTRAINT "ContactHash_userId_User_id_fk"
+      FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ContactHash_phoneHash_idx" ON "ContactHash" ("phoneHash");
+--> statement-breakpoint
+ALTER TABLE "Friendship"
+  ADD COLUMN IF NOT EXISTS "personalNote" text;
+--> statement-breakpoint
+ALTER TABLE "Friendship"
+  ADD COLUMN IF NOT EXISTS "expiresAt" timestamptz;
+--> statement-breakpoint
+ALTER TABLE "Friendship"
+  ADD COLUMN IF NOT EXISTS "resolvedAt" timestamptz;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'Friendship'
+      AND constraint_name = 'friendship_personal_note_length'
+  ) THEN
+    ALTER TABLE "Friendship"
+      ADD CONSTRAINT friendship_personal_note_length
+      CHECK (char_length("personalNote") <= 160);
+  END IF;
+END $$;
+--> statement-breakpoint
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM information_schema.table_constraints
+    WHERE table_schema = 'public'
+      AND table_name = 'Friendship'
+      AND constraint_name = 'friendship_users_distinct'
+  ) THEN
+    ALTER TABLE "Friendship"
+      ADD CONSTRAINT friendship_users_distinct
+      CHECK ("userAId" <> "userBId");
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Friendship_expiresAt_pending_idx"
+  ON "Friendship" ("expiresAt") WHERE status = 'pending';
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Friendship_resolvedAt_decay_idx"
+  ON "Friendship" ("resolvedAt") WHERE status IN ('declined', 'expired');

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -337,6 +337,13 @@
       "when": 1780617600000,
       "tag": "0047_user_profile_fields",
       "breakpoints": true
+    },
+    {
+      "idx": 48,
+      "version": "7",
+      "when": 1780704000000,
+      "tag": "0048_friends_privacy_foundation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/account/privacy/PrivacyForm.tsx
+++ b/src/app/account/privacy/PrivacyForm.tsx
@@ -1,0 +1,144 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { DiscoverabilityState } from '@/server/db/queries/account';
+
+type Props = {
+  initialState: DiscoverabilityState;
+};
+
+type PatchKey = 'contacts' | 'mutualFriends';
+
+async function patchDiscoverability(
+  body: Partial<Record<PatchKey, boolean>>,
+): Promise<{
+  ok: boolean;
+  state: DiscoverabilityState | null;
+  errorMessage: string | null;
+}> {
+  const response = await fetch('/api/account/discoverability', {
+    method: 'PATCH',
+    credentials: 'include',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const json = (await response.json().catch(() => null)) as {
+    state?: DiscoverabilityState;
+    message?: string;
+  } | null;
+  if (!response.ok) {
+    return { ok: false, state: null, errorMessage: json?.message ?? 'Could not save.' };
+  }
+  return { ok: true, state: json?.state ?? null, errorMessage: null };
+}
+
+function ToggleRow({
+  title,
+  description,
+  checked,
+  saving,
+  disabled,
+  onToggle,
+}: {
+  title: string;
+  description: string;
+  checked: boolean;
+  saving?: boolean;
+  disabled?: boolean;
+  onToggle?: () => void;
+}) {
+  return (
+    <section className="rounded-xl border bg-card p-5 text-card-foreground">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex min-w-0 flex-1 flex-col">
+          <h2 className="font-serif text-lg font-semibold">{title}</h2>
+          <p className="mt-1 text-sm text-muted-foreground">{description}</p>
+        </div>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={checked}
+          aria-disabled={disabled || undefined}
+          disabled={disabled || saving}
+          onClick={onToggle}
+          className={`relative inline-flex h-7 w-12 flex-none items-center rounded-full border transition ${
+            checked ? 'bg-emerald-500 border-emerald-500' : 'bg-muted border-border'
+          } ${disabled ? 'cursor-not-allowed opacity-60' : ''} ${
+            saving ? 'opacity-60' : ''
+          }`}
+        >
+          <span
+            className={`inline-block size-5 rounded-full bg-white shadow transition ${
+              checked ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
+    </section>
+  );
+}
+
+export function PrivacyForm({ initialState }: Props) {
+  const [state, setState] = useState<DiscoverabilityState>(initialState);
+  const [savingKey, setSavingKey] = useState<PatchKey | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function toggle(key: PatchKey) {
+    const previous = state;
+    const next: DiscoverabilityState =
+      key === 'contacts'
+        ? { ...state, discoverableByContacts: !state.discoverableByContacts }
+        : { ...state, discoverableByMutualFriends: !state.discoverableByMutualFriends };
+
+    setState(next);
+    setSavingKey(key);
+    setErrorMessage(null);
+
+    const body: Partial<Record<PatchKey, boolean>> =
+      key === 'contacts'
+        ? { contacts: next.discoverableByContacts }
+        : { mutualFriends: next.discoverableByMutualFriends };
+
+    const result = await patchDiscoverability(body);
+    setSavingKey(null);
+
+    if (!result.ok || !result.state) {
+      setState(previous);
+      setErrorMessage(result.errorMessage ?? 'Could not save.');
+      return;
+    }
+    setState(result.state);
+  }
+
+  return (
+    <div className="mt-8 space-y-6">
+      <ToggleRow
+        title="Match my phone contacts to other Joshing players"
+        description="When you tap Refresh on Find Friends, we hash your contacts on your device and compare them against other players who also opted in. We never store the raw numbers."
+        checked={state.discoverableByContacts}
+        saving={savingKey === 'contacts'}
+        onToggle={() => void toggle('contacts')}
+      />
+
+      <ToggleRow
+        title="Suggest me through mutual friends"
+        description="Lets people who share a friend with you see you in their Find Friends suggestions."
+        checked={state.discoverableByMutualFriends}
+        saving={savingKey === 'mutualFriends'}
+        onToggle={() => void toggle('mutualFriends')}
+      />
+
+      <ToggleRow
+        title="Findable by exact handle or phone number"
+        description="Always on. Anyone who already knows your @handle or phone number can send you a friend request."
+        checked
+        disabled
+      />
+
+      {errorMessage ? (
+        <p className="text-sm text-destructive">{errorMessage}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/account/privacy/page.tsx
+++ b/src/app/account/privacy/page.tsx
@@ -1,10 +1,38 @@
-import { StubPage } from '@/components/account/StubPage';
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { ChevronLeft } from 'lucide-react';
 
-export default function PrivacySettingsPage() {
+import { getSession } from '@/server/auth/session';
+import { getDiscoverability } from '@/server/db/queries/account';
+
+import { PrivacyForm } from './PrivacyForm';
+
+export const dynamic = 'force-dynamic';
+
+export default async function PrivacySettingsPage() {
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const state = await getDiscoverability(session.userId);
+  if (!state) redirect('/login');
+
   return (
-    <StubPage
-      title="Privacy & visibility"
-      description="Control what others can see."
-    />
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
+      <Link
+        href="/account"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Back
+      </Link>
+      <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
+        Privacy &amp; visibility
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Choose how other people can find you on Joshing.
+      </p>
+
+      <PrivacyForm initialState={state} />
+    </main>
   );
 }

--- a/src/app/api/account/discoverability/route.ts
+++ b/src/app/api/account/discoverability/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  getDiscoverability,
+  updateDiscoverability,
+} from '@/server/db/queries/account';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z
+  .object({
+    contacts: z.boolean().optional(),
+    mutualFriends: z.boolean().optional(),
+  })
+  .refine(
+    (b) => b.contacts !== undefined || b.mutualFriends !== undefined,
+    'must specify at least one change',
+  );
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const state = await getDiscoverability(session.userId);
+  if (!state) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  return NextResponse.json({ state });
+}
+
+export async function PATCH(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const json = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'No discoverability changes provided.' },
+      { status: 400 },
+    );
+  }
+
+  const state = await updateDiscoverability(session.userId, parsed.data);
+  if (!state) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  return NextResponse.json({ state });
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,5 +1,16 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    // PHONE_HASH_SALT seeds the SHA-256 used by hashPhoneNumber()
+    // (src/server/lib/phone-hashing.ts) and the client-side hashing path
+    // B-Friends-4 will add. The salt itself isn't a true secret — it lives on
+    // every authenticated client — but losing it invalidates every
+    // ContactHash row, so we fail-fast in production if it's unset.
+    if (process.env.NODE_ENV === 'production' && !process.env.PHONE_HASH_SALT) {
+      throw new Error(
+        'PHONE_HASH_SALT must be set in production; without it contact-hash matching is non-functional',
+      );
+    }
+
     const { migrate } = await import('drizzle-orm/node-postgres/migrator');
     const { drizzle } = await import('drizzle-orm/node-postgres');
     const { Pool } = await import('pg');
@@ -635,6 +646,107 @@ export async function register() {
     } catch {
       // User may not exist yet on a fresh database — migrate() creates it
       // before this migration runs.
+    }
+
+    // Migration 0048 adds the friends/privacy foundation:
+    //   • User.discoverable_by_contacts / .discoverable_by_mutual_friends
+    //     (default FALSE) — read by B-Friends-3/4 once those land.
+    //   • ContactHash table — stores per-user SHA-256 contact hashes for
+    //     the B-Friends-4 matching channel. Cascades on User delete.
+    //   • Friendship extensions — personalNote (≤160), expiresAt,
+    //     resolvedAt + two CHECKs (length, users distinct) + two partial
+    //     indexes (expiry cron, declined/expired decay GC).
+    // Guard for preview/production databases that may have the migration
+    // recorded without the columns/table/constraints actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "discoverable_by_contacts" boolean NOT NULL DEFAULT false
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "discoverable_by_mutual_friends" boolean NOT NULL DEFAULT false
+      `);
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "ContactHash" (
+          "userId"     text NOT NULL,
+          "phoneHash"  text NOT NULL,
+          "uploadedAt" timestamptz NOT NULL DEFAULT NOW(),
+          PRIMARY KEY ("userId", "phoneHash")
+        )
+      `);
+      await db.execute(sql`
+        DO $$
+        DECLARE
+          hash_table regclass := to_regclass('public."ContactHash"');
+          user_table regclass := to_regclass('public."User"');
+        BEGIN
+          IF hash_table IS NOT NULL
+            AND user_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'ContactHash_userId_User_id_fk'
+                AND conrelid = hash_table
+            )
+          THEN
+            ALTER TABLE "ContactHash"
+              ADD CONSTRAINT "ContactHash_userId_User_id_fk"
+              FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE;
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "ContactHash_phoneHash_idx"
+          ON "ContactHash" ("phoneHash")
+      `);
+      await db.execute(sql`
+        ALTER TABLE "Friendship"
+          ADD COLUMN IF NOT EXISTS "personalNote" text
+      `);
+      await db.execute(sql`
+        ALTER TABLE "Friendship"
+          ADD COLUMN IF NOT EXISTS "expiresAt" timestamptz
+      `);
+      await db.execute(sql`
+        ALTER TABLE "Friendship"
+          ADD COLUMN IF NOT EXISTS "resolvedAt" timestamptz
+      `);
+      await db.execute(sql`
+        DO $$
+        BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+              AND table_name = 'Friendship'
+              AND constraint_name = 'friendship_personal_note_length'
+          ) THEN
+            ALTER TABLE "Friendship"
+              ADD CONSTRAINT friendship_personal_note_length
+              CHECK (char_length("personalNote") <= 160);
+          END IF;
+          IF NOT EXISTS (
+            SELECT 1 FROM information_schema.table_constraints
+            WHERE table_schema = 'public'
+              AND table_name = 'Friendship'
+              AND constraint_name = 'friendship_users_distinct'
+          ) THEN
+            ALTER TABLE "Friendship"
+              ADD CONSTRAINT friendship_users_distinct
+              CHECK ("userAId" <> "userBId");
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "Friendship_expiresAt_pending_idx"
+          ON "Friendship" ("expiresAt") WHERE status = 'pending'
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "Friendship_resolvedAt_decay_idx"
+          ON "Friendship" ("resolvedAt") WHERE status IN ('declined', 'expired')
+      `);
+    } catch {
+      // User or Friendship may not exist yet on a fresh database — migrate()
+      // creates the base tables before this migration runs.
     }
 
     try {

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, sql } from 'drizzle-orm';
 
 import {
+  contactHashes,
   db,
   declaredInterests,
   playerMastery,
@@ -400,6 +401,75 @@ export async function assignInitialHandle(params: {
   return { ok: true };
 }
 
+export type DiscoverabilityState = {
+  discoverableByContacts: boolean;
+  discoverableByMutualFriends: boolean;
+};
+
+export async function getDiscoverability(
+  userId: string,
+): Promise<DiscoverabilityState | null> {
+  const [row] = await db
+    .select({
+      discoverableByContacts: users.discoverableByContacts,
+      discoverableByMutualFriends: users.discoverableByMutualFriends,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!row) return null;
+  return row;
+}
+
+export type DiscoverabilityPatch = {
+  contacts?: boolean;
+  mutualFriends?: boolean;
+};
+
+// Updates one or both discoverability flags. Wraps both writes (and the
+// optional ContactHash purge below) in a single transaction so the table
+// can't be left holding rows after the user has revoked their consent.
+//
+// Side effect: when discoverableByContacts is flipped TRUE → FALSE, every
+// ContactHash row for the user is deleted in the same transaction.
+// Re-enabling later requires re-uploading hashes via B-Friends-4 (which
+// will land the upload endpoint).
+export async function updateDiscoverability(
+  userId: string,
+  patch: DiscoverabilityPatch,
+): Promise<DiscoverabilityState | null> {
+  return db.transaction(async (tx) => {
+    const [current] = await tx
+      .select({
+        discoverableByContacts: users.discoverableByContacts,
+        discoverableByMutualFriends: users.discoverableByMutualFriends,
+      })
+      .from(users)
+      .where(eq(users.id, userId))
+      .limit(1);
+
+    if (!current) return null;
+
+    const set: Record<string, unknown> = { updatedAt: new Date() };
+    if (patch.contacts !== undefined) set.discoverableByContacts = patch.contacts;
+    if (patch.mutualFriends !== undefined) set.discoverableByMutualFriends = patch.mutualFriends;
+
+    await tx.update(users).set(set).where(eq(users.id, userId));
+
+    const turningContactsOff =
+      patch.contacts === false && current.discoverableByContacts === true;
+    if (turningContactsOff) {
+      await tx.delete(contactHashes).where(eq(contactHashes.userId, userId));
+    }
+
+    return {
+      discoverableByContacts: patch.contacts ?? current.discoverableByContacts,
+      discoverableByMutualFriends:
+        patch.mutualFriends ?? current.discoverableByMutualFriends,
+    };
+  });
+}
 
 export async function deleteUserAccount(userId: string): Promise<void> {
   await db.transaction(async (tx) => {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -9,6 +9,7 @@ import {
   jsonb,
   pgEnum,
   pgTable,
+  primaryKey,
   text,
   timestamp,
   unique,
@@ -171,6 +172,8 @@ export const users = pgTable(
     bio: text('bio'),
     tagline: text('tagline'),
     location: text('location'),
+    discoverableByContacts: boolean('discoverable_by_contacts').notNull().default(false),
+    discoverableByMutualFriends: boolean('discoverable_by_mutual_friends').notNull().default(false),
     authorProfilePublic: boolean('authorProfilePublic').notNull().default(true),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
     birthYear: integer('birth_year'),
@@ -686,12 +689,30 @@ export const friendships = pgTable(
     removedAt: timestamp('removedAt', { withTimezone: true }),
     removedByUserId: text('removedByUserId').references(() => users.id),
     requestContext: jsonb('requestContext').$type<{ suggestedInterests?: string[] }>(),
+    personalNote: text('personalNote'),
+    expiresAt: timestamp('expiresAt', { withTimezone: true }),
+    resolvedAt: timestamp('resolvedAt', { withTimezone: true }),
     createdAt: timestamp('createdAt', { withTimezone: true }).notNull().defaultNow(),
   },
   (table) => [
     unique('Friendship_userAId_userBId_key').on(table.userAId, table.userBId),
     index('Friendship_userAId_status_idx').on(table.userAId, table.status),
     index('Friendship_userBId_status_idx').on(table.userBId, table.status),
+  ],
+);
+
+export const contactHashes = pgTable(
+  'ContactHash',
+  {
+    userId: text('userId')
+      .notNull()
+      .references(() => users.id, { onDelete: 'cascade' }),
+    phoneHash: text('phoneHash').notNull(),
+    uploadedAt: timestamp('uploadedAt', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    primaryKey({ columns: [table.userId, table.phoneHash] }),
+    index('ContactHash_phoneHash_idx').on(table.phoneHash),
   ],
 );
 

--- a/src/server/lib/phone-hashing.ts
+++ b/src/server/lib/phone-hashing.ts
@@ -1,0 +1,15 @@
+import { createHash } from 'crypto';
+
+// SHA-256(salt + e164Phone) — used by both the server-side User.phone_hash
+// computation (added in B-Friends-4 at signup) and the ContactHash upload
+// path. The client-side hashing path in B-Friends-4 MUST produce identical
+// output for the same E.164 input + salt; a parity test will enforce this.
+//
+// The salt itself isn't a true secret — the client needs it to hash phone
+// contacts before upload — but rotating it invalidates every ContactHash
+// row and every persisted User.phone_hash.
+export function hashPhoneNumber(e164Phone: string): string {
+  const salt = process.env.PHONE_HASH_SALT;
+  if (!salt) throw new Error('PHONE_HASH_SALT not set');
+  return createHash('sha256').update(salt + e164Phone).digest('hex');
+}


### PR DESCRIPTION
## Summary
Implements the schema foundation and UI for user privacy & discoverability settings (B-Friends-1). Users can now control whether they're discoverable by phone contacts and mutual friends, with a new privacy settings page and API endpoint to manage these preferences.

## Key Changes

**Schema & Migrations**
- Migration 0048 adds three independent pieces:
  - `User.discoverable_by_contacts` and `User.discoverable_by_mutual_friends` boolean flags (default FALSE)
  - `ContactHash` table to store SHA-256 hashes of user phone contacts for B-Friends-4 matching, with cascade delete on user removal
  - `Friendship` table extensions: `personalNote` (≤160 chars), `expiresAt`, `resolvedAt` with CHECK constraints and partial indexes for expiry cron and decay GC
- Idempotent guards in `src/instrumentation.ts` ensure preview/production databases can boot even if migrations are partially recorded
- Added `PHONE_HASH_SALT` validation in production to fail-fast if contact-hash matching would be non-functional

**Database Layer**
- New `getDiscoverability()` and `updateDiscoverability()` query helpers in `src/server/db/queries/account.ts`
- `updateDiscoverability()` wraps flag updates and optional ContactHash purge in a transaction — when `discoverableByContacts` flips TRUE → FALSE, all user contact hashes are deleted to enforce consent revocation
- Added `hashPhoneNumber()` utility in `src/server/lib/phone-hashing.ts` for SHA-256(salt + E.164) hashing used by both server and future client-side contact upload

**API & UI**
- New `PATCH /api/account/discoverability` endpoint with Zod validation; supports partial updates to either flag
- New `GET /api/account/discoverability` endpoint to fetch current state
- New `PrivacyForm` client component with toggle UI for both discoverability settings plus a disabled "findable by handle/phone" toggle (always on)
- Replaced stub privacy settings page with full implementation including back navigation and form integration
- Toggle component shows saving state and error messages; optimistic updates with rollback on failure

## Implementation Details
- Privacy form uses client-side state management with optimistic updates; failed saves revert to previous state and display error message
- ContactHash table uses composite primary key (userId, phoneHash) with index on phoneHash for B-Friends-4 matching queries
- Friendship extensions are additive and backward-compatible; existing rows will have NULL values for new columns
- All database changes are guarded with `IF NOT EXISTS` checks to handle preview/production databases with partially-recorded migrations

https://claude.ai/code/session_01FWqbGGGzQo7sJdhj2uJZTs