### PR TITLE
test(smoke): cover D-1/D-2/D-3/D-4 provenance, milestones, and dedup

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,9 @@
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",
     "smoke:area-top-up": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/area-top-up.smoke.mjs",
     "smoke:sms-message-types": "tsx scripts/sms-message-types.smoke.ts",
+    "smoke:house-authorship": "tsx scripts/house-authorship.smoke.ts",
+    "smoke:lately-milestones": "tsx scripts/lately-milestones.smoke.ts",
+    "smoke:niche-match-dedup": "tsx scripts/niche-match-dedup.smoke.ts",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "format": "node scripts/format-changed.mjs",
     "format:all": "prettier --write ."

--- a/scripts/house-authorship.smoke.ts
+++ b/scripts/house-authorship.smoke.ts
@@ -1,0 +1,183 @@
+import assert from 'node:assert/strict';
+
+// D-3 house/editorial author + D-1 Stage 5 feed flip.
+//
+// These two surfaces share one provenance discriminator — the (source, creatorId)
+// pair — and carry the load-bearing invariants:
+//   H-1  a house question NEVER resolves to a users row (no person, no FK).
+//   H-2  the client badges a house question off an explicit flag, not a name match.
+//   C    house content never enters the Feed (it is curated, NOT LLM-origin).
+//   D-1  friend_answered (type-3) is no longer rendered in the Feed.
+// The unit tests cover the same modules; this smoke run guards them at the
+// `npm run smoke:*` boundary so a regression trips the same gate as the others.
+import {
+  HOUSE_AUTHOR,
+  LLM_QUESTION_ATTRIBUTION,
+  QUESTION_SOURCES,
+  isHouseAttribution,
+  isLlmAttribution,
+  parseQuestionSource,
+  resolveAuthorDisplay,
+  resolveQuestionAuthor,
+} from '../src/lib/questions-types';
+import {
+  ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES,
+  SOCIAL_FEED_SOURCE_TYPE,
+  isCorrectAnswerFeedEligible,
+  isLlmOriginQuestion,
+  isMainFeedSourceVisible,
+} from '../src/server/feed/visibility';
+
+// --- Provenance union -------------------------------------------------------
+// house_authored joined the union as a type-only change (free text, no migration).
+assert.deepEqual(
+  [...QUESTION_SOURCES],
+  ['authored', 'daily_generated', 'curated_sent', 'house_authored'],
+);
+
+// parseQuestionSource is the trust-boundary guard: known values pass, unknown
+// values fail LOUDLY rather than silently misrouting (e.g. a house question
+// rendering as a person).
+for (const source of QUESTION_SOURCES) {
+  assert.equal(parseQuestionSource(source), source);
+}
+assert.throws(() => parseQuestionSource('person'), /Unknown Question\.source/);
+assert.throws(() => parseQuestionSource(''), /Unknown Question\.source/);
+
+// --- House identity is a sentinel, never a users row ------------------------
+assert.equal(HOUSE_AUTHOR.id, 'house');
+assert.equal(HOUSE_AUTHOR.kind, 'house');
+assert.equal(LLM_QUESTION_ATTRIBUTION, 'Generated');
+// The house label must NOT collide with the LLM-origin attribution.
+assert.notEqual(HOUSE_AUTHOR.displayName, LLM_QUESTION_ATTRIBUTION);
+
+// --- resolveQuestionAuthor: the single (creatorId, source) router -----------
+// A real human creator hydrates the users row regardless of source.
+assert.deepEqual(
+  resolveQuestionAuthor({ creatorId: 'u1', source: 'authored', user: { name: 'Bob' } }),
+  { kind: 'human', user: { name: 'Bob' } },
+);
+// Even a (set creatorId, house_authored) pair stays human — creatorId wins.
+assert.equal(
+  resolveQuestionAuthor({ creatorId: 'u1', source: 'house_authored', user: { name: 'Bob' } }).kind,
+  'human',
+);
+
+// H-1: a house question (null creatorId) resolves to the house constant and is
+// NEVER 'human'. This is the invariant that keeps the house unfollowable.
+const house = resolveQuestionAuthor({ creatorId: null, source: 'house_authored', user: { name: 'Bob' } });
+assert.deepEqual(house, { kind: 'house', displayName: 'Joshing', label: 'Editorial' });
+assert.notEqual(house.kind, 'human');
+
+// LLM origins (and an inconsistent null-creator 'authored') get the non-person
+// 'Generated' treatment, never a person and never the house.
+for (const source of ['daily_generated', 'curated_sent', 'authored'] as const) {
+  assert.deepEqual(
+    resolveQuestionAuthor({ creatorId: null, source, user: { name: 'Bob' } }),
+    { kind: 'generated', name: 'Generated' },
+  );
+}
+
+// --- resolveAuthorDisplay: explicit authorIsHouse flag (H-2) ----------------
+assert.deepEqual(
+  resolveAuthorDisplay('u1', 'authored', 'Bob'),
+  { authorName: 'Bob', authorIsHouse: false },
+);
+// A house question yields the house name AND the robust flag, so the client
+// never has to string-match the name (a human literally named "Joshing" must
+// not be mistaken for the house author).
+assert.deepEqual(
+  resolveAuthorDisplay(null, 'house_authored', null),
+  { authorName: 'Joshing', authorIsHouse: true },
+);
+// A human named "Joshing" is NOT the house author.
+assert.deepEqual(
+  resolveAuthorDisplay('u1', 'authored', 'Joshing'),
+  { authorName: 'Joshing', authorIsHouse: false },
+);
+assert.deepEqual(
+  resolveAuthorDisplay(null, 'daily_generated', null),
+  { authorName: null, authorIsHouse: false },
+);
+
+// --- Attribution predicates -------------------------------------------------
+assert.equal(isHouseAttribution('Joshing'), true);
+assert.equal(isHouseAttribution('  Joshing  '), true); // trims
+assert.equal(isHouseAttribution('Generated'), false);
+assert.equal(isHouseAttribution(null), false);
+assert.equal(isHouseAttribution(undefined), false);
+
+assert.equal(isLlmAttribution('Generated'), true);
+assert.equal(isLlmAttribution('  Generated '), true);
+assert.equal(isLlmAttribution('Joshing'), false);
+assert.equal(isLlmAttribution(null), false);
+
+// --- isLlmOriginQuestion: house is curated, NOT LLM-origin ------------------
+assert.equal(isLlmOriginQuestion('daily_generated'), true);
+assert.equal(isLlmOriginQuestion('curated_sent'), true);
+assert.equal(isLlmOriginQuestion('authored'), false);
+// The crux of D-3 §C: house questions are editorial, so they are not LLM-origin.
+assert.equal(isLlmOriginQuestion('house_authored'), false);
+
+// --- isCorrectAnswerFeedEligible -------------------------------------------
+const base = { answerIsCorrect: true, answererUserId: 'answerer', hasVisibleSocialContext: true } as const;
+
+// An LLM-origin correct answer is feed-eligible (no author to key on).
+assert.equal(
+  isCorrectAnswerFeedEligible({
+    ...base,
+    question: { creatorId: null, source: 'daily_generated', visibility: 'public', deletedAt: null },
+  }),
+  true,
+);
+
+// C invariant: a house question NEVER enters the Feed. It is not LLM-origin and
+// has no creatorId, so it falls through to the null-creator guard → false.
+assert.equal(
+  isCorrectAnswerFeedEligible({
+    ...base,
+    question: { creatorId: null, source: 'house_authored', visibility: 'public', deletedAt: null },
+  }),
+  false,
+);
+
+// A human-authored question is eligible for a different answerer...
+assert.equal(
+  isCorrectAnswerFeedEligible({
+    ...base,
+    question: { creatorId: 'author', source: 'authored', visibility: 'public', deletedAt: null },
+  }),
+  true,
+);
+// ...but never for the author answering their own question.
+assert.equal(
+  isCorrectAnswerFeedEligible({
+    ...base,
+    answererUserId: 'author',
+    question: { creatorId: 'author', source: 'authored', visibility: 'public', deletedAt: null },
+  }),
+  false,
+);
+// Hard gates: wrong answer, no social context, private, deleted, missing question.
+assert.equal(isCorrectAnswerFeedEligible({ ...base, answerIsCorrect: false, question: { creatorId: 'a', source: 'authored', visibility: 'public', deletedAt: null } }), false);
+assert.equal(isCorrectAnswerFeedEligible({ ...base, hasVisibleSocialContext: false, question: { creatorId: 'a', source: 'authored', visibility: 'public', deletedAt: null } }), false);
+assert.equal(isCorrectAnswerFeedEligible({ ...base, question: { creatorId: 'a', source: 'authored', visibility: 'private', deletedAt: null } }), false);
+assert.equal(isCorrectAnswerFeedEligible({ ...base, question: { creatorId: 'a', source: 'authored', visibility: 'public', deletedAt: new Date() } }), false);
+assert.equal(isCorrectAnswerFeedEligible({ ...base, question: null }), false);
+
+// --- D-1 Stage 5 feed flip: friend_answered (type-3) leaves the Feed --------
+// The social source type is still WRITTEN (it backs Daily +2 and "Recently
+// exploring"), but it is no longer one of the always-visible main-feed types.
+assert.equal(SOCIAL_FEED_SOURCE_TYPE, 'friend_answered');
+assert.equal(isMainFeedSourceVisible('friend_answered'), false);
+assert.ok(
+  !(ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES as readonly string[]).includes('friend_answered'),
+  'friend_answered must not be a visible main-feed source after the feed flip',
+);
+// Broadcasts (authored_shared + legacy thumbs_upped) and Sent (direct_sent) stay.
+assert.equal(isMainFeedSourceVisible('authored_shared'), true);
+assert.equal(isMainFeedSourceVisible('direct_sent'), true);
+assert.equal(isMainFeedSourceVisible('thumbs_upped'), true);
+assert.equal(isMainFeedSourceVisible('totally_made_up'), false);
+
+console.log('house-authorship.smoke: ok');

--- a/scripts/lately-milestones.smoke.ts
+++ b/scripts/lately-milestones.smoke.ts
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict';
+
+// D-4 §A Lately skill milestones (dual-form split + CORRECTION 3 5-cap).
+//
+// deriveLatelyMilestones is a pure transform over a viewer's correct
+// `friend_answered` rows. The load-bearing rules it must keep:
+//   - DEEP: a (friend, domain) group with ≥ MILESTONE_DEEP_MIN correct answers
+//     becomes its own line, excluded from the breadth roll-up (no double-count).
+//   - BREADTH: a friend's remaining light domains aggregate — but ONLY with ≥ 2
+//     of them. A lone light domain is silent (neither form).
+//   - DEDUP: the same canonical question answered twice cannot inflate a count.
+//   - 5-CAP: no line surfaces more than MILESTONE_CARD_QUESTION_CAP questions; a
+//     deep line keeps the 5 most-recent, and over-cap breadth SPLITS into
+//     several honest lines instead of a "+N others" mega-card.
+//   - ORDER: deterministic (sortAt desc, id tie-break) so the shape is assertable.
+import {
+  MILESTONE_CARD_QUESTION_CAP,
+  MILESTONE_DEEP_MIN,
+  MILESTONE_MIN_CORRECT,
+  breadthMilestoneCopy,
+  collectMilestoneQuestionIds,
+  deriveLatelyMilestones,
+  type MilestoneAnswerRow,
+  type MilestoneBreadth,
+  type MilestoneDeep,
+  deepMilestoneCopy,
+} from '../src/lib/lately-milestones';
+
+// Seconds-since-epoch helper so the recency ordering in assertions is obvious.
+const at = (t: number) => new Date(t * 1000);
+const row = (
+  friendId: string,
+  friendFirstName: string,
+  domain: string,
+  questionId: string,
+  t: number,
+): MilestoneAnswerRow => ({
+  friendId,
+  friendName: `${friendFirstName} Lovelace`,
+  friendFirstName,
+  domain,
+  questionId,
+  answeredAt: at(t),
+});
+
+// --- Tunable thresholds -----------------------------------------------------
+assert.equal(MILESTONE_MIN_CORRECT, 1);
+assert.equal(MILESTONE_DEEP_MIN, 3);
+assert.equal(MILESTONE_CARD_QUESTION_CAP, 5);
+
+// --- Scenario A: one deep line + one breadth line ---------------------------
+// Ada: Jazz ×3 (deep), Poetry ×2 + Film ×1 (two light domains → breadth).
+const scenarioA = deriveLatelyMilestones([
+  row('f1', 'Ada', 'Jazz', 'q1', 10),
+  row('f1', 'Ada', 'Jazz', 'q2', 9),
+  row('f1', 'Ada', 'Jazz', 'q3', 8),
+  row('f1', 'Ada', 'Poetry', 'q5', 7),
+  row('f1', 'Ada', 'Poetry', 'q6', 6),
+  row('f1', 'Ada', 'Film', 'q4', 5),
+]);
+
+assert.equal(scenarioA.length, 2);
+// Deep sorts ahead of breadth (its sortAt is the most recent answer, t=10).
+const deep = scenarioA[0] as MilestoneDeep;
+assert.equal(deep.kind, 'milestone_deep');
+assert.equal(deep.domain, 'Jazz');
+assert.equal(deep.correctCount, 3);
+assert.deepEqual([...deep.questionIds].sort(), ['q1', 'q2', 'q3']);
+assert.equal(deep.id, 'deep:f1:Jazz');
+
+const breadth = scenarioA[1] as MilestoneBreadth;
+assert.equal(breadth.kind, 'milestone_breadth');
+// Light domains ordered most-recent first: Poetry (t=7) before Film (t=5).
+assert.deepEqual(breadth.domains.map((d) => d.domain), ['Poetry', 'Film']);
+// Jazz (the deep domain) is NOT double-counted into the breadth roll-up.
+assert.ok(!breadth.domains.some((d) => d.domain === 'Jazz'));
+assert.deepEqual(breadth.questionIds, ['q5', 'q6', 'q4']);
+
+// Copy (PLACEHOLDER per spec, but the shape is contractual for the render layer).
+assert.equal(deepMilestoneCopy(deep), 'Ada went deep on Jazz');
+assert.equal(breadthMilestoneCopy(breadth), "Ada's been killing it — Poetry and Film");
+
+// --- Scenario B: a lone light domain is silent ------------------------------
+// One light domain (below the deep threshold, only one of it) → no milestone.
+assert.deepEqual(
+  deriveLatelyMilestones([
+    row('f2', 'Bo', 'Chess', 'q7', 5),
+    row('f2', 'Bo', 'Chess', 'q8', 4),
+  ]),
+  [],
+);
+
+// --- Scenario C: dedup keeps a repeat-answer off the deep threshold ---------
+// The same questionId answered three times is ONE distinct question, so this
+// single domain stays light-and-lonely (→ silent) rather than crossing to deep.
+assert.deepEqual(
+  deriveLatelyMilestones([
+    row('f3', 'Cy', 'Opera', 'q9', 1),
+    row('f3', 'Cy', 'Opera', 'q9', 2),
+    row('f3', 'Cy', 'Opera', 'q9', 3),
+  ]),
+  [],
+);
+
+// --- Scenario D: breadth splits at the 5-question cap -----------------------
+// Three light domains of 2 questions each = 6 > cap, so breadth packs into two
+// lines (most-recent first), never a single over-cap card.
+const scenarioD = deriveLatelyMilestones([
+  row('f4', 'Di', 'D1', 'a1', 30),
+  row('f4', 'Di', 'D1', 'a2', 29),
+  row('f4', 'Di', 'D2', 'b1', 20),
+  row('f4', 'Di', 'D2', 'b2', 19),
+  row('f4', 'Di', 'D3', 'c1', 10),
+  row('f4', 'Di', 'D3', 'c2', 9),
+]);
+assert.equal(scenarioD.length, 2);
+for (const milestone of scenarioD) {
+  assert.equal(milestone.kind, 'milestone_breadth');
+  assert.ok(
+    milestone.questionIds.length <= MILESTONE_CARD_QUESTION_CAP,
+    'no breadth line may exceed the 5-question cap',
+  );
+}
+// First line packs the two most-recent domains (D1+D2 = 4 ≤ 5); D3 spills over.
+const [lineOne, lineTwo] = scenarioD as MilestoneBreadth[];
+assert.deepEqual(lineOne.domains.map((d) => d.domain), ['D1', 'D2']);
+assert.deepEqual(lineTwo.domains.map((d) => d.domain), ['D3']);
+
+// --- Scenario E: a deep line keeps only the 5 most-recent questions ---------
+const scenarioE = deriveLatelyMilestones(
+  Array.from({ length: 7 }, (_, i) => row('f5', 'Ev', 'Sci', `s${i}`, i + 1)),
+);
+assert.equal(scenarioE.length, 1);
+const bigDeep = scenarioE[0] as MilestoneDeep;
+assert.equal(bigDeep.kind, 'milestone_deep');
+assert.equal(bigDeep.correctCount, 7); // the true count is preserved...
+assert.equal(bigDeep.questionIds.length, MILESTONE_CARD_QUESTION_CAP); // ...but only 5 surface
+// The 5 most-recent (highest t) are kept: s6,s5,s4,s3,s2; s1,s0 are dropped.
+assert.deepEqual([...bigDeep.questionIds].sort(), ['s2', 's3', 's4', 's5', 's6']);
+
+// --- collectMilestoneQuestionIds: union of everything playable --------------
+const ids = collectMilestoneQuestionIds(scenarioA);
+assert.deepEqual([...ids].sort(), ['q1', 'q2', 'q3', 'q4', 'q5', 'q6']);
+assert.deepEqual([...collectMilestoneQuestionIds([])], []);
+
+console.log('lately-milestones.smoke: ok');

--- a/scripts/niche-match-dedup.smoke.ts
+++ b/scripts/niche-match-dedup.smoke.ts
@@ -1,0 +1,107 @@
+import assert from 'node:assert/strict';
+
+// D-2 WS4 — niche-match dedup NON-collision guard.
+//
+// /activities runs filterUtilityActivities to drop activity rows that a Lately
+// "connection moment" already narrates, so the same event never double-renders.
+// The load-bearing D-2 invariant is the OPPOSITE: the two niche_match_* types
+// must SURVIVE this filter unconditionally. Lately moments are friend-scoped,
+// but niche-match fires only between strangers (the 'none' relationship), so the
+// two are disjoint by construction — dropping a niche_match item here would
+// silently delete the only surface the discovery loop renders on. This run
+// guards that boundary at the `npm run smoke:*` layer.
+import { filterUtilityActivities } from '../src/app/activities/filter-utility-activities';
+import type { ActivityItemView } from '../src/server/db/queries/activity';
+import type { LatelyMoment } from '../src/server/db/queries/lately';
+
+// Minimal typed factory — only the fields filterUtilityActivities reads matter,
+// but the base columns are required by ActivityItemView so we fill them.
+function mk(
+  id: string,
+  type: ActivityItemView['type'],
+  reference: ActivityItemView['reference'] = {},
+): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer',
+    actorUserId: 'actor',
+    referenceId: 'ref',
+    referenceType: 'question',
+    read: false,
+    createdAt: new Date('2026-06-01T00:00:00.000Z'),
+    type,
+    actor: { displayName: 'Someone' },
+    reference,
+  };
+}
+
+function youGotThemMoment(questionId: string): LatelyMoment {
+  return {
+    momentId: `m-${questionId}`,
+    dir: 'you_got_them',
+    friendId: 'f1',
+    friendName: 'Ada Lovelace',
+    friendFirstName: 'Ada',
+    questionId,
+    questionText: 'Q?',
+    category: 'music',
+    gameTitle: 'Daily',
+    answeredAt: new Date('2026-06-01T00:00:00.000Z'),
+  };
+}
+
+// A full mix of items: the two niche_match types, the three utility types that
+// SHOULD be deduped, and the variants of those types that should survive.
+const items: ActivityItemView[] = [
+  // niche-match — must always survive.
+  mk('nm-author', 'niche_match_answered_your_question', { nicheMatch: { domain: 'Free Jazz', questionText: 'Q?' } }),
+  mk('nm-answerer', 'niche_match_you_answered', { nicheMatch: { domain: 'Free Jazz', questionText: 'Q?' } }),
+  // A niche-match item whose questionId collides with a you_got_them moment —
+  // still must survive (niche-match is never keyed on questionId here).
+  mk('nm-collide', 'niche_match_you_answered', { directQuestion: { feedItemId: 'fi', questionId: 'q-shared', questionText: 'Q?', personalMessage: null, category: null } }),
+
+  // Utility types that the Lately moments already narrate — should be dropped.
+  mk('drop-friend-correct', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'correct' } }),
+  mk('drop-declared', 'declared_promoted'),
+  mk('drop-direct-covered', 'received_direct_question', { directQuestion: { feedItemId: 'fi', questionId: 'q-shared', questionText: 'Q?', personalMessage: null, category: null } }),
+
+  // Same families, but NOT covered by a moment — should survive.
+  mk('keep-friend-incorrect', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'incorrect' } }),
+  mk('keep-direct-uncovered', 'received_direct_question', { directQuestion: { feedItemId: 'fi', questionId: 'q-other', questionText: 'Q?', personalMessage: null, category: null } }),
+];
+
+const moments: LatelyMoment[] = [youGotThemMoment('q-shared')];
+
+const surviving = filterUtilityActivities(items, moments).map((i) => i.id);
+
+// The crux: both niche_match items survive, including the one whose questionId
+// collides with a you_got_them moment.
+assert.ok(surviving.includes('nm-author'), 'niche_match_answered_your_question must survive dedup');
+assert.ok(surviving.includes('nm-answerer'), 'niche_match_you_answered must survive dedup');
+assert.ok(surviving.includes('nm-collide'), 'niche-match must survive even on a questionId collision');
+
+// The three covered utility rows are dropped.
+assert.ok(!surviving.includes('drop-friend-correct'), 'a correct friend_answered_your_question is covered by they_got_you');
+assert.ok(!surviving.includes('drop-declared'), 'declared_promoted is a strict subset of they_got_you');
+assert.ok(!surviving.includes('drop-direct-covered'), 'a received_direct_question the viewer already got is covered by you_got_them');
+
+// Their uncovered variants survive.
+assert.ok(surviving.includes('keep-friend-incorrect'), 'an incorrect friend_answered_your_question is not deduped');
+assert.ok(surviving.includes('keep-direct-uncovered'), 'a received_direct_question with no matching moment survives');
+
+// Exact surviving set (order preserved from input).
+assert.deepEqual(surviving, [
+  'nm-author',
+  'nm-answerer',
+  'nm-collide',
+  'keep-friend-incorrect',
+  'keep-direct-uncovered',
+]);
+
+// No moments at all: only the type-keyed drops apply (friend-correct, declared).
+const noMoments = filterUtilityActivities(items, []).map((i) => i.id);
+assert.ok(noMoments.includes('drop-direct-covered'), 'with no you_got_them moment, the direct question is not deduped');
+assert.ok(!noMoments.includes('drop-friend-correct'));
+assert.ok(!noMoments.includes('drop-declared'));
+
+console.log('niche-match-dedup.smoke: ok');


### PR DESCRIPTION
The past week's feature work (the D-1..D-4 line) shipped several pure,
invariant-bearing decision functions that the smoke layer didn't yet guard.
Add three hermetic smoke tests over the import-safe modules:

- smoke:house-authorship — D-3 house/editorial provenance + the D-1 Stage 5
  feed flip. Asserts the (creatorId, source) author router (H-1: house never
  resolves to a users row; H-2: an explicit authorIsHouse flag, never a name
  match), that house questions are curated-not-LLM and so never enter the Feed
  (D-3 §C), and that friend_answered (type-3) is no longer a visible main-feed
  source while Broadcasts/Sent remain.
- smoke:lately-milestones — D-4 §A deep/breadth split, the dedup that keeps a
  repeat-answer off the deep threshold, the universal 5-question cap with
  breadth multi-line splitting, deterministic ordering, and the copy contract.
- smoke:niche-match-dedup — D-2 WS4 non-collision guard: the two niche_match_*
  types survive /activities dedup (including on a questionId collision), while
  the three Lately-covered utility types are dropped.

All three are dependency-light (type-only DB imports) so they stay hermetic at
the npm run smoke:* boundary, matching the existing smoke convention.