### PR TITLE
fix: stop passing lucide forwardRef components across RSC boundary

### DIFF
--- a/src/app/account/page.tsx
+++ b/src/app/account/page.tsx
@@ -164,19 +164,19 @@ export default function AccountPage() {
         <h2 className="mb-3 font-serif text-2xl font-semibold">Account</h2>
         <SettingsGroup>
           <SettingsRow
-            icon={Lock}
+            icon={<Lock className="size-5" />}
             title="Privacy & visibility"
             subtitle="Control what others can see"
             href="/account/privacy"
           />
           <SettingsRow
-            icon={MessageSquare}
+            icon={<MessageSquare className="size-5" />}
             title="SMS & notifications"
             subtitle="Manage how you get updates"
             href="/account/notifications"
           />
           <SettingsRow
-            icon={Palette}
+            icon={<Palette className="size-5" />}
             title="App preferences"
             subtitle="Theme, language, and more"
             href="/account/preferences"
@@ -188,31 +188,31 @@ export default function AccountPage() {
         <h2 className="mb-3 font-serif text-2xl font-semibold">Developer Tools</h2>
         <SettingsGroup>
           <SettingsRow
-            icon={FlaskConical}
+            icon={<FlaskConical className="size-5" />}
             title="Create test game"
             subtitle="Spin up a test game instantly"
             href="/dev/test-game"
           />
           <SettingsRow
-            icon={RefreshCw}
+            icon={<RefreshCw className="size-5" />}
             title="Reset session"
             subtitle="Clear current session data"
             href="/dev/reset-session"
           />
           <SettingsRow
-            icon={Sun}
+            icon={<Sun className="size-5" />}
             title="Trigger noon reset"
             subtitle="Simulate daily reset"
             href="/dev/noon-reset"
           />
           <SettingsRow
-            icon={Code2}
+            icon={<Code2 className="size-5" />}
             title="View staging flags"
             subtitle="See feature flag status"
             href="/dev/flags"
           />
           <SettingsRow
-            icon={BarChart3}
+            icon={<BarChart3 className="size-5" />}
             title="Points diagnostic"
             subtitle="Inspect a user's mastery events and where points came from"
             href="/dev/points-diagnostic"
@@ -222,7 +222,7 @@ export default function AccountPage() {
         <div className="mt-4">
           <SettingsGroup>
             <SettingsRow
-              icon={LogOut}
+              icon={<LogOut className="size-5" />}
               title="Log out"
               subtitle="Sign out of your account"
               onClick={() => {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -180,13 +180,13 @@ export default async function UserProfilePage({
           <h2 className="mb-3 font-serif text-2xl font-semibold">Preview</h2>
           <SettingsGroup>
             <SettingsRow
-              icon={UsersIcon}
+              icon={<UsersIcon className="size-5" />}
               title="View as friend"
               subtitle="See what an active mutual friend sees."
               href={`/users/${portrait.user.id}?previewAs=friend`}
             />
             <SettingsRow
-              icon={Globe}
+              icon={<Globe className="size-5" />}
               title="View as public"
               subtitle="See only what's public to everyone else."
               href={`/users/${portrait.user.id}?previewAs=public`}
@@ -198,7 +198,7 @@ export default async function UserProfilePage({
           <h2 className="mb-3 font-serif text-2xl font-semibold">Settings</h2>
           <SettingsGroup>
             <SettingsRow
-              icon={SettingsIcon}
+              icon={<SettingsIcon className="size-5" />}
               title="Account settings"
               subtitle="Notifications, preferences, and more."
               href="/account"

--- a/src/components/account/SettingsRow.tsx
+++ b/src/components/account/SettingsRow.tsx
@@ -1,11 +1,16 @@
 'use client';
 
 import Link from 'next/link';
-import { ChevronRight, type LucideIcon } from 'lucide-react';
+import { ChevronRight } from 'lucide-react';
 import type { ReactNode } from 'react';
 
+// `icon` is a ReactNode (pre-rendered JSX) rather than a LucideIcon
+// component reference so that server components can use this client
+// component without violating the RSC serialization rule that forbids
+// passing functions (lucide icons are forwardRef refs) across the
+// server→client boundary as props.
 type CommonProps = {
-  icon: LucideIcon;
+  icon: ReactNode;
   title: string;
   subtitle: string;
   tone?: 'default' | 'destructive';
@@ -19,7 +24,6 @@ type ButtonProps = CommonProps & {
 };
 
 export function SettingsRow(props: LinkProps | ButtonProps): ReactNode {
-  const Icon = props.icon;
   const tone = props.tone ?? 'default';
   const titleClass = tone === 'destructive' ? 'text-destructive' : '';
   const iconWrap =
@@ -33,7 +37,7 @@ export function SettingsRow(props: LinkProps | ButtonProps): ReactNode {
         className={`grid size-10 flex-none place-items-center rounded-full ${iconWrap}`}
         aria-hidden="true"
       >
-        <Icon className="size-5" />
+        {props.icon}
       </span>
       <span className="flex min-w-0 flex-1 flex-col">
         <span className={`font-serif text-base font-semibold leading-tight ${titleClass}`}>


### PR DESCRIPTION
## Summary

- Fixes the "Application error: a server-side exception has occurred" (digest `3949167590`) thrown on `/users/[id]` after the profile redesign merged in 4f0ab6a.
- Root cause: the redesigned `/users/[id]/page.tsx` (server component) passed `icon={Lucide}` directly to `<SettingsRow>` (`'use client'`). Lucide icons are `React.forwardRef` refs — functions — and functions can't cross the server→client boundary as props, producing the `{$$typeof, render, displayName}` stringify error.
- `/account` only worked because it's `'use client'`, so the prop never crossed a boundary.

## Fix

Changed `SettingsRow`'s `icon` prop from `LucideIcon` to `ReactNode`, and updated all 12 callers (3 in `/users/[id]`, 9 in `/account`) to pass pre-rendered JSX (`icon={<Foo className="size-5" />}`). Already-rendered SVG serializes safely as host elements.

`PrivacyRow` (local helper in `page.tsx`) deliberately untouched — it's server-only and the icon never crosses a client boundary.

## Test plan

- [ ] Visit the owner self-view of `/users/<id>` on the preview deploy — page renders without the Application error
- [ ] Visit `/account` on the preview deploy — settings rows still render with icons
- [ ] Tap "View as friend" / "View as public" from the owner view — navigates and renders
- [ ] `npx tsc -p tsconfig.typecheck.json` clean (verified locally)

https://claude.ai/code/session_01LWf97b54ZFnuQ5FnmX1KBY

---
_Generated by [Claude Code](https://claude.ai/code/session_01LWf97b54ZFnuQ5FnmX1KBY)_