### PR TITLE
catch-up: fall back to question explainer when breadcrumb is absent

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -475,6 +475,7 @@ export default function DailyPage() {
           consolation: slot.reveal_quip ?? null,
           insideJoke: slot.reveal_inside_joke ?? null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
+          explanation: slot.reveal_explainer ?? null,
           copyVariant: slot.slot_index,
           creatorName: slot.source === 'friend' ? (slot.author_name ?? null) : null,
           canonicalSubcategory: slot.domain,

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -42,6 +42,20 @@ function questionBadges(q: QuestionRow): Array<{ label: string; tone?: 'warning'
   return [level === 'specialist' ? { label, tone: 'warning' as const } : { label }];
 }
 
+function pickExplainer(question: QuestionRow, isCorrect: boolean): string | null {
+  const correctFirst = question.explainerFullCorrect
+    ?? question.explainerFull
+    ?? question.explainerBriefCorrect
+    ?? question.explainerBrief
+    ?? question.factualExplanation;
+  const wrongFirst = question.explainerFullWrong
+    ?? question.explainerFull
+    ?? question.explainerBriefWrong
+    ?? question.explainerBrief
+    ?? question.factualExplanation;
+  return (isCorrect ? correctFirst : wrongFirst) ?? null;
+}
+
 type GradeResponse = {
   isCorrect: boolean;
   explanation: string;
@@ -89,6 +103,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
         correctAnswer: response.isCorrect ? null : item.question.answerText,
         consolation: null,
         breadcrumb: null,
+        explanation: pickExplainer(item.question, Boolean(response.isCorrect)),
         copyVariant: item.position,
           creatorName: game.creator.displayName,
           canonicalSubcategory: item.question.canonicalSubcategory,
@@ -165,6 +180,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
           consolation: null,
           insideJoke: body.insideJoke ?? null,
           breadcrumb: null,
+          explanation: body.explanation ?? pickExplainer(currentQuestion.question, body.isCorrect),
           copyVariant: currentQuestion.position,
           creatorName: game.creator.displayName,
           canonicalSubcategory: currentQuestion.question.canonicalSubcategory,

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -71,6 +71,8 @@ export type ChatMessage =
       canonicalSubcategory?: string | null;
       /** Per-answer commentary quip shown below the result bubble */
       quip?: string | null;
+      /** Question's stored factual explainer. Rendered as a fallback below the verdict when no breadcrumb arrives (e.g. feed-sourced catch-up items, or when /api/breadcrumb times out). */
+      explanation?: string | null;
       reactionPrompt?: ReactionPromptData | null;
       pointsAwarded?: number | null;
       pointsLabel?: string | null;
@@ -370,6 +372,29 @@ function BreadcrumbLine({ text, creatorName }: { text: string; creatorName: stri
   );
 }
 
+function ExplanationLine({ text }: { text: string }) {
+  return (
+    <div
+      style={{
+        marginTop: '9px',
+        borderLeft: '2px solid color-mix(in srgb, var(--text) 20%, transparent)',
+        paddingLeft: '8px',
+      }}
+    >
+      <p
+        style={{
+          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+          fontSize: '0.9rem',
+          color: 'color-mix(in srgb, var(--text-muted) 50%, var(--text))',
+          lineHeight: 1.4,
+        }}
+      >
+        {text}
+      </p>
+    </div>
+  );
+}
+
 function RelationalFeedbackFade({ text }: { text: string }) {
   const [faded, setFaded] = useState(false);
   useEffect(() => {
@@ -617,6 +642,7 @@ function ResultRow({
   insideJoke,
   breadcrumb,
   quip,
+  explanation,
   copyVariant,
   creatorName,
   relationalFeedbackLine,
@@ -633,6 +659,7 @@ function ResultRow({
   insideJoke?: string | null;
   breadcrumb: string | null;
   quip?: string | null;
+  explanation?: string | null;
   copyVariant: number;
   creatorName: string | null;
   relationalFeedbackLine?: string | null;
@@ -818,7 +845,9 @@ function ResultRow({
             ) : null}
           </>
         )}
-        {breadcrumb ? <BreadcrumbLine text={breadcrumb} creatorName={creatorName} /> : null}
+        {breadcrumb
+          ? <BreadcrumbLine text={breadcrumb} creatorName={creatorName} />
+          : explanation ? <ExplanationLine text={explanation} /> : null}
         {quip ? <QuipLine text={quip} /> : null}
         {typeof pointsAwarded === 'number' ? (
           <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '10px' }}>
@@ -1070,6 +1099,7 @@ export function GameplayChatThread({
                 insideJoke={m.insideJoke}
                 breadcrumb={m.breadcrumb}
                 quip={m.quip}
+                explanation={m.explanation}
                 copyVariant={m.copyVariant}
                 creatorName={m.creatorName}
                 relationalFeedbackLine={m.relationalFeedbackLine}

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -277,6 +277,7 @@ export function useCatchupFlow() {
           correctAnswer: isCorrect ? null : data.correctAnswer ?? data.answer ?? item.correctAnswer,
           consolation: data.consolation ?? data.quip ?? null,
           breadcrumb: null,
+          explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
           copyVariant: item.queueAge,
           creatorName: 'Joshing',
           canonicalSubcategory: item.domain,


### PR DESCRIPTION
The breadcrumb LLM call is fire-and-forget after the answer settles, and
it's skipped entirely for feed-sourced catch-up items (no breadcrumb
support in /api/breadcrumb for the feed source). When that happens, the
catch-up answer card has no contextual line under the verdict, which
reads as inconsistent next to the other cards on the same screen.

Pipe the question's stored explainer through to the result message and
render it via a new ExplanationLine when the breadcrumb is null. If the
breadcrumb arrives later, the message update swaps the explainer out for
the more situational copy.

https://claude.ai/code/session_01DWP8we9qcGQBXqoBgLJHLZ