### PR TITLE
dedup repeated daily questions at the fact level (Götterdämmerung pattern)

### DIFF
--- a/drizzle/0051_generated_question_fact_key.sql
+++ b/drizzle/0051_generated_question_fact_key.sql
@@ -1,0 +1,24 @@
+-- Migration: GeneratedQuestion.fact_key — fact-level dedup for daily generation.
+--
+-- The LLM repeatedly regenerates famous canonical trivia (e.g. "What instrument
+-- does Hagen play to summon the Gibichungs in Götterdämmerung?") under slightly
+-- different wordings. The existing text-level dedup in persistGeneratedQuestion
+-- only catches identical strings, so each re-wording lands as its own
+-- GeneratedQuestion → its own Question → the same fact surfaces in the user's
+-- queue multiple times.
+--
+-- fact_key is a normalized identifier for the underlying fact (lowercase,
+-- hyphenated, ~80 char cap). We dedup against recent fact_keys for the same
+-- user both at LLM-prompt time (so the avoid list is compact) and at persist
+-- time (so a slipped-through re-wording can't reach the Question table).
+--
+-- Nullable so rows generated before this column existed remain valid. The
+-- index is `(user_id, fact_key)` because the only lookup is "recent fact_keys
+-- for this user."
+--
+-- Idempotent guards also pre-applied in src/instrumentation.ts.
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "fact_key" text;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_user_id_fact_key_idx"
+  ON "GeneratedQuestion" ("user_id", "fact_key");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -358,6 +358,13 @@
       "when": 1780876800000,
       "tag": "0050_user_phone_hash_discovery",
       "breakpoints": true
+    },
+    {
+      "idx": 51,
+      "version": "7",
+      "when": 1780963200000,
+      "tag": "0051_generated_question_fact_key",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -793,6 +793,25 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0051 adds GeneratedQuestion.fact_key (nullable) plus the
+    // (user_id, fact_key) lookup index used by the fact-level dedup in
+    // persistGeneratedQuestion + the recent-fact-keys avoid list in
+    // generateDailyQuestions. Guard for preview/production databases that may
+    // have the migration recorded without the column or index actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "GeneratedQuestion"
+          ADD COLUMN IF NOT EXISTS "fact_key" text
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "GeneratedQuestion_user_id_fact_key_idx"
+          ON "GeneratedQuestion" ("user_id", "fact_key")
+      `);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -12,12 +12,21 @@ import {
   mapAdaptiveLevelToDifficultyHint,
   updateAdaptiveLevel,
 } from '@/server/adaptive-difficulty';
-import { getKnowledgeBase, getRecentDailyQuestionTexts } from '@/server/db/queries/daily';
+import { getKnowledgeBase, getRecentDailyQuestionTexts, getRecentFactKeys } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import { normalizeFactKey } from '@/server/questions/fact-key';
 import { resolveDailyBasePoints } from './types';
+
+// Cap the recent question-text block at this many entries inside the prompt.
+// The full recent history (up to 200) is still used to derive the fact-key
+// avoid set; only this slice is shown verbatim to stay within a reasonable
+// token budget.
+const RECENT_QUESTION_TEXT_LIMIT = 80;
+// Cap the recent fact-key block at this many entries inside the prompt.
+const RECENT_FACT_KEY_LIMIT = 200;
 
 export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
 
@@ -52,6 +61,20 @@ Do not invent meta-categories. Do not append qualifiers like "themes," "characte
 
 When in doubt: prefer the broader, work-level label. Use the exact domain name provided to you — the canonical_subcategory for a question should match the domain it was generated for.
 
+REPETITION RULES (read carefully):
+The user will supply two avoid lists: previous question texts and previous fact_keys. A "fact" is the underlying piece of trivia, independent of phrasing. Two questions are the SAME FACT if they probe the same answer about the same subject under the same angle — even if the wording, framing, or sentence structure is completely different.
+
+- "What instrument does Hagen play to summon the Gibichungs in Götterdämmerung?" and "Hagen calls the Gibichung vassals to assembly using which instrument?" are the SAME FACT.
+- Do NOT generate a question whose fact appears in either avoid list, even if you can phrase it differently.
+- Pick a genuinely new angle on the domain: a different work, character, scene, technique, year, person, or detail.
+
+For each question, also emit a fact_key: a short hyphenated lowercase identifier for the underlying fact, in the form "<domain-slug>-<subject>-<answer-topic>". Examples:
+- "gotterdammerung-hagen-summons-vassals-instrument"
+- "mrs-dalloway-clarissa-party-guest-arrival-order"
+- "tchaikovsky-pathetique-symphony-final-tempo-marking"
+
+Keep fact_keys under 80 characters. Two questions with the same fact_key are duplicates and will be rejected.
+
 Return ONLY valid JSON. No preamble, no markdown fences, no explanation.
 
 Return format:
@@ -63,7 +86,8 @@ Return format:
       "question_text": "string",
       "answer": "string",
       "explainer": "string, 2-3 sentences of educational context",
-      "difficulty_estimate": "accessible | moderate | specialist"
+      "difficulty_estimate": "accessible | moderate | specialist",
+      "fact_key": "string, short hyphenated lowercase identifier for the underlying fact (see REPETITION RULES)"
     }
   ]
 }`;
@@ -75,6 +99,7 @@ type LlmQuestion = {
   answer: string;
   explainer: string;
   difficulty_estimate: 'accessible' | 'moderate' | 'specialist';
+  fact_key: string | null;
 };
 
 const FIXED_DIFFICULTY_LEVELS: Record<string, number> = {
@@ -97,12 +122,18 @@ function buildUserPrompt(
   domains: string[],
   count: number,
   prev: string[],
+  prevFactKeys: string[],
   domainSkips: ReadonlyMap<string, number> | undefined,
   difficultyPreference?: string,
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
 ): string {
-  const prevBlock = prev.length > 0 ? prev.slice(-40).join('\n') : '(none yet)';
+  const prevBlock = prev.length > 0
+    ? prev.slice(0, RECENT_QUESTION_TEXT_LIMIT).join('\n')
+    : '(none yet)';
+  const factKeyBlock = prevFactKeys.length > 0
+    ? prevFactKeys.slice(0, RECENT_FACT_KEY_LIMIT).join('\n')
+    : '(none yet)';
 
   let calibration = '';
   if (domainSkips && domainSkips.size > 0) {
@@ -150,8 +181,11 @@ ${lines.join('\n')}`;
 
   return `${domainSection}${calibration}${difficultyHint}
 
-Previously generated questions to avoid repeating:
-${prevBlock}`;
+Previously generated questions to avoid repeating (do not re-ask any of these facts, even rephrased):
+${prevBlock}
+
+Fact keys already covered for this user (do not produce any question whose fact_key matches one of these):
+${factKeyBlock}`;
 }
 
 function asString(value: unknown): string | null {
@@ -205,6 +239,7 @@ function parseQuestions(raw: string): LlmQuestion[] {
       answer: normalizeCanonicalAnswerLabel(answer),
       explainer,
       difficulty_estimate: difficulty,
+      fact_key: normalizeFactKey(asString(rec.fact_key)),
     });
   }
   return result;
@@ -214,6 +249,7 @@ async function callLlmOnce(
   domains: string[],
   count: number,
   previousQuestionTexts: string[],
+  previousFactKeys: string[],
   domainSkips: ReadonlyMap<string, number> | undefined,
   difficultyPreference?: string,
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
@@ -234,6 +270,7 @@ async function callLlmOnce(
           domains,
           count,
           previousQuestionTexts,
+          previousFactKeys,
           domainSkips,
           difficultyPreference,
           domainDifficultyOverrides,
@@ -257,10 +294,15 @@ export async function generateDailyQuestions(
   difficultyPreference?: string,
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
+  previousFactKeys: string[] = [],
 ): Promise<GeneratedQuestionRow[]> {
   if (count <= 0 || domains.length === 0) return [];
 
-  const avoidList = [...extraAvoidTexts, ...previousQuestionTexts].slice(-40);
+  // Avoid list ordering: newest first so the slice in buildUserPrompt keeps
+  // recency. extraAvoidTexts (caller-supplied, e.g. same-batch peers) goes
+  // first so it always reaches the prompt even if the recent history is long.
+  const avoidList = [...extraAvoidTexts, ...previousQuestionTexts];
+  const factKeyAvoidSet = new Set(previousFactKeys);
 
   let generated: LlmQuestion[] = [];
   try {
@@ -268,6 +310,7 @@ export async function generateDailyQuestions(
       domains,
       count,
       avoidList,
+      previousFactKeys,
       domainSkips,
       difficultyPreference,
       domainDifficultyOverrides,
@@ -279,6 +322,7 @@ export async function generateDailyQuestions(
         domains,
         count,
         avoidList,
+        previousFactKeys,
         domainSkips,
         difficultyPreference,
         domainDifficultyOverrides,
@@ -294,6 +338,7 @@ export async function generateDailyQuestions(
         domains,
         count,
         avoidList,
+        previousFactKeys,
         domainSkips,
         difficultyPreference,
         domainDifficultyOverrides,
@@ -311,6 +356,7 @@ export async function generateDailyQuestions(
 
   const expiresAt = getNextDailyResetBoundary();
   const persisted: GeneratedQuestionRow[] = [];
+  const seenFactKeysThisBatch = new Set<string>();
 
   for (const question of generated.slice(0, count)) {
     const { canonicalDomain } = await reconcileProposedDomain(
@@ -326,6 +372,21 @@ export async function generateDailyQuestions(
       continue;
     }
 
+    // Belt-and-suspenders: even with the avoid list, the LLM occasionally
+    // returns a fact_key that matches a recent one (or duplicates another
+    // question in the same batch). Drop those rather than persist them.
+    const factKey = question.fact_key;
+    if (factKey) {
+      if (factKeyAvoidSet.has(factKey) || seenFactKeysThisBatch.has(factKey)) {
+        console.warn('[daily/generate-questions] skipping question with already-seen fact_key', {
+          factKey,
+          canonicalDomain,
+        });
+        continue;
+      }
+      seenFactKeysThisBatch.add(factKey);
+    }
+
     const basePoints = resolveDailyBasePoints(question.difficulty_estimate);
     const [row] = await db
       .insert(generatedQuestions)
@@ -338,6 +399,7 @@ export async function generateDailyQuestions(
         explainer: question.explainer,
         difficultyEstimate: question.difficulty_estimate,
         basePoints,
+        factKey,
         expiresAt,
         usedInQueue: false,
       })
@@ -402,10 +464,11 @@ export async function generateDailyQuestionsFromKnowledgeBase(
   userId: string,
   count: number,
 ): Promise<GeneratedQuestionRow[]> {
-  const [knowledgeBase, preferences, previousQuestionTexts] = await Promise.all([
+  const [knowledgeBase, preferences, previousQuestionTexts, previousFactKeys] = await Promise.all([
     getKnowledgeBase(userId),
     getDailyPreferences(userId),
     getRecentDailyQuestionTexts(userId),
+    getRecentFactKeys(userId),
   ]);
   const adaptiveLevel = preferences.difficulty === 'adaptive'
     ? await updateAdaptiveLevel(userId)
@@ -437,5 +500,6 @@ export async function generateDailyQuestionsFromKnowledgeBase(
     preferences.difficulty,
     domainDifficultyOverrides,
     adaptiveLevel,
+    previousFactKeys,
   );
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -710,7 +710,13 @@ export async function createDailyQueueItemFromAuthored(
   });
 }
 
-export async function getRecentDailyQuestionTexts(userId: string, limit = 60): Promise<string[]> {
+// Default widened from 60 to 200: the LLM repeatedly regenerated canonical
+// trivia (the Götterdämmerung Hagen-summons-vassals question surfaced ~4×)
+// because anything beyond ~12 days fell out of the avoid window. The full list
+// is now used to derive a compact fact-key avoid set; only the most recent
+// slice of full question texts is included verbatim (see RECENT_QUESTION_TEXT_LIMIT
+// in src/server/daily/generate-questions.ts).
+export async function getRecentDailyQuestionTexts(userId: string, limit = 200): Promise<string[]> {
   const rows = await db
     .select({ questionText: generatedQuestions.questionText })
     .from(generatedQuestions)
@@ -719,6 +725,27 @@ export async function getRecentDailyQuestionTexts(userId: string, limit = 60): P
     .limit(limit);
 
   return rows.map((row) => row.questionText);
+}
+
+// Recent fact_keys for the same user, newest first. Used both for the LLM
+// avoid list (compact: ~40 chars per key vs. ~80+ per full question text)
+// and the persist-time dedup check in persistGeneratedQuestion.
+export async function getRecentFactKeys(userId: string, limit = 200): Promise<string[]> {
+  const rows = await db
+    .select({ factKey: generatedQuestions.factKey })
+    .from(generatedQuestions)
+    .where(and(
+      eq(generatedQuestions.userId, userId),
+      isNotNull(generatedQuestions.factKey),
+    ))
+    .orderBy(sql`${generatedQuestions.createdAt} desc`)
+    .limit(limit);
+
+  const out: string[] = [];
+  for (const row of rows) {
+    if (row.factKey) out.push(row.factKey);
+  }
+  return out;
 }
 
 export async function getAnsweredDailyCount(queue: DailyQueueRow): Promise<number> {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -502,6 +502,11 @@ export const generatedQuestions = pgTable(
     explainer: text('explainer').notNull(),
     difficultyEstimate: text('difficulty_estimate').notNull(),
     basePoints: integer('base_points').notNull(),
+    // Normalized identifier for the underlying fact (e.g.
+    // 'gotterdammerung-hagen-summons-vassals-instrument'). Lets us dedup
+    // re-wordings of the same trivia that the text-level check misses.
+    // Nullable so older rows generated before this column existed remain valid.
+    factKey: text('fact_key'),
     createdAt: createdAt(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     usedInQueue: boolean('used_in_queue').notNull().default(false),
@@ -509,6 +514,7 @@ export const generatedQuestions = pgTable(
   (table) => [
     index('GeneratedQuestion_user_id_idx').on(table.userId),
     index('GeneratedQuestion_user_id_used_in_queue_idx').on(table.userId, table.usedInQueue),
+    index('GeneratedQuestion_user_id_fact_key_idx').on(table.userId, table.factKey),
   ],
 );
 

--- a/src/server/questions/__tests__/fact-key.test.ts
+++ b/src/server/questions/__tests__/fact-key.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+
+import { FACT_KEY_MAX_CHARS, normalizeFactKey } from '@/server/questions/fact-key';
+
+describe('normalizeFactKey', () => {
+  it('returns null for non-strings, empty, and pure-punctuation input', () => {
+    expect(normalizeFactKey(null)).toBeNull();
+    expect(normalizeFactKey(undefined)).toBeNull();
+    expect(normalizeFactKey('')).toBeNull();
+    expect(normalizeFactKey('   ')).toBeNull();
+    expect(normalizeFactKey('—//——')).toBeNull();
+  });
+
+  it('lowercases, slugifies, strips diacritics, and trims hyphens', () => {
+    expect(normalizeFactKey('Götterdämmerung — Hagen summons vassals (instrument)'))
+      .toBe('gotterdammerung-hagen-summons-vassals-instrument');
+  });
+
+  it('collapses repeated non-alphanumerics into single hyphens', () => {
+    expect(normalizeFactKey('foo___bar...baz!!!qux')).toBe('foo-bar-baz-qux');
+  });
+
+  it('preserves an already-clean slug verbatim', () => {
+    expect(normalizeFactKey('mrs-dalloway-clarissa-party-guest-arrival-order'))
+      .toBe('mrs-dalloway-clarissa-party-guest-arrival-order');
+  });
+
+  it('caps length at FACT_KEY_MAX_CHARS without leaving a trailing hyphen', () => {
+    const long = 'a'.repeat(50) + '-' + 'b'.repeat(50);
+    const normalized = normalizeFactKey(long);
+    expect(normalized).not.toBeNull();
+    expect(normalized!.length).toBeLessThanOrEqual(FACT_KEY_MAX_CHARS);
+    expect(normalized!.endsWith('-')).toBe(false);
+  });
+
+  it('produces the SAME key for two re-wordings of the same fact', () => {
+    const a = normalizeFactKey('gotterdammerung-hagen-summons-vassals-instrument');
+    const b = normalizeFactKey('Götterdämmerung Hagen summons vassals instrument');
+    expect(a).toBe(b);
+  });
+});

--- a/src/server/questions/fact-key.ts
+++ b/src/server/questions/fact-key.ts
@@ -1,0 +1,31 @@
+/**
+ * fact_key normalization for daily question dedup.
+ *
+ * The LLM produces a short label identifying the underlying fact (not the
+ * wording) — e.g. "Gotterdammerung — Hagen summons vassals (instrument)".
+ * We normalize it to a stable hyphen-slug that's safe to compare across
+ * re-wordings of the same trivia.
+ *
+ * Output shape: lowercase ASCII-ish, words joined by single hyphens, no
+ * leading/trailing hyphens, capped at FACT_KEY_MAX_CHARS so a runaway label
+ * can't blow up the index row width.
+ */
+
+export const FACT_KEY_MAX_CHARS = 80;
+
+const COMBINING_MARKS = /[̀-ͯ]/g;
+
+export function normalizeFactKey(value: string | null | undefined): string | null {
+  if (typeof value !== 'string') return null;
+  const ascii = value
+    .normalize('NFKD')
+    .replace(COMBINING_MARKS, '')
+    .toLowerCase();
+  const slug = ascii
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!slug) return null;
+  return slug.length > FACT_KEY_MAX_CHARS
+    ? slug.slice(0, FACT_KEY_MAX_CHARS).replace(/-+$/g, '')
+    : slug;
+}

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -48,6 +48,35 @@ export async function persistGeneratedQuestion(generatedQuestionId: string, slot
       throw new Error(`Generated question not found: ${generatedQuestionId}`);
     }
 
+    // Fact-key dedup: even when the LLM is told to avoid a fact, it sometimes
+    // produces a re-worded version with a fresh question_text — which slips
+    // past the text-level check below. The fact_key column is the canonical
+    // identifier for the underlying trivia (set by the LLM, normalized in
+    // src/server/questions/fact-key.ts) and is shared across re-wordings.
+    // If any prior daily_generated Question is keyed to a GeneratedQuestion
+    // with the same fact_key, reuse that Question rather than create a new
+    // one. Runs before the text-level check because it's the stricter test.
+    const factKey = generated.factKey;
+    if (factKey) {
+      const [factMatch] = await db
+        .select({ id: questions.id })
+        .from(questions)
+        .innerJoin(
+          generatedQuestions,
+          eq(questions.generatedQuestionId, generatedQuestions.id),
+        )
+        .where(and(
+          isNull(questions.deletedAt),
+          eq(questions.source, 'daily_generated'),
+          eq(generatedQuestions.factKey, factKey),
+        ))
+        .limit(1);
+
+      if (factMatch) {
+        return { questionId: factMatch.id, alreadyExisted: true };
+      }
+    }
+
     // Text-level dedup: the LLM occasionally returns identical question text
     // across separate per-user GeneratedQuestion rows. Without this check each
     // generation would land as its own Question, then a "friend answered"


### PR DESCRIPTION
Same canonical trivia (the Hagen-summons-vassals instrument question) kept
surfacing ~4× because the avoid list was 60 items at the prompt and silently
sliced to 40, and dedup keyed on exact question text — so the LLM's re-wordings
of the same fact each landed as a fresh Question.

Three layered fixes:
- Widen the avoid window (60 → 200) and stop the silent 40-item truncation.
  Tighten the prompt with explicit "same fact, different wording is still a
  repeat" guidance and a concrete Hagen example.
- Add GeneratedQuestion.fact_key (migration 0051 + instrumentation guard).
  LLM emits a normalized slug per question; recent fact_keys are passed back
  as a compact avoid list and used at persist time to collapse re-wordings
  onto the existing Question row.
- Belt-and-suspenders: drop any LLM output whose fact_key matches a recent
  one or duplicates another question in the same batch.