### PR TITLE
fix(home): directional v2 wording for friend_answered_your_question

### DIFF
--- a/src/components/home/NewsRow.tsx
+++ b/src/components/home/NewsRow.tsx
@@ -36,14 +36,35 @@ function buildCopy(item: ActivityItemView): NewsRowCopy {
     case 'friend_answered_your_question': {
       const faq = item.reference.friendAnsweredQuestion
       const correct = faq?.result === 'correct'
+      // Directional v2 wording for the "they_got_you" half. The "incorrect"
+      // half keeps the generic "answered your question" line — it has no
+      // connection-moment counterpart, so the wording isn't redundant.
+      if (correct) {
+        return {
+          headline: (
+            <>
+              <b>{actor}</b> got you on{' '}
+              <em
+                style={{ fontFamily: 'var(--font-display), Georgia, serif' }}
+              >
+                {faq?.domain ?? 'something'}
+              </em>
+              .
+            </>
+          ),
+          secondLine: null,
+          accentColor: '#d97706',
+          href: '/activities',
+        }
+      }
       return {
         headline: (
           <>
-            <b>{actor}</b> {correct ? 'got your question' : 'answered your question'}
+            <b>{actor}</b> answered your question
           </>
         ),
         secondLine: faq?.domain ?? null,
-        accentColor: correct ? '#d97706' : '#a8a29e',
+        accentColor: '#a8a29e',
         href: '/activities',
       }
     }


### PR DESCRIPTION
## Summary

The HOME tab's WHAT'S HAPPENING preview rendered correct friend answers as the v1 anti-pattern the v2 Lately PRD explicitly called out: `Robyn got your question` repeated for every row, with the category as a separate italic second line. Three Robyn moments in a row read as:

```
Robyn got your question                    8H
Stephen Sondheim musicals

Robyn got your question                    1D
Shakespearean Tragedy

Robyn got your question                    1D
John Milton's Paradise Lost
```

Switch the correct half to the v2 directional sentence — single inline sentence with the category italicized via Georgia (`--font-display`), matching the editorial moment cards on `/activities`:

```
Robyn got you on Stephen Sondheim musicals.    8H
Robyn got you on Shakespearean Tragedy.        1D
Robyn got you on John Milton's Paradise Lost.  1D
```

The **incorrect** half (`friend_answered_your_question` with `result === 'wrong'`) keeps the existing "Robyn answered your question" + domain pattern. That row has no connection-moment counterpart, so its wording isn't redundant — and "got you on" would be wrong copy for an event where the friend *didn't* get it.

Touches only `src/components/home/NewsRow.tsx`. No other surfaces or types affected.

## Test plan

- [ ] On HOME, the WHAT'S HAPPENING block renders correct-answer rows as a single sentence: `<actor> got you on <category>.` with the category italic in the display serif font.
- [ ] The same row links to `/activities` (unchanged).
- [ ] Incorrect-answer rows still read `<actor> answered your question` with the domain on the second line.
- [ ] Non-FAQ rows (`declared_promoted`, `friend_mastery`, `reaction_received`, `question_curated`, `authored_question_shared`, `creator_note_received`, default) are visually unchanged.

https://claude.ai/code/session_017Ysz5NPc84oxzaWFQh9Kkg

---
_Generated by [Claude Code](https://claude.ai/code/session_017Ysz5NPc84oxzaWFQh9Kkg)_