### PR TITLE
D-2 WS3: niche-match write-point + asymmetric two-flag gate

### DIFF
--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -1,4 +1,4 @@
-import { eq, sql } from 'drizzle-orm';
+import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import {
   contactHashes,
@@ -377,6 +377,25 @@ export async function updateDiscoverability(
       discoverableByNicheMatch: patch.nicheMatch ?? current.discoverableByNicheMatch,
     };
   });
+}
+
+// Batched lookup of the niche-match opt-in flag for the niche-match write-point
+// (D-2 WS3). Returns the subset of the supplied ids whose
+// discoverableByNicheMatch is currently true. Used to resolve the asymmetric
+// two-flag gate in notifyNicheMatch with a single query rather than a
+// per-user getDiscoverability round-trip.
+export async function getNicheMatchDiscoverable(
+  userIds: string[],
+): Promise<Set<string>> {
+  if (userIds.length === 0) return new Set();
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(
+      inArray(users.id, userIds),
+      eq(users.discoverableByNicheMatch, true),
+    ));
+  return new Set(rows.map((r) => r.id));
 }
 
 export async function deleteUserAccount(userId: string): Promise<void> {

--- a/src/server/feed/__tests__/notify-niche-match.test.ts
+++ b/src/server/feed/__tests__/notify-niche-match.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RelationshipState } from '@/server/db/queries/friend-requests';
+
+// notifyNicheMatch only reaches out to three collaborators: getRelationship
+// (the stranger gate), getNicheMatchDiscoverable (the asymmetric flag gate),
+// and writeActivity (the two writes). We mock exactly those and assert on the
+// resulting writeActivity calls. '@/server/db' is mocked to keep the module's
+// top-level table/pool imports from initializing a real connection.
+const { writeActivityMock, getRelationshipMock, getNicheMatchDiscoverableMock } = vi.hoisted(() => ({
+  writeActivityMock: vi.fn(async () => undefined),
+  getRelationshipMock: vi.fn(),
+  getNicheMatchDiscoverableMock: vi.fn(),
+}));
+
+vi.mock('@/server/db', () => ({
+  db: {},
+  feedDismissedDomains: {},
+  feedItems: {},
+  masteryEvents: {},
+  questionFeedback: {},
+  questionRatings: {},
+  questions: {},
+}));
+
+vi.mock('@/server/activity/write-activity', () => ({ writeActivity: writeActivityMock }));
+vi.mock('@/server/db/queries/friend-requests', () => ({ getRelationship: getRelationshipMock }));
+vi.mock('@/server/db/queries/account', () => ({ getNicheMatchDiscoverable: getNicheMatchDiscoverableMock }));
+
+import { notifyNicheMatch } from '@/server/feed/create-feed-items-for-answer';
+
+const ANSWERER = 'answerer-1';
+const AUTHOR = 'author-1';
+const QUESTION = 'question-1';
+
+function relationship(state: RelationshipState) {
+  return { state, friendshipId: null, formedAt: null, isBlocked: false };
+}
+
+// optedIn is the set the gate consults; default both parties opted in (the
+// test-phase DEFAULT-ON posture).
+function bothOptedIn() {
+  return new Set([ANSWERER, AUTHOR]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getRelationshipMock.mockResolvedValue(relationship('none'));
+  getNicheMatchDiscoverableMock.mockResolvedValue(bothOptedIn());
+});
+
+describe('notifyNicheMatch — stranger gate', () => {
+  it('writes exactly two rows for a correct stranger answer when both parties are opted in', async () => {
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR);
+
+    expect(writeActivityMock).toHaveBeenCalledTimes(2);
+    // Author-side: the AUTHOR is told a stranger (the answerer) answered.
+    expect(writeActivityMock).toHaveBeenCalledWith({
+      userId: AUTHOR,
+      type: 'niche_match_answered_your_question',
+      actorUserId: ANSWERER,
+      referenceId: QUESTION,
+      referenceType: 'question',
+    });
+    // Answerer-side: the ANSWERER is told they answered a stranger's (author's) question.
+    expect(writeActivityMock).toHaveBeenCalledWith({
+      userId: ANSWERER,
+      type: 'niche_match_you_answered',
+      actorUserId: AUTHOR,
+      referenceId: QUESTION,
+      referenceType: 'question',
+    });
+  });
+
+  it.each<RelationshipState>([
+    'friends',
+    'following',
+    'follows_you',
+    'pending_outbound',
+    'pending_inbound',
+  ])('writes nothing when the relationship is %s (not a stranger)', async (state) => {
+    getRelationshipMock.mockResolvedValue(relationship(state));
+
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR);
+
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing when the answerer is the author (self)', async () => {
+    await notifyNicheMatch(AUTHOR, QUESTION, AUTHOR);
+
+    expect(getRelationshipMock).not.toHaveBeenCalled();
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for an LLM-origin question with no author (null creatorId)', async () => {
+    await notifyNicheMatch(ANSWERER, QUESTION, null);
+
+    expect(getRelationshipMock).not.toHaveBeenCalled();
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+
+  it('writes nothing for joshing-games (excluded surface, detected by sourceAnswerId prefix)', async () => {
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR, `joshing_game:game-9:${QUESTION}:${ANSWERER}`);
+
+    expect(getRelationshipMock).not.toHaveBeenCalled();
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+
+  it('still fires for the other organic surfaces (e.g. a daily-prefixed sourceAnswerId)', async () => {
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR, `daily:key:${ANSWERER}`);
+
+    expect(writeActivityMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('notifyNicheMatch — asymmetric two-flag gate (both directions)', () => {
+  it('only the answerer opted in: writes ONLY the author-side row (which exposes the answerer)', async () => {
+    getNicheMatchDiscoverableMock.mockResolvedValue(new Set([ANSWERER]));
+
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR);
+
+    expect(writeActivityMock).toHaveBeenCalledTimes(1);
+    expect(writeActivityMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: AUTHOR,
+      type: 'niche_match_answered_your_question',
+      actorUserId: ANSWERER,
+    }));
+  });
+
+  it('only the author opted in: writes ONLY the answerer-side row (which exposes the author)', async () => {
+    getNicheMatchDiscoverableMock.mockResolvedValue(new Set([AUTHOR]));
+
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR);
+
+    expect(writeActivityMock).toHaveBeenCalledTimes(1);
+    expect(writeActivityMock).toHaveBeenCalledWith(expect.objectContaining({
+      userId: ANSWERER,
+      type: 'niche_match_you_answered',
+      actorUserId: AUTHOR,
+    }));
+  });
+
+  it('neither opted in: writes nothing', async () => {
+    getNicheMatchDiscoverableMock.mockResolvedValue(new Set<string>());
+
+    await notifyNicheMatch(ANSWERER, QUESTION, AUTHOR);
+
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -2,9 +2,18 @@ import { and, eq, inArray, isNull } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, masteryEvents, questionFeedback, questionRatings, questions } from '@/server/db';
 import { writeActivity } from '@/server/activity/write-activity';
+import { getNicheMatchDiscoverable } from '@/server/db/queries/account';
 import { getFollowers } from '@/server/db/queries/friends';
+import { getRelationship } from '@/server/db/queries/friend-requests';
 import { rollOffOldItems } from '@/server/db/queries/feed';
 import { isCorrectAnswerFeedEligible, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+
+// Joshing-games funnel through this same after() entrypoint but stamp their
+// sourceAnswerId with this prefix (see src/app/api/joshing-games/[id]/answer/
+// route.ts). Niche-match discovery is explicitly EXCLUDED for them — a
+// joshing-game is an invited context, not organic stranger discovery
+// (D-2 spec §Q7) — so we detect and skip on this prefix.
+const JOSHING_GAME_SOURCE_PREFIX = 'joshing_game:';
 
 export async function createFeedItemsForFriendsFromAnswer(
   userId: string,
@@ -76,6 +85,14 @@ async function _createFeedItemsForFriendsFromAnswer(
 
   const domain = question.canonicalSubcategory ?? question.broadCategory;
   if (!domain) return;
+
+  // D-2 niche-match stranger discovery. Fires HERE — before the friend
+  // fan-out's `friends.length === 0` early return below — because the core
+  // atonal-stranger case (the one other person who knows your obscure corner)
+  // has zero followers who share the niche, so it must run independent of the
+  // friend-feed path. notifyNicheMatch owns its own try/catch so a niche
+  // failure can't abort the friend fan-out that follows.
+  await notifyNicheMatch(userId, questionId, question.creatorId, sourceAnswerId);
 
   // friend_answered fan-out reaches my followers — people who follow me see
   // that I answered correctly (directional follow model, D-1 Stage 3).
@@ -190,4 +207,81 @@ async function notifyPreviousAnswerers(userId: string, questionId: string): Prom
       referenceType: 'question',
     }),
   ));
+}
+
+// D-2 niche-match: the stranger discovery loop. A correct answer to a question
+// authored by a *stranger* surfaces each party to the other as an activity
+// item — the notify-and-connect loop the engine is built on. Both writes are
+// asymmetrically gated so identity is only ever exposed to a third party with
+// the exposed party's own consent. See PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md
+// §"The notify-and-connect loop" / §"Gate direction".
+//
+// Exported for unit testing (the gate is correctness-critical — a mis-wire
+// exposes people to strangers they didn't intend, doubly so under the
+// test-phase DEFAULT-ON for discoverableByNicheMatch).
+export async function notifyNicheMatch(
+  answererId: string,
+  questionId: string,
+  creatorId: string | null,
+  sourceAnswerId?: string,
+): Promise<void> {
+  try {
+    // Excluded surface: joshing-games (invited context, not organic discovery).
+    if (sourceAnswerId?.startsWith(JOSHING_GAME_SOURCE_PREFIX)) return;
+
+    // Fire condition: a real human author who isn't the answerer. LLM-origin
+    // questions (daily_generated / curated_sent) carry a null creatorId and so
+    // never trigger niche-match — there is no author to discover.
+    if (!creatorId || creatorId === answererId) return;
+
+    // Fire condition: STRANGER gate. Only the 'none' relationship state
+    // qualifies. Any approved-or-pending follow edge in either direction
+    // (friends / following / follows_you / pending_outbound / pending_inbound)
+    // means they are not strangers — friends already see each other through
+    // friend_answered_your_question + Lately, so firing for them is noise.
+    const relationship = await getRelationship(answererId, creatorId);
+    if (relationship.state !== 'none') return;
+
+    // Fire condition: the ASYMMETRIC two-flag gate. The flag of the party whose
+    // identity a notification would EXPOSE gates that notification. Do NOT
+    // invert this.
+    const optedIn = await getNicheMatchDiscoverable([answererId, creatorId]);
+
+    const writes: Array<Promise<void>> = [];
+
+    // Author-side: tells the AUTHOR (creatorId) that a stranger — the answerer —
+    // answered their question. It exposes the ANSWERER, so it is gated by the
+    // ANSWERER's flag.
+    if (optedIn.has(answererId)) {
+      writes.push(writeActivity({
+        userId: creatorId,
+        type: 'niche_match_answered_your_question',
+        actorUserId: answererId,
+        referenceId: questionId,
+        referenceType: 'question',
+      }));
+    }
+
+    // Answerer-side: tells the ANSWERER that they answered a stranger's — the
+    // author's — question. It exposes the AUTHOR, so it is gated by the
+    // AUTHOR's flag.
+    if (optedIn.has(creatorId)) {
+      writes.push(writeActivity({
+        userId: answererId,
+        type: 'niche_match_you_answered',
+        actorUserId: creatorId,
+        referenceId: questionId,
+        referenceType: 'question',
+      }));
+    }
+
+    await Promise.all(writes);
+  } catch (error) {
+    console.error('[notifyNicheMatch] suppressed error:', {
+      answererId,
+      questionId,
+      creatorId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
 }


### PR DESCRIPTION
Add notifyNicheMatch() inside createFeedItemsForFriendsFromAnswer, fired
from the same after() the four organic surfaces (feed / daily / catchup /
questions) funnel through. It runs the stranger discovery loop: a correct
answer to a question authored by a stranger surfaces each party to the
other as an /activities item (the WS2 types).

Placement: before the friend fan-out's `friends.length === 0` early
return, because the core atonal-stranger case has zero followers who share
the niche, so it must run independent of the friend-feed path. The
function owns its own try/catch so a niche failure can't abort the friend
fan-out.

Fire conditions (all must hold):
- result === 'correct' (inherited from the function's early return)
- a real human author (creatorId) who isn't the answerer; LLM-origin
  questions (null creatorId) never fire
- getRelationship(answerer, creator) === 'none' (STRANGER gate — any
  approved-or-pending follow edge in either direction is skipped)
- the asymmetric two-flag gate passes

Asymmetric gate (correctness-critical, default-ON test posture raises the
stakes — a mis-wire exposes people to strangers unintentionally):
- author-side ("a stranger answered your question") exposes the ANSWERER,
  so it is gated by the ANSWERER's discoverableByNicheMatch flag
- answerer-side ("you answered a stranger's question") exposes the AUTHOR,
  so it is gated by the AUTHOR's flag
The exposed party's own flag gates the OTHER party's notification.

Joshing-games is EXCLUDED (invited context, not organic discovery): it
funnels through the same after() but is detected and skipped via its
sourceAnswerId 'joshing_game:' prefix.

Adds getNicheMatchDiscoverable() (batched flag lookup) in queries/account.
Adds unit tests covering the stranger gate (fires only on 'none'; skipped
for friends/following/follows_you/pending_*/self/null-author/joshing-game)
and the asymmetric flag gate in BOTH directions.

https://claude.ai/code/session_01PYuqEPM7yyjs5Ci9Mou5v5