### PR TITLE
Add playtest harness for automated gameplay smoke testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,8 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # TWILIO_ACCOUNT_SID=""
 # TWILIO_AUTH_TOKEN=""
 # TWILIO_MESSAGING_SERVICE_SID=""
+
+# ── Playtest harness (scripts/playtest) ──────────────────────
+# Used only by `npm run smoke:gameplay`. The harness drives the local dev
+# server with Playwright; this is the URL it connects to.
+PLAYTEST_BASE_URL="http://localhost:3000"

--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "drizzle-kit": "^0.31.10",
         "eslint": "latest",
         "eslint-config-next": "16.1.6",
+        "playwright": "^1.60.0",
         "postcss": "latest",
         "prettier": "latest",
         "prettier-plugin-tailwindcss": "latest",
@@ -11510,6 +11511,53 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
+    "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "format": "prettier --write ."
   },
   "dependencies": {
@@ -45,6 +46,7 @@
     "drizzle-kit": "^0.31.10",
     "eslint": "latest",
     "eslint-config-next": "16.1.6",
+    "playwright": "^1.60.0",
     "postcss": "latest",
     "prettier": "latest",
     "prettier-plugin-tailwindcss": "latest",

--- a/scripts/playtest/lib/args.ts
+++ b/scripts/playtest/lib/args.ts
@@ -7,6 +7,7 @@ export type PlaytestArgs = {
   clean: boolean;
   runId: string | null;
   keep: boolean;
+  scenarioIds: string[];
 };
 
 function readFlag(args: string[], name: string): string | null {
@@ -44,6 +45,18 @@ function readFloatFlag(args: string[], name: string, fallback: number): number {
 
 export function parsePlaytestArgs(argv: string[]): PlaytestArgs {
   const args = argv.slice(2);
+
+  const single = readFlag(args, 'scenario');
+  const multi = readFlag(args, 'scenarios');
+  const scenarioIds: string[] = [];
+  if (single) scenarioIds.push(single.trim());
+  if (multi) {
+    for (const id of multi.split(',')) {
+      const trimmed = id.trim();
+      if (trimmed) scenarioIds.push(trimmed);
+    }
+  }
+
   return {
     players: readIntFlag(args, 'players', 3),
     questions: readIntFlag(args, 'questions', 3),
@@ -53,5 +66,6 @@ export function parsePlaytestArgs(argv: string[]): PlaytestArgs {
     clean: args.includes('--clean'),
     runId: readFlag(args, 'run-id'),
     keep: readBoolFlag(args, 'keep', true),
+    scenarioIds,
   };
 }

--- a/scripts/playtest/lib/args.ts
+++ b/scripts/playtest/lib/args.ts
@@ -1,0 +1,57 @@
+export type PlaytestArgs = {
+  players: number;
+  questions: number;
+  correctnessRate: number;
+  headed: boolean;
+  baseUrl: string;
+  clean: boolean;
+  runId: string | null;
+  keep: boolean;
+};
+
+function readFlag(args: string[], name: string): string | null {
+  const prefix = `--${name}=`;
+  const direct = args.find((arg) => arg.startsWith(prefix));
+  if (direct) return direct.slice(prefix.length);
+  const idx = args.indexOf(`--${name}`);
+  if (idx >= 0 && idx + 1 < args.length && !args[idx + 1].startsWith('--')) {
+    return args[idx + 1];
+  }
+  return null;
+}
+
+function readBoolFlag(args: string[], name: string, fallback: boolean): boolean {
+  const raw = readFlag(args, name);
+  if (raw === null) return args.includes(`--${name}`) ? true : fallback;
+  if (raw === 'true' || raw === '1') return true;
+  if (raw === 'false' || raw === '0') return false;
+  return fallback;
+}
+
+function readIntFlag(args: string[], name: string, fallback: number): number {
+  const raw = readFlag(args, name);
+  if (raw === null) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function readFloatFlag(args: string[], name: string, fallback: number): number {
+  const raw = readFlag(args, name);
+  if (raw === null) return fallback;
+  const parsed = Number.parseFloat(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+export function parsePlaytestArgs(argv: string[]): PlaytestArgs {
+  const args = argv.slice(2);
+  return {
+    players: readIntFlag(args, 'players', 3),
+    questions: readIntFlag(args, 'questions', 3),
+    correctnessRate: readFloatFlag(args, 'correctness-rate', 0.7),
+    headed: readBoolFlag(args, 'headed', true),
+    baseUrl: readFlag(args, 'base-url') ?? process.env.PLAYTEST_BASE_URL ?? 'http://localhost:3000',
+    clean: args.includes('--clean'),
+    runId: readFlag(args, 'run-id'),
+    keep: readBoolFlag(args, 'keep', true),
+  };
+}

--- a/scripts/playtest/lib/asserts.ts
+++ b/scripts/playtest/lib/asserts.ts
@@ -1,0 +1,39 @@
+import type { AssertionResult } from './scenario-context';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+export class AssertionRecorder {
+  readonly results: AssertionResult[] = [];
+
+  pass(label: string): void {
+    this.results.push({ kind: 'assert_pass', label, at: now() });
+  }
+
+  fail(label: string, message: string): void {
+    this.results.push({ kind: 'assert_fail', label, message, at: now() });
+  }
+
+  check(label: string, condition: boolean, message: string): void {
+    if (condition) this.pass(label);
+    else this.fail(label, message);
+  }
+
+  expectEqual<T>(label: string, actual: T, expected: T): void {
+    if (Object.is(actual, expected)) {
+      this.pass(label);
+    } else {
+      this.fail(label, `expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+    }
+  }
+
+  expectTruthy(label: string, value: unknown): void {
+    if (value) this.pass(label);
+    else this.fail(label, `expected truthy, got ${JSON.stringify(value)}`);
+  }
+
+  hasFailures(): boolean {
+    return this.results.some((r) => r.kind === 'assert_fail');
+  }
+}

--- a/scripts/playtest/lib/auth.ts
+++ b/scripts/playtest/lib/auth.ts
@@ -1,0 +1,43 @@
+const SESSION_COOKIE_NAME = 'joshing_session';
+
+export type SessionCookie = { name: string; value: string };
+
+function parseSetCookie(header: string | null): SessionCookie | null {
+  if (!header) return null;
+  for (const piece of header.split(/,(?=\s*[A-Za-z0-9_-]+=)/)) {
+    const trimmed = piece.trim();
+    if (!trimmed.startsWith(`${SESSION_COOKIE_NAME}=`)) continue;
+    const value = trimmed.slice(SESSION_COOKIE_NAME.length + 1).split(';')[0];
+    return { name: SESSION_COOKIE_NAME, value };
+  }
+  return null;
+}
+
+export async function authenticateAsTestUser(
+  baseUrl: string,
+  phone: string,
+): Promise<SessionCookie> {
+  const otpRes = await fetch(`${baseUrl}/api/auth/request-otp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ phone }),
+  });
+  if (!otpRes.ok) {
+    throw new Error(`[playtest/auth] request-otp failed ${otpRes.status} for ${phone}: ${await otpRes.text()}`);
+  }
+
+  const verifyRes = await fetch(`${baseUrl}/api/auth/verify-otp`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ phone, code: '000000' }),
+  });
+  if (!verifyRes.ok) {
+    throw new Error(`[playtest/auth] verify-otp failed ${verifyRes.status} for ${phone}: ${await verifyRes.text()}`);
+  }
+
+  const cookie = parseSetCookie(verifyRes.headers.get('set-cookie'));
+  if (!cookie) {
+    throw new Error(`[playtest/auth] verify-otp returned no ${SESSION_COOKIE_NAME} cookie for ${phone}`);
+  }
+  return cookie;
+}

--- a/scripts/playtest/lib/browser.ts
+++ b/scripts/playtest/lib/browser.ts
@@ -1,0 +1,33 @@
+import { chromium, type Browser, type BrowserContext } from 'playwright';
+
+export async function launchBrowser(headed: boolean): Promise<Browser> {
+  return chromium.launch({ headless: !headed });
+}
+
+export async function contextForPlayer(
+  browser: Browser,
+  baseUrl: string,
+  sessionCookieValue: string,
+): Promise<BrowserContext> {
+  const context = await browser.newContext({
+    viewport: { width: 390, height: 844 },
+    deviceScaleFactor: 2,
+    userAgent:
+      'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+  });
+
+  const url = new URL(baseUrl);
+  await context.addCookies([
+    {
+      name: 'joshing_session',
+      value: sessionCookieValue,
+      domain: url.hostname,
+      path: '/',
+      httpOnly: true,
+      secure: url.protocol === 'https:',
+      sameSite: 'Lax',
+    },
+  ]);
+
+  return context;
+}

--- a/scripts/playtest/lib/claude.ts
+++ b/scripts/playtest/lib/claude.ts
@@ -1,0 +1,128 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { getAnthropicClient, HAIKU_MODEL, loggedMessagesCreate, ANTHROPIC_MODEL, extractTextContent } from '@/lib/llm';
+
+import type { PlayerLog } from './player';
+
+export type ReviewResult = {
+  ok: boolean;
+  summary: string;
+  observations: string[];
+  bugs: string[];
+  uxNotes: string[];
+};
+
+function fallbackReview(reason: string): ReviewResult {
+  return {
+    ok: false,
+    summary: `LLM review skipped: ${reason}`,
+    observations: [],
+    bugs: [],
+    uxNotes: [],
+  };
+}
+
+function parseReview(text: string): ReviewResult {
+  const trimmed = text.trim();
+  const match = trimmed.match(/\{[\s\S]*\}/);
+  if (!match) return fallbackReview('no_json');
+  try {
+    const parsed = JSON.parse(match[0]) as Partial<ReviewResult>;
+    return {
+      ok: true,
+      summary: typeof parsed.summary === 'string' ? parsed.summary : '',
+      observations: Array.isArray(parsed.observations) ? parsed.observations.filter((x): x is string => typeof x === 'string') : [],
+      bugs: Array.isArray(parsed.bugs) ? parsed.bugs.filter((x): x is string => typeof x === 'string') : [],
+      uxNotes: Array.isArray(parsed.uxNotes) ? parsed.uxNotes.filter((x): x is string => typeof x === 'string') : [],
+    };
+  } catch {
+    return fallbackReview('invalid_json');
+  }
+}
+
+function pickReviewScreenshots(logs: PlayerLog[], limit = 6): string[] {
+  const files: string[] = [];
+  for (const log of logs) {
+    for (const event of log.events) {
+      if (event.kind === 'screenshot') files.push(event.file);
+      if (files.length >= limit) return files;
+    }
+  }
+  return files;
+}
+
+function imageBlock(filePath: string): { type: 'image'; source: { type: 'base64'; media_type: 'image/png'; data: string } } {
+  const data = readFileSync(filePath).toString('base64');
+  return { type: 'image', source: { type: 'base64', media_type: 'image/png', data } };
+}
+
+export async function reviewSession(params: {
+  logs: PlayerLog[];
+  runId: string;
+}): Promise<ReviewResult> {
+  const client = getAnthropicClient();
+  if (!client) return fallbackReview('no_anthropic_client');
+
+  const screenshots = pickReviewScreenshots(params.logs);
+  const transcript = params.logs.map((log) => ({
+    player: log.displayName,
+    events: log.events.map((e) => {
+      if (e.kind === 'screenshot') return { kind: e.kind, note: e.note, file: path.basename(e.file) };
+      return e;
+    }),
+  }));
+
+  const userContent: Array<{ type: 'text'; text: string } | ReturnType<typeof imageBlock>> = [
+    {
+      type: 'text',
+      text:
+        'You are reviewing a multi-player playthrough of "Joshing", a small trivia game. ' +
+        'Several test players just played a 3-question game. Look at the transcript and screenshots below, then ' +
+        'return JSON only with this shape: ' +
+        '{"summary": "<one paragraph>", "observations": [<short strings>], "bugs": [<short strings>], "uxNotes": [<short strings>]}. ' +
+        'Be specific. Even on a clean run, you must surface at least one UX observation worth investigating. ' +
+        `Transcript: ${JSON.stringify(transcript)}`,
+    },
+    ...screenshots.map(imageBlock),
+  ];
+
+  try {
+    const response = await loggedMessagesCreate(client, 'playtest-review', {
+      model: ANTHROPIC_MODEL,
+      max_tokens: 1500,
+      temperature: 0.4,
+      system: [
+        {
+          type: 'text',
+          text:
+            'You are a careful QA reviewer. You only return strict JSON. ' +
+            'You distinguish "bug" (functionally wrong) from "uxNote" (works but feels off).',
+        },
+      ],
+      messages: [{ role: 'user', content: userContent }],
+    });
+    const text = extractTextContent(response.content);
+    return parseReview(text);
+  } catch (error) {
+    return fallbackReview(error instanceof Error ? error.message : 'unknown');
+  }
+}
+
+export async function quickWrongAnswer(canonical: string): Promise<string> {
+  const client = getAnthropicClient();
+  if (!client) return `not-${canonical.toLowerCase()}`;
+  try {
+    const response = await loggedMessagesCreate(client, 'playtest-wrong-answer', {
+      model: HAIKU_MODEL,
+      max_tokens: 30,
+      temperature: 0.6,
+      system: [{ type: 'text', text: 'Return one short, plausibly-wrong trivia answer in the same category. No prose, just the answer.' }],
+      messages: [{ role: 'user', content: `Canonical correct answer: ${canonical}. Give a plausible wrong answer in the same category.` }],
+    });
+    const text = extractTextContent(response.content).trim();
+    return text || `not-${canonical.toLowerCase()}`;
+  } catch {
+    return `not-${canonical.toLowerCase()}`;
+  }
+}

--- a/scripts/playtest/lib/claude.ts
+++ b/scripts/playtest/lib/claude.ts
@@ -3,7 +3,7 @@ import path from 'node:path';
 
 import { getAnthropicClient, HAIKU_MODEL, loggedMessagesCreate, ANTHROPIC_MODEL, extractTextContent } from '@/lib/llm';
 
-import type { PlayerLog } from './player';
+import type { ScenarioLog } from './scenario-context';
 
 export type ReviewResult = {
   ok: boolean;
@@ -41,13 +41,18 @@ function parseReview(text: string): ReviewResult {
   }
 }
 
-function pickReviewScreenshots(logs: PlayerLog[], limit = 6): string[] {
+function pickReviewScreenshots(logs: ScenarioLog[], perScenarioLimit = 2, totalLimit = 12): string[] {
   const files: string[] = [];
   for (const log of logs) {
+    let perScenario = 0;
     for (const event of log.events) {
-      if (event.kind === 'screenshot') files.push(event.file);
-      if (files.length >= limit) return files;
+      if (event.kind !== 'screenshot') continue;
+      files.push(event.file);
+      perScenario += 1;
+      if (perScenario >= perScenarioLimit) break;
+      if (files.length >= totalLimit) return files;
     }
+    if (files.length >= totalLimit) return files;
   }
   return files;
 }
@@ -58,7 +63,7 @@ function imageBlock(filePath: string): { type: 'image'; source: { type: 'base64'
 }
 
 export async function reviewSession(params: {
-  logs: PlayerLog[];
+  logs: ScenarioLog[];
   runId: string;
 }): Promise<ReviewResult> {
   const client = getAnthropicClient();
@@ -66,7 +71,13 @@ export async function reviewSession(params: {
 
   const screenshots = pickReviewScreenshots(params.logs);
   const transcript = params.logs.map((log) => ({
-    player: log.displayName,
+    scenario: log.scenarioId,
+    displayName: log.displayName,
+    status: log.status,
+    durationMs: log.durationMs,
+    assertions: log.assertions.map((a) =>
+      a.kind === 'assert_pass' ? { pass: a.label } : { fail: a.label, message: a.message },
+    ),
     events: log.events.map((e) => {
       if (e.kind === 'screenshot') return { kind: e.kind, note: e.note, file: path.basename(e.file) };
       return e;
@@ -77,11 +88,11 @@ export async function reviewSession(params: {
     {
       type: 'text',
       text:
-        'You are reviewing a multi-player playthrough of "Joshing", a small trivia game. ' +
-        'Several test players just played a 3-question game. Look at the transcript and screenshots below, then ' +
-        'return JSON only with this shape: ' +
-        '{"summary": "<one paragraph>", "observations": [<short strings>], "bugs": [<short strings>], "uxNotes": [<short strings>]}. ' +
-        'Be specific. Even on a clean run, you must surface at least one UX observation worth investigating. ' +
+        'You are reviewing an automated regression run of "Joshing", a multi-player trivia app. ' +
+        'Several scenarios just executed (each a distinct user flow). For EACH scenario, look at the assertions, transcript events, and screenshots. ' +
+        'Return JSON only: ' +
+        '{"summary": "<one paragraph across all scenarios>", "observations": [<short strings>], "bugs": [<short strings>], "uxNotes": [<short strings>]}. ' +
+        'Surface at least one UX observation worth investigating even on a clean run. Be specific — name the scenario when a bug or note is scenario-specific. ' +
         `Transcript: ${JSON.stringify(transcript)}`,
     },
     ...screenshots.map(imageBlock),

--- a/scripts/playtest/lib/cleanup.ts
+++ b/scripts/playtest/lib/cleanup.ts
@@ -35,14 +35,23 @@ function ids<K extends TrackedRow['kind']>(
 async function assertTestUsersOnly(userIds: string[]): Promise<void> {
   if (userIds.length === 0) return;
   const rows = await db
-    .select({ id: users.id, displayName: users.displayName })
+    .select({ id: users.id, displayName: users.displayName, phoneNumber: users.phoneNumber })
     .from(users)
     .where(inArray(users.id, userIds));
-  const bad = rows.filter((row) => !(row.displayName ?? '').startsWith('[TEST]'));
+  // A row is "ours" if its displayName starts with [TEST] OR its phone is in
+  // the +15557 test block. The second branch covers users created by the
+  // signup flow (e.g. the accept-invitation scenario's invitee) where the
+  // OTP route doesn't set a displayName — but the test-phone allocation
+  // still proves intent.
+  const bad = rows.filter((row) => {
+    const tagged = (row.displayName ?? '').startsWith('[TEST]');
+    const inTestBlock = (row.phoneNumber ?? '').startsWith('+15557');
+    return !(tagged || inTestBlock);
+  });
   if (bad.length > 0) {
     throw new Error(
-      `[playtest/cleanup] refusing to delete users whose display_name does not start with "[TEST]": ` +
-        bad.map((b) => `${b.id}=${JSON.stringify(b.displayName)}`).join(', '),
+      `[playtest/cleanup] refusing to delete users without [TEST] displayName or +15557 phone: ` +
+        bad.map((b) => `${b.id}=${JSON.stringify({ name: b.displayName, phone: b.phoneNumber })}`).join(', '),
     );
   }
 }

--- a/scripts/playtest/lib/cleanup.ts
+++ b/scripts/playtest/lib/cleanup.ts
@@ -1,0 +1,99 @@
+import { and, eq, inArray, like, or } from 'drizzle-orm';
+
+import {
+  activityItems,
+  db,
+  feedItems,
+  friendInvitations,
+  joshingGameQuestions,
+  joshingGameRecipients,
+  joshingGameResponses,
+  joshingGames,
+  masteryEvents,
+  otpCodes,
+  playerMastery,
+  questions,
+  smsLogs,
+  userQuestionBank,
+  userSessions,
+  users,
+} from '@/server/db';
+
+import type { PlaytestManifest } from './manifest';
+
+async function assertTestUsersOnly(userIds: string[]): Promise<void> {
+  if (userIds.length === 0) return;
+  const rows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(inArray(users.id, userIds));
+  const bad = rows.filter((row) => !(row.displayName ?? '').startsWith('[TEST]'));
+  if (bad.length > 0) {
+    throw new Error(
+      `[playtest/cleanup] refusing to delete users whose display_name does not start with "[TEST]": ` +
+        bad.map((b) => `${b.id}=${JSON.stringify(b.displayName)}`).join(', '),
+    );
+  }
+}
+
+export async function wipeTestData(manifest: PlaytestManifest): Promise<void> {
+  const allUserIds = [manifest.inviter.id, ...manifest.players.map((p) => p.id)];
+  const playerUserIds = manifest.players.map((p) => p.id);
+  const inviterId = manifest.inviter.id;
+  const gameId = manifest.gameId;
+  const questionIds = manifest.questionIds;
+
+  await assertTestUsersOnly(allUserIds);
+
+  // Order matters: delete leaves first, then their parents.
+  if (gameId) {
+    await db.delete(joshingGameResponses).where(eq(joshingGameResponses.gameId, gameId));
+    await db.delete(joshingGameRecipients).where(eq(joshingGameRecipients.gameId, gameId));
+    await db.delete(joshingGameQuestions).where(eq(joshingGameQuestions.gameId, gameId));
+    await db.delete(feedItems).where(eq(feedItems.joshingGameId, gameId));
+  }
+
+  if (allUserIds.length > 0) {
+    await db.delete(feedItems).where(or(
+      inArray(feedItems.recipientUserId, allUserIds),
+      inArray(feedItems.sourceUserId, allUserIds),
+    ));
+    await db.delete(activityItems).where(or(
+      inArray(activityItems.userId, allUserIds),
+      inArray(activityItems.actorUserId, allUserIds),
+    ));
+    await db.delete(masteryEvents).where(inArray(masteryEvents.userId, allUserIds));
+    await db.delete(playerMastery).where(inArray(playerMastery.userId, allUserIds));
+    await db.delete(userQuestionBank).where(inArray(userQuestionBank.userId, allUserIds));
+    await db.delete(userSessions).where(inArray(userSessions.userId, allUserIds));
+    await db.delete(smsLogs).where(inArray(smsLogs.userId, allUserIds));
+  }
+
+  if (playerUserIds.length > 0) {
+    await db.delete(friendInvitations).where(or(
+      eq(friendInvitations.inviterUserId, inviterId),
+      inArray(friendInvitations.inviteeUserId, playerUserIds),
+    ));
+  } else {
+    await db.delete(friendInvitations).where(eq(friendInvitations.inviterUserId, inviterId));
+  }
+
+  if (gameId) {
+    await db.delete(joshingGames).where(eq(joshingGames.id, gameId));
+  }
+
+  if (questionIds.length > 0) {
+    await db.delete(questions).where(and(
+      inArray(questions.id, questionIds),
+      eq(questions.creatorId, inviterId),
+    ));
+  }
+
+  // OtpCode rows are keyed by phone, not user — match by the [TEST] phone block.
+  await db.delete(otpCodes).where(like(otpCodes.phoneNumber, '+15557%'));
+  await db.delete(smsLogs).where(like(smsLogs.phoneNumber, '+15557%'));
+
+  if (allUserIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, allUserIds));
+  }
+}

--- a/scripts/playtest/lib/cleanup.ts
+++ b/scripts/playtest/lib/cleanup.ts
@@ -2,9 +2,11 @@ import { and, eq, inArray, like, or } from 'drizzle-orm';
 
 import {
   activityItems,
+  dailyQueues,
   db,
   feedItems,
   friendInvitations,
+  friendships,
   joshingGameQuestions,
   joshingGameRecipients,
   joshingGameResponses,
@@ -19,7 +21,16 @@ import {
   users,
 } from '@/server/db';
 
-import type { PlaytestManifest } from './manifest';
+import type { PlaytestManifest, TrackedRow } from './manifest';
+
+function ids<K extends TrackedRow['kind']>(
+  rows: TrackedRow[],
+  kind: K,
+): Array<Extract<TrackedRow, { kind: K }>['id']> {
+  return rows
+    .filter((row): row is Extract<TrackedRow, { kind: K }> => row.kind === kind)
+    .map((row) => row.id);
+}
 
 async function assertTestUsersOnly(userIds: string[]): Promise<void> {
   if (userIds.length === 0) return;
@@ -37,63 +48,83 @@ async function assertTestUsersOnly(userIds: string[]): Promise<void> {
 }
 
 export async function wipeTestData(manifest: PlaytestManifest): Promise<void> {
-  const allUserIds = [manifest.inviter.id, ...manifest.players.map((p) => p.id)];
-  const playerUserIds = manifest.players.map((p) => p.id);
-  const inviterId = manifest.inviter.id;
-  const gameId = manifest.gameId;
-  const questionIds = manifest.questionIds;
+  const userIds = ids(manifest.rows, 'user');
+  const questionIds = ids(manifest.rows, 'question');
+  const invitationIds = ids(manifest.rows, 'invitation');
+  const friendshipIds = ids(manifest.rows, 'friendship');
+  const gameIds = ids(manifest.rows, 'game');
+  const dailyQueueIds = ids(manifest.rows, 'daily-queue');
 
-  await assertTestUsersOnly(allUserIds);
+  await assertTestUsersOnly(userIds);
 
-  // Order matters: delete leaves first, then their parents.
-  if (gameId) {
-    await db.delete(joshingGameResponses).where(eq(joshingGameResponses.gameId, gameId));
-    await db.delete(joshingGameRecipients).where(eq(joshingGameRecipients.gameId, gameId));
-    await db.delete(joshingGameQuestions).where(eq(joshingGameQuestions.gameId, gameId));
-    await db.delete(feedItems).where(eq(feedItems.joshingGameId, gameId));
+  // FK-safe order: leaves first, then their parents.
+  if (gameIds.length > 0) {
+    await db.delete(joshingGameResponses).where(inArray(joshingGameResponses.gameId, gameIds));
+    await db.delete(joshingGameRecipients).where(inArray(joshingGameRecipients.gameId, gameIds));
+    await db.delete(joshingGameQuestions).where(inArray(joshingGameQuestions.gameId, gameIds));
+    await db.delete(feedItems).where(inArray(feedItems.joshingGameId, gameIds));
   }
 
-  if (allUserIds.length > 0) {
+  if (userIds.length > 0) {
     await db.delete(feedItems).where(or(
-      inArray(feedItems.recipientUserId, allUserIds),
-      inArray(feedItems.sourceUserId, allUserIds),
+      inArray(feedItems.recipientUserId, userIds),
+      inArray(feedItems.sourceUserId, userIds),
     ));
     await db.delete(activityItems).where(or(
-      inArray(activityItems.userId, allUserIds),
-      inArray(activityItems.actorUserId, allUserIds),
+      inArray(activityItems.userId, userIds),
+      inArray(activityItems.actorUserId, userIds),
     ));
-    await db.delete(masteryEvents).where(inArray(masteryEvents.userId, allUserIds));
-    await db.delete(playerMastery).where(inArray(playerMastery.userId, allUserIds));
-    await db.delete(userQuestionBank).where(inArray(userQuestionBank.userId, allUserIds));
-    await db.delete(userSessions).where(inArray(userSessions.userId, allUserIds));
-    await db.delete(smsLogs).where(inArray(smsLogs.userId, allUserIds));
+    await db.delete(masteryEvents).where(inArray(masteryEvents.userId, userIds));
+    await db.delete(playerMastery).where(inArray(playerMastery.userId, userIds));
+    await db.delete(userQuestionBank).where(inArray(userQuestionBank.userId, userIds));
+    await db.delete(userSessions).where(inArray(userSessions.userId, userIds));
+    await db.delete(smsLogs).where(inArray(smsLogs.userId, userIds));
   }
 
-  if (playerUserIds.length > 0) {
+  if (dailyQueueIds.length > 0) {
+    await db.delete(dailyQueues).where(inArray(dailyQueues.id, dailyQueueIds));
+  } else if (userIds.length > 0) {
+    // Daily queues weren't explicitly tracked but the daily scenario may
+    // have created them; wipe any belonging to our test users.
+    await db.delete(dailyQueues).where(inArray(dailyQueues.userId, userIds));
+  }
+
+  if (friendshipIds.length > 0) {
+    await db.delete(friendships).where(inArray(friendships.id, friendshipIds));
+  }
+  if (userIds.length > 0) {
+    // Catch any friendship rows the scenario forgot to track explicitly
+    // (e.g. created via acceptFriendInvitation's transaction).
+    await db.delete(friendships).where(or(
+      inArray(friendships.userAId, userIds),
+      inArray(friendships.userBId, userIds),
+    ));
+  }
+
+  if (invitationIds.length > 0) {
+    await db.delete(friendInvitations).where(inArray(friendInvitations.id, invitationIds));
+  }
+  if (userIds.length > 0) {
     await db.delete(friendInvitations).where(or(
-      eq(friendInvitations.inviterUserId, inviterId),
-      inArray(friendInvitations.inviteeUserId, playerUserIds),
+      inArray(friendInvitations.inviterUserId, userIds),
+      inArray(friendInvitations.inviteeUserId, userIds),
     ));
-  } else {
-    await db.delete(friendInvitations).where(eq(friendInvitations.inviterUserId, inviterId));
-  }
-
-  if (gameId) {
-    await db.delete(joshingGames).where(eq(joshingGames.id, gameId));
   }
 
   if (questionIds.length > 0) {
-    await db.delete(questions).where(and(
-      inArray(questions.id, questionIds),
-      eq(questions.creatorId, inviterId),
-    ));
+    await db.delete(questions).where(inArray(questions.id, questionIds));
   }
 
-  // OtpCode rows are keyed by phone, not user — match by the [TEST] phone block.
+  // OtpCode and SmsLog are phone-scoped; clear the test phone block.
   await db.delete(otpCodes).where(like(otpCodes.phoneNumber, '+15557%'));
   await db.delete(smsLogs).where(like(smsLogs.phoneNumber, '+15557%'));
 
-  if (allUserIds.length > 0) {
-    await db.delete(users).where(inArray(users.id, allUserIds));
+  if (userIds.length > 0) {
+    await db.delete(users).where(inArray(users.id, userIds));
   }
+
+  // Suppress unused-import warning when no friendship rows referenced
+  // (TypeScript doesn't tree-shake schema imports).
+  void and;
+  void eq;
 }

--- a/scripts/playtest/lib/manifest.ts
+++ b/scripts/playtest/lib/manifest.ts
@@ -1,14 +1,66 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import path from 'node:path';
 
+export type TrackedUser = {
+  kind: 'user';
+  id: string;
+  phone: string;
+  displayName: string;
+  scenarioId: string;
+};
+
+export type TrackedQuestion = {
+  kind: 'question';
+  id: string;
+  creatorId: string;
+  scenarioId: string;
+};
+
+export type TrackedInvitation = {
+  kind: 'invitation';
+  id: string;
+  inviterUserId: string;
+  inviteePhone: string;
+  scenarioId: string;
+};
+
+export type TrackedFriendship = {
+  kind: 'friendship';
+  id: string;
+  scenarioId: string;
+};
+
+export type TrackedGame = {
+  kind: 'game';
+  id: string;
+  scenarioId: string;
+};
+
+export type TrackedDailyQueue = {
+  kind: 'daily-queue';
+  id: string;
+  userId: string;
+  scenarioId: string;
+};
+
+export type TrackedRow =
+  | TrackedUser
+  | TrackedQuestion
+  | TrackedInvitation
+  | TrackedFriendship
+  | TrackedGame
+  | TrackedDailyQueue;
+
 export type PlaytestManifest = {
   runId: string;
   baseUrl: string;
   createdAt: string;
-  inviter: { id: string; phone: string; displayName: string };
-  players: { id: string; phone: string; displayName: string; sessionCookie: string }[];
-  questionIds: string[];
-  gameId: string;
+  rows: TrackedRow[];
+  /**
+   * Per-scenario stash for things the cleanup doesn't need but
+   * scenarios want to remember (e.g. session cookies for replay).
+   */
+  scenarioData: Record<string, Record<string, unknown>>;
 };
 
 const ROOT = path.resolve(process.cwd(), 'audits');
@@ -48,4 +100,14 @@ export function readManifest(runId: string): PlaytestManifest {
 
 export function newRunId(): string {
   return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+export function newManifest(runId: string, baseUrl: string): PlaytestManifest {
+  return {
+    runId,
+    baseUrl,
+    createdAt: new Date().toISOString(),
+    rows: [],
+    scenarioData: {},
+  };
 }

--- a/scripts/playtest/lib/manifest.ts
+++ b/scripts/playtest/lib/manifest.ts
@@ -1,0 +1,51 @@
+import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+
+export type PlaytestManifest = {
+  runId: string;
+  baseUrl: string;
+  createdAt: string;
+  inviter: { id: string; phone: string; displayName: string };
+  players: { id: string; phone: string; displayName: string; sessionCookie: string }[];
+  questionIds: string[];
+  gameId: string;
+};
+
+const ROOT = path.resolve(process.cwd(), 'audits');
+
+export function runDir(runId: string): string {
+  return path.join(ROOT, `playtest-${runId}`);
+}
+
+export function manifestPath(runId: string): string {
+  return path.join(runDir(runId), 'manifest.json');
+}
+
+export function screenshotDir(runId: string): string {
+  return path.join(runDir(runId), 'screenshots');
+}
+
+export function reportPath(runId: string): string {
+  return path.join(ROOT, `playtest-${runId}.md`);
+}
+
+export function ensureRunDirs(runId: string): void {
+  mkdirSync(screenshotDir(runId), { recursive: true });
+}
+
+export function writeManifest(manifest: PlaytestManifest): void {
+  ensureRunDirs(manifest.runId);
+  writeFileSync(manifestPath(manifest.runId), JSON.stringify(manifest, null, 2));
+}
+
+export function readManifest(runId: string): PlaytestManifest {
+  const p = manifestPath(runId);
+  if (!existsSync(p)) {
+    throw new Error(`[playtest] manifest not found at ${p}`);
+  }
+  return JSON.parse(readFileSync(p, 'utf8')) as PlaytestManifest;
+}
+
+export function newRunId(): string {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}

--- a/scripts/playtest/lib/player.ts
+++ b/scripts/playtest/lib/player.ts
@@ -85,10 +85,31 @@ export async function playGame(params: {
   log.events.push({ kind: 'navigated', url: page.url(), at: now() });
   await snap(page, params.runId, 'arrived', log);
 
+  // The first answer input must mount within a few seconds. If it doesn't,
+  // something is broken upstream (commonly: Next.js dev server ChunkLoadError
+  // on stale .next/, an unauthenticated session that landed on /login, or a
+  // proxy redirect loop). Surface it loudly — without this guard, the loop
+  // below would exit with zero iterations and the run would falsely report
+  // success.
+  const inputLocator = page.locator('input[placeholder="Your answer..."]');
+  try {
+    await inputLocator.first().waitFor({ state: 'visible', timeout: 10_000 });
+  } catch {
+    const overlay = await page.locator('[data-nextjs-dialog], #nextjs__container_errors_label').first().innerText().catch(() => '');
+    const trimmedOverlay = overlay.trim();
+    const detail = trimmedOverlay
+      ? ` Next.js error overlay: ${trimmedOverlay.slice(0, 200)}`
+      : ` URL ended at ${page.url()}.`;
+    throw new Error(
+      `[playtest] answer input never appeared on /games/${params.gameId} for ${params.displayName}.` +
+        `${detail} Check the dev server: rm .next, restart, and look for the ChunkLoadError.`,
+    );
+  }
+
   const answerUrlMatcher = `**/api/joshing-games/${params.gameId}/answer`;
   let index = 0;
   while (true) {
-    if ((await page.locator('input[placeholder="Your answer..."]').count()) === 0) break;
+    if ((await inputLocator.count()) === 0) break;
     if (index >= 5) break;
     index += 1;
 

--- a/scripts/playtest/lib/player.ts
+++ b/scripts/playtest/lib/player.ts
@@ -1,0 +1,138 @@
+import path from 'node:path';
+
+import type { BrowserContext, ConsoleMessage, Page, Request, Response } from 'playwright';
+
+import { canonicalAnswerFor } from './seed';
+import { screenshotDir } from './manifest';
+
+export type PlayerEvent =
+  | { kind: 'navigated'; url: string; at: string }
+  | { kind: 'question_seen'; index: number; text: string; at: string }
+  | { kind: 'answer_submitted'; index: number; text: string; intent: 'correct' | 'wrong'; at: string }
+  | { kind: 'result_observed'; index: number; correct: boolean; pointsAwarded: number | null; at: string }
+  | { kind: 'console'; level: string; text: string; at: string }
+  | { kind: 'network_error'; url: string; status: number | null; at: string }
+  | { kind: 'screenshot'; file: string; note: string; at: string }
+  | { kind: 'finished'; at: string }
+  | { kind: 'error'; message: string; at: string };
+
+export type PlayerLog = {
+  playerId: string;
+  displayName: string;
+  events: PlayerEvent[];
+};
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+async function snap(page: Page, runId: string, label: string, log: PlayerLog): Promise<void> {
+  const safe = label.replace(/[^a-z0-9_-]/gi, '-');
+  const fileName = `${log.displayName.replace(/[^a-z0-9]/gi, '-')}--${safe}.png`;
+  const file = path.join(screenshotDir(runId), fileName);
+  await page.screenshot({ path: file, fullPage: false });
+  log.events.push({ kind: 'screenshot', file, note: label, at: now() });
+}
+
+function wrongAnswerFor(canonical: string): string {
+  return `definitely-not-${canonical.toLowerCase()}-${Math.floor(Math.random() * 1000)}`;
+}
+
+function pickIntent(rate: number): 'correct' | 'wrong' {
+  return Math.random() < rate ? 'correct' : 'wrong';
+}
+
+async function readCurrentQuestionText(page: Page): Promise<string> {
+  // Our seeded questions all start with "[TEST]"; pick the last such bubble on the page.
+  // Fallback to the last visible <p> inside the chat thread.
+  const testNodes = page.locator('p', { hasText: '[TEST]' });
+  if ((await testNodes.count()) > 0) {
+    return ((await testNodes.last().innerText().catch(() => '')) ?? '').trim();
+  }
+  return ((await page.locator('main p').last().innerText().catch(() => '')) ?? '').trim();
+}
+
+export async function playGame(params: {
+  context: BrowserContext;
+  baseUrl: string;
+  runId: string;
+  gameId: string;
+  playerId: string;
+  displayName: string;
+  correctnessRate: number;
+}): Promise<PlayerLog> {
+  const log: PlayerLog = { playerId: params.playerId, displayName: params.displayName, events: [] };
+  const page = await params.context.newPage();
+
+  page.on('console', (msg: ConsoleMessage) => {
+    const level = msg.type();
+    if (level === 'log' || level === 'debug') return;
+    log.events.push({ kind: 'console', level, text: msg.text(), at: now() });
+  });
+  page.on('requestfailed', (req: Request) => {
+    log.events.push({ kind: 'network_error', url: req.url(), status: null, at: now() });
+  });
+  page.on('response', (response: Response) => {
+    const status = response.status();
+    if (status >= 500) {
+      log.events.push({ kind: 'network_error', url: response.url(), status, at: now() });
+    }
+  });
+
+  const url = `${params.baseUrl}/games/${params.gameId}`;
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  log.events.push({ kind: 'navigated', url: page.url(), at: now() });
+  await snap(page, params.runId, 'arrived', log);
+
+  const answerUrlMatcher = `**/api/joshing-games/${params.gameId}/answer`;
+  let index = 0;
+  while (true) {
+    if ((await page.locator('input[placeholder="Your answer..."]').count()) === 0) break;
+    if (index >= 5) break;
+    index += 1;
+
+    const questionText = await readCurrentQuestionText(page);
+    log.events.push({ kind: 'question_seen', index, text: questionText, at: now() });
+
+    const intent = pickIntent(params.correctnessRate);
+    const canonical = canonicalAnswerFor(questionText);
+    const answer = intent === 'correct' && canonical
+      ? canonical
+      : wrongAnswerFor(canonical ?? 'unknown');
+
+    await page.locator('input[placeholder="Your answer..."]').fill(answer);
+    await snap(page, params.runId, `q${index}-before-submit`, log);
+
+    const responsePromise = page.waitForResponse(answerUrlMatcher, { timeout: 15_000 }).catch(() => null);
+    await page.locator('button[type="submit"]').click();
+    log.events.push({ kind: 'answer_submitted', index, text: answer, intent, at: now() });
+
+    const response = await responsePromise;
+    let correct = false;
+    let pointsAwarded: number | null = null;
+    if (response) {
+      const body = await response.json().catch(() => null) as { isCorrect?: boolean; pointsAwarded?: number } | null;
+      if (body) {
+        correct = body.isCorrect === true;
+        pointsAwarded = typeof body.pointsAwarded === 'number' ? body.pointsAwarded : null;
+      }
+    } else {
+      log.events.push({ kind: 'error', message: `no response to ${answerUrlMatcher} within 15s`, at: now() });
+    }
+    log.events.push({ kind: 'result_observed', index, correct, pointsAwarded, at: now() });
+
+    // play-client.tsx pauses 850ms before revealing the next question.
+    await page.waitForTimeout(1100);
+    await snap(page, params.runId, `q${index}-after-result`, log);
+  }
+
+  // After the last answer the play client redirects to /summary; capture it.
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(500);
+  await snap(page, params.runId, 'summary', log);
+  log.events.push({ kind: 'finished', at: now() });
+
+  await page.close();
+  return log;
+}

--- a/scripts/playtest/lib/player.ts
+++ b/scripts/playtest/lib/player.ts
@@ -101,11 +101,18 @@ export async function playGame(params: {
       ? canonical
       : wrongAnswerFor(canonical ?? 'unknown');
 
-    await page.locator('input[placeholder="Your answer..."]').fill(answer);
+    const input = page.locator('input[placeholder="Your answer..."]');
+    await input.fill(answer);
     await snap(page, params.runId, `q${index}-before-submit`, log);
 
     const responsePromise = page.waitForResponse(answerUrlMatcher, { timeout: 15_000 }).catch(() => null);
-    await page.locator('button[type="submit"]').click();
+    // Press Enter rather than clicking [type="submit"]. The bottom <nav
+    // aria-label="Primary navigation"> is fixed at the same bottom edge as
+    // the sticky answer form and intercepts pointer events on the Send
+    // button — that's a real mobile UX bug worth noting (see the LLM
+    // review section of the report), and it would make the harness flaky
+    // if we relied on the click.
+    await input.press('Enter');
     log.events.push({ kind: 'answer_submitted', index, text: answer, intent, at: now() });
 
     const response = await responsePromise;

--- a/scripts/playtest/lib/player.ts
+++ b/scripts/playtest/lib/player.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 
 import type { BrowserContext, ConsoleMessage, Page, Request, Response } from 'playwright';
 
+import { quickWrongAnswer } from './claude';
 import { canonicalAnswerFor } from './seed';
 import { screenshotDir } from './manifest';
 
@@ -34,8 +35,18 @@ async function snap(page: Page, runId: string, label: string, log: PlayerLog): P
   log.events.push({ kind: 'screenshot', file, note: label, at: now() });
 }
 
-function wrongAnswerFor(canonical: string): string {
-  return `definitely-not-${canonical.toLowerCase()}-${Math.floor(Math.random() * 1000)}`;
+async function wrongAnswerFor(canonical: string): Promise<string> {
+  // Prefer a Haiku-generated near-miss (same domain, factually off) so the
+  // grader is being exercised on realistic inputs — "Venus" for Mercury,
+  // "1990" for the Berlin Wall — not on obvious junk strings. Falls back to
+  // a deterministic junk string when ANTHROPIC_API_KEY isn't set.
+  const candidate = await quickWrongAnswer(canonical);
+  const normalizedCandidate = candidate.trim().toLowerCase();
+  const normalizedCanonical = canonical.trim().toLowerCase();
+  if (!normalizedCandidate || normalizedCandidate === normalizedCanonical) {
+    return `definitely-not-${normalizedCanonical}-${Math.floor(Math.random() * 1000)}`;
+  }
+  return candidate.trim();
 }
 
 function pickIntent(rate: number): 'correct' | 'wrong' {
@@ -74,9 +85,11 @@ export async function playGame(params: {
   });
   page.on('response', (response: Response) => {
     const status = response.status();
-    if (status >= 500) {
-      log.events.push({ kind: 'network_error', url: response.url(), status, at: now() });
-    }
+    if (status < 400) return;
+    const u = response.url();
+    // favicon.ico 404s on dev are noise; everything else is signal.
+    if (u.endsWith('/favicon.ico')) return;
+    log.events.push({ kind: 'network_error', url: u, status, at: now() });
   });
 
   const url = `${params.baseUrl}/games/${params.gameId}`;
@@ -120,7 +133,7 @@ export async function playGame(params: {
     const canonical = canonicalAnswerFor(questionText);
     const answer = intent === 'correct' && canonical
       ? canonical
-      : wrongAnswerFor(canonical ?? 'unknown');
+      : await wrongAnswerFor(canonical ?? 'unknown');
 
     const input = page.locator('input[placeholder="Your answer..."]');
     await input.fill(answer);

--- a/scripts/playtest/lib/preflight.ts
+++ b/scripts/playtest/lib/preflight.ts
@@ -1,0 +1,26 @@
+import type { PlaytestArgs } from './args';
+
+const MAX_PLAYERS = 6;
+
+export function preflight(args: PlaytestArgs): void {
+  if (process.env.NODE_ENV === 'production') {
+    throw new Error(
+      '[playtest] refusing to run with NODE_ENV=production. This harness creates and deletes real rows in the configured DATABASE_URL.',
+    );
+  }
+  if (!process.env.DATABASE_URL) {
+    throw new Error('[playtest] DATABASE_URL is required.');
+  }
+  if (args.players < 1 || args.players > MAX_PLAYERS) {
+    throw new Error(
+      `[playtest] --players must be between 1 and ${MAX_PLAYERS} ` +
+        `(the Postgres pool is capped at 5 in src/server/db/index.ts; more players overload it).`,
+    );
+  }
+  if (args.questions < 1 || args.questions > 5) {
+    throw new Error('[playtest] --questions must be between 1 and 5 (matches Joshing game limit).');
+  }
+  if (args.correctnessRate < 0 || args.correctnessRate > 1) {
+    throw new Error('[playtest] --correctness-rate must be between 0 and 1.');
+  }
+}

--- a/scripts/playtest/lib/report.ts
+++ b/scripts/playtest/lib/report.ts
@@ -1,0 +1,111 @@
+import { writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+import type { ReviewResult } from './claude';
+import type { PlaytestManifest } from './manifest';
+import type { PlayerLog } from './player';
+import { reportPath, runDir } from './manifest';
+
+export function writeReport(params: {
+  manifest: PlaytestManifest;
+  logs: PlayerLog[];
+  review: ReviewResult;
+}): string {
+  const { manifest, logs, review } = params;
+  const lines: string[] = [];
+  const rd = runDir(manifest.runId);
+
+  lines.push(`# Playtest report — ${manifest.runId}`);
+  lines.push('');
+  lines.push(`- **Game ID:** \`${manifest.gameId}\``);
+  lines.push(`- **Inviter:** ${manifest.inviter.displayName} (\`${manifest.inviter.id}\`)`);
+  lines.push(`- **Players:** ${manifest.players.length}`);
+  lines.push(`- **Questions:** ${manifest.questionIds.length}`);
+  lines.push(`- **Base URL:** ${manifest.baseUrl}`);
+  lines.push(`- **Created:** ${manifest.createdAt}`);
+  lines.push('');
+  lines.push('## Cleanup');
+  lines.push('');
+  lines.push(`Run \`npm run smoke:gameplay -- --clean --run-id=${manifest.runId}\` to remove the test rows for this run.`);
+  lines.push('');
+  lines.push(`Manifest: \`${path.relative(process.cwd(), path.join(rd, 'manifest.json'))}\``);
+  lines.push('');
+
+  lines.push('## LLM review');
+  lines.push('');
+  lines.push(`**Summary:** ${review.summary || '_(no summary)_'}`);
+  lines.push('');
+  if (review.bugs.length > 0) {
+    lines.push('### Bugs');
+    lines.push('');
+    for (const item of review.bugs) lines.push(`- ${item}`);
+    lines.push('');
+  }
+  if (review.uxNotes.length > 0) {
+    lines.push('### UX notes');
+    lines.push('');
+    for (const item of review.uxNotes) lines.push(`- ${item}`);
+    lines.push('');
+  }
+  if (review.observations.length > 0) {
+    lines.push('### Observations');
+    lines.push('');
+    for (const item of review.observations) lines.push(`- ${item}`);
+    lines.push('');
+  }
+
+  lines.push('## Per-player timelines');
+  for (const log of logs) {
+    lines.push('');
+    lines.push(`### ${log.displayName} (\`${log.playerId}\`)`);
+    lines.push('');
+    for (const event of log.events) {
+      switch (event.kind) {
+        case 'navigated':
+          lines.push(`- \`${event.at}\` navigated → ${event.url}`);
+          break;
+        case 'question_seen':
+          lines.push(`- \`${event.at}\` Q${event.index}: ${event.text}`);
+          break;
+        case 'answer_submitted':
+          lines.push(`- \`${event.at}\` submitted (${event.intent}): "${event.text}"`);
+          break;
+        case 'result_observed':
+          lines.push(`- \`${event.at}\` result: ${event.correct ? '✓ correct' : '✗ wrong'}`);
+          break;
+        case 'console':
+          lines.push(`- \`${event.at}\` console.${event.level}: ${event.text}`);
+          break;
+        case 'network_error':
+          lines.push(`- \`${event.at}\` NETWORK ${event.status ?? 'failed'} ${event.url}`);
+          break;
+        case 'screenshot':
+          lines.push(`- \`${event.at}\` screenshot (${event.note}): \`${path.relative(process.cwd(), event.file)}\``);
+          break;
+        case 'finished':
+          lines.push(`- \`${event.at}\` finished`);
+          break;
+        case 'error':
+          lines.push(`- \`${event.at}\` ERROR: ${event.message}`);
+          break;
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push('## Screenshots');
+  lines.push('');
+  const allShots = logs.flatMap((log) =>
+    log.events
+      .filter((e): e is Extract<PlayerLog['events'][number], { kind: 'screenshot' }> => e.kind === 'screenshot')
+      .map((e) => ({ player: log.displayName, file: e.file, note: e.note })),
+  );
+  for (const shot of allShots) {
+    const rel = path.relative(path.dirname(reportPath(manifest.runId)), shot.file);
+    lines.push(`![${shot.player} — ${shot.note}](${rel})`);
+  }
+
+  const out = reportPath(manifest.runId);
+  writeFileSync(out, lines.join('\n'));
+  return out;
+}

--- a/scripts/playtest/lib/report.ts
+++ b/scripts/playtest/lib/report.ts
@@ -2,13 +2,12 @@ import { writeFileSync } from 'node:fs';
 import path from 'node:path';
 
 import type { ReviewResult } from './claude';
-import type { PlaytestManifest } from './manifest';
-import type { PlayerLog } from './player';
-import { reportPath, runDir } from './manifest';
+import { reportPath, runDir, type PlaytestManifest } from './manifest';
+import type { ScenarioLog } from './scenario-context';
 
 export function writeReport(params: {
   manifest: PlaytestManifest;
-  logs: PlayerLog[];
+  logs: ScenarioLog[];
   review: ReviewResult;
 }): string {
   const { manifest, logs, review } = params;
@@ -17,18 +16,29 @@ export function writeReport(params: {
 
   lines.push(`# Playtest report — ${manifest.runId}`);
   lines.push('');
-  lines.push(`- **Game ID:** \`${manifest.gameId}\``);
-  lines.push(`- **Inviter:** ${manifest.inviter.displayName} (\`${manifest.inviter.id}\`)`);
-  lines.push(`- **Players:** ${manifest.players.length}`);
-  lines.push(`- **Questions:** ${manifest.questionIds.length}`);
+  lines.push(`- **Run ID:** \`${manifest.runId}\``);
   lines.push(`- **Base URL:** ${manifest.baseUrl}`);
   lines.push(`- **Created:** ${manifest.createdAt}`);
+  lines.push(`- **Scenarios run:** ${logs.length}`);
+  lines.push(`- **Rows tracked:** ${manifest.rows.length}`);
   lines.push('');
   lines.push('## Cleanup');
   lines.push('');
   lines.push(`Run \`npm run smoke:gameplay -- --clean --run-id=${manifest.runId}\` to remove the test rows for this run.`);
   lines.push('');
   lines.push(`Manifest: \`${path.relative(process.cwd(), path.join(rd, 'manifest.json'))}\``);
+  lines.push('');
+
+  lines.push('## Summary');
+  lines.push('');
+  lines.push('| Scenario | Status | Duration | Assertions (pass/fail) | Events |');
+  lines.push('| --- | --- | ---: | --- | ---: |');
+  for (const log of logs) {
+    const passes = log.assertions.filter((a) => a.kind === 'assert_pass').length;
+    const fails = log.assertions.filter((a) => a.kind === 'assert_fail').length;
+    const statusIcon = log.status === 'pass' ? '✓ pass' : log.status === 'fail' ? '✗ fail' : '— skip';
+    lines.push(`| \`${log.scenarioId}\` | ${statusIcon} | ${log.durationMs} ms | ${passes}/${fails} | ${log.events.length} |`);
+  }
   lines.push('');
 
   lines.push('## LLM review');
@@ -54,10 +64,30 @@ export function writeReport(params: {
     lines.push('');
   }
 
-  lines.push('## Per-player timelines');
   for (const log of logs) {
+    lines.push(`## ${log.displayName} (\`${log.scenarioId}\`)`);
     lines.push('');
-    lines.push(`### ${log.displayName} (\`${log.playerId}\`)`);
+    lines.push(`Status: **${log.status}** — ${log.durationMs} ms`);
+    if (log.errorMessage) {
+      lines.push('');
+      lines.push(`> Scenario threw: \`${log.errorMessage}\``);
+    }
+    lines.push('');
+
+    if (log.assertions.length > 0) {
+      lines.push('### Assertions');
+      lines.push('');
+      for (const a of log.assertions) {
+        if (a.kind === 'assert_pass') {
+          lines.push(`- ✓ ${a.label}`);
+        } else {
+          lines.push(`- ✗ **${a.label}** — ${a.message}`);
+        }
+      }
+      lines.push('');
+    }
+
+    lines.push('### Timeline');
     lines.push('');
     for (const event of log.events) {
       switch (event.kind) {
@@ -90,19 +120,18 @@ export function writeReport(params: {
           break;
       }
     }
-  }
 
-  lines.push('');
-  lines.push('## Screenshots');
-  lines.push('');
-  const allShots = logs.flatMap((log) =>
-    log.events
-      .filter((e): e is Extract<PlayerLog['events'][number], { kind: 'screenshot' }> => e.kind === 'screenshot')
-      .map((e) => ({ player: log.displayName, file: e.file, note: e.note })),
-  );
-  for (const shot of allShots) {
-    const rel = path.relative(path.dirname(reportPath(manifest.runId)), shot.file);
-    lines.push(`![${shot.player} — ${shot.note}](${rel})`);
+    const shots = log.events.filter((e): e is Extract<typeof e, { kind: 'screenshot' }> => e.kind === 'screenshot');
+    if (shots.length > 0) {
+      lines.push('');
+      lines.push('### Screenshots');
+      lines.push('');
+      for (const shot of shots) {
+        const rel = path.relative(path.dirname(reportPath(manifest.runId)), shot.file);
+        lines.push(`![${log.scenarioId} — ${shot.note}](${rel})`);
+      }
+    }
+    lines.push('');
   }
 
   const out = reportPath(manifest.runId);

--- a/scripts/playtest/lib/scenario-context.ts
+++ b/scripts/playtest/lib/scenario-context.ts
@@ -1,0 +1,81 @@
+import type { Browser } from 'playwright';
+
+import type { PlaytestArgs } from './args';
+import type {
+  PlaytestManifest,
+  TrackedDailyQueue,
+  TrackedFriendship,
+  TrackedGame,
+  TrackedInvitation,
+  TrackedQuestion,
+  TrackedUser,
+} from './manifest';
+import type { PlayerEvent } from './player';
+
+export type ScenarioStatus = 'pass' | 'fail' | 'skip';
+
+export type AssertionResult =
+  | { kind: 'assert_pass'; label: string; at: string }
+  | { kind: 'assert_fail'; label: string; message: string; at: string };
+
+export type ScenarioLog = {
+  scenarioId: string;
+  displayName: string;
+  status: ScenarioStatus;
+  durationMs: number;
+  events: PlayerEvent[];
+  assertions: AssertionResult[];
+  notes?: string;
+  errorMessage?: string;
+};
+
+export class ManifestBuilder {
+  constructor(private readonly manifest: PlaytestManifest) {}
+
+  trackUser(row: Omit<TrackedUser, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'user', ...row });
+  }
+  trackQuestion(row: Omit<TrackedQuestion, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'question', ...row });
+  }
+  trackInvitation(row: Omit<TrackedInvitation, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'invitation', ...row });
+  }
+  trackFriendship(row: Omit<TrackedFriendship, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'friendship', ...row });
+  }
+  trackGame(row: Omit<TrackedGame, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'game', ...row });
+  }
+  trackDailyQueue(row: Omit<TrackedDailyQueue, 'kind'>): void {
+    this.manifest.rows.push({ kind: 'daily-queue', ...row });
+  }
+
+  putScenarioData(scenarioId: string, key: string, value: unknown): void {
+    if (!this.manifest.scenarioData[scenarioId]) {
+      this.manifest.scenarioData[scenarioId] = {};
+    }
+    this.manifest.scenarioData[scenarioId][key] = value;
+  }
+
+  raw(): PlaytestManifest {
+    return this.manifest;
+  }
+}
+
+export type ScenarioContext = {
+  baseUrl: string;
+  runId: string;
+  browser: Browser;
+  manifest: ManifestBuilder;
+  screenshotDir: string;
+  args: PlaytestArgs;
+  scenarioId: string;
+};
+
+export type Scenario = {
+  id: string;
+  displayName: string;
+  description: string;
+  run(ctx: ScenarioContext): Promise<ScenarioLog>;
+};

--- a/scripts/playtest/lib/seed.ts
+++ b/scripts/playtest/lib/seed.ts
@@ -1,0 +1,171 @@
+import { randomUUID } from 'node:crypto';
+
+import { eq } from 'drizzle-orm';
+
+import { db, questions, users } from '@/server/db';
+import { createJoshingGame } from '@/server/db/queries/joshing-game';
+
+import { authenticateAsTestUser } from './auth';
+import type { PlaytestManifest } from './manifest';
+
+const PHONE_BASE = '+15557000000';
+
+function phoneFor(index: number): string {
+  const tail = PHONE_BASE.length - String(index).length;
+  return PHONE_BASE.slice(0, tail) + String(index);
+}
+
+type SeededQuestion = {
+  questionText: string;
+  answerText: string;
+  acceptedAlternatives: string[];
+  category: 'literature' | 'science' | 'history';
+  broadCategory: string;
+  canonicalSubcategory: string;
+};
+
+const TEST_QUESTIONS: SeededQuestion[] = [
+  {
+    questionText: '[TEST] What is the name of the dog in Peanuts?',
+    answerText: 'Snoopy',
+    acceptedAlternatives: ['snoopy'],
+    category: 'literature',
+    broadCategory: 'Pop Culture',
+    canonicalSubcategory: 'Mid-Century Newspaper Comics',
+  },
+  {
+    questionText: '[TEST] What planet is closest to the Sun?',
+    answerText: 'Mercury',
+    acceptedAlternatives: ['mercury'],
+    category: 'science',
+    broadCategory: 'Science',
+    canonicalSubcategory: 'Inner Planets',
+  },
+  {
+    questionText: '[TEST] In what year did the Berlin Wall fall?',
+    answerText: '1989',
+    acceptedAlternatives: ['nineteen eighty-nine'],
+    category: 'history',
+    broadCategory: 'History',
+    canonicalSubcategory: 'Cold War Endgame',
+  },
+  {
+    questionText: '[TEST] Who painted the Mona Lisa?',
+    answerText: 'Leonardo da Vinci',
+    acceptedAlternatives: ['da vinci', 'leonardo'],
+    category: 'literature',
+    broadCategory: 'Visual Arts',
+    canonicalSubcategory: 'Italian Renaissance Painting',
+  },
+  {
+    questionText: '[TEST] What is the chemical symbol for gold?',
+    answerText: 'Au',
+    acceptedAlternatives: ['au'],
+    category: 'science',
+    broadCategory: 'Science',
+    canonicalSubcategory: 'Periodic Table Symbols',
+  },
+];
+
+async function provisionUser(params: {
+  phone: string;
+  displayName: string;
+}): Promise<{ id: string }> {
+  // Mark onboardingComplete so the edge proxy doesn't redirect to /onboarding.
+  // refresh-onboarding-claim will re-mint the JWT to match on first nav.
+  const id = randomUUID();
+  await db
+    .insert(users)
+    .values({
+      id,
+      phoneNumber: params.phone,
+      displayName: params.displayName,
+      phoneVerified: true,
+      onboardingComplete: true,
+    })
+    .onConflictDoNothing({ target: users.phoneNumber });
+
+  const [existing] = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.phoneNumber, params.phone))
+    .limit(1);
+  if (!existing) {
+    throw new Error(`[playtest/seed] failed to provision user for ${params.phone}`);
+  }
+  return existing;
+}
+
+async function insertQuestions(
+  inviterId: string,
+  count: number,
+): Promise<string[]> {
+  const picks = TEST_QUESTIONS.slice(0, count);
+  if (picks.length < count) {
+    throw new Error(`[playtest/seed] only ${TEST_QUESTIONS.length} canned questions available; requested ${count}`);
+  }
+
+  const rows = await db
+    .insert(questions)
+    .values(
+      picks.map((q) => ({
+        creatorId: inviterId,
+        questionText: q.questionText,
+        answerText: q.answerText,
+        acceptedAlternatives: q.acceptedAlternatives,
+        category: q.category,
+        broadCategory: q.broadCategory,
+        canonicalSubcategory: q.canonicalSubcategory,
+        questionType: 'factual' as const,
+        status: 'verified' as const,
+        verified: true,
+        visibility: 'friends' as const,
+      })),
+    )
+    .returning({ id: questions.id });
+
+  return rows.map((row) => row.id);
+}
+
+export async function seed(params: {
+  runId: string;
+  baseUrl: string;
+  numPlayers: number;
+  numQuestions: number;
+}): Promise<PlaytestManifest> {
+  const inviterPhone = phoneFor(0);
+  const inviter = await provisionUser({ phone: inviterPhone, displayName: '[TEST] Inviter' });
+
+  const players: PlaytestManifest['players'] = [];
+  for (let i = 1; i <= params.numPlayers; i += 1) {
+    const phone = phoneFor(i);
+    const displayName = `[TEST] Player ${i}`;
+    const user = await provisionUser({ phone, displayName });
+    const cookie = await authenticateAsTestUser(params.baseUrl, phone);
+    players.push({ id: user.id, phone, displayName, sessionCookie: cookie.value });
+  }
+
+  const questionIds = await insertQuestions(inviter.id, params.numQuestions);
+
+  const { id: gameId } = await createJoshingGame({
+    title: '[TEST] Automated Playtest',
+    creatorId: inviter.id,
+    recipientIds: players.map((p) => p.id),
+    questionIds,
+  });
+
+  return {
+    runId: params.runId,
+    baseUrl: params.baseUrl,
+    createdAt: new Date().toISOString(),
+    inviter: { id: inviter.id, phone: inviterPhone, displayName: '[TEST] Inviter' },
+    players,
+    questionIds,
+    gameId,
+  };
+}
+
+export function canonicalAnswerFor(questionText: string): string | null {
+  const match = TEST_QUESTIONS.find((q) => q.questionText === questionText);
+  return match?.answerText ?? null;
+}

--- a/scripts/playtest/lib/seed.ts
+++ b/scripts/playtest/lib/seed.ts
@@ -5,17 +5,17 @@ import { eq } from 'drizzle-orm';
 import { db, questions, users } from '@/server/db';
 import { createJoshingGame } from '@/server/db/queries/joshing-game';
 
-import { authenticateAsTestUser } from './auth';
-import type { PlaytestManifest } from './manifest';
+import { authenticateAsTestUser, type SessionCookie } from './auth';
+import type { ManifestBuilder } from './scenario-context';
 
 const PHONE_BASE = '+15557000000';
 
-function phoneFor(index: number): string {
+export function phoneFor(index: number): string {
   const tail = PHONE_BASE.length - String(index).length;
   return PHONE_BASE.slice(0, tail) + String(index);
 }
 
-type SeededQuestion = {
+export type SeededQuestion = {
   questionText: string;
   answerText: string;
   acceptedAlternatives: string[];
@@ -24,7 +24,7 @@ type SeededQuestion = {
   canonicalSubcategory: string;
 };
 
-const TEST_QUESTIONS: SeededQuestion[] = [
+export const TEST_QUESTIONS: SeededQuestion[] = [
   {
     questionText: '[TEST] What is the name of the dog in Peanuts?',
     answerText: 'Snoopy',
@@ -67,12 +67,14 @@ const TEST_QUESTIONS: SeededQuestion[] = [
   },
 ];
 
-async function provisionUser(params: {
+export type ProvisionedUser = { id: string; phone: string; displayName: string };
+
+export async function provisionTestUser(params: {
   phone: string;
   displayName: string;
-}): Promise<{ id: string }> {
-  // Mark onboardingComplete so the edge proxy doesn't redirect to /onboarding.
-  // refresh-onboarding-claim will re-mint the JWT to match on first nav.
+  scenarioId: string;
+  manifest: ManifestBuilder;
+}): Promise<ProvisionedUser> {
   const id = randomUUID();
   await db
     .insert(users)
@@ -85,31 +87,50 @@ async function provisionUser(params: {
     })
     .onConflictDoNothing({ target: users.phoneNumber });
 
-  const [existing] = await db
+  const [row] = await db
     .select({ id: users.id })
     .from(users)
     .where(eq(users.phoneNumber, params.phone))
     .limit(1);
-  if (!existing) {
+  if (!row) {
     throw new Error(`[playtest/seed] failed to provision user for ${params.phone}`);
   }
-  return existing;
+
+  params.manifest.trackUser({
+    id: row.id,
+    phone: params.phone,
+    displayName: params.displayName,
+    scenarioId: params.scenarioId,
+  });
+
+  return { id: row.id, phone: params.phone, displayName: params.displayName };
 }
 
-async function insertQuestions(
-  inviterId: string,
-  count: number,
-): Promise<string[]> {
-  const picks = TEST_QUESTIONS.slice(0, count);
-  if (picks.length < count) {
-    throw new Error(`[playtest/seed] only ${TEST_QUESTIONS.length} canned questions available; requested ${count}`);
+export async function authenticateAndCookie(
+  baseUrl: string,
+  phone: string,
+): Promise<SessionCookie> {
+  return authenticateAsTestUser(baseUrl, phone);
+}
+
+export async function insertTestQuestions(params: {
+  creatorId: string;
+  count: number;
+  scenarioId: string;
+  manifest: ManifestBuilder;
+}): Promise<string[]> {
+  const picks = TEST_QUESTIONS.slice(0, params.count);
+  if (picks.length < params.count) {
+    throw new Error(
+      `[playtest/seed] only ${TEST_QUESTIONS.length} canned questions available; requested ${params.count}`,
+    );
   }
 
   const rows = await db
     .insert(questions)
     .values(
       picks.map((q) => ({
-        creatorId: inviterId,
+        creatorId: params.creatorId,
         questionText: q.questionText,
         answerText: q.answerText,
         acceptedAlternatives: q.acceptedAlternatives,
@@ -124,45 +145,33 @@ async function insertQuestions(
     )
     .returning({ id: questions.id });
 
+  for (const row of rows) {
+    params.manifest.trackQuestion({
+      id: row.id,
+      creatorId: params.creatorId,
+      scenarioId: params.scenarioId,
+    });
+  }
+
   return rows.map((row) => row.id);
 }
 
-export async function seed(params: {
-  runId: string;
-  baseUrl: string;
-  numPlayers: number;
-  numQuestions: number;
-}): Promise<PlaytestManifest> {
-  const inviterPhone = phoneFor(0);
-  const inviter = await provisionUser({ phone: inviterPhone, displayName: '[TEST] Inviter' });
-
-  const players: PlaytestManifest['players'] = [];
-  for (let i = 1; i <= params.numPlayers; i += 1) {
-    const phone = phoneFor(i);
-    const displayName = `[TEST] Player ${i}`;
-    const user = await provisionUser({ phone, displayName });
-    const cookie = await authenticateAsTestUser(params.baseUrl, phone);
-    players.push({ id: user.id, phone, displayName, sessionCookie: cookie.value });
-  }
-
-  const questionIds = await insertQuestions(inviter.id, params.numQuestions);
-
-  const { id: gameId } = await createJoshingGame({
-    title: '[TEST] Automated Playtest',
-    creatorId: inviter.id,
-    recipientIds: players.map((p) => p.id),
-    questionIds,
+export async function createTestGame(params: {
+  title: string;
+  creatorId: string;
+  recipientIds: string[];
+  questionIds: string[];
+  scenarioId: string;
+  manifest: ManifestBuilder;
+}): Promise<string> {
+  const { id } = await createJoshingGame({
+    title: params.title,
+    creatorId: params.creatorId,
+    recipientIds: params.recipientIds,
+    questionIds: params.questionIds,
   });
-
-  return {
-    runId: params.runId,
-    baseUrl: params.baseUrl,
-    createdAt: new Date().toISOString(),
-    inviter: { id: inviter.id, phone: inviterPhone, displayName: '[TEST] Inviter' },
-    players,
-    questionIds,
-    gameId,
-  };
+  params.manifest.trackGame({ id, scenarioId: params.scenarioId });
+  return id;
 }
 
 export function canonicalAnswerFor(questionText: string): string | null {

--- a/scripts/playtest/lib/suite.ts
+++ b/scripts/playtest/lib/suite.ts
@@ -1,0 +1,77 @@
+import type { Browser } from 'playwright';
+
+import type { PlaytestArgs } from './args';
+import { ManifestBuilder, type Scenario, type ScenarioContext, type ScenarioLog } from './scenario-context';
+import { newManifest, screenshotDir, writeManifest, type PlaytestManifest } from './manifest';
+
+export type SuiteResult = {
+  manifest: PlaytestManifest;
+  logs: ScenarioLog[];
+};
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function selectScenarios(all: Scenario[], args: PlaytestArgs): Scenario[] {
+  if (args.scenarioIds.length === 0) return all;
+  const wanted = new Set(args.scenarioIds);
+  const picked = all.filter((s) => wanted.has(s.id));
+  const missing = [...wanted].filter((id) => !all.some((s) => s.id === id));
+  if (missing.length > 0) {
+    throw new Error(
+      `[playtest] unknown scenario id(s): ${missing.join(', ')}. ` +
+        `Known: ${all.map((s) => s.id).join(', ')}`,
+    );
+  }
+  return picked;
+}
+
+export async function runSuite(params: {
+  scenarios: Scenario[];
+  args: PlaytestArgs;
+  browser: Browser;
+  runId: string;
+}): Promise<SuiteResult> {
+  const manifest = newManifest(params.runId, params.args.baseUrl);
+  const builder = new ManifestBuilder(manifest);
+  const scenarios = selectScenarios(params.scenarios, params.args);
+
+  const logs: ScenarioLog[] = [];
+
+  for (const scenario of scenarios) {
+    console.log(`[playtest] scenario "${scenario.id}" — ${scenario.displayName}`);
+    const startedAt = Date.now();
+    const ctx: ScenarioContext = {
+      baseUrl: params.args.baseUrl,
+      runId: params.runId,
+      browser: params.browser,
+      manifest: builder,
+      screenshotDir: screenshotDir(params.runId),
+      args: params.args,
+      scenarioId: scenario.id,
+    };
+    let log: ScenarioLog;
+    try {
+      log = await scenario.run(ctx);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(`[playtest] scenario "${scenario.id}" threw: ${message}`);
+      log = {
+        scenarioId: scenario.id,
+        displayName: scenario.displayName,
+        status: 'fail',
+        durationMs: Date.now() - startedAt,
+        events: [{ kind: 'error', message, at: nowIso() }],
+        assertions: [],
+        errorMessage: message,
+      };
+    }
+    logs.push(log);
+    // Persist the manifest after every scenario so a crash mid-suite
+    // still leaves a usable cleanup target.
+    writeManifest(manifest);
+  }
+
+  return { manifest, logs };
+}

--- a/scripts/playtest/playtest.ts
+++ b/scripts/playtest/playtest.ts
@@ -3,14 +3,14 @@ import 'dotenv/config';
 import { pool } from '@/server/db';
 
 import { parsePlaytestArgs } from './lib/args';
-import { launchBrowser, contextForPlayer } from './lib/browser';
+import { launchBrowser } from './lib/browser';
 import { wipeTestData } from './lib/cleanup';
 import { reviewSession } from './lib/claude';
-import { ensureRunDirs, newRunId, readManifest, runDir, writeManifest } from './lib/manifest';
-import { playGame } from './lib/player';
+import { ensureRunDirs, newRunId, readManifest, runDir } from './lib/manifest';
 import { preflight } from './lib/preflight';
 import { writeReport } from './lib/report';
-import { seed } from './lib/seed';
+import { runSuite, selectScenarios } from './lib/suite';
+import { allScenarios } from './scenarios';
 
 async function main(): Promise<void> {
   const args = parsePlaytestArgs(process.argv);
@@ -28,41 +28,22 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Validate scenario ids before doing anything expensive.
+  const picked = selectScenarios(allScenarios, args);
+
   const runId = args.runId ?? newRunId();
   ensureRunDirs(runId);
   console.log(`[playtest] starting run ${runId} (audits/playtest-${runId}/)`);
-  console.log(`[playtest] seeding ${args.players} players, ${args.questions} questions against ${args.baseUrl}`);
-
-  const manifest = await seed({
-    runId,
-    baseUrl: args.baseUrl,
-    numPlayers: args.players,
-    numQuestions: args.questions,
-  });
-  writeManifest(manifest);
-  console.log(`[playtest] seeded game ${manifest.gameId}`);
+  console.log(`[playtest] running ${picked.length} scenario(s): ${picked.map((s) => s.id).join(', ')}`);
 
   const browser = await launchBrowser(args.headed);
   try {
-    const logs = [];
-    for (const player of manifest.players) {
-      console.log(`[playtest] playing as ${player.displayName}`);
-      const context = await contextForPlayer(browser, args.baseUrl, player.sessionCookie);
-      try {
-        const log = await playGame({
-          context,
-          baseUrl: args.baseUrl,
-          runId,
-          gameId: manifest.gameId,
-          playerId: player.id,
-          displayName: player.displayName,
-          correctnessRate: args.correctnessRate,
-        });
-        logs.push(log);
-      } finally {
-        await context.close();
-      }
-    }
+    const { manifest, logs } = await runSuite({
+      scenarios: picked,
+      args,
+      browser,
+      runId,
+    });
 
     console.log('[playtest] running LLM review');
     const review = await reviewSession({ logs, runId });
@@ -70,6 +51,12 @@ async function main(): Promise<void> {
     const reportFile = writeReport({ manifest, logs, review });
     console.log(`[playtest] report written → ${reportFile}`);
     console.log(`[playtest] run dir → ${runDir(runId)}`);
+
+    const failedScenarios = logs.filter((log) => log.status === 'fail');
+    if (failedScenarios.length > 0) {
+      console.error(`[playtest] ${failedScenarios.length} scenario(s) failed: ${failedScenarios.map((s) => s.scenarioId).join(', ')}`);
+      process.exitCode = 1;
+    }
 
     if (!args.keep) {
       console.log('[playtest] --keep=false: cleaning up test rows immediately');

--- a/scripts/playtest/playtest.ts
+++ b/scripts/playtest/playtest.ts
@@ -1,0 +1,92 @@
+import 'dotenv/config';
+
+import { pool } from '@/server/db';
+
+import { parsePlaytestArgs } from './lib/args';
+import { launchBrowser, contextForPlayer } from './lib/browser';
+import { wipeTestData } from './lib/cleanup';
+import { reviewSession } from './lib/claude';
+import { ensureRunDirs, newRunId, readManifest, runDir, writeManifest } from './lib/manifest';
+import { playGame } from './lib/player';
+import { preflight } from './lib/preflight';
+import { writeReport } from './lib/report';
+import { seed } from './lib/seed';
+
+async function main(): Promise<void> {
+  const args = parsePlaytestArgs(process.argv);
+  preflight(args);
+
+  if (args.clean) {
+    const runId = args.runId;
+    if (!runId) {
+      throw new Error('[playtest] --clean requires --run-id=<id>');
+    }
+    const manifest = readManifest(runId);
+    console.log(`[playtest] cleaning run ${runId}`);
+    await wipeTestData(manifest);
+    console.log(`[playtest] cleanup complete for ${runId}`);
+    return;
+  }
+
+  const runId = args.runId ?? newRunId();
+  ensureRunDirs(runId);
+  console.log(`[playtest] starting run ${runId} (audits/playtest-${runId}/)`);
+  console.log(`[playtest] seeding ${args.players} players, ${args.questions} questions against ${args.baseUrl}`);
+
+  const manifest = await seed({
+    runId,
+    baseUrl: args.baseUrl,
+    numPlayers: args.players,
+    numQuestions: args.questions,
+  });
+  writeManifest(manifest);
+  console.log(`[playtest] seeded game ${manifest.gameId}`);
+
+  const browser = await launchBrowser(args.headed);
+  try {
+    const logs = [];
+    for (const player of manifest.players) {
+      console.log(`[playtest] playing as ${player.displayName}`);
+      const context = await contextForPlayer(browser, args.baseUrl, player.sessionCookie);
+      try {
+        const log = await playGame({
+          context,
+          baseUrl: args.baseUrl,
+          runId,
+          gameId: manifest.gameId,
+          playerId: player.id,
+          displayName: player.displayName,
+          correctnessRate: args.correctnessRate,
+        });
+        logs.push(log);
+      } finally {
+        await context.close();
+      }
+    }
+
+    console.log('[playtest] running LLM review');
+    const review = await reviewSession({ logs, runId });
+
+    const reportFile = writeReport({ manifest, logs, review });
+    console.log(`[playtest] report written → ${reportFile}`);
+    console.log(`[playtest] run dir → ${runDir(runId)}`);
+
+    if (!args.keep) {
+      console.log('[playtest] --keep=false: cleaning up test rows immediately');
+      await wipeTestData(manifest);
+    } else {
+      console.log(`[playtest] retained test rows; cleanup later with --clean --run-id=${runId}`);
+    }
+  } finally {
+    await browser.close();
+  }
+}
+
+main()
+  .catch((error) => {
+    console.error('[playtest] failed:', error);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end().catch(() => undefined);
+  });

--- a/scripts/playtest/scenarios/accept-invitation.ts
+++ b/scripts/playtest/scenarios/accept-invitation.ts
@@ -80,7 +80,10 @@ async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
 
       // 2. Click through to /login?invitationToken=…
       const seeNoteLink = page.locator('a', { hasText: 'See the note' }).first();
-      await seeNoteLink.click();
+      await Promise.all([
+        page.waitForURL((url) => url.pathname.startsWith('/login'), { timeout: 10_000 }).catch(() => undefined),
+        seeNoteLink.click(),
+      ]);
       await page.waitForLoadState('networkidle').catch(() => undefined);
       events.push({ kind: 'navigated', url: page.url(), at: now() });
       asserts.check(

--- a/scripts/playtest/scenarios/accept-invitation.ts
+++ b/scripts/playtest/scenarios/accept-invitation.ts
@@ -1,0 +1,184 @@
+import path from 'node:path';
+
+import { and, eq, isNotNull, or } from 'drizzle-orm';
+
+import { db, friendInvitations, friendships, users } from '@/server/db';
+import { createFriendInvitation } from '@/server/friends/invitations';
+
+import { AssertionRecorder } from '../lib/asserts';
+import type { PlayerEvent } from '../lib/player';
+import type { Scenario, ScenarioContext, ScenarioLog } from '../lib/scenario-context';
+import { phoneFor, provisionTestUser } from '../lib/seed';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const INVITEE_PHONE = phoneFor(101);
+const INVITEE_DISPLAY_NAME = '[TEST] Invitee Carol';
+
+async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
+  const startedAt = Date.now();
+  const asserts = new AssertionRecorder();
+  const events: PlayerEvent[] = [];
+
+  try {
+    // Need a fresh inviter for this scenario so we don't depend on
+    // send-invitation having run first.
+    const alice = await provisionTestUser({
+      phone: phoneFor(51),
+      displayName: '[TEST] Alice (accept-invitation)',
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    // Seed an invitation directly (rather than via the HTTP route the
+    // send-invitation scenario covers). This keeps the scenarios independent
+    // and lets us run --scenario=accept-invitation in isolation.
+    const invitation = await createFriendInvitation({
+      inviterUserId: alice.id,
+      inviteePhone: INVITEE_PHONE,
+      inviteeDisplayName: INVITEE_DISPLAY_NAME,
+      preSeededInterests: ['Trivia'],
+    });
+    ctx.manifest.trackInvitation({
+      id: invitation.id,
+      inviterUserId: alice.id,
+      inviteePhone: INVITEE_PHONE,
+      scenarioId: ctx.scenarioId,
+    });
+
+    // New browser context — Carol has no existing session.
+    const browserCtx = await ctx.browser.newContext({
+      viewport: { width: 390, height: 844 },
+      userAgent:
+        'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    });
+
+    try {
+      const page = await browserCtx.newPage();
+
+      // 1. Visit the invite landing.
+      await page.goto(`${ctx.baseUrl}/invite/${invitation.token}`, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      events.push({ kind: 'navigated', url: page.url(), at: now() });
+      const landingShot = path.join(ctx.screenshotDir, 'accept-invitation--landing.png');
+      await page.screenshot({ path: landingShot, fullPage: false });
+      events.push({ kind: 'screenshot', file: landingShot, note: 'invite landing', at: now() });
+
+      const landingText = await page.locator('body').innerText().catch(() => '');
+      asserts.check(
+        'invite landing names inviter',
+        landingText.includes('[TEST] Alice'),
+        `landing text did not include inviter name; got: ${landingText.slice(0, 200)}`,
+      );
+      asserts.check(
+        'invite landing has "See the note" link',
+        landingText.includes('See the note'),
+        'expected "See the note" text on landing',
+      );
+
+      // 2. Click through to /login?invitationToken=…
+      const seeNoteLink = page.locator('a', { hasText: 'See the note' }).first();
+      await seeNoteLink.click();
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      events.push({ kind: 'navigated', url: page.url(), at: now() });
+      asserts.check(
+        'landed on /login with invitationToken',
+        page.url().includes('/login') && page.url().includes('invitationToken='),
+        `unexpected URL after click: ${page.url()}`,
+      );
+
+      // 3. Enter phone and request OTP.
+      const phoneInput = page.locator('input[placeholder="555-123-4567"]').first();
+      await phoneInput.waitFor({ state: 'visible', timeout: 10_000 });
+      await phoneInput.fill(INVITEE_PHONE);
+      await phoneInput.press('Enter');
+
+      // 4. Wait for the code input to appear, then submit magic code '000000'.
+      const codeInput = page.locator('input[placeholder="000000"]').first();
+      await codeInput.waitFor({ state: 'visible', timeout: 10_000 });
+      await codeInput.fill('000000');
+      const verifyResponsePromise = page.waitForResponse('**/api/auth/verify-otp', { timeout: 15_000 });
+      await codeInput.press('Enter');
+      const verifyResponse = await verifyResponsePromise.catch(() => null);
+      asserts.expectTruthy('/api/auth/verify-otp response observed', !!verifyResponse);
+      if (verifyResponse) {
+        asserts.expectEqual('verify-otp returned 200', verifyResponse.status(), 200);
+      }
+
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      const postOtpShot = path.join(ctx.screenshotDir, 'accept-invitation--post-otp.png');
+      await page.screenshot({ path: postOtpShot, fullPage: false });
+      events.push({ kind: 'screenshot', file: postOtpShot, note: 'post-otp', at: now() });
+
+      // 5. DB assertions: Carol user row exists; invitation accepted; friendship active.
+      const [carol] = await db
+        .select({ id: users.id, displayName: users.displayName })
+        .from(users)
+        .where(eq(users.phoneNumber, INVITEE_PHONE))
+        .limit(1);
+      asserts.expectTruthy('Carol user row created', !!carol);
+      if (carol) {
+        ctx.manifest.trackUser({
+          id: carol.id,
+          phone: INVITEE_PHONE,
+          displayName: carol.displayName ?? INVITEE_DISPLAY_NAME,
+          scenarioId: ctx.scenarioId,
+        });
+
+        const [acceptedRow] = await db
+          .select({ id: friendInvitations.id, acceptedAt: friendInvitations.acceptedAt, inviteeUserId: friendInvitations.inviteeUserId })
+          .from(friendInvitations)
+          .where(and(eq(friendInvitations.id, invitation.id), isNotNull(friendInvitations.acceptedAt)))
+          .limit(1);
+        asserts.expectTruthy('invitation row marked accepted', !!acceptedRow);
+        if (acceptedRow) asserts.expectEqual('invitation.inviteeUserId is Carol.id', acceptedRow.inviteeUserId, carol.id);
+
+        const [friendship] = await db
+          .select({ id: friendships.id, status: friendships.status, formedVia: friendships.formedVia })
+          .from(friendships)
+          .where(or(
+            and(eq(friendships.userAId, alice.id), eq(friendships.userBId, carol.id)),
+            and(eq(friendships.userAId, carol.id), eq(friendships.userBId, alice.id)),
+          ))
+          .limit(1);
+        asserts.expectTruthy('friendship row created', !!friendship);
+        if (friendship) {
+          ctx.manifest.trackFriendship({ id: friendship.id, scenarioId: ctx.scenarioId });
+          asserts.expectEqual('friendship status active', friendship.status, 'active');
+          asserts.expectEqual('friendship formedVia invitation', friendship.formedVia, 'invitation');
+        }
+      }
+
+      // 6. Confirm a session cookie was set.
+      const cookies = await browserCtx.cookies();
+      const sessionCookie = cookies.find((c) => c.name === 'joshing_session');
+      asserts.expectTruthy('joshing_session cookie set', !!sessionCookie?.value);
+
+      await page.close();
+    } finally {
+      await browserCtx.close();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    asserts.fail('accept-invitation scenario threw', message);
+    events.push({ kind: 'error', message, at: now() });
+  }
+
+  return {
+    scenarioId: ctx.scenarioId,
+    displayName: 'Accept a friend invitation end-to-end',
+    status: asserts.hasFailures() ? 'fail' : 'pass',
+    durationMs: Date.now() - startedAt,
+    events,
+    assertions: asserts.results,
+  };
+}
+
+export const acceptInvitationScenario: Scenario = {
+  id: 'accept-invitation',
+  displayName: 'Accept a friend invitation end-to-end',
+  description: 'Open /invite/<token> in a fresh context, complete OTP signup, verify Friendship row exists.',
+  run,
+};

--- a/scripts/playtest/scenarios/author-question.ts
+++ b/scripts/playtest/scenarios/author-question.ts
@@ -1,0 +1,100 @@
+import path from 'node:path';
+
+import { and, eq, like } from 'drizzle-orm';
+
+import { db, questions } from '@/server/db';
+
+import { AssertionRecorder } from '../lib/asserts';
+import { contextForPlayer } from '../lib/browser';
+import type { PlayerEvent } from '../lib/player';
+import type { Scenario, ScenarioContext, ScenarioLog } from '../lib/scenario-context';
+import { authenticateAndCookie, phoneFor, provisionTestUser } from '../lib/seed';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const QUESTION_TEXT = '[TEST] What is the capital of France?';
+const ANSWER_TEXT = 'Paris';
+
+async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
+  const startedAt = Date.now();
+  const asserts = new AssertionRecorder();
+  const events: PlayerEvent[] = [];
+
+  try {
+    const alice = await provisionTestUser({
+      phone: phoneFor(53),
+      displayName: '[TEST] Alice (author)',
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    const cookie = await authenticateAndCookie(ctx.baseUrl, alice.phone);
+    const browserCtx = await contextForPlayer(ctx.browser, ctx.baseUrl, cookie.value);
+
+    try {
+      const page = await browserCtx.newPage();
+      await page.goto(`${ctx.baseUrl}/questions`, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      events.push({ kind: 'navigated', url: page.url(), at: now() });
+
+      const shot = path.join(ctx.screenshotDir, 'author-question--page.png');
+      await page.screenshot({ path: shot, fullPage: false });
+      events.push({ kind: 'screenshot', file: shot, note: 'questions page', at: now() });
+
+      // Hit the create API via the authenticated browser context. The full
+      // /questions UI has multiple steps including LLM-assisted answer
+      // suggestion; driving it via the API still exercises auth, validation,
+      // categorization, and DB writes.
+      const response = await page.request.post(`${ctx.baseUrl}/api/questions`, {
+        data: {
+          text: QUESTION_TEXT,
+          correctAnswer: ANSWER_TEXT,
+          alternateAnswers: ['paris'],
+          verified: true,
+        },
+      });
+      const body = (await response.json().catch(() => null)) as { question?: { id: string } } | null;
+
+      asserts.expectEqual('POST /api/questions returns 2xx', Math.floor(response.status() / 100), 2);
+      asserts.expectTruthy('response contains question.id', typeof body?.question?.id === 'string');
+
+      // DB-level: the row exists with the right creatorId.
+      const [row] = await db
+        .select({ id: questions.id, creatorId: questions.creatorId, source: questions.source })
+        .from(questions)
+        .where(and(eq(questions.creatorId, alice.id), like(questions.questionText, '[TEST]%')))
+        .limit(1);
+      asserts.expectTruthy('question row exists with creatorId=Alice', !!row);
+      if (row) {
+        ctx.manifest.trackQuestion({ id: row.id, creatorId: alice.id, scenarioId: ctx.scenarioId });
+        asserts.expectEqual('question.source is authored', row.source, 'authored');
+      }
+
+      await page.close();
+    } finally {
+      await browserCtx.close();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    asserts.fail('author-question scenario threw', message);
+    events.push({ kind: 'error', message, at: now() });
+  }
+
+  return {
+    scenarioId: ctx.scenarioId,
+    displayName: 'Author a new question',
+    status: asserts.hasFailures() ? 'fail' : 'pass',
+    durationMs: Date.now() - startedAt,
+    events,
+    assertions: asserts.results,
+  };
+}
+
+export const authorQuestionScenario: Scenario = {
+  id: 'author-question',
+  displayName: 'Author a new question',
+  description: 'A test user POSTs to /api/questions and the question row appears with source=authored.',
+  run,
+};

--- a/scripts/playtest/scenarios/author-question.ts
+++ b/scripts/playtest/scenarios/author-question.ts
@@ -55,10 +55,33 @@ async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
           verified: true,
         },
       });
-      const body = (await response.json().catch(() => null)) as { question?: { id: string } } | null;
+      const bodyText = await response.text().catch(() => '');
+      const body = (() => {
+        try { return JSON.parse(bodyText) as { question?: { id: string }; error?: string; message?: string }; }
+        catch { return null; }
+      })();
 
-      asserts.expectEqual('POST /api/questions returns 2xx', Math.floor(response.status() / 100), 2);
-      asserts.expectTruthy('response contains question.id', typeof body?.question?.id === 'string');
+      const status = response.status();
+      const ok2xx = Math.floor(status / 100) === 2;
+      if (!ok2xx) {
+        // Surface the actual error body so the report tells us exactly
+        // why the route refused. The most common rejection in this
+        // environment is `category_too_generic` (422) — fires when
+        // ANTHROPIC_API_KEY is unset and the deterministic fallback
+        // can't find a hyper-specific subcategory from question text alone.
+        asserts.fail(
+          `POST /api/questions returns 2xx (got ${status})`,
+          `body: ${bodyText.slice(0, 300)}`,
+        );
+        events.push({
+          kind: 'error',
+          message: `POST /api/questions returned ${status}: ${bodyText.slice(0, 300)}`,
+          at: now(),
+        });
+      } else {
+        asserts.pass(`POST /api/questions returns 2xx (got ${status})`);
+        asserts.expectTruthy('response contains question.id', typeof body?.question?.id === 'string');
+      }
 
       // DB-level: the row exists with the right creatorId.
       const [row] = await db

--- a/scripts/playtest/scenarios/daily-queue.ts
+++ b/scripts/playtest/scenarios/daily-queue.ts
@@ -1,0 +1,100 @@
+import path from 'node:path';
+
+import { eq } from 'drizzle-orm';
+
+import { dailyQueues, db } from '@/server/db';
+
+import { AssertionRecorder } from '../lib/asserts';
+import { contextForPlayer } from '../lib/browser';
+import type { PlayerEvent } from '../lib/player';
+import type { Scenario, ScenarioContext, ScenarioLog } from '../lib/scenario-context';
+import { authenticateAndCookie, insertTestQuestions, phoneFor, provisionTestUser } from '../lib/seed';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
+  const startedAt = Date.now();
+  const asserts = new AssertionRecorder();
+  const events: PlayerEvent[] = [];
+
+  try {
+    const alice = await provisionTestUser({
+      phone: phoneFor(52),
+      displayName: '[TEST] Alice (daily)',
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    // Seed a small pool of authored questions on Alice so the daily
+    // queue generator has material to draw from.
+    await insertTestQuestions({
+      creatorId: alice.id,
+      count: 3,
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    const cookie = await authenticateAndCookie(ctx.baseUrl, alice.phone);
+    const browserCtx = await contextForPlayer(ctx.browser, ctx.baseUrl, cookie.value);
+
+    try {
+      const page = await browserCtx.newPage();
+      await page.goto(`${ctx.baseUrl}/daily`, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      events.push({ kind: 'navigated', url: page.url(), at: now() });
+
+      const shot = path.join(ctx.screenshotDir, 'daily-queue--page.png');
+      await page.screenshot({ path: shot, fullPage: false });
+      events.push({ kind: 'screenshot', file: shot, note: 'daily page loaded', at: now() });
+
+      // Ask the API directly whether a queue exists or can be created. This
+      // exercises the route without depending on the somewhat-stateful UI.
+      const queueRes = await page.request.get(`${ctx.baseUrl}/api/daily/queue`);
+      asserts.expectEqual('GET /api/daily/queue returns 200', queueRes.status(), 200);
+
+      // The queue may be empty for a brand-new test user with no
+      // generated/authored questions in their domain. Either way the row
+      // should land in dailyQueues after the GET (if the route auto-fills)
+      // or after a POST.
+      const [queueRow] = await db
+        .select({ id: dailyQueues.id, userId: dailyQueues.userId })
+        .from(dailyQueues)
+        .where(eq(dailyQueues.userId, alice.id))
+        .limit(1);
+      if (queueRow) {
+        ctx.manifest.trackDailyQueue({ id: queueRow.id, userId: alice.id, scenarioId: ctx.scenarioId });
+        asserts.pass('dailyQueues row created for test user');
+      } else {
+        // Not strictly a failure — the test user has no generated questions,
+        // so the queue may be empty. Record as a note for the LLM review.
+        asserts.pass('daily page loaded (no queue row — empty domain pool)');
+      }
+
+      await page.close();
+    } finally {
+      await browserCtx.close();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    asserts.fail('daily-queue scenario threw', message);
+    events.push({ kind: 'error', message, at: now() });
+  }
+
+  return {
+    scenarioId: ctx.scenarioId,
+    displayName: 'Daily queue loads',
+    status: asserts.hasFailures() ? 'fail' : 'pass',
+    durationMs: Date.now() - startedAt,
+    events,
+    assertions: asserts.results,
+  };
+}
+
+export const dailyQueueScenario: Scenario = {
+  id: 'daily-queue',
+  displayName: 'Daily queue loads',
+  description: 'A test user navigates to /daily; the queue endpoint responds 200 and (if questions are available) a dailyQueues row is created.',
+  run,
+};

--- a/scripts/playtest/scenarios/index.ts
+++ b/scripts/playtest/scenarios/index.ts
@@ -1,0 +1,17 @@
+import { acceptInvitationScenario } from './accept-invitation';
+import { authorQuestionScenario } from './author-question';
+import { dailyQueueScenario } from './daily-queue';
+import { playGameScenario } from './play-game';
+import { sendInvitationScenario } from './send-invitation';
+import type { Scenario } from '../lib/scenario-context';
+
+// Order matters: scenarios run sequentially. Put the cheaper / faster
+// scenarios first so a CI failure surfaces quickly. Each scenario seeds
+// its own users (different phone ranges) so they're independent.
+export const allScenarios: Scenario[] = [
+  sendInvitationScenario,
+  acceptInvitationScenario,
+  authorQuestionScenario,
+  dailyQueueScenario,
+  playGameScenario,
+];

--- a/scripts/playtest/scenarios/play-game.ts
+++ b/scripts/playtest/scenarios/play-game.ts
@@ -1,0 +1,94 @@
+import { contextForPlayer } from '../lib/browser';
+import { authenticateAndCookie, createTestGame, insertTestQuestions, phoneFor, provisionTestUser } from '../lib/seed';
+import { playGame, type PlayerEvent } from '../lib/player';
+import type { Scenario, ScenarioContext, ScenarioLog } from '../lib/scenario-context';
+import { AssertionRecorder } from '../lib/asserts';
+
+async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
+  const startedAt = Date.now();
+  const asserts = new AssertionRecorder();
+  const events: PlayerEvent[] = [];
+
+  try {
+    // Seed inviter + N players, plus N pre-authored questions and the game.
+    const inviter = await provisionTestUser({
+      phone: phoneFor(0),
+      displayName: '[TEST] Inviter',
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    const players: Array<{ id: string; phone: string; displayName: string; sessionCookie: string }> = [];
+    for (let i = 1; i <= ctx.args.players; i += 1) {
+      const phone = phoneFor(i);
+      const displayName = `[TEST] Player ${i}`;
+      const user = await provisionTestUser({ phone, displayName, scenarioId: ctx.scenarioId, manifest: ctx.manifest });
+      const cookie = await authenticateAndCookie(ctx.baseUrl, phone);
+      players.push({ id: user.id, phone, displayName, sessionCookie: cookie.value });
+    }
+
+    const questionIds = await insertTestQuestions({
+      creatorId: inviter.id,
+      count: ctx.args.questions,
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+
+    const gameId = await createTestGame({
+      title: '[TEST] Automated Playtest',
+      creatorId: inviter.id,
+      recipientIds: players.map((p) => p.id),
+      questionIds,
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+    ctx.manifest.putScenarioData(ctx.scenarioId, 'gameId', gameId);
+    asserts.pass('seeded game and players');
+
+    // Each player plays sequentially (pool is capped at 5).
+    for (const player of players) {
+      console.log(`[playtest/play-game]   ${player.displayName}`);
+      const browserCtx = await contextForPlayer(ctx.browser, ctx.baseUrl, player.sessionCookie);
+      try {
+        const log = await playGame({
+          context: browserCtx,
+          baseUrl: ctx.baseUrl,
+          runId: ctx.runId,
+          gameId,
+          playerId: player.id,
+          displayName: player.displayName,
+          correctnessRate: ctx.args.correctnessRate,
+        });
+        events.push(...log.events);
+        const anyAnswers = log.events.some((e) => e.kind === 'answer_submitted');
+        asserts.check(
+          `${player.displayName} submitted at least one answer`,
+          anyAnswers,
+          'no answer_submitted event recorded',
+        );
+      } finally {
+        await browserCtx.close();
+      }
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    asserts.fail('play-game scenario threw', message);
+  }
+
+  const failed = asserts.hasFailures();
+  return {
+    scenarioId: ctx.scenarioId,
+    displayName: 'Play a Joshing game (multi-player)',
+    status: failed ? 'fail' : 'pass',
+    durationMs: Date.now() - startedAt,
+    events,
+    assertions: asserts.results,
+  };
+}
+
+export const playGameScenario: Scenario = {
+  id: 'play-game',
+  displayName: 'Play a Joshing game (multi-player)',
+  description: 'Seeds N players and a game; each plays in their own browser context.',
+  run,
+};

--- a/scripts/playtest/scenarios/send-invitation.ts
+++ b/scripts/playtest/scenarios/send-invitation.ts
@@ -1,0 +1,112 @@
+import path from 'node:path';
+
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { db, friendInvitations } from '@/server/db';
+
+import { AssertionRecorder } from '../lib/asserts';
+import { contextForPlayer } from '../lib/browser';
+import type { PlayerEvent } from '../lib/player';
+import type { Scenario, ScenarioContext, ScenarioLog } from '../lib/scenario-context';
+import { authenticateAndCookie, phoneFor, provisionTestUser } from '../lib/seed';
+
+function now(): string {
+  return new Date().toISOString();
+}
+
+const INVITEE_PHONE = phoneFor(100); // outside the player block to avoid collision
+const INVITEE_DISPLAY_NAME = '[TEST] Invitee Bob';
+
+async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
+  const startedAt = Date.now();
+  const asserts = new AssertionRecorder();
+  const events: PlayerEvent[] = [];
+
+  try {
+    const alice = await provisionTestUser({
+      phone: phoneFor(50),
+      displayName: '[TEST] Alice (inviter)',
+      scenarioId: ctx.scenarioId,
+      manifest: ctx.manifest,
+    });
+    const cookie = await authenticateAndCookie(ctx.baseUrl, alice.phone);
+
+    const browserCtx = await contextForPlayer(ctx.browser, ctx.baseUrl, cookie.value);
+    try {
+      const page = await browserCtx.newPage();
+      await page.goto(`${ctx.baseUrl}/friends`, { waitUntil: 'domcontentloaded' });
+      await page.waitForLoadState('networkidle').catch(() => undefined);
+      events.push({ kind: 'navigated', url: page.url(), at: now() });
+
+      const screenshotFile = path.join(ctx.screenshotDir, 'send-invitation--friends.png');
+      await page.screenshot({ path: screenshotFile, fullPage: false });
+      events.push({ kind: 'screenshot', file: screenshotFile, note: 'friends page', at: now() });
+
+      const response = await page.request.post(`${ctx.baseUrl}/api/friend-invitations`, {
+        data: {
+          inviteeDisplayName: INVITEE_DISPLAY_NAME,
+          phone: INVITEE_PHONE,
+          suggestedInterests: ['1980s Animation', 'Classical Music'],
+        },
+      });
+      const body = (await response.json().catch(() => null)) as
+        | { ok: boolean; type?: string; inviteUrl?: string; id?: string; expiresAt?: string }
+        | null;
+
+      asserts.expectEqual('POST /api/friend-invitations returns 200', response.status(), 200);
+      asserts.expectTruthy('response body present', body);
+      asserts.expectEqual('response type is friend_invitation', body?.type, 'friend_invitation');
+      asserts.expectTruthy('inviteUrl returned', typeof body?.inviteUrl === 'string' && body.inviteUrl.startsWith('/invite/'));
+
+      if (body?.id) {
+        ctx.manifest.trackInvitation({
+          id: body.id,
+          inviterUserId: alice.id,
+          inviteePhone: INVITEE_PHONE,
+          scenarioId: ctx.scenarioId,
+        });
+        ctx.manifest.putScenarioData(ctx.scenarioId, 'invitationId', body.id);
+        ctx.manifest.putScenarioData(ctx.scenarioId, 'inviteUrl', body.inviteUrl);
+        ctx.manifest.putScenarioData(ctx.scenarioId, 'inviteePhone', INVITEE_PHONE);
+        ctx.manifest.putScenarioData(ctx.scenarioId, 'inviterUserId', alice.id);
+      }
+
+      // DB-level assertion: the row exists and is unaccepted.
+      const [row] = await db
+        .select({ id: friendInvitations.id, acceptedAt: friendInvitations.acceptedAt })
+        .from(friendInvitations)
+        .where(and(eq(friendInvitations.inviterUserId, alice.id), eq(friendInvitations.inviteePhone, INVITEE_PHONE), isNull(friendInvitations.acceptedAt)))
+        .limit(1);
+      asserts.expectTruthy('friendInvitations row exists in DB', !!row);
+      if (row) asserts.expectEqual('acceptedAt is null pre-acceptance', row.acceptedAt, null);
+
+      const after = path.join(ctx.screenshotDir, 'send-invitation--after.png');
+      await page.screenshot({ path: after, fullPage: false });
+      events.push({ kind: 'screenshot', file: after, note: 'after invite submit', at: now() });
+
+      await page.close();
+    } finally {
+      await browserCtx.close();
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    asserts.fail('send-invitation scenario threw', message);
+    events.push({ kind: 'error', message, at: now() });
+  }
+
+  return {
+    scenarioId: ctx.scenarioId,
+    displayName: 'Send a friend invitation',
+    status: asserts.hasFailures() ? 'fail' : 'pass',
+    durationMs: Date.now() - startedAt,
+    events,
+    assertions: asserts.results,
+  };
+}
+
+export const sendInvitationScenario: Scenario = {
+  id: 'send-invitation',
+  displayName: 'Send a friend invitation',
+  description: 'Alice (test inviter) hits POST /api/friend-invitations and the friendInvitations row appears.',
+  run,
+};

--- a/scripts/playtest/scenarios/send-invitation.ts
+++ b/scripts/playtest/scenarios/send-invitation.ts
@@ -56,7 +56,10 @@ async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
       asserts.expectEqual('POST /api/friend-invitations returns 200', response.status(), 200);
       asserts.expectTruthy('response body present', body);
       asserts.expectEqual('response type is friend_invitation', body?.type, 'friend_invitation');
-      asserts.expectTruthy('inviteUrl returned', typeof body?.inviteUrl === 'string' && body.inviteUrl.startsWith('/invite/'));
+      asserts.expectTruthy(
+        'inviteUrl points at an /invite/ path',
+        typeof body?.inviteUrl === 'string' && body.inviteUrl.includes('/invite/'),
+      );
 
       if (body?.id) {
         ctx.manifest.trackInvitation({


### PR DESCRIPTION
## Summary
Adds a comprehensive playtest harness (`scripts/playtest/`) that automates multi-player game testing, screenshot capture, and LLM-powered review. This enables rapid validation of gameplay flow, UI/UX, and error handling without manual testing.

## Key Changes

- **Seed module** (`lib/seed.ts`): Provisions test users with deterministic phone numbers, creates a game with seeded questions, and returns a manifest for test orchestration.

- **Player automation** (`lib/player.ts`): Launches Playwright browser contexts for each player, navigates to the game, answers questions (with configurable correctness rate), captures screenshots at key moments, and logs all events (navigation, questions seen, answers submitted, results, console errors, network failures).

- **LLM review** (`lib/claude.ts`): Uses Claude to analyze player logs and screenshots, returning structured feedback on bugs, UX issues, and observations. Includes fallback handling for missing Anthropic client.

- **Report generation** (`lib/report.ts`): Writes a markdown report with game metadata, LLM review summary, per-player event timelines, and embedded screenshots.

- **Cleanup** (`lib/cleanup.ts`): Safely wipes all test data (users, games, questions, sessions, etc.) with safeguards to prevent accidental deletion of non-test rows.

- **CLI orchestration** (`playtest.ts`): Main entry point that seeds, launches browser automation, collects logs, runs LLM review, generates reports, and optionally cleans up.

- **Supporting modules**:
  - `lib/args.ts`: Parses CLI flags (players, questions, correctness-rate, headed, base-url, clean, run-id, keep).
  - `lib/manifest.ts`: Manages run metadata and file paths under `audits/playtest-<runId>/`.
  - `lib/auth.ts`: Authenticates test users via OTP flow (hardcoded `000000` code).
  - `lib/browser.ts`: Launches Chromium with mobile viewport and injects session cookies.
  - `lib/preflight.ts`: Validates environment (rejects production, checks pool limits, validates arg ranges).

- **package.json**: Adds `smoke:gameplay` script to invoke the harness.

- **.env.example**: Documents `PLAYTEST_BASE_URL` and `ANTHROPIC_API_KEY` for the harness.

## Notable Implementation Details

- **Phone generation**: Test users are assigned sequential phone numbers from `+15557000000` block to avoid conflicts.
- **Question seeding**: Five canned questions (literature, science, history) with marked `[TEST]` prefix for easy identification.
- **Event logging**: Comprehensive event types (navigated, question_seen, answer_submitted, result_observed, console, network_error, screenshot, finished, error) enable detailed post-game analysis.
- **Screenshot capture**: Taken at arrival, before/after each answer, and at summary screen; filenames sanitized for safe filesystem storage.
- **Correctness control**: `--correctness-rate` flag (0–1) allows testing both success and failure paths.
- **Cleanup safeguards**: Refuses to delete users unless display name starts with `[TEST]`; matches OTP/SMS logs by phone prefix.
- **Run isolation**: Each run gets a unique ID (ISO timestamp), separate manifest, and screenshot directory under `audits/`.
- **Retention option**: `--keep` flag allows retaining test rows for manual inspection; `--clean --run-id=<id>` removes them later.

## Testing
Run with:
```bash
npm run smoke:gameplay -- --players=3 --questions=3 --correctness-rate=0.7 --base-url=http://localhost:3000
```

Cleanup a previous run:
```bash
npm run smoke:gameplay -- --clean --run-id=2025-01-15T12-34-56-789Z
```

https://claude.ai/code/session_01LZjd1oiUjzuW8uSg8oAmc9