### PR TITLE
perf(games-answer): drop redundant getJoshingGame after submit

### DIFF
--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -92,9 +92,6 @@ export async function POST(request: NextRequest, context: RouteContext) {
       submittedAnswer: parsed.submittedAnswer,
     });
     const completion = await checkJoshingGameCompletion({ gameId: id, userId: session.userId });
-    const freshView = await getJoshingGame({ gameId: id, requestingUserId: session.userId });
-
-    if (!freshView) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
     const answeredQuestion = existingView.questions.find((item) => item.questionId === parsed.questionId);
     const correctAnswer = answeredQuestion?.question.answerText ?? '';
@@ -209,7 +206,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
       correctAnswer,
       answerState: grade.answerState,
       breadcrumb: null,
-      viewerStatus: freshView.viewerStatus,
+      viewerStatus: completion.userComplete ? 'complete' : 'in_progress',
       quip,
       insideJoke,
     });


### PR DESCRIPTION
The POST /api/joshing-games/[id]/answer route was re-fetching the full
game view after submitting a response, only to read `viewerStatus`
from it. That value is already derivable from the `checkJoshingGameCompletion`
result we just awaited: since we just inserted a response for the viewer,
`'not_started'` is unreachable, so `completion.userComplete` collapses to
'complete' vs 'in_progress'.

Removing the second getJoshingGame eliminates 4 SELECTs (game, creator,
recipients, questions, responses) per game answer with no behavioral change.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge