### PR TITLE
feat(B-Friends-3): Find Friends + invite links + soft cap

### DIFF
--- a/drizzle/0049_user_invite_token.sql
+++ b/drizzle/0049_user_invite_token.sql
@@ -1,0 +1,21 @@
+-- Migration: add per-user invite token for shareable invite links (B-Friends-3).
+--
+-- users.invite_token is the inviter's evergreen invite link slug. URLs look
+-- like /invite/<handle>/<token>. Distinct from the existing
+-- FriendInvitation.token mechanism (per-invitation, expires, may pre-seed
+-- interests). The per-user token is generated lazily on first GET to
+-- /api/account/invite-token and can be rotated via /rotate, which 404s the
+-- old URL.
+--
+-- Nullable for now — users get one assigned on first read of the API. The
+-- unique partial index lets multiple users sit at NULL but enforces global
+-- uniqueness once tokens are assigned.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded
+-- without the column or index actually present.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "invite_token" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_invite_token"
+  ON "User" ("invite_token") WHERE "invite_token" IS NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -344,6 +344,13 @@
       "when": 1780704000000,
       "tag": "0048_friends_privacy_foundation",
       "breakpoints": true
+    },
+    {
+      "idx": 49,
+      "version": "7",
+      "when": 1780790400000,
+      "tag": "0049_user_invite_token",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/account/privacy/PrivacyForm.tsx
+++ b/src/app/account/privacy/PrivacyForm.tsx
@@ -1,14 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import type { DiscoverabilityState } from '@/server/db/queries/account';
 
 type Props = {
   initialState: DiscoverabilityState;
+  initialInviteUrl: string | null;
 };
 
 type PatchKey = 'contacts' | 'mutualFriends';
+
+type InviteTokenResponse = { token: string; url: string };
 
 async function patchDiscoverability(
   body: Partial<Record<PatchKey, boolean>>,
@@ -79,10 +82,63 @@ function ToggleRow({
   );
 }
 
-export function PrivacyForm({ initialState }: Props) {
+export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
   const [state, setState] = useState<DiscoverabilityState>(initialState);
   const [savingKey, setSavingKey] = useState<PatchKey | null>(null);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [inviteUrl, setInviteUrl] = useState<string | null>(initialInviteUrl);
+  const [rotating, setRotating] = useState(false);
+  const [inviteToast, setInviteToast] = useState<string | null>(null);
+  const [inviteError, setInviteError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!inviteToast) return;
+    const timer = window.setTimeout(() => setInviteToast(null), 1800);
+    return () => window.clearTimeout(timer);
+  }, [inviteToast]);
+
+  async function copyInviteUrl() {
+    if (!inviteUrl) return;
+    setInviteError(null);
+    try {
+      await navigator.clipboard.writeText(inviteUrl);
+      setInviteToast('Link copied.');
+    } catch {
+      setInviteError('Could not copy. Long-press the field to copy manually.');
+    }
+  }
+
+  async function rotateInviteUrl() {
+    if (rotating) return;
+    const confirmed = window.confirm(
+      'Rotate your invite link? The old link will stop working immediately.',
+    );
+    if (!confirmed) return;
+    setRotating(true);
+    setInviteError(null);
+    try {
+      const response = await fetch('/api/account/invite-token/rotate', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null;
+        setInviteError(body?.message ?? 'Could not rotate your link.');
+        return;
+      }
+      const body = (await response.json().catch(() => null)) as InviteTokenResponse | null;
+      if (!body?.url) {
+        setInviteError('Could not build the new link.');
+        return;
+      }
+      setInviteUrl(body.url);
+      setInviteToast('New link generated.');
+    } catch {
+      setInviteError('Network error. Try again.');
+    } finally {
+      setRotating(false);
+    }
+  }
 
   async function toggle(key: PatchKey) {
     const previous = state;
@@ -138,6 +194,48 @@ export function PrivacyForm({ initialState }: Props) {
 
       {errorMessage ? (
         <p className="text-sm text-destructive">{errorMessage}</p>
+      ) : null}
+
+      {inviteUrl ? (
+        <section className="rounded-xl border bg-card p-5 text-card-foreground">
+          <h2 className="font-serif text-lg font-semibold">Your invite link</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Anyone you share this with can join Joshing and land as your friend.
+          </p>
+          <input
+            type="text"
+            readOnly
+            value={inviteUrl}
+            onFocus={(event) => event.currentTarget.select()}
+            className="border-border bg-background text-foreground mt-3 h-11 w-full rounded-md border px-3 text-sm outline-none"
+          />
+          <div className="mt-2 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={() => void copyInviteUrl()}
+              className="btn-primary min-h-9 rounded-full px-4 text-sm"
+            >
+              Copy
+            </button>
+            <button
+              type="button"
+              onClick={() => void rotateInviteUrl()}
+              disabled={rotating}
+              className="btn-ghost min-h-9 rounded-full px-4 text-sm"
+            >
+              {rotating ? 'Rotating…' : 'Rotate link'}
+            </button>
+          </div>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Rotating invalidates the old link. Use this if you accidentally shared it broadly.
+          </p>
+          {inviteError ? <p className="mt-2 text-sm text-destructive">{inviteError}</p> : null}
+          {inviteToast ? (
+            <div className="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+              {inviteToast}
+            </div>
+          ) : null}
+        </section>
       ) : null}
     </div>
   );

--- a/src/app/account/privacy/page.tsx
+++ b/src/app/account/privacy/page.tsx
@@ -4,6 +4,12 @@ import { ChevronLeft } from 'lucide-react';
 
 import { getSession } from '@/server/auth/session';
 import { getDiscoverability } from '@/server/db/queries/account';
+import {
+  buildInviteUrl,
+  getBaseUrl,
+  getOrCreateInviteToken,
+} from '@/server/friends/user-invite-token';
+import { headers } from 'next/headers';
 
 import { PrivacyForm } from './PrivacyForm';
 
@@ -15,6 +21,16 @@ export default async function PrivacySettingsPage() {
 
   const state = await getDiscoverability(session.userId);
   if (!state) redirect('/login');
+
+  // Build the per-user invite URL server-side so the input renders populated
+  // on first paint. If the user doesn't have a handle yet (pre-P0-A
+  // accounts that haven't picked one), skip — the section won't render.
+  const tokenResult = await getOrCreateInviteToken(session.userId);
+  let inviteUrl: string | null = null;
+  if (tokenResult?.handle) {
+    const requestHeaders = await headers();
+    inviteUrl = buildInviteUrl(getBaseUrl(requestHeaders), tokenResult.handle, tokenResult.token);
+  }
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
@@ -32,7 +48,7 @@ export default async function PrivacySettingsPage() {
         Choose how other people can find you on Joshing.
       </p>
 
-      <PrivacyForm initialState={state} />
+      <PrivacyForm initialState={state} initialInviteUrl={inviteUrl} />
     </main>
   );
 }

--- a/src/app/api/account/invite-token/rotate/route.ts
+++ b/src/app/api/account/invite-token/rotate/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import {
+  buildInviteUrl,
+  getBaseUrl,
+  rotateInviteToken,
+} from '@/server/friends/user-invite-token'
+
+export const dynamic = 'force-dynamic'
+
+export async function POST(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const result = await rotateInviteToken(session.userId)
+  if (!result) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  if (!result.handle) {
+    return NextResponse.json(
+      {
+        error: 'handle_required',
+        message: 'Set a handle in your profile before generating an invite link.',
+      },
+      { status: 409 },
+    )
+  }
+
+  const url = buildInviteUrl(getBaseUrl(request), result.handle, result.token)
+  return NextResponse.json({ token: result.token, url })
+}

--- a/src/app/api/account/invite-token/route.ts
+++ b/src/app/api/account/invite-token/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import {
+  buildInviteUrl,
+  getBaseUrl,
+  getOrCreateInviteToken,
+} from '@/server/friends/user-invite-token'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const result = await getOrCreateInviteToken(session.userId)
+  if (!result) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+  if (!result.handle) {
+    return NextResponse.json(
+      {
+        error: 'handle_required',
+        message: 'Set a handle in your profile before generating an invite link.',
+      },
+      { status: 409 },
+    )
+  }
+
+  const url = buildInviteUrl(getBaseUrl(request), result.handle, result.token)
+  return NextResponse.json({ token: result.token, url })
+}

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -13,11 +13,22 @@ import {
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations'
+import { acceptUserInviteLink } from '@/server/friends/user-invite-token'
 
 type VerifyOtpBody = {
   phone?: unknown
   code?: unknown
   invitationToken?: unknown
+  userInvite?: unknown
+}
+
+function parseUserInvite(value: unknown): { handle: string; token: string } | null {
+  if (!value || typeof value !== 'object') return null
+  const candidate = value as { handle?: unknown; token?: unknown }
+  const handle = typeof candidate.handle === 'string' ? candidate.handle.trim() : ''
+  const token = typeof candidate.token === 'string' ? candidate.token.trim() : ''
+  if (!handle || !token) return null
+  return { handle, token }
 }
 
 type AuthUser = {
@@ -103,6 +114,7 @@ export async function POST(request: Request) {
         ? body.invitationToken.trim()
         : ''
     const hasUsableToken = tokenProvided && invitationToken.length > 0
+    const userInvite = parseUserInvite(body?.userInvite)
 
     if (!phone || !code) {
       return NextResponse.json(
@@ -144,6 +156,18 @@ export async function POST(request: Request) {
         })
       }
 
+      // Per-user invite-link flow (B-Friends-3): when the visitor arrived
+      // via /invite/<handle>/<token>, create the active friendship now.
+      // Silent on failure — the worst case is the user logs in without
+      // the new friendship, which they can fix via Add Friend.
+      if (userInvite) {
+        await acceptUserInviteLink({
+          handle: userInvite.handle,
+          token: userInvite.token,
+          inviteeUserId: existingUser.id,
+        })
+      }
+
       await createSession(existingUser.id, {
         invitationAccepted: true,
         onboardingComplete: false,
@@ -161,36 +185,54 @@ export async function POST(request: Request) {
       })
     }
 
-    // New-user path: invitation is a hard precondition.
-    if (!hasUsableToken) {
+    // New-user path: an invitation is a hard precondition. Either a
+    // FriendInvitation token (SMS-style) or a per-user invite link
+    // (B-Friends-3) satisfies the gate.
+    if (!hasUsableToken && !userInvite) {
       return inviteRequiredRejection()
     }
 
-    // Pre-validate the invitation read-only so we don't provision a user
-    // for a bad token.
-    const candidateInvitation = await getValidInvitationForPhone({
-      token: invitationToken,
-      verifiedPhone: normalizedPhone,
-    })
+    // Pre-validate the FriendInvitation read-only so we don't provision a
+    // user for a bad token. Only required when no per-user invite link is
+    // present — userInvite alone is a sufficient gate.
+    if (hasUsableToken) {
+      const candidateInvitation = await getValidInvitationForPhone({
+        token: invitationToken,
+        verifiedPhone: normalizedPhone,
+      })
 
-    if (!candidateInvitation) {
-      return invitationRejection()
+      if (!candidateInvitation) {
+        return invitationRejection()
+      }
     }
 
     const user = await provisionUserForPhone(normalizedPhone)
 
-    const invitation = await acceptFriendInvitation({
-      token: invitationToken,
-      inviteeUserId: user.id,
-      verifiedPhone: normalizedPhone,
-    })
+    let invitation: { accepted: boolean } = { accepted: false }
 
-    if (!invitation.accepted) {
-      // Race condition: the invitation was claimed between our pre-validate
-      // and accept. The user row already exists but has no accepted
-      // invitation — future logins will hit the orphan-rejection branch
-      // above, so the access surface is closed.
-      return invitationRejection()
+    if (hasUsableToken) {
+      invitation = await acceptFriendInvitation({
+        token: invitationToken,
+        inviteeUserId: user.id,
+        verifiedPhone: normalizedPhone,
+      })
+
+      if (!invitation.accepted) {
+        // Race condition: the invitation was claimed between our pre-validate
+        // and accept. The user row already exists but has no accepted
+        // invitation — future logins will hit the orphan-rejection branch
+        // above, so the access surface is closed.
+        return invitationRejection()
+      }
+    } else if (userInvite) {
+      // Per-user invite link path: create the active friendship now. If
+      // the link is bad we still let the user through — they're already
+      // provisioned, and a missing friendship is recoverable.
+      invitation = await acceptUserInviteLink({
+        handle: userInvite.handle,
+        token: userInvite.token,
+        inviteeUserId: user.id,
+      })
     }
 
     await createSession(user.id, {

--- a/src/app/api/friends/invite-reflections/route.ts
+++ b/src/app/api/friends/invite-reflections/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { listInviteReflections } from '@/server/db/queries/friend-invitations'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const reflections = await listInviteReflections(session.userId)
+  return NextResponse.json({ reflections })
+}

--- a/src/app/api/friends/search/route.ts
+++ b/src/app/api/friends/search/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getSession } from '@/server/auth/session'
+import { searchFriendByHandleOrPhone } from '@/server/db/queries/friend-search'
+
+export const dynamic = 'force-dynamic'
+
+const querySchema = z.object({
+  q: z.string().trim().min(1).max(80),
+})
+
+export async function GET(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const url = new URL(request.url)
+  const parsed = querySchema.safeParse({ q: url.searchParams.get('q') ?? '' })
+  if (!parsed.success) {
+    return NextResponse.json({ match: null })
+  }
+
+  const match = await searchFriendByHandleOrPhone(session.userId, parsed.data.q)
+  return NextResponse.json({ match })
+}

--- a/src/app/friends/find/page.tsx
+++ b/src/app/friends/find/page.tsx
@@ -1,0 +1,147 @@
+import Link from 'next/link'
+import { redirect } from 'next/navigation'
+import { ChevronLeft } from 'lucide-react'
+
+import AddFriendInvite from '@/components/AddFriendInvite'
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch'
+import { InviteSomeoneNew } from '@/components/friends/InviteSomeoneNew'
+import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
+import { getSession } from '@/server/auth/session'
+import { listInviteReflections } from '@/server/db/queries/friend-invitations'
+import { db, users } from '@/server/db'
+import { eq } from 'drizzle-orm'
+
+export const dynamic = 'force-dynamic'
+
+function initialsFor(name: string | null, fallback: string): string {
+  const source = (name?.trim() || fallback).replace(/[^a-zA-Z]+/g, ' ').trim()
+  if (!source) return '??'
+  const parts = source.split(/\s+/)
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+}
+
+export default async function FindFriendsPage() {
+  const session = await getSession()
+  if (!session) redirect('/login')
+
+  const [viewer] = await db
+    .select({
+      discoverableByMutualFriends: users.discoverableByMutualFriends,
+    })
+    .from(users)
+    .where(eq(users.id, session.userId))
+    .limit(1)
+
+  if (!viewer) redirect('/login')
+
+  const reflections = await listInviteReflections(session.userId)
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
+      <Link
+        href="/friends"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Back
+      </Link>
+      <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
+        Find friends
+      </h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Search for someone, see who you&rsquo;ve nudged, or invite a friend.
+      </p>
+
+      <div className="mt-6 space-y-5">
+        {/* Block 1 — Search by handle or phone */}
+        <FindFriendsSearch />
+
+        {/* Block 2 — Contact matches (placeholder; B-Friends-4 replaces) */}
+        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+          <h2 className="font-serif text-lg font-semibold">
+            Find friends already on Joshing
+          </h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            We can check which of your phone contacts are here. We never share your contacts.
+          </p>
+          <button
+            type="button"
+            disabled
+            title="Coming soon."
+            aria-disabled
+            className="bg-muted text-muted-foreground mt-3 inline-flex h-11 cursor-not-allowed items-center justify-center rounded-full px-4 text-sm opacity-60"
+          >
+            Match my contacts
+          </button>
+        </section>
+
+        {/* Block 3 — Existing-invite reflection */}
+        {reflections.length > 0 ? (
+          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+            <h2 className="font-serif text-lg font-semibold">
+              People you invited
+            </h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              They showed up. Want to make it official?
+            </p>
+            <div className="mt-3 space-y-3">
+              {reflections.map((reflection) => {
+                const displayName = reflection.displayName?.trim() || `@${reflection.handle ?? ''}`
+                const initials = initialsFor(reflection.displayName, reflection.handle ?? '?')
+                const swatch = reflection.avatarColor || colorForUser(reflection.inviteeUserId)
+                return (
+                  <article
+                    key={reflection.invitationId}
+                    className="bg-background flex items-start gap-3 rounded-xl border p-3"
+                  >
+                    <span
+                      aria-hidden
+                      className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
+                      style={{ background: swatch }}
+                    >
+                      {initials}
+                    </span>
+                    <div className="min-w-0 flex-1">
+                      <h3 className="text-foreground font-medium">{displayName}</h3>
+                      <p className="text-muted-foreground/70 mt-1 text-xs">
+                        invited {formatRelativeTime(reflection.invitedAt.toISOString())}{' '}
+                        · joined {formatRelativeTime(reflection.joinedAt.toISOString())}
+                      </p>
+                    </div>
+                    <AddFriendButton
+                      targetUserId={reflection.inviteeUserId}
+                      targetDisplayName={displayName}
+                      relationship={reflection.relationship}
+                    />
+                  </article>
+                )
+              })}
+            </div>
+          </section>
+        ) : null}
+
+        {/* Block 4 — Invite someone new */}
+        <InviteSomeoneNew />
+
+        {/* Block 5 — Suggested via mutual friends (placeholder; hidden when opted out) */}
+        {viewer.discoverableByMutualFriends ? (
+          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+            <h2 className="font-serif text-lg font-semibold">
+              Suggested via mutual friends
+            </h2>
+            <p className="text-muted-foreground mt-1 text-sm">
+              Coming soon — suggestions from people you have friends in common with.
+            </p>
+          </section>
+        ) : null}
+      </div>
+
+      {/* Listener for the 'Send a personal invite' button — AddFriendInvite
+          subscribes to the friend-invitations:create-new event and opens its
+          3-step modal. Must be mounted here so the event has a listener. */}
+      <AddFriendInvite />
+    </main>
+  )
+}

--- a/src/app/invite/[handle]/[token]/page.tsx
+++ b/src/app/invite/[handle]/[token]/page.tsx
@@ -1,0 +1,130 @@
+// Per-user invite link handler (B-Friends-3).
+//
+// DISTINCT from /invite/[token]/page.tsx — that route resolves a
+// FriendInvitation.token (per-invitation, expires, may pre-seed interests).
+// THIS route resolves the inviter's evergreen users.invite_token, generated
+// on demand at /api/account/invite-token and rotatable from /account/privacy.
+// Both must coexist.
+
+import type { ReactNode } from 'react'
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { getSession } from '@/server/auth/session'
+import { getRelationship } from '@/server/db/queries/friend-requests'
+import { resolveInviteLink } from '@/server/friends/user-invite-token'
+
+type InvitePageProps = {
+  params: Promise<{ handle: string; token: string }>
+}
+
+function InviteShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
+      <section className="bg-card w-full max-w-sm rounded-2xl border p-5 shadow-sm">
+        {children}
+      </section>
+    </main>
+  )
+}
+
+function loginHref(handle: string, token: string): string {
+  const params = new URLSearchParams({
+    inviteHandle: handle,
+    inviteUserToken: token,
+  })
+  return `/login?${params.toString()}`
+}
+
+export default async function UserInvitePage({ params }: InvitePageProps) {
+  const { handle, token } = await params
+  const inviter = await resolveInviteLink(handle, token)
+
+  if (!inviter) {
+    return (
+      <InviteShell>
+        <div className="space-y-4 text-center">
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            Link not valid
+          </p>
+          <h1 className="text-2xl font-semibold tracking-normal">
+            This invite link is no longer valid.
+          </h1>
+          <p className="text-muted-foreground text-sm leading-6">
+            Ask your friend for a fresh link.
+          </p>
+          <Link
+            href="/login"
+            className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
+          >
+            Go to login
+          </Link>
+        </div>
+      </InviteShell>
+    )
+  }
+
+  const session = await getSession()
+  const displayName = inviter.inviterDisplayName?.trim() || `@${inviter.inviterHandle}`
+
+  // Logged-in as the inviter themselves — bounce to /friends.
+  if (session?.userId === inviter.inviterUserId) {
+    redirect('/friends')
+  }
+
+  // Logged-in as someone else — render an inline send-friend-request UI.
+  if (session) {
+    const relationship = await getRelationship(session.userId, inviter.inviterUserId)
+    return (
+      <InviteShell>
+        <div className="space-y-5">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+              You were invited
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold tracking-normal">
+              {displayName} invited you to connect on Joshing.
+            </h1>
+          </div>
+          <AddFriendButton
+            targetUserId={inviter.inviterUserId}
+            targetDisplayName={displayName}
+            relationship={relationship}
+          />
+          <Link
+            href={`/users/${inviter.inviterUserId}`}
+            className="text-muted-foreground inline-flex text-sm underline underline-offset-4"
+          >
+            View {displayName}&rsquo;s profile
+          </Link>
+        </div>
+      </InviteShell>
+    )
+  }
+
+  // Logged-out — landing card → /login with the invite params attached.
+  return (
+    <InviteShell>
+      <div className="space-y-5">
+        <div>
+          <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
+            A note from a friend
+          </p>
+          <h1 className="mt-2 text-3xl font-semibold tracking-normal">
+            {displayName} invited you to Joshing.
+          </h1>
+          <p className="text-muted-foreground mt-3 text-sm leading-6">
+            Pick up your phone — we&rsquo;ll text you a code to get started.
+          </p>
+        </div>
+        <Link
+          href={loginHref(inviter.inviterHandle, token)}
+          className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
+        >
+          Continue
+        </Link>
+      </div>
+    </InviteShell>
+  )
+}

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -27,18 +27,30 @@ export function readInvitationToken(searchParams: URLSearchParams) {
   return searchParams.get('invitationToken') ?? searchParams.get('invite') ?? searchParams.get('token');
 }
 
+export function readUserInvite(searchParams: URLSearchParams) {
+  const handle = searchParams.get('inviteHandle');
+  const token = searchParams.get('inviteUserToken');
+  return handle && token ? { handle, token } : null;
+}
+
 export function buildVerifyOtpRequestBody(
   phone: string,
   code: string,
   searchParams: URLSearchParams
 ) {
-  return { phone, code, invitationToken: readInvitationToken(searchParams) };
+  return {
+    phone,
+    code,
+    invitationToken: readInvitationToken(searchParams),
+    userInvite: readUserInvite(searchParams),
+  };
 }
 
 export default function LoginPanel() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = readInvitationToken(searchParams);
+  const userInvite = readUserInvite(searchParams);
 
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
@@ -56,7 +68,7 @@ export default function LoginPanel() {
       return;
     }
 
-    if (invitationToken) sendTelemetry('friend_invite_auth_started');
+    if (invitationToken || userInvite) sendTelemetry('friend_invite_auth_started');
 
     setLoading(true);
     try {

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import Link from 'next/link'
+
 import AddFriendInvite from '@/components/AddFriendInvite'
 import FriendsList from '@/components/FriendsList'
 
@@ -16,13 +18,21 @@ export default function FriendsHubPage() {
         <h1 className="text-foreground font-serif text-3xl font-semibold">
           Friends
         </h1>
-        <button
-          type="button"
-          className="btn-primary min-h-10 shrink-0 rounded-full px-4 text-sm"
-          onClick={openAddFriend}
-        >
-          Add friend
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          <Link
+            href="/friends/find"
+            className="btn-ghost min-h-10 rounded-full px-4 text-sm"
+          >
+            Find friends
+          </Link>
+          <button
+            type="button"
+            className="btn-primary min-h-10 rounded-full px-4 text-sm"
+            onClick={openAddFriend}
+          >
+            Add friend
+          </button>
+        </div>
       </header>
 
       <AddFriendInvite />

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -7,6 +7,8 @@ import { useCallback, useEffect, useState } from 'react'
 
 type Tab = 'friends' | 'invitations' | 'sent'
 
+const SOFT_CAP = 25
+
 type Friend = {
   id: string
   displayName: string
@@ -58,6 +60,8 @@ export default function FriendsList() {
   const [error, setError] = useState<string | null>(null)
   const [pendingRequest, setPendingRequest] = useState<string | null>(null)
   const [activeTab, setActiveTab] = useState<Tab>('friends')
+  // Session-local: nudge reappears on next page load if still over the cap.
+  const [softCapDismissed, setSoftCapDismissed] = useState(false)
 
   const loadFriends = useCallback(async () => {
     setError(null)
@@ -203,6 +207,27 @@ export default function FriendsList() {
       {/* Friends tab */}
       {activeTab === 'friends' ? (
         <section>
+          {friends.length > SOFT_CAP && !softCapDismissed ? (
+            <div className="bg-muted/50 mb-3 flex items-start justify-between gap-3 rounded-xl border p-3">
+              <div className="min-w-0">
+                <p className="text-foreground text-sm font-medium">
+                  Joshing works best with a small group — you&rsquo;re at {friends.length}.
+                </p>
+                <p className="text-muted-foreground mt-1 text-xs">
+                  No rule, just a nudge.
+                </p>
+              </div>
+              <button
+                type="button"
+                aria-label="Dismiss"
+                onClick={() => setSoftCapDismissed(true)}
+                className="text-muted-foreground hover:text-foreground -mr-1 px-2 text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+          ) : null}
+
           {error ? (
             <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
           ) : null}
@@ -270,7 +295,16 @@ export default function FriendsList() {
 
       {/* Invitations tab */}
       {activeTab === 'invitations' ? (
-        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <div className="space-y-3">
+          <Link
+            href="/friends/find"
+            className="bg-card hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"
+          >
+            <p className="text-foreground text-sm font-medium">
+              Find friends already on Joshing or invite someone new →
+            </p>
+          </Link>
+          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
           {loading ? (
             <p className="text-muted-foreground text-sm">Loading invitations…</p>
           ) : incomingRequests.length > 0 ? (
@@ -344,6 +378,7 @@ export default function FriendsList() {
             </p>
           )}
         </section>
+        </div>
       ) : null}
 
       {/* Sent tab */}

--- a/src/components/friends/FindFriendsSearch.tsx
+++ b/src/components/friends/FindFriendsSearch.tsx
@@ -1,0 +1,164 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
+import type { RelationshipResult } from '@/server/db/queries/friend-requests'
+
+type Match = {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarColor: string | null
+  createdAt: string
+  relationship: RelationshipResult
+}
+
+type SearchResponse = { match: Match | null }
+
+const DEBOUNCE_MS = 400
+
+function initialsFor(name: string | null, fallback: string): string {
+  const source = (name?.trim() || fallback).replace(/[^a-zA-Z]+/g, ' ').trim()
+  if (!source) return '??'
+  const parts = source.split(/\s+/)
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+}
+
+export function FindFriendsSearch() {
+  const [query, setQuery] = useState('')
+  const [searching, setSearching] = useState(false)
+  const [match, setMatch] = useState<Match | null>(null)
+  const [searched, setSearched] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const requestSeq = useRef(0)
+  const debounceRef = useRef<number | null>(null)
+
+  async function runSearch(value: string) {
+    const trimmed = value.trim()
+    if (!trimmed) {
+      setMatch(null)
+      setSearched(false)
+      setError(null)
+      return
+    }
+    const seq = ++requestSeq.current
+    setSearching(true)
+    setError(null)
+    try {
+      const response = await fetch(
+        `/api/friends/search?q=${encodeURIComponent(trimmed)}`,
+        { credentials: 'include' },
+      )
+      if (seq !== requestSeq.current) return
+      if (!response.ok) {
+        setError('Search failed. Try again.')
+        setMatch(null)
+        setSearched(true)
+        return
+      }
+      const body = (await response.json().catch(() => null)) as SearchResponse | null
+      setMatch(body?.match ?? null)
+      setSearched(true)
+    } catch {
+      if (seq !== requestSeq.current) return
+      setError('Network error. Try again.')
+      setMatch(null)
+      setSearched(true)
+    } finally {
+      if (seq === requestSeq.current) setSearching(false)
+    }
+  }
+
+  // Debounced fetch only — never setState synchronously inside the effect
+  // body (linter rule react-hooks/set-state-in-effect). The "clear on
+  // empty query" path is handled in handleQueryChange below.
+  useEffect(() => {
+    if (!query.trim()) return
+    if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    debounceRef.current = window.setTimeout(() => {
+      void runSearch(query)
+    }, DEBOUNCE_MS)
+    return () => {
+      if (debounceRef.current) window.clearTimeout(debounceRef.current)
+    }
+  }, [query])
+
+  function handleQueryChange(value: string) {
+    setQuery(value)
+    if (!value.trim()) {
+      setMatch(null)
+      setSearched(false)
+      setError(null)
+    }
+  }
+
+  function refreshAfterAction() {
+    void runSearch(query)
+  }
+
+  const matchDisplayName = match ? match.displayName?.trim() || `@${match.handle ?? ''}` : ''
+  const initials = match ? initialsFor(match.displayName, match.handle ?? '?') : ''
+  const swatch = match ? match.avatarColor || colorForUser(match.id) : null
+
+  return (
+    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <h2 className="font-serif text-lg font-semibold">Search</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        By @handle or US phone number. Exact matches only.
+      </p>
+      <input
+        type="search"
+        value={query}
+        onChange={(event) => handleQueryChange(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault()
+            void runSearch(query)
+          }
+        }}
+        placeholder="@handle or (415) 555-1234"
+        className="border-border bg-background text-foreground placeholder:text-muted-foreground mt-3 h-11 w-full rounded-md border px-3 text-sm outline-none focus:ring-2 focus:ring-primary/40"
+      />
+
+      <div className="mt-3 min-h-[44px]">
+        {searching ? (
+          <p className="text-muted-foreground text-sm">Searching…</p>
+        ) : error ? (
+          <p className="text-destructive text-sm">{error}</p>
+        ) : match ? (
+          <article className="bg-background flex items-start gap-3 rounded-xl border p-3">
+            <span
+              aria-hidden
+              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
+              style={{ background: swatch ?? '#888' }}
+            >
+              {initials}
+            </span>
+            <div className="min-w-0 flex-1">
+              <h3 className="text-foreground font-medium">{matchDisplayName}</h3>
+              {match.handle ? (
+                <p className="text-muted-foreground text-xs">@{match.handle}</p>
+              ) : null}
+              <p className="text-muted-foreground/70 mt-1 text-xs">
+                joined {formatRelativeTime(match.createdAt)}
+              </p>
+            </div>
+            <AddFriendButton
+              targetUserId={match.id}
+              targetDisplayName={matchDisplayName}
+              relationship={match.relationship}
+              onChange={refreshAfterAction}
+            />
+          </article>
+        ) : searched ? (
+          <p className="text-muted-foreground text-sm">
+            No one by that name. They may not be on Joshing yet — you can invite them below.
+          </p>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/src/components/friends/InviteSomeoneNew.tsx
+++ b/src/components/friends/InviteSomeoneNew.tsx
@@ -1,0 +1,85 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type InviteTokenResponse = { token: string; url: string }
+
+// Side-by-side: "Send a personal invite" (opens the existing AddFriendInvite
+// 3-step modal via the friend-invitations:create-new event) and "Copy invite
+// link" (fetches/persists the per-user invite token and copies the URL).
+export function InviteSomeoneNew() {
+  const [copying, setCopying] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = window.setTimeout(() => setToast(null), 1800)
+    return () => window.clearTimeout(timer)
+  }, [toast])
+
+  function openPersonalInvite() {
+    window.dispatchEvent(
+      new CustomEvent('friend-invitations:create-new', { detail: {} }),
+    )
+  }
+
+  async function copyInviteLink() {
+    if (copying) return
+    setCopying(true)
+    setError(null)
+    try {
+      const response = await fetch('/api/account/invite-token', {
+        credentials: 'include',
+      })
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        setError(body?.message ?? 'Could not fetch your invite link.')
+        return
+      }
+      const body = (await response.json().catch(() => null)) as InviteTokenResponse | null
+      if (!body?.url) {
+        setError('Could not build your invite link.')
+        return
+      }
+      await navigator.clipboard.writeText(body.url)
+      setToast('Link copied.')
+    } catch {
+      setError('Could not copy your invite link.')
+    } finally {
+      setCopying(false)
+    }
+  }
+
+  return (
+    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <h2 className="font-serif text-lg font-semibold">Invite someone new</h2>
+      <p className="text-muted-foreground mt-1 text-sm">
+        A personal note for someone specific, or a casual link you can share anywhere.
+      </p>
+      <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
+        <button
+          type="button"
+          onClick={openPersonalInvite}
+          className="btn-primary min-h-11 rounded-full px-4 text-sm"
+        >
+          Send a personal invite
+        </button>
+        <button
+          type="button"
+          onClick={() => void copyInviteLink()}
+          disabled={copying}
+          className="btn-ghost min-h-11 rounded-full px-4 text-sm"
+        >
+          {copying ? 'Loading…' : 'Copy invite link'}
+        </button>
+      </div>
+      {error ? <p className="text-destructive mt-2 text-sm">{error}</p> : null}
+      {toast ? (
+        <div className="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -752,6 +752,24 @@ export async function register() {
       // creates the base tables before this migration runs.
     }
 
+    // Migration 0049 adds the per-user invite token (users.invite_token)
+    // used by /invite/<handle>/<token> shareable links. Guard for preview/
+    // production databases that may have the migration recorded without
+    // the column or the unique partial index actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "invite_token" text
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "idx_users_invite_token"
+          ON "User" ("invite_token") WHERE "invite_token" IS NOT NULL
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/db/queries/friend-invitations.ts
+++ b/src/server/db/queries/friend-invitations.ts
@@ -1,0 +1,82 @@
+import { sql } from 'drizzle-orm'
+
+import { db } from '@/server/db'
+import { getRelationships, type RelationshipResult } from '@/server/db/queries/friend-requests'
+
+export type InviteReflection = {
+  invitationId: string
+  inviteeUserId: string
+  handle: string | null
+  displayName: string | null
+  avatarColor: string | null
+  joinedAt: Date
+  invitedAt: Date
+  acceptedAt: Date | null
+  relationship: RelationshipResult
+}
+
+// Lists users that this player previously invited (via the SMS-style
+// FriendInvitation flow) who have since joined Joshing AND don't already
+// have an active or pending Friendship with the player. Used by the Find
+// Friends page Block 3 ("here are people you nudged who showed up").
+//
+// Filters out blocked rows (isBlocked === true from getRelationships).
+export async function listInviteReflections(userId: string, limit = 20): Promise<InviteReflection[]> {
+  const rows = await db.execute<{
+    invitation_id: string
+    invitee_user_id: string
+    handle: string | null
+    display_name: string | null
+    avatar_color: string | null
+    joined_at: Date
+    invited_at: Date
+    accepted_at: Date | null
+  }>(sql`
+    SELECT
+      fi."id"             AS invitation_id,
+      fi."inviteeUserId"  AS invitee_user_id,
+      u."handle"          AS handle,
+      u."display_name"    AS display_name,
+      u."avatar_color"    AS avatar_color,
+      u."created_at"      AS joined_at,
+      fi."sentAt"         AS invited_at,
+      fi."acceptedAt"     AS accepted_at
+    FROM "FriendInvitation" fi
+    JOIN "User" u ON u."id" = fi."inviteeUserId"
+    WHERE fi."inviterUserId" = ${userId}
+      AND fi."inviteeUserId" IS NOT NULL
+      AND NOT EXISTS (
+        SELECT 1 FROM "Friendship" f
+        WHERE f."status" IN ('active', 'pending')
+          AND (
+            (f."userAId" = ${userId} AND f."userBId" = u."id")
+            OR (f."userAId" = u."id" AND f."userBId" = ${userId})
+          )
+      )
+    ORDER BY u."created_at" DESC
+    LIMIT ${limit}
+  `)
+
+  if (rows.rows.length === 0) return []
+
+  const inviteeIds = rows.rows.map((row) => row.invitee_user_id)
+  const relationships = await getRelationships(userId, inviteeIds)
+
+  const result: InviteReflection[] = []
+  for (const row of rows.rows) {
+    const relationship = relationships.get(row.invitee_user_id)
+    if (!relationship || relationship.isBlocked) continue
+    result.push({
+      invitationId: row.invitation_id,
+      inviteeUserId: row.invitee_user_id,
+      handle: row.handle,
+      displayName: row.display_name,
+      avatarColor: row.avatar_color,
+      joinedAt: new Date(row.joined_at),
+      invitedAt: new Date(row.invited_at),
+      acceptedAt: row.accepted_at ? new Date(row.accepted_at) : null,
+      relationship,
+    })
+  }
+  return result
+}

--- a/src/server/db/queries/friend-search.ts
+++ b/src/server/db/queries/friend-search.ts
@@ -1,0 +1,79 @@
+import { eq, sql } from 'drizzle-orm'
+
+import { isUsPhoneNumber, normalizePhone } from '@/server/auth'
+import { db, users } from '@/server/db'
+import { getRelationship, type RelationshipResult } from '@/server/db/queries/friend-requests'
+
+export type FriendSearchMatch = {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarColor: string | null
+  createdAt: Date
+  relationship: RelationshipResult
+}
+
+const HANDLE_QUERY_PATTERN = /^@?[a-z0-9_]{3,20}$/i
+
+function stripAtSign(value: string): string {
+  return value.startsWith('@') ? value.slice(1) : value
+}
+
+// Exact-match only — no partial leakage. Handle is case-insensitive,
+// phone is normalized to US E.164 before matching. Returns null when no
+// match OR when the matched user has soft-removed the viewer (block
+// detection via getRelationship.isBlocked).
+export async function searchFriendByHandleOrPhone(
+  viewerId: string,
+  query: string,
+): Promise<FriendSearchMatch | null> {
+  const trimmed = query.trim()
+  if (!trimmed) return null
+
+  let candidate: {
+    id: string
+    handle: string | null
+    displayName: string | null
+    avatarColor: string | null
+    createdAt: Date
+  } | null = null
+
+  if (HANDLE_QUERY_PATTERN.test(trimmed)) {
+    const bareHandle = stripAtSign(trimmed)
+    const [row] = await db
+      .select({
+        id: users.id,
+        handle: users.handle,
+        displayName: users.displayName,
+        avatarColor: users.avatarColor,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(sql`LOWER(${users.handle}) = LOWER(${bareHandle})`)
+      .limit(1)
+    candidate = row ?? null
+  } else if (isUsPhoneNumber(trimmed)) {
+    const normalized = normalizePhone(trimmed)
+    const [row] = await db
+      .select({
+        id: users.id,
+        handle: users.handle,
+        displayName: users.displayName,
+        avatarColor: users.avatarColor,
+        createdAt: users.createdAt,
+      })
+      .from(users)
+      .where(eq(users.phoneNumber, normalized))
+      .limit(1)
+    candidate = row ?? null
+  }
+
+  if (!candidate) return null
+  // Self-match returns null (don't surface the viewer's own profile).
+  if (candidate.id === viewerId) return null
+
+  const relationship = await getRelationship(viewerId, candidate.id)
+  if (relationship.isBlocked) return null
+
+  return { ...candidate, relationship }
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -168,6 +168,7 @@ export const users = pgTable(
     slug: text('slug'),
     handle: text('handle'),
     handleLastChangedAt: timestamp('handle_last_changed_at', { withTimezone: true }),
+    inviteToken: text('invite_token'),
     avatarColor: text('avatar_color'),
     bio: text('bio'),
     tagline: text('tagline'),

--- a/src/server/friends/user-invite-token.ts
+++ b/src/server/friends/user-invite-token.ts
@@ -1,0 +1,154 @@
+import { randomBytes } from 'node:crypto'
+
+import { eq, sql } from 'drizzle-orm'
+
+import { db, users } from '@/server/db'
+import { upsertInvitationFriendship } from '@/server/friends/friendships'
+
+// Match the prior-art token primitive used for FriendInvitation tokens at
+// src/server/friends/invitations.ts:166 — randomBytes(32).toString('base64url')
+// yields a 43-char URL-safe string.
+export function generateUserInviteToken(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+export type UserInviteTokenResult = {
+  token: string
+  handle: string | null
+}
+
+// Returns the user's invite token, generating + persisting one if NULL.
+// Handle may be null for pre-handle accounts (shouldn't happen post-P0-A
+// rollout, but be defensive — callers that need to build a URL should
+// surface a "set a handle first" error in that case).
+export async function getOrCreateInviteToken(userId: string): Promise<UserInviteTokenResult | null> {
+  const [row] = await db
+    .select({ inviteToken: users.inviteToken, handle: users.handle })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  if (!row) return null
+  if (row.inviteToken) return { token: row.inviteToken, handle: row.handle }
+
+  const token = generateUserInviteToken()
+  await db
+    .update(users)
+    .set({ inviteToken: token, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+
+  return { token, handle: row.handle }
+}
+
+// Always regenerates + persists. The old token, if any, stops resolving
+// immediately — /invite/<handle>/<old-token> returns 404.
+export async function rotateInviteToken(userId: string): Promise<UserInviteTokenResult | null> {
+  const [row] = await db
+    .select({ handle: users.handle })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
+
+  if (!row) return null
+
+  const token = generateUserInviteToken()
+  await db
+    .update(users)
+    .set({ inviteToken: token, updatedAt: new Date() })
+    .where(eq(users.id, userId))
+
+  return { token, handle: row.handle }
+}
+
+// Lifted from src/app/api/friend-invitations/route.ts:158-173 so invite-link
+// URLs use the same base-resolution as SMS invitation URLs. Accepts either
+// a Request (route handlers) or a Headers map (server components reading
+// via next/headers).
+export function getBaseUrl(source?: Request | Headers): string {
+  const configured = process.env.NEXT_PUBLIC_APP_URL ?? process.env.APP_URL
+  if (configured) return configured.replace(/\/$/, '')
+
+  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  if (vercelProd) return `https://${vercelProd.replace(/\/$/, '')}`
+
+  if (source) {
+    const headers = source instanceof Request ? source.headers : source
+    const host = headers.get('x-forwarded-host') ?? headers.get('host')
+    const protocol = headers.get('x-forwarded-proto') ?? 'https'
+    if (host) return `${protocol}://${host}`
+    if (source instanceof Request) return new URL(source.url).origin
+  }
+
+  return 'http://localhost:3000'
+}
+
+export function buildInviteUrl(baseUrl: string, handle: string, token: string): string {
+  return `${baseUrl}/invite/${encodeURIComponent(handle)}/${encodeURIComponent(token)}`
+}
+
+// Resolves /invite/<handle>/<token> by looking up the inviter case-
+// insensitively on handle and verifying the token matches exactly.
+// Returns null when not found OR mismatched (don't reveal which).
+export type InviteLinkResolution = {
+  inviterUserId: string
+  inviterHandle: string
+  inviterDisplayName: string | null
+  inviterAvatarColor: string | null
+}
+
+export async function resolveInviteLink(handle: string, token: string): Promise<InviteLinkResolution | null> {
+  const [row] = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      avatarColor: users.avatarColor,
+      inviteToken: users.inviteToken,
+    })
+    .from(users)
+    .where(sql`LOWER(${users.handle}) = LOWER(${handle})`)
+    .limit(1)
+
+  if (!row || !row.handle || !row.inviteToken) return null
+  if (row.inviteToken !== token) return null
+
+  return {
+    inviterUserId: row.id,
+    inviterHandle: row.handle,
+    inviterDisplayName: row.displayName,
+    inviterAvatarColor: row.avatarColor,
+  }
+}
+
+// Called from verify-otp when the user arrives via /invite/<handle>/<token>.
+// Validates server-side and creates an active Friendship via the existing
+// upsertInvitationFriendship helper. Silent failure (don't block login on
+// any error path — the worst case is the user logs in without the new
+// friendship, which they can fix by tapping Add Friend on the inviter's
+// profile).
+export async function acceptUserInviteLink({
+  handle,
+  token,
+  inviteeUserId,
+  now = new Date(),
+}: {
+  handle: string
+  token: string
+  inviteeUserId: string
+  now?: Date
+}): Promise<{ accepted: boolean }> {
+  const inviter = await resolveInviteLink(handle, token)
+  if (!inviter) return { accepted: false }
+  if (inviter.inviterUserId === inviteeUserId) return { accepted: false }
+
+  try {
+    await upsertInvitationFriendship(db, {
+      inviterUserId: inviter.inviterUserId,
+      inviteeUserId,
+      formedAt: now,
+    })
+    return { accepted: true }
+  } catch {
+    return { accepted: false }
+  }
+}


### PR DESCRIPTION
## Summary

Builds the Find Friends surface, the per-user invite-link mechanism, and the soft-cap nudge. Built on top of `users.handle` (P0-A), `users.avatarColor` (P0-B), discoverability flags (B-Friends-1), and `AddFriendButton` + `getRelationship` (B-Friends-2) — all already in `dev2`.

**Schema:**
- Migration 0049: `users.invite_token` (nullable text, unique partial index where NOT NULL). Generated lazily on first GET to `/api/account/invite-token`.
- Instrumentation guard mirrors the migration so partial-state preview DBs still boot.

**Server:**
- `src/server/friends/user-invite-token.ts` — token gen (matches the existing `randomBytes(32).toString('base64url')` primitive), `getOrCreateInviteToken`, `rotateInviteToken`, URL builder (lifts `getBaseUrl` from `friend-invitations/route.ts` so it accepts Request OR Headers), `resolveInviteLink`, `acceptUserInviteLink`.
- New search query at `src/server/db/queries/friend-search.ts` — exact-match only. Handle `^@?[a-z0-9_]{3,20}$` case-insensitive, US phone via `isUsPhoneNumber + normalizePhone`. Uses `getRelationship.isBlocked` to silently filter blocked users.
- New invite-reflection query at `src/server/db/queries/friend-invitations.ts` — lists users you SMS-invited who joined and aren't already friends/pending.
- New API routes: `GET /api/account/invite-token`, `POST /api/account/invite-token/rotate`, `GET /api/friends/search`, `GET /api/friends/invite-reflections`.

**Auth handoff for per-user link:**
- `LoginPanel.tsx` reads `?inviteHandle=X&inviteUserToken=Y` (alongside the existing `?invitationToken=…` for FriendInvitation links) and forwards both to `verify-otp`.
- `verify-otp/route.ts` accepts `userInvite` as a valid alternative to the new-user invite gate. After provisioning (or login), calls `acceptUserInviteLink` which creates the active friendship via the existing `upsertInvitationFriendship` helper.

**New `/invite/[handle]/[token]` route** — distinct from the existing `/invite/[token]` (FriendInvitation tokens, expirable, may pre-seed interests). Three branches:
1. Logged-out → landing card + Continue → `/login?inviteHandle=…&inviteUserToken=…`
2. Logged-in as someone else → inline `AddFriendButton` with the inviter as target (`getRelationship`-derived)
3. Logged-in as the inviter themselves → 302 to `/friends`

**Find Friends page** (`/friends/find`) — server-rendered shell, five blocks:
1. Search by handle or phone (debounced client island)
2. Contact matches placeholder (disabled; B-Friends-4 replaces)
3. Existing-invite reflection (server-loaded; omits when empty)
4. Invite someone new (two buttons: "Send a personal invite" dispatches the existing `friend-invitations:create-new` event to open the 3-step `AddFriendInvite` modal; "Copy invite link" fetches the per-user URL and copies)
5. Suggested via mutual friends placeholder (hidden when `discoverableByMutualFriends = false`)

**Privacy page extension** — "Your invite link" section under the discoverability toggles. SSR'd URL, Copy + Rotate buttons.

**Entry points:**
- "Find friends" outline button in `FriendsHubPage` header beside "Add friend"
- CTA card at the top of the `FriendsList` Invitations tab

**Soft cap nudge** — Friends tab shows a dismissible banner when `friends.length > 25`. Session-local dismissal (in-memory `useState`), no DB column.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npm run lint` — same pre-existing errors only; no new ones
- [ ] `npm run db:migrate` applies 0049 cleanly on dev DB
- [ ] Invite link round-trip: `/account/privacy` shows your URL → Copy → open in incognito → landing → Continue → `/login?inviteHandle=…&inviteUserToken=…` → OTP for new phone → new user logs in with an active Friendship to the inviter
- [ ] `/invite/[handle]/[token]` as the inviter → redirect to `/friends`
- [ ] `/invite/[handle]/[token]` as an existing user not friends with the inviter → inline AddFriendButton works
- [ ] `/invite/[handle]/[token]` with a stale token (after rotation) → "no longer valid" 404 card
- [ ] Find Friends search: by `@handle` (case-insensitive), by formatted US phone, self-search returns null
- [ ] Find Friends search of a user who has soft-removed me → returns null (block detection)
- [ ] Block 2 button is disabled with tooltip
- [ ] Block 3 only renders when there are reflections (you SMS-invited someone who joined and you're not already friends)
- [ ] Block 4 "Send a personal invite" opens the existing 3-step modal
- [ ] Block 4 "Copy invite link" copies the URL and toasts "Link copied."
- [ ] Block 5 hidden when `discoverableByMutualFriends = false`
- [ ] Entry points: header button + Invitations-tab CTA both navigate to `/friends/find`
- [ ] Soft cap nudge: seed >25 friends → Friends tab shows the banner → × dismisses for session → reload → reappears
- [ ] No regression to `/invite/[token]` (the FriendInvitation flow)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWqbGGGzQo7sJdhj2uJZTs)_