### PR TITLE
fix(daily): make a short Daily Five traceable and backfill generic slots

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -12,6 +12,8 @@ const {
   updateDomainDifficultyOnAnswerMock,
   writeMasteryEventMock,
   dbState,
+  selectCallChain,
+  dbMock,
 } = vi.hoisted(() => {
   const QUEUE = {
     id: 'queue-1',
@@ -50,6 +52,31 @@ const {
     },
   }
 
+  // Drizzle chain mock: db.select().from().where().limit() — returns canned rows
+  // based on which "table" was selected. We dispatch on the order of select()
+  // calls within a single request: queue → question → persistedQuestion. Defined
+  // inside vi.hoisted() so it's initialized before the hoisted vi.mock factory
+  // below references it (otherwise: "Cannot access 'dbMock' before initialization").
+  const selectCallChain: Array<() => Promise<unknown[]>> = []
+
+  const dbMock = {
+    select: vi.fn(() => {
+      const handler = selectCallChain.shift() ?? (async () => [])
+      return {
+        from: () => ({
+          where: () => ({
+            limit: handler,
+          }),
+        }),
+      }
+    }),
+    update: vi.fn(() => ({
+      set: () => ({
+        where: vi.fn(async () => undefined),
+      }),
+    })),
+  }
+
   return {
     createFeedItemsForFriendsFromAnswerMock: vi.fn(async () => undefined),
     getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
@@ -72,31 +99,10 @@ const {
       openedNewTerritory: false,
     })),
     dbState,
+    selectCallChain,
+    dbMock,
   }
 })
-
-// Drizzle chain mock: db.select().from().where().limit() — returns canned rows
-// based on which "table" was selected. We dispatch on the order of select()
-// calls within a single request: queue → question → persistedQuestion.
-const selectCallChain: Array<() => Promise<unknown[]>> = []
-
-const dbMock = {
-  select: vi.fn(() => {
-    const handler = selectCallChain.shift() ?? (async () => [])
-    return {
-      from: () => ({
-        where: () => ({
-          limit: handler,
-        }),
-      }),
-    }
-  }),
-  update: vi.fn(() => ({
-    set: () => ({
-      where: vi.fn(async () => undefined),
-    }),
-  })),
-}
 
 vi.mock('@/server/grading', () => ({
   gradeAnswer: gradeAnswerMock,
@@ -121,7 +127,10 @@ vi.mock('@/server/db', () => ({
     canonicalSubcategory: 'q.cs',
     broadCategory: 'q.bc',
     category: 'q.c',
+    insideJoke: 'q.ij',
   },
+  // PRD §8.4.3: bot slots with points run an extra playerMastery domain check.
+  playerMastery: { userId: 'pm.userId', canonicalSubcategory: 'pm.cs' },
 }))
 
 vi.mock('@/server/mastery/write-mastery-event', () => ({
@@ -156,11 +165,19 @@ vi.mock('@/server/answer-history', () => ({
 import { POST } from '@/app/api/daily/answer/route'
 
 function setupDbChain() {
-  // Reset and re-seed for one full POST: queue, question, persistedQuestion.
+  // Reset and re-seed the select() responses in the order the route issues them
+  // for a bot slot: dailyQueues (queue) → generatedQuestions (question) →
+  // questions (persisted creator info, post-persist) → playerMastery (the
+  // §8.4.3 domain check). The domain row must be truthy so the route doesn't
+  // zero out points / skip the mastery write for an "unknown domain". When
+  // persistGeneratedQuestion throws, the route skips the creator select, so the
+  // playerMastery check consumes the creator handler instead — still truthy, so
+  // both the happy path and the persist-failure path resolve correctly.
   selectCallChain.length = 0
   selectCallChain.push(async () => [dbState.queue])
   selectCallChain.push(async () => [dbState.question])
   selectCallChain.push(async () => [dbState.persistedQuestion])
+  selectCallChain.push(async () => [{ canonicalSubcategory: 'history' }])
 }
 
 function jsonRequest(body: unknown) {
@@ -303,7 +320,10 @@ describe('POST /api/daily/answer mastery scoring (F2.1)', () => {
   it('when persist fails, still records mastery event but with null eventQuestionId (graceful fallback)', async () => {
     setupDbChain()
     gradeAnswerMock.mockResolvedValueOnce({ result: 'correct', consolation: null })
-    persistGeneratedQuestionMock.mockRejectedValueOnce(new Error('persist boom'))
+    // The route retries persistence once (persistAttempt < 2), so reject ALL
+    // calls — not just the first — to exercise the full-failure fallback this
+    // test asserts (canonicalQuestionId stays null → eventQuestionId null).
+    persistGeneratedQuestionMock.mockRejectedValue(new Error('persist boom'))
 
     await POST(jsonRequest(VALID_BODY) as never)
 

--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -4,7 +4,7 @@ import { getSession } from '@/server/auth/session';
 import { getTodaysDailyQueue } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
-import { type QueueSlot } from '@/server/daily/types';
+import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export const dynamic = 'force-dynamic';
@@ -21,16 +21,49 @@ function asQueueSlots(value: unknown): QueueSlot[] {
 
 // Drop slots whose domain is a bucket-level label. Older queues built before
 // the upstream guard could contain "general"/"general knowledge" slots; we
-// suppress them here so the user never sees a general question.
-function filterNonGenericSlots(slots: QueueSlot[]): QueueSlot[] {
-  return slots.filter((slot) => !isGenericSubcategory(slot.domain));
+// suppress them here so the user never sees a general question. The orchestrator
+// now counts generic picks as a shortfall and backfills them at build time, so
+// for a freshly built queue this should drop nothing — if it does, the warning
+// below makes it visible instead of silently shrinking the user's Daily Five.
+function partitionGenericSlots(slots: QueueSlot[]): { kept: QueueSlot[]; dropped: QueueSlot[] } {
+  const kept: QueueSlot[] = [];
+  const dropped: QueueSlot[] = [];
+  for (const slot of slots) {
+    (isGenericSubcategory(slot.domain) ? dropped : kept).push(slot);
+  }
+  return { kept, dropped };
 }
 
-function serializeQueue(queue: NonNullable<Awaited<ReturnType<typeof getTodaysDailyQueue>>>, difficultyMode: string) {
+function serializeQueue(
+  queue: NonNullable<Awaited<ReturnType<typeof getTodaysDailyQueue>>>,
+  difficultyMode: string,
+  userId: string,
+) {
+  const raw = asQueueSlots(queue.slots);
+  const { kept, dropped } = partitionGenericSlots(raw);
+
+  // A served queue shorter than DAILY_QUEUE_SIZE is the exact symptom a user
+  // reports as "only 3 of my 5 showed up." Trace it at the moment of serving,
+  // and separate the two causes so the logs say which one happened:
+  //   - dropped.length > 0  → generic slots filtered here on read
+  //   - raw.length < SIZE    → orchestrator persisted a short queue (low yield;
+  //     it logs its own '[daily/queue-orchestrator] persisted short queue')
+  if (kept.length < DAILY_QUEUE_SIZE) {
+    console.warn('[daily/queue] served short queue', {
+      userId,
+      queueDate: queue.queueDate,
+      served: kept.length,
+      expected: DAILY_QUEUE_SIZE,
+      persistedSlots: raw.length,
+      droppedGeneric: dropped.length,
+      droppedGenericDomains: dropped.map((slot) => slot.domain),
+    });
+  }
+
   return {
     queue_id: queue.id,
     queue_date: queue.queueDate,
-    slots: filterNonGenericSlots(asQueueSlots(queue.slots)),
+    slots: kept,
     difficulty_mode: difficultyMode,
   };
 }
@@ -53,7 +86,7 @@ export async function GET() {
     return NextResponse.json({ queue: null, slots: [] });
   }
 
-  return NextResponse.json(serializeQueue(queue, prefs.difficulty));
+  return NextResponse.json(serializeQueue(queue, prefs.difficulty, userId));
 }
 
 export async function POST() {
@@ -81,5 +114,5 @@ export async function POST() {
     return NextResponse.json({ error: 'queue_not_created' }, { status: 500 });
   }
 
-  return NextResponse.json(serializeQueue(queue, prefs.difficulty));
+  return NextResponse.json(serializeQueue(queue, prefs.difficulty, userId));
 }

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -10,6 +10,7 @@ import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
 import { generateDailyQuestionsFromKnowledgeBase } from '@/server/daily/generate-questions';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
 
@@ -118,7 +119,16 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
   const dedupedGenerated: typeof generated = [];
   let droppedDuplicates = 0;
+  let droppedGeneric = 0;
   for (const question of generated) {
+    // Drop bucket-level domains ("general"/"trivia"/short labels) BEFORE the
+    // shortfall count below, so a generic pick is treated as a missing slot the
+    // top-up can backfill — rather than persisting it and letting the read path
+    // (api/daily/queue) silently filter it out, leaving the user one short.
+    if (isGenericSubcategory(question.canonicalSubcategory)) {
+      droppedGeneric += 1;
+      continue;
+    }
     const key = normalize(question.questionText);
     if (seenTexts.has(key)) {
       droppedDuplicates += 1;
@@ -149,6 +159,10 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   if (shortfall > 0 && Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS) {
     const extra = await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(shortfall));
     for (const question of extra) {
+      if (isGenericSubcategory(question.canonicalSubcategory)) {
+        droppedGeneric += 1;
+        continue;
+      }
       const key = normalize(question.questionText);
       if (seenTexts.has(key)) continue;
       seenTexts.add(key);
@@ -183,6 +197,7 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       knowledgeBaseDomains: knowledgeBase.length,
       generatedRaw: generated.length,
       droppedDuplicates,
+      droppedGeneric,
       domainMode: preferences.domainMode,
       selectedDomains: preferences.selectedDomains.length,
       elapsedMs: Date.now() - startedAt,
@@ -205,6 +220,7 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       dedupedGenerated: dedupedGenerated.length,
       topUpRecovered: topUpGenerated.length,
       droppedDuplicates,
+      droppedGeneric,
       knowledgeBaseDomains: knowledgeBase.length,
       domainMode: preferences.domainMode,
       selectedDomains: preferences.selectedDomains.length,


### PR DESCRIPTION
A user reported playing only 3 of their 5 daily questions. Two ways a queue can come up short, and the worse of the two left no trace at all:

1. Read-path filter (api/daily/queue) drops slots whose domain is a bucket-level label ("general"/"trivia"/short labels) so the user never sees a generic question — but it did so silently and never backfilled, so a 5-slot queue with 2 generic slots was served as 3 with nothing in the logs to explain it.

2. The orchestrator graceful-degrades a low-yield batch to a short queue, which it already logs as "persisted short queue".

Changes:

- api/daily/queue/route.ts: when the served queue is shorter than DAILY_QUEUE_SIZE, log "[daily/queue] served short queue" with the user, persisted vs served counts, and the dropped generic domains — separating "filtered on read" from "persisted short" so the logs say which cause hit. This is the missing trace.

- queue-orchestrator.ts: drop generic-domain picks BEFORE the shortfall count (in both the generation dedupe and top-up loops) so a generic pick is treated as a missing slot the existing top-up backfills, rather than being persisted and silently filtered on read. droppedGeneric is threaded into the existing short-queue / generation-failed diagnostics.

Backfill stays at the build layer (where the top-up machinery lives), not the GET path — no LLM call or write on read.

Also repairs src/app/api/daily/answer/__tests__/route.test.ts, which had silently stopped running: a vi.mock factory referenced dbMock before its hoisted initialization (moved dbMock/selectCallChain into vi.hoisted), the @/server/db mock was missing the playerMastery export the route now reads (PRD 8.4.3 domain check), the select-chain seeding lacked that 4th select, and the persist-failure test rejected only the first of the route's two persist attempts. 7/7 pass.