### PR TITLE
feed answer: prompt to add a freshly-opened territory to Daily Five

### DIFF
--- a/src/app/api/daily/preferences/add-domain/route.ts
+++ b/src/app/api/daily/preferences/add-domain/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getKnowledgeBase } from '@/server/db/queries/daily';
+import { getDailyPreferences, updateDailyPreferences } from '@/server/db/queries/daily-preferences';
+
+export const dynamic = 'force-dynamic';
+
+function parseDomain(value: unknown): string | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const domain = (value as Record<string, unknown>).domain;
+  return typeof domain === 'string' && domain.trim() ? domain.trim() : null;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const domain = parseDomain(await request.json().catch(() => null));
+  if (!domain) {
+    return NextResponse.json({ error: 'validation', message: 'domain is required' }, { status: 400 });
+  }
+
+  const [preferences, knowledgeBase] = await Promise.all([
+    getDailyPreferences(session.userId),
+    getKnowledgeBase(session.userId),
+  ]);
+
+  const knownDomains = knowledgeBase.map((entry) => entry.domain);
+  const domainKey = domain.toLowerCase();
+  const matched = knownDomains.find((d) => d.toLowerCase() === domainKey) ?? domain;
+
+  // Custom mode: append the new domain (dedup, preserve order).
+  // Random mode: switch to custom and seed with every opened territory the
+  // user currently has, plus the new one. Preserves variety while honoring
+  // their pick — see "i-think-i-want-synchronous-hanrahan" plan.
+  let nextDomainMode: 'custom' | 'random' = preferences.domainMode;
+  let nextSelected: string[];
+
+  if (preferences.domainMode === 'custom') {
+    const set = new Set(preferences.selectedDomains.map((d) => d.toLowerCase()));
+    if (set.has(domainKey)) {
+      nextSelected = preferences.selectedDomains;
+    } else {
+      nextSelected = [...preferences.selectedDomains, matched];
+    }
+  } else {
+    nextDomainMode = 'custom';
+    const seeded = new Map<string, string>();
+    for (const d of knownDomains) {
+      seeded.set(d.toLowerCase(), d);
+    }
+    seeded.set(domainKey, matched);
+    nextSelected = [...seeded.values()];
+  }
+
+  const updated = await updateDailyPreferences(session.userId, {
+    domainMode: nextDomainMode,
+    selectedDomains: nextSelected,
+  });
+
+  return NextResponse.json({
+    ok: true,
+    domainMode: updated.domainMode,
+    selectedDomains: updated.selectedDomains,
+  });
+}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -367,6 +367,13 @@ function pickOpenedNewTerritory(raw: unknown): boolean {
   return r.openedNewTerritory === true
 }
 
+function pickOpenedTerritoryDomain(raw: unknown): string | null {
+  if (!raw || typeof raw !== 'object') return null
+  const r = raw as Record<string, unknown>
+  if (r.openedNewTerritory !== true) return null
+  return typeof r.domain === 'string' && r.domain.trim() ? r.domain : null
+}
+
 function pickBroadCategory(
   raw: unknown,
   item: FeedApiItem
@@ -1151,6 +1158,7 @@ function FeedListContent({
             quip={result.quip}
             insideJoke={result.insideJoke}
             openedNewTerritory={pickOpenedNewTerritory(result.masteryDelta)}
+            openedTerritoryDomain={pickOpenedTerritoryDomain(result.masteryDelta)}
             questionId={sheetItem.question_id}
             feedItemId={sheetItem.id}
             onClose={() => setFeedbackSheetId(null)}

--- a/src/components/feed/AddToDailyFivePrompt.tsx
+++ b/src/components/feed/AddToDailyFivePrompt.tsx
@@ -1,0 +1,113 @@
+'use client'
+
+import { useState } from 'react'
+import Link from 'next/link'
+
+type Status = 'idle' | 'submitting' | 'accepted' | 'dismissed' | 'error'
+
+const SETTINGS_HREF = '/daily/setup'
+
+export function AddToDailyFivePrompt({ domain }: { domain: string }) {
+  const [status, setStatus] = useState<Status>('idle')
+
+  const accept = async () => {
+    if (status === 'submitting') return
+    setStatus('submitting')
+    try {
+      const response = await fetch('/api/daily/preferences/add-domain', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain }),
+      })
+      if (!response.ok) throw new Error('add failed')
+      setStatus('accepted')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  const dismiss = () => {
+    if (status === 'submitting') return
+    setStatus('dismissed')
+  }
+
+  if (status === 'accepted') {
+    return (
+      <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-[13px] text-emerald-900">
+        Added <strong>{domain}</strong> to your Daily Five.{' '}
+        <Link
+          href={SETTINGS_HREF}
+          className="font-semibold underline underline-offset-2 hover:text-emerald-950"
+        >
+          Manage topics
+        </Link>
+        .
+      </div>
+    )
+  }
+
+  if (status === 'dismissed') {
+    return (
+      <div className="mt-3 rounded-2xl border border-stone-200 bg-stone-50 px-4 py-3 text-[13px] text-stone-700">
+        Got it. You can add topics anytime in{' '}
+        <Link
+          href={SETTINGS_HREF}
+          className="font-semibold underline underline-offset-2 hover:text-stone-900"
+        >
+          Daily Five settings
+        </Link>
+        .
+      </div>
+    )
+  }
+
+  return (
+    <div className="mt-3 rounded-2xl border border-amber-300/70 bg-amber-50/60 px-4 py-3">
+      <p className="font-serif text-[14px] leading-snug text-amber-950">
+        Want questions on <strong>{domain}</strong> in your Daily Five?
+      </p>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void accept()}
+          disabled={status === 'submitting'}
+          className="inline-flex items-center rounded-full bg-amber-700 px-3 py-1.5 text-[13px] font-semibold text-white transition hover:bg-amber-800 disabled:cursor-default disabled:opacity-60"
+        >
+          {status === 'submitting' ? 'Adding…' : 'Add to Daily Five'}
+        </button>
+        <button
+          type="button"
+          onClick={dismiss}
+          disabled={status === 'submitting'}
+          className="inline-flex items-center rounded-full border border-amber-300 bg-white px-3 py-1.5 text-[13px] font-semibold text-amber-900 transition hover:bg-amber-50 disabled:cursor-default disabled:opacity-60"
+        >
+          No thanks
+        </button>
+      </div>
+      {status === 'error' ? (
+        <p className="mt-2 text-[12px] text-red-700">
+          Could not update your Daily Five. Try again from{' '}
+          <Link
+            href={SETTINGS_HREF}
+            className="font-semibold underline underline-offset-2"
+          >
+            Daily Five settings
+          </Link>
+          .
+        </p>
+      ) : (
+        <p className="mt-2 text-[11px] text-amber-800/80">
+          You can change this anytime in{' '}
+          <Link
+            href={SETTINGS_HREF}
+            className="font-semibold underline underline-offset-2 hover:text-amber-900"
+          >
+            Daily Five settings
+          </Link>
+          .
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Check, Sparkles, X } from 'lucide-react'
 
 import { Button } from '@/components/ui/button'
+import { AddToDailyFivePrompt } from './AddToDailyFivePrompt'
 import { visibleFeedCategory } from './category'
 
 type AnswerFeedbackSheetProps = {
@@ -17,6 +18,7 @@ type AnswerFeedbackSheetProps = {
   quip: string | null
   insideJoke?: string | null
   openedNewTerritory?: boolean
+  openedTerritoryDomain?: string | null
   questionId: string
   feedItemId: string
   onClose: () => void
@@ -35,12 +37,14 @@ export function AnswerFeedbackSheet({
   quip,
   insideJoke = null,
   openedNewTerritory = false,
+  openedTerritoryDomain = null,
   questionId,
   feedItemId,
   onClose,
 }: AnswerFeedbackSheetProps) {
   const visibleCategory = visibleFeedCategory(category)
   const showNewTerritory = openedNewTerritory && isCorrect
+  const showAddToDailyFive = Boolean(openedTerritoryDomain) && isCorrect
   const [bankState, setBankState] = useState<BankState>('idle')
   const hasAutoSavedRef = useRef(false)
 
@@ -181,6 +185,10 @@ export function AnswerFeedbackSheet({
                 </p>
               </div>
             </div>
+          ) : null}
+
+          {showAddToDailyFive && openedTerritoryDomain ? (
+            <AddToDailyFivePrompt domain={openedTerritoryDomain} />
           ) : null}
 
           <p className="pb-3 font-serif text-lg leading-7 text-stone-950">


### PR DESCRIPTION
When a feed answer opens a new territory (masteryDelta.openedNewTerritory),
the answer-feedback sheet now offers a one-tap "Add to Daily Five" prompt.
Accept patches DailyPreference.selectedDomains; if the user is in random
mode it switches to custom and seeds with all opened territories so they
don't lose variety. Dismiss leaves a pointer to /daily/setup.

https://claude.ai/code/session_01DYE8P9ZxT4zfX5d5zofS3p