### PR TITLE
loosen question grading so legitimate categorizations are not rejected

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -126,22 +126,14 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
 
   const shouldRecategorize = values.text !== undefined || values.correctAnswer !== undefined;
   if (shouldRecategorize) {
-    const categorization = await categorizeQuestion(effectiveText, effectiveAnswer);
+    const categorization = await categorizeQuestion(effectiveText, effectiveAnswer, effectiveAlternates);
     const category = normalizeBroadQuestionCategoryOrDefault(categorization.broad_category);
     const canonicalSubcategory = normalizeCanonicalSubcategory(categorization.subcategory) || 'General Knowledge';
     if (textContainsAnswer(canonicalSubcategory, effectiveAnswer, effectiveAlternates)) {
-      console.warn('[questions/patch] rejected category that leaks answer', {
+      console.warn('[questions/patch] category leaks answer (saving anyway)', {
         subcategory: canonicalSubcategory,
         answer: effectiveAnswer,
       });
-      return NextResponse.json(
-        {
-          error: 'category_leaks_answer',
-          message:
-            "This question's category would give away the answer. Try rephrasing the question so a different category fits.",
-        },
-        { status: 422 },
-      );
     }
     values.category = category;
     values.broadCategory = broadCategoryDisplayName(category);

--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -5,6 +5,7 @@ const {
   categorizeQuestionMock,
   createQuestionMock,
   dbMock,
+  generateInsideJokeMock,
   getFriendsMock,
   getQuestionMock,
   getSessionMock,
@@ -12,6 +13,7 @@ const {
   rollOffOldItemsMock,
   state,
   userHasQuestionInBlockingFeedMock,
+  vetQuestionMock,
 } = vi.hoisted(() => {
   const state = {
     dismissedRows: [] as Array<{ userId: string }>,
@@ -44,6 +46,7 @@ const {
     categorizeQuestionMock: vi.fn(),
     createQuestionMock: vi.fn(),
     dbMock,
+    generateInsideJokeMock: vi.fn(),
     getFriendsMock: vi.fn(),
     getQuestionMock: vi.fn(),
     getSessionMock: vi.fn(),
@@ -51,6 +54,7 @@ const {
     rollOffOldItemsMock: vi.fn(),
     state,
     userHasQuestionInBlockingFeedMock: vi.fn(),
+    vetQuestionMock: vi.fn(),
   }
 })
 
@@ -63,6 +67,21 @@ vi.mock('drizzle-orm', () => ({
 
 vi.mock('@/lib/llm', () => ({
   categorizeQuestion: categorizeQuestionMock,
+  generateInsideJoke: generateInsideJokeMock,
+}))
+
+vi.mock('@/server/llm/vet-question', () => ({
+  vetQuestion: vetQuestionMock,
+  verdictToPublicStatus: (verdict: { status: string; score: number | null; reason: string }) => ({
+    publicStatus:
+      verdict.status === 'approved'
+        ? 'eligible_pending'
+        : verdict.status === 'rejected'
+          ? 'rejected'
+          : 'not_scored',
+    publicEligibilityScore: verdict.score,
+    publicEligibilityReason: verdict.reason,
+  }),
 }))
 
 vi.mock('@/server/auth/session', () => ({
@@ -146,10 +165,12 @@ describe('POST /api/questions shareToFeed', () => {
     })
     assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
     createQuestionMock.mockResolvedValue({ id: 'question-1' })
+    generateInsideJokeMock.mockResolvedValue(null)
     getQuestionMock.mockResolvedValue({ id: 'question-1', question_text: 'Who wrote Middlemarch?' })
     openKBDomainMock.mockResolvedValue({ opened: true })
     rollOffOldItemsMock.mockResolvedValue(0)
     userHasQuestionInBlockingFeedMock.mockResolvedValue(false)
+    vetQuestionMock.mockResolvedValue({ status: 'approved', score: 0.8, reason: 'looks good' })
   })
 
   afterEach(() => {
@@ -434,5 +455,80 @@ describe('POST /api/questions shareToFeed', () => {
       skippedDismissedDomainRecipientIds: ['friend-3'],
       skippedExistingFeedRecipientIds: ['friend-2'],
     }))
+  })
+})
+
+describe('POST /api/questions category leak handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.dismissedRows = []
+    state.feedInsertValues = []
+    state.questionUpdateValues = []
+
+    getSessionMock.mockResolvedValue({ userId: 'creator-1' })
+    assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
+    createQuestionMock.mockResolvedValue({ id: 'question-1' })
+    generateInsideJokeMock.mockResolvedValue(null)
+    getQuestionMock.mockResolvedValue({ id: 'question-1' })
+    openKBDomainMock.mockResolvedValue({ opened: true })
+    rollOffOldItemsMock.mockResolvedValue(0)
+    userHasQuestionInBlockingFeedMock.mockResolvedValue(false)
+    vetQuestionMock.mockResolvedValue({ status: 'approved', score: 0.8, reason: 'looks good' })
+  })
+
+  it('saves a question with a leaky category instead of 422-rejecting, and marks publicStatus rejected', async () => {
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Civics',
+      subcategory: "Robert's Rules of Order",
+    })
+
+    const response = await POST(questionRequest({
+      text: 'What is the name of the standard parliamentary authority used by most organizations in the United States?',
+      correctAnswer: "Robert's Rules of Order",
+      alternateAnswers: ['RONR', "Robert's Rules", 'Rules of Order'],
+    }))
+
+    expect(response.status).toBe(201)
+    expect(createQuestionMock).toHaveBeenCalledTimes(1)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as {
+      publicStatus: string
+      publicEligibilityReason: string
+    }
+    expect(createArgs.publicStatus).toBe('rejected')
+    expect(createArgs.publicEligibilityReason).toBe('category_leaks_answer')
+  })
+
+  it('saves with publicStatus eligible_pending when the category does not leak the answer', async () => {
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Civics',
+      subcategory: 'Parliamentary Procedure',
+    })
+
+    const response = await POST(questionRequest({
+      text: 'What is the name of the standard parliamentary authority used by most organizations in the United States?',
+      correctAnswer: "Robert's Rules of Order",
+      alternateAnswers: ['RONR', "Robert's Rules", 'Rules of Order'],
+    }))
+
+    expect(response.status).toBe(201)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { publicStatus: string }
+    expect(createArgs.publicStatus).toBe('eligible_pending')
+  })
+
+  it('returns 500 with a friendly message when an enrichment step throws', async () => {
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'Victorian Literature',
+    })
+    assessQuestionDifficultyMock.mockRejectedValue(new Error('boom'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await POST(questionRequest({}))
+    const body = await response.json()
+
+    expect(response.status).toBe(500)
+    expect(body.error).toBe('server_error')
+    expect(body.message).toMatch(/something went wrong/i)
+    expect(createQuestionMock).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -76,7 +76,28 @@ export async function POST(request: NextRequest) {
   }
 
   const { sendToFriendIds, shareToFeed, ...rawQuestionFields } = value;
-  const categorization = await categorizeQuestion(rawQuestionFields.text, rawQuestionFields.correctAnswer);
+
+  let categorization;
+  let difficultyAssessment;
+  let insideJoke;
+  let verdict;
+  try {
+    categorization = await categorizeQuestion(
+      rawQuestionFields.text,
+      rawQuestionFields.correctAnswer,
+      rawQuestionFields.alternateAnswers,
+    );
+  } catch (error) {
+    console.error('[questions/create] unexpected_failure', {
+      stage: 'categorize',
+      userId: session.userId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: 'server_error', message: 'Something went wrong saving that question. Try again.' },
+      { status: 500 },
+    );
+  }
   const category = normalizeBroadQuestionCategoryOrDefault(categorization.broad_category);
   const normalizedSubcategory = normalizeCanonicalSubcategory(categorization.subcategory);
 
@@ -99,19 +120,20 @@ export async function POST(request: NextRequest) {
       { status: 422 },
     );
   }
-  if (textContainsAnswer(normalizedSubcategory, value.correctAnswer, value.alternateAnswers)) {
-    console.warn('[questions/create] rejected category that leaks answer', {
+  // The categorizer has its own de-leak retry (see categorizeQuestion in
+  // src/lib/llm.ts). If a leaky label still slipped through, save anyway and
+  // mark the question ineligible for the shared pool — the user wrote a
+  // legitimate question and we shouldn't block them on the categorizer.
+  const categoryLeaksAnswer = textContainsAnswer(
+    normalizedSubcategory,
+    value.correctAnswer,
+    value.alternateAnswers,
+  );
+  if (categoryLeaksAnswer) {
+    console.warn('[questions/create] category leaks answer (saving anyway)', {
       subcategory: normalizedSubcategory,
       answer: value.correctAnswer,
     });
-    return NextResponse.json(
-      {
-        error: 'category_leaks_answer',
-        message:
-          "This question's category would give away the answer. Try rephrasing the question so a different category fits.",
-      },
-      { status: 422 },
-    );
   }
   const canonicalSubcategory = normalizedSubcategory;
   const questionFields = {
@@ -122,37 +144,57 @@ export async function POST(request: NextRequest) {
     subcategory: canonicalSubcategory,
     domain: canonicalSubcategory,
   };
-  const difficultyAssessment = await assessQuestionDifficulty({
-    questionText: questionFields.text,
-    correctAnswer: questionFields.correctAnswer,
-    broadCategory: questionFields.broadCategory,
-    canonicalSubcategory: questionFields.canonicalSubcategory,
-    explanation: questionFields.explanation,
-  });
-  const insideJoke = await generateInsideJoke({
-    questionText: questionFields.text,
-    correctAnswer: questionFields.correctAnswer,
-    broadCategory: questionFields.broadCategory,
-    canonicalSubcategory: questionFields.canonicalSubcategory,
-  });
-  // Haiku-vet for the shared Daily 5 pool — approved questions become eligible
-  // to surface in other users' games (prioritised by friends + friends-of-
-  // friends). Failure is non-fatal: we leave publicStatus at 'not_scored'
-  // and the /api/cron/vet-questions sweep will retry.
-  const verdict = await vetQuestion({
-    questionText: questionFields.text,
-    answer: questionFields.correctAnswer,
-    alternateAnswers: questionFields.alternateAnswers,
-    explanation: questionFields.explanation ?? null,
-    broadCategory: questionFields.broadCategory,
-    canonicalSubcategory: questionFields.canonicalSubcategory,
-  });
-  const publicScoring = verdictToPublicStatus(verdict);
+  try {
+    difficultyAssessment = await assessQuestionDifficulty({
+      questionText: questionFields.text,
+      correctAnswer: questionFields.correctAnswer,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+      explanation: questionFields.explanation,
+    });
+    insideJoke = await generateInsideJoke({
+      questionText: questionFields.text,
+      correctAnswer: questionFields.correctAnswer,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+    });
+    // Haiku-vet for the shared Daily 5 pool — approved questions become eligible
+    // to surface in other users' games (prioritised by friends + friends-of-
+    // friends). Failure is non-fatal: we leave publicStatus at 'not_scored'
+    // and the /api/cron/vet-questions sweep will retry.
+    verdict = await vetQuestion({
+      questionText: questionFields.text,
+      answer: questionFields.correctAnswer,
+      alternateAnswers: questionFields.alternateAnswers,
+      explanation: questionFields.explanation ?? null,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+    });
+  } catch (error) {
+    console.error('[questions/create] unexpected_failure', {
+      stage: 'enrichment',
+      userId: session.userId,
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json(
+      { error: 'server_error', message: 'Something went wrong saving that question. Try again.' },
+      { status: 500 },
+    );
+  }
+  let publicScoring = verdictToPublicStatus(verdict);
+  if (categoryLeaksAnswer && publicScoring.publicStatus !== 'rejected') {
+    publicScoring = {
+      publicStatus: 'rejected',
+      publicEligibilityScore: publicScoring.publicEligibilityScore,
+      publicEligibilityReason: 'category_leaks_answer',
+    };
+  }
   console.info('[questions/vet]', {
     userId: session.userId,
     verdictStatus: verdict.status,
     overallScore: publicScoring.publicEligibilityScore,
     publicStatus: publicScoring.publicStatus,
+    categoryLeaksAnswer,
   });
 
   const categorizedQuestionFields = {

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -24,6 +24,7 @@ type CreateQuestionResponse = {
   question?: QuestionView;
   id?: string;
   error?: string;
+  message?: string;
   feedShare?: {
     requested: boolean;
     createdCount: number;
@@ -161,7 +162,7 @@ function QuestionsPageContent() {
       body: JSON.stringify(values),
     });
     const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
-    if (!response.ok || !body?.question) throw new Error(body?.error ?? 'Could not save that question.');
+    if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not save that question.');
     setQuestions((current) => [body.question!, ...current]);
     setDrawer({ mode: 'closed' });
     if (values.sendToFriendIds.length > 0) {
@@ -184,8 +185,8 @@ function QuestionsPageContent() {
       credentials: 'include',
       body: JSON.stringify(values),
     });
-    const body = await response.json().catch(() => null) as { question?: QuestionView; error?: string } | null;
-    if (!response.ok || !body?.question) throw new Error(body?.error ?? 'Could not update that question.');
+    const body = await response.json().catch(() => null) as { question?: QuestionView; error?: string; message?: string } | null;
+    if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not update that question.');
     setQuestions((current) => current.map((question) => question.id === questionId ? body.question! : question));
     setDrawer({ mode: 'closed' });
     setToast('Question updated.');

--- a/src/lib/llm.categorization.test.ts
+++ b/src/lib/llm.categorization.test.ts
@@ -131,3 +131,102 @@ describe('categorizeQuestion final subcategory guard', () => {
     expect(persistedDomain).not.toBe(result.broad_category)
   })
 })
+
+describe('categorizeQuestion de-leak retry', () => {
+  beforeEach(() => {
+    createMessageMock.mockReset()
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test-key-with-enough-length'
+    process.env.LLM_ENABLED = 'true'
+  })
+
+  it('re-prompts when the LLM picks the answer as the subcategory', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: "Robert's Rules of Order",
+          broad_category: 'Civics',
+          confidence: 0.9,
+        })
+      )
+      .mockResolvedValueOnce(
+        anthropicTextResponse({ subcategory: 'Parliamentary Procedure' })
+      )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What is the standard parliamentary authority used by most US organizations?',
+      "Robert's Rules of Order",
+      ['RONR', "Robert's Rules", 'Rules of Order']
+    )
+
+    expect(createMessageMock).toHaveBeenCalledTimes(2)
+    expect(result.subcategory).toBe('Parliamentary Procedure')
+  })
+
+  it('re-prompts when the LLM picks an alternate answer as the subcategory', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: 'Soil Acidity',
+          broad_category: 'Gardening',
+          confidence: 0.85,
+        })
+      )
+      .mockResolvedValueOnce(
+        anthropicTextResponse({ subcategory: 'Hydrangea Cultivation' })
+      )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What is the factor that makes hydrangeas pink or blue?',
+      'Soil pH',
+      ['Soil acidity', 'Aluminum availability']
+    )
+
+    expect(createMessageMock).toHaveBeenCalledTimes(2)
+    expect(result.subcategory).toBe('Hydrangea Cultivation')
+  })
+
+  it('keeps the original leaky subcategory if the retry also leaks (API guard handles it)', async () => {
+    createMessageMock
+      .mockResolvedValueOnce(
+        anthropicTextResponse({
+          subcategory: "Robert's Rules of Order",
+          broad_category: 'Civics',
+          confidence: 0.9,
+        })
+      )
+      .mockResolvedValueOnce(
+        anthropicTextResponse({ subcategory: 'Rules of Order' })
+      )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What is the standard parliamentary authority used by most US organizations?',
+      "Robert's Rules of Order",
+      ['Rules of Order']
+    )
+
+    expect(createMessageMock).toHaveBeenCalledTimes(2)
+    expect(result.subcategory).toBe("Robert's Rules of Order")
+  })
+
+  it('does not retry when the subcategory does not leak the answer', async () => {
+    createMessageMock.mockResolvedValueOnce(
+      anthropicTextResponse({
+        subcategory: 'Parliamentary Procedure',
+        broad_category: 'Civics',
+        confidence: 0.9,
+      })
+    )
+
+    const categorizeQuestion = await importCategorizer()
+    const result = await categorizeQuestion(
+      'What is the standard parliamentary authority used by most US organizations?',
+      "Robert's Rules of Order"
+    )
+
+    expect(createMessageMock).toHaveBeenCalledTimes(1)
+    expect(result.subcategory).toBe('Parliamentary Procedure')
+  })
+})

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -12,6 +12,8 @@
 
 import Anthropic from '@anthropic-ai/sdk';
 
+import { textContainsAnswer } from '@/server/questions/self-answering';
+
 // ─── Types ────────────────────────────────────────────────────────────────────
 
 export type GradeResult = 'correct' | 'wrong';
@@ -552,7 +554,8 @@ Return only valid JSON with keys: result, confidence, reason, consolation. No ex
 
 export async function categorizeQuestion(
   questionText: string,
-  answerText: string
+  answerText: string,
+  alternateAnswers: readonly string[] = []
 ): Promise<CategoryResult> {
   const systemPrompt = `You are a hyper-specific categorizer for a personal trivia game.
 Return exactly this JSON shape:
@@ -572,6 +575,7 @@ Rules:
 - The subcategory must always be narrower than the broad_category. Never return the broad_category value itself as the subcategory (e.g. if broad_category is "Pop Culture", the subcategory must be something more specific than "Pop Culture"; if broad_category is "Music", the subcategory must be more specific than "Music").
 - For music, film, TV, or pop culture questions: name the specific artist, franchise, era, or cultural moment — not the genre or medium (e.g. "Late-Career David Bowie", "MCU Phase 3", "Drag Race Seasons 1–5", "Early 2010s Internet Memes", "Survivor Original Era").
 - Include temporal or stylistic specificity whenever it meaningfully narrows the territory (e.g. "Golden Age Hip-Hop" not "Hip-Hop", "New Hollywood Cinema" not "Film").
+- The subcategory must NOT contain the correct answer or any alternate answer as a token (case- and punctuation-insensitive). If the natural niche label IS the answer, step one level out to the surrounding territory or one level over to the domain. Example: answer "Robert's Rules of Order" → use "Parliamentary Procedure" (NOT "Robert's Rules of Order" / "Rules of Order"). Example: answer "Soil pH" → use "Hydrangea Cultivation" or "Garden Soil Chemistry" (NOT "Soil pH" / "Soil Acidity").
 
 STRICT PROHIBITION — never use these as subcategory values (they are too generic):
 "Pop Culture", "Music", "Literature", "History", "World History", "Film", "Television",
@@ -590,8 +594,11 @@ Bad subcategories: "Classical Music", "Rock Music", "Musical Theatre", "Literatu
 
 Return JSON only.`;
 
+  const alternatesLine = alternateAnswers.length > 0
+    ? `\nAccepted alternates (do NOT use as the subcategory label): ${alternateAnswers.join(' | ')}`
+    : '';
   const userMessage = `Question: ${questionText}
-Answer: ${answerText}
+Answer: ${answerText}${alternatesLine}
 Categorize this question. Return JSON only.`;
 
   try {
@@ -667,6 +674,56 @@ Return JSON only.`;
       const refined = asTrimmedString(refinementParsed?.subcategory);
       if (refined && !isTooGenericSubcategory(refined, broadCategory)) {
         subcategory = refined;
+      }
+    }
+
+    if (textContainsAnswer(subcategory, answerText, alternateAnswers)) {
+      const leakPrompt = `You refine trivia subcategories so they do NOT give away the answer.
+Return valid JSON only:
+{ "subcategory": "<label>" }
+
+Rules:
+- The subcategory must NOT contain the correct answer or any alternate answer as a token (case- and punctuation-insensitive).
+- Step one level out: name the surrounding territory or domain, not the answer itself.
+- Keep it hyper-specific in flavor (era/person/movement/topic), just not the answer phrase.
+- Keep title case. Never return generic labels like "Music", "History", "General Knowledge".
+
+Examples:
+- Answer "Robert's Rules of Order" → "Parliamentary Procedure" (NOT "Robert's Rules of Order", NOT "Rules of Order")
+- Answer "Soil pH" → "Hydrangea Cultivation" (NOT "Soil pH", NOT "Soil Acidity")
+- Answer "The Waste Land" → "Modernist Poetry" (NOT "The Waste Land", NOT "Waste Land")`;
+      const altLine = alternateAnswers.length > 0
+        ? `\nAlternates to avoid: ${alternateAnswers.join(' | ')}`
+        : '';
+      const leakMessage = `Question: ${questionText}
+Answer: ${answerText}${altLine}
+Broad category: ${broadCategory}
+Current subcategory (leaks the answer): ${subcategory}
+Return JSON only.`;
+
+      const leakResponse = await loggedMessagesCreate(client, 'categorize-deleak', {
+        model: ANTHROPIC_MODEL,
+        max_tokens: 120,
+        temperature: 0,
+        system: [{ type: 'text', text: leakPrompt, cache_control: { type: 'ephemeral' } }],
+        messages: [{ role: 'user', content: leakMessage }],
+      });
+
+      const leakText = extractTextContent(leakResponse.content);
+      const leakParsed = parseJsonObject(leakText);
+      const deleaked = asTrimmedString(leakParsed?.subcategory);
+      if (
+        deleaked
+        && !isTooGenericSubcategory(deleaked, broadCategory)
+        && !textContainsAnswer(deleaked, answerText, alternateAnswers)
+      ) {
+        subcategory = deleaked;
+      } else {
+        console.warn('[categorizeQuestion] could not de-leak subcategory after retry', {
+          subcategory,
+          deleaked,
+          answer: answerText,
+        });
       }
     }
 


### PR DESCRIPTION
When the LLM categorizer picked a label that overlapped the answer (e.g.
"Robert's Rules of Order" / "Soil pH"), the API hard-rejected the
question with 422 category_leaks_answer. Now we (a) teach the
categorizer to avoid the answer phrase and add a one-shot re-prompt
that targets leaky labels, and (b) soften the API guard so a leaky
label is logged and the question is saved with publicStatus=rejected
instead of failing the request. The Haiku vetter still checks for the
real concern — answer leaking into the question text — for shared-pool
eligibility.

Also fixes a silent "Could not save that question." path by wrapping
the post-validation enrichment in a try/catch that returns a friendly
500 message, and preferring body.message over body.error in the
question-form UI so users see prose instead of raw error codes.