### PR TITLE
Design token sweep: TodaysFiveCard, MissedQuestionsCard, KnowledgeCard, knowledge heading

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -474,7 +474,7 @@ function KnowledgePageContent() {
 
   return (
     <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-[0.9rem]">
-      <h1 className="m-0 px-[0.2rem] font-serif text-[2.2rem] leading-tight text-[var(--brand-ink)]">
+      <h1 className="m-0 px-[0.2rem] font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
         Knowledge
       </h1>
 

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -225,8 +225,7 @@ export default function TodaysFiveCard({
         </Link>
       </div>
 
-      <h2 className="mt-3 mb-2 font-serif text-[32px] leading-[40px] font-medium tracking-normal text-black">
-
+      <h2 className="mt-3 mb-2 font-serif text-[32px] leading-[40px] font-medium tracking-[-0.1px] text-[var(--brand-ink)]">
         {headline}
       </h2>
 

--- a/src/components/home/MissedQuestionsCard.tsx
+++ b/src/components/home/MissedQuestionsCard.tsx
@@ -11,7 +11,7 @@ export function MissedQuestionsCard({
   const missedLabel = count === 1 ? '1 missed question' : `${count} missed questions`
   return (
     <div
-      className="bg-card text-card-foreground flex items-center justify-between gap-3 rounded-md border border-[var(--brand-rule)] px-3 py-4"
+      className="bg-card text-card-foreground flex items-center justify-between gap-3 rounded-[4px] border border-[var(--brand-rule)] px-3 py-4"
       style={
         expiringCount > 0
           ? { borderColor: 'color-mix(in srgb, var(--brand-orange) 40%, var(--brand-rule))' }
@@ -19,7 +19,7 @@ export function MissedQuestionsCard({
       }
     >
       <div className="min-w-0">
-        <p className="text-[15px] font-medium tracking-[0.02em] text-[var(--brand-ink)]">
+        <p className="font-serif text-[16px] leading-[24px] font-semibold tracking-[0.04em] text-[var(--brand-ink)]">
           Catch up
         </p>
         <p className="mt-1 text-xs font-medium tracking-[0.06em] text-[var(--brand-ink-400)]">
@@ -29,7 +29,7 @@ export function MissedQuestionsCard({
       </div>
       <Link
         href="/daily/catchup"
-        className="font-serif text-lg font-semibold tracking-wide whitespace-nowrap text-[var(--brand-link)] underline underline-offset-4"
+        className="font-serif text-lg leading-[24px] font-semibold tracking-[0.05em] whitespace-nowrap text-[var(--brand-link)] underline underline-offset-4"
         aria-label={`Catch up on ${missedLabel}`}
       >
         Play →

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -178,10 +178,10 @@ const wordmarkStyle: CSSProperties = {
 const shareButtonStyle: CSSProperties = {
   minHeight: 38,
   padding: '0 0.82rem',
-  border: '1px solid #ddd6c7',
+  border: '1px solid var(--brand-border)',
   borderRadius: 999,
-  background: '#fffdf8',
-  color: '#1a1208',
+  background: 'var(--brand-card)',
+  color: 'var(--brand-ink)',
   display: 'inline-flex',
   alignItems: 'center',
   justifyContent: 'center',
@@ -213,24 +213,24 @@ const circlesWrapStyle: CSSProperties = {
 const overflowStyle: CSSProperties = {
   margin: 0,
   fontSize: 11,
-  color: '#8a8070',
+  color: 'var(--brand-ink-400)',
   textAlign: 'center',
 }
 
 const tierStyle: CSSProperties = {
   margin: 0,
   fontSize: 13,
-  color: '#1a1208',
+  color: 'var(--brand-ink)',
 }
 
 const rarestStyle: CSSProperties = {
   margin: 0,
   fontSize: 11,
-  color: '#8a8070',
+  color: 'var(--brand-ink-400)',
 }
 
 const attributionStyle: CSSProperties = {
   margin: 0,
   fontSize: 11,
-  color: '#8a8070',
+  color: 'var(--brand-ink-400)',
 }


### PR DESCRIPTION
Four more surfaces moved off off-system colors/values onto brand tokens — the same sweep as the main design-audit work, for edits that were sitting uncommitted in the working tree.

- **KnowledgeCard** share card: raw inline-style hex (`#ddd6c7` / `#fffdf8` / `#1a1208` / `#8a8070`) → `var(--brand-border / --brand-card / --brand-ink / --brand-ink-400)`.
- **TodaysFiveCard** headline: `text-black` → `var(--brand-ink)` + tracking tweak. Kept the `mt-3 mb-2` spacing introduced by #516 (resolved that overlap as a union, not an overwrite).
- **MissedQuestionsCard**: `rounded-md` → `rounded-[4px]`; "Catch up" / "Play →" onto the serif heading/link scale.
- **knowledge/page** heading: `2.2rem` → `2rem` medium.

Branched fresh off the latest `main` (not the already-merged `claude/design-audit-fixes`). Typecheck (`tsc -p tsconfig.typecheck.json`) exit 0; ESLint clean on these files.

Note: `TodaysFiveCard` stays on the token-enforcement grandfather list — it still has one unrelated off-system color (~line 308) outside this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)