### PR TITLE
fix(playtest): add critiqueIterations to author-question smoke payload

### DIFF
--- a/scripts/playtest/scenarios/author-question.ts
+++ b/scripts/playtest/scenarios/author-question.ts
@@ -53,6 +53,7 @@ async function run(ctx: ScenarioContext): Promise<ScenarioLog> {
           correctAnswer: ANSWER_TEXT,
           alternateAnswers: ['paris'],
           verified: true,
+          critiqueIterations: 0,
         },
       });
       const bodyText = await response.text().catch(() => '');


### PR DESCRIPTION
The /api/questions route requires critiqueIterations to be a non-negative
integer (validated in create-payload.ts). The smoke test was not sending
this field, causing a 400 validation error.

https://claude.ai/code/session_011SJP2oR3jPo6e3W1j2qfqf