### PR TITLE
Restore the sparkle "envelope" design for directly-sent feed questions

### DIFF
--- a/PRD-V11.1-AUDIT.md
+++ b/PRD-V11.1-AUDIT.md
@@ -4,6 +4,18 @@
 **Audit date:** 2026-05-05  
 **Methodology:** Function-body and route logic reviewed per section; statuses use ✅ 🟡 🔴 ⚠️ ❓ as specified.
 
+> **⚠️ Partially superseded (correction added 2026-05-29).** This is a
+> point-in-time snapshot. **Section 2 ("Broadcast Share Rollback"), and the
+> related rows in §9 (9.1) and §12, are no longer accurate.** The broadcast
+> "share to all friends" path (`shareToFeed` → `authored_shared` feed rows)
+> was **reintroduced in PR #254 (`1897977`, 2026-05-17)** and is now an active
+> feature: `QuestionForm` has a "Share with all friends" checkbox, the
+> `/api/questions` POST writes `authored_shared` rows, and those render as the
+> `friend_added` "Handwritten" sparkle envelope (`FriendAddedCard`). The
+> cleanup script (`scripts/cleanup-authored-shared-feed-items.ts`) would now
+> delete/convert **live** feature data — do not run it. The rest of the audit
+> has not been re-verified against the current tree.
+
 ---
 
 ## Section 1 — Build Health

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -1,9 +1,10 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
-import { FeedCard } from './FeedCard'
 import { visibleFeedCategory } from './category'
+import { SparkleEnvelope } from './SparkleEnvelope'
 import type { DirectSentFeedItem } from './types'
+import { colorForCategory } from './visual'
 
 type DirectSentCardProps = {
   item: DirectSentFeedItem
@@ -12,49 +13,65 @@ type DirectSentCardProps = {
 }
 
 export function DirectSentCard({ item, overflow, onAnswer }: DirectSentCardProps) {
-  const merged: DirectSentFeedItem = {
-    ...item,
-    avatarName: item.avatarName ?? item.senderName,
-    authorHref: item.authorHref ?? item.senderHref ?? null,
-  }
   const visibleCategory = visibleFeedCategory(item.category)
-  const senderHref = item.senderHref ?? merged.authorHref ?? null
+  const accent = colorForCategory(item.category)
+  const senderName = item.senderName || item.avatarName || 'A friend'
+  const senderHref = item.senderHref ?? item.authorHref ?? null
 
-  // Restores the distinguishing "sent to you" treatment that the
-  // author+category header redesign (67f104d) flattened away: a small
-  // eyebrow plus the original "{sender} thought you'd like this" signal.
-  const headerContent = (
+  const eyebrow = (
     <>
-      <p
-        className="text-[11px] uppercase leading-none tracking-[0.08em]"
-        style={{ color: 'var(--ink)', opacity: 0.7 }}
-      >
-        Sent to you
-      </p>
-      <p className="mt-1 text-[14px] leading-snug text-[var(--ink)]">
-        {senderHref ? (
-          <Link
-            href={senderHref}
-            className="font-semibold underline underline-offset-2"
-            style={{ textDecorationColor: 'rgb(0 0 0 / 0.35)' }}
-          >
-            {item.senderName}
-          </Link>
-        ) : (
-          <span className="font-semibold">{item.senderName}</span>
-        )}{' '}
-        thought you&rsquo;d like this
-        {visibleCategory ? <> about {visibleCategory}</> : null}.
-      </p>
+      Sent to you <span className="opacity-50">·</span> From {senderName}
+    </>
+  )
+
+  const kicker = (
+    <>
+      For you
+      {visibleCategory ? (
+        <>
+          <span className="mx-1.5 opacity-60">·</span>
+          {visibleCategory}
+        </>
+      ) : null}
+    </>
+  )
+
+  const signal = (
+    <>
+      {senderHref ? (
+        <Link
+          href={senderHref}
+          className="font-semibold text-[var(--ink)] underline underline-offset-2"
+          style={{ textDecorationColor: 'rgb(0 0 0 / 0.3)' }}
+        >
+          {senderName}
+        </Link>
+      ) : (
+        <span className="font-semibold text-[var(--ink)]">{senderName}</span>
+      )}{' '}
+      thought you&rsquo;d like this
+      {visibleCategory ? <> about {visibleCategory}</> : null}.
+      {item.personalMessage ? (
+        <span
+          className="mt-1 block italic"
+          style={{ fontFamily: 'Georgia, "Times New Roman", serif', opacity: 0.9 }}
+        >
+          &ldquo;{item.personalMessage}&rdquo;
+        </span>
+      ) : null}
     </>
   )
 
   return (
-    <FeedCard
-      item={merged}
+    <SparkleEnvelope
+      eyebrow={eyebrow}
+      accent={accent}
+      kicker={kicker}
+      signal={signal}
+      question={item.question}
+      timestamp={item.timestamp}
       overflow={overflow}
       onAnswer={onAnswer}
-      headerContent={headerContent}
     />
   )
 }

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -1,9 +1,8 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
-import { cn } from '@/lib/utils'
-
 import { visibleFeedCategory } from './category'
+import { SparkleEnvelope } from './SparkleEnvelope'
 import type { FriendAddedFeedItem } from './types'
 import { colorForCategory } from './visual'
 
@@ -13,32 +12,6 @@ type FriendAddedCardProps = {
   onAnswer?: () => void
   onHideCategory?: () => void
   className?: string
-}
-
-function Sparkle({
-  size,
-  className,
-  opacity = 1,
-}: {
-  size: number
-  className?: string
-  opacity?: number
-}) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      className={cn('pointer-events-none absolute', className)}
-      style={{ color: '#c79a4f', opacity }}
-    >
-      <path
-        d="M12 0 C 12.4 5.6 18.4 11.6 24 12 C 18.4 12.4 12.4 18.4 12 24 C 11.6 18.4 5.6 12.4 0 12 C 5.6 11.6 11.6 5.6 12 0 Z"
-        fill="currentColor"
-      />
-    </svg>
-  )
 }
 
 export function FriendAddedCard({
@@ -53,109 +26,65 @@ export function FriendAddedCard({
   const friendName = item.friendName || item.avatarName || 'A friend'
   const friendHref = item.friendHref ?? item.authorHref ?? null
 
-  return (
-    <article
-      className={cn(
-        'overflow-hidden rounded-[1.5rem] bg-[var(--ink)] p-[6px] shadow-[0_10px_24px_-8px_rgb(0_0_0/0.28)]',
-        className,
-      )}
-    >
-      <p
-        className="px-3 pb-[10px] pt-[6px] text-[10px] font-bold uppercase leading-none tracking-[0.22em]"
-        style={{ color: 'var(--cream)' }}
-      >
-        Handwritten <span className="opacity-50">·</span> By {friendName}
-      </p>
+  const eyebrow = (
+    <>
+      Handwritten <span className="opacity-50">·</span> By {friendName}
+    </>
+  )
 
-      <div className="relative overflow-hidden rounded-[1.15rem] border border-[var(--border-warm)] bg-[var(--cream)] px-5 py-5 sm:px-7 sm:py-6">
-        <Sparkle size={26} className="left-3 top-5 rotate-[8deg]" opacity={0.95} />
-        <Sparkle size={14} className="left-7 top-14" opacity={0.7} />
-        <Sparkle size={10} className="left-4 bottom-6" opacity={0.55} />
+  const kicker = (
+    <>
+      New question
+      {visibleCategory ? (
+        <>
+          <span className="mx-1.5 opacity-60">·</span>
+          {visibleCategory}
+        </>
+      ) : null}
+    </>
+  )
 
-        <Sparkle size={22} className="right-4 top-12 -rotate-[6deg]" opacity={0.9} />
-        <Sparkle size={12} className="right-9 top-4" opacity={0.6} />
-        <Sparkle size={9} className="right-6 bottom-8" opacity={0.5} />
-
-        <div className="relative pl-6 pr-4 sm:pl-10 sm:pr-8">
-        <div className="flex items-start justify-between gap-3">
-          <p
-            className="text-[11px] font-bold uppercase leading-none tracking-[0.14em]"
-            style={{ color: accent }}
-          >
-            New question
-            {visibleCategory ? (
-              <>
-                <span className="mx-1.5 opacity-60">·</span>
-                {visibleCategory}
-              </>
-            ) : null}
-          </p>
-          <div className="flex shrink-0 items-center gap-1.5">
-            {item.timestamp ? (
-              <span
-                className="text-[11px] leading-none"
-                style={{ color: 'var(--ink)', opacity: 0.6 }}
-              >
-                {item.timestamp}
-              </span>
-            ) : null}
-            {overflow}
-          </div>
-        </div>
-
-        <p
-          className="mt-1.5 text-[14px] leading-snug"
-          style={{ color: 'var(--ink)', opacity: 0.85 }}
+  const signal = (
+    <>
+      {friendHref ? (
+        <Link
+          href={friendHref}
+          className="font-semibold text-[var(--ink)] underline underline-offset-2"
+          style={{ textDecorationColor: 'rgb(0 0 0 / 0.3)' }}
         >
-          {friendHref ? (
-            <Link
-              href={friendHref}
-              className="font-semibold text-[var(--ink)] underline underline-offset-2"
-              style={{ textDecorationColor: 'rgb(0 0 0 / 0.3)' }}
-            >
-              {friendName}
-            </Link>
-          ) : (
-            <span className="font-semibold text-[var(--ink)]">{friendName}</span>
-          )}{' '}
-          added a question
-          {visibleCategory ? <> about {visibleCategory}</> : null}
-          {visibleCategory && onHideCategory ? (
-            <>
-              <span className="mx-1.5 opacity-50">·</span>
-              <button
-                type="button"
-                onClick={onHideCategory}
-                className="font-medium text-[#1d4ed8] hover:underline"
-              >
-                Hide questions about {visibleCategory}
-              </button>
-            </>
-          ) : null}
-        </p>
-
-        <div className="mt-4 flex items-center gap-4 sm:gap-5">
-          <p
-            className="min-w-0 flex-1 text-[19px] leading-snug text-[var(--ink)] sm:text-[22px]"
-            style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+          {friendName}
+        </Link>
+      ) : (
+        <span className="font-semibold text-[var(--ink)]">{friendName}</span>
+      )}{' '}
+      added a question
+      {visibleCategory ? <> about {visibleCategory}</> : null}
+      {visibleCategory && onHideCategory ? (
+        <>
+          <span className="mx-1.5 opacity-50">·</span>
+          <button
+            type="button"
+            onClick={onHideCategory}
+            className="font-medium text-[#1d4ed8] hover:underline"
           >
-            <span aria-hidden className="opacity-60">&ldquo;</span>
-            {item.question}
-            <span aria-hidden className="opacity-60">&rdquo;</span>
-          </p>
+            Hide questions about {visibleCategory}
+          </button>
+        </>
+      ) : null}
+    </>
+  )
 
-          {onAnswer ? (
-            <button
-              type="button"
-              onClick={onAnswer}
-              className="shrink-0 rounded-full bg-[#1d4ed8] px-5 py-2.5 text-[14px] font-medium text-white shadow-sm transition hover:bg-[#1e40af] active:translate-y-px"
-            >
-              Answer this
-            </button>
-          ) : null}
-        </div>
-        </div>
-      </div>
-    </article>
+  return (
+    <SparkleEnvelope
+      eyebrow={eyebrow}
+      accent={accent}
+      kicker={kicker}
+      signal={signal}
+      question={item.question}
+      timestamp={item.timestamp}
+      overflow={overflow}
+      onAnswer={onAnswer}
+      className={className}
+    />
   )
 }

--- a/src/components/feed/SparkleEnvelope.tsx
+++ b/src/components/feed/SparkleEnvelope.tsx
@@ -1,0 +1,141 @@
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Sparkle({
+  size,
+  className,
+  opacity = 1,
+}: {
+  size: number
+  className?: string
+  opacity?: number
+}) {
+  return (
+    <svg
+      aria-hidden="true"
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      className={cn('pointer-events-none absolute', className)}
+      style={{ color: '#c79a4f', opacity }}
+    >
+      <path
+        d="M12 0 C 12.4 5.6 18.4 11.6 24 12 C 18.4 12.4 12.4 18.4 12 24 C 11.6 18.4 5.6 12.4 0 12 C 5.6 11.6 11.6 5.6 12 0 Z"
+        fill="currentColor"
+      />
+    </svg>
+  )
+}
+
+type SparkleEnvelopeProps = {
+  /** Cream label across the top of the dark ink frame. */
+  eyebrow: ReactNode
+  /** Category-derived accent color used for the inner kicker. */
+  accent: string
+  /** Small uppercase label at the top-left of the cream card. */
+  kicker: ReactNode
+  /** The attribution / "who and why" sentence under the kicker. */
+  signal: ReactNode
+  question: string
+  timestamp?: string | null
+  overflow?: ReactNode
+  onAnswer?: () => void
+  answerLabel?: string
+  className?: string
+}
+
+/**
+ * The "Handwritten" envelope shell: a dark ink frame matting a cream card
+ * speckled with gold sparkles. Shared by the question-sharing feed cards
+ * (FriendAddedCard, DirectSentCard) so the sparkle/frame markup lives in one
+ * place — callers supply only the copy that differs between surfaces.
+ */
+export function SparkleEnvelope({
+  eyebrow,
+  accent,
+  kicker,
+  signal,
+  question,
+  timestamp,
+  overflow,
+  onAnswer,
+  answerLabel = 'Answer this',
+  className,
+}: SparkleEnvelopeProps) {
+  return (
+    <article
+      className={cn(
+        'overflow-hidden rounded-[1.5rem] bg-[var(--ink)] p-[6px] shadow-[0_10px_24px_-8px_rgb(0_0_0/0.28)]',
+        className,
+      )}
+    >
+      <p
+        className="px-3 pb-[10px] pt-[6px] text-[10px] font-bold uppercase leading-none tracking-[0.22em]"
+        style={{ color: 'var(--cream)' }}
+      >
+        {eyebrow}
+      </p>
+
+      <div className="relative overflow-hidden rounded-[1.15rem] border border-[var(--border-warm)] bg-[var(--cream)] px-5 py-5 sm:px-7 sm:py-6">
+        <Sparkle size={26} className="left-3 top-5 rotate-[8deg]" opacity={0.95} />
+        <Sparkle size={14} className="left-7 top-14" opacity={0.7} />
+        <Sparkle size={10} className="left-4 bottom-6" opacity={0.55} />
+
+        <Sparkle size={22} className="right-4 top-12 -rotate-[6deg]" opacity={0.9} />
+        <Sparkle size={12} className="right-9 top-4" opacity={0.6} />
+        <Sparkle size={9} className="right-6 bottom-8" opacity={0.5} />
+
+        <div className="relative pl-6 pr-4 sm:pl-10 sm:pr-8">
+          <div className="flex items-start justify-between gap-3">
+            <p
+              className="text-[11px] font-bold uppercase leading-none tracking-[0.14em]"
+              style={{ color: accent }}
+            >
+              {kicker}
+            </p>
+            <div className="flex shrink-0 items-center gap-1.5">
+              {timestamp ? (
+                <span
+                  className="text-[11px] leading-none"
+                  style={{ color: 'var(--ink)', opacity: 0.6 }}
+                >
+                  {timestamp}
+                </span>
+              ) : null}
+              {overflow}
+            </div>
+          </div>
+
+          <p
+            className="mt-1.5 text-[14px] leading-snug"
+            style={{ color: 'var(--ink)', opacity: 0.85 }}
+          >
+            {signal}
+          </p>
+
+          <div className="mt-4 flex items-center gap-4 sm:gap-5">
+            <p
+              className="min-w-0 flex-1 text-[19px] leading-snug text-[var(--ink)] sm:text-[22px]"
+              style={{ fontFamily: 'Georgia, "Times New Roman", serif' }}
+            >
+              <span aria-hidden className="opacity-60">&ldquo;</span>
+              {question}
+              <span aria-hidden className="opacity-60">&rdquo;</span>
+            </p>
+
+            {onAnswer ? (
+              <button
+                type="button"
+                onClick={onAnswer}
+                className="shrink-0 rounded-full bg-[#1d4ed8] px-5 py-2.5 text-[14px] font-medium text-white shadow-sm transition hover:bg-[#1e40af] active:translate-y-px"
+              >
+                {answerLabel}
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -122,7 +122,7 @@ describe('Feed unanswered card actions', () => {
       />
     )
 
-    expect(rendered).toContain('Answer →')
+    expect(rendered).toContain('Answer this')
     expect(rendered).not.toContain('Skip')
     expect(rendered).not.toContain('Not my focus')
     expect(rendered).not.toContain('Bookmark')
@@ -132,7 +132,7 @@ describe('Feed unanswered card actions', () => {
     const rendered = html(
       <DirectSentCard item={feedCardPreviewFixtures.directSentUnanswered} />
     )
-    expect(rendered).not.toContain('Answer →')
+    expect(rendered).not.toContain('Answer this')
   })
 
   it('shows overflow menu when passed', () => {

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -5,11 +5,14 @@ import type { feedItems, questions } from '@/server/db';
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
 export const DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent' as const;
 
-// 'authored_shared' and 'thumbs_upped' are legacy-read-only source types.
-// PRD v11.1 §8.2 killed authored_shared as a write path. thumbs_upped was
-// retired earlier. Both values may still exist in DB rows written before those
-// decisions; read queries include them for legacy support only. Do not write
-// new rows with these sourceType values.
+// 'authored_shared' is an ACTIVE write path again: PRD v11.1 §8.2 removed the
+// broadcast "share to all friends" path, but it was reintroduced in PR #254
+// (2026-05-17) and now backs the "Share with all friends" checkbox in question
+// creation — these rows render as the friend_added "Handwritten" envelope.
+// (PRD-V11.1-AUDIT.md §2/§9/§12 predate that reintroduction and are stale.)
+//
+// 'thumbs_upped' is genuinely legacy-read-only: it was retired and is no longer
+// written. Read queries still include it so pre-retirement rows keep rendering.
 
 export const ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES = [
   'authored_shared',
@@ -68,7 +71,7 @@ export function isMainFeedSourceVisible(sourceType: string, sourceResult: string
 
 export function visibleFeedSourcePredicate(feedItemColumns: FeedItemsVisibilityColumns) {
   return or(
-    eq(feedItemColumns.sourceType, 'authored_shared'), // legacy-read-only
+    eq(feedItemColumns.sourceType, 'authored_shared'), // active: friend_added envelope
     eq(feedItemColumns.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
     eq(feedItemColumns.sourceType, 'thumbs_upped'), // legacy-read-only
     and(


### PR DESCRIPTION
## Why

The "SENT TO YOU" feed card (a question a friend sends you directly) had lost its distinctive look. The May-17 card redesign (`67f104d`) flattened it into a plain cream card with no visual signal, while friend-*created* questions kept the gold-sparkle "Handwritten" envelope. This brings the two "someone gave you a question" surfaces back into visual parity.

## What changed

**Sparkle envelope for directly-sent cards** (`7f02162`)
- Extracted the dark ink frame + gold sparkles + cream card into a shared `SparkleEnvelope` component — one source of truth, no duplicated sparkle markup.
- `FriendAddedCard` now composes that shell; its rendered output is unchanged.
- `DirectSentCard` renders the envelope with a **"SENT TO YOU · FROM {sender}"** eyebrow, a **"For you · {category}"** kicker, the *"{sender} thought you'd like this about {category}"* signal (sender still links to their profile), an optional handwritten personal-message line, and the shared **"Answer this"** button.

**Earlier text-header restore** (`44b376d`)
- First-pass fix that restored a "Sent to you" header via `FeedCard`'s `headerContent` slot. Superseded visually by the sparkle envelope above, but kept in history.

**Feed-route test repair** (`348bc1f`)
- `src/app/api/feed/__tests__/route.test.ts` couldn't run (passed a plain `Request` with no `nextUrl`; drizzle/db mocks predated the actionable-inbox queries; assertions expected wire fields the payload-trimming commits removed). Repaired the harness and updated assertions — the `authored_shared → friend_added` mapping guard now actually runs and passes.

**Audit reconciliation** (`80febb4`)
- The broadcast `authored_shared` share path was reintroduced in PR #254 (2026-05-17), but `visibility.ts` comments still called it "legacy-read-only / do not write" and `PRD-V11.1-AUDIT.md` still recorded it as rolled back. Corrected the in-code comments (keeping `thumbs_upped` flagged as genuinely legacy) and added a dated correction banner to the audit, including a warning that `scripts/cleanup-authored-shared-feed-items.ts` would now delete/convert **live** feature data.

## Testing
- `FeedCards.test.tsx` — 25/25 pass (updated the two `direct_sent` action tests for the new "Answer this" label).
- `api/feed/route.test.ts` — 8/8 pass (previously could not execute at all).
- `tsc -p tsconfig.typecheck.json` and `eslint` clean on touched files.

## Note
The directly-sent card now matches the friend-created card's look exactly, for consistency. If they should be visually distinct, that's an easy follow-up.

https://claude.ai/code/session_017pXxSvDWJDKuLSRssitjKV

---
_Generated by [Claude Code](https://claude.ai/code/session_017pXxSvDWJDKuLSRssitjKV)_