### PR TITLE
daily: show the reset time in the viewer's local timezone

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -246,7 +246,7 @@ export default function AccountPage() {
           <SettingsRow
             icon={Sun}
             title="Trigger noon reset"
-            subtitle="Simulate daily reset (noon ET)"
+            subtitle="Simulate daily reset"
             href="/dev/noon-reset"
           />
           <SettingsRow

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -9,6 +9,7 @@ import {
   useMemo,
   useRef,
   useState,
+  useSyncExternalStore,
   useTransition,
 } from 'react'
 
@@ -17,11 +18,18 @@ import { AddToBankAction } from '@/components/AddToBankAction'
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay'
 import MasteryMoment from '@/components/review/MasteryMoment'
 import { cn } from '@/lib/utils'
+import { formatNextResetTimeLocal } from '@/lib/games/timezone'
 import type {
   DailySummaryView,
   QuestionRecap,
 } from '@/server/db/queries/daily-summary'
 import { RoundReminderCard } from './RoundReminderCard'
+
+// useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
+// the subscribe/snapshot functions are stable across renders.
+const subscribeNoop = () => () => {}
+const getResetTimeSnapshot = () => formatNextResetTimeLocal()
+const getResetTimeServerSnapshot = (): string | null => null
 
 type FeedbackSignal = 'thumbs_up' | 'thumbs_down'
 
@@ -129,6 +137,12 @@ export default function DailySummaryPage() {
   const [summary, setSummary] = useState<DailySummaryView | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // Client-only reset-time label; null during SSR to keep hydration stable.
+  const resetTime = useSyncExternalStore(
+    subscribeNoop,
+    getResetTimeSnapshot,
+    getResetTimeServerSnapshot,
+  )
 
   useEffect(() => {
     let cancelled = false
@@ -273,7 +287,7 @@ export default function DailySummaryPage() {
       <section className="card mt-5 px-5 py-4">
         <h2 style={titleStyle}>Tomorrow</h2>
         <p className="text-foreground mt-2 text-sm leading-6">
-          Five new at noon.
+          {resetTime ? `Five new at ${resetTime}.` : 'Five new tomorrow.'}
         </p>
       </section>
 

--- a/src/app/dev/noon-reset/page.tsx
+++ b/src/app/dev/noon-reset/page.tsx
@@ -4,7 +4,7 @@ export default function DevNoonResetPage() {
   return (
     <StubPage
       title="Trigger noon reset"
-      description="Simulate daily reset (noon ET)."
+      description="Simulate daily reset."
     />
   );
 }

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -2,7 +2,15 @@
 
 import Link from 'next/link'
 import { CheckCircle2, Clock, MessageCircleQuestion, Settings } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
+
+import { formatNextResetTimeLocal } from '@/lib/games/timezone'
+
+// useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
+// the subscribe/snapshot functions are stable across renders.
+const subscribeNoop = () => () => {}
+const getResetTimeSnapshot = () => formatNextResetTimeLocal()
+const getResetTimeServerSnapshot = (): string | null => null
 
 export type SlotOutcome = 'correct' | 'incorrect' | 'skipped' | 'unanswered'
 
@@ -80,6 +88,12 @@ export default function TodaysFiveCard({
   const [preferences, setPreferences] = useState<DailyPreferences | null>(initialPreferences)
   const [resetting, setResetting] = useState(false)
   const [resetError, setResetError] = useState<string | null>(null)
+  // Client-only reset-time label; null during SSR to keep hydration stable.
+  const resetTime = useSyncExternalStore(
+    subscribeNoop,
+    getResetTimeSnapshot,
+    getResetTimeServerSnapshot,
+  )
   // Skip the initial /api/daily/* fetch when the server already provided both.
   const skipInitialFetchRef = useRef(initialStatus !== null && initialPreferences !== null)
 
@@ -160,7 +174,9 @@ export default function TodaysFiveCard({
       ? 'Resume round'
       : 'Play now'
   const subtext = isComplete
-    ? 'Today done · Five new at noon tomorrow'
+    ? resetTime
+      ? `Today done · Five new at ${resetTime} tomorrow`
+      : 'Today done · Five new tomorrow'
     : answered > 0
       ? `${answered} of 5 answered`
       : 'Ready when you are'

--- a/src/lib/game-constants.ts
+++ b/src/lib/game-constants.ts
@@ -9,7 +9,7 @@ import { CATEGORIES } from '@/lib/questions-types';
 export const QUESTIONS_PER_DAY = 5;
 /** @deprecated Legacy flat scoring constant. Use `canonicalPointsForAnswer` instead. */
 export const POINTS_PER_CORRECT = 3;
-/** Daily reset hour in UTC — noon EST (UTC-5). New questions available at 17:00 UTC every day. */
+/** Global daily reset boundary, in UTC. Every player worldwide shares this instant; UI formats it into each viewer's local timezone. */
 export const DAILY_RESET_HOUR_UTC = 17;
 export const DEFAULT_MINIMUM_QUESTIONS = 5;
 export const MINIMUM_QUESTIONS_FLOOR = 5;

--- a/src/lib/games/timezone.ts
+++ b/src/lib/games/timezone.ts
@@ -1,7 +1,8 @@
 /**
- * Daily reset helpers — Wordle-style noon EST cutoff.
- * The "day" runs from noon EST (17:00 UTC) to the next noon EST.
- * All players worldwide share the same daily window regardless of timezone.
+ * Daily reset helpers — Wordle-style fixed UTC cutoff.
+ * The "day" runs from 17:00 UTC to the next 17:00 UTC. All players worldwide
+ * share the same daily window; UI formats that instant in each viewer's local
+ * timezone (see `formatNextResetTimeLocal`).
  */
 
 import { DAILY_RESET_HOUR_UTC } from '@/lib/game-constants';
@@ -99,4 +100,28 @@ export function getNextDailyResetBoundary(from: Date = new Date()): Date {
  */
 export function getMsUntilNextDailyResetBoundary(from: Date = new Date()): number {
   return Math.max(0, getNextDailyResetBoundary(from).getTime() - from.getTime());
+}
+
+/**
+ * Format the next daily reset boundary as a wall-clock time string in the
+ * viewer's local timezone. Falls back to the browser's resolved zone when none
+ * is passed. Examples: "1 PM" (Eastern DST), "10 AM" (Pacific DST),
+ * "10:30 PM" (India). On-the-hour minutes are dropped for readability.
+ */
+export function formatNextResetTimeLocal(
+  timezone?: string,
+  from: Date = new Date(),
+): string {
+  const next = getNextDailyResetBoundary(from);
+  const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const parts = new Intl.DateTimeFormat('en-US', {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+    timeZone: tz,
+  }).formatToParts(next);
+  const hour = parts.find((p) => p.type === 'hour')?.value ?? '';
+  const minute = parts.find((p) => p.type === 'minute')?.value ?? '';
+  const period = parts.find((p) => p.type === 'dayPeriod')?.value ?? '';
+  return minute === '00' ? `${hour} ${period}` : `${hour}:${minute} ${period}`;
 }


### PR DESCRIPTION
The app called the 17:00 UTC reset "noon", which was only true in EST.
During DST that instant is 1 PM Eastern, and for non-Eastern users it
was never noon at all. Keep the global Wordle-style cutoff, but format
the time in each viewer's local zone via a new `formatNextResetTimeLocal`
helper read on the client through `useSyncExternalStore` to avoid SSR
hydration mismatch.

https://claude.ai/code/session_01EPpTyxFYt76tWdPPMAx655