### PR TITLE
fix(friend-search): tighten handle regex so bare 10-digit phone searches reach the phone branch

### DIFF
--- a/src/server/db/queries/friend-search.ts
+++ b/src/server/db/queries/friend-search.ts
@@ -13,7 +13,11 @@ export type FriendSearchMatch = {
   relationship: RelationshipResult
 }
 
-const HANDLE_QUERY_PATTERN = /^@?[a-z0-9_]{3,20}$/i
+// Mirrors the registration format in src/server/lib/handle-validation.ts:58
+// (leading letter required). The looser /^@?[a-z0-9_]{3,20}$/i pattern used
+// to swallow bare 10-digit phone searches like "7346578284", which then
+// missed the phone branch below and silently returned no match.
+const HANDLE_QUERY_PATTERN = /^@?[a-z][a-z0-9_]{2,19}$/i
 
 function stripAtSign(value: string): string {
   return value.startsWith('@') ? value.slice(1) : value


### PR DESCRIPTION
The handle pattern /^@?[a-z0-9_]{3,20}$/i matched digit-only strings,
so the if/else-if order in searchFriendByHandleOrPhone treated a query
like "7346578284" as a handle, queried users.handle (where it never
matched), and never tried the phone branch — surfacing "No one by that
name" for accounts that exist. Aligning the pattern with the canonical
registration format (leading letter required, per
src/server/lib/handle-validation.ts:58) lets the phone branch run for
bare 10-digit input.

https://claude.ai/code/session_01RGADAsYkkTJ51N18eu8LQd