### PR TITLE
perf(feed): skip totalCount query on paginated requests

### DIFF
--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -399,24 +399,30 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
   const isFirstPage = !options.cursor;
 
   // Pinned items are deliberately returned only on the first page, ahead of the chronological feed.
+  // The totalCount query is also gated to first-page requests: it re-evaluates the same heavy
+  // visibility predicate (notExists masteryEvents join, etc.) as the page query, and its only
+  // downstream consumer is the empty-state copy in FeedList — which can only fire on the first page.
+  // Subsequent paginated loads see `totalCount: 0`; this is a sentinel, not an accurate count.
   const [pinned, nonPinnedRaw, countRows] = await Promise.all([
     isFirstPage
       ? fetchVisibleFeedItems(userId, dismissedDomains, { limit, pinned: true, filter })
       : Promise.resolve([]),
     fetchVisibleFeedItems(userId, dismissedDomains, { limit: limit + 1, cursor: options.cursor, pinned: false, filter }),
-    db
-      .select({ value: count() })
-      .from(feedItems)
-      .innerJoin(questions, eq(feedItems.questionId, questions.id))
-      .where(and(
-        eq(feedItems.recipientUserId, userId),
-        visibleSourcePredicate,
-        feedFilterPredicate(filter),
-        inArray(feedItems.state, ACTIONABLE_FEED_STATES),
-        visibleQuestionPredicate(dismissedDomains),
-        viewerNotAuthorPredicate(userId),
-        viewerNotAlreadyAnsweredPredicate(userId),
-      )),
+    isFirstPage
+      ? db
+          .select({ value: count() })
+          .from(feedItems)
+          .innerJoin(questions, eq(feedItems.questionId, questions.id))
+          .where(and(
+            eq(feedItems.recipientUserId, userId),
+            visibleSourcePredicate,
+            feedFilterPredicate(filter),
+            inArray(feedItems.state, ACTIONABLE_FEED_STATES),
+            visibleQuestionPredicate(dismissedDomains),
+            viewerNotAuthorPredicate(userId),
+            viewerNotAlreadyAnsweredPredicate(userId),
+          ))
+      : Promise.resolve<{ value: number }[]>([]),
   ]);
 
   const nonPinnedPage = nonPinnedRaw.slice(0, limit);


### PR DESCRIPTION
## Summary

`getFeedForUser` (`src/server/db/queries/feed.ts`) ran a `count()` query in parallel with the page fetch on **every** request. The count re-evaluates the same heavy visibility predicate the page query already runs — `notExists` masteryEvents subquery, Question join, `ACTIONABLE` state filter, `viewerNotAuthor`, dismissed-domain filter.

Its only downstream consumer (`feedPage.totalCount` → `active_item_count`) is used in two places:
1. **`FeedList.tsx` empty-state copy** — only renders when `items.length === 0`, which by definition can only happen on a first-page request, not on a paginated continuation.
2. **`/api/feed` route handler `console.info`** — diagnostic logging only.

So gate the count on `!options.cursor` (first-page-only). Subsequent infinite-scroll loads skip a full predicate evaluation + Question join + masteryEvents `notExists` subquery. Paginated responses get `totalCount: 0` as a sentinel — documented in the comment.

> **Note on the audit's wording:** the original audit suggested `count(*) OVER ()` here. On closer reading, that doesn't fit — the count's predicate is wider than the page's (no cursor, no pinned, no limit), so a window count on the page query would give wrong semantics. This first-page gate captures the same intent: removing redundant work per pagination.

- File: `src/server/db/queries/feed.ts`
- 19 insertions, 13 deletions (mostly the comment + ternary indentation)
- Expected savings: one full predicate+join evaluation per paginated request (every infinite-scroll trigger past the first page)

This is quick win #6 from the performance audit on branch `claude/codebase-performance-audit-navuB`.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean.
- [x] `npx vitest run src/server/db/queries/__tests__/feed.test.ts` — all 7 tests pass unmodified (none paginate, so all hit the first-page branch where behavior is unchanged).

Manual smoke before merge:

- [ ] Load `/` fresh → empty-state copy renders correctly on a real empty feed, and `feedMeta.total_item_count` / `active_item_count` debug values are non-zero in dev console.
- [ ] On a feed with > 20 items, scroll to trigger pagination → second-page response in the Network tab includes `meta.active_item_count: 0` (this is expected, documented as a sentinel). Items continue loading normally.
- [ ] Watch `[feed/get]` logs in Vercel for paginated requests (`cursorPresent: true`) — `activeItemCount` field will be `0` going forward; not a regression.

## Rollback

Single-file revert. No DB migration, no schema change, no client change.

## Follow-ups (out of scope)

The same gating pattern would apply to `totalItemCount` and `preFilterActiveCount` in `src/server/feed/get-feed-page.ts` (used in empty-state copy as well — also first-page-only). Worth a separate quick win if perf gains are needed beyond this PR.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_