### PR TITLE
Loading screen: dial all motion back ~3x

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -202,11 +202,11 @@
   background: linear-gradient(
     90deg,
     rgba(245, 235, 211, 0) 0%,
-    rgba(245, 235, 211, 0.55) 50%,
+    rgba(245, 235, 211, 0.4) 50%,
     rgba(245, 235, 211, 0) 100%
   );
   mix-blend-mode: screen;
-  animation: triangle-sweep 4.5s linear infinite;
+  animation: triangle-sweep 12s linear infinite;
   will-change: transform, opacity;
 }
 

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -70,11 +70,11 @@ function buildTriangles(): Tri[] {
       let colorBIdx = Math.floor(r4 * PALETTE.length);
       if (colorBIdx === colorAIdx) colorBIdx = (colorBIdx + 1) % PALETTE.length;
 
-      const breatheDuration = 1.6 + r2 * 1.4;
+      const breatheDuration = 5 + r2 * 4;
       const breatheDelay = -r3 * breatheDuration;
-      const swapDuration = 3 + r5 * 3;
+      const swapDuration = 10 + r5 * 6;
       const swapDelay = -r1 * swapDuration;
-      const opacityLow = 0.25 + r1 * 0.2;
+      const opacityLow = 0.55 + r1 * 0.2;
       const opacityHigh = 0.95 + r2 * 0.05;
 
       tris.push({
@@ -134,11 +134,11 @@ function buildFloaters(): FloatTri[] {
       .map(([x, y]) => `${x},${y}`)
       .join(" ");
     const seed = i + 1;
-    const dx = (rand(seed * 31) - 0.5) * 240;
-    const dy = (rand(seed * 47) - 0.5) * 240;
-    const dr = (rand(seed * 59) - 0.5) * 120;
-    const ds = 1 + rand(seed * 67) * 0.3;
-    const duration = 5 + rand(seed * 71) * 5;
+    const dx = (rand(seed * 31) - 0.5) * 100;
+    const dy = (rand(seed * 47) - 0.5) * 100;
+    const dr = (rand(seed * 59) - 0.5) * 40;
+    const ds = 1 + rand(seed * 67) * 0.1;
+    const duration = 16 + rand(seed * 71) * 10;
     const delay = -rand(seed * 89) * duration;
 
     return { points, color, cx, cy, dx, dy, dr, ds, duration, delay, opacity };


### PR DESCRIPTION
## Summary
User feedback after #466: "that loading page is very very very kinetic… slow it down a whole lot." Dialing every motion parameter roughly **3× slower / gentler**.

| Parameter | Before (#466) | After |
|---|---|---|
| Breathe cycle | 1.6–3.0s | 5–9s |
| Breathe opacity swing | 0.25 ↔ 1.0 | 0.55 ↔ 1.0 |
| Color swap cycle | 3–6s | 10–16s |
| Floater drift | ±120px | ±50px |
| Floater rotation | ±60° | ±20° |
| Floater scale max | 1.3 | 1.1 |
| Floater cycle | 5–10s | 16–26s |
| Sweep band cycle | 4.5s | 12s |
| Sweep band opacity | 0.55 | 0.4 |

No structural changes — just tuning the existing keyframes/values. Floater count (12), triangle count, layout, reduced-motion rule, all unchanged.

## Test plan
- [ ] On Vercel preview, visit `/dev/loading-preview`. The triangle field should feel ambient: gentle color shifts every 10–16s, no flicker, floaters drift slowly across long arcs, sweep band passes once every 12s.
- [ ] OS reduce-motion still freezes everything (existing rule from #462/#466).

## Notes
- These are easy to tune further if it's now too calm — every value is a single literal at the top of `LoadingScreen.tsx` / in the sweep CSS.
- Independent of #470 (the all-wireins PR) — that one is about where the loader appears; this one is about how it moves. They can merge in either order.

https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9

---
_Generated by [Claude Code](https://claude.ai/code/session_01HoBxbBchNFmGmkWb2SgfU9)_