### PR TITLE
Fix JOSHING wordmark falling back to system font

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,7 +66,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${playfair.variable} ${caveat.variable} ${cormorant.variable}`}
+      className={`font-sans ${montserrat.variable} ${playfair.variable} ${caveat.variable} ${cormorant.variable}`}
     >
       <body className={montserrat.className}>
         <Nav


### PR DESCRIPTION
The font-sans utility resolves to var(--font-sans-body, ...) but the
Montserrat .variable that defines --font-sans-body was never applied to
any element — only montserrat.className was set on <body>. Body text
inherited Montserrat, but elements using the font-sans utility (e.g. the
JOSHING <h1> on /login) fell through to the system-ui fallback.

Apply montserrat.variable on <html> alongside the other font variables so
--font-sans-body is defined and font-sans actually resolves to Montserrat.

https://claude.ai/code/session_015Gsb1etkTx9DPd6uAJtPjv