### PR TITLE
Add live LLM grading evaluation tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "next build",
     "start": "next start",
     "test": "vitest run",
+    "test:evals": "RUN_LLM_EVALS=1 vitest run src/lib/llm.grading.eval.test.ts",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
     "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",

--- a/src/lib/llm.grading.eval.test.ts
+++ b/src/lib/llm.grading.eval.test.ts
@@ -1,0 +1,46 @@
+// Live grading evals — these call the REAL Haiku grader, not a mock.
+//
+// Unlike llm.grading.test.ts (which mocks @anthropic-ai/sdk and can only verify
+// wiring), these tests exercise the model's actual judgment so a real grading
+// regression on a known case will fail the suite.
+//
+// They are OPT-IN: they hit the Anthropic API, cost tokens, and are
+// non-deterministic, so they must never run in normal `npm test` / CI. Run them
+// explicitly with:
+//
+//   RUN_LLM_EVALS=1 ANTHROPIC_API_KEY=sk-... npx vitest run src/lib/llm.grading.eval.test.ts
+//
+// (or `npm run test:evals`). Without RUN_LLM_EVALS=1 and a valid key, the whole
+// describe block is skipped.
+
+import { describe, expect, it } from 'vitest'
+import { gradeAnswerWithLLM, getAnthropicClient } from '@/lib/llm'
+
+const evalsEnabled = process.env.RUN_LLM_EVALS === '1' && getAnthropicClient() !== null
+
+// 30s: the grader's own timeout is 8s, but a live round-trip plus retries can run
+// longer than vitest's 5s default.
+const EVAL_TIMEOUT_MS = 30_000
+
+describe.skipIf(!evalsEnabled)('gradeAnswerWithLLM (live grader)', () => {
+  // Regression guard for the Hum Aapke Hain Koun..! daughter-in-law case.
+  // Pooja — the deceased — IS the daughter-in-law (bahu) of Prem's household, so
+  // "the death of the daughter in law" names the right event and the right person,
+  // just by family role rather than by name. The first-pass grader marked this
+  // wrong in production; per the prompt's "capture the core concept" leniency rule
+  // it should be correct. See the LENIENCY RULES in gradeAnswerWithLLM.
+  const HAHK_QUESTION =
+    'In the blockbuster Bollywood family film Hum Aapke Hain Koun..!, the central ' +
+    'romance unfolds between Prem and Nisha, but a family tragedy threatens their ' +
+    'union. What tragic event forces the families to reconsider who should marry whom?'
+  const HAHK_CANONICAL = "Nisha's sister Pooja dies (after falling from a staircase / in an accident)"
+
+  it.each([
+    'The death of the daughter in law',
+    'the daughter-in-law dies',
+    "Pooja's death",
+  ])('marks "%s" correct', async (submitted) => {
+    const outcome = await gradeAnswerWithLLM(HAHK_QUESTION, HAHK_CANONICAL, submitted, 'factual')
+    expect(outcome.result).toBe('correct')
+  }, EVAL_TIMEOUT_MS)
+})


### PR DESCRIPTION
## Summary
Adds opt-in live evaluation tests for the LLM grading system that call the real Anthropic Haiku model instead of mocking it. These tests serve as regression guards for known grading cases and must be explicitly enabled to run.

## Changes
- **New test file:** `src/lib/llm.grading.eval.test.ts`
  - Implements live grading evals that exercise the model's actual judgment
  - Includes a regression guard for the "Hum Aapke Hain Koun..!" daughter-in-law case, which previously failed due to insufficient leniency in the grader
  - Tests three variations of a correct answer to verify the grader's flexibility in recognizing equivalent responses
  - Skipped by default; only runs when `RUN_LLM_EVALS=1` environment variable is set and a valid `ANTHROPIC_API_KEY` is available
  - Uses a 30-second timeout to account for real API round-trips and retries (vs. the grader's own 8-second timeout)

- **Updated package.json:** Added `test:evals` npm script
  - Provides convenient command: `npm run test:evals` (requires `ANTHROPIC_API_KEY` to be set)
  - Runs only the live eval tests with `RUN_LLM_EVALS=1` flag enabled

## Implementation Details
- Tests are gated by `describe.skipIf(!evalsEnabled)` to prevent accidental API calls and token consumption in normal CI/test runs
- The regression case validates that the grader correctly applies its "capture the core concept" leniency rule when answers identify the right event and person by role rather than by name
- Live evals are non-deterministic and costly, so they remain strictly opt-in and never run in standard `npm test` workflows

https://claude.ai/code/session_01PG35u82gi3SoAGdCD8jzZk