### PR TITLE
B-6: surface authored-vs-curated provenance in feed verb

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -58,6 +58,9 @@ type FeedApiItem = {
   state: string
   is_pinned: boolean
   question_text?: string | null
+  // B-6: provenance of the underlying question, used to pick the recipient-facing
+  // verb ("wrote you this" for human-authored vs "sent you this" for curated LLM).
+  question_source?: 'authored' | 'daily_generated' | 'curated_sent' | null
   is_in_bank: boolean
   domain_pill?: string | null
   broad_category?: string | null
@@ -230,6 +233,24 @@ function comparisonCopy(
   return 'This one is still waiting for common ground.'
 }
 
+// B-6: the recipient-facing verb. For a direct send, the verb is keyed off the
+// underlying question's provenance, NOT the send mechanism: a human-authored
+// question reads "wrote you this"; a curated LLM forward reads "sent you this".
+// Only an explicit 'authored' source yields the human-authorship verb — any other
+// or absent provenance defaults to the curated verb, so a curated/LLM send can
+// never imply a human wrote it (B-5).
+export function feedSourceVerb(
+  sourceType: string,
+  questionSource: FeedApiItem['question_source'],
+): string {
+  if (sourceType === 'direct_sent') {
+    return questionSource === 'authored' ? 'wrote you this' : 'sent you this'
+  }
+  if (sourceType === 'authored_shared') return 'wrote this'
+  if (sourceType === 'thumbs_upped') return 'liked this'
+  return 'answered this'
+}
+
 function feedMetadata(item: FeedApiItem, answered = false) {
   const time = formatEventTime(item.source_event_at)
   const source = (
@@ -238,13 +259,7 @@ function feedMetadata(item: FeedApiItem, answered = false) {
         href={item.source_profile_href ?? profileHref(item.source_user_id)}
         name={item.source_friend_display_name}
       />{' '}
-      {item.source_type === 'direct_sent'
-        ? 'sent this to you'
-        : item.source_type === 'authored_shared'
-          ? 'wrote this'
-          : item.source_type === 'thumbs_upped'
-            ? 'liked this'
-            : 'answered this'}
+      {feedSourceVerb(item.source_type, item.question_source)}
     </span>
   )
 

--- a/src/components/__tests__/feedSourceVerb.test.ts
+++ b/src/components/__tests__/feedSourceVerb.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { feedSourceVerb } from '@/components/FeedList'
+
+describe('feedSourceVerb (B-6 authored-vs-curated provenance)', () => {
+  it('uses the human-authorship verb for a directly-sent authored question', () => {
+    expect(feedSourceVerb('direct_sent', 'authored')).toBe('wrote you this')
+  })
+
+  it('uses the curated verb for a directly-sent curated LLM question', () => {
+    expect(feedSourceVerb('direct_sent', 'curated_sent')).toBe('sent you this')
+  })
+
+  it('defaults a directly-sent question with missing provenance to the curated verb', () => {
+    // B-5: a curated/LLM send must never imply a human wrote it, so anything that
+    // is not an explicit 'authored' source falls back to "sent you this".
+    expect(feedSourceVerb('direct_sent', null)).toBe('sent you this')
+    expect(feedSourceVerb('direct_sent', undefined)).toBe('sent you this')
+    expect(feedSourceVerb('direct_sent', 'daily_generated')).toBe('sent you this')
+  })
+
+  it('two direct sends of different provenance are distinguishable', () => {
+    expect(feedSourceVerb('direct_sent', 'authored')).not.toBe(
+      feedSourceVerb('direct_sent', 'curated_sent'),
+    )
+  })
+
+  it('leaves the non-direct-send verbs unchanged', () => {
+    expect(feedSourceVerb('authored_shared', null)).toBe('wrote this')
+    expect(feedSourceVerb('thumbs_upped', null)).toBe('liked this')
+    expect(feedSourceVerb('answered_by_you', null)).toBe('answered this')
+  })
+})

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -32,6 +32,7 @@ const feedQuestionSelectColumns = {
   questionText: questions.questionText,
   answerText: questions.answerText,
   creatorId: questions.creatorId,
+  source: questions.source,
   explainerBrief: questions.explainerBrief,
   factualExplanation: questions.factualExplanation,
   canonicalSubcategory: questions.canonicalSubcategory,
@@ -295,6 +296,13 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         state: item.state,
         is_pinned: item.isPinned,
         question_text: question?.questionText ?? null,
+        // B-6: question provenance so the recipient-facing verb reflects who
+        // actually authored the question (human-authored vs curated LLM), not
+        // the feed item's send mechanism. Only an explicit 'authored' source
+        // ever reads as human authorship downstream; everything else defaults
+        // to the curated verb (B-5: a curated/LLM send must never imply a human
+        // wrote it).
+        question_source: question?.source ?? null,
         is_in_bank: item.questionId ? Boolean(bankedById[item.questionId]) : false,
         explanation: question?.explainerBrief ?? question?.factualExplanation ?? null,
         domain_pill: domain,


### PR DESCRIPTION
The recipient-facing verb on a feed card was keyed off the feed item's
source_type (send mechanism), so a hand-authored question and a one-tap
curated-LLM forward — both sent directly — rendered identically as
"sent this to you". The decided distinction was never surfaced.

Key the direct-send verb off the underlying question's provenance instead:
- source='authored' (real author) -> "wrote you this"
- curated LLM / any non-authored / absent -> "sent you this"

Only an explicit 'authored' source yields the human-authorship verb, so a
curated/LLM send can never imply a human wrote it (B-5). Carries the
question source through the feed hydration (provenance only) and extracts a
pure feedSourceVerb helper with unit coverage.