### PR TITLE
perf(daily-answer): void-fire updateDomainDifficultyOnAnswer

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -360,7 +360,10 @@ export async function POST(request: NextRequest) {
       }
     }
 
-    await updateDomainDifficultyOnAnswer(
+    // Adaptive-difficulty bookkeeping is not consumed by the response; let it
+    // run after we've already returned. The function swallows its own errors
+    // via the .catch below, so an unhandled rejection cannot escape.
+    void updateDomainDifficultyOnAnswer(
       session.userId,
       question.canonicalSubcategory,
       isCorrect,


### PR DESCRIPTION
## Summary

`updateDomainDifficultyOnAnswer` writes adaptive-difficulty bookkeeping for the answered domain. Its result is not consumed by the response, but `src/app/api/daily/answer/route.ts` was awaiting it before returning — ~15–40ms of pure serial latency on every Daily Five submit.

Switching to `void`-fire preserves the existing `.catch`, so unhandled rejections still cannot escape; the call simply runs after `NextResponse.json` is on its way back to the client.

- File: `src/app/api/daily/answer/route.ts`
- 4 insertions, 1 deletion
- Expected latency saved: ~15–40ms per Daily Five submit

This is quick win #4 from the performance audit on branch `claude/codebase-performance-audit-navuB`. Quick win #3 (the 5 proposed indexes) is being deferred pending `EXPLAIN ANALYZE` validation against production.

## Test plan

`npx tsc -p tsconfig.typecheck.json` — clean.

`npx vitest run src/app/api/daily/answer/__tests__/route.test.ts` currently fails on **both this branch and main** with `Cannot access 'dbMock' before initialization` — a pre-existing `vi.mock` hoisting bug in the test file, unrelated to this change. Flagging here so it's not re-attributed to this PR; should be cleaned up in a separate change.

Manual smoke before merge:

- [ ] Answer a Daily Five slot for a domain you've answered correctly before → response returns normally, and the `PlayerMastery.lastDifficulty` / domain-difficulty bookkeeping eventually updates (visible in `/dev/points-diagnostic` or DB)
- [ ] Answer a Daily Five slot for a brand-new domain → response returns normally; check function-execution logs for `[daily/answer] updateDomainDifficultyOnAnswer failed` warnings (should be absent)

## Rollback

Single-file revert. No DB migration, no schema change, no client change.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_