### PR TITLE
Add niche-match discovery activity types (D-2)

### DIFF
--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
 import type { ReactNode } from 'react';
 
@@ -28,6 +29,26 @@ import { getUserById } from '@/server/db/queries/users';
 
 function actorName(item: ActivityItemView) {
   return item.actor?.displayName ?? 'Someone';
+}
+
+// D-2 niche-match: the discovery loop's whole point is "go connect with this
+// stranger," so the actor name must be a profile link (-> /users/{id} ->
+// ProfileFriendButton). Other activity types intentionally render the actor
+// as a plain UnderlineName; only the niche-match rows opt into the link, and
+// only when we actually have an actorUserId.
+function NicheMatchActor({ item }: { item: ActivityItemView }) {
+  const name = actorName(item);
+  if (!item.actorUserId) {
+    return <UnderlineName>{name}</UnderlineName>;
+  }
+  return (
+    <Link
+      href={`/users/${item.actorUserId}`}
+      style={{ color: 'inherit', textDecoration: 'none' }}
+    >
+      <UnderlineName>{name}</UnderlineName>
+    </Link>
+  );
 }
 
 function ActivityCopy({ item }: { item: ActivityItemView }) {
@@ -177,6 +198,34 @@ function ActivityCopy({ item }: { item: ActivityItemView }) {
     );
   }
 
+  if (item.type === 'niche_match_answered_your_question') {
+    const nm = item.reference.nicheMatch;
+    const domain = nm?.domain;
+    const domainText = domain ? ` ${domain}` : '';
+    return (
+      <>
+        <NicheMatchActor item={item} /> answered your{domainText} question —
+        someone out there shares this corner
+      </>
+    );
+  }
+
+  if (item.type === 'niche_match_you_answered') {
+    const nm = item.reference.nicheMatch;
+    const domain = nm?.domain;
+    return domain ? (
+      <>
+        You answered <NicheMatchActor item={item} />&apos;s {domain} question —
+        you found someone in {domain}
+      </>
+    ) : (
+      <>
+        You answered <NicheMatchActor item={item} />&apos;s question — you found
+        someone who shares this corner
+      </>
+    );
+  }
+
   if (item.type === 'declared_promoted') {
     const dp = item.reference.declaredPromoted;
     const domain = dp?.domain;
@@ -273,6 +322,19 @@ export function ActivitySubcopy({ item }: { item: ActivityItemView }) {
           {disputeStatusLabel(dispute.status, dispute.acceptedAlternative)}
         </p>
       </div>
+    );
+  }
+
+  if (
+    item.type === 'niche_match_answered_your_question' ||
+    item.type === 'niche_match_you_answered'
+  ) {
+    const nm = item.reference.nicheMatch;
+    if (!nm?.questionText) return null;
+    return (
+      <p className="text-muted-foreground mt-1 line-clamp-2 text-sm">
+        {nm.questionText}
+      </p>
     );
   }
 

--- a/src/components/home/NewsRow.tsx
+++ b/src/components/home/NewsRow.tsx
@@ -64,6 +64,37 @@ function buildCopy(item: ActivityItemView, actor: React.ReactNode): NewsRowCopy 
       }
     }
 
+    // D-2 niche-match discovery. These are excluded from Home's top-3
+    // (not in HOME_TOP3_ELIGIBLE_TYPES), so in practice NewsRow won't be
+    // asked to render them — but the branch keeps the switch honest and
+    // mirrors the friend_answered template. The actor (the opted-in stranger)
+    // links to their profile via <ActorName>, which is the connect path.
+    case 'niche_match_answered_your_question': {
+      const nm = item.reference.nicheMatch
+      const domain = nm?.domain?.trim() || null
+      return {
+        headline: (
+          <>
+            {actor} answered your question
+          </>
+        ),
+        secondLine: domain,
+      }
+    }
+
+    case 'niche_match_you_answered': {
+      const nm = item.reference.nicheMatch
+      const domain = nm?.domain?.trim() || null
+      return {
+        headline: (
+          <>
+            You answered {actor}&apos;s question
+          </>
+        ),
+        secondLine: domain,
+      }
+    }
+
     case 'declared_promoted': {
       const dp = item.reference.declaredPromoted
       const domain = dp?.domain?.trim() || null

--- a/src/server/activity/write-activity.ts
+++ b/src/server/activity/write-activity.ts
@@ -32,7 +32,18 @@ export type ActivityItemType =
   // answerer disputes their wrong-answer grade. The dispute is the
   // answerer's explicit ask for a second look, which is the consent gate
   // that exposes their submitted text to the author.
-  | 'grade_dispute_filed';
+  | 'grade_dispute_filed'
+  // D-2 niche-match discovery (slow-burn organic discovery between strangers
+  // through a shared authored question). Two asymmetric writes from
+  // notifyNicheMatch() in src/server/feed/create-feed-items-for-answer.ts,
+  // each gated by the *exposed* party's discoverableByNicheMatch flag.
+  // Deliberately NOT the same as friend_answered_your_question (which targets
+  // prior answerers, is friend-scoped, and carries a got-it/couldn't-get-it
+  // framing). Kept OUT of HOME_TOP3_ELIGIBLE_TYPES and the bell badge below —
+  // this is a slow-burn delight with no volume cues; it surfaces only in the
+  // full /activities list.
+  | 'niche_match_answered_your_question' // author-side: a stranger correctly answered a question you authored
+  | 'niche_match_you_answered'; // answerer-side: you correctly answered a stranger's authored question
 
 // Events surfaced in Home's top-3 RecentActivity and counted by the bell
 // badge. Light type filtering only — chronological within this set. Single

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -71,6 +71,16 @@ export type ActivityItemView = Pick<
       questionText: string | null;
       result: 'correct' | 'incorrect';
     };
+    // D-2 niche-match discovery. Hydrated for both new types
+    // (niche_match_answered_your_question / niche_match_you_answered). Reuses
+    // referenceType: 'question' + referenceId: questionId. The result is always
+    // 'correct' by construction (the write only fires on a correct answer), so
+    // unlike friendAnsweredQuestion there is no got-it/couldn't framing — the
+    // domain is the discovery hook.
+    nicheMatch?: {
+      domain: string | null;
+      questionText: string | null;
+    };
     authoredSharedQuestion?: {
       domain: string;
       recipientCount: number;
@@ -130,6 +140,8 @@ function isActivityType(value: string): value is ActivityItemType {
     'authored_question_shared',
     'declared_promoted',
     'grade_dispute_filed',
+    'niche_match_answered_your_question',
+    'niche_match_you_answered',
   ].includes(value);
 }
 
@@ -602,6 +614,52 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
   );
 }
 
+// D-2 niche-match. A parallel hydrator to hydrateFriendAnsweredQuestions —
+// NOT shared, because that one hardcodes its own type filter
+// (friend_answered_your_question) and a mastery-event correctness lookup the
+// niche types don't need (they only ever fire on a correct answer). Both
+// niche types reference the answered question (referenceType 'question'); we
+// surface its domain (the discovery hook) and text. Keyed by item.id so each
+// row hydrates independently even when two rows point at the same question.
+async function hydrateNicheMatchQuestions(items: ActivityItemRow[]) {
+  const relevant = items.filter(
+    (item) =>
+      (item.type === 'niche_match_answered_your_question'
+        || item.type === 'niche_match_you_answered')
+      && item.referenceType === 'question'
+      && item.referenceId,
+  );
+  if (relevant.length === 0) {
+    return new Map<string, NonNullable<ActivityItemView['reference']['nicheMatch']>>();
+  }
+
+  const questionIds = [...new Set(relevant.map((item) => item.referenceId!))];
+  const questionRows = await db
+    .select({
+      id: questions.id,
+      questionText: questions.questionText,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+    })
+    .from(questions)
+    .where(inArray(questions.id, questionIds));
+
+  const questionById = new Map(questionRows.map((r) => [r.id, r]));
+
+  return new Map(
+    relevant.map((item) => {
+      const q = questionById.get(item.referenceId!);
+      return [
+        item.id,
+        {
+          domain: q ? (q.canonicalSubcategory ?? q.broadCategory ?? null) : null,
+          questionText: q?.questionText ?? null,
+        } satisfies NonNullable<ActivityItemView['reference']['nicheMatch']>,
+      ];
+    }),
+  );
+}
+
 async function hydrateAuthoredSharedQuestions(items: ActivityItemRow[]) {
   const relevant = items.filter(
     (item) => item.type === 'authored_question_shared' && item.referenceType === 'question' && item.referenceId,
@@ -679,6 +737,7 @@ async function hydrateActivityRows(
     directQuestionsById,
     curatedQuestionsById,
     friendAnsweredQuestionsById,
+    nicheMatchById,
     authoredSharedQuestionsById,
     declaredPromotedById,
     gradeDisputesById,
@@ -691,6 +750,7 @@ async function hydrateActivityRows(
     hydrateDirectQuestions(rows),
     hydrateCuratedQuestions(rows),
     hydrateFriendAnsweredQuestions(rows),
+    hydrateNicheMatchQuestions(rows),
     hydrateAuthoredSharedQuestions(rows),
     hydrateDeclaredPromoted(rows),
     hydrateGradeDisputes(rows),
@@ -729,6 +789,10 @@ async function hydrateActivityRows(
           : undefined,
         friendAnsweredQuestion: row.type === 'friend_answered_your_question'
           ? friendAnsweredQuestionsById.get(row.id)
+          : undefined,
+        nicheMatch: row.type === 'niche_match_answered_your_question'
+          || row.type === 'niche_match_you_answered'
+          ? nicheMatchById.get(row.id)
           : undefined,
         authoredSharedQuestion: row.type === 'authored_question_shared'
           ? authoredSharedQuestionsById.get(row.id)


### PR DESCRIPTION
## Summary
Implements the niche-match discovery feature (D-2) by adding two new activity types that surface when strangers connect through correctly answered authored questions. These activities are gated by the `discoverableByNicheMatch` flag and intentionally excluded from Home's top-3 badge to maintain a slow-burn discovery experience.

## Key Changes

**Database & Query Layer** (`src/server/db/queries/activity.ts`)
- Added `nicheMatch` field to `ActivityItemView.reference` with `domain` and `questionText` properties
- Registered two new activity types: `niche_match_answered_your_question` and `niche_match_you_answered`
- Implemented `hydrateNicheMatchQuestions()` hydrator that parallels `hydrateFriendAnsweredQuestions()` but:
  - Filters both niche-match types independently (not shared type filtering)
  - Omits mastery-event correctness lookup (niche types only fire on correct answers by construction)
  - Surfaces domain (discovery hook) and question text via `canonicalSubcategory` or `broadCategory`

**Activity Type Definition** (`src/server/activity/write-activity.ts`)
- Added `niche_match_answered_your_question` (author-side: stranger correctly answered your question)
- Added `niche_match_you_answered` (answerer-side: you correctly answered stranger's question)
- Documented that these are deliberately excluded from `HOME_TOP3_ELIGIBLE_TYPES` and bell badge

**Activities Page** (`src/app/activities/page.tsx`)
- Added `NicheMatchActor` component that renders actor as a profile link (`/users/{id}`) when `actorUserId` is present, enabling the "connect with this stranger" UX
- Implemented copy templates for both niche-match types with domain context
- Added subcopy rendering for question text

**Home News Row** (`src/components/home/NewsRow.tsx`)
- Added case handlers for both niche-match types (mirrors `friend_answered` template)
- Surfaces domain as secondary line; actor links to profile via `<ActorName>`
- Noted that these won't render in practice (excluded from `HOME_TOP3_ELIGIBLE_TYPES`) but keeps the switch exhaustive

## Implementation Details

- Both niche types reuse `referenceType: 'question'` + `referenceId: questionId` for consistency
- Domain extraction prioritizes `canonicalSubcategory` over `broadCategory` (same as other activity hydrators)
- Niche-match rows hydrate independently even when multiple rows reference the same question (keyed by `item.id`)
- Actor name is always a profile link for niche-match (unlike other activity types which use plain `UnderlineName`)

https://claude.ai/code/session_01Hnb5bnnXmEJBkXYbvEfJCX