### PR TITLE
fix(activities): drop "X sent you a question" once the you_got_them moment covers it

### DIFF
--- a/src/app/activities/__tests__/filter-utility-activities.test.ts
+++ b/src/app/activities/__tests__/filter-utility-activities.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'vitest';
+
+import { filterUtilityActivities } from '@/app/activities/filter-utility-activities';
+import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+function directQuestionActivity(
+  id: string,
+  feedItemId: string,
+  questionId: string,
+): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer-1',
+    type: 'received_direct_question',
+    actorUserId: 'sender-1',
+    referenceId: feedItemId,
+    referenceType: 'feed_item',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'Testing account 1' },
+    reference: {
+      directQuestion: {
+        feedItemId,
+        questionId,
+        questionText: 'Stephen Sondheim question text…',
+        personalMessage: null,
+        category: 'Stephen Sondheim musicals',
+      },
+    },
+  };
+}
+
+function youGotThemMoment(questionId: string): LatelyMoment {
+  return {
+    momentId: `moment-${questionId}`,
+    dir: 'you_got_them',
+    friendId: 'sender-1',
+    friendName: 'Testing account 1',
+    friendFirstName: 'Testing',
+    questionId,
+    questionText: 'Stephen Sondheim question text…',
+    category: 'Stephen Sondheim musicals',
+    gameTitle: 'asterisk',
+    answeredAt: new Date('2026-05-24T11:01:00.000Z'),
+  };
+}
+
+function theyGotYouMoment(questionId: string): LatelyMoment {
+  return {
+    ...youGotThemMoment(questionId),
+    momentId: `tgyou-${questionId}`,
+    dir: 'they_got_you',
+  };
+}
+
+function friendAnsweredActivity(
+  id: string,
+  result: 'correct' | 'incorrect',
+): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer-1',
+    type: 'friend_answered_your_question',
+    actorUserId: 'friend-1',
+    referenceId: 'q-1',
+    referenceType: 'question',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'A friend' },
+    reference: {
+      friendAnsweredQuestion: { domain: 'music', result },
+    },
+  };
+}
+
+function declaredPromotedActivity(id: string): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer-1',
+    type: 'declared_promoted',
+    actorUserId: 'friend-1',
+    referenceId: 'q-1',
+    referenceType: 'question',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'A friend' },
+    reference: {
+      declaredPromoted: { domain: 'music', questionText: 'q' },
+    },
+  };
+}
+
+describe('filterUtilityActivities', () => {
+  it('drops received_direct_question when a you_got_them moment covers the same questionId', () => {
+    const items = [directQuestionActivity('a-1', 'fi-1', 'q-sondheim')];
+    const moments = [youGotThemMoment('q-sondheim')];
+
+    expect(filterUtilityActivities(items, moments)).toEqual([]);
+  });
+
+  it('keeps received_direct_question when no matching moment exists (unanswered or wrong)', () => {
+    const items = [directQuestionActivity('a-1', 'fi-1', 'q-sondheim')];
+
+    expect(filterUtilityActivities(items, [])).toHaveLength(1);
+  });
+
+  it('keeps received_direct_question when only a they_got_you moment exists (different direction)', () => {
+    const items = [directQuestionActivity('a-1', 'fi-1', 'q-sondheim')];
+    const moments = [theyGotYouMoment('q-sondheim')];
+
+    expect(filterUtilityActivities(items, moments)).toHaveLength(1);
+  });
+
+  it('keeps received_direct_question for a different questionId than the moment', () => {
+    const items = [directQuestionActivity('a-1', 'fi-1', 'q-other')];
+    const moments = [youGotThemMoment('q-sondheim')];
+
+    expect(filterUtilityActivities(items, moments)).toHaveLength(1);
+  });
+
+  it('still drops friend_answered_your_question (correct) and declared_promoted', () => {
+    const items = [
+      friendAnsweredActivity('a-1', 'correct'),
+      friendAnsweredActivity('a-2', 'incorrect'),
+      declaredPromotedActivity('a-3'),
+    ];
+
+    const kept = filterUtilityActivities(items, []);
+    expect(kept.map((i) => i.id)).toEqual(['a-2']);
+  });
+});

--- a/src/app/activities/filter-utility-activities.ts
+++ b/src/app/activities/filter-utility-activities.ts
@@ -1,0 +1,34 @@
+import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+// Connection moments come from getLatelyMoments (both directions). Three
+// activity types narrate the same event and would double-render:
+//   - friend_answered_your_question (correct): already covered by the
+//     they_got_you moment.
+//   - declared_promoted: a strict subset of they_got_you (correct answer
+//     plus a domain transition). The "SEE YOUR MAP" CTA lives on /knowledge.
+//   - received_direct_question whose question the viewer already got
+//     correctly: covered by the you_got_them moment for that questionId.
+export function filterUtilityActivities(
+  items: ActivityItemView[],
+  moments: LatelyMoment[],
+): ActivityItemView[] {
+  const youGotThemQuestionIds = new Set(
+    moments
+      .filter((m) => m.dir === 'you_got_them')
+      .map((m) => m.questionId),
+  );
+  return items.filter((i) => {
+    if (
+      i.type === 'friend_answered_your_question' &&
+      i.reference.friendAnsweredQuestion?.result === 'correct'
+    ) return false;
+    if (i.type === 'declared_promoted') return false;
+    if (
+      i.type === 'received_direct_question' &&
+      i.reference.directQuestion?.questionId &&
+      youGotThemQuestionIds.has(i.reference.directQuestion.questionId)
+    ) return false;
+    return true;
+  });
+}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -2,6 +2,7 @@ import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
 import { CreatorNoteReadButton } from '@/app/activities/CreatorNoteReadButton';
+import { filterUtilityActivities } from '@/app/activities/filter-utility-activities';
 import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
 import { MarkActivitiesRead } from '@/app/activities/MarkActivitiesRead';
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
@@ -453,21 +454,7 @@ export default async function ActivitiesPage() {
   ]);
   const tz = viewer?.timezone ?? 'America/New_York';
 
-  // Connection moments come from getLatelyMoments (both directions). Two
-  // legacy activity types narrate the same event and would double-render:
-  //   - friend_answered_your_question (when correct): the raw "X answered
-  //     your Y question" copy, already covered by the they_got_you moment.
-  //   - declared_promoted: emitted only when a friend correctly answers AND
-  //     the domain transitions to demonstrated — strictly a subset of
-  //     they_got_you. The "SEE YOUR MAP" CTA lives on /knowledge.
-  const utilityItems: LatelyFeedItem[] = items
-    .filter(
-      (i) =>
-        !(
-          i.type === 'friend_answered_your_question' &&
-          i.reference.friendAnsweredQuestion?.result === 'correct'
-        ) && i.type !== 'declared_promoted',
-    )
+  const utilityItems: LatelyFeedItem[] = filterUtilityActivities(items, moments)
     .map(activityToFeedItem);
 
   const momentItems: LatelyFeedItem[] = moments.map((m) => ({

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -58,6 +58,7 @@ export type ActivityItemView = Pick<
     };
     directQuestion?: {
       feedItemId: string;
+      questionId: string;
       questionText: string;
       personalMessage: string | null;
       category: string | null;
@@ -437,6 +438,7 @@ async function hydrateDirectQuestions(items: ActivityItemRow[]) {
   const rows = await db
     .select({
       feedItemId: feedItems.id,
+      questionId: questions.id,
       personalMessage: feedItems.personalMessage,
       questionText: questions.questionText,
       canonicalSubcategory: questions.canonicalSubcategory,
@@ -450,6 +452,7 @@ async function hydrateDirectQuestions(items: ActivityItemRow[]) {
     row.feedItemId,
     {
       feedItemId: row.feedItemId,
+      questionId: row.questionId,
       questionText: row.questionText,
       personalMessage: row.personalMessage,
       category: row.canonicalSubcategory?.trim() || row.category || null,


### PR DESCRIPTION
When the viewer correctly answers a direct question, the Lately page rendered
two cards for the same event: the you_got_them moment plus the stale
received_direct_question notification. Extend the existing utility-activity
filter (already drops friend_answered_your_question/declared_promoted in the
opposite direction) to also drop received_direct_question whose questionId
matches a you_got_them moment. Wrong-answer case is unchanged: no moment
exists, so the activity stays.