### PR TITLE
Replace grainy login phone icon with crisp solid glyph

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -3,7 +3,7 @@
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { MessageCircle, Phone } from 'lucide-react';
+import { MessageCircle } from 'lucide-react';
 
 const US_E164_REGEX = /^\+1\d{10}$/;
 
@@ -162,8 +162,16 @@ export default function LoginPanel() {
       {step === 'phone' ? (
         <form className="space-y-[14px]" onSubmit={continueWithPhone}>
           {/* Solid filled handset, matching the Figma black phone glyph
-              (and the filled treatment of the OTP step's bubble icon). */}
-          <Phone className="mx-auto h-12 w-12 fill-black text-black" strokeWidth={1.5} aria-hidden="true" />
+              (and the filled treatment of the OTP step's bubble icon).
+              Hand-drawn as a fill-only glyph rather than a force-filled
+              lucide outline, which rendered with a muddy stroked edge. */}
+          <svg
+            className="mx-auto h-12 w-12 fill-black"
+            viewBox="0 0 24 24"
+            aria-hidden="true"
+          >
+            <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z" />
+          </svg>
           <label
             className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"
             htmlFor="phone"


### PR DESCRIPTION
The login page rendered lucide-react's outline Phone icon force-filled
black with a stroke on top, collapsing its interior detail into a muddy,
grainy-looking blob. Swap it for a purpose-built fill-only handset glyph
that renders crisply at any size while preserving the same size, color,
and centering.

https://claude.ai/code/session_01Mn94VVCPLyaSrPRfeJ22Qm