### PR TITLE
fix(daily): prevent 503 on synchronous daily-queue generation

### DIFF
--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -8,6 +8,12 @@ import { type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export const dynamic = 'force-dynamic';
+// The POST path can fall through to synchronous LLM generation when the cron
+// hasn't pre-built today's queue. A single Sonnet batch is capped at
+// GENERATION_TIMEOUT_MS (35s) and a bounded top-up can follow, so the default
+// function budget is too small — give it headroom so the work completes
+// instead of being platform-killed mid-generation. See queue-orchestrator.ts.
+export const maxDuration = 90;
 
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -266,8 +266,16 @@ export default function DailyPage() {
           cache: 'no-store',
         });
         if (!createResponse.ok) {
-          router.replace('/daily/setup');
-          return;
+          const createBody = await createResponse.json().catch(() => null);
+          // 409 (no_knowledge_base) means the user genuinely has nothing to
+          // generate from — send them to setup. A 503 (generation_failed) is a
+          // transient/slow-generation hiccup; surface the retryable message
+          // instead of bouncing a user with a valid knowledge base to setup.
+          if (createResponse.status === 409) {
+            router.replace('/daily/setup');
+            return;
+          }
+          throw new Error(createBody?.message ?? 'Could not load today.');
         }
         const refetchResponse = await fetch('/api/daily/queue', { cache: 'no-store', credentials: 'include' });
         const refetchBody = await refetchResponse.json().catch(() => null);

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -23,7 +23,14 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+// Only start a recovery top-up generation while this much of the function
+// budget is still unspent. A second generation call can take up to
+// GENERATION_TIMEOUT_MS (35s); gating it on elapsed time keeps the retry from
+// pushing the request past the route's maxDuration.
+const TOP_UP_TIME_BUDGET_MS = 30_000;
+
 export async function fillDailyQueueForUser(userId: string): Promise<void> {
+  const startedAt = Date.now();
   const existing = await getTodaysDailyQueue(userId);
   if (existing && asQueueSlots(existing.slots).length > 0) return;
 
@@ -105,13 +112,42 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     });
   }
 
+  // If the first pass came up short — the LLM returned fewer usable questions
+  // than requested, or the quality/dedup gates dropped some — attempt a single
+  // bounded top-up for just the missing slots before failing. A transient slow
+  // or partial Anthropic response (e.g. prod request 9lssf-…, where one Sonnet
+  // call ran ~34s and the queue fell one slot short) otherwise 503s the entire
+  // Daily Five even though most slots generated fine. The top-up is gated on
+  // remaining time budget so the recovery can't push the request past the
+  // route's maxDuration.
+  const topUpGenerated: typeof dedupedGenerated = [];
+  const shortfall = DAILY_QUEUE_SIZE - (authored.length + dedupedGenerated.length);
+  if (shortfall > 0 && Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS) {
+    const extra = await generateDailyQuestionsFromKnowledgeBase(userId, shortfall);
+    for (const question of extra) {
+      const key = normalize(question.questionText);
+      if (seenTexts.has(key)) continue;
+      seenTexts.add(key);
+      topUpGenerated.push(question);
+    }
+    if (topUpGenerated.length > 0) {
+      console.info('[daily/queue-orchestrator] topped up short queue', {
+        userId,
+        shortfall,
+        recovered: topUpGenerated.length,
+      });
+    }
+  }
+
+  const generatedForQueue = [...dedupedGenerated, ...topUpGenerated];
+
   // A short queue used to be persisted silently when generation returned
   // fewer than the requested count (or when cross-source dedup dropped some):
   // the play page treats "no pending slot" as round-over, so a 2-slot queue
   // ended the round after 2 answers with three blank progress dots. Fail
   // loudly instead so /api/daily/queue surfaces a 503 and the play page
   // shows the fill-error UI.
-  if (authored.length + dedupedGenerated.length < DAILY_QUEUE_SIZE) {
+  if (authored.length + generatedForQueue.length < DAILY_QUEUE_SIZE) {
     throw new DailyQueueFillError(
       'generation_failed',
       "Today's Daily Five is taking longer than usual.",
@@ -123,7 +159,7 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     await createDailyQueueItemFromAuthored(userId, pick, position);
     position += 1;
   }
-  for (const question of dedupedGenerated.slice(0, DAILY_QUEUE_SIZE - position)) {
+  for (const question of generatedForQueue.slice(0, DAILY_QUEUE_SIZE - position)) {
     await createDailyQueueItem(userId, question.id, position);
     position += 1;
   }


### PR DESCRIPTION
POST /api/daily/queue can fall through to synchronous LLM generation when
the cron hasn't pre-built today's queue. In prod (request 9lssf-…) a single
Sonnet batch ran ~34s, pushing the request to ~39s, and when the queue fell
one slot short fillDailyQueueForUser threw generation_failed -> 503, with the
play page then bouncing the user to /daily/setup.

- queue-orchestrator: attempt one bounded, time-budgeted top-up for the
  missing slots before failing, so a transient slow/partial Anthropic
  response no longer 503s the whole Daily Five.
- route: add maxDuration so the generation path (35s gen timeout + top-up)
  isn't platform-killed mid-flight.
- daily page: only redirect to setup on 409 (no_knowledge_base); surface the
  retryable message on a 503 instead of bouncing a user with a valid
  knowledge base.

https://claude.ai/code/session_01H8VWxoXRAUMqJrqGhajgqH