### PR TITLE
D-2 WS4: niche-match dedup non-collision note + tests

### DIFF
--- a/src/app/activities/__tests__/filter-utility-activities.test.ts
+++ b/src/app/activities/__tests__/filter-utility-activities.test.ts
@@ -74,6 +74,27 @@ function friendAnsweredActivity(
   };
 }
 
+function nicheMatchActivity(
+  id: string,
+  type: 'niche_match_answered_your_question' | 'niche_match_you_answered',
+  questionId: string,
+): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer-1',
+    type,
+    actorUserId: 'stranger-1',
+    referenceId: questionId,
+    referenceType: 'question',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'A stranger' },
+    reference: {
+      nicheMatch: { domain: 'Stephen Sondheim musicals', questionText: 'q' },
+    },
+  };
+}
+
 function declaredPromotedActivity(id: string): ActivityItemView {
   return {
     id,
@@ -128,5 +149,31 @@ describe('filterUtilityActivities', () => {
 
     const kept = filterUtilityActivities(items, []);
     expect(kept.map((i) => i.id)).toEqual(['a-2']);
+  });
+
+  // D-2 dedup non-collision: niche-match is stranger-scoped and Lately moments
+  // are friend-scoped, so the two never overlap. These assert filterUtilityActivities
+  // keeps both niche-match types — and keeps them even when (defensively) a
+  // same-questionId moment is present — so a future edit can't silently route
+  // the discovery loop's only surface into the dedup set.
+  it('keeps both niche_match_* types (not part of the dedup set)', () => {
+    const items = [
+      nicheMatchActivity('nm-1', 'niche_match_answered_your_question', 'q-sondheim'),
+      nicheMatchActivity('nm-2', 'niche_match_you_answered', 'q-sondheim'),
+    ];
+
+    const kept = filterUtilityActivities(items, []);
+    expect(kept.map((i) => i.id)).toEqual(['nm-1', 'nm-2']);
+  });
+
+  it('keeps niche_match_* even when a same-questionId Lately moment exists (defensive — they are disjoint by construction)', () => {
+    const items = [
+      nicheMatchActivity('nm-1', 'niche_match_answered_your_question', 'q-sondheim'),
+      nicheMatchActivity('nm-2', 'niche_match_you_answered', 'q-sondheim'),
+    ];
+    const moments = [youGotThemMoment('q-sondheim'), theyGotYouMoment('q-sondheim')];
+
+    const kept = filterUtilityActivities(items, moments);
+    expect(kept.map((i) => i.id)).toEqual(['nm-1', 'nm-2']);
   });
 });

--- a/src/app/activities/filter-utility-activities.ts
+++ b/src/app/activities/filter-utility-activities.ts
@@ -9,6 +9,15 @@ import type { LatelyMoment } from '@/server/db/queries/lately';
 //     plus a domain transition). The "SEE YOUR MAP" CTA lives on /knowledge.
 //   - received_direct_question whose question the viewer already got
 //     correctly: covered by the you_got_them moment for that questionId.
+//
+// D-2 NICHE-MATCH NOTE — do NOT add the niche_match_* types to this dedup set.
+// Lately moments (getLatelyMoments, both directions) are FRIEND-scoped, but
+// niche-match only fires between strangers (the 'none' relationship state — see
+// notifyNicheMatch's stranger gate), so a niche-match item can never collide
+// with a they_got_you / you_got_them moment for the same questionId. They are
+// disjoint by construction; dropping them here would silently delete the only
+// surface the discovery loop renders on. Covered by the
+// filter-utility-activities tests.
 export function filterUtilityActivities(
   items: ActivityItemView[],
   moments: LatelyMoment[],


### PR DESCRIPTION
Confirm filterUtilityActivities never drops the niche_match_* types and add a
guard against a future edit routing the discovery loop's only surface into the
dedup set. Niche-match fires only between strangers ('none' relationship state)
while Lately moments are friend-scoped, so the two are disjoint by construction.

- Code note on filterUtilityActivities documenting why the niche_match_* types
  must stay out of the dedup set (reinforces the spec's dedup-safety note).
- Tests: both niche_match_* types survive the filter, and survive even when a
  same-questionId Lately moment is present (defensive).

The stranger-gate and asymmetric two-flag gate tests already landed with WS3
(src/server/feed/__tests__/notify-niche-match.test.ts); verified green here.

Both daily/catchup after() sites (catchup/answer/route.ts:294 and :450) route
through createFeedItemsForFriendsFromAnswer -> notifyNicheMatch (line 95),
confirmed by code read. Note: `npm run smoke:daily-catchup` is currently
unrunnable in CI/sandbox for a pre-existing reason unrelated to D-2 -- commit
257d322 added a `@/`-alias import to src/server/daily/catchup.ts that
`node --experimental-strip-types` cannot resolve; it fails identically on a
clean tree at HEAD.