### PR TITLE
Show LoadingScreen during game route transitions

### DIFF
--- a/src/app/games/[id]/loading.tsx
+++ b/src/app/games/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingScreen from "@/components/LoadingScreen";
+
+export default function Loading() {
+  return <LoadingScreen fullScreen />;
+}


### PR DESCRIPTION
## Summary
- Adds `src/app/games/[id]/loading.tsx` so the triangle `LoadingScreen` (merged in #462) actually surfaces in the live app.
- Next.js renders this file automatically during the route's RSC data-fetch window when navigating into `/games/[id]`, so clicking into a game now flashes the animated triangle overlay until the play screen mounts.
- This is the first place the LoadingScreen appears during normal user flow. The component file, preview route, and CSS keyframes from #462 remain unchanged.

## Why this PR exists
PR #462 merged the LoadingScreen component but didn't wire it into any user-facing surface, so it was only visible at the auth-gated `/dev/loading-preview` page. This PR connects it to the first natural slot: the game route transition.

## Test plan
- [ ] `npm run dev`, log in, click a game from the home feed. The triangle loader flashes briefly during the route transition.
- [ ] In DevTools, throttle to "Slow 3G" and repeat — the loader is held visibly long enough to see the animation.
- [ ] Confirm no regressions on the play screen itself once it mounts (the loader is only during the RSC fetch).
- [ ] With OS reduce-motion enabled, the triangle field freezes (existing `globals.css` rule).

## Follow-ups (not in scope)
- Same wire-in for `/feed`, `/friends`, and other heavy routes if desired.
- Inline (non-fullscreen) usage during the grading `pending` window in `play-client.tsx` — currently judged too brief (~hundreds of ms) for a full-screen takeover.

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_