### PR TITLE
Replace lucide MessageCircle icon with custom SVG in login

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { MessageCircle } from 'lucide-react';
 
 const US_E164_REGEX = /^\+1\d{10}$/;
 
@@ -20,6 +19,12 @@ const INPUT_CLASS =
   'h-11 w-full rounded-[4px] border border-[var(--tri-amber)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none ring-offset-2 ring-offset-[var(--brand-cream-card)] focus:ring-2 focus:ring-[var(--brand-navy)]';
 const SUBMIT_CLASS =
   'h-11 w-full rounded-[4px] bg-[var(--brand-navy)] px-4 text-base font-bold tracking-[0.04em] text-white transition hover:opacity-90 disabled:opacity-60';
+
+// A single rounded-rectangle speech bubble (28×20, 6px radius) with a tail at
+// the bottom-left. Reused for both bubbles in the OTP mark — the front bubble
+// is mirrored via an SVG transform so its tail points the other way.
+const BUBBLE_PATH =
+  'M6 0 H22 A6 6 0 0 1 28 6 V14 A6 6 0 0 1 22 20 H13 L7 27 L9 20 H6 A6 6 0 0 1 0 14 V6 A6 6 0 0 1 6 0 Z';
 
 function sendTelemetry(event: string) {
   void fetch('/api/telemetry', {
@@ -195,19 +200,26 @@ export default function LoginPanel() {
         </form>
       ) : (
         <form className="space-y-[14px]" onSubmit={verifyCode}>
-          {/* Two overlapping speech bubbles (orange in front, navy behind),
-              recreating the Figma two-tone icon. The front bubble takes a cream
-              stroke so it reads as a crescent where it crosses the navy one. */}
-          <div className="mx-auto flex w-fit flex-row-reverse items-end" aria-hidden="true">
-            <MessageCircle
-              className="h-12 w-12 -translate-x-3 -scale-x-100 fill-[var(--brand-navy)] text-[var(--brand-navy)]"
-              strokeWidth={1.5}
-            />
-            <MessageCircle
-              className="h-12 w-12 fill-[var(--brand-orange)] text-[var(--brand-cream-card)]"
+          {/* Two overlapping rounded speech bubbles — navy behind, orange in
+              front — recreating the Figma two-tone mark. The front bubble is
+              mirrored (tail to the right) and carries a cream halo stroke so it
+              reads as a distinct bubble where it crosses the navy one. */}
+          <svg
+            className="mx-auto h-14 w-auto"
+            viewBox="-2 -2 52 41"
+            fill="none"
+            aria-hidden="true"
+          >
+            <path d={BUBBLE_PATH} fill="var(--brand-navy)" />
+            <path
+              d={BUBBLE_PATH}
+              transform="translate(47 9) scale(-1 1)"
+              fill="var(--brand-orange)"
+              stroke="var(--brand-cream-card)"
               strokeWidth={2.5}
+              strokeLinejoin="round"
             />
-          </div>
+          </svg>
           <label
             className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"
             htmlFor="code"

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -20,12 +20,6 @@ const INPUT_CLASS =
 const SUBMIT_CLASS =
   'h-11 w-full rounded-[4px] bg-[var(--brand-navy)] px-4 text-base font-bold tracking-[0.04em] text-white transition hover:opacity-90 disabled:opacity-60';
 
-// A single rounded-rectangle speech bubble (28×20, 6px radius) with a tail at
-// the bottom-left. Reused for both bubbles in the OTP mark — the front bubble
-// is mirrored via an SVG transform so its tail points the other way.
-const BUBBLE_PATH =
-  'M6 0 H22 A6 6 0 0 1 28 6 V14 A6 6 0 0 1 22 20 H13 L7 27 L9 20 H6 A6 6 0 0 1 0 14 V6 A6 6 0 0 1 6 0 Z';
-
 function sendTelemetry(event: string) {
   void fetch('/api/telemetry', {
     method: 'POST',
@@ -200,25 +194,23 @@ export default function LoginPanel() {
         </form>
       ) : (
         <form className="space-y-[14px]" onSubmit={verifyCode}>
-          {/* Two overlapping rounded speech bubbles — navy behind, orange in
-              front — recreating the Figma two-tone mark. The front bubble is
-              mirrored (tail to the right) and carries a cream halo stroke so it
-              reads as a distinct bubble where it crosses the navy one. */}
+          {/* Two overlapping circular speech bubbles — navy behind, orange in
+              front — recreating the Figma two-tone mark. The bubbles overlap
+              directly (no separating stroke) so the colors meet, with tails
+              pointing down-left and down-right. */}
           <svg
             className="mx-auto h-14 w-auto"
-            viewBox="-2 -2 52 41"
-            fill="none"
+            viewBox="-3 -3 52 44"
             aria-hidden="true"
           >
-            <path d={BUBBLE_PATH} fill="var(--brand-navy)" />
-            <path
-              d={BUBBLE_PATH}
-              transform="translate(47 9) scale(-1 1)"
-              fill="var(--brand-orange)"
-              stroke="var(--brand-cream-card)"
-              strokeWidth={2.5}
-              strokeLinejoin="round"
-            />
+            <g fill="var(--brand-navy)">
+              <circle cx="14" cy="14" r="14" />
+              <path d="M2 21 L9.2 27.2 L1.5 31.5 Z" />
+            </g>
+            <g fill="var(--brand-orange)">
+              <circle cx="30" cy="22" r="14" />
+              <path d="M42 29 L34.8 35.2 L42.5 39.5 Z" />
+            </g>
           </svg>
           <label
             className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -194,22 +194,31 @@ export default function LoginPanel() {
         </form>
       ) : (
         <form className="space-y-[14px]" onSubmit={verifyCode}>
-          {/* Two overlapping circular speech bubbles — navy behind, orange in
-              front — recreating the Figma two-tone mark. The bubbles overlap
-              directly (no separating stroke) so the colors meet, with tails
-              pointing down-left and down-right. */}
+          {/* Two overlapping oval speech bubbles — navy behind, orange in front
+              — recreating the Figma two-tone mark. The front bubble is drawn
+              twice: first as a slightly larger cream copy (the page background
+              color) so a crescent of background shows where it overlaps the
+              navy, then as the orange bubble on top. */}
           <svg
             className="mx-auto h-14 w-auto"
-            viewBox="-3 -3 52 44"
+            viewBox="-3 -3 54 44"
             aria-hidden="true"
           >
             <g fill="var(--brand-navy)">
-              <circle cx="14" cy="14" r="14" />
-              <path d="M2 21 L9.2 27.2 L1.5 31.5 Z" />
+              <ellipse cx="15" cy="15" rx="15" ry="12" />
+              <path d="M3 22 L11 26.5 L1 31 Z" />
+            </g>
+            {/* cream halo — background color showing through the overlap */}
+            <g
+              fill="var(--brand-cream-card)"
+              transform="translate(32 23) scale(1.14) translate(-32 -23)"
+            >
+              <ellipse cx="32" cy="23" rx="15" ry="12" />
+              <path d="M44 30 L36 34.5 L46.5 39 Z" />
             </g>
             <g fill="var(--brand-orange)">
-              <circle cx="30" cy="22" r="14" />
-              <path d="M42 29 L34.8 35.2 L42.5 39.5 Z" />
+              <ellipse cx="32" cy="23" rx="15" ry="12" />
+              <path d="M44 30 L36 34.5 L46.5 39 Z" />
             </g>
           </svg>
           <label


### PR DESCRIPTION
## Summary
Replaced the lucide-react `MessageCircle` icon implementation with a custom SVG in the login verification code form. This provides better visual control over the two-tone speech bubble design and removes a dependency on icon library transforms.

## Changes
- Removed `MessageCircle` import from lucide-react
- Replaced dual overlapping `MessageCircle` components with a custom SVG implementation
- The new SVG uses three layered groups to create the two-tone effect:
  - Navy ellipse and triangle (background bubble)
  - Cream-colored scaled copy (creates the crescent overlap effect)
  - Orange ellipse and triangle (foreground bubble)
- Updated the comment to reflect the new SVG-based approach

## Implementation Details
The custom SVG achieves the two-tone crescent effect by:
1. Drawing the navy bubble with a pointer triangle
2. Scaling a cream-colored copy of the orange bubble (1.14x) and positioning it to create a visible halo where it overlaps the navy bubble
3. Drawing the final orange bubble on top

This approach provides more precise control over the visual appearance compared to the previous icon-based implementation and eliminates the need for CSS transforms and stroke-width adjustments.

https://claude.ai/code/session_01WcFidMC7crXX47o2yBZwYw