### PR TITLE
news: put the domain inline in What's Happening headlines

### DIFF
--- a/src/components/home/NewsRow.tsx
+++ b/src/components/home/NewsRow.tsx
@@ -36,13 +36,15 @@ function buildCopy(item: ActivityItemView): NewsRowCopy {
     case 'friend_answered_your_question': {
       const faq = item.reference.friendAnsweredQuestion
       const correct = faq?.result === 'correct'
+      const verb = correct ? 'got' : 'answered'
+      const domain = faq?.domain?.trim() || null
       return {
         headline: (
           <>
-            <b>{actor}</b> {correct ? 'got your question' : 'answered your question'}
+            <b>{actor}</b> {verb} your{domain ? ` ${domain}` : ''} question
           </>
         ),
-        secondLine: faq?.questionText ?? faq?.domain ?? null,
+        secondLine: faq?.questionText ?? null,
         accentColor: correct ? '#d97706' : '#a8a29e',
         href: '/activities',
       }
@@ -50,16 +52,20 @@ function buildCopy(item: ActivityItemView): NewsRowCopy {
 
     case 'declared_promoted': {
       const dp = item.reference.declaredPromoted
+      const domain = dp?.domain?.trim() || null
       return {
         headline: (
           <>
-            <b>{actor}</b> proved a domain on your map
+            <b>{actor}</b>{' '}
+            {domain
+              ? <>opened up the domain in <b>{domain}</b></>
+              : 'opened up a new domain on your map'}
           </>
         ),
-        secondLine: dp?.questionText || dp?.domain || null,
+        secondLine: dp?.questionText || null,
         accentColor: '#16a34a',
-        href: dp?.domain
-          ? `/knowledge/${encodeURIComponent(dp.domain)}`
+        href: domain
+          ? `/knowledge/${encodeURIComponent(domain)}`
           : '/knowledge',
       }
     }


### PR DESCRIPTION
The previous fix moved the specific question text to the second line but
left the headline generic ("Robyn got your question", "David proved a
domain on your map"). The user expected the domain name in the headline
itself — "Robyn got your DuckTales question", "David opened up the
domain in Disney Saturday Morning Cartoons". The data is already there;
just plumb it through to the headline and drop it from the second line
(question text already wins there).

https://claude.ai/code/session_017kmpHrdN59aMsrm32z6F4D