### PR TITLE
fix(profile): match interests case- and punctuation-insensitively

### DIFF
--- a/src/server/profile/__tests__/friend.test.ts
+++ b/src/server/profile/__tests__/friend.test.ts
@@ -120,6 +120,29 @@ describe('friend portrait data', () => {
     })
   })
 
+  it('treats interests as overlapping when they only differ by case or punctuation', async () => {
+    state.interestRows = [
+      {
+        userId: 'friend-1',
+        domain: 'Star Trek: The Next Generation',
+        broadCategory: 'Television',
+      },
+      { userId: 'friend-1', domain: 'Star Wars', broadCategory: 'Film' },
+      {
+        userId: 'viewer-1',
+        domain: 'star trek the next generation',
+        broadCategory: 'Television',
+      },
+      { userId: 'viewer-1', domain: '90s Cartoons', broadCategory: 'Television' },
+    ]
+
+    const portrait = await getFriendPortraitData('friend-1', 'viewer-1')
+
+    expect(portrait?.sharedInterests).toEqual(['Star Trek: The Next Generation'])
+    expect(portrait?.viewerSoloInterests).toEqual(['90s Cartoons'])
+    expect(portrait?.friendSoloInterests).toEqual(['Star Wars'])
+  })
+
   it('falls back to the verified phone number when a friend has no display name yet', async () => {
     getUserByIdMock.mockResolvedValueOnce({
       id: 'friend-1',

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -55,6 +55,12 @@ function profileDisplayName(
   return name?.trim() || fallback?.trim() || 'Joshing friend'
 }
 
+// Match interests regardless of case, punctuation, or whitespace so that
+// e.g. "Star Trek: The Next Generation" overlaps with "Star Trek The Next Generation".
+function normalizeInterestKey(domain: string): string {
+  return domain.toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').trim()
+}
+
 export async function getFriendPortraitData(
   userId: string,
   viewerId: string
@@ -99,24 +105,31 @@ export async function getFriendPortraitData(
     )
     .orderBy(asc(declaredInterests.domain))
 
-  const viewerInterests = new Set(
-    interestRows
-      .filter((interest) => interest.userId === normalizedViewerId)
-      .map((interest) => interest.domain)
-  )
+  const viewerInterestsByKey = new Map<string, string>()
+  for (const interest of interestRows) {
+    if (interest.userId !== normalizedViewerId) continue
+    viewerInterestsByKey.set(
+      normalizeInterestKey(interest.domain),
+      interest.domain
+    )
+  }
 
   const interests = interestRows
     .filter((interest) => interest.userId === normalizedUserId)
     .map((interest) => ({
       domain: interest.domain,
       broadCategory: interest.broadCategory,
-      shared: isActiveFriend && viewerInterests.has(interest.domain),
+      shared:
+        isActiveFriend &&
+        viewerInterestsByKey.has(normalizeInterestKey(interest.domain)),
     }))
 
-  const friendInterestDomains = new Set(interests.map((i) => i.domain))
+  const friendInterestKeys = new Set(
+    interests.map((i) => normalizeInterestKey(i.domain))
+  )
   const viewerSoloInterests = isActiveFriend
-    ? Array.from(viewerInterests)
-        .filter((domain) => !friendInterestDomains.has(domain))
+    ? Array.from(viewerInterestsByKey.values())
+        .filter((domain) => !friendInterestKeys.has(normalizeInterestKey(domain)))
         .sort((a, b) => a.localeCompare(b))
     : []
   const friendSoloInterests = isActiveFriend


### PR DESCRIPTION
The friend portrait was using exact string equality on `domain`, so
"Star Trek: The Next Generation" and "Star Trek The Next Generation"
landed on opposite sides of the Venn diagram with "No overlap yet."
Normalize to a lowercase, alphanumeric-only key for comparison; the
stored and displayed strings are unchanged.