### PR TITLE
B-4: three-way create choice + homepage authoring prompt

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import TodaysFiveCard, {
   type DailyStatus,
   type SlotOutcome,
 } from '@/components/TodaysFiveCard'
+import { AuthoringPrompt } from '@/components/home/AuthoringPrompt'
 import { CeremonyPin } from '@/components/home/CeremonyPin'
 import { MissedQuestionsCard } from '@/components/home/MissedQuestionsCard'
 import { RecentActivitySection } from '@/components/home/RecentActivitySection'
@@ -66,6 +67,8 @@ export default async function Home() {
           <RecentActivityServerSection userId={session.userId} />
         </Suspense>
       ) : null}
+
+      {session ? <AuthoringPrompt /> : null}
 
       <section id="feed">
         {session ? (

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -11,10 +11,41 @@ import type { QuestionView } from '@/server/db/queries/questions';
 
 type SortMode = 'newest' | 'most_answered' | 'hardest' | 'easiest';
 type Tab = 'authored' | 'answered';
+// Capability 8 (B-4 Stage A): the CreateChooser passes a three-way intent that
+// pre-selects the composer's destinations. 'followers' maps to D-1 Stage 4's
+// 'friends' visibility (followers-only) — not a hardcoded 'public'.
+type CreateIntent = 'bank' | 'followers' | 'specific';
 type DrawerState =
   | { mode: 'closed' }
-  | { mode: 'create' }
+  // intent is null for the page's own "Write a question" buttons (and the
+  // legacy `?create=1` link), which keep the form's existing defaults. Only the
+  // CreateChooser supplies an explicit intent.
+  | { mode: 'create'; intent: CreateIntent | null }
   | { mode: 'edit'; question: QuestionView };
+
+function parseIntent(raw: string | null): CreateIntent | null {
+  return raw === 'bank' || raw === 'followers' || raw === 'specific' ? raw : null;
+}
+
+// Translate the create intent into the QuestionForm's initial destination
+// state. The form still surfaces every control, so these are starting points
+// the author can adjust — not a locked mode. A null intent returns no
+// overrides, preserving the form's pre-existing default destinations.
+function createFormProps(intent: CreateIntent | null): {
+  initialValues?: Partial<QuestionFormValues>;
+  initialSpecificMode?: boolean;
+} {
+  switch (intent) {
+    case 'followers':
+      return { initialValues: { shareToFeed: true, visibility: 'friends' } };
+    case 'specific':
+      return { initialSpecificMode: true };
+    case 'bank':
+      return { initialValues: { shareToFeed: false } };
+    default:
+      return {};
+  }
+}
 
 type AnsweredApiResponse = {
   items?: AnsweredQuestionItem[];
@@ -104,7 +135,9 @@ function QuestionsPageContent() {
   const [sortMode, setSortMode] = useState<SortMode>('newest');
   const [search, setSearch] = useState('');
   const [drawer, setDrawer] = useState<DrawerState>(() => (
-    searchParams.get('create') === '1' ? { mode: 'create' } : { mode: 'closed' }
+    searchParams.get('create') === '1'
+      ? { mode: 'create', intent: parseIntent(searchParams.get('intent')) }
+      : { mode: 'closed' }
   ));
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [cardError, setCardError] = useState<Record<string, string>>({});
@@ -305,7 +338,7 @@ function QuestionsPageContent() {
               <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
               <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
             </div>
-            <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create' })}>
+            <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create', intent: null })}>
               <Plus className="size-4" />
               Write a question
             </button>
@@ -351,7 +384,7 @@ function QuestionsPageContent() {
               <p className="mt-2 max-w-sm text-sm text-muted-foreground">
                 You haven&apos;t written any questions yet. Write one to get started.
               </p>
-              <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create' })}>
+              <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create', intent: null })}>
                 Write a question
               </button>
             </section>
@@ -424,7 +457,8 @@ function QuestionsPageContent() {
             </div>
             <QuestionForm
               mode={drawer.mode}
-              initialValues={drawer.mode === 'edit' ? initialValues(drawer.question) : undefined}
+              initialValues={drawer.mode === 'edit' ? initialValues(drawer.question) : createFormProps(drawer.intent).initialValues}
+              initialSpecificMode={drawer.mode === 'create' ? createFormProps(drawer.intent).initialSpecificMode : undefined}
               onSubmit={drawer.mode === 'edit' ? (values) => saveEdit(drawer.question.id, values) : saveCreate}
               onCancel={() => setDrawer({ mode: 'closed' })}
             />

--- a/src/components/CreateChooser.tsx
+++ b/src/components/CreateChooser.tsx
@@ -2,7 +2,41 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
-import { Gamepad2, Pencil } from 'lucide-react';
+import { Gamepad2, Pencil, Send, Users } from 'lucide-react';
+
+// Capability 8: creating a question is a three-way choice surfaced up front —
+// bank it only, send to your followers, or send to specific people. Sending
+// always banks it too; these intents pre-select the matching destinations in
+// the composer (the form still lets you adjust before saving). The
+// 'send-to-followers' intent maps to the D-1 Stage 4 'friends' visibility
+// (followers-only), not a hardcoded 'public'.
+type CreateIntent = 'bank' | 'followers' | 'specific';
+
+const QUESTION_OPTIONS: ReadonlyArray<{
+  intent: CreateIntent;
+  icon: typeof Pencil;
+  title: string;
+  description: string;
+}> = [
+  {
+    intent: 'bank',
+    icon: Pencil,
+    title: 'Add to your bank',
+    description: 'Save a question for yourself — improves your own Daily Five.',
+  },
+  {
+    intent: 'followers',
+    icon: Users,
+    title: 'Send to followers',
+    description: 'Share it with everyone who follows you (also banked).',
+  },
+  {
+    intent: 'specific',
+    icon: Send,
+    title: 'Send to specific people',
+    description: 'Pick exactly who gets it (also banked).',
+  },
+];
 
 export function CreateChooser({ open, onClose }: { open: boolean; onClose: () => void }) {
   const router = useRouter();
@@ -20,30 +54,36 @@ export function CreateChooser({ open, onClose }: { open: boolean; onClose: () =>
 
   if (!open) return null;
 
-  function addQuestion() {
+  function addQuestion(intent: CreateIntent) {
     onClose();
-    router.push('/questions?create=1');
+    router.push(`/questions?create=1&intent=${intent}`);
   }
 
   return (
     <div className="fixed inset-0 z-[70] flex items-end justify-center bg-black/35 px-0 pb-0 md:items-center md:px-4 md:pb-4" role="dialog" aria-modal="true" aria-labelledby="create-chooser-title">
       <button className="absolute inset-0 cursor-default" type="button" aria-label="Close create chooser" onClick={onClose} />
       <section className="relative w-full rounded-t-2xl bg-background p-5 shadow-xl md:max-w-md md:rounded-2xl">
-        <h2 id="create-chooser-title" className="font-serif text-2xl font-semibold">Create</h2>
+        <h2 id="create-chooser-title" className="font-serif text-2xl font-semibold">Create a question</h2>
         <div className="mt-5 grid gap-3">
-          <button
-            type="button"
-            className="flex min-h-20 w-full items-center gap-4 rounded-lg border bg-card px-4 py-3 text-left transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
-            onClick={addQuestion}
-          >
-            <span className="grid size-10 shrink-0 place-items-center rounded-full bg-primary/10 text-primary" aria-hidden="true">
-              <Pencil className="size-5" />
-            </span>
-            <span>
-              <span className="block font-medium">Add a question</span>
-              <span className="mt-1 block text-sm text-muted-foreground">Write a trivia question for the bank.</span>
-            </span>
-          </button>
+          {QUESTION_OPTIONS.map((option) => {
+            const Icon = option.icon;
+            return (
+              <button
+                key={option.intent}
+                type="button"
+                className="flex min-h-20 w-full items-center gap-4 rounded-lg border bg-card px-4 py-3 text-left transition hover:bg-muted focus:outline-none focus:ring-2 focus:ring-primary"
+                onClick={() => addQuestion(option.intent)}
+              >
+                <span className="grid size-10 shrink-0 place-items-center rounded-full bg-primary/10 text-primary" aria-hidden="true">
+                  <Icon className="size-5" />
+                </span>
+                <span>
+                  <span className="block font-medium">{option.title}</span>
+                  <span className="mt-1 block text-sm text-muted-foreground">{option.description}</span>
+                </span>
+              </button>
+            );
+          })}
 
           <button
             type="button"

--- a/src/components/home/AuthoringPrompt.tsx
+++ b/src/components/home/AuthoringPrompt.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+
+// Capability 12 (B-4 Stage B): a homepage nudge encouraging question authoring,
+// framed around the author's own benefit — writing questions opens new domains
+// in your Knowledge base and feeds your own Daily Five — not as a chore. Kept
+// lightweight and placed below the daily ritual so it never crowds Today's Five
+// or its +2 bonus slots.
+export function AuthoringPrompt() {
+  return (
+    <div className="bg-card text-card-foreground flex items-center justify-between gap-3 rounded-[4px] border border-[var(--brand-border)] px-3 py-4">
+      <div className="min-w-0">
+        <p className="font-serif text-[16px] leading-[24px] font-semibold tracking-[0.04em] text-[var(--brand-ink)]">
+          Write a question
+        </p>
+        <p className="mt-1 text-xs font-medium tracking-[0.06em] text-[var(--brand-ink-400)]">
+          Sharpens your own Daily Five — and gives you something to share.
+        </p>
+      </div>
+      <Link
+        href="/questions?create=1&intent=bank"
+        className="font-serif text-lg leading-[24px] font-semibold tracking-[0.05em] whitespace-nowrap text-[var(--brand-link)] underline underline-offset-4"
+        aria-label="Write a question"
+      >
+        Write →
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
Stage A (capability 8): surface bank-only / send-to-followers /
send-to-specific as an explicit choice in CreateChooser. Each intent
pre-selects the composer's destinations; 'send-to-followers' maps to
D-1 Stage 4's 'friends' visibility (followers-only), not hardcoded
'public'. The questions page reads the intent and seeds QuestionForm's
initial state; the form still surfaces every control, so intents are
starting points, not locked modes. Legacy create entry points (in-page
buttons, ?create=1 link) keep their prior defaults via a null intent.

Stage B (capability 12): add a homepage authoring prompt framed around
the author's own benefit (sharpens your Daily Five, gives you something
to share). Placed below the daily ritual so it does not crowd Today's
Five or its +2 slots.