### PR TITLE
fix: drop .ts extensions from smoke test imports

### DIFF
--- a/scripts/daily-catchup.smoke.ts
+++ b/scripts/daily-catchup.smoke.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert/strict';
 import {
   dedupeCatchUpItems,
   orderCatchUpItems,
-} from '../src/server/play/catch-up-turn-sequencing.ts';
+} from '../src/server/play/catch-up-turn-sequencing';
 
 import {
   dailyQueueItemId,
@@ -11,7 +11,7 @@ import {
   isCatchupQueueDate,
   minusUtcDays,
   replaceQueueSlot,
-} from '../src/server/daily/catchup.ts';
+} from '../src/server/daily/catchup';
 
 assert.equal(minusUtcDays('2026-05-01', 7), '2026-04-24');
 


### PR DESCRIPTION
next build's TypeScript pass rejects import paths ending in .ts unless
allowImportingTsExtensions is enabled. tsx resolves the extensionless
paths to the same .ts modules, so the smoke test still runs.