### PR TITLE
Add niche-match discoverability flag (D-2 WS1)

### DIFF
--- a/PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md
+++ b/PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md
@@ -90,12 +90,23 @@ filter. **Do not** add the new type to the dedup set in a future change.
 
 ## Privacy gating (detail)
 
-- New column **`discoverable_by_niche_match boolean NOT NULL DEFAULT false`** on `User`.
+> **OPEN DECISION (test-phase amendment).** This spec specifies `discoverable_by_niche_match`
+> **DEFAULT false**. For the **test phase only** this is changed to **DEFAULT true**, including a
+> backfill-by-default for existing users — the whole cohort is enrolled (migration `0059`). This flips
+> a privacy posture retroactively for people who joined under the old default-OFF assumption, so the
+> test cohort **must be told** they are niche-discoverable by default before the test begins (a
+> non-code pre-test communication step). **The production default for `discoverable_by_niche_match`
+> remains an OPEN DECISION to revisit after observing the test.** Default-ON here is deliberate for the
+> test cohort only; do not assume it as the shipping default.
+
+- New column **`discoverable_by_niche_match boolean NOT NULL DEFAULT false`** on `User`
+  (**test-phase override: `DEFAULT true`** per the amendment above).
 - Extend `DiscoverabilityState` / patch type / `getDiscoverability` / `updateDiscoverability`
   (`src/server/db/queries/account.ts`). **No purge side-effect needed** — niche-match stores no uploaded
   data to revoke (unlike the contacts flag, which purges `ContactHash`). Zod on the PATCH input.
 - Add a third toggle to `PrivacyForm.tsx`: *"Let people I've never met discover me through questions we
-  both answer."* Default off.
+  both answer."* Default off per the original spec; **default ON for the test phase** (see OPEN
+  DECISION note above).
 - The asymmetric two-flag check is stated explicitly in §"Gate direction" above so it isn't wired
   backwards: each notification is gated by the flag of the party whose identity it would expose.
 

--- a/drizzle/0059_niche_match_discoverability.sql
+++ b/drizzle/0059_niche_match_discoverability.sql
@@ -1,0 +1,21 @@
+-- Migration: D-2 WS1 — niche-match discoverability flag.
+--
+-- Adds the third discoverability flag, `discoverable_by_niche_match`, alongside
+-- the existing `discoverable_by_contacts` / `discoverable_by_mutual_friends`.
+-- Additive boolean with a default — the safe migration case per CLAUDE.md (no
+-- backfill pass needed; the DEFAULT applies to every existing row).
+--
+-- TEST-PHASE DEFAULT — DELIBERATE, NOT THE SHIPPING DEFAULT.
+-- The spec (PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md §"Privacy gating") specifies
+-- DEFAULT false. For the test phase this is changed to DEFAULT true so the
+-- whole test cohort — including users who joined under the old default-OFF
+-- assumption — is enrolled. The production default for
+-- `discoverable_by_niche_match` is an OPEN DECISION to revisit after the test.
+-- Default-ON here is deliberate for the test cohort only; do not assume it as
+-- the shipping default. Flipping a privacy posture retroactively requires
+-- telling the cohort first (a non-code pre-test communication step).
+--
+-- No purge side-effect on toggle-off: niche-match stores no uploaded data to
+-- revoke (unlike the contacts flag, which purges ContactHash rows).
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "discoverable_by_niche_match" boolean NOT NULL DEFAULT true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -414,6 +414,13 @@
       "when": 1781568000000,
       "tag": "0058_follow_model",
       "breakpoints": true
+    },
+    {
+      "idx": 59,
+      "version": "7",
+      "when": 1781654400000,
+      "tag": "0059_niche_match_discoverability",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/account/discoverability/route.ts
+++ b/src/app/api/account/discoverability/route.ts
@@ -13,9 +13,13 @@ const bodySchema = z
   .object({
     contacts: z.boolean().optional(),
     mutualFriends: z.boolean().optional(),
+    nicheMatch: z.boolean().optional(),
   })
   .refine(
-    (b) => b.contacts !== undefined || b.mutualFriends !== undefined,
+    (b) =>
+      b.contacts !== undefined
+      || b.mutualFriends !== undefined
+      || b.nicheMatch !== undefined,
     'must specify at least one change',
   );
 

--- a/src/components/profile/settings/PrivacyForm.tsx
+++ b/src/components/profile/settings/PrivacyForm.tsx
@@ -10,7 +10,7 @@ type Props = {
   initialInviteUrl: string | null;
 };
 
-type PatchKey = 'contacts' | 'mutualFriends';
+type PatchKey = 'contacts' | 'mutualFriends' | 'nicheMatch';
 
 type InviteTokenResponse = { token: string; url: string };
 
@@ -131,7 +131,9 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
     const next: DiscoverabilityState =
       key === 'contacts'
         ? { ...state, discoverableByContacts: !state.discoverableByContacts }
-        : { ...state, discoverableByMutualFriends: !state.discoverableByMutualFriends };
+        : key === 'mutualFriends'
+          ? { ...state, discoverableByMutualFriends: !state.discoverableByMutualFriends }
+          : { ...state, discoverableByNicheMatch: !state.discoverableByNicheMatch };
 
     setState(next);
     setSavingKey(key);
@@ -140,7 +142,9 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
     const body: Partial<Record<PatchKey, boolean>> =
       key === 'contacts'
         ? { contacts: next.discoverableByContacts }
-        : { mutualFriends: next.discoverableByMutualFriends };
+        : key === 'mutualFriends'
+          ? { mutualFriends: next.discoverableByMutualFriends }
+          : { nicheMatch: next.discoverableByNicheMatch };
 
     const result = await patchDiscoverability(body);
     setSavingKey(null);
@@ -169,6 +173,14 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
         checked={state.discoverableByMutualFriends}
         saving={savingKey === 'mutualFriends'}
         onToggle={() => void toggle('mutualFriends')}
+      />
+
+      <ToggleRow
+        title="Let people I've never met discover me through questions we both answer"
+        description="When you correctly answer a stranger's question (or they answer yours), each of you can see the other — a slow way to meet people through shared curiosity. Turn this off to stay hidden from strangers."
+        checked={state.discoverableByNicheMatch}
+        saving={savingKey === 'nicheMatch'}
+        onToggle={() => void toggle('nicheMatch')}
       />
 
       <ToggleRow

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -847,6 +847,23 @@ export async function register() {
       // creates them and applies 0058 in normal order.
     }
 
+    // Migration 0059 (D-2 WS1) adds User.discoverable_by_niche_match, the third
+    // discoverability flag. Additive boolean with a default — the safe case.
+    // TEST-PHASE default is ON (DEFAULT true): the whole cohort, including
+    // pre-existing users, is enrolled in the niche-match test. The production
+    // default is an OPEN DECISION to revisit after the test; default-ON here is
+    // deliberate for the test cohort only. Guard for preview/production
+    // databases that may have the migration recorded without the column present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "discoverable_by_niche_match" boolean NOT NULL DEFAULT true
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -305,6 +305,7 @@ export async function assignInitialHandle(params: {
 export type DiscoverabilityState = {
   discoverableByContacts: boolean;
   discoverableByMutualFriends: boolean;
+  discoverableByNicheMatch: boolean;
 };
 
 export async function getDiscoverability(
@@ -314,6 +315,7 @@ export async function getDiscoverability(
     .select({
       discoverableByContacts: users.discoverableByContacts,
       discoverableByMutualFriends: users.discoverableByMutualFriends,
+      discoverableByNicheMatch: users.discoverableByNicheMatch,
     })
     .from(users)
     .where(eq(users.id, userId))
@@ -326,6 +328,7 @@ export async function getDiscoverability(
 export type DiscoverabilityPatch = {
   contacts?: boolean;
   mutualFriends?: boolean;
+  nicheMatch?: boolean;
 };
 
 // Updates one or both discoverability flags. Wraps both writes (and the
@@ -345,6 +348,7 @@ export async function updateDiscoverability(
       .select({
         discoverableByContacts: users.discoverableByContacts,
         discoverableByMutualFriends: users.discoverableByMutualFriends,
+        discoverableByNicheMatch: users.discoverableByNicheMatch,
       })
       .from(users)
       .where(eq(users.id, userId))
@@ -355,6 +359,8 @@ export async function updateDiscoverability(
     const set: Record<string, unknown> = { updatedAt: new Date() };
     if (patch.contacts !== undefined) set.discoverableByContacts = patch.contacts;
     if (patch.mutualFriends !== undefined) set.discoverableByMutualFriends = patch.mutualFriends;
+    // No purge side-effect for niche-match: it stores no uploaded data to revoke.
+    if (patch.nicheMatch !== undefined) set.discoverableByNicheMatch = patch.nicheMatch;
 
     await tx.update(users).set(set).where(eq(users.id, userId));
 
@@ -368,6 +374,7 @@ export async function updateDiscoverability(
       discoverableByContacts: patch.contacts ?? current.discoverableByContacts,
       discoverableByMutualFriends:
         patch.mutualFriends ?? current.discoverableByMutualFriends,
+      discoverableByNicheMatch: patch.nicheMatch ?? current.discoverableByNicheMatch,
     };
   });
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -191,6 +191,11 @@ export const users = pgTable(
     avatarColor: text('avatar_color'),
     discoverableByContacts: boolean('discoverable_by_contacts').notNull().default(false),
     discoverableByMutualFriends: boolean('discoverable_by_mutual_friends').notNull().default(false),
+    // D-2 niche-match discovery. TEST-PHASE default ON (DEFAULT true) — deliberate
+    // for the test cohort only. The production default is an OPEN DECISION to
+    // revisit after the test; do not assume default-ON as the shipping default.
+    // See drizzle/0059_niche_match_discoverability.sql.
+    discoverableByNicheMatch: boolean('discoverable_by_niche_match').notNull().default(true),
     // D-1 Stage 3 — gate on new followers. Default approval_required; public is opt-in.
     followPrivacy: followPrivacyEnum('follow_privacy').notNull().default('approval_required'),
     phoneHash: text('phone_hash'),


### PR DESCRIPTION
## Summary
Adds the third discoverability flag, `discoverable_by_niche_match`, enabling users to control whether they can be discovered by strangers through shared question answers. This implements the privacy gating for the niche-match discovery feature (D-2).

## Key Changes

- **Database schema & migration (0059):** Added `discoverable_by_niche_match` boolean column to `User` table with `DEFAULT true` for the test phase (spec default is `false`, but test cohort is enrolled by default per OPEN DECISION).

- **Query layer (`src/server/db/queries/account.ts`):** Extended `DiscoverabilityState` type and `getDiscoverability` / `updateDiscoverability` functions to handle the new flag. No purge side-effect needed (unlike contacts flag).

- **API validation (`src/app/api/account/discoverability/route.ts`):** Updated Zod schema to accept optional `nicheMatch` boolean in PATCH requests; refined validation to require at least one flag change.

- **UI (`src/components/profile/settings/PrivacyForm.tsx`):** Added third toggle with user-facing copy: *"Let people I've never met discover me through questions we both answer."* Wired state management and API calls for the new flag.

- **Boot-time guard (`src/instrumentation.ts`):** Added idempotent migration guard for preview/production databases that may have the migration recorded without the column present.

- **Schema definition (`src/server/db/schema.ts`):** Declared the new column with test-phase default and explanatory comments.

- **Spec amendment (`PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md`):** Documented the test-phase override (DEFAULT true instead of false) and the requirement for pre-test user communication about the retroactive privacy posture change.

## Notable Details

- **Test-phase default is intentionally ON:** The whole cohort, including pre-existing users, is enrolled in niche-match discovery by default. This is a deliberate test-phase amendment; the production default remains an OPEN DECISION.
- **Privacy communication required:** Flipping the default retroactively for existing users requires a non-code pre-test communication step (not included in this PR).
- **No data revocation:** Unlike the contacts flag, niche-match stores no uploaded data to revoke on toggle-off.

https://claude.ai/code/session_011JxVLox3g3Gbo9bQHkM9ye