### PR TITLE
Hold Daily answers for retry when the grader is unreachable (#6)

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -339,3 +339,51 @@ describe('POST /api/daily/answer mastery scoring (F2.1)', () => {
     expect(createFeedItemsForFriendsFromAnswerMock).not.toHaveBeenCalled()
   })
 })
+
+describe('POST /api/daily/answer grader outage (#6 — never score wrong on LLM failure)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readPriorAnswersForQuestionMock.mockResolvedValue([])
+  })
+
+  it('holds the answer for retry (503) and persists nothing when the grader is unreachable', async () => {
+    setupDbChain()
+    // gradeAnswer signals an unreachable LLM grader via gradedVia: 'fallback'.
+    // Its result is a deterministic 'wrong' placeholder, NOT a real verdict —
+    // the route must refuse to score it rather than penalise an infra outage.
+    gradeAnswerMock.mockResolvedValueOnce({
+      result: 'wrong',
+      consolation: null,
+      confidence: 0,
+      gradedVia: 'fallback',
+    })
+
+    const res = await POST(jsonRequest(VALID_BODY) as never)
+
+    expect(res.status).toBe(503)
+    const body = await res.json()
+    expect(body.error).toBe('grader_unavailable')
+
+    // The slot must stay untouched (unanswered) so the player can resubmit, and
+    // no scoring side effects may fire.
+    expect(dbMock.update).not.toHaveBeenCalled()
+    expect(writeMasteryEventMock).not.toHaveBeenCalled()
+    expect(updateDomainDifficultyOnAnswerMock).not.toHaveBeenCalled()
+    expect(createFeedItemsForFriendsFromAnswerMock).not.toHaveBeenCalled()
+  })
+
+  it('still scores give-ups as wrong (grader is skipped, so never held for retry)', async () => {
+    setupDbChain()
+    // gaveUp short-circuits gradeAnswer with gradedVia: 'exact', so this path
+    // must persist a real wrong answer — the outage hold must not swallow it.
+    const res = await POST(
+      jsonRequest({ ...VALID_BODY, gave_up: true, submitted_answer: '' }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
+    expect(writeMasteryEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ answerState: 'incorrect', pointsAwarded: 0 }),
+    )
+  })
+})

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -36,6 +36,7 @@ type DailyAnswerErrorCode =
   | 'invalid_state'
   | 'question_not_found'
   | 'forbidden'
+  | 'grader_unavailable'
   | 'unexpected';
 
 function dailyAnswerErrorResponse(status: number, error: DailyAnswerErrorCode, message: string) {
@@ -204,16 +205,25 @@ export async function POST(request: NextRequest) {
           question.questionText,
           'factual',
         );
-    // TODO: when grade.gradedVia === 'fallback', the LLM grader was unreachable
-    // and the slot is being marked wrong as a deterministic safeguard. Wire this
-    // to /api/daily/recheck or surface an "answer pending review" UI so users
-    // aren't silently penalised for an Anthropic outage.
+    // The LLM grader was unreachable (timeout, parse error, no client), so its
+    // 'wrong' verdict is not a real judgement of the answer — it's a deterministic
+    // placeholder. Scoring the player wrong for an Anthropic outage is the most
+    // off-brand failure mode in a product whose thesis is "wrong answers are
+    // connection events, not penalties." Instead of persisting anything, hold the
+    // answer in a non-scored retry state: leave the slot untouched (unanswered) and
+    // return a transparent, retryable error so the player can simply resubmit.
+    // Give-ups skip the grader entirely (gradedVia: 'exact'), so they're never held.
     if (grade.gradedVia === 'fallback') {
-      console.warn('[daily/answer] grading fell back to deterministic wrong', {
+      console.warn('[daily/answer] grader unavailable; holding answer for retry', {
         queueId: parsed.queueId,
         slotIndex: parsed.slotIndex,
         userId: session.userId,
       });
+      return dailyAnswerErrorResponse(
+        503,
+        'grader_unavailable',
+        "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      );
     }
     const isCorrect = grade.result === 'correct';
     const answerState = isCorrect ? 'correct' : 'incorrect';

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -65,6 +65,8 @@ const ANSWER_ERROR_MESSAGES: Record<string, string> = {
   not_found: 'We could not find that Daily Five queue.',
   invalid_state: 'That question is already closed.',
   question_not_found: 'We could not find that Daily Five question.',
+  grader_unavailable:
+    "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
   unexpected: 'Could not record that answer.',
 };
 


### PR DESCRIPTION
When the Haiku grader timed out, errored, returned unparseable JSON, or had
no client, gradeAnswerWithLLM returned a deterministic 'wrong' placeholder
(gradedVia: 'fallback'). The Daily answer route detected that signal but
still persisted answer_state 'incorrect', awarded 0 points, and broke
mastery — silently penalising the player for an Anthropic outage. That's the
most off-brand failure mode in a product whose thesis is "wrong answers are
connection events, not penalties."

Instead of scoring it, hold the answer in a non-scored retry state: on a
'fallback' grade for a real submission, return 503 grader_unavailable before
any slot mutation or mastery write, leaving the slot unanswered so the player
can simply resubmit. The client surfaces a transparent "answer-checker is
taking a breather — give it another go" message; the input stays editable
with the typed answer intact.

Give-ups (gradedVia: 'exact') and exact-match hits are unaffected.