### PR TITLE
perf: memoize JWT secret + cache share-ceremony page (quick wins #9 + #10)

### DIFF
--- a/src/app/share/ceremony/[token]/page.tsx
+++ b/src/app/share/ceremony/[token]/page.tsx
@@ -4,6 +4,12 @@ import { notFound } from 'next/navigation';
 import { ShareCard } from '@/components/ShareCard';
 import type { ShareCardBeatsPayload } from '@/components/ShareCard';
 
+// Public share URLs are immutable per token in the steady state — the only
+// way a payload changes is a manual ceremony re-fire, which is rare. Cache
+// for an hour so social/SMS previews and link-clicks don't repeatedly hit
+// the API. Stale 1-hour content is acceptable for this surface.
+export const revalidate = 3600;
+
 type ShareCardResponse = {
   userName: string;
   cycleStart: string;
@@ -16,7 +22,9 @@ function baseUrl(): string {
 }
 
 async function getShareCard(token: string): Promise<ShareCardResponse | null> {
-  const response = await fetch(`${baseUrl()}/api/share/ceremony/${token}`, { cache: 'no-store' });
+  const response = await fetch(`${baseUrl()}/api/share/ceremony/${token}`, {
+    next: { revalidate: 3600 },
+  });
   if (response.status === 404) return null;
   if (!response.ok) throw new Error('Could not load share card.');
   return response.json();

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -70,6 +70,8 @@ function readConfiguredSessionSecret(): string | null {
 }
 
 function getJwtSecret(): Uint8Array {
+  if (cachedJwtSecret) return cachedJwtSecret;
+
   const secret = readConfiguredSessionSecret();
 
   if (!secret && process.env.NODE_ENV === 'production') {
@@ -77,14 +79,20 @@ function getJwtSecret(): Uint8Array {
   }
 
   if (!secret) {
-    return new TextEncoder().encode('development-only-joshing-session-secret');
+    cachedJwtSecret = new TextEncoder().encode('development-only-joshing-session-secret');
+    return cachedJwtSecret;
   }
 
   const decoded = Buffer.from(secret, 'base64');
-  if (decoded.length > 0) return decoded;
-
-  return new TextEncoder().encode(secret);
+  cachedJwtSecret = decoded.length > 0 ? new Uint8Array(decoded) : new TextEncoder().encode(secret);
+  return cachedJwtSecret;
 }
+
+// Memoize across the worker's lifetime. The secret is process-stable; without
+// this, every readSessionClaims / validateSessionToken call re-walks the env
+// lookup chain and re-runs Buffer.from(_, 'base64'). Tests that need to vary
+// the secret should mock this function or use vi.resetModules() between cases.
+let cachedJwtSecret: Uint8Array | null = null;
 
 /**
  * Create a new UserSession for the user and set the session cookie.


### PR DESCRIPTION
## Summary

Batch of two unrelated, independently-revertable perf quick wins from the audit. Originally planned as a four-item batch (#7, #8, #9, #10) — **#7 and #8 dropped after verification**:

- **#7 (`compress: true` in `next.config.ts`) — dropped.** `compress: true` is already Next.js's default. Setting it explicitly is a no-op.
- **#8 (push `isActive=true` into WHERE in `src/server/db/queries/friends.ts`) — dropped.** Re-reading the file shows line 190 already has `eq(declaredInterests.isActive, true)` inside the SQL WHERE. The audit's claim that the filter happened in JS was wrong — the loop at lines 195-199 is just a regrouping into a `Map<userId, string[]>`. Already correct.

The two real wins, one commit each:

### Commit 1 — `perf(auth): memoize decoded JWT secret`
`src/server/auth/session.ts` · `getJwtSecret()` walked the 3-key env-var lookup chain and ran `Buffer.from(_, 'base64')` on every call. It's called twice per request in the steady state (middleware `readSessionClaims` + route-handler `validateSessionToken`) plus extra in sign paths. Memoized at module level — secret is process-stable.

- 12 insertions, 4 deletions
- All 10 tests in `auth/session.test.ts` still pass (single SECRET constant, so the cache locks in the expected value)
- Comment notes that tests varying the secret per case must mock or use `vi.resetModules()`

### Commit 2 — `perf(share-ceremony): cache public share-card page for 1 hour`
`src/app/share/ceremony/[token]/page.tsx` server-fetched its own `/api/share/ceremony/[token]` route with `cache: 'no-store'`, forcing dynamic rendering on every visit. Each page hit (SMS unfurls, link previews, real visits) hit Postgres for the same immutable JSONB payload.

Switched to `next: { revalidate: 3600 }` on the inner fetch + matching page-level `export const revalidate = 3600`.

- 9 insertions, 1 deletion
- 1-hour staleness is acceptable for an immutable per-token share snapshot
- **Caveat:** if a ceremony is manually re-fired (rare), the cached page persists for up to 1 hour. If that becomes a real concern, the right next step is on-demand revalidation via `revalidatePath` from the re-fire path.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean.
- [x] `npx vitest run src/server/auth/__tests__/session.test.ts` — 10/10 pass.

Manual smoke before merge:

- [ ] Sign in fresh, navigate around. Confirm `/auth/me`, `/api/feed`, `/daily` all behave normally (no auth regressions from memoized secret).
- [ ] Sign out, sign back in with a new session. Confirm the new JWT validates correctly (cache lookup uses the right secret).
- [ ] Visit a real `/share/ceremony/[token]` URL twice. Network tab on first hit shows freshly-fetched response; on second hit (within 1 hr) shows cached output. Response headers include `cache-control: s-maxage=3600` or similar.
- [ ] Visit `/share/ceremony/invalid-token-xyz` → 404 page renders.

## Rollback

Each commit is self-contained and reverts cleanly. No DB migrations, no client API changes, no schema changes.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_