### PR TITLE
Guard house questions from peer-to-peer send & show editorial badge

### DIFF
--- a/src/app/api/questions/answered/route.ts
+++ b/src/app/api/questions/answered/route.ts
@@ -23,6 +23,7 @@ export async function GET() {
     correctAnswer: item.correctAnswer,
     result: item.result,
     askerName: item.askerName,
+    authorIsHouse: item.authorIsHouse,
     answeredAt: item.answeredAt,
     sourceLabel: item.sourceLabel,
   }));

--- a/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
+++ b/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
@@ -1,27 +1,39 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Sentinel table objects so the db mock can tell which table a select hits.
-const { dbMock, state, QUESTIONS, GENERATED } = vi.hoisted(() => {
+const { dbMock, state, QUESTIONS, GENERATED, USERS, FEED_ITEMS } = vi.hoisted(() => {
   const QUESTIONS = { __table: 'questions' };
   const GENERATED = { __table: 'generatedQuestions' };
+  const USERS = { __table: 'users' };
+  const FEED_ITEMS = { __table: 'feedItems' };
 
   const state = {
-    existingQuestion: null as { id: string } | null,
+    existingQuestion: null as { id: string; source?: string } | null,
     generated: null as Record<string, unknown> | null,
+    userRow: null as Record<string, unknown> | null,
     insertedValues: null as Record<string, unknown> | null,
     insertedId: 'new-question-id',
+  };
+
+  // `where()` returns a Promise (awaited directly by aggregate queries like the
+  // 24h send-count) that also carries a `.limit()` method (used by the
+  // single-row lookups). This keeps both call shapes working off one mock.
+  const rowsFor = (table: unknown): unknown[] => {
+    if (table === QUESTIONS) return state.existingQuestion ? [state.existingQuestion] : [];
+    if (table === GENERATED) return state.generated ? [state.generated] : [];
+    if (table === USERS) return state.userRow ? [state.userRow] : [];
+    return [];
   };
 
   const dbMock = {
     select: vi.fn(() => ({
       from: vi.fn((table: unknown) => ({
-        where: vi.fn(() => ({
-          limit: vi.fn(async () => {
-            if (table === QUESTIONS) return state.existingQuestion ? [state.existingQuestion] : [];
-            if (table === GENERATED) return state.generated ? [state.generated] : [];
-            return [];
-          }),
-        })),
+        where: vi.fn(() => {
+          const rows = rowsFor(table);
+          const result = Promise.resolve(rows) as Promise<unknown[]> & { limit: ReturnType<typeof vi.fn> };
+          result.limit = vi.fn(async () => rows);
+          return result;
+        }),
       })),
     })),
     insert: vi.fn(() => ({
@@ -32,15 +44,15 @@ const { dbMock, state, QUESTIONS, GENERATED } = vi.hoisted(() => {
     })),
   };
 
-  return { dbMock, state, QUESTIONS, GENERATED };
+  return { dbMock, state, QUESTIONS, GENERATED, USERS, FEED_ITEMS };
 });
 
 vi.mock('@/server/db', () => ({
   db: dbMock,
   questions: QUESTIONS,
   generatedQuestions: GENERATED,
-  feedItems: {},
-  users: {},
+  feedItems: FEED_ITEMS,
+  users: USERS,
 }));
 
 vi.mock('drizzle-orm', () => ({
@@ -63,7 +75,14 @@ vi.mock('@/server/db/queries/feed', () => ({
 vi.mock('@/server/db/queries/friends', () => ({ getFriends: vi.fn() }));
 vi.mock('@/server/sms', () => ({ sendSms: vi.fn() }));
 
-import { resolveQuestionIdForSend } from '@/app/api/questions/send/route';
+import { POST, resolveQuestionIdForSend } from '@/app/api/questions/send/route';
+import { getSession } from '@/server/auth/session';
+import { getFriends } from '@/server/db/queries/friends';
+import {
+  createFeedItem,
+  userAnsweredQuestionCorrectly,
+  userHasQuestionInBlockingFeed,
+} from '@/server/db/queries/feed';
 
 describe('resolveQuestionIdForSend', () => {
   beforeEach(() => {
@@ -113,5 +132,46 @@ describe('resolveQuestionIdForSend', () => {
       questionText: 'What is the capital of France?',
       answerText: 'Paris',
     });
+  });
+});
+
+describe('POST /api/questions/send — house guard (D-3)', () => {
+  function buildRequest(body: Record<string, unknown>) {
+    return {
+      json: async () => body,
+      nextUrl: { origin: 'http://localhost:3000' },
+    } as never;
+  }
+
+  beforeEach(() => {
+    state.existingQuestion = null;
+    state.generated = null;
+    // No phone number ⇒ the SMS branch is skipped (keeps the test focused).
+    state.userRow = { id: 'recipient-1', displayName: 'Rae', phoneNumber: null, smsOptIn: 'opted_out' };
+    vi.mocked(getSession).mockResolvedValue({ userId: 'sender-1' } as never);
+    vi.mocked(getFriends).mockResolvedValue([{ id: 'recipient-1' }] as never);
+    vi.mocked(userAnsweredQuestionCorrectly).mockResolvedValue(false as never);
+    vi.mocked(userHasQuestionInBlockingFeed).mockResolvedValue(false as never);
+    vi.mocked(createFeedItem).mockResolvedValue({ id: 'feed-1' } as never);
+    dbMock.insert.mockClear();
+  });
+
+  it('rejects a house_authored question with 400 and does not create a feed item', async () => {
+    state.existingQuestion = { id: 'house-q', source: 'house_authored' };
+
+    const response = await POST(buildRequest({ question_id: 'house-q', recipient_user_id: 'recipient-1' }));
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toMatchObject({ error: 'invalid_question' });
+    expect(createFeedItem).not.toHaveBeenCalled();
+  });
+
+  it('lets a normal authored question through the guard', async () => {
+    state.existingQuestion = { id: 'authored-q', source: 'authored' };
+
+    const response = await POST(buildRequest({ question_id: 'authored-q', recipient_user_id: 'recipient-1' }));
+
+    expect(response.status).toBe(201);
+    expect(createFeedItem).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -48,6 +48,17 @@ export async function POST(request: NextRequest) {
 
   if (!question[0] || !recipient[0]) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
+  // Defensive: house/editorial questions are content infrastructure, never
+  // peer-to-peer sendable (D-3). No UI path forwards one and feed fan-out would
+  // reject it (null creatorId, non-LLM origin), but reject it explicitly here so
+  // the invariant is enforced at the entry point rather than implicitly downstream.
+  if (question[0].source === 'house_authored') {
+    return NextResponse.json(
+      { error: 'invalid_question', message: 'House questions cannot be sent.' },
+      { status: 400 },
+    );
+  }
+
   const [alreadyCorrect, alreadyInFeed] = await Promise.all([
     userAnsweredQuestionCorrectly(parsed.recipientUserId, sendableQuestionId!),
     userHasQuestionInBlockingFeed(parsed.recipientUserId, sendableQuestionId!),

--- a/src/app/archive/page.tsx
+++ b/src/app/archive/page.tsx
@@ -7,6 +7,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { QuestionRatingButtons } from '@/components/games/QuestionRatingButtons';
+import { EditorialBadge } from '@/components/EditorialBadge';
 import { cn } from '@/lib/utils';
 
 type ArchiveSource = 'daily' | 'feed' | 'joshing_game' | 'sent_to_me' | 'written_by_me';
@@ -30,6 +31,8 @@ type ArchiveItem = {
   myRating: 'up' | 'down' | null;
   canUseQuestionActions?: boolean;
   verified: boolean;
+  askerName: string;
+  authorIsHouse: boolean;
 };
 
 type ArchiveFacet = {
@@ -397,6 +400,12 @@ function ArchiveCard({ item }: { item: ArchiveItem }) {
           <span className="font-mono font-semibold text-foreground">+{Math.round(item.pointsAwarded)} pts</span>
         ) : null}
         {item.answeredAt ? <span>· {formatDate(item.answeredAt)}</span> : null}
+        {item.askerName.trim() ? (
+          <span className="inline-flex items-center gap-1">
+            · Asked by {item.askerName}
+            {item.authorIsHouse ? <EditorialBadge /> : null}
+          </span>
+        ) : null}
       </div>
 
       <div className="mt-4 flex flex-wrap items-center justify-end gap-2">

--- a/src/components/questions/AnsweredQuestionsList.tsx
+++ b/src/components/questions/AnsweredQuestionsList.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { EditorialBadge } from '@/components/EditorialBadge';
+
 export type AnsweredQuestionItem = {
   id: string;
   questionId: string;
@@ -8,6 +10,7 @@ export type AnsweredQuestionItem = {
   correctAnswer: string;
   result: 'correct' | 'incorrect' | 'skipped' | null;
   askerName: string;
+  authorIsHouse: boolean;
   answeredAt: string | null;
   sourceLabel: string;
 };
@@ -84,11 +87,14 @@ export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[]
                   </span>
                 ) : null}
                 <p className="mt-0.5 text-xs text-muted-foreground sm:hidden">
-                  Asked by {askerDisplay(item)} · {formatDate(item.answeredAt)}
+                  Asked by {askerDisplay(item)}
+                  {item.authorIsHouse ? <EditorialBadge style={{ marginLeft: 4 }} /> : null}
+                  {' · '}{formatDate(item.answeredAt)}
                 </p>
               </div>
               <div className="hidden text-sm text-muted-foreground sm:block">
                 {askerDisplay(item)}
+                {item.authorIsHouse ? <EditorialBadge style={{ marginLeft: 4 }} /> : null}
               </div>
               <div className="hidden text-sm text-muted-foreground sm:block">
                 {formatDate(item.answeredAt)}

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -15,7 +15,7 @@ import {
   users,
 } from '@/server/db';
 import type { QueueSlot } from '@/server/daily/types';
-import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
+import { LLM_QUESTION_ATTRIBUTION, resolveAuthorDisplay } from '@/lib/questions-types';
 
 export type ArchiveSource = 'daily' | 'feed' | 'joshing_game' | 'sent_to_me' | 'written_by_me';
 export type ArchiveResultFilter = 'correct' | 'incorrect' | 'skipped';
@@ -39,6 +39,7 @@ export type ArchiveItem = {
   canUseQuestionActions: boolean;
   verified: boolean;
   askerName: string;
+  authorIsHouse: boolean;
 };
 
 export type ArchiveKind = 'all' | 'answered';
@@ -197,6 +198,13 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
         const domain = slot.domain || generated?.canonicalSubcategory || questionDomain(bankQuestion);
         const questionId = slot.question_id ?? slot.generated_question_id ?? `${queue.id}:${slot.slot_index}`;
         const askerDisplay = bankQuestion?.creatorId ? creatorById.get(bankQuestion.creatorId) ?? null : null;
+        // Route the canonical question through resolveAuthorDisplay so a house
+        // slot (creatorId null, source 'house_authored') positively resolves to
+        // 'Joshing' + authorIsHouse, instead of falling through to ''. Pure-LLM
+        // slots carry no bankQuestion, so they keep the 'Generated'/'' fallback.
+        const authored = bankQuestion
+          ? resolveAuthorDisplay(bankQuestion.creatorId, bankQuestion.source, askerDisplay)
+          : { authorName: null, authorIsHouse: false };
         return {
           id: `daily:${queue.id}:${slot.slot_index}`,
           questionId,
@@ -215,7 +223,8 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
           myRating: null,
           canUseQuestionActions: Boolean(slot.question_id),
           verified: bankQuestion?.verified ?? true,
-          askerName: askerDisplay ?? (generated ? LLM_QUESTION_ATTRIBUTION : ''),
+          askerName: authored.authorName ?? askerDisplay ?? (generated ? LLM_QUESTION_ATTRIBUTION : ''),
+          authorIsHouse: authored.authorIsHouse,
         } satisfies ArchiveItem;
       }),
   );
@@ -292,6 +301,7 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       // null creatorId here ⟹ LLM-origin (curated_sent); authored feed questions
       // resolve a real name via the creatorUser left join.
       askerName: creatorUser?.displayName ?? LLM_QUESTION_ATTRIBUTION,
+      authorIsHouse: false,
     } satisfies ArchiveItem;
   });
 }
@@ -333,6 +343,7 @@ async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
       canUseQuestionActions: true,
       verified: question.verified,
       askerName: creatorUser?.displayName ?? '',
+      authorIsHouse: false,
     } satisfies ArchiveItem;
   });
 }
@@ -387,6 +398,7 @@ async function readWrittenByMeItems(userId: string): Promise<ArchiveItem[]> {
       canUseQuestionActions: true,
       verified: question.verified,
       askerName: '',
+      authorIsHouse: false,
     } satisfies ArchiveItem;
   });
 }


### PR DESCRIPTION
## Summary
Adds a defensive guard to prevent house/editorial questions from being sent peer-to-peer, and surfaces editorial authorship in the UI with a new badge component.

## Key Changes

- **API guard (D-3):** Added explicit validation in `POST /api/questions/send` to reject `house_authored` questions with a 400 error before feed item creation. This enforces the invariant at the entry point rather than relying on downstream implicit rejection.

- **Archive query enhancement:** Updated `readDailyItems()` to use `resolveAuthorDisplay()` for canonical questions, ensuring house questions properly resolve to 'Joshing' + `authorIsHouse: true` flag instead of falling through to empty string.

- **UI display:** Added `authorIsHouse` field to `ArchiveItem` type and integrated `EditorialBadge` component in:
  - Archive page card footer (shows "Asked by [name]" with badge if house-authored)
  - Answered questions list (both mobile and desktop layouts)

- **API response:** Updated `/api/questions/answered` route to include `authorIsHouse` in response payload.

- **Test coverage:** Enhanced `resolve-question-id-for-send.test.ts` with:
  - Improved mock setup to support `USERS` and `FEED_ITEMS` table lookups
  - Refactored `where()` mock to return a Promise with attached `.limit()` method (supporting both aggregate and single-row query patterns)
  - New test suite validating that house questions are rejected with 400 and non-house questions proceed normally

## Implementation Details

The `where()` mock refactoring allows a single mock to satisfy both query patterns:
- Aggregate queries (24h send-count) that await `where()` directly
- Single-row lookups that chain `.limit()` on the `where()` result

The `authorIsHouse` flag is computed via `resolveAuthorDisplay()` for bank questions in daily slots, ensuring consistent author resolution logic across the codebase.

https://claude.ai/code/session_01YJRNn9tYqpqRDEg3ULcekL