### PR TITLE
Add restructure documentation: PRD-D-0, conformance audit, and decision index

### DIFF
--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -1,0 +1,34 @@
+# Decisions & Docs Index
+
+A short index of the durable restructure (D-1 / D-2 / D-3) documentation, and — critically — a pointer
+to what is **settled** vs. **still open**, so the next reader doesn't re-litigate closed decisions or
+miss the live thread.
+
+Last updated: 2026-06-02.
+
+## Durable docs
+
+| Doc | What it is |
+|-----|------------|
+| [`PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md`](./PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md) | Canonical "what the product is and why": target capabilities, deferred items, open hypotheses, **amended decisions**. |
+| [`PRD-D-1-FEED-DAILY-RESTRUCTURE-SPEC.md`](./PRD-D-1-FEED-DAILY-RESTRUCTURE-SPEC.md) | Spec — directional follow + Feed/Daily split. |
+| [`PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md`](./PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md) | Spec — niche-match discovery engine. |
+| [`PRD-D-3-HOUSE-EDITORIAL-AUTHOR-SPEC.md`](./PRD-D-3-HOUSE-EDITORIAL-AUTHOR-SPEC.md) | Spec — house / editorial author (**unbuilt**). |
+| [`audits/2026-06-02-restructure-conformance-audit.md`](./audits/2026-06-02-restructure-conformance-audit.md) | Read-only conformance audit of the shipped code against the specs. |
+
+Execution scaffolding (kept separate, not product spec): [`docs/build-prompts/`](./docs/build-prompts/).
+
+## Settled decisions (don't re-open without cause)
+
+- **Directional follow is the primitive.** Symmetric friendship replaced; "friend" = mutual follow. (`PRD-D-1` Decision 1.)
+- **Authored-vs-curated provenance is honest.** Forwarded LLM questions get `creatorId: null`, `source: 'curated_sent'`; credit never accrues to the forwarder. (Conformance audit §2.1.)
+- **Send difficulty travels with the question.** The forwarded question keeps its own `difficultyEstimate`. (`PRD-D-0` §4.1.)
+- **Broadcast rolls off after unfollow — won't fix.** Already-surfaced broadcasts are not retroactively purged on unfollow. (`PRD-D-0` §4.2.)
+
+## Open — pick these up
+
+- **Option B (live thread): should the aside amplify a human's `creatorNote` when one exists?** Aside and creator note are independent surfaces today; no code merges them. (`PRD-D-0` §5.)
+- **Niche-match production default.** Ships `false`, test-phase `true`; production default is an open decision to revisit after the test. (`PRD-D-2`; `PRD-D-0` §3.)
+- **Thumbs-up → surface priority.** No effect on feed ordering yet; computation model and weighting formula undecided. (`PRD-D-0` §3.)
+- **House author (Capability 23) + Invariant H-1 guard.** D-3 is spec-only; when built, replace the `'A friend'` fallback for house-origin questions and lock H-1 with a regression test. (Conformance audit §3.1, §5.)
+- **Feed verb `'wrote this'` on broadcast.** The `authored_shared` branch claims authorship unconditionally; resolve before D-3. (Conformance audit §3.2.)

--- a/PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md
+++ b/PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md
@@ -1,0 +1,139 @@
+# D-0 — Product Direction & Amended Decisions
+
+> **Canonical "what the product is and why" doc for the restructure (D-1 / D-2 / D-3) work.**
+> This sits *above* the three spec files (`PRD-D-1-…`, `PRD-D-2-…`, `PRD-D-3-…`) and records the
+> target product model, what is deliberately deferred, the open hypotheses, and — most importantly —
+> the decisions that were **amended after the build** so the next reader knows what is settled and what
+> is still open.
+>
+> **Provenance of this document.** The numbered capability list below was **reconstructed** from the
+> cited PRD/audit/spec sources and the shipped code; the repo did not previously contain a single
+> canonical enumeration. Lines marked `[reconstructed]` are derived, not quoted — correct them against
+> the authoritative list if one exists. Everything in **Amended decisions** and **Open threads** is a
+> product decision recorded as stated, grounded in code where possible.
+>
+> Date filed: 2026-06-02.
+
+---
+
+## 1. The target product model — capabilities
+
+Joshing is a daily knowledge game: five questions a day drawn from your declared interests, shared
+with friends. The restructure work reorganizes the social surface around a **directional follow**
+primitive and an honest **authored-vs-curated** provenance model. The capabilities below describe the
+product the restructure is steering toward.
+
+> `[reconstructed]` — assembled from the master alignment audit's enumerated systems
+> (`PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1) and the D-1/D-2/D-3 specs. Capabilities **21–22**
+> (authoring / niche discovery) and **23** (house author) are the ones the specs name explicitly and
+> are grounded below; the rest are reconstructed groupings.
+
+### Daily play & knowledge
+1. **Daily Five** — five LLM-generated questions a day, calibrated to the player's Knowledge base. `PRD-AUDIT.md` §2.1.
+2. **Difficulty configuration** — five difficulty options (`normal`, `moderate`, `challenging`, `ridiculous`, `adaptive`). `PRD-AUDIT.md` §2.1.
+3. **Chat-first play** — narrow chat thread, one active question, quiet sequential reveal, no visible countdown. `PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1.
+4. **Catch-up** — a dedicated play session for missed Daily Five questions, surfaced when eligible. `PRD_BACKLOG.md` §8.7.
+5. **Knowledge portrait / map** — domain tiers, portrait/circle visualization, dismissed-domain re-open, "Grow your map" explainer. `PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1.
+6. **Knowledge base calibration** — declared + demonstrated domains feed daily generation. `PRD-AUDIT.md` §2.1.
+7. **Mastery progression** — domain tiers advanced from `masteryEvents`. `[reconstructed]`
+
+### Social surface (the restructure core)
+8. **Directional follow** — symmetric friendship replaced by a directional follow edge; "friend" = mutual follow. `PRD-D-1-…` Decision 1 (keystone).
+9. **Feed** — broadcasts + questions sent to me, split from the Daily. `PRD-D-1-…` Context.
+10. **"Sent to you" tab** — direct sends promoted from in-list filter to a first-class Feed tab. `PRD-D-1-…` Decision 3.
+11. **Friend-answer propagation** — a friend's answered question propagates to my Daily +2 bonus slots; thumbs-down does not propagate; dismissed domains respected. `PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1.
+12. **Daily +2 bonus slots** — 5 base + 0/1/2 friend slots (total 5–7); friend slots are never LLM-backfilled. `PRD-D-1-…` Decision 7.
+13. **Broadcast (followers-only)** — "share with all friends" writes a followers-only broadcast. `PRD-D-1-…` Decision 2.
+14. **Direct send** — send a specific question to a specific person. `PRD-D-1-…` Type 2 (`direct_sent`).
+15. **Presence / "recently exploring"** — activity-based recent domains shown on a friend's profile (`/users/[id]`), distinct from demonstrated-territory overlap. `PRD-D-1-…` Decisions 8–9.
+16. **Creator note ("author's why")** — a note an author attaches at creation, revealed to anyone who answers (correct or incorrect). `src/components/feed/AnswerFeedbackSheet.tsx` ("Why they asked").
+17. **Aside / "between us"** — a short provenance-labeled commentary line; `relational` ("Between us friends") for human authors, `editorial` ("Between us!", placeholder copy) for machine-origin. `src/lib/questions-types.ts:47-50`.
+
+### Ceremony & reflection
+18. **Biweekly Ceremony** — the major reflective artifact (banner, viewed, share token/page, compute/fire services). `PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1, §22.
+
+### Onboarding
+19. **Onboarding with cultural anchor** — `birth_year`, `grew_up_country`, `grew_up_region` captured; proposal/canonicalization/save routes. `PRD-11.1-MASTER-ALIGNMENT-AUDIT-2.md` §1.
+
+### Authoring & discovery (specs name these explicitly)
+20. **Authoring** — players author questions into their bank for circulation; no per-round submission cap. `PRD_BACKLOG.md` §5.
+21. **Authoring payoff (Capability 21)** — authoring is worthwhile even when no friend shares the niche. `PRD-D-2-…` Context ("Capabilities 21–22").
+22. **Niche-match discovery (Capability 22)** — when a stranger answers a question I authored I can go see and follow them, and symmetrically; the "atonal-stranger" story. Privacy-gated by `discoverable_by_niche_match`. `PRD-D-2-…` Context + Decision ledger.
+
+### House / editorial (spec only — not built)
+23. **House / editorial author (Capability 23)** — a clearly-labeled, non-human curator that seeds questions into niches to ease content scarcity at small scale. **Never** a simulated friend, never followable, never a niche-match target. `PRD-D-3-…` Context + Decision 6. **Status: spec only, unbuilt** — see the conformance audit.
+
+> The product target is **22 built-or-building capabilities plus Capability 23 (house) held as spec**.
+> If the canonical numbered list differs, replace this section and keep the citations.
+
+---
+
+## 2. Deferred items
+
+Recorded in `PRD_BACKLOG.md`; deferred deliberately, not dropped.
+
+- **Personal Rounds** — on-demand practice from the Knowledge page. *Deferred to a future phase.* `PRD_BACKLOG.md` §8.37.
+- **Archive** — searchable history of all interactions. *Deferred to a future phase* (Catch-up split out as its own shipped surface). `PRD_BACKLOG.md` §8.7.
+- **Activities Tab** — fully implemented but not linked from nav/Account; not a reachable surface. *Deferred until re-enabled.* `PRD_BACKLOG.md` §8.15.
+- **Joshing Games** — fully implemented (schema, API, play, summary, feed, SMS) but creation gated off by `GAME_CREATION_DISABLED_IN_V11_1 = true` (`src/app/api/joshing-games/route.ts:12`). *Deferred until re-enabled.* `PRD_BACKLOG.md` §8.14.
+- **House / editorial author (Capability 23)** — spec complete (`PRD-D-3-…`), implementation deferred. Depends on D-1's follow model and D-2's niche-match rules.
+
+---
+
+## 3. Open hypotheses
+
+Unsettled questions to validate, not yet decided.
+
+- **Niche-match default visibility.** `discoverable_by_niche_match` ships **DEFAULT false**; for the **test phase only** it is flipped to **DEFAULT true**. The **production default is an OPEN DECISION** to revisit after observing the test. `PRD-D-2-…` ("OPEN DECISION (test-phase amendment)").
+- **Thumbs-up → surface priority.** The thumbs-up signal currently has no effect on feed ordering. Open: eager update to `surface_priority_score` vs. dynamic weighted sort joining `question_feedback`, and what the weighting formula is. `PRD_BACKLOG.md` §8.1.11.
+- **Onboarding cultural-anchor step.** Post-acceptance cultural-anchor step described but not yet wired into `OnboardingFlow` / §7.3. `PRD_BACKLOG.md`.
+
+---
+
+## 4. Decisions Amended After Build
+
+These changed *after* the restructure shipped. They are **settled** unless marked otherwise.
+
+### 4.1 Send difficulty travels with the question — **settled**
+When a question is sent to someone, the question's **own difficulty estimate travels with it** rather
+than being recomputed for the recipient. The send route materializes the forwarded question with the
+source question's `difficultyEstimate` (`src/app/api/questions/send/route.ts:179-181`).
+
+> Implementation note (flagged for confirmation): only `difficultyEstimate` is carried. The schema
+> also has `llmDifficulty` and `calibratedDifficulty` (`src/server/db/schema.ts:272-274`), which are
+> **not** copied on forward. If "difficulty travels" is meant to include the calibrated values, that is
+> a follow-up; as decided and as built, the carried value is `difficultyEstimate`.
+
+### 4.2 Broadcast rolls off after unfollow — **won't fix**
+When you unfollow someone, a broadcast of theirs that has already surfaced in your Feed is **not**
+retroactively purged — it **rolls off** naturally rather than disappearing on unfollow. This is an
+accepted **won't-fix**: the cost of retroactive removal is not worth it, and a broadcast already seen
+is not a privacy leak. Future broadcasts stop, because broadcast fan-out is followers-only
+(`PRD-D-1-…` Decision 2; fan-out targets "my followers").
+
+---
+
+## 5. Open threads (not settled)
+
+### Option B — should the aside amplify a human's `creatorNote` when one exists?
+Today the **aside** ("between us" / inside-joke line) and the **creator note** ("Why they asked") are
+**independent surfaces** that render separately:
+- The aside is provenance-labeled and gated by relationship: `relational` for human authors (shown to
+  author + friends), `editorial` for machine-origin (shown to everyone, no relationship gate).
+  `src/server/questions/inside-joke.ts`, `src/lib/questions-types.ts:47-50`.
+- The creator note is the author's optional "why," revealed on any answer.
+  `src/components/feed/AnswerFeedbackSheet.tsx`.
+
+**Open question (Option B):** when a human author *has* attached a `creatorNote`, should the aside
+**amplify that human voice** (use/extend the note) instead of presenting a separately-generated line?
+No code currently merges them. **This is the live open thread the next reader should pick up.**
+
+---
+
+## 6. Related documents
+
+- `PRD-D-1-FEED-DAILY-RESTRUCTURE-SPEC.md` — follow model + Feed/Daily split (spec).
+- `PRD-D-2-NICHE-MATCH-DISCOVERY-SPEC.md` — niche-match discovery engine (spec).
+- `PRD-D-3-HOUSE-EDITORIAL-AUTHOR-SPEC.md` — house / editorial author (spec, unbuilt).
+- `audits/2026-06-02-restructure-conformance-audit.md` — read-only conformance audit (this doc's companion).
+- `DECISIONS.md` — index of settled vs. open decisions.

--- a/audits/2026-06-02-restructure-conformance-audit.md
+++ b/audits/2026-06-02-restructure-conformance-audit.md
@@ -1,0 +1,174 @@
+# Restructure Conformance Audit — D-1 / D-2 / D-3 (2026-06-02)
+
+**Date:** 2026-06-02
+**Method:** read-only. Every claim below was verified by reading the cited source file directly; no
+code was changed. Companion to `PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md`.
+**Scope:** does the shipped code conform to the restructure specs (D-1 follow/Feed split, D-2
+niche-match, D-3 house author) and the post-build amended decisions?
+
+## Legend
+- ✅ CONFORMS — matches the spec / decision
+- ⚠️ DIVERGES — implemented differently than the spec
+- 🔴 UNBUILT — spec exists, no implementation
+- 🟡 WON'T-FIX — divergence that is a deliberate, accepted decision
+
+---
+
+## 1. Summary
+
+The provenance backbone the restructure depends on is **shipped and conforming**: questions carry an
+honest `authored | daily_generated | curated_sent` source, forwarded LLM questions never accrue author
+credit, and the aside line is provenance-labeled. **Two real divergences** remain: the **house /
+editorial author is unbuilt** (D-3), and the **feed verb surfaces a "wrote vs sent" label** that can
+overstate authorship on the broadcast path. Two further items are **deliberate won't-fix** decisions,
+and there is one **latent guard requirement** (house-attribution) that should be locked with a test
+before D-3 is built.
+
+| # | Area | Status |
+|---|------|--------|
+| 2.1 | Authored-vs-curated provenance (send path) | ✅ CONFORMS |
+| 2.2 | Aside provenance labeling | ✅ CONFORMS |
+| 2.3 | Send difficulty travels with the question | ✅ CONFORMS (partial scope — see note) |
+| 3.1 | House / editorial author | 🔴 UNBUILT |
+| 3.2 | Feed verb "wrote vs sent" label | ⚠️ DIVERGES |
+| 4.1 | Broadcast rolls off after unfollow | 🟡 WON'T-FIX |
+| 4.2 | `editorial` aside copy ("Between us!") | 🟡 WON'T-FIX (placeholder, flagged) |
+| 5 | House-attribution guard | ⚠️ LATENT REQUIREMENT (untested) |
+
+---
+
+## 2. What conforms
+
+### 2.1 Authored-vs-curated provenance — ✅ CONFORMS
+The send route materializes a forwarded LLM question with **no author** and a distinct source, so
+credit never flows to the forwarder:
+
+```
+src/app/api/questions/send/route.ts:163-172
+  // (creatorId stays null so author/curator credit never accrues to the
+  // forwarder), and source is 'curated_sent' so it is queryably distinct from
+  // both authored questions and daily-generated ones.
+      creatorId: null,
+      ...
+      source: 'curated_sent',
+```
+
+The schema's `source` column carries the three honest values:
+
+```
+src/server/db/schema.ts:254
+  source: text('source').$type<'authored' | 'daily_generated' | 'curated_sent'>()...
+```
+
+### 2.2 Aside provenance labeling — ✅ CONFORMS
+The aside ("between us" line) is labeled by provenance and gated by relationship — a human author's
+aside is relational and gated to friends; a machine-origin aside is editorial and ungated:
+
+```
+src/lib/questions-types.ts:47-50
+  export type InsideJokeKind = 'relational' | 'editorial';
+  export const INSIDE_JOKE_LABELS: Record<InsideJokeKind, string> = {
+    relational: 'Between us friends',
+    editorial: 'Between us!', // PLACEHOLDER copy — flagged for product sign-off
+  };
+```
+
+Selector: `src/server/questions/inside-joke.ts` — null `creatorId` → `editorial`, no friend check;
+human author → `relational`, shown to author + friends.
+
+### 2.3 Send difficulty travels with the question — ✅ CONFORMS (partial scope)
+The forwarded question keeps the source question's difficulty estimate rather than recomputing it:
+
+```
+src/app/api/questions/send/route.ts:179-181
+  difficultyEstimate: generated.difficultyEstimate === 'accessible' || ... ? generated.difficultyEstimate : null,
+```
+
+> Scope note: only `difficultyEstimate` is carried; `llmDifficulty` / `calibratedDifficulty`
+> (`schema.ts:272-274`) are not. See amended decision 4.1 in `PRD-D-0`.
+
+---
+
+## 3. Divergences
+
+### 3.1 House / editorial author — 🔴 UNBUILT
+D-3 specifies a first-class, labeled house author. None of it is implemented:
+- No house identity constant (D-3 expects a single `{ id, displayName: 'Joshing', label: 'Editorial' }` source of truth) — absent from `src/`.
+- `source` enum is **not** widened to include `'house_authored'` (`schema.ts:254` lists only the three).
+- No `Joshing` + `Editorial` badge rendering.
+- Null-author questions still resolve through the generic person fallback (see 3.2 / §5).
+
+This is expected: D-3 is a **spec-only deliverable** that depends on D-1 (follow model) and D-2
+(niche-match), and is correctly held until those land.
+
+### 3.2 Feed verb "wrote vs sent" label — ⚠️ DIVERGES
+The surfaced feed verb collapses provenance into a **wrote-vs-sent** framing:
+
+```
+src/components/FeedList.tsx:242-251
+  export function feedSourceVerb(sourceType, questionSource): string {
+    if (sourceType === 'direct_sent') {
+      return questionSource === 'authored' ? 'wrote you this' : 'sent you this'
+    }
+    if (sourceType === 'authored_shared') return 'wrote this'
+    if (sourceType === 'thumbs_upped') return 'liked this'
+    return 'answered this'
+  }
+```
+
+The **direct-send** path conforms (it consults `questionSource`: `'wrote you this'` only for `authored`,
+`'sent you this'` otherwise). The **broadcast** path (`authored_shared`) returns **`'wrote this'`
+unconditionally**, without consulting `questionSource` — so a broadcast of a non-authored (curated /
+LLM-origin) question would still read **"wrote this,"** an authorship claim the provenance model would
+not support.
+
+> **Flagged as my interpretation of the "wrote-vs-sent label" divergence** (the prompt named it
+> tersely). The concrete, code-grounded finding is the unconditional `'wrote this'` on the
+> `authored_shared` branch. Confirm this is the intended reading before treating it as the canonical
+> divergence statement.
+
+---
+
+## 4. Deliberate won't-fix decisions
+
+### 4.1 Broadcast rolls off after unfollow — 🟡 WON'T-FIX
+Unfollowing does not retroactively purge an already-surfaced broadcast from the Feed; it rolls off
+naturally. Accepted: retroactive removal isn't worth the cost, and an already-seen broadcast is not a
+leak. Future broadcasts stop because fan-out is followers-only (`PRD-D-1-…` Decision 2). Recorded in
+`PRD-D-0` §4.2.
+
+### 4.2 `editorial` aside copy ("Between us!") — 🟡 WON'T-FIX (placeholder, flagged)
+The editorial-aside copy is a self-flagged placeholder (`questions-types.ts:50` —
+`// PLACEHOLDER copy — flagged for product sign-off`). Functionally correct; copy pending product
+sign-off. Not a conformance failure.
+
+---
+
+## 5. Latent requirement — house-attribution guard
+
+D-3 carries **Invariant H-1**: no code path may resolve a house question to a real `users` row or to
+the generic person fallback. The fallback that the invariant must defend against is live today:
+
+```
+src/server/feed/get-feed-page.ts:84
+  function displayName(user, fallback = 'A friend') { ... return fallback; }
+```
+
+Null-author questions currently resolve to **`'A friend'`** — exactly the peer-impersonation outcome
+H-1 forbids for house questions. Existing tests cover the *aside* label
+(`src/server/questions/__tests__/inside-joke.test.ts`) and feed *eligibility*
+(`src/server/feed/__tests__/visibility.test.ts`) for null authors, but **no test asserts that a
+null/house author never renders as `'A friend'` or a `users` row.**
+
+**Recommendation (latent, do at D-3 build time):** when the house author lands, replace the `'A friend'`
+fallback for house-origin questions with the house constant and lock H-1 with a regression test. Until
+D-3 is built this is a documented latent requirement, not a live bug (no house questions exist yet).
+
+---
+
+## 6. Verdict
+
+The restructure's provenance foundation conforms. Nothing here blocks shipping the built capabilities.
+Before **D-3 (house author)** is built: (a) resolve the broadcast `'wrote this'` divergence (3.2), and
+(b) implement Invariant H-1 with a regression test (§5). The open **Option B** thread (aside amplifying
+a human `creatorNote`) is tracked in `PRD-D-0` §5 and `DECISIONS.md`.

--- a/docs/build-prompts/README.md
+++ b/docs/build-prompts/README.md
@@ -1,0 +1,37 @@
+# Build prompts — implementation log (NOT product spec)
+
+> **This directory holds execution instructions, not product documentation.** The staged build prompts
+> are how the restructure was *built*; they are kept here as an implementation log. For *what the
+> product is and why*, read [`PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md`](../../PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md)
+> and the `PRD-D-1/2/3` specs — **not** these prompts. Prompts go stale the moment the code merges;
+> do not treat them as current spec.
+
+## What lives here
+
+- *(none of the staged prompt bodies are filed yet — see "Not yet filed" below)*
+
+## Already in the repo (root)
+
+- [`B-Friends-prompts-revised.md`](../../B-Friends-prompts-revised.md) — the B-Friends build prompts
+  (P0-A…P0-D, B-Friends-1…4), already committed at repo root before this filing. Left in place to avoid
+  breaking references; logged here for discoverability. Move it under this directory only if you want
+  all build prompts colocated.
+
+## Not yet filed (source content needed)
+
+The filing task asked to include these under a clearly-separate path. They were **not present in the
+repo and their bodies were not provided**, so they have not been filed (I will not fabricate execution
+prompts). Drop the source text here and they'll slot in:
+
+- The **staged build prompts** — D-1 / D-2 / D-3 stage prompts and **B-1 … B-8**.
+- The **investigation prompts** — the "cheeky-context" investigation prompts.
+
+Suggested layout once content is available:
+
+```
+docs/build-prompts/
+  README.md            (this file)
+  d1/ d2/ d3/          (staged D-1/D-2/D-3 build prompts)
+  b1..b8/              (B-1 … B-8 build prompts)
+  investigation/       (cheeky-context investigation prompts)
+```


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the restructure work (D-1 / D-2 / D-3), establishing a canonical record of product direction, conformance status, and settled vs. open decisions. No code changes; documentation only.

## Changes

- **`PRD-D-0-PRODUCT-DIRECTION-AND-DECISIONS.md`** — Canonical "what the product is and why" document. Enumerates 23 capabilities (22 built/building, 1 spec-only), records deferred items, open hypotheses, and **amended decisions made after the build shipped**. Serves as the single source of truth for product intent and what changed post-implementation.

- **`audits/2026-06-02-restructure-conformance-audit.md`** — Read-only conformance audit verifying shipped code against D-1/D-2/D-3 specs. Documents:
  - ✅ What conforms: authored-vs-curated provenance, aside labeling, difficulty traveling with questions
  - ⚠️ Divergences: house/editorial author unbuilt, feed verb "wrote vs sent" label overstates authorship on broadcast
  - 🟡 Won't-fix decisions: broadcast rolloff on unfollow, placeholder editorial aside copy
  - ⚠️ Latent requirement: house-attribution guard (H-1 invariant) needs regression test at D-3 build time

- **`DECISIONS.md`** — Index of durable docs and decision status. Clearly separates **settled decisions** (directional follow, honest provenance, send difficulty, broadcast rolloff) from **open threads** (Option B aside/creatorNote merge, niche-match production default, thumbs-up priority, house author guard, feed verb divergence).

- **`docs/build-prompts/README.md`** — Scaffolding for execution logs. Clarifies that build prompts are implementation instructions, not product spec, and directs readers to PRD-D-0/1/2/3 for product intent. Reserves space for staged D-1/D-2/D-3 and B-1…B-8 prompts (bodies not provided in this filing).

## Notable details

- **Reconstructed capability list** — PRD-D-0 §1 assembles the first canonical enumeration of 23 capabilities from scattered PRD/audit/spec sources and shipped code. Marked `[reconstructed]` where derived rather than quoted; should be validated against any existing authoritative list.

- **Amended decisions** — PRD-D-0 §4 records two decisions that changed *after* the restructure shipped: send difficulty travels with the question (settled), and broadcast rolls off after unfollow (won't-fix). These are now locked and should not be re-litigated.

- **Live open thread** — PRD-D-0 §5 flags **Option B** (should the aside amplify a human's `creatorNote`?) as the active decision point for the next reader to pick up.

- **Latent guard requirement** — Conformance audit §5 documents that Invariant H-1 (house questions never resolve to `'A friend'` fallback) is currently unguarded by tests. Recommendation: implement at D-3 build time with a regression test.

All documents are cross-referenced and point readers to the right place for product intent vs. conformance vs. execution scaffolding.

https://claude.ai/code/session_01SDKPbQKSTWdmoVcSvFw7Hs