### PR TITLE
fix(lately): make MomentRow card tappable on iOS Safari

### DIFF
--- a/src/components/lately/MomentRow.tsx
+++ b/src/components/lately/MomentRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { useState, type MouseEvent } from 'react';
+import { useState, type KeyboardEvent, type MouseEvent } from 'react';
 
 import type { LatelyMoment } from '@/server/db/queries/lately';
 
@@ -23,6 +23,20 @@ export function MomentRow({
   defaultOpen = false,
 }: Props) {
   const [open, setOpen] = useState(defaultOpen);
+
+  function toggle() {
+    setOpen((v) => !v);
+  }
+
+  // iOS Safari is unreliable about firing click on plain <div> even with
+  // cursor:pointer; role=button + keyboard handler makes the tap target
+  // unambiguous to the gesture engine and to assistive tech.
+  function handleKeyDown(e: KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      toggle();
+    }
+  }
 
   function handleSend(e: MouseEvent) {
     e.stopPropagation();
@@ -63,7 +77,11 @@ export function MomentRow({
 
   return (
     <div
-      onClick={() => setOpen((v) => !v)}
+      role="button"
+      tabIndex={0}
+      aria-expanded={open}
+      onClick={toggle}
+      onKeyDown={handleKeyDown}
       style={{
         background: PAPER,
         border: `1.5px solid ${featured ? INK : RULE}`,
@@ -72,6 +90,7 @@ export function MomentRow({
         marginBottom: 14,
         cursor: 'pointer',
         transition: 'border-color 120ms ease',
+        WebkitTapHighlightColor: 'transparent',
       }}
     >
       <div


### PR DESCRIPTION
The card relied on cursor:pointer to coax iOS Safari into firing click
events on a plain <div>. That heuristic is unreliable on newer iOS
versions — taps land but onClick never fires, so the card never expands
and the question text stays hidden.

Promote the card to an explicit role="button" with tabIndex=0, an
onKeyDown handler for Enter/Space, and aria-expanded so assistive tech
sees the disclosure state. WebkitTapHighlightColor: transparent
suppresses the default iOS tap flash on what is now an interactive
element. Visuals and click semantics for the contained friend Link and
SEND TO A FRIEND button are unchanged (still stopPropagation), so the
nested-button HTML constraint doesn't apply.