### PR TITLE
question drawer: raise z-index above floating "+" FAB

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -319,7 +319,7 @@ function QuestionsPageContent() {
       )}
 
       {drawer.mode !== 'closed' ? (
-        <div className="fixed inset-0 z-50 flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
+        <div className="fixed inset-0 z-[60] flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
           <button className="absolute inset-0 cursor-default" type="button" aria-label="Close" onClick={() => setDrawer({ mode: 'closed' })} />
           <aside className="relative max-h-[92dvh] w-full overflow-y-auto rounded-t-lg bg-background p-5 shadow-xl md:h-full md:max-h-none md:w-[440px] md:rounded-none">
             <div className="mb-5 flex items-center justify-between gap-3">

--- a/src/components/CreateChooser.tsx
+++ b/src/components/CreateChooser.tsx
@@ -26,7 +26,7 @@ export function CreateChooser({ open, onClose }: { open: boolean; onClose: () =>
   }
 
   return (
-    <div className="fixed inset-0 z-[60] flex items-end justify-center bg-black/35 px-0 pb-0 md:items-center md:px-4 md:pb-4" role="dialog" aria-modal="true" aria-labelledby="create-chooser-title">
+    <div className="fixed inset-0 z-[70] flex items-end justify-center bg-black/35 px-0 pb-0 md:items-center md:px-4 md:pb-4" role="dialog" aria-modal="true" aria-labelledby="create-chooser-title">
       <button className="absolute inset-0 cursor-default" type="button" aria-label="Close create chooser" onClick={onClose} />
       <section className="relative w-full rounded-t-2xl bg-background p-5 shadow-xl md:max-w-md md:rounded-2xl">
         <h2 id="create-chooser-title" className="font-serif text-2xl font-semibold">Create</h2>


### PR DESCRIPTION
The /questions edit/create drawer and Nav's bottom-right "+" FAB
both sat at z-50. The drawer is later in DOM order so should win
ties, but iOS Safari's stacking-context handling lets the FAB leak
through, producing the appearance of an extra "Save question / Cancel"
pair once the form re-renders after the user taps Save.

Bump the drawer to z-[60] (always above the z-50 FAB) and shift
CreateChooser to z-[70] so it still layers above the drawer when
opened on top of it.

https://claude.ai/code/session_01BWscRikU4Se8fAzsjvWqYm