### PR TITLE
fix(home): Figma-fidelity pass on home top sections

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -106,7 +106,7 @@ export function Nav({
         <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
-            className="font-sans text-[22px] font-semibold leading-none tracking-[0.01em] text-foreground"
+            className="font-sans text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"
           >
             Joshing
           </Link>

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -211,7 +211,7 @@ export default function TodaysFiveCard({
   }
 
   return (
-    <div className="bg-card text-card-foreground w-full rounded-md border border-[var(--brand-border)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
+    <div className="bg-card text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
       <div className="flex items-start justify-between gap-2">
         <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
           Today&apos;s Five
@@ -225,7 +225,7 @@ export default function TodaysFiveCard({
         </Link>
       </div>
 
-      <h2 className="mt-1.5 font-serif text-[32px] leading-[1.1] font-medium tracking-tight text-[var(--brand-ink)]">
+      <h2 className="mt-1.5 font-serif text-[32px] leading-[40px] font-medium tracking-normal text-black">
         {headline}
       </h2>
 
@@ -305,7 +305,7 @@ export default function TodaysFiveCard({
       ) : (
         <Link
           href={playHref}
-          className="btn-primary mt-4 min-h-12 w-full justify-center rounded-md text-base font-bold tracking-wide"
+          className="btn-primary mt-4 min-h-12 w-full justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"
         >
           {actionLabel}
         </Link>

--- a/src/components/home/NewsRow.tsx
+++ b/src/components/home/NewsRow.tsx
@@ -164,16 +164,16 @@ export function NewsRow({ item }: { item: ActivityItemView }) {
   return (
     <div className="flex items-start justify-between gap-3">
       <div className="min-w-0 flex-1">
-        <p className="text-[15px] leading-[23px] text-[var(--brand-ink)] [&_b]:font-bold [&_b]:text-[var(--brand-link)]">
+        <p className="text-[15px] leading-[23px] tracking-[0.05em] text-black [&_b]:font-bold [&_b]:text-[var(--brand-link)]">
           {copy.headline}
         </p>
         {copy.secondLine ? (
-          <p className="mt-0.5 line-clamp-2 font-serif text-[14px] leading-[22px] tracking-[0.04em] text-[var(--brand-ink-700)]">
+          <p className="mt-0.5 line-clamp-2 font-serif text-[14px] leading-[22px] tracking-[0.08em] text-black">
             {copy.secondLine}
           </p>
         ) : null}
       </div>
-      <span className="shrink-0 text-sm leading-[23px] text-[var(--brand-ink-400)]">
+      <span className="shrink-0 text-[15px] leading-[23px] text-[var(--brand-ink-400)]">
         {timestamp}
       </span>
     </div>


### PR DESCRIPTION
Figma-fidelity pass on the home top sections (frame `121:9892`), verified via Playwright computed styles at 402px.

| Element | Before | After (Figma) |
|---|---|---|
| Today's Five heading | navy / lh 1.1 / tracking-tight | **black / lh 40px / ~0** |
| Today's Five card | radius 6px | **radius 4px** |
| Play button | navy / cream text / 0.025em | **`--brand-link` #4a5d75 / white / 0.04em**, radius 4px |
| Wordmark | tracking 0.01em | **0.05em (~1.1px)** |
| Activity body | navy | **black** |
| Activity second line | 0.04em / ink-700 | **0.08em / black** |
| Activity timestamp | 14px | **15px** |

Already correct (no change): the "TODAY'S FIVE" label (13/700/1.56px/#3a4a5f). The empty-feed debug line is already gated to non-production.

### ⚠️ One choice to confirm
Figma uses the **link slate `#4a5d75`** for the home Play button, not navy. I applied it per the review, but it now differs from the **navy** login button / app-wide primary. If you'd rather keep navy for consistency, say so and I'll revert just that.

### Not in this PR
The **feed cards** (SparkleEnvelope / "knows" cards) couldn't be reviewed — the dev account's feed is empty. Doing that pass next.

Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
