### PR TITLE
Fix TypeScript source type error in daily-catchup smoke test

### DIFF
--- a/scripts/daily-catchup.smoke.ts
+++ b/scripts/daily-catchup.smoke.ts
@@ -12,6 +12,7 @@ import {
   minusUtcDays,
   replaceQueueSlot,
 } from '../src/server/daily/catchup';
+import type { QueueSlot } from '../src/server/daily/types';
 
 assert.equal(minusUtcDays('2026-05-01', 7), '2026-04-24');
 
@@ -22,7 +23,7 @@ assert.equal(isCatchupQueueDate('2026-04-23', '2026-05-01'), false);
 
 assert.equal(dailyQueueItemId('queue-1', 3), 'queue-1:3');
 
-const slots = [
+const slots: QueueSlot[] = [
   {
     slot_index: 3,
     source: 'bot',


### PR DESCRIPTION
Annotate the slots literal as QueueSlot[] so the source field is
checked against the queueSlotSource union instead of being widened to
string, which broke the next build TypeScript step.