### PR TITLE
fix(catchup): stop serving stale breadcrumbs on re-answered questions

### DIFF
--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -226,6 +226,12 @@ async function handleDailyCatchupAnswer({
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
       reveal_quip: grade.consolation,
+      // Drop any breadcrumb persisted from the original (often wrong) live
+      // answer. This slot is being re-answered in catch-up, so the old
+      // breadcrumb no longer matches the submitted answer or verdict; leaving
+      // it would make /api/breadcrumb short-circuit on the stale value and
+      // render a correction for an answer the user never gave this turn.
+      reveal_breadcrumb: null,
       quip,
     } satisfies QueueSlot;
   });

--- a/src/server/daily/generate-breadcrumb.ts
+++ b/src/server/daily/generate-breadcrumb.ts
@@ -17,7 +17,14 @@ const breadcrumbCache = new Map<string, string | null>();
 
 function cacheKey(params: GenerateBreadcrumbParams): string {
   const questionKey = params.questionId?.trim() || params.questionText.trim().toLowerCase();
-  return `${questionKey}:${params.isCorrect ? 'correct' : 'wrong'}`;
+  // Correct-answer breadcrumbs don't reference the submitted text, so they're
+  // shareable per question. Wrong-answer breadcrumbs embed the exact guess
+  // ("you answered X instead of Y"), so they MUST be keyed by that guess —
+  // otherwise the first miss poisons the shared cache and every later user who
+  // misses the same question sees the first user's answer.
+  if (params.isCorrect) return `${questionKey}:correct`;
+  const answerKey = params.submittedAnswer.trim().toLowerCase();
+  return `${questionKey}:wrong:${answerKey}`;
 }
 
 function setCacheEntry(key: string, value: string | null): void {


### PR DESCRIPTION
A catch-up result could show a "Right on" verdict paired with a "COMMON GROUND" breadcrumb correcting an answer the user never gave that turn. Two independent causes:

1. The live daily answer persists a breadcrumb onto the queue slot (reveal_breadcrumb) reflecting the original, often-wrong answer. When the slot resurfaces in catch-up and is re-answered, the catch-up answer route rewrote submitted_answer/answer_state/reveal_* but left reveal_breadcrumb in place, so /api/breadcrumb short-circuited on the stale value. Now cleared on re-answer.

2. generateBreadcrumb cached wrong-answer breadcrumbs under `questionId:wrong`, but the breadcrumb text embeds the specific submitted guess. The module-level cache is shared across users, so the first miss poisoned the cache for everyone. Wrong-answer breadcrumbs are now keyed by the normalized submitted answer.