### PR TITLE
Refine GameplayChat typography and spacing for better readability

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -272,19 +272,19 @@ function QuestionRow({
       <div
         style={{
           alignSelf: 'flex-start',
-          maxWidth: '88%',
+          maxWidth: '81%',
           background: 'var(--game-card-question)',
           border: '1px solid var(--brand-rule)',
           borderRadius: 'var(--radius-md)',
           // effect/card/question — soft layered drop shadow.
           boxShadow: '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
-          padding: '16px 18px',
+          padding: '14px 18px',
           fontFamily: 'var(--font-cormorant), Georgia, serif',
-          fontSize: '1.75rem',
+          fontSize: '1.4875rem',
           fontWeight: 700,
           letterSpacing: 0,
           color: 'var(--brand-ink)',
-          lineHeight: 1.3,
+          lineHeight: 1.14,
         }}
       >
         <p style={{ margin: 0 }}>{questionText}</p>
@@ -297,7 +297,7 @@ function QuestionRow({
                   // Figma display/pill/sans — Georgia, 12px, title-case (not the
                   // mono uppercase used elsewhere).
                   fontFamily: 'Georgia, "Times New Roman", serif',
-                  fontSize: '0.75rem',
+                  fontSize: '0.675rem',
                   lineHeight: 1.1,
                   letterSpacing: '0.01em',
                   borderRadius: '999px',
@@ -306,6 +306,7 @@ function QuestionRow({
                     ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
                     : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
                   color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
+                  opacity: 0.9,
                   padding: '3px 9px',
                 }}
               >
@@ -353,13 +354,13 @@ function UserRow({ text }: { text: string }) {
           maxWidth: '88%',
           background: 'var(--brand-navy)',
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
-          padding: '10px 16px',
+          padding: '9px 15px',
           // Figma answer bubble — Cormorant serif, not the sans body font.
           fontFamily: 'var(--font-cormorant), Georgia, serif',
-          fontSize: '1.15rem',
-          fontWeight: 600,
-          letterSpacing: '0.01em',
-          lineHeight: 1.3,
+          fontSize: '1.495rem',
+          fontWeight: 700,
+          letterSpacing: '-0.01em',
+          lineHeight: 1.2,
           color: 'var(--primary-foreground)',
         }}
       >
@@ -398,10 +399,11 @@ function BreadcrumbLine({ text, creatorName, creatorIsHouse = false }: { text: s
         style={{
           marginTop: showAuthor ? '2px' : '0',
           fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
-          fontSize: '0.92rem',
+          fontSize: '0.782rem',
           fontStyle: 'italic',
           color: 'color-mix(in srgb, var(--text-muted) 50%, var(--text))',
-          lineHeight: 1.35,
+          opacity: 0.78,
+          lineHeight: 1.46,
         }}
       >
         &ldquo;{text}&rdquo;
@@ -422,9 +424,10 @@ function ExplanationLine({ text }: { text: string }) {
       <p
         style={{
           fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
-          fontSize: '0.9rem',
+          fontSize: '0.765rem',
           color: 'color-mix(in srgb, var(--text-muted) 50%, var(--text))',
-          lineHeight: 1.4,
+          opacity: 0.78,
+          lineHeight: 1.51,
         }}
       >
         {text}
@@ -805,9 +808,10 @@ function ResultRow({
           ...resultToneStyle,
           borderRadius: 'var(--radius-md)',
           padding: '10px 14px',
-          fontSize: '0.9rem',
+          fontSize: '0.81rem',
           color: 'var(--text)',
-          lineHeight: 1.45,
+          opacity: 0.92,
+          lineHeight: 1.36,
           width: '100%',
         }}
       >
@@ -859,12 +863,12 @@ function ResultRow({
               <p
                 style={{
                   marginTop: '8px',
-                  // Figma question/game/answer — Cormorant Bold 28.
+                  // Figma question/game/answer — Cormorant Bold, scaled to match question text.
                   fontFamily: 'var(--font-cormorant), Georgia, serif',
-                  fontSize: '1.75rem',
+                  fontSize: '1.4875rem',
                   fontWeight: 700,
                   color: 'var(--brand-ink)',
-                  lineHeight: 1.3,
+                  lineHeight: 1.14,
                 }}
               >
                 {correctAnswer}


### PR DESCRIPTION
## Summary
Adjusted typography, spacing, and opacity across the GameplayChat component to improve visual hierarchy and readability. Changes include refined font sizes, line heights, padding, and subtle opacity adjustments to better match design specifications.

## Key Changes
- **Question text styling:** Reduced font size from 1.75rem to 1.4875rem, adjusted padding (16px → 14px vertical), and line height (1.3 → 1.14) for tighter, more refined appearance
- **Question container:** Reduced max-width from 88% to 81% for better proportions
- **Badge styling:** Decreased font size (0.75rem → 0.675rem) and added 0.9 opacity for subtler appearance
- **User answer text:** Increased font size (1.15rem → 1.495rem), upgraded font weight (600 → 700), adjusted letter spacing (0.01em → -0.01em), and refined line height (1.3 → 1.2)
- **User answer padding:** Tightened from 10px 16px to 9px 15px
- **Breadcrumb/quote text:** Reduced font size (0.92rem → 0.782rem), added 0.78 opacity, and adjusted line height (1.35 → 1.46)
- **Explanation text:** Reduced font size (0.9rem → 0.765rem), added 0.78 opacity, and increased line height (1.4 → 1.51)
- **Result text:** Reduced font size (0.9rem → 0.81rem), added 0.92 opacity, and adjusted line height (1.45 → 1.36)
- **Correct answer display:** Matched font size to question text (1.4875rem) and line height (1.14) for visual consistency

## Implementation Details
- Opacity adjustments replace or complement color-mix approaches for secondary text elements, providing more consistent visual hierarchy
- Font size reductions are proportional across related elements to maintain design coherence
- Line height adjustments account for the new font sizes to preserve readability and spacing
- Updated comment for correct answer styling to reflect the intentional alignment with question text sizing

https://claude.ai/code/session_01TrpUygv9vpkdKYww7Z3z2B