### PR TITLE
feat(news): show specific question text in What's Happening, not broad topic

### DIFF
--- a/src/app/activities/__tests__/filter-utility-activities.test.ts
+++ b/src/app/activities/__tests__/filter-utility-activities.test.ts
@@ -69,7 +69,7 @@ function friendAnsweredActivity(
     createdAt: new Date('2026-05-24T12:00:00.000Z'),
     actor: { displayName: 'A friend' },
     reference: {
-      friendAnsweredQuestion: { domain: 'music', result },
+      friendAnsweredQuestion: { domain: 'music', questionText: null, result },
     },
   };
 }

--- a/src/components/home/NewsRow.tsx
+++ b/src/components/home/NewsRow.tsx
@@ -42,7 +42,7 @@ function buildCopy(item: ActivityItemView): NewsRowCopy {
             <b>{actor}</b> {correct ? 'got your question' : 'answered your question'}
           </>
         ),
-        secondLine: faq?.domain ?? null,
+        secondLine: faq?.questionText ?? faq?.domain ?? null,
         accentColor: correct ? '#d97706' : '#a8a29e',
         href: '/activities',
       }
@@ -56,7 +56,7 @@ function buildCopy(item: ActivityItemView): NewsRowCopy {
             <b>{actor}</b> proved a domain on your map
           </>
         ),
-        secondLine: dp?.domain ?? null,
+        secondLine: dp?.questionText || dp?.domain || null,
         accentColor: '#16a34a',
         href: dp?.domain
           ? `/knowledge/${encodeURIComponent(dp.domain)}`

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -68,6 +68,7 @@ export type ActivityItemView = Pick<
     };
     friendAnsweredQuestion?: {
       domain: string | null;
+      questionText: string | null;
       result: 'correct' | 'incorrect';
     };
     authoredSharedQuestion?: {
@@ -616,7 +617,7 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
 
   const [questionRows, masteryRows] = await Promise.all([
     db
-      .select({ id: questions.id, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
+      .select({ id: questions.id, questionText: questions.questionText, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
       .from(questions)
       .where(inArray(questions.id, questionIds)),
     db
@@ -630,19 +631,21 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
       )),
   ]);
 
-  const domainByQuestion = new Map(
-    questionRows.map((r) => [r.id, r.canonicalSubcategory ?? r.broadCategory ?? null]),
-  );
+  const questionById = new Map(questionRows.map((r) => [r.id, r]));
   const correctSet = new Set(masteryRows.map((r) => `${r.userId}:${r.questionId}`));
 
   return new Map(
-    relevant.map((item) => [
-      item.id,
-      {
-        domain: domainByQuestion.get(item.referenceId!) ?? null,
-        result: correctSet.has(`${item.actorUserId}:${item.referenceId}`) ? 'correct' : 'incorrect',
-      } satisfies NonNullable<ActivityItemView['reference']['friendAnsweredQuestion']>,
-    ]),
+    relevant.map((item) => {
+      const q = questionById.get(item.referenceId!);
+      return [
+        item.id,
+        {
+          domain: q ? (q.canonicalSubcategory ?? q.broadCategory ?? null) : null,
+          questionText: q?.questionText ?? null,
+          result: correctSet.has(`${item.actorUserId}:${item.referenceId}`) ? 'correct' : 'incorrect',
+        } satisfies NonNullable<ActivityItemView['reference']['friendAnsweredQuestion']>,
+      ];
+    }),
   );
 }
 


### PR DESCRIPTION
Instead of "Robyn got you on Shakespearean Tragedy" with a topic-name
subline, surface the actual question (e.g. the one about Goneril and
her sisters) so the row is hyper-specific. Applies to both
friend_answered_your_question and declared_promoted rows; falls back
to the domain when question text is missing.