### PR TITLE
perf(daily-answer): precompute reveal breadcrumb in void fan-out

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -16,6 +16,7 @@ import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
+import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { type QueueSlot } from '@/server/daily/types';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
@@ -371,6 +372,54 @@ export async function POST(request: NextRequest) {
     ).catch((err) => {
       console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
     });
+
+    // Precompute the reveal breadcrumb in the background so the client's
+    // follow-up POST /api/breadcrumb hits the slot-cache short-circuit
+    // (handleDaily at src/app/api/breadcrumb/route.ts:52) instead of waiting
+    // on Haiku. Skipped for give-ups to match the breadcrumb route's own
+    // gaveUp gate. Race window: if the client POST lands before this finishes,
+    // both paths generate independently; the second persist wins (same input
+    // → same output, so functionally identical), at the cost of one extra
+    // Haiku call per occurrence.
+    if (!parsed.gaveUp) {
+      void (async () => {
+        try {
+          const breadcrumb = await generateBreadcrumb({
+            questionId: question.generatedId ?? question.canonicalId ?? undefined,
+            questionText: question.questionText,
+            correctAnswer: canonicalAnswer,
+            submittedAnswer: parsed.submittedAnswer,
+            isCorrect,
+            domain: question.canonicalSubcategory,
+          });
+          if (!breadcrumb) return;
+
+          const [freshQueue] = await db
+            .select()
+            .from(dailyQueues)
+            .where(eq(dailyQueues.id, queue.id))
+            .limit(1);
+          if (!freshQueue) return;
+
+          const freshSlots = asQueueSlots(freshQueue.slots);
+          const updatedSlots = freshSlots.map((s) =>
+            s.slot_index === parsed.slotIndex
+              ? ({ ...s, reveal_breadcrumb: breadcrumb } satisfies QueueSlot)
+              : s,
+          );
+          await db
+            .update(dailyQueues)
+            .set({ slots: updatedSlots })
+            .where(eq(dailyQueues.id, queue.id));
+        } catch (error) {
+          console.warn('[daily/answer] precompute breadcrumb failed', {
+            queueId: queue.id,
+            slotIndex: parsed.slotIndex,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      })();
+    }
 
     if (canonicalQuestionId && !parsed.gaveUp) {
       const propagationKey = question.generatedId ?? question.canonicalId ?? canonicalQuestionId;


### PR DESCRIPTION
## Summary

The next biggest win from the audit. Every Daily Five answer today incurs a perceived ~500–1500ms gap between the result reveal and the breadcrumb line because the client POSTs `/api/breadcrumb` after the answer, which runs a Haiku call inline.

The `/api/breadcrumb` endpoint already short-circuits when `slot.reveal_breadcrumb` is set (`src/app/api/breadcrumb/route.ts:52`). So the cheapest cleanup is: kick off the same `generateBreadcrumb` call from the answer route's void fan-out and persist it to the slot. The follow-up client POST then returns in ~50ms instead of waiting on Haiku.

- File: `src/app/api/daily/answer/route.ts`
- +49 lines, no client change, no DB migration, no new endpoint
- Expected savings: **~500–1500ms of perceived latency on every Daily Five answer**
- Section 5 P0 #3 + Section 4 game-loop win #5 from the audit

## Why server-only

Doing this without touching the client captures the bulk of the Haiku-call savings while keeping the diff one-file. The cleaner long-term shape — drop the client's `/api/breadcrumb` POST entirely and read `reveal_breadcrumb` straight from the slot — is a worthwhile follow-up but doubles scope (touches `daily/page.tsx`, `useCatchupFlow.ts`, joshing-game flow stays on the existing endpoint as a separate surface).

## Race window — honest trade-off

If the client POST lands while the server fan-out is still in flight, both paths call Haiku independently. Inputs are identical (cache key is `questionId + isCorrect`), so the outputs match; the second slot-write wins. Net cost per race: one extra Haiku call (~$0.0001), no user-visible regression.

Most of the time the server wins the race because its fan-out has an 850ms head start (the client pauses 850ms after the answer response before posting per `daily/page.tsx:626`). The worst case is a one-time-doubling of Haiku spend during the transition; long-term hit rate normalizes as the in-memory LRU warms.

## Test plan

- [x] `npx tsc -p tsconfig.typecheck.json` — clean.
- [ ] `npx vitest run src/app/api/daily/answer/__tests__/route.test.ts` — currently fails on **both this branch and dev2** with `Cannot access 'dbMock' before initialization` (pre-existing `vi.mock` hoist bug, same as I flagged in #424). Unrelated to this change; should be cleaned up in a separate PR.

Manual smoke before merge:

- [ ] Answer a Daily Five slot. Network tab: confirm the follow-up `POST /api/breadcrumb` returns in ~50–100ms (not 500–1500ms). The response body still has a breadcrumb string.
- [ ] Answer a Daily Five slot, then immediately reload `/api/daily/queue`. The relevant slot's `reveal_breadcrumb` field is populated.
- [ ] Give up on a Daily Five slot (gaveUp=true). Server logs do NOT include `[daily/answer] precompute breadcrumb failed` and no extra Haiku call is made (the route's `if (!parsed.gaveUp)` gate matches the breadcrumb endpoint's own gate).
- [ ] Bot question in a domain not in your Knowledge Base (skipMasteryForUnknownDomain path): breadcrumb still precomputes since that gate is independent.
- [ ] Stress: answer 5 slots in rapid succession. Server logs show 5 precompute attempts, no race-condition errors. Each slot ends with `reveal_breadcrumb` set.

## Rollback

Single-file revert. No DB migration, no client change, no schema change.

## Follow-up worth doing next

Drop the client's `POST /api/breadcrumb` call from `daily/page.tsx:546-571,622` and `useCatchupFlow.ts:67-92,294`. Read `reveal_breadcrumb` from the slot directly in the next queue poll. Eliminates the round-trip HTTP overhead (~50–100ms) and prevents the race-window 2× Haiku scenario described above.

https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge

---
_Generated by [Claude Code](https://claude.ai/code/session_017879PrBiwisRGD51Vs19Ge)_