### PR TITLE
Replace feed footer with question idea prompt

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -20,7 +20,7 @@ type DrawerState =
   // intent is null for the page's own "Write a question" buttons (and the
   // legacy `?create=1` link), which keep the form's existing defaults. Only the
   // CreateChooser supplies an explicit intent.
-  | { mode: 'create'; intent: CreateIntent | null }
+  | { mode: 'create'; intent: CreateIntent | null; prefillText?: string }
   | { mode: 'edit'; question: QuestionView };
 
 function parseIntent(raw: string | null): CreateIntent | null {
@@ -134,11 +134,13 @@ function QuestionsPageContent() {
   const [domainFilter, setDomainFilter] = useState('all');
   const [sortMode, setSortMode] = useState<SortMode>('newest');
   const [search, setSearch] = useState('');
-  const [drawer, setDrawer] = useState<DrawerState>(() => (
-    searchParams.get('create') === '1'
-      ? { mode: 'create', intent: parseIntent(searchParams.get('intent')) }
-      : { mode: 'closed' }
-  ));
+  const [drawer, setDrawer] = useState<DrawerState>(() => {
+    if (searchParams.get('create') !== '1') return { mode: 'closed' };
+    // The feed's "what would you like to be asked?" prompt rides the idea in
+    // via ?text= so the composer opens pre-filled with the reader's words.
+    const prefillText = searchParams.get('text')?.trim() || undefined;
+    return { mode: 'create', intent: parseIntent(searchParams.get('intent')), prefillText };
+  });
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [cardError, setCardError] = useState<Record<string, string>>({});
   const [removingId, setRemovingId] = useState<string | null>(null);
@@ -457,7 +459,9 @@ function QuestionsPageContent() {
             </div>
             <QuestionForm
               mode={drawer.mode}
-              initialValues={drawer.mode === 'edit' ? initialValues(drawer.question) : createFormProps(drawer.intent).initialValues}
+              initialValues={drawer.mode === 'edit'
+                ? initialValues(drawer.question)
+                : { ...createFormProps(drawer.intent).initialValues, ...(drawer.prefillText ? { text: drawer.prefillText } : {}) }}
               initialSpecificMode={drawer.mode === 'create' ? createFormProps(drawer.intent).initialSpecificMode : undefined}
               onSubmit={drawer.mode === 'edit' ? (values) => saveEdit(drawer.question.id, values) : saveCreate}
               onCancel={() => setDrawer({ mode: 'closed' })}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -2,7 +2,7 @@
 
 import { Fragment, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
 import Link from 'next/link'
-import { useSearchParams } from 'next/navigation'
+import { useRouter, useSearchParams } from 'next/navigation'
 import {
   AnsweredByYouCard,
   AnswerFeedbackSheet,
@@ -517,31 +517,62 @@ function FeedSurfaceTabs({
   )
 }
 
-// The two ways to keep the feed alive, paired as one lightweight footer at the
-// bottom of the feed surface — replacing the standalone "Write a question" card
-// that used to duplicate the "Catch up" card's look on the home page.
+// The bottom-of-feed prompt: instead of a passive "two ways to fill your feed"
+// footer, ask the reader what they actually want to be asked and hand their idea
+// straight to the question writer. The typed idea rides through as ?text= so the
+// composer opens pre-filled (see app/questions/page.tsx). "Invite a friend"
+// survives as a secondary link so we don't lose that path.
+// The reader's typed idea rides to the composer via ?text=; an empty box still
+// opens the writer. Pure so the two branches stay test-covered without a DOM.
+export function buildQuestionWriterHref(idea: string): string {
+  const trimmed = idea.trim()
+  return trimmed
+    ? `/questions?create=1&intent=bank&text=${encodeURIComponent(trimmed)}`
+    : '/questions?create=1&intent=bank'
+}
+
 function FeedContributeFooter() {
+  const router = useRouter()
+  const [idea, setIdea] = useState('')
+
+  function handleSubmit(event: React.FormEvent) {
+    event.preventDefault()
+    router.push(buildQuestionWriterHref(idea))
+  }
+
   return (
-    <footer className="flex flex-col items-center gap-1.5 border-t pt-5 pb-8 text-center">
-      <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
-        Two ways to fill your Feed
-      </p>
-      <div className="flex items-center justify-center gap-3 text-sm font-medium">
+    <footer className="border-t pt-6 pb-8">
+      <div className="mx-auto flex max-w-md flex-col items-center gap-2 text-center">
+        <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
+          Make the questions better
+        </p>
+        <h2 className="font-serif text-xl font-semibold">
+          What&apos;s the best question you&apos;d like to be asked?
+        </h2>
+        <p className="text-muted-foreground text-sm">
+          Tell us the kind of questions you want to see — we&apos;ll take you
+          straight to the question writer.
+        </p>
+        <form
+          onSubmit={handleSubmit}
+          className="mt-2 flex w-full flex-col gap-2 sm:flex-row"
+        >
+          <input
+            value={idea}
+            onChange={(event) => setIdea(event.target.value)}
+            placeholder="A question you'd love to be asked…"
+            aria-label="What question would you like to be asked?"
+            className="h-11 flex-1 rounded-md border bg-background px-3 text-sm outline-none focus:border-primary"
+          />
+          <button type="submit" className="btn-primary h-11 shrink-0">
+            Write a question
+          </button>
+        </form>
         <Link
           href="/friends"
-          className="text-[var(--brand-link)] underline-offset-4 hover:underline"
+          className="text-[var(--brand-link)] mt-1 text-sm font-medium underline-offset-4 hover:underline"
         >
-          Invite a friend
-        </Link>
-        <span aria-hidden className="text-muted-foreground/40">
-          ·
-        </span>
-        <Link
-          href="/questions?create=1&intent=bank"
-          className="text-[var(--brand-link)] underline-offset-4 hover:underline"
-          aria-label="Write a question"
-        >
-          Write a question
+          Or invite a friend
         </Link>
       </div>
     </footer>

--- a/src/components/__tests__/buildQuestionWriterHref.test.ts
+++ b/src/components/__tests__/buildQuestionWriterHref.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildQuestionWriterHref } from '@/components/FeedList'
+
+describe('buildQuestionWriterHref', () => {
+  it('routes to the writer with no text when the idea is empty', () => {
+    expect(buildQuestionWriterHref('')).toBe('/questions?create=1&intent=bank')
+  })
+
+  it('treats a whitespace-only idea as empty', () => {
+    expect(buildQuestionWriterHref('   ')).toBe('/questions?create=1&intent=bank')
+  })
+
+  it('carries a trimmed, encoded idea through as ?text=', () => {
+    expect(buildQuestionWriterHref('  Which Broadway musical opened in 1957?  ')).toBe(
+      '/questions?create=1&intent=bank&text=Which%20Broadway%20musical%20opened%20in%201957%3F'
+    )
+  })
+})


### PR DESCRIPTION
## Summary
Transform the feed's bottom-of-page footer from a passive "two ways to fill your feed" message into an active prompt that captures reader ideas and routes them directly to the question composer. The reader's typed idea pre-fills the composer via a `?text=` query parameter, streamlining the path from consumption to contribution.

## Changes
- **FeedContributeFooter component:** Replaced static dual-link footer with an interactive form that accepts a question idea, validates/trims it, and routes to the composer with the idea pre-filled via `buildQuestionWriterHref()`
- **buildQuestionWriterHref() utility:** New pure function that constructs the composer URL, encoding the trimmed idea as `?text=` or omitting it if empty; kept separate for testability
- **Test coverage:** Added `buildQuestionWriterHref.test.ts` with three cases (empty, whitespace-only, and populated ideas with URL encoding)
- **QuestionsPageContent:** Updated drawer state to accept optional `prefillText` from the `?text=` query parameter and merge it into the form's initial values when opening the composer
- **UI/UX:** Reframed the prompt from "two ways to fill your feed" to "what's the best question you'd like to be asked?" with supporting copy; "Invite a friend" survives as a secondary link below the form

## Implementation details
- The `buildQuestionWriterHref()` function is pure and side-effect-free, enabling straightforward unit testing without DOM mocking
- Query parameter `?text=` is trimmed on both sides (in the utility and in the page component) to handle whitespace-only submissions gracefully
- The form uses `router.push()` to navigate, maintaining the existing intent-based routing pattern (`intent=bank`)
- Initial form values are merged using object spread to preserve other defaults from `createFormProps()`

https://claude.ai/code/session_018dobCJJYLR3pThs2SxeiCa