### PR TITLE
add parenthetical-descriptor leniency to answer grader

### DIFF
--- a/src/lib/llm.grading.test.ts
+++ b/src/lib/llm.grading.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, beforeEach, vi } from 'vitest'
+
+const createMessageMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@anthropic-ai/sdk', () => ({
+  default: class MockAnthropic {
+    messages = { create: createMessageMock };
+  },
+}))
+
+function anthropicTextResponse(json: Record<string, unknown>) {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(json) }],
+    usage: { input_tokens: 0, output_tokens: 0 },
+  }
+}
+
+async function importGrader() {
+  const mod = await import('@/lib/llm')
+  return mod.gradeAnswerWithLLM
+}
+
+describe('gradeAnswerWithLLM', () => {
+  beforeEach(() => {
+    createMessageMock.mockReset()
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-with-enough-length'
+    process.env.LLM_ENABLED = 'true'
+  })
+
+  it('passes the canonical answer and submitted answer in the user message', async () => {
+    createMessageMock.mockResolvedValueOnce(
+      anthropicTextResponse({ result: 'correct', confidence: 0.9, reason: 'matches generic descriptor', consolation: null }),
+    )
+
+    const gradeAnswerWithLLM = await importGrader()
+    await gradeAnswerWithLLM(
+      "In the TNG episode 'The Inner Light,' Picard lives an entire lifetime as a man named Katan on a dying alien world. What object, which he learns to play during his 'life' on that world, does he find aboard the Enterprise when he awakens?",
+      'A Ressikan flute (a small flute)',
+      'A penny whistle flute thungy',
+      'factual',
+    )
+
+    expect(createMessageMock).toHaveBeenCalledOnce()
+    const callArgs = createMessageMock.mock.calls[0]![0] as {
+      system: Array<{ text: string }>
+      messages: Array<{ content: string }>
+    }
+    expect(callArgs.messages[0]!.content).toContain('A Ressikan flute (a small flute)')
+    expect(callArgs.messages[0]!.content).toContain('A penny whistle flute thungy')
+  })
+
+  it('returns correct when the model accepts the answer', async () => {
+    createMessageMock.mockResolvedValueOnce(
+      anthropicTextResponse({ result: 'correct', confidence: 0.85, reason: 'matches generic descriptor', consolation: null }),
+    )
+
+    const gradeAnswerWithLLM = await importGrader()
+    const outcome = await gradeAnswerWithLLM(
+      'What instrument does Picard find aboard the Enterprise?',
+      'A Ressikan flute (a small flute)',
+      'A penny whistle flute thungy',
+      'factual',
+    )
+
+    expect(outcome.result).toBe('correct')
+    expect(outcome.consolation).toBeNull()
+  })
+
+  it('includes the parenthetical-descriptor leniency rule in the system prompt', async () => {
+    // Regression guard: the Ressikan-flute case ("penny whistle flute thungy") was
+    // marked wrong before this rule existed. If the rule is deleted, that bug returns.
+    createMessageMock.mockResolvedValueOnce(
+      anthropicTextResponse({ result: 'correct', confidence: 0.9, reason: 'ok', consolation: null }),
+    )
+
+    const gradeAnswerWithLLM = await importGrader()
+    await gradeAnswerWithLLM('q', 'A Ressikan flute (a small flute)', 'penny whistle', 'factual')
+
+    const systemPrompt = (createMessageMock.mock.calls[0]![0] as { system: Array<{ text: string }> })
+      .system[0]!
+      .text
+    expect(systemPrompt).toMatch(/parenthetical generic descriptor/i)
+    expect(systemPrompt).toMatch(/thing|thingy|thingamajig/i)
+  })
+})

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -491,6 +491,7 @@ LENIENCY RULES — mark as correct if:
 - The answer is phonetically close and contextually plausible (account for voice transcription errors)
 - The answer includes the correct answer among other text (e.g. "I think it's Bucephalus" is correct)
 - If the canonical answer is long or explanatory (more than ~10 words), focus on whether the submitted answer captures the core concept or mechanism. Do not require matching supporting detail, background context, or explanatory sentences. A short answer that demonstrates clear understanding of the key idea should be marked correct even if it omits elaboration.
+- If the canonical answer contains a parenthetical generic descriptor (e.g. "A Ressikan flute (a small flute)", "Bucephalus (a horse)", "The Eroica (a symphony)"), the parenthetical signals that the descriptor is itself an acceptable answer. Mark as correct when the submission matches the descriptor — including a recognizable member of that category (e.g. "penny whistle" or "tin whistle" for "a small flute"; "stallion" or "warhorse" for "a horse") — even with hedging filler like "thing", "thingy", "thingamajig", or "something". Filler does not make an otherwise-correct categorical answer vague.
 
 STRICTNESS RULES — mark as wrong if:
 - The answer is a different person, place, or thing entirely


### PR DESCRIPTION
The grader marked "A penny whistle flute thungy" wrong for a canonical
"A Ressikan flute (a small flute)" even though the parenthetical is
itself an acceptable answer. New rule tells the grader to treat
parenthetical generic descriptors as acceptable, including recognizable
members of the category and hedging filler words.

Adds llm.grading.test.ts as a regression guard so the rule cannot be
silently removed.