### PR TITLE
Add animated triangle loading screen

### DIFF
--- a/src/app/dev/loading-preview/page.tsx
+++ b/src/app/dev/loading-preview/page.tsx
@@ -1,0 +1,9 @@
+import LoadingScreen from "@/components/LoadingScreen";
+
+export default function LoadingPreviewPage() {
+  return (
+    <div className="min-h-screen w-full">
+      <LoadingScreen fullScreen />
+    </div>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -174,3 +174,27 @@
     @apply inline-flex min-h-10 items-center justify-center rounded-md border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted disabled:pointer-events-none disabled:opacity-45;
   }
 }
+
+@keyframes triangle-breathe {
+  0%, 100% { opacity: var(--tri-opacity-low, 0.75); }
+  50%      { opacity: var(--tri-opacity-high, 1); }
+}
+
+@keyframes triangle-drift {
+  0%   { transform: translate(0, 0) rotate(0deg); }
+  50%  { transform: translate(var(--tri-dx, 0), var(--tri-dy, 0)) rotate(var(--tri-dr, 0deg)); }
+  100% { transform: translate(0, 0) rotate(0deg); }
+}
+
+@keyframes loading-dot {
+  0%, 80%, 100% { opacity: 0.25; transform: translateY(0); }
+  40%           { opacity: 1;    transform: translateY(-2px); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .triangle-loader-tri,
+  .triangle-loader-float,
+  .triangle-loader-dot {
+    animation: none !important;
+  }
+}

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import * as React from "react";
+
+type LoadingScreenProps = {
+  label?: string;
+  className?: string;
+  fullScreen?: boolean;
+};
+
+const VIEWBOX_W = 400;
+const VIEWBOX_H = 900;
+const SIZE = 56;
+const TRI_H = SIZE * 0.8660254;
+
+const PALETTE = [
+  "#1F3556",
+  "#BC4632",
+  "#5D7E96",
+  "#D9A441",
+  "#E8DCC0",
+  "#F4ECD8",
+  "#3A5973",
+  "#A03A2C",
+];
+
+function rand(seed: number) {
+  let h = (seed * 2654435761) >>> 0;
+  h = ((h ^ (h >>> 13)) * 1274126177) >>> 0;
+  return ((h ^ (h >>> 16)) >>> 0) / 4294967295;
+}
+
+type Tri = {
+  points: string;
+  color: string;
+  delay: number;
+  duration: number;
+  opacityLow: number;
+  opacityHigh: number;
+};
+
+function buildTriangles(): Tri[] {
+  const tris: Tri[] = [];
+  const rows = Math.ceil(VIEWBOX_H / TRI_H) + 2;
+  const trisPerRow = Math.ceil((VIEWBOX_W * 2) / SIZE) + 4;
+
+  let idx = 0;
+  for (let row = -1; row < rows; row++) {
+    for (let i = -2; i < trisPerRow; i++) {
+      const y = row * TRI_H;
+      const xBase = (i * SIZE) / 2;
+      let points: string;
+
+      if (((i % 2) + 2) % 2 === 0) {
+        points = `${xBase},${y + TRI_H} ${xBase + SIZE},${y + TRI_H} ${xBase + SIZE / 2},${y}`;
+      } else {
+        points = `${xBase},${y} ${xBase + SIZE},${y} ${xBase + SIZE / 2},${y + TRI_H}`;
+      }
+
+      const r1 = rand(idx * 7 + 11);
+      const r2 = rand(idx * 13 + 29);
+      const r3 = rand(idx * 17 + 53);
+      const color = PALETTE[Math.floor(r1 * PALETTE.length)];
+      const duration = 4 + r2 * 5;
+      const delay = -r3 * duration;
+      const opacityLow = 0.55 + r1 * 0.25;
+      const opacityHigh = 0.95 + r2 * 0.05;
+
+      tris.push({ points, color, delay, duration, opacityLow, opacityHigh });
+      idx++;
+    }
+  }
+  return tris;
+}
+
+type FloatTri = {
+  points: string;
+  color: string;
+  cx: number;
+  cy: number;
+  dx: number;
+  dy: number;
+  dr: number;
+  duration: number;
+  delay: number;
+  opacity: number;
+};
+
+function buildFloaters(): FloatTri[] {
+  const specs: Array<[number, number, number, string, number]> = [
+    [80, 180, 110, "#BC4632", 0.45],
+    [310, 240, 140, "#1F3556", 0.4],
+    [60, 540, 130, "#D9A441", 0.4],
+    [340, 650, 100, "#5D7E96", 0.45],
+    [200, 380, 160, "#3A5973", 0.32],
+    [160, 780, 90, "#A03A2C", 0.4],
+  ];
+
+  return specs.map(([cx, cy, size, color, opacity], i) => {
+    const h = size * 0.8660254;
+    const points = [
+      [cx - size / 2, cy + h / 2],
+      [cx + size / 2, cy + h / 2],
+      [cx, cy - h / 2],
+    ]
+      .map(([x, y]) => `${x},${y}`)
+      .join(" ");
+    const seed = i + 1;
+    const dx = (rand(seed * 31) - 0.5) * 80;
+    const dy = (rand(seed * 47) - 0.5) * 80;
+    const dr = (rand(seed * 59) - 0.5) * 30;
+    const duration = 14 + rand(seed * 71) * 10;
+    const delay = -rand(seed * 89) * duration;
+
+    return { points, color, cx, cy, dx, dy, dr, duration, delay, opacity };
+  });
+}
+
+export default function LoadingScreen({
+  label = "Loading",
+  className,
+  fullScreen = false,
+}: LoadingScreenProps) {
+  const triangles = React.useMemo(() => buildTriangles(), []);
+  const floaters = React.useMemo(() => buildFloaters(), []);
+
+  const wrapperClass = [
+    "relative isolate flex items-center justify-center overflow-hidden bg-[#E8DCC0]",
+    fullScreen ? "fixed inset-0 z-50" : "h-full w-full min-h-[480px]",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <div
+      className={wrapperClass}
+      role="status"
+      aria-live="polite"
+      aria-busy="true"
+      aria-label={`${label}…`}
+    >
+      <svg
+        className="absolute inset-0 h-full w-full"
+        viewBox={`0 0 ${VIEWBOX_W} ${VIEWBOX_H}`}
+        preserveAspectRatio="xMidYMid slice"
+        aria-hidden="true"
+      >
+        <g>
+          {triangles.map((t, i) => (
+            <polygon
+              key={i}
+              className="triangle-loader-tri"
+              points={t.points}
+              fill={t.color}
+              style={
+                {
+                  animation: `triangle-breathe ${t.duration}s ease-in-out ${t.delay}s infinite`,
+                  ["--tri-opacity-low" as string]: String(t.opacityLow),
+                  ["--tri-opacity-high" as string]: String(t.opacityHigh),
+                } as React.CSSProperties
+              }
+            />
+          ))}
+        </g>
+
+        <g style={{ mixBlendMode: "multiply" }}>
+          {floaters.map((f, i) => (
+            <g
+              key={i}
+              className="triangle-loader-float"
+              style={
+                {
+                  transformBox: "fill-box",
+                  transformOrigin: `${f.cx}px ${f.cy}px`,
+                  animation: `triangle-drift ${f.duration}s ease-in-out ${f.delay}s infinite`,
+                  ["--tri-dx" as string]: `${f.dx}px`,
+                  ["--tri-dy" as string]: `${f.dy}px`,
+                  ["--tri-dr" as string]: `${f.dr}deg`,
+                } as React.CSSProperties
+              }
+            >
+              <polygon points={f.points} fill={f.color} opacity={f.opacity} />
+            </g>
+          ))}
+        </g>
+      </svg>
+
+      <div className="relative z-10 mx-6 flex w-full max-w-xs flex-col items-center rounded-2xl bg-[#F5EBD3] px-8 py-10 shadow-[0_8px_24px_rgba(20,18,8,0.18)] ring-1 ring-black/5">
+        <p
+          className="text-3xl font-black tracking-[0.18em] text-[#1a1208]"
+          style={{ fontFamily: "var(--font-literata, Georgia), serif" }}
+        >
+          JOSHING
+        </p>
+        <div className="mt-6 h-px w-12 bg-[#1a1208]/20" aria-hidden="true" />
+        <p className="mt-5 flex items-baseline gap-1 text-sm font-medium tracking-wider uppercase text-[#1a1208]/70">
+          <span>{label}</span>
+          <span className="ml-0.5 inline-flex gap-0.5" aria-hidden="true">
+            <span
+              className="triangle-loader-dot inline-block"
+              style={{ animation: "loading-dot 1.2s ease-in-out 0s infinite" }}
+            >
+              .
+            </span>
+            <span
+              className="triangle-loader-dot inline-block"
+              style={{ animation: "loading-dot 1.2s ease-in-out 0.2s infinite" }}
+            >
+              .
+            </span>
+            <span
+              className="triangle-loader-dot inline-block"
+              style={{ animation: "loading-dot 1.2s ease-in-out 0.4s infinite" }}
+            >
+              .
+            </span>
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export { LoadingScreen };


### PR DESCRIPTION
## Summary
- New reusable `LoadingScreen` component (`src/components/LoadingScreen.tsx`) with a tessellated triangle background that breathes in opacity, plus six larger semi-transparent triangles drifting on a `mix-blend-mode: multiply` layer to create the overlap effect from the design mockups.
- Center card shows the **JOSHING** wordmark + animated `Loading…` dots, matching the cream card style of the existing screens.
- Pure CSS keyframes added to `src/app/globals.css` — no new dependencies. Honors `prefers-reduced-motion`. `aria-busy` / `aria-live` for accessibility.
- Preview route at `/dev/loading-preview` (behind the same auth gate as the other `/dev/*` routes).

## Tuning knobs
First-cut visual; exact triangle palette, sizes, and motion to be dialed in next pass. All are plain literals near the top of `LoadingScreen.tsx`:
- `PALETTE` — triangle colors
- `SIZE` — base triangle side length
- `buildFloaters()` specs — the six drifting overlay triangles (position, size, color, opacity)
- Per-triangle `duration` / `delay` ranges inside `buildTriangles()`

## Test plan
- [ ] `npm run dev`, visit `/dev/loading-preview`, confirm the tile field breathes and the six floating triangles drift/rotate.
- [ ] Toggle OS "reduce motion" and confirm animations stop.
- [ ] Drop `<LoadingScreen />` into a real loading slot (e.g. inside the game while a round loads) and verify it fills the container without layout shift.
- [ ] Inspect on a small viewport (390x844) — wordmark card stays centered, triangle field still tiles edge-to-edge.

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_