### PR TITLE
fix(feed): Figma-fidelity pass on shared feed card

### DIFF
--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -23,23 +23,23 @@ type FeedCardProps = {
 // border/rule, 4px radius (space/1), soft shadow. The category/domain accent is
 // a 2px bar across the top (Figma renders it via an inset top shadow).
 const CARD_CLASS =
-  'relative overflow-hidden rounded-md border border-[var(--brand-rule)] bg-[var(--brand-card)] shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
+  'relative overflow-hidden rounded-[4px] border border-[var(--brand-rule)] bg-[var(--brand-card)] shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
 
-// display/card/update — category line in Cormorant serif.
+// display/card/update — category line in Cormorant SemiBold (Figma 16/24/0.64px/black).
 function CategoryLine({ category }: { category: string }) {
   return (
-    <p className="font-serif text-[16px] leading-[24px] tracking-[0.03em] text-[var(--brand-ink)]">
+    <p className="font-serif text-[16px] font-semibold leading-[24px] tracking-[0.04em] text-black">
       {category}
     </p>
   )
 }
 
-// display/card/question — the focal serif question.
+// display/card/question — the focal serif question (Figma Cormorant SemiBold 24/32/1.2px).
 function QuestionText({ question, dim }: { question: string; dim?: boolean }) {
   return (
     <p
       className={cn(
-        'mt-3 font-serif leading-[32px] tracking-[0.04em] text-[var(--brand-ink)]',
+        'mt-3 font-serif font-semibold leading-[32px] tracking-[0.05em] text-[var(--brand-ink)]',
         dim ? 'text-[16px] opacity-65' : 'text-[24px]',
       )}
     >
@@ -124,7 +124,7 @@ export function FeedCard({
               headerContent
             ) : (
               <>
-                <p className="text-[15px] leading-[23px] tracking-[0.02em] text-[var(--brand-ink)]">
+                <p className="text-[15px] leading-[23px] tracking-[0.05em] text-black">
                   {item.authorHref ? (
                     <Link href={item.authorHref} className="font-medium" style={{ color: nameColor }}>
                       {authorName}
@@ -156,7 +156,7 @@ export function FeedCard({
             <button
               type="button"
               onClick={onAnswer}
-              className="font-serif text-[18px] font-semibold tracking-wide text-[var(--brand-link)] underline underline-offset-4 transition hover:opacity-70"
+              className="font-serif text-[18px] font-semibold tracking-[0.05em] text-[var(--brand-link)] underline underline-offset-4 transition hover:opacity-70"
             >
               Answer →
             </button>


### PR DESCRIPTION
Figma-fidelity pass on the **shared `FeedCard`** (the "knows"/friend-answered and friend-added cards), verified by rendering the mock fixtures through the real components on a throwaway preview page (no DB seeding; page removed before commit).

Aligned to the Figma feed-card type tokens (frame `137:5911`, `display/card/*`):

| Element | Before | After (Figma) |
|---|---|---|
| Question | Cormorant **400** / 0.04em | **SemiBold 600** / 0.05em (24/32/1.2px) |
| Category line | 400 / 0.03em / navy | **600 / 0.04em / black** (16/24/0.64px) |
| Actor/verb line | tracking 0.02em / navy body | **0.05em / black body** (actor keeps avatar color, per Figma) |
| Answer → link | tracking-wide | **0.05em** (18/24/0.9px / #4a5d75) |
| Card radius | 6px | **4px** |

Typecheck + lint clean.

### ⚠️ Direct-sent card ("someone sent you a question") — needs your call
The direct-sent card (`SparkleEnvelope`) is **structurally different** from the Figma version on purpose: it's your navy "envelope" with sparkle accents, because you earlier chose **"Skip triangle frame"** for it. Figma shows a **triangle-pattern-bordered** card instead (cream inner, "Sarah thought you would like this", grey rule, serif question, "Answer →"). I left it as-is rather than reverse that decision. Tell me which you want:
- **(a)** Keep the navy envelope (current).
- **(b)** Rebuild it to the Figma triangle-border design.
- **(c)** Keep the envelope but match its serif weights/tracking to the new card tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
