### PR TITLE
Pin question form actions to a sticky, opaque footer

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -785,7 +785,7 @@ function KnowledgePageContent() {
 
       {activeModal?.type === 'write-question' ? (
         <div className="fixed inset-0 z-[55] flex items-center justify-center bg-black/30 p-4">
-          <div className="w-[min(540px,100%)] max-h-[92vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
+          <div className="w-[min(540px,100%)] max-h-[92vh] overflow-y-auto bg-white border border-[var(--border-warm)] px-5 pt-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Write a question</h2>
               <button type="button" className="w-[34px] h-[34px] border-none bg-transparent text-[var(--text-muted-warm)] grid place-items-center cursor-pointer" onClick={() => setActiveModal(null)} aria-label="Close">

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -412,7 +412,7 @@ function QuestionsPageContent() {
       {drawer.mode !== 'closed' ? (
         <div className="fixed inset-0 z-[60] flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
           <button className="absolute inset-0 cursor-default" type="button" aria-label="Close" onClick={() => setDrawer({ mode: 'closed' })} />
-          <aside className="relative max-h-[92dvh] w-full overflow-y-auto rounded-t-lg bg-background p-5 shadow-xl md:h-full md:max-h-none md:w-[440px] md:rounded-none">
+          <aside className="relative max-h-[92dvh] w-full overflow-y-auto rounded-t-lg bg-background px-5 pt-5 shadow-xl md:h-full md:max-h-none md:w-[440px] md:rounded-none">
             <div className="mb-5 flex items-center justify-between gap-3">
               <div>
                 <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">{drawer.mode === 'edit' ? 'Edit' : 'Create'}</p>

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -415,6 +415,14 @@ export function QuestionForm({
   const critique = state.critiqueResult;
   const counter = remainingCopy(state);
   const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'SUBMITTING' || mode === 'edit';
+  // The form lives inside a scrollable drawer/modal (questions + knowledge
+  // pages). Keep the action buttons pinned to the bottom on an opaque,
+  // composited footer: the backdrop-blur layer prevents the iOS Safari
+  // repaint artifact that left a ghost copy of these buttons painted over the
+  // scrolling content, and sticky keeps Save/Cancel reachable on long forms.
+  // `-mx-5 px-5 pb-5` full-bleeds the bar within the host's px-5 padding
+  // (which drops its own bottom padding so this footer sits flush).
+  const actionBarClass = 'sticky bottom-0 z-10 -mx-5 flex flex-wrap items-center gap-3 border-t bg-background/95 px-5 pb-5 pt-3 backdrop-blur';
 
   return (
     <div className="space-y-5">
@@ -480,7 +488,7 @@ export function QuestionForm({
       ) : null}
 
       {!canShowAnswering ? (
-        <div className="flex flex-wrap items-center gap-3">
+        <div className={actionBarClass}>
           <button type="button" onClick={() => void runCritique()} disabled={!state.questionText.trim() || state.stage === 'CRITIQUING'} className="btn-primary">
             {state.stage === 'CRITIQUING' ? 'Reviewing...' : 'Continue'}
           </button>
@@ -663,7 +671,7 @@ export function QuestionForm({
             </div>
           ) : null}
 
-          <div className="flex flex-wrap items-center gap-3 pt-2">
+          <div className={actionBarClass}>
             <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">{submitDisabled ? loadingLabel : resolvedSubmitLabel}</button>
             {onCancel ? <button type="button" onClick={onCancel} className="btn-ghost" disabled={submitDisabled}>Cancel</button> : null}
           </div>


### PR DESCRIPTION
The Save/Cancel (and Continue) buttons in QuestionForm sat in normal flow
at the bottom of a scrollable drawer/modal inside a position:fixed overlay.
On iOS Safari this triggered a scroll repaint artifact that left a ghosted,
offset copy of the buttons painted over the form content — the reported
'button z-level' problem.

Move both action bars onto a sticky, full-bleed footer with an opaque
bg-background/95 + backdrop-blur layer (matching the existing sticky-footer
convention in daily/ and games/). The composited layer eliminates the ghost
paint, the opaque background cleanly covers scrolling content, and sticky
positioning keeps the actions reachable on long forms. The two host
containers drop their bottom padding so the footer pins flush.