### PR TITLE
perf(cron): cap concurrency at 4 for daily-assignments + vet-questions

### DIFF
--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -5,9 +5,14 @@ import { getTodaysDailyQueue } from '@/server/db/queries/daily';
 import { db, users } from '@/server/db';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { type QueueSlot } from '@/server/daily/types';
+import { runWithConcurrency } from '@/server/lib/concurrency';
 import { sendSms } from '@/server/sms';
 
 export const dynamic = 'force-dynamic';
+
+// Capped at 4 to stay one connection below the 5-cap DB pool. Tune down if
+// the SMS provider's per-second rate becomes the binding limit instead of DB.
+const USER_CONCURRENCY = 4;
 
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
@@ -51,7 +56,7 @@ export async function GET(request: NextRequest) {
     smsSent: 0,
   };
 
-  for (const user of onboardedUsers) {
+  await runWithConcurrency(onboardedUsers, USER_CONCURRENCY, async (user) => {
     try {
       let queue = await getTodaysDailyQueue(user.id);
       const existingSlots = queue ? asQueueSlots(queue.slots) : [];
@@ -76,7 +81,7 @@ export async function GET(request: NextRequest) {
     } catch (error) {
       if (error instanceof DailyQueueFillError) {
         results.failed += 1;
-        continue;
+        return;
       }
 
       console.error('[cron/daily-assignments] user failed', {
@@ -85,7 +90,7 @@ export async function GET(request: NextRequest) {
       });
       results.failed += 1;
     }
-  }
+  });
 
   return NextResponse.json(results);
 }

--- a/src/app/api/cron/vet-questions/route.ts
+++ b/src/app/api/cron/vet-questions/route.ts
@@ -2,12 +2,17 @@ import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { db, questions } from '@/server/db';
+import { runWithConcurrency } from '@/server/lib/concurrency';
 import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
 
 const BATCH_SIZE = 25;
+// Capped at 4 to stay one connection below the 5-cap DB pool. Each worker
+// holds a Haiku call in flight (~1–2s); tune down if Anthropic tier limits
+// become binding before DB does.
+const VET_CONCURRENCY = 4;
 
 function isAuthorized(request: NextRequest): boolean {
   const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
@@ -53,7 +58,7 @@ export async function GET(request: NextRequest) {
     failed: 0,
   };
 
-  for (const row of pending) {
+  await runWithConcurrency(pending, VET_CONCURRENCY, async (row) => {
     try {
       const verdict = await vetQuestion({
         questionText: row.questionText,
@@ -92,7 +97,7 @@ export async function GET(request: NextRequest) {
         error: error instanceof Error ? error.message : String(error),
       });
     }
-  }
+  });
 
   return NextResponse.json(results);
 }

--- a/src/server/lib/concurrency.ts
+++ b/src/server/lib/concurrency.ts
@@ -1,0 +1,26 @@
+/**
+ * Drives `items` through `worker` with at most `limit` in flight at any time.
+ * Workers run in arbitrary order; failures are not isolated, so the worker
+ * MUST handle its own errors (otherwise a single rejection cancels the run).
+ *
+ * The DB pool is capped at 5 (see src/server/db/index.ts) — keep `limit` ≤ 4
+ * in callers that hold a connection per iteration so other work in the same
+ * process isn't starved.
+ */
+export async function runWithConcurrency<T>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T) => Promise<void>,
+): Promise<void> {
+  if (items.length === 0) return;
+  const cappedLimit = Math.max(1, Math.min(limit, items.length));
+  let cursor = 0;
+  const runners = Array.from({ length: cappedLimit }, async () => {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) return;
+      await worker(items[index]!);
+    }
+  });
+  await Promise.all(runners);
+}


### PR DESCRIPTION
## Summary

Both daily-assignments and vet-questions crons were serial per-iteration loops, which doesn't scale. With N onboarded users at ~50ms each, daily-assignments grows linearly; with `BATCH_SIZE = 25` Haiku calls at ~1–2s each, vet-questions wall-clocks ~25–50s every morning.

Adds a small `runWithConcurrency` helper at `src/server/lib/concurrency.ts` and applies it at concurrency 4 in both crons. Four is chosen deliberately to stay one connection below the 5-cap DB pool (`src/server/db/index.ts:23`), so the cron worker still leaves room for any other work in the same process.

- New file: `src/server/lib/concurrency.ts` (24 lines, no deps)
- `src/app/api/cron/daily-assignments/route.ts` — for-of → `runWithConcurrency(…, 4, …)`
- `src/app/api/cron/vet-questions/route.ts` — same shape

Per-iteration try/catch is preserved verbatim, so failure isolation is unchanged. Counters mutated from worker closures are safe because Node's event loop is single-threaded; only one worker's `+=` runs at a time.

Expected wall-clock improvement:
- daily-assignments: ~75% reduction (limited by sequential SMS within an iteration, not across)
- vet-questions: ~75% reduction (25-question batch: ~25–50s → ~6–13s)

This is quick win #5 from the performance audit on branch `claude/codebase-performance-audit-navuB`.

## Caveats worth a second look

- **SMS rate limits.** With concurrency 4, up to four `sendSms` calls can be in flight. Twilio messaging-service caps are ~100 msg/sec which leaves plenty of headroom; a stricter long-code (1 msg/sec) setup would need a lower cap. If the cron starts logging Twilio 429s, drop `USER_CONCURRENCY` to 1 and split the loop into two passes (concurrent fill, serial SMS).
- **Anthropic tier limits for vet-questions.** Tier-1 Haiku is ~50 req/min; at concurrency 4 with 1–2s calls we'd burn ~120–240 req/min. If the team is on tier-1 this will trip rate limits — drop `VET_CONCURRENCY` to 2 in that case.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean.
- [ ] Manually trigger `/api/cron/daily-assignments` against a preview env with a `CRON_SECRET` set. Confirm response counters (`users`, `generated`, `existing`, `failed`, `smsSent`) match a known-good baseline run, and no DB pool-saturation warnings (`[db-pool] waiting > 0`) appear in logs.
- [ ] Manually trigger `/api/cron/vet-questions`. Confirm `scanned + approved + rejected + deferred + failed` arithmetic still adds up; check Anthropic dashboard for 429s.
- [ ] Watch the next scheduled run (06:00 UTC for daily-assignments, 07:00 UTC for vet-questions) and compare wall-clock from Vercel logs against the prior week.

## Rollback

Revert the PR. The helper file is new and unused outside these two crons; no schema, no client, no migration changes.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_