### PR TITLE
feat(questions): add Answered tab listing every question you've answered

### DIFF
--- a/src/app/api/questions/answered/route.ts
+++ b/src/app/api/questions/answered/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getArchiveForUser } from '@/server/db/queries/archive';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const archive = await getArchiveForUser({
+    userId: session.userId,
+    kind: 'answered',
+    limit: 100,
+  });
+
+  const items = archive.items.map((item) => ({
+    id: item.id,
+    questionId: item.questionId,
+    questionText: item.questionText,
+    submittedAnswer: item.submittedAnswer,
+    correctAnswer: item.correctAnswer,
+    result: item.result,
+    askerName: item.askerName,
+    answeredAt: item.answeredAt,
+    sourceLabel: item.sourceLabel,
+  }));
+
+  return NextResponse.json({ items, nextCursor: archive.nextCursor });
+}

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -6,13 +6,21 @@ import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 import { MyQuestionCard } from '@/components/questions/MyQuestionCard';
+import { AnsweredQuestionsList, type AnsweredQuestionItem } from '@/components/questions/AnsweredQuestionsList';
 import type { QuestionView } from '@/server/db/queries/questions';
 
 type SortMode = 'newest' | 'most_answered' | 'hardest' | 'easiest';
+type Tab = 'authored' | 'answered';
 type DrawerState =
   | { mode: 'closed' }
   | { mode: 'create' }
   | { mode: 'edit'; question: QuestionView };
+
+type AnsweredApiResponse = {
+  items?: AnsweredQuestionItem[];
+  error?: string;
+  message?: string;
+};
 
 type QuestionsApiResponse = {
   questions?: QuestionView[] | null;
@@ -85,9 +93,13 @@ export default function QuestionsPage() {
 
 function QuestionsPageContent() {
   const searchParams = useSearchParams();
+  const [tab, setTab] = useState<Tab>('authored');
   const [questions, setQuestions] = useState<QuestionView[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [answered, setAnswered] = useState<AnsweredQuestionItem[] | null>(null);
+  const [answeredLoading, setAnsweredLoading] = useState(false);
+  const [answeredError, setAnsweredError] = useState<string | null>(null);
   const [domainFilter, setDomainFilter] = useState('all');
   const [sortMode, setSortMode] = useState<SortMode>('newest');
   const [search, setSearch] = useState('');
@@ -121,6 +133,29 @@ function QuestionsPageContent() {
   useEffect(() => {
     void Promise.resolve().then(loadQuestions);
   }, [loadQuestions]);
+
+  const loadAnswered = useCallback(async () => {
+    setAnsweredLoading(true);
+    setAnsweredError(null);
+    try {
+      const response = await fetch('/api/questions/answered', { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null) as AnsweredApiResponse | null;
+      if (!response.ok || !Array.isArray(body?.items)) {
+        throw new Error(body?.message ?? body?.error ?? 'Could not load your answered questions.');
+      }
+      setAnswered(body.items);
+    } catch (caught) {
+      setAnsweredError(caught instanceof Error ? caught.message : 'Could not load your answered questions.');
+    } finally {
+      setAnsweredLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (tab !== 'answered') return;
+    if (answered !== null || answeredLoading) return;
+    void Promise.resolve().then(loadAnswered);
+  }, [tab, answered, answeredLoading, loadAnswered]);
 
   useEffect(() => {
     if (!toast) return;
@@ -222,9 +257,9 @@ function QuestionsPageContent() {
     }, 180);
   }
 
-  if (loading) return <LoadingSkeleton />;
+  if (loading && tab === 'authored') return <LoadingSkeleton />;
 
-  if (error) {
+  if (error && tab === 'authored') {
     return (
       <main className="mx-auto flex min-h-dvh max-w-2xl flex-col items-center justify-center px-4 py-10 text-center">
         <h1 className="font-serif text-3xl font-semibold">Could not load your questions</h1>
@@ -238,84 +273,140 @@ function QuestionsPageContent() {
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24">
-      <header className="mb-5 flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
-        <div>
-          <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
-          <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
-        </div>
-        <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create' })}>
-          <Plus className="size-4" />
-          Write a question
+      <div className="mb-5 flex border-b">
+        <button
+          type="button"
+          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
+            tab === 'authored'
+              ? 'border-b-2 border-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setTab('authored')}
+        >
+          Your Questions
         </button>
-      </header>
-
-      <section className="mb-5 grid grid-cols-2 gap-2 rounded-lg border bg-card p-2 sm:grid-cols-[1fr_1fr_2fr] sm:gap-3 sm:p-3">
-        <select
-          value={domainFilter}
-          onChange={(event) => setDomainFilter(event.target.value)}
-          className="h-11 rounded-md border bg-background px-3 text-sm"
-          aria-label="Filter by domain"
+        <button
+          type="button"
+          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
+            tab === 'answered'
+              ? 'border-b-2 border-foreground text-foreground'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setTab('answered')}
         >
-          <option value="all">All domains</option>
-          {availableDomains.map((item) => (
-            <option key={item.domain} value={item.domain}>{item.label}</option>
-          ))}
-        </select>
-        <select
-          value={sortMode}
-          onChange={(event) => setSortMode(event.target.value as SortMode)}
-          className="h-11 rounded-md border bg-background px-3 text-sm"
-          aria-label="Sort by"
-        >
-          <option value="newest">Newest</option>
-          <option value="most_answered">Most answered</option>
-          <option value="hardest">Hardest</option>
-          <option value="easiest">Easiest</option>
-        </select>
-        <label className="relative col-span-2 sm:col-span-1">
-          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
-          <input
-            value={search}
-            onChange={(event) => setSearch(event.target.value)}
-            placeholder="Search questions..."
-            className="h-11 w-full rounded-md border bg-background pl-10 pr-3 text-sm outline-none focus:border-primary"
-          />
-        </label>
-      </section>
+          Answered
+        </button>
+      </div>
 
-      {questions.length === 0 ? (
-        <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
-          <h2 className="font-serif text-2xl font-semibold">No questions yet.</h2>
-          <p className="mt-2 max-w-sm text-sm text-muted-foreground">
-            You haven&apos;t written any questions yet. Write one to get started.
-          </p>
-          <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
-            Write a question
-          </button>
-        </section>
-      ) : filteredQuestions.length === 0 ? (
-        <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
-          <h2 className="font-serif text-2xl font-semibold">No questions match your filter.</h2>
-          <button className="mt-3 text-sm text-primary underline" type="button" onClick={clearFilters}>
-            Clear filters
-          </button>
-        </section>
+      {tab === 'authored' ? (
+        <>
+          <header className="mb-5 flex flex-col gap-4 border-b pb-5 sm:flex-row sm:items-end sm:justify-between">
+            <div>
+              <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
+              <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
+            </div>
+            <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create' })}>
+              <Plus className="size-4" />
+              Write a question
+            </button>
+          </header>
+
+          <section className="mb-5 grid grid-cols-2 gap-2 rounded-lg border bg-card p-2 sm:grid-cols-[1fr_1fr_2fr] sm:gap-3 sm:p-3">
+            <select
+              value={domainFilter}
+              onChange={(event) => setDomainFilter(event.target.value)}
+              className="h-11 rounded-md border bg-background px-3 text-sm"
+              aria-label="Filter by domain"
+            >
+              <option value="all">All domains</option>
+              {availableDomains.map((item) => (
+                <option key={item.domain} value={item.domain}>{item.label}</option>
+              ))}
+            </select>
+            <select
+              value={sortMode}
+              onChange={(event) => setSortMode(event.target.value as SortMode)}
+              className="h-11 rounded-md border bg-background px-3 text-sm"
+              aria-label="Sort by"
+            >
+              <option value="newest">Newest</option>
+              <option value="most_answered">Most answered</option>
+              <option value="hardest">Hardest</option>
+              <option value="easiest">Easiest</option>
+            </select>
+            <label className="relative col-span-2 sm:col-span-1">
+              <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+              <input
+                value={search}
+                onChange={(event) => setSearch(event.target.value)}
+                placeholder="Search questions..."
+                className="h-11 w-full rounded-md border bg-background pl-10 pr-3 text-sm outline-none focus:border-primary"
+              />
+            </label>
+          </section>
+
+          {questions.length === 0 ? (
+            <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
+              <h2 className="font-serif text-2xl font-semibold">No questions yet.</h2>
+              <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+                You haven&apos;t written any questions yet. Write one to get started.
+              </p>
+              <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
+                Write a question
+              </button>
+            </section>
+          ) : filteredQuestions.length === 0 ? (
+            <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
+              <h2 className="font-serif text-2xl font-semibold">No questions match your filter.</h2>
+              <button className="mt-3 text-sm text-primary underline" type="button" onClick={clearFilters}>
+                Clear filters
+              </button>
+            </section>
+          ) : (
+            <section className="space-y-3">
+              {filteredQuestions.map((question) => (
+                <MyQuestionCard
+                  key={question.id}
+                  question={question}
+                  confirming={confirmingId === question.id}
+                  cardError={cardError[question.id]}
+                  deleting={removingId === question.id}
+                  onEdit={() => setDrawer({ mode: 'edit', question })}
+                  onDeleteRequest={() => setConfirmingId(question.id)}
+                  onConfirmDelete={() => void confirmDelete(question)}
+                  onCancelConfirm={() => setConfirmingId(null)}
+                />
+              ))}
+            </section>
+          )}
+        </>
       ) : (
-        <section className="space-y-3">
-          {filteredQuestions.map((question) => (
-            <MyQuestionCard
-              key={question.id}
-              question={question}
-              confirming={confirmingId === question.id}
-              cardError={cardError[question.id]}
-              deleting={removingId === question.id}
-              onEdit={() => setDrawer({ mode: 'edit', question })}
-              onDeleteRequest={() => setConfirmingId(question.id)}
-              onConfirmDelete={() => void confirmDelete(question)}
-              onCancelConfirm={() => setConfirmingId(null)}
-            />
-          ))}
-        </section>
+        <>
+          <header className="mb-5 border-b pb-5">
+            <h1 className="font-serif text-3xl font-semibold">Answered</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              {answered === null ? 'Loading…' : `${answered.length} answered`}
+            </p>
+          </header>
+
+          {answeredLoading ? (
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div key={index} className="h-16 animate-pulse rounded-lg border bg-card" />
+              ))}
+            </div>
+          ) : answeredError ? (
+            <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
+              <h2 className="font-serif text-2xl font-semibold">Could not load your answers</h2>
+              <p className="mt-2 text-sm text-muted-foreground">{answeredError}</p>
+              <button className="btn-primary mt-5" type="button" onClick={() => void loadAnswered()}>
+                Try again
+              </button>
+            </section>
+          ) : (
+            <AnsweredQuestionsList items={answered ?? []} />
+          )}
+        </>
       )}
 
       {drawer.mode !== 'closed' ? (

--- a/src/components/questions/AnsweredQuestionsList.tsx
+++ b/src/components/questions/AnsweredQuestionsList.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+export type AnsweredQuestionItem = {
+  id: string;
+  questionId: string;
+  questionText: string;
+  submittedAnswer: string | null;
+  correctAnswer: string;
+  result: 'correct' | 'incorrect' | 'skipped' | null;
+  askerName: string;
+  answeredAt: string | null;
+  sourceLabel: string;
+};
+
+const DATE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+
+function formatDate(value: string | null): string {
+  if (!value) return '';
+  const date = new Date(value);
+  return Number.isNaN(date.getTime()) ? '' : DATE_FORMAT.format(date);
+}
+
+function answerDisplay(item: AnsweredQuestionItem): { text: string; muted: boolean } {
+  if (item.result === 'skipped') return { text: 'Skipped', muted: true };
+  const submitted = item.submittedAnswer?.trim();
+  if (!submitted) return { text: '—', muted: true };
+  return { text: submitted, muted: false };
+}
+
+function askerDisplay(item: AnsweredQuestionItem): string {
+  return item.askerName?.trim() || 'Unknown';
+}
+
+export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[] }) {
+  if (items.length === 0) {
+    return (
+      <section className="flex flex-1 flex-col items-center justify-center py-16 text-center">
+        <h2 className="font-serif text-2xl font-semibold">No answers yet.</h2>
+        <p className="mt-2 max-w-sm text-sm text-muted-foreground">
+          Questions you answer in your feed, daily five, or Joshing games will show up here.
+        </p>
+      </section>
+    );
+  }
+
+  return (
+    <section>
+      <div className="hidden grid-cols-[2fr_2fr_1fr_1fr] gap-3 border-b px-3 pb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground sm:grid">
+        <div>Question</div>
+        <div>Your answer</div>
+        <div>Asked by</div>
+        <div>Date answered</div>
+      </div>
+      <ul className="divide-y">
+        {items.map((item) => {
+          const answer = answerDisplay(item);
+          const correct = item.result === 'correct';
+          const skipped = item.result === 'skipped';
+          return (
+            <li
+              key={item.id}
+              className="grid grid-cols-1 gap-2 px-3 py-3 sm:grid-cols-[2fr_2fr_1fr_1fr] sm:items-start sm:gap-3"
+            >
+              <div className="text-sm">
+                <p className="line-clamp-3 text-foreground">{item.questionText}</p>
+              </div>
+              <div className="text-sm">
+                <span
+                  className={
+                    answer.muted
+                      ? 'italic text-muted-foreground'
+                      : correct
+                        ? 'text-foreground'
+                        : skipped
+                          ? 'italic text-muted-foreground'
+                          : 'text-foreground line-through decoration-muted-foreground/60'
+                  }
+                >
+                  {answer.text}
+                </span>
+                {!answer.muted && !correct && !skipped ? (
+                  <span className="ml-2 text-xs text-muted-foreground">
+                    correct: {item.correctAnswer}
+                  </span>
+                ) : null}
+                <p className="mt-0.5 text-xs text-muted-foreground sm:hidden">
+                  Asked by {askerDisplay(item)} · {formatDate(item.answeredAt)}
+                </p>
+              </div>
+              <div className="hidden text-sm text-muted-foreground sm:block">
+                {askerDisplay(item)}
+              </div>
+              <div className="hidden text-sm text-muted-foreground sm:block">
+                {formatDate(item.answeredAt)}
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </section>
+  );
+}

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -1,4 +1,5 @@
 import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 
 import {
   dailyQueues,
@@ -38,7 +39,10 @@ export type ArchiveItem = {
   canUseQuestionActions: boolean;
   creatorNote: DeliveredCreatorNote | null;
   verified: boolean;
+  askerName: string;
 };
+
+export type ArchiveKind = 'all' | 'answered';
 
 export type ArchiveResult = {
   items: ArchiveItem[];
@@ -178,6 +182,15 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
   const generatedById = new Map(generatedRows.map((question) => [question.id, question]));
   const questionById = new Map(questionRows.map((question) => [question.id, question]));
 
+  const creatorIds = [...new Set(questionRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)))];
+  const creatorRows = creatorIds.length
+    ? await db
+        .select({ id: users.id, displayName: users.displayName })
+        .from(users)
+        .where(inArray(users.id, creatorIds))
+    : [];
+  const creatorById = new Map(creatorRows.map((row) => [row.id, row.displayName]));
+
   return queues.flatMap((queue) =>
     asQueueSlots(queue.slots)
       .filter((slot) => slot.answered || slot.skipped)
@@ -186,6 +199,7 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
         const bankQuestion = slot.question_id ? questionById.get(slot.question_id) : null;
         const domain = slot.domain || generated?.canonicalSubcategory || questionDomain(bankQuestion);
         const questionId = slot.question_id ?? slot.generated_question_id ?? `${queue.id}:${slot.slot_index}`;
+        const askerDisplay = bankQuestion?.creatorId ? creatorById.get(bankQuestion.creatorId) ?? null : null;
         return {
           id: `daily:${queue.id}:${slot.slot_index}`,
           questionId,
@@ -205,21 +219,25 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
           canUseQuestionActions: Boolean(slot.question_id),
           creatorNote: null,
           verified: bankQuestion?.verified ?? true,
+          askerName: askerDisplay ?? (generated ? 'Daily Five' : ''),
         } satisfies ArchiveItem;
       }),
   );
 }
 
 async function readFeedItems(userId: string, source?: ArchiveSource): Promise<ArchiveItem[]> {
+  const creatorUsers = alias(users, 'creator_users');
   const rows = await db
     .select({
       feedItem: feedItems,
       question: questions,
       sourceUser: { displayName: users.displayName },
+      creatorUser: { displayName: creatorUsers.displayName },
     })
     .from(feedItems)
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
     .innerJoin(users, eq(feedItems.sourceUserId, users.id))
+    .leftJoin(creatorUsers, eq(questions.creatorId, creatorUsers.id))
     .where(and(eq(feedItems.recipientUserId, userId), eq(feedItems.state, 'answered')))
     .orderBy(desc(feedItems.sourceEventAt));
 
@@ -252,7 +270,7 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
     if (feedId) eventByFeedId.set(feedId, event);
   }
 
-  return relevantRows.map(({ feedItem, question, sourceUser }) => {
+  return relevantRows.map(({ feedItem, question, sourceUser, creatorUser }) => {
     const sourceName = personName(sourceUser.displayName);
     const domain = questionDomain(question);
     const correctEvent = eventByFeedId.get(feedItem.id);
@@ -266,7 +284,7 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       source: archiveSource,
       sourceLabel: feedItem.sourceType === 'direct_sent' ? `From ${sourceName}` : `Feed · ${sourceName}`,
       result: correctEvent ? 'correct' : 'incorrect',
-      submittedAnswer: null,
+      submittedAnswer: feedItem.submittedAnswer ?? null,
       correctAnswer: question.answerText,
       explanation: questionExplanation(question),
       pointsAwarded: correctEvent ? Number(correctEvent.awardedPoints ?? 0) : 0,
@@ -276,24 +294,28 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       canUseQuestionActions: true,
       creatorNote: null,
       verified: question.verified,
+      askerName: creatorUser?.displayName ?? '',
     } satisfies ArchiveItem;
   });
 }
 
 async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
+  const creatorUsers = alias(users, 'creator_users_jg');
   const rows = await db
     .select({
       response: joshingGameResponses,
       question: questions,
       game: { title: joshingGames.title },
+      creatorUser: { displayName: creatorUsers.displayName },
     })
     .from(joshingGameResponses)
     .innerJoin(questions, eq(joshingGameResponses.questionId, questions.id))
     .innerJoin(joshingGames, eq(joshingGameResponses.gameId, joshingGames.id))
+    .leftJoin(creatorUsers, eq(questions.creatorId, creatorUsers.id))
     .where(eq(joshingGameResponses.userId, userId))
     .orderBy(desc(joshingGameResponses.answeredAt));
 
-  return rows.map(({ response, question, game }) => {
+  return rows.map(({ response, question, game, creatorUser }) => {
     const domain = questionDomain(question);
     return {
       id: `joshing_game:${response.id}`,
@@ -314,6 +336,7 @@ async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
       canUseQuestionActions: true,
       creatorNote: null,
       verified: question.verified,
+      askerName: creatorUser?.displayName ?? '',
     } satisfies ArchiveItem;
   });
 }
@@ -368,16 +391,21 @@ async function readWrittenByMeItems(userId: string): Promise<ArchiveItem[]> {
       canUseQuestionActions: true,
       creatorNote: null,
       verified: question.verified,
+      askerName: '',
     } satisfies ArchiveItem;
   });
 }
 
-async function readAllArchiveItems(userId: string, source?: ArchiveSource): Promise<ArchiveItem[]> {
+async function readAllArchiveItems(
+  userId: string,
+  source?: ArchiveSource,
+  kind: ArchiveKind = 'all',
+): Promise<ArchiveItem[]> {
   const readers: Promise<ArchiveItem[]>[] = [];
   if (!source || source === 'daily') readers.push(readDailyItems(userId));
   if (!source || source === 'feed' || source === 'sent_to_me') readers.push(readFeedItems(userId, source));
   if (!source || source === 'joshing_game') readers.push(readJoshingGameItems(userId));
-  if (!source || source === 'written_by_me') readers.push(readWrittenByMeItems(userId));
+  if (kind !== 'answered' && (!source || source === 'written_by_me')) readers.push(readWrittenByMeItems(userId));
 
   const items = (await Promise.all(readers)).flat();
   return decorateItems(userId, items);
@@ -401,11 +429,14 @@ export async function getArchiveForUser(params: {
   result?: ArchiveResultFilter;
   limit?: number;
   cursor?: string;
+  kind?: ArchiveKind;
 }): Promise<ArchiveResult> {
   const limit = Math.min(Math.max(params.limit ?? DEFAULT_LIMIT, 1), MAX_LIMIT);
   const cursor = decodeCursor(params.cursor);
-  const allItems = applyFilters(await readAllArchiveItems(params.userId, params.source), params)
-    .sort(compareArchiveItems);
+  const allItems = applyFilters(
+    await readAllArchiveItems(params.userId, params.source, params.kind),
+    params,
+  ).sort(compareArchiveItems);
   const cursorItems = cursor ? allItems.filter((item) => afterCursor(item, cursor)) : allItems;
   const pageItems = cursorItems.slice(0, limit);
 


### PR DESCRIPTION
Adds a toggle at the top of /questions between "Your Questions" and a new
"Answered" view. The Answered view is a table-like list of every question
the user has answered across daily, feed, and joshing-game sources, with
columns for question, submitted answer, question author, and date answered.

Reuses getArchiveForUser by adding an askerName field plus an opt-in
kind: 'answered' filter that skips the written-by-me reader. Also fixes a
small drive-by: the feed reader was hard-coding submittedAnswer to null
even though FeedItem.submittedAnswer is populated.

https://claude.ai/code/session_01TKRUUtX9KMxCjHHkFVzh3g