### PR TITLE
Redesign homepage feed bottom with editorial empty state + larger question box

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -21,6 +21,7 @@ import {
   type FriendLikedFeedItem,
 } from '@/components/feed'
 import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion'
+import { SparkleDivider, SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import type { InsideJokeKind, QuestionSource } from '@/lib/questions-types'
@@ -541,39 +542,39 @@ function FeedContributeFooter() {
   }
 
   return (
-    <footer className="border-t pt-6 pb-8">
-      <div className="mx-auto flex max-w-md flex-col items-center gap-2 text-center">
-        <p className="text-muted-foreground text-[11px] font-medium tracking-[0.12em] uppercase">
-          Make the questions better
-        </p>
-        <h2 className="font-serif text-xl font-semibold">
-          What&apos;s the best question you&apos;d like to be asked?
+    <footer className="pt-6 pb-8">
+      <SparkleDivider />
+      <div className="mx-auto mt-6 flex max-w-md flex-col items-center gap-2 text-center">
+        <h2 className="text-foreground max-w-sm font-serif text-2xl font-semibold text-balance">
+          The best games start with one great question.
         </h2>
         <p className="text-muted-foreground text-sm">
-          Tell us the kind of questions you want to see — we&apos;ll take you
-          straight to the question writer.
+          Wish someone would ask about your favorite album, movie, or book? Start
+          there.
         </p>
-        <form
-          onSubmit={handleSubmit}
-          className="mt-2 flex w-full flex-col gap-2 sm:flex-row"
-        >
-          <input
+        <form onSubmit={handleSubmit} className="mt-2 flex w-full flex-col gap-2">
+          <textarea
             value={idea}
             onChange={(event) => setIdea(event.target.value)}
             placeholder="A question you'd love to be asked…"
             aria-label="What question would you like to be asked?"
-            className="h-11 flex-1 rounded-md border bg-background px-3 text-sm outline-none focus:border-primary"
+            rows={5}
+            className="min-h-[140px] w-full resize-none rounded-md border bg-background px-3 py-2 text-sm outline-none focus:border-primary"
           />
-          <button type="submit" className="btn-primary h-11 shrink-0">
+          <button type="submit" className="btn-primary h-11 w-full">
             Write a question
           </button>
         </form>
-        <Link
-          href="/friends"
-          className="text-[var(--brand-link)] mt-1 text-sm font-medium underline-offset-4 hover:underline"
-        >
-          Or invite a friend
-        </Link>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Or{' '}
+          <Link
+            href="/friends"
+            className="text-[var(--brand-link)] font-medium underline-offset-4 hover:underline"
+          >
+            invite a friend
+          </Link>{' '}
+          instead.
+        </p>
       </div>
     </footer>
   )
@@ -767,9 +768,14 @@ function FeedListContent({
       return "You've focused your Feed. You can re-open domains from your Knowledge page."
     }
     if (feedMeta.total_item_count > 0)
-      return "You've answered every question your friends sent. Invite more friends and their questions will show up here."
+      return "You've answered every question your friends sent."
     return 'Quiet today. Check back when your friends have played.'
   }, [error, feedFilter, feedMeta, loadingInitial])
+
+  // Short surface label shown under the serif empty-state headline. Skipped on
+  // the error path (the headline carries the error message there instead).
+  const emptySubtitle =
+    feedFilter === 'sent-to-me' ? 'No questions sent yet.' : 'No broadcasts yet.'
 
   // The invite CTA only makes sense on the friend-sourced Broadcasts surface.
   const showInviteFriendCta =
@@ -1174,15 +1180,17 @@ function FeedListContent({
 
       {items.length === 0 ? (
         <section className="flex min-h-48 flex-col items-center justify-center gap-3 py-12 text-center">
-          <p
-            className={
-              error
-                ? 'text-destructive text-sm'
-                : 'text-muted-foreground text-sm'
-            }
-          >
-            {emptyCopy}
-          </p>
+          {error ? (
+            <p className="text-destructive text-sm">{emptyCopy}</p>
+          ) : (
+            <>
+              <SpeechBubbleIllustration className="mb-1 h-24 w-auto" />
+              <h2 className="text-foreground max-w-sm font-serif text-2xl font-semibold text-balance">
+                {emptyCopy}
+              </h2>
+              <p className="text-muted-foreground text-sm">{emptySubtitle}</p>
+            </>
+          )}
           {showInviteFriendCta && !showContributeFooter ? (
             <Link
               href="/friends"

--- a/src/components/home/FeedEmptyArt.tsx
+++ b/src/components/home/FeedEmptyArt.tsx
@@ -1,0 +1,80 @@
+// Decorative art for the bottom of the homepage feed: the empty-state speech
+// bubbles and the sparkle divider that separates the empty state from the
+// "write a question" prompt. Hand-built inline SVGs (no asset existed) using the
+// brand palette from globals.css, in the stroke-based idiom of
+// src/components/icons/domain-icons.tsx. Purely presentational + aria-hidden.
+
+export function SpeechBubbleIllustration({ className }: { className?: string }) {
+  return (
+    <svg
+      role="img"
+      aria-hidden="true"
+      viewBox="0 0 120 96"
+      className={className ?? 'h-24 w-auto'}
+    >
+      {/* sparkle strokes above the bubbles */}
+      <g
+        stroke="var(--brand-orange)"
+        strokeWidth={2}
+        strokeLinecap="round"
+        fill="none"
+      >
+        <path d="M62 8v9" />
+        <path d="M50 13l4 7" />
+        <path d="M74 13l-4 7" />
+      </g>
+
+      {/* large cream bubble with three navy dots */}
+      <path
+        d="M20 30h52a8 8 0 0 1 8 8v16a8 8 0 0 1-8 8H40l-10 11v-11h-10a8 8 0 0 1-8-8V38a8 8 0 0 1 8-8z"
+        fill="var(--brand-cream)"
+        stroke="var(--brand-rule)"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <g fill="var(--brand-ink)">
+        <circle cx="34" cy="46" r="3.5" />
+        <circle cx="46" cy="46" r="3.5" />
+        <circle cx="58" cy="46" r="3.5" />
+      </g>
+
+      {/* smaller gray question bubble */}
+      <path
+        d="M86 50h18a6 6 0 0 1 6 6v10a6 6 0 0 1-6 6h-4l-7 8v-8h-7a6 6 0 0 1-6-6V56a6 6 0 0 1 6-6z"
+        fill="#e5e3df"
+        stroke="var(--brand-rule)"
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+      />
+      <text
+        x="95"
+        y="68"
+        textAnchor="middle"
+        fontFamily="var(--font-serif), Georgia, serif"
+        fontSize="18"
+        fontWeight="600"
+        fill="var(--brand-ink)"
+      >
+        ?
+      </text>
+    </svg>
+  )
+}
+
+export function SparkleDivider({ className }: { className?: string }) {
+  return (
+    <div
+      aria-hidden="true"
+      className={`flex items-center justify-center gap-4 ${className ?? ''}`}
+    >
+      <span className="h-px w-16 bg-[var(--brand-rule)]" />
+      <svg viewBox="0 0 24 24" className="h-4 w-4 shrink-0">
+        <path
+          d="M12 1c.6 5.2 5.8 10.4 11 11-5.2.6-10.4 5.8-11 11-.6-5.2-5.8-10.4-11-11C6.2 11.4 11.4 6.2 12 1z"
+          fill="var(--brand-orange)"
+        />
+      </svg>
+      <span className="h-px w-16 bg-[var(--brand-rule)]" />
+    </div>
+  )
+}


### PR DESCRIPTION
Rework the bottom of the authenticated homepage feed to match the new
editorial design:

- New empty state with a hand-built speech-bubble illustration, a serif
  headline, and a short surface subtitle ("No broadcasts yet." /
  "No questions sent yet.").
- Add a sparkle divider above the contribute prompt.
- Refresh the contribute prompt copy ("The best games start with one
  great question.") and replace the single-line input with a large
  ~5-row textarea and a full-width "Write a question" button.
- Restyle the secondary CTA to "Or invite a friend instead."

Adds src/components/home/FeedEmptyArt.tsx for the inline-SVG illustration
and sparkle divider, using brand design tokens.

https://claude.ai/code/session_01VoJcjyrNyPtEiPzdbGcYVh