### PR TITLE
fix(knowledge): lift modals above the z-50 FAB to stop ghosted Save/Cancel pair

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -705,7 +705,7 @@ function KnowledgePageContent() {
       ) : null}
 
       {activeModal?.type === 'tidy' ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+        <div className="fixed inset-0 z-[55] flex items-center justify-center bg-black/30 p-4">
           <div className="w-[min(430px,100%)] max-h-[90vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <div>
@@ -737,7 +737,7 @@ function KnowledgePageContent() {
       ) : null}
 
       {activeModal?.type === 'manage-interests' ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+        <div className="fixed inset-0 z-[55] flex items-center justify-center bg-black/30 p-4">
           <div className="w-[min(540px,100%)] max-h-[90vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <div>
@@ -779,7 +779,7 @@ function KnowledgePageContent() {
       ) : null}
 
       {activeModal?.type === 'write-question' ? (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4">
+        <div className="fixed inset-0 z-[55] flex items-center justify-center bg-black/30 p-4">
           <div className="w-[min(540px,100%)] max-h-[92vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Write a question</h2>

--- a/src/components/SendQuestionDrawer.tsx
+++ b/src/components/SendQuestionDrawer.tsx
@@ -114,7 +114,7 @@ export function SendQuestionDrawer({ isOpen, onClose, question, onSent }: SendQu
 
   return (
     <>
-      <div className="fixed inset-0 z-50 flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
+      <div className="fixed inset-0 z-[55] flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
         <button className="absolute inset-0 cursor-default" type="button" aria-label="Close" onClick={onClose} />
         <aside className="relative flex max-h-[92dvh] w-full flex-col overflow-hidden rounded-t-lg bg-background shadow-xl md:h-full md:max-h-none md:w-[440px] md:rounded-none">
           <header className="flex items-center justify-between gap-3 border-b p-5">

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -100,7 +100,7 @@ export function AnswerFeedbackSheet({
   const points = typeof pointsAwarded === 'number' ? pointsAwarded : 0
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center">
+    <div className="fixed inset-0 z-[55] flex items-end justify-center">
       <button
         type="button"
         className="absolute inset-0 bg-black/40"

--- a/src/components/feed/AnswerSheet.tsx
+++ b/src/components/feed/AnswerSheet.tsx
@@ -47,7 +47,7 @@ export function AnswerSheet({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-end justify-center">
+    <div className="fixed inset-0 z-[55] flex items-end justify-center">
       <button
         type="button"
         className="absolute inset-0 bg-black/40"

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -134,7 +134,7 @@ export function FeedOverflowMenu({
         <MoreHorizontal className="size-5" />
       </button>
       {open ? (
-        <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
+        <div className="fixed inset-0 z-[55] flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
           <button
             className="absolute inset-0 cursor-default sm:hidden"
             type="button"


### PR DESCRIPTION
The /knowledge full-screen modals (tidy, manage-interests, write-question)
sat at z-50 — the same layer as Nav's floating "+" FAB. As documented in
d53611b for the /questions drawer, an exact z-index tie with the fixed FAB
lets iOS Safari leak the FAB's stacking context through and ghost a second
"Save question / Cancel" button pair when the form re-renders.

d53611b fixed the /questions drawer but missed these knowledge modals. The
sibling 'interests' modal was already bumped to z-[55]; bring the other
three in line so all knowledge modals clear the FAB while staying below the
z-[60] confirmation toasts.