### PR TITLE
fix(feed): rebuild direct-sent card to Figma triangle-border design

### DIFF
--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { visibleFeedCategory } from './category'
 import { SparkleEnvelope } from './SparkleEnvelope'
 import type { DirectSentFeedItem } from './types'
-import { colorForCategory } from './visual'
 
 type DirectSentCardProps = {
   item: DirectSentFeedItem
@@ -14,48 +13,24 @@ type DirectSentCardProps = {
 
 export function DirectSentCard({ item, overflow, onAnswer }: DirectSentCardProps) {
   const visibleCategory = visibleFeedCategory(item.category)
-  const accent = colorForCategory(item.category)
   const senderName = item.senderName || item.avatarName || 'A friend'
   const senderHref = item.senderHref ?? item.authorHref ?? null
 
-  const eyebrow = (
-    <>
-      Sent to you <span className="opacity-50">·</span> From {senderName}
-    </>
-  )
-
-  const kicker = (
-    <>
-      For you
-      {visibleCategory ? (
-        <>
-          <span className="mx-1.5 opacity-60">·</span>
-          {visibleCategory}
-        </>
-      ) : null}
-    </>
-  )
-
+  // Figma header line: actor in the link slate, the rest in black, with the
+  // optional personal note in italic serif beneath.
   const signal = (
     <>
       {senderHref ? (
-        <Link
-          href={senderHref}
-          className="font-semibold text-[var(--ink)] underline underline-offset-2"
-          style={{ textDecorationColor: 'rgb(0 0 0 / 0.3)' }}
-        >
+        <Link href={senderHref} className="font-semibold text-[var(--brand-link)] hover:opacity-70">
           {senderName}
         </Link>
       ) : (
-        <span className="font-semibold text-[var(--ink)]">{senderName}</span>
+        <span className="font-semibold text-[var(--brand-link)]">{senderName}</span>
       )}{' '}
       thought you&rsquo;d like this
       {visibleCategory ? <> about {visibleCategory}</> : null}.
       {item.personalMessage ? (
-        <span
-          className="mt-1 block italic"
-          style={{ fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif', opacity: 0.9 }}
-        >
+        <span className="mt-1 block font-serif text-[14px] italic leading-snug text-[var(--brand-ink-700)]">
           &ldquo;{item.personalMessage}&rdquo;
         </span>
       ) : null}
@@ -64,14 +39,10 @@ export function DirectSentCard({ item, overflow, onAnswer }: DirectSentCardProps
 
   return (
     <SparkleEnvelope
-      eyebrow={eyebrow}
-      accent={accent}
-      kicker={kicker}
       signal={signal}
       question={item.question}
-      timestamp={item.timestamp}
       overflow={overflow}
-      onAnswer={onAnswer}
+      onAnswer={item.viewerIsAuthor ? undefined : onAnswer}
     />
   )
 }

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -4,7 +4,6 @@ import Link from 'next/link'
 import { visibleFeedCategory } from './category'
 import { SparkleEnvelope } from './SparkleEnvelope'
 import type { FriendAddedFeedItem } from './types'
-import { colorForCategory } from './visual'
 
 type FriendAddedCardProps = {
   item: FriendAddedFeedItem
@@ -22,40 +21,17 @@ export function FriendAddedCard({
   className,
 }: FriendAddedCardProps) {
   const visibleCategory = visibleFeedCategory(item.category)
-  const accent = colorForCategory(item.category)
   const friendName = item.friendName || item.avatarName || 'A friend'
   const friendHref = item.friendHref ?? item.authorHref ?? null
-
-  const eyebrow = (
-    <>
-      Handwritten <span className="opacity-50">·</span> By {friendName}
-    </>
-  )
-
-  const kicker = (
-    <>
-      New question
-      {visibleCategory ? (
-        <>
-          <span className="mx-1.5 opacity-60">·</span>
-          {visibleCategory}
-        </>
-      ) : null}
-    </>
-  )
 
   const signal = (
     <>
       {friendHref ? (
-        <Link
-          href={friendHref}
-          className="font-semibold text-[var(--ink)] underline underline-offset-2"
-          style={{ textDecorationColor: 'rgb(0 0 0 / 0.3)' }}
-        >
+        <Link href={friendHref} className="font-semibold text-[var(--brand-link)] hover:opacity-70">
           {friendName}
         </Link>
       ) : (
-        <span className="font-semibold text-[var(--ink)]">{friendName}</span>
+        <span className="font-semibold text-[var(--brand-link)]">{friendName}</span>
       )}{' '}
       added a question
       {visibleCategory ? <> about {visibleCategory}</> : null}
@@ -76,14 +52,11 @@ export function FriendAddedCard({
 
   return (
     <SparkleEnvelope
-      eyebrow={eyebrow}
-      accent={accent}
-      kicker={kicker}
       signal={signal}
       question={item.question}
-      timestamp={item.timestamp}
       overflow={overflow}
-      onAnswer={onAnswer}
+      // You can't answer your own question — suppress the action on authored cards.
+      onAnswer={item.viewerIsAuthor ? undefined : onAnswer}
       className={className}
     />
   )

--- a/src/components/feed/SparkleEnvelope.tsx
+++ b/src/components/feed/SparkleEnvelope.tsx
@@ -2,43 +2,10 @@ import type { ReactNode } from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Sparkle({
-  size,
-  className,
-  opacity = 1,
-}: {
-  size: number
-  className?: string
-  opacity?: number
-}) {
-  return (
-    <svg
-      aria-hidden="true"
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      className={cn('pointer-events-none absolute', className)}
-      style={{ color: '#c79a4f', opacity }}
-    >
-      <path
-        d="M12 0 C 12.4 5.6 18.4 11.6 24 12 C 18.4 12.4 12.4 18.4 12 24 C 11.6 18.4 5.6 12.4 0 12 C 5.6 11.6 11.6 5.6 12 0 Z"
-        fill="currentColor"
-      />
-    </svg>
-  )
-}
-
 type SparkleEnvelopeProps = {
-  /** Cream label across the top of the dark ink frame. */
-  eyebrow: ReactNode
-  /** Category-derived accent color used for the inner kicker. */
-  accent: string
-  /** Small uppercase label at the top-left of the cream card. */
-  kicker: ReactNode
-  /** The attribution / "who and why" sentence under the kicker. */
+  /** Attribution line — e.g. "<actor> thought you'd like this about <category>." */
   signal: ReactNode
   question: string
-  timestamp?: string | null
   overflow?: ReactNode
   onAnswer?: () => void
   answerLabel?: string
@@ -46,93 +13,57 @@ type SparkleEnvelopeProps = {
 }
 
 /**
- * The "Handwritten" envelope shell: a dark ink frame matting a cream card
- * speckled with gold sparkles. Shared by the question-sharing feed cards
- * (FriendAddedCard, DirectSentCard) so the sparkle/frame markup lives in one
- * place — callers supply only the copy that differs between surfaces.
+ * The "shared with you" feed card (DirectSentCard, FriendAddedCard), built to
+ * the Figma triangle-bordered design (frame 137:5911): the app triangle pattern
+ * mats a cream card with a grey rule, a focal serif question, and an "Answer →"
+ * link. The pattern is the same /images/Variant4.png used on the login/home
+ * triangle banner, so the motif and scale stay consistent across surfaces.
  */
 export function SparkleEnvelope({
-  eyebrow,
-  accent,
-  kicker,
   signal,
   question,
-  timestamp,
   overflow,
   onAnswer,
-  answerLabel = 'Answer this',
+  answerLabel = 'Answer →',
   className,
 }: SparkleEnvelopeProps) {
   return (
     <article
       className={cn(
-        'overflow-hidden rounded-[1.5rem] bg-[var(--brand-navy)] p-[6px] shadow-[0_10px_24px_-8px_rgb(0_0_0/0.28)]',
+        "overflow-hidden rounded-[4px] bg-[url('/images/Variant4.png')] bg-[length:300px_auto] bg-center p-3 shadow-[0_4px_12px_rgba(40,32,30,0.04)]",
         className,
       )}
     >
-      <p
-        className="px-3 pb-[10px] pt-[6px] text-[10px] font-bold uppercase leading-none tracking-[0.22em]"
-        style={{ color: '#fbf4e3' }}
-      >
-        {eyebrow}
-      </p>
-
-      <div className="relative overflow-hidden rounded-[1.15rem] border border-[var(--border-warm)] bg-[var(--cream)] px-5 py-5 sm:px-7 sm:py-6">
-        <Sparkle size={26} className="left-3 top-5 rotate-[8deg]" opacity={0.95} />
-        <Sparkle size={14} className="left-7 top-14" opacity={0.7} />
-        <Sparkle size={10} className="left-4 bottom-6" opacity={0.55} />
-
-        <Sparkle size={22} className="right-4 top-12 -rotate-[6deg]" opacity={0.9} />
-        <Sparkle size={12} className="right-9 top-4" opacity={0.6} />
-        <Sparkle size={9} className="right-6 bottom-8" opacity={0.5} />
-
-        <div className="relative pl-6 pr-4 sm:pl-10 sm:pr-8">
-          <div className="flex items-start justify-between gap-3">
-            <p
-              className="text-[11px] font-bold uppercase leading-none tracking-[0.14em]"
-              style={{ color: accent }}
-            >
-              {kicker}
-            </p>
-            <div className="flex shrink-0 items-center gap-1.5">
-              {timestamp ? (
-                <span
-                  className="text-[11px] leading-none"
-                  style={{ color: 'var(--ink)', opacity: 0.6 }}
-                >
-                  {timestamp}
-                </span>
-              ) : null}
-              {overflow}
-            </div>
-          </div>
-
-          <p
-            className="mt-1.5 text-[14px] leading-snug"
-            style={{ color: 'var(--ink)', opacity: 0.85 }}
-          >
+      <div className="flex flex-col items-center gap-5 rounded-[4px] bg-[var(--brand-card)] p-[14px]">
+        <div className="flex w-full items-start justify-between gap-3">
+          <p className="font-sans text-[15px] leading-[23px] tracking-[0.05em] text-black">
             {signal}
           </p>
+          {overflow ? <div className="shrink-0">{overflow}</div> : null}
+        </div>
 
-          <div className="mt-4 flex items-center gap-4 sm:gap-5">
-            <p
-              className="min-w-0 flex-1 font-serif text-[20px] leading-snug text-[var(--ink)] sm:text-[23px]"
+        <div aria-hidden className="h-px w-[70px] bg-[var(--brand-rule)]" />
+
+        <div className="flex w-full flex-col items-end gap-5">
+          <p className="w-full font-serif text-[24px] font-semibold leading-[32px] tracking-[0.05em] text-[var(--brand-ink)]">
+            <span aria-hidden className="opacity-60">
+              &ldquo;
+            </span>
+            {question}
+            <span aria-hidden className="opacity-60">
+              &rdquo;
+            </span>
+          </p>
+
+          {onAnswer ? (
+            <button
+              type="button"
+              onClick={onAnswer}
+              className="font-serif text-[18px] font-semibold tracking-[0.05em] text-[var(--brand-link)] underline underline-offset-4 transition hover:opacity-70"
             >
-              <span aria-hidden className="opacity-60">&ldquo;</span>
-              {question}
-              <span aria-hidden className="opacity-60">&rdquo;</span>
-            </p>
-
-            {onAnswer ? (
-              <button
-                type="button"
-                onClick={onAnswer}
-                className="shrink-0 rounded-full bg-[var(--brand-navy)] px-5 py-2.5 text-[14px] font-semibold text-[#fbf4e3] shadow-sm transition hover:opacity-90 active:translate-y-px"
-              >
-                {answerLabel}
-              </button>
-            ) : null}
-          </div>
+              {answerLabel}
+            </button>
+          ) : null}
         </div>
       </div>
     </article>

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -122,7 +122,7 @@ describe('Feed unanswered card actions', () => {
       />
     )
 
-    expect(rendered).toContain('Answer this')
+    expect(rendered).toContain('Answer →')
     expect(rendered).not.toContain('Skip')
     expect(rendered).not.toContain('Not my focus')
     expect(rendered).not.toContain('Bookmark')
@@ -301,13 +301,13 @@ describe('FriendAnsweredCard viewer-already-answered footer', () => {
 })
 
 describe('Authored-by-viewer card', () => {
-  it('renders a "New question" eyebrow with the italic category', () => {
+  it('renders the authored attribution and category (Figma triangle card has no eyebrow)', () => {
     const rendered = html(
       <FriendAddedCard
         item={feedCardPreviewFixtures.authoredByViewerUnanswered}
       />
     )
-    expect(rendered).toContain('New question')
+    expect(rendered).toContain('added a question')
     expect(rendered).toContain('Detroit Techno')
   })
 


### PR DESCRIPTION
Rebuilds the **direct-sent card** ("someone sent you a question") to the Figma triangle-border design (frame `137:5911`), reversing the earlier "skip triangle frame" treatment. (Follow-up to the merged feed-card typography PR.)

`SparkleEnvelope` (shared by **DirectSentCard** + **FriendAddedCard**) goes from the navy "envelope + gold sparkles" shell to the Figma design:
- **Triangle pattern** (reusing `/images/Variant4.png` — same motif/scale as the login + home banners) matting a **cream card**, 4px radius.
- Header = attribution line (actor in `--brand-link`, rest black) + 3-dot overflow; the navy eyebrow bar and uppercase kicker are dropped.
- Centered 70px grey rule → focal **serif question** (Cormorant SemiBold 24/32/1.2px) → **"Answer →"** link (18/0.9px / `--brand-link`).
- Props slimmed to `{signal, question, overflow, onAnswer, answerLabel}`; both callers updated; authored-by-viewer cards suppress the Answer action.

Verified by rendering the mock fixtures through the real components (no DB seeding). Typecheck + lint clean; **32 feed tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
