### PR TITLE
Daily Five: honor pre-play settings changes & stop re-billing the LLM for absent users

### DIFF
--- a/src/app/api/daily/preferences/route.ts
+++ b/src/app/api/daily/preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { getKnowledgeBase, invalidateTodaysDailyQueueIfUntouched } from '@/server/db/queries/daily';
+import { getKnowledgeBase, invalidateUntouchedDailyQueues } from '@/server/db/queries/daily';
 import {
   DAILY_DIFFICULTIES,
   DAILY_DOMAIN_MODES,
@@ -137,16 +137,18 @@ export async function PATCH(request: NextRequest) {
   // A change to the question-defining preferences — topics (selected domains),
   // domain mode, or difficulty — should give the player a Daily Five that
   // matches the new settings rather than the set the cron pre-built under the
-  // old ones. Drop today's queue if it hasn't been started yet; the next load
+  // old ones. Drop every untouched queue in the catch-up window; the next load
   // of /api/daily/queue (always a POST → fillDailyQueueForUser) regenerates it
-  // from these preferences. An in-progress round is left intact, so points
-  // already earned today survive and the change instead applies next day.
+  // from these preferences. Clearing prior untouched queues too — not just
+  // today's — keeps carry-forward from re-dating an old-settings queue onto
+  // today. In-progress rounds are left intact, so points already earned survive
+  // and the change instead applies to the next freshly generated queue.
   const questionInputsChanged =
     before.difficulty !== preferences.difficulty ||
     before.domainMode !== preferences.domainMode ||
     !selectedDomainsEqual(before.selectedDomains, preferences.selectedDomains);
   if (questionInputsChanged) {
-    await invalidateTodaysDailyQueueIfUntouched(userId);
+    await invalidateUntouchedDailyQueues(userId);
   }
 
   return NextResponse.json({ preferences: serializePreferences(preferences) });

--- a/src/app/api/daily/preferences/route.ts
+++ b/src/app/api/daily/preferences/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { getKnowledgeBase } from '@/server/db/queries/daily';
+import { getKnowledgeBase, invalidateTodaysDailyQueueIfUntouched } from '@/server/db/queries/daily';
 import {
   DAILY_DIFFICULTIES,
   DAILY_DOMAIN_MODES,
@@ -30,6 +30,15 @@ function parseStringArray(value: unknown): string[] | null {
     if (trimmed) result.push(trimmed);
   }
   return [...new Set(result)];
+}
+
+// Order-insensitive comparison; both inputs are already de-duped upstream
+// (normalizeSelectedDomains / parseStringArray), so a length + membership check
+// is sufficient to decide whether the topic selection actually changed.
+function selectedDomainsEqual(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) return false;
+  const set = new Set(a);
+  return b.every((domain) => set.has(domain));
 }
 
 async function requireUserId() {
@@ -117,11 +126,28 @@ export async function PATCH(request: NextRequest) {
     );
   }
 
+  const before = await getDailyPreferences(userId);
+
   const preferences = await updateDailyPreferences(userId, {
     ...(isValidDifficulty(difficultyValue) ? { difficulty: difficultyValue } : {}),
     ...(nextDomainMode ? { domainMode: nextDomainMode } : {}),
     ...(sanitizedDomains ? { selectedDomains: sanitizedDomains } : {}),
   });
+
+  // A change to the question-defining preferences — topics (selected domains),
+  // domain mode, or difficulty — should give the player a Daily Five that
+  // matches the new settings rather than the set the cron pre-built under the
+  // old ones. Drop today's queue if it hasn't been started yet; the next load
+  // of /api/daily/queue (always a POST → fillDailyQueueForUser) regenerates it
+  // from these preferences. An in-progress round is left intact, so points
+  // already earned today survive and the change instead applies next day.
+  const questionInputsChanged =
+    before.difficulty !== preferences.difficulty ||
+    before.domainMode !== preferences.domainMode ||
+    !selectedDomainsEqual(before.selectedDomains, preferences.selectedDomains);
+  if (questionInputsChanged) {
+    await invalidateTodaysDailyQueueIfUntouched(userId);
+  }
 
   return NextResponse.json({ preferences: serializePreferences(preferences) });
 }

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -11,6 +11,11 @@ export type AdaptiveDifficultyHint = {
   targetCorrectRate: number;
   difficultyLabel: string;
   promptHint: string;
+  // The difficulty_estimate tier a question generated at this level targets.
+  // The generator only emits three tiers, so the two hardest adaptive bands
+  // both map to 'specialist'. Lets the bank-reuse path request a stored
+  // question whose tier matches what fresh generation would have produced.
+  estimate: 'accessible' | 'moderate' | 'specialist';
 };
 
 type RecentAnswerRow = {
@@ -122,6 +127,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
       targetCorrectRate: 0.78,
       difficultyLabel: 'approachable trivia',
       promptHint: 'Target roughly a 78% correct rate. Write friendly, recognizable questions a casually interested person in the domain would get — lean on well-known facts, not deep cuts.',
+      estimate: 'accessible',
     };
   }
 
@@ -130,6 +136,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
       targetCorrectRate: 0.62,
       difficultyLabel: 'fair and familiar',
       promptHint: 'Target roughly a 62% correct rate. Write questions a reasonably engaged fan of the domain should know without needing specialist depth.',
+      estimate: 'moderate',
     };
   }
 
@@ -138,6 +145,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
       targetCorrectRate: 0.35,
       difficultyLabel: 'hard for someone with depth',
       promptHint: 'Target roughly a 35% correct rate. Write questions that are hard even for someone with real depth in the domain.',
+      estimate: 'specialist',
     };
   }
 
@@ -145,6 +153,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
     targetCorrectRate: 0.15,
     difficultyLabel: 'expert-level deep cuts',
     promptHint: 'Target roughly a 15% correct rate. Write expert-level deep cuts with specific facts, dates, terminology, or details.',
+    estimate: 'specialist',
   };
 }
 

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -23,7 +23,8 @@ import {
   getRecentDomainCounts,
   getRecentFactKeys,
   getRecentSubAnglesByDomain,
-  pickAccessibleBankSource,
+  pickBankSource,
+  type BankDifficulty,
   type RecentDailyQuestionEntry,
   type RecentFactKeyEntry,
 } from '@/server/db/queries/daily';
@@ -1067,12 +1068,13 @@ export async function generateDailyQuestionsFromKnowledgeBase(
 
   const subAnglesByDomain = await getRecentSubAnglesByDomain(userId, domainsForRound).catch(() => undefined);
 
-  // Try to fill any accessible-difficulty slots from the cross-user bank
-  // (previously-generated questions for the same domain) before burning
-  // fresh Sonnet calls. The bank only ever returns rows the viewer hasn't
-  // seen — empty bank for a domain falls through to LLM generation, which
-  // incidentally adds new accessible rows back into the pool.
-  const bankPicks = await pickBankPicksForAccessibleDomains(
+  // Try to fill slots from the cross-user bank (previously-generated questions
+  // for the same domain AND difficulty tier) before burning fresh Sonnet calls.
+  // The bank only ever returns rows the viewer hasn't seen — an empty bank for
+  // a domain falls through to LLM generation, which incidentally adds new rows
+  // back into the pool. Spans accessible/moderate/specialist so harder slots
+  // are reused too, not just warm-ups.
+  const bankPicks = await pickBankPicksForDomains(
     userId,
     domainsForRound,
     preferences.difficulty,
@@ -1105,24 +1107,33 @@ export async function generateDailyQuestionsFromKnowledgeBase(
   return [...bankPicks, ...llmGenerated];
 }
 
-function resolvesToAccessible(
+// Resolve the difficulty *tier* a freshly-generated question for this domain
+// would land at, so a bank reuse matches the player's intended difficulty.
+// Mirrors the generation prompt's own difficulty resolution: fixed preferences
+// map through FIXED_DIFFICULTY_LEVELS, adaptive uses the per-domain override (if
+// any) or the user's current adaptive level — and both run through the same
+// mapAdaptiveLevelToDifficultyHint estimate the generator targets.
+function resolveDomainDifficulty(
   domain: string,
   difficultyPreference: string | undefined,
   overrides: ReadonlyMap<string, string> | undefined,
   adaptiveLevel: number | null,
-): boolean {
-  if (!difficultyPreference) return false;
-  if (difficultyPreference === 'normal') return true;
+): BankDifficulty | null {
+  if (!difficultyPreference) return null;
+
   if (difficultyPreference === 'adaptive') {
     const override = overrides?.get(domain);
-    if (override === 'normal') return true;
-    if (override === 'moderate' || override === 'challenging') return false;
-    return (adaptiveLevel ?? 1) < 1.5;
+    const overrideLevel = override ? FIXED_DIFFICULTY_LEVELS[override] : undefined;
+    const level = overrideLevel ?? adaptiveLevel ?? 1;
+    return mapAdaptiveLevelToDifficultyHint(level).estimate;
   }
-  return false;
+
+  const fixedLevel = FIXED_DIFFICULTY_LEVELS[difficultyPreference];
+  if (fixedLevel === undefined) return null;
+  return mapAdaptiveLevelToDifficultyHint(fixedLevel).estimate;
 }
 
-async function pickBankPicksForAccessibleDomains(
+async function pickBankPicksForDomains(
   userId: string,
   domains: string[],
   difficultyPreference: string | undefined,
@@ -1135,10 +1146,14 @@ async function pickBankPicksForAccessibleDomains(
   const expiresAt = getNextDailyResetBoundary();
 
   for (const domain of domains) {
-    if (!resolvesToAccessible(domain, difficultyPreference, domainDifficultyOverrides, adaptiveLevel)) {
-      continue;
-    }
-    const source = await pickAccessibleBankSource(userId, domain, avoidFactKeys).catch(() => null);
+    const difficulty = resolveDomainDifficulty(
+      domain,
+      difficultyPreference,
+      domainDifficultyOverrides,
+      adaptiveLevel,
+    );
+    if (!difficulty) continue;
+    const source = await pickBankSource(userId, domain, difficulty, avoidFactKeys).catch(() => null);
     if (!source) continue;
     if (isGenericSubcategory(source.canonicalSubcategory)) continue;
 

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1,4 +1,5 @@
 import {
+  carryForwardUntouchedDailyQueue,
   createDailyQueueItem,
   createDailyQueueItemFromAuthored,
   getKnowledgeBase,
@@ -42,6 +43,14 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   const startedAt = Date.now();
   const existing = await getTodaysDailyQueue(userId);
   if (existing && asQueueSlots(existing.slots).length > 0) return;
+
+  // Before billing the LLM for a new set, roll a previous *unplayed* queue
+  // forward to today. The cron builds a queue for every onboarded user daily
+  // with no activity filter, so an absent user would otherwise accrue a fresh
+  // generation every day for questions they never opened. Their last queue is
+  // still sitting unplayed; re-dating it gives them the same five at zero cost.
+  // A played prior queue is left alone, so engaged users still get a fresh set.
+  if (await carryForwardUntouchedDailyQueue(userId)) return;
 
   const [knowledgeBase, preferences] = await Promise.all([
     getKnowledgeBase(userId),

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lte, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNotNull, isNull, lt, lte, sql } from 'drizzle-orm';
 
 import {
   dailyPreferences,
@@ -17,7 +17,7 @@ import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
-import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId } from '@/server/daily/catchup';
+import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
 import type { QueueSlot } from '@/server/daily/types';
 import {
   catchUpExpiresAt,
@@ -255,25 +255,107 @@ export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow
 }
 
 /**
- * Deletes today's daily queue ONLY when the user hasn't started it yet (no slot
- * answered or skipped). Returns true if a queue was deleted.
+ * Deletes the user's untouched daily queues (none of whose slots are answered or
+ * skipped) within the catch-up window. Returns the number of queues deleted.
  *
  * Used when daily preferences (topics / domain mode / difficulty) change before
- * play: dropping the untouched queue lets the next queue load regenerate it from
- * the new settings (POST /api/daily/queue → fillDailyQueueForUser reads current
- * preferences). An in-progress round is left intact so points already earned
- * today are never discarded — the new settings then take effect next day, when
- * the cron rebuilds the queue.
+ * play: dropping untouched queues lets the next queue load regenerate from the
+ * new settings (POST /api/daily/queue → fillDailyQueueForUser reads current
+ * preferences). We clear not just today's queue but every still-eligible prior
+ * untouched queue, because carryForwardUntouchedDailyQueue would otherwise
+ * re-date one of those old-settings queues onto today and defeat the change.
+ *
+ * Started queues (any slot answered or skipped) are left intact, so points
+ * already earned survive and that day's questions remain available in catch-up;
+ * the new settings take effect on the next freshly generated queue.
  */
-export async function invalidateTodaysDailyQueueIfUntouched(userId: string): Promise<boolean> {
-  const queue = await getTodaysDailyQueue(userId);
-  if (!queue) return false;
+export async function invalidateUntouchedDailyQueues(userId: string): Promise<number> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+  const oldestEligible = minusUtcDays(assignmentDateStr, CATCHUP_LOOKBACK_DAYS);
 
-  const started = asQueueSlots(queue.slots).some((slot) => slot.answered || slot.skipped);
-  if (started) return false;
+  const queues = await db
+    .select()
+    .from(dailyQueues)
+    .where(and(
+      eq(dailyQueues.userId, userId),
+      lte(dailyQueues.queueDate, assignmentDateStr),
+      gte(dailyQueues.queueDate, oldestEligible),
+    ));
 
-  await db.delete(dailyQueues).where(eq(dailyQueues.id, queue.id));
-  return true;
+  const untouchedIds = queues
+    .filter((queue) => !asQueueSlots(queue.slots).some((slot) => slot.answered || slot.skipped))
+    .map((queue) => queue.id);
+
+  if (untouchedIds.length === 0) return 0;
+
+  await db.delete(dailyQueues).where(inArray(dailyQueues.id, untouchedIds));
+  return untouchedIds.length;
+}
+
+/**
+ * Rolls an unplayed previous Daily Five forward to today instead of generating
+ * a brand-new (LLM-billed) set the user may again skip. Returns true when the
+ * caller should treat today's queue as ready (either it already existed, or a
+ * prior untouched queue was re-dated to today); false when there's nothing to
+ * carry forward and the caller should generate.
+ *
+ * Rationale: the cron builds a queue for every onboarded user every day with no
+ * activity filter, so a user who's been away for N days accrued N fresh
+ * generations they never saw. Their previous queue is still sitting unplayed
+ * (and surfaces in catch-up for CATCHUP_LOOKBACK_DAYS), so re-dating it gives
+ * them the same five at zero LLM cost. A *played* prior queue (any slot answered
+ * or skipped) is left alone — that user is engaged and should get a fresh set.
+ *
+ * Re-dating reuses the same row, so the carried-forward queue keeps rolling
+ * forward each day until the user actually plays it; only real engagement (or
+ * no prior queue at all) triggers generation.
+ */
+export async function carryForwardUntouchedDailyQueue(userId: string): Promise<boolean> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+
+  const today = await getTodaysDailyQueue(userId);
+  if (today && asQueueSlots(today.slots).length > 0) return true;
+
+  // Only carry forward a queue still inside the catch-up window. An older queue
+  // has already aged out of catch-up, so re-dating it would surface stale
+  // questions the user can no longer otherwise reach; let that regenerate.
+  const oldestEligible = minusUtcDays(assignmentDateStr, CATCHUP_LOOKBACK_DAYS);
+  const [prior] = await db
+    .select()
+    .from(dailyQueues)
+    .where(and(
+      eq(dailyQueues.userId, userId),
+      lt(dailyQueues.queueDate, assignmentDateStr),
+      gte(dailyQueues.queueDate, oldestEligible),
+    ))
+    .orderBy(desc(dailyQueues.queueDate))
+    .limit(1);
+
+  if (!prior) return false;
+
+  const priorSlots = asQueueSlots(prior.slots);
+  if (priorSlots.length === 0) return false;
+  if (priorSlots.some((slot) => slot.answered || slot.skipped)) return false;
+
+  // Clear any empty/partial today-row first so the unique (user, queue_date)
+  // constraint doesn't block the re-date.
+  if (today) {
+    await db.delete(dailyQueues).where(eq(dailyQueues.id, today.id));
+  }
+
+  try {
+    await db
+      .update(dailyQueues)
+      .set({ queueDate: assignmentDateStr })
+      .where(eq(dailyQueues.id, prior.id));
+    return true;
+  } catch (error) {
+    // 23505 = unique_violation: a today-row was created concurrently (e.g. the
+    // on-demand POST raced the cron). Let the caller fall through; the existing
+    // queue stands.
+    if (pgErrorCode(error) === '23505') return false;
+    throw error;
+  }
 }
 
 export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
@@ -856,7 +938,7 @@ export async function getRecentDailyQuestionTexts(
   }));
 }
 
-export type AccessibleBankSource = {
+export type BankSource = {
   questionText: string;
   answer: string;
   explainer: string;
@@ -868,10 +950,17 @@ export type AccessibleBankSource = {
   subAngles: string[];
 };
 
-// Pull one previously-generated "accessible" question for the given domain
-// that the current user has NOT seen, sourced from any OTHER user. Lets us
-// reuse canonical accessible trivia ("Mrs. Lovett's name", "Send in the
+export type BankDifficulty = 'accessible' | 'moderate' | 'specialist';
+
+// Pull one previously-generated question of the requested difficulty tier for
+// the given domain that the current user has NOT seen, sourced from any OTHER
+// user. Lets us reuse canonical trivia ("Mrs. Lovett's name", "Send in the
 // Clowns") instead of re-discovering it via Sonnet each week.
+//
+// Originally accessible-only; now spans accessible/moderate/specialist so the
+// harder slots draw from the shared pool before billing the LLM too. The
+// caller passes the difficulty the slot would otherwise generate at, so a
+// reused question always matches the player's intended difficulty.
 //
 // Restrictions:
 // - fact_key must be present (predates 2026-05-24; older rows lack it)
@@ -880,13 +969,14 @@ export type AccessibleBankSource = {
 // - not authored by the viewer
 // - fact_key not already in the viewer's recent avoid set
 //
-// Returns null when the bank is empty for this domain — caller falls back
-// to fresh LLM generation, which incidentally grows the bank.
-export async function pickAccessibleBankSource(
+// Returns null when the bank is empty for this domain+difficulty — caller
+// falls back to fresh LLM generation, which incidentally grows the bank.
+export async function pickBankSource(
   userId: string,
   domain: string,
+  difficulty: BankDifficulty,
   avoidFactKeys: ReadonlySet<string>,
-): Promise<AccessibleBankSource | null> {
+): Promise<BankSource | null> {
   const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
@@ -895,7 +985,7 @@ export async function pickAccessibleBankSource(
       .from(generatedQuestions)
       .where(and(
         eq(generatedQuestions.canonicalSubcategory, domain),
-        eq(generatedQuestions.difficultyEstimate, 'accessible'),
+        eq(generatedQuestions.difficultyEstimate, difficulty),
         isNotNull(generatedQuestions.factKey),
         sql`${generatedQuestions.userId} <> ${userId}`,
         gte(generatedQuestions.createdAt, since),

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -254,6 +254,28 @@ export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow
   return queue ?? null;
 }
 
+/**
+ * Deletes today's daily queue ONLY when the user hasn't started it yet (no slot
+ * answered or skipped). Returns true if a queue was deleted.
+ *
+ * Used when daily preferences (topics / domain mode / difficulty) change before
+ * play: dropping the untouched queue lets the next queue load regenerate it from
+ * the new settings (POST /api/daily/queue → fillDailyQueueForUser reads current
+ * preferences). An in-progress round is left intact so points already earned
+ * today are never discarded — the new settings then take effect next day, when
+ * the cron rebuilds the queue.
+ */
+export async function invalidateTodaysDailyQueueIfUntouched(userId: string): Promise<boolean> {
+  const queue = await getTodaysDailyQueue(userId);
+  if (!queue) return false;
+
+  const started = asQueueSlots(queue.slots).some((slot) => slot.answered || slot.skipped);
+  if (started) return false;
+
+  await db.delete(dailyQueues).where(eq(dailyQueues.id, queue.id));
+  return true;
+}
+
 export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
   const generatedIds = asQueueSlots(queue.slots)
     .map((slot) => slot.generated_question_id)


### PR DESCRIPTION
## Summary

Three related fixes to the Daily Five queue/generation path, all driven by the same observation: the cron pre-builds a queue for **every** onboarded user every day with no activity filter, and `fillDailyQueueForUser` early-returns once a queue exists for the day — so settings changes were ignored until the next day, and absent users accrued one wasted LLM generation per day.

### 1. Pre-play settings changes now take effect today (commit `f102e12`)
Changing topics / domain mode / difficulty before starting today's Five previously had no effect until the next day. Now, on a question-defining preference change, untouched queues are dropped so the next queue load regenerates from the new settings. An **in-progress round is left intact** (no lost points); the change applies to the next freshly generated queue instead.

### 2. Carry forward unplayed queues instead of regenerating (commit `cd510ab`)
A user away for N days used to generate N fresh sets they never saw. `fillDailyQueueForUser` now rolls a prior **untouched** queue (still inside the 7-day catch-up window) forward to today by re-dating the row — **zero LLM cost** — before generating. A played queue is left alone so engaged users still get a fresh set. Both the cron and the on-demand POST benefit.

A 4-day-absent user goes from **4 generations → 1**, then carry-forward.

### 3. Extend cross-user question reuse beyond `accessible` (commit `cd510ab`)
The reuse "bank" previously only reused `accessible`-difficulty questions; moderate/specialist slots always hit the LLM. `pickBankSource` now spans all three tiers, matching the difficulty the slot would otherwise generate at, so harder slots draw from the shared pool first. `mapAdaptiveLevelToDifficultyHint` gains an `estimate` tier for resolving a domain's target difficulty.

## How it fits together
The settings-change path clears **every** untouched queue in the catch-up window (not just today's), so carry-forward can't resurrect an old-settings queue and defeat the change. No client changes needed — the play page already does GET → (if null) POST → GET, so a dropped queue regenerates on next load.

## Files
- `src/app/api/daily/preferences/route.ts` — invalidate untouched queues on question-defining preference change
- `src/server/db/queries/daily.ts` — `invalidateUntouchedDailyQueues`, `carryForwardUntouchedDailyQueue`, bank query spanning all difficulties
- `src/server/daily/queue-orchestrator.ts` — carry-forward before generating
- `src/server/daily/generate-questions.ts` — bank reuse across difficulty tiers
- `src/server/adaptive-difficulty.ts` — `estimate` tier on the difficulty hint

## Verification
- `npx tsc -p tsconfig.typecheck.json` — **0 errors**
- `eslint` on changed files — **0 errors** (1 pre-existing unrelated warning)
- No `src/middleware.ts` introduced (repo uses `src/proxy.ts`)

## Notes / follow-ups
- Carry-forward removes the **LLM** cost for dormant users; the cron still iterates every onboarded user nightly (now a cheap DB re-date for dormant ones). An activity-gate on the cron's user query could skip them entirely — left as a potential follow-up.
- Regeneration on the on-demand path can take up to ~90s cold; carry-forward makes the common absent-user case instant since it only re-dates a row.

https://claude.ai/code/session_01NjzBxCbpBsLemT4RjZzmJo

---
_Generated by [Claude Code](https://claude.ai/code/session_01NjzBxCbpBsLemT4RjZzmJo)_