### PR TITLE
feat(B-Friends-2): friend-request lifecycle on the Friendship table

### DIFF
--- a/src/app/api/cron/expire-friend-requests/route.ts
+++ b/src/app/api/cron/expire-friend-requests/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { sql } from 'drizzle-orm'
+
+import { db } from '@/server/db'
+
+export const dynamic = 'force-dynamic'
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET
+  if (!secret) return true
+  const authHeader = request.headers.get('authorization')
+  return authHeader === `Bearer ${secret}`
+}
+
+// Two-step cleanup on the Friendship table:
+//   1. Expire stale pending requests whose expiresAt has passed.
+//   2. GC declined/expired rows whose resolvedAt is older than 60 days.
+//
+// Both operations are idempotent; running twice in a single window is harmless.
+// No ActivityItems are written — expiration and GC are passive.
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  }
+
+  const expiredResult = await db.execute(sql`
+    UPDATE "Friendship"
+    SET "status" = 'expired',
+        "resolvedAt" = NOW()
+    WHERE "status" = 'pending'
+      AND "expiresAt" IS NOT NULL
+      AND "expiresAt" < NOW()
+  `)
+
+  const deletedResult = await db.execute(sql`
+    DELETE FROM "Friendship"
+    WHERE "status" IN ('declined', 'expired')
+      AND "resolvedAt" IS NOT NULL
+      AND "resolvedAt" < NOW() - INTERVAL '60 days'
+  `)
+
+  return NextResponse.json({
+    ok: true,
+    expired: expiredResult.rowCount ?? 0,
+    deleted: deletedResult.rowCount ?? 0,
+  })
+}

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -556,6 +556,10 @@ export async function POST(request: Request) {
           inviterUserId: session.userId,
           inviteeUserId: existingUser.id,
           suggestedInterests,
+          // SMS-style invitations don't expire under v12. Pass null
+          // explicitly so the new 30-day direct-request default doesn't
+          // bleed into this flow.
+          expiresAt: null,
         })
 
       const inviteUrl = `${getBaseUrl(request)}/activities#friendship-${encodeURIComponent(friendshipRequest.id)}`

--- a/src/app/api/friend-requests/route.ts
+++ b/src/app/api/friend-requests/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
 import { getSession } from '@/server/auth/session'
+import { getRelationship } from '@/server/db/queries/friend-requests'
 import { getUserById } from '@/server/db/queries/users'
 import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
 import { logTelemetry } from '@/server/telemetry'
@@ -10,7 +11,10 @@ export const dynamic = 'force-dynamic'
 
 const bodySchema = z.object({
   inviteeUserId: z.string().min(1),
+  personalNote: z.string().trim().max(160).optional(),
 })
+
+const RECENTLY_SENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
 
 export async function POST(request: Request) {
   const session = await getSession()
@@ -21,12 +25,12 @@ export async function POST(request: Request) {
   const parsed = bodySchema.safeParse(json)
   if (!parsed.success) {
     return NextResponse.json(
-      { error: 'invalid_body', message: 'Missing inviteeUserId.' },
+      { error: 'invalid_body', message: 'Missing or invalid request body.' },
       { status: 400 }
     )
   }
 
-  const { inviteeUserId } = parsed.data
+  const { inviteeUserId, personalNote } = parsed.data
   if (inviteeUserId === session.userId) {
     return NextResponse.json(
       { error: 'self_request', message: 'You cannot friend yourself.' },
@@ -42,9 +46,61 @@ export async function POST(request: Request) {
     )
   }
 
+  const now = new Date()
+  const relationship = await getRelationship(session.userId, inviteeUserId, now)
+
+  // Block detection: target has soft-removed the friendship. Return 404
+  // (don't reveal the block) and don't write anything.
+  if (relationship.isBlocked) {
+    return NextResponse.json(
+      { error: 'not_found', message: 'No such user.' },
+      { status: 404 }
+    )
+  }
+
+  if (relationship.state === 'friends') {
+    return NextResponse.json(
+      { error: 'already_friends', message: 'You are already friends.' },
+      { status: 409 }
+    )
+  }
+  if (relationship.state === 'pending_outbound') {
+    return NextResponse.json(
+      {
+        error: 'already_pending',
+        message: 'You already have a pending request with this person.',
+      },
+      { status: 409 }
+    )
+  }
+  if (relationship.state === 'pending_inbound') {
+    return NextResponse.json(
+      {
+        error: 'inbound_exists',
+        message: 'They sent you a request — accept it instead.',
+        friendshipId: relationship.friendshipId,
+      },
+      { status: 409 }
+    )
+  }
+  if (relationship.state === 'recently_sent') {
+    return NextResponse.json(
+      {
+        error: 'recently_sent',
+        message: 'You sent this person a request recently. Try again later.',
+        // Best-effort retry hint: 30 days from now is the latest the
+        // cooldown could last. Callers don't need millisecond precision.
+        retryAfter: new Date(now.getTime() + RECENTLY_SENT_WINDOW_MS).toISOString(),
+      },
+      { status: 429 }
+    )
+  }
+
   const { friendship, state } = await createOrReusePendingFriendshipRequest({
     inviterUserId: session.userId,
     inviteeUserId,
+    personalNote,
+    now,
   })
 
   logTelemetry('friend_request_from_profile', {
@@ -52,6 +108,7 @@ export async function POST(request: Request) {
     invitee_user_id: inviteeUserId,
     friendship_id: friendship.id,
     state,
+    has_personal_note: Boolean(personalNote),
   })
 
   return NextResponse.json({

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -20,6 +20,15 @@ type IncomingRequest = {
   requesterId: string
   requesterName: string
   suggestedInterests: string[]
+  personalNote: string | null
+  createdAt: string
+}
+
+type OutboundRequest = {
+  id: string
+  recipientId: string
+  recipientName: string
+  personalNote: string | null
   createdAt: string
 }
 
@@ -27,6 +36,7 @@ type FriendsHubResponse = {
   ok: boolean
   friends: Friend[]
   incomingRequests: IncomingRequest[]
+  outboundRequests: OutboundRequest[]
 }
 
 type RequestAction = 'accept' | 'ignore'
@@ -39,6 +49,9 @@ function previewInterests(interests: string[]) {
 export default function FriendsList() {
   const [friends, setFriends] = useState<Friend[]>([])
   const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>(
+    []
+  )
+  const [outboundRequests, setOutboundRequests] = useState<OutboundRequest[]>(
     []
   )
   const [loading, setLoading] = useState(true)
@@ -69,6 +82,7 @@ export default function FriendsList() {
 
       setFriends(body.friends)
       setIncomingRequests(body.incomingRequests)
+      setOutboundRequests(body.outboundRequests ?? [])
     } catch (caught) {
       setError(
         caught instanceof Error ? caught.message : 'Could not load friends.'
@@ -108,6 +122,34 @@ export default function FriendsList() {
         caught instanceof Error
           ? caught.message
           : 'Could not update this request.'
+      )
+    } finally {
+      setPendingRequest(null)
+    }
+  }
+
+  async function cancelOutbound(requestId: string) {
+    setPendingRequest(`${requestId}:cancel`)
+    setError(null)
+    // Optimistic: remove the row immediately; restore on error.
+    const previous = outboundRequests
+    setOutboundRequests((current) => current.filter((row) => row.id !== requestId))
+
+    try {
+      const response = await fetch(`/api/friend-requests/${requestId}/cancel`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        setOutboundRequests(previous)
+        throw new Error(body?.message ?? 'Could not cancel this request.')
+      }
+    } catch (caught) {
+      setError(
+        caught instanceof Error
+          ? caught.message
+          : 'Could not cancel this request.'
       )
     } finally {
       setPendingRequest(null)
@@ -259,6 +301,11 @@ export default function FriendsList() {
                           No ideas attached — just a friendly hello.
                         </p>
                       )}
+                      {request.personalNote ? (
+                        <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
+                          “{request.personalNote}”
+                        </blockquote>
+                      ) : null}
                     </div>
 
                     <div className="grid grid-cols-2 gap-2 sm:min-w-48">
@@ -300,7 +347,55 @@ export default function FriendsList() {
       ) : null}
 
       {/* Sent tab */}
-      {activeTab === 'sent' ? <PeopleYouInvited /> : null}
+      {activeTab === 'sent' ? (
+        <div className="space-y-6">
+          {outboundRequests.length > 0 ? (
+            <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+              <h2 className="font-serif text-lg font-semibold">
+                Sent friend requests
+              </h2>
+              <p className="text-muted-foreground mt-1 text-sm">
+                Waiting on a reply. They expire after 30 days.
+              </p>
+              <div className="mt-3 space-y-3">
+                {outboundRequests.map((request) => (
+                  <article
+                    key={request.id}
+                    className="bg-background rounded-xl border p-3"
+                  >
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="min-w-0">
+                        <h3 className="text-foreground font-medium">
+                          {request.recipientName}
+                        </h3>
+                        <p className="text-muted-foreground/70 mt-1 text-xs">
+                          sent {formatRelativeTime(request.createdAt)}
+                        </p>
+                        {request.personalNote ? (
+                          <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
+                            “{request.personalNote}”
+                          </blockquote>
+                        ) : null}
+                      </div>
+                      <button
+                        type="button"
+                        className="btn-ghost min-h-9 self-start rounded-full px-4 text-sm"
+                        disabled={Boolean(pendingRequest)}
+                        onClick={() => void cancelOutbound(request.id)}
+                      >
+                        {pendingRequest === `${request.id}:cancel`
+                          ? 'Cancelling…'
+                          : 'Cancel'}
+                      </button>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ) : null}
+          <PeopleYouInvited />
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/components/friends/AddFriendButton.tsx
+++ b/src/components/friends/AddFriendButton.tsx
@@ -1,0 +1,200 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+import { AddFriendRequestModal } from '@/components/friends/AddFriendRequestModal'
+import type { RelationshipResult } from '@/server/db/queries/friend-requests'
+
+type Props = {
+  targetUserId: string
+  targetDisplayName: string
+  relationship: RelationshipResult
+  // Called after a successful add / cancel / accept / ignore / remove so
+  // the parent can refresh its data (router.refresh() or refetch).
+  onChange?: () => void
+  // If true, confirm Unfriend via window.confirm (the existing
+  // ProfileFriendButton behavior we want to preserve when this component
+  // is used on profile pages). Defaults to true.
+  confirmUnfriend?: boolean
+}
+
+type Action = 'cancel' | 'accept' | 'ignore' | 'remove'
+
+export function AddFriendButton({
+  targetUserId,
+  targetDisplayName,
+  relationship,
+  onChange,
+  confirmUnfriend = true,
+}: Props) {
+  const [pendingAction, setPendingAction] = useState<Action | 'open' | null>(null)
+  const [modalOpen, setModalOpen] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = window.setTimeout(() => setToast(null), 1800)
+    return () => window.clearTimeout(timer)
+  }, [toast])
+
+  async function runAction(action: Action, friendshipId: string, successToast: string) {
+    if (pendingAction) return
+    setPendingAction(action)
+    setError(null)
+    try {
+      const response = await fetch(`/api/friend-requests/${friendshipId}/${action}`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        setError(body?.message ?? 'Could not update this request.')
+        return
+      }
+      setToast(successToast)
+      onChange?.()
+    } catch {
+      setError('Network error. Please try again.')
+    } finally {
+      setPendingAction(null)
+    }
+  }
+
+  function handleAddClick() {
+    setError(null)
+    setModalOpen(true)
+  }
+
+  function handleSent() {
+    setToast('Sent.')
+    onChange?.()
+  }
+
+  function handleCancel() {
+    if (!relationship.friendshipId) return
+    void runAction('cancel', relationship.friendshipId, 'Cancelled.')
+  }
+
+  function handleAccept() {
+    if (!relationship.friendshipId) return
+    void runAction('accept', relationship.friendshipId, 'Friends.')
+  }
+
+  function handleIgnore() {
+    if (!relationship.friendshipId) return
+    void runAction('ignore', relationship.friendshipId, 'Set aside.')
+  }
+
+  function handleRemove() {
+    if (!relationship.friendshipId) return
+    if (confirmUnfriend) {
+      const confirmed = window.confirm(`Remove ${targetDisplayName} from your friends?`)
+      if (!confirmed) return
+    }
+    void runAction('remove', relationship.friendshipId, 'Removed.')
+  }
+
+  return (
+    <div className="flex flex-col gap-1">
+      <div className="flex flex-wrap items-center gap-2">
+        {relationship.state === 'none' ? (
+          <Button
+            type="button"
+            size="sm"
+            onClick={handleAddClick}
+            disabled={pendingAction !== null}
+          >
+            Add friend
+          </Button>
+        ) : null}
+
+        {relationship.state === 'pending_outbound' ? (
+          <>
+            <Button type="button" size="sm" variant="secondary" disabled>
+              Request sent
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleCancel}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'cancel' ? 'Cancelling…' : 'Cancel'}
+            </Button>
+          </>
+        ) : null}
+
+        {relationship.state === 'pending_inbound' ? (
+          <>
+            <Button
+              type="button"
+              size="sm"
+              onClick={handleAccept}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'accept' ? 'Joining…' : 'Accept'}
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleIgnore}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'ignore' ? 'Setting aside…' : 'Not now'}
+            </Button>
+          </>
+        ) : null}
+
+        {relationship.state === 'friends' ? (
+          <>
+            <Button type="button" size="sm" variant="secondary" disabled>
+              Friends ✓
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              variant="ghost"
+              onClick={handleRemove}
+              disabled={pendingAction !== null}
+            >
+              {pendingAction === 'remove' ? 'Removing…' : 'Unfriend'}
+            </Button>
+          </>
+        ) : null}
+
+        {relationship.state === 'recently_sent' ? (
+          <Button
+            type="button"
+            size="sm"
+            variant="secondary"
+            disabled
+            title="You sent a request to this person in the last 30 days."
+          >
+            Recently sent
+          </Button>
+        ) : null}
+      </div>
+
+      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+
+      {toast ? (
+        <div className="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+
+      {modalOpen ? (
+        <AddFriendRequestModal
+          onClose={() => setModalOpen(false)}
+          targetUserId={targetUserId}
+          targetDisplayName={targetDisplayName}
+          onSent={handleSent}
+        />
+      ) : null}
+    </div>
+  )
+}

--- a/src/components/friends/AddFriendRequestModal.tsx
+++ b/src/components/friends/AddFriendRequestModal.tsx
@@ -1,0 +1,217 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { Button } from '@/components/ui/button'
+
+const MAX_NOTE_LENGTH = 160
+const COUNTER_VISIBLE_AT = 120
+
+type Props = {
+  onClose: () => void
+  targetUserId: string
+  targetDisplayName: string
+  // Called with the new friendship id after a successful send. The parent
+  // typically flips its UI to "pending_outbound" and refreshes.
+  onSent: (friendshipId: string) => void
+}
+
+type SendErrorKey =
+  | 'already_friends'
+  | 'already_pending'
+  | 'inbound_exists'
+  | 'recently_sent'
+  | 'not_found'
+  | 'invalid_body'
+  | 'self_request'
+  | 'network'
+  | 'unknown'
+
+function describeError(error: SendErrorKey, message?: string): string {
+  if (message) return message
+  switch (error) {
+    case 'already_friends':
+      return 'You are already friends.'
+    case 'already_pending':
+      return 'You already have a pending request with this person.'
+    case 'inbound_exists':
+      return 'They sent you a request — accept it instead.'
+    case 'recently_sent':
+      return 'You sent this person a request recently. Try again later.'
+    case 'not_found':
+      return 'This person isn’t available right now.'
+    case 'invalid_body':
+      return 'That note didn’t look right. Try shortening it.'
+    case 'self_request':
+      return 'You cannot friend yourself.'
+    case 'network':
+      return 'Network error. Please try again.'
+    default:
+      return 'Something went wrong. Please try again.'
+  }
+}
+
+// Parent mounts this component when the modal should be open and unmounts
+// it on close. That keeps state (note draft, error) fresh on each open
+// without needing a reset-on-open effect.
+export function AddFriendRequestModal({
+  onClose,
+  targetUserId,
+  targetDisplayName,
+  onSent,
+}: Props) {
+  const [note, setNote] = useState('')
+  const [sending, setSending] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    textareaRef.current?.focus()
+  }, [])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  async function send() {
+    if (sending) return
+    const trimmed = note.trim()
+    if (trimmed.length > MAX_NOTE_LENGTH) {
+      setError(`Notes are capped at ${MAX_NOTE_LENGTH} characters.`)
+      return
+    }
+    setSending(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/friend-requests', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          inviteeUserId: targetUserId,
+          personalNote: trimmed.length > 0 ? trimmed : undefined,
+        }),
+      })
+      const body = (await response.json().catch(() => null)) as
+        | { ok: boolean; friendship?: { id: string } }
+        | { error: SendErrorKey; message?: string }
+        | null
+
+      if (!response.ok || !body || !('ok' in body) || !body.ok || !body.friendship) {
+        const errorBody = body && 'error' in body ? body : null
+        setError(
+          describeError(errorBody?.error ?? 'unknown', errorBody?.message)
+        )
+        return
+      }
+      onSent(body.friendship.id)
+      onClose()
+    } catch {
+      setError(describeError('network'))
+    } finally {
+      setSending(false)
+    }
+  }
+
+  const counterVisible = note.length >= COUNTER_VISIBLE_AT
+  const remaining = MAX_NOTE_LENGTH - note.length
+
+  return (
+    <>
+      <div
+        onClick={() => {
+          if (!sending) onClose()
+        }}
+        style={{
+          position: 'fixed',
+          inset: 0,
+          background: 'rgba(0,0,0,0.4)',
+          zIndex: 100,
+        }}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-friend-request-title"
+        style={{
+          position: 'fixed',
+          top: '50%',
+          left: '50%',
+          transform: 'translate(-50%, -50%)',
+          zIndex: 101,
+          width: 'min(520px, calc(100vw - 32px))',
+          maxHeight: 'calc(100dvh - 64px)',
+          overflowY: 'auto',
+          background: 'var(--bg)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-lg)',
+          boxShadow: 'var(--shadow-paper-rest)',
+          padding: '24px',
+        }}
+      >
+        <div className="mb-3 flex items-baseline justify-between gap-3">
+          <h2 id="add-friend-request-title" className="font-serif text-xl font-semibold">
+            Send {targetDisplayName} a friend request
+          </h2>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            disabled={sending}
+            className="text-muted-foreground hover:text-foreground -mr-1 px-2 text-lg leading-none"
+          >
+            ×
+          </button>
+        </div>
+        <p className="text-muted-foreground mb-4 text-sm">
+          Add a short note (optional) — they’ll see it with the request.
+        </p>
+        <textarea
+          ref={textareaRef}
+          value={note}
+          onChange={(event) => setNote(event.target.value.slice(0, MAX_NOTE_LENGTH))}
+          maxLength={MAX_NOTE_LENGTH}
+          rows={4}
+          placeholder="Hey — I keep meaning to ask you about that thing…"
+          disabled={sending}
+          className="border-border bg-card text-foreground placeholder:text-muted-foreground w-full resize-none rounded-lg border p-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary/40"
+        />
+        <div className="mt-1 flex h-5 items-center justify-end">
+          {counterVisible ? (
+            <span
+              className={`text-xs ${remaining < 0 ? 'text-destructive' : 'text-muted-foreground'}`}
+            >
+              {remaining} left
+            </span>
+          ) : null}
+        </div>
+        {error ? (
+          <p className="text-destructive mt-2 text-sm">{error}</p>
+        ) : null}
+        <div className="mt-4 flex justify-end gap-2">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            disabled={sending}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => void send()}
+            disabled={sending}
+          >
+            {sending ? 'Sending…' : 'Send'}
+          </Button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/src/components/profile/ProfileFriendButton.tsx
+++ b/src/components/profile/ProfileFriendButton.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useState } from 'react'
+import { useMemo } from 'react'
 
-import { Button } from '@/components/ui/button'
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import type { RelationshipResult } from '@/server/db/queries/friend-requests'
 
 type FriendshipShape = {
   id: string
@@ -17,12 +18,27 @@ type ProfileFriendButtonProps = {
   targetDisplayName: string
 }
 
-type Action =
-  | 'create'
-  | 'accept'
-  | 'ignore'
-  | 'cancel'
-  | 'remove'
+// Derives a RelationshipResult from the limited shape the profile page
+// passes today. We don't surface "recently_sent" here — the profile is
+// not a re-send surface, and FriendPortraitData doesn't carry resolvedAt.
+// If a recently-sent state is ever needed on profiles, expand
+// getFriendPortraitData to pass resolvedAt and refine this mapping.
+function deriveRelationship(friendship: FriendshipShape): RelationshipResult {
+  if (!friendship) {
+    return { state: 'none', friendshipId: null, isBlocked: false }
+  }
+  if (friendship.status === 'active') {
+    return { state: 'friends', friendshipId: friendship.id, isBlocked: false }
+  }
+  if (friendship.status === 'pending') {
+    return {
+      state: friendship.viewerIsRequester ? 'pending_outbound' : 'pending_inbound',
+      friendshipId: friendship.id,
+      isBlocked: false,
+    }
+  }
+  return { state: 'none', friendshipId: null, isBlocked: false }
+}
 
 export function ProfileFriendButton({
   targetUserId,
@@ -30,133 +46,16 @@ export function ProfileFriendButton({
   targetDisplayName,
 }: ProfileFriendButtonProps) {
   const router = useRouter()
-  const [pendingAction, setPendingAction] = useState<Action | null>(null)
-  const [error, setError] = useState<string | null>(null)
-
-  async function run(action: Action, request: () => Promise<Response>) {
-    if (pendingAction) return
-    setPendingAction(action)
-    setError(null)
-    try {
-      const response = await request()
-      if (!response.ok) {
-        setError('Something went wrong. Please try again.')
-        return
-      }
-      router.refresh()
-    } catch {
-      setError('Network error. Please try again.')
-    } finally {
-      setPendingAction(null)
-    }
-  }
-
-  const createRequest = () =>
-    run('create', () =>
-      fetch('/api/friend-requests', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ inviteeUserId: targetUserId }),
-      })
-    )
-
-  const accept = () => {
-    if (!friendship) return
-    return run('accept', () =>
-      fetch(`/api/friend-requests/${friendship.id}/accept`, { method: 'POST' })
-    )
-  }
-
-  const ignore = () => {
-    if (!friendship) return
-    return run('ignore', () =>
-      fetch(`/api/friend-requests/${friendship.id}/ignore`, { method: 'POST' })
-    )
-  }
-
-  const cancel = () => {
-    if (!friendship) return
-    return run('cancel', () =>
-      fetch(`/api/friend-requests/${friendship.id}/cancel`, { method: 'POST' })
-    )
-  }
-
-  const remove = () => {
-    if (!friendship) return
-    const confirmed = window.confirm(
-      `Remove ${targetDisplayName} from your friends?`
-    )
-    if (!confirmed) return
-    return run('remove', () =>
-      fetch(`/api/friend-requests/${friendship.id}/remove`, { method: 'POST' })
-    )
-  }
-
-  const status = friendship?.status ?? null
-  const isPending = status === 'pending'
-  const isActive = status === 'active'
-  const viewerIsRequester = friendship?.viewerIsRequester ?? false
+  const relationship = useMemo(() => deriveRelationship(friendship), [friendship])
 
   return (
-    <div className="mt-4 flex flex-col gap-2">
-      <div className="flex flex-wrap items-center gap-2">
-        {isActive ? (
-          <>
-            <Button size="sm" variant="secondary" disabled>
-              Friends ✓
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={remove}
-              disabled={pendingAction !== null}
-            >
-              {pendingAction === 'remove' ? 'Removing…' : 'Unfriend'}
-            </Button>
-          </>
-        ) : isPending && viewerIsRequester ? (
-          <>
-            <Button size="sm" variant="secondary" disabled>
-              Request sent
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={cancel}
-              disabled={pendingAction !== null}
-            >
-              {pendingAction === 'cancel' ? 'Cancelling…' : 'Cancel'}
-            </Button>
-          </>
-        ) : isPending && !viewerIsRequester ? (
-          <>
-            <Button
-              size="sm"
-              onClick={accept}
-              disabled={pendingAction !== null}
-            >
-              {pendingAction === 'accept' ? 'Joining…' : 'Accept'}
-            </Button>
-            <Button
-              size="sm"
-              variant="ghost"
-              onClick={ignore}
-              disabled={pendingAction !== null}
-            >
-              {pendingAction === 'ignore' ? 'Setting aside…' : 'Not now'}
-            </Button>
-          </>
-        ) : (
-          <Button
-            size="sm"
-            onClick={createRequest}
-            disabled={pendingAction !== null}
-          >
-            {pendingAction === 'create' ? 'Sending…' : 'Add friend'}
-          </Button>
-        )}
-      </div>
-      {error ? <p className="text-destructive text-xs">{error}</p> : null}
+    <div className="mt-4">
+      <AddFriendButton
+        targetUserId={targetUserId}
+        targetDisplayName={targetDisplayName}
+        relationship={relationship}
+        onChange={() => router.refresh()}
+      />
     </div>
   )
 }

--- a/src/server/db/queries/friend-requests.ts
+++ b/src/server/db/queries/friend-requests.ts
@@ -1,0 +1,159 @@
+import { and, eq, inArray, sql } from 'drizzle-orm'
+
+import { db, friendships } from '@/server/db'
+import { friendshipPair } from '@/server/friends/friendships'
+
+export type RelationshipState =
+  | 'none'
+  | 'pending_outbound'
+  | 'pending_inbound'
+  | 'friends'
+  | 'recently_sent'
+
+export type RelationshipResult = {
+  state: RelationshipState
+  // Present when state is pending_outbound, pending_inbound, or friends —
+  // so callers can drive accept/cancel/unfriend actions without a second
+  // lookup. null when the row doesn't exist or has been resolved.
+  friendshipId: string | null
+  // True when the target party has soft-removed this friendship. The UI
+  // never shows a separate "blocked" state — to the viewer it looks like
+  // "none" — but POST /api/friend-requests refuses with 404 (doesn't
+  // reveal the block). Callers that render add-friend affordances on
+  // lists (search results, contact matches) should filter rows where
+  // isBlocked === true before rendering.
+  isBlocked: boolean
+}
+
+const RECENTLY_SENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+
+// Single source of truth for the viewer's relationship to a target user.
+// Resolution order (highest precedence first):
+//   1. status='active' row                    -> 'friends'
+//   2. status='removed' by target             -> 'none' + isBlocked: true
+//      status='removed' by viewer             -> 'none' (the viewer chose
+//                                                to disconnect; they can re-add)
+//   3. status='pending', requested by viewer  -> 'pending_outbound'
+//   4. status='pending', requested by target  -> 'pending_inbound'
+//   5. status in ('declined','expired') with resolvedAt within 30 days -> 'recently_sent'
+//   6. otherwise                              -> 'none'
+export async function getRelationship(
+  viewerId: string,
+  targetId: string,
+  now: Date = new Date(),
+): Promise<RelationshipResult> {
+  if (viewerId === targetId) {
+    return { state: 'none', friendshipId: null, isBlocked: false }
+  }
+
+  const pair = friendshipPair(viewerId, targetId)
+  const [row] = await db
+    .select()
+    .from(friendships)
+    .where(and(eq(friendships.userAId, pair.userAId), eq(friendships.userBId, pair.userBId)))
+    .limit(1)
+
+  if (!row) {
+    return { state: 'none', friendshipId: null, isBlocked: false }
+  }
+
+  if (row.status === 'active') {
+    return { state: 'friends', friendshipId: row.id, isBlocked: false }
+  }
+
+  if (row.status === 'removed') {
+    const removedByTarget = row.removedByUserId === targetId
+    return { state: 'none', friendshipId: null, isBlocked: removedByTarget }
+  }
+
+  if (row.status === 'pending') {
+    return {
+      state: row.requestedByUserId === viewerId ? 'pending_outbound' : 'pending_inbound',
+      friendshipId: row.id,
+      isBlocked: false,
+    }
+  }
+
+  if (row.status === 'declined' || row.status === 'expired') {
+    const resolvedAt = row.resolvedAt
+    if (resolvedAt && now.getTime() - resolvedAt.getTime() < RECENTLY_SENT_WINDOW_MS) {
+      // Only the original requester is gated by the cooldown — the
+      // declinee can re-send immediately if they change their mind.
+      if (row.requestedByUserId === viewerId) {
+        return { state: 'recently_sent', friendshipId: null, isBlocked: false }
+      }
+    }
+  }
+
+  return { state: 'none', friendshipId: null, isBlocked: false }
+}
+
+// Bulk lookup variant for list surfaces (search results, contact matches).
+// Returns a Map keyed by target user id. Same precedence as getRelationship.
+export async function getRelationships(
+  viewerId: string,
+  targetIds: string[],
+  now: Date = new Date(),
+): Promise<Map<string, RelationshipResult>> {
+  const result = new Map<string, RelationshipResult>()
+  if (targetIds.length === 0) return result
+
+  const uniqueTargets = Array.from(new Set(targetIds.filter((id) => id !== viewerId)))
+  if (uniqueTargets.length === 0) return result
+
+  const rows = await db
+    .select()
+    .from(friendships)
+    .where(
+      and(
+        sql`(${friendships.userAId} = ${viewerId} AND ${friendships.userBId} IN ${uniqueTargets})
+          OR (${friendships.userBId} = ${viewerId} AND ${friendships.userAId} IN ${uniqueTargets})`,
+        inArray(friendships.status, ['active', 'pending', 'declined', 'expired', 'removed']),
+      ),
+    )
+
+  const rowsByOther = new Map<string, typeof rows[number]>()
+  for (const row of rows) {
+    const otherId = row.userAId === viewerId ? row.userBId : row.userAId
+    rowsByOther.set(otherId, row)
+  }
+
+  for (const targetId of uniqueTargets) {
+    const row = rowsByOther.get(targetId)
+    if (!row) {
+      result.set(targetId, { state: 'none', friendshipId: null, isBlocked: false })
+      continue
+    }
+    if (row.status === 'active') {
+      result.set(targetId, { state: 'friends', friendshipId: row.id, isBlocked: false })
+      continue
+    }
+    if (row.status === 'removed') {
+      const removedByTarget = row.removedByUserId === targetId
+      result.set(targetId, { state: 'none', friendshipId: null, isBlocked: removedByTarget })
+      continue
+    }
+    if (row.status === 'pending') {
+      result.set(targetId, {
+        state: row.requestedByUserId === viewerId ? 'pending_outbound' : 'pending_inbound',
+        friendshipId: row.id,
+        isBlocked: false,
+      })
+      continue
+    }
+    if (row.status === 'declined' || row.status === 'expired') {
+      const resolvedAt = row.resolvedAt
+      if (
+        resolvedAt
+        && now.getTime() - resolvedAt.getTime() < RECENTLY_SENT_WINDOW_MS
+        && row.requestedByUserId === viewerId
+      ) {
+        result.set(targetId, { state: 'recently_sent', friendshipId: null, isBlocked: false })
+        continue
+      }
+    }
+    result.set(targetId, { state: 'none', friendshipId: null, isBlocked: false })
+  }
+
+  return result
+}

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -27,12 +27,22 @@ export type IncomingFriendRequest = {
   requesterId: string
   requesterName: string
   suggestedInterests: string[]
+  personalNote: string | null
+  createdAt: Date
+}
+
+export type OutboundFriendRequest = {
+  id: string
+  recipientId: string
+  recipientName: string
+  personalNote: string | null
   createdAt: Date
 }
 
 export type FriendsHub = {
   friends: FriendHubFriend[]
   incomingRequests: IncomingFriendRequest[]
+  outboundRequests: OutboundFriendRequest[]
 }
 
 function displayName(name: string | null, fallback: string): string {
@@ -202,6 +212,7 @@ export async function getFriendsHub(userId: string): Promise<FriendsHub> {
       requesterDisplayName: users.displayName,
       requesterPhoneNumber: users.phoneNumber,
       requestContext: friendships.requestContext,
+      personalNote: friendships.personalNote,
       createdAt: friendships.createdAt,
     })
     .from(friendships)
@@ -212,6 +223,39 @@ export async function getFriendsHub(userId: string): Promise<FriendsHub> {
       or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
     ))
     .orderBy(asc(friendships.createdAt))
+
+  const outboundRows = await db
+    .select({
+      id: friendships.id,
+      recipientUserAId: friendships.userAId,
+      recipientUserBId: friendships.userBId,
+      personalNote: friendships.personalNote,
+      createdAt: friendships.createdAt,
+    })
+    .from(friendships)
+    .where(and(
+      eq(friendships.status, 'pending'),
+      eq(friendships.requestedByUserId, userId),
+      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
+    ))
+    .orderBy(desc(friendships.createdAt))
+
+  const outboundRecipientIds = outboundRows.map((row) => (
+    row.recipientUserAId === userId ? row.recipientUserBId : row.recipientUserAId
+  ))
+
+  const outboundRecipients = outboundRecipientIds.length === 0
+    ? []
+    : await db
+      .select({
+        id: users.id,
+        displayName: users.displayName,
+        phoneNumber: users.phoneNumber,
+      })
+      .from(users)
+      .where(inArray(users.id, outboundRecipientIds))
+
+  const outboundRecipientById = new Map(outboundRecipients.map((row) => [row.id, row] as const))
 
   return {
     friends: friendRows.map((friend) => {
@@ -229,8 +273,23 @@ export async function getFriendsHub(userId: string): Promise<FriendsHub> {
       requesterId: request.requesterId,
       requesterName: displayName(request.requesterDisplayName, request.requesterPhoneNumber),
       suggestedInterests: normalizeSuggestedInterests(request.requestContext),
+      personalNote: request.personalNote,
       createdAt: request.createdAt,
     })),
+    outboundRequests: outboundRows
+      .map((row) => {
+        const recipientId = row.recipientUserAId === userId ? row.recipientUserBId : row.recipientUserAId
+        const recipient = outboundRecipientById.get(recipientId)
+        if (!recipient) return null
+        return {
+          id: row.id,
+          recipientId,
+          recipientName: displayName(recipient.displayName, recipient.phoneNumber),
+          personalNote: row.personalNote,
+          createdAt: row.createdAt,
+        }
+      })
+      .filter((row): row is OutboundFriendRequest => row !== null),
   }
 }
 

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -34,17 +34,30 @@ function requestContextForSuggestedInterests(suggestedInterests: string[]): Frie
   return suggestedInterests.length > 0 ? { suggestedInterests } : null
 }
 
+const DIRECT_REQUEST_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000
+
 export async function createOrReusePendingFriendshipRequest({
   inviterUserId,
   inviteeUserId,
   suggestedInterests = [],
+  personalNote,
+  expiresAt,
+  now = new Date(),
 }: {
   inviterUserId: string
   inviteeUserId: string
   suggestedInterests?: string[]
+  personalNote?: string
+  // Defaults to NOW() + 30 days when undefined. Pass null to opt out
+  // (the SMS-invite caller does this — those invitations don't expire).
+  expiresAt?: Date | null
+  now?: Date
 }): Promise<{ friendship: typeof friendships.$inferSelect; state: FriendshipRequestState }> {
   const pair = friendshipPair(inviterUserId, inviteeUserId)
   const requestContext = requestContextForSuggestedInterests(suggestedInterests)
+  const trimmedNote = personalNote?.trim() || null
+  const resolvedExpiresAt =
+    expiresAt === undefined ? new Date(now.getTime() + DIRECT_REQUEST_EXPIRY_MS) : expiresAt
 
   const [existingFriendship] = await db
     .select()
@@ -57,6 +70,7 @@ export async function createOrReusePendingFriendshipRequest({
   }
 
   if (existingFriendship?.status === 'pending') {
+    // Reuse — caller must Cancel first to overwrite the note or expiry.
     return {
       friendship: existingFriendship,
       state: existingFriendship.requestedByUserId === inviterUserId ? 'pending_existing' : 'reverse_pending',
@@ -74,6 +88,11 @@ export async function createOrReusePendingFriendshipRequest({
         removedAt: null,
         removedByUserId: null,
         requestContext,
+        // Reopen: clear resolvedAt, refresh expiry, overwrite note only if
+        // the caller provided one (existing value wins otherwise).
+        resolvedAt: null,
+        expiresAt: resolvedExpiresAt,
+        ...(trimmedNote !== null ? { personalNote: trimmedNote } : {}),
       })
       .where(eq(friendships.id, existingFriendship.id))
       .returning()
@@ -102,6 +121,9 @@ export async function createOrReusePendingFriendshipRequest({
       removedAt: null,
       removedByUserId: null,
       requestContext,
+      personalNote: trimmedNote,
+      expiresAt: resolvedExpiresAt,
+      resolvedAt: null,
     })
     .returning()
 
@@ -134,6 +156,7 @@ export async function acceptPendingFriendshipRequest({
       formedAt: now,
       removedAt: null,
       removedByUserId: null,
+      resolvedAt: now,
     })
     .where(
       and(
@@ -173,6 +196,7 @@ export async function ignorePendingFriendshipRequest({
       status: 'declined',
       removedAt: now,
       removedByUserId: userId,
+      resolvedAt: now,
     })
     .where(
       and(
@@ -202,6 +226,7 @@ export async function cancelPendingFriendshipRequest({
       status: 'cancelled',
       removedAt: now,
       removedByUserId: userId,
+      resolvedAt: now,
     })
     .where(
       and(

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/vet-questions",
       "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/cron/expire-friend-requests",
+      "schedule": "30 6 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Builds the friend-request lifecycle on top of the schema columns added in PR #406 (B-Friends-1). Stacked on that PR — the diff here is just the B-Friends-2 work.

**What lands:**

- `createOrReusePendingFriendshipRequest` persists `personalNote` (trimmed, ≤160 via the B-Friends-1 CHECK) and `expiresAt` (defaults to NOW()+30d; SMS-invite caller passes `null` to opt out).
- accept / ignore / cancel helpers stamp `resolvedAt` alongside the existing `removedAt` audit writes — `resolvedAt` is the new semantic field the cron, GC, and recently-sent cooldown query against.
- New `getRelationship` / `getRelationships` helpers in `queries/friend-requests.ts` resolve the viewer↔target state across all five UI states and surface a block flag via removed-by-target detection.
- `POST /api/friend-requests` gains the `personalNote` field and uses `getRelationship` to enforce conflict semantics: 409 `already_friends` / `already_pending` / `inbound_exists`, 429 `recently_sent`, 404 on block.
- `AddFriendButton` (generic, surface-agnostic) + `AddFriendRequestModal` land in `src/components/friends/`. Modal mounts only while open so the lint rule against setState-in-effect stays happy. `ProfileFriendButton` is now a thin wrapper that derives the relationship from the existing `FriendPortraitData` shape.
- `getFriendsHub` returns `outboundRequests` alongside `incomingRequests`; `FriendsList` renders the new outbound section above `PeopleYouInvited` in the Sent tab and shows the personal note as an italic quoted block in both inbound and outbound rows.
- New cron `/api/cron/expire-friend-requests` (`30 6 * * *`) expires stale pending rows and GCs declined/expired rows older than 60 days.

## Test plan

- [ ] `npx tsc -p tsconfig.typecheck.json` — clean
- [ ] `npm run lint` — no new errors in the changed files (24 pre-existing errors elsewhere unchanged)
- [ ] Personal-note round-trip: `/users/[friend-id]` → Add friend → modal → 50-char note → Send. DB row has `personalNote` + `expiresAt = createdAt + 30d`. Recipient's `/friends` Invitations tab shows the note in the italic block.
- [ ] Empty-note path still works (server schema treats `personalNote` as optional).
- [ ] Sent tab shows the new outbound section above `PeopleYouInvited`. Cancel optimistically removes the row.
- [ ] Conflict statuses: re-send while pending → 409. Already-friends → 409. Inbound → 409 with `friendshipId`. Decline + immediate re-send → 429 `recently_sent`.
- [ ] Block detection: A removes B → B → POST /api/friend-requests inviteeUserId=A → 404.
- [ ] 160-char CHECK: direct UPDATE attempting 161-char personalNote fails.
- [ ] Cron: manually backdate `expiresAt` → hit cron → row transitions to `expired` with `resolvedAt`. Backdate `resolvedAt` 70 days → cron deletes.
- [ ] SMS-invite path unchanged: existing-user invitations create a Friendship row with `personalNote=NULL`, `expiresAt=NULL`.
- [ ] 24-hour in-memory ignore cooldown for SMS invitations still gates after a direct-request ignore.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWqbGGGzQo7sJdhj2uJZTs)_