### PR TITLE
Loading screen: fix fullscreen overlay + make motion visibly dynamic

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -180,10 +180,34 @@
   50%      { opacity: var(--tri-opacity-high, 1); }
 }
 
+@keyframes triangle-color-swap {
+  0%, 49%   { fill: var(--tri-color-a, currentColor); }
+  50%, 100% { fill: var(--tri-color-b, currentColor); }
+}
+
 @keyframes triangle-drift {
-  0%   { transform: translate(0, 0) rotate(0deg); }
-  50%  { transform: translate(var(--tri-dx, 0), var(--tri-dy, 0)) rotate(var(--tri-dr, 0deg)); }
-  100% { transform: translate(0, 0) rotate(0deg); }
+  0%   { transform: translate(0, 0) rotate(0deg) scale(1); }
+  50%  { transform: translate(var(--tri-dx, 0), var(--tri-dy, 0)) rotate(var(--tri-dr, 0deg)) scale(var(--tri-ds, 1)); }
+  100% { transform: translate(0, 0) rotate(0deg) scale(1); }
+}
+
+@keyframes triangle-sweep {
+  0%   { transform: translate3d(-110%, -50%, 0) rotate(-22deg); opacity: 0; }
+  20%  { opacity: 0.7; }
+  80%  { opacity: 0.7; }
+  100% { transform: translate3d(110%, -50%, 0) rotate(-22deg); opacity: 0; }
+}
+
+.triangle-loader-sweep {
+  background: linear-gradient(
+    90deg,
+    rgba(245, 235, 211, 0) 0%,
+    rgba(245, 235, 211, 0.55) 50%,
+    rgba(245, 235, 211, 0) 100%
+  );
+  mix-blend-mode: screen;
+  animation: triangle-sweep 4.5s linear infinite;
+  will-change: transform, opacity;
 }
 
 @keyframes loading-dot {
@@ -194,6 +218,7 @@
 @media (prefers-reduced-motion: reduce) {
   .triangle-loader-tri,
   .triangle-loader-float,
+  .triangle-loader-sweep,
   .triangle-loader-dot {
     animation: none !important;
   }

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -32,9 +32,12 @@ function rand(seed: number) {
 
 type Tri = {
   points: string;
-  color: string;
-  delay: number;
-  duration: number;
+  colorA: string;
+  colorB: string;
+  breatheDelay: number;
+  breatheDuration: number;
+  swapDelay: number;
+  swapDuration: number;
   opacityLow: number;
   opacityHigh: number;
 };
@@ -60,13 +63,31 @@ function buildTriangles(): Tri[] {
       const r1 = rand(idx * 7 + 11);
       const r2 = rand(idx * 13 + 29);
       const r3 = rand(idx * 17 + 53);
-      const color = PALETTE[Math.floor(r1 * PALETTE.length)];
-      const duration = 4 + r2 * 5;
-      const delay = -r3 * duration;
-      const opacityLow = 0.55 + r1 * 0.25;
+      const r4 = rand(idx * 23 + 71);
+      const r5 = rand(idx * 29 + 97);
+
+      const colorAIdx = Math.floor(r1 * PALETTE.length);
+      let colorBIdx = Math.floor(r4 * PALETTE.length);
+      if (colorBIdx === colorAIdx) colorBIdx = (colorBIdx + 1) % PALETTE.length;
+
+      const breatheDuration = 1.6 + r2 * 1.4;
+      const breatheDelay = -r3 * breatheDuration;
+      const swapDuration = 3 + r5 * 3;
+      const swapDelay = -r1 * swapDuration;
+      const opacityLow = 0.25 + r1 * 0.2;
       const opacityHigh = 0.95 + r2 * 0.05;
 
-      tris.push({ points, color, delay, duration, opacityLow, opacityHigh });
+      tris.push({
+        points,
+        colorA: PALETTE[colorAIdx],
+        colorB: PALETTE[colorBIdx],
+        breatheDelay,
+        breatheDuration,
+        swapDelay,
+        swapDuration,
+        opacityLow,
+        opacityHigh,
+      });
       idx++;
     }
   }
@@ -81,6 +102,7 @@ type FloatTri = {
   dx: number;
   dy: number;
   dr: number;
+  ds: number;
   duration: number;
   delay: number;
   opacity: number;
@@ -88,12 +110,18 @@ type FloatTri = {
 
 function buildFloaters(): FloatTri[] {
   const specs: Array<[number, number, number, string, number]> = [
-    [80, 180, 110, "#BC4632", 0.45],
-    [310, 240, 140, "#1F3556", 0.4],
-    [60, 540, 130, "#D9A441", 0.4],
-    [340, 650, 100, "#5D7E96", 0.45],
-    [200, 380, 160, "#3A5973", 0.32],
-    [160, 780, 90, "#A03A2C", 0.4],
+    [80, 180, 110, "#BC4632", 0.5],
+    [310, 240, 140, "#1F3556", 0.45],
+    [60, 540, 130, "#D9A441", 0.45],
+    [340, 650, 100, "#5D7E96", 0.5],
+    [200, 380, 160, "#3A5973", 0.35],
+    [160, 780, 90, "#A03A2C", 0.45],
+    [40, 80, 120, "#5D7E96", 0.4],
+    [360, 420, 110, "#D9A441", 0.5],
+    [220, 120, 80, "#A03A2C", 0.5],
+    [120, 320, 100, "#1F3556", 0.4],
+    [280, 560, 130, "#BC4632", 0.35],
+    [80, 720, 110, "#3A5973", 0.4],
   ];
 
   return specs.map(([cx, cy, size, color, opacity], i) => {
@@ -106,13 +134,14 @@ function buildFloaters(): FloatTri[] {
       .map(([x, y]) => `${x},${y}`)
       .join(" ");
     const seed = i + 1;
-    const dx = (rand(seed * 31) - 0.5) * 80;
-    const dy = (rand(seed * 47) - 0.5) * 80;
-    const dr = (rand(seed * 59) - 0.5) * 30;
-    const duration = 14 + rand(seed * 71) * 10;
+    const dx = (rand(seed * 31) - 0.5) * 240;
+    const dy = (rand(seed * 47) - 0.5) * 240;
+    const dr = (rand(seed * 59) - 0.5) * 120;
+    const ds = 1 + rand(seed * 67) * 0.3;
+    const duration = 5 + rand(seed * 71) * 5;
     const delay = -rand(seed * 89) * duration;
 
-    return { points, color, cx, cy, dx, dy, dr, duration, delay, opacity };
+    return { points, color, cx, cy, dx, dy, dr, ds, duration, delay, opacity };
   });
 }
 
@@ -125,8 +154,10 @@ export default function LoadingScreen({
   const floaters = React.useMemo(() => buildFloaters(), []);
 
   const wrapperClass = [
-    "relative isolate flex items-center justify-center overflow-hidden bg-[#E8DCC0]",
-    fullScreen ? "fixed inset-0 z-50" : "h-full w-full min-h-[480px]",
+    "isolate flex items-center justify-center overflow-hidden bg-[#E8DCC0]",
+    fullScreen
+      ? "fixed inset-0 z-[60]"
+      : "relative h-full w-full min-h-[480px]",
     className ?? "",
   ]
     .filter(Boolean)
@@ -152,10 +183,12 @@ export default function LoadingScreen({
               key={i}
               className="triangle-loader-tri"
               points={t.points}
-              fill={t.color}
               style={
                 {
-                  animation: `triangle-breathe ${t.duration}s ease-in-out ${t.delay}s infinite`,
+                  fill: "var(--tri-color-a)",
+                  animation: `triangle-breathe ${t.breatheDuration}s ease-in-out ${t.breatheDelay}s infinite, triangle-color-swap ${t.swapDuration}s steps(1, end) ${t.swapDelay}s infinite`,
+                  ["--tri-color-a" as string]: t.colorA,
+                  ["--tri-color-b" as string]: t.colorB,
                   ["--tri-opacity-low" as string]: String(t.opacityLow),
                   ["--tri-opacity-high" as string]: String(t.opacityHigh),
                 } as React.CSSProperties
@@ -177,6 +210,7 @@ export default function LoadingScreen({
                   ["--tri-dx" as string]: `${f.dx}px`,
                   ["--tri-dy" as string]: `${f.dy}px`,
                   ["--tri-dr" as string]: `${f.dr}deg`,
+                  ["--tri-ds" as string]: String(f.ds),
                 } as React.CSSProperties
               }
             >
@@ -185,6 +219,11 @@ export default function LoadingScreen({
           ))}
         </g>
       </svg>
+
+      <div
+        className="triangle-loader-sweep pointer-events-none absolute -inset-x-1/2 top-1/2 h-[60vh]"
+        aria-hidden="true"
+      />
 
       <div className="relative z-10 mx-6 flex w-full max-w-xs flex-col items-center rounded-2xl bg-[#F5EBD3] px-8 py-10 shadow-[0_8px_24px_rgba(20,18,8,0.18)] ring-1 ring-black/5">
         <p


### PR DESCRIPTION
## Summary
Two fixes to the merged LoadingScreen that the user flagged from a production screenshot.

### Layout fix
The wrapper class merged `"relative isolate ..."` (base) with `"fixed inset-0 z-50"` (fullScreen modifier). Tailwind emits position utilities alphabetically, so `relative` always overrode `fixed` — the overlay was rendering inline inside the page slot, not as a viewport overlay. That's why the production screenshot showed the cream card with only a thin strip of triangles around it and the rest of the page white.

Split the merge so each mode owns its position utility, and bumped the z-index to `z-[60]` to cover the Nav's `z-50` create button.

### Motion overhaul (user feedback: "I really wanted a very dynamic page")
Previous animation parameters were below the perceptual threshold for motion. New layered approach:

- **Per-triangle opacity breathe**: 1.6–3.0s cycle (was 4–9s), 0.25↔1.0 swing (was 0.55↔0.95).
- **Per-triangle color cycling**: new `triangle-color-swap` keyframe swaps `fill` between two palette colors via CSS variables, 3–6s per cycle, staggered per triangle. Creates the shimmering field.
- **Floaters**: 12 (was 6), drifting ±120px (was ±40px), rotating ±60° (was ±15°), scaling to 1.3, over 5–10s (was 14–24s). `mix-blend-mode: multiply` preserved for the overlap colors.
- **Diagonal sweep band**: new translucent cream gradient strip that wipes diagonally across the screen every 4.5s on a `mix-blend-mode: screen` layer.

Reduced-motion media query extended to disable color cycling and the sweep too.

## Test plan
- [ ] `npm run dev`, log in, visit `/dev/loading-preview`. Confirm triangle field fills the entire viewport (no Joshing header or bottom nav bleeding through), shimmers with visible color shifts, 12 floaters drift/rotate/scale, and a cream band passes across diagonally every ~4.5s.
- [ ] After PR #465 merges, click into a game — same fullscreen takeover during route transition.
- [ ] Toggle OS reduce-motion — all animations freeze.
- [ ] Inspect at 390×844: card stays centered, triangle field tiles edge-to-edge.
- [ ] No regressions to the rest of the app (only LoadingScreen + globals.css keyframes touched).

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_