### PR TITLE
Daily Five +2: friend-answered bonus slots

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,27 @@
+# The repo source predates this Prettier config and was never normalized to it
+# (see the `format` script — it only touches files you've changed, so Prettier
+# never rewrites the whole tree). This file keeps `format`/`format:all` off
+# things that should never be auto-reformatted.
+
+# Dependencies & build output
+node_modules/
+.next/
+dist/
+build/
+coverage/
+*.tsbuildinfo
+
+# Excluded from the project entirely (see CLAUDE.md / tsconfig.json)
+_salvaged/
+
+# Generated Drizzle artifacts — hand-editing these would corrupt migration state
+drizzle/meta/
+
+# Lockfile
+package-lock.json
+
+# Prose / specs are authored by hand; Prettier's markdown rewrites add noise
+*.md
+_docs/
+docs/
+audit/

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,7 +1,8 @@
 {
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5",
+  "printWidth": 100,
+  "trailingComma": "all",
   "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",
     "smoke:area-top-up": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/area-top-up.smoke.mjs",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
-    "format": "prettier --write ."
+    "format": "node scripts/format-changed.mjs",
+    "format:all": "prettier --write ."
   },
   "dependencies": {
     "@anthropic-ai/sdk": "latest",

--- a/scripts/format-changed.mjs
+++ b/scripts/format-changed.mjs
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Formats only the files you've actually changed (or files passed as args),
+ * never the whole tree.
+ *
+ * Why: this repo's source predates the Prettier config and was never normalized
+ * to it, so `prettier --write .` rewrites hundreds of unrelated files (and used
+ * to fight the committed style). Scoping to changed files keeps `npm run format`
+ * useful for the diff you're working on without that churn. Use `npm run
+ * format:all` if you ever deliberately want to reformat everything.
+ *
+ * Prettier still honors .prettierignore, so ignored paths are skipped even if
+ * they show up as changed.
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+const PRETTIER_EXTENSIONS = new Set([
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'json',
+  'css',
+  'scss',
+  'html',
+  'yaml',
+  'yml',
+]);
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8' })
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function changedFiles() {
+  // Working-tree changes vs HEAD (staged + unstaged), excluding deletions, plus
+  // untracked files that aren't gitignored.
+  const tracked = git(['diff', '--name-only', '--diff-filter=ACMR', 'HEAD']);
+  const untracked = git(['ls-files', '--others', '--exclude-standard']);
+  return [...new Set([...tracked, ...untracked])];
+}
+
+function hasPrettierExtension(file) {
+  const ext = file.split('.').pop()?.toLowerCase();
+  return ext ? PRETTIER_EXTENSIONS.has(ext) : false;
+}
+
+const explicit = process.argv.slice(2);
+const candidates = (explicit.length > 0 ? explicit : changedFiles())
+  .filter(hasPrettierExtension)
+  .filter((file) => existsSync(file));
+
+if (candidates.length === 0) {
+  console.log('format: no changed files to format.');
+  process.exit(0);
+}
+
+console.log(`format: writing ${candidates.length} file(s)…`);
+execFileSync('prettier', ['--write', ...candidates], { stdio: 'inherit' });

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -20,7 +20,14 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
     (slot.broad_category && slot.broad_category.trim()) ||
     (slot.category ? categoryLabel(slot.category) : '') ||
     slot.domain;
-  return category ? [{ label: category }] : [];
+  const badges: Array<{ label: string; tone?: 'muted' | 'warning' }> = category ? [{ label: category }] : [];
+  // Daily Five +2 bonus slots (friend-answered) carry an answerer and are always
+  // "accessible" — surface the accessibility badge so the lighter pick reads as
+  // a deliberate, easier add rather than a generation miss.
+  if (slot.answerer_name && slot.difficulty_estimate === 'accessible') {
+    badges.push({ label: 'Accessible', tone: 'muted' });
+  }
+  return badges;
 }
 
 type QueueResponse = {
@@ -290,6 +297,7 @@ export default function DailyPage() {
           assignmentId: String(slot.slot_index),
           questionText: slot.question_text,
           creatorName: null,
+          answererName: slot.answerer_name ?? null,
           badges: questionBadges(slot),
         });
         if (slot.submitted_answer) {
@@ -335,6 +343,7 @@ export default function DailyPage() {
           assignmentId: String(slot.slot_index),
           questionText: slot.question_text,
           creatorName: null,
+          answererName: slot.answerer_name ?? null,
           isNew: true,
           badges: questionBadges(slot),
         });

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -38,6 +38,11 @@ export type ChatMessage =
       assignmentId: string;
       questionText: string;
       creatorName: string | null;
+      /**
+       * Daily Five +2 bonus slot: the friend who answered this correctly. When
+       * set, the card shows "{name} answered this correctly" attribution.
+       */
+      answererName?: string | null;
       isNew?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -168,6 +173,7 @@ function QuestionRow({
   badges = [],
   questionText,
   creatorName,
+  answererName = null,
   isNew = false,
   onGiveUp,
   giveUpDisabled = false,
@@ -176,6 +182,7 @@ function QuestionRow({
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
   questionText: string;
   creatorName: string | null;
+  answererName?: string | null;
   isNew?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
@@ -226,6 +233,22 @@ function QuestionRow({
           {creatorName.trim().toLowerCase() === 'joshing' ? null : (
             <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>gave you this</span>
           )}
+        </p>
+      ) : null}
+      {answererName ? (
+        <p
+          style={{
+            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+            fontSize: '0.86rem',
+            color: 'var(--text)',
+            paddingLeft: '2px',
+            paddingBottom: '2px',
+            opacity: 0.82,
+            lineHeight: 1.3,
+          }}
+        >
+          <span style={{ fontWeight: 600 }}>{firstNameFrom(answererName)}</span>
+          <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>answered this correctly</span>
         </p>
       ) : null}
       <div
@@ -1120,6 +1143,7 @@ export function GameplayChatThread({
                 key={m.id}
                 questionText={m.questionText}
                 creatorName={m.creatorName}
+                answererName={m.answererName}
                 isNew={m.isNew}
                 subhead={m.subhead}
                 badges={m.badges}

--- a/src/server/daily/__tests__/round-completion.test.ts
+++ b/src/server/daily/__tests__/round-completion.test.ts
@@ -64,3 +64,32 @@ describe('isRoundComplete / hasPendingSlot', () => {
     expect(isRoundComplete([])).toBe(false);
   });
 });
+
+// Daily Five +2: the queue is variable-length (core 5 + 0–2 bonus slots), so
+// completion must track the ACTUAL slot count at 5, 6, and 7 — not a fixed five.
+describe('isRoundComplete — variable 5–7 slot queues (Daily Five +2)', () => {
+  function bonusSlot(slot_index: number, answered: boolean): QueueSlot {
+    return {
+      ...slot(slot_index, { answered }),
+      answerer_id: `answerer-${slot_index}`,
+      answerer_name: 'Robyn',
+      difficulty_estimate: 'accessible',
+    } as QueueSlot;
+  }
+
+  for (const total of [5, 6, 7]) {
+    it(`a ${total}-slot queue is incomplete until the last slot is answered`, () => {
+      const indices = Array.from({ length: total }, (_, i) => i);
+      const partial = indices.map((i) =>
+        i < total - 1
+          ? (i < 5 ? slot(i, { answered: true }) : bonusSlot(i, true))
+          : (i < 5 ? slot(i) : bonusSlot(i, false)),
+      );
+      expect(isRoundComplete(partial)).toBe(false);
+
+      const full = indices.map((i) => (i < 5 ? slot(i, { answered: true }) : bonusSlot(i, true)));
+      expect(isRoundComplete(full)).toBe(true);
+      expect(hasPendingSlot(full)).toBe(false);
+    });
+  }
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -2,15 +2,17 @@ import {
   carryForwardUntouchedDailyQueue,
   clearStaleShortTodayQueue,
   createDailyQueueItem,
+  createDailyQueueItemFromAnswerer,
   createDailyQueueItemFromAuthored,
   getKnowledgeBase,
   getTodaysDailyQueue,
+  pickBonusAnswererSlots,
   pickEligibleAuthoredQuestions,
 } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
-import { getFriendAndFoFUserIds } from '@/server/db/queries/friends';
+import { getFollowing, getFriendAndFoFUserIds } from '@/server/db/queries/friends';
 import { generateDailyQuestionsFromKnowledgeBase } from '@/server/daily/generate-questions';
-import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
@@ -240,12 +242,36 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
 
   let position = 0;
+  const coreQuestionIds = new Set<string>();
   for (const pick of authored) {
     await createDailyQueueItemFromAuthored(userId, pick, position);
+    coreQuestionIds.add(pick.id);
     position += 1;
   }
   for (const question of generatedForQueue.slice(0, DAILY_QUEUE_SIZE - position)) {
     await createDailyQueueItem(userId, question.id, position);
+    position += 1;
+  }
+
+  // Daily Five +2 (D-1 §D). Append up to DAILY_BONUS_SLOT_MAX bonus slots built
+  // from questions that people the viewer follows answered correctly. This is
+  // purely additive: it is NOT counted toward DAILY_QUEUE_SIZE / the achieved
+  // backstop above, never triggers the N<5 generation top-up, and never
+  // backfills a friend slot with LLM/authored content. If 0 qualify we append
+  // nothing (graceful shrink), yielding a 5–7 slot queue. coreQuestionIds keeps
+  // a friend-answered question that already landed as an authored core slot from
+  // also surfacing as a bonus slot.
+  const following = await getFollowing(userId);
+  const followingIds = new Set(following.map((user) => user.id));
+  const bonus = await pickBonusAnswererSlots(
+    userId,
+    followingIds,
+    knowledgeBase,
+    DAILY_BONUS_SLOT_MAX,
+    coreQuestionIds,
+  );
+  for (const pick of bonus) {
+    await createDailyQueueItemFromAnswerer(userId, pick, position);
     position += 1;
   }
 }

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -29,6 +29,16 @@ export const queueSlotSchema = z.object({
   author_name: z.string().nullish(),
   /** Optional creator note — only ever set for friend questions. */
   author_note: z.string().nullish(),
+  /**
+   * Bonus-slot answerer attribution (Daily Five +2). Set only on a +2 bonus slot —
+   * a friend-answered question surfaced because someone the viewer follows answered
+   * it correctly. The presence of these fields is what marks a slot as a bonus slot
+   * (the question itself is still a canonical friend question, so `source` stays
+   * 'friend' and `author_*` still describe the question's author).
+   */
+  answerer_id: z.string().optional(),
+  /** Display name for "X answered this correctly" — null if the answerer has no display_name. */
+  answerer_name: z.string().nullish(),
   domain: z.string(),
   /** Free-text broader topic for this slot (e.g. "Saturday morning cartoons"). Optional — populated for newly built slots. */
   broad_category: z.string().nullish(),
@@ -81,6 +91,15 @@ export const DAILY_SKIP_LIMIT = 5;
 
 export const PERSONAL_DAILY_SESSION_CONTEXT = 'personal_daily';
 export const DAILY_QUEUE_SIZE = 5;
+
+/**
+ * Daily Five +2 — up to this many bonus slots are appended after the core
+ * DAILY_QUEUE_SIZE, sourced from friend-answered questions (see
+ * pickBonusAnswererSlots). Total queue size is therefore 5–7. This is
+ * additive and independent of the orchestrator's N<5 generation backstop:
+ * a bonus shortfall simply appends fewer slots, never backfills.
+ */
+export const DAILY_BONUS_SLOT_MAX = 2;
 
 /** A slot the player can still act on (neither answered nor skipped). */
 export function hasPendingSlot(slots: QueueSlot[]): boolean {

--- a/src/server/db/queries/__tests__/bonus-answerer-picks.test.ts
+++ b/src/server/db/queries/__tests__/bonus-answerer-picks.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  selectBonusAnswererPicks,
+  type BonusAnswererRow,
+  type KnowledgeBaseDomain,
+} from '@/server/db/queries/daily';
+
+// Knowledge base used across cases: one declared domain ("star wars") whose
+// broad category is "film_tv".
+const KB: KnowledgeBaseDomain[] = [
+  {
+    domain: 'Star Wars',
+    broadCategory: 'film_tv',
+    source: 'declared',
+    territoryType: 'declared',
+    totalPoints: 0,
+    tier: 'establishing',
+  },
+];
+
+let rowSeq = 0;
+function row(overrides: Partial<BonusAnswererRow> = {}): BonusAnswererRow {
+  rowSeq += 1;
+  return {
+    questionId: `q${rowSeq}`,
+    answererId: `a${rowSeq}`,
+    sourceEventAt: new Date(2026, 0, rowSeq + 1),
+    creatorId: `c${rowSeq}`,
+    questionText: `question ${rowSeq}`,
+    answerText: 'answer',
+    alternateAnswers: [],
+    factualExplanation: null,
+    canonicalSubcategory: 'Star Wars',
+    broadCategory: 'film_tv',
+    category: 'film_tv',
+    calibratedDifficulty: 'accessible',
+    llmDifficulty: 'accessible',
+    difficultyEstimate: 'accessible',
+    creatorNote: null,
+    ...overrides,
+  };
+}
+
+const NO_EXCLUDE = new Set<string>();
+const opts = (over: Partial<Parameters<typeof selectBonusAnswererPicks>[1]> = {}) => ({
+  knowledgeBase: KB,
+  excludeQuestionIds: NO_EXCLUDE,
+  answeredQuestionIds: NO_EXCLUDE,
+  limit: 2,
+  ...over,
+});
+
+describe('selectBonusAnswererPicks — accessibility filter', () => {
+  it('keeps calibratedDifficulty === accessible', () => {
+    const picks = selectBonusAnswererPicks([row({ calibratedDifficulty: 'accessible' })], opts());
+    expect(picks).toHaveLength(1);
+  });
+
+  it('drops calibratedDifficulty === moderate even if llm is accessible', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ calibratedDifficulty: 'moderate', llmDifficulty: 'accessible' })],
+      opts(),
+    );
+    expect(picks).toHaveLength(0);
+  });
+
+  it('falls back to llmDifficulty === accessible only when calibrated is null', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ calibratedDifficulty: null, llmDifficulty: 'accessible' })],
+      opts(),
+    );
+    expect(picks).toHaveLength(1);
+  });
+
+  it('drops when calibrated is null and llm is not accessible', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ calibratedDifficulty: null, llmDifficulty: 'specialist' })],
+      opts(),
+    );
+    expect(picks).toHaveLength(0);
+  });
+
+  it('always tags surviving picks as accessible difficulty', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ calibratedDifficulty: null, llmDifficulty: 'accessible' })],
+      opts(),
+    );
+    expect(picks[0].difficultyEstimate).toBe('accessible');
+  });
+});
+
+describe('selectBonusAnswererPicks — relevance ranking', () => {
+  it('ranks exact subcategory > broadCategory > any, ignoring recency across tiers', () => {
+    // "any" row is the newest; subcategory match is the oldest. Tier must win.
+    const any = row({
+      questionId: 'any',
+      canonicalSubcategory: 'Cooking',
+      broadCategory: 'food',
+      sourceEventAt: new Date(2026, 5, 1),
+    });
+    const broad = row({
+      questionId: 'broad',
+      canonicalSubcategory: 'Star Trek',
+      broadCategory: 'film_tv',
+      sourceEventAt: new Date(2026, 3, 1),
+    });
+    const exact = row({
+      questionId: 'exact',
+      canonicalSubcategory: 'Star Wars',
+      broadCategory: 'film_tv',
+      sourceEventAt: new Date(2026, 0, 1),
+    });
+    const picks = selectBonusAnswererPicks([any, broad, exact], opts({ limit: 3 }));
+    expect(picks.map((p) => p.id)).toEqual(['exact', 'broad', 'any']);
+  });
+
+  it('within the same tier, newer sourceEventAt ranks first', () => {
+    const older = row({ questionId: 'older', sourceEventAt: new Date(2026, 0, 1) });
+    const newer = row({ questionId: 'newer', sourceEventAt: new Date(2026, 6, 1) });
+    const picks = selectBonusAnswererPicks([older, newer], opts({ limit: 2 }));
+    expect(picks.map((p) => p.id)).toEqual(['newer', 'older']);
+  });
+});
+
+describe('selectBonusAnswererPicks — caps and dedup', () => {
+  it('caps the result at limit (top 2)', () => {
+    const picks = selectBonusAnswererPicks([row(), row(), row()], opts({ limit: 2 }));
+    expect(picks).toHaveLength(2);
+  });
+
+  it('returns nothing when limit <= 0', () => {
+    expect(selectBonusAnswererPicks([row(), row()], opts({ limit: 0 }))).toEqual([]);
+  });
+
+  it('drops questions already in the core slots (excludeQuestionIds)', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ questionId: 'dupe' }), row({ questionId: 'fresh' })],
+      opts({ excludeQuestionIds: new Set(['dupe']) }),
+    );
+    expect(picks.map((p) => p.id)).toEqual(['fresh']);
+  });
+
+  it('drops questions the viewer already answered correctly', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ questionId: 'solved' }), row({ questionId: 'fresh' })],
+      opts({ answeredQuestionIds: new Set(['solved']) }),
+    );
+    expect(picks.map((p) => p.id)).toEqual(['fresh']);
+  });
+
+  it('yields one slot per question, keeping the first (most recent) answerer', () => {
+    // Same questionId from two friends; rows are newest-first per the DB ordering.
+    const recent = row({ questionId: 'shared', answererId: 'robyn', sourceEventAt: new Date(2026, 6, 1) });
+    const older = row({ questionId: 'shared', answererId: 'sam', sourceEventAt: new Date(2026, 0, 1) });
+    const picks = selectBonusAnswererPicks([recent, older], opts());
+    expect(picks).toHaveLength(1);
+    expect(picks[0].answererId).toBe('robyn');
+  });
+
+  it('drops generic subcategories', () => {
+    const picks = selectBonusAnswererPicks(
+      [row({ questionId: 'generic', canonicalSubcategory: 'general' }), row({ questionId: 'real' })],
+      opts(),
+    );
+    expect(picks.map((p) => p.id)).toEqual(['real']);
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -32,6 +32,7 @@ import {
 } from '@/server/play/catch-up-turn-sequencing';
 import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 function asQueueSlotDifficulty(
   value: string | null | undefined,
@@ -901,6 +902,279 @@ export async function createDailyQueueItemFromAuthored(
     category: authored.category || null,
     question_text: authored.questionText,
     difficulty_estimate: authored.difficultyEstimate ?? undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.userId, userId), eq(dailyQueues.queueDate, assignmentDateStr)))
+      .limit(1);
+
+    if (!existing) {
+      const [created] = await tx
+        .insert(dailyQueues)
+        .values({
+          userId,
+          queueDate: assignmentDateStr,
+          slots: [slot],
+        })
+        .returning();
+      return created;
+    }
+
+    const slots = asQueueSlots(existing.slots).filter((item) => item.slot_index !== position);
+    const nextSlots = [...slots, slot].sort((a, b) => a.slot_index - b.slot_index);
+    const [updated] = await tx
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, existing.id))
+      .returning();
+    return updated;
+  });
+}
+
+/**
+ * A friend-answered question selected for a Daily Five +2 bonus slot. Carries
+ * both the question's author (author_*) and the friend who answered it correctly
+ * (answerer_*), which the UI surfaces as "X answered this correctly".
+ */
+export type AnswererPick = AuthoredPick & {
+  answererId: string;
+  answererName: string | null;
+};
+
+/** A friend-answered feed item joined to its canonical question — the raw input to the bonus picker's ranking. */
+export type BonusAnswererRow = {
+  questionId: string | null;
+  answererId: string;
+  sourceEventAt: Date | null;
+  creatorId: string | null;
+  questionText: string;
+  answerText: string;
+  alternateAnswers: string[] | null;
+  factualExplanation: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  calibratedDifficulty: string | null;
+  llmDifficulty: string | null;
+  difficultyEstimate: string | null;
+  creatorNote: string | null;
+};
+
+/**
+ * Pure ranking/filter/dedup for the Daily Five +2 bonus picker, extracted so the
+ * accessibility filter, relevance tiering, and dedup can be unit-tested without a
+ * database. Returns picks with `authorName`/`answererName` left null — the DB
+ * wrapper hydrates display names. `rows` must be ordered newest-first so the
+ * one-slot-per-question dedup keeps the most recent answerer.
+ */
+export function selectBonusAnswererPicks(
+  rows: BonusAnswererRow[],
+  options: {
+    knowledgeBase: KnowledgeBaseDomain[];
+    excludeQuestionIds: ReadonlySet<string>;
+    answeredQuestionIds: ReadonlySet<string>;
+    limit: number;
+  },
+): AnswererPick[] {
+  const { knowledgeBase, excludeQuestionIds, answeredQuestionIds, limit } = options;
+  if (limit <= 0) return [];
+
+  // Relevance tiers: 0 = exact canonicalSubcategory match, 1 = broadCategory
+  // match, 2 = any remaining. Built lowercased from the merged declared +
+  // demonstrated knowledge base.
+  const subcatSet = new Set(knowledgeBase.map((d) => d.domain.toLowerCase()));
+  const broadCatSet = new Set(
+    knowledgeBase
+      .map((d) => d.broadCategory?.toLowerCase())
+      .filter((c): c is string => Boolean(c)),
+  );
+  const tierOf = (canonicalSubcategory: string | null, broadCategory: string | null): number => {
+    if (canonicalSubcategory && subcatSet.has(canonicalSubcategory.toLowerCase())) return 0;
+    if (broadCategory && broadCatSet.has(broadCategory.toLowerCase())) return 1;
+    return 2;
+  };
+
+  const seenQuestionIds = new Set<string>();
+  const candidates: Array<{ pick: AnswererPick; tier: number; sourceEventAt: number }> = [];
+  for (const row of rows) {
+    if (!row.questionId) continue;
+    if (excludeQuestionIds.has(row.questionId)) continue;
+    if (answeredQuestionIds.has(row.questionId)) continue;
+    if (seenQuestionIds.has(row.questionId)) continue; // one slot per question (rows ordered newest-first)
+    const subcategory = row.canonicalSubcategory;
+    if (!subcategory || isGenericSubcategory(subcategory)) continue;
+
+    const isAccessible =
+      row.calibratedDifficulty === 'accessible' ||
+      (row.calibratedDifficulty == null && row.llmDifficulty === 'accessible');
+    if (!isAccessible) continue;
+
+    seenQuestionIds.add(row.questionId);
+    candidates.push({
+      pick: {
+        id: row.questionId,
+        creatorId: row.creatorId,
+        questionText: row.questionText,
+        answerText: row.answerText,
+        alternateAnswers: row.alternateAnswers ?? [],
+        factualExplanation: row.factualExplanation,
+        canonicalSubcategory: subcategory,
+        broadCategory: row.broadCategory,
+        category: String(row.category ?? ''),
+        difficultyEstimate: 'accessible',
+        authorName: null, // hydrated by the DB wrapper alongside the answerer name
+        authorNote: row.creatorNote ?? null,
+        answererId: row.answererId,
+        answererName: null,
+      },
+      tier: tierOf(subcategory, row.broadCategory),
+      sourceEventAt: row.sourceEventAt?.getTime() ?? 0,
+    });
+  }
+
+  return candidates
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+      return b.sourceEventAt - a.sourceEventAt;
+    })
+    .slice(0, limit)
+    .map((c) => c.pick);
+}
+
+/**
+ * Picks up to `limit` Daily Five +2 bonus slots: questions that someone the
+ * viewer follows answered correctly (surfaced via `friend_answered` feed items),
+ * restricted to "accessible" difficulty and ranked by relevance to the viewer's
+ * knowledge base.
+ *
+ * Accessibility (D-1 §D / Q5): a question qualifies iff
+ * `calibratedDifficulty === 'accessible'`, falling back to
+ * `llmDifficulty === 'accessible'` only when calibrated is null.
+ *
+ * Relevance ranking (Q6): exact `canonicalSubcategory` match to a knowledge-base
+ * domain → near `broadCategory` match → any remaining friend-answered question.
+ *
+ * This is a friend-slot picker, never backfilled with LLM/authored content. If
+ * fewer than `limit` qualify, the caller simply appends fewer slots (graceful
+ * shrink) — distinct from the orchestrator's N<5 generation backstop.
+ *
+ * `excludeQuestionIds` drops questions already present in today's core slots; we
+ * additionally drop questions the viewer has already answered correctly.
+ */
+export async function pickBonusAnswererSlots(
+  viewerUserId: string,
+  followingIds: ReadonlySet<string>,
+  knowledgeBase: KnowledgeBaseDomain[],
+  limit: number,
+  excludeQuestionIds: ReadonlySet<string>,
+): Promise<AnswererPick[]> {
+  if (limit <= 0) return [];
+  if (followingIds.size === 0) return [];
+
+  // Questions the viewer has already answered correctly on any surface — the
+  // same signal pickEligibleAuthoredQuestions uses so a bonus slot never
+  // re-serves something the viewer has already solved.
+  const answeredRows = await db
+    .select({ questionId: masteryEvents.questionId })
+    .from(masteryEvents)
+    .where(and(
+      eq(masteryEvents.userId, viewerUserId),
+      inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+      isNotNull(masteryEvents.questionId),
+    ));
+  const answeredQuestionIds = new Set<string>();
+  for (const row of answeredRows) {
+    if (row.questionId) answeredQuestionIds.add(row.questionId);
+  }
+
+  const rows = await db
+    .select({
+      questionId: feedItems.questionId,
+      answererId: feedItems.sourceUserId,
+      sourceEventAt: feedItems.sourceEventAt,
+      creatorId: canonicalQuestions.creatorId,
+      questionText: canonicalQuestions.questionText,
+      answerText: canonicalQuestions.answerText,
+      alternateAnswers: canonicalQuestions.acceptedAlternatives,
+      factualExplanation: canonicalQuestions.factualExplanation,
+      canonicalSubcategory: canonicalQuestions.canonicalSubcategory,
+      broadCategory: canonicalQuestions.broadCategory,
+      category: canonicalQuestions.category,
+      calibratedDifficulty: canonicalQuestions.calibratedDifficulty,
+      llmDifficulty: canonicalQuestions.llmDifficulty,
+      difficultyEstimate: canonicalQuestions.difficultyEstimate,
+      creatorNote: canonicalQuestions.creatorNote,
+    })
+    .from(feedItems)
+    .innerJoin(canonicalQuestions, eq(feedItems.questionId, canonicalQuestions.id))
+    .where(and(
+      eq(feedItems.recipientUserId, viewerUserId),
+      eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+      eq(feedItems.sourceResult, 'correct'),
+      inArray(feedItems.sourceUserId, [...followingIds]),
+      isNull(canonicalQuestions.deletedAt),
+      isNotNull(canonicalQuestions.canonicalSubcategory),
+    ))
+    .orderBy(desc(feedItems.sourceEventAt));
+
+  const top = selectBonusAnswererPicks(rows, {
+    knowledgeBase,
+    excludeQuestionIds,
+    answeredQuestionIds,
+    limit,
+  });
+
+  if (top.length === 0) return [];
+
+  // Hydrate display names for both the question author and the answerer in one shot.
+  const nameIds = new Set<string>();
+  for (const pick of top) {
+    if (pick.creatorId) nameIds.add(pick.creatorId);
+    nameIds.add(pick.answererId);
+  }
+  const nameRows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(inArray(users.id, [...nameIds]));
+  const nameById = new Map(nameRows.map((u) => [u.id, u.displayName] as const));
+
+  return top.map((pick) => ({
+    ...pick,
+    authorName: pick.creatorId ? nameById.get(pick.creatorId) ?? null : null,
+    answererName: nameById.get(pick.answererId) ?? null,
+  }));
+}
+
+/**
+ * Persists a Daily Five +2 bonus slot. Mirrors createDailyQueueItemFromAuthored
+ * but additionally records answerer_id/answerer_name (the bonus-slot marker).
+ */
+export async function createDailyQueueItemFromAnswerer(
+  userId: string,
+  pick: AnswererPick,
+  position: number,
+): Promise<DailyQueueRow> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+
+  const slot: QueueSlot = {
+    slot_index: position,
+    source: 'friend',
+    question_id: pick.id,
+    author_id: pick.creatorId ?? undefined,
+    author_name: pick.authorName,
+    author_note: pick.authorNote,
+    answerer_id: pick.answererId,
+    answerer_name: pick.answererName,
+    domain: pick.canonicalSubcategory,
+    broad_category: pick.broadCategory,
+    category: pick.category || null,
+    question_text: pick.questionText,
+    difficulty_estimate: pick.difficultyEstimate ?? 'accessible',
     answered: false,
     difficulty_stepped_up: false,
   };

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -81,6 +81,18 @@ export async function getFriends(userId: string): Promise<User[]> {
     .orderBy(asc(users.displayName), asc(users.phoneNumber));
 }
 
+/**
+ * Returns the set of users `userId` follows.
+ *
+ * Stage 1 stub (D-1 Daily Five +2): the directional follow model does not land
+ * until Stage 3, so this currently reads the symmetric active-friendship set as
+ * the follow set. Stage 3 repoints only this helper's internals to the `follows`
+ * table; callers must not depend on the relation being bidirectional.
+ */
+export async function getFollowing(userId: string): Promise<User[]> {
+  return getFriends(userId);
+}
+
 export async function getRecentDirectSendRecipients(userId: string, limit = 3): Promise<User[]> {
   if (limit <= 0) return [];
 


### PR DESCRIPTION
Implements the Daily Five +2 feature (D-1 §D), which appends 0–2 bonus slots to the core 5-slot daily queue. These bonus slots surface questions that people the viewer follows answered correctly, ranked by relevance to the viewer's knowledge base and filtered to "accessible" difficulty.

## Key changes

- **New query functions** (`src/server/db/queries/daily.ts`):
  - `selectBonusAnswererPicks()` — pure ranking/filtering/dedup logic for bonus slot selection, extracted for unit testability. Implements accessibility filter (calibrated or LLM difficulty = "accessible"), relevance tiering (exact subcategory match → broad category match → any), and one-slot-per-question dedup.
  - `pickBonusAnswererSlots()` — database wrapper that fetches friend-answered feed items, applies the pure picker, and hydrates display names for both question authors and answerers.
  - `createDailyQueueItemFromAnswerer()` — persists a bonus slot, mirroring `createDailyQueueItemFromAuthored` but additionally recording `answerer_id` and `answerer_name`.

- **Queue orchestrator** (`src/server/daily/queue-orchestrator.ts`):
  - After filling core 5 slots, appends up to `DAILY_BONUS_SLOT_MAX` (2) bonus slots from friend-answered questions.
  - Tracks core question IDs to prevent a question from surfacing as both a core and bonus slot.
  - Bonus slots are purely additive: never counted toward `DAILY_QUEUE_SIZE`, never trigger N<5 generation top-up, never backfill with LLM/authored content. Gracefully shrinks to 5 if no bonus questions qualify.

- **Type & schema updates**:
  - `QueueSlot` schema (`src/server/daily/types.ts`) now includes optional `answerer_id` and `answerer_name` fields to mark bonus slots.
  - New constant `DAILY_BONUS_SLOT_MAX = 2`.
  - New type `AnswererPick` extends `AuthoredPick` with answerer attribution.

- **UI updates** (`src/components/play/GameplayChat.tsx`, `src/app/daily/page.tsx`):
  - Question cards now display "{name} answered this correctly" attribution when `answererName` is set.
  - Bonus slots automatically badge as "Accessible" to surface the deliberate easier pick.

- **Test coverage** (`src/server/db/queries/__tests__/bonus-answerer-picks.test.ts`):
  - Comprehensive unit tests for `selectBonusAnswererPicks` covering accessibility filtering, relevance ranking, dedup, and edge cases.

- **Round completion logic** (`src/server/daily/__tests__/round-completion.test.ts`):
  - Updated to handle variable-length 5–7 slot queues; completion now tracks the actual slot count rather than assuming a fixed five.

- **Tooling**:
  - Added `scripts/format-changed.mjs` to format only changed files (avoiding tree-wide rewrites of pre-Prettier code).
  - Updated `.prettierrc` (semi: true, printWidth: 100, trailingComma: all) and added `.prettierignore`.

- **Helper** (`src/server/db/queries/friends.ts`):
  - New `getFollowing()` function (Stage 1 stub reading symmetric friendships; will repoint to directional `follows` table in Stage 3).

## Implementation notes

- Accessibility is strict: `calibratedDifficulty === 'accessible'` always wins; only when calibrated is null do we fall back to `llmDifficulty === 'accessible'`.
- Relevance ranking is tier-based (exact subcategory > broad category > any), with recency (sourceEventAt) as tiebreaker within tier.
- The pure picker (`selectBonusAnswererPicks`) is stateless and testable; the DB wrapper handles feed item fetching and name hydration.
- Bonus slots carry both author and answerer attribution; the presence of `

https://claude.ai/code/session_0182uPdUtK5pod176N8XtiqE