### PR TITLE
fix(daily): add factual-correctness gate to bot question generation

### DIFF
--- a/src/app/api/daily/recheck/route.ts
+++ b/src/app/api/daily/recheck/route.ts
@@ -161,8 +161,16 @@ export async function POST(request: NextRequest) {
 
     const accepted = review.decision === 'accept';
     const pointsAwarded = accepted ? question.basePoints : 0;
+    // User-facing outcome. A disputed answer key reads as "we're taking
+    // another look" rather than a confident rejection — we will not tell the
+    // player they were wrong against an answer the reviewer flagged as wrong.
     const recheckStatus = accepted ? 'accepted' : review.decision === 'reject' ? 'rejected' : 'needs_human';
-    const disputeStatus = accepted ? 'alternative_added' : review.decision === 'reject' ? 'dismissed' : 'pending';
+    // Backend dispute lifecycle. Only an accept auto-resolves (the alternative
+    // is added). Everything else — including plain rejects — now stays 'pending'
+    // so a human can review it, instead of being auto-dismissed. The precise
+    // verdict is preserved in reviewDecision below for the review queue.
+    const disputeStatus = accepted ? 'alternative_added' : 'pending';
+    const reviewedAt = accepted ? new Date() : null;
     const answerId = `daily:${queue.id}:${parsed.slotIndex}:${session.userId}`;
 
     const nextSlots = slots.map((item) => {
@@ -228,7 +236,7 @@ export async function POST(request: NextRequest) {
           reviewReason: review.reason,
           acceptedAlternative: review.acceptedAlternative,
           status: disputeStatus,
-          reviewedAt: review.decision === 'needs_human' ? null : new Date(),
+          reviewedAt,
         })
         .onConflictDoUpdate({
           target: gradeDisputes.answerId,
@@ -240,7 +248,7 @@ export async function POST(request: NextRequest) {
             reviewReason: review.reason,
             acceptedAlternative: review.acceptedAlternative,
             status: disputeStatus,
-            reviewedAt: review.decision === 'needs_human' ? null : new Date(),
+            reviewedAt,
           },
         });
     });

--- a/src/app/api/feed/[feedItemId]/recheck/route.ts
+++ b/src/app/api/feed/[feedItemId]/recheck/route.ts
@@ -64,8 +64,13 @@ export async function POST(_request: NextRequest, context: RouteContext) {
     });
 
     const accepted = review.decision === 'accept';
+    // A disputed answer key reads as "taking another look", not a rejection.
     const recheckStatus = accepted ? 'accepted' : review.decision === 'reject' ? 'rejected' : 'needs_human';
-    const disputeStatus = accepted ? 'alternative_added' : review.decision === 'reject' ? 'dismissed' : 'pending';
+    // Only an accept auto-resolves; rejects and disputed keys stay 'pending'
+    // for human review rather than auto-dismissed. reviewDecision preserves
+    // the exact verdict for the review queue.
+    const disputeStatus = accepted ? 'alternative_added' : 'pending';
+    const reviewedAt = accepted ? new Date() : null;
     const domain = question.canonicalSubcategory || question.broadCategory || question.category;
 
     let pointsAwarded = 0;
@@ -95,7 +100,7 @@ export async function POST(_request: NextRequest, context: RouteContext) {
           reviewReason: review.reason,
           acceptedAlternative: review.acceptedAlternative,
           status: disputeStatus,
-          reviewedAt: review.decision === 'needs_human' ? null : new Date(),
+          reviewedAt,
         })
         .returning({ id: gradeDisputes.id });
       return inserted?.id ?? null;

--- a/src/server/daily/__tests__/factual-gate.test.ts
+++ b/src/server/daily/__tests__/factual-gate.test.ts
@@ -1,0 +1,52 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// generate-questions.ts imports @/server/db, which throws at module load
+// without a connection string. The parser under test never touches the DB;
+// a dummy URL plus dynamic import (the repo convention) keeps the unit pure.
+let parseFactualGateResponse: typeof import('@/server/daily/generate-questions').parseFactualGateResponse;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  ({ parseFactualGateResponse } = await import('@/server/daily/generate-questions'));
+});
+
+describe('parseFactualGateResponse', () => {
+  it('collects in-range drop indices and their reasons', () => {
+    const result = parseFactualGateResponse(
+      '{"drop_indices":[1],"reasons":{"1":"Rubyfruit Jungle was written by Rita Mae Brown, not Roberta Achtenberg."}}',
+      3,
+    );
+    expect([...result.toDrop]).toEqual([1]);
+    expect(result.reasons[1]).toContain('Rita Mae Brown');
+  });
+
+  it('ignores out-of-range, non-integer, and negative indices', () => {
+    const result = parseFactualGateResponse('{"drop_indices":[5,-1,1.5,0]}', 3);
+    expect([...result.toDrop].sort()).toEqual([0]);
+  });
+
+  it('drops reasons whose index was not flagged', () => {
+    const result = parseFactualGateResponse(
+      '{"drop_indices":[0],"reasons":{"0":"wrong","2":"orphan reason"}}',
+      3,
+    );
+    expect(result.reasons).toEqual({ 0: 'wrong' });
+  });
+
+  it('returns an empty result for malformed or non-object output', () => {
+    for (const raw of ['not json', '[]', '{}', '{"drop_indices":"nope"}']) {
+      const result = parseFactualGateResponse(raw, 3);
+      expect(result.toDrop.size).toBe(0);
+      expect(result.reasons).toEqual({});
+    }
+  });
+
+  it('truncates very long reason strings', () => {
+    const long = 'x'.repeat(500);
+    const result = parseFactualGateResponse(
+      `{"drop_indices":[0],"reasons":{"0":"${long}"}}`,
+      1,
+    );
+    expect(result.reasons[0].length).toBe(200);
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -550,6 +550,100 @@ async function findQualityFailures(generated: LlmQuestion[]): Promise<{
   }
 }
 
+// Factual-correctness gate. The dedup and quality gates above never check
+// whether the *stated answer is actually correct for the question* — they
+// only catch repeats, leaks, vagueness, and false premises in the setup. A
+// generator hallucination that pairs a good question with the wrong answer
+// (e.g. asking who wrote "Rubyfruit Jungle" but answering with a politician)
+// sails straight through. User-authored questions get this check via
+// vetQuestion() on the /api/questions path; bot-generated daily questions
+// had no equivalent until this gate. Like the others it is batch-based,
+// runs in parallel, and fails open.
+const FACTUAL_GATE_SYSTEM_PROMPT = `You are fact-checking a small batch of just-generated trivia questions before they are served to a player. Each item has a question and the stated answer the game will mark as correct. Your only job is to catch questions whose stated answer is WRONG.
+
+For each question decide:
+- WRONG — the stated answer is factually incorrect for the question, OR the question's clearly-correct answer is a different thing/person than the stated answer, OR the question and answer come from mismatched subjects (e.g. a literature question answered with an unrelated political figure).
+- OK — the stated answer is correct, or a reasonable equivalent/alternate form of the correct answer.
+- UNVERIFIABLE — you genuinely cannot verify the fact (extremely niche, recent, or personal). Treat these as OK; do NOT flag them.
+
+Flag (drop) ONLY questions you judge WRONG with high confidence. A high bar applies — when in doubt, leave it. Do not flag for style, difficulty, phrasing, or ambiguity; only for a factually incorrect stated answer.
+
+Return JSON only:
+{ "drop_indices": [list of zero-based indices whose stated answer is wrong], "reasons": { "<index>": "<short reason naming the correct answer>" } }
+
+If no answers are wrong, return { "drop_indices": [], "reasons": {} }.${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+export function parseFactualGateResponse(
+  raw: string,
+  batchSize: number,
+): { toDrop: Set<number>; reasons: Record<number, string> } {
+  const parsed = parseJsonObject(raw);
+  const toDrop = new Set<number>();
+  const reasons: Record<number, string> = {};
+  if (!parsed) return { toDrop, reasons };
+
+  const rawList = parsed.drop_indices;
+  if (Array.isArray(rawList)) {
+    for (const value of rawList) {
+      if (
+        typeof value === 'number' &&
+        Number.isInteger(value) &&
+        value >= 0 &&
+        value < batchSize
+      ) {
+        toDrop.add(value);
+      }
+    }
+  }
+
+  const rawReasons = parsed.reasons;
+  if (rawReasons && typeof rawReasons === 'object' && !Array.isArray(rawReasons)) {
+    for (const [key, value] of Object.entries(rawReasons as Record<string, unknown>)) {
+      const idx = Number.parseInt(key, 10);
+      if (Number.isInteger(idx) && toDrop.has(idx) && typeof value === 'string') {
+        reasons[idx] = value.slice(0, 200);
+      }
+    }
+  }
+
+  return { toDrop, reasons };
+}
+
+async function findFactualFailures(generated: LlmQuestion[]): Promise<{
+  toDrop: Set<number>;
+  reasons: Record<number, string>;
+}> {
+  if (generated.length === 0) return { toDrop: new Set(), reasons: {} };
+  const client = getAnthropicClient();
+  if (!client) return { toDrop: new Set(), reasons: {} };
+
+  const body = generated
+    .map(
+      (q, i) =>
+        `[${i}] domain=${q.canonical_subcategory}\n    q=${q.question_text}\n    a=${q.answer}`,
+    )
+    .join('\n\n');
+  const userMessage = wrapUserInput('batch', body);
+
+  try {
+    const response = await loggedMessagesCreate(client, 'factual-gate', {
+      model: HAIKU_MODEL,
+      max_tokens: 500,
+      temperature: 0,
+      system: FACTUAL_GATE_SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMessage }],
+    }, { timeoutMs: HAIKU_GATE_TIMEOUT_MS });
+    return parseFactualGateResponse(extractTextContent(response.content), generated.length);
+  } catch (err) {
+    // Fail open: a Haiku outage should not block the daily queue. A wrong
+    // answer slipping through is no worse than the pre-gate status quo.
+    console.warn('[daily/generate-questions] factual gate failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return { toDrop: new Set(), reasons: {} };
+  }
+}
+
 const RECENT_HISTORY_GATE_LIMIT = 30;
 
 const RECENT_HISTORY_GATE_SYSTEM_PROMPT = `You are reviewing newly-generated trivia questions against a list of questions this same user has already been asked. For each NEW question, decide whether it probes the same underlying fact as ANY of the RECENT questions.
@@ -755,11 +849,14 @@ export async function generateDailyQuestions(
   //   covered by fact_key dedup at persist time.
   // - findQualityFailures: LLM-generated counterpart to critiqueQuestion() —
   //   catches answer-leakage, opinion/vague, false-premise, self-answering.
+  // - findFactualFailures: verifies the stated answer is actually correct for
+  //   the question — the one defect class the other gates never inspect.
   const recentForGate = avoidList.slice(0, RECENT_HISTORY_GATE_LIMIT);
-  const [batchDuplicates, recentDuplicates, qualityResult] = await Promise.all([
+  const [batchDuplicates, recentDuplicates, qualityResult, factualResult] = await Promise.all([
     findBatchDuplicates(generated),
     findRecentHistoryDuplicates(generated, recentForGate),
     findQualityFailures(generated),
+    findFactualFailures(generated),
   ]);
 
   if (batchDuplicates.size > 0) {
@@ -784,11 +881,20 @@ export async function generateDailyQuestions(
       originalCount: generated.length,
     });
   }
+  if (factualResult.toDrop.size > 0) {
+    console.warn('[daily/generate-questions] dropping factually-wrong questions', {
+      droppedCount: factualResult.toDrop.size,
+      droppedIndices: [...factualResult.toDrop].sort((a, b) => a - b),
+      reasons: factualResult.reasons,
+      originalCount: generated.length,
+    });
+  }
 
   const allDrops = new Set<number>([
     ...batchDuplicates,
     ...recentDuplicates,
     ...qualityResult.toDrop,
+    ...factualResult.toDrop,
   ]);
   if (allDrops.size > 0) {
     generated = generated.filter((_, i) => !allDrops.has(i));

--- a/src/server/llm/__tests__/recheck.test.ts
+++ b/src/server/llm/__tests__/recheck.test.ts
@@ -20,4 +20,19 @@ describe('answer recheck parser', () => {
       acceptedAlternative: null,
     });
   });
+
+  it('parses a canonical_disputed verdict and never carries an accepted alternative', () => {
+    expect(
+      parseAnswerRecheck(
+        '{"decision":"canonical_disputed","confidence":0.88,"reason":"Rubyfruit Jungle was written by Rita Mae Brown, not the canonical answer.","accepted_alternative":"Rita Mae Brown"}',
+      ),
+    ).toEqual({
+      decision: 'canonical_disputed',
+      confidence: 0.88,
+      reason: 'Rubyfruit Jungle was written by Rita Mae Brown, not the canonical answer.',
+      // accepted_alternative is only honoured for an accept; a disputed key
+      // must not silently add the submitted text as an alternative.
+      acceptedAlternative: null,
+    });
+  });
 });

--- a/src/server/llm/recheck.ts
+++ b/src/server/llm/recheck.ts
@@ -8,7 +8,7 @@ import {
   wrapUserInput,
 } from '@/lib/llm';
 
-export type AnswerRecheckDecision = 'accept' | 'reject' | 'needs_human';
+export type AnswerRecheckDecision = 'accept' | 'reject' | 'canonical_disputed' | 'needs_human';
 
 export type AnswerRecheckResult = {
   decision: AnswerRecheckDecision;
@@ -39,9 +39,13 @@ export function parseAnswerRecheck(rawText: string): AnswerRecheckResult {
   const parsed = parseJsonObject(rawText);
   if (!parsed) return FALLBACK_RECHECK;
 
-  const decision = parsed.decision === 'accept' || parsed.decision === 'reject' || parsed.decision === 'needs_human'
-    ? parsed.decision
-    : null;
+  const decision =
+    parsed.decision === 'accept' ||
+    parsed.decision === 'reject' ||
+    parsed.decision === 'canonical_disputed' ||
+    parsed.decision === 'needs_human'
+      ? parsed.decision
+      : null;
   if (!decision) return FALLBACK_RECHECK;
 
   return {
@@ -73,7 +77,9 @@ Return "accept" only when the submitted answer should count as correct under at 
 - The question is ambiguous and the submitted answer is a reasonable correct answer to that wording.
 - For personal questions, it is a reasonable match to the creator's intended answer.
 
-Return "reject" when the answer is factually different, too vague, missing the key required fact, or only in the same general topic.
+Return "reject" when the submitted answer is factually different, too vague, missing the key required fact, or only in the same general topic — AND the canonical answer is itself correct for the question.
+
+Return "canonical_disputed" when the submitted answer is not acceptable, BUT the canonical answer provided to you is itself factually wrong for the question (for example, the question and the canonical answer come from mismatched subjects, or the canonical answer names the wrong person, work, date, or thing). This is the case where rejecting the player would mean defending a wrong answer key. Use a high bar: only choose this when you are confident the canonical answer is wrong, not merely when you are unsure. Do not use it just because the question is hard or niche. When you do choose it, name the answer you believe is actually correct in "reason". (If the submitted answer is in fact the correct one and the canonical is the wrong one, return "accept" — give the player credit.)
 
 Return "needs_human" when the question wording or factual dispute requires outside context you cannot confidently resolve.
 
@@ -81,7 +87,7 @@ Do not be generous just because the answer is close; do be generous when the ans
 
 Return JSON only with exactly these keys:
 {
-  "decision": "accept" | "reject" | "needs_human",
+  "decision": "accept" | "reject" | "canonical_disputed" | "needs_human",
   "confidence": 0.0,
   "reason": "one concise sentence for the player",
   "accepted_alternative": "the submitted answer normalized for future accepted alternatives, or null"


### PR DESCRIPTION
Bot-generated Daily Five questions had no check that the stated answer is
actually correct for the question. The existing gates only catch dupes,
answer-leaks, vagueness, and false premises in the setup; vetQuestion's
factual check runs only on the user-authored /api/questions path. A
generator hallucination that pairs a sound question with the wrong answer
(e.g. asking who wrote 'Rubyfruit Jungle' and answering with a politician)
shipped unchecked, then the recheck reviewer — which treats the canonical
answer as ground truth — confidently defended it.

Add findFactualFailures as a fourth batch gate running in parallel with
the dedup/quality gates: a Haiku pass that drops only answers it judges
wrong with high confidence (unverifiable facts are left in), unioned into
the existing drop set. Fails open on outage. Parser extracted and
unit-tested.