### PR TITLE
Reduce homepage head limit from 4 to 3 items

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -124,7 +124,7 @@ async function CeremonyPinSection({ userId }: { userId: string }) {
 }
 
 // How many of the unified stream's home-eligible items the homepage head shows.
-const HOME_HEAD_LIMIT = 4
+const HOME_HEAD_LIMIT = 3
 
 async function RecentActivityServerSection({ userId }: { userId: string }) {
   // The homepage head is the curated top of the one unified stream (same source


### PR DESCRIPTION
## Summary
Reduces the number of home-eligible items displayed in the homepage head (curated top section of the unified stream) from 4 to 3.

## Changes
- Updated `HOME_HEAD_LIMIT` constant in `src/app/page.tsx` from `4` to `3`

## Details
This change affects the `RecentActivityServerSection` component, which uses this constant to control how many items from the unified stream are shown in the homepage's featured section.

https://claude.ai/code/session_01NkASV6HvcpRugFYEScuWKi