### PR TITLE
Restructure Daily Five question card layout

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -13,23 +13,6 @@ import { categoryLabel } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
 import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
 
-type ExclusionScope = 'subcategory' | 'broad_category' | 'category';
-
-type ExclusionTick = { scope: ExclusionScope; label: string; value: string };
-
-function buildExclusionTicks(slot: QueueSlot): ExclusionTick[] {
-  const ticks: ExclusionTick[] = [
-    { scope: 'subcategory', label: slot.domain, value: slot.domain },
-  ];
-  if (slot.broad_category && slot.broad_category.trim()) {
-    ticks.push({ scope: 'broad_category', label: slot.broad_category, value: slot.broad_category });
-  }
-  if (slot.category && slot.category.trim()) {
-    ticks.push({ scope: 'category', label: categoryLabel(slot.category), value: slot.category });
-  }
-  return ticks;
-}
-
 function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' | 'warning' }> {
   // Figma shows the topic/category as the question chip (not the difficulty tier).
   const category =
@@ -117,130 +100,6 @@ function sessionCloseLines(slots: QueueSlot[]): { scoreLine: string; interpretiv
   return buildSessionCloseLines(summaries);
 }
 
-function UnfamiliarDialog({
-  ticks,
-  busy,
-  onExclude,
-  onSkipOnly,
-  onCancel,
-}: {
-  ticks: ExclusionTick[];
-  busy: boolean;
-  onExclude: (tick: ExclusionTick) => void;
-  onSkipOnly: () => void;
-  onCancel: () => void;
-}) {
-  const [tickIndex, setTickIndex] = useState(0);
-  const maxIndex = Math.max(0, ticks.length - 1);
-  const safeIndex = Math.min(tickIndex, maxIndex);
-  const selected = ticks[safeIndex] ?? ticks[0];
-
-  useEffect(() => {
-    const handleKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onCancel(); };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
-  }, [onCancel]);
-
-  return (
-    <div
-      role="dialog"
-      aria-modal="true"
-      aria-labelledby="unfamiliar-dialog-title"
-      style={{
-        position: 'fixed',
-        inset: 0,
-        zIndex: 60,
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        padding: '1rem',
-        background: 'rgba(0,0,0,0.45)',
-      }}
-      onClick={(e) => { if (e.target === e.currentTarget) onCancel(); }}
-    >
-      <div
-        style={{
-          background: 'var(--surface)',
-          border: '1px solid var(--border)',
-          borderRadius: 'var(--radius-lg)',
-          padding: '1.5rem',
-          maxWidth: '24rem',
-          width: '100%',
-        }}
-      >
-        <p id="unfamiliar-dialog-title" className="text-sm font-semibold text-[var(--text)]">
-          How familiar are you with this?
-        </p>
-        <p className="mt-1 text-sm text-[var(--text-muted)]">
-          Slide to the scope you&rsquo;d like to skip going forward.
-        </p>
-
-        {ticks.length > 1 ? (
-          <div className="mt-5">
-            <input
-              type="range"
-              min={0}
-              max={maxIndex}
-              step={1}
-              value={safeIndex}
-              onChange={(event) => setTickIndex(Number(event.target.value))}
-              aria-label="Unfamiliarity scope"
-              style={{ width: '100%' }}
-            />
-            <div className="mt-2 flex justify-between gap-1 text-[0.65rem] uppercase tracking-[0.06em] text-[var(--text-muted)]">
-              {ticks.map((tick, i) => (
-                <span
-                  key={`${tick.scope}-${i}`}
-                  style={{
-                    flex: '1 1 0',
-                    textAlign: i === 0 ? 'left' : i === ticks.length - 1 ? 'right' : 'center',
-                    color: i === safeIndex ? 'var(--text)' : 'var(--text-muted)',
-                    fontWeight: i === safeIndex ? 600 : 400,
-                  }}
-                >
-                  {tick.label}
-                </span>
-              ))}
-            </div>
-          </div>
-        ) : null}
-
-        <p className="mt-4 text-sm text-[var(--text-muted)]">
-          We&rsquo;ll stop sending you questions about{' '}
-          <span className="font-semibold text-[var(--text)]">{selected?.label ?? ''}</span>.
-        </p>
-
-        <div className="mt-4 flex flex-col gap-2">
-          <button
-            type="button"
-            className="btn-primary w-full"
-            disabled={busy || !selected}
-            onClick={() => { if (selected) onExclude(selected); }}
-          >
-            {busy ? '...' : 'Remove from my topics'}
-          </button>
-          <button
-            type="button"
-            className="w-full rounded-[var(--radius-md)] border px-4 py-2 text-sm font-medium text-[var(--text)] hover:bg-[var(--surface-raised)] transition-colors"
-            style={{ borderColor: 'var(--border)' }}
-            disabled={busy}
-            onClick={onSkipOnly}
-          >
-            Just skip this one
-          </button>
-          <button
-            type="button"
-            className="text-sm text-[var(--text-muted)] hover:text-[var(--text)] transition-colors"
-            onClick={onCancel}
-          >
-            Cancel
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-}
-
 export default function DailyPage() {
   const router = useRouter();
   const [queue, setQueue] = useState<QueueResponse | null>(null);
@@ -249,8 +108,6 @@ export default function DailyPage() {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [pausedAfterSlotIndex, setPausedAfterSlotIndex] = useState<number | null>(null);
-  const [showUnfamiliarDialog, setShowUnfamiliarDialog] = useState(false);
-  const [excludingDomain, setExcludingDomain] = useState(false);
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [areaTopUp, setAreaTopUp] = useState<{ existing: TopUpInterest[]; maxNew: number } | null>(null);
 
@@ -370,87 +227,6 @@ export default function DailyPage() {
   const allDone = Boolean(queue && queue.slots.length > 0 && !actualCurrentSlot);
 
 
-  const skipCurrent = useCallback(async () => {
-    if (!queue || !currentSlot || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const response = await fetch('/api/daily/skip', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ queue_id: queue.queue_id, slot_index: currentSlot.slot_index }),
-      });
-      const body = await response.json().catch(() => null);
-      if (!response.ok) {
-        throw new Error(body?.message ?? 'Could not skip that question.');
-      }
-      const nextSlots = Array.isArray(body?.slots) ? (body.slots as QueueSlot[]) : null;
-      setQueue((existing) => {
-        if (!existing) return existing;
-        if (nextSlots) return { ...existing, slots: nextSlots };
-        return {
-          ...existing,
-          slots: existing.slots.map((slot) =>
-            slot.slot_index === currentSlot.slot_index ? { ...slot, skipped: true } : slot
-          ),
-        };
-      });
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not skip that question.');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [currentSlot, queue, submitting]);
-
-  const excludeDomainAndSkip = useCallback(async (tick: ExclusionTick) => {
-    if (!currentSlot) return;
-    setExcludingDomain(true);
-    try {
-      await fetch('/api/users/domain-exclusions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ canonical_subcategory: tick.value, scope: tick.scope }),
-      });
-      // Subcategory exclusions also need to drop the domain from the user's
-      // selectedDomains list in Custom mode so today's queue rebuild can't
-      // re-pull it; broader scopes are filtered out by getKnowledgeBase via
-      // userDomainExclusions and don't touch selectedDomains.
-      if (tick.scope === 'subcategory') {
-        try {
-          const prefsResponse = await fetch('/api/daily/preferences', { credentials: 'include' });
-          if (prefsResponse.ok) {
-            const prefsBody = await prefsResponse.json().catch(() => null) as {
-              preferences: { domainMode: string; selectedDomains: string[] };
-              domains: Array<{ domain: string }>;
-            } | null;
-            if (prefsBody && prefsBody.preferences.domainMode === 'custom') {
-              const nextDomains = prefsBody.preferences.selectedDomains.filter((d) => d !== tick.value);
-              if (nextDomains.length > 0 && nextDomains.length !== prefsBody.preferences.selectedDomains.length) {
-                await fetch('/api/daily/preferences', {
-                  method: 'PATCH',
-                  headers: { 'content-type': 'application/json' },
-                  credentials: 'include',
-                  body: JSON.stringify({ domainMode: 'custom', selectedDomains: nextDomains }),
-                });
-              }
-            }
-          }
-        } catch {
-          // preferences sync is best-effort; the exclusion write above already
-          // ensures future queue builds skip this domain.
-        }
-      }
-    } catch {
-      // exclusion is best-effort; still skip the slot so the user can move on
-    } finally {
-      setExcludingDomain(false);
-    }
-    setShowUnfamiliarDialog(false);
-    void skipCurrent();
-  }, [currentSlot, skipCurrent]);
-
   const requestRecheck = useCallback(async (slotIndex: number): Promise<RecheckActionResult> => {
     if (!queue) throw new Error('No active queue');
 
@@ -556,9 +332,6 @@ export default function DailyPage() {
           creatorName: null,
           isNew: true,
           badges: questionBadges(slot),
-          onDismiss: () => setShowUnfamiliarDialog(true),
-          dismissLabel: 'Not familiar with this topic',
-          dismissImmediate: false,
         });
         if (submitting && answer.trim()) {
           rows.push({ id: 'u-pending', kind: 'user', text: answer.trim() });
@@ -745,7 +518,11 @@ export default function DailyPage() {
             {error}
           </div>
         ) : (
-          <GameplayChatThread messages={messages} />
+          <GameplayChatThread
+            messages={messages}
+            onGiveUp={() => void giveUpCurrent()}
+            giveUpDisabled={submitting}
+          />
         )}
       </section>
 
@@ -776,27 +553,7 @@ export default function DailyPage() {
               {submitting ? '...' : 'Answer'}
             </button>
           </div>
-          <div className="mt-2 flex items-center justify-end gap-3">
-            <button
-              type="button"
-              className="text-xs font-medium uppercase tracking-[0.08em] text-muted-foreground underline underline-offset-4"
-              disabled={submitting}
-              onClick={() => void giveUpCurrent()}
-            >
-              Show me the answer
-            </button>
-          </div>
         </form>
-      ) : null}
-
-      {showUnfamiliarDialog && currentSlot ? (
-        <UnfamiliarDialog
-          ticks={buildExclusionTicks(currentSlot)}
-          busy={excludingDomain || submitting}
-          onExclude={(tick) => void excludeDomainAndSkip(tick)}
-          onSkipOnly={() => { setShowUnfamiliarDialog(false); void skipCurrent(); }}
-          onCancel={() => setShowUnfamiliarDialog(false)}
-        />
       ) : null}
 
       {areaTopUp && areaTopUp.maxNew > 0 ? (

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -38,10 +38,6 @@ export type ChatMessage =
       questionText: string;
       creatorName: string | null;
       isNew?: boolean;
-      onDismiss?: () => void;
-      dismissLabel?: string;
-      /** When false, the dismiss button calls onDismiss but does not flip into the "Skipped" inline state — used when the click opens a dialog instead of completing the action. Defaults to true to preserve legacy behavior. */
-      dismissImmediate?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
     }
@@ -170,20 +166,17 @@ function QuestionRow({
   questionText,
   creatorName,
   isNew = false,
-  onDismiss,
-  dismissLabel = "Skip - don't show again",
-  dismissImmediate = true,
+  onGiveUp,
+  giveUpDisabled = false,
 }: {
   subhead?: string | null;
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
   questionText: string;
   creatorName: string | null;
   isNew?: boolean;
-  onDismiss?: () => void;
-  dismissLabel?: string;
-  dismissImmediate?: boolean;
+  onGiveUp?: () => void;
+  giveUpDisabled?: boolean;
 }) {
-  const [dismissed, setDismissed] = useState(false);
   const [visible, setVisible] = useState(!isNew);
 
   useEffect(() => {
@@ -192,11 +185,6 @@ function QuestionRow({
     return () => window.clearTimeout(t);
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  const handleDismiss = useCallback(() => {
-    if (dismissImmediate) setDismissed(true);
-    onDismiss?.();
-  }, [onDismiss, dismissImmediate]);
 
   return (
     <div
@@ -256,72 +244,58 @@ function QuestionRow({
         }}
       >
         <p style={{ margin: 0 }}>{questionText}</p>
+        {badges.length > 0 ? (
+          <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '12px' }}>
+            {badges.map((badge) => (
+              <span
+                key={badge.label}
+                style={{
+                  // Figma display/pill/sans — Georgia, 12px, title-case (not the
+                  // mono uppercase used elsewhere).
+                  fontFamily: 'Georgia, "Times New Roman", serif',
+                  fontSize: '0.75rem',
+                  lineHeight: 1.1,
+                  letterSpacing: '0.01em',
+                  borderRadius: '999px',
+                  border: '1px solid var(--border)',
+                  background: badge.tone === 'warning'
+                    ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
+                    : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
+                  color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
+                  padding: '3px 9px',
+                }}
+              >
+                {badge.label}
+              </span>
+            ))}
+          </div>
+        ) : null}
       </div>
-      {badges.length > 0 ? (
-        <div className="flex flex-wrap items-center gap-1.5 pt-1 pl-0.5">
-          {badges.map((badge) => (
-            <span
-              key={badge.label}
-              style={{
-                // Figma display/pill/sans — Georgia, 12px, title-case (not the
-                // mono uppercase used elsewhere).
-                fontFamily: 'Georgia, "Times New Roman", serif',
-                fontSize: '0.75rem',
-                lineHeight: 1.1,
-                letterSpacing: '0.01em',
-                borderRadius: '999px',
-                border: '1px solid var(--border)',
-                background: badge.tone === 'warning'
-                  ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
-                  : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
-                color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
-                padding: '3px 9px',
-              }}
-            >
-              {badge.label}
-            </span>
-          ))}
-        </div>
-      ) : null}
-      {onDismiss ? (
-        dismissed ? (
-          <p
-            style={{
-              ...monoStyle,
-              fontSize: '0.58rem',
-              color: 'var(--text-muted)',
-              paddingLeft: '2px',
-              marginTop: '2px',
-            }}
-          >
-            Skipped
-          </p>
-        ) : (
-          <button
-            type="button"
-            aria-label={dismissLabel === 'X' ? 'Dismiss question' : dismissLabel}
-            onClick={handleDismiss}
-            style={{
-              alignSelf: 'flex-start',
-              background: 'none',
-              border: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              fontFamily: 'var(--font-mono)',
-              fontSize: '0.58rem',
-              textTransform: 'uppercase',
-              letterSpacing: '0.06em',
-              color: 'var(--text-muted)',
-              textDecoration: 'underline',
-              textUnderlineOffset: '2px',
-              opacity: 0.7,
-              marginTop: '4px',
-              paddingLeft: '2px',
-            }}
-          >
-            {dismissLabel}
-          </button>
-        )
+      {onGiveUp ? (
+        <button
+          type="button"
+          onClick={onGiveUp}
+          disabled={giveUpDisabled}
+          style={{
+            alignSelf: 'flex-start',
+            background: 'none',
+            border: 'none',
+            padding: 0,
+            cursor: 'pointer',
+            fontFamily: 'var(--font-mono)',
+            fontSize: '0.58rem',
+            textTransform: 'uppercase',
+            letterSpacing: '0.06em',
+            color: 'var(--text-muted)',
+            textDecoration: 'underline',
+            textUnderlineOffset: '2px',
+            opacity: 0.7,
+            marginTop: '4px',
+            paddingLeft: '2px',
+          }}
+        >
+          Show me the answer
+        </button>
       ) : null}
     </div>
   );
@@ -1103,8 +1077,12 @@ function BonusOfferRow({
 
 export function GameplayChatThread({
   messages,
+  onGiveUp,
+  giveUpDisabled,
 }: {
   messages: ChatMessage[];
+  onGiveUp?: () => void;
+  giveUpDisabled?: boolean;
 }) {
   return (
     <div className="space-y-2.5">
@@ -1119,11 +1097,10 @@ export function GameplayChatThread({
                 questionText={m.questionText}
                 creatorName={m.creatorName}
                 isNew={m.isNew}
-                onDismiss={m.onDismiss}
-                dismissLabel={m.dismissLabel}
-                dismissImmediate={m.dismissImmediate}
                 subhead={m.subhead}
                 badges={m.badges}
+                onGiveUp={onGiveUp}
+                giveUpDisabled={giveUpDisabled}
               />
             );
           case 'user':


### PR DESCRIPTION
## Summary
Restructures the Daily Five question card layout per design feedback:

- **Category pill moved inside the card** — renders under the question text, inside the cream card, instead of below/outside it.
- **"Show me the answer" relocated under the card** — moved out of the sticky footer (where it sat under the answer box) to directly under the question card. Threaded through `GameplayChatThread` via new optional `onGiveUp`/`giveUpDisabled` props, so it only appears where a handler is passed (Daily Five) — `replay`, `games/[id]`, and `catchup` are unaffected.
- **Removed "Not familiar with this topic"** and the now-unreachable topic-exclusion flow it was the sole entry point for: `UnfamiliarDialog`, `buildExclusionTicks`, `skipCurrent`, `excludeDomainAndSkip`, the `Exclusion*` types, and related state.

Net **−266 lines**.

## Notes
- The pill-inside-card change applies to the shared `QuestionRow`, so it also affects `/replay`, `/games/[id]`, and `/daily/catchup` (consistent, intended).

## Verification
- `npx tsc -p tsconfig.typecheck.json` → 0 errors
- `npx eslint src/app/daily/page.tsx src/components/play/GameplayChat.tsx` → clean
- `npx vitest run` → **537 passed / 0 failed** (no test referenced the removed code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
