### PR TITLE
feat(knowledge): make Solid and Mastery circles 3-4x larger

### DIFF
--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -226,6 +226,7 @@ export function PortraitDomainCircle({
     entry.tier !== 'establishing' &&
     entry.authoredAnsweredCount > 0
   const resolvedCircleSlotSize = Math.max(circleSlotSize ?? size, size)
+  const countFontSize = Math.min(48, Math.max(10, Math.round(size * 0.13)))
 
   const handleClick = () => {
     if (!editMode || !onToggleHidden || pending) return
@@ -258,6 +259,7 @@ export function PortraitDomainCircle({
       style={{
         ...circleItemStyle,
         width: Math.max(90, resolvedCircleSlotSize + 8),
+        maxWidth: '100%',
         cursor: interactive ? (pending ? 'wait' : 'pointer') : undefined,
         userSelect: interactive ? 'none' : undefined,
         opacity: pending ? 0.6 : 1,
@@ -288,7 +290,7 @@ export function PortraitDomainCircle({
             {showMasteryCount && (
               <span
                 style={{
-                  fontSize: size > 52 ? 13 : 10,
+                  fontSize: countFontSize,
                   color: dc.primary,
                   fontFamily: 'Georgia, "Times New Roman", serif',
                   fontWeight: 'bold',
@@ -359,7 +361,7 @@ export function PortraitDomainCircle({
           fontFamily: 'Georgia, "Times New Roman", serif',
           textAlign: 'center',
           lineHeight: 1.3,
-          maxWidth: 90,
+          maxWidth: Math.max(90, resolvedCircleSlotSize),
           wordWrap: 'break-word',
           opacity: labelOpacity,
           textDecoration: dimForHidden ? 'line-through' : undefined,

--- a/src/lib/knowledge/circle-sizing.ts
+++ b/src/lib/knowledge/circle-sizing.ts
@@ -3,15 +3,15 @@ export type CircleSizingTier = 'establishing' | 'familiar' | 'solid' | 'mastery'
 const TIER_RANGES_DESKTOP: Record<CircleSizingTier, { min: number; max: number }> = {
   establishing: { min: 18, max: 28 },
   familiar: { min: 32, max: 48 },
-  solid: { min: 52, max: 72 },
-  mastery: { min: 76, max: 96 },
+  solid: { min: 156, max: 216 },
+  mastery: { min: 304, max: 384 },
 };
 
 const TIER_RANGES_MOBILE: Record<CircleSizingTier, { min: number; max: number }> = {
   establishing: { min: 15, max: 22 },
   familiar: { min: 26, max: 38 },
-  solid: { min: 42, max: 56 },
-  mastery: { min: 60, max: 76 },
+  solid: { min: 126, max: 168 },
+  mastery: { min: 240, max: 304 },
 };
 
 export function getDomainCircleSize(


### PR DESCRIPTION
Bump TIER_RANGES so the upper two tiers feel like a real reward:
Solid circles render at 3x their previous size, Mastery at 4x. The
in-circle count font scales proportionally (clamped 10-48px), and
labels widen to track the new slot so they sit centered under the
huge bubbles instead of wrapping into a 90px column. Establishing
and Familiar are unchanged on purpose, so the contrast between
"just started" and "deep" is unmissable.