### PR TITLE
Implement directional follow model (D-1 Stage 3)

### DIFF
--- a/drizzle/0058_follow_model.sql
+++ b/drizzle/0058_follow_model.sql
@@ -1,0 +1,65 @@
+-- Migration: D-1 Stage 3 — directional follow model.
+--
+-- Replaces the symmetric Friendship primitive with directional Follow edges.
+-- Two approved edges == a mutual ("friend") relationship; one edge == a
+-- one-directional follow. A follow targeting an approval_required user lands
+-- `pending` (a request the followee approves); a follow targeting a public user
+-- lands `approved`. Invitations create approved edges in both directions.
+--
+-- Friendship is FROZEN (no new writes) but left in place for rollback. The
+-- matching idempotent boot guard lives in src/instrumentation.ts. Backfills are
+-- ON CONFLICT DO NOTHING so they are safe to re-run and safe to race the boot
+-- guard.
+DO $$ BEGIN
+  CREATE TYPE "public"."FollowState" AS ENUM('pending', 'approved');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."FollowPrivacy" AS ENUM('public', 'approval_required');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "follow_privacy" "public"."FollowPrivacy" NOT NULL DEFAULT 'approval_required';
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "Follow" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "followerId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "followeeId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "state" "public"."FollowState" NOT NULL DEFAULT 'pending',
+  "personalNote" text,
+  "requestContext" jsonb,
+  "created_at" timestamptz NOT NULL DEFAULT now(),
+  "approvedAt" timestamptz,
+  CONSTRAINT "Follow_followerId_followeeId_key" UNIQUE ("followerId", "followeeId"),
+  CONSTRAINT "Follow_distinct_users" CHECK ("followerId" <> "followeeId")
+);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Follow_followerId_state_idx" ON "Follow" ("followerId", "state");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Follow_followeeId_state_idx" ON "Follow" ("followeeId", "state");
+--> statement-breakpoint
+-- Backfill: each active friendship (A,B) -> two approved edges.
+INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
+SELECT gen_random_uuid()::text, "userAId", "userBId", 'approved'::"public"."FollowState",
+       COALESCE("formedAt", now()), "createdAt"
+FROM "Friendship" WHERE "status" = 'active'
+ON CONFLICT ("followerId", "followeeId") DO NOTHING;
+--> statement-breakpoint
+INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
+SELECT gen_random_uuid()::text, "userBId", "userAId", 'approved'::"public"."FollowState",
+       COALESCE("formedAt", now()), "createdAt"
+FROM "Friendship" WHERE "status" = 'active'
+ON CONFLICT ("followerId", "followeeId") DO NOTHING;
+--> statement-breakpoint
+-- Backfill: each pending request -> one pending edge requester -> other,
+-- carrying the personal note and suggested-interest context.
+INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "personalNote", "requestContext", "created_at")
+SELECT gen_random_uuid()::text,
+       "requestedByUserId",
+       CASE WHEN "requestedByUserId" = "userAId" THEN "userBId" ELSE "userAId" END,
+       'pending'::"public"."FollowState",
+       "personalNote", "requestContext", "createdAt"
+FROM "Friendship" WHERE "status" = 'pending'
+ON CONFLICT ("followerId", "followeeId") DO NOTHING;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -407,6 +407,13 @@
       "when": 1781481600000,
       "tag": "0057_retire_creator_notes_and_quips",
       "breakpoints": true
+    },
+    {
+      "idx": 58,
+      "version": "7",
+      "when": 1781568000000,
+      "tag": "0058_follow_model",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -95,6 +95,30 @@ function ActivityCopy({ item }: { item: ActivityItemView }) {
     );
   }
 
+  if (item.type === 'follow_request') {
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> wants to follow you.
+      </>
+    );
+  }
+
+  if (item.type === 'follow') {
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> started following you.
+      </>
+    );
+  }
+
+  if (item.type === 'follow_approved') {
+    return (
+      <>
+        <UnderlineName>{actorName(item)}</UnderlineName> accepted your follow.
+      </>
+    );
+  }
+
   if (item.type === 'invited_friend_played_first_five') {
     return (
       <>
@@ -208,7 +232,7 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
     );
   }
 
-  if (item.type === 'friend_request') {
+  if (item.type === 'friend_request' || item.type === 'follow_request') {
     const interests = item.reference.friendshipRequest?.suggestedInterests ?? [];
     if (interests.length === 0) return null;
 
@@ -347,7 +371,7 @@ function activityAction(item: ActivityItemView): ReactNode | null {
     return <UtilityActionLink href="/" label="Answer" />;
   }
 
-  if (item.type === 'friend_request') {
+  if (item.type === 'friend_request' || item.type === 'follow_request') {
     const request = item.reference.friendshipRequest;
     if (
       !request ||
@@ -374,6 +398,7 @@ const INCOMING_TYPES = new Set([
   'received_direct_question',
   'received_joshing_game',
   'friend_request',
+  'follow_request',
 ]);
 
 function activityCaption(item: ActivityItemView): string {
@@ -390,7 +415,7 @@ function activityToFeedItem(item: ActivityItemView): LatelyFeedItem {
       : null;
 
   const anchorId =
-    item.type === 'friend_request' && item.referenceId
+    (item.type === 'friend_request' || item.type === 'follow_request') && item.referenceId
       ? `friendship-${item.referenceId}`
       : null;
 

--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -72,6 +72,11 @@ vi.mock('@/server/db', () => ({
     userAId: 'friendships.userAId',
     userBId: 'friendships.userBId',
   },
+  follows: {
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
+    state: 'follows.state',
+  },
   masteryEvents: {
     id: 'masteryEvents.id',
     userId: 'masteryEvents.userId',

--- a/src/app/api/feed/debug/route.ts
+++ b/src/app/api/feed/debug/route.ts
@@ -1,8 +1,9 @@
-import { and, desc, eq, isNull, or } from 'drizzle-orm';
+import { and, desc, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { db, feedDismissedDomains, feedItems, friendships, questions } from '@/server/db';
+import { db, feedDismissedDomains, feedItems, questions } from '@/server/db';
+import { areFriends } from '@/server/db/queries/friends';
 import { isMainFeedSourceVisible } from '@/server/feed/visibility';
 
 export const dynamic = 'force-dynamic';
@@ -71,18 +72,10 @@ export async function GET(request: NextRequest) {
   ]);
 
   const questionCreatorId = question?.creatorId ?? null;
-  const [friendship, dismissedDomain] = await Promise.all([
+  const [isMutual, dismissedDomain] = await Promise.all([
     questionCreatorId && questionCreatorId !== session.userId
-      ? db
-        .select({ status: friendships.status })
-        .from(friendships)
-        .where(or(
-          and(eq(friendships.userAId, session.userId), eq(friendships.userBId, questionCreatorId)),
-          and(eq(friendships.userAId, questionCreatorId), eq(friendships.userBId, session.userId)),
-        ))
-        .limit(1)
-        .then((rows) => rows[0] ?? null)
-      : Promise.resolve(null),
+      ? areFriends(session.userId, questionCreatorId)
+      : Promise.resolve(false),
     question?.canonicalSubcategory
       ? db
         .select({ id: feedDismissedDomains.id })
@@ -97,7 +90,7 @@ export async function GET(request: NextRequest) {
       : Promise.resolve(null),
   ]);
 
-  const friendshipStatus = friendship?.status ?? null;
+  const friendshipStatus = isMutual ? 'active' : null;
   const domainDismissed = Boolean(dismissedDomain);
 
   return NextResponse.json({

--- a/src/app/api/feed/friend-coverage/route.ts
+++ b/src/app/api/feed/friend-coverage/route.ts
@@ -6,7 +6,7 @@ import {
   db,
   feedDismissedDomains,
   feedItems,
-  friendships,
+  follows,
   masteryEvents,
   questionFeedback,
   questionRatings,
@@ -111,26 +111,43 @@ export async function loadFriendCoverage(
   friendQuery: string | null,
   limit: number,
 ): Promise<FriendCoverageResponse> {
-  const allFriendships = await db
+  // Follow model (D-1 Stage 3): a "friend" is a mutual follow. Build the
+  // per-other map from approved/pending follow edges in both directions.
+  const followEdges = await db
     .select({
-      friendshipId: friendships.id,
-      status: friendships.status,
-      userAId: friendships.userAId,
-      userBId: friendships.userBId,
+      id: follows.id,
+      followerId: follows.followerId,
+      followeeId: follows.followeeId,
+      state: follows.state,
     })
-    .from(friendships)
+    .from(follows)
     .where(or(
-      eq(friendships.userAId, viewerUserId),
-      eq(friendships.userBId, viewerUserId),
+      eq(follows.followerId, viewerUserId),
+      eq(follows.followeeId, viewerUserId),
     ));
 
-  const friendshipByOtherUserId = new Map<string, { friendshipId: string; status: string }>();
-  for (const row of allFriendships) {
-    const otherId = row.userAId === viewerUserId ? row.userBId : row.userAId;
-    friendshipByOtherUserId.set(otherId, { friendshipId: row.friendshipId, status: row.status });
+  const outboundByOther = new Map<string, { id: string; state: string }>();
+  const inboundStateByOther = new Map<string, string>();
+  for (const edge of followEdges) {
+    if (edge.followerId === viewerUserId) {
+      outboundByOther.set(edge.followeeId, { id: edge.id, state: edge.state });
+    } else {
+      inboundStateByOther.set(edge.followerId, edge.state);
+    }
   }
 
-  const activeFriendCount = allFriendships.filter((row) => row.status === 'active').length;
+  const otherIdsSet = new Set<string>([...outboundByOther.keys(), ...inboundStateByOther.keys()]);
+  const friendshipByOtherUserId = new Map<string, { friendshipId: string | null; status: string }>();
+  for (const otherId of otherIdsSet) {
+    const outbound = outboundByOther.get(otherId);
+    const mutual = outbound?.state === 'approved' && inboundStateByOther.get(otherId) === 'approved';
+    friendshipByOtherUserId.set(otherId, {
+      friendshipId: outbound?.id ?? null,
+      status: mutual ? 'active' : 'pending',
+    });
+  }
+
+  const activeFriendCount = [...friendshipByOtherUserId.values()].filter((f) => f.status === 'active').length;
 
   const viewerActiveFeedItemCount = await db
     .select({ value: sql<number>`COUNT(*)::int`.as('value') })
@@ -143,7 +160,7 @@ export async function loadFriendCoverage(
     .then((rows) => rows[0]?.value ?? 0);
 
   const summary = {
-    totalFriendshipsForViewer: allFriendships.length,
+    totalFriendshipsForViewer: otherIdsSet.size,
     activeFriendCount,
     viewerActiveFeedItemCount,
     rolloffCap: ROLLOFF_CAP,

--- a/src/app/api/friend-invitations/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/__tests__/route.test.ts
@@ -10,8 +10,11 @@ const {
 } = vi.hoisted(() => {
   const state = {
     existingUser: null as { id: string } | null,
+    // A pre-existing follow edge inviter -> invitee (shape: { id, state }).
     existingFriendship: null as Record<string, unknown> | null,
-    insertedFriendship: { id: 'friendship-1', status: 'pending' } as Record<
+    // The invitee's follow-privacy gate, returned by the followPrivacy lookup.
+    targetFollowPrivacy: 'approval_required' as 'public' | 'approval_required',
+    insertedFriendship: { id: 'friendship-1', state: 'pending' } as Record<
       string,
       unknown
     >,
@@ -23,6 +26,9 @@ const {
       from: vi.fn(() => ({
         where: vi.fn(() => ({
           limit: vi.fn(async () => {
+            if (selection && 'followPrivacy' in selection) {
+              return [{ followPrivacy: state.targetFollowPrivacy }]
+            }
             if (selection && Object.values(selection).includes('users.id')) {
               return state.existingUser ? [state.existingUser] : []
             }
@@ -83,16 +89,16 @@ vi.mock('@/server/db', () => ({
   db: dbMock,
   activityItems: { id: 'activityItems.id' },
   friendInvitations: { id: 'friendInvitations.id' },
-  friendships: {
-    id: 'friendships.id',
-    userAId: 'friendships.userAId',
-    userBId: 'friendships.userBId',
-    status: 'friendships.status',
-    requestedByUserId: 'friendships.requestedByUserId',
+  follows: {
+    id: 'follows.id',
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
+    state: 'follows.state',
   },
   users: {
     id: 'users.id',
     phoneNumber: 'users.phoneNumber',
+    followPrivacy: 'users.followPrivacy',
   },
 }))
 
@@ -143,7 +149,8 @@ describe('POST /api/friend-invitations', () => {
     getSessionMock.mockResolvedValue({ userId: 'user-inviter' })
     state.existingUser = null
     state.existingFriendship = null
-    state.insertedFriendship = { id: 'friendship-1', status: 'pending' }
+    state.targetFollowPrivacy = 'approval_required'
+    state.insertedFriendship = { id: 'friendship-1', state: 'pending' }
     state.updateValues = undefined
     process.env.NEXT_PUBLIC_APP_URL = 'https://joshing.example'
   })
@@ -351,12 +358,11 @@ describe('POST /api/friend-invitations', () => {
     )
   })
 
-  it('returns already-friends state without creating a duplicate friendship request', async () => {
+  it('returns already-following state without creating a duplicate follow', async () => {
     state.existingUser = { id: 'user-invitee' }
     state.existingFriendship = {
       id: 'friendship-active',
-      status: 'active',
-      requestedByUserId: 'user-inviter',
+      state: 'approved',
     }
 
     const response = await POST(
@@ -367,12 +373,12 @@ describe('POST /api/friend-invitations', () => {
     expect(response.status).toBe(200)
     expect(createFriendInvitationMock).not.toHaveBeenCalled()
     expect(dbMock.insert).not.toHaveBeenCalled()
-    expect(body.state).toBe('already_friends')
+    expect(body.state).toBe('already_following')
     expect(body.friendshipRequest).toEqual(
       expect.objectContaining({
         id: 'friendship-active',
-        status: 'active',
-        state: 'already_friends',
+        status: 'approved',
+        state: 'already_following',
       })
     )
   })
@@ -381,8 +387,7 @@ describe('POST /api/friend-invitations', () => {
     state.existingUser = { id: 'user-invitee' }
     state.existingFriendship = {
       id: 'friendship-pending',
-      status: 'pending',
-      requestedByUserId: 'user-inviter',
+      state: 'pending',
     }
 
     const response = await POST(
@@ -395,13 +400,11 @@ describe('POST /api/friend-invitations', () => {
     expect(body.state).toBe('pending_existing')
   })
 
-  it('handles reverse pending requests without creating a duplicate friendship request', async () => {
+  it('auto-approves the follow when the invitee is a public account', async () => {
     state.existingUser = { id: 'user-invitee' }
-    state.existingFriendship = {
-      id: 'friendship-reverse',
-      status: 'pending',
-      requestedByUserId: 'user-invitee',
-    }
+    state.existingFriendship = null
+    state.targetFollowPrivacy = 'public'
+    state.insertedFriendship = { id: 'friendship-1', state: 'approved' }
 
     const response = await POST(
       jsonRequest({ inviteeDisplayName: 'Sara', phone: '7345551234' })
@@ -409,8 +412,11 @@ describe('POST /api/friend-invitations', () => {
     const body = await response.json()
 
     expect(response.status).toBe(200)
-    expect(dbMock.insert).not.toHaveBeenCalled()
-    expect(body.state).toBe('reverse_pending')
+    expect(dbMock.insert).toHaveBeenCalled()
+    expect(body.state).toBe('auto_approved')
+    expect(body.friendshipRequest).toEqual(
+      expect.objectContaining({ id: 'friendship-1', status: 'approved', state: 'auto_approved' }),
+    )
   })
 
   it('rejects 4 interests', async () => {

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -551,15 +551,13 @@ export async function POST(request: Request) {
         )
       }
 
+      // Inviting an existing user from the invite flow follows them (pending or
+      // auto-approved per their privacy gate). Follow requests don't expire.
       const { friendship: friendshipRequest, state } =
         await createOrReusePendingFriendshipRequest({
           inviterUserId: session.userId,
           inviteeUserId: existingUser.id,
           suggestedInterests,
-          // SMS-style invitations don't expire under v12. Pass null
-          // explicitly so the new 30-day direct-request default doesn't
-          // bleed into this flow.
-          expiresAt: null,
         })
 
       const inviteUrl = `${getBaseUrl(request)}/activities#friendship-${encodeURIComponent(friendshipRequest.id)}`
@@ -593,7 +591,7 @@ export async function POST(request: Request) {
         expiresAt: null,
         friendshipRequest: {
           id: friendshipRequest.id,
-          status: friendshipRequest.status,
+          status: friendshipRequest.state,
           state,
           inviteeUserId: existingUser.id,
         },

--- a/src/app/api/friend-requests/[friendshipId]/__tests__/route.test.ts
+++ b/src/app/api/friend-requests/[friendshipId]/__tests__/route.test.ts
@@ -39,8 +39,8 @@ describe('friend request action routes', () => {
     getSessionMock.mockResolvedValue({ userId: 'recipient-user' })
   })
 
-  it('accept creates an active friendship through the shared helper', async () => {
-    acceptPendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'active' })
+  it('accept approves the pending follow through the shared helper', async () => {
+    acceptPendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', state: 'approved' })
 
     const response = await acceptRequest(request, context)
     const body = await response.json()
@@ -50,11 +50,15 @@ describe('friend request action routes', () => {
       friendshipId: 'friendship-1',
       userId: 'recipient-user',
     })
-    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'active' })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'approved' })
   })
 
-  it('ignore does not create an active friendship', async () => {
-    ignorePendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'declined' })
+  it('ignore deletes the pending follow', async () => {
+    ignorePendingFriendshipRequestMock.mockResolvedValueOnce({
+      id: 'friendship-1',
+      state: 'pending',
+      followerId: 'requester-user',
+    })
 
     const response = await ignoreRequest(request, context)
     const body = await response.json()
@@ -64,11 +68,11 @@ describe('friend request action routes', () => {
       friendshipId: 'friendship-1',
       userId: 'recipient-user',
     })
-    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'declined' })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'pending' })
   })
 
-  it('cancel marks the requester’s pending request as cancelled', async () => {
-    cancelPendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'cancelled' })
+  it('cancel deletes the requester’s pending follow', async () => {
+    cancelPendingFriendshipRequestMock.mockResolvedValueOnce({ id: 'friendship-1', state: 'pending' })
 
     const response = await cancelRequest(request, context)
     const body = await response.json()
@@ -78,7 +82,7 @@ describe('friend request action routes', () => {
       friendshipId: 'friendship-1',
       userId: 'recipient-user',
     })
-    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'cancelled' })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'pending' })
   })
 
   it('cancel returns 404 when nothing matches', async () => {
@@ -88,8 +92,8 @@ describe('friend request action routes', () => {
     expect(response.status).toBe(404)
   })
 
-  it('remove marks an active friendship as removed', async () => {
-    removeFriendshipMock.mockResolvedValueOnce({ id: 'friendship-1', status: 'removed' })
+  it('remove (unfollow) deletes the viewer’s outbound follow edge', async () => {
+    removeFriendshipMock.mockResolvedValueOnce({ id: 'friendship-1', state: 'approved' })
 
     const response = await removeRequest(request, context)
     const body = await response.json()
@@ -99,10 +103,10 @@ describe('friend request action routes', () => {
       friendshipId: 'friendship-1',
       userId: 'recipient-user',
     })
-    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'removed' })
+    expect(body.friendship).toEqual({ id: 'friendship-1', status: 'approved' })
   })
 
-  it('remove returns 404 when no active friendship matches', async () => {
+  it('remove returns 404 when no follow edge matches', async () => {
     removeFriendshipMock.mockResolvedValueOnce(null)
 
     const response = await removeRequest(request, context)

--- a/src/app/api/friend-requests/[friendshipId]/accept/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/accept/route.ts
@@ -31,5 +31,5 @@ export async function POST(
     user_id: session.userId,
   })
 
-  return NextResponse.json({ ok: true, friendship: { id: friendship.id, status: friendship.status } })
+  return NextResponse.json({ ok: true, friendship: { id: friendship.id, status: friendship.state } })
 }

--- a/src/app/api/friend-requests/[friendshipId]/cancel/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/cancel/route.ts
@@ -34,6 +34,6 @@ export async function POST(
 
   return NextResponse.json({
     ok: true,
-    friendship: { id: friendship.id, status: friendship.status },
+    friendship: { id: friendship.id, status: friendship.state },
   })
 }

--- a/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/ignore/route.ts
@@ -28,16 +28,16 @@ export async function POST(
     )
   }
 
-  rememberIgnoredFriendRequest(friendship.requestedByUserId, session.userId)
+  rememberIgnoredFriendRequest(friendship.followerId, session.userId)
 
   logTelemetry('friend_request_ignored', {
     friendship_id: friendship.id,
-    requester_user_id: friendship.requestedByUserId,
+    requester_user_id: friendship.followerId,
     user_id: session.userId,
   })
 
   return NextResponse.json({
     ok: true,
-    friendship: { id: friendship.id, status: friendship.status },
+    friendship: { id: friendship.id, status: friendship.state },
   })
 }

--- a/src/app/api/friend-requests/[friendshipId]/remove/route.ts
+++ b/src/app/api/friend-requests/[friendshipId]/remove/route.ts
@@ -34,6 +34,6 @@ export async function POST(
 
   return NextResponse.json({
     ok: true,
-    friendship: { id: friendship.id, status: friendship.status },
+    friendship: { id: friendship.id, status: friendship.state },
   })
 }

--- a/src/app/api/friend-requests/__tests__/route.test.ts
+++ b/src/app/api/friend-requests/__tests__/route.test.ts
@@ -46,14 +46,14 @@ describe('POST /api/friend-requests', () => {
     vi.clearAllMocks()
     getSessionMock.mockResolvedValue({ userId: 'viewer-user' })
     getUserByIdMock.mockResolvedValue({ id: 'invitee-user' })
-    getRelationshipMock.mockResolvedValue({ state: 'none', isBlocked: false })
+    getRelationshipMock.mockResolvedValue({ state: 'none', friendshipId: null, isBlocked: false })
     createOrReusePendingFriendshipRequestMock.mockResolvedValue({
-      friendship: { id: 'friendship-1', status: 'pending' },
+      friendship: { id: 'friendship-1', state: 'pending' },
       state: 'created',
     })
   })
 
-  it('creates a friendship request via the shared helper', async () => {
+  it('creates a follow request via the shared helper', async () => {
     const response = await createFriendRequest(
       buildRequest({ inviteeUserId: 'invitee-user' })
     )
@@ -73,6 +73,20 @@ describe('POST /api/friend-requests', () => {
       state: 'created',
       friendship: { id: 'friendship-1', status: 'pending' },
     })
+  })
+
+  it('blocks a follow when already following', async () => {
+    getRelationshipMock.mockResolvedValueOnce({ state: 'following', friendshipId: 'f1', isBlocked: false })
+    const response = await createFriendRequest(buildRequest({ inviteeUserId: 'invitee-user' }))
+    expect(response.status).toBe(409)
+    expect(createOrReusePendingFriendshipRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('allows a follow-back when they already follow me', async () => {
+    getRelationshipMock.mockResolvedValueOnce({ state: 'follows_you', friendshipId: null, isBlocked: false })
+    const response = await createFriendRequest(buildRequest({ inviteeUserId: 'invitee-user' }))
+    expect(response.status).toBe(200)
+    expect(createOrReusePendingFriendshipRequestMock).toHaveBeenCalled()
   })
 
   it('rejects unauthenticated callers', async () => {

--- a/src/app/api/friend-requests/route.ts
+++ b/src/app/api/friend-requests/route.ts
@@ -14,8 +14,6 @@ const bodySchema = z.object({
   personalNote: z.string().trim().max(160).optional(),
 })
 
-const RECENTLY_SENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
-
 export async function POST(request: Request) {
   const session = await getSession()
   if (!session)
@@ -47,20 +45,12 @@ export async function POST(request: Request) {
   }
 
   const now = new Date()
-  const relationship = await getRelationship(session.userId, inviteeUserId, now)
+  const relationship = await getRelationship(session.userId, inviteeUserId)
 
-  // Block detection: target has soft-removed the friendship. Return 404
-  // (don't reveal the block) and don't write anything.
-  if (relationship.isBlocked) {
+  // Already following (mutual or one-directional) — nothing to do.
+  if (relationship.state === 'friends' || relationship.state === 'following') {
     return NextResponse.json(
-      { error: 'not_found', message: 'No such user.' },
-      { status: 404 }
-    )
-  }
-
-  if (relationship.state === 'friends') {
-    return NextResponse.json(
-      { error: 'already_friends', message: 'You are already friends.' },
+      { error: 'already_following', message: 'You already follow this person.' },
       { status: 409 }
     )
   }
@@ -68,7 +58,7 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: 'already_pending',
-        message: 'You already have a pending request with this person.',
+        message: 'You already requested to follow this person.',
       },
       { status: 409 }
     )
@@ -77,25 +67,14 @@ export async function POST(request: Request) {
     return NextResponse.json(
       {
         error: 'inbound_exists',
-        message: 'They sent you a request — accept it instead.',
+        message: 'They requested to follow you — approve it instead.',
         friendshipId: relationship.friendshipId,
       },
       { status: 409 }
     )
   }
-  if (relationship.state === 'recently_sent') {
-    return NextResponse.json(
-      {
-        error: 'recently_sent',
-        message: 'You sent this person a request recently. Try again later.',
-        // Best-effort retry hint: 30 days from now is the latest the
-        // cooldown could last. Callers don't need millisecond precision.
-        retryAfter: new Date(now.getTime() + RECENTLY_SENT_WINDOW_MS).toISOString(),
-      },
-      { status: 429 }
-    )
-  }
 
+  // 'follows_you' and 'none' fall through: the viewer may follow / follow back.
   const { friendship, state } = await createOrReusePendingFriendshipRequest({
     inviterUserId: session.userId,
     inviteeUserId,
@@ -114,6 +93,6 @@ export async function POST(request: Request) {
   return NextResponse.json({
     ok: true,
     state,
-    friendship: { id: friendship.id, status: friendship.status },
+    friendship: { id: friendship.id, status: friendship.state },
   })
 }

--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -113,6 +113,9 @@ vi.mock('@/server/db/queries/questions', () => ({
 
 vi.mock('@/server/db/queries/friends', () => ({
   getFriends: getFriendsMock,
+  // Broadcast fan-out now reads my followers; in these tests the recipient set
+  // is the same fixture, so alias it to the existing mock.
+  getFollowers: getFriendsMock,
 }))
 
 vi.mock('@/server/db/queries/feed', () => ({

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -11,7 +11,7 @@ import {
   getQuestion,
   getQuestionsForUser,
 } from '@/server/db/queries/questions';
-import { getFriends } from '@/server/db/queries/friends';
+import { getFollowers, getFriends } from '@/server/db/queries/friends';
 import {
   rollOffOldItems,
   userHasQuestionInBlockingFeed,
@@ -240,7 +240,9 @@ export async function POST(request: NextRequest) {
   };
 
   if (shareToFeed) {
-    const friends = await getFriends(session.userId);
+    // Broadcast fan-out reaches my followers (people who follow me), not just
+    // mutuals — directional follow model (D-1 Stage 3).
+    const friends = await getFollowers(session.userId);
     const friendIds = friends.map((friend) => friend.id);
     const dismissedRecipientIds = new Set<string>();
 

--- a/src/app/api/users/me/__tests__/route.test.ts
+++ b/src/app/api/users/me/__tests__/route.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSessionMock, setFollowPrivacyMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  setFollowPrivacyMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }))
+vi.mock('@/server/db/queries/users', () => ({ setFollowPrivacy: setFollowPrivacyMock }))
+
+import { PATCH } from '@/app/api/users/me/route'
+
+function patch(body: unknown) {
+  return new Request('https://joshing.example/api/users/me', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  })
+}
+
+describe('PATCH /api/users/me', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    getSessionMock.mockResolvedValue({ userId: 'me' })
+    setFollowPrivacyMock.mockResolvedValue({ id: 'me', followPrivacy: 'public' })
+  })
+
+  it('updates the follow-privacy gate', async () => {
+    const response = await PATCH(patch({ followPrivacy: 'public' }))
+    const body = await response.json()
+    expect(response.status).toBe(200)
+    expect(setFollowPrivacyMock).toHaveBeenCalledWith('me', 'public')
+    expect(body).toEqual({ ok: true, followPrivacy: 'public' })
+  })
+
+  it('rejects unauthenticated callers', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const response = await PATCH(patch({ followPrivacy: 'public' }))
+    expect(response.status).toBe(401)
+    expect(setFollowPrivacyMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid privacy value', async () => {
+    const response = await PATCH(patch({ followPrivacy: 'everyone' }))
+    expect(response.status).toBe(400)
+    expect(setFollowPrivacyMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server'
+import { z } from 'zod'
+
+import { getSession } from '@/server/auth/session'
+import { setFollowPrivacy } from '@/server/db/queries/users'
+
+export const dynamic = 'force-dynamic'
+
+const bodySchema = z.object({
+  followPrivacy: z.enum(['public', 'approval_required']),
+})
+
+// PATCH /api/users/me — update the current user's follow-privacy gate.
+export async function PATCH(request: Request) {
+  const session = await getSession()
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const json = await request.json().catch(() => null)
+  const parsed = bodySchema.safeParse(json)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'Missing or invalid request body.' },
+      { status: 400 },
+    )
+  }
+
+  const updated = await setFollowPrivacy(session.userId, parsed.data.followPrivacy)
+  if (!updated) {
+    return NextResponse.json({ error: 'not_found', message: 'No such user.' }, { status: 404 })
+  }
+
+  return NextResponse.json({ ok: true, followPrivacy: updated.followPrivacy })
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -309,7 +309,7 @@ export default async function UserProfilePage({
             !isOwnerView ? (
               <ProfileFriendButton
                 targetUserId={portrait.user.id}
-                friendship={portrait.friendship}
+                relationship={portrait.relationship}
                 targetDisplayName={portrait.user.displayName}
               />
             ) : null
@@ -364,12 +364,12 @@ export default async function UserProfilePage({
         mindStatement={mindStatement}
         memberSince={portrait.user.memberSince}
         editable={false}
-        friendshipFormedAt={portrait.friendship?.formedAt ?? null}
+        friendshipFormedAt={portrait.relationship?.formedAt ?? null}
         friendButton={
           !isOwnerView ? (
             <ProfileFriendButton
               targetUserId={portrait.user.id}
-              friendship={portrait.friendship}
+              relationship={portrait.relationship}
               targetDisplayName={portrait.user.displayName}
             />
           ) : null

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -5,16 +5,16 @@ import PeopleYouInvited from '@/components/PeopleYouInvited'
 import { formatRelativeTime } from '@/components/feed/visual'
 import { useCallback, useEffect, useState } from 'react'
 
-type Tab = 'friends' | 'invitations' | 'sent'
+type Tab = 'following' | 'followers' | 'pending'
 
-const SOFT_CAP = 25
-
-type Friend = {
+type Person = {
   id: string
   displayName: string
   declaredInterests: string[]
   sharedInterests: string[]
   lastActiveAt: string | null
+  youFollow: boolean
+  followsYou: boolean
 }
 
 type IncomingRequest = {
@@ -34,11 +34,15 @@ type OutboundRequest = {
   createdAt: string
 }
 
+type FollowPrivacy = 'public' | 'approval_required'
+
 type FriendsHubResponse = {
   ok: boolean
-  friends: Friend[]
+  following: Person[]
+  followers: Person[]
   incomingRequests: IncomingRequest[]
   outboundRequests: OutboundRequest[]
+  followPrivacy: FollowPrivacy
 }
 
 type RequestAction = 'accept' | 'ignore'
@@ -48,21 +52,65 @@ function previewInterests(interests: string[]) {
   return interests.join(', ')
 }
 
+function PersonCard({
+  person,
+  action,
+}: {
+  person: Person
+  action?: React.ReactNode
+}) {
+  const interests = previewInterests(person.declaredInterests)
+  const sharedInterest = person.sharedInterests[0]
+  const lastActiveLabel = person.lastActiveAt ? formatRelativeTime(person.lastActiveAt) : null
+
+  return (
+    <div className="bg-background hover:border-foreground/30 flex items-start justify-between gap-3 rounded-xl border p-3 transition hover:shadow-sm">
+      <Link href={`/users/${person.id}`} className="min-w-0 flex-1">
+        <h3 className="text-primary decoration-primary/40 hover:decoration-primary font-medium underline underline-offset-4">
+          {person.displayName}
+        </h3>
+        {interests ? (
+          <p className="text-muted-foreground mt-1 text-sm leading-6">A mind into {interests}</p>
+        ) : (
+          <p className="text-muted-foreground mt-1 text-sm leading-6">
+            Interests will appear here as they declare them.
+          </p>
+        )}
+        <div className="mt-1 flex flex-wrap items-center gap-2">
+          {person.followsYou && person.youFollow ? (
+            <span className="text-muted-foreground/70 text-xs">Mutual</span>
+          ) : person.followsYou ? (
+            <span className="text-muted-foreground/70 text-xs">Follows you</span>
+          ) : null}
+          {lastActiveLabel ? (
+            <span className="text-muted-foreground/70 text-xs">Active {lastActiveLabel}</span>
+          ) : null}
+        </div>
+      </Link>
+      <div className="flex shrink-0 flex-col items-end gap-2">
+        {sharedInterest ? (
+          <span className="bg-muted text-foreground max-w-[12rem] rounded-full px-3 py-1 text-center text-xs font-medium break-words whitespace-normal">
+            Shared: {sharedInterest}
+          </span>
+        ) : null}
+        {action}
+      </div>
+    </div>
+  )
+}
+
 export default function FriendsList() {
-  const [friends, setFriends] = useState<Friend[]>([])
-  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>(
-    []
-  )
-  const [outboundRequests, setOutboundRequests] = useState<OutboundRequest[]>(
-    []
-  )
+  const [following, setFollowing] = useState<Person[]>([])
+  const [followers, setFollowers] = useState<Person[]>([])
+  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>([])
+  const [outboundRequests, setOutboundRequests] = useState<OutboundRequest[]>([])
+  const [followPrivacy, setFollowPrivacy] = useState<FollowPrivacy>('approval_required')
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [pendingRequest, setPendingRequest] = useState<string | null>(null)
-  const [activeTab, setActiveTab] = useState<Tab>('friends')
-  // Session-local: nudge reappears on next page load if still over the cap.
-  const [softCapDismissed, setSoftCapDismissed] = useState(false)
-  // Passive Invitations-tab row count — null while loading, 0 when there's
+  const [privacyUpdating, setPrivacyUpdating] = useState(false)
+  const [activeTab, setActiveTab] = useState<Tab>('following')
+  // Passive Pending-tab row count — null while loading, 0 when there's
   // nothing new. Cleared after the user visits /friends/find.
   const [newDiscoveryCount, setNewDiscoveryCount] = useState<number | null>(null)
 
@@ -79,21 +127,19 @@ export default function FriendsList() {
         | { message?: string }
         | null
 
-      if (!response.ok || !body || !('friends' in body)) {
+      if (!response.ok || !body || !('following' in body)) {
         throw new Error(
-          body && 'message' in body && body.message
-            ? body.message
-            : 'Could not load friends.'
+          body && 'message' in body && body.message ? body.message : 'Could not load follows.',
         )
       }
 
-      setFriends(body.friends)
+      setFollowing(body.following)
+      setFollowers(body.followers)
       setIncomingRequests(body.incomingRequests)
       setOutboundRequests(body.outboundRequests ?? [])
+      setFollowPrivacy(body.followPrivacy)
     } catch (caught) {
-      setError(
-        caught instanceof Error ? caught.message : 'Could not load friends.'
-      )
+      setError(caught instanceof Error ? caught.message : 'Could not load follows.')
     } finally {
       setLoading(false)
     }
@@ -103,9 +149,6 @@ export default function FriendsList() {
     queueMicrotask(() => void loadFriends())
   }, [loadFriends])
 
-  // Load the discovery signal once on mount. Cache-Control:max-age=60 on
-  // the response keeps repeat navigations cheap. Fire-and-forget — a
-  // failure just means the passive row doesn't render this session.
   useEffect(() => {
     let cancelled = false
     void (async () => {
@@ -134,16 +177,11 @@ export default function FriendsList() {
     setError(null)
 
     try {
-      const response = await fetch(
-        `/api/friend-requests/${requestId}/${action}`,
-        {
-          method: 'POST',
-          credentials: 'include',
-        }
-      )
-      const body = (await response.json().catch(() => null)) as {
-        message?: string
-      } | null
+      const response = await fetch(`/api/friend-requests/${requestId}/${action}`, {
+        method: 'POST',
+        credentials: 'include',
+      })
+      const body = (await response.json().catch(() => null)) as { message?: string } | null
 
       if (!response.ok) {
         throw new Error(body?.message ?? 'Could not update this request.')
@@ -151,11 +189,7 @@ export default function FriendsList() {
 
       await loadFriends()
     } catch (caught) {
-      setError(
-        caught instanceof Error
-          ? caught.message
-          : 'Could not update this request.'
-      )
+      setError(caught instanceof Error ? caught.message : 'Could not update this request.')
     } finally {
       setPendingRequest(null)
     }
@@ -164,7 +198,6 @@ export default function FriendsList() {
   async function cancelOutbound(requestId: string) {
     setPendingRequest(`${requestId}:cancel`)
     setError(null)
-    // Optimistic: remove the row immediately; restore on error.
     const previous = outboundRequests
     setOutboundRequests((current) => current.filter((row) => row.id !== requestId))
 
@@ -179,270 +212,286 @@ export default function FriendsList() {
         throw new Error(body?.message ?? 'Could not cancel this request.')
       }
     } catch (caught) {
-      setError(
-        caught instanceof Error
-          ? caught.message
-          : 'Could not cancel this request.'
-      )
+      setError(caught instanceof Error ? caught.message : 'Could not cancel this request.')
     } finally {
       setPendingRequest(null)
     }
   }
 
+  async function followBack(personId: string) {
+    setPendingRequest(`${personId}:follow`)
+    setError(null)
+    try {
+      const response = await fetch('/api/friend-requests', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ inviteeUserId: personId }),
+      })
+      if (!response.ok) {
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        throw new Error(body?.message ?? 'Could not follow this person.')
+      }
+      await loadFriends()
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not follow this person.')
+    } finally {
+      setPendingRequest(null)
+    }
+  }
+
+  async function togglePrivacy(next: FollowPrivacy) {
+    setPrivacyUpdating(true)
+    setError(null)
+    const previous = followPrivacy
+    setFollowPrivacy(next)
+    try {
+      const response = await fetch('/api/users/me', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ followPrivacy: next }),
+      })
+      if (!response.ok) {
+        setFollowPrivacy(previous)
+        const body = (await response.json().catch(() => null)) as { message?: string } | null
+        throw new Error(body?.message ?? 'Could not update your privacy setting.')
+      }
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not update your privacy setting.')
+    } finally {
+      setPrivacyUpdating(false)
+    }
+  }
+
   return (
     <div className="space-y-5">
+      {/* Privacy gate */}
+      <div className="bg-muted/40 flex items-start justify-between gap-3 rounded-xl border p-3">
+        <div className="min-w-0">
+          <p className="text-foreground text-sm font-medium">Who can follow you</p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            {followPrivacy === 'public'
+              ? 'Anyone can follow you instantly.'
+              : 'New followers ask first — you approve each one.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="btn-ghost min-h-9 shrink-0 rounded-full px-4 text-sm"
+          disabled={privacyUpdating}
+          onClick={() =>
+            void togglePrivacy(followPrivacy === 'public' ? 'approval_required' : 'public')
+          }
+        >
+          {privacyUpdating
+            ? 'Saving…'
+            : followPrivacy === 'public'
+              ? 'Require approval'
+              : 'Make public'}
+        </button>
+      </div>
+
       {/* Tab bar */}
       <div className="flex border-b">
         <button
           type="button"
           className={`px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'friends'
-              ? 'border-b-2 border-foreground text-foreground'
+            activeTab === 'following'
+              ? 'border-foreground text-foreground border-b-2'
               : 'text-muted-foreground hover:text-foreground'
           }`}
-          onClick={() => setActiveTab('friends')}
+          onClick={() => setActiveTab('following')}
         >
-          Friends
+          Following
+        </button>
+        <button
+          type="button"
+          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
+            activeTab === 'followers'
+              ? 'border-foreground text-foreground border-b-2'
+              : 'text-muted-foreground hover:text-foreground'
+          }`}
+          onClick={() => setActiveTab('followers')}
+        >
+          Followers
         </button>
         <button
           type="button"
           className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'invitations'
-              ? 'border-b-2 border-foreground text-foreground'
+            activeTab === 'pending'
+              ? 'border-foreground text-foreground border-b-2'
               : 'text-muted-foreground hover:text-foreground'
           }`}
-          onClick={() => setActiveTab('invitations')}
+          onClick={() => setActiveTab('pending')}
         >
-          Invitations
+          Pending
           {incomingRequests.length > 0 ? (
             <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-xs leading-none">
               {incomingRequests.length}
             </span>
           ) : null}
         </button>
-        <button
-          type="button"
-          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'sent'
-              ? 'border-b-2 border-foreground text-foreground'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-          onClick={() => setActiveTab('sent')}
-        >
-          Sent
-        </button>
       </div>
 
-      {/* Friends tab */}
-      {activeTab === 'friends' ? (
+      {error ? <p className="text-destructive text-sm font-medium">{error}</p> : null}
+
+      {/* Following tab */}
+      {activeTab === 'following' ? (
         <section>
-          {friends.length > SOFT_CAP && !softCapDismissed ? (
-            <div className="bg-muted/50 mb-3 flex items-start justify-between gap-3 rounded-xl border p-3">
-              <div className="min-w-0">
-                <p className="text-foreground text-sm font-medium">
-                  Joshing works best with a small group — you&rsquo;re at {friends.length}.
-                </p>
-                <p className="text-muted-foreground mt-1 text-xs">
-                  No rule, just a nudge.
-                </p>
-              </div>
-              <button
-                type="button"
-                aria-label="Dismiss"
-                onClick={() => setSoftCapDismissed(true)}
-                className="text-muted-foreground hover:text-foreground -mr-1 px-2 text-lg leading-none"
-              >
-                ×
-              </button>
-            </div>
-          ) : null}
-
-          {error ? (
-            <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
-          ) : null}
-
           {loading ? (
-            <p className="text-muted-foreground text-sm">Loading friends…</p>
-          ) : friends.length > 0 ? (
+            <p className="text-muted-foreground text-sm">Loading…</p>
+          ) : following.length > 0 ? (
             <div className="space-y-3">
-              {friends.map((friend) => {
-                const interests = previewInterests(friend.declaredInterests)
-                const sharedInterest = friend.sharedInterests[0]
-                const lastActiveLabel = friend.lastActiveAt
-                  ? formatRelativeTime(friend.lastActiveAt)
-                  : null
-
-                return (
-                  <Link
-                    key={friend.id}
-                    href={`/users/${friend.id}`}
-                    className="bg-background hover:border-foreground/30 block rounded-xl border p-3 transition hover:shadow-sm"
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0 flex-1">
-                        <h3 className="text-primary font-medium underline decoration-primary/40 underline-offset-4 hover:decoration-primary">
-                          {friend.displayName}
-                        </h3>
-                        {interests ? (
-                          <p className="text-muted-foreground mt-1 text-sm leading-6">
-                            A mind into {interests}
-                          </p>
-                        ) : (
-                          <p className="text-muted-foreground mt-1 text-sm leading-6">
-                            Interests will appear here as they declare them.
-                          </p>
-                        )}
-                        {lastActiveLabel ? (
-                          <p className="text-muted-foreground/70 mt-1 text-xs">
-                            Active {lastActiveLabel}
-                          </p>
-                        ) : null}
-                      </div>
-                      {sharedInterest ? (
-                        <span className="bg-muted text-foreground shrink-0 max-w-[45%] rounded-full px-3 py-1 text-xs font-medium whitespace-normal break-words text-center">
-                          Shared: {sharedInterest}
-                        </span>
-                      ) : null}
-                    </div>
-                  </Link>
-                )
-              })}
+              {following.map((person) => (
+                <PersonCard key={person.id} person={person} />
+              ))}
             </div>
           ) : (
             <div className="py-2 text-center">
               <h2 className="font-serif text-xl font-semibold">
-                Joshing gets better when your people are here.
+                Follow the people you trade facts with.
               </h2>
               <p className="text-muted-foreground mt-2 text-sm leading-6">
-                Invite someone you already trade facts, recommendations, and
-                inside jokes with.
+                When you follow someone, their questions and moments start showing up for you.
               </p>
             </div>
           )}
         </section>
       ) : null}
 
-      {/* Invitations tab */}
-      {activeTab === 'invitations' ? (
-        <div className="space-y-3">
-          {newDiscoveryCount && newDiscoveryCount > 0 ? (
-            <Link
-              href="/friends/find"
-              className="bg-primary/5 ring-primary/20 hover:border-foreground/30 text-card-foreground block rounded-2xl border ring-1 p-4 shadow-sm transition"
-            >
-              <p className="text-foreground text-sm font-medium">
-                ✨ {newDiscoveryCount} new {newDiscoveryCount === 1 ? 'contact is' : 'contacts are'} on Joshing.
-              </p>
-              <p className="text-muted-foreground mt-1 text-xs">→ Find friends</p>
-            </Link>
-          ) : null}
-          <Link
-            href="/friends/find"
-            className="bg-card hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"
-          >
-            <p className="text-foreground text-sm font-medium">
-              Find friends already on Joshing or invite someone new →
-            </p>
-          </Link>
-          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      {/* Followers tab */}
+      {activeTab === 'followers' ? (
+        <section>
           {loading ? (
-            <p className="text-muted-foreground text-sm">Loading invitations…</p>
-          ) : incomingRequests.length > 0 ? (
+            <p className="text-muted-foreground text-sm">Loading…</p>
+          ) : followers.length > 0 ? (
             <div className="space-y-3">
-              {incomingRequests.map((request) => (
-                <article
-                  key={request.id}
-                  className="bg-background rounded-xl border p-3"
-                >
-                  <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                    <div>
-                      <h3 className="text-foreground font-medium">
-                        {request.requesterName}
-                      </h3>
-                      {request.suggestedInterests.length > 0 ? (
-                        <div className="mt-3 flex flex-wrap gap-2">
-                          {request.suggestedInterests.map((interest) => (
-                            <span
-                              key={interest}
-                              className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
-                            >
-                              {interest}
-                            </span>
-                          ))}
-                        </div>
-                      ) : (
-                        <p className="text-muted-foreground mt-1 text-sm">
-                          No ideas attached — just a friendly hello.
-                        </p>
-                      )}
-                      {request.personalNote ? (
-                        <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
-                          “{request.personalNote}”
-                        </blockquote>
-                      ) : null}
-                    </div>
-
-                    <div className="grid grid-cols-2 gap-2 sm:min-w-48">
+              {followers.map((person) => (
+                <PersonCard
+                  key={person.id}
+                  person={person}
+                  action={
+                    person.youFollow ? null : (
                       <button
                         type="button"
-                        className="btn-primary min-h-11 rounded-full"
+                        className="btn-ghost min-h-9 rounded-full px-4 text-sm"
                         disabled={Boolean(pendingRequest)}
-                        onClick={() =>
-                          void updateRequest(request.id, 'accept')
-                        }
+                        onClick={() => void followBack(person.id)}
                       >
-                        {pendingRequest === `${request.id}:accept`
-                          ? 'Accepting…'
-                          : 'Accept'}
+                        {pendingRequest === `${person.id}:follow` ? 'Following…' : 'Follow back'}
                       </button>
-                      <button
-                        type="button"
-                        className="btn-ghost min-h-11 rounded-full"
-                        disabled={Boolean(pendingRequest)}
-                        onClick={() =>
-                          void updateRequest(request.id, 'ignore')
-                        }
-                      >
-                        {pendingRequest === `${request.id}:ignore`
-                          ? 'Setting aside…'
-                          : 'Not now'}
-                      </button>
-                    </div>
-                  </div>
-                </article>
+                    )
+                  }
+                />
               ))}
             </div>
           ) : (
             <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
-              No incoming invitations right now.
+              No one follows you yet.
             </p>
           )}
         </section>
-        </div>
       ) : null}
 
-      {/* Sent tab */}
-      {activeTab === 'sent' ? (
+      {/* Pending tab */}
+      {activeTab === 'pending' ? (
         <div className="space-y-6">
+          {newDiscoveryCount && newDiscoveryCount > 0 ? (
+            <Link
+              href="/friends/find"
+              className="bg-primary/5 ring-primary/20 hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm ring-1 transition"
+            >
+              <p className="text-foreground text-sm font-medium">
+                ✨ {newDiscoveryCount} new{' '}
+                {newDiscoveryCount === 1 ? 'contact is' : 'contacts are'} on Joshing.
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">→ Find friends</p>
+            </Link>
+          ) : (
+            <Link
+              href="/friends/find"
+              className="bg-card hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"
+            >
+              <p className="text-foreground text-sm font-medium">
+                Find friends already on Joshing or invite someone new →
+              </p>
+            </Link>
+          )}
+
+          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+            <h2 className="font-serif text-lg font-semibold">Follow requests</h2>
+            {loading ? (
+              <p className="text-muted-foreground mt-2 text-sm">Loading…</p>
+            ) : incomingRequests.length > 0 ? (
+              <div className="mt-3 space-y-3">
+                {incomingRequests.map((request) => (
+                  <article key={request.id} className="bg-background rounded-xl border p-3">
+                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                      <div>
+                        <h3 className="text-foreground font-medium">{request.requesterName}</h3>
+                        {request.suggestedInterests.length > 0 ? (
+                          <div className="mt-3 flex flex-wrap gap-2">
+                            {request.suggestedInterests.map((interest) => (
+                              <span
+                                key={interest}
+                                className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
+                              >
+                                {interest}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-muted-foreground mt-1 text-sm">
+                            Wants to follow you.
+                          </p>
+                        )}
+                        {request.personalNote ? (
+                          <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
+                            “{request.personalNote}”
+                          </blockquote>
+                        ) : null}
+                      </div>
+
+                      <div className="grid grid-cols-2 gap-2 sm:min-w-48">
+                        <button
+                          type="button"
+                          className="btn-primary min-h-11 rounded-full"
+                          disabled={Boolean(pendingRequest)}
+                          onClick={() => void updateRequest(request.id, 'accept')}
+                        >
+                          {pendingRequest === `${request.id}:accept` ? 'Approving…' : 'Approve'}
+                        </button>
+                        <button
+                          type="button"
+                          className="btn-ghost min-h-11 rounded-full"
+                          disabled={Boolean(pendingRequest)}
+                          onClick={() => void updateRequest(request.id, 'ignore')}
+                        >
+                          {pendingRequest === `${request.id}:ignore` ? 'Setting aside…' : 'Not now'}
+                        </button>
+                      </div>
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : (
+              <p className="text-muted-foreground bg-muted mt-2 rounded-xl px-3 py-2 text-sm">
+                No follow requests right now.
+              </p>
+            )}
+          </section>
+
           {outboundRequests.length > 0 ? (
             <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-              <h2 className="font-serif text-lg font-semibold">
-                Sent friend requests
-              </h2>
-              <p className="text-muted-foreground mt-1 text-sm">
-                Waiting on a reply. They expire after 30 days.
-              </p>
+              <h2 className="font-serif text-lg font-semibold">Sent requests</h2>
+              <p className="text-muted-foreground mt-1 text-sm">Waiting on their approval.</p>
               <div className="mt-3 space-y-3">
                 {outboundRequests.map((request) => (
-                  <article
-                    key={request.id}
-                    className="bg-background rounded-xl border p-3"
-                  >
+                  <article key={request.id} className="bg-background rounded-xl border p-3">
                     <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                       <div className="min-w-0">
-                        <h3 className="text-foreground font-medium">
-                          {request.recipientName}
-                        </h3>
+                        <h3 className="text-foreground font-medium">{request.recipientName}</h3>
                         <p className="text-muted-foreground/70 mt-1 text-xs">
                           sent {formatRelativeTime(request.createdAt)}
                         </p>
@@ -458,9 +507,7 @@ export default function FriendsList() {
                         disabled={Boolean(pendingRequest)}
                         onClick={() => void cancelOutbound(request.id)}
                       >
-                        {pendingRequest === `${request.id}:cancel`
-                          ? 'Cancelling…'
-                          : 'Cancel'}
+                        {pendingRequest === `${request.id}:cancel` ? 'Cancelling…' : 'Cancel'}
                       </button>
                     </div>
                   </article>
@@ -468,6 +515,7 @@ export default function FriendsList() {
               </div>
             </section>
           ) : null}
+
           <PeopleYouInvited />
         </div>
       ) : null}

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -32,13 +32,13 @@ describe('Friends page QA surface', () => {
     expect(html).not.toMatch(forbiddenGamificationCopy)
   })
 
-  it('renders the Friends / Invitations / Sent tab bar with the friends tab active by default', () => {
+  it('renders the Following / Followers / Pending tab bar with following active by default', () => {
     const html = renderToStaticMarkup(<FriendsList />)
 
-    expect(html).toContain('Friends')
-    expect(html).toContain('Invitations')
-    expect(html).toContain('Sent')
-    expect(html).toContain('Loading friends')
+    expect(html).toContain('Following')
+    expect(html).toContain('Followers')
+    expect(html).toContain('Pending')
+    expect(html).toContain('Who can follow you')
     expect(html).not.toMatch(forbiddenGamificationCopy)
   })
 })

--- a/src/components/friends/AddFriendButton.tsx
+++ b/src/components/friends/AddFriendButton.tsx
@@ -78,7 +78,7 @@ export function AddFriendButton({
 
   function handleAccept() {
     if (!relationship.friendshipId) return
-    void runAction('accept', relationship.friendshipId, 'Friends.')
+    void runAction('accept', relationship.friendshipId, 'Approved.')
   }
 
   function handleIgnore() {
@@ -89,18 +89,18 @@ export function AddFriendButton({
   function handleRemove() {
     if (!relationship.friendshipId) return
     if (confirmUnfriend) {
-      // Swap the Unfriend button for an inline Remove/Keep confirmation rather
+      // Swap the Unfollow button for an inline Unfollow/Keep confirmation rather
       // than punching out to native window.confirm chrome.
       setConfirmingRemove(true)
       return
     }
-    void runAction('remove', relationship.friendshipId, 'Removed.')
+    void runAction('remove', relationship.friendshipId, 'Unfollowed.')
   }
 
   function confirmRemove() {
     if (!relationship.friendshipId) return
     setConfirmingRemove(false)
-    void runAction('remove', relationship.friendshipId, 'Removed.')
+    void runAction('remove', relationship.friendshipId, 'Unfollowed.')
   }
 
   return (
@@ -113,14 +113,25 @@ export function AddFriendButton({
             onClick={handleAddClick}
             disabled={pendingAction !== null}
           >
-            Add friend
+            Follow
+          </button>
+        ) : null}
+
+        {relationship.state === 'follows_you' ? (
+          <button
+            type="button"
+            className="btn-primary"
+            onClick={handleAddClick}
+            disabled={pendingAction !== null}
+          >
+            Follow back
           </button>
         ) : null}
 
         {relationship.state === 'pending_outbound' ? (
           <>
             <button type="button" className="btn-ghost" disabled>
-              Request sent
+              Requested
             </button>
             <button
               type="button"
@@ -141,7 +152,7 @@ export function AddFriendButton({
               onClick={handleAccept}
               disabled={pendingAction !== null}
             >
-              {pendingAction === 'accept' ? 'Joining…' : 'Accept'}
+              {pendingAction === 'accept' ? 'Approving…' : 'Approve'}
             </button>
             <button
               type="button"
@@ -154,15 +165,15 @@ export function AddFriendButton({
           </>
         ) : null}
 
-        {relationship.state === 'friends' ? (
+        {relationship.state === 'friends' || relationship.state === 'following' ? (
           confirmingRemove ? (
             <div
               className="flex flex-wrap items-center gap-2"
               role="group"
-              aria-label={`Remove ${targetDisplayName} from your friends?`}
+              aria-label={`Unfollow ${targetDisplayName}?`}
             >
               <span className="text-sm text-foreground">
-                Remove {targetDisplayName}?
+                Unfollow {targetDisplayName}?
               </span>
               <button
                 type="button"
@@ -170,7 +181,7 @@ export function AddFriendButton({
                 onClick={confirmRemove}
                 disabled={pendingAction !== null}
               >
-                {pendingAction === 'remove' ? 'Removing…' : 'Remove'}
+                {pendingAction === 'remove' ? 'Unfollowing…' : 'Unfollow'}
               </button>
               <button
                 type="button"
@@ -184,7 +195,7 @@ export function AddFriendButton({
           ) : (
             <>
               <button type="button" className="btn-ghost" disabled>
-                Friends ✓
+                {relationship.state === 'friends' ? 'Friends ✓' : 'Following ✓'}
               </button>
               <button
                 type="button"
@@ -192,21 +203,10 @@ export function AddFriendButton({
                 onClick={handleRemove}
                 disabled={pendingAction !== null}
               >
-                Unfriend
+                Unfollow
               </button>
             </>
           )
-        ) : null}
-
-        {relationship.state === 'recently_sent' ? (
-          <button
-            type="button"
-            className="btn-ghost"
-            disabled
-            title="You sent a request to this person in the last 30 days."
-          >
-            Recently sent
-          </button>
         ) : null}
       </div>
 

--- a/src/components/profile/ProfileFriendButton.tsx
+++ b/src/components/profile/ProfileFriendButton.tsx
@@ -1,59 +1,39 @@
 'use client'
 
 import { useRouter } from 'next/navigation'
-import { useMemo } from 'react'
 
 import { AddFriendButton } from '@/components/friends/AddFriendButton'
 import type { RelationshipResult } from '@/server/db/queries/friend-requests'
 
-type FriendshipShape = {
-  id: string
-  status: string
-  viewerIsRequester: boolean
-} | null
-
 type ProfileFriendButtonProps = {
   targetUserId: string
-  friendship: FriendshipShape
+  // The viewer's directional relationship to this profile (follow model).
+  // `null` only on a profile with no edge in either direction — treated as a
+  // fresh "none" relationship.
+  relationship: RelationshipResult | null
   targetDisplayName: string
 }
 
-// Derives a RelationshipResult from the limited shape the profile page
-// passes today. We don't surface "recently_sent" here — the profile is
-// not a re-send surface, and FriendPortraitData doesn't carry resolvedAt.
-// If a recently-sent state is ever needed on profiles, expand
-// getFriendPortraitData to pass resolvedAt and refine this mapping.
-function deriveRelationship(friendship: FriendshipShape): RelationshipResult {
-  if (!friendship) {
-    return { state: 'none', friendshipId: null, isBlocked: false }
-  }
-  if (friendship.status === 'active') {
-    return { state: 'friends', friendshipId: friendship.id, isBlocked: false }
-  }
-  if (friendship.status === 'pending') {
-    return {
-      state: friendship.viewerIsRequester ? 'pending_outbound' : 'pending_inbound',
-      friendshipId: friendship.id,
-      isBlocked: false,
-    }
-  }
-  return { state: 'none', friendshipId: null, isBlocked: false }
+const NO_RELATIONSHIP: RelationshipResult = {
+  state: 'none',
+  friendshipId: null,
+  formedAt: null,
+  isBlocked: false,
 }
 
 export function ProfileFriendButton({
   targetUserId,
-  friendship,
+  relationship,
   targetDisplayName,
 }: ProfileFriendButtonProps) {
   const router = useRouter()
-  const relationship = useMemo(() => deriveRelationship(friendship), [friendship])
 
   return (
     <div className="mt-4">
       <AddFriendButton
         targetUserId={targetUserId}
         targetDisplayName={targetDisplayName}
-        relationship={relationship}
+        relationship={relationship ?? NO_RELATIONSHIP}
         onChange={() => router.refresh()}
       />
     </div>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -774,6 +774,79 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0058 (D-1 Stage 3) introduces the directional Follow model:
+    // the FollowState/FollowPrivacy enums, the User.follow_privacy column, the
+    // Follow table, and a backfill from the frozen Friendship table. Guard for
+    // preview/production databases that may have the migration recorded without
+    // the objects present — relationship reads now go through Follow and would
+    // 42P01/42703/42704 before app code can recover. Backfills are
+    // ON CONFLICT DO NOTHING, so this whole block is safe to re-run.
+    try {
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."FollowState" AS ENUM('pending', 'approved');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."FollowPrivacy" AS ENUM('public', 'approval_required');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "follow_privacy" "public"."FollowPrivacy" NOT NULL DEFAULT 'approval_required'
+      `);
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "Follow" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "followerId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "followeeId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "state" "public"."FollowState" NOT NULL DEFAULT 'pending',
+          "personalNote" text,
+          "requestContext" jsonb,
+          "created_at" timestamptz NOT NULL DEFAULT now(),
+          "approvedAt" timestamptz,
+          CONSTRAINT "Follow_followerId_followeeId_key" UNIQUE ("followerId", "followeeId"),
+          CONSTRAINT "Follow_distinct_users" CHECK ("followerId" <> "followeeId")
+        )
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "Follow_followerId_state_idx" ON "Follow" ("followerId", "state")
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "Follow_followeeId_state_idx" ON "Follow" ("followeeId", "state")
+      `);
+      await db.execute(sql`
+        INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
+        SELECT gen_random_uuid()::text, "userAId", "userBId", 'approved'::"public"."FollowState",
+               COALESCE("formedAt", now()), "createdAt"
+        FROM "Friendship" WHERE "status" = 'active'
+        ON CONFLICT ("followerId", "followeeId") DO NOTHING
+      `);
+      await db.execute(sql`
+        INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "approvedAt", "created_at")
+        SELECT gen_random_uuid()::text, "userBId", "userAId", 'approved'::"public"."FollowState",
+               COALESCE("formedAt", now()), "createdAt"
+        FROM "Friendship" WHERE "status" = 'active'
+        ON CONFLICT ("followerId", "followeeId") DO NOTHING
+      `);
+      await db.execute(sql`
+        INSERT INTO "Follow" ("id", "followerId", "followeeId", "state", "personalNote", "requestContext", "created_at")
+        SELECT gen_random_uuid()::text,
+               "requestedByUserId",
+               CASE WHEN "requestedByUserId" = "userAId" THEN "userBId" ELSE "userAId" END,
+               'pending'::"public"."FollowState",
+               "personalNote", "requestContext", "createdAt"
+        FROM "Friendship" WHERE "status" = 'pending'
+        ON CONFLICT ("followerId", "followeeId") DO NOTHING
+      `);
+    } catch {
+      // User or Friendship may not exist yet on a fresh database — migrate()
+      // creates them and applies 0058 in normal order.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/activity/write-activity.ts
+++ b/src/server/activity/write-activity.ts
@@ -6,8 +6,17 @@ export type ActivityItemType =
   | 'joshing_game_progress'
   | 'friend_mastery'
   | 'ceremony_ready'
+  // Legacy friend-request types — no longer written (the follow model below
+  // supersedes them) but retained so historical activity rows still type-check
+  // and render against the frozen Friendship table.
   | 'friend_request'
   | 'friend_request_accepted'
+  // D-1 Stage 3 follow model. `follow` = someone followed you (public account,
+  // auto-approved). `follow_request` = someone requested to follow you
+  // (approval_required). `follow_approved` = you approved their request.
+  | 'follow'
+  | 'follow_request'
+  | 'follow_approved'
   // An invited friend both accepted the inviter's invitation and got far
   // enough into the product to play their first five questions. Surfaced to
   // the inviter as a "your invite stuck" milestone. Written from

--- a/src/server/db/queries/__tests__/follow-relationship.test.ts
+++ b/src/server/db/queries/__tests__/follow-relationship.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// getRelationship issues a single select(...).from(follows).where(...) that
+// resolves to the two directional edges between viewer and target. The mock
+// returns `state.rows` from that awaited chain.
+const { dbMock, state } = vi.hoisted(() => {
+  const state = { rows: [] as unknown[] }
+
+  function makeChain() {
+    const chain: Record<string, unknown> = {}
+    for (const method of ['from', 'innerJoin', 'where', 'orderBy', 'limit']) {
+      chain[method] = vi.fn(() => chain)
+    }
+    chain.then = (resolve: (rows: unknown[]) => unknown) => resolve(state.rows)
+    return chain
+  }
+
+  return { dbMock: { select: vi.fn(() => makeChain()) }, state }
+})
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  follows: {
+    id: 'follows.id',
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
+    state: 'follows.state',
+    approvedAt: 'follows.approvedAt',
+  },
+}))
+
+import { getRelationship } from '@/server/db/queries/friend-requests'
+
+const VIEWER = 'viewer'
+const TARGET = 'target'
+
+function outbound(stateValue: 'pending' | 'approved', approvedAt: Date | null = null) {
+  return { id: 'out', followerId: VIEWER, followeeId: TARGET, state: stateValue, approvedAt }
+}
+function inbound(stateValue: 'pending' | 'approved', approvedAt: Date | null = null) {
+  return { id: 'in', followerId: TARGET, followeeId: VIEWER, state: stateValue, approvedAt }
+}
+
+describe('getRelationship over follow edges', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.rows = []
+  })
+
+  it('returns none for self', async () => {
+    await expect(getRelationship(VIEWER, VIEWER)).resolves.toMatchObject({ state: 'none' })
+    expect(dbMock.select).not.toHaveBeenCalled()
+  })
+
+  it('returns none when there are no edges', async () => {
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'none',
+      friendshipId: null,
+    })
+  })
+
+  it('returns friends when both directions are approved', async () => {
+    const at = new Date('2026-02-01T00:00:00.000Z')
+    state.rows = [outbound('approved', at), inbound('approved')]
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'friends',
+      friendshipId: 'out',
+      formedAt: at,
+    })
+  })
+
+  it('returns following when only my outbound edge is approved', async () => {
+    state.rows = [outbound('approved')]
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'following',
+      friendshipId: 'out',
+    })
+  })
+
+  it('returns follows_you when only their inbound edge is approved', async () => {
+    state.rows = [inbound('approved')]
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'follows_you',
+      friendshipId: null,
+    })
+  })
+
+  it('returns pending_outbound when my follow awaits their approval', async () => {
+    state.rows = [outbound('pending')]
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'pending_outbound',
+      friendshipId: 'out',
+    })
+  })
+
+  it('returns pending_inbound (and lets me approve) even if I already follow them', async () => {
+    state.rows = [outbound('approved'), inbound('pending')]
+    await expect(getRelationship(VIEWER, TARGET)).resolves.toMatchObject({
+      state: 'pending_inbound',
+      friendshipId: 'in',
+    })
+  })
+})

--- a/src/server/db/queries/__tests__/friends.test.ts
+++ b/src/server/db/queries/__tests__/friends.test.ts
@@ -1,100 +1,91 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+// The follow helpers issue joined queries (select(...).from(follows)
+// [.innerJoin(...)]* .where(...) [.orderBy(...)]). The mock returns a single
+// chainable, awaitable object whose methods all return itself and which
+// resolves to `state.rows` when awaited or after .orderBy(). Each test sets
+// `state.rows` to the rows the query under test should yield.
 const { dbMock, state } = vi.hoisted(() => {
-  const state = {
-    friendshipRows: [] as Array<{ userAId: string; userBId: string }>,
-    userRows: [] as Array<{
-      id: string
-      phoneNumber: string
-      displayName: string | null
-    }>,
-    selectCount: 0,
-  }
+  const state = { rows: [] as unknown[] }
 
-  function makeWhereBuilder(rows: unknown[]) {
-    return {
-      // where() must be BOTH awaitable (the friendships query awaits it
-      // directly) AND chainable into orderBy/limit (the users query does
-      // .where().orderBy(...)). Return a promise with the chain methods
-      // attached so both call shapes resolve to the same rows.
-      where: vi.fn(() => {
-        const p = Promise.resolve(rows) as Promise<unknown[]> & {
-          orderBy: () => Promise<unknown[]>
-          limit: () => Promise<unknown[]>
-        }
-        p.orderBy = vi.fn(async () => rows)
-        p.limit = vi.fn(async () => rows)
-        return p
-      }),
+  function makeChain() {
+    const chain: Record<string, unknown> = {}
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy']) {
+      chain[method] = vi.fn(() => chain)
     }
+    chain.then = (resolve: (rows: unknown[]) => unknown) => resolve(state.rows)
+    return chain
   }
 
-  const dbMock = {
-    select: vi.fn(() => {
-      state.selectCount += 1
-      const rows =
-        state.selectCount === 1 ? state.friendshipRows : state.userRows
-      return {
-        from: vi.fn(() => makeWhereBuilder(rows)),
-      }
-    }),
-  }
-
+  const dbMock = { select: vi.fn(() => makeChain()) }
   return { dbMock, state }
 })
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
-  declaredInterests: {
-    userId: 'declaredInterests.userId',
-    domain: 'declaredInterests.domain',
-    isActive: 'declaredInterests.isActive',
+  declaredInterests: { userId: 'di.userId', domain: 'di.domain', isActive: 'di.isActive' },
+  feedItems: {},
+  follows: {
+    id: 'follows.id',
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
+    state: 'follows.state',
+    approvedAt: 'follows.approvedAt',
   },
-  friendships: {
-    id: 'friendships.id',
-    userAId: 'friendships.userAId',
-    userBId: 'friendships.userBId',
-    status: 'friendships.status',
-    requestedByUserId: 'friendships.requestedByUserId',
-    requestContext: 'friendships.requestContext',
-    createdAt: 'friendships.createdAt',
-  },
-  users: {
-    id: 'users.id',
-    phoneNumber: 'users.phoneNumber',
-    displayName: 'users.displayName',
-  },
+  joshingGameResponses: {},
+  masteryEvents: {},
+  users: { id: 'users.id', phoneNumber: 'users.phoneNumber', displayName: 'users.displayName' },
 }))
 
-import { getFriends } from '@/server/db/queries/friends'
+vi.mock('@/server/feed/visibility', () => ({ DIRECT_SENT_FEED_SOURCE_TYPE: 'direct_sent' }))
 
-describe('getFriends invitation friendship symmetry', () => {
+import { areFriends, getFollowers, getFollowing, getFriends, getMutualFollows } from '@/server/db/queries/friends'
+
+describe('follow query helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    state.friendshipRows = []
-    state.userRows = []
-    state.selectCount = 0
+    state.rows = []
   })
 
-  it('getFriends(Jaime) includes Josh after an active invitation friendship', async () => {
-    state.friendshipRows = [{ userAId: 'user-jaime', userBId: 'user-josh' }]
-    state.userRows = [
-      { id: 'user-josh', displayName: 'Josh', phoneNumber: '+17345550001' },
-    ]
-
-    await expect(getFriends('user-jaime')).resolves.toEqual([
+  it('getFollowing returns the users I follow (approved outbound)', async () => {
+    state.rows = [{ user: { id: 'user-josh', displayName: 'Josh', phoneNumber: '+1734' } }]
+    await expect(getFollowing('user-jaime')).resolves.toEqual([
       expect.objectContaining({ id: 'user-josh', displayName: 'Josh' }),
     ])
   })
 
-  it('getFriends(Josh) includes Jaime from the same active invitation friendship', async () => {
-    state.friendshipRows = [{ userAId: 'user-jaime', userBId: 'user-josh' }]
-    state.userRows = [
-      { id: 'user-jaime', displayName: 'Jaime', phoneNumber: '+17345550002' },
-    ]
-
-    await expect(getFriends('user-josh')).resolves.toEqual([
-      expect.objectContaining({ id: 'user-jaime', displayName: 'Jaime' }),
+  it('getFollowers returns the users who follow me (approved inbound)', async () => {
+    state.rows = [{ user: { id: 'user-robyn', displayName: 'Robyn', phoneNumber: '+1313' } }]
+    await expect(getFollowers('user-jaime')).resolves.toEqual([
+      expect.objectContaining({ id: 'user-robyn', displayName: 'Robyn' }),
     ])
+  })
+
+  it('getMutualFollows / getFriends return the mutual (both-approved) set', async () => {
+    state.rows = [{ user: { id: 'user-josh', displayName: 'Josh', phoneNumber: '+1734' } }]
+    await expect(getMutualFollows('user-jaime')).resolves.toEqual([
+      expect.objectContaining({ id: 'user-josh' }),
+    ])
+
+    state.rows = [{ user: { id: 'user-josh', displayName: 'Josh', phoneNumber: '+1734' } }]
+    await expect(getFriends('user-jaime')).resolves.toEqual([
+      expect.objectContaining({ id: 'user-josh' }),
+    ])
+  })
+
+  it('areFriends is true only when both directional approved edges exist', async () => {
+    state.rows = [
+      { followerId: 'a', followeeId: 'b' },
+      { followerId: 'b', followeeId: 'a' },
+    ]
+    await expect(areFriends('a', 'b')).resolves.toBe(true)
+
+    state.rows = [{ followerId: 'a', followeeId: 'b' }]
+    await expect(areFriends('a', 'b')).resolves.toBe(false)
+  })
+
+  it('areFriends is false for self', async () => {
+    await expect(areFriends('a', 'a')).resolves.toBe(false)
+    expect(dbMock.select).not.toHaveBeenCalled()
   })
 })

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -4,6 +4,7 @@ import {
   activityItems,
   db,
   feedItems,
+  follows,
   friendships,
   gradeDisputes,
   joshingGameQuestions,
@@ -118,6 +119,9 @@ function isActivityType(value: string): value is ActivityItemType {
     'ceremony_ready',
     'friend_request',
     'friend_request_accepted',
+    'follow',
+    'follow_request',
+    'follow_approved',
     'invited_friend_played_first_five',
     'received_direct_question',
     'reaction_received',
@@ -142,6 +146,40 @@ function parseFriendshipRequestInterests(value: unknown): string[] {
 }
 
 async function hydrateFriendshipRequests(items: ActivityItemRow[]) {
+  const result = new Map<string, NonNullable<ActivityItemView['reference']['friendshipRequest']>>();
+
+  // New follow-model rows reference the `follows` table; legacy friend-request
+  // rows reference the frozen `friendships` table. Hydrate both into one map
+  // keyed by referenceId, normalising follow `state` onto the same `status`
+  // shape the activity card already reads ('approved' -> 'active').
+  const followIds = [
+    ...new Set(
+      items
+        .filter((item) => item.referenceType === 'follow')
+        .map((item) => item.referenceId)
+        .filter((id): id is string => Boolean(id)),
+    ),
+  ];
+  if (followIds.length > 0) {
+    const followRows = await db
+      .select({
+        id: follows.id,
+        state: follows.state,
+        followerId: follows.followerId,
+        requestContext: follows.requestContext,
+      })
+      .from(follows)
+      .where(inArray(follows.id, followIds));
+    for (const row of followRows) {
+      result.set(row.id, {
+        id: row.id,
+        status: row.state === 'approved' ? 'active' : 'pending',
+        requestedByUserId: row.followerId,
+        suggestedInterests: parseFriendshipRequestInterests(row.requestContext),
+      });
+    }
+  }
+
   const friendshipIds = [
     ...new Set(
       items
@@ -150,29 +188,27 @@ async function hydrateFriendshipRequests(items: ActivityItemRow[]) {
         .filter((id): id is string => Boolean(id)),
     ),
   ];
-  if (friendshipIds.length === 0) {
-    return new Map<string, NonNullable<ActivityItemView['reference']['friendshipRequest']>>();
+  if (friendshipIds.length > 0) {
+    const rows = await db
+      .select({
+        id: friendships.id,
+        status: friendships.status,
+        requestedByUserId: friendships.requestedByUserId,
+        requestContext: friendships.requestContext,
+      })
+      .from(friendships)
+      .where(inArray(friendships.id, friendshipIds));
+    for (const row of rows) {
+      result.set(row.id, {
+        id: row.id,
+        status: row.status,
+        requestedByUserId: row.requestedByUserId,
+        suggestedInterests: parseFriendshipRequestInterests(row.requestContext),
+      });
+    }
   }
 
-  const rows = await db
-    .select({
-      id: friendships.id,
-      status: friendships.status,
-      requestedByUserId: friendships.requestedByUserId,
-      requestContext: friendships.requestContext,
-    })
-    .from(friendships)
-    .where(inArray(friendships.id, friendshipIds));
-
-  return new Map(rows.map((row) => [
-    row.id,
-    {
-      id: row.id,
-      status: row.status,
-      requestedByUserId: row.requestedByUserId,
-      suggestedInterests: parseFriendshipRequestInterests(row.requestContext),
-    },
-  ]));
+  return result;
 }
 
 async function hydrateActors(items: ActivityItemRow[]) {
@@ -673,7 +709,7 @@ async function hydrateActivityRows(
       createdAt: row.createdAt,
       actor: row.actorUserId ? actorsById.get(row.actorUserId) ?? null : null,
       reference: {
-        friendshipRequest: row.referenceType === 'friendship' && row.referenceId
+        friendshipRequest: (row.referenceType === 'friendship' || row.referenceType === 'follow') && row.referenceId
           ? friendshipRequestsById.get(row.referenceId)
           : undefined,
         game: row.referenceType === 'joshing_game' && row.referenceId

--- a/src/server/db/queries/friend-requests.ts
+++ b/src/server/db/queries/friend-requests.ts
@@ -1,91 +1,92 @@
-import { and, eq, inArray, sql } from 'drizzle-orm'
+import { and, eq, inArray, or } from 'drizzle-orm'
 
-import { db, friendships } from '@/server/db'
-import { friendshipPair } from '@/server/friends/friendships'
+import { db, follows } from '@/server/db'
 
 export type RelationshipState =
   | 'none'
-  | 'pending_outbound'
-  | 'pending_inbound'
-  | 'friends'
-  | 'recently_sent'
+  | 'pending_outbound' // I requested to follow them; awaiting their approval
+  | 'pending_inbound' // they requested to follow me; awaiting my approval
+  | 'following' // I follow them (approved), one-directional
+  | 'follows_you' // they follow me (approved); I don't follow back
+  | 'friends' // mutual follow (both directions approved)
 
 export type RelationshipResult = {
   state: RelationshipState
-  // Present when state is pending_outbound, pending_inbound, or friends —
-  // so callers can drive accept/cancel/unfriend actions without a second
-  // lookup. null when the row doesn't exist or has been resolved.
+  // The follow-edge id that drives the next action:
+  //   pending_outbound / following / friends -> my outbound edge (cancel / unfollow)
+  //   pending_inbound                        -> their inbound edge (approve / ignore)
+  //   follows_you / none                     -> null (the action is to create a follow)
   friendshipId: string | null
-  // True when the target party has soft-removed this friendship. The UI
-  // never shows a separate "blocked" state — to the viewer it looks like
-  // "none" — but POST /api/friend-requests refuses with 404 (doesn't
-  // reveal the block). Callers that render add-friend affordances on
-  // lists (search results, contact matches) should filter rows where
-  // isBlocked === true before rendering.
+  // When the relevant approved edge formed (mutual or one-directional follow).
+  formedAt: Date | null
+  // Retained for API/type compatibility with list surfaces that filter on it.
+  // Explicit blocking is not modelled under the follow model (an unwanted
+  // follower is handled by the approval gate / unfollow), so this is always
+  // false now.
   isBlocked: boolean
 }
 
-const RECENTLY_SENT_WINDOW_MS = 30 * 24 * 60 * 60 * 1000
+type EdgeRow = {
+  id: string
+  followerId: string
+  followeeId: string
+  state: 'pending' | 'approved'
+  approvedAt: Date | null
+}
+
+// Resolve the relationship from the viewer's two directional edges.
+//   outbound = viewer -> target, inbound = target -> viewer
+function resolve(outbound: EdgeRow | undefined, inbound: EdgeRow | undefined): RelationshipResult {
+  const out = outbound?.state
+  const inb = inbound?.state
+
+  if (out === 'approved' && inb === 'approved') {
+    return { state: 'friends', friendshipId: outbound!.id, formedAt: outbound!.approvedAt, isBlocked: false }
+  }
+  // An incoming request I can act on takes precedence so I can approve it.
+  if (inb === 'pending') {
+    return { state: 'pending_inbound', friendshipId: inbound!.id, formedAt: null, isBlocked: false }
+  }
+  if (out === 'pending') {
+    return { state: 'pending_outbound', friendshipId: outbound!.id, formedAt: null, isBlocked: false }
+  }
+  if (out === 'approved') {
+    return { state: 'following', friendshipId: outbound!.id, formedAt: outbound!.approvedAt, isBlocked: false }
+  }
+  if (inb === 'approved') {
+    return { state: 'follows_you', friendshipId: null, formedAt: null, isBlocked: false }
+  }
+  return { state: 'none', friendshipId: null, formedAt: null, isBlocked: false }
+}
 
 // Single source of truth for the viewer's relationship to a target user.
-// Resolution order (highest precedence first):
-//   1. status='active' row                    -> 'friends'
-//   2. status='removed' by target             -> 'none' + isBlocked: true
-//      status='removed' by viewer             -> 'none' (the viewer chose
-//                                                to disconnect; they can re-add)
-//   3. status='pending', requested by viewer  -> 'pending_outbound'
-//   4. status='pending', requested by target  -> 'pending_inbound'
-//   5. status in ('declined','expired') with resolvedAt within 30 days -> 'recently_sent'
-//   6. otherwise                              -> 'none'
 export async function getRelationship(
   viewerId: string,
   targetId: string,
-  now: Date = new Date(),
 ): Promise<RelationshipResult> {
   if (viewerId === targetId) {
-    return { state: 'none', friendshipId: null, isBlocked: false }
+    return { state: 'none', friendshipId: null, formedAt: null, isBlocked: false }
   }
 
-  const pair = friendshipPair(viewerId, targetId)
-  const [row] = await db
-    .select()
-    .from(friendships)
-    .where(and(eq(friendships.userAId, pair.userAId), eq(friendships.userBId, pair.userBId)))
-    .limit(1)
+  const rows = await db
+    .select({
+      id: follows.id,
+      followerId: follows.followerId,
+      followeeId: follows.followeeId,
+      state: follows.state,
+      approvedAt: follows.approvedAt,
+    })
+    .from(follows)
+    .where(
+      or(
+        and(eq(follows.followerId, viewerId), eq(follows.followeeId, targetId)),
+        and(eq(follows.followerId, targetId), eq(follows.followeeId, viewerId)),
+      ),
+    )
 
-  if (!row) {
-    return { state: 'none', friendshipId: null, isBlocked: false }
-  }
-
-  if (row.status === 'active') {
-    return { state: 'friends', friendshipId: row.id, isBlocked: false }
-  }
-
-  if (row.status === 'removed') {
-    const removedByTarget = row.removedByUserId === targetId
-    return { state: 'none', friendshipId: null, isBlocked: removedByTarget }
-  }
-
-  if (row.status === 'pending') {
-    return {
-      state: row.requestedByUserId === viewerId ? 'pending_outbound' : 'pending_inbound',
-      friendshipId: row.id,
-      isBlocked: false,
-    }
-  }
-
-  if (row.status === 'declined' || row.status === 'expired') {
-    const resolvedAt = row.resolvedAt
-    if (resolvedAt && now.getTime() - resolvedAt.getTime() < RECENTLY_SENT_WINDOW_MS) {
-      // Only the original requester is gated by the cooldown — the
-      // declinee can re-send immediately if they change their mind.
-      if (row.requestedByUserId === viewerId) {
-        return { state: 'recently_sent', friendshipId: null, isBlocked: false }
-      }
-    }
-  }
-
-  return { state: 'none', friendshipId: null, isBlocked: false }
+  const outbound = rows.find((row) => row.followerId === viewerId)
+  const inbound = rows.find((row) => row.followerId === targetId)
+  return resolve(outbound, inbound)
 }
 
 // Bulk lookup variant for list surfaces (search results, contact matches).
@@ -93,7 +94,6 @@ export async function getRelationship(
 export async function getRelationships(
   viewerId: string,
   targetIds: string[],
-  now: Date = new Date(),
 ): Promise<Map<string, RelationshipResult>> {
   const result = new Map<string, RelationshipResult>()
   if (targetIds.length === 0) return result
@@ -102,57 +102,30 @@ export async function getRelationships(
   if (uniqueTargets.length === 0) return result
 
   const rows = await db
-    .select()
-    .from(friendships)
+    .select({
+      id: follows.id,
+      followerId: follows.followerId,
+      followeeId: follows.followeeId,
+      state: follows.state,
+      approvedAt: follows.approvedAt,
+    })
+    .from(follows)
     .where(
-      and(
-        sql`(${friendships.userAId} = ${viewerId} AND ${friendships.userBId} IN ${uniqueTargets})
-          OR (${friendships.userBId} = ${viewerId} AND ${friendships.userAId} IN ${uniqueTargets})`,
-        inArray(friendships.status, ['active', 'pending', 'declined', 'expired', 'removed']),
+      or(
+        and(eq(follows.followerId, viewerId), inArray(follows.followeeId, uniqueTargets)),
+        and(eq(follows.followeeId, viewerId), inArray(follows.followerId, uniqueTargets)),
       ),
     )
 
-  const rowsByOther = new Map<string, typeof rows[number]>()
+  const outboundByTarget = new Map<string, EdgeRow>()
+  const inboundByTarget = new Map<string, EdgeRow>()
   for (const row of rows) {
-    const otherId = row.userAId === viewerId ? row.userBId : row.userAId
-    rowsByOther.set(otherId, row)
+    if (row.followerId === viewerId) outboundByTarget.set(row.followeeId, row)
+    else inboundByTarget.set(row.followerId, row)
   }
 
   for (const targetId of uniqueTargets) {
-    const row = rowsByOther.get(targetId)
-    if (!row) {
-      result.set(targetId, { state: 'none', friendshipId: null, isBlocked: false })
-      continue
-    }
-    if (row.status === 'active') {
-      result.set(targetId, { state: 'friends', friendshipId: row.id, isBlocked: false })
-      continue
-    }
-    if (row.status === 'removed') {
-      const removedByTarget = row.removedByUserId === targetId
-      result.set(targetId, { state: 'none', friendshipId: null, isBlocked: removedByTarget })
-      continue
-    }
-    if (row.status === 'pending') {
-      result.set(targetId, {
-        state: row.requestedByUserId === viewerId ? 'pending_outbound' : 'pending_inbound',
-        friendshipId: row.id,
-        isBlocked: false,
-      })
-      continue
-    }
-    if (row.status === 'declined' || row.status === 'expired') {
-      const resolvedAt = row.resolvedAt
-      if (
-        resolvedAt
-        && now.getTime() - resolvedAt.getTime() < RECENTLY_SENT_WINDOW_MS
-        && row.requestedByUserId === viewerId
-      ) {
-        result.set(targetId, { state: 'recently_sent', friendshipId: null, isBlocked: false })
-        continue
-      }
-    }
-    result.set(targetId, { state: 'none', friendshipId: null, isBlocked: false })
+    result.set(targetId, resolve(outboundByTarget.get(targetId), inboundByTarget.get(targetId)))
   }
 
   return result

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -1,10 +1,11 @@
-import { and, asc, desc, eq, inArray, ne, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
 
 import {
   db,
   declaredInterests,
   feedItems,
-  friendships,
+  follows,
   joshingGameResponses,
   masteryEvents,
   users,
@@ -12,17 +13,23 @@ import {
 import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 export type User = typeof users.$inferSelect;
-export type Friendship = typeof friendships.$inferSelect;
+export type Follow = typeof follows.$inferSelect;
 
-export type FriendHubFriend = {
+// A person row in the friends hub. `youFollow` / `followsYou` let the UI label
+// each row (Following / Follows you / Follow back) and `youFollow && followsYou`
+// is the mutual ("friend") case.
+export type HubPerson = {
   id: string
   displayName: string
   declaredInterests: string[]
   sharedInterests: string[]
   lastActiveAt: Date | null
+  youFollow: boolean
+  followsYou: boolean
 }
 
-export type IncomingFriendRequest = {
+export type IncomingFollowRequest = {
+  // The pending follow edge id — drives approve/ignore.
   id: string
   requesterId: string
   requesterName: string
@@ -31,7 +38,8 @@ export type IncomingFriendRequest = {
   createdAt: Date
 }
 
-export type OutboundFriendRequest = {
+export type OutboundFollowRequest = {
+  // The pending follow edge id — drives cancel.
   id: string
   recipientId: string
   recipientName: string
@@ -40,9 +48,16 @@ export type OutboundFriendRequest = {
 }
 
 export type FriendsHub = {
-  friends: FriendHubFriend[]
-  incomingRequests: IncomingFriendRequest[]
-  outboundRequests: OutboundFriendRequest[]
+  // People I follow (approved outbound).
+  following: HubPerson[]
+  // People who follow me (approved inbound).
+  followers: HubPerson[]
+  // Follow requests awaiting my approval (pending inbound).
+  incomingRequests: IncomingFollowRequest[]
+  // My follow requests awaiting the other person's approval (pending outbound).
+  outboundRequests: OutboundFollowRequest[]
+  // My own gate on new followers.
+  followPrivacy: 'public' | 'approval_required'
 }
 
 function displayName(name: string | null, fallback: string): string {
@@ -61,36 +76,83 @@ function normalizeSuggestedInterests(value: unknown): string[] {
     .filter(Boolean)
 }
 
-export async function getFriends(userId: string): Promise<User[]> {
+/**
+ * Returns the set of users `userId` follows (approved outbound edges). This is
+ * the directional "people I follow" set — NOT necessarily reciprocal.
+ */
+export async function getFollowing(userId: string): Promise<User[]> {
   const rows = await db
-    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
-    .from(friendships)
-    .where(and(
-      eq(friendships.status, 'active'),
-      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
-    ));
-  const friendIds = rows.map((friendship) => (
-    friendship.userAId === userId ? friendship.userBId : friendship.userAId
-  ));
-  if (friendIds.length === 0) return [];
-
-  return db
-    .select()
-    .from(users)
-    .where(inArray(users.id, friendIds))
-    .orderBy(asc(users.displayName), asc(users.phoneNumber));
+    .select({ user: users })
+    .from(follows)
+    .innerJoin(users, eq(users.id, follows.followeeId))
+    .where(and(eq(follows.followerId, userId), eq(follows.state, 'approved')))
+    .orderBy(asc(users.displayName), asc(users.phoneNumber))
+  return rows.map((row) => row.user)
 }
 
 /**
- * Returns the set of users `userId` follows.
- *
- * Stage 1 stub (D-1 Daily Five +2): the directional follow model does not land
- * until Stage 3, so this currently reads the symmetric active-friendship set as
- * the follow set. Stage 3 repoints only this helper's internals to the `follows`
- * table; callers must not depend on the relation being bidirectional.
+ * Returns the set of users who follow `userId` (approved inbound edges) — "my
+ * followers", the broadcast / friend_answered fan-out audience.
  */
-export async function getFollowing(userId: string): Promise<User[]> {
-  return getFriends(userId);
+export async function getFollowers(userId: string): Promise<User[]> {
+  const rows = await db
+    .select({ user: users })
+    .from(follows)
+    .innerJoin(users, eq(users.id, follows.followerId))
+    .where(and(eq(follows.followeeId, userId), eq(follows.state, 'approved')))
+    .orderBy(asc(users.displayName), asc(users.phoneNumber))
+  return rows.map((row) => row.user)
+}
+
+/**
+ * Returns users in a mutual follow with `userId` (both directions approved).
+ * This is the canonical "friend" relationship that the symmetric `getFriends`
+ * delegated to before the follow model — reciprocal features (inside jokes,
+ * shared interests, ceremony) read this.
+ */
+export async function getMutualFollows(userId: string): Promise<User[]> {
+  const back = alias(follows, 'follows_back')
+  const rows = await db
+    .select({ user: users })
+    .from(follows)
+    .innerJoin(
+      back,
+      and(
+        eq(back.followerId, follows.followeeId),
+        eq(back.followeeId, userId),
+        eq(back.state, 'approved'),
+      ),
+    )
+    .innerJoin(users, eq(users.id, follows.followeeId))
+    .where(and(eq(follows.followerId, userId), eq(follows.state, 'approved')))
+    .orderBy(asc(users.displayName), asc(users.phoneNumber))
+  return rows.map((row) => row.user)
+}
+
+/**
+ * Mutual-follow shim. Pre-follow-model `getFriends` meant "active symmetric
+ * friendship"; under the directional model that is exactly a mutual follow.
+ * The ~18 reciprocal call-sites keep calling `getFriends` unchanged.
+ */
+export async function getFriends(userId: string): Promise<User[]> {
+  return getMutualFollows(userId)
+}
+
+export async function areFriends(userAId: string, userBId: string): Promise<boolean> {
+  if (userAId === userBId) return false
+  const rows = await db
+    .select({ followerId: follows.followerId, followeeId: follows.followeeId })
+    .from(follows)
+    .where(
+      and(
+        eq(follows.state, 'approved'),
+        or(
+          and(eq(follows.followerId, userAId), eq(follows.followeeId, userBId)),
+          and(eq(follows.followerId, userBId), eq(follows.followeeId, userAId)),
+        ),
+      ),
+    )
+  return rows.length === 2
 }
 
 export async function getRecentDirectSendRecipients(userId: string, limit = 3): Promise<User[]> {
@@ -169,38 +231,68 @@ async function getLastActiveByUserId(userIds: string[]): Promise<Map<string, Dat
 }
 
 export async function getFriendsHub(userId: string): Promise<FriendsHub> {
-  const activeFriendships = await db
-    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
-    .from(friendships)
-    .where(and(
-      eq(friendships.status, 'active'),
-      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
-    ))
+  // All follow edges touching me, in either direction.
+  const edges = await db
+    .select({
+      id: follows.id,
+      followerId: follows.followerId,
+      followeeId: follows.followeeId,
+      state: follows.state,
+      personalNote: follows.personalNote,
+      requestContext: follows.requestContext,
+      createdAt: follows.createdAt,
+    })
+    .from(follows)
+    .where(or(eq(follows.followerId, userId), eq(follows.followeeId, userId)))
 
-  const friendIds = activeFriendships.map((friendship) => (
-    friendship.userAId === userId ? friendship.userBId : friendship.userAId
-  ))
+  const followingIds = new Set<string>()
+  const followerIds = new Set<string>()
+  const incoming: Array<{ id: string; requesterId: string; suggestedInterests: string[]; personalNote: string | null; createdAt: Date }> = []
+  const outbound: Array<{ id: string; recipientId: string; personalNote: string | null; createdAt: Date }> = []
 
-  const friendRows = friendIds.length === 0
+  for (const edge of edges) {
+    const outboundEdge = edge.followerId === userId
+    const other = outboundEdge ? edge.followeeId : edge.followerId
+    if (edge.state === 'approved') {
+      if (outboundEdge) followingIds.add(other)
+      else followerIds.add(other)
+    } else {
+      // pending
+      if (outboundEdge) {
+        outbound.push({ id: edge.id, recipientId: other, personalNote: edge.personalNote, createdAt: edge.createdAt })
+      } else {
+        incoming.push({
+          id: edge.id,
+          requesterId: other,
+          suggestedInterests: normalizeSuggestedInterests(edge.requestContext),
+          personalNote: edge.personalNote,
+          createdAt: edge.createdAt,
+        })
+      }
+    }
+  }
+
+  const personIds = Array.from(new Set<string>([...followingIds, ...followerIds]))
+  const requesterIds = incoming.map((r) => r.requesterId)
+  const recipientIds = outbound.map((r) => r.recipientId)
+  const allIds = Array.from(new Set<string>([...personIds, ...requesterIds, ...recipientIds]))
+
+  const userRows = allIds.length === 0
     ? []
     : await db
-      .select({
-        id: users.id,
-        displayName: users.displayName,
-        phoneNumber: users.phoneNumber,
-      })
+      .select({ id: users.id, displayName: users.displayName, phoneNumber: users.phoneNumber })
       .from(users)
-      .where(inArray(users.id, friendIds))
-      .orderBy(asc(users.displayName), asc(users.phoneNumber))
+      .where(inArray(users.id, allIds))
+  const usersById = new Map(userRows.map((row) => [row.id, row] as const))
 
-  const interestRows = friendIds.length === 0
+  const interestRows = allIds.length === 0
     ? []
     : await db
       .select({ userId: declaredInterests.userId, domain: declaredInterests.domain })
       .from(declaredInterests)
       .where(and(
         eq(declaredInterests.isActive, true),
-        inArray(declaredInterests.userId, [userId, ...friendIds]),
+        inArray(declaredInterests.userId, [userId, ...allIds]),
       ))
       .orderBy(asc(declaredInterests.domain))
 
@@ -210,175 +302,110 @@ export async function getFriendsHub(userId: string): Promise<FriendsHub> {
     current.push(row.domain)
     interestsByUser.set(row.userId, current)
   }
-
   const viewerInterests = new Set(interestsByUser.get(userId) ?? [])
 
-  const lastActiveByUser = friendIds.length === 0
+  const lastActiveByUser = personIds.length === 0
     ? new Map<string, Date>()
-    : await getLastActiveByUserId(friendIds)
+    : await getLastActiveByUserId(personIds)
 
-  const incomingRows = await db
-    .select({
-      id: friendships.id,
-      requesterId: users.id,
-      requesterDisplayName: users.displayName,
-      requesterPhoneNumber: users.phoneNumber,
-      requestContext: friendships.requestContext,
-      personalNote: friendships.personalNote,
-      createdAt: friendships.createdAt,
-    })
-    .from(friendships)
-    .innerJoin(users, eq(users.id, friendships.requestedByUserId))
-    .where(and(
-      eq(friendships.status, 'pending'),
-      ne(friendships.requestedByUserId, userId),
-      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
-    ))
-    .orderBy(asc(friendships.createdAt))
+  const [me] = await db
+    .select({ followPrivacy: users.followPrivacy })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1)
 
-  const outboundRows = await db
-    .select({
-      id: friendships.id,
-      recipientUserAId: friendships.userAId,
-      recipientUserBId: friendships.userBId,
-      personalNote: friendships.personalNote,
-      createdAt: friendships.createdAt,
-    })
-    .from(friendships)
-    .where(and(
-      eq(friendships.status, 'pending'),
-      eq(friendships.requestedByUserId, userId),
-      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
-    ))
-    .orderBy(desc(friendships.createdAt))
+  function toPerson(id: string): HubPerson {
+    const user = usersById.get(id)
+    const name = displayName(user?.displayName ?? null, user?.phoneNumber ?? '')
+    const personInterests = interestsByUser.get(id) ?? []
+    return {
+      id,
+      displayName: name,
+      declaredInterests: personInterests,
+      sharedInterests: personInterests.filter((interest) => viewerInterests.has(interest)),
+      lastActiveAt: lastActiveByUser.get(id) ?? null,
+      youFollow: followingIds.has(id),
+      followsYou: followerIds.has(id),
+    }
+  }
 
-  const outboundRecipientIds = outboundRows.map((row) => (
-    row.recipientUserAId === userId ? row.recipientUserBId : row.recipientUserAId
-  ))
-
-  const outboundRecipients = outboundRecipientIds.length === 0
-    ? []
-    : await db
-      .select({
-        id: users.id,
-        displayName: users.displayName,
-        phoneNumber: users.phoneNumber,
-      })
-      .from(users)
-      .where(inArray(users.id, outboundRecipientIds))
-
-  const outboundRecipientById = new Map(outboundRecipients.map((row) => [row.id, row] as const))
+  const byName = (a: HubPerson, b: HubPerson) => a.displayName.localeCompare(b.displayName)
 
   return {
-    friends: friendRows.map((friend) => {
-      const friendInterests = interestsByUser.get(friend.id) ?? []
-      return {
-        id: friend.id,
-        displayName: displayName(friend.displayName, friend.phoneNumber),
-        declaredInterests: friendInterests,
-        sharedInterests: friendInterests.filter((interest) => viewerInterests.has(interest)),
-        lastActiveAt: lastActiveByUser.get(friend.id) ?? null,
-      }
-    }),
-    incomingRequests: incomingRows.map((request) => ({
-      id: request.id,
-      requesterId: request.requesterId,
-      requesterName: displayName(request.requesterDisplayName, request.requesterPhoneNumber),
-      suggestedInterests: normalizeSuggestedInterests(request.requestContext),
-      personalNote: request.personalNote,
-      createdAt: request.createdAt,
-    })),
-    outboundRequests: outboundRows
-      .map((row) => {
-        const recipientId = row.recipientUserAId === userId ? row.recipientUserBId : row.recipientUserAId
-        const recipient = outboundRecipientById.get(recipientId)
-        if (!recipient) return null
+    following: Array.from(followingIds).map(toPerson).sort(byName),
+    followers: Array.from(followerIds).map(toPerson).sort(byName),
+    incomingRequests: incoming
+      .map((request) => {
+        const user = usersById.get(request.requesterId)
         return {
-          id: row.id,
-          recipientId,
-          recipientName: displayName(recipient.displayName, recipient.phoneNumber),
-          personalNote: row.personalNote,
-          createdAt: row.createdAt,
+          id: request.id,
+          requesterId: request.requesterId,
+          requesterName: displayName(user?.displayName ?? null, user?.phoneNumber ?? ''),
+          suggestedInterests: request.suggestedInterests,
+          personalNote: request.personalNote,
+          createdAt: request.createdAt,
         }
       })
-      .filter((row): row is OutboundFriendRequest => row !== null),
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime()),
+    outboundRequests: outbound
+      .map((request) => {
+        const user = usersById.get(request.recipientId)
+        return {
+          id: request.id,
+          recipientId: request.recipientId,
+          recipientName: displayName(user?.displayName ?? null, user?.phoneNumber ?? ''),
+          personalNote: request.personalNote,
+          createdAt: request.createdAt,
+        }
+      })
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime()),
+    followPrivacy: me?.followPrivacy ?? 'approval_required',
   }
 }
 
-export async function getFriendship(userAId: string, userBId: string): Promise<Friendship | null> {
-  const [friendship] = await db
-    .select()
-    .from(friendships)
-    .where(or(
-      and(eq(friendships.userAId, userAId), eq(friendships.userBId, userBId)),
-      and(eq(friendships.userAId, userBId), eq(friendships.userBId, userAId)),
-    ))
-    .limit(1);
-
-  return friendship ?? null;
-}
-
-export async function areFriends(userAId: string, userBId: string): Promise<boolean> {
-  if (userAId === userBId) return false;
-  const friendship = await getFriendship(userAId, userBId);
-  return friendship?.status === 'active';
-}
-
 /**
- * Returns the viewer's 1st-degree friend ids and 2nd-degree (friends of
- * friends) ids, with FoF de-duplicated against direct friends and the
- * viewer themselves. Used by the Daily 5 picker to rank eligible
- * user-authored questions: direct friends first, then FoF, then everyone
- * else.
+ * Returns the viewer's 1st-degree mutual-follow ids and 2nd-degree
+ * (mutual-follows of mutual-follows) ids, with the extended set de-duplicated
+ * against direct mutuals and the viewer. Used by the Daily 5 picker to rank
+ * eligible user-authored questions: direct first, then extended, then everyone.
  *
- * The friend graph is small and uncached, so we run two normal queries
- * rather than a recursive CTE — the second pass is bounded by
- * `directIds.length` which is itself indexed via the existing
- * Friendship_userAId_status_idx / Friendship_userBId_status_idx pair.
+ * "Direct" stays mutual-follow (the migrated symmetric friendship), preserving
+ * the picker's ranking semantics under the follow model.
  */
 export async function getFriendAndFoFUserIds(userId: string): Promise<{
   direct: Set<string>;
   extended: Set<string>;
 }> {
-  const directRows = await db
-    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
-    .from(friendships)
-    .where(and(
-      eq(friendships.status, 'active'),
-      or(eq(friendships.userAId, userId), eq(friendships.userBId, userId)),
-    ));
-
-  const direct = new Set<string>();
-  for (const row of directRows) {
-    const friendId = row.userAId === userId ? row.userBId : row.userAId;
-    direct.add(friendId);
-  }
+  const directUsers = await getMutualFollows(userId)
+  const direct = new Set<string>(directUsers.map((user) => user.id))
 
   if (direct.size === 0) {
-    return { direct, extended: new Set<string>() };
+    return { direct, extended: new Set<string>() }
   }
 
-  const directList = [...direct];
+  const directList = [...direct]
+  const extended = new Set<string>()
+  const seen = new Set<string>([userId, ...directList])
+
+  // Mutual follows of each direct mutual, in a single bounded query: an edge
+  // direct→candidate that has an approved reverse edge candidate→direct.
+  const back = alias(follows, 'fof_back')
   const fofRows = await db
-    .select({ userAId: friendships.userAId, userBId: friendships.userBId })
-    .from(friendships)
-    .where(and(
-      eq(friendships.status, 'active'),
-      or(
-        inArray(friendships.userAId, directList),
-        inArray(friendships.userBId, directList),
+    .select({ candidate: follows.followeeId })
+    .from(follows)
+    .innerJoin(
+      back,
+      and(
+        eq(back.followerId, follows.followeeId),
+        eq(back.followeeId, follows.followerId),
+        eq(back.state, 'approved'),
       ),
-    ));
+    )
+    .where(and(eq(follows.state, 'approved'), inArray(follows.followerId, directList)))
 
-  const extended = new Set<string>();
   for (const row of fofRows) {
-    if (directList.includes(row.userAId) && row.userBId !== userId && !direct.has(row.userBId)) {
-      extended.add(row.userBId);
-    }
-    if (directList.includes(row.userBId) && row.userAId !== userId && !direct.has(row.userAId)) {
-      extended.add(row.userAId);
-    }
+    if (!seen.has(row.candidate)) extended.add(row.candidate)
   }
 
-  return { direct, extended };
+  return { direct, extended }
 }

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -114,6 +114,17 @@ export function updateUser(id: string, data: Partial<User>) {
     .then(([user]) => user);
 }
 
+// D-1 Stage 3 — gate on new followers. 'public' lets anyone follow instantly;
+// 'approval_required' makes a follow a request the user approves.
+export function setFollowPrivacy(id: string, followPrivacy: 'public' | 'approval_required') {
+  return db
+    .update(users)
+    .set({ followPrivacy, updatedAt: new Date() })
+    .where(eq(users.id, id))
+    .returning({ id: users.id, followPrivacy: users.followPrivacy })
+    .then(([row]) => row);
+}
+
 export async function saveDeclaredInterests(userId: string, interests: DeclaredInterestInput[]) {
   const normalized = normalizeDeclaredInterests(interests);
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -36,6 +36,14 @@ export const categoryEnum = pgEnum('Category', [
 ]);
 
 export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends']);
+
+// D-1 Stage 3 — directional follow model.
+// `state` on a follow edge: a follow targeting an approval_required user lands
+// as `pending` (a request the followee approves); a follow targeting a public
+// user lands `approved` immediately. Invites create approved edges directly.
+export const followStateEnum = pgEnum('FollowState', ['pending', 'approved']);
+// Per-user gate on *new* followers. Default approval_required (opt into public).
+export const followPrivacyEnum = pgEnum('FollowPrivacy', ['public', 'approval_required']);
 export const publicStatusEnum = pgEnum('PublicStatus', [
   'not_scored',
   'eligible_pending',
@@ -183,6 +191,8 @@ export const users = pgTable(
     avatarColor: text('avatar_color'),
     discoverableByContacts: boolean('discoverable_by_contacts').notNull().default(false),
     discoverableByMutualFriends: boolean('discoverable_by_mutual_friends').notNull().default(false),
+    // D-1 Stage 3 — gate on new followers. Default approval_required; public is opt-in.
+    followPrivacy: followPrivacyEnum('follow_privacy').notNull().default('approval_required'),
     phoneHash: text('phone_hash'),
     lastFriendDiscoveryCheckAt: timestamp('last_friend_discovery_check_at', { withTimezone: true }),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
@@ -716,6 +726,34 @@ export const friendships = pgTable(
     unique('Friendship_userAId_userBId_key').on(table.userAId, table.userBId),
     index('Friendship_userAId_status_idx').on(table.userAId, table.status),
     index('Friendship_userBId_status_idx').on(table.userBId, table.status),
+  ],
+);
+
+// D-1 Stage 3 — directional follow edges. Two rows model a mutual ("friend")
+// relationship; one row models a one-directional follow. The follower is always
+// the requester, so there is no separate requestedByUserId. Unfollow is a hard
+// delete (no `removed` state). `friendships` is frozen and kept for rollback;
+// all relationship reads/writes go through this table.
+export const follows = pgTable(
+  'Follow',
+  {
+    id: id(),
+    followerId: text('followerId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    followeeId: text('followeeId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    state: followStateEnum('state').notNull().default('pending'),
+    // Carried from the originating request so the incoming-request card can
+    // still render a personal note and suggested interests.
+    personalNote: text('personalNote'),
+    requestContext: jsonb('requestContext').$type<{ suggestedInterests?: string[] }>(),
+    createdAt: createdAt(),
+    approvedAt: timestamp('approvedAt', { withTimezone: true }),
+  },
+  (table) => [
+    unique('Follow_followerId_followeeId_key').on(table.followerId, table.followeeId),
+    // "who I follow" + outbound pending; "my followers" + inbound pending.
+    index('Follow_followerId_state_idx').on(table.followerId, table.state),
+    index('Follow_followeeId_state_idx').on(table.followeeId, table.state),
+    check('Follow_distinct_users', sql`${table.followerId} <> ${table.followeeId}`),
   ],
 );
 

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -2,7 +2,7 @@ import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questionFeedback, questionRatings, questions } from '@/server/db';
 import { writeActivity } from '@/server/activity/write-activity';
-import { getFriends } from '@/server/db/queries/friends';
+import { getFollowers } from '@/server/db/queries/friends';
 import { rollOffOldItems } from '@/server/db/queries/feed';
 import { isCorrectAnswerFeedEligible, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
@@ -77,7 +77,9 @@ async function _createFeedItemsForFriendsFromAnswer(
   const domain = question.canonicalSubcategory ?? question.broadCategory;
   if (!domain) return;
 
-  const friends = await getFriends(userId);
+  // friend_answered fan-out reaches my followers — people who follow me see
+  // that I answered correctly (directional follow model, D-1 Stage 3).
+  const friends = await getFollowers(userId);
   if (friends.length === 0) {
     await notifyPreviousAnswerers(userId, questionId);
     return;

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -9,7 +9,7 @@
 
 import { and, count, eq, inArray, isNull, ne, notExists, or } from 'drizzle-orm';
 
-import { db, feedItems, friendships, masteryEvents, questions, users } from '@/server/db';
+import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import {
   getDismissedDomains,
@@ -155,12 +155,15 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
 
   const [feedPage, friendCount, dismissedDomains, totalItemCount, preFilterActiveCount] = await Promise.all([
     getFeedForUser(viewerUserId, { limit, cursor, filter }),
+    // "has_friends" empty-state signal: people I follow are exactly the
+    // authors who can populate my feed, so an approved-outbound-follow count
+    // is the right, single-index proxy (D-1 Stage 3 follow model).
     db
       .select({ value: count() })
-      .from(friendships)
+      .from(follows)
       .where(and(
-        eq(friendships.status, 'active'),
-        or(eq(friendships.userAId, viewerUserId), eq(friendships.userBId, viewerUserId)),
+        eq(follows.followerId, viewerUserId),
+        eq(follows.state, 'approved'),
       ))
       .then((rows) => rows[0]?.value ?? 0),
     getDismissedDomains(viewerUserId),

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -147,18 +147,11 @@ vi.mock('@/server/db', () => ({
     personalMessage: 'friendInvitations.personalMessage',
     inviteeUserId: 'friendInvitations.inviteeUserId',
   },
-  // upsertInvitationFriendship imports `friendships` from @/server/db (not the
-  // schema barrel). Mirror the columns it touches so the conflict-upsert builds.
-  friendships: {
-    userAId: 'friendships.userAId',
-    userBId: 'friendships.userBId',
-  },
-}))
-
-vi.mock('@/server/db/schema', () => ({
-  friendships: {
-    userAId: 'friendships.userAId',
-    userBId: 'friendships.userBId',
+  // upsertInvitationFriendship imports `follows` from @/server/db. Mirror the
+  // columns it touches so the conflict-upsert builds.
+  follows: {
+    followerId: 'follows.followerId',
+    followeeId: 'follows.followeeId',
   },
 }))
 
@@ -221,16 +214,19 @@ describe('acceptFriendInvitation', () => {
       })
     )
     expect(dbMock.transaction).toHaveBeenCalledTimes(1)
+    // Invitation creates a mutual follow: two approved edges, both directions.
     expect(state.friendshipValues).toEqual([
       expect.objectContaining({
-        userAId: 'user-invitee',
-        userBId: 'user-inviter',
-        status: 'active',
-        requestedByUserId: 'user-inviter',
-        formedVia: 'invitation',
-        formedAt: now,
-        removedAt: null,
-        removedByUserId: null,
+        followerId: 'user-inviter',
+        followeeId: 'user-invitee',
+        state: 'approved',
+        approvedAt: now,
+      }),
+      expect.objectContaining({
+        followerId: 'user-invitee',
+        followeeId: 'user-inviter',
+        state: 'approved',
+        approvedAt: now,
       }),
     ])
   })
@@ -269,12 +265,16 @@ describe('acceptFriendInvitation', () => {
     )
     expect(state.friendshipValues).toEqual([
       expect.objectContaining({
-        userAId: 'user-jaime',
-        userBId: 'user-josh',
-        status: 'active',
-        requestedByUserId: 'user-josh',
-        formedVia: 'invitation',
-        formedAt: now,
+        followerId: 'user-josh',
+        followeeId: 'user-jaime',
+        state: 'approved',
+        approvedAt: now,
+      }),
+      expect.objectContaining({
+        followerId: 'user-jaime',
+        followeeId: 'user-josh',
+        state: 'approved',
+        approvedAt: now,
       }),
     ])
 
@@ -286,11 +286,13 @@ describe('acceptFriendInvitation', () => {
         now,
       })
     ).resolves.toEqual({ accepted: false, reason: 'accepted' })
+    // The already-accepted re-attempt writes no further edges: still exactly
+    // the two approved edges from the single successful acceptance.
     expect(
       state.friendshipValues.filter(
-        (friendship) => (friendship as { status?: string }).status === 'active'
+        (edge) => (edge as { state?: string }).state === 'approved'
       )
-    ).toHaveLength(1)
+    ).toHaveLength(2)
   })
 
   it('rejects a valid token when the verified phone does not match the invitation phone', async () => {

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -1,145 +1,112 @@
-import { and, eq, ne, or } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 
 import { writeActivity } from '@/server/activity/write-activity'
-import { db, friendships } from '@/server/db'
+import { db, follows, users } from '@/server/db'
 
+export type Follow = typeof follows.$inferSelect
+
+// Outcome of a follow attempt. (Kept the historical export name so the API
+// routes that destructure `state` don't need to change.)
 export type FriendshipRequestState =
-  | 'created'
-  | 'already_friends'
-  | 'pending_existing'
-  | 'reverse_pending'
-  | 'reopened'
+  | 'created' // new pending request — target requires approval
+  | 'auto_approved' // new approved follow — target is public
+  | 'already_following' // an approved edge already exists
+  | 'pending_existing' // a pending request already exists
 
 export type FriendshipRequestContext = {
   suggestedInterests?: string[]
 }
 
-type FriendshipWriter = {
-  insert: (table: typeof friendships) => {
-    values: (values: typeof friendships.$inferInsert) => {
+// Structural type for a Drizzle transaction/db handle that can upsert a follow.
+type FollowWriter = {
+  insert: (table: typeof follows) => {
+    values: (values: typeof follows.$inferInsert) => {
       onConflictDoUpdate: (config: {
-        target: [typeof friendships.userAId, typeof friendships.userBId]
-        set: Partial<typeof friendships.$inferInsert>
+        target: [typeof follows.followerId, typeof follows.followeeId]
+        set: Partial<typeof follows.$inferInsert>
       }) => Promise<unknown>
     }
   }
 }
 
-export function friendshipPair(a: string, b: string) {
-  return a < b ? { userAId: a, userBId: b } : { userAId: b, userBId: a }
-}
-
-
 function requestContextForSuggestedInterests(suggestedInterests: string[]): FriendshipRequestContext | null {
   return suggestedInterests.length > 0 ? { suggestedInterests } : null
 }
 
-const DIRECT_REQUEST_EXPIRY_MS = 30 * 24 * 60 * 60 * 1000
-
+/**
+ * Follow `inviteeUserId`. If the target's followPrivacy is `public` the edge is
+ * approved immediately; otherwise it lands `pending` for the target to approve.
+ * Reuses an existing edge (approved -> already_following, pending ->
+ * pending_existing). The follower is always the requester, so there is no
+ * separate requestedByUserId.
+ */
 export async function createOrReusePendingFriendshipRequest({
   inviterUserId,
   inviteeUserId,
   suggestedInterests = [],
   personalNote,
-  expiresAt,
   now = new Date(),
 }: {
   inviterUserId: string
   inviteeUserId: string
   suggestedInterests?: string[]
   personalNote?: string
-  // Defaults to NOW() + 30 days when undefined. Pass null to opt out
-  // (the SMS-invite caller does this — those invitations don't expire).
-  expiresAt?: Date | null
   now?: Date
-}): Promise<{ friendship: typeof friendships.$inferSelect; state: FriendshipRequestState }> {
-  const pair = friendshipPair(inviterUserId, inviteeUserId)
+}): Promise<{ friendship: Follow; state: FriendshipRequestState }> {
+  const followerId = inviterUserId
+  const followeeId = inviteeUserId
   const requestContext = requestContextForSuggestedInterests(suggestedInterests)
   const trimmedNote = personalNote?.trim() || null
-  const resolvedExpiresAt =
-    expiresAt === undefined ? new Date(now.getTime() + DIRECT_REQUEST_EXPIRY_MS) : expiresAt
 
-  const [existingFriendship] = await db
+  const [existing] = await db
     .select()
-    .from(friendships)
-    .where(and(eq(friendships.userAId, pair.userAId), eq(friendships.userBId, pair.userBId)))
+    .from(follows)
+    .where(and(eq(follows.followerId, followerId), eq(follows.followeeId, followeeId)))
     .limit(1)
 
-  if (existingFriendship?.status === 'active') {
-    return { friendship: existingFriendship, state: 'already_friends' }
+  if (existing?.state === 'approved') {
+    return { friendship: existing, state: 'already_following' }
+  }
+  if (existing?.state === 'pending') {
+    return { friendship: existing, state: 'pending_existing' }
   }
 
-  if (existingFriendship?.status === 'pending') {
-    // Reuse — caller must Cancel first to overwrite the note or expiry.
-    return {
-      friendship: existingFriendship,
-      state: existingFriendship.requestedByUserId === inviterUserId ? 'pending_existing' : 'reverse_pending',
-    }
-  }
+  const [target] = await db
+    .select({ followPrivacy: users.followPrivacy })
+    .from(users)
+    .where(eq(users.id, followeeId))
+    .limit(1)
+  const autoApprove = target?.followPrivacy === 'public'
 
-  if (existingFriendship) {
-    const [reopenedFriendship] = await db
-      .update(friendships)
-      .set({
-        status: 'pending',
-        requestedByUserId: inviterUserId,
-        formedVia: 'direct_request',
-        formedAt: null,
-        removedAt: null,
-        removedByUserId: null,
-        requestContext,
-        // Reopen: clear resolvedAt, refresh expiry, overwrite note only if
-        // the caller provided one (existing value wins otherwise).
-        resolvedAt: null,
-        expiresAt: resolvedExpiresAt,
-        ...(trimmedNote !== null ? { personalNote: trimmedNote } : {}),
-      })
-      .where(eq(friendships.id, existingFriendship.id))
-      .returning()
-
-    if (!reopenedFriendship) throw new Error('Friendship request could not be reopened')
-
-    await writeActivity({
-      userId: inviteeUserId,
-      type: 'friend_request',
-      actorUserId: inviterUserId,
-      referenceId: reopenedFriendship.id,
-      referenceType: 'friendship',
-    })
-
-    return { friendship: reopenedFriendship, state: 'reopened' }
-  }
-
-  const [friendship] = await db
-    .insert(friendships)
+  const [edge] = await db
+    .insert(follows)
     .values({
-      ...pair,
-      status: 'pending',
-      requestedByUserId: inviterUserId,
-      formedVia: 'direct_request',
-      formedAt: null,
-      removedAt: null,
-      removedByUserId: null,
-      requestContext,
+      followerId,
+      followeeId,
+      state: autoApprove ? 'approved' : 'pending',
+      approvedAt: autoApprove ? now : null,
       personalNote: trimmedNote,
-      expiresAt: resolvedExpiresAt,
-      resolvedAt: null,
+      requestContext,
     })
     .returning()
 
-  if (!friendship) throw new Error('Friendship request could not be created')
+  if (!edge) throw new Error('Follow could not be created')
 
   await writeActivity({
-    userId: inviteeUserId,
-    type: 'friend_request',
-    actorUserId: inviterUserId,
-    referenceId: friendship.id,
-    referenceType: 'friendship',
+    userId: followeeId,
+    type: autoApprove ? 'follow' : 'follow_request',
+    actorUserId: followerId,
+    referenceId: edge.id,
+    referenceType: 'follow',
   })
 
-  return { friendship, state: 'created' }
+  return { friendship: edge, state: autoApprove ? 'auto_approved' : 'created' }
 }
 
+/**
+ * Approve a pending follow request targeting `userId`. `friendshipId` is the
+ * pending follow edge id.
+ */
 export async function acceptPendingFriendshipRequest({
   friendshipId,
   userId,
@@ -148,129 +115,109 @@ export async function acceptPendingFriendshipRequest({
   friendshipId: string
   userId: string
   now?: Date
-}): Promise<typeof friendships.$inferSelect | null> {
-  const [friendship] = await db
-    .update(friendships)
-    .set({
-      status: 'active',
-      formedAt: now,
-      removedAt: null,
-      removedByUserId: null,
-      resolvedAt: now,
-    })
+}): Promise<Follow | null> {
+  const [edge] = await db
+    .update(follows)
+    .set({ state: 'approved', approvedAt: now })
     .where(
       and(
-        eq(friendships.id, friendshipId),
-        eq(friendships.status, 'pending'),
-        ne(friendships.requestedByUserId, userId),
-        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
-      )
+        eq(follows.id, friendshipId),
+        eq(follows.state, 'pending'),
+        eq(follows.followeeId, userId),
+      ),
     )
     .returning()
 
-  if (!friendship) return null
+  if (!edge) return null
 
   await writeActivity({
-    userId: friendship.requestedByUserId,
-    type: 'friend_request_accepted',
+    userId: edge.followerId,
+    type: 'follow_approved',
     actorUserId: userId,
-    referenceId: friendship.id,
-    referenceType: 'friendship',
+    referenceId: edge.id,
+    referenceType: 'follow',
   })
 
-  return friendship
+  return edge
 }
 
+/**
+ * Decline a pending follow request targeting `userId` — hard-deletes the edge
+ * (no terminal state). `friendshipId` is the pending follow edge id.
+ */
 export async function ignorePendingFriendshipRequest({
   friendshipId,
   userId,
-  now = new Date(),
 }: {
   friendshipId: string
   userId: string
-  now?: Date
-}): Promise<typeof friendships.$inferSelect | null> {
-  const [friendship] = await db
-    .update(friendships)
-    .set({
-      status: 'declined',
-      removedAt: now,
-      removedByUserId: userId,
-      resolvedAt: now,
-    })
+}): Promise<Follow | null> {
+  const [edge] = await db
+    .delete(follows)
     .where(
       and(
-        eq(friendships.id, friendshipId),
-        eq(friendships.status, 'pending'),
-        ne(friendships.requestedByUserId, userId),
-        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
-      )
+        eq(follows.id, friendshipId),
+        eq(follows.state, 'pending'),
+        eq(follows.followeeId, userId),
+      ),
     )
     .returning()
 
-  return friendship ?? null
+  return edge ?? null
 }
 
+/**
+ * Cancel a pending follow request the viewer sent. `friendshipId` is the
+ * pending follow edge id (`followerId = userId`).
+ */
 export async function cancelPendingFriendshipRequest({
   friendshipId,
   userId,
-  now = new Date(),
 }: {
   friendshipId: string
   userId: string
-  now?: Date
-}): Promise<typeof friendships.$inferSelect | null> {
-  const [friendship] = await db
-    .update(friendships)
-    .set({
-      status: 'cancelled',
-      removedAt: now,
-      removedByUserId: userId,
-      resolvedAt: now,
-    })
+}): Promise<Follow | null> {
+  const [edge] = await db
+    .delete(follows)
     .where(
       and(
-        eq(friendships.id, friendshipId),
-        eq(friendships.status, 'pending'),
-        eq(friendships.requestedByUserId, userId),
-        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
-      )
+        eq(follows.id, friendshipId),
+        eq(follows.state, 'pending'),
+        eq(follows.followerId, userId),
+      ),
     )
     .returning()
 
-  return friendship ?? null
+  return edge ?? null
 }
 
+/**
+ * Unfollow: delete the viewer's outbound follow edge. This is directional — it
+ * only removes my follow of them; their follow of me (if any) is untouched.
+ * `friendshipId` is my outbound edge id.
+ */
 export async function removeFriendship({
   friendshipId,
   userId,
-  now = new Date(),
 }: {
   friendshipId: string
   userId: string
-  now?: Date
-}): Promise<typeof friendships.$inferSelect | null> {
-  const [friendship] = await db
-    .update(friendships)
-    .set({
-      status: 'removed',
-      removedAt: now,
-      removedByUserId: userId,
-    })
-    .where(
-      and(
-        eq(friendships.id, friendshipId),
-        eq(friendships.status, 'active'),
-        or(eq(friendships.userAId, userId), eq(friendships.userBId, userId))
-      )
-    )
+}): Promise<Follow | null> {
+  const [edge] = await db
+    .delete(follows)
+    .where(and(eq(follows.id, friendshipId), eq(follows.followerId, userId)))
     .returning()
 
-  return friendship ?? null
+  return edge ?? null
 }
 
+/**
+ * Invitation acceptance auto-creates a mutual follow: two approved edges in
+ * both directions, bypassing approval (the invite is the consent). Idempotent
+ * via ON CONFLICT, so re-accepting an invitation just refreshes the edges.
+ */
 export async function upsertInvitationFriendship(
-  writer: FriendshipWriter,
+  writer: FollowWriter,
   {
     inviterUserId,
     inviteeUserId,
@@ -279,32 +226,28 @@ export async function upsertInvitationFriendship(
     inviterUserId: string
     inviteeUserId: string
     formedAt: Date
-  }
+  },
 ) {
-  const pair = friendshipPair(inviterUserId, inviteeUserId)
-
-  await writer
-    .insert(friendships)
-    .values({
-      ...pair,
-      status: 'active',
-      requestedByUserId: inviterUserId,
-      formedVia: 'invitation',
-      formedAt,
-      removedAt: null,
-      removedByUserId: null,
-      requestContext: null,
-    })
-    .onConflictDoUpdate({
-      target: [friendships.userAId, friendships.userBId],
-      set: {
-        status: 'active',
-        requestedByUserId: inviterUserId,
-        formedVia: 'invitation',
-        formedAt,
-        removedAt: null,
-        removedByUserId: null,
+  for (const [followerId, followeeId] of [
+    [inviterUserId, inviteeUserId],
+    [inviteeUserId, inviterUserId],
+  ] as const) {
+    await writer
+      .insert(follows)
+      .values({
+        followerId,
+        followeeId,
+        state: 'approved',
+        approvedAt: formedAt,
+        personalNote: null,
         requestContext: null,
-      },
-    })
+      })
+      .onConflictDoUpdate({
+        target: [follows.followerId, follows.followeeId],
+        set: {
+          state: 'approved',
+          approvedAt: formedAt,
+        },
+      })
+  }
 }

--- a/src/server/profile/__tests__/friend.test.ts
+++ b/src/server/profile/__tests__/friend.test.ts
@@ -2,7 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   dbMock,
-  getFriendshipMock,
+  getRelationshipMock,
   getFriendsMock,
   getUserByIdMock,
   areFriendsMock,
@@ -34,7 +34,7 @@ const {
 
   return {
     dbMock,
-    getFriendshipMock: vi.fn(),
+    getRelationshipMock: vi.fn(),
     getFriendsMock: vi.fn(),
     getUserByIdMock: vi.fn(),
     areFriendsMock: vi.fn(async () => false),
@@ -61,9 +61,12 @@ vi.mock('@/server/db', () => ({
 }))
 
 vi.mock('@/server/db/queries/friends', () => ({
-  getFriendship: getFriendshipMock,
   getFriends: getFriendsMock,
   areFriends: areFriendsMock,
+}))
+
+vi.mock('@/server/db/queries/friend-requests', () => ({
+  getRelationship: getRelationshipMock,
 }))
 
 vi.mock('@/server/db/queries/users', () => ({
@@ -93,11 +96,11 @@ describe('friend portrait data', () => {
       phoneNumber: '+15550101010',
       handle: null,
     })
-    getFriendshipMock.mockResolvedValue({
-      id: 'friendship-1',
-      status: 'active',
+    getRelationshipMock.mockResolvedValue({
+      state: 'friends',
+      friendshipId: 'friendship-1',
       formedAt: new Date('2026-02-01T00:00:00.000Z'),
-      requestedByUserId: 'viewer-1',
+      isBlocked: false,
     })
     getFriendsMock.mockResolvedValue([])
   })
@@ -119,12 +122,11 @@ describe('friend portrait data', () => {
         memberSince: new Date('2026-01-01T00:00:00.000Z'),
       },
       visibility: 'friend',
-      friendship: {
-        id: 'friendship-1',
-        status: 'active',
+      relationship: {
+        state: 'friends',
+        friendshipId: 'friendship-1',
         formedAt: new Date('2026-02-01T00:00:00.000Z'),
-        requestedByUserId: 'viewer-1',
-        viewerIsRequester: true,
+        isBlocked: false,
       },
       interests: [
         { domain: 'Jazz piano', broadCategory: 'Music', shared: true },
@@ -199,22 +201,21 @@ describe('friend portrait data', () => {
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       phoneNumber: '+15550101011',
     })
-    getFriendshipMock.mockResolvedValueOnce({
-      id: 'friendship-2',
-      status: 'pending',
+    getRelationshipMock.mockResolvedValueOnce({
+      state: 'pending_outbound',
+      friendshipId: 'friendship-2',
       formedAt: null,
-      requestedByUserId: 'viewer-1',
+      isBlocked: false,
     })
 
     const portrait = await getFriendPortraitData('stranger-1', 'viewer-1')
 
     expect(portrait?.visibility).toBe('stranger')
-    expect(portrait?.friendship).toEqual({
-      id: 'friendship-2',
-      status: 'pending',
+    expect(portrait?.relationship).toEqual({
+      state: 'pending_outbound',
+      friendshipId: 'friendship-2',
       formedAt: null,
-      requestedByUserId: 'viewer-1',
-      viewerIsRequester: true,
+      isBlocked: false,
     })
     expect(portrait?.interests).toEqual([])
     expect(portrait?.sharedInterests).toEqual([])
@@ -229,12 +230,22 @@ describe('friend portrait data', () => {
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       phoneNumber: '+15550101012',
     })
-    getFriendshipMock.mockResolvedValueOnce(null)
+    getRelationshipMock.mockResolvedValueOnce({
+      state: 'none',
+      friendshipId: null,
+      formedAt: null,
+      isBlocked: false,
+    })
 
     const portrait = await getFriendPortraitData('stranger-2', 'viewer-1')
 
     expect(portrait?.visibility).toBe('stranger')
-    expect(portrait?.friendship).toBeNull()
+    expect(portrait?.relationship).toEqual({
+      state: 'none',
+      friendshipId: null,
+      formedAt: null,
+      isBlocked: false,
+    })
   })
 
   it('returns mutual friends for non-self views', async () => {
@@ -291,7 +302,12 @@ describe('friend portrait data', () => {
       createdAt: new Date('2026-01-01T00:00:00.000Z'),
       phoneNumber: '+15550101013',
     })
-    getFriendshipMock.mockResolvedValueOnce(null)
+    getRelationshipMock.mockResolvedValueOnce({
+      state: 'none',
+      friendshipId: null,
+      formedAt: null,
+      isBlocked: false,
+    })
     // Knowledge base is friends-only; everything else is the default 'public'.
     state.sectionSettings = {
       ...state.sectionSettings,

--- a/src/server/profile/friend.ts
+++ b/src/server/profile/friend.ts
@@ -1,7 +1,8 @@
 import { and, asc, eq, inArray } from 'drizzle-orm'
 
 import { db, declaredInterests } from '@/server/db'
-import { areFriends, getFriends, getFriendship } from '@/server/db/queries/friends'
+import { areFriends, getFriends } from '@/server/db/queries/friends'
+import { getRelationship, type RelationshipResult } from '@/server/db/queries/friend-requests'
 import { getUserById } from '@/server/db/queries/users'
 import type { PreviewAs } from '@/server/profile/preview'
 import {
@@ -28,14 +29,6 @@ export type FriendPortraitMutualFriend = {
   displayName: string
 }
 
-export type FriendPortraitFriendship = {
-  id: string
-  status: string
-  formedAt: Date | null
-  requestedByUserId: string
-  viewerIsRequester: boolean
-}
-
 export type FriendPortraitData = {
   user: {
     id: string
@@ -44,7 +37,9 @@ export type FriendPortraitData = {
     memberSince: Date
   }
   visibility: FriendProfileVisibility
-  friendship: FriendPortraitFriendship | null
+  // The viewer's directional relationship to this profile (follow model).
+  // Drives the follow button and the "friends since" date. Null on own view.
+  relationship: RelationshipResult | null
   interests: FriendPortraitInterest[]
   sharedInterests: string[]
   viewerSoloInterests: string[]
@@ -98,11 +93,11 @@ export async function getFriendPortraitData(
   if (!viewedUser) return null
 
   const isOwnerView = normalizedUserId === normalizedViewerId
-  const friendship = isOwnerView
+  const relationship = isOwnerView
     ? null
-    : await getFriendship(normalizedViewerId, normalizedUserId)
+    : await getRelationship(normalizedViewerId, normalizedUserId)
 
-  const isActiveFriend = !isOwnerView && friendship?.status === 'active'
+  const isActiveFriend = !isOwnerView && relationship?.state === 'friends'
   const realViewer: FriendProfileVisibility = isOwnerView
     ? 'self'
     : isActiveFriend
@@ -211,16 +206,6 @@ export async function getFriendPortraitData(
     mutualFriendsOverflow = Math.max(0, mutuals.length - mutualFriends.length)
   }
 
-  const portraitFriendship: FriendPortraitFriendship | null = friendship
-    ? {
-        id: friendship.id,
-        status: friendship.status,
-        formedAt: friendship.formedAt,
-        requestedByUserId: friendship.requestedByUserId,
-        viewerIsRequester: friendship.requestedByUserId === normalizedViewerId,
-      }
-    : null
-
   // Batch-fetch the owner's per-section visibility settings exactly once,
   // then evaluate the gate purely against the effective viewer. Owners
   // get the full settings map back (for editing UI); other viewers get
@@ -244,7 +229,7 @@ export async function getFriendPortraitData(
       memberSince: viewedUser.createdAt,
     },
     visibility,
-    friendship: portraitFriendship,
+    relationship,
     interests,
     sharedInterests: interests
       .filter((interest) => interest.shared)


### PR DESCRIPTION
## Summary
Replaces the symmetric `Friendship` primitive with a directional `Follow` edge model. Two approved edges in opposite directions represent a mutual ("friend") relationship; a single edge represents a one-directional follow. Follows targeting users with `followPrivacy: 'public'` are auto-approved; those targeting `'approval_required'` users land pending for approval.

## Key Changes

**Schema & Migrations**
- Added `FollowState` enum (`pending` | `approved`) and `FollowPrivacy` enum (`public` | `approval_required`)
- Added `User.follow_privacy` column (defaults to `'approval_required'`)
- Created `Follow` table with directional `followerId` → `followeeId` edges, replacing symmetric `Friendship`
- Migration 0058 includes idempotent boot guards in `src/instrumentation.ts` for preview/production databases

**Query Helpers** (`src/server/db/queries/`)
- `getFollowing(userId)` — users I follow (approved outbound edges)
- `getFollowers(userId)` — users who follow me (approved inbound edges)
- `getMutualFollows(userId)` — mutual follows (both directions approved); `getFriends()` now delegates to this
- `areFriends(userAId, userBId)` — checks for mutual follow in both directions
- `getFriendsHub(userId)` — returns `{ following, followers, incomingRequests, outboundRequests, followPrivacy }`
- `getRelationship(viewerId, targetId)` — resolves viewer's two directional edges into a `RelationshipState` (`none` | `pending_outbound` | `pending_inbound` | `following` | `follows_you` | `friends`)

**Follow Request Logic** (`src/server/friends/friendships.ts`)
- `createOrReusePendingFriendshipRequest()` now checks target's `followPrivacy` gate
- Auto-approves follows to `public` users; pending requests for `approval_required` users
- Removed expiry logic (follows don't expire; pending requests are explicit)
- Removed symmetric pair normalization (`friendshipPair`)

**Friends Hub UI** (`src/components/FriendsList.tsx`)
- Renamed tabs: `'friends'` → `'following'`, `'invitations'` → `'followers'`, `'sent'` → `'pending'`
- Extracted `PersonCard` component to render users with follow status labels (`Mutual`, `Follows you`)
- Added privacy gate toggle (`public` / `approval_required`) with optimistic updates
- Added `followBack()` action for followers who don't follow back
- Removed soft-cap nudge (no longer applicable)

**API Routes**
- `POST /api/friend-requests` — creates follow request (auto-approved or pending per target's privacy)
- `POST /api/friend-requests/[id]/accept` — approves pending inbound follow
- `POST /api/friend-requests/[id]/ignore` — rejects pending inbound follow
- `POST /api/friend-requests/[id]/cancel` — cancels pending outbound follow
- `POST /api/friend-requests/[id]/remove` — unfollows (removes approved edge)
- `PATCH /api/users/me` — updates current user's `followPrivacy` setting

**Activity & Feed**
- Added activity types: `follow`, `follow_request`, `follow_approved`
- Feed visibility now reads `getFollowers()` for broadcast fan-out (instead of symmetric friends)
- Activity hydration handles both legacy `friendships` rows and new `follows` rows

**Profile & Relationship Display**
- `ProfileFriendButton` now reads `RelationshipResult` (directional model) instead of symmetric friendship
- Relationship states map to UI affordances: pending outbound → "Pending", pending inbound → "Approve", following → "Unfollow", follows_you → "Follow Back", friends → "Unfriend"

## Implementation Details

- **Backward compatibility:** `Friendship` table is frozen (no new writes) but left in place for rollback

https://claude.ai/code/session_018TieRAiczrmownpWSfbG8y