### PR TITLE
feat(feed): nudge users to invite more friends from caught-up empty state

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -617,11 +617,12 @@ function FeedListContent({
     ) {
       return "You've focused your Feed. You can re-open domains from your Knowledge page."
     }
-    if (feedMeta.total_item_count > 0) return "You're caught up."
+    if (feedMeta.total_item_count > 0)
+      return "You've answered every question your friends sent. Invite more friends and their questions will show up here."
     return 'Quiet today. Check back when your friends have played.'
   }, [error, feedMeta, loadingInitial])
 
-  const showInviteFriendCta = !loadingInitial && !error && feedMeta && !feedMeta.has_friends
+  const showInviteFriendCta = !loadingInitial && !error && Boolean(feedMeta)
 
   const emptyDiagnostics = useMemo(() => {
     if (process.env.NODE_ENV === 'production' || !feedMeta) return null


### PR DESCRIPTION
The "From your friends" feed's caught-up empty state previously read
"You're caught up." with no next action. Replace it with copy that
explains they've finished what's available and that more friends bring
more questions, and surface the existing /friends invite link on every
empty state (not just for users with zero friends) so the CTA matches
the new copy.