### PR TITLE
B-9: widen FeedApiItem.question_source to canonical type + wire catch-up commentary/aside to render

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -23,7 +23,7 @@ import {
 import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
-import type { InsideJokeKind } from '@/lib/questions-types'
+import type { InsideJokeKind, QuestionSource } from '@/lib/questions-types'
 
 type FriendResult = {
   userId: string
@@ -60,7 +60,10 @@ type FeedApiItem = {
   question_text?: string | null
   // B-6: provenance of the underlying question, used to pick the recipient-facing
   // verb ("wrote you this" for human-authored vs "sent you this" for curated LLM).
-  question_source?: 'authored' | 'daily_generated' | 'curated_sent' | null
+  // Derived from the canonical QuestionSource (D-3 added 'house_authored') so this
+  // can't drift out of sync with the server emitter again — a hand-written literal
+  // here was the B-9 regression (typecheck broke when 'house_authored' was added).
+  question_source?: QuestionSource | null
   is_in_bank: boolean
   domain_pill?: string | null
   broad_category?: string | null

--- a/src/components/play/__tests__/useCatchupFlow.message.test.tsx
+++ b/src/components/play/__tests__/useCatchupFlow.message.test.tsx
@@ -1,0 +1,149 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
+import {
+  buildCatchupResultMessage,
+  type CatchupAnswerResponse,
+  type CatchupQueueItem,
+} from '@/components/play/useCatchupFlow';
+import { INSIDE_JOKE_LABELS } from '@/lib/questions-types';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock('lucide-react', () => ({
+  Flag: () => <span aria-hidden="true" />,
+  MoreHorizontal: () => <span aria-hidden="true" />,
+  X: () => <span aria-hidden="true" />,
+}));
+
+function html(messages: ChatMessage[]) {
+  return renderToStaticMarkup(<GameplayChatThread messages={messages} />);
+}
+
+function catchupItem(over: Partial<CatchupQueueItem> = {}): CatchupQueueItem {
+  return {
+    dailyQueueItemId: 'queue-1:0',
+    questionId: 'q-1',
+    questionText: 'Which composer wrote the Goldberg Variations?',
+    correctAnswer: 'Bach',
+    alternateAnswers: [],
+    explanation: null,
+    domain: 'music',
+    domainDisplayName: 'Music',
+    queueDate: '2026-06-01',
+    queueAge: 1,
+    wasSkipped: false,
+    expiresAt: '2026-06-03T00:00:00.000Z',
+    ...over,
+  };
+}
+
+// These mirror the JSON shape the catch-up answer route returns (lines 364-366,
+// 524-526): the server has already resolved creatorNote and gated the aside
+// (insideJoke / insideJokeKind) through selectInsideJokeForViewer.
+function answerResponse(over: Partial<CatchupAnswerResponse> = {}): CatchupAnswerResponse {
+  return {
+    result: 'correct',
+    isCorrect: true,
+    correctAnswer: 'Bach',
+    ...over,
+  };
+}
+
+describe('useCatchupFlow result message (B-9: commentary + aside reach the render layer)', () => {
+  it('carries the server creatorNote, insideJoke, and insideJokeKind onto the built message', () => {
+    // This is the exact regression guard: the shipped hook set creatorName /
+    // creatorIsHouse but dropped these three fields, so the message it built
+    // never carried them and the player saw nothing. If the wiring is reverted,
+    // these expectations fail.
+    const message = buildCatchupResultMessage({
+      id: 'r-1',
+      item: catchupItem({ authorName: 'Dana' }),
+      data: answerResponse({
+        creatorNote: 'I lost a bet over this in 2019.',
+        insideJoke: 'You still owe me a coffee.',
+        insideJokeKind: 'relational',
+      }),
+      isCorrect: true,
+      submittedAnswer: 'Bach',
+      pointsAwarded: 4,
+    });
+
+    expect(message.kind).toBe('result');
+    expect(message.authorNote).toBe('I lost a bet over this in 2019.');
+    expect(message.insideJoke).toBe('You still owe me a coffee.');
+    expect(message.insideJokeKind).toBe('relational');
+  });
+
+  it('renders a human author\'s commentary and the relational aside, identical to the live path', () => {
+    const rendered = html([
+      buildCatchupResultMessage({
+        id: 'r-1',
+        item: catchupItem({ authorName: 'Dana', authorIsHouse: false }),
+        data: answerResponse({
+          creatorNote: 'I lost a bet over this in 2019.',
+          insideJoke: 'You still owe me a coffee.',
+          insideJokeKind: 'relational',
+        }),
+        isCorrect: true,
+        submittedAnswer: 'Bach',
+        pointsAwarded: 4,
+      }),
+    ]);
+
+    // Commentary reaches the screen with the relational "Why {name} asked" label.
+    expect(rendered).toContain('I lost a bet over this in 2019.');
+    expect(rendered).toContain('Why Dana asked');
+    // Aside reaches the screen with the relational (human-authored) label.
+    expect(rendered).toContain('You still owe me a coffee.');
+    expect(rendered).toContain(INSIDE_JOKE_LABELS.relational);
+    expect(rendered).not.toContain(INSIDE_JOKE_LABELS.editorial);
+  });
+
+  it('renders the editorial label + editor\'s note for a house-authored question (no relational copy)', () => {
+    const rendered = html([
+      buildCatchupResultMessage({
+        id: 'r-1',
+        item: catchupItem({ authorName: 'Joshing', authorIsHouse: true }),
+        data: answerResponse({
+          creatorNote: 'A favourite of the editorial desk.',
+          insideJoke: 'One for the archive.',
+          insideJokeKind: 'editorial',
+        }),
+        isCorrect: true,
+        submittedAnswer: 'Bach',
+        pointsAwarded: 4,
+      }),
+    ]);
+
+    expect(rendered).toContain('A favourite of the editorial desk.');
+    expect(rendered).toContain('One for the archive.');
+    expect(rendered).toContain(INSIDE_JOKE_LABELS.editorial);
+    // House commentary is editorial, never relational — no "Why {name} asked".
+    expect(rendered).not.toContain('Why Joshing asked');
+    expect(rendered).toContain('Editor');
+  });
+
+  it('renders no aside when the server gated it out (selectInsideJokeForViewer returned null)', () => {
+    const rendered = html([
+      buildCatchupResultMessage({
+        id: 'r-1',
+        item: catchupItem({ authorName: 'Dana' }),
+        data: answerResponse({ creatorNote: null, insideJoke: null, insideJokeKind: null }),
+        isCorrect: true,
+        submittedAnswer: 'Bach',
+        pointsAwarded: 4,
+      }),
+    ]);
+
+    // Under-exposure check: a hidden aside must not leak either label.
+    expect(rendered).not.toContain(INSIDE_JOKE_LABELS.relational);
+    expect(rendered).not.toContain(INSIDE_JOKE_LABELS.editorial);
+  });
+});

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type 
 
 import { newMessageId, type ChatMessage } from '@/components/play/GameplayChat';
 import { difficultyEstimateToTierLabel } from '@/lib/questions/difficulty-tier';
-import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
+import { LLM_QUESTION_ATTRIBUTION, type InsideJokeKind } from '@/lib/questions-types';
 import {
   parseCatchUpAnswerErrorBody,
   userFacingCatchUpSubmitMessage,
@@ -32,7 +32,7 @@ export type CatchupQueueItem = {
   authorIsHouse?: boolean;
 };
 
-type CatchupAnswerResponse = {
+export type CatchupAnswerResponse = {
   result?: 'correct' | 'wrong';
   isCorrect?: boolean;
   correct?: boolean;
@@ -44,6 +44,14 @@ type CatchupAnswerResponse = {
   explainer?: string | null;
   consolation?: string | null;
   breadcrumb?: string | null;
+  // B-7/B-9: author commentary + aside travel with the question into catch-up,
+  // gated server-side by selectInsideJokeForViewer (same provenance-calibrated
+  // label and display gate as the live path). The server emits `creatorNote`,
+  // which maps to the message's `authorNote` (matching the live path field name
+  // so GameplayChat renders it with no special-casing).
+  creatorNote?: string | null;
+  insideJoke?: string | null;
+  insideJokeKind?: InsideJokeKind | null;
   nextItem?: CatchupQueueItem | null;
 };
 
@@ -93,6 +101,49 @@ async function fetchBreadcrumbForCatchupMessage(
   } catch {
     // Breadcrumb is purely additive context; failure is silently ignored.
   }
+}
+
+// Builds the result-turn message a catch-up answer produces, mapping the
+// server's provenance-resolved commentary + aside onto the exact field names
+// GameplayChat renders (B-9). Extracted as a pure function so a test can assert
+// these values reach the render layer — the B-7 regression was that the inline
+// builder set creatorName/creatorIsHouse but silently dropped the note/aside,
+// and a green route test never caught it because it asserted on the route JSON
+// the player never sees, not the message the hook builds.
+export function buildCatchupResultMessage(params: {
+  id: string;
+  item: CatchupQueueItem;
+  data: CatchupAnswerResponse;
+  isCorrect: boolean;
+  submittedAnswer: string;
+  pointsAwarded: number;
+}): Extract<ChatMessage, { kind: 'result' }> {
+  const { id, item, data, isCorrect, submittedAnswer, pointsAwarded } = params;
+  return {
+    id,
+    kind: 'result',
+    assignmentId: item.dailyQueueItemId,
+    questionText: item.questionText,
+    result: isCorrect ? 'correct' : 'wrong',
+    submitted: submittedAnswer,
+    correctAnswer: isCorrect ? null : data.correctAnswer ?? data.answer ?? item.correctAnswer,
+    consolation: data.consolation ?? null,
+    breadcrumb: null,
+    explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
+    copyVariant: item.queueAge,
+    creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
+    creatorIsHouse: item.authorIsHouse ?? false,
+    // B-9: surface the server's provenance-resolved commentary + aside.
+    // GameplayChat renders `authorNote` (live path maps server `creatorNote`
+    // to this name) and gates the aside via insideJoke/insideJokeKind, which
+    // the route already calibrated through selectInsideJokeForViewer.
+    authorNote: data.creatorNote ?? null,
+    insideJoke: data.insideJoke ?? null,
+    insideJokeKind: data.insideJokeKind ?? null,
+    canonicalSubcategory: item.domain,
+    pointsAwarded,
+    pointsLabel: 'Catch-up - 0.25x points',
+  };
 }
 
 function questionMessage(item: CatchupQueueItem): ChatMessage {
@@ -278,24 +329,14 @@ export function useCatchupFlow() {
       setMessages((existing) => [
         ...existing,
         { id: newMessageId(), kind: 'user', text: trimmedAnswer },
-        {
+        buildCatchupResultMessage({
           id: resultMessageId,
-          kind: 'result',
-          assignmentId: item.dailyQueueItemId,
-          questionText: item.questionText,
-          result: isCorrect ? 'correct' : 'wrong',
-          submitted: trimmedAnswer,
-          correctAnswer: isCorrect ? null : data.correctAnswer ?? data.answer ?? item.correctAnswer,
-          consolation: data.consolation ?? null,
-          breadcrumb: null,
-          explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
-          copyVariant: item.queueAge,
-          creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
-          creatorIsHouse: item.authorIsHouse ?? false,
-          canonicalSubcategory: item.domain,
+          item,
+          data,
+          isCorrect,
+          submittedAnswer: trimmedAnswer,
           pointsAwarded,
-          pointsLabel: 'Catch-up - 0.25x points',
-        },
+        }),
       ]);
 
       // Breadcrumbs are computed from daily-queue slots only; feed-sourced


### PR DESCRIPTION
Fix 1: FeedApiItem.question_source was a hand-written literal union that was
not widened when D-3 added 'house_authored', breaking typecheck at page.tsx:146.
Derive it from the canonical QuestionSource so it can't drift again. Root-cause
check: D-3 Stage 1's exhaustiveness guard (parseQuestionSource + assertNever in
resolveQuestionAuthor/isLlmOriginQuestion) DID ship and friend-coverage already
uses parseQuestionSource — this union was the lone escapee precisely because it
was a hand-written literal not derived from QuestionSource.

Fix 2: B-7's server half resolves creatorNote/insideJoke/insideJokeKind, but the
client half was never wired — CatchupAnswerResponse did not declare them and the
result-message builder dropped them, so a player answering a catch-up question
saw no commentary and no aside. Declare the fields and pass them through to the
message, mapping server creatorNote -> message authorNote (live path field name)
so GameplayChat renders them with no special-casing. The aside keeps the same
provenance-calibrated label and display gate as the live path (gated server-side
by selectInsideJokeForViewer).

Process correction: extract the message builder (buildCatchupResultMessage) and
add a hook-level test that renders the built message through GameplayChatThread,
asserting the commentary + aside reach the render layer. The test fails if the
wiring is reverted — the exact regression a green route test masked.