### PR TITLE
fix(game): Figma-fidelity pass on gameplay screen

### DIFF
--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -2,6 +2,8 @@
 
 import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { useRouter } from 'next/navigation';
+import Link from 'next/link';
+import { X } from 'lucide-react';
 
 import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
 
@@ -64,6 +66,22 @@ type GradeResponse = {
   breadcrumb?: string | null;
   insideJoke?: string | null;
   viewerStatus: 'not_started' | 'in_progress' | 'complete';
+};
+
+// Mono underlined link style for the per-question actions ("Show me the answer",
+// "Skip"), mirroring the dismiss link inside QuestionRow.
+const questionActionStyle = {
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+  fontSize: '0.58rem',
+  textTransform: 'uppercase' as const,
+  letterSpacing: '0.06em',
+  color: 'var(--text-muted)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
 };
 
 export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameView; viewerId: string }) {
@@ -225,18 +243,110 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
     }
   }
 
+  // Consume the current question locally and advance to the next one (or the
+  // summary when none remain). Shared by "Show me the answer" and "Skip", which
+  // — like the daily catch-up give-up — resolve client-side without recording a
+  // server response; unanswered questions surface as "skipped" on the summary.
+  function consumeCurrentAndAdvance(consumed: JoshingGameView['questions'][number], appended: ChatMessage[]) {
+    if (nextQuestionTimerRef.current) window.clearTimeout(nextQuestionTimerRef.current);
+    const nextAnswered = new Set(answeredIds);
+    nextAnswered.add(consumed.questionId);
+    setAnsweredIds(nextAnswered);
+    const nextQuestion = orderedQuestions.find((question) => !nextAnswered.has(question.questionId));
+    setError(null);
+    setAnswer('');
+    setPausingAfterAnswer(true);
+    if (appended.length > 0) setMessages((current) => [...current, ...appended]);
+    nextQuestionTimerRef.current = window.setTimeout(() => {
+      setPausingAfterAnswer(false);
+      if (nextQuestion) {
+        setMessages((current) => [
+          ...current,
+          {
+            id: `current-${nextQuestion.questionId}`,
+            kind: 'question' as const,
+            assignmentId: nextQuestion.questionId,
+            questionText: nextQuestion.question.questionText,
+            creatorName: game.creator.displayName,
+            badges: questionBadges(nextQuestion.question),
+          },
+        ]);
+      } else {
+        router.push(`/games/${game.game.id}/summary`);
+      }
+    }, 850);
+  }
+
+  function revealCurrentAnswer() {
+    if (!currentQuestion || pending || pausingAfterAnswer) return;
+    consumeCurrentAndAdvance(currentQuestion, [
+      {
+        id: `reveal-${currentQuestion.questionId}`,
+        kind: 'result',
+        assignmentId: currentQuestion.questionId,
+        questionText: currentQuestion.question.questionText,
+        result: 'gave_up',
+        submitted: '',
+        correctAnswer: currentQuestion.question.answerText,
+        consolation: null,
+        breadcrumb: null,
+        explanation: pickExplainer(currentQuestion.question, false),
+        copyVariant: currentQuestion.position,
+        creatorName: game.creator.displayName,
+        canonicalSubcategory: currentQuestion.question.canonicalSubcategory,
+        reactionPrompt: null,
+      },
+    ]);
+  }
+
   return (
     <main className="mx-auto flex min-h-dvh max-w-lg flex-col px-0">
-      <header className="sticky top-0 z-20 border-b bg-background/95 px-4 py-3 backdrop-blur">
-        <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Joshing Game</p>
-        <h1 className="font-serif text-xl font-semibold">{game.game.title}</h1>
-        <p className="text-sm text-muted-foreground">{answeredIds.size} of {orderedQuestions.length}</p>
+      <header className="sticky top-0 z-20 flex items-center gap-2 border-b bg-background/95 px-4 py-3 backdrop-blur">
+        <h1
+          className="min-w-0 truncate font-serif text-[1.75rem] font-semibold leading-none"
+          style={{ color: 'var(--brand-ink)', letterSpacing: 0 }}
+        >
+          {game.game.title}
+        </h1>
+        {/* Progress dots (Figma "Game" header) — filled for answered, hollow for
+            the rest — replacing the old "N of M" text counter. */}
+        <div className="flex flex-1 items-center justify-center gap-1.5" aria-hidden>
+          {orderedQuestions.map((question, index) => (
+            <span
+              key={question.questionId}
+              className="size-2 rounded-full"
+              style={
+                index < answeredIds.size
+                  ? { background: 'var(--brand-navy)' }
+                  : { border: '1.5px solid color-mix(in srgb, var(--brand-navy) 35%, transparent)' }
+              }
+            />
+          ))}
+        </div>
+        <p className="sr-only" aria-live="polite">
+          {answeredIds.size} of {orderedQuestions.length} answered
+        </p>
+        <Link
+          href="/"
+          aria-label="Exit game"
+          className="inline-flex size-8 shrink-0 items-center justify-center transition hover:opacity-70"
+          style={{ color: 'var(--brand-ink)' }}
+        >
+          <X className="size-5" strokeWidth={1.8} />
+        </Link>
       </header>
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
-        style={{ paddingBottom: 'calc(140px + env(safe-area-inset-bottom))' }}
+        style={{ paddingBottom: 'calc(96px + env(safe-area-inset-bottom))' }}
       >
         <GameplayChatThread messages={messages} />
+        {currentQuestion && !pending && !pausingAfterAnswer ? (
+          <div className="mt-3 flex flex-wrap items-center gap-x-5 gap-y-2 pl-0.5">
+            <button type="button" onClick={revealCurrentAnswer} style={questionActionStyle}>
+              Show me the answer
+            </button>
+          </div>
+        ) : null}
         {error ? <p className="mt-4 rounded-md border border-destructive p-3 text-sm text-destructive">{error}</p> : null}
       </section>
       {currentQuestion ? (
@@ -254,8 +364,12 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
             placeholder="Your answer..."
             className="min-h-11 flex-1 rounded-md border bg-background px-4 text-base outline-none"
           />
-          <button type="submit" className="btn-primary" disabled={pending || !answer.trim()}>
-            {pending ? '...' : 'Send'}
+          <button
+            type="submit"
+            className="btn-primary font-serif text-base font-semibold"
+            disabled={pending || !answer.trim()}
+          >
+            {pending ? '...' : 'Answer'}
           </button>
         </form>
       ) : null}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -80,6 +80,15 @@
     --tri-darkyellow:    #deae5c;
     --tri-lighttan:      #edd2a3;
     --tri-amber:         #d9a82e;
+    /* Gameplay surface — sourced from the Figma "Game" frame variables.
+       game/card/question fill, plus the forest-green/terracotta result accents
+       (Correct, text/wrong, Color/game/wrong/in-question). These intentionally
+       differ from the vivid --success/destructive used elsewhere. */
+    --game-card-question: #faf4e9;  /* game/card/question — question bubble fill */
+    --game-correct:       #366045;  /* Correct — forest green result accent      */
+    --game-correct-soft:  #5d6f5b;  /* text/right — muted correct label          */
+    --game-wrong:         #c96b4a;  /* text/wrong — terracotta result accent     */
+    --game-wrong-strong:  #c33d14;  /* game/wrong/in-question — strong terracotta */
     /* ──────────────────────────────────────────────────────────────────────
        Conventions:
        • Cream tones — `--brand-cream-page` (#fcf8f2) is the app background;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,7 +31,9 @@ const playfair = Playfair_Display({
 // via --font-cormorant and surfaced to Tailwind as `font-serif` in globals.css.
 const cormorant = Cormorant_Garamond({
   subsets: ['latin'],
-  weight: ['500', '600'],
+  // 700 added for the gameplay question/answer text (Figma display/game/question
+  // is Cormorant Bold 28). Without it the bold synthesizes from 600.
+  weight: ['500', '600', '700'],
   style: ['normal', 'italic'],
   variable: '--font-cormorant',
   display: 'swap',

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -56,11 +56,20 @@ export function Nav({
     isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;
 
+  // The Joshing-game play screen (/games/<id>) is a focused flow with its own
+  // in-screen header (title + progress dots + X-to-exit) per the Figma "Game"
+  // frame, so the global app chrome is suppressed there — matching how the
+  // sibling /daily gameplay flow already hides Nav. The summary route
+  // (/games/<id>/summary) keeps the nav.
+  const gameSegments = pathname.split('/').filter(Boolean);
+  const isGamePlayScreen = gameSegments[0] === 'games' && gameSegments.length === 2;
+
   if (
     pathname === '/onboarding' ||
     pathname.startsWith('/daily') ||
     pathname === '/login' ||
-    pathname.startsWith('/invite/')
+    pathname.startsWith('/invite/') ||
+    isGamePlayScreen
   ) {
     return null;
   }

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -236,15 +236,18 @@ function QuestionRow({
         style={{
           alignSelf: 'flex-start',
           maxWidth: '88%',
-          background: 'var(--brand-card)',
+          background: 'var(--game-card-question)',
           border: '1px solid var(--brand-rule)',
           borderRadius: 'var(--radius-md)',
-          padding: '14px 16px',
+          // effect/card/question — soft layered drop shadow.
+          boxShadow: '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
+          padding: '16px 18px',
           fontFamily: 'var(--font-cormorant), Georgia, serif',
-          fontSize: '1.3rem',
-          letterSpacing: '0.01em',
+          fontSize: '1.75rem',
+          fontWeight: 700,
+          letterSpacing: 0,
           color: 'var(--brand-ink)',
-          lineHeight: 1.35,
+          lineHeight: 1.3,
         }}
       >
         <p style={{ margin: 0 }}>{questionText}</p>
@@ -255,15 +258,19 @@ function QuestionRow({
             <span
               key={badge.label}
               style={{
-                ...monoStyle,
+                // Figma display/pill/sans — Georgia, 12px, title-case (not the
+                // mono uppercase used elsewhere).
+                fontFamily: 'Georgia, "Times New Roman", serif',
+                fontSize: '0.75rem',
+                lineHeight: 1.1,
+                letterSpacing: '0.01em',
                 borderRadius: '999px',
                 border: '1px solid var(--border)',
                 background: badge.tone === 'warning'
                   ? 'color-mix(in srgb, #b45309 12%, var(--surface))'
                   : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
                 color: badge.tone === 'warning' ? '#b45309' : 'var(--text-muted)',
-                fontSize: '0.52rem',
-                padding: '2px 6px',
+                padding: '3px 9px',
               }}
             >
               {badge.label}
@@ -324,9 +331,12 @@ function UserRow({ text }: { text: string }) {
           background: 'var(--brand-navy)',
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
           padding: '10px 16px',
-          fontSize: '0.9rem',
+          // Figma answer bubble — Cormorant serif, not the sans body font.
+          fontFamily: 'var(--font-cormorant), Georgia, serif',
+          fontSize: '1.15rem',
           fontWeight: 600,
           letterSpacing: '0.01em',
+          lineHeight: 1.3,
           color: '#fbf4e3',
         }}
       >
@@ -707,9 +717,11 @@ function ResultRow({
     }
     : correct
       ? {
-        background: 'color-mix(in srgb, var(--success) 9%, var(--surface-2))',
-        border: '1px solid color-mix(in srgb, var(--success) 30%, var(--border))',
-        borderLeft: '3px solid var(--success)',
+        // Figma Correct (#366045) — forest green, lighter card body than the
+        // vivid --success used elsewhere.
+        background: 'color-mix(in srgb, var(--game-correct) 6%, var(--surface))',
+        border: '1px solid color-mix(in srgb, var(--game-correct) 26%, var(--border))',
+        borderLeft: '3px solid var(--game-correct)',
       }
       : gaveUp
         ? {
@@ -718,9 +730,10 @@ function ResultRow({
           borderLeft: '3px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)',
         }
         : {
-          background: 'color-mix(in srgb, #b42318 7%, var(--surface-2))',
-          border: '1px solid color-mix(in srgb, #b42318 24%, var(--border))',
-          borderLeft: '3px solid #b42318',
+          // Figma text/wrong (#c96b4a) body + game/wrong/in-question (#c33d14) bar.
+          background: 'color-mix(in srgb, var(--game-wrong) 12%, var(--surface))',
+          border: '1px solid color-mix(in srgb, var(--game-wrong) 30%, var(--border))',
+          borderLeft: '3px solid var(--game-wrong-strong)',
         };
 
   return (
@@ -740,8 +753,8 @@ function ResultRow({
           <span style={{ color: 'var(--text-muted)' }}>This one wasn&apos;t recorded in time.</span>
         ) : correct ? (
           <>
-            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif' }}>
-              <span style={{ color: '#178245', marginRight: '6px' }}>✓</span>
+            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--game-correct)', fontWeight: 600 }}>
+              <span style={{ color: 'var(--game-correct)', marginRight: '6px' }}>✓</span>
               {copy.headline}
             </p>
             <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '4px' }}>
@@ -776,18 +789,20 @@ function ResultRow({
           </>
         ) : (
           <>
-            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif' }}>
-              <span style={{ color: '#8b1f16', marginRight: '6px' }}>✕</span>
+            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--game-wrong-strong)', fontWeight: 600 }}>
+              <span style={{ color: 'var(--game-wrong-strong)', marginRight: '6px' }}>✕</span>
               {wrongHeadline(copyVariant)}
             </p>
             {correctAnswer ? (
               <p
                 style={{
                   marginTop: '8px',
+                  // Figma question/game/answer — Cormorant Bold 28.
                   fontFamily: 'var(--font-cormorant), Georgia, serif',
-                  fontSize: '1.3rem',
+                  fontSize: '1.75rem',
+                  fontWeight: 700,
                   color: 'var(--brand-ink)',
-                  lineHeight: 1.2,
+                  lineHeight: 1.3,
                 }}
               >
                 {correctAnswer}


### PR DESCRIPTION
Align the Joshing-game play screen with the Figma "Game" frame:

- Question cards: warm cream #faf4e9 fill + soft shadow, Cormorant Bold 28/36 question text (load 700 weight), Georgia title-case domain pill.
- Result cards: forest-green (#366045) correct / terracotta (#c33d14) wrong accents via new --game-* tokens; lighter correct fill; 28/700 wrong-answer reveal. Answer bubble switched to Cormorant serif.
- Header: drop the eyebrow + "N of M" text counter for the Figma layout (28px serif title, 5 progress dots, X-to-exit); suppress the global Nav on the /games/<id> play route so it's a focused flow like /daily.
- Input bar: "Answer" (serif) submit label.
- Add a per-question "Show me the answer" link beneath the current question (client-side reveal, mirroring the daily catch-up give-up); the input bar stays link-free.