### PR TITLE
style(knowledge): match Recently Expanding card to Knowledge Portrait

### DIFF
--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -225,10 +225,10 @@ async function copyShareText(text: string) {
 }
 
 const boxStyle: CSSProperties = {
-  background: '#fffdf8',
-  border: '1px solid #eee7dc',
-  borderRadius: 14,
-  boxShadow: '0 1px 8px rgba(26, 18, 8, 0.04)',
+  background: 'var(--brand-cream-card)',
+  border: '1px solid var(--brand-border)',
+  borderRadius: 12,
+  boxShadow: '0 4px 12px rgba(40, 32, 30, 0.04)',
   padding: '1.05rem 0.95rem 0.65rem',
   display: 'grid',
   gap: '0.75rem',
@@ -243,19 +243,22 @@ const headerStyle: CSSProperties = {
 
 const wordmarkStyle: CSSProperties = {
   margin: 0,
-  fontFamily: 'var(--font-literata), serif',
-  fontStyle: 'italic',
-  fontSize: '0.78rem',
-  color: '#1a1208',
+  fontFamily: 'var(--font-sans-body), system-ui, sans-serif',
+  fontWeight: 700,
+  fontSize: '0.92rem',
+  color: 'var(--brand-ink)',
+  letterSpacing: '0.01em',
   lineHeight: 1,
 };
 
 const titleStyle: CSSProperties = {
   margin: 0,
-  color: '#1a1208',
-  fontFamily: 'var(--font-literata), Georgia, serif',
-  fontSize: '1rem',
+  color: 'var(--brand-ink)',
+  fontFamily: 'var(--font-sans-body), system-ui, sans-serif',
+  fontSize: '0.8rem',
   fontWeight: 700,
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
 };
 
 const shareButtonStyle: CSSProperties = {


### PR DESCRIPTION
Use the cream card background (--brand-cream-card / --brand-border) and
the same top font treatment — bold sans-serif wordmark and uppercase,
letter-spaced sans-serif title — so the Recently Expanding card visually
matches the Knowledge Portrait card above it.

https://claude.ai/code/session_01C9HgGorL9sMEaTQ4toWJZH