### PR TITLE
Restyle profile "Recently exploring" + add search/filter to authored questions

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -338,6 +338,8 @@ export default async function UserProfilePage({
     id: question.id,
     questionText: question.questionText,
     category: question.canonicalSubcategory ?? question.broadCategory,
+    broadCategory: question.broadCategory,
+    difficulty: question.difficulty,
     createdAt: question.createdAt,
     viewerAnswered: question.viewerAnswered,
   }))

--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import { useCallback, useState, type ReactNode } from 'react'
+import { useCallback, useMemo, useState, type ReactNode } from 'react'
+import { Search } from 'lucide-react'
 
 import {
   AnsweredByYouCard,
@@ -9,14 +10,27 @@ import {
   type AnsweredByYouFeedItem,
   type DirectSentFeedItem,
 } from '@/components/feed'
+import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy'
+
+export type AuthoredQuestionDifficulty = 'accessible' | 'moderate' | 'specialist'
 
 export type AuthoredQuestionItem = {
   id: string
   questionText: string
   category: string | null
+  broadCategory: string | null
+  difficulty: AuthoredQuestionDifficulty | null
   createdAt: string
   viewerAnswered: { result: 'correct' | 'incorrect' } | null
 }
+
+// Ordered so the difficulty dropdown reads easiest → hardest regardless of
+// the order questions happen to arrive in.
+const DIFFICULTY_ORDER: AuthoredQuestionDifficulty[] = [
+  'accessible',
+  'moderate',
+  'specialist',
+]
 
 type AnswerResult = {
   isCorrect: boolean
@@ -83,6 +97,44 @@ export function AuthoredQuestionsFeed({
   const [answerSheetId, setAnswerSheetId] = useState<string | null>(null)
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+  const [searchQuery, setSearchQuery] = useState('')
+  const [selectedCategory, setSelectedCategory] = useState('')
+  const [selectedDifficulty, setSelectedDifficulty] = useState('')
+
+  const categoryOptions = useMemo(() => {
+    const seen = new Set<string>()
+    for (const question of questions) {
+      if (question.broadCategory) seen.add(question.broadCategory)
+    }
+    return Array.from(seen).sort((a, b) => a.localeCompare(b))
+  }, [questions])
+
+  const difficultyOptions = useMemo(() => {
+    const present = new Set<AuthoredQuestionDifficulty>()
+    for (const question of questions) {
+      if (question.difficulty) present.add(question.difficulty)
+    }
+    return DIFFICULTY_ORDER.filter((value) => present.has(value)).map((value) => ({
+      value,
+      label: difficultyCopyFromEstimate(value) ?? value,
+    }))
+  }, [questions])
+
+  const visibleQuestions = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase()
+    return questions.filter((question) => {
+      if (query && !question.questionText.toLowerCase().includes(query)) {
+        return false
+      }
+      if (selectedCategory && question.broadCategory !== selectedCategory) {
+        return false
+      }
+      if (selectedDifficulty && question.difficulty !== selectedDifficulty) {
+        return false
+      }
+      return true
+    })
+  }, [questions, searchQuery, selectedCategory, selectedDifficulty])
 
   const submitAnswer = useCallback(
     async (item: AuthoredQuestionItem, submittedAnswer: string) => {
@@ -161,7 +213,60 @@ export function AuthoredQuestionsFeed({
         </p>
       ) : (
         <div className="space-y-3">
-          {questions.map((item) => {
+          <div className="space-y-2">
+            <label className="relative block">
+              <Search className="text-muted-foreground pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2" />
+              <input
+                className="bg-background focus:border-primary h-11 w-full rounded-md border pr-3 pl-10 text-sm outline-none"
+                value={searchQuery}
+                onChange={(event) => setSearchQuery(event.target.value)}
+                placeholder="Search questions..."
+                aria-label="Search questions"
+              />
+            </label>
+            {categoryOptions.length > 1 || difficultyOptions.length > 1 ? (
+              <div className="flex flex-wrap gap-2">
+                {categoryOptions.length > 1 ? (
+                  <select
+                    className="bg-background text-foreground h-10 flex-1 rounded-md border px-3 text-sm"
+                    value={selectedCategory}
+                    onChange={(event) => setSelectedCategory(event.target.value)}
+                    aria-label="Filter by category"
+                  >
+                    <option value="">All categories</option>
+                    {categoryOptions.map((category) => (
+                      <option key={category} value={category}>
+                        {category}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+                {difficultyOptions.length > 1 ? (
+                  <select
+                    className="bg-background text-foreground h-10 flex-1 rounded-md border px-3 text-sm"
+                    value={selectedDifficulty}
+                    onChange={(event) => setSelectedDifficulty(event.target.value)}
+                    aria-label="Filter by difficulty"
+                  >
+                    <option value="">All difficulties</option>
+                    {difficultyOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
+
+          {visibleQuestions.length === 0 ? (
+            <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
+              No questions match your filters.
+            </p>
+          ) : null}
+
+          {visibleQuestions.map((item) => {
             const localResult = results[item.id]
             const persistedAnswered = item.viewerAnswered !== null
             const isAnswered = Boolean(localResult) || persistedAnswered

--- a/src/components/profile/RecentlyExploringSection.tsx
+++ b/src/components/profile/RecentlyExploringSection.tsx
@@ -1,3 +1,5 @@
+import { type CSSProperties } from 'react'
+
 import { formatRelativeTime } from '@/components/feed/visual'
 import type { RecentlyExploringDomain } from '@/server/profile/recently-exploring'
 
@@ -6,12 +8,29 @@ type RecentlyExploringSectionProps = {
   friendFirstName: string
 }
 
+// Rotating accent palette for the row initial badges. Mirrors the visual
+// treatment of the Knowledge page's "Recently Expanding" card
+// (src/components/knowledge/RecentlyExpanding.tsx) so the two surfaces read
+// as the same component family.
+const ROW_ACCENTS = [
+  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
+  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
+  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
+  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.20)' },
+  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
+]
+
 /**
  * "Recently exploring" presence section on a friend's profile. Shows which
  * domains the friend has been answering in lately, derived from `masteryEvents`
  * recency. Distinct from the historical knowledge map (sorted by points) and
  * from declared shared interests. Renders nothing when there is no recent
  * activity (the page also guards on a non-empty list).
+ *
+ * Styled to match the Knowledge page's "Recently Expanding" card: a cream card
+ * box with a circular initial badge, serif domain names, and border-separated
+ * rows. The supporting line keeps this surface's real data — a relative
+ * timestamp — rather than the reason strings the knowledge version derives.
  */
 export function RecentlyExploringSection({
   domains,
@@ -21,27 +40,107 @@ export function RecentlyExploringSection({
 
   return (
     <section className="mt-5" aria-label="Recently exploring">
-      <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-        Recently exploring
-      </p>
-      <p className="text-muted-foreground mt-2 text-sm leading-6">
-        What {friendFirstName}’s been answering lately.
-      </p>
-      <ul className="mt-3 flex flex-col gap-2">
-        {domains.map((domain) => (
-          <li
-            key={domain.domain}
-            className="flex items-baseline justify-between gap-3"
-          >
-            <span className="text-foreground text-sm font-medium">
-              {domain.displayName}
-            </span>
-            <span className="text-muted-foreground shrink-0 text-xs">
-              {formatRelativeTime(domain.lastActivityAt)}
-            </span>
-          </li>
-        ))}
-      </ul>
+      <div style={boxStyle}>
+        <div>
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+            Recently exploring
+          </p>
+          <p className="text-muted-foreground mt-2 text-sm leading-6">
+            What {friendFirstName}’s been answering lately.
+          </p>
+        </div>
+        <div style={rowsStyle}>
+          {domains.map((domain, index) => {
+            const accent = ROW_ACCENTS[index % ROW_ACCENTS.length]
+            return (
+              <div key={domain.domain} style={rowStyle} data-exploring-row="true">
+                <div
+                  style={{
+                    ...badgeStyle,
+                    borderColor: accent.border,
+                    background: accent.fill,
+                  }}
+                  aria-hidden="true"
+                >
+                  {getDomainInitial(domain.displayName)}
+                </div>
+                <div style={rowTextStyle}>
+                  <h3 style={domainNameStyle}>{domain.displayName}</h3>
+                  <p style={supportingStyle}>
+                    {formatRelativeTime(domain.lastActivityAt)}
+                  </p>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
     </section>
   )
+}
+
+function getDomainInitial(domain: string): string {
+  const firstMeaningfulWord = domain
+    .replace(/&/g, ' ')
+    .split(/\s+/)
+    .find((word) => /^[a-z0-9]/i.test(word))
+  return (firstMeaningfulWord?.[0] ?? domain[0] ?? '?').toUpperCase()
+}
+
+const boxStyle: CSSProperties = {
+  background: 'var(--brand-cream-card)',
+  border: '1px solid var(--brand-border)',
+  borderRadius: 12,
+  boxShadow: '0 4px 12px rgba(40, 32, 30, 0.04)',
+  padding: '1.05rem 0.95rem 0.65rem',
+  display: 'grid',
+  gap: '0.75rem',
+}
+
+const rowsStyle: CSSProperties = {
+  display: 'grid',
+}
+
+const rowStyle: CSSProperties = {
+  minHeight: 62,
+  display: 'grid',
+  gridTemplateColumns: '44px minmax(0, 1fr)',
+  alignItems: 'center',
+  columnGap: '0.75rem',
+  padding: '0.54rem 0',
+  borderTop: '1px solid #eee8dd',
+}
+
+const badgeStyle: CSSProperties = {
+  width: 32,
+  height: 32,
+  borderRadius: 999,
+  border: '1px solid',
+  color: '#1a1208',
+  display: 'grid',
+  placeItems: 'center',
+  fontSize: '0.86rem',
+  fontWeight: 700,
+  lineHeight: 1,
+}
+
+const rowTextStyle: CSSProperties = {
+  minWidth: 0,
+}
+
+const domainNameStyle: CSSProperties = {
+  margin: 0,
+  color: '#1a1208',
+  fontFamily: 'var(--font-literata), Georgia, serif',
+  fontSize: '0.92rem',
+  fontWeight: 700,
+  lineHeight: 1.18,
+  overflowWrap: 'anywhere',
+}
+
+const supportingStyle: CSSProperties = {
+  margin: '0.18rem 0 0',
+  color: '#696257',
+  fontSize: '0.68rem',
+  lineHeight: 1.25,
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -271,6 +271,7 @@ export type AuthoredQuestionPreview = {
   questionText: string;
   canonicalSubcategory: string | null;
   broadCategory: string | null;
+  difficulty: 'accessible' | 'moderate' | 'specialist' | null;
   createdAt: string;
   viewerAnswered: { result: 'correct' | 'incorrect' } | null;
 };
@@ -318,6 +319,9 @@ export async function getAuthoredQuestionsForUser(params: {
       questionText: questions.questionText,
       canonicalSubcategory: questions.canonicalSubcategory,
       broadCategory: questions.broadCategory,
+      calibratedDifficulty: questions.calibratedDifficulty,
+      llmDifficulty: questions.llmDifficulty,
+      difficultyEstimate: questions.difficultyEstimate,
       createdAt: questions.createdAt,
     })
     .from(questions)
@@ -359,6 +363,8 @@ export async function getAuthoredQuestionsForUser(params: {
     questionText: row.questionText,
     canonicalSubcategory: row.canonicalSubcategory,
     broadCategory: row.broadCategory,
+    difficulty:
+      row.calibratedDifficulty ?? row.llmDifficulty ?? row.difficultyEstimate ?? null,
     createdAt: row.createdAt.toISOString(),
     viewerAnswered: viewerStatus.get(row.id) ?? null,
   }));


### PR DESCRIPTION
- Give the profile "Recently exploring" section the same card visual
  treatment as the Knowledge page's "Recently Expanding": cream card box,
  circular initial badges, serif domain names, and separator rows. Keeps the
  relative-timestamp supporting line (this surface's real data).
- Add a search box and category/difficulty dropdowns to the authored
  questions feed, filtering the list client-side. Thread `difficulty`
  (calibrated/llm/estimate fallback) and `broadCategory` through
  getAuthoredQuestionsForUser and the profile page.

https://claude.ai/code/session_01JGaCuoULB3VKVYcTGBPgVr