### PR TITLE
fix(login): solid filled phone icon to match Figma glyph

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -161,7 +161,9 @@ export default function LoginPanel() {
     >
       {step === 'phone' ? (
         <form className="space-y-[14px]" onSubmit={continueWithPhone}>
-          <Phone className="mx-auto h-9 w-9 text-[var(--brand-navy)]" strokeWidth={2.25} aria-hidden="true" />
+          {/* Solid filled handset, matching the Figma black phone glyph
+              (and the filled treatment of the OTP step's bubble icon). */}
+          <Phone className="mx-auto h-12 w-12 fill-black text-black" strokeWidth={1.5} aria-hidden="true" />
           <label
             className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"
             htmlFor="phone"


### PR DESCRIPTION
Recreates the phone-step icon to match the Figma glyph (node 84:1760): a **solid black filled handset**, up from the navy lucide outline. Sized 36→48px to match and to pair with the OTP step's filled two-tone bubble icon.

Like the OTP icon, the Figma source is a raster screenshot, so this fills the existing lucide `Phone` rather than embedding the image — crisp at any density.

**Stacked on #495** (login Figma-fidelity pass). The diff will show #495's commits until that merges, then narrow to just this one-line icon change. Merge #495 first, or I can rebase if you prefer.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
