### PR TITLE
Unify LLM-question attribution into one non-person, non-house label

### DIFF
--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -54,6 +54,7 @@ function nextItemPayload(item: CatchupQuestion | null) {
     expiresAt: item.expiresAt,
     expiresSoon: item.expiresSoon,
     difficultyEstimate: item.difficultyEstimate,
+    authorName: item.authorName,
   };
 }
 

--- a/src/app/api/daily/catchup/route.ts
+++ b/src/app/api/daily/catchup/route.ts
@@ -30,6 +30,7 @@ export async function GET() {
       expiresAt: item.expiresAt,
       expiresSoon: item.expiresSoon,
       difficultyEstimate: item.difficultyEstimate,
+      authorName: item.authorName,
     })),
     introCopy: first
       ? formatCatchUpSessionThreadIntro(items.length, first.queueDate, last?.queueDate)

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -19,6 +19,7 @@ import { AddToBankAction } from '@/components/AddToBankAction'
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay'
 import MasteryMoment from '@/components/review/MasteryMoment'
 import { cn } from '@/lib/utils'
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types'
 import { formatNextResetTimeLocal } from '@/lib/games/timezone'
 import type {
   DailySummaryView,
@@ -456,7 +457,7 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
               : 'WRONG'}
         </span>
         <p className="pt-1" style={{ ...monoStyle, color: 'var(--text-muted)' }}>
-          {question.authorName ? null : `JOSHING BOT · ${question.domainDisplayName.toUpperCase()}`}
+          {question.authorName ? null : `${LLM_QUESTION_ATTRIBUTION.toUpperCase()} · ${question.domainDisplayName.toUpperCase()}`}
         </p>
         {question.authorName ? (
           <p

--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { GameplayChatThread, newMessageId, type ChatMessage } from '@/components/play/GameplayChat';
 import { ReplaySummary, type ReplaySessionResult } from '@/components/replay/ReplaySummary';
 import type { ReplayItem } from '@/server/replay/session';
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
 type ReplayResponse = {
   items: ReplayItem[];
@@ -28,7 +29,7 @@ function questionMessage(item: ReplayItem): ChatMessage {
     kind: 'question',
     assignmentId: item.dailyQueueItemId,
     questionText: item.questionText,
-    creatorName: null,
+    creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
     subhead: `FROM ${item.queueDate}`,
     badges: [{ label: 'practice', tone: 'muted' }],
   };
@@ -163,7 +164,7 @@ export default function ReplayPage() {
           consolation: body.consolation ?? null,
           breadcrumb: body.breadcrumb ?? null,
           copyVariant: currentIndex,
-          creatorName: 'Joshing',
+          creatorName: currentItem.authorName ?? LLM_QUESTION_ATTRIBUTION,
           canonicalSubcategory: currentItem.domain,
           pointsAwarded: 0,
           pointsLabel: 'Replay - practice only',

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -13,6 +13,7 @@ import {
   isWrongAnswerReactionKey,
   type ReactionKey,
 } from '@/lib/reactions';
+import { isLlmAttribution } from '@/lib/questions-types';
 
 export type ReactionPromptData = {
   senderName: string;
@@ -143,7 +144,7 @@ function firstNameFrom(creatorName: string): string {
 
 function wrongNamedSubLabel(creatorName: string | null, variant: number): string | null {
   if (!creatorName) return null;
-  if (creatorName.trim().toLowerCase() === 'joshing') return null;
+  if (isLlmAttribution(creatorName)) return null;
   const firstName = firstNameFrom(creatorName);
   if (!firstName) return null;
   return WRONG_NAMED_SUBLABEL[variant % WRONG_NAMED_SUBLABEL.length]!(firstName);
@@ -230,7 +231,7 @@ function QuestionRow({
             FROM
           </span>
           <span style={{ fontWeight: 600 }}>{creatorName}</span>
-          {creatorName.trim().toLowerCase() === 'joshing' ? null : (
+          {isLlmAttribution(creatorName) ? null : (
             <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>gave you this</span>
           )}
         </p>
@@ -353,7 +354,7 @@ function UserRow({ text }: { text: string }) {
 
 function BreadcrumbLine({ text, creatorName }: { text: string; creatorName: string | null }) {
   const author = creatorName?.trim() ?? null;
-  const isBot = author?.toLowerCase() === 'joshing';
+  const isBot = isLlmAttribution(author);
   const showAuthor = author && !isBot;
   return (
     <div

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type 
 
 import { newMessageId, type ChatMessage } from '@/components/play/GameplayChat';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 import {
   parseCatchUpAnswerErrorBody,
   userFacingCatchUpSubmitMessage,
@@ -25,6 +26,8 @@ export type CatchupQueueItem = {
   expiresAt: string;
   expiresSoon?: boolean;
   difficultyEstimate?: 'accessible' | 'moderate' | 'specialist' | null;
+  /** Human author's name, or null for LLM-origin questions (rendered non-relationally). */
+  authorName?: string | null;
 };
 
 type CatchupAnswerResponse = {
@@ -102,7 +105,7 @@ function questionMessage(item: CatchupQueueItem): ChatMessage {
     kind: 'question',
     assignmentId: item.dailyQueueItemId,
     questionText: item.questionText,
-    creatorName: null,
+    creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
     subhead: formatQuestionSubhead(item),
     badges,
   };
@@ -198,7 +201,7 @@ export function useCatchupFlow() {
         consolation: null,
         breadcrumb: null,
         copyVariant: item.queueAge,
-        creatorName: 'Joshing',
+        creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
         canonicalSubcategory: item.domain,
       },
     ]);
@@ -283,7 +286,7 @@ export function useCatchupFlow() {
           breadcrumb: null,
           explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
           copyVariant: item.queueAge,
-          creatorName: 'Joshing',
+          creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
           canonicalSubcategory: item.domain,
           pointsAwarded,
           pointsLabel: 'Catch-up - 0.25x points',

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -27,6 +27,20 @@ export type QuestionRecord = {
   contribution_state?: 'addable' | 'already_added' | 'locked_permission' | 'locked_game_state';
 };
 
+// Non-person, non-house attribution for LLM-origin questions
+// (source 'daily_generated' | 'curated_sent'; creatorId === null). A machine
+// question must never render a human name or imply a person wrote it.
+// PLACEHOLDER COPY — flagged for product sign-off. Must NOT be "Joshing"/"Editorial"
+// (those are the house identity, owned by D-3); this is for the non-house LLM origins.
+export const LLM_QUESTION_ATTRIBUTION = 'Generated' as const;
+
+// True when an attribution name is the LLM/non-person label, used to gate
+// person-style copy (e.g. "{name} gave you this") so it never fires for machine
+// questions. Keeps consumers decoupled from the literal value above.
+export function isLlmAttribution(name: string | null | undefined): boolean {
+  return name?.trim() === LLM_QUESTION_ATTRIBUTION;
+}
+
 export const CATEGORIES = [
   'music',
   'literature',

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -15,6 +15,7 @@ import {
   users,
 } from '@/server/db';
 import type { QueueSlot } from '@/server/daily/types';
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
 export type ArchiveSource = 'daily' | 'feed' | 'joshing_game' | 'sent_to_me' | 'written_by_me';
 export type ArchiveResultFilter = 'correct' | 'incorrect' | 'skipped';
@@ -214,7 +215,7 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
           myRating: null,
           canUseQuestionActions: Boolean(slot.question_id),
           verified: bankQuestion?.verified ?? true,
-          askerName: askerDisplay ?? (generated ? 'Daily Five' : ''),
+          askerName: askerDisplay ?? (generated ? LLM_QUESTION_ATTRIBUTION : ''),
         } satisfies ArchiveItem;
       }),
   );
@@ -288,7 +289,9 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       myRating: null,
       canUseQuestionActions: true,
       verified: question.verified,
-      askerName: creatorUser?.displayName ?? '',
+      // null creatorId here ⟹ LLM-origin (curated_sent); authored feed questions
+      // resolve a real name via the creatorUser left join.
+      askerName: creatorUser?.displayName ?? LLM_QUESTION_ATTRIBUTION,
     } satisfies ArchiveItem;
   });
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -86,6 +86,13 @@ export type CatchupQueueItem = {
   difficultyEstimate: 'accessible' | 'moderate' | 'specialist' | null;
   submittedAnswer: string | null;
   wasSkipped: boolean;
+  /**
+   * Display name of the human author, when one exists. Null for LLM-origin
+   * questions (daily-generated, or curated_sent feed items with no creator) —
+   * the client renders the non-person LLM_QUESTION_ATTRIBUTION label for those
+   * rather than implying a person wrote it.
+   */
+  authorName: string | null;
 };
 
 export type CatchupQuestion = CatchupQueueItem;
@@ -411,6 +418,19 @@ export async function getGeneratedQuestionsForQueue(queue: DailyQueueRow) {
     .where(inArray(generatedQuestions.id, generatedIds));
 }
 
+// Resolve creator display names for a set of (possibly null/duplicate) creator
+// ids, returning a id→name map. Null/absent ids are skipped — their questions
+// are LLM-origin and the client labels them non-relationally.
+async function resolveCreatorNames(creatorIds: Array<string | null>): Promise<Map<string, string | null>> {
+  const ids = [...new Set(creatorIds.filter((id): id is string => Boolean(id)))];
+  if (ids.length === 0) return new Map();
+  const nameRows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(inArray(users.id, ids));
+  return new Map(nameRows.map((row) => [row.id, row.displayName]));
+}
+
 export async function getCatchupQuestions(userId: string): Promise<CatchupQuestion[]> {
   const { assignmentDateStr } = getDailyAssignmentBounds();
 
@@ -471,6 +491,10 @@ async function getDailyCatchupItems(
   const generatedById = new Map(generatedRows.map((question) => [question.id, question]));
   const canonicalById = new Map(canonicalRows.map((question) => [question.id, question]));
 
+  // Resolve human author names for canonical (friend-authored) slots so the
+  // client shows the real person; generated slots have no creator and stay null.
+  const authorNameById = await resolveCreatorNames(canonicalRows.map((q) => q.creatorId));
+
   return candidateSlots
     .map(({ queue, slot }): CatchupQuestion | null => {
       const queueDate = String(queue.queueDate);
@@ -507,6 +531,7 @@ async function getDailyCatchupItems(
           difficultyEstimate: asQueueSlotDifficulty(question.difficultyEstimate) ?? null,
           submittedAnswer: slot.submitted_answer ?? null,
           wasSkipped: Boolean(slot.skipped),
+          authorName: null, // daily-generated: LLM origin, no human author
         } satisfies CatchupQuestion;
       }
 
@@ -545,6 +570,7 @@ async function getDailyCatchupItems(
         difficultyEstimate: difficulty,
         submittedAnswer: slot.submitted_answer ?? null,
         wasSkipped: Boolean(slot.skipped),
+        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
       } satisfies CatchupQuestion;
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
@@ -580,6 +606,10 @@ async function getFeedCatchupItems(
     if (pgErrorCode(error) === '42703') return [];
     throw error;
   }
+
+  // Feed catch-up items can be friend-authored (authored_shared) or LLM
+  // (curated_sent, null creator) — resolve the real author for the former.
+  const authorNameById = await resolveCreatorNames(rows.map(({ question }) => question.creatorId));
 
   return rows
     .map(({ feedItem, question }): CatchupQuestion | null => {
@@ -618,6 +648,7 @@ async function getFeedCatchupItems(
         difficultyEstimate: difficulty,
         submittedAnswer: feedItem.submittedAnswer ?? null,
         wasSkipped: false,
+        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
       } satisfies CatchupQuestion;
     })
     .filter((item): item is CatchupQuestion => Boolean(item));

--- a/src/server/db/queries/replay.ts
+++ b/src/server/db/queries/replay.ts
@@ -2,7 +2,7 @@ import { and, desc, eq, inArray } from 'drizzle-orm';
 
 import { categoryLabel } from '@/lib/questions-types';
 import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
-import { dailyQueues, db, generatedQuestions, questions as canonicalQuestions } from '@/server/db';
+import { dailyQueues, db, generatedQuestions, questions as canonicalQuestions, users } from '@/server/db';
 import type { ReplayItem } from '@/server/replay/session';
 
 export async function getReplayWrongQuestions(userId: string): Promise<ReplayItem[]> {
@@ -55,6 +55,18 @@ export async function getReplayWrongQuestions(userId: string): Promise<ReplayIte
   const generatedById = new Map(generatedRows.map((question) => [question.id, question]));
   const canonicalById = new Map(canonicalRows.map((question) => [question.id, question]));
 
+  // Resolve human author names for friend-authored slots; bot slots have no
+  // creator and the client labels them non-relationally.
+  const creatorIds = [...new Set(canonicalRows.map((q) => q.creatorId).filter((id): id is string => Boolean(id)))];
+  const authorNameById = creatorIds.length > 0
+    ? new Map(
+        (await db
+          .select({ id: users.id, displayName: users.displayName })
+          .from(users)
+          .where(inArray(users.id, creatorIds))).map((row) => [row.id, row.displayName]),
+      )
+    : new Map<string, string | null>();
+
   return candidates
     .map(({ queue, slot }): ReplayItem | null => {
       if (slot.generated_question_id) {
@@ -72,6 +84,7 @@ export async function getReplayWrongQuestions(userId: string): Promise<ReplayIte
           domain,
           domainDisplayName: categoryLabel(domain),
           originalSubmittedAnswer: slot.submitted_answer ?? null,
+          authorName: null, // bot slot: LLM origin, no human author
         } satisfies ReplayItem;
       }
 
@@ -96,6 +109,7 @@ export async function getReplayWrongQuestions(userId: string): Promise<ReplayIte
         domain,
         domainDisplayName: categoryLabel(domain),
         originalSubmittedAnswer: slot.submitted_answer ?? null,
+        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
       } satisfies ReplayItem;
     })
     .filter((item): item is ReplayItem => Boolean(item));

--- a/src/server/replay/session.ts
+++ b/src/server/replay/session.ts
@@ -9,6 +9,8 @@ export type ReplayItem = {
   domain: string;
   domainDisplayName: string;
   originalSubmittedAnswer: string | null;
+  /** Human author's name, or null for LLM-origin (bot) slots. */
+  authorName: string | null;
 };
 
 export function selectReplaySession<T extends ReplayItem>(


### PR DESCRIPTION
The honesty concern in B-5 Change 1 — LLM/non-human questions rendering as
"A friend" — does not reproduce: every "A friend" fallback attributes a real
human (sender, friend, endorser, or a real author with a blank name). What did
exist was inconsistent, partly house-flavored non-person attribution for
LLM-origin questions: "JOSHING BOT", "Daily Five", "Joshing", "", null.

This consolidates those into a single shared, client-safe constant
(LLM_QUESTION_ATTRIBUTION) plus an isLlmAttribution() helper, keyed on
source/creatorId. The label is non-house (placeholder "Generated", flagged for
product sign-off) so it doesn't pre-empt D-3's house identity.

Catchup and replay previously hardcoded "Joshing" for every item, mis-attributing
friend-authored questions to the bot. Author name is now threaded through the
catchup/replay payloads so friend-authored items show the real person and only
true LLM items get the non-person label. GameplayChat's bot-copy gates now route
through isLlmAttribution() so they stay correct independent of the label value.

Real-human "A friend" fallbacks are left untouched.

https://claude.ai/code/session_015bJKcKVsHcG8XZkDYFKDnN