### PR TITLE
Add one-time "top up your areas" prompt for invite-seeded users

### DIFF
--- a/drizzle/0056_area_top_up_prompt.sql
+++ b/drizzle/0056_area_top_up_prompt.sql
@@ -1,0 +1,14 @@
+-- Migration: one-time "add two more areas" prompt dismissal flag.
+--
+-- Invite-seeded users start with up to three declared interests (the
+-- inviter's pre-seeded suggestions). The app supports up to five active
+-- interests, so the next time such a user plays we surface a one-time prompt
+-- offering to top up to five. This nullable timestamp records that the prompt
+-- was dismissed or completed, so it never reappears.
+--
+-- Additive nullable column — safe and non-destructive. An idempotent guard
+-- mirroring this statement also lands in src/instrumentation.ts so a
+-- preview/production database that records this migration without the column
+-- actually present can still boot.
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "area_top_up_prompt_dismissed_at" timestamptz;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -393,6 +393,13 @@
       "when": 1781308800000,
       "tag": "0055_question_sub_angles",
       "breakpoints": true
+    },
+    {
+      "idx": 56,
+      "version": "7",
+      "when": 1781395200000,
+      "tag": "0056_area_top_up_prompt",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
+    "smoke:area-top-up": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/area-top-up.smoke.mjs",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "format": "prettier --write ."
   },

--- a/scripts/area-top-up.smoke.mjs
+++ b/scripts/area-top-up.smoke.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+
+import {
+  AREA_TOP_UP_MAX_INTERESTS,
+  AREA_TOP_UP_TRIGGER_COUNT,
+  filterTopUpSuggestions,
+  isAreaTopUpEligible,
+  remainingTopUpSlots,
+} from '../src/server/area-top-up/rules.ts';
+
+// --- Constants -------------------------------------------------------------
+// Invite-seeded users start at 3 interests; the app caps at 5, so a fully
+// taken-up user can add exactly 2 more.
+assert.equal(AREA_TOP_UP_TRIGGER_COUNT, 3);
+assert.equal(AREA_TOP_UP_MAX_INTERESTS, 5);
+
+// --- isAreaTopUpEligible ---------------------------------------------------
+// The happy path: onboarded, never dismissed, sitting at exactly 3 interests.
+assert.equal(
+  isAreaTopUpEligible({ onboardingComplete: true, dismissedAt: null, activeInterestCount: 3 }),
+  true,
+);
+
+// Not yet onboarded — never prompt mid-onboarding.
+assert.equal(
+  isAreaTopUpEligible({ onboardingComplete: false, dismissedAt: null, activeInterestCount: 3 }),
+  false,
+);
+
+// Already dismissed/completed — the prompt is strictly one-time, regardless of
+// whether the timestamp arrives as a Date or an ISO string.
+assert.equal(
+  isAreaTopUpEligible({ onboardingComplete: true, dismissedAt: new Date(), activeInterestCount: 3 }),
+  false,
+);
+assert.equal(
+  isAreaTopUpEligible({
+    onboardingComplete: true,
+    dismissedAt: '2026-05-31T00:00:00.000Z',
+    activeInterestCount: 3,
+  }),
+  false,
+);
+
+// Wrong interest count — only users at exactly the trigger count qualify.
+for (const activeInterestCount of [0, 1, 2, 4, 5, 6]) {
+  assert.equal(
+    isAreaTopUpEligible({ onboardingComplete: true, dismissedAt: null, activeInterestCount }),
+    false,
+    `count ${activeInterestCount} should be ineligible`,
+  );
+}
+
+// --- remainingTopUpSlots ---------------------------------------------------
+assert.equal(remainingTopUpSlots(3), 2); // the canonical invite case
+assert.equal(remainingTopUpSlots(0), 5);
+assert.equal(remainingTopUpSlots(4), 1);
+assert.equal(remainingTopUpSlots(5), 0);
+assert.equal(remainingTopUpSlots(7), 0); // clamped, never negative
+
+// --- filterTopUpSuggestions ------------------------------------------------
+const proposed = [
+  { domain: 'Late Tchaikovsky', broadCategory: 'Music' },
+  { domain: 'Weimar-Era Cinema', broadCategory: 'Film & Television' },
+  { domain: 'Modernist American Poetry', broadCategory: 'Literature' },
+];
+
+// Drops a domain the user already declared, case-insensitively and ignoring
+// surrounding whitespace; preserves the order of what remains.
+const filtered = filterTopUpSuggestions(proposed, ['  late tchaikovsky ']);
+assert.deepEqual(
+  filtered.map((item) => item.domain),
+  ['Weimar-Era Cinema', 'Modernist American Poetry'],
+);
+
+// Nothing taken — everything passes through, order intact.
+assert.deepEqual(
+  filterTopUpSuggestions(proposed, []).map((item) => item.domain),
+  ['Late Tchaikovsky', 'Weimar-Era Cinema', 'Modernist American Poetry'],
+);
+
+// Respects the limit argument.
+assert.equal(filterTopUpSuggestions(proposed, [], 2).length, 2);
+
+console.log('area-top-up smoke test passed');

--- a/src/app/api/declared-interests/top-up/dismiss/route.ts
+++ b/src/app/api/declared-interests/top-up/dismiss/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { dismissAreaTopUpPrompt } from '@/server/db/queries/area-top-up';
+
+// POST /api/declared-interests/top-up/dismiss
+//
+// Records the one-time dismissal of the "add two more areas" prompt so it
+// never reappears. Called both when the user skips the prompt and (by the
+// client) after a successful save, so saving also stops future prompts.
+export async function POST() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  await dismissAreaTopUpPrompt(session.userId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/declared-interests/top-up/route.ts
+++ b/src/app/api/declared-interests/top-up/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import {
+  AREA_TOP_UP_MAX_INTERESTS,
+  getAreaTopUpContext,
+} from '@/server/db/queries/area-top-up';
+
+// GET /api/declared-interests/top-up
+//
+// Cheap eligibility check for the one-time "add two more areas" prompt shown
+// on the daily page. Returns whether the prompt should show plus the user's
+// existing interests (so the client can send the union when saving) and how
+// many more areas they may add.
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const context = await getAreaTopUpContext(session.userId);
+  if (!context) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  return NextResponse.json({
+    eligible: context.eligible,
+    existing: context.existing.map((interest) => ({
+      label: interest.domain,
+      broadCategory: interest.broadCategory,
+    })),
+    remainingSlots: Math.max(0, AREA_TOP_UP_MAX_INTERESTS - context.existing.length),
+  });
+}

--- a/src/app/api/declared-interests/top-up/route.ts
+++ b/src/app/api/declared-interests/top-up/route.ts
@@ -1,10 +1,8 @@
 import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import {
-  AREA_TOP_UP_MAX_INTERESTS,
-  getAreaTopUpContext,
-} from '@/server/db/queries/area-top-up';
+import { getAreaTopUpContext } from '@/server/db/queries/area-top-up';
+import { remainingTopUpSlots } from '@/server/area-top-up/rules';
 
 // GET /api/declared-interests/top-up
 //
@@ -25,6 +23,6 @@ export async function GET() {
       label: interest.domain,
       broadCategory: interest.broadCategory,
     })),
-    remainingSlots: Math.max(0, AREA_TOP_UP_MAX_INTERESTS - context.existing.length),
+    remainingSlots: remainingTopUpSlots(context.existing.length),
   });
 }

--- a/src/app/api/declared-interests/top-up/suggestions/route.ts
+++ b/src/app/api/declared-interests/top-up/suggestions/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getAreaTopUpContext } from '@/server/db/queries/area-top-up';
+import { proposeInterests, type CulturalAnchor, type WarmupAnswers } from '@/server/llm/interests';
+
+// GET /api/declared-interests/top-up/suggestions
+//
+// Lazily generates area suggestions for the top-up prompt. Called when the
+// modal opens (not on the daily-page eligibility check) so the LLM cost is
+// only paid when a user actually engages. Reuses the onboarding
+// proposeInterests() helper, seeding it with the user's stored cultural
+// anchor and treating their existing declared interests as warm-up signal —
+// this keeps birthYear server-side and avoids re-collecting warm-up answers.
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const context = await getAreaTopUpContext(session.userId);
+  if (!context) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  // Defensive: only spend an LLM call for users who are actually eligible.
+  if (!context.eligible) return NextResponse.json({ suggestions: [] });
+
+  // Treat the user's three existing interests as warm-up answers. proposeInterests
+  // requires at least one non-empty answer to call the model; three domains give
+  // it strong, personalised signal to extend from.
+  const [first, second, third] = context.existing;
+  const warmupAnswers: WarmupAnswers = {
+    deepDive: first?.domain,
+    hourLongTopic: second?.domain,
+    anythingElse: third?.domain,
+  };
+
+  const culturalAnchor: CulturalAnchor | undefined = context.anchor
+    ? {
+        birthYear: context.anchor.birthYear,
+        grewUpCountry: context.anchor.grewUpCountry,
+        grewUpRegion: context.anchor.grewUpRegion ?? undefined,
+      }
+    : undefined;
+
+  try {
+    const proposed = await proposeInterests({ warmupAnswers, culturalAnchor });
+
+    // Drop anything the user already has so we never suggest a duplicate.
+    const existingDomains = new Set(context.existing.map((interest) => interest.domain.toLowerCase()));
+    const suggestions = proposed
+      .filter((interest) => !existingDomains.has(interest.domain.toLowerCase()))
+      .slice(0, 8);
+
+    return NextResponse.json({ suggestions });
+  } catch {
+    return NextResponse.json(
+      { error: "We couldn't generate suggestions. Please try again." },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/declared-interests/top-up/suggestions/route.ts
+++ b/src/app/api/declared-interests/top-up/suggestions/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import { getAreaTopUpContext } from '@/server/db/queries/area-top-up';
+import { filterTopUpSuggestions } from '@/server/area-top-up/rules';
 import { proposeInterests, type CulturalAnchor, type WarmupAnswers } from '@/server/llm/interests';
 
 // GET /api/declared-interests/top-up/suggestions
@@ -44,10 +45,10 @@ export async function GET() {
     const proposed = await proposeInterests({ warmupAnswers, culturalAnchor });
 
     // Drop anything the user already has so we never suggest a duplicate.
-    const existingDomains = new Set(context.existing.map((interest) => interest.domain.toLowerCase()));
-    const suggestions = proposed
-      .filter((interest) => !existingDomains.has(interest.domain.toLowerCase()))
-      .slice(0, 8);
+    const suggestions = filterTopUpSuggestions(
+      proposed,
+      context.existing.map((interest) => interest.domain),
+    );
 
     return NextResponse.json({ suggestions });
   } catch {

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -7,6 +7,7 @@ import { X } from 'lucide-react';
 
 import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
+import { TopUpAreasModal, type TopUpInterest } from '@/components/daily/TopUpAreasModal';
 import LoadingScreen from '@/components/LoadingScreen';
 import { categoryLabel } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
@@ -251,6 +252,7 @@ export default function DailyPage() {
   const [showUnfamiliarDialog, setShowUnfamiliarDialog] = useState(false);
   const [excludingDomain, setExcludingDomain] = useState(false);
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
+  const [areaTopUp, setAreaTopUp] = useState<{ existing: TopUpInterest[]; maxNew: number } | null>(null);
 
   const loadQueue = useCallback(async () => {
     setLoading(true);
@@ -327,6 +329,36 @@ export default function DailyPage() {
 
     return () => window.clearTimeout(initialTimer);
   }, [loadQueue]);
+
+  // One-time nudge for invite-seeded users who only declared three interests:
+  // the next time they play, offer to top up to five. Eligibility (onboarded,
+  // exactly three active interests, not yet dismissed) and persistence both
+  // live server-side, so this just asks whether to show and renders the modal.
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch('/api/declared-interests/top-up', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        if (!response.ok) return;
+        const body = (await response.json().catch(() => null)) as
+          | { eligible?: boolean; existing?: TopUpInterest[]; remainingSlots?: number }
+          | null;
+        if (cancelled || !body?.eligible) return;
+        setAreaTopUp({
+          existing: Array.isArray(body.existing) ? body.existing : [],
+          maxNew: Math.max(0, body.remainingSlots ?? 0),
+        });
+      } catch {
+        // Non-fatal — the prompt simply won't show this session.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const actualCurrentSlot = useMemo(() => currentPendingSlot(queue?.slots ?? []), [queue?.slots]);
   const currentSlot = pausedAfterSlotIndex === null ? actualCurrentSlot : null;
@@ -764,6 +796,15 @@ export default function DailyPage() {
           onExclude={(tick) => void excludeDomainAndSkip(tick)}
           onSkipOnly={() => { setShowUnfamiliarDialog(false); void skipCurrent(); }}
           onCancel={() => setShowUnfamiliarDialog(false)}
+        />
+      ) : null}
+
+      {areaTopUp && areaTopUp.maxNew > 0 ? (
+        <TopUpAreasModal
+          existing={areaTopUp.existing}
+          maxNew={areaTopUp.maxNew}
+          onDismiss={() => setAreaTopUp(null)}
+          onSaved={() => setAreaTopUp(null)}
         />
       ) : null}
     </main>

--- a/src/components/daily/TopUpAreasModal.tsx
+++ b/src/components/daily/TopUpAreasModal.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+export type TopUpInterest = {
+  label: string;
+  broadCategory: string | null;
+};
+
+type Suggestion = {
+  domain: string;
+  broadCategory: string;
+  rationale: string;
+};
+
+type SuggestionsResponse = {
+  suggestions?: Suggestion[];
+};
+
+type CanonicalizeResponse = {
+  suggested?: string;
+  broadCategory?: string;
+};
+
+// One-time prompt offering invite-seeded users (who sit at exactly three
+// declared interests) the chance to top up to five. Reuses the onboarding
+// suggestion + canonicalize endpoints; saves via PATCH /api/declared-interests
+// with the union of existing + newly chosen areas, then records the dismissal
+// so the prompt never reappears.
+//
+// onDismiss fires when the user skips; onSaved fires after a successful save.
+// Both should clear the prompt from the parent (the dismissal is persisted
+// server-side either way).
+export function TopUpAreasModal({
+  existing,
+  maxNew,
+  onDismiss,
+  onSaved,
+}: {
+  existing: TopUpInterest[];
+  maxNew: number;
+  onDismiss: () => void;
+  onSaved: () => void;
+}) {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loadingSuggestions, setLoadingSuggestions] = useState(true);
+  const [selected, setSelected] = useState<TopUpInterest[]>([]);
+  const [customInput, setCustomInput] = useState('');
+  const [addingCustom, setAddingCustom] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [dismissing, setDismissing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const remaining = Math.max(0, maxNew - selected.length);
+  const isSelected = useCallback(
+    (label: string) => selected.some((item) => item.label.toLowerCase() === label.toLowerCase()),
+    [selected],
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch('/api/declared-interests/top-up/suggestions', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        const body = (await response.json().catch(() => null)) as SuggestionsResponse | null;
+        if (!cancelled) setSuggestions(Array.isArray(body?.suggestions) ? body.suggestions : []);
+      } catch {
+        if (!cancelled) setSuggestions([]);
+      } finally {
+        if (!cancelled) setLoadingSuggestions(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const toggle = useCallback(
+    (interest: TopUpInterest) => {
+      setError(null);
+      setSelected((current) => {
+        const already = current.findIndex(
+          (item) => item.label.toLowerCase() === interest.label.toLowerCase(),
+        );
+        if (already !== -1) {
+          return current.filter((_, i) => i !== already);
+        }
+        if (current.length >= maxNew) return current;
+        return [...current, interest];
+      });
+    },
+    [maxNew],
+  );
+
+  const addCustom = useCallback(async () => {
+    const raw = customInput.trim();
+    if (raw.length < 2) return;
+    if (selected.length >= maxNew) {
+      setError(`You can add ${maxNew} more.`);
+      return;
+    }
+    if (isSelected(raw)) {
+      setCustomInput('');
+      return;
+    }
+    setAddingCustom(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/onboarding/canonicalize', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ rawInput: raw }),
+      });
+      const body = (await response.json().catch(() => null)) as CanonicalizeResponse | null;
+      const label = body?.suggested?.trim() || raw;
+      const broadCategory = body?.broadCategory?.trim() || 'General Knowledge';
+      if (!isSelected(label)) {
+        setSelected((current) =>
+          current.length >= maxNew ? current : [...current, { label, broadCategory }],
+        );
+      }
+      setCustomInput('');
+    } catch {
+      // Fall back to the raw input if canonicalization fails.
+      setSelected((current) =>
+        current.length >= maxNew ? current : [...current, { label: raw, broadCategory: 'General Knowledge' }],
+      );
+      setCustomInput('');
+    } finally {
+      setAddingCustom(false);
+    }
+  }, [customInput, isSelected, maxNew, selected.length]);
+
+  const dismissPrompt = useCallback(async () => {
+    try {
+      await fetch('/api/declared-interests/top-up/dismiss', {
+        method: 'POST',
+        credentials: 'include',
+      });
+    } catch {
+      // Non-fatal: the eligibility check will simply offer once more next time.
+    }
+  }, []);
+
+  const skip = useCallback(async () => {
+    if (dismissing || saving) return;
+    setDismissing(true);
+    await dismissPrompt();
+    onDismiss();
+  }, [dismissPrompt, dismissing, onDismiss, saving]);
+
+  const save = useCallback(async () => {
+    if (selected.length === 0) {
+      await skip();
+      return;
+    }
+    setSaving(true);
+    setError(null);
+    try {
+      const interests = [
+        ...existing.map((item) => ({ label: item.label, broadCategory: item.broadCategory })),
+        ...selected.map((item) => ({ label: item.label, broadCategory: item.broadCategory })),
+      ];
+      const response = await fetch('/api/declared-interests', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ interests }),
+      });
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null;
+        throw new Error(body?.message ?? 'Could not save your areas.');
+      }
+      await dismissPrompt();
+      onSaved();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not save your areas.');
+      setSaving(false);
+    }
+  }, [dismissPrompt, existing, onSaved, selected, skip]);
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') void skip();
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [skip]);
+
+  const busy = saving || dismissing;
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="top-up-areas-title"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        zIndex: 60,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        padding: '1rem',
+        background: 'rgba(0,0,0,0.45)',
+      }}
+      onClick={(e) => {
+        if (e.target === e.currentTarget && !busy) void skip();
+      }}
+    >
+      <div
+        style={{
+          background: 'var(--surface)',
+          border: '1px solid var(--border)',
+          borderRadius: 'var(--radius-lg)',
+          padding: '1.5rem',
+          maxWidth: '26rem',
+          width: '100%',
+          maxHeight: '85dvh',
+          overflowY: 'auto',
+        }}
+      >
+        <p id="top-up-areas-title" className="font-serif text-lg font-semibold text-[var(--text)]">
+          Add two more areas?
+        </p>
+        <p className="mt-1 text-sm text-[var(--text-muted)]">
+          You started with three. Pick up to {maxNew} more and we&rsquo;ll weave them into your daily
+          questions.
+        </p>
+
+        <div className="mt-4">
+          {loadingSuggestions ? (
+            <p className="text-sm text-[var(--text-muted)]">Finding ideas for you&hellip;</p>
+          ) : suggestions.length === 0 ? (
+            <p className="text-sm text-[var(--text-muted)]">
+              No suggestions right now — add your own below.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {suggestions.map((suggestion) => {
+                const active = isSelected(suggestion.domain);
+                const atCap = !active && selected.length >= maxNew;
+                return (
+                  <li key={suggestion.domain}>
+                    <button
+                      type="button"
+                      disabled={busy || atCap}
+                      onClick={() =>
+                        toggle({ label: suggestion.domain, broadCategory: suggestion.broadCategory })
+                      }
+                      className="w-full rounded-[var(--radius-md)] border px-3 py-2 text-left transition-colors disabled:opacity-50"
+                      style={{
+                        borderColor: active ? 'var(--accent)' : 'var(--border)',
+                        background: active ? 'color-mix(in srgb, var(--accent) 12%, transparent)' : 'transparent',
+                      }}
+                    >
+                      <span className="flex items-center justify-between gap-2">
+                        <span className="text-sm font-medium text-[var(--text)]">{suggestion.domain}</span>
+                        <span className="text-[0.65rem] uppercase tracking-[0.06em] text-[var(--text-muted)]">
+                          {suggestion.broadCategory}
+                        </span>
+                      </span>
+                      {suggestion.rationale ? (
+                        <span className="mt-1 block text-xs text-[var(--text-muted)]">{suggestion.rationale}</span>
+                      ) : null}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+
+        <div className="mt-3 flex gap-2">
+          <input
+            value={customInput}
+            onChange={(event) => setCustomInput(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter') {
+                event.preventDefault();
+                void addCustom();
+              }
+            }}
+            maxLength={100}
+            disabled={busy || selected.length >= maxNew}
+            placeholder="Or write your own…"
+            className="min-h-10 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-3 text-sm text-[var(--text)] outline-none"
+            style={{ borderColor: 'var(--border)' }}
+          />
+          <button
+            type="button"
+            className="shrink-0 rounded-[var(--radius-md)] border px-3 py-2 text-sm font-medium text-[var(--text)] transition-colors hover:bg-[var(--surface-raised)] disabled:opacity-50"
+            style={{ borderColor: 'var(--border)' }}
+            disabled={busy || addingCustom || selected.length >= maxNew || customInput.trim().length < 2}
+            onClick={() => void addCustom()}
+          >
+            {addingCustom ? '…' : 'Add'}
+          </button>
+        </div>
+
+        {selected.length > 0 ? (
+          <div className="mt-3 flex flex-wrap gap-2">
+            {selected.map((item) => (
+              <button
+                key={item.label}
+                type="button"
+                disabled={busy}
+                onClick={() => toggle(item)}
+                className="rounded-full border px-3 py-1 text-xs font-medium text-[var(--text)] transition-colors hover:bg-[var(--surface-raised)]"
+                style={{ borderColor: 'var(--accent)', background: 'color-mix(in srgb, var(--accent) 12%, transparent)' }}
+              >
+                {item.label} ✕
+              </button>
+            ))}
+          </div>
+        ) : null}
+
+        <p className="mt-3 text-xs text-[var(--text-muted)]">
+          {remaining > 0 ? `You can add ${remaining} more.` : "That's the max — nicely done."}
+        </p>
+
+        {error ? <p className="mt-2 text-sm text-[var(--danger)]">{error}</p> : null}
+
+        <div className="mt-4 flex flex-col gap-2">
+          <button
+            type="button"
+            className="btn-primary w-full"
+            disabled={busy || selected.length === 0}
+            onClick={() => void save()}
+          >
+            {saving ? '…' : `Add ${selected.length || ''} ${selected.length === 1 ? 'area' : 'areas'}`.trim()}
+          </button>
+          <button
+            type="button"
+            className="text-sm text-[var(--text-muted)] transition-colors hover:text-[var(--text)]"
+            disabled={busy}
+            onClick={() => void skip()}
+          >
+            Maybe later
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -874,6 +874,23 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0056 adds the nullable User.area_top_up_prompt_dismissed_at
+    // timestamp. It records that a user dismissed (or completed) the one-time
+    // "add two more areas" prompt shown to invite-seeded users who only have
+    // three declared interests. Guard for preview/production databases that may
+    // have the migration recorded without the column actually present — the
+    // GET /api/declared-interests/top-up eligibility query selects it and would
+    // 42703 before app code can recover.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "area_top_up_prompt_dismissed_at" timestamp with time zone
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/area-top-up/rules.ts
+++ b/src/server/area-top-up/rules.ts
@@ -1,0 +1,56 @@
+// Pure, dependency-free business rules for the one-time "add two more areas"
+// prompt. Kept free of DB/network imports so it can be unit/smoke-tested in
+// isolation (see scripts/area-top-up.smoke.mjs). The DB query in
+// ./area-top-up.ts and the suggestions route both reuse these helpers.
+
+// Invite-seeded users start with exactly this many declared interests (the
+// inviter's pre-seeded suggestions, capped at 3). Only users sitting at this
+// exact count are offered the one-time top-up prompt — the product decision
+// is "exactly 3 → top up to 5".
+export const AREA_TOP_UP_TRIGGER_COUNT = 3;
+// The DeclaredInterest cap enforced by saveDeclaredInterests. The top-up
+// prompt lets a user add up to (MAX - TRIGGER) = 2 more areas.
+export const AREA_TOP_UP_MAX_INTERESTS = 5;
+
+export type AreaTopUpEligibilityInput = {
+  onboardingComplete: boolean;
+  // The dismissal timestamp from User.area_top_up_prompt_dismissed_at. A
+  // non-null value (the user already saw and resolved the prompt) makes them
+  // ineligible — the prompt is strictly one-time.
+  dismissedAt: Date | string | null;
+  activeInterestCount: number;
+};
+
+// The core eligibility rule. A user sees the prompt exactly once, the next
+// time they play after onboarding, only while they sit at the trigger count.
+export function isAreaTopUpEligible({
+  onboardingComplete,
+  dismissedAt,
+  activeInterestCount,
+}: AreaTopUpEligibilityInput): boolean {
+  return (
+    onboardingComplete === true &&
+    dismissedAt === null &&
+    activeInterestCount === AREA_TOP_UP_TRIGGER_COUNT
+  );
+}
+
+// How many more areas the user may add, clamped to [0, MAX]. Used to cap the
+// picker and to short-circuit the modal when there is no room left.
+export function remainingTopUpSlots(activeInterestCount: number): number {
+  return Math.max(0, AREA_TOP_UP_MAX_INTERESTS - activeInterestCount);
+}
+
+// Drops any proposed suggestion whose domain the user already declared
+// (case-insensitive) and trims to `limit`, so we never offer a duplicate.
+export function filterTopUpSuggestions<T extends { domain: string }>(
+  proposed: T[],
+  existingDomains: Iterable<string>,
+  limit = 8,
+): T[] {
+  const taken = new Set<string>();
+  for (const domain of existingDomains) {
+    taken.add(domain.trim().toLowerCase());
+  }
+  return proposed.filter((item) => !taken.has(item.domain.trim().toLowerCase())).slice(0, limit);
+}

--- a/src/server/db/queries/area-top-up.ts
+++ b/src/server/db/queries/area-top-up.ts
@@ -1,0 +1,83 @@
+import { eq } from 'drizzle-orm';
+
+import { db, users } from '@/server/db';
+import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+
+// Invite-seeded users start with exactly this many declared interests (the
+// inviter's pre-seeded suggestions, capped at 3). Only users sitting at this
+// exact count are offered the one-time top-up prompt — see the product
+// decision in the plan: "exactly 3 → top up to 5".
+export const AREA_TOP_UP_TRIGGER_COUNT = 3;
+// The DeclaredInterest cap enforced by saveDeclaredInterests. The top-up
+// prompt lets a user add up to (MAX - TRIGGER) = 2 more areas.
+export const AREA_TOP_UP_MAX_INTERESTS = 5;
+
+export type ExistingInterest = {
+  domain: string;
+  broadCategory: string | null;
+};
+
+export type CulturalAnchorContext = {
+  birthYear: number;
+  grewUpCountry: string;
+  grewUpRegion: string | null;
+};
+
+export type AreaTopUpContext = {
+  // True when the user has finished onboarding, sits at exactly the trigger
+  // count of active interests, and has not already dismissed/completed the
+  // prompt.
+  eligible: boolean;
+  existing: ExistingInterest[];
+  anchor: CulturalAnchorContext | null;
+};
+
+// Loads everything both the eligibility check and the suggestion generator
+// need in a single pass: onboarding state, the dismissal flag, the user's
+// current declared interests, and the stored cultural anchor.
+export async function getAreaTopUpContext(userId: string): Promise<AreaTopUpContext | null> {
+  const [user] = await db
+    .select({
+      onboardingComplete: users.onboardingComplete,
+      dismissedAt: users.areaTopUpPromptDismissedAt,
+      birthYear: users.birthYear,
+      grewUpCountry: users.grewUpCountry,
+      grewUpRegion: users.grewUpRegion,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  if (!user) return null;
+
+  const interests = await getActiveDeclaredInterests(userId);
+  const existing: ExistingInterest[] = interests.map((interest) => ({
+    domain: interest.domain,
+    broadCategory: interest.broadCategory,
+  }));
+
+  const eligible =
+    user.onboardingComplete === true &&
+    user.dismissedAt === null &&
+    existing.length === AREA_TOP_UP_TRIGGER_COUNT;
+
+  const anchor: CulturalAnchorContext | null =
+    typeof user.birthYear === 'number' && user.grewUpCountry
+      ? {
+          birthYear: user.birthYear,
+          grewUpCountry: user.grewUpCountry,
+          grewUpRegion: user.grewUpRegion,
+        }
+      : null;
+
+  return { eligible, existing, anchor };
+}
+
+// Stamps the one-time dismissal so the prompt never reappears. Called both
+// when the user saves new areas and when they skip the prompt.
+export async function dismissAreaTopUpPrompt(userId: string): Promise<void> {
+  await db
+    .update(users)
+    .set({ areaTopUpPromptDismissedAt: new Date(), updatedAt: new Date() })
+    .where(eq(users.id, userId));
+}

--- a/src/server/db/queries/area-top-up.ts
+++ b/src/server/db/queries/area-top-up.ts
@@ -2,15 +2,9 @@ import { eq } from 'drizzle-orm';
 
 import { db, users } from '@/server/db';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { isAreaTopUpEligible } from '@/server/area-top-up/rules';
 
-// Invite-seeded users start with exactly this many declared interests (the
-// inviter's pre-seeded suggestions, capped at 3). Only users sitting at this
-// exact count are offered the one-time top-up prompt — see the product
-// decision in the plan: "exactly 3 → top up to 5".
-export const AREA_TOP_UP_TRIGGER_COUNT = 3;
-// The DeclaredInterest cap enforced by saveDeclaredInterests. The top-up
-// prompt lets a user add up to (MAX - TRIGGER) = 2 more areas.
-export const AREA_TOP_UP_MAX_INTERESTS = 5;
+export { AREA_TOP_UP_MAX_INTERESTS, AREA_TOP_UP_TRIGGER_COUNT } from '@/server/area-top-up/rules';
 
 export type ExistingInterest = {
   domain: string;
@@ -56,10 +50,11 @@ export async function getAreaTopUpContext(userId: string): Promise<AreaTopUpCont
     broadCategory: interest.broadCategory,
   }));
 
-  const eligible =
-    user.onboardingComplete === true &&
-    user.dismissedAt === null &&
-    existing.length === AREA_TOP_UP_TRIGGER_COUNT;
+  const eligible = isAreaTopUpEligible({
+    onboardingComplete: user.onboardingComplete,
+    dismissedAt: user.dismissedAt,
+    activeInterestCount: existing.length,
+  });
 
   const anchor: CulturalAnchorContext | null =
     typeof user.birthYear === 'number' && user.grewUpCountry

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -170,6 +170,7 @@ export const users = pgTable(
     emailVerified: boolean('email_verified').notNull().default(false),
     pendingEmail: text('pending_email'),
     reminderPromptDismissedAt: timestamp('reminder_prompt_dismissed_at', { withTimezone: true }),
+    areaTopUpPromptDismissedAt: timestamp('area_top_up_prompt_dismissed_at', { withTimezone: true }),
     lastActivityBellOpenedAt: timestamp('last_activity_bell_opened_at', { withTimezone: true }),
     knowledgeCardShareToken: text('knowledge_card_share_token'),
     knowledgeCardShareExpiresAt: timestamp('knowledge_card_share_expires_at', { withTimezone: true }),


### PR DESCRIPTION
Invited users start with only the 3 interests their inviter pre-seeded,
but the app supports up to 5. The next time they play, offer to add two
more areas of interest, reusing the onboarding suggestion + canonicalize
endpoints.

- Schema: nullable User.area_top_up_prompt_dismissed_at (migration 0056)
  plus an idempotent guard in instrumentation.ts, mirroring the existing
  reminder_prompt_dismissed_at pattern.
- Queries: area-top-up.ts computes eligibility (onboarded, exactly 3
  active interests, not yet dismissed) and stamps the one-time dismissal.
- API: GET /api/declared-interests/top-up (eligibility), .../suggestions
  (lazy LLM proposals seeded from the user's stored cultural anchor and
  existing interests), and .../dismiss (one-time flag). Saving reuses the
  existing PATCH /api/declared-interests with the union of existing + new
  interests, which is idempotent and non-destructive.
- UI: TopUpAreasModal shown once on the daily page; capped at 2 new picks,
  dismissible, persists dismissal on both save and skip.