### PR TITLE
feat(B-Friends-4): contact-hash matching + reflection signals

### DIFF
--- a/drizzle/0050_user_phone_hash_discovery.sql
+++ b/drizzle/0050_user_phone_hash_discovery.sql
@@ -1,0 +1,30 @@
+-- Migration: per-user phone hash + Find Friends discovery threshold (B-Friends-4).
+--
+-- Two columns on User:
+--   • phone_hash — SHA-256(salt + E.164(phone_number)). Populated at signup
+--     (provisionUserForPhone in src/app/api/auth/verify-otp/route.ts) and
+--     backfilled for existing users via scripts/backfill-phone-hashes.ts.
+--     Required for the contact-hash match query at /api/contact-hashes/matches
+--     — uploaded ContactHash.phoneHash rows join against this.
+--   • last_friend_discovery_check_at — when the user last visited
+--     /friends/find. The discovery dot (Nav) and the passive Invitations-tab
+--     row use this as the threshold for "new since you last checked".
+--
+-- Both nullable. phone_hash is NULL for accounts that haven't been backfilled
+-- yet (they're invisible to contact matching until the backfill script runs
+-- or they re-trigger signup). last_friend_discovery_check_at is NULL on first
+-- visit and treated as "show all" by getNewDiscoveryStatus.
+--
+-- Index is non-unique. Salt rotation could in theory produce transient
+-- collisions, and the match query joins on equality only — uniqueness isn't
+-- required for correctness.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "phone_hash" text;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "last_friend_discovery_check_at" timestamptz;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "idx_users_phone_hash"
+  ON "User" ("phone_hash");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -351,6 +351,13 @@
       "when": 1780790400000,
       "tag": "0049_user_invite_token",
       "breakpoints": true
+    },
+    {
+      "idx": 50,
+      "version": "7",
+      "when": 1780876800000,
+      "tag": "0050_user_phone_hash_discovery",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "drizzle-orm": "^0.45.2",
         "html2canvas": "^1.4.1",
         "jose": "latest",
+        "libphonenumber-js": "^1.13.3",
         "lucide-react": "^1.14.0",
         "next": "16.1.6",
         "pg": "^8.20.0",
@@ -10195,6 +10196,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/libphonenumber-js": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.13.3.tgz",
+      "integrity": "sha512-xMkdAMqcyG7iN2WZZmGIfWbYxW4orRkny+0/AXIbwL0xll2zkDX0Vzo/BXFa6+7mh2UvJl9MbcTtHk0YXkFtBA==",
+      "license": "MIT"
     },
     "node_modules/lightningcss": {
       "version": "1.32.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "drizzle-orm": "^0.45.2",
     "html2canvas": "^1.4.1",
     "jose": "latest",
+    "libphonenumber-js": "^1.13.3",
     "lucide-react": "^1.14.0",
     "next": "16.1.6",
     "pg": "^8.20.0",

--- a/scripts/backfill-phone-hashes.ts
+++ b/scripts/backfill-phone-hashes.ts
@@ -1,0 +1,77 @@
+// One-shot script: populate users.phone_hash for every row with a phone
+// number but no hash yet. SHA-256(salt + E.164(phone)) — server side of the
+// B-Friends-4 contact-hash matching channel. Skips rows where phone_hash is
+// already set (idempotent) and rows whose phoneNumber doesn't normalize to
+// a valid US E.164 (logged for manual review).
+//
+// PHONE_HASH_SALT must be set in the environment — without it the hash
+// can't be computed. The salt is the same one served by
+// /api/account/phone-hash-salt to clients; rotating it invalidates every
+// hashed row.
+//
+// Usage:
+//   PHONE_HASH_SALT=... npx tsx scripts/backfill-phone-hashes.ts            # dry-run
+//   PHONE_HASH_SALT=... npx tsx scripts/backfill-phone-hashes.ts --apply    # actually write
+
+import 'dotenv/config';
+
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+
+import { normalizeToE164 } from '../src/lib/phone-e164';
+import { db, pool, users } from '../src/server/db';
+import { hashPhoneNumber } from '../src/server/lib/phone-hashing';
+
+const args = process.argv.slice(2);
+const APPLY = args.includes('--apply');
+
+async function main() {
+  if (!process.env.PHONE_HASH_SALT) {
+    console.error('[backfill-phone-hashes] PHONE_HASH_SALT is not set. Exiting.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`[backfill-phone-hashes] ${APPLY ? 'APPLY' : 'DRY RUN'} mode\n`);
+
+  const candidates = await db
+    .select({ id: users.id, phoneNumber: users.phoneNumber })
+    .from(users)
+    .where(and(isNotNull(users.phoneNumber), isNull(users.phoneHash)));
+
+  console.log(`[backfill-phone-hashes] ${candidates.length} users without a phone hash.`);
+
+  let hashed = 0;
+  let skipped = 0;
+
+  for (const user of candidates) {
+    const e164 = normalizeToE164(user.phoneNumber);
+    if (!e164) {
+      console.warn(`[backfill-phone-hashes] skip ${user.id} — phone ${user.phoneNumber} did not normalize to E.164`);
+      skipped++;
+      continue;
+    }
+    const phoneHash = hashPhoneNumber(e164);
+    console.log(`[backfill-phone-hashes] ${user.id} → ${phoneHash.slice(0, 8)}…`);
+    if (APPLY) {
+      // Race-safe: only update rows that still have NULL phone_hash. Avoids
+      // clobbering a phone_hash written by the signup hook between the
+      // SELECT and the UPDATE.
+      await db
+        .update(users)
+        .set({ phoneHash, updatedAt: new Date() })
+        .where(and(eq(users.id, user.id), isNull(users.phoneHash)));
+      hashed++;
+    }
+  }
+
+  console.log(`\n[backfill-phone-hashes] done. hashed=${hashed} skipped=${skipped}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-phone-hashes] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/app/api/account/phone-hash-salt/route.ts
+++ b/src/app/api/account/phone-hash-salt/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+
+export const dynamic = 'force-dynamic'
+
+// Returns the PHONE_HASH_SALT used by the client-side contact-hashing path
+// (ContactMatchBlock). The salt is NOT a true secret — it lives on every
+// authenticated client. Its purpose is rainbow-table defense, not
+// insider-attack defense. See B-Friends-prompts §9.6.3.6.
+//
+// 500 if unset — the client can't hash without it, and contact matching
+// is therefore non-functional until ops sets the env var. The rest of the
+// app keeps working (the boot guard at instrumentation.ts only warns).
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const salt = process.env.PHONE_HASH_SALT
+  if (!salt) {
+    return NextResponse.json(
+      {
+        error: 'salt_unset',
+        message: 'Contact-hash matching is not configured. Try again later.',
+      },
+      { status: 500 },
+    )
+  }
+
+  return NextResponse.json({ salt })
+}

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -4,9 +4,11 @@ import { eq } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 
 import { colorForUser } from '@/components/feed/visual'
+import { normalizeToE164 } from '@/lib/phone-e164'
 import { verifyOtp } from '@/server/auth'
 import { createSession } from '@/server/auth/session'
 import { db, users } from '@/server/db'
+import { hashPhoneNumber } from '@/server/lib/phone-hashing'
 import {
   acceptFriendInvitation,
   getValidInvitationForPhone,
@@ -57,6 +59,16 @@ async function findUserByPhone(
   return existing ?? null
 }
 
+function computePhoneHash(phoneNumber: string): string | null {
+  // Skip when the salt is unset (dev environments without
+  // PHONE_HASH_SALT — production sets it). The hash can be filled in
+  // later via scripts/backfill-phone-hashes.ts once the salt is set.
+  if (!process.env.PHONE_HASH_SALT) return null
+  const e164 = normalizeToE164(phoneNumber)
+  if (!e164) return null
+  return hashPhoneNumber(e164)
+}
+
 async function provisionUserForPhone(
   phoneNumber: string
 ): Promise<AuthUser> {
@@ -64,9 +76,10 @@ async function provisionUserForPhone(
   // same insert (colorForUser hashes the id). Without this, avatar_color
   // would be NULL until the next signup backfill.
   const id = randomUUID()
+  const phoneHash = computePhoneHash(phoneNumber)
   const [created] = await db
     .insert(users)
-    .values({ id, phoneNumber, avatarColor: colorForUser(id) })
+    .values({ id, phoneNumber, avatarColor: colorForUser(id), phoneHash })
     .onConflictDoNothing({ target: users.phoneNumber })
     .returning(USER_SELECTION)
 

--- a/src/app/api/contact-hashes/matches/route.ts
+++ b/src/app/api/contact-hashes/matches/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import {
+  getLastContactHashUpload,
+  isRefreshDue,
+  listContactMatches,
+} from '@/server/db/queries/contact-hashes'
+
+export const dynamic = 'force-dynamic'
+
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const [matches, lastUploadedAt] = await Promise.all([
+    listContactMatches(session.userId),
+    getLastContactHashUpload(session.userId),
+  ])
+
+  return NextResponse.json({
+    matches,
+    lastUploadedAt: lastUploadedAt?.toISOString() ?? null,
+    refreshDue: isRefreshDue(lastUploadedAt),
+  })
+}

--- a/src/app/api/contact-hashes/route.ts
+++ b/src/app/api/contact-hashes/route.ts
@@ -1,0 +1,56 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getSession } from '@/server/auth/session'
+import { clearContactHashes, replaceContactHashes } from '@/server/db/queries/contact-hashes'
+
+export const dynamic = 'force-dynamic'
+
+const MAX_HASHES = 5000
+
+const bodySchema = z.object({
+  hashes: z
+    .array(z.string().regex(/^[a-f0-9]{64}$/, 'must be 64-char lowercase hex'))
+    .max(MAX_HASHES),
+})
+
+// Atomic replace of the caller's ContactHash rows. Per the privacy invariant
+// in B-Friends-1's updateDiscoverability: when the user toggles
+// discoverableByContacts OFF, the same rows are deleted in that handler — so
+// uploading via this endpoint while contacts-discoverability is OFF would
+// leave the rows in place until the next toggle. That's fine; matching only
+// returns rows for users with the flag TRUE, so dormant hashes don't leak.
+export async function POST(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const json = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    const tooMany = parsed.error.issues.some((issue) => issue.code === 'too_big')
+    if (tooMany) {
+      return NextResponse.json(
+        {
+          error: 'too_many_hashes',
+          message: `At most ${MAX_HASHES} contacts per upload.`,
+        },
+        { status: 413 },
+      )
+    }
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'Hash list malformed.' },
+      { status: 400 },
+    )
+  }
+
+  const result = await replaceContactHashes(session.userId, parsed.data.hashes)
+  return NextResponse.json(result)
+}
+
+export async function DELETE() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  await clearContactHashes(session.userId)
+  return NextResponse.json({ ok: true })
+}

--- a/src/app/api/friends/has-new-discovery/route.ts
+++ b/src/app/api/friends/has-new-discovery/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+
+import { getSession } from '@/server/auth/session'
+import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes'
+
+export const dynamic = 'force-dynamic'
+
+// Lightweight "is there anything new on Find Friends?" probe. Used by
+// FriendsList to render the passive Invitations-tab row. The layout
+// already loads this for the Nav dot, but the client component needs a
+// fresh number after navigating in.
+export async function GET() {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const status = await getNewDiscoveryStatus(session.userId)
+  return NextResponse.json(status, {
+    headers: { 'Cache-Control': 'max-age=60' },
+  })
+}

--- a/src/app/friends/find/page.tsx
+++ b/src/app/friends/find/page.tsx
@@ -4,10 +4,17 @@ import { ChevronLeft } from 'lucide-react'
 
 import AddFriendInvite from '@/components/AddFriendInvite'
 import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { ContactMatchBlock } from '@/components/friends/ContactMatchBlock'
 import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch'
 import { InviteSomeoneNew } from '@/components/friends/InviteSomeoneNew'
 import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
 import { getSession } from '@/server/auth/session'
+import {
+  getLastContactHashUpload,
+  isRefreshDue,
+  listContactMatches,
+  markDiscoveryChecked,
+} from '@/server/db/queries/contact-hashes'
 import { listInviteReflections } from '@/server/db/queries/friend-invitations'
 import { db, users } from '@/server/db'
 import { eq } from 'drizzle-orm'
@@ -28,6 +35,7 @@ export default async function FindFriendsPage() {
 
   const [viewer] = await db
     .select({
+      discoverableByContacts: users.discoverableByContacts,
       discoverableByMutualFriends: users.discoverableByMutualFriends,
     })
     .from(users)
@@ -36,7 +44,16 @@ export default async function FindFriendsPage() {
 
   if (!viewer) redirect('/login')
 
-  const reflections = await listInviteReflections(session.userId)
+  // Stamp the discovery threshold AS the user lands here — clears the
+  // Nav-tab dot and the Invitations-tab passive row on next render.
+  await markDiscoveryChecked(session.userId)
+
+  const [reflections, contactMatches, lastContactUpload] = await Promise.all([
+    listInviteReflections(session.userId),
+    viewer.discoverableByContacts ? listContactMatches(session.userId) : Promise.resolve([]),
+    viewer.discoverableByContacts ? getLastContactHashUpload(session.userId) : Promise.resolve(null),
+  ])
+  const contactRefreshDue = isRefreshDue(lastContactUpload)
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
@@ -58,24 +75,20 @@ export default async function FindFriendsPage() {
         {/* Block 1 — Search by handle or phone */}
         <FindFriendsSearch />
 
-        {/* Block 2 — Contact matches (placeholder; B-Friends-4 replaces) */}
-        <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-          <h2 className="font-serif text-lg font-semibold">
-            Find friends already on Joshing
-          </h2>
-          <p className="text-muted-foreground mt-1 text-sm">
-            We can check which of your phone contacts are here. We never share your contacts.
-          </p>
-          <button
-            type="button"
-            disabled
-            title="Coming soon."
-            aria-disabled
-            className="bg-muted text-muted-foreground mt-3 inline-flex h-11 cursor-not-allowed items-center justify-center rounded-full px-4 text-sm opacity-60"
-          >
-            Match my contacts
-          </button>
-        </section>
+        {/* Block 2 — Contact matches (client island; SSR'd with initial data
+            so the rich UI shows immediately when matches already exist) */}
+        <ContactMatchBlock
+          discoverableByContacts={viewer.discoverableByContacts}
+          initialMatches={contactMatches.map((match) => ({
+            id: match.id,
+            handle: match.handle,
+            displayName: match.displayName,
+            avatarColor: match.avatarColor,
+            createdAt: match.createdAt.toISOString(),
+            relationship: match.relationship,
+          }))}
+          initialRefreshDue={contactRefreshDue}
+        />
 
         {/* Block 3 — Existing-invite reflection */}
         {reflections.length > 0 ? (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { Nav } from "@/components/Nav";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
 import { getBellBadgeCount } from '@/server/db/queries/activity';
+import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes';
 
 // Intentional product choice (2026-05-16): Montserrat is the body font.
 // PRD §typography spec'd Inter, but Montserrat ships. Update PRD to reflect this.
@@ -43,12 +44,13 @@ export default async function RootLayout({
 }) {
   const sessionToken = await getSessionToken()
   const claims = await readSessionClaims(sessionToken)
-  const [profile, bellBadgeCount] = claims
+  const [profile, bellBadgeCount, discoveryStatus] = claims
     ? await Promise.all([
         getUserOnboardingProfile(claims.userId),
         getBellBadgeCount(claims.userId).catch(() => 0),
+        getNewDiscoveryStatus(claims.userId).catch(() => ({ hasNew: false, count: 0 })),
       ])
-    : [null, 0]
+    : [null, 0, { hasNew: false, count: 0 }]
   return (
     <html
       lang="en"
@@ -59,6 +61,7 @@ export default async function RootLayout({
           initialUserId={claims?.userId ?? null}
           initialDisplayName={profile?.displayName ?? null}
           bellBadgeCount={bellBadgeCount}
+          friendsDotVisible={discoveryStatus.hasNew}
         />
         {children}
       </body>

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -62,6 +62,9 @@ export default function FriendsList() {
   const [activeTab, setActiveTab] = useState<Tab>('friends')
   // Session-local: nudge reappears on next page load if still over the cap.
   const [softCapDismissed, setSoftCapDismissed] = useState(false)
+  // Passive Invitations-tab row count — null while loading, 0 when there's
+  // nothing new. Cleared after the user visits /friends/find.
+  const [newDiscoveryCount, setNewDiscoveryCount] = useState<number | null>(null)
 
   const loadFriends = useCallback(async () => {
     setError(null)
@@ -99,6 +102,32 @@ export default function FriendsList() {
   useEffect(() => {
     queueMicrotask(() => void loadFriends())
   }, [loadFriends])
+
+  // Load the discovery signal once on mount. Cache-Control:max-age=60 on
+  // the response keeps repeat navigations cheap. Fire-and-forget — a
+  // failure just means the passive row doesn't render this session.
+  useEffect(() => {
+    let cancelled = false
+    void (async () => {
+      try {
+        const response = await fetch('/api/friends/has-new-discovery', {
+          credentials: 'include',
+        })
+        if (!response.ok) return
+        const body = (await response.json().catch(() => null)) as
+          | { hasNew: boolean; count: number }
+          | null
+        if (!cancelled && body) {
+          setNewDiscoveryCount(body.hasNew ? body.count : 0)
+        }
+      } catch {
+        // Swallow — passive signal, OK to skip.
+      }
+    })()
+    return () => {
+      cancelled = true
+    }
+  }, [])
 
   async function updateRequest(requestId: string, action: RequestAction) {
     setPendingRequest(`${requestId}:${action}`)
@@ -296,6 +325,17 @@ export default function FriendsList() {
       {/* Invitations tab */}
       {activeTab === 'invitations' ? (
         <div className="space-y-3">
+          {newDiscoveryCount && newDiscoveryCount > 0 ? (
+            <Link
+              href="/friends/find"
+              className="bg-accent/10 hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"
+            >
+              <p className="text-foreground text-sm font-medium">
+                ✨ {newDiscoveryCount} new {newDiscoveryCount === 1 ? 'contact is' : 'contacts are'} on Joshing.
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">→ Find friends</p>
+            </Link>
+          ) : null}
           <Link
             href="/friends/find"
             className="bg-card hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -30,10 +30,12 @@ export function Nav({
   initialUserId = null,
   initialDisplayName = null,
   bellBadgeCount = 0,
+  friendsDotVisible = false,
 }: {
   initialUserId?: string | null;
   initialDisplayName?: string | null;
   bellBadgeCount?: number;
+  friendsDotVisible?: boolean;
 }) {
   const pathname = usePathname();
   const accountInitials = initialDisplayName ? initialsFor(initialDisplayName) || null : null;
@@ -147,7 +149,7 @@ export function Nav({
                   active ? 'text-foreground opacity-100' : 'text-foreground/55 hover:text-foreground',
                 ].join(' ')}
               >
-                <span aria-hidden="true" className="grid place-items-center">
+                <span aria-hidden="true" className="relative grid place-items-center">
                   {isAccount ? (
                     <AccountIcon active={active} />
                   ) : (
@@ -157,6 +159,14 @@ export function Nav({
                       fill={active && label === 'Home' ? 'currentColor' : 'none'}
                     />
                   )}
+                  {/* Discovery indicator for the Friends tab — muted neutral
+                      so it doesn't compete with the bell badge accent. */}
+                  {friendsDotVisible && label === 'Friends' ? (
+                    <span
+                      className="absolute -right-1 -top-1 size-2 rounded-full"
+                      style={{ backgroundColor: '#8a8a9a' }}
+                    />
+                  ) : null}
                 </span>
                 <span
                   className={[

--- a/src/components/friends/ContactMatchBlock.tsx
+++ b/src/components/friends/ContactMatchBlock.tsx
@@ -1,0 +1,261 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
+import { normalizeToE164 } from '@/lib/phone-e164'
+import type { RelationshipResult } from '@/server/db/queries/friend-requests'
+
+type Match = {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarColor: string | null
+  createdAt: string
+  relationship: RelationshipResult
+}
+
+type MatchesResponse = {
+  matches: Match[]
+  lastUploadedAt: string | null
+  refreshDue: boolean
+}
+
+type Props = {
+  discoverableByContacts: boolean
+  initialMatches: Match[]
+  initialRefreshDue: boolean
+}
+
+function initialsFor(name: string | null, fallback: string): string {
+  const source = (name?.trim() || fallback).replace(/[^a-zA-Z]+/g, ' ').trim()
+  if (!source) return '??'
+  const parts = source.split(/\s+/)
+  if (parts.length === 1) return parts[0]!.slice(0, 2).toUpperCase()
+  return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
+}
+
+function supportsContactsAPI(): boolean {
+  if (typeof navigator === 'undefined') return false
+  const contacts = (navigator as Navigator).contacts
+  return Boolean(contacts && typeof contacts.select === 'function')
+}
+
+async function hashPhoneClient(salt: string, e164: string): Promise<string> {
+  const data = new TextEncoder().encode(salt + e164)
+  const buf = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+export function ContactMatchBlock({
+  discoverableByContacts,
+  initialMatches,
+  initialRefreshDue,
+}: Props) {
+  const [matches, setMatches] = useState<Match[]>(initialMatches)
+  const [refreshDue, setRefreshDue] = useState(initialRefreshDue)
+  const [matching, setMatching] = useState(false)
+  const [toast, setToast] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!toast) return
+    const timer = window.setTimeout(() => setToast(null), 1800)
+    return () => window.clearTimeout(timer)
+  }, [toast])
+
+  if (!supportsContactsAPI()) {
+    return (
+      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <h2 className="font-serif text-lg font-semibold">
+          Find friends already on Joshing
+        </h2>
+        <p className="text-muted-foreground mt-1 text-sm leading-6">
+          Your browser doesn&rsquo;t support automatic contact matching. You can still
+          search by @handle or phone number (above), or send a friend an invite link.
+        </p>
+      </section>
+    )
+  }
+
+  if (!discoverableByContacts) {
+    return (
+      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+        <h2 className="font-serif text-lg font-semibold">
+          Find friends already on Joshing
+        </h2>
+        <p className="text-muted-foreground mt-1 text-sm leading-6">
+          Turn on contact matching to see which of your contacts are here. We hash
+          your contacts on your device and never share them.
+        </p>
+        <a
+          href="/account/privacy"
+          className="btn-primary mt-3 inline-flex h-11 items-center rounded-full px-4 text-sm"
+        >
+          Open privacy settings
+        </a>
+      </section>
+    )
+  }
+
+  async function matchContacts() {
+    if (matching) return
+    setMatching(true)
+    setError(null)
+    try {
+      const navContacts = (navigator as Navigator).contacts
+      if (!navContacts) throw new Error('Contacts API unavailable.')
+
+      const contacts = await navContacts.select(['tel'], { multiple: true })
+      const phones = new Set<string>()
+      for (const contact of contacts) {
+        for (const tel of contact.tel ?? []) {
+          const e164 = normalizeToE164(tel)
+          if (e164) phones.add(e164)
+        }
+      }
+
+      if (phones.size === 0) {
+        setError('No valid US phone numbers found in your contacts.')
+        return
+      }
+
+      const saltResponse = await fetch('/api/account/phone-hash-salt', {
+        credentials: 'include',
+      })
+      if (!saltResponse.ok) {
+        setError('Contact matching is temporarily unavailable. Try again later.')
+        return
+      }
+      const { salt } = (await saltResponse.json()) as { salt: string }
+
+      const hashes = await Promise.all(
+        Array.from(phones).map((e164) => hashPhoneClient(salt, e164)),
+      )
+
+      const uploadResponse = await fetch('/api/contact-hashes', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ hashes }),
+      })
+      if (!uploadResponse.ok) {
+        const body = (await uploadResponse.json().catch(() => null)) as { message?: string } | null
+        setError(body?.message ?? 'Could not upload your contacts.')
+        return
+      }
+
+      const matchesResponse = await fetch('/api/contact-hashes/matches', {
+        credentials: 'include',
+      })
+      if (!matchesResponse.ok) {
+        setError('Matches couldn’t load. Try again.')
+        return
+      }
+      const matchBody = (await matchesResponse.json()) as MatchesResponse
+      setMatches(matchBody.matches)
+      setRefreshDue(matchBody.refreshDue)
+      setToast(
+        matchBody.matches.length === 0
+          ? 'No one yet — check back as more friends join.'
+          : `Matched ${matchBody.matches.length} ${matchBody.matches.length === 1 ? 'person' : 'people'}.`,
+      )
+    } catch (err) {
+      // navigator.contacts.select throws on user-cancel; treat as no-op.
+      if (err instanceof DOMException && err.name === 'AbortError') return
+      setError('Contact matching failed. Try again.')
+    } finally {
+      setMatching(false)
+    }
+  }
+
+  return (
+    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-serif text-lg font-semibold">
+          {matches.length > 0 ? 'Contacts on Joshing' : 'Find friends already on Joshing'}
+        </h2>
+        {matches.length > 0 ? (
+          <button
+            type="button"
+            onClick={() => void matchContacts()}
+            disabled={matching}
+            className="text-muted-foreground hover:text-foreground text-sm underline underline-offset-4"
+          >
+            {matching ? 'Refreshing…' : 'Refresh ↻'}
+          </button>
+        ) : null}
+      </div>
+
+      {matches.length === 0 ? (
+        <>
+          <p className="text-muted-foreground mt-1 text-sm leading-6">
+            We can check which of your phone contacts are here. We hash your contacts
+            on your device and never share them.
+          </p>
+          <button
+            type="button"
+            onClick={() => void matchContacts()}
+            disabled={matching}
+            className="btn-primary mt-3 inline-flex h-11 items-center rounded-full px-4 text-sm"
+          >
+            {matching ? 'Matching…' : 'Match my contacts'}
+          </button>
+        </>
+      ) : (
+        <>
+          {refreshDue ? (
+            <p className="text-muted-foreground/80 mt-1 text-xs">
+              Last refreshed over a week ago. Tap Refresh to pick up new joiners.
+            </p>
+          ) : null}
+          <div className="mt-3 space-y-3">
+            {matches.map((match) => {
+              const displayName = match.displayName?.trim() || `@${match.handle ?? ''}`
+              const initials = initialsFor(match.displayName, match.handle ?? '?')
+              const swatch = match.avatarColor || colorForUser(match.id)
+              return (
+                <article
+                  key={match.id}
+                  className="bg-background flex items-start gap-3 rounded-xl border p-3"
+                >
+                  <span
+                    aria-hidden
+                    className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full text-sm font-semibold text-white"
+                    style={{ background: swatch }}
+                  >
+                    {initials}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <h3 className="text-foreground font-medium">{displayName}</h3>
+                    {match.handle ? (
+                      <p className="text-muted-foreground text-xs">@{match.handle}</p>
+                    ) : null}
+                    <p className="text-muted-foreground/70 mt-1 text-xs">
+                      joined {formatRelativeTime(match.createdAt)}
+                    </p>
+                  </div>
+                  <AddFriendButton
+                    targetUserId={match.id}
+                    targetDisplayName={displayName}
+                    relationship={match.relationship}
+                  />
+                </article>
+              )
+            })}
+          </div>
+        </>
+      )}
+
+      {error ? <p className="text-destructive mt-3 text-sm">{error}</p> : null}
+      {toast ? (
+        <div className="fixed bottom-24 left-1/2 z-50 -translate-x-1/2 rounded-full bg-foreground px-4 py-2 text-sm text-background shadow-lg">
+          {toast}
+        </div>
+      ) : null}
+    </section>
+  )
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -770,6 +770,29 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0050 adds users.phone_hash (the user's own SHA-256(salt+E.164)
+    // for the contact-hash match query) and users.last_friend_discovery_check_at
+    // (the threshold for the Find Friends discovery dot + passive
+    // Invitations-tab row). Guard for preview/production databases that may
+    // have the migration recorded without the columns or index present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "phone_hash" text
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "last_friend_discovery_check_at" timestamptz
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "idx_users_phone_hash"
+          ON "User" ("phone_hash")
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/lib/phone-e164.ts
+++ b/src/lib/phone-e164.ts
@@ -1,0 +1,14 @@
+import { parsePhoneNumber } from 'libphonenumber-js/min'
+
+// Normalize a raw phone string to E.164 ("+15551234567"). US-only for
+// Phase 1 — country-aware normalization is tracked as a fast-follow.
+// Returns null when the input doesn't parse to a valid number; callers
+// should skip those rows (the backfill script logs them).
+export function normalizeToE164(raw: string, defaultCountry: 'US' = 'US'): string | null {
+  try {
+    const parsed = parsePhoneNumber(raw, defaultCountry)
+    return parsed?.isValid() ? parsed.number : null
+  } catch {
+    return null
+  }
+}

--- a/src/server/db/queries/contact-hashes.ts
+++ b/src/server/db/queries/contact-hashes.ts
@@ -1,0 +1,197 @@
+import { and, count, desc, eq, gt, ne, sql } from 'drizzle-orm'
+
+import { contactHashes, db, friendInvitations, users } from '@/server/db'
+import { getRelationships, type RelationshipResult } from '@/server/db/queries/friend-requests'
+
+const ONE_WEEK_MS = 7 * 24 * 60 * 60 * 1000
+
+// Count of other users who (a) have uploaded a ContactHash that matches the
+// caller's phoneHash AND (b) are discoverableByContacts. Used by the upload
+// endpoint to return a preview after the user uploads their own hashes.
+export async function countMatchableUsers(callerId: string): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(users)
+    .innerJoin(contactHashes, eq(contactHashes.phoneHash, users.phoneHash))
+    .where(
+      and(
+        eq(contactHashes.userId, callerId),
+        ne(users.id, callerId),
+        eq(users.discoverableByContacts, true),
+      ),
+    )
+
+  return row?.value ?? 0
+}
+
+export type ContactMatch = {
+  id: string
+  handle: string | null
+  displayName: string | null
+  avatarColor: string | null
+  createdAt: Date
+  relationship: RelationshipResult
+}
+
+// Users whose phoneHash equals one of the caller's uploaded ContactHash rows
+// AND who have opted into contact-based discovery. Block detection (via
+// getRelationships.isBlocked) silently filters anyone who has soft-removed
+// the caller.
+export async function listContactMatches(callerId: string): Promise<ContactMatch[]> {
+  const rows = await db
+    .select({
+      id: users.id,
+      handle: users.handle,
+      displayName: users.displayName,
+      avatarColor: users.avatarColor,
+      createdAt: users.createdAt,
+    })
+    .from(contactHashes)
+    .innerJoin(users, eq(users.phoneHash, contactHashes.phoneHash))
+    .where(
+      and(
+        eq(contactHashes.userId, callerId),
+        ne(users.id, callerId),
+        eq(users.discoverableByContacts, true),
+      ),
+    )
+    .orderBy(desc(users.createdAt))
+
+  if (rows.length === 0) return []
+
+  const relationships = await getRelationships(callerId, rows.map((r) => r.id))
+
+  const result: ContactMatch[] = []
+  for (const row of rows) {
+    const relationship = relationships.get(row.id)
+    if (!relationship || relationship.isBlocked) continue
+    result.push({ ...row, relationship })
+  }
+  return result
+}
+
+// MAX(uploadedAt) for the caller's ContactHash rows. NULL when they've never
+// uploaded. Used to drive the weekly "Refresh contact matches?" prompt.
+export async function getLastContactHashUpload(callerId: string): Promise<Date | null> {
+  const [row] = await db
+    .select({ uploadedAt: sql<Date>`MAX(${contactHashes.uploadedAt})`.as('uploaded_at') })
+    .from(contactHashes)
+    .where(eq(contactHashes.userId, callerId))
+
+  if (!row?.uploadedAt) return null
+  return row.uploadedAt instanceof Date ? row.uploadedAt : new Date(row.uploadedAt)
+}
+
+// "Has anything new happened in the discovery space since this user last
+// checked Find Friends?" Two sources:
+//   • A contact-match user joined since lastFriendDiscoveryCheckAt AND no
+//     active/pending Friendship exists with the caller.
+//   • An SMS-invite reflection: someone the caller invited has joined since
+//     the threshold and there's no active/pending Friendship.
+//
+// The threshold is users.last_friend_discovery_check_at. NULL is treated as
+// "show everything" — the user has never visited Find Friends so every
+// reachable discovery row is "new".
+//
+// Result is opaque to callers: `{ hasNew, count }` only. No row data is
+// surfaced from this helper; the actual rendering pulls fresh data via
+// listContactMatches / listInviteReflections.
+export type NewDiscoveryStatus = { hasNew: boolean; count: number }
+
+export async function getNewDiscoveryStatus(callerId: string): Promise<NewDiscoveryStatus> {
+  const [thresholdRow] = await db
+    .select({ threshold: users.lastFriendDiscoveryCheckAt })
+    .from(users)
+    .where(eq(users.id, callerId))
+    .limit(1)
+
+  if (!thresholdRow) return { hasNew: false, count: 0 }
+  const threshold = thresholdRow.threshold ?? new Date(0)
+
+  // Friend-pair filter: "no active or pending Friendship between caller and X".
+  // Reused for both halves.
+  const noFriendshipExists = (otherId: typeof users.id) => sql`NOT EXISTS (
+    SELECT 1 FROM "Friendship" f
+    WHERE f."status" IN ('active', 'pending')
+      AND (
+        (f."userAId" = ${callerId} AND f."userBId" = ${otherId})
+        OR (f."userAId" = ${otherId} AND f."userBId" = ${callerId})
+      )
+  )`
+
+  // Contact-hash matches who joined since the threshold.
+  const contactMatchRows = await db
+    .select({ id: users.id })
+    .from(contactHashes)
+    .innerJoin(users, eq(users.phoneHash, contactHashes.phoneHash))
+    .where(
+      and(
+        eq(contactHashes.userId, callerId),
+        ne(users.id, callerId),
+        eq(users.discoverableByContacts, true),
+        gt(users.createdAt, threshold),
+        noFriendshipExists(users.id),
+      ),
+    )
+
+  // SMS-invite reflections — users the caller invited who joined since the
+  // threshold AND aren't already friends/pending.
+  const reflectionRows = await db
+    .select({ id: users.id })
+    .from(friendInvitations)
+    .innerJoin(users, eq(users.id, friendInvitations.inviteeUserId))
+    .where(
+      and(
+        eq(friendInvitations.inviterUserId, callerId),
+        gt(users.createdAt, threshold),
+        noFriendshipExists(users.id),
+      ),
+    )
+
+  // Dedupe — a single user could be both a contact match AND an invite
+  // reflection. Both are valid signals but they shouldn't double-count.
+  const ids = new Set<string>()
+  for (const row of contactMatchRows) ids.add(row.id)
+  for (const row of reflectionRows) ids.add(row.id)
+
+  return { hasNew: ids.size > 0, count: ids.size }
+}
+
+// Stamp NOW() onto users.last_friend_discovery_check_at. Called on every
+// visit to /friends/find. Idempotent.
+export async function markDiscoveryChecked(callerId: string, now: Date = new Date()): Promise<void> {
+  await db
+    .update(users)
+    .set({ lastFriendDiscoveryCheckAt: now })
+    .where(eq(users.id, callerId))
+}
+
+export function isRefreshDue(lastUploadedAt: Date | null, now: Date = new Date()): boolean {
+  if (!lastUploadedAt) return true
+  return now.getTime() - lastUploadedAt.getTime() > ONE_WEEK_MS
+}
+
+// Replaces all ContactHash rows for a user in one transaction. Returns the
+// count uploaded and a preview of how many of those resolve to a
+// discoverable user.
+export async function replaceContactHashes(callerId: string, hashes: string[]): Promise<{ uploaded: number; matchCount: number }> {
+  await db.transaction(async (tx) => {
+    await tx.delete(contactHashes).where(eq(contactHashes.userId, callerId))
+    if (hashes.length > 0) {
+      await tx
+        .insert(contactHashes)
+        .values(hashes.map((phoneHash) => ({ userId: callerId, phoneHash })))
+        .onConflictDoNothing()
+    }
+  })
+
+  const matchCount = hashes.length === 0 ? 0 : await countMatchableUsers(callerId)
+  return { uploaded: hashes.length, matchCount }
+}
+
+export async function clearContactHashes(callerId: string): Promise<void> {
+  await db.delete(contactHashes).where(eq(contactHashes.userId, callerId))
+}
+
+// Re-export so callers don't need a second import path.
+export { contactHashes }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -175,6 +175,8 @@ export const users = pgTable(
     location: text('location'),
     discoverableByContacts: boolean('discoverable_by_contacts').notNull().default(false),
     discoverableByMutualFriends: boolean('discoverable_by_mutual_friends').notNull().default(false),
+    phoneHash: text('phone_hash'),
+    lastFriendDiscoveryCheckAt: timestamp('last_friend_discovery_check_at', { withTimezone: true }),
     authorProfilePublic: boolean('authorProfilePublic').notNull().default(true),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
     birthYear: integer('birth_year'),

--- a/src/server/lib/__tests__/phone-hashing.test.ts
+++ b/src/server/lib/__tests__/phone-hashing.test.ts
@@ -1,0 +1,67 @@
+// Parity test: the client-side Web Crypto hashing in
+// src/components/friends/ContactMatchBlock.tsx MUST produce identical
+// output to server-side hashPhoneNumber() for the same salt + E.164 input.
+// If they drift, contact matching silently breaks — the uploaded
+// ContactHash rows won't equal the User.phone_hash they're meant to match.
+//
+// This test re-implements the client hashing logic inline (rather than
+// importing it from the component, which is `'use client'` and pulls in
+// React) and asserts byte-for-byte equality against the server impl.
+
+import { describe, expect, it, beforeAll } from 'vitest'
+
+import { hashPhoneNumber } from '../phone-hashing'
+
+const SALT = 'parity-test-salt-not-for-prod-use'
+
+async function hashPhoneClientEquivalent(salt: string, e164: string): Promise<string> {
+  const data = new TextEncoder().encode(salt + e164)
+  const buf = await crypto.subtle.digest('SHA-256', data)
+  return Array.from(new Uint8Array(buf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('')
+}
+
+describe('phone-hashing parity', () => {
+  beforeAll(() => {
+    process.env.PHONE_HASH_SALT = SALT
+  })
+
+  it('produces identical 64-char hex for a typical US E.164 number', async () => {
+    const e164 = '+14155551234'
+    const server = hashPhoneNumber(e164)
+    const client = await hashPhoneClientEquivalent(SALT, e164)
+    expect(server).toBe(client)
+    expect(server).toMatch(/^[a-f0-9]{64}$/)
+  })
+
+  it('produces different output for different inputs', async () => {
+    const a = hashPhoneNumber('+14155551234')
+    const b = hashPhoneNumber('+14155551235')
+    expect(a).not.toBe(b)
+  })
+
+  it('handles a representative spread of E.164 inputs identically across impls', async () => {
+    const inputs = [
+      '+14155551234',
+      '+19175550000',
+      '+12125558888',
+      '+18005551212',
+    ]
+    for (const e164 of inputs) {
+      const server = hashPhoneNumber(e164)
+      const client = await hashPhoneClientEquivalent(SALT, e164)
+      expect(server).toBe(client)
+    }
+  })
+
+  it('throws when the salt is unset', () => {
+    const prev = process.env.PHONE_HASH_SALT
+    delete process.env.PHONE_HASH_SALT
+    try {
+      expect(() => hashPhoneNumber('+14155551234')).toThrow(/PHONE_HASH_SALT/)
+    } finally {
+      process.env.PHONE_HASH_SALT = prev
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Wires up contact-hash matching (Block 2 of `/friends/find`) and the two passive discovery signals (Friends-tab dot + Invitations-tab ✨ row). Built on the B-Friends-1 schema groundwork (`contactHashes` table, `discoverableByContacts` flag, `src/server/lib/phone-hashing.ts`) and B-Friends-2/3 UI primitives (`AddFriendButton`, `getRelationship`, the existing avatar+initials chip pattern).

**Schema:**
- Migration 0050: `users.phone_hash` (text, non-unique index) + `users.last_friend_discovery_check_at` (timestamptz). Both nullable. Instrumentation guard mirrors the migration.

**Foundation:**
- `libphonenumber-js` dep (~150KB gzipped, US-only Phase 1).
- `src/lib/phone-e164.ts` — `normalizeToE164(raw)` wrapper.
- `scripts/backfill-phone-hashes.ts` — one-shot, idempotent, dry-run by default. Race-safe UPDATE that only touches rows still NULL.
- `provisionUserForPhone` in `verify-otp/route.ts` now computes `phoneHash` inline at signup (silently skips when `PHONE_HASH_SALT` is unset).

**Endpoints:**
- `GET /api/account/phone-hash-salt` — auth-required, returns the salt the client needs to hash on-device. 500 when unset.
- `POST /api/contact-hashes` — Zod-validates `{ hashes: string[] }` (each 64-char lowercase hex, max 5000 — 413 above). Atomic-replace in one transaction. Returns `{ uploaded, matchCount }`.
- `DELETE /api/contact-hashes` — idempotent clear.
- `GET /api/contact-hashes/matches` — joins ContactHash.phoneHash to User.phone_hash, filters to `discoverableByContacts=TRUE`, attaches a `RelationshipResult` per match, drops blocked rows.
- `GET /api/friends/has-new-discovery` — auth, `Cache-Control: max-age=60`. Returns `{ hasNew, count }` for the FriendsList passive row.

**`src/server/db/queries/contact-hashes.ts`** — query layer:
- `countMatchableUsers`, `listContactMatches`, `getLastContactHashUpload`, `isRefreshDue`
- `replaceContactHashes` (single-tx delete+insert), `clearContactHashes`
- `getNewDiscoveryStatus` — deduplicates contact-hash matches and SMS-invite reflections to drive both the Nav dot and the passive row
- `markDiscoveryChecked` — stamped on every `/friends/find` visit

**UI:**
- `ContactMatchBlock` replaces the disabled Block 2 placeholder. Three modes:
  1. Contacts API unsupported → fallback copy ("Search by handle or phone above, or send an invite link")
  2. `discoverableByContacts = false` → CTA to open `/account/privacy`
  3. Otherwise → "Match my contacts" / "Refresh ↻" CTA, weekly-refresh prompt when `MAX(uploadedAt) > 7 days ago`, match rows with `AddFriendButton`
  - On-device pipeline: `navigator.contacts.select(['tel'])` → `normalizeToE164` → fetch salt → `crypto.subtle.digest` SHA-256 → POST hashes → reload matches
- `Nav.tsx` accepts `friendsDotVisible: boolean`, renders a muted INK3 (#8a8a9a) dot on the Friends icon when true. Visually distinct from the bell's accent color.
- `layout.tsx` plumbs `getNewDiscoveryStatus` alongside `getBellBadgeCount` in the same `Promise.all`.
- `FriendsList` Invitations tab gets a ✨ passive row above the existing CTA when `hasNew === true`. Tapping → `/friends/find` clears the threshold → next render hides both signals.
- `/friends/find/page.tsx` SSRs initial match data and stamps `lastFriendDiscoveryCheckAt = NOW()` on every visit.

**Parity test** at `src/server/lib/__tests__/phone-hashing.test.ts` — asserts server `hashPhoneNumber` and client Web Crypto SHA-256 produce identical 64-char hex for the same salt + E.164. 4 cases, all passing.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean
- [x] `npm run lint` — same 28-problem baseline as before, zero in my files
- [x] `npx vitest run src/server/lib/__tests__/phone-hashing.test.ts` — 4/4 pass
- [ ] `npm run db:migrate` applies 0050 cleanly on dev DB
- [ ] Backfill round-trip: `PHONE_HASH_SALT=… npx tsx scripts/backfill-phone-hashes.ts --apply` populates all NULL rows; rerunning is a no-op
- [ ] New signup → row has `phoneHash` populated (when `PHONE_HASH_SALT` is set)
- [ ] `GET /api/account/phone-hash-salt` returns 200 with the salt while authenticated, 401 logged-out, 500 when unset
- [ ] Upload round-trip: `POST /api/contact-hashes` with 3 hex hashes (one matches an opted-in user, one matches an opted-out user, one matches nobody) → `{ uploaded: 3, matchCount: 1 }`; subsequent `GET /matches` returns one row
- [ ] Block detection: A removes B (soft-removed) → B's matches don't include A
- [ ] iOS Safari (or browser without `navigator.contacts`) → ContactMatchBlock renders the fallback copy
- [ ] Toggle `discoverableByContacts = false` from `/account/privacy` → ContactHash rows for that user are deleted (B-Friends-1 behavior) → matches re-query returns nothing
- [ ] Discovery dot: seed a new opted-in user whose phone hashes to a hash you've uploaded → Nav Friends tab shows the dot; visit `/friends/find` → dot clears on next render
- [ ] Passive Invitations-tab row appears with correct count, clears after `/friends/find` visit
- [ ] Weekly refresh prompt renders when `MAX(ContactHash.uploadedAt) > 7 days ago`
- [ ] Salt-unset signup: `provisionUserForPhone` still succeeds; `phoneHash` is NULL; user can be backfilled later

## Out of scope (deferred)

- Mutual-friend suggestion algorithm (Phase 2; Block 5 placeholder still in place)
- Google contacts integration (Phase 2+)
- Native iOS contact upload (Phase 3+)
- Country-aware E.164 beyond `US` (fast-follow)
- Dedicated `user_blocks` table (Phase 2; piggybacks on soft-removed Friendship)
- Phone-change flow that recomputes `phoneHash` (Phase 2)
- Re-tightening the `PHONE_HASH_SALT` boot check (hotfix #409 downgraded it to a warn; intentionally not re-tightened — signup is robust to missing salt)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWqbGGGzQo7sJdhj2uJZTs)_