### PR TITLE
daily/generate-questions: add 34 curated style exemplars as few-shot anchor

### DIFF
--- a/src/server/daily/exemplars.ts
+++ b/src/server/daily/exemplars.ts
@@ -1,0 +1,64 @@
+// Curated style exemplars supplied by the product owner. These are
+// gold-standard trivia questions used as few-shot reference in the daily
+// generator and quality-gate prompts. They demonstrate the register,
+// specificity, and concision Joshing aims for — not the literal facts
+// to copy. Edit the list here; both prompts read from STYLE_EXEMPLAR_BLOCK.
+
+export type StyleExemplarShape =
+  | 'identification'
+  | 'year_or_date'
+  | 'in_which_work'
+  | 'who_did_what'
+  | 'sequence_or_order'
+  | 'technique_or_term'
+  | 'what_happens_next'
+  | 'fill_in_blank'
+  | 'complete_the_quote'
+  | 'name_multiple';
+
+export type StyleExemplar = {
+  q: string;
+  a: string;
+  shape: StyleExemplarShape;
+};
+
+export const STYLE_EXEMPLARS: readonly StyleExemplar[] = [
+  { q: "Who was the character of Buck Mulligan based on?", a: "Oliver St. John Gogarty", shape: 'identification' },
+  { q: "What was the name of Alexander the Great's horse?", a: "Bucephalus", shape: 'identification' },
+  { q: "Who were Arnold Schoenberg's two most famous pupils?", a: "Alban Berg; Anton Webern", shape: 'name_multiple' },
+  { q: "Fill in the blank in this line from Don Giovanni: Don Giovanni a …… teco", a: "cenar", shape: 'fill_in_blank' },
+  { q: "What fruit does the narrator of The Love Song of J. Alfred Prufrock dare to eat?", a: "a peach", shape: 'identification' },
+  { q: "In what Bach cantata does Jesu Joy of Man's Desiring first appear?", a: "BWV 147 (Herz und Mund und Tat und Leben)", shape: 'in_which_work' },
+  { q: "Which late 20th-century composer developed the tintinnabuli technique?", a: "Arvo Pärt", shape: 'identification' },
+  { q: "Which philosopher used the example of a bat's echolocation to argue that subjective experience can never be fully captured by science?", a: "Thomas Nagel", shape: 'identification' },
+  { q: "According to T.S. Eliot, which is the cruelest month?", a: "April", shape: 'identification' },
+  { q: "Where was the first self-sustained nuclear reaction?", a: "University of Chicago (Chicago Pile-1)", shape: 'identification' },
+  { q: "What is the title of Beethoven's Third Symphony?", a: "Eroica", shape: 'identification' },
+  { q: "What is the name of the most famous opera house in Venice?", a: "La Fenice", shape: 'identification' },
+  { q: "Scarpia is the villain in what Puccini opera?", a: "Tosca", shape: 'in_which_work' },
+  { q: "What is the plural of \"focus\"?", a: "foci", shape: 'technique_or_term' },
+  { q: "Which apostle was chosen to replace Judas Iscariot?", a: "Matthias", shape: 'identification' },
+  { q: "What physical anomaly is Anne Boleyn rumored to have had?", a: "a sixth finger", shape: 'identification' },
+  { q: "What is it called when Venice floods?", a: "acqua alta", shape: 'technique_or_term' },
+  { q: "Name the four operas that make up Wagner's Ring Cycle.", a: "Das Rheingold; Die Walküre; Siegfried; Götterdämmerung", shape: 'name_multiple' },
+  { q: "Which German Jewish philosopher described the \"angel of history\" being blown backward into the future by the storm of progress?", a: "Walter Benjamin", shape: 'identification' },
+  { q: "Septimus Warren Smith is a major character in which novel?", a: "Mrs. Dalloway", shape: 'in_which_work' },
+  { q: "How many balls appear on the most common version of the Medici coat of arms?", a: "six", shape: 'identification' },
+  { q: "Which band has a song featuring the lyric \"how did I get to this beautiful house?\"", a: "Talking Heads", shape: 'identification' },
+  { q: "What embiggens us all?", a: "a noble spirit", shape: 'complete_the_quote' },
+  { q: "Clovis, Clotaire, and Chilperic were all kings of which Frankish dynasty?", a: "Merovingian", shape: 'identification' },
+  { q: "Complete the Shakespeare quote: \"A horse, a horse, ……\"", a: "my kingdom for a horse", shape: 'complete_the_quote' },
+  { q: "Which philosopher developed the \"veil of ignorance\" concept?", a: "John Rawls", shape: 'identification' },
+  { q: "To which cartoon theme tune can the opening verses of Paradise Lost be sung?", a: "Gilligan's Island", shape: 'identification' },
+  { q: "Which Gershwin melody is said to be based on the Jewish Aleinu prayer?", a: "It Ain't Necessarily So", shape: 'identification' },
+  { q: "Name at least two musicians who played on Miles Davis's Kind of Blue.", a: "John Coltrane; Cannonball Adderley; Bill Evans; Paul Chambers; Jimmy Cobb; Wynton Kelly", shape: 'name_multiple' },
+  { q: "What voice type, combining power and stamina, is required for Wagner's Siegfried?", a: "Heldentenor", shape: 'technique_or_term' },
+  { q: "Who has \"information, vegetable, animal and mineral\"?", a: "the Modern Major-General", shape: 'identification' },
+  { q: "Which famous piano work by Debussy quotes and mocks a theme from Wagner's Tristan und Isolde?", a: "Golliwogg's Cakewalk", shape: 'in_which_work' },
+  { q: "Kitty O'Shea had an affair with what famous Irish statesman?", a: "Charles Stewart Parnell", shape: 'identification' },
+  { q: "What is the name of the rope that raises or lowers a sail on a sailboat?", a: "halyard", shape: 'identification' },
+];
+
+export const STYLE_EXEMPLAR_BLOCK: string = STYLE_EXEMPLARS
+  .map((e) => `- [${e.shape}] ${e.q} (A: ${e.a})`)
+  .join('\n');

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -29,6 +29,7 @@ import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/serve
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { normalizeFactKey } from '@/server/questions/fact-key';
 import { resolveDailyBasePoints } from './types';
+import { STYLE_EXEMPLAR_BLOCK } from './exemplars';
 
 // Cap the recent question-text block at this many entries inside the prompt.
 // The full recent history (up to 200) is still used to derive the fact-key
@@ -42,7 +43,7 @@ export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
 
 const SYSTEM_PROMPT = `You are generating trivia questions for Joshing, a social trivia game played among friends.
 Questions must be:
-- Factual with a single objectively correct answer
+- Factual with a single objectively correct answer, or — for the "name_multiple" shape only — a small fixed set of correct answers (typically 2–4)
 - Drawn from the intellectual and cultural world of the domain, not biographical trivia
 - Calibrated to the difficulty instruction below: at easier tiers, lean on well-known, recognizable facts that anyone interested in the domain would have encountered; save specific, surprising deep cuts for higher difficulty tiers
 - Recall questions, not selection questions: the player must produce the answer from memory
@@ -56,6 +57,13 @@ BAD (multiple-choice phrasing — never produce these):
 GOOD (open recall):
 - "What does Sally Seton represent to the young Clarissa in Mrs. Dalloway?"
 - "In what year did Tchaikovsky premiere his Sixth Symphony?"
+
+STYLE EXEMPLARS (match this register, specificity, and concision):
+These are gold-standard Joshing questions. Mimic their tone — literate, confident, and specific. Pull from comparable depth (named characters, named works, technical terms, specific years, named figures) rather than vague appreciation or "explain why" questions. Notice how they assume a cultured audience without condescension.
+
+${STYLE_EXEMPLAR_BLOCK}
+
+Do NOT copy these questions or their underlying facts. Use them only as a model for how a Joshing question should feel.
 
 GRANULARITY RULES:
 Domain labels identify a body of knowledge — a work, an artist, a period, a discipline. They never identify a facet, aspect, or angle on that knowledge.
@@ -104,8 +112,11 @@ Trivia gets monotonous when every question follows the same template ("What is t
 - "in_which_work": asks which work, scene, chapter, movement, or section something appears in
 - "who_did_what": asks which character/person performs a specific act (e.g. "Who kills Polonius?")
 - "sequence_or_order": asks for ordering of events, items, or steps
-- "technique_or_term": asks for the technical term for a described concept
+- "technique_or_term": asks for the technical term for a described concept (e.g. "What is it called when Venice floods?")
 - "what_happens_next": asks what immediately follows a described scene/event
+- "fill_in_blank": gives a short line with one word elided and asks the player to supply it (e.g. "Fill in the blank in this line from Don Giovanni: Don Giovanni a …… teco")
+- "complete_the_quote": gives the opening of a well-known quote and asks for the remainder (e.g. "Complete the Shakespeare quote: 'A horse, a horse, ……'")
+- "name_multiple": asks for a small fixed set of items — only use when the canonical answer is a closed enumeration of 2–4 items (e.g. "Name the four operas that make up Wagner's Ring Cycle."). For this shape, emit the canonical answers in the "answer" field as a semicolon-delimited list (e.g. "Das Rheingold; Die Walküre; Siegfried; Götterdämmerung"). NOTE: do not emit "name_multiple" until further notice — the grading path does not yet handle multi-answer questions. Choose another shape instead.
 
 Rules:
 - Within a single batch of questions, no two questions may share the same question_shape unless the batch has more questions than there are shapes in the catalog.
@@ -133,7 +144,7 @@ Return format:
       "difficulty_estimate": "accessible | moderate | specialist",
       "fact_key": "string, short hyphenated lowercase identifier for the underlying fact (see REPETITION RULES)",
       "sub_angles": ["1-3 short tags identifying the facets of the domain covered (see above)"],
-      "question_shape": "one of: identification | year_or_date | in_which_work | who_did_what | sequence_or_order | technique_or_term | what_happens_next"
+      "question_shape": "one of: identification | year_or_date | in_which_work | who_did_what | sequence_or_order | technique_or_term | what_happens_next | fill_in_blank | complete_the_quote | name_multiple (held back — do not emit)"
     }
   ]
 }`;
@@ -146,6 +157,9 @@ const QUESTION_SHAPES = [
   'sequence_or_order',
   'technique_or_term',
   'what_happens_next',
+  'fill_in_blank',
+  'complete_the_quote',
+  'name_multiple',
 ] as const;
 type QuestionShape = (typeof QUESTION_SHAPES)[number];
 
@@ -460,6 +474,12 @@ const QUALITY_GATE_SYSTEM_PROMPT = `You are reviewing a small batch of just-gene
 4. SELF_ANSWERING — the question names the answer in its own text ("Who wrote the 1922 poem 'The Waste Land' by T. S. Eliot?").
 
 A high bar applies — flag a question only when one of these defects is clearly present. Subtle wordsmithing concerns are NOT defects.
+
+The following styles are explicitly ACCEPTABLE and must NOT be flagged on style grounds alone — fill-in-the-blank, complete-the-quote, name-multiple, and concise idiomatic questions all belong in Joshing. Reference exemplars:
+
+${STYLE_EXEMPLAR_BLOCK}
+
+Only flag a question matching one of those styles if it independently exhibits ANSWER_LEAKED, OPINION_OR_VAGUE, FALSE_PREMISE, or SELF_ANSWERING.
 
 Return JSON only:
 { "drop_indices": [list of zero-based indices to drop], "reasons": { "<index>": "<short reason>" } }


### PR DESCRIPTION
Embeds the user's curated list of 34 gold-standard trivia questions as a
shared exemplar block, threaded into both the generator SYSTEM_PROMPT and
the QUALITY_GATE prompt so the gate doesn't reject the very styles the
generator is being asked to mimic.

- new src/server/daily/exemplars.ts with STYLE_EXEMPLARS + a pre-rendered
  STYLE_EXEMPLAR_BLOCK for prompt interpolation
- QUESTION_SHAPES gains fill_in_blank, complete_the_quote, name_multiple;
  name_multiple is documented but held back until the answer-grading path
  supports multi-answer canonical answers
- loosen "single objectively correct answer" to admit small enumerated
  sets, but only for the (still-disabled) name_multiple shape