### PR TITLE
Align Catch up border and What's happening rows on home

### DIFF
--- a/src/components/home/MissedQuestionsCard.tsx
+++ b/src/components/home/MissedQuestionsCard.tsx
@@ -11,10 +11,10 @@ export function MissedQuestionsCard({
   const missedLabel = count === 1 ? '1 missed question' : `${count} missed questions`
   return (
     <div
-      className="bg-card text-card-foreground flex items-center justify-between gap-3 rounded-[4px] border border-[var(--brand-rule)] px-3 py-4"
+      className="bg-card text-card-foreground flex items-center justify-between gap-3 rounded-[4px] border border-[var(--brand-border)] px-3 py-4"
       style={
         expiringCount > 0
-          ? { borderColor: 'color-mix(in srgb, var(--brand-orange) 40%, var(--brand-rule))' }
+          ? { borderColor: 'color-mix(in srgb, var(--brand-orange) 40%, var(--brand-border))' }
           : undefined
       }
     >

--- a/src/components/home/RecentActivitySection.tsx
+++ b/src/components/home/RecentActivitySection.tsx
@@ -9,7 +9,7 @@ export function RecentActivitySection({
   items: ActivityItemView[]
 }) {
   return (
-    <section>
+    <section className="px-3">
       <p className="text-muted-foreground mb-2 text-xs font-medium tracking-[0.1em] uppercase">
         What&rsquo;s happening
       </p>


### PR DESCRIPTION
- Match the Catch up card border to the warm --brand-border used by the
  Today's Five card above (was --brand-rule, a cooler/darker divider tone)
- Add px-3 to the What's happening section so activity rows align with the
  Catch up card's inner content and timestamps right-align with Play →