### PR TITLE
perf(daily-answer): fan out priorAnswers + insideJoke in parallel

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -271,9 +271,16 @@ export async function POST(request: NextRequest) {
     // determined correctly across surfaces (F2.1). Falls back to the old
     // behaviour (treat as first attempt) only if persistence failed and we
     // have no canonical id to look up history against.
-    const priorAnswers = canonicalQuestionId
-      ? await readPriorAnswersForQuestion(session.userId, canonicalQuestionId)
-      : [];
+    // priorAnswers (mastery history) and insideJokeForViewer (friendship check)
+    // are independent of each other and of the grader output, so fan them out
+    // in parallel. The viewer joke isn't consumed until nextSlots is built
+    // below; pre-resolving it here removes a serial round-trip.
+    const [priorAnswers, insideJokeForViewer] = await Promise.all([
+      canonicalQuestionId
+        ? readPriorAnswersForQuestion(session.userId, canonicalQuestionId)
+        : Promise.resolve<{ result: 'correct' | 'wrong' }[]>([]),
+      selectInsideJokeForViewer(persistedInsideJoke, persistedCreatorId, session.userId),
+    ]);
     const masteryAnswerState = computeAnswerState(
       isCorrect ? 'correct' : 'wrong',
       priorAnswers,
@@ -311,12 +318,6 @@ export async function POST(request: NextRequest) {
       }
     }
     const pointsAwarded = skipMasteryForUnknownDomain ? 0 : uncheckedPointsAwarded;
-
-    const insideJokeForViewer = await selectInsideJokeForViewer(
-      persistedInsideJoke,
-      persistedCreatorId,
-      session.userId,
-    );
 
     const nextSlots = slots.map((item) => {
       if (item.slot_index !== parsed.slotIndex) return item;


### PR DESCRIPTION
## Summary

In `POST /api/daily/answer`, `readPriorAnswersForQuestion` (mastery history) and `selectInsideJokeForViewer` (friendship check) were awaited sequentially even though both depend only on values resolved well above the mastery-state block. Fan them out via `Promise.all` to shave one DB round-trip off every Daily Five submit.

The third candidate from the audit — the `playerMastery` existence check on line ~296 — has to stay sequential because it's gated on `uncheckedPointsAwarded > 0`, which transitively depends on `priorAnswers`. So the conservative version of the win is shipped here; the existingDomain query keeps its current ordering.

- File: `src/app/api/daily/answer/route.ts`
- 10 insertions, 9 deletions
- Expected latency saved: ~10–30ms per Daily Five submit (0ms when `areFriends` short-circuits on `creatorId === viewerId` or null inside-joke)

This is quick win #2 from the performance audit on branch `claude/codebase-performance-audit-navuB`.

## Test plan

No automated coverage on this route — manual smoke before merge:

- [ ] Answer a Daily Five slot whose canonical question was authored by a friend → response includes the `insideJoke`
- [ ] Answer a slot authored by a non-friend → `insideJoke` is `null`
- [ ] Answer a slot you authored yourself → `insideJoke` is returned (creator-as-viewer short-circuit)
- [ ] Bot-source slot, first correct answer → `pointsAwarded` matches `basePoints`, mastery event written
- [ ] Bot-source slot in a domain not in your Knowledge Base → mastery event skipped, `pointsAwarded === 0` (unchanged behavior)
- [ ] `npx tsc -p tsconfig.typecheck.json` (already clean locally)

## Rollback

Single-file revert. No DB migration, no schema change, no client change.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_