### PR TITLE
chore: silence dotenv@17 promotional startup log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,3 +35,9 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # Used only by `npm run smoke:gameplay`. The harness drives the local dev
 # server with Playwright; this is the URL it connects to.
 PLAYTEST_BASE_URL="http://localhost:3000"
+
+# ── Tooling ──────────────────────────────────────────────────
+# Silence dotenv@17's promotional startup log/tip lines (the "// tip: ..."
+# noise printed by CLI scripts and drizzle-kit migrate). Read by dotenv from
+# the .env file itself; no code change needed.
+DOTENV_CONFIG_QUIET=true


### PR DESCRIPTION
`dotenv@17` prints a random promotional "tip" on every load — currently advertising the author's new "vestauth" project:

```
injected env (1) from .env // tip: ⌁ auth for agents [www.vestauth.com]
```

I traced it: it's the **genuine** `dotenv@17.4.2` (motdotla/dotenv), not a compromised/typosquatted package — the author added it to dotenv's random-tip rotation (`lib/main.js:10`, confirmed in the CHANGELOG). So it's harmless noise, not a security issue. It surfaces during `npm run db:migrate` and the ~11 scripts that `import 'dotenv/config'`.

**Fix:** document `DOTENV_CONFIG_QUIET=true` in `.env.example`. dotenv reads this key from the `.env` file *itself* (it re-parses `DOTENV_CONFIG_QUIET` after loading), so one line suppresses the log across every call site with zero code change. Already set in the local `.env`; existing devs can add the same line to theirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)