### PR TITLE
Add deterministic answer-leak gate to daily question generation

### DIFF
--- a/src/server/daily/__tests__/answer-leak-gate.test.ts
+++ b/src/server/daily/__tests__/answer-leak-gate.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// generate-questions.ts imports @/server/db, which throws at module load
+// without a connection string. findAnswerLeaks never touches the DB; a dummy
+// URL plus dynamic import (the repo convention) keeps the unit pure.
+let findAnswerLeaks: typeof import('@/server/daily/generate-questions').findAnswerLeaks;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  ({ findAnswerLeaks } = await import('@/server/daily/generate-questions'));
+});
+
+// Minimal stand-in for the LlmQuestion shape findAnswerLeaks reads. Only
+// question_text and answer are inspected; the rest satisfy the type.
+function q(question_text: string, answer: string) {
+  return {
+    canonical_subcategory: 'User Experience Design',
+    broad_category: 'Design',
+    question_text,
+    answer,
+    explainer: '',
+    difficulty_estimate: 'moderate' as const,
+    fact_key: null,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+describe('findAnswerLeaks', () => {
+  it('drops the reported case where the answer appears in the question text', () => {
+    const result = findAnswerLeaks([
+      q(
+        'In UX design, what term describes the mental model a user forms about how a system works?',
+        'Mental model',
+      ),
+    ]);
+    expect([...result.toDrop]).toEqual([0]);
+    expect(result.reasons[0]).toContain('Mental model');
+  });
+
+  it('keeps a clean question whose answer is absent from the setup', () => {
+    const result = findAnswerLeaks([
+      q('What cognitive bias makes recent information feel more important?', 'Recency bias'),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+    expect(result.reasons).toEqual({});
+  });
+
+  it('keeps a complete-the-quote question where the answer is the missing word', () => {
+    const result = findAnswerLeaks([
+      q('Complete the design maxim: "Don\'t make me ___."', 'think'),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+
+  it('only flags the leaking entries within a mixed batch', () => {
+    const result = findAnswerLeaks([
+      q('Which Gestalt principle groups nearby elements together?', 'Proximity'),
+      q('What is the heuristic about keeping users informed of system status?', 'System status'),
+      q('What pricing tactic ends prices in .99?', 'Charm pricing'),
+    ]);
+    expect([...result.toDrop].sort()).toEqual([1]);
+  });
+
+  it('does not flag short answers below the leak-check token threshold', () => {
+    // "UI" normalizes to length 2 (< MIN_ANSWER_TOKEN_LENGTH = 3), so
+    // textContainsAnswer ignores it even though it appears in the text.
+    const result = findAnswerLeaks([
+      q('What two-letter abbreviation refers to UI in product work?', 'UI'),
+    ]);
+    expect(result.toDrop.size).toBe(0);
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -33,6 +33,7 @@ import { reconcileProposedDomain } from '@/lib/questions/categorization';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { normalizeFactKey } from '@/server/questions/fact-key';
+import { textContainsAnswer } from '@/server/questions/self-answering';
 import { resolveDailyBasePoints } from './types';
 import { STYLE_EXEMPLAR_BLOCK } from './exemplars';
 
@@ -54,6 +55,8 @@ Questions must be:
 - Recall questions, not selection questions: the player must produce the answer from memory
 
 NEVER generate multiple-choice questions. Do not list candidate answers inside the question_text, and do not use phrasings like "Which of the following…", "is it X, Y, or Z?", or "— A, B, or C?". The question must stand alone as an open-ended prompt; the player writes a free-text answer.
+
+NEVER name the answer in the question_text. The answer (or a near-paraphrase of it) must not appear anywhere in the setup — if the very term you are asking the player to produce shows up in your own phrasing, the question gives itself away. Rephrase so it doesn't. E.g. do NOT ask "what term describes the mental model a user forms…" when the answer is "mental model".
 
 BAD (multiple-choice phrasing — never produce these):
 - "Which of the following best describes Sally — a romantic rival, a radical free spirit, or a steadying maternal figure?"
@@ -645,6 +648,30 @@ async function findFactualFailures(generated: LlmQuestion[]): Promise<{
   }
 }
 
+// Deterministic answer-leak gate. The Haiku quality gate above lists
+// ANSWER_LEAKED / SELF_ANSWERING among the defects it looks for, but it is an
+// LLM check that fails open on a Haiku outage and misses subtle lexical leaks
+// (e.g. "the mental model a user forms" with answer "Mental model"). User-
+// authored questions already get a fail-closed string check via
+// textContainsAnswer() at create time; this gives daily-generated questions the
+// same fallback. It is pure (no LLM, no DB) so it cannot fail open. Only
+// question_text is checked — the explainer is *supposed* to contain the answer.
+export function findAnswerLeaks(generated: LlmQuestion[]): {
+  toDrop: Set<number>;
+  reasons: Record<number, string>;
+} {
+  const toDrop = new Set<number>();
+  const reasons: Record<number, string> = {};
+  for (let i = 0; i < generated.length; i += 1) {
+    const q = generated[i];
+    if (textContainsAnswer(q.question_text, q.answer)) {
+      toDrop.add(i);
+      reasons[i] = `answer "${q.answer}" appears in question text`.slice(0, 200);
+    }
+  }
+  return { toDrop, reasons };
+}
+
 const RECENT_HISTORY_GATE_LIMIT = 30;
 
 const RECENT_HISTORY_GATE_SYSTEM_PROMPT = `You are reviewing newly-generated trivia questions against a list of questions this same user has already been asked. For each NEW question, decide whether it probes the same underlying fact as ANY of the RECENT questions.
@@ -864,9 +891,10 @@ export async function generateDailyQuestions(
 
   if (generated.length === 0) return [];
 
-  // Three independent gates run against the same input batch, then the drop
-  // sets are unioned. Sequential awaits would 3x the gate-phase latency for
-  // no benefit — none of the gates depend on each other's verdicts.
+  // Four LLM gates run against the same input batch, then the drop sets are
+  // unioned (the deterministic findAnswerLeaks gate runs synchronously after).
+  // Sequential awaits would multiply the gate-phase latency for no benefit —
+  // none of the gates depend on each other's verdicts.
   //
   // - findBatchDuplicates: catches intra-batch dupes (e.g. two Proprietor
   //   questions in one call on 2026-05-20). Persist-time fact_key guard only
@@ -879,6 +907,8 @@ export async function generateDailyQuestions(
   //   catches answer-leakage, opinion/vague, false-premise, self-answering.
   // - findFactualFailures: verifies the stated answer is actually correct for
   //   the question — the one defect class the other gates never inspect.
+  // - findAnswerLeaks (below, synchronous): deterministic fail-closed backstop
+  //   for answer leakage when the Haiku quality gate misses or fails open.
   const recentForGate = avoidList.slice(0, RECENT_HISTORY_GATE_LIMIT);
   const [batchDuplicates, recentDuplicates, qualityResult, factualResult] = await Promise.all([
     findBatchDuplicates(generated),
@@ -918,11 +948,25 @@ export async function generateDailyQuestions(
     });
   }
 
+  // Deterministic fallback for the answer-leak case the Haiku quality gate can
+  // miss or fail open on. Synchronous, so it runs after the Promise.all rather
+  // than inside it.
+  const answerLeaks = findAnswerLeaks(generated);
+  if (answerLeaks.toDrop.size > 0) {
+    console.warn('[daily/generate-questions] dropping answer-leaking questions', {
+      droppedCount: answerLeaks.toDrop.size,
+      droppedIndices: [...answerLeaks.toDrop].sort((a, b) => a - b),
+      reasons: answerLeaks.reasons,
+      originalCount: generated.length,
+    });
+  }
+
   const allDrops = new Set<number>([
     ...batchDuplicates,
     ...recentDuplicates,
     ...qualityResult.toDrop,
     ...factualResult.toDrop,
+    ...answerLeaks.toDrop,
   ]);
   if (allDrops.size > 0) {
     generated = generated.filter((_, i) => !allDrops.has(i));


### PR DESCRIPTION
Daily-generated questions could ship with their answer visible in the
question text (e.g. "what term describes the mental model a user
forms..." with answer "Mental model"). The only existing guard was
the Haiku quality gate, which fails open on outage and misses subtle
lexical leaks.

Add findAnswerLeaks(), a pure fail-closed gate reusing the same
textContainsAnswer() check that already gates user-authored questions,
and union its drops into the existing gate phase. Also tighten the
Sonnet generation prompt to forbid naming the answer in the setup.

https://claude.ai/code/session_01Xs9Nn6ZYv4aZ4mCzkz3Met