### PR TITLE
B-7: carry creator note + aside into catch-up answers; B-8 cleanup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 Project-specific guidance for Claude. Keep this file short; reference, don't duplicate.
 
 ## ORM & migrations
-- **ORM is Drizzle, not Prisma.** Migrations live in `drizzle/` (currently `0000_material_lyja.sql` through `0034_territory_type_enum.sql`).
+- **ORM is Drizzle, not Prisma.** Migrations live in `drizzle/`, numbered from `0000_material_lyja.sql` up to the current head (`0060_generated_question_inside_joke.sql` at time of writing — run `ls drizzle/*.sql | sort | tail -1` for the live head rather than trusting this number).
 - Schema: `src/server/db/schema.ts`. Query helpers: `src/server/db/queries/`.
 - Run migrations manually with `npm run db:migrate`. They are also auto-applied at boot from `src/instrumentation.ts`, which additionally pre-applies several idempotent guards for partially-recorded preview/production databases — read that file before adding a new migration that touches enums, NOT NULL columns, or additive columns.
 

--- a/src/app/api/daily/catchup/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/answer/__tests__/route.test.ts
@@ -308,6 +308,55 @@ describe('POST /api/daily/catchup/answer mastery scoring (F2.2)', () => {
     expect(order).toEqual(['persist', 'writeMastery'])
   })
 
+  it('reveals creatorNote + provenance-calibrated aside on the catch-up response (B-7)', async () => {
+    selectCallChain.length = 0
+    selectCallChain.push(async () => [QUEUE])
+    // Self-authored (creatorId === viewer) resolves the relational label
+    // without a friendship lookup, exercising selectInsideJokeForViewer.
+    selectCallChain.push(async () => [
+      {
+        creatorId: 'user-1',
+        domain: 'history',
+        broadCategory: 'humanities',
+        category: 'humanities',
+        insideJoke: 'between us, you nailed this last time',
+        creatorNote: 'wrote this after our trivia night',
+      },
+    ])
+    gradeAnswerMock.mockResolvedValueOnce({ result: 'correct', consolation: null })
+
+    const response = await POST(jsonRequest(VALID_BODY) as never)
+    const body = await response.json()
+
+    expect(body.insideJoke).toBe('between us, you nailed this last time')
+    expect(body.insideJokeKind).toBe('relational')
+    expect(body.creatorNote).toBe('wrote this after our trivia night')
+  })
+
+  it('hides the aside but still reveals creatorNote when the answer is wrong (one-directional reveal)', async () => {
+    selectCallChain.length = 0
+    selectCallChain.push(async () => [QUEUE])
+    selectCallChain.push(async () => [
+      {
+        creatorId: 'user-1',
+        domain: 'history',
+        broadCategory: 'humanities',
+        category: 'humanities',
+        insideJoke: 'between us',
+        creatorNote: 'a note',
+      },
+    ])
+    gradeAnswerMock.mockResolvedValueOnce({ result: 'wrong', consolation: null })
+
+    const response = await POST(jsonRequest(VALID_BODY) as never)
+    const body = await response.json()
+
+    // Reveal is one-directional: shown on correct OR incorrect, per B-3.
+    expect(body.insideJoke).toBe('between us')
+    expect(body.insideJokeKind).toBe('relational')
+    expect(body.creatorNote).toBe('a note')
+  })
+
   it('graceful fallback when persist fails on every retry: mastery event still written with null eventQuestionId', async () => {
     setupDbChain()
     gradeAnswerMock.mockResolvedValueOnce({ result: 'correct', consolation: null })

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -18,6 +18,7 @@ import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
+import { selectInsideJokeForViewer } from '@/server/questions/inside-joke';
 import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
 import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
@@ -147,6 +148,13 @@ async function handleDailyCatchupAnswer({
   let canonicalQuestionId: string | null = null;
   let persistedCreatorId: string | null = null;
   let persistedDomainForCreator: string | null = null;
+  // Author commentary + aside travel with the question regardless of whether
+  // it's answered live or here in catch-up (B-7). Resolved from the same
+  // canonical row we already load for creator/domain, then gated through
+  // selectInsideJokeForViewer so catch-up neither over- nor under-exposes the
+  // aside relative to the live path.
+  let persistedInsideJoke: string | null = null;
+  let persistedCreatorNote: string | null = null;
 
   if (slot.source === 'friend') {
     if (!slot.question_id) {
@@ -159,6 +167,8 @@ async function handleDailyCatchupAnswer({
         domain: questions.canonicalSubcategory,
         broadCategory: questions.broadCategory,
         category: questions.category,
+        insideJoke: questions.insideJoke,
+        creatorNote: questions.creatorNote,
       })
       .from(questions)
       .where(eq(questions.id, slot.question_id))
@@ -166,6 +176,8 @@ async function handleDailyCatchupAnswer({
     persistedCreatorId = canonicalRow?.creatorId ?? null;
     persistedDomainForCreator =
       canonicalRow?.domain || canonicalRow?.broadCategory || canonicalRow?.category || null;
+    persistedInsideJoke = canonicalRow?.insideJoke ?? null;
+    persistedCreatorNote = canonicalRow?.creatorNote ?? null;
   } else {
     let persistAttempt = 0;
     while (persistAttempt < 2 && canonicalQuestionId === null) {
@@ -174,13 +186,15 @@ async function handleDailyCatchupAnswer({
         const persisted = await persistGeneratedQuestion(catchupItem.questionId, catchupItem.domain);
         canonicalQuestionId = persisted.questionId;
         const [persistedQuestion] = await db
-          .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category })
+          .select({ creatorId: questions.creatorId, domain: questions.canonicalSubcategory, broadCategory: questions.broadCategory, category: questions.category, insideJoke: questions.insideJoke, creatorNote: questions.creatorNote })
           .from(questions)
           .where(eq(questions.id, persisted.questionId))
           .limit(1);
         persistedCreatorId = persistedQuestion?.creatorId ?? null;
         persistedDomainForCreator =
           persistedQuestion?.domain || persistedQuestion?.broadCategory || persistedQuestion?.category || null;
+        persistedInsideJoke = persistedQuestion?.insideJoke ?? null;
+        persistedCreatorNote = persistedQuestion?.creatorNote ?? null;
       } catch (error) {
         const finalAttempt = persistAttempt >= 2;
         console.warn(
@@ -196,6 +210,15 @@ async function handleDailyCatchupAnswer({
       }
     }
   }
+
+  // Same provenance-calibrated gate the live path uses (B-5): relational label
+  // for authored questions shown to author/friends, editorial label for
+  // LLM-origin questions shown to everyone, hidden from strangers otherwise.
+  const insideJokeForViewer = await selectInsideJokeForViewer(
+    persistedInsideJoke,
+    persistedCreatorId,
+    userId,
+  );
 
   const priorAnswers = canonicalQuestionId
     ? await readPriorAnswersForQuestion(userId, canonicalQuestionId)
@@ -226,6 +249,8 @@ async function handleDailyCatchupAnswer({
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
       reveal_quip: grade.consolation,
+      reveal_inside_joke: insideJokeForViewer?.text ?? null,
+      reveal_inside_joke_kind: insideJokeForViewer?.kind ?? null,
       // Drop any breadcrumb persisted from the original (often wrong) live
       // answer. This slot is being re-answered in catch-up, so the old
       // breadcrumb no longer matches the submitted answer or verdict; leaving
@@ -326,6 +351,9 @@ async function handleDailyCatchupAnswer({
     explanation: catchupItem.explanation,
     explainer: catchupItem.explanation,
     consolation: grade.consolation,
+    insideJoke: insideJokeForViewer?.text ?? null,
+    insideJokeKind: insideJokeForViewer?.kind ?? null,
+    creatorNote: persistedCreatorNote,
     nextItem: nextItemPayload(nextItem),
   });
 }
@@ -376,6 +404,14 @@ async function handleFeedCatchupAnswer({
   );
   const isCorrect = grade.result === 'correct';
   const answerState = isCorrect ? 'correct' : 'incorrect';
+
+  // Carry the author's commentary + provenance-calibrated aside on the feed
+  // catch-up path too (B-7 / B-5), gated identically to the live feed answer.
+  const insideJokeForViewer = await selectInsideJokeForViewer(
+    feedRow.question.insideJoke,
+    feedRow.question.creatorId,
+    userId,
+  );
 
   const priorAnswers = await readPriorAnswersForQuestion(userId, feedRow.question.id);
   const masteryAnswerState = computeAnswerState(
@@ -475,6 +511,9 @@ async function handleFeedCatchupAnswer({
     explanation: catchupItem.explanation,
     explainer: catchupItem.explanation,
     consolation: grade.consolation,
+    insideJoke: insideJokeForViewer?.text ?? null,
+    insideJokeKind: insideJokeForViewer?.kind ?? null,
+    creatorNote: feedRow.question.creatorNote ?? null,
     nextItem: nextItemPayload(nextItem),
   });
 }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -44,7 +44,7 @@ function asQueueSlotDifficulty(
 export type KnowledgeBaseDomain = {
   domain: string;
   broadCategory: string | null;
-  source: 'declared' | 'friend_mediated' | 'authorship';
+  source: 'declared' | 'demonstrated';
   territoryType: 'declared' | 'demonstrated';
   totalPoints: number;
   tier: 'establishing' | 'familiar' | 'solid' | 'mastery';
@@ -225,7 +225,7 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     domainsByKey.set(key, {
       domain,
       broadCategory: row.broadCategory,
-      source: row.territoryType === 'declared' ? 'declared' : 'friend_mediated',
+      source: row.territoryType === 'declared' ? 'declared' : 'demonstrated',
       territoryType: row.territoryType,
       totalPoints: row.totalPoints,
       tier: row.tier,
@@ -1486,21 +1486,6 @@ export async function getRecentFactKeys(
 
 export async function getAnsweredDailyCount(queue: DailyQueueRow): Promise<number> {
   return asQueueSlots(queue.slots).filter((slot) => slot.answered).length;
-}
-
-export async function userHasFriendMediatedDomain(userId: string, domain: string): Promise<boolean> {
-  const [row] = await db
-    .select({ id: masteryEvents.id })
-    .from(masteryEvents)
-    .where(and(
-      eq(masteryEvents.userId, userId),
-      eq(masteryEvents.canonicalSubcategory, domain),
-      inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
-      isNotNull(masteryEvents.questionId),
-    ))
-    .limit(1);
-
-  return Boolean(row);
 }
 
 export async function getKBDomainEntry(userId: string, domain: string) {


### PR DESCRIPTION
## B-7 — Catch-up shows commentary + aside (voice hole closed)

**The gap:** the catch-up answer path omitted `creatorNote` and the `insideJoke` aside that the live answer paths return — so a question with author commentary, answered late via catch-up, silently dropped its voice for no reason other than timing.

**Fix** (`src/app/api/daily/catchup/answer/route.ts`, both the daily and feed handlers):
- Fields are read from the **same canonical `questions` rows already loaded** for creator/domain — no extra queries. The daily handler extends its two existing selects; the feed handler already had the full `questions` row in hand.
- The aside is gated through `selectInsideJokeForViewer` — the identical shared helper the live daily/feed paths use — so catch-up applies the **same provenance-calibrated label** (B-5: `relational` for authored, `editorial` for LLM-origin) and the **same friend/self display gate**. No over- or under-exposure relative to live.
- `creatorNote` + the aside are returned regardless of correct/incorrect (one-directional reveal, per B-3). The daily slot also persists `reveal_inside_joke`/`reveal_inside_joke_kind`, mirroring the live route so the reveal re-renders.

## B-8 — Cleanup (no behavior change)

- **Removed** `userHasFriendMediatedDomain` — confirmed zero callers.
- **Renamed** the vestigial `friend_mediated` source label to `demonstrated` (matches the existing `territoryType` value; the topic-lock it implied is gone) and dropped the never-produced `authorship` value. `KnowledgeBaseDomain.source` is serialized in `/api/daily/preferences` but read by no client or logic, so the rename is safe and keeps the API shape stable.
- **Updated** `CLAUDE.md`'s migration range to the current head (`0060`), reworded to point at `ls drizzle/*.sql | sort | tail -1` so it won't go stale again.

## Verification
- Added two response-level catch-up tests (relational reveal on correct; aside + note both present on wrong).
- Full suite **603/603 green**, typecheck clean (exit 0), lint 0 errors.
- `/check-middleware` all clear — no `src/middleware.ts`, 13 proxy/middleware tests pass.

Did **not** touch the two deliberate won't-fix / pending items (broadcast roll-off, send-path difficulty) — those remain as recorded decisions.

https://claude.ai/code/session_015joJzot8ZqdXMbErj6h3Qs

---
_Generated by [Claude Code](https://claude.ai/code/session_015joJzot8ZqdXMbErj6h3Qs)_