### PR TITLE
Wire LoadingScreen into Daily Five flow and home feed Suspense

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -7,6 +7,7 @@ import { X } from 'lucide-react';
 
 import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
+import LoadingScreen from '@/components/LoadingScreen';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
 import { categoryLabel } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
@@ -691,7 +692,7 @@ export default function DailyPage() {
         style={{ paddingBottom: "calc(24px + env(safe-area-inset-bottom))" }}
       >
         {loading ? (
-          <p className="text-sm text-[var(--text-muted)]">Loading today...</p>
+          <LoadingScreen fullScreen label="Loading today" />
         ) : error ? (
           <div className="rounded-[var(--radius-sm)] border px-3 py-2 text-sm text-[var(--danger)]" style={{ borderColor: 'var(--danger)' }}>
             {error}

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Check } from 'lucide-react';
 import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
+import LoadingScreen from '@/components/LoadingScreen';
 
 type Difficulty = 'normal' | 'moderate' | 'challenging' | 'ridiculous' | 'adaptive';
 type DomainMode = 'random' | 'custom';
@@ -253,11 +254,7 @@ function DailySetupContent() {
   }, [canStart, difficulty, domainMode, hasUnstartedQueue, roundComplete, router, selectedDomains]);
 
   if (loading) {
-    return (
-      <main className="mx-auto max-w-xl px-4 py-8">
-        <p className="text-sm uppercase tracking-[0.12em] text-muted-foreground">Loading...</p>
-      </main>
-    );
+    return <LoadingScreen fullScreen />;
   }
 
   return (

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Flag, Heart, MoreHorizontal, X } from 'lucide-react'
+import LoadingScreen from '@/components/LoadingScreen'
 import {
   type CSSProperties,
   useCallback,
@@ -190,13 +191,7 @@ export default function DailySummaryPage() {
   const firstTierCrossing = summary?.tierCrossings[0] ?? null
 
   if (loading) {
-    return (
-      <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
-        <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>
-          Loading summary...
-        </p>
-      </main>
-    )
+    return <LoadingScreen fullScreen label="Loading summary" />
   }
 
   if (error || !summary) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import FeedList from '@/components/FeedList'
+import LoadingScreen from '@/components/LoadingScreen'
 import TodaysFiveCard, {
   type DailyPreferences,
   type DailyStatus,
@@ -202,8 +203,8 @@ function HeroSkeleton() {
 
 function FeedSkeleton() {
   return (
-    <div className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
-      Loading feed…
+    <div className="overflow-hidden rounded-lg">
+      <LoadingScreen label="Loading feed" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
User reported the triangle loading screen still wasn't visible — this time on the Daily Five flow at `/daily`. Root cause: the Daily Five pages each rendered their own plain `<p>Loading…</p>` text instead of using the merged `LoadingScreen` component. Same was true of the home feed Suspense fallback.

Swaps the four plain-text loading slots for the animated component:

| File | Was | Now |
|---|---|---|
| `src/app/daily/page.tsx` | `<p>Loading today...</p>` | `<LoadingScreen fullScreen label="Loading today" />` |
| `src/app/daily/summary/page.tsx` | `<p>Loading summary...</p>` (inside `<main>`) | `<LoadingScreen fullScreen label="Loading summary" />` |
| `src/app/daily/setup/page.tsx` | `<p>Loading...</p>` (inside `<main>`) | `<LoadingScreen fullScreen />` |
| `src/app/page.tsx` `FeedSkeleton` | dashed-border `<div>` with `Loading feed…` | `<LoadingScreen label="Loading feed" />` (inline — not fullScreen, since only the feed slot is in the Suspense boundary) |

Net change: +9 / -15 lines.

## Why fullScreen for the daily flow
The daily/setup, daily/summary, and daily/today pages each have their own sticky header. With `fullScreen` the LoadingScreen overlays everything including those headers; the alternative (inline) leaves the header visible but compresses the animation into a padded section, which is what the user said felt invisible last round. Picking max-impact since the loading windows are brief.

The home feed slot is intentionally **not** `fullScreen` — the rest of the home page (Hero, TodaysFiveCard, etc.) is already loaded and shouldn't be covered.

## Test plan
- [ ] On the Vercel preview: visit `/daily` (or click "Play Now" from home). The triangle loader fills the viewport with "LOADING TODAY ..." in the center card.
- [ ] Visit `/daily/setup` — same triangle loader during the initial fetch.
- [ ] Visit `/daily/summary` after a round — same.
- [ ] Load `/` (home) — the feed area shows the triangle loader (in-section, not fullscreen) while the Suspense fallback is active; the rest of the home page stays interactive.
- [ ] Reduce-motion still disables all animations (handled in `globals.css` from #466).

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_