### PR TITLE
B-5 Changes 2 & 3 — LLM-question asides + provenance-carrying labels

### DIFF
--- a/drizzle/0060_generated_question_inside_joke.sql
+++ b/drizzle/0060_generated_question_inside_joke.sql
@@ -1,0 +1,17 @@
+-- Migration: precomputed aside ("inside joke") for generated questions.
+--
+-- B-5 Change 2 extends the "between us" aside to LLM-generated daily questions.
+-- The aside is generated once at question-generation time and stored here, then
+-- copied into Question.inside_joke when the generated question is persisted —
+-- so it is present at first reveal with no user-facing LLM latency.
+--
+-- Additive nullable column — safe and non-destructive. Older rows (and any where
+-- aside generation failed) simply carry NULL and show no aside. An idempotent
+-- guard mirroring this statement also lands in src/instrumentation.ts so a
+-- preview/production database that records this migration without the column
+-- actually present can still boot.
+--
+-- Rollback: ALTER TABLE "GeneratedQuestion" DROP COLUMN IF EXISTS "inside_joke";
+-- (drops only the precomputed asides; no other data depends on it.)
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "inside_joke" text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -421,6 +421,13 @@
       "when": 1781654400000,
       "tag": "0059_niche_match_discoverability",
       "breakpoints": true
+    },
+    {
+      "idx": 60,
+      "version": "7",
+      "when": 1781740800000,
+      "tag": "0060_generated_question_inside_joke",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -24,7 +24,7 @@ import { suggestAnswer } from '@/lib/llm';
 import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
 import { RECOVERY_STATE_WEIGHT } from '@/server/mastery/constants';
-import { areFriends } from '@/server/db/queries/friends';
+import { selectInsideJokeForViewer } from '@/server/questions/inside-joke';
 
 export const dynamic = 'force-dynamic';
 
@@ -338,7 +338,8 @@ export async function POST(request: NextRequest) {
         awarded_points: pointsAwarded,
         reveal_canonical_answer: canonicalAnswer,
         reveal_explainer: question.explainer ?? undefined,
-        reveal_inside_joke: insideJokeForViewer,
+        reveal_inside_joke: insideJokeForViewer?.text ?? null,
+        reveal_inside_joke_kind: insideJokeForViewer?.kind ?? null,
         reveal_quip: grade.consolation,
       } satisfies QueueSlot;
     });
@@ -484,21 +485,11 @@ export async function POST(request: NextRequest) {
       explainer: question.explainer,
       awarded_points: pointsAwarded,
       mastery_delta: masteryDelta,
-      insideJoke: insideJokeForViewer,
+      insideJoke: insideJokeForViewer?.text ?? null,
+      insideJokeKind: insideJokeForViewer?.kind ?? null,
     });
   } catch (error) {
     console.error('[daily/answer] unexpected failure', error);
     return dailyAnswerErrorResponse(500, 'unexpected', 'Could not record that answer.');
   }
-}
-
-async function selectInsideJokeForViewer(
-  insideJoke: string | null,
-  creatorId: string | null,
-  viewerId: string,
-): Promise<string | null> {
-  if (!insideJoke || !creatorId) return null;
-  if (creatorId === viewerId) return insideJoke;
-  const friends = await areFriends(viewerId, creatorId);
-  return friends ? insideJoke : null;
 }

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -11,7 +11,7 @@ import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-i
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
-import { areFriends } from '@/server/db/queries/friends';
+import { selectInsideJokeForViewer } from '@/server/questions/inside-joke';
 import { getFeedItemAnswerForRecipient } from '@/server/db/queries/feed';
 
 export const dynamic = 'force-dynamic';
@@ -240,17 +240,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     masteryDelta,
     correctAnswer: question.answerText,
     creatorNote: question.creatorNote ?? null,
-    insideJoke,
+    insideJoke: insideJoke?.text ?? null,
+    insideJokeKind: insideJoke?.kind ?? null,
   });
-}
-
-async function selectInsideJokeForViewer(
-  insideJoke: string | null,
-  creatorId: string | null,
-  viewerId: string,
-): Promise<string | null> {
-  if (!insideJoke || !creatorId) return null;
-  if (creatorId === viewerId) return insideJoke;
-  const friends = await areFriends(viewerId, creatorId);
-  return friends ? insideJoke : null;
 }

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -13,7 +13,7 @@ import {
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { sendSms } from '@/server/sms';
-import { areFriends } from '@/server/db/queries/friends';
+import { selectInsideJokeForViewer } from '@/server/questions/inside-joke';
 
 export const dynamic = 'force-dynamic';
 
@@ -174,7 +174,8 @@ export async function POST(request: NextRequest, context: RouteContext) {
       answerState: grade.answerState,
       breadcrumb: null,
       viewerStatus: completion.userComplete ? 'complete' : 'in_progress',
-      insideJoke,
+      insideJoke: insideJoke?.text ?? null,
+      insideJokeKind: insideJoke?.kind ?? null,
     });
   } catch (error) {
     if (error instanceof JoshingGameValidationError) {
@@ -183,15 +184,4 @@ export async function POST(request: NextRequest, context: RouteContext) {
     }
     throw error;
   }
-}
-
-async function selectInsideJokeForViewer(
-  insideJoke: string | null,
-  creatorId: string | null,
-  viewerId: string,
-): Promise<string | null> {
-  if (!insideJoke || !creatorId) return null;
-  if (creatorId === viewerId) return insideJoke;
-  const friends = await areFriends(viewerId, creatorId);
-  return friends ? insideJoke : null;
 }

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -10,7 +10,7 @@ import { pickOpenedTerritoryDomain } from '@/components/feed/territory';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { TopUpAreasModal, type TopUpInterest } from '@/components/daily/TopUpAreasModal';
 import LoadingScreen from '@/components/LoadingScreen';
-import { categoryLabel } from '@/lib/questions-types';
+import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
 import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
 
@@ -48,6 +48,7 @@ type AnswerResponse = {
   answer?: string;
   consolation?: string | null;
   insideJoke?: string | null;
+  insideJokeKind?: InsideJokeKind | null;
   breadcrumb?: string | null;
   masteryDelta?: unknown | null;
   mastery_delta?: unknown | null;
@@ -315,6 +316,7 @@ export default function DailyPage() {
           correctAnswer: slot.answer_state === 'correct' ? null : slot.reveal_canonical_answer ?? null,
           consolation: slot.reveal_quip ?? null,
           insideJoke: slot.reveal_inside_joke ?? null,
+          insideJokeKind: slot.reveal_inside_joke_kind ?? null,
           authorNote: slot.source === 'friend' ? (slot.author_note ?? null) : null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
           explanation: slot.reveal_explainer ?? null,
@@ -464,6 +466,7 @@ export default function DailyPage() {
                     reveal_breadcrumb: null,
                     reveal_quip: opts.gaveUp ? null : body.consolation ?? null,
                     reveal_inside_joke: body.insideJoke ?? null,
+                    reveal_inside_joke_kind: body.insideJokeKind ?? null,
                   }
                 : slot
             ),

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -34,6 +34,7 @@ async function fetchJoshingGameBreadcrumb(
   }
 }
 import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
+import type { InsideJokeKind } from '@/lib/questions-types';
 import type { JoshingGameView, QuestionRow } from '@/server/db/queries/joshing-game';
 
 function questionBadges(q: QuestionRow): Array<{ label: string; tone?: 'warning' }> | undefined {
@@ -65,6 +66,7 @@ type GradeResponse = {
   correctAnswer?: string;
   breadcrumb?: string | null;
   insideJoke?: string | null;
+  insideJokeKind?: InsideJokeKind | null;
   viewerStatus: 'not_started' | 'in_progress' | 'complete';
 };
 
@@ -206,6 +208,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
           correctAnswer: body.isCorrect ? null : body.correctAnswer ?? currentQuestion.question.answerText,
           consolation: null,
           insideJoke: body.insideJoke ?? null,
+          insideJokeKind: body.insideJokeKind ?? null,
           breadcrumb: null,
           explanation: body.explanation ?? pickExplainer(currentQuestion.question, body.isCorrect),
           copyVariant: currentQuestion.position,

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -23,6 +23,7 @@ import {
 import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
+import type { InsideJokeKind } from '@/lib/questions-types'
 
 type FriendResult = {
   userId: string
@@ -102,6 +103,7 @@ type AnswerResponse = {
   explanation?: string | null
   creatorNote?: string | null
   insideJoke?: string | null
+  insideJokeKind?: InsideJokeKind | null
   pointsAwarded?: number | null
   masteryDelta?: unknown | null
 }
@@ -113,6 +115,7 @@ type ResultState = {
   explanation: string | null
   creatorNote: string | null
   insideJoke: string | null
+  insideJokeKind: InsideJokeKind | null
   awardedPoints: number | null
   masteryDelta: unknown | null
 }
@@ -981,6 +984,7 @@ function FeedListContent({
             explanation: body.explanation ?? null,
             creatorNote: body.creatorNote ?? null,
             insideJoke: body.insideJoke ?? null,
+            insideJokeKind: body.insideJokeKind ?? null,
             awardedPoints: body.pointsAwarded ?? null,
             masteryDelta: body.masteryDelta ?? null,
           },
@@ -1304,6 +1308,7 @@ function FeedListContent({
             explanation={result.explanation}
             creatorNote={result.creatorNote}
             insideJoke={result.insideJoke}
+            insideJokeKind={result.insideJokeKind}
             openedNewTerritory={pickOpenedNewTerritory(result.masteryDelta)}
             openedTerritoryDomain={pickOpenedTerritoryDomain(result.masteryDelta)}
             questionId={sheetItem.question_id}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -5,6 +5,7 @@ import { Check, Sparkles, X } from 'lucide-react'
 
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
+import { INSIDE_JOKE_LABELS, type InsideJokeKind } from '@/lib/questions-types'
 
 // Darkened triangle-gold for text/eyebrows that need to clear AA on the cream
 // card (raw --tri-amber #d9a82e is too light for small text). Used by the
@@ -21,6 +22,7 @@ type AnswerFeedbackSheetProps = {
   explanation: string | null
   creatorNote: string | null
   insideJoke?: string | null
+  insideJokeKind?: InsideJokeKind | null
   openedNewTerritory?: boolean
   openedTerritoryDomain?: string | null
   questionId: string
@@ -40,6 +42,7 @@ export function AnswerFeedbackSheet({
   explanation,
   creatorNote,
   insideJoke = null,
+  insideJokeKind = null,
   openedNewTerritory = false,
   openedTerritoryDomain = null,
   questionId,
@@ -233,7 +236,7 @@ export function AnswerFeedbackSheet({
                 className="text-[0.62rem] font-semibold tracking-[0.18em] uppercase"
                 style={{ color: GOLD_INK }}
               >
-                Between us friends
+                {INSIDE_JOKE_LABELS[insideJokeKind ?? 'relational']}
               </p>
               <p className="mt-1.5 font-serif text-[15px] leading-7 text-[var(--brand-ink)]">
                 {insideJoke}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -13,7 +13,7 @@ import {
   isWrongAnswerReactionKey,
   type ReactionKey,
 } from '@/lib/reactions';
-import { isLlmAttribution } from '@/lib/questions-types';
+import { isLlmAttribution, INSIDE_JOKE_LABELS, type InsideJokeKind } from '@/lib/questions-types';
 
 export type ReactionPromptData = {
   senderName: string;
@@ -61,8 +61,10 @@ export type ChatMessage =
       correctAnswer: string | null;
       /** Near-miss quip from LLM grader */
       consolation: string | null;
-      /** LLM-generated friends-only aside; only present when the viewer is the creator or an active friend. */
+      /** LLM-generated aside; for authored questions only present when the viewer is the creator or an active friend. */
       insideJoke?: string | null;
+      /** Provenance of the aside label: relational (a person authored it) vs editorial (LLM-origin). */
+      insideJokeKind?: InsideJokeKind | null;
       breadcrumb: string | null;
       /** 0–3 index for rotating copy phrases */
       copyVariant: number;
@@ -680,6 +682,7 @@ function ResultRow({
   correctAnswer,
   consolation,
   insideJoke,
+  insideJokeKind,
   breadcrumb,
   authorNote,
   explanation,
@@ -699,6 +702,7 @@ function ResultRow({
   correctAnswer: string | null;
   consolation: string | null;
   insideJoke?: string | null;
+  insideJokeKind?: InsideJokeKind | null;
   breadcrumb: string | null;
   authorNote?: string | null;
   explanation?: string | null;
@@ -938,7 +942,7 @@ function ResultRow({
               textTransform: 'uppercase',
             }}
           >
-            Between us friends
+            {INSIDE_JOKE_LABELS[insideJokeKind ?? 'relational']}
           </p>
           <p
             style={{
@@ -1166,6 +1170,7 @@ export function GameplayChatThread({
                 correctAnswer={m.correctAnswer}
                 consolation={m.consolation}
                 insideJoke={m.insideJoke}
+                insideJokeKind={m.insideJokeKind}
                 breadcrumb={m.breadcrumb}
                 authorNote={m.authorNote}
                 explanation={m.explanation}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -427,6 +427,20 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0060 adds the nullable GeneratedQuestion.inside_joke column,
+    // which holds the precomputed aside copied into Question.inside_joke at
+    // persist time. Apply it idempotently in case the migration is recorded
+    // without the column actually present.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "GeneratedQuestion"
+          ADD COLUMN IF NOT EXISTS "inside_joke" text
+      `);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -41,6 +41,15 @@ export function isLlmAttribution(name: string | null | undefined): boolean {
   return name?.trim() === LLM_QUESTION_ATTRIBUTION;
 }
 
+// The aside ("inside joke") label carries provenance: a relational label means a
+// real person authored the question; the editorial label is for machine-authored
+// (LLM-origin) questions, where there is no person and no relationship to imply.
+export type InsideJokeKind = 'relational' | 'editorial';
+export const INSIDE_JOKE_LABELS: Record<InsideJokeKind, string> = {
+  relational: 'Between us friends',
+  editorial: 'Between us!', // PLACEHOLDER copy — flagged for product sign-off
+};
+
 export const CATEGORIES = [
   'music',
   'literature',

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -5,6 +5,7 @@ import {
   HAIKU_MODEL,
   INSTRUCTION_USER_INPUT_GUIDANCE,
   extractTextContent,
+  generateInsideJoke,
   getAnthropicClient,
   loggedMessagesCreate,
   parseJsonObject,
@@ -983,7 +984,25 @@ export async function generateDailyQuestions(
   const persisted: GeneratedQuestionRow[] = [];
   const seenFactKeysThisBatch = new Set<string>();
 
-  for (const question of generated.slice(0, count)) {
+  // Precompute the "between us" aside once per question, in parallel, before the
+  // sequential persist loop. generateInsideJoke fails open (returns null), so a
+  // slow/failed aside never blocks question generation — it just lands with no
+  // aside. Mirrors the parallel/fail-open pattern of the LLM gates above.
+  const toPersist = generated.slice(0, count);
+  const insideJokeByQuestion = new Map<(typeof toPersist)[number], string | null>();
+  await Promise.all(
+    toPersist.map(async (question) => {
+      const aside = await generateInsideJoke({
+        questionText: question.question_text,
+        correctAnswer: question.answer,
+        broadCategory: question.broad_category,
+        canonicalSubcategory: question.canonical_subcategory,
+      }).catch(() => null);
+      insideJokeByQuestion.set(question, aside);
+    }),
+  );
+
+  for (const question of toPersist) {
     const { canonicalDomain } = await reconcileProposedDomain(
       question.canonical_subcategory,
       userId,
@@ -1026,6 +1045,7 @@ export async function generateDailyQuestions(
         basePoints,
         factKey,
         subAngles: question.sub_angles,
+        insideJoke: insideJokeByQuestion.get(question) ?? null,
         expiresAt,
         usedInQueue: false,
       })

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -70,8 +70,10 @@ export const queueSlotSchema = z.object({
   reveal_breadcrumb: z.string().nullish(),
   /** LLM consolation quip for near-miss wrong answers (PRD §8.1.14). */
   reveal_quip: z.string().nullish(),
-  /** LLM-generated friends-only aside; only populated when the viewer is the creator or an active friend. */
+  /** LLM-generated aside; for authored questions only populated when the viewer is the creator or an active friend, for LLM-origin questions always populated. */
   reveal_inside_joke: z.string().nullish(),
+  /** Provenance of the aside label: 'relational' (a person authored it) or 'editorial' (LLM-origin). */
+  reveal_inside_joke_kind: z.enum(['relational', 'editorial']).nullish(),
   /** Optional appeal state after a player asks the app to recheck a wrong grade. */
   recheck_status: z.enum(['accepted', 'rejected', 'needs_human']).optional(),
   /** Short player-facing explanation from the recheck reviewer. */

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -512,6 +512,11 @@ export const generatedQuestions = pgTable(
     // per domain and fed back to the generation prompt as positive guidance:
     // "you've covered X, Y, Z — pick something else." See migration 0055.
     subAngles: text('sub_angles').array().notNull().default([]),
+    // Precomputed "between us" aside, generated once at question-generation time
+    // (src/server/daily/generate-questions.ts) and copied into Question.inside_joke
+    // when the row is persisted. Nullable: older rows and any where generation
+    // failed simply have no aside.
+    insideJoke: text('inside_joke'),
     createdAt: createdAt(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     usedInQueue: boolean('used_in_queue').notNull().default(false),

--- a/src/server/questions/__tests__/inside-joke.test.ts
+++ b/src/server/questions/__tests__/inside-joke.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// B-5 Change 3: the aside's label carries provenance. A human-authored question
+// (non-null creatorId) resolves to the relational label and keeps the
+// self/friend display gate; an LLM-origin question (null creatorId) resolves to
+// the non-relational editorial label and is NEVER relationally gated — and a
+// machine question must never surface under the relational label.
+const { areFriendsMock } = vi.hoisted(() => ({
+  areFriendsMock: vi.fn(async () => false),
+}))
+
+vi.mock('@/server/db/queries/friends', () => ({
+  areFriends: areFriendsMock,
+}))
+
+import { selectInsideJokeForViewer } from '@/server/questions/inside-joke'
+
+describe('selectInsideJokeForViewer', () => {
+  beforeEach(() => {
+    areFriendsMock.mockReset()
+    areFriendsMock.mockResolvedValue(false)
+  })
+
+  it('returns null when there is no aside, without touching the friend graph', async () => {
+    expect(await selectInsideJokeForViewer(null, 'creator-1', 'viewer-1')).toBeNull()
+    expect(areFriendsMock).not.toHaveBeenCalled()
+  })
+
+  it('labels an LLM-origin (null creatorId) aside as editorial and never gates it', async () => {
+    expect(await selectInsideJokeForViewer('a machine aside', null, 'viewer-1')).toEqual({
+      text: 'a machine aside',
+      kind: 'editorial',
+    })
+    // No relationship to gate on — the friend check must not run.
+    expect(areFriendsMock).not.toHaveBeenCalled()
+  })
+
+  it('labels the author’s own authored aside as relational without a friend check', async () => {
+    expect(await selectInsideJokeForViewer('an authored aside', 'creator-1', 'creator-1')).toEqual({
+      text: 'an authored aside',
+      kind: 'relational',
+    })
+    expect(areFriendsMock).not.toHaveBeenCalled()
+  })
+
+  it('shows an authored aside to a friend under the relational label', async () => {
+    areFriendsMock.mockResolvedValueOnce(true)
+    expect(await selectInsideJokeForViewer('an authored aside', 'creator-1', 'viewer-1')).toEqual({
+      text: 'an authored aside',
+      kind: 'relational',
+    })
+    expect(areFriendsMock).toHaveBeenCalledWith('viewer-1', 'creator-1')
+  })
+
+  it('hides an authored aside from a stranger', async () => {
+    areFriendsMock.mockResolvedValueOnce(false)
+    expect(await selectInsideJokeForViewer('an authored aside', 'creator-1', 'viewer-1')).toBeNull()
+  })
+
+  it('never labels a machine aside as relational', async () => {
+    const result = await selectInsideJokeForViewer('a machine aside', null, 'viewer-1')
+    expect(result?.kind).not.toBe('relational')
+  })
+})

--- a/src/server/questions/inside-joke.ts
+++ b/src/server/questions/inside-joke.ts
@@ -1,0 +1,25 @@
+import { areFriends } from '@/server/db/queries/friends';
+import type { InsideJokeKind } from '@/lib/questions-types';
+
+export type ViewerInsideJoke = { text: string; kind: InsideJokeKind };
+
+// Decides whether a question's aside is shown to a viewer, and under which
+// provenance label. Shared by the daily / feed / joshing-game answer routes
+// (previously three identical copies).
+//
+// - LLM-origin questions (null creatorId) have no human author and no
+//   relationship to gate on: the aside shows under the non-relational
+//   `editorial` label.
+// - Human-authored questions keep the relational gate: shown to the author and
+//   to friends under the `relational` label, hidden from strangers.
+export async function selectInsideJokeForViewer(
+  insideJoke: string | null,
+  creatorId: string | null,
+  viewerId: string,
+): Promise<ViewerInsideJoke | null> {
+  if (!insideJoke) return null;
+  if (!creatorId) return { text: insideJoke, kind: 'editorial' };
+  if (creatorId === viewerId) return { text: insideJoke, kind: 'relational' };
+  const friends = await areFriends(viewerId, creatorId);
+  return friends ? { text: insideJoke, kind: 'relational' } : null;
+}

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -145,6 +145,9 @@ export async function persistGeneratedQuestion(generatedQuestionId: string, slot
         calibratedDifficulty: asDifficulty(generated.difficultyEstimate),
         status: 'verified',
         visibility: 'public',
+        // Carry the precomputed aside through; the editorial label is applied at
+        // display time (selectInsideJokeForViewer) for these null-creator rows.
+        insideJoke: generated.insideJoke,
       })
       .onConflictDoNothing({ target: questions.generatedQuestionId })
       .returning({ id: questions.id });


### PR DESCRIPTION
## Summary

Continues the B-5 "honest attribution" work. **Change 1 already merged via #556**; this PR is **Changes 2 & 3**.

The aside ("inside joke") now extends to LLM daily questions, and its label carries provenance: a **relational** label ("Between us friends") means a real person authored it; an **editorial** label ("Between us!") means it's machine-generated. A machine question can never surface under the relational label.

## Change 2 — Generate asides for LLM daily questions, under a non-relational label

- **Precompute at generation time** (no user-facing latency): new nullable `generated_questions.inside_joke` column (**migration `0060`** + idempotent `instrumentation.ts` guard mirroring the existing `Question.inside_joke` guard). `generate-questions.ts` generates the aside once per question, in parallel and fail-open, reusing `generateInsideJoke` as-is. `persistGeneratedQuestion` copies it into the canonical `Question`, so it's present at first reveal — `persistGeneratedQuestion` runs inline in the daily answer request, so a persist-time LLM call would have added latency.
- **De-duplicated display gate**: the three identical copies of `selectInsideJokeForViewer` are replaced by one shared `src/server/questions/inside-joke.ts` returning `{ text, kind }`. Only behavioural change: a null-creator (LLM) question with an aside now **shows** it (kind `editorial`) instead of being suppressed; authored self/friend gating is unchanged.
- **Label plumbing**: `InsideJokeKind` + `INSIDE_JOKE_LABELS` in `questions-types.ts`; `kind` threaded from the daily / feed / joshing-game answer routes (and the daily slot via a new `reveal_inside_joke_kind`, no DB migration) through the client carriers to `GameplayChat` and `AnswerFeedbackSheet`, which render the label from the kind.
- **Scope**: `daily_generated` only. `curated_sent` and the send route are untouched.

## Change 3 — Authored questions keep the (now earned) relational label

The provenance mechanism above already satisfies Change 3: authored questions resolve to the relational label "Between us friends" and keep the self/friend gate; LLM questions resolve to the editorial label; no LLM question can show the relational label. Label copy stays as-is per product decision — so this change is a **focused regression test** (`src/server/questions/__tests__/inside-joke.test.ts`) codifying those guarantees, including "a machine aside is never labelled relational."

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` — 0 errors
- Full suite: **601/601 passing** (81 files; +6 new)
- `db:migrate` not run here (no DB in the ephemeral container); migration auto-applies at boot, guarded idempotently
- No `src/middleware.ts` added (routing untouched)

## Flags for product sign-off

- **Placeholder copy** — both labels are placeholders: `LLM_QUESTION_ATTRIBUTION = "Generated"` (from Change 1) and `INSIDE_JOKE_LABELS.editorial = "Between us!"`. The editorial label intentionally shares the "Between us" prefix with the authored label, so the two are only weakly distinct — one-line change to `INSIDE_JOKE_LABELS.editorial` if you want them more distinct.
- **Generator tone** — `generateInsideJoke`'s prompt is framed as a "between us friends" aside; output is subject-focused, so reused as-is per the brief. An editorial-toned prompt variant is a fast follow if the tone reads too insider for machine questions.

https://claude.ai/code/session_015bJKcKVsHcG8XZkDYFKDnN

---
_Generated by [Claude Code](https://claude.ai/code/session_015bJKcKVsHcG8XZkDYFKDnN)_