### PR TITLE
fix(profile): stack privacy-row toggle below text so it stops fighting the FAB

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -537,25 +537,30 @@ function PrivacyRow({
   visibility: 'public' | 'friends' | 'private'
 }) {
   return (
-    <div className="flex w-full items-center gap-4 px-4 py-4">
-      <span
-        className="grid size-10 flex-none place-items-center rounded-full bg-muted text-foreground/70"
-        aria-hidden="true"
-      >
-        <Icon className="size-5" />
-      </span>
-      <span className="flex min-w-0 flex-1 flex-col">
-        <span className="font-serif text-base font-semibold leading-tight">
-          {title}
+    <div className="flex w-full flex-col gap-3 px-4 py-4">
+      <div className="flex w-full items-center gap-4">
+        <span
+          className="grid size-10 flex-none place-items-center rounded-full bg-muted text-foreground/70"
+          aria-hidden="true"
+        >
+          <Icon className="size-5" />
         </span>
-        <span className="mt-0.5 text-sm text-muted-foreground">{subtitle}</span>
-      </span>
-      <SectionVisibilityToggle
-        section={section}
-        label={title.toLowerCase()}
-        initialVisibility={visibility}
-        size="compact"
-      />
+        <span className="flex min-w-0 flex-1 flex-col">
+          <span className="font-serif text-base font-semibold leading-tight">
+            {title}
+          </span>
+          <span className="mt-0.5 text-sm text-muted-foreground">{subtitle}</span>
+        </span>
+      </div>
+      <div className="pl-14">
+        <SectionVisibilityToggle
+          section={section}
+          label={title.toLowerCase()}
+          initialVisibility={visibility}
+          size="compact"
+          fullWidth
+        />
+      </div>
     </div>
   )
 }

--- a/src/components/profile/SectionVisibilityToggle.tsx
+++ b/src/components/profile/SectionVisibilityToggle.tsx
@@ -22,6 +22,10 @@ type Props = {
   // 3-column grid. Use compact when the toggle sits next to a section
   // header or inline with a field.
   size?: 'default' | 'compact';
+  // Stretches the pill to fill its container with three equal columns
+  // instead of sizing to content. Useful when the toggle is stacked
+  // below a label rather than placed inline beside it.
+  fullWidth?: boolean;
 };
 
 // Generalization of DomainVisibilityToggle (which is per-knowledge-domain).
@@ -35,6 +39,7 @@ export function SectionVisibilityToggle({
   initialVisibility,
   onSaved,
   size = 'default',
+  fullWidth = false,
 }: Props) {
   const [visibility, setVisibility] = useState<SectionVisibility>(initialVisibility);
   const [isSaving, setIsSaving] = useState(false);
@@ -65,13 +70,17 @@ export function SectionVisibilityToggle({
 
   const baseBtn =
     size === 'compact'
-      ? 'px-2 py-1 text-xs'
+      ? 'min-h-9 px-3 py-1.5 text-xs'
       : 'min-h-10 px-3 text-sm';
+
+  const wrapperLayout = fullWidth
+    ? 'grid w-full grid-cols-3'
+    : 'inline-grid grid-cols-3';
 
   return (
     <div>
       <div
-        className="inline-grid grid-cols-3 rounded-full border bg-card p-1 font-medium"
+        className={`${wrapperLayout} rounded-full border bg-card p-1 font-medium`}
         aria-label={`Visibility for ${label}`}
       >
         {OPTIONS.map((option) => (


### PR DESCRIPTION
On phone widths each Privacy row squeezed the title/subtitle between a 40px
icon and a 3-button pill, leaving ~120px for text — "Knowledge base" wrapped
mid-word and the "Friends list" pill slipped under the floating "+" FAB.

PrivacyRow now vertical-stacks: text on top, full-width segmented control
below at a pl-14 inset that lines up with the title. SectionVisibilityToggle
gains an opt-in `fullWidth` prop (defaults off so inline call sites are
unchanged) and bumps compact tap targets from ~24px to 36px.

https://claude.ai/code/session_01D4yHj4XPUx3hL5kivafVV5