### PR TITLE
Support forwarding LLM-generated questions with curated_sent source

### DIFF
--- a/src/app/api/feed/friend-coverage/route.ts
+++ b/src/app/api/feed/friend-coverage/route.ts
@@ -219,7 +219,7 @@ export async function loadFriendCoverage(
     for (const event of events) {
       const questionPayload = event.questionId ? {
         creatorId: event.questionCreatorId,
-        source: event.questionSource as 'authored' | 'daily_generated',
+        source: event.questionSource as 'authored' | 'daily_generated' | 'curated_sent',
         visibility: event.questionVisibility as 'public' | 'private',
         deletedAt: event.questionDeletedAt,
       } : null;

--- a/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
+++ b/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Sentinel table objects so the db mock can tell which table a select hits.
+const { dbMock, state, QUESTIONS, GENERATED } = vi.hoisted(() => {
+  const QUESTIONS = { __table: 'questions' };
+  const GENERATED = { __table: 'generatedQuestions' };
+
+  const state = {
+    existingQuestion: null as { id: string } | null,
+    generated: null as Record<string, unknown> | null,
+    insertedValues: null as Record<string, unknown> | null,
+    insertedId: 'new-question-id',
+  };
+
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: vi.fn((table: unknown) => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(async () => {
+            if (table === QUESTIONS) return state.existingQuestion ? [state.existingQuestion] : [];
+            if (table === GENERATED) return state.generated ? [state.generated] : [];
+            return [];
+          }),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((values: Record<string, unknown>) => {
+        state.insertedValues = values;
+        return { returning: vi.fn(async () => [{ id: state.insertedId }]) };
+      }),
+    })),
+  };
+
+  return { dbMock, state, QUESTIONS, GENERATED };
+});
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  questions: QUESTIONS,
+  generatedQuestions: GENERATED,
+  feedItems: {},
+  users: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...predicates) => ({ op: 'and', predicates })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  gt: vi.fn((column, value) => ({ op: 'gt', column, value })),
+  sql: Object.assign(vi.fn(() => ({ op: 'sql' })), { raw: vi.fn() }),
+}));
+
+// The route module pulls in several collaborators at import time; stub them so
+// importing resolveQuestionIdForSend doesn't drag in env/cookie-dependent code.
+vi.mock('@/server/activity/write-activity', () => ({ writeActivity: vi.fn() }));
+vi.mock('@/server/auth/session', () => ({ getSession: vi.fn() }));
+vi.mock('@/server/db/queries/feed', () => ({
+  createFeedItem: vi.fn(),
+  rollOffOldItems: vi.fn(),
+  userAnsweredQuestionCorrectly: vi.fn(),
+  userHasQuestionInBlockingFeed: vi.fn(),
+}));
+vi.mock('@/server/db/queries/friends', () => ({ getFriends: vi.fn() }));
+vi.mock('@/server/sms', () => ({ sendSms: vi.fn() }));
+
+import { resolveQuestionIdForSend } from '@/app/api/questions/send/route';
+
+describe('resolveQuestionIdForSend', () => {
+  beforeEach(() => {
+    state.existingQuestion = null;
+    state.generated = null;
+    state.insertedValues = null;
+    dbMock.insert.mockClear();
+  });
+
+  it('returns a real Question id unchanged without inserting', async () => {
+    state.existingQuestion = { id: 'question-1' };
+
+    const result = await resolveQuestionIdForSend('question-1');
+
+    expect(result).toBe('question-1');
+    expect(dbMock.insert).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the id matches neither a Question nor a GeneratedQuestion', async () => {
+    const result = await resolveQuestionIdForSend('missing');
+
+    expect(result).toBeNull();
+    expect(dbMock.insert).not.toHaveBeenCalled();
+  });
+
+  it('materializes a GeneratedQuestion with curated_sent provenance and no author', async () => {
+    state.generated = {
+      id: 'gen-1',
+      questionText: 'What is the capital of France?',
+      answer: 'Paris',
+      explainer: 'Paris has been the capital since 987.',
+      broadCategory: 'Geography',
+      canonicalSubcategory: 'European Capitals',
+      difficultyEstimate: 'accessible',
+    };
+
+    const result = await resolveQuestionIdForSend('gen-1');
+
+    expect(result).toBe('new-question-id');
+    expect(dbMock.insert).toHaveBeenCalledTimes(1);
+    // The crux of B-2: no author is recorded (so author/curator credit can't
+    // accrue to the forwarder) and the LLM/curated origin is preserved.
+    expect(state.insertedValues).toMatchObject({
+      creatorId: null,
+      source: 'curated_sent',
+      sourceQuestionId: 'gen-1',
+      questionText: 'What is the capital of France?',
+      answerText: 'Paris',
+    });
+  });
+});

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -36,7 +36,7 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Recipient is not a friend.' }, { status: 403 });
   }
 
-  const sendableQuestionId = await resolveQuestionIdForSend(parsed.questionId, session.userId);
+  const sendableQuestionId = await resolveQuestionIdForSend(parsed.questionId);
 
   const [question, recipient, senderNameRow] = await Promise.all([
     sendableQuestionId
@@ -147,7 +147,7 @@ function lastTwentyFourHours(date = new Date()) {
   return new Date(date.getTime() - 24 * 60 * 60 * 1000);
 }
 
-async function resolveQuestionIdForSend(questionId: string, senderUserId: string): Promise<string | null> {
+export async function resolveQuestionIdForSend(questionId: string): Promise<string | null> {
   const [question] = await db.select({ id: questions.id }).from(questions).where(eq(questions.id, questionId)).limit(1);
   if (question) return question.id;
 
@@ -159,12 +159,17 @@ async function resolveQuestionIdForSend(questionId: string, senderUserId: string
 
   if (!generated) return null;
 
+  // A sent LLM question keeps its LLM/curated provenance: no author is recorded
+  // (creatorId stays null so author/curator credit never accrues to the
+  // forwarder), and source is 'curated_sent' so it is queryably distinct from
+  // both authored questions and daily-generated ones. Who sent it is preserved
+  // separately on the FeedItem (sourceUserId) written by the caller.
   const [created] = await db
     .insert(questions)
     .values({
-      creatorId: senderUserId,
+      creatorId: null,
       sourceQuestionId: generated.id,
-      source: 'authored',
+      source: 'curated_sent',
       questionText: generated.questionText,
       answerText: generated.answer,
       factualExplanation: generated.explainer,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -234,7 +234,7 @@ export const questions = pgTable(
     id: id(),
     creatorId: text('creator_id').references(() => users.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id, { onDelete: 'set null' }),
-    source: text('source').$type<'authored' | 'daily_generated'>().notNull().default('authored'),
+    source: text('source').$type<'authored' | 'daily_generated' | 'curated_sent'>().notNull().default('authored'),
     sourceQuestionId: text('source_question_id'),
     sourceCreatorId: text('source_creator_id'),
     questionText: text('question_text').notNull(),

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   QUESTION_SHARING_FEED_SOURCE_VISIBILITY,
   isCorrectAnswerFeedEligible,
+  isLlmOriginQuestion,
   isMainFeedSourceVisible,
   socialFeedDomainLabel,
 } from '@/server/feed/visibility';
@@ -44,6 +45,40 @@ describe('correct-answer social feed eligibility', () => {
       },
       hasVisibleSocialContext: true,
     })).toBe(true);
+  });
+
+  it('allows public curated-sent (forwarded LLM) questions without an author to propagate correct friend answers', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: {
+        creatorId: null,
+        source: 'curated_sent' as const,
+        visibility: 'public' as const,
+        deletedAt: null,
+      },
+      hasVisibleSocialContext: true,
+    })).toBe(true);
+  });
+
+  it('rejects wrong answers to curated-sent questions', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: false,
+      answererUserId: 'answerer-1',
+      question: {
+        creatorId: null,
+        source: 'curated_sent' as const,
+        visibility: 'public' as const,
+        deletedAt: null,
+      },
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+  });
+
+  it('classifies LLM-origin sources', () => {
+    expect(isLlmOriginQuestion('daily_generated')).toBe(true);
+    expect(isLlmOriginQuestion('curated_sent')).toBe(true);
+    expect(isLlmOriginQuestion('authored')).toBe(false);
   });
 
   it('rejects a correct answer by the author', () => {

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -48,13 +48,21 @@ export type FeedEventEligibilityInput = {
   hasVisibleSocialContext: boolean;
 };
 
+// LLM-origin questions have no human author. Both daily-generated questions and
+// curated sends ('curated_sent', written by /api/questions/send) carry a null
+// creatorId, so feed eligibility for their correct answers can't be keyed on
+// authorship — they are always eligible (subject to the checks above).
+export function isLlmOriginQuestion(source: string): boolean {
+  return source === 'daily_generated' || source === 'curated_sent';
+}
+
 export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): boolean {
   if (!input.answerIsCorrect) return false;
   if (!input.hasVisibleSocialContext) return false;
   if (!input.question) return false;
   if (input.question.deletedAt) return false;
   if (input.question.visibility !== 'public') return false;
-  if (input.question.source === 'daily_generated') return true;
+  if (isLlmOriginQuestion(input.question.source)) return true;
   if (!input.question.creatorId) return false;
   return input.answererUserId !== input.question.creatorId;
 }


### PR DESCRIPTION
## Summary
Enable users to forward LLM-generated questions (both daily-generated and curated) while preserving their LLM origin and preventing unintended author/curator credit accrual to the forwarder.

## Changes
- **New question source type `curated_sent`**: Added to the `questions.source` enum to represent LLM questions that have been forwarded via `/api/questions/send`. This is distinct from `authored` (human-created) and `daily_generated` (daily LLM questions).

- **Materialization logic in `resolveQuestionIdForSend`**: When a `GeneratedQuestion` is sent, it is now materialized into the `questions` table with:
  - `creatorId: null` (no author recorded, preventing credit accrual to the forwarder)
  - `source: 'curated_sent'` (preserving LLM/curated provenance)
  - `sourceQuestionId` pointing to the original generated question
  - The forwarder's identity is recorded separately on the `FeedItem` (via `sourceUserId`)

- **Feed eligibility for LLM-origin questions**: Extracted `isLlmOriginQuestion()` helper to classify both `daily_generated` and `curated_sent` sources. Correct answers to LLM-origin questions are now eligible for the social feed (they have no human author to exclude), matching the existing behavior for daily-generated questions.

- **Type safety**: Updated `questions.source` schema type and feed route type annotations to include `'curated_sent'`.

- **Test coverage**: Added comprehensive test suite for `resolveQuestionIdForSend` covering:
  - Pass-through of existing real questions
  - Null return for missing questions
  - Materialization of generated questions with correct provenance fields
  - Feed eligibility tests for curated-sent questions

## Implementation Details
The key insight is that LLM-origin questions (whether daily-generated or curated-sent) should not accrue author credit to anyone, since they have no human author. The `creatorId: null` + `source: 'curated_sent'` combination makes this queryable and distinct from both authored questions and daily-generated ones, while the `FeedItem.sourceUserId` separately tracks who forwarded it.

https://claude.ai/code/session_01YDTGRpMwqSZkYkgDgCFY74