### PR TITLE
D-1 Stage 2: "Recently exploring" presence on friend profiles

### DIFF
--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -447,4 +447,190 @@ describe('/users/[id] friend profile page', () => {
     )
     expect(html).not.toContain('Previewing your profile')
   })
+
+  describe('Recently exploring section', () => {
+    const daysAgo = (days: number) =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString()
+
+    // Domain names also appear in the knowledge map / mind statement, so scope
+    // assertions to just the "Recently exploring" section markup.
+    const recentlyExploringMarkup = (html: string): string => {
+      const start = html.indexOf('aria-label="Recently exploring"')
+      if (start === -1) return ''
+      const end = html.indexOf('<section', start + 1)
+      return end === -1 ? html.slice(start) : html.slice(start, end)
+    }
+
+    const makeDomain = (
+      overrides: Partial<{
+        domain: string
+        displayName: string
+        lastActivityAt: string | null
+        isHidden: boolean
+      }>,
+    ) => ({
+      domain: 'french-cinema',
+      displayName: 'French Cinema',
+      points: 10,
+      tier: 'familiar',
+      tierProgress: 0.5,
+      questionsAnswered: 4,
+      questionsCorrect: 3,
+      correctRate: 0.75,
+      lastActivityAt: daysAgo(2),
+      broadCategory: 'Film',
+      iconKey: 'film',
+      isDeclared: false,
+      isDeclaredInterest: false,
+      isDemonstrated: true,
+      territoryType: 'demonstrated' as const,
+      isHidden: false,
+      ...overrides,
+    })
+
+    it('renders recent, visible domains ordered most-recent-first', async () => {
+      getKnowledgePageDataMock.mockResolvedValueOnce({
+        allDomains: [
+          makeDomain({
+            domain: 'norse-myth',
+            displayName: 'Norse Mythology',
+            lastActivityAt: daysAgo(5),
+          }),
+          makeDomain({
+            domain: 'french-cinema',
+            displayName: 'French Cinema',
+            lastActivityAt: daysAgo(1),
+          }),
+        ],
+        declaredInterests: [],
+        expandingDomains: [],
+      })
+
+      const element = await UserProfilePage({
+        params: Promise.resolve({ id: 'friend-1' }),
+        searchParams: Promise.resolve({}),
+      })
+      const html = renderToStaticMarkup(element)
+
+      const section = recentlyExploringMarkup(html)
+      expect(section).toContain('French Cinema')
+      expect(section).toContain('Norse Mythology')
+      // Most recent (French Cinema, 1d) appears before Norse Mythology (5d).
+      expect(section.indexOf('French Cinema')).toBeLessThan(
+        section.indexOf('Norse Mythology'),
+      )
+    })
+
+    it('excludes hidden and out-of-window domains', async () => {
+      getKnowledgePageDataMock.mockResolvedValueOnce({
+        allDomains: [
+          makeDomain({
+            domain: 'visible-recent',
+            displayName: 'Visible Recent',
+            lastActivityAt: daysAgo(3),
+          }),
+          makeDomain({
+            domain: 'hidden-domain',
+            displayName: 'Hidden Domain',
+            lastActivityAt: daysAgo(1),
+            isHidden: true,
+          }),
+          makeDomain({
+            domain: 'stale-domain',
+            displayName: 'Stale Domain',
+            lastActivityAt: daysAgo(90),
+          }),
+        ],
+        declaredInterests: [],
+        expandingDomains: [],
+      })
+
+      const element = await UserProfilePage({
+        params: Promise.resolve({ id: 'friend-1' }),
+        searchParams: Promise.resolve({}),
+      })
+      const html = renderToStaticMarkup(element)
+
+      const section = recentlyExploringMarkup(html)
+      expect(section).toContain('Visible Recent')
+      expect(section).not.toContain('Hidden Domain')
+      expect(section).not.toContain('Stale Domain')
+    })
+
+    it('omits the section when there is no recent activity', async () => {
+      getKnowledgePageDataMock.mockResolvedValueOnce({
+        allDomains: [
+          makeDomain({
+            domain: 'stale-domain',
+            displayName: 'Stale Domain',
+            lastActivityAt: daysAgo(120),
+          }),
+          makeDomain({
+            domain: 'declared-no-activity',
+            displayName: 'Declared No Activity',
+            lastActivityAt: null,
+          }),
+        ],
+        declaredInterests: [],
+        expandingDomains: [],
+      })
+
+      const element = await UserProfilePage({
+        params: Promise.resolve({ id: 'friend-1' }),
+        searchParams: Promise.resolve({}),
+      })
+      const html = renderToStaticMarkup(element)
+
+      expect(html).not.toContain('Recently exploring')
+    })
+
+    it('omits the section when the knowledge_base gate is off', async () => {
+      getFriendPortraitDataMock.mockResolvedValueOnce({
+        user: {
+          id: 'friend-1',
+          displayName: 'Frances Friend',
+          handle: null,
+          memberSince: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        visibility: 'friend',
+        friendship: {
+          id: 'friendship-1',
+          formedAt: new Date('2026-02-01T00:00:00.000Z'),
+        },
+        interests: [],
+        sharedInterests: [],
+        viewerSoloInterests: [],
+        friendSoloInterests: [],
+        mutualFriends: [],
+        mutualFriendsOverflow: 0,
+        isOwnerView: false,
+        sectionSettings: null,
+        sectionVisibleTo: {
+          knowledge_base: false,
+          friends_list: true,
+          authored_questions: true,
+        },
+        previewedAs: null,
+      })
+      getKnowledgePageDataMock.mockResolvedValueOnce({
+        allDomains: [
+          makeDomain({
+            domain: 'french-cinema',
+            displayName: 'French Cinema',
+            lastActivityAt: daysAgo(1),
+          }),
+        ],
+        declaredInterests: [],
+        expandingDomains: [],
+      })
+
+      const element = await UserProfilePage({
+        params: Promise.resolve({ id: 'friend-1' }),
+        searchParams: Promise.resolve({}),
+      })
+      const html = renderToStaticMarkup(element)
+
+      expect(html).not.toContain('Recently exploring')
+    })
+  })
 })

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -16,6 +16,7 @@ import { InlineHandleField } from '@/components/profile/InlineHandleField'
 import { MutualFriendsSection } from '@/components/profile/MutualFriendsSection'
 import { PreviewBanner } from '@/components/profile/PreviewBanner'
 import { ProfileFriendButton } from '@/components/profile/ProfileFriendButton'
+import { RecentlyExploringSection } from '@/components/profile/RecentlyExploringSection'
 import { SectionVisibilityToggle } from '@/components/profile/SectionVisibilityToggle'
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow'
 import { SharedInterestsOverlap } from '@/components/profile/SharedInterestsOverlap'
@@ -41,6 +42,7 @@ import {
   topPointPositiveDomains,
 } from '@/server/profile/knowledge-view'
 import { resolvePreviewAs } from '@/server/profile/preview'
+import { selectRecentlyExploring } from '@/server/profile/recently-exploring'
 import {
   buildInviteUrl,
   getBaseUrl,
@@ -167,6 +169,11 @@ export default async function UserProfilePage({
   const totalPointPositiveDomains = sortedDomains.filter(
     (domain) => domain.points > 0,
   ).length
+  // Activity-based presence: which domains the user has been answering in
+  // lately (recent masteryEvents), distinct from the points-sorted knowledge
+  // map above and from declared interests. Per-domain hidden domains are
+  // already filtered out by `isHidden`.
+  const recentlyExploring = selectRecentlyExploring(pageData.allDomains)
   const mindStatement = buildMindStatement(portrait.user.displayName, topDomains)
   const tierSignature = `${new Intl.NumberFormat().format(
     Math.round(mastery.totalPoints),
@@ -424,6 +431,14 @@ export default async function UserProfilePage({
               : `View ${friendFirstName}’s full knowledge base →`}
           </Link>
         </section>
+      ) : null}
+
+      {portrait.sectionVisibleTo.knowledge_base &&
+      recentlyExploring.length > 0 ? (
+        <RecentlyExploringSection
+          domains={recentlyExploring}
+          friendFirstName={friendFirstName}
+        />
       ) : null}
 
       {portrait.sectionVisibleTo.authored_questions ? (

--- a/src/components/profile/RecentlyExploringSection.tsx
+++ b/src/components/profile/RecentlyExploringSection.tsx
@@ -1,0 +1,47 @@
+import { formatRelativeTime } from '@/components/feed/visual'
+import type { RecentlyExploringDomain } from '@/server/profile/recently-exploring'
+
+type RecentlyExploringSectionProps = {
+  domains: RecentlyExploringDomain[]
+  friendFirstName: string
+}
+
+/**
+ * "Recently exploring" presence section on a friend's profile. Shows which
+ * domains the friend has been answering in lately, derived from `masteryEvents`
+ * recency. Distinct from the historical knowledge map (sorted by points) and
+ * from declared shared interests. Renders nothing when there is no recent
+ * activity (the page also guards on a non-empty list).
+ */
+export function RecentlyExploringSection({
+  domains,
+  friendFirstName,
+}: RecentlyExploringSectionProps) {
+  if (domains.length === 0) return null
+
+  return (
+    <section className="mt-5" aria-label="Recently exploring">
+      <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+        Recently exploring
+      </p>
+      <p className="text-muted-foreground mt-2 text-sm leading-6">
+        What {friendFirstName}’s been answering lately.
+      </p>
+      <ul className="mt-3 flex flex-col gap-2">
+        {domains.map((domain) => (
+          <li
+            key={domain.domain}
+            className="flex items-baseline justify-between gap-3"
+          >
+            <span className="text-foreground text-sm font-medium">
+              {domain.displayName}
+            </span>
+            <span className="text-muted-foreground shrink-0 text-xs">
+              {formatRelativeTime(domain.lastActivityAt)}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}

--- a/src/server/profile/__tests__/recently-exploring.test.ts
+++ b/src/server/profile/__tests__/recently-exploring.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest'
+
+import type { DomainMastery } from '@/server/db/queries/knowledge'
+import { selectRecentlyExploring } from '@/server/profile/recently-exploring'
+
+const NOW = new Date('2026-06-01T00:00:00.000Z').getTime()
+
+const daysAgo = (days: number) =>
+  new Date(NOW - days * 24 * 60 * 60 * 1000).toISOString()
+
+function makeDomain(overrides: Partial<DomainMastery> = {}): DomainMastery {
+  return {
+    domain: 'french-cinema',
+    displayName: 'French Cinema',
+    points: 10,
+    tier: 'familiar',
+    tierProgress: 0.5,
+    questionsAnswered: 4,
+    questionsCorrect: 3,
+    correctRate: 0.75,
+    lastActivityAt: daysAgo(2),
+    broadCategory: 'Film',
+    iconKey: 'film',
+    isDeclared: false,
+    isDeclaredInterest: false,
+    isDemonstrated: true,
+    territoryType: 'demonstrated',
+    isHidden: false,
+    ...overrides,
+  }
+}
+
+describe('selectRecentlyExploring', () => {
+  it('sorts domains most-recent-first', () => {
+    const result = selectRecentlyExploring(
+      [
+        makeDomain({ domain: 'a', displayName: 'A', lastActivityAt: daysAgo(5) }),
+        makeDomain({ domain: 'b', displayName: 'B', lastActivityAt: daysAgo(1) }),
+        makeDomain({ domain: 'c', displayName: 'C', lastActivityAt: daysAgo(3) }),
+      ],
+      { now: NOW },
+    )
+
+    expect(result.map((d) => d.domain)).toEqual(['b', 'c', 'a'])
+  })
+
+  it('excludes hidden domains', () => {
+    const result = selectRecentlyExploring(
+      [
+        makeDomain({ domain: 'visible', displayName: 'Visible' }),
+        makeDomain({ domain: 'hidden', displayName: 'Hidden', isHidden: true }),
+      ],
+      { now: NOW },
+    )
+
+    expect(result.map((d) => d.domain)).toEqual(['visible'])
+  })
+
+  it('excludes domains with no activity or activity outside the window', () => {
+    const result = selectRecentlyExploring(
+      [
+        makeDomain({ domain: 'recent', displayName: 'Recent', lastActivityAt: daysAgo(2) }),
+        makeDomain({ domain: 'stale', displayName: 'Stale', lastActivityAt: daysAgo(45) }),
+        makeDomain({ domain: 'none', displayName: 'None', lastActivityAt: null }),
+      ],
+      { now: NOW },
+    )
+
+    expect(result.map((d) => d.domain)).toEqual(['recent'])
+  })
+
+  it('respects a custom window', () => {
+    const result = selectRecentlyExploring(
+      [
+        makeDomain({ domain: 'd5', displayName: 'D5', lastActivityAt: daysAgo(5) }),
+        makeDomain({ domain: 'd2', displayName: 'D2', lastActivityAt: daysAgo(2) }),
+      ],
+      { now: NOW, windowDays: 3 },
+    )
+
+    expect(result.map((d) => d.domain)).toEqual(['d2'])
+  })
+
+  it('caps the list at the limit', () => {
+    const domains = Array.from({ length: 8 }, (_, i) =>
+      makeDomain({
+        domain: `d${i}`,
+        displayName: `D${i}`,
+        lastActivityAt: daysAgo(i + 1),
+      }),
+    )
+
+    const result = selectRecentlyExploring(domains, { now: NOW })
+    expect(result).toHaveLength(5)
+    expect(result.map((d) => d.domain)).toEqual(['d0', 'd1', 'd2', 'd3', 'd4'])
+  })
+
+  it('ignores unparseable timestamps', () => {
+    const result = selectRecentlyExploring(
+      [
+        makeDomain({ domain: 'bad', displayName: 'Bad', lastActivityAt: 'not-a-date' }),
+        makeDomain({ domain: 'good', displayName: 'Good', lastActivityAt: daysAgo(1) }),
+      ],
+      { now: NOW },
+    )
+
+    expect(result.map((d) => d.domain)).toEqual(['good'])
+  })
+
+  it('returns the display shape', () => {
+    const result = selectRecentlyExploring(
+      [makeDomain({ domain: 'french-cinema', displayName: 'French Cinema', lastActivityAt: daysAgo(1) })],
+      { now: NOW },
+    )
+
+    expect(result[0]).toEqual({
+      domain: 'french-cinema',
+      displayName: 'French Cinema',
+      lastActivityAt: daysAgo(1),
+    })
+  })
+})

--- a/src/server/profile/recently-exploring.ts
+++ b/src/server/profile/recently-exploring.ts
@@ -1,0 +1,61 @@
+import type { DomainMastery } from '@/server/db/queries/knowledge'
+
+/**
+ * A single domain surfaced in the "Recently exploring" presence section on a
+ * friend's profile. Activity-based (recent `masteryEvents`), distinct from the
+ * historical knowledge map and from declared interests.
+ */
+export type RecentlyExploringDomain = {
+  displayName: string
+  domain: string
+  lastActivityAt: string
+}
+
+const DEFAULT_WINDOW_DAYS = 30
+const DEFAULT_LIMIT = 5
+
+type SelectOptions = {
+  now?: number
+  windowDays?: number
+  limit?: number
+}
+
+/**
+ * Derive the "Recently exploring" list from the domains the profile page
+ * already loads via `getKnowledgePageData`. Pure transform — no DB access.
+ *
+ * Each `DomainMastery.lastActivityAt` is the max `masteryEvents.createdAt` for
+ * that domain (the same recency signal `getFriendsHub` uses for `lastActiveAt`,
+ * surfaced as *which* domains, recently). We keep only domains the viewer is
+ * allowed to see (`!isHidden`) that have activity inside the recency window,
+ * sort most-recent-first, and cap the list.
+ */
+export function selectRecentlyExploring(
+  allDomains: DomainMastery[],
+  opts: SelectOptions = {},
+): RecentlyExploringDomain[] {
+  const now = opts.now ?? Date.now()
+  const windowDays = opts.windowDays ?? DEFAULT_WINDOW_DAYS
+  const limit = opts.limit ?? DEFAULT_LIMIT
+  const cutoff = now - windowDays * 24 * 60 * 60 * 1000
+
+  return allDomains
+    .filter((domain): domain is DomainMastery & { lastActivityAt: string } => {
+      if (domain.isHidden) return false
+      if (!domain.lastActivityAt) return false
+      const activityAt = new Date(domain.lastActivityAt).getTime()
+      if (Number.isNaN(activityAt)) return false
+      return activityAt >= cutoff
+    })
+    .sort(
+      (a, b) =>
+        new Date(b.lastActivityAt).getTime() -
+        new Date(a.lastActivityAt).getTime(),
+    )
+    .slice(0, limit)
+    .map((domain) => ({
+      displayName: domain.displayName,
+      domain: domain.domain,
+      lastActivityAt: domain.lastActivityAt,
+    }))
+}


### PR DESCRIPTION
Adds the awareness destination for the type-3 signal: a "Recently
exploring" section on /users/[id], below the knowledge map, showing which
domains a friend has been answering in lately.

Derived purely from data the profile page already loads — each
DomainMastery row from getKnowledgePageData carries lastActivityAt (max
masteryEvents.createdAt per domain, the same recency getFriendsHub uses for
lastActiveAt) and isHidden. selectRecentlyExploring filters to visible,
in-window domains, sorts most-recent-first, and caps the list. No new DB
query, no migration.

Distinct from the points-sorted knowledge map and from declared
sharedInterests/SharedInterestsOverlap (untouched). No demonstrated-overlap
computation (Q9); not on Lately (Q8). Gated by the existing knowledge_base
section visibility, so it inherits the owner's privacy choice with no new
toggle.

Tests: unit coverage for selectRecentlyExploring (window, sort, limit,
isHidden) and profile-page rendering (order, hidden/stale exclusion, empty
state, gate-off).