### PR TITLE
Restyle dismissed feed card as a card back with the answer

### DIFF
--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -13,12 +13,27 @@ import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
 import { areFriends } from '@/server/db/queries/friends';
+import { getFeedItemAnswerForRecipient } from '@/server/db/queries/feed';
 
 export const dynamic = 'force-dynamic';
 
 type RouteContext = {
   params: Promise<{ feedItemId: string }>;
 };
+
+// Reveal a feed item's answer for the dismissed-card "back of the card" view.
+// The only input is the path param, so there is no body to validate (matching
+// the sibling recheck route). Recipient scoping lives in the query helper.
+export async function GET(_request: NextRequest, context: RouteContext) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const { feedItemId } = await context.params;
+  const reveal = await getFeedItemAnswerForRecipient(feedItemId, session.userId);
+  if (!reveal) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  return NextResponse.json({ answer: reveal.answer, questionText: reveal.questionText });
+}
 
 type MasteryTier = 'establishing' | 'familiar' | 'solid' | 'mastery';
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -533,6 +533,18 @@ function FeedListContent({
     Record<string, 'collapsing' | 'dismissed'>
   >({})
   const dismissTimersRef = useRef<Record<string, number>>({})
+  // The question's answer, fetched on-demand when a card is dismissed, to show
+  // on the "back of the card". Keyed by feed-item id; cached across undo so a
+  // re-dismiss reuses it without a refetch.
+  const [dismissedAnswers, setDismissedAnswers] = useState<
+    Record<string, { status: 'loading' | 'loaded' | 'error'; answer?: string | null }>
+  >({})
+  // Mirrors dismissPhase so async answer fetches can drop stale writes after an
+  // undo / re-dismiss race.
+  const dismissPhaseRef = useRef(dismissPhase)
+  useEffect(() => {
+    dismissPhaseRef.current = dismissPhase
+  }, [dismissPhase])
   const reducedMotion = usePrefersReducedMotion()
   const [answerSheetId, setAnswerSheetId] = useState<string | null>(null)
   const [feedbackSheetId, setFeedbackSheetId] = useState<string | null>(null)
@@ -765,21 +777,66 @@ function FeedListContent({
     }
   }, [])
 
+  // Fetch the question's answer to show on the dismissed card back. Already-
+  // answered cards carry it in the payload; answerless items short-circuit.
+  // Skips refetching anything already loading/loaded (only errors retry).
+  const loadDismissedAnswer = useCallback((item: FeedApiItem) => {
+    if (item.correct_answer) {
+      setDismissedAnswers((c) => ({
+        ...c,
+        [item.id]: { status: 'loaded', answer: item.correct_answer },
+      }))
+      return
+    }
+    if (!item.question_id) {
+      setDismissedAnswers((c) => ({ ...c, [item.id]: { status: 'loaded', answer: null } }))
+      return
+    }
+    let shouldFetch = true
+    setDismissedAnswers((c) => {
+      const existing = c[item.id]
+      if (existing && existing.status !== 'error') {
+        shouldFetch = false
+        return c
+      }
+      return { ...c, [item.id]: { status: 'loading' } }
+    })
+    if (!shouldFetch) return
+
+    void (async () => {
+      try {
+        const res = await fetch(`/api/feed/${item.id}/answer`, { method: 'GET' })
+        if (!res.ok) throw new Error(String(res.status))
+        const data = (await res.json()) as { answer: string | null }
+        setDismissedAnswers((c) => {
+          // Drop the write if the card is no longer dismissed (undo race).
+          if (dismissPhaseRef.current[item.id] !== 'dismissed') return c
+          return { ...c, [item.id]: { status: 'loaded', answer: data.answer } }
+        })
+      } catch {
+        setDismissedAnswers((c) => ({ ...c, [item.id]: { status: 'error' } }))
+      }
+    })()
+  }, [])
+
   // Shared by the left-swipe and the on-card Dismiss button — one handler, one
   // animation. Plays the collapse, then swaps to the inline "Dismissed" bar.
   const requestDismiss = useCallback(
-    (itemId: string) => {
+    (item: FeedApiItem) => {
+      const itemId = item.id
       if (reducedMotion) {
         setDismissPhase((current) => ({ ...current, [itemId]: 'dismissed' }))
+        loadDismissedAnswer(item)
         return
       }
       setDismissPhase((current) => ({ ...current, [itemId]: 'collapsing' }))
       dismissTimersRef.current[itemId] = window.setTimeout(() => {
         delete dismissTimersRef.current[itemId]
         setDismissPhase((current) => ({ ...current, [itemId]: 'dismissed' }))
+        loadDismissedAnswer(item)
       }, 200)
     },
-    [reducedMotion],
+    [reducedMotion, loadDismissedAnswer],
   )
 
   // Undo fully restores the card — no side effects, nothing learned.
@@ -1047,10 +1104,18 @@ function FeedListContent({
                 // Undo restores it; "Not into {category}?" is the one mute path
                 // here, reusing the existing category-mute handler.
                 if (dismissPhase[item.id] === 'dismissed') {
+                  const dismissedAnswer = dismissedAnswers[item.id]
                   return (
                     <DismissedFeedBar
                       key={item.id}
                       category={visibleFeedCategory(item.domain_pill)}
+                      answer={
+                        dismissedAnswer?.status === 'loaded'
+                          ? dismissedAnswer.answer
+                          : undefined
+                      }
+                      answerLoading={!dismissedAnswer || dismissedAnswer.status === 'loading'}
+                      answerError={dismissedAnswer?.status === 'error'}
                       onUndo={() => undoDismiss(item.id)}
                       onMute={() => void hideCategory(item)}
                       disabled={isBusy}
@@ -1111,7 +1176,7 @@ function FeedListContent({
                   (typedItem.viewerResult ?? null) !== null
                 const dismissible = !item.viewer_is_author && !viewerAnsweredFriendCard
                 const onAnswer = dismissible ? () => setAnswerSheetId(item.id) : undefined
-                const onDismiss = dismissible ? () => requestDismiss(item.id) : undefined
+                const onDismiss = dismissible ? () => requestDismiss(item) : undefined
 
                 let card: ReactNode
                 if (typedItem.type === 'direct_sent') {
@@ -1166,7 +1231,7 @@ function FeedListContent({
                     className={collapsing ? 'feed-card-collapsing' : undefined}
                   >
                     <FeedCardSwipe
-                      onSwipeLeft={() => requestDismiss(item.id)}
+                      onSwipeLeft={() => requestDismiss(item)}
                       onSwipeRight={onAnswer}
                       disabled={isBusy || collapsing}
                     >

--- a/src/components/feed/DismissedFeedBar.tsx
+++ b/src/components/feed/DismissedFeedBar.tsx
@@ -6,11 +6,18 @@ type DismissedFeedBarProps = {
   /** The only mute path from here — wired to the existing category-mute handler. */
   onMute: () => void
   disabled?: boolean
+  /** The canonical answer to surface on the card back. null = none to show. */
+  answer?: string | null
+  /** True while the on-demand answer fetch is in flight. */
+  answerLoading?: boolean
+  /** True if the on-demand answer fetch failed. */
+  answerError?: boolean
 }
 
 /**
- * The collapsed inline bar shown in place of a dismissed card (modeled on the
- * thumbs-down confirmation row). Dismiss is view-state only; the deliberate
+ * The dismissed card rendered as the "back of the card": a solid muted surface
+ * (no dashed border) that surfaces the question's answer, fetched on-demand when
+ * the card is dismissed. Dismiss is view-state only; the deliberate
  * "Not into {category}?" second tap is the single place — alongside the "…"
  * menu — that fires the existing category mute.
  */
@@ -19,32 +26,59 @@ export function DismissedFeedBar({
   onUndo,
   onMute,
   disabled,
+  answer,
+  answerLoading,
+  answerError,
 }: DismissedFeedBarProps) {
   return (
     <div
       role="status"
       aria-live="polite"
-      className="text-muted-foreground flex items-center justify-between gap-3 rounded-lg border border-dashed px-3 py-2 text-sm italic"
+      className="relative overflow-hidden rounded-[4px] border border-[var(--brand-rule)] bg-[var(--game-card-question)] px-4 py-3 shadow-[0_4px_12px_rgba(40,32,30,0.04)]"
     >
-      <span>Dismissed</span>
-      <div className="flex items-center gap-4 not-italic">
-        <button
-          type="button"
-          disabled={disabled}
-          onClick={onUndo}
-          className="text-foreground text-xs font-medium underline-offset-4 hover:underline disabled:opacity-50"
-        >
-          Undo
-        </button>
-        {category ? (
+      <div className="flex items-center justify-between gap-3">
+        <span className="text-muted-foreground text-sm italic">Dismissed</span>
+        <div className="flex items-center gap-4">
           <button
             type="button"
             disabled={disabled}
-            onClick={onMute}
-            className="text-xs font-medium underline-offset-4 hover:underline disabled:opacity-50"
+            onClick={onUndo}
+            className="text-foreground text-xs font-medium underline-offset-4 hover:underline disabled:opacity-50"
           >
-            Not into {category}?
+            Undo
           </button>
+          {category ? (
+            <button
+              type="button"
+              disabled={disabled}
+              onClick={onMute}
+              className="text-muted-foreground text-xs font-medium underline-offset-4 hover:underline disabled:opacity-50"
+            >
+              Not into {category}?
+            </button>
+          ) : null}
+        </div>
+      </div>
+      <div className="mt-2">
+        {answerLoading ? (
+          <span className="text-muted-foreground text-[13px] italic">
+            Revealing answer…
+          </span>
+        ) : answerError ? (
+          <span className="text-muted-foreground text-[13px] italic">
+            Answer unavailable
+          </span>
+        ) : answer ? (
+          <p
+            className="text-[13px] italic"
+            style={{
+              fontFamily: 'var(--font-literata)',
+              color: 'var(--ink)',
+              opacity: 0.7,
+            }}
+          >
+            {answer}
+          </p>
         ) : null}
       </div>
     </div>

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -209,6 +209,45 @@ describe('Feed card dismiss (B-Feed-Swipe-1)', () => {
     expect(rendered).toContain('Undo')
     expect(rendered).not.toContain('Not into')
   })
+
+  it('reveals the answer on the card back when loaded', () => {
+    const rendered = html(
+      <DismissedFeedBar
+        category="Roman aqueducts"
+        answer="Pont du Gard"
+        answerLoading={false}
+        onUndo={() => undefined}
+        onMute={() => undefined}
+      />
+    )
+    expect(rendered).toContain('Dismissed')
+    expect(rendered).toContain('Pont du Gard')
+  })
+
+  it('shows a loading state while the answer is being fetched', () => {
+    const rendered = html(
+      <DismissedFeedBar
+        category={null}
+        answerLoading
+        onUndo={() => undefined}
+        onMute={() => undefined}
+      />
+    )
+    expect(rendered).toContain('Revealing answer')
+  })
+
+  it('falls back to an unavailable message when the answer fetch errors', () => {
+    const rendered = html(
+      <DismissedFeedBar
+        category={null}
+        answerError
+        answerLoading={false}
+        onUndo={() => undefined}
+        onMute={() => undefined}
+      />
+    )
+    expect(rendered).toContain('Answer unavailable')
+  })
 })
 
 describe('Feed answered states', () => {

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -550,6 +550,33 @@ export async function getViewerAnswerStatusForQuestions(
   return result;
 }
 
+// Reveal a single feed item's canonical answer to its recipient, for the
+// dismissed-card "back of the card" view. The inner join on `questions` means a
+// missing, foreign, or question-less feed item yields no row → null. Scoping to
+// the recipient is the only authorization needed: they already received this
+// question in their feed. Intentionally NOT gated on feedItem.state — a
+// dismissed item must still reveal its answer.
+export async function getFeedItemAnswerForRecipient(
+  feedItemId: string,
+  recipientUserId: string,
+): Promise<{ answer: string | null; questionText: string } | null> {
+  const [row] = await db
+    .select({
+      answer: questions.answerText,
+      questionText: questions.questionText,
+    })
+    .from(feedItems)
+    .innerJoin(questions, eq(feedItems.questionId, questions.id))
+    .where(and(
+      eq(feedItems.id, feedItemId),
+      eq(feedItems.recipientUserId, recipientUserId),
+    ))
+    .limit(1);
+
+  if (!row) return null;
+  return { answer: row.answer ?? null, questionText: row.questionText };
+}
+
 export async function userAnsweredQuestionCorrectly(userId: string, questionId: string): Promise<boolean> {
   const [row] = await db
     .select({ id: masteryEvents.id })


### PR DESCRIPTION
Replace the haphazard dashed 'Dismissed / Undo' inline bar with a solid
muted card surface (the 'back of the card') and surface the question's
answer on it.

Because the answer is gated server-side and only sent for already-answered
cards, fetch it on-demand via a new GET /api/feed/[id]/answer endpoint when
a card is dismissed, caching the result across undo/re-dismiss.

https://claude.ai/code/session_01JSRayM3rWGDXKUsma6qLQb