### PR TITLE
D-3: Add house/editorial author support to Daily

### DIFF
--- a/docs/house-editorial-copy-checklist.md
+++ b/docs/house-editorial-copy-checklist.md
@@ -1,0 +1,37 @@
+# House / Editorial author — commentary copy checklist (D-3 §E)
+
+The house author (`Joshing` / `Editorial`, `HOUSE_AUTHOR` in
+`src/lib/questions-types.ts`) is **content infrastructure, not a peer**. Its
+creator-notes/asides may have voice and personality, but they must read as an
+**editor or curator**, never as a friend who has a relationship with the reader.
+
+This is a **content/review guideline, enforced in authoring and PR review — not a
+runtime validation gate.** The render layer already strips relational *chrome*
+for house questions (no "gave you this", no "Why {name} asked", no
+"{name} carries this one" — see `AuthorNoteCard` / `QuestionRow` in
+`src/components/play/GameplayChat.tsx` and the summary "Editor's note:"), but the
+note *text itself* is human-written and must follow this checklist.
+
+## Reviewing a house creator-note / aside — checklist
+
+- [ ] **No relational framing.** Reject anything that implies a peer
+      relationship with the reader: "between us friends", "just for you", "our
+      little secret", "I picked this for you", "you and I", "trust me", etc.
+- [ ] **No simulated personal history or feelings toward the reader.** The house
+      author has not met the player and shares no in-jokes with them.
+- [ ] **Editorial / curator voice only.** Allowed: "A favorite from the
+      archives.", "One the whole table usually trips on.", "Worth knowing if you
+      like the deep cuts." — asides *about the question or the domain*, not about
+      a relationship.
+- [ ] **First person is fine if it's an editor's voice**, not a friend's: "We
+      love this one" (editorial we) is OK; "Just between us" is not.
+- [ ] **No follow / social hooks.** The note must not invite following,
+      messaging, or any peer affordance — the house author is never followable.
+
+## Why this matters
+
+The whole house concept rests on one line: *a labeled non-human author that fills
+content is fine; a non-human pretending to be a peer who connects with you is
+forbidden.* Relational copy on house content crosses exactly that line, so it is
+the one thing a house note can get wrong even when every render-layer guard is
+correct.

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -11,7 +11,7 @@ import {
   questions,
 } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
-import { awardAuthorCredit } from '@/server/mastery/author-credit';
+import { awardAuthorCredit, isAuthorCreditEligible } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
@@ -430,10 +430,16 @@ export async function POST(request: NextRequest) {
     if (canonicalQuestionId && !parsed.gaveUp) {
       const propagationKey = question.generatedId ?? question.canonicalId ?? canonicalQuestionId;
       try {
-        if (isCorrect && persistedCreatorId && persistedCreatorId !== session.userId && persistedDomainForCreator) {
+        const creditContext = {
+          isCorrect,
+          creatorId: persistedCreatorId,
+          answererUserId: session.userId,
+          domain: persistedDomainForCreator,
+        };
+        if (isAuthorCreditEligible(creditContext)) {
           void promoteDeclaredToDemonstrated({
-            userId: persistedCreatorId,
-            domain: persistedDomainForCreator,
+            userId: creditContext.creatorId,
+            domain: creditContext.domain,
             triggeringFriendId: session.userId,
             questionId: canonicalQuestionId,
           });
@@ -441,10 +447,10 @@ export async function POST(request: NextRequest) {
           // Author credit (PRD §8.32): off the user's hot path — three queries
           // the answerer never sees in their response.
           void awardAuthorCredit({
-            creatorUserId: persistedCreatorId,
+            creatorUserId: creditContext.creatorId,
             answererUserId: session.userId,
             questionId: canonicalQuestionId,
-            domain: persistedDomainForCreator,
+            domain: creditContext.domain,
             sourceId: `daily:${propagationKey}:${session.userId}`,
             scope: 'daily/answer',
           });

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -14,7 +14,7 @@ import {
 } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
-import { awardAuthorCredit } from '@/server/mastery/author-credit';
+import { awardAuthorCredit, isAuthorCreditEligible } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
@@ -277,20 +277,26 @@ async function handleDailyCatchupAnswer({
 
   if (canonicalQuestionId) {
     try {
-      if (isCorrect && persistedCreatorId && persistedCreatorId !== userId && persistedDomainForCreator) {
+      const creditContext = {
+        isCorrect,
+        creatorId: persistedCreatorId,
+        answererUserId: userId,
+        domain: persistedDomainForCreator,
+      };
+      if (isAuthorCreditEligible(creditContext)) {
         void promoteDeclaredToDemonstrated({
-          userId: persistedCreatorId,
-          domain: persistedDomainForCreator,
+          userId: creditContext.creatorId,
+          domain: creditContext.domain,
           triggeringFriendId: userId,
           questionId: canonicalQuestionId,
         });
 
         // Author credit (PRD §8.32): off the user's hot path.
         void awardAuthorCredit({
-          creatorUserId: persistedCreatorId,
+          creatorUserId: creditContext.creatorId,
           answererUserId: userId,
           questionId: canonicalQuestionId,
-          domain: persistedDomainForCreator,
+          domain: creditContext.domain,
           sourceId: `catchup:${catchupItem.dailyQueueItemId}:${userId}`,
           scope: 'daily/catchup/answer',
         });

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -148,9 +148,13 @@ async function handleDailyCatchupAnswer({
   let persistedCreatorId: string | null = null;
   let persistedDomainForCreator: string | null = null;
 
-  if (slot.source === 'friend') {
+  // Friend and house (D-3) slots both already live in the canonical `questions`
+  // table — resolve by question_id rather than promoting a GeneratedQuestion.
+  // House questions carry creatorId=null, so persistedCreatorId stays null and
+  // no author credit accrues (house is mastery-ineligible by construction).
+  if (slot.source === 'friend' || slot.source === 'house') {
     if (!slot.question_id) {
-      return catchUpErrorResponse(500, 'invalid_state', 'Friend catch-up slot missing canonical question id');
+      return catchUpErrorResponse(500, 'invalid_state', 'Canonical catch-up slot missing question id');
     }
     canonicalQuestionId = slot.question_id;
     const [canonicalRow] = await db

--- a/src/app/api/daily/catchup/route.ts
+++ b/src/app/api/daily/catchup/route.ts
@@ -31,6 +31,7 @@ export async function GET() {
       expiresSoon: item.expiresSoon,
       difficultyEstimate: item.difficultyEstimate,
       authorName: item.authorName,
+      authorIsHouse: item.authorIsHouse,
     })),
     introCopy: first
       ? formatCatchUpSessionThreadIntro(items.length, first.queueDate, last?.queueDate)

--- a/src/app/api/feed/friend-coverage/route.ts
+++ b/src/app/api/feed/friend-coverage/route.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, ilike, inArray, isNull, or, sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
+import { parseQuestionSource } from '@/lib/questions-types';
 import { getSession } from '@/server/auth/session';
 import {
   db,
@@ -234,9 +235,9 @@ export async function loadFriendCoverage(
     const rows: FriendCoverageEventRow[] = [];
 
     for (const event of events) {
-      const questionPayload = event.questionId ? {
+      const questionPayload = event.questionId && event.questionSource !== null ? {
         creatorId: event.questionCreatorId,
-        source: event.questionSource as 'authored' | 'daily_generated' | 'curated_sent',
+        source: parseQuestionSource(event.questionSource),
         visibility: event.questionVisibility as 'public' | 'private',
         deletedAt: event.questionDeletedAt,
       } : null;

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -317,11 +317,14 @@ export default function DailyPage() {
           consolation: slot.reveal_quip ?? null,
           insideJoke: slot.reveal_inside_joke ?? null,
           insideJokeKind: slot.reveal_inside_joke_kind ?? null,
-          authorNote: slot.source === 'friend' ? (slot.author_note ?? null) : null,
+          authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
           explanation: slot.reveal_explainer ?? null,
           copyVariant: slot.slot_index,
-          creatorName: slot.source === 'friend' ? (slot.author_name ?? null) : null,
+          // D-3: house core slots surface the 'Joshing' name + Editorial badge
+          // (creatorIsHouse), rendered non-relationally by GameplayChat.
+          creatorName: slot.source === 'friend' || slot.source === 'house' ? (slot.author_name ?? null) : null,
+          creatorIsHouse: slot.source === 'house',
           canonicalSubcategory: slot.domain,
           openedTerritoryDomain: openedTerritoryBySlot[slot.slot_index] ?? null,
           recheckAction: slot.answer_state === 'incorrect' && !gaveUp && !slot.recheck_status

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -16,6 +16,7 @@ import {
 
 import { SendQuestionAction } from '@/components/SendQuestionAction'
 import { AddToBankAction } from '@/components/AddToBankAction'
+import { EditorialBadge } from '@/components/EditorialBadge'
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay'
 import MasteryMoment from '@/components/review/MasteryMoment'
 import { cn } from '@/lib/utils'
@@ -481,6 +482,7 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
               FROM
             </span>
             <span style={{ fontWeight: 600 }}>{question.authorName}</span>
+            {question.authorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
             <span
               style={{
                 ...monoStyle,
@@ -527,7 +529,9 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
       {question.authorNote ? (
         <p className="bg-muted/40 text-foreground mt-4 rounded-xl border p-3 text-sm leading-6">
           <span className="font-medium">
-            {question.authorName ? `Why ${question.authorName} asked:` : 'Why they asked:'}
+            {question.authorIsHouse
+              ? 'Editor’s note:'
+              : question.authorName ? `Why ${question.authorName} asked:` : 'Why they asked:'}
           </span>{' '}
           {question.authorNote}
         </p>

--- a/src/app/replay/page.tsx
+++ b/src/app/replay/page.tsx
@@ -30,6 +30,7 @@ function questionMessage(item: ReplayItem): ChatMessage {
     assignmentId: item.dailyQueueItemId,
     questionText: item.questionText,
     creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
+    creatorIsHouse: item.authorIsHouse,
     subhead: `FROM ${item.queueDate}`,
     badges: [{ label: 'practice', tone: 'muted' }],
   };
@@ -165,6 +166,7 @@ export default function ReplayPage() {
           breadcrumb: body.breadcrumb ?? null,
           copyVariant: currentIndex,
           creatorName: currentItem.authorName ?? LLM_QUESTION_ATTRIBUTION,
+          creatorIsHouse: currentItem.authorIsHouse,
           canonicalSubcategory: currentItem.domain,
           pointsAwarded: 0,
           pointsLabel: 'Replay - practice only',

--- a/src/components/EditorialBadge.tsx
+++ b/src/components/EditorialBadge.tsx
@@ -1,0 +1,38 @@
+import type { CSSProperties } from 'react';
+
+import { HOUSE_AUTHOR } from '@/lib/questions-types';
+
+/**
+ * D-3 — the persistent non-human marker that renders wherever the house author's
+ * name ("Joshing") appears (Invariant H-2). It is deliberately a small, quiet
+ * editorial pill, NOT a peer/profile affordance: the house author is content
+ * infrastructure, never a followable person.
+ *
+ * The label text is sourced from the single HOUSE_AUTHOR constant so the badge
+ * and the name can never drift apart.
+ */
+export function EditorialBadge({ style }: { style?: CSSProperties }) {
+  return (
+    <span
+      data-testid="editorial-badge"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        fontFamily: 'var(--font-mono)',
+        fontSize: '0.5rem',
+        textTransform: 'uppercase',
+        letterSpacing: '0.1em',
+        color: 'var(--text-muted)',
+        border: '1px solid var(--border)',
+        borderRadius: '999px',
+        padding: '1px 6px',
+        lineHeight: 1.4,
+        verticalAlign: 'middle',
+        whiteSpace: 'nowrap',
+        ...style,
+      }}
+    >
+      {HOUSE_AUTHOR.label}
+    </span>
+  );
+}

--- a/src/components/__tests__/EditorialBadge.test.tsx
+++ b/src/components/__tests__/EditorialBadge.test.tsx
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { EditorialBadge } from '@/components/EditorialBadge';
+import { HOUSE_AUTHOR } from '@/lib/questions-types';
+
+describe('EditorialBadge', () => {
+  it('renders the house label from the single HOUSE_AUTHOR constant', () => {
+    const rendered = renderToStaticMarkup(<EditorialBadge />);
+    expect(rendered).toContain(HOUSE_AUTHOR.label);
+    expect(rendered).toContain('editorial-badge');
+  });
+
+  it('merges caller style overrides', () => {
+    const rendered = renderToStaticMarkup(<EditorialBadge style={{ marginLeft: '6px' }} />);
+    expect(rendered).toContain('margin-left:6px');
+  });
+});

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -5,6 +5,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
+import { EditorialBadge } from '@/components/EditorialBadge';
 import { SessionCloseMessage } from '@/components/play/SessionCloseMessage';
 import { NewTerritoryUndo } from '@/components/feed/NewTerritoryUndo';
 import {
@@ -40,6 +41,14 @@ export type ChatMessage =
       questionText: string;
       creatorName: string | null;
       /**
+       * D-3: the named author is the non-human house/editorial author. Renders
+       * the persistent `Editorial` badge and suppresses all relational copy
+       * ("gave you this", "{name} carries this one"). Set explicitly by the
+       * server resolver — never inferred from the name string, so a human named
+       * "Joshing" is never mistaken for the house author.
+       */
+      creatorIsHouse?: boolean;
+      /**
        * Daily Five +2 bonus slot: the friend who answered this correctly. When
        * set, the card shows "{name} answered this correctly" attribution.
        */
@@ -57,6 +66,8 @@ export type ChatMessage =
       questionText: string;
       result: 'correct' | 'wrong' | 'expired' | 'gave_up';
       submitted: string;
+      /** D-3: the named author is the non-human house author (see question variant). */
+      creatorIsHouse?: boolean;
       /** Canonical answer when wrong */
       correctAnswer: string | null;
       /** Near-miss quip from LLM grader */
@@ -144,9 +155,10 @@ function firstNameFrom(creatorName: string): string {
   return space === -1 ? trimmed : trimmed.slice(0, space);
 }
 
-function wrongNamedSubLabel(creatorName: string | null, variant: number): string | null {
+function wrongNamedSubLabel(creatorName: string | null, variant: number, isHouse = false): string | null {
   if (!creatorName) return null;
-  if (isLlmAttribution(creatorName)) return null;
+  // House and LLM origins are non-relational: no "{name} carries this one".
+  if (isHouse || isLlmAttribution(creatorName)) return null;
   const firstName = firstNameFrom(creatorName);
   if (!firstName) return null;
   return WRONG_NAMED_SUBLABEL[variant % WRONG_NAMED_SUBLABEL.length]!(firstName);
@@ -176,6 +188,7 @@ function QuestionRow({
   badges = [],
   questionText,
   creatorName,
+  creatorIsHouse = false,
   answererName = null,
   isNew = false,
   onGiveUp,
@@ -185,6 +198,7 @@ function QuestionRow({
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
   questionText: string;
   creatorName: string | null;
+  creatorIsHouse?: boolean;
   answererName?: string | null;
   isNew?: boolean;
   onGiveUp?: () => void;
@@ -233,7 +247,8 @@ function QuestionRow({
             FROM
           </span>
           <span style={{ fontWeight: 600 }}>{creatorName}</span>
-          {isLlmAttribution(creatorName) ? null : (
+          {creatorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
+          {creatorIsHouse || isLlmAttribution(creatorName) ? null : (
             <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>gave you this</span>
           )}
         </p>
@@ -354,9 +369,10 @@ function UserRow({ text }: { text: string }) {
   );
 }
 
-function BreadcrumbLine({ text, creatorName }: { text: string; creatorName: string | null }) {
+function BreadcrumbLine({ text, creatorName, creatorIsHouse = false }: { text: string; creatorName: string | null; creatorIsHouse?: boolean }) {
   const author = creatorName?.trim() ?? null;
-  const isBot = isLlmAttribution(author);
+  // House is non-relational like the LLM origin: no "From {firstName}." line.
+  const isBot = creatorIsHouse || isLlmAttribution(author);
   const showAuthor = author && !isBot;
   return (
     <div
@@ -612,7 +628,7 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
   );
 }
 
-function AuthorNoteCard({ text, creatorName }: { text: string; creatorName: string | null }) {
+function AuthorNoteCard({ text, creatorName, creatorIsHouse = false }: { text: string; creatorName: string | null; creatorIsHouse?: boolean }) {
   return (
     <div
       style={{
@@ -628,13 +644,24 @@ function AuthorNoteCard({ text, creatorName }: { text: string; creatorName: stri
       <p
         style={{
           ...monoStyle,
+          display: 'flex',
+          alignItems: 'center',
+          gap: '6px',
           fontSize: '0.55rem',
           color: 'var(--text-muted)',
           letterSpacing: '0.18em',
           textTransform: 'uppercase',
         }}
       >
-        {creatorName ? `Why ${creatorName} asked` : 'Why they asked'}
+        {/* House notes are editorial, never relational — no "Why {name} asked". */}
+        {creatorIsHouse ? (
+          <>
+            <span>Editor&rsquo;s note</span>
+            <EditorialBadge />
+          </>
+        ) : (
+          <span>{creatorName ? `Why ${creatorName} asked` : 'Why they asked'}</span>
+        )}
       </p>
       <p
         style={{
@@ -688,6 +715,7 @@ function ResultRow({
   explanation,
   copyVariant,
   creatorName,
+  creatorIsHouse = false,
   relationalFeedbackLine,
   reactionPrompt,
   pointsAwarded,
@@ -708,6 +736,7 @@ function ResultRow({
   explanation?: string | null;
   copyVariant: number;
   creatorName: string | null;
+  creatorIsHouse?: boolean;
   relationalFeedbackLine?: string | null;
   canonicalSubcategory?: string | null;
   reactionPrompt?: ReactionPromptData | null;
@@ -845,7 +874,7 @@ function ResultRow({
               Now it&rsquo;s in yours too
             </p>
             {(() => {
-              const namedSubLabel = wrongNamedSubLabel(creatorName, copyVariant);
+              const namedSubLabel = wrongNamedSubLabel(creatorName, copyVariant, creatorIsHouse);
               return namedSubLabel ? (
                 <p style={{ ...monoStyle, fontSize: '0.6rem', color: 'var(--text-muted)', marginTop: '4px' }}>
                   {namedSubLabel}
@@ -912,7 +941,7 @@ function ResultRow({
           </>
         )}
         {breadcrumb
-          ? <BreadcrumbLine text={breadcrumb} creatorName={creatorName} />
+          ? <BreadcrumbLine text={breadcrumb} creatorName={creatorName} creatorIsHouse={creatorIsHouse} />
           : explanation ? <ExplanationLine text={explanation} /> : null}
         {typeof pointsAwarded === 'number' ? (
           <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '10px' }}>
@@ -956,7 +985,7 @@ function ResultRow({
           </p>
         </div>
       ) : null}
-      {authorNote ? <AuthorNoteCard text={authorNote} creatorName={creatorName} /> : null}
+      {authorNote ? <AuthorNoteCard text={authorNote} creatorName={creatorName} creatorIsHouse={creatorIsHouse} /> : null}
       {correct && openedTerritoryDomain ? (
         <NewTerritoryUndo domain={openedTerritoryDomain} category={canonicalSubcategory} />
       ) : null}
@@ -1148,6 +1177,7 @@ export function GameplayChatThread({
                 key={m.id}
                 questionText={m.questionText}
                 creatorName={m.creatorName}
+                creatorIsHouse={m.creatorIsHouse}
                 answererName={m.answererName}
                 isNew={m.isNew}
                 subhead={m.subhead}
@@ -1176,6 +1206,7 @@ export function GameplayChatThread({
                 explanation={m.explanation}
                 copyVariant={m.copyVariant}
                 creatorName={m.creatorName}
+                creatorIsHouse={m.creatorIsHouse}
                 relationalFeedbackLine={m.relationalFeedbackLine}
                 canonicalSubcategory={m.canonicalSubcategory}
                 reactionPrompt={m.reactionPrompt}

--- a/src/components/play/__tests__/GameplayChat.house.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.house.test.tsx
@@ -1,0 +1,68 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+import { HOUSE_AUTHOR } from '@/lib/questions-types';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Flag: () => <span aria-hidden="true" />,
+  MoreHorizontal: () => <span aria-hidden="true" />,
+  X: () => <span aria-hidden="true" />,
+}));
+
+function html(messages: ChatMessage[]) {
+  return renderToStaticMarkup(<GameplayChatThread messages={messages} />);
+}
+
+function questionMessage(over: Partial<Extract<ChatMessage, { kind: 'question' }>>): ChatMessage {
+  return {
+    id: 'q1',
+    kind: 'question',
+    assignmentId: 'a1',
+    questionText: 'Which composer wrote the Goldberg Variations?',
+    creatorName: null,
+    ...over,
+  };
+}
+
+describe('GameplayChat house author labeling (D-3 Stage 2)', () => {
+  it('renders the house name with the Editorial badge and no relational copy (Invariant H-2)', () => {
+    const rendered = html([
+      questionMessage({ creatorName: HOUSE_AUTHOR.displayName, creatorIsHouse: true }),
+    ]);
+    expect(rendered).toContain('Joshing');
+    expect(rendered).toContain('Editorial'); // the persistent badge
+    expect(rendered).toContain('editorial-badge');
+    // Non-relational: a machine/house question never implies a person.
+    expect(rendered).not.toContain('gave you this');
+    // Invariant H-1 at the render layer: house never falls back to 'A friend'.
+    expect(rendered).not.toContain('A friend');
+  });
+
+  it('does NOT badge a human author who merely happens to be named "Joshing" (no string-match false positive)', () => {
+    const rendered = html([
+      // Same display name, but a real human author (creatorIsHouse is false).
+      questionMessage({ creatorName: 'Joshing', creatorIsHouse: false }),
+    ]);
+    expect(rendered).toContain('Joshing');
+    expect(rendered).toContain('gave you this'); // treated as a person
+    expect(rendered).not.toContain('editorial-badge');
+    expect(rendered).not.toContain('Editorial');
+  });
+
+  it('leaves the existing LLM "Generated" treatment unbadged and non-relational', () => {
+    const rendered = html([
+      questionMessage({ creatorName: 'Generated', creatorIsHouse: false }),
+    ]);
+    expect(rendered).toContain('Generated');
+    expect(rendered).not.toContain('gave you this');
+    expect(rendered).not.toContain('editorial-badge');
+  });
+});

--- a/src/components/play/__tests__/GameplayChat.house.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.house.test.tsx
@@ -44,6 +44,12 @@ describe('GameplayChat house author labeling (D-3 Stage 2)', () => {
     expect(rendered).not.toContain('gave you this');
     // Invariant H-1 at the render layer: house never falls back to 'A friend'.
     expect(rendered).not.toContain('A friend');
+    // Invariant H-3: the house author's name is never a follow/peer-profile
+    // affordance. It renders as plain text — no profile link, no Add-friend CTA.
+    expect(rendered).not.toContain('href="/users/');
+    expect(rendered).not.toMatch(/<a[^>]*>Joshing<\/a>/);
+    expect(rendered).not.toContain('Add friend');
+    expect(rendered).not.toContain('Follow');
   });
 
   it('does NOT badge a human author who merely happens to be named "Joshing" (no string-match false positive)', () => {

--- a/src/components/play/__tests__/GameplayChat.house.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.house.test.tsx
@@ -66,3 +66,36 @@ describe('GameplayChat house author labeling (D-3 Stage 2)', () => {
     expect(rendered).not.toContain('editorial-badge');
   });
 });
+
+function houseResultWithNote(): ChatMessage {
+  return {
+    id: 'r1',
+    kind: 'result',
+    assignmentId: 'a1',
+    questionText: 'Who produced Low (1977)?',
+    result: 'correct',
+    submitted: 'Visconti',
+    correctAnswer: null,
+    consolation: null,
+    breadcrumb: null,
+    copyVariant: 0,
+    creatorName: HOUSE_AUTHOR.displayName,
+    creatorIsHouse: true,
+    authorNote: 'A favorite from the archives.',
+  };
+}
+
+describe('GameplayChat house commentary (D-3 Stage 5)', () => {
+  it('renders a house creator-note in editorial voice with the badge, never relational framing', () => {
+    const rendered = html([houseResultWithNote()]);
+    expect(rendered).toContain('A favorite from the archives.');
+    // Editorial treatment, not "Why {name} asked".
+    expect(rendered).toContain('Editor');
+    expect(rendered).toContain('editorial-badge');
+    expect(rendered).not.toContain('Why Joshing asked');
+    // No relational copy anywhere on a house result.
+    expect(rendered).not.toContain('gave you this');
+    expect(rendered).not.toContain('carries this one');
+    expect(rendered).not.toContain('From Joshing');
+  });
+});

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -26,8 +26,10 @@ export type CatchupQueueItem = {
   expiresAt: string;
   expiresSoon?: boolean;
   difficultyEstimate?: 'accessible' | 'moderate' | 'specialist' | null;
-  /** Human author's name, or null for LLM-origin questions (rendered non-relationally). */
+  /** Human author's name, the house name ('Joshing'), or null for LLM-origin questions (rendered non-relationally). */
   authorName?: string | null;
+  /** D-3: the author is the non-human house/editorial author (renders the Editorial badge, no relational copy). */
+  authorIsHouse?: boolean;
 };
 
 type CatchupAnswerResponse = {
@@ -106,6 +108,7 @@ function questionMessage(item: CatchupQueueItem): ChatMessage {
     assignmentId: item.dailyQueueItemId,
     questionText: item.questionText,
     creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
+    creatorIsHouse: item.authorIsHouse ?? false,
     subhead: formatQuestionSubhead(item),
     badges,
   };
@@ -202,6 +205,7 @@ export function useCatchupFlow() {
         breadcrumb: null,
         copyVariant: item.queueAge,
         creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
+        creatorIsHouse: item.authorIsHouse ?? false,
         canonicalSubcategory: item.domain,
       },
     ]);
@@ -287,6 +291,7 @@ export function useCatchupFlow() {
           explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
           copyVariant: item.queueAge,
           creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
+          creatorIsHouse: item.authorIsHouse ?? false,
           canonicalSubcategory: item.domain,
           pointsAwarded,
           pointsLabel: 'Catch-up - 0.25x points',

--- a/src/lib/__tests__/questions-types.test.ts
+++ b/src/lib/__tests__/questions-types.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  HOUSE_AUTHOR,
+  LLM_QUESTION_ATTRIBUTION,
+  QUESTION_SOURCES,
+  isHouseAttribution,
+  parseQuestionSource,
+  resolveQuestionAuthor,
+} from '@/lib/questions-types';
+
+describe('parseQuestionSource', () => {
+  it('accepts every QuestionSource value', () => {
+    for (const source of QUESTION_SOURCES) {
+      expect(parseQuestionSource(source)).toBe(source);
+    }
+    expect(QUESTION_SOURCES).toContain('house_authored');
+  });
+
+  it('throws on an unknown stored value rather than misrouting it', () => {
+    expect(() => parseQuestionSource('synthetic_peer')).toThrow();
+    expect(() => parseQuestionSource('')).toThrow();
+  });
+});
+
+describe('resolveQuestionAuthor', () => {
+  const user = { id: 'user-1', displayName: 'Ada' };
+
+  it('resolves a human author when creatorId is set, regardless of source', () => {
+    const resolved = resolveQuestionAuthor({ creatorId: 'user-1', source: 'authored', user });
+    expect(resolved).toEqual({ kind: 'human', user });
+  });
+
+  it('resolves the house identity for (null, house_authored)', () => {
+    const resolved = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user });
+    expect(resolved).toEqual({ kind: 'house', displayName: 'Joshing', label: 'Editorial' });
+  });
+
+  it('resolves the non-person Generated treatment for null-creator LLM origins', () => {
+    for (const source of ['daily_generated', 'curated_sent'] as const) {
+      expect(resolveQuestionAuthor({ creatorId: null, source, user })).toEqual({
+        kind: 'generated',
+        name: LLM_QUESTION_ATTRIBUTION,
+      });
+    }
+  });
+
+  // Invariant H-1: a house question must never resolve to the 'A friend' fallback
+  // or to a users row. The resolver makes this true by construction.
+  it('Invariant H-1: a house question never resolves to a users row or "A friend"', () => {
+    const resolved = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user });
+    expect(resolved.kind).toBe('house');
+    expect(JSON.stringify(resolved)).not.toContain('A friend');
+    expect('user' in resolved).toBe(false);
+    if (resolved.kind === 'house') {
+      expect(resolved.displayName).toBe(HOUSE_AUTHOR.displayName);
+      expect(resolved.label).toBe(HOUSE_AUTHOR.label);
+    }
+  });
+
+  it('never resolves a house question to the LLM Generated label', () => {
+    const resolved = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user });
+    expect(resolved.kind).not.toBe('generated');
+  });
+});
+
+describe('isHouseAttribution', () => {
+  it('matches the house display name and nothing else', () => {
+    expect(isHouseAttribution(HOUSE_AUTHOR.displayName)).toBe(true);
+    expect(isHouseAttribution('  Joshing  ')).toBe(true);
+    expect(isHouseAttribution(LLM_QUESTION_ATTRIBUTION)).toBe(false);
+    expect(isHouseAttribution('Ada')).toBe(false);
+    expect(isHouseAttribution(null)).toBe(false);
+  });
+
+  it('keeps the house identity distinct from a users.id (sentinel, never an FK)', () => {
+    expect(HOUSE_AUTHOR.id).toBe('house');
+    expect(HOUSE_AUTHOR.kind).toBe('house');
+  });
+});

--- a/src/lib/__tests__/questions-types.test.ts
+++ b/src/lib/__tests__/questions-types.test.ts
@@ -6,6 +6,7 @@ import {
   QUESTION_SOURCES,
   isHouseAttribution,
   parseQuestionSource,
+  resolveAuthorDisplay,
   resolveQuestionAuthor,
 } from '@/lib/questions-types';
 
@@ -61,6 +62,38 @@ describe('resolveQuestionAuthor', () => {
   it('never resolves a house question to the LLM Generated label', () => {
     const resolved = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user });
     expect(resolved.kind).not.toBe('generated');
+  });
+});
+
+describe('resolveAuthorDisplay (view-builder shape)', () => {
+  it('returns the human display name and isHouse=false when a creatorId is set', () => {
+    expect(resolveAuthorDisplay('user-1', 'authored', 'Ada')).toEqual({
+      authorName: 'Ada',
+      authorIsHouse: false,
+    });
+  });
+
+  it('returns the house name and isHouse=true for a house question', () => {
+    expect(resolveAuthorDisplay(null, 'house_authored', null)).toEqual({
+      authorName: HOUSE_AUTHOR.displayName,
+      authorIsHouse: true,
+    });
+  });
+
+  it('returns a null name (client renders Generated) and isHouse=false for LLM origins', () => {
+    for (const source of ['daily_generated', 'curated_sent'] as const) {
+      expect(resolveAuthorDisplay(null, source, null)).toEqual({
+        authorName: null,
+        authorIsHouse: false,
+      });
+    }
+  });
+
+  it('never marks a real human named "Joshing" as house', () => {
+    expect(resolveAuthorDisplay('user-9', 'authored', HOUSE_AUTHOR.displayName)).toEqual({
+      authorName: 'Joshing',
+      authorIsHouse: false,
+    });
   });
 });
 

--- a/src/lib/assert-never.ts
+++ b/src/lib/assert-never.ts
@@ -1,0 +1,8 @@
+// Exhaustiveness guard. Call in the `default` branch of a switch (or the final
+// `else`) over a finite union: TypeScript only allows the call when every member
+// has already been handled, so adding a new union member becomes a compile error
+// until every consumer handles it. At runtime it throws, so an unexpected value
+// fails loudly instead of silently falling through.
+export function assertNever(value: never, context = 'value'): never {
+  throw new Error(`Unhandled ${context}: ${JSON.stringify(value)}`);
+}

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -119,6 +119,34 @@ export function resolveQuestionAuthor<U>(input: {
   }
 }
 
+// Server-side convenience for the many view-builders that carry an
+// `authorName: string | null` field to the client. Collapses the resolver into
+// the display name plus an explicit `authorIsHouse` flag, so a house question
+// yields the house name AND a robust signal the client can badge on (Invariant
+// H-2) WITHOUT the client string-matching the name (a human named "Joshing"
+// must not be mistaken for the house author). Shaped for spreading straight
+// into a view object: `{ ...resolveAuthorDisplay(creatorId, source, name) }`.
+//   - human author      → { authorName: displayName, authorIsHouse: false }
+//   - house             → { authorName: 'Joshing',   authorIsHouse: true  }
+//   - LLM-origin / null  → { authorName: null,        authorIsHouse: false } (client renders 'Generated')
+export function resolveAuthorDisplay(
+  creatorId: string | null,
+  source: QuestionSource,
+  displayName: string | null,
+): { authorName: string | null; authorIsHouse: boolean } {
+  const resolved = resolveQuestionAuthor({ creatorId, source, user: displayName });
+  switch (resolved.kind) {
+    case 'human':
+      return { authorName: resolved.user, authorIsHouse: false };
+    case 'house':
+      return { authorName: resolved.displayName, authorIsHouse: true };
+    case 'generated':
+      return { authorName: null, authorIsHouse: false };
+    default:
+      return assertNever(resolved, 'ResolvedQuestionAuthor');
+  }
+}
+
 // True when an attribution name is the LLM/non-person label, used to gate
 // person-style copy (e.g. "{name} gave you this") so it never fires for machine
 // questions. Keeps consumers decoupled from the literal value above.

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -1,3 +1,5 @@
+import { assertNever } from '@/lib/assert-never';
+
 /** Question shape returned by /api/questions (matches Prisma Question) */
 export type QuestionRecord = {
   id: string;
@@ -27,12 +29,95 @@ export type QuestionRecord = {
   contribution_state?: 'addable' | 'already_added' | 'locked_permission' | 'locked_game_state';
 };
 
+// The provenance of a canonical Question, stored as free text() in
+// schema.ts (NOT a pgEnum), so widening this union is a type-only change with no
+// DB migration. The (source, creatorId) pair is the single provenance
+// discriminator across the app:
+//   - 'authored'        — a human wrote it (creatorId set)
+//   - 'daily_generated' — LLM batch generation (creatorId null)
+//   - 'curated_sent'    — a forwarded LLM question (creatorId null; B-2)
+//   - 'house_authored'  — the labeled non-human house/editorial author (creatorId
+//                         null; D-3). NOT LLM-origin — curated/editorial.
+export const QUESTION_SOURCES = ['authored', 'daily_generated', 'curated_sent', 'house_authored'] as const;
+export type QuestionSource = (typeof QUESTION_SOURCES)[number];
+
+// Validate a raw DB string into the QuestionSource union at a trust boundary.
+// Use this instead of an unchecked `as QuestionSource` cast so an unexpected
+// stored value fails loudly rather than silently misrouting (e.g. a house
+// question rendering as a person).
+export function parseQuestionSource(value: string): QuestionSource {
+  if ((QUESTION_SOURCES as readonly string[]).includes(value)) {
+    return value as QuestionSource;
+  }
+  throw new Error(`Unknown Question.source: ${JSON.stringify(value)}`);
+}
+
 // Non-person, non-house attribution for LLM-origin questions
 // (source 'daily_generated' | 'curated_sent'; creatorId === null). A machine
 // question must never render a human name or imply a person wrote it.
 // PLACEHOLDER COPY — flagged for product sign-off. Must NOT be "Joshing"/"Editorial"
-// (those are the house identity, owned by D-3); this is for the non-house LLM origins.
+// (those are the house identity below); this is for the non-house LLM origins.
 export const LLM_QUESTION_ATTRIBUTION = 'Generated' as const;
+
+// D-3 — the single, fixed house/editorial author identity. House questions carry
+// creatorId === null + source 'house_authored'; this identity is resolved at
+// RENDER from this constant, never from a users row. `id` is a sentinel string
+// and must never be used as a users.id foreign key (Invariant H-1: house is
+// unfollowable / unmatchable / mastery-ineligible by construction).
+// displayName/label are PLACEHOLDER COPY pending product sign-off.
+export const HOUSE_AUTHOR = {
+  id: 'house',
+  displayName: 'Joshing',
+  label: 'Editorial',
+  kind: 'house',
+} as const;
+
+// True when an attribution name is the house label, mirroring isLlmAttribution.
+// Lets Stage 2 consumers gate house-specific rendering without coupling to the
+// literal display name.
+export function isHouseAttribution(name: string | null | undefined): boolean {
+  return name?.trim() === HOUSE_AUTHOR.displayName;
+}
+
+// Render-layer resolver for a question's display author from its provenance.
+// This is the ONLY place the (creatorId, source) → author decision is made for
+// house/LLM/human routing; Stage 2 wires every attribution surface through it.
+//
+//   - creatorId set                      → human author (hydrate the users row)
+//   - (null, 'house_authored')           → the house identity constant
+//   - (null, 'daily_generated' | 'curated_sent') → the non-person 'Generated'
+//                                          treatment (B-5)
+//
+// The switch ends in assertNever, so a future source value cannot compile until
+// it is routed here deliberately. No branch can resolve a house question to a
+// users row or the 'A friend' fallback (Invariant H-1).
+export type ResolvedQuestionAuthor<U> =
+  | { kind: 'human'; user: U }
+  | { kind: 'house'; displayName: string; label: string }
+  | { kind: 'generated'; name: string };
+
+export function resolveQuestionAuthor<U>(input: {
+  creatorId: string | null;
+  source: QuestionSource;
+  user: U;
+}): ResolvedQuestionAuthor<U> {
+  if (input.creatorId !== null) {
+    return { kind: 'human', user: input.user };
+  }
+  switch (input.source) {
+    case 'house_authored':
+      return { kind: 'house', displayName: HOUSE_AUTHOR.displayName, label: HOUSE_AUTHOR.label };
+    case 'daily_generated':
+    case 'curated_sent':
+      return { kind: 'generated', name: LLM_QUESTION_ATTRIBUTION };
+    case 'authored':
+      // A null-creator 'authored' question is an inconsistent provenance pair;
+      // treat it as non-person rather than inventing a human, and never as house.
+      return { kind: 'generated', name: LLM_QUESTION_ATTRIBUTION };
+    default:
+      return assertNever(input.source, 'Question.source');
+  }
+}
 
 // True when an attribution name is the LLM/non-person label, used to gate
 // person-style copy (e.g. "{name} gave you this") so it never fires for machine

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -65,6 +65,10 @@ export const LLM_QUESTION_ATTRIBUTION = 'Generated' as const;
 // and must never be used as a users.id foreign key (Invariant H-1: house is
 // unfollowable / unmatchable / mastery-ineligible by construction).
 // displayName/label are PLACEHOLDER COPY pending product sign-off.
+//
+// House commentary (creator-notes/asides) must be editorial/curator voice and is
+// NEVER relational — see docs/house-editorial-copy-checklist.md (D-3 §E). The
+// render layer strips relational chrome; the note text is a review-gate concern.
 export const HOUSE_AUTHOR = {
   id: 'house',
   displayName: 'Joshing',

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -4,10 +4,12 @@ import {
   createDailyQueueItem,
   createDailyQueueItemFromAnswerer,
   createDailyQueueItemFromAuthored,
+  createDailyQueueItemFromHouse,
   getKnowledgeBase,
   getTodaysDailyQueue,
   pickBonusAnswererSlots,
   pickEligibleAuthoredQuestions,
+  pickHouseQuestions,
 } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getFollowing, getFriendAndFoFUserIds } from '@/server/db/queries/friends';
@@ -115,7 +117,17 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     allowedSubcategories,
   );
 
-  const remaining = DAILY_QUEUE_SIZE - authored.length;
+  // D-3: seed curated house/editorial questions into the core for the niches
+  // friend content didn't cover, before falling back to LLM generation. Matched
+  // by domain (the viewer's knowledge base), never the +2 friend-answer ranking.
+  // House content does not enter the Feed and never occupies a +2 bonus slot.
+  const housePicks = await pickHouseQuestions(
+    userId,
+    DAILY_QUEUE_SIZE - authored.length,
+    allowedSubcategories,
+  );
+
+  const remaining = DAILY_QUEUE_SIZE - authored.length - housePicks.length;
   const generated = remaining > 0
     ? await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(remaining))
     : [];
@@ -128,6 +140,9 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   const seenTexts = new Set<string>();
   const normalize = (text: string) => text.trim().toLowerCase();
   for (const pick of authored) {
+    seenTexts.add(normalize(pick.questionText));
+  }
+  for (const pick of housePicks) {
     seenTexts.add(normalize(pick.questionText));
   }
   const dedupedGenerated: typeof generated = [];
@@ -168,7 +183,7 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   // remaining time budget so the recovery can't push the request past the
   // route's maxDuration.
   const topUpGenerated: typeof dedupedGenerated = [];
-  const shortfall = DAILY_QUEUE_SIZE - (authored.length + dedupedGenerated.length);
+  const shortfall = DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length);
   if (shortfall > 0 && Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS) {
     const extra = await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(shortfall));
     for (const question of extra) {
@@ -191,7 +206,7 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
 
   const generatedForQueue = [...dedupedGenerated, ...topUpGenerated];
-  const achieved = authored.length + generatedForQueue.length;
+  const achieved = authored.length + housePicks.length + generatedForQueue.length;
 
   // Graceful degrade: persist whatever we have instead of failing on a short
   // queue. Some niche domains have very low generation yield — the
@@ -245,6 +260,11 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   const coreQuestionIds = new Set<string>();
   for (const pick of authored) {
     await createDailyQueueItemFromAuthored(userId, pick, position);
+    coreQuestionIds.add(pick.id);
+    position += 1;
+  }
+  for (const pick of housePicks.slice(0, DAILY_QUEUE_SIZE - position)) {
+    await createDailyQueueItemFromHouse(userId, pick, position);
     coreQuestionIds.add(pick.id);
     position += 1;
   }

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -13,7 +13,12 @@ import type { DifficultyEstimate } from '@/types/db';
 
 type DailyDifficultyEstimate = DifficultyEstimate | 'accessible' | 'moderate' | 'specialist';
 
-export const queueSlotSourceSchema = z.enum(['friend', 'bot', 'community']);
+// 'house' (D-3) — a labeled non-human house/editorial question seeded into the
+// Daily core to ease content scarcity in sparse niches. Carries a canonical
+// question_id (source='house_authored', creatorId null) and author_name='Joshing'
+// with no author_id (the house identity is never a users.id). 'community' is a
+// legacy enum value, never produced by any picker.
+export const queueSlotSourceSchema = z.enum(['friend', 'bot', 'community', 'house']);
 export const queueSlotAnswerStateSchema = z.enum(['correct', 'incorrect']);
 
 export const queueSlotSchema = z.object({

--- a/src/server/db/queries/__tests__/house-picks.test.ts
+++ b/src/server/db/queries/__tests__/house-picks.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildHouseSlot,
+  selectHousePicks,
+  type HouseCandidateRow,
+  type HousePick,
+} from '@/server/db/queries/daily';
+import { isCorrectAnswerFeedEligible } from '@/server/feed/visibility';
+import { HOUSE_AUTHOR } from '@/lib/questions-types';
+
+let seq = 0;
+function candidate(over: Partial<HouseCandidateRow> = {}): HouseCandidateRow {
+  seq += 1;
+  return {
+    id: `house-${seq}`,
+    questionText: `House question ${seq}`,
+    answerText: `Answer ${seq}`,
+    alternateAnswers: [],
+    factualExplanation: null,
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    category: 'music',
+    difficultyEstimate: 'moderate',
+    creatorNote: null,
+    createdAt: new Date(2026, 0, seq + 1),
+    ...over,
+  };
+}
+
+describe('selectHousePicks (domain-matched, deduped — not +2 relevance ranking)', () => {
+  it('drops questions the viewer has already seen', () => {
+    const rows = [candidate({ id: 'seen-1' }), candidate({ id: 'fresh-1' })];
+    const picks = selectHousePicks(rows, new Set(['seen-1']), 5);
+    expect(picks.map((p) => p.id)).toEqual(['fresh-1']);
+  });
+
+  it('drops generic bucket domains', () => {
+    const rows = [
+      candidate({ id: 'generic', canonicalSubcategory: 'general' }),
+      candidate({ id: 'specific', canonicalSubcategory: 'Bowie-era Glam Rock' }),
+    ];
+    const picks = selectHousePicks(rows, new Set(), 5);
+    expect(picks.map((p) => p.id)).toEqual(['specific']);
+  });
+
+  it('prefers newest curated content and caps at the limit', () => {
+    const older = candidate({ id: 'older', createdAt: new Date(2026, 0, 1) });
+    const newer = candidate({ id: 'newer', createdAt: new Date(2026, 5, 1) });
+    const picks = selectHousePicks([older, newer], new Set(), 1);
+    expect(picks.map((p) => p.id)).toEqual(['newer']);
+  });
+
+  it('returns nothing when the limit is zero or negative', () => {
+    expect(selectHousePicks([candidate()], new Set(), 0)).toEqual([]);
+  });
+});
+
+describe('buildHouseSlot (Daily core slot, never a +2 bonus, never a users row)', () => {
+  const pick: HousePick = {
+    id: 'house-q-1',
+    questionText: 'Who produced Low (1977)?',
+    answerText: 'Tony Visconti & David Bowie',
+    alternateAnswers: [],
+    factualExplanation: null,
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    category: 'music',
+    difficultyEstimate: 'specialist',
+    authorNote: null,
+  };
+
+  it('labels the slot as house with the Joshing name and a canonical question id', () => {
+    const slot = buildHouseSlot(pick, 2);
+    expect(slot.source).toBe('house');
+    expect(slot.question_id).toBe('house-q-1');
+    expect(slot.author_name).toBe(HOUSE_AUTHOR.displayName);
+    expect(slot.difficulty_estimate).toBe('specialist');
+    expect(slot.slot_index).toBe(2);
+  });
+
+  it('never carries a users.id author_id (Invariant H-1)', () => {
+    const slot = buildHouseSlot(pick, 0);
+    expect(slot.author_id).toBeUndefined();
+  });
+
+  it('never carries answerer_* fields, so it can never be mistaken for a +2 bonus slot', () => {
+    const slot = buildHouseSlot(pick, 0);
+    expect(slot.answerer_id).toBeUndefined();
+    expect(slot.answerer_name).toBeUndefined();
+  });
+});
+
+describe('house questions never enter the Feed (documented isLlmOriginQuestion branch)', () => {
+  it('is not feed-eligible on a correct answer (null creatorId, non-LLM origin)', () => {
+    // This is the upstream gate in create-feed-items-for-answer.ts that runs
+    // before BOTH the friend fan-out and the +2 bonus source (friend_answered
+    // feed items). House being feed-ineligible is therefore what keeps it out of
+    // the Feed AND out of every +2 bonus slot.
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'viewer-1',
+      question: {
+        creatorId: null,
+        source: 'house_authored',
+        visibility: 'public',
+        deletedAt: null,
+      },
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+  });
+});

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -52,10 +52,12 @@ export type QuestionRecap = {
   domain: string;
   domainDisplayName: string;
   isInBank: boolean;
-  /** Author display name — set for friend-authored questions (B-3 author's why). */
+  /** Author display name — set for friend-authored and house questions. */
   authorName: string | null;
   /** Author's why — commentary attached at creation, surfaced in the recap. */
   authorNote: string | null;
+  /** D-3: the author is the non-human house/editorial author (Editorial badge, non-relational copy). */
+  authorIsHouse: boolean;
 };
 
 export type DomainGain = {
@@ -224,8 +226,9 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
       domain,
       domainDisplayName: displayNameForDomain(domain),
       isInBank: slot.question_id ? Boolean(bankedById[slot.question_id]) : false,
-      authorName: slot.source === 'friend' ? (slot.author_name ?? null) : null,
-      authorNote: slot.source === 'friend' ? (slot.author_note ?? null) : null,
+      authorName: slot.source === 'friend' || slot.source === 'house' ? (slot.author_name ?? null) : null,
+      authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
+      authorIsHouse: slot.source === 'house',
     };
   });
 

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -16,7 +16,7 @@ import {
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
-import { CATEGORIES, categoryLabel, resolveAuthorDisplay } from '@/lib/questions-types';
+import { CATEGORIES, categoryLabel, HOUSE_AUTHOR, resolveAuthorDisplay } from '@/lib/questions-types';
 import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import {
@@ -752,6 +752,26 @@ export type AuthoredPick = {
 };
 
 /**
+ * D-3: a labeled non-human house/editorial question selected for the Daily core.
+ * Mirrors AuthoredPick minus the human-author fields — the house identity is
+ * fixed (resolved from HOUSE_AUTHOR at slot-build time), never a users row, so
+ * there is no creatorId / authorName here. `authorNote` carries an optional
+ * editorial aside (populated in Stage 5).
+ */
+export type HousePick = {
+  id: string;
+  questionText: string;
+  answerText: string;
+  alternateAnswers: string[];
+  factualExplanation: string | null;
+  canonicalSubcategory: string;
+  broadCategory: string | null;
+  category: string;
+  difficultyEstimate: 'accessible' | 'moderate' | 'specialist' | null;
+  authorNote: string | null;
+};
+
+/**
  * Returns up to `limit` vetted user-authored questions for the viewer's
  * Daily 5, ranked by social tier: direct friends first, then friends-of-
  * friends, then everyone else. The orchestrator tops up the remaining
@@ -943,6 +963,195 @@ export async function createDailyQueueItemFromAuthored(
     answered: false,
     difficulty_stepped_up: false,
   };
+
+  return db.transaction(async (tx) => {
+    const [existing] = await tx
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.userId, userId), eq(dailyQueues.queueDate, assignmentDateStr)))
+      .limit(1);
+
+    if (!existing) {
+      const [created] = await tx
+        .insert(dailyQueues)
+        .values({
+          userId,
+          queueDate: assignmentDateStr,
+          slots: [slot],
+        })
+        .returning();
+      return created;
+    }
+
+    const slots = asQueueSlots(existing.slots).filter((item) => item.slot_index !== position);
+    const nextSlots = [...slots, slot].sort((a, b) => a.slot_index - b.slot_index);
+    const [updated] = await tx
+      .update(dailyQueues)
+      .set({ slots: nextSlots })
+      .where(eq(dailyQueues.id, existing.id))
+      .returning();
+    return updated;
+  });
+}
+
+/** Candidate row shape for the pure house selector (subset of canonical columns). */
+export type HouseCandidateRow = {
+  id: string;
+  questionText: string;
+  answerText: string;
+  alternateAnswers: string[] | null;
+  factualExplanation: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  category: string | null;
+  difficultyEstimate: string | null;
+  creatorNote: string | null;
+  createdAt: Date | null;
+};
+
+/**
+ * Pure selection step for house questions (extracted for testing, mirroring
+ * selectBonusAnswererPicks). Drops anything the viewer has already seen and
+ * anything in a generic bucket domain, prefers newest curated content, and caps
+ * at `limit`. Domain matching to the viewer's niches happens in the SQL filter
+ * (allowedSubcategories); this step is the in-memory dedup + ordering, NOT the
+ * +2 friend-answer relevance ranking.
+ */
+export function selectHousePicks(
+  rows: HouseCandidateRow[],
+  seenQuestionIds: ReadonlySet<string>,
+  limit: number,
+): HousePick[] {
+  if (limit <= 0) return [];
+  return rows
+    .filter((row) => !seenQuestionIds.has(row.id))
+    .filter((row) => row.canonicalSubcategory && !isGenericSubcategory(row.canonicalSubcategory))
+    .sort((a, b) => (b.createdAt?.getTime() ?? 0) - (a.createdAt?.getTime() ?? 0))
+    .slice(0, limit)
+    .map((row) => ({
+      id: row.id,
+      questionText: row.questionText,
+      answerText: row.answerText,
+      alternateAnswers: row.alternateAnswers ?? [],
+      factualExplanation: row.factualExplanation,
+      canonicalSubcategory: row.canonicalSubcategory ?? '',
+      broadCategory: row.broadCategory,
+      category: String(row.category ?? ''),
+      difficultyEstimate: asQueueSlotDifficulty(row.difficultyEstimate ?? null) ?? null,
+      authorNote: row.creatorNote ?? null,
+    } satisfies HousePick));
+}
+
+/**
+ * D-3 — selects up to `limit` house/editorial questions (canonical rows with
+ * source='house_authored', creatorId null) matched to the viewer's niches by
+ * domain. This is the bank/domain matching path (NOT the +2 relevance ranking):
+ * candidates are constrained to `allowedSubcategories` (the viewer's knowledge
+ * base) exactly like the bot/bank pool, and deduped against questions the viewer
+ * has already seen on a past daily or answered. House questions never enter the
+ * Feed and never occupy a +2 bonus slot (see createDailyQueueItemFromHouse /
+ * isCorrectAnswerFeedEligible).
+ *
+ * House content is editorially curated, so it is NOT gated on the public-vetting
+ * status the authored picker requires — only visibility='public' and not deleted.
+ */
+export async function pickHouseQuestions(
+  viewerUserId: string,
+  limit: number,
+  allowedSubcategories: ReadonlySet<string>,
+): Promise<HousePick[]> {
+  if (limit <= 0) return [];
+  if (allowedSubcategories.size === 0) return [];
+
+  // House questions never reach the viewer's feed (Invariant — house is not
+  // feed-eligible), so dedup only needs past daily queues + answered questions.
+  const [pastQueues, answeredRows] = await Promise.all([
+    db
+      .select({ slots: dailyQueues.slots })
+      .from(dailyQueues)
+      .where(eq(dailyQueues.userId, viewerUserId)),
+    db
+      .select({ questionId: masteryEvents.questionId })
+      .from(masteryEvents)
+      .where(and(
+        eq(masteryEvents.userId, viewerUserId),
+        inArray(masteryEvents.sourceType, ['live_correct', 'catchup_correct']),
+        isNotNull(masteryEvents.questionId),
+      )),
+  ]);
+  const seenQuestionIds = new Set<string>();
+  for (const row of pastQueues) {
+    for (const slot of asQueueSlots(row.slots)) {
+      if (slot.question_id) seenQuestionIds.add(slot.question_id);
+    }
+  }
+  for (const row of answeredRows) {
+    if (row.questionId) seenQuestionIds.add(row.questionId);
+  }
+
+  const candidates = await db
+    .select({
+      id: canonicalQuestions.id,
+      questionText: canonicalQuestions.questionText,
+      answerText: canonicalQuestions.answerText,
+      alternateAnswers: canonicalQuestions.acceptedAlternatives,
+      factualExplanation: canonicalQuestions.factualExplanation,
+      canonicalSubcategory: canonicalQuestions.canonicalSubcategory,
+      broadCategory: canonicalQuestions.broadCategory,
+      category: canonicalQuestions.category,
+      difficultyEstimate: canonicalQuestions.difficultyEstimate,
+      creatorNote: canonicalQuestions.creatorNote,
+      createdAt: canonicalQuestions.createdAt,
+    })
+    .from(canonicalQuestions)
+    .where(and(
+      eq(canonicalQuestions.source, 'house_authored'),
+      isNull(canonicalQuestions.creatorId),
+      eq(canonicalQuestions.visibility, 'public'),
+      isNotNull(canonicalQuestions.canonicalSubcategory),
+      inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
+      isNull(canonicalQuestions.deletedAt),
+    ))
+    .orderBy(desc(canonicalQuestions.createdAt))
+    .limit(Math.max(limit * 4, 20));
+
+  return selectHousePicks(candidates, seenQuestionIds, limit);
+}
+
+/**
+ * Builds the QueueSlot for a house core slot (pure; extracted for testing).
+ * source='house', a canonical question_id, author_name='Joshing' — and crucially
+ * NO author_id (the house identity is never a users.id; Invariant H-1) and NO
+ * answerer_* fields (so it is unmistakably a core slot, never a +2 bonus slot).
+ */
+export function buildHouseSlot(pick: HousePick, position: number): QueueSlot {
+  return {
+    slot_index: position,
+    source: 'house',
+    question_id: pick.id,
+    author_name: HOUSE_AUTHOR.displayName,
+    author_note: pick.authorNote ?? undefined,
+    domain: pick.canonicalSubcategory,
+    broad_category: pick.broadCategory,
+    category: pick.category || null,
+    question_text: pick.questionText,
+    difficulty_estimate: pick.difficultyEstimate ?? undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+}
+
+/**
+ * Inserts a house/editorial question into the viewer's daily queue as a
+ * `source: 'house'` core slot. Counterpart to createDailyQueueItemFromAuthored.
+ */
+export async function createDailyQueueItemFromHouse(
+  userId: string,
+  pick: HousePick,
+  position: number,
+): Promise<DailyQueueRow> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+  const slot = buildHouseSlot(pick, position);
 
   return db.transaction(async (tx) => {
     const [existing] = await tx

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -16,7 +16,7 @@ import {
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { pgErrorCode } from '@/server/db/pg-error';
-import { CATEGORIES, categoryLabel } from '@/lib/questions-types';
+import { CATEGORIES, categoryLabel, resolveAuthorDisplay } from '@/lib/questions-types';
 import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import {
@@ -93,6 +93,12 @@ export type CatchupQueueItem = {
    * rather than implying a person wrote it.
    */
   authorName: string | null;
+  /**
+   * D-3: the author is the non-human house/editorial author. `authorName` is the
+   * house name ('Joshing') and the client renders the persistent Editorial badge
+   * with no relational copy. Set explicitly (not inferred from the name string).
+   */
+  authorIsHouse: boolean;
 };
 
 export type CatchupQuestion = CatchupQueueItem;
@@ -532,6 +538,7 @@ async function getDailyCatchupItems(
           submittedAnswer: slot.submitted_answer ?? null,
           wasSkipped: Boolean(slot.skipped),
           authorName: null, // daily-generated: LLM origin, no human author
+          authorIsHouse: false,
         } satisfies CatchupQuestion;
       }
 
@@ -570,7 +577,7 @@ async function getDailyCatchupItems(
         difficultyEstimate: difficulty,
         submittedAnswer: slot.submitted_answer ?? null,
         wasSkipped: Boolean(slot.skipped),
-        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
+        ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
       } satisfies CatchupQuestion;
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
@@ -648,7 +655,7 @@ async function getFeedCatchupItems(
         difficultyEstimate: difficulty,
         submittedAnswer: feedItem.submittedAnswer ?? null,
         wasSkipped: false,
-        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
+        ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
       } satisfies CatchupQuestion;
     })
     .filter((item): item is CatchupQuestion => Boolean(item));

--- a/src/server/db/queries/replay.ts
+++ b/src/server/db/queries/replay.ts
@@ -1,6 +1,6 @@
 import { and, desc, eq, inArray } from 'drizzle-orm';
 
-import { categoryLabel } from '@/lib/questions-types';
+import { categoryLabel, resolveAuthorDisplay } from '@/lib/questions-types';
 import { asQueueSlots, dailyQueueItemId } from '@/server/daily/catchup';
 import { dailyQueues, db, generatedQuestions, questions as canonicalQuestions, users } from '@/server/db';
 import type { ReplayItem } from '@/server/replay/session';
@@ -85,6 +85,7 @@ export async function getReplayWrongQuestions(userId: string): Promise<ReplayIte
           domainDisplayName: categoryLabel(domain),
           originalSubmittedAnswer: slot.submitted_answer ?? null,
           authorName: null, // bot slot: LLM origin, no human author
+          authorIsHouse: false,
         } satisfies ReplayItem;
       }
 
@@ -109,7 +110,7 @@ export async function getReplayWrongQuestions(userId: string): Promise<ReplayIte
         domain,
         domainDisplayName: categoryLabel(domain),
         originalSubmittedAnswer: slot.submitted_answer ?? null,
-        authorName: question.creatorId ? authorNameById.get(question.creatorId) ?? null : null,
+        ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
       } satisfies ReplayItem;
     })
     .filter((item): item is ReplayItem => Boolean(item));

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,4 +1,6 @@
 import { sql } from 'drizzle-orm';
+
+import type { QuestionSource } from '@/lib/questions-types';
 import {
   boolean,
   check,
@@ -251,7 +253,7 @@ export const questions = pgTable(
     id: id(),
     creatorId: text('creator_id').references(() => users.id),
     generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id, { onDelete: 'set null' }),
-    source: text('source').$type<'authored' | 'daily_generated' | 'curated_sent'>().notNull().default('authored'),
+    source: text('source').$type<QuestionSource>().notNull().default('authored'),
     sourceQuestionId: text('source_question_id'),
     sourceCreatorId: text('source_creator_id'),
     questionText: text('question_text').notNull(),

--- a/src/server/feed/__tests__/notify-niche-match.test.ts
+++ b/src/server/feed/__tests__/notify-niche-match.test.ts
@@ -114,6 +114,24 @@ describe('notifyNicheMatch — stranger gate', () => {
   });
 });
 
+describe('notifyNicheMatch — D-3 house discovery exclusion (Invariant H-3)', () => {
+  // A house question carries source='house_authored' + creatorId=null, so it
+  // reaches notifyNicheMatch (if at all) with a null creatorId and is dropped by
+  // the same author-gate as the LLM origins — there is no author to discover and
+  // the house author is never a peer. This is held by construction (null
+  // creatorId); the test exists so a future refactor that gives house a real
+  // users.id can't silently turn it into a niche-match discovery target.
+  it('writes NO niche_match_* activity for a correctly-answered house question (null creatorId)', async () => {
+    const HOUSE_CREATOR_ID = null; // house identity is a sentinel, never a users.id
+
+    await notifyNicheMatch(ANSWERER, QUESTION, HOUSE_CREATOR_ID, `daily:house-key:${ANSWERER}`);
+
+    expect(getRelationshipMock).not.toHaveBeenCalled();
+    expect(getNicheMatchDiscoverableMock).not.toHaveBeenCalled();
+    expect(writeActivityMock).not.toHaveBeenCalled();
+  });
+});
+
 describe('notifyNicheMatch — asymmetric two-flag gate (both directions)', () => {
   it('only the answerer opted in: writes ONLY the author-side row (which exposes the answerer)', async () => {
     getNicheMatchDiscoverableMock.mockResolvedValue(new Set([ANSWERER]));

--- a/src/server/feed/__tests__/visibility.test.ts
+++ b/src/server/feed/__tests__/visibility.test.ts
@@ -83,6 +83,24 @@ describe('correct-answer social feed eligibility', () => {
     expect(isLlmOriginQuestion('authored')).toBe(false);
   });
 
+  it('does NOT classify house_authored as LLM-origin (D-3 §C: house is curated, not LLM, and never enters the feed)', () => {
+    expect(isLlmOriginQuestion('house_authored')).toBe(false);
+  });
+
+  it('rejects a correct answer to a house question from the feed (null creatorId, non-LLM origin)', () => {
+    expect(isCorrectAnswerFeedEligible({
+      answerIsCorrect: true,
+      answererUserId: 'answerer-1',
+      question: {
+        creatorId: null,
+        source: 'house_authored' as const,
+        visibility: 'public' as const,
+        deletedAt: null,
+      },
+      hasVisibleSocialContext: true,
+    })).toBe(false);
+  });
+
   it('rejects a correct answer by the author', () => {
     expect(isCorrectAnswerFeedEligible({
       answerIsCorrect: true,

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -1,5 +1,7 @@
 import { eq, or } from 'drizzle-orm';
 
+import { assertNever } from '@/lib/assert-never';
+import type { QuestionSource } from '@/lib/questions-types';
 import type { feedItems, questions } from '@/server/db';
 
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
@@ -47,8 +49,23 @@ export type FeedEventEligibilityInput = {
 // curated sends ('curated_sent', written by /api/questions/send) carry a null
 // creatorId, so feed eligibility for their correct answers can't be keyed on
 // authorship — they are always eligible (subject to the checks above).
-export function isLlmOriginQuestion(source: string): boolean {
-  return source === 'daily_generated' || source === 'curated_sent';
+//
+// Exhaustive over QuestionSource so a new source value (e.g. D-3's
+// 'house_authored') cannot compile until its feed-origin status is decided here.
+// 'house_authored' is deliberately NOT LLM-origin (it is curated/editorial, and
+// per D-3 §C house content never enters the Feed) — it returns false, and
+// isCorrectAnswerFeedEligible then rejects it via the null-creatorId guard.
+export function isLlmOriginQuestion(source: QuestionSource): boolean {
+  switch (source) {
+    case 'daily_generated':
+    case 'curated_sent':
+      return true;
+    case 'authored':
+    case 'house_authored':
+      return false;
+    default:
+      return assertNever(source, 'Question.source');
+  }
 }
 
 export function isCorrectAnswerFeedEligible(input: FeedEventEligibilityInput): boolean {

--- a/src/server/mastery/__tests__/author-credit-house.test.ts
+++ b/src/server/mastery/__tests__/author-credit-house.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAuthorCreditEligible } from '@/server/mastery/author-credit';
+import { resolveQuestionAuthor } from '@/lib/questions-types';
+
+// D-3 Stage 4 — provenance + mastery invariants.
+//
+// House authorship accrues NO mastery. isAuthorCreditEligible is the single gate
+// the daily and catch-up answer routes pass through before writing an
+// `author_credit` mastery event (and before promoteDeclaredToDemonstrated). A
+// house question carries creatorId=null, so it can never pass the gate — which
+// is exactly why a correctly-answered house question:
+//   - writes no author_credit / curator mastery event, AND
+//   - never appears in the "written by me" archive (keyed on creatorId = me), AND
+//   - contributes no knowledge "recently expanding" saved-questions signal
+//     (keyed on author_credit events).
+// All three derive from this one gate, so this is the load-bearing regression.
+//
+// The curator-credit path (addToBank in db/queries/bank.ts) is a SEPARATE writer
+// but is gated identically — `question.creatorId && creatorId !== userId` — so a
+// null-creator house question accrues no curator_credit either. Both gates fail
+// on the same `creatorId === null` construction; this suite asserts the shared
+// answer-route gate and the provenance coherence it relies on.
+
+describe('isAuthorCreditEligible — house questions accrue zero author/curator mastery', () => {
+  const answerer = 'answerer-1';
+
+  it('denies credit for a correctly-answered house question (creatorId is null)', () => {
+    expect(isAuthorCreditEligible({
+      isCorrect: true,
+      creatorId: null, // house_authored questions are creatorId=null by construction
+      answererUserId: answerer,
+      domain: 'Bowie-era Glam Rock',
+    })).toBe(false);
+  });
+
+  it('also denies credit for the LLM origins (same null-creator construction)', () => {
+    expect(isAuthorCreditEligible({
+      isCorrect: true,
+      creatorId: null,
+      answererUserId: answerer,
+      domain: 'Bowie-era Glam Rock',
+    })).toBe(false);
+  });
+
+  it('still grants credit to a real human author who is not the answerer', () => {
+    expect(isAuthorCreditEligible({
+      isCorrect: true,
+      creatorId: 'human-author-9',
+      answererUserId: answerer,
+      domain: 'Bowie-era Glam Rock',
+    })).toBe(true);
+  });
+
+  it('denies credit for wrong answers, self-answers, and missing domains', () => {
+    const base = { creatorId: 'human-author-9', answererUserId: answerer, domain: 'music' };
+    expect(isAuthorCreditEligible({ ...base, isCorrect: false })).toBe(false);
+    expect(isAuthorCreditEligible({ ...base, isCorrect: true, answererUserId: 'human-author-9' })).toBe(false);
+    expect(isAuthorCreditEligible({ ...base, isCorrect: true, domain: null })).toBe(false);
+    expect(isAuthorCreditEligible({ ...base, isCorrect: true, domain: '' })).toBe(false);
+  });
+});
+
+describe('house provenance is coherent: (source=house_authored, creatorId=null) never resolves to a creditable human', () => {
+  it('resolves to the house identity, not a human author', () => {
+    const resolved = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user: { id: 'x' } });
+    expect(resolved.kind).toBe('house');
+    // A 'house' result has no `user` — there is no users row to credit.
+    expect('user' in resolved).toBe(false);
+  });
+});

--- a/src/server/mastery/author-credit.ts
+++ b/src/server/mastery/author-credit.ts
@@ -27,6 +27,39 @@ export async function countAuthorCreditEvents(questionId: string, authorId: stri
   return row?.value ?? 0;
 }
 
+export type AuthorCreditContext = {
+  isCorrect: boolean;
+  creatorId: string | null;
+  answererUserId: string;
+  domain: string | null;
+};
+
+/**
+ * The single gate for author/curator mastery accrual on a correct answer.
+ * Author credit is awarded ONLY to a real human creator who is not the answerer.
+ *
+ * This is what keeps every non-human origin mastery-ineligible by construction:
+ * D-3 house questions (creatorId null, source 'house_authored') and the LLM
+ * origins (daily_generated / curated_sent, also creatorId null) all fail the
+ * `creatorId !== null` check, so no `author_credit` mastery event is ever
+ * written for them. Because the "written by me" archive (keyed on
+ * `creatorId = me`) and the knowledge "recently expanding" saved-questions
+ * signal (keyed on `author_credit` events) both derive from that, a house
+ * question also produces no "written by me" entry and no knowledge-domain author
+ * signal — there is no author to credit. (Invariant: D-3 §D / Verified fact #10.)
+ */
+export function isAuthorCreditEligible(
+  ctx: AuthorCreditContext,
+): ctx is AuthorCreditContext & { creatorId: string; domain: string } {
+  return (
+    ctx.isCorrect
+    && ctx.creatorId !== null
+    && ctx.creatorId !== ctx.answererUserId
+    && ctx.domain !== null
+    && ctx.domain !== ''
+  );
+}
+
 type QuestionStats = {
   correctCount: number;
   askedCount: number;

--- a/src/server/replay/session.ts
+++ b/src/server/replay/session.ts
@@ -9,8 +9,10 @@ export type ReplayItem = {
   domain: string;
   domainDisplayName: string;
   originalSubmittedAnswer: string | null;
-  /** Human author's name, or null for LLM-origin (bot) slots. */
+  /** Human author's name, the house name ('Joshing'), or null for LLM-origin (bot) slots. */
   authorName: string | null;
+  /** D-3: the author is the non-human house/editorial author (Editorial badge, no relational copy). */
+  authorIsHouse: boolean;
 };
 
 export function selectReplaySession<T extends ReplayItem>(


### PR DESCRIPTION
## Summary

Implements D-3 (house/editorial author feature) for the Daily queue system. Introduces a non-human, fixed "house" author identity (`Joshing` / `Editorial`) for curated editorial questions that are selected by domain matching (not social ranking) and never enter the Feed or occupy bonus slots.

## Key Changes

**Core Types & Constants**
- Added `HOUSE_AUTHOR` constant in `src/lib/questions-types.ts` with sentinel `id: 'house'` (Invariant H-1: never a users.id foreign key)
- Added `QuestionSource` union including `'house_authored'` with validation via `parseQuestionSource()`
- Added `resolveQuestionAuthor()` and `resolveAuthorDisplay()` to route (creatorId, source) pairs to the correct author kind (human/house/generated)
- Added `isHouseAttribution()` to distinguish house identity from a human who happens to be named "Joshing"

**Daily Queue Selection & Building**
- Added `pickHouseQuestions()` to select up to N house questions matched to viewer's knowledge base (allowedSubcategories), deduped against past daily queues and answered questions
- Added `selectHousePicks()` (pure, testable) to filter/sort/limit candidates by recency, dropping generic domains and seen questions
- Added `buildHouseSlot()` to construct a `QueueSlot` with `source: 'house'`, `author_name: 'Joshing'`, and no `author_id` or `answerer_*` fields (core slot, never +2 bonus)
- Added `createDailyQueueItemFromHouse()` to persist house slots into the daily queue
- Integrated house selection into `fillDailyQueueForUser()` after friend-authored picks, before LLM fallback

**Mastery & Feed Gating**
- Added `isAuthorCreditEligible()` type guard to gate author/curator mastery accrual; house questions (creatorId=null) fail the gate and accrue zero mastery (Invariant D-3 §D)
- Updated `isCorrectAnswerFeedEligible()` to reject house questions from the Feed (non-LLM origin, never feed-eligible)
- Updated `isLlmOriginQuestion()` to exhaustively handle all `QuestionSource` values, preventing silent misrouting if a new source is added

**Render Layer**
- Added `EditorialBadge` component to render the persistent "Editorial" label wherever the house name appears
- Updated `GameplayChat` to accept `creatorIsHouse` flag on question and result messages; renders badge and suppresses relational copy ("gave you this", "{name} carries this one") for house questions
- Updated `wrongNamedSubLabel()` to treat house questions as non-relational (like LLM origins)

**Data Flow Updates**
- Updated `CatchupQueueItem` type to include `authorIsHouse: boolean` field
- Updated `getDailyCatchupItems()` and `getFeedCatchupItems()` to use `resolveAuthorDisplay()` for author resolution
- Updated daily answer routes (`/api/daily/answer`, `/api/daily/catchup/answer`) to use `isAuthorCreditEligible()` before awarding author credit
- Updated daily summary and replay pages to wire `authorIsHouse` through to chat messages

**Tests & Documentation**
- Added comprehensive test suites:
  - `src/lib/__tests__/questions-types.test.ts` — source parsing, author resolution, invariants
  - `src/server/db/queries/__tests__/house-picks.test.ts` — selection logic, slot building, feed ineligibility
  - `src/components/play/__tests__/GameplayChat.house.test.tsx` — badge rendering, relational copy suppression
  - `src/server/mastery/__tests__/author-credit-house.test.ts` — mastery gating, provenance coherence
  - `src/components/__tests__/EditorialBadge.test.tsx` — badge component
  - Updated `src/server/feed/__tests

https://claude.ai/code/session_011GPegczkR4GtR6r1dDL9cK