### PR TITLE
Wire LoadingScreen into all plain-text loading slots

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -7,6 +7,7 @@ import { X } from 'lucide-react';
 
 import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
+import LoadingScreen from '@/components/LoadingScreen';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
 import { categoryLabel } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
@@ -691,7 +692,7 @@ export default function DailyPage() {
         style={{ paddingBottom: "calc(24px + env(safe-area-inset-bottom))" }}
       >
         {loading ? (
-          <p className="text-sm text-[var(--text-muted)]">Loading today...</p>
+          <LoadingScreen fullScreen label="Loading today" />
         ) : error ? (
           <div className="rounded-[var(--radius-sm)] border px-3 py-2 text-sm text-[var(--danger)]" style={{ borderColor: 'var(--danger)' }}>
             {error}

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Check } from 'lucide-react';
 import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
+import LoadingScreen from '@/components/LoadingScreen';
 
 type Difficulty = 'normal' | 'moderate' | 'challenging' | 'ridiculous' | 'adaptive';
 type DomainMode = 'random' | 'custom';
@@ -253,11 +254,7 @@ function DailySetupContent() {
   }, [canStart, difficulty, domainMode, hasUnstartedQueue, roundComplete, router, selectedDomains]);
 
   if (loading) {
-    return (
-      <main className="mx-auto max-w-xl px-4 py-8">
-        <p className="text-sm uppercase tracking-[0.12em] text-muted-foreground">Loading...</p>
-      </main>
-    );
+    return <LoadingScreen fullScreen />;
   }
 
   return (

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link'
 import { Flag, Heart, MoreHorizontal, X } from 'lucide-react'
+import LoadingScreen from '@/components/LoadingScreen'
 import {
   type CSSProperties,
   useCallback,
@@ -190,13 +191,7 @@ export default function DailySummaryPage() {
   const firstTierCrossing = summary?.tierCrossings[0] ?? null
 
   if (loading) {
-    return (
-      <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
-        <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>
-          Loading summary...
-        </p>
-      </main>
-    )
+    return <LoadingScreen fullScreen label="Loading summary" />
   }
 
   if (error || !summary) {

--- a/src/app/games/[id]/loading.tsx
+++ b/src/app/games/[id]/loading.tsx
@@ -1,0 +1,5 @@
+import LoadingScreen from "@/components/LoadingScreen";
+
+export default function Loading() {
+  return <LoadingScreen fullScreen />;
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from 'react'
 import FeedList from '@/components/FeedList'
+import LoadingScreen from '@/components/LoadingScreen'
 import TodaysFiveCard, {
   type DailyPreferences,
   type DailyStatus,
@@ -202,8 +203,8 @@ function HeroSkeleton() {
 
 function FeedSkeleton() {
   return (
-    <div className="text-muted-foreground rounded-lg border border-dashed p-4 text-sm">
-      Loading feed…
+    <div className="overflow-hidden rounded-lg">
+      <LoadingScreen label="Loading feed" />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Single PR that wires the animated `LoadingScreen` into every plain-text loading slot in the app. Supersedes #465 and #469 — merging this one PR gets you everything; the older two can be closed.

| File | Was | Now |
|---|---|---|
| `src/app/games/[id]/loading.tsx` *(new)* | (no route loader, blank flash) | `<LoadingScreen fullScreen />` during the game route's RSC data fetch |
| `src/app/daily/page.tsx` | `<p>Loading today...</p>` | `<LoadingScreen fullScreen label="Loading today" />` |
| `src/app/daily/summary/page.tsx` | `<p>Loading summary...</p>` inside `<main>` | `<LoadingScreen fullScreen label="Loading summary" />` |
| `src/app/daily/setup/page.tsx` | `<p>Loading...</p>` inside `<main>` | `<LoadingScreen fullScreen />` |
| `src/app/page.tsx` `FeedSkeleton` | dashed-border `<div>` with `Loading feed…` | `<LoadingScreen label="Loading feed" />` (inline — only the feed slot is in the Suspense boundary; the rest of the home page stays interactive) |

Net change: +14 / -15 lines across 5 files.

## Why fullScreen for the daily flow
Daily setup, summary, and today each have their own sticky header. The previous attempt (#469) used inline mode which kept the header visible but compressed the animation into a padded sub-section that felt invisible. fullScreen overlays everything and makes the dynamic motion the loading experience. Loading windows here are brief.

The home feed slot stays inline — only the feed Suspense is loading, the rest of the home page is already up.

## Test plan
- [ ] Click into a game from the home feed → triangle loader flashes during the route transition.
- [ ] Visit `/daily` → fullscreen triangle loader with "LOADING TODAY ..." in the card.
- [ ] Visit `/daily/setup` → fullscreen triangle loader.
- [ ] Land on `/daily/summary` after a round → fullscreen with "LOADING SUMMARY ...".
- [ ] Load `/` → feed slot shows triangle loader inline; Hero, TodaysFiveCard, etc. stay interactive.
- [ ] OS reduce-motion still disables all animations (from #466).
- [ ] No regressions to the play screens themselves once they mount.

## Supersedes
- #465 (game route loader) — close in favor of this PR
- #469 (Daily Five wire-ins) — close in favor of this PR

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_