### PR TITLE
Fix stuck "Resume round" state after skipping a daily question

### DIFF
--- a/src/app/api/daily/status/route.ts
+++ b/src/app/api/daily/status/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from 'next/server';
 import { getSession } from '@/server/auth/session';
 import { getTodaysDailyQueue } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types';
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 
 export const dynamic = 'force-dynamic';
@@ -62,8 +62,13 @@ export async function GET() {
   const answered = slots.filter((slot) => slot.answered).length;
   const total = DAILY_QUEUE_SIZE;
   const questionsAnswered = Math.min(answered, DAILY_QUEUE_SIZE);
-  const questionsRemaining = Math.max(DAILY_QUEUE_SIZE - questionsAnswered, 0);
-  const isComplete = questionsAnswered >= DAILY_QUEUE_SIZE;
+  // Completion follows "no slot left to play", not "5 answered" — a skipped
+  // slot whose replacement failed to generate leaves nothing pending, so the
+  // round is genuinely over even though fewer than five were answered.
+  const isComplete = isRoundComplete(slots);
+  const questionsRemaining = isComplete
+    ? 0
+    : Math.max(DAILY_QUEUE_SIZE - questionsAnswered, 0);
 
   return NextResponse.json({
     questionsRemaining,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -9,7 +9,7 @@ import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionR
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
 import { categoryLabel } from '@/lib/questions-types';
-import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
 import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
 
 type ExclusionScope = 'subcategory' | 'broad_category' | 'category';
@@ -84,7 +84,13 @@ function answerFailureMessage(body: FailedAnswerResponse | null): string {
   return body?.message ?? (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined) ?? 'Could not record that answer.';
 }
 
+// Returns the slot the player should be on, or null when the round is over.
+// The `!answered && !skipped` predicate is the canonical "pending" definition
+// shared with the status API via isRoundComplete (see @/server/daily/types) —
+// when nothing is pending we redirect to the summary, and the home card now
+// agrees by treating the round as complete instead of offering "Resume".
 function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {
+  if (!hasPendingSlot(slots)) return null;
   return slots.find((slot) => !slot.answered && !slot.skipped) ?? null;
 }
 

--- a/src/server/daily/__tests__/round-completion.test.ts
+++ b/src/server/daily/__tests__/round-completion.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+
+import { hasPendingSlot, isRoundComplete, type QueueSlot } from '@/server/daily/types';
+
+// Minimal slot factory — only the fields the completion predicates read.
+function slot(
+  slot_index: number,
+  state: { answered?: boolean; skipped?: boolean } = {},
+): QueueSlot {
+  return {
+    slot_index,
+    source: 'bot',
+    domain: 'test',
+    question_text: 'q',
+    answered: state.answered ?? false,
+    skipped: state.skipped,
+  } as QueueSlot;
+}
+
+describe('isRoundComplete / hasPendingSlot', () => {
+  it('a fresh round (all pending) is not complete', () => {
+    const slots = [0, 1, 2, 3, 4].map((i) => slot(i));
+    expect(hasPendingSlot(slots)).toBe(true);
+    expect(isRoundComplete(slots)).toBe(false);
+  });
+
+  it('four answered + one pending is not complete', () => {
+    const slots = [
+      slot(0, { answered: true }),
+      slot(1, { answered: true }),
+      slot(2, { answered: true }),
+      slot(3, { answered: true }),
+      slot(4),
+    ];
+    expect(isRoundComplete(slots)).toBe(false);
+  });
+
+  it('four answered + one skipped with no replacement is complete (the bug case)', () => {
+    const slots = [
+      slot(0, { answered: true }),
+      slot(1, { answered: true }),
+      slot(2, { answered: true }),
+      slot(3, { answered: true }),
+      slot(4, { skipped: true }),
+    ];
+    expect(hasPendingSlot(slots)).toBe(false);
+    expect(isRoundComplete(slots)).toBe(true);
+  });
+
+  it('a skipped slot with a generated replacement keeps the round resumable', () => {
+    const slots = [
+      slot(0, { answered: true }),
+      slot(1, { answered: true }),
+      slot(2, { answered: true }),
+      slot(3, { answered: true }),
+      slot(4, { skipped: true }),
+      slot(5), // replacement question
+    ];
+    expect(hasPendingSlot(slots)).toBe(true);
+    expect(isRoundComplete(slots)).toBe(false);
+  });
+
+  it('an empty queue is not complete', () => {
+    expect(isRoundComplete([])).toBe(false);
+  });
+});

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -84,6 +84,23 @@ export const DAILY_SKIP_LIMIT = 5;
 export const PERSONAL_DAILY_SESSION_CONTEXT = 'personal_daily';
 export const DAILY_QUEUE_SIZE = 5;
 
+/** A slot the player can still act on (neither answered nor skipped). */
+export function hasPendingSlot(slots: QueueSlot[]): boolean {
+  return slots.some((slot) => !slot.answered && !slot.skipped);
+}
+
+/**
+ * A round is complete once it has slots and none of them are still pending.
+ *
+ * This is the canonical definition of "done" — the status API and the play
+ * page both derive from it so the home card and the player can't disagree
+ * (a skipped-but-unreplaced slot used to leave the round advertising "Resume"
+ * while the player bounced straight to the summary).
+ */
+export function isRoundComplete(slots: QueueSlot[]): boolean {
+  return slots.length > 0 && !hasPendingSlot(slots);
+}
+
 /**
  * Difficulty → base points for B9 personal daily. Always prefer
  * calibrated_difficulty, fall back to llm_difficulty, then difficulty_estimate.


### PR DESCRIPTION
A round with answered + skipped slots but no replacement-generated pending
slot left the home card advertising "Resume round" (it counted only answered
slots toward completion) while the play page bounced straight to the summary
(it found no pending slot). Tapping resume dead-ended at the recap.

Unify both surfaces on a single canonical predicate: a round is complete when
no slot is pending (every slot is answered or skipped). The status API now
derives isComplete / questionsRemaining from isRoundComplete(), so when a
skip's replacement fails to generate the home card shows the "Today done"
recap state instead of a broken "Resume round" button.

Adds isRoundComplete/hasPendingSlot helpers in daily/types.ts (reused by the
play page) and a unit test covering the bug case and the resumable cases.