### PR TITLE
Default the "Add to my Daily Five" checkbox to checked

### DIFF
--- a/src/components/feed/AddToDailyFivePrompt.tsx
+++ b/src/components/feed/AddToDailyFivePrompt.tsx
@@ -1,10 +1,8 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import Link from 'next/link'
 import { Sparkles } from 'lucide-react'
-
-type Status = 'idle' | 'submitting' | 'accepted' | 'error'
 
 const SETTINGS_HREF = '/daily/setup'
 
@@ -19,26 +17,101 @@ export function AddToDailyFivePrompt({
   domain: string
   category?: string | null
 }) {
-  const [status, setStatus] = useState<Status>('idle')
-  const checked = status === 'accepted'
+  // Opt-out by default: the freshly opened territory is added to the Daily Five
+  // automatically (checkbox starts checked, add fires on mount), and the user
+  // can uncheck to pull it back out. Mirrors the practice-bank auto-save + undo
+  // flow in AnswerFeedbackSheet so "New territory" celebrations don't require an
+  // extra tap to start practicing the topic.
+  const [checked, setChecked] = useState(true)
+  const [pending, setPending] = useState(true)
+  const [error, setError] = useState(false)
+  // Latest selectedDomains the server has confirmed, so an uncheck can PATCH the
+  // list with this domain removed. Also remember the canonical (server-cased)
+  // form of the domain for accurate removal.
+  const selectedDomainsRef = useRef<string[]>([])
+  const matchedDomainRef = useRef(domain)
+  const didAutoAddRef = useRef(false)
   const label = category || domain
 
-  const toggle = async () => {
-    if (status === 'submitting' || status === 'accepted') return
-    setStatus('submitting')
-    try {
-      const response = await fetch('/api/daily/preferences/add-domain', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ domain }),
-      })
-      if (!response.ok) throw new Error('add failed')
-      setStatus('accepted')
-    } catch {
-      setStatus('error')
+  const addDomain = useCallback(async () => {
+    const response = await fetch('/api/daily/preferences/add-domain', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ domain }),
+    })
+    if (!response.ok) throw new Error('add failed')
+    const data = (await response.json()) as { selectedDomains?: unknown }
+    if (Array.isArray(data.selectedDomains)) {
+      const domains = data.selectedDomains.filter((d): d is string => typeof d === 'string')
+      selectedDomainsRef.current = domains
+      const match = domains.find((d) => d.toLowerCase() === domain.toLowerCase())
+      if (match) matchedDomainRef.current = match
     }
+  }, [domain])
+
+  const removeDomain = useCallback(async () => {
+    const key = matchedDomainRef.current.toLowerCase()
+    const next = selectedDomainsRef.current.filter((d) => d.toLowerCase() !== key)
+    const response = await fetch('/api/daily/preferences', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ selectedDomains: next }),
+    })
+    if (!response.ok) throw new Error('remove failed')
+    const data = (await response.json()) as { preferences?: { selectedDomains?: unknown } }
+    const updated = data.preferences?.selectedDomains
+    if (Array.isArray(updated)) {
+      selectedDomainsRef.current = updated.filter((d): d is string => typeof d === 'string')
+    } else {
+      selectedDomainsRef.current = next
+    }
+  }, [])
+
+  // Auto-add on mount so the default-checked box reflects reality.
+  useEffect(() => {
+    if (didAutoAddRef.current) return
+    didAutoAddRef.current = true
+    void (async () => {
+      try {
+        await addDomain()
+        setError(false)
+      } catch {
+        setChecked(false)
+        setError(true)
+      } finally {
+        setPending(false)
+      }
+    })()
+  }, [addDomain])
+
+  const toggle = () => {
+    if (pending) return
+    const next = !checked
+    setChecked(next)
+    setPending(true)
+    setError(false)
+    void (async () => {
+      try {
+        if (next) await addDomain()
+        else await removeDomain()
+      } catch {
+        setChecked(!next)
+        setError(true)
+      } finally {
+        setPending(false)
+      }
+    })()
   }
+
+  const statusLabel = pending
+    ? checked
+      ? 'Adding to your Daily Five…'
+      : 'Removing from your Daily Five…'
+    : checked
+      ? 'Added to your Daily Five'
+      : 'Add to my Daily Five'
 
   return (
     <div
@@ -69,19 +142,13 @@ export function AddToDailyFivePrompt({
             <input
               type="checkbox"
               checked={checked}
-              disabled={status === 'submitting' || status === 'accepted'}
-              onChange={() => void toggle()}
+              disabled={pending}
+              onChange={() => toggle()}
               className="size-4 shrink-0 rounded accent-[var(--tri-amber)] disabled:cursor-default"
             />
-            <span>
-              {status === 'submitting'
-                ? 'Adding to your Daily Five…'
-                : status === 'accepted'
-                  ? 'Added to your Daily Five'
-                  : 'Add to my Daily Five'}
-            </span>
+            <span>{statusLabel}</span>
           </label>
-          {status === 'error' ? (
+          {error ? (
             <p className="mt-1.5 text-[12px]" style={{ color: 'var(--game-wrong-strong)' }}>
               Could not update your Daily Five. Try from{' '}
               <Link


### PR DESCRIPTION
Makes the new-territory prompt opt-out instead of opt-in.

## What changed
`src/components/feed/AddToDailyFivePrompt.tsx`:
- The checkbox now **starts checked** and the freshly opened territory is added to the user's Daily Five **automatically on mount** (`POST /api/daily/preferences/add-domain`, fired once via a guarded effect), mirroring the practice-bank auto-save + undo flow in `AnswerFeedbackSheet`.
- **Unchecking removes** the domain again via `PATCH /api/daily/preferences` with the domain stripped from the confirmed `selectedDomains` list (no dedicated remove endpoint exists, so this reuses the preferences PATCH path).
- Optimistic toggle with revert + error message on failure, and contextual labels ("Adding…", "Added to your Daily Five", "Removing…", "Add to my Daily Five").

## Verification
- `npx tsc -p tsconfig.typecheck.json` passes
- ESLint clean on the changed file

https://claude.ai/code/session_011ovX7rQFFYGnLrGLAi33XK

---
_Generated by [Claude Code](https://claude.ai/code/session_011ovX7rQFFYGnLrGLAi33XK)_