### PR TITLE
fix(daily): stop /api/daily/queue 503s — align cron with reset + harden request path

### DIFF
--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -9,6 +9,17 @@ import { runWithConcurrency } from '@/server/lib/concurrency';
 import { sendSms } from '@/server/sms';
 
 export const dynamic = 'force-dynamic';
+// Scheduled at 17:05 UTC (vercel.json) to fire just after the 17:00 UTC daily
+// reset (DAILY_RESET_HOUR_UTC), so it pre-builds the window users are about to
+// play. The previous 06:00 UTC schedule built the window that expired at 17:00
+// UTC and left the 17:00→06:00 UTC span uncovered, forcing evening-US / APAC
+// users onto the synchronous /api/daily/queue generation path.
+//
+// This fans out generation across every onboarded user at USER_CONCURRENCY,
+// each costing up to GENERATION_TIMEOUT_MS, so the default function budget is
+// far too small for a non-trivial user base — give it the plan maximum so the
+// tail of the user list doesn't get dropped by a platform timeout mid-run.
+export const maxDuration = 300;
 
 // Capped at 4 to stay one connection below the 5-cap DB pool. Tune down if
 // the SMS provider's per-second rate becomes the binding limit instead of DB.

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/cron/daily-assignments",
-      "schedule": "0 6 * * *"
+      "schedule": "5 17 * * *"
     },
     {
       "path": "/api/cron/weekly-ceremony",


### PR DESCRIPTION
## Problem

A prod request returned **503** on `POST /api/daily/queue` after **39s** (Vercel request `9lssf-…`), with one Sonnet generation call running ~34s.

Two distinct issues combined to produce this:

1. **Cron/reset misalignment (root cause of why the synchronous path fired at all).** The daily window is a fixed **17:00 UTC** cutoff (`DAILY_RESET_HOUR_UTC`), but the `daily-assignments` cron ran at **06:00 UTC**. At 06:00 it built the window that *expires* at 17:00 UTC; at 17:00 the queue date rolled over to a fresh, unbuilt window. That left a **13-hour blind spot (17:00 → 06:00 UTC)** in which every user opening `/daily` fell through to synchronous LLM generation. Evening-US / APAC players (after 17:00 UTC) were effectively never pre-built — the failing request at 23:50 UTC sat squarely in the gap.

2. **The synchronous fallback was fragile.** `fillDailyQueueForUser` requires all 5 slots; a slow/partial Anthropic response or gate drops made it throw `generation_failed` → 503. The route had no `maxDuration`, and the `/daily` page treated *any* non-OK POST as "go to setup", bouncing users with a valid knowledge base.

## Changes

**Cron coverage**
- `vercel.json`: move `daily-assignments` from `0 6 * * *` → `5 17 * * *`, so it pre-builds the window users are about to play (and sends the daily SMS at noon ET / 9 AM PT instead of 1 AM ET).
- `daily-assignments/route.ts`: add `export const maxDuration = 300` so a large user fan-out at `USER_CONCURRENCY = 4` isn't partially covered by a platform timeout mid-run.

**Request-path hardening**
- `queue-orchestrator.ts`: when the first pass comes up short, attempt one **bounded, time-budgeted top-up** for just the missing slots before failing (gated on elapsed time so it can't blow `maxDuration`). Benefits the cron path too.
- `api/daily/queue/route.ts`: add `export const maxDuration = 90` so the generation + top-up path completes instead of being platform-killed.
- `daily/page.tsx`: only redirect to `/daily/setup` on **409** (`no_knowledge_base`); surface the retryable message on **503** instead of bouncing a user with a valid knowledge base.

## Resulting coverage

1. Cron builds queues at the reset for all users across the full window.
2. Top-up retry recovers partial fills in both the cron and the request path.
3. The request-path fallback (with `maxDuration` + graceful 503 handling) is now a real safety net for the edges the cron can't cover (late onboarders, a user whose cron generation failed).

## Verification

- `npx tsc -p tsconfig.typecheck.json` → 0 errors
- `vitest run src/server/daily` → 10/10 passing
- ESLint clean on all touched files; `vercel.json` validated
- No `src/middleware.ts` regression (repo uses `src/proxy.ts`)

## Notes / deliberately out of scope

- Per-user cron failures are still counted and skipped without a dedicated retry loop (the in-orchestrator top-up already absorbs most transient hiccups). Easy follow-up if the cron `failed` count stays non-trivial.
- The deeper architectural option — moving the request-path fallback fully async (202 + poll) rather than blocking — is left for a separate change.

https://claude.ai/code/session_01H8VWxoXRAUMqJrqGhajgqH

---
_Generated by [Claude Code](https://claude.ai/code/session_01H8VWxoXRAUMqJrqGhajgqH)_