### PR TITLE
Migrate daily-catchup smoke test to TypeScript and add SMS message types test

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run src/lib/llm.grading.eval.test.ts",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
-    "smoke:daily-catchup": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/daily-catchup.smoke.mjs",
+    "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",
     "smoke:area-top-up": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/area-top-up.smoke.mjs",
+    "smoke:sms-message-types": "tsx scripts/sms-message-types.smoke.ts",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "format": "node scripts/format-changed.mjs",
     "format:all": "prettier --write ."

--- a/scripts/daily-catchup.smoke.ts
+++ b/scripts/daily-catchup.smoke.ts
@@ -93,3 +93,5 @@ assert.deepEqual(
   dedupedCatchupItems.map((item) => item.dailyQueueItemId),
   ['queue-3:0', 'queue-1:0'],
 );
+
+console.log('daily-catchup.smoke: ok');

--- a/scripts/sms-message-types.smoke.ts
+++ b/scripts/sms-message-types.smoke.ts
@@ -21,3 +21,5 @@ const smokeInsert: typeof smsLogs.$inferInsert = {
 };
 
 assert.equal(smokeInsert.messageType, 'joshing_game_received');
+
+console.log('sms-message-types.smoke: ok');


### PR DESCRIPTION
## Summary
Modernizes the daily-catchup smoke test by migrating it from Node's experimental TypeScript support to `tsx`, and adds a new smoke test for SMS message types validation.

## Changes
- **Migrated `daily-catchup.smoke.mjs` → `daily-catchup.smoke.ts`**: Converted from `.mjs` with Node's `--experimental-strip-types` flag to a proper TypeScript file run via `tsx`, simplifying the command and aligning with the project's existing TypeScript tooling (as used by `smoke:gameplay`)
- **Added `sms-message-types.smoke.ts`**: New smoke test validating SMS message type inference from the Drizzle schema, ensuring type safety for SMS log inserts
- **Updated npm scripts**: 
  - `smoke:daily-catchup` now uses `tsx scripts/daily-catchup.smoke.ts`
  - Added `smoke:sms-message-types` script
- **Added console output**: Both smoke tests now log completion messages for clarity in CI/test runs

## Implementation Details
- The daily-catchup test logic remains unchanged; only the execution method was modernized
- Both smoke tests follow the existing pattern of asserting expected behavior and logging success
- This aligns the smoke test infrastructure with the project's preference for `tsx` over Node's experimental TypeScript features

https://claude.ai/code/session_01XBzxxZvYGWo6kyj6JX3A2z