### PR TITLE
show full question text in feed cards

### DIFF
--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -97,7 +97,7 @@ export function FeedCard({
           </div>
 
           <p
-            className="mt-3 line-clamp-4 text-[17px] leading-snug text-[var(--ink)]"
+            className="mt-3 text-[17px] leading-snug text-[var(--ink)]"
             style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
           >
             &ldquo;{item.question}&rdquo;
@@ -194,7 +194,7 @@ export function FeedCard({
 
         <p
           className={cn(
-            'mt-3 line-clamp-4 leading-snug text-[var(--ink)]',
+            'mt-3 leading-snug text-[var(--ink)]',
             dimQuestion ? 'text-[14px]' : 'text-[17px]',
           )}
           style={{


### PR DESCRIPTION
The 4-line clamp truncated longer questions (e.g. the Clark Gable
biographies prompt) so the reader couldn't see the full question
before tapping Answer. Remove line-clamp-4 on both the viewer-is-author
and friend-asked variants so the card grows to fit the question, matching
AnsweredByYouCard which already shows the full question.

https://claude.ai/code/session_01P3Tjz6FQU6NMWU4umBoxhV