### PR TITLE
unify Lately into one feed with utility cards + directional moments

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,185 +1,191 @@
-import Link from 'next/link'
-import { redirect } from 'next/navigation'
+import { redirect } from 'next/navigation';
+import type { ReactNode } from 'react';
 
-import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton'
-import { FriendRequestActions } from '@/app/activities/FriendRequestActions'
-import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead'
-import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton'
-import { DayDivider } from '@/components/lately/DayDivider'
-import { LatelyFeed } from '@/components/lately/LatelyFeed'
+import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton';
+import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
+import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead';
+import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
+import { LatelyFeed, type LatelyFeedItem } from '@/components/lately/LatelyFeed';
 import {
   CREAM,
   FH,
-  FM,
   FS,
   HILITE,
   INK,
   INK2,
-  INK3,
-  RULE,
-} from '@/components/lately/tokens'
-import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer'
-import { getSession } from '@/server/auth/session'
+} from '@/components/lately/tokens';
+import {
+  UnderlineName,
+  UtilityActionLink,
+} from '@/components/lately/UtilityCard';
+import { creatorNoteSubmittedAnswerText } from '@/lib/creator-note-submitted-answer';
+import { getSession } from '@/server/auth/session';
 import {
   getActivitiesForUser,
   type ActivityItemView,
-} from '@/server/db/queries/activity'
-import { getLatelyMoments } from '@/server/db/queries/lately'
-import { getUserById } from '@/server/db/queries/users'
-
-function formatActivityTime(value: Date) {
-  return new Intl.DateTimeFormat(undefined, {
-    month: 'short',
-    day: 'numeric',
-  }).format(value)
-}
+} from '@/server/db/queries/activity';
+import { getLatelyMoments } from '@/server/db/queries/lately';
+import { getUserById } from '@/server/db/queries/users';
 
 function actorName(item: ActivityItemView) {
-  return item.actor?.displayName ?? 'Someone'
-}
-
-function isUnread(item: ActivityItemView) {
-  if (item.type === 'reaction_received')
-    return !item.reference.reaction?.repliedAt
-  return !item.read
+  return item.actor?.displayName ?? 'Someone';
 }
 
 function ActivityCopy({ item }: { item: ActivityItemView }) {
-  const game = item.reference.game
-  const title = game?.title ?? 'a Joshing Game'
-  const masteryEvent = item.reference.masteryEvent
+  const game = item.reference.game;
+  const title = game?.title ?? 'a Joshing Game';
+  const masteryEvent = item.reference.masteryEvent;
 
   if (item.type === 'received_joshing_game') {
     if (game?.viewerStatus === 'complete') {
       return (
         <>
-          {actorName(item)} sent you {title}{' '}
-          <span className="text-muted-foreground">
-            · You got {game.viewerScore}/{game.totalQuestions}
-          </span>
+          <UnderlineName>{actorName(item)}</UnderlineName> sent you {title}
         </>
-      )
+      );
     }
-
     return (
       <>
-        {actorName(item)} sent you a Joshing Game: {title}
+        <UnderlineName>{actorName(item)}</UnderlineName> sent you a Joshing
+        Game: {title}
       </>
-    )
+    );
   }
 
   if (item.type === 'joshing_game_progress') {
     return (
       <>
-        {actorName(item)} played {title}{' '}
-        <span className="text-muted-foreground">
-          · {game?.completedCount ?? 0} of {game?.totalRecipients ?? 0} have
-          played
-        </span>
+        <UnderlineName>{actorName(item)}</UnderlineName> played {title}
       </>
-    )
+    );
   }
 
   if (item.type === 'joshing_game_result') {
-    return <>Everyone played {title}</>
+    return <>Everyone played {title}</>;
   }
 
   if (item.type === 'friend_mastery') {
     return (
       <>
-        {actorName(item)} reached {masteryEvent?.tier ?? 'a new tier'} in{' '}
+        <UnderlineName>{actorName(item)}</UnderlineName> reached{' '}
+        {masteryEvent?.tier ?? 'a new tier'} in{' '}
         {masteryEvent?.domain ?? 'a domain'}
       </>
-    )
+    );
   }
 
   if (item.type === 'ceremony_ready') {
-    return <>Your weekly reflection is ready</>
+    return <>Your weekly reflection is ready</>;
   }
 
   if (item.type === 'friend_request') {
-    return <>{actorName(item)} thought of you for Joshing.</>
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> thought of you for
+        Joshing.
+      </>
+    );
   }
 
   if (item.type === 'friend_request_accepted') {
-    return <>You and {actorName(item)} are now friends</>
+    return (
+      <>
+        You and <UnderlineName>{actorName(item)}</UnderlineName> are now
+        friends
+      </>
+    );
   }
 
   if (item.type === 'reaction_received') {
-    return <>{actorName(item)} reacted to your question</>
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> reacted to your
+        question
+      </>
+    );
   }
 
   if (item.type === 'received_direct_question') {
-    return <>{actorName(item)} sent you a question</>
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> sent you a question.
+      </>
+    );
   }
 
   if (item.type === 'question_curated') {
-    return <>{actorName(item)} saved your question</>
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> saved your question
+      </>
+    );
   }
 
   if (item.type === 'creator_note_received') {
-    return <>{actorName(item)} sent you a note about a question you missed</>
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> sent you a note about
+        a question you missed
+      </>
+    );
   }
 
   if (item.type === 'authored_question_shared') {
-    const shared = item.reference.authoredSharedQuestion
-    const count = shared?.recipientCount ?? 0
-    const friendWord = count === 1 ? 'friend' : 'friends'
-    const domain = shared?.domain ?? 'a domain'
+    const shared = item.reference.authoredSharedQuestion;
+    const count = shared?.recipientCount ?? 0;
+    const friendWord = count === 1 ? 'friend' : 'friends';
+    const domain = shared?.domain ?? 'a domain';
     return (
       <>
         You shared a question with {count} {friendWord} — {domain}
       </>
-    )
+    );
   }
 
   if (item.type === 'friend_answered_your_question') {
-    const faq = item.reference.friendAnsweredQuestion
-    const domain = faq?.domain
-    const domainText = domain ? ` ${domain}` : ''
-    return faq?.result === 'correct' ? (
+    const faq = item.reference.friendAnsweredQuestion;
+    const domain = faq?.domain;
+    const domainText = domain ? ` ${domain}` : '';
+    return (
       <>
-        {actorName(item)} got your{domainText} question right
+        <UnderlineName>{actorName(item)}</UnderlineName> answered your
+        {domainText} question — couldn&apos;t get it
       </>
-    ) : (
-      <>
-        {actorName(item)} answered your{domainText} question — couldn&apos;t get
-        it
-      </>
-    )
+    );
   }
 
   if (item.type === 'declared_promoted') {
-    const dp = item.reference.declaredPromoted
-    const domain = dp?.domain
+    const dp = item.reference.declaredPromoted;
+    const domain = dp?.domain;
     return domain ? (
       <>
-        {actorName(item)} answered your {domain} question — that domain is now
-        proven territory on your map
+        <UnderlineName>{actorName(item)}</UnderlineName> answered your {domain}{' '}
+        question — that domain is now proven territory on your map
       </>
     ) : (
       <>
-        {actorName(item)} answered your question — a domain is now proven
-        territory on your map
+        <UnderlineName>{actorName(item)}</UnderlineName> answered your question
+        — a domain is now proven territory on your map
       </>
-    )
+    );
   }
 
   if (item.type === 'grade_dispute_filed') {
     return (
       <>
-        {actorName(item)} asked for a re-look at your question
+        <UnderlineName>{actorName(item)}</UnderlineName> asked for a re-look at
+        your question
       </>
-    )
+    );
   }
 
-  return <>Something happened on Joshing</>
+  return <>Something happened on Joshing</>;
 }
 
 export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
   if (item.type === 'creator_note_received') {
-    const note = item.reference.creatorNote
-    if (!note) return null
+    const note = item.reference.creatorNote;
+    if (!note) return null;
     return (
       <CreatorNoteReadButton noteId={note.id}>
         <div className="bg-background rounded-md border p-3 text-sm leading-6">
@@ -200,12 +206,12 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
           </blockquote>
         </div>
       </CreatorNoteReadButton>
-    )
+    );
   }
 
   if (item.type === 'received_direct_question') {
-    const directQuestion = item.reference.directQuestion
-    if (!directQuestion) return null
+    const directQuestion = item.reference.directQuestion;
+    if (!directQuestion) return null;
 
     return (
       <div className="text-muted-foreground mt-1 space-y-1 text-sm">
@@ -216,40 +222,40 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
         ) : null}
         <p className="line-clamp-2">{directQuestion.questionText}</p>
       </div>
-    )
+    );
   }
 
   if (item.type === 'question_curated') {
-    const curatedQuestion = item.reference.curatedQuestion
-    if (!curatedQuestion) return null
+    const curatedQuestion = item.reference.curatedQuestion;
+    if (!curatedQuestion) return null;
     return (
       <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
         {curatedQuestion.questionText}
       </p>
-    )
+    );
   }
 
   if (item.type === 'friend_request') {
-    const interests = item.reference.friendshipRequest?.suggestedInterests ?? []
-    if (interests.length === 0) return null
+    const interests = item.reference.friendshipRequest?.suggestedInterests ?? [];
+    if (interests.length === 0) return null;
 
     const label =
       interests.length === 1
         ? interests[0]
         : interests.length === 2
           ? `${interests[0]} and ${interests[1]}`
-          : `${interests[0]}, ${interests[1]}, and ${interests[2]}`
+          : `${interests[0]}, ${interests[1]}, and ${interests[2]}`;
 
     return (
       <p className="text-muted-foreground mt-1 text-sm">
         They left a few ideas: {label}. Keep, edit, or ignore them.
       </p>
-    )
+    );
   }
 
   if (item.type === 'grade_dispute_filed') {
-    const dispute = item.reference.gradeDispute
-    if (!dispute) return null
+    const dispute = item.reference.gradeDispute;
+    if (!dispute) return null;
     return (
       <div className="bg-background mt-1 space-y-1 rounded-md border p-3 text-sm leading-6">
         <p>
@@ -270,12 +276,12 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
           {disputeStatusLabel(dispute.status, dispute.acceptedAlternative)}
         </p>
       </div>
-    )
+    );
   }
 
-  if (item.type !== 'reaction_received') return null
-  const reaction = item.reference.reaction
-  if (!reaction) return null
+  if (item.type !== 'reaction_received') return null;
+  const reaction = item.reference.reaction;
+  if (!reaction) return null;
 
   return (
     <div className="text-muted-foreground mt-1 space-y-1 text-sm">
@@ -294,7 +300,7 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
         </p>
       ) : null}
     </div>
-  )
+  );
 }
 
 function disputeStatusLabel(
@@ -304,54 +310,55 @@ function disputeStatusLabel(
   if (status === 'alternative_added') {
     return acceptedAlternative
       ? `Accepted — added "${acceptedAlternative}" as an alternative.`
-      : 'Accepted — alternative added.'
+      : 'Accepted — alternative added.';
   }
-  if (status === 'dismissed') return 'Dismissed — grade stands.'
-  if (status === 'reviewed') return 'Reviewed.'
-  return 'Pending review.'
+  if (status === 'dismissed') return 'Dismissed — grade stands.';
+  if (status === 'reviewed') return 'Reviewed.';
+  return 'Pending review.';
 }
 
-function ActivityCta({ item }: { item: ActivityItemView }) {
-  if (!item.referenceId) return null
+function activityAction(item: ActivityItemView): ReactNode | null {
+  if (!item.referenceId) return null;
 
   if (item.type === 'received_joshing_game') {
-    const complete = item.reference.game?.viewerStatus === 'complete'
+    const complete = item.reference.game?.viewerStatus === 'complete';
     return (
-      <Link
+      <UtilityActionLink
         href={
           complete
             ? `/games/${item.referenceId}/summary`
             : `/games/${item.referenceId}`
         }
-        className="btn-primary"
-      >
-        {complete ? 'See results' : 'Play'}
-      </Link>
-    )
+        label={complete ? 'See results' : 'Play'}
+      />
+    );
   }
 
   if (item.type === 'joshing_game_progress') {
     return (
-      <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">
-        See so far
-      </Link>
-    )
+      <UtilityActionLink
+        href={`/games/${item.referenceId}/summary`}
+        label="See so far"
+      />
+    );
   }
 
   if (item.type === 'joshing_game_result') {
     return (
-      <Link href={`/games/${item.referenceId}/summary`} className="btn-primary">
-        See results
-      </Link>
-    )
+      <UtilityActionLink
+        href={`/games/${item.referenceId}/summary`}
+        label="See results"
+      />
+    );
   }
 
   if (item.type === 'ceremony_ready') {
     return (
-      <Link href={`/ceremony/${item.referenceId}`} className="btn-primary">
-        See it now
-      </Link>
-    )
+      <UtilityActionLink
+        href={`/ceremony/${item.referenceId}`}
+        label="See it now"
+      />
+    );
   }
 
   if (item.type === 'reaction_received') {
@@ -360,59 +367,113 @@ function ActivityCta({ item }: { item: ActivityItemView }) {
         reactionId={item.reference.reaction?.id ?? item.referenceId}
         replied={Boolean(item.reference.reaction?.repliedAt)}
       />
-    )
+    );
   }
 
   if (item.type === 'received_direct_question') {
-    return (
-      <Link href="/" className="btn-primary">
-        Answer
-      </Link>
-    )
+    return <UtilityActionLink href="/" label="Answer" />;
   }
 
   if (item.type === 'friend_request') {
-    const request = item.reference.friendshipRequest
+    const request = item.reference.friendshipRequest;
     if (
       !request ||
       request.status !== 'pending' ||
       request.requestedByUserId === item.userId
     ) {
-      return null
+      return null;
     }
-
-    return <FriendRequestActions friendshipId={request.id} />
-  }
-
-  if (item.type === 'authored_question_shared') {
-    return null
+    return <FriendRequestActions friendshipId={request.id} />;
   }
 
   if (item.type === 'declared_promoted') {
-    const domain = item.reference.declaredPromoted?.domain
+    const domain = item.reference.declaredPromoted?.domain;
     const href = domain
       ? `/knowledge/${encodeURIComponent(domain)}`
-      : '/knowledge'
-    return (
-      <Link href={href} className="btn-primary">
-        See your map
-      </Link>
-    )
+      : '/knowledge';
+    return <UtilityActionLink href={href} label="See your map" />;
   }
 
-  return null
+  return null;
+}
+
+const INCOMING_TYPES = new Set([
+  'received_direct_question',
+  'received_joshing_game',
+  'friend_request',
+  'creator_note_received',
+]);
+
+function activityCaption(item: ActivityItemView): string {
+  return INCOMING_TYPES.has(item.type) ? 'INCOMING' : 'FROM JOSHING';
+}
+
+function activityToFeedItem(item: ActivityItemView): LatelyFeedItem {
+  const title = <ActivityCopy item={item} />;
+  const subcopy = <ActivitySubcopy item={item} />;
+
+  const italicBody: ReactNode | null =
+    item.type === 'received_direct_question'
+      ? item.reference.directQuestion?.category ?? null
+      : null;
+
+  const anchorId =
+    item.type === 'friend_request' && item.referenceId
+      ? `friendship-${item.referenceId}`
+      : null;
+
+  return {
+    kind: 'utility',
+    id: item.id,
+    sortAt: item.createdAt,
+    utility: {
+      caption: activityCaption(item),
+      title,
+      italicBody,
+      regularBody:
+        item.type === 'ceremony_ready'
+          ? 'A look at the questions, friends, and territories that defined your week.'
+          : null,
+      extra:
+        item.type === 'received_direct_question' ? null : subcopy,
+      action: activityAction(item),
+      anchorId,
+    },
+  };
 }
 
 export default async function ActivitiesPage() {
-  const session = await getSession()
-  if (!session) redirect('/login')
+  const session = await getSession();
+  if (!session) redirect('/login');
 
   const [items, moments, viewer] = await Promise.all([
     getActivitiesForUser(session.userId),
     getLatelyMoments(session.userId),
     getUserById(session.userId),
-  ])
-  const tz = viewer?.timezone ?? 'America/New_York'
+  ]);
+  const tz = viewer?.timezone ?? 'America/New_York';
+
+  // Connection moments come from getLatelyMoments (both directions). The
+  // legacy activity stream also emits friend_answered_your_question correct
+  // rows for the they_got_you direction — drop those to avoid double-renders.
+  const utilityItems: LatelyFeedItem[] = items
+    .filter(
+      (i) =>
+        !(
+          i.type === 'friend_answered_your_question' &&
+          i.reference.friendAnsweredQuestion?.result === 'correct'
+        ),
+    )
+    .map(activityToFeedItem);
+
+  const momentItems: LatelyFeedItem[] = moments.map((m) => ({
+    kind: 'moment',
+    id: m.momentId,
+    sortAt: m.answeredAt,
+    moment: m,
+  }));
+
+  const feedItems: LatelyFeedItem[] = [...momentItems, ...utilityItems];
 
   return (
     <main
@@ -487,70 +548,8 @@ export default async function ActivitiesPage() {
           — the people who get you, getting you.
         </div>
 
-        <LatelyFeed moments={moments} tz={tz} />
-
-        {items.length > 0 ? (
-          <>
-            <DayDivider label="EARLIER ACTIVITY" />
-            <section className="space-y-3 pb-8">
-              {items.map((item) => (
-                <article
-                  key={item.id}
-                  id={
-                    item.type === 'friend_request'
-                      ? `friendship-${item.referenceId}`
-                      : undefined
-                  }
-                  className={[
-                    'bg-card text-card-foreground rounded-lg border p-4 transition',
-                    isUnread(item)
-                      ? 'border-l-primary border-l-[3px]'
-                      : 'border-l-transparent opacity-75',
-                  ].join(' ')}
-                >
-                  <div className="flex items-start justify-between gap-4">
-                    <div>
-                      <p className="text-base leading-7">
-                        <ActivityCopy item={item} />
-                      </p>
-                      <ActivitySubcopy item={item} />
-                      <p className="text-muted-foreground mt-1 text-xs">
-                        {formatActivityTime(item.createdAt)}
-                      </p>
-                    </div>
-                    <ActivityCta item={item} />
-                  </div>
-                </article>
-              ))}
-            </section>
-          </>
-        ) : null}
-
-        {moments.length > 0 || items.length > 0 ? (
-          <div
-            style={{
-              marginTop: 36,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              gap: 12,
-            }}
-          >
-            <div style={{ width: 40, height: 1, background: RULE }} />
-            <div
-              style={{
-                fontSize: 9,
-                fontFamily: FM,
-                color: INK3,
-                letterSpacing: 3,
-              }}
-            >
-              END OF FEED
-            </div>
-            <div style={{ width: 40, height: 1, background: RULE }} />
-          </div>
-        ) : null}
+        <LatelyFeed items={feedItems} tz={tz} />
       </div>
     </main>
-  )
+  );
 }

--- a/src/components/lately/LatelyFeed.tsx
+++ b/src/components/lately/LatelyFeed.tsx
@@ -1,19 +1,39 @@
-import { Fragment } from 'react';
+import { Fragment, type ReactNode } from 'react';
 
-import { assignCaption, bucketMoments, formatMomentTime } from '@/lib/lately';
+import {
+  assignCaption,
+  bucketByDay,
+  formatMomentTime,
+  type LatelyBucketLabel,
+} from '@/lib/lately';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 
 import { DayDivider } from './DayDivider';
 import { MomentRow } from './MomentRow';
-import { FS, INK2 } from './tokens';
+import { FM, FS, INK2, INK3, RULE } from './tokens';
+import { UtilityCard } from './UtilityCard';
+
+export type LatelyUtilityProps = {
+  caption: string;
+  title: ReactNode;
+  italicBody?: ReactNode | null;
+  regularBody?: ReactNode | null;
+  extra?: ReactNode | null;
+  action?: ReactNode | null;
+  anchorId?: string | null;
+};
+
+export type LatelyFeedItem =
+  | { kind: 'moment'; id: string; sortAt: Date; moment: LatelyMoment }
+  | { kind: 'utility'; id: string; sortAt: Date; utility: LatelyUtilityProps };
 
 type Props = {
-  moments: LatelyMoment[];
+  items: LatelyFeedItem[];
   tz: string;
 };
 
-export function LatelyFeed({ moments, tz }: Props) {
-  if (moments.length === 0) {
+export function LatelyFeed({ items, tz }: Props) {
+  if (items.length === 0) {
     return (
       <div
         style={{
@@ -23,6 +43,7 @@ export function LatelyFeed({ moments, tz }: Props) {
           color: INK2,
           textAlign: 'center',
           paddingTop: 40,
+          lineHeight: 1.5,
         }}
       >
         No moments yet. They&rsquo;ll appear here once you and your friends start
@@ -31,26 +52,106 @@ export function LatelyFeed({ moments, tz }: Props) {
     );
   }
 
-  const buckets = bucketMoments(moments, tz);
-  const featuredId = moments[0]?.momentId;
+  const sorted = [...items].sort(
+    (a, b) => b.sortAt.getTime() - a.sortAt.getTime(),
+  );
+  const buckets = bucketByDay(sorted, (i) => i.sortAt, tz);
+  const visibleItems = buckets.flatMap((b) => b.items);
+
+  if (visibleItems.length === 0) {
+    return (
+      <div
+        style={{
+          fontFamily: FS,
+          fontStyle: 'italic',
+          fontSize: 16,
+          color: INK2,
+          textAlign: 'center',
+          paddingTop: 40,
+          lineHeight: 1.5,
+        }}
+      >
+        No moments yet. They&rsquo;ll appear here once you and your friends start
+        answering each other&rsquo;s questions.
+      </div>
+    );
+  }
+
+  const featuredMomentId =
+    visibleItems.find((i) => i.kind === 'moment')?.id ?? null;
 
   return (
     <>
       {buckets.map((bucket) => (
         <Fragment key={bucket.label}>
           <DayDivider label={bucket.label} />
-          {bucket.items.map((moment) => (
-            <MomentRow
-              key={moment.momentId}
-              moment={moment}
-              caption={assignCaption(moment.momentId, moment.dir, moment.friendFirstName)}
-              footnoteTime={formatMomentTime(moment.answeredAt, bucket.label, tz)}
-              featured={moment.momentId === featuredId}
-              defaultOpen={moment.momentId === featuredId}
-            />
-          ))}
+          {bucket.items.map((item) =>
+            renderFeedItem(item, bucket.label, tz, featuredMomentId),
+          )}
         </Fragment>
       ))}
+
+      <div
+        style={{
+          marginTop: 36,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          gap: 12,
+        }}
+      >
+        <div style={{ width: 40, height: 1, background: RULE }} />
+        <div
+          style={{
+            fontSize: 9,
+            fontFamily: FM,
+            color: INK3,
+            letterSpacing: 3,
+          }}
+        >
+          END OF FEED
+        </div>
+        <div style={{ width: 40, height: 1, background: RULE }} />
+      </div>
     </>
+  );
+}
+
+function renderFeedItem(
+  item: LatelyFeedItem,
+  bucket: LatelyBucketLabel,
+  tz: string,
+  featuredMomentId: string | null,
+) {
+  if (item.kind === 'moment') {
+    const { moment } = item;
+    return (
+      <MomentRow
+        key={item.id}
+        moment={moment}
+        caption={assignCaption(
+          moment.momentId,
+          moment.dir,
+          moment.friendFirstName,
+        )}
+        footnoteTime={formatMomentTime(moment.answeredAt, bucket, tz)}
+        featured={item.id === featuredMomentId}
+        defaultOpen={item.id === featuredMomentId}
+      />
+    );
+  }
+
+  return (
+    <UtilityCard
+      key={item.id}
+      caption={item.utility.caption}
+      title={item.utility.title}
+      italicBody={item.utility.italicBody}
+      regularBody={item.utility.regularBody}
+      extra={item.utility.extra}
+      timestamp={formatMomentTime(item.sortAt, bucket, tz)}
+      action={item.utility.action}
+      anchorId={item.utility.anchorId}
+    />
   );
 }

--- a/src/components/lately/MomentRow.tsx
+++ b/src/components/lately/MomentRow.tsx
@@ -97,7 +97,15 @@ export function MomentRow({
           marginBottom: open ? 14 : 12,
         }}
       >
-        <>You and {nameLink} both know {categorySpan}.</>
+        {moment.dir === 'they_got_you' ? (
+          <>
+            {nameLink} got you on {categorySpan}.
+          </>
+        ) : (
+          <>
+            You got {nameLink} on {categorySpan}.
+          </>
+        )}
       </div>
 
       {open ? (

--- a/src/components/lately/UtilityCard.tsx
+++ b/src/components/lately/UtilityCard.tsx
@@ -1,0 +1,169 @@
+import Link from 'next/link';
+import type { ReactNode } from 'react';
+
+import {
+  CREAM,
+  FF,
+  FI,
+  FM,
+  FS,
+  INK,
+  INK2,
+  INK3,
+  PAPER,
+  RULE,
+} from './tokens';
+
+type Props = {
+  caption: string;
+  title: ReactNode;
+  italicBody?: ReactNode | null;
+  regularBody?: ReactNode | null;
+  extra?: ReactNode | null;
+  timestamp: string;
+  action?: ReactNode | null;
+  // Optional DOM id — used by the friend-invitation deep link
+  // (/activities#friendship-{id}) to scroll the relevant card into view.
+  anchorId?: string | null;
+};
+
+export function UtilityCard({
+  caption,
+  title,
+  italicBody,
+  regularBody,
+  extra,
+  timestamp,
+  action,
+  anchorId,
+}: Props) {
+  return (
+    <div
+      id={anchorId ?? undefined}
+      style={{
+        background: PAPER,
+        border: `1.5px solid ${RULE}`,
+        padding: '14px 18px 14px',
+        marginBottom: 14,
+        display: 'flex',
+        gap: 14,
+        alignItems: 'flex-start',
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0 }}>
+        <div
+          style={{
+            fontSize: 9,
+            fontFamily: FM,
+            color: INK3,
+            letterSpacing: 2.5,
+            marginBottom: 8,
+          }}
+        >
+          {caption}
+        </div>
+
+        <div
+          style={{
+            fontSize: 17,
+            fontFamily: FS,
+            fontWeight: 500,
+            color: INK,
+            lineHeight: 1.35,
+            letterSpacing: -0.2,
+            marginBottom: 6,
+          }}
+        >
+          {title}
+        </div>
+
+        {italicBody ? (
+          <div
+            style={{
+              fontFamily: FI,
+              fontStyle: 'italic',
+              color: INK2,
+              fontSize: 13,
+              marginBottom: 10,
+            }}
+          >
+            {italicBody}
+          </div>
+        ) : null}
+
+        {regularBody ? (
+          <div
+            style={{
+              fontFamily: FF,
+              color: INK2,
+              fontSize: 13,
+              lineHeight: 1.5,
+              marginBottom: 10,
+            }}
+          >
+            {regularBody}
+          </div>
+        ) : null}
+
+        {extra ? <div style={{ marginBottom: 10 }}>{extra}</div> : null}
+
+        <div
+          style={{
+            fontSize: 9,
+            fontFamily: FM,
+            color: INK3,
+            letterSpacing: 2,
+          }}
+        >
+          {timestamp}
+        </div>
+      </div>
+
+      {action ? <div style={{ alignSelf: 'flex-start' }}>{action}</div> : null}
+    </div>
+  );
+}
+
+const inkButtonStyle = {
+  display: 'inline-block',
+  background: INK,
+  color: CREAM,
+  border: 'none',
+  fontFamily: FM,
+  fontSize: 10,
+  letterSpacing: 2,
+  padding: '10px 14px',
+  cursor: 'pointer',
+  boxShadow: `2px 2px 0 ${INK2}`,
+  whiteSpace: 'nowrap',
+  textDecoration: 'none',
+} as const;
+
+export function UtilityActionLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  return (
+    <Link href={href} style={inkButtonStyle}>
+      {label.toUpperCase()} →
+    </Link>
+  );
+}
+
+export function UnderlineName({ children }: { children: ReactNode }) {
+  return (
+    <span
+      style={{
+        textDecoration: 'underline',
+        textDecorationColor: INK,
+        textUnderlineOffset: 4,
+        textDecorationThickness: 1.5,
+      }}
+    >
+      {children}
+    </span>
+  );
+}

--- a/src/lib/__tests__/lately.test.ts
+++ b/src/lib/__tests__/lately.test.ts
@@ -4,7 +4,8 @@ import {
   assignCaption,
   bucketMoments,
   formatMomentTime,
-  SHARED_CAPTIONS,
+  THEY_GOT_YOU_CAPTIONS,
+  YOU_GOT_THEM_CAPTIONS,
 } from '@/lib/lately';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 
@@ -25,27 +26,41 @@ function moment(overrides: Partial<LatelyMoment> & { answeredAt: Date }): Lately
 }
 
 describe('assignCaption', () => {
-  const pool = new Set<string>(SHARED_CAPTIONS);
+  function expandPool(pool: readonly string[], name: string): Set<string> {
+    return new Set(pool.map((t) => t.replace('{NAME}', name.toUpperCase())));
+  }
 
-  it('returns a caption from the shared pool regardless of direction', () => {
+  it('picks from the they_got_you pool for that direction', () => {
+    const pool = expandPool(THEY_GOT_YOU_CAPTIONS, 'Robyn');
     expect(pool.has(assignCaption('any-id', 'they_got_you', 'Robyn'))).toBe(true);
-    expect(pool.has(assignCaption('any-id', 'you_got_them', 'Robyn'))).toBe(true);
   });
 
-  it('returns the same caption for both directions given the same momentId', () => {
-    const a = assignCaption('stable-id', 'they_got_you', 'Robyn');
-    const b = assignCaption('stable-id', 'you_got_them', 'Jamie');
-    expect(a).toBe(b);
+  it('picks from the you_got_them pool for that direction', () => {
+    const pool = expandPool(YOU_GOT_THEM_CAPTIONS, 'Jamie');
+    expect(pool.has(assignCaption('any-id', 'you_got_them', 'Jamie'))).toBe(true);
   });
 
-  it('is deterministic across calls', () => {
-    expect(assignCaption('stable-id', 'they_got_you', 'Robyn'))
-      .toBe(assignCaption('stable-id', 'they_got_you', 'Robyn'));
+  it('substitutes the friend first name (uppercased) for the {NAME} token', () => {
+    // Find an id that hashes to the {NAME} template in the they_got_you pool.
+    const target = THEY_GOT_YOU_CAPTIONS.indexOf('{NAME} GOT IT');
+    expect(target).toBeGreaterThanOrEqual(0);
+    for (let i = 0; i < 100; i++) {
+      const id = `probe-${i}`;
+      const result = assignCaption(id, 'they_got_you', 'Robyn');
+      if (result === 'ROBYN GOT IT') return; // pass
+    }
+    throw new Error('Never sampled the {NAME} template');
+  });
+
+  it('is deterministic across calls for the same momentId + direction', () => {
+    expect(assignCaption('stable-id', 'they_got_you', 'Robyn')).toBe(
+      assignCaption('stable-id', 'they_got_you', 'Robyn'),
+    );
   });
 
   it('distributes across the pool over many ids', () => {
     const seen = new Set<string>();
-    for (let i = 0; i < 20; i++) {
+    for (let i = 0; i < 30; i++) {
       seen.add(assignCaption(`probe-${i}`, 'they_got_you', 'Robyn'));
     }
     expect(seen.size).toBeGreaterThanOrEqual(3);

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -7,14 +7,20 @@ export type LatelyBucket = {
   items: LatelyMoment[];
 };
 
-export const SHARED_CAPTIONS = [
-  'SHARED FREQUENCY',
-  'BOTH OF YOU',
-  'COMMON GROUND',
+export const THEY_GOT_YOU_CAPTIONS = [
+  'THEY KNEW YOU',
+  '{NAME} GOT IT',
+  'THEY SAW IT',
   'A MATCH',
-  'ON THE SAME WAVELENGTH',
-  'TWO MINDS, ONE ANSWER',
-  'A SHARED CORNER',
+  'ON YOUR FREQUENCY',
+] as const;
+
+export const YOU_GOT_THEM_CAPTIONS = [
+  'YOU KNEW THEM',
+  'YOU SAW IT',
+  'YOU NAILED IT',
+  'A MATCH',
+  'ON THEIR FREQUENCY',
 ] as const;
 
 function djb2(input: string): number {
@@ -27,10 +33,13 @@ function djb2(input: string): number {
 
 export function assignCaption(
   momentId: string,
-  _dir: LatelyDirection,
-  _friendFirstName: string,
+  dir: LatelyDirection,
+  friendFirstName: string,
 ): string {
-  return SHARED_CAPTIONS[djb2(momentId) % SHARED_CAPTIONS.length];
+  const pool =
+    dir === 'they_got_you' ? THEY_GOT_YOU_CAPTIONS : YOU_GOT_THEM_CAPTIONS;
+  const template = pool[djb2(momentId) % pool.length];
+  return template.replace('{NAME}', friendFirstName.toUpperCase());
 }
 
 function ymdInZone(date: Date, tz: string): string {
@@ -53,32 +62,41 @@ function addDays(ymd: string, delta: number): string {
   return `${yy}-${mm}-${dd}`;
 }
 
+export function bucketByDay<T>(
+  items: T[],
+  getDate: (item: T) => Date,
+  tz: string,
+  now: Date = new Date(),
+): { label: LatelyBucketLabel; items: T[] }[] {
+  const today = ymdInZone(now, tz);
+  const yesterday = addDays(today, -1);
+  const sevenAgo = addDays(today, -7);
+
+  const todayItems: T[] = [];
+  const yesterdayItems: T[] = [];
+  const earlierItems: T[] = [];
+
+  for (const item of items) {
+    const ymd = ymdInZone(getDate(item), tz);
+    if (ymd === today) todayItems.push(item);
+    else if (ymd === yesterday) yesterdayItems.push(item);
+    else if (ymd > sevenAgo && ymd < yesterday) earlierItems.push(item);
+    // anything older than 7 days is dropped per spec
+  }
+
+  const buckets: { label: LatelyBucketLabel; items: T[] }[] = [];
+  if (todayItems.length) buckets.push({ label: 'TODAY', items: todayItems });
+  if (yesterdayItems.length) buckets.push({ label: 'YESTERDAY', items: yesterdayItems });
+  if (earlierItems.length) buckets.push({ label: 'EARLIER THIS WEEK', items: earlierItems });
+  return buckets;
+}
+
 export function bucketMoments(
   moments: LatelyMoment[],
   tz: string,
   now: Date = new Date(),
 ): LatelyBucket[] {
-  const today = ymdInZone(now, tz);
-  const yesterday = addDays(today, -1);
-  const sevenAgo = addDays(today, -7);
-
-  const todayItems: LatelyMoment[] = [];
-  const yesterdayItems: LatelyMoment[] = [];
-  const earlierItems: LatelyMoment[] = [];
-
-  for (const m of moments) {
-    const ymd = ymdInZone(m.answeredAt, tz);
-    if (ymd === today) todayItems.push(m);
-    else if (ymd === yesterday) yesterdayItems.push(m);
-    else if (ymd > sevenAgo && ymd < yesterday) earlierItems.push(m);
-    // anything older than 7 days is dropped per spec
-  }
-
-  const buckets: LatelyBucket[] = [];
-  if (todayItems.length) buckets.push({ label: 'TODAY', items: todayItems });
-  if (yesterdayItems.length) buckets.push({ label: 'YESTERDAY', items: yesterdayItems });
-  if (earlierItems.length) buckets.push({ label: 'EARLIER THIS WEEK', items: earlierItems });
-  return buckets;
+  return bucketByDay(moments, (m) => m.answeredAt, tz, now);
 }
 
 export function formatMomentTime(

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -60,6 +60,7 @@ export type ActivityItemView = Pick<
       feedItemId: string;
       questionText: string;
       personalMessage: string | null;
+      category: string | null;
     };
     curatedQuestion?: {
       questionText: string;
@@ -438,6 +439,8 @@ async function hydrateDirectQuestions(items: ActivityItemRow[]) {
       feedItemId: feedItems.id,
       personalMessage: feedItems.personalMessage,
       questionText: questions.questionText,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      category: questions.category,
     })
     .from(feedItems)
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
@@ -449,6 +452,7 @@ async function hydrateDirectQuestions(items: ActivityItemRow[]) {
       feedItemId: row.feedItemId,
       questionText: row.questionText,
       personalMessage: row.personalMessage,
+      category: row.canonicalSubcategory?.trim() || row.category || null,
     },
   ] as const));
 }


### PR DESCRIPTION
The previous Lately landing only replaced the page chrome; connection
moments rendered in the new editorial card but the rest of the activity
items continued to render in the old style under a second EARLIER
ACTIVITY divider, and the empty state fired above whatever utility
items happened to exist.

This redesign collapses everything into a single timeline:

- Moments and activity items are merged into one chronological feed,
  grouped into TODAY / YESTERDAY / EARLIER THIS WEEK buckets in the
  viewer's timezone (bucketByDay generalizes bucketMoments).
- Connection moments use the editorial MomentRow with directional copy
  ("Robyn got you on …" vs "You got Robyn on …"), restoring per-direction
  caption pools (THEY_GOT_YOU / YOU_GOT_THEM) with {NAME} substitution.
- Sent-question, system, and other activity items render through a new
  UtilityCard in the cream/ink visual register, with INCOMING /
  FROM JOSHING captions and INK-on-cream action buttons (Answer,
  See it now, Play, See so far, See results, See your map). Existing
  client actions (FriendRequestActions, ReactionGotItButton,
  CreatorNoteReadButton) are preserved so routing is untouched.
- The empty state and END OF FEED divider live inside LatelyFeed so the
  empty copy only renders when the entire feed is empty, never above
  utility items.
- friend_answered_your_question (correct) is suppressed in the utility
  stream because LatelyMoments already emits the they_got_you direction.
- hydrateDirectQuestions now joins the question's category so the
  sent-question utility card can show it as the italic body line.
- The /activities#friendship-{id} deep link still works via the
  anchorId prop on UtilityCard.

https://claude.ai/code/session_01M3LUGiv3rGZdNxNu94afJD