### PR TITLE
Add Convergence "same-correct overlap" moment to Lately

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -15,6 +15,7 @@ import type {
 
 import { InlineAnswerFlow } from './InlineAnswerFlow';
 import { FM, INK, INK2, INK3, RULE } from '@/components/lately/tokens';
+import { assertNever } from '@/lib/assert-never';
 
 function ActorLink({ name, userId }: { name: string; userId: string | null }) {
   if (!userId) return <b style={{ fontWeight: 600 }}>{name}</b>;
@@ -59,8 +60,20 @@ function Line({ parts }: { parts: StreamLinePart[] }) {
 
 function questionBacked(expand: StreamExpand | null): boolean {
   if (!expand) return false;
-  if (expand.kind === 'milestone') return expand.questions.length > 0;
-  return true;
+  switch (expand.kind) {
+    // Question-list reveals: only expandable when there's something to reveal.
+    case 'milestone':
+    case 'same_correct':
+      return expand.questions.length > 0;
+    // Single-question reveals are always backed by their one question.
+    case 'your_question':
+    case 'niche_match':
+      return true;
+    default:
+      // Exhaustiveness guard: a new StreamExpand kind won't compile until it's
+      // handled here (and in the expansion render below).
+      return assertNever(expand, 'StreamExpand');
+  }
 }
 
 export function ActivityStreamItem({
@@ -198,7 +211,13 @@ export function ActivityStreamItem({
           <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap' }}>{timestamp}</span>
           {expandable ? (
             <span style={{ fontFamily: FM, fontSize: 9, letterSpacing: 1.5, color: INK3 }}>
-              {open ? '− QUESTION' : '+ QUESTION'}
+              {expand?.kind === 'same_correct'
+                ? open
+                  ? '− QUESTIONS'
+                  : '+ QUESTIONS'
+                : open
+                  ? '− QUESTION'
+                  : '+ QUESTION'}
             </span>
           ) : null}
         </div>
@@ -213,6 +232,8 @@ export function ActivityStreamItem({
             answeredIds={answeredIds}
             onAnswered={markAnswered}
           />
+        ) : expand.kind === 'same_correct' ? (
+          <ConvergenceExpansion expand={expand} />
         ) : (
           <SendOnwardExpansion expand={expand} />
         )
@@ -280,6 +301,60 @@ function MilestoneExpansion({
           answered={answeredIds.has(q.questionId)}
           onAnswered={onAnswered}
         />
+      ))}
+    </div>
+  );
+}
+
+// Convergence (B-Convergence-1) reveal. READ-ONLY: both people already answered
+// these correctly, so it just lists the cluster's questions in the editorial
+// serif register — domains appear quietly as texture (never promoted to the
+// headline). No Answer, no Send Onward, no reaction affordance.
+export function ConvergenceExpansion({
+  expand,
+}: {
+  expand: Extract<StreamExpand, { kind: 'same_correct' }>;
+}) {
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        marginTop: 12,
+        borderLeft: `2px solid ${RULE}`,
+        paddingLeft: 12,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 12,
+      }}
+    >
+      {expand.questions.map((q) => (
+        <div key={q.questionId}>
+          <p
+            style={{
+              margin: 0,
+              fontFamily: 'Georgia, serif',
+              fontStyle: 'italic',
+              fontSize: 14,
+              lineHeight: 1.55,
+              color: INK2,
+            }}
+          >
+            &ldquo;{q.text}&rdquo;
+          </p>
+          {q.domain ? (
+            <p
+              style={{
+                margin: '4px 0 0',
+                fontFamily: FM,
+                fontSize: 10,
+                letterSpacing: 1,
+                color: INK3,
+              }}
+            >
+              {q.domain.toUpperCase()}
+            </p>
+          ) : null}
+        </div>
       ))}
     </div>
   );

--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -1,0 +1,132 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { convergenceToStreamItem, type StreamExpand } from '@/lib/activity-stream';
+import type { Convergence } from '@/lib/convergence';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// Heavy children of ActivityStreamItem that a convergence item never renders —
+// mocked so the module imports cleanly in the node test environment.
+vi.mock('@/components/activity/InlineAnswerFlow', () => ({
+  InlineAnswerFlow: () => <div data-mock="inline-answer" />,
+}));
+vi.mock('@/components/SendQuestionDrawer', () => ({
+  SendQuestionDrawer: () => <div data-mock="send-drawer" />,
+}));
+vi.mock('@/app/activities/FriendRequestActions', () => ({
+  FriendRequestActions: () => <div data-mock="friend-request" />,
+}));
+vi.mock('@/app/activities/ReactionGotItButton', () => ({
+  ReactionGotItButton: () => <div data-mock="reaction" />,
+}));
+
+// Imported AFTER the mocks are registered.
+import {
+  ActivityStreamItem,
+  ConvergenceExpansion,
+} from '@/components/activity/ActivityStreamItem';
+
+const CONVERGENCE: Convergence = {
+  kind: 'same_correct',
+  id: 'converge:F:q1_q2_q3',
+  friendId: 'friend-1',
+  friendName: 'Robyn Fielding',
+  friendFirstName: 'Robyn',
+  questionIds: ['q1', 'q2', 'q3'],
+  sortAt: new Date('2026-05-20T12:00:00Z'),
+};
+
+const QUESTIONS = [
+  { questionId: 'q1', text: 'Who painted Guernica?', domain: 'Cubism', answered: true },
+  { questionId: 'q2', text: 'What is the capital of Mongolia?', domain: 'Geography', answered: true },
+  { questionId: 'q3', text: 'Who composed The Rite of Spring?', domain: 'Composers', answered: true },
+];
+
+const CAPTION = 'You and {Name} keep landing in the same place.';
+
+function build() {
+  return convergenceToStreamItem(CONVERGENCE, QUESTIONS, CAPTION);
+}
+
+describe('convergenceToStreamItem — person-first, Lately-only, read-only', () => {
+  it('builds a person-first headline that names no domain', () => {
+    const item = build();
+    // The friend is an actor (link) part; the rest is plain copy. No domain
+    // ever reaches the headline (no `category` part, no domain string).
+    const actorPart = item.line.find((p) => p.t === 'actor');
+    expect(actorPart).toMatchObject({ name: 'Robyn', userId: 'friend-1' });
+    expect(item.line.some((p) => p.t === 'category')).toBe(false);
+    const headlineText = item.line.map((p) => ('v' in p ? p.v : p.name)).join('');
+    expect(headlineText).toBe('You and Robyn keep landing in the same place.');
+    for (const q of QUESTIONS) {
+      expect(headlineText).not.toContain(q.domain);
+    }
+  });
+
+  it('is excluded from the homepage top-few (homeEligible false) and read-only', () => {
+    const item = build();
+    expect(item.homeEligible).toBe(false);
+    expect(item.action).toBeNull();
+    expect(item.expand?.kind).toBe('same_correct');
+  });
+
+  it('carries the 3 cluster questions in the reveal', () => {
+    const item = build();
+    expect(item.expand?.kind).toBe('same_correct');
+    if (item.expand?.kind !== 'same_correct') throw new Error('expected same_correct');
+    expect(item.expand.questions.map((q) => q.questionId)).toEqual(['q1', 'q2', 'q3']);
+  });
+});
+
+describe('ActivityStreamItem — collapsed convergence one-liner', () => {
+  it('renders the person-first line and a QUESTIONS expand affordance, questions hidden', () => {
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem item={build()} timestamp="2:00 PM" />,
+    );
+    expect(html).toContain('You and');
+    expect(html).toContain('Robyn');
+    expect(html).toContain('keep landing in the same place');
+    // Expandable, plural affordance.
+    expect(html).toContain('+ QUESTIONS');
+    // Collapsed: the cluster questions are NOT shown yet.
+    expect(html).not.toContain('Who painted Guernica');
+    // No domain leaks into the collapsed headline.
+    expect(html).not.toContain('Cubism');
+  });
+});
+
+describe('ConvergenceExpansion — the expanded reveal', () => {
+  it('shows the 3 co-correct questions with domains as quiet texture, no actions', () => {
+    const item = build();
+    if (item.expand?.kind !== 'same_correct') throw new Error('expected same_correct');
+    const expand = item.expand as Extract<StreamExpand, { kind: 'same_correct' }>;
+    const html = renderToStaticMarkup(<ConvergenceExpansion expand={expand} />);
+
+    // All three questions revealed.
+    expect(html).toContain('Who painted Guernica?');
+    expect(html).toContain('What is the capital of Mongolia?');
+    expect(html).toContain('Who composed The Rite of Spring?');
+    // Domains appear here as texture (uppercased), never in the headline.
+    expect(html).toContain('CUBISM');
+
+    // Read-only: no answer / send / reaction affordances.
+    expect(html).not.toContain('SEND IT ONWARD');
+    expect(html).not.toContain('DISCOVER');
+    expect(html.toLowerCase()).not.toContain('<button');
+  });
+});

--- a/src/lib/__tests__/convergence.test.ts
+++ b/src/lib/__tests__/convergence.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CONVERGENCE_THRESHOLD,
+  deriveConvergences,
+  type ConvergenceCoCorrectRow,
+} from '@/lib/convergence';
+import {
+  CONVERGENCE_CAPTIONS,
+  convergenceCaptionTemplate,
+} from '@/lib/lately';
+
+const DAY = 24 * 60 * 60 * 1000;
+const BASE = Date.UTC(2026, 0, 1);
+const day = (n: number) => new Date(BASE + n * DAY);
+
+function row(
+  questionId: string,
+  viewerDay: number,
+  friendDay: number,
+  friendId = 'F',
+): ConvergenceCoCorrectRow {
+  return {
+    friendId,
+    friendName: 'Robyn Friend',
+    friendFirstName: 'Robyn',
+    questionId,
+    viewerAnsweredAt: day(viewerDay),
+    friendAnsweredAt: day(friendDay),
+  };
+}
+
+describe('deriveConvergences — firing threshold', () => {
+  it('does not fire below 3 co-correct questions', () => {
+    const rows = [row('q1', 0, 2), row('q2', 1, 3)];
+    expect(deriveConvergences('V', rows)).toEqual([]);
+  });
+
+  it('fires exactly at 3 (N > 2)', () => {
+    // Viewer answered each before the friend, so the friend's answer is the
+    // qualifying (co-correct) moment and the viewer owns the cluster.
+    const rows = [row('q1', 0, 3), row('q2', 0, 5), row('q3', 0, 7)];
+    const out = deriveConvergences('V', rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].kind).toBe('same_correct');
+    expect(out[0].questionIds.sort()).toEqual(['q1', 'q2', 'q3']);
+    // sortAt = the cluster-completing question's qualifying moment (day 7).
+    expect(out[0].sortAt).toEqual(day(7));
+    expect(CONVERGENCE_THRESHOLD).toBe(3);
+  });
+
+  it('does not let a duplicate question inflate toward the threshold', () => {
+    const rows = [row('q1', 0, 3), row('q2', 0, 5), row('q1', 0, 6)];
+    expect(deriveConvergences('V', rows)).toEqual([]);
+  });
+});
+
+describe('deriveConvergences — 14-day cluster window', () => {
+  it('counts 3 questions spanning exactly 14 days', () => {
+    const rows = [row('q1', 0, 0), row('q2', 0, 7), row('q3', 0, 14)];
+    const out = deriveConvergences('V', rows);
+    expect(out).toHaveLength(1);
+    expect(out[0].questionIds.sort()).toEqual(['q1', 'q2', 'q3']);
+  });
+
+  it('does NOT pad to 3 with questions outside the 14-day span', () => {
+    // q1/q2 age out once q3 (>14 days later) arrives, so no cluster of 3 forms
+    // even though four questions are co-correct overall.
+    const rows = [
+      row('q1', 0, 0),
+      row('q2', 0, 1),
+      row('q3', 0, 20),
+      row('q4', 0, 21),
+    ];
+    expect(deriveConvergences('V', rows)).toEqual([]);
+  });
+});
+
+describe('deriveConvergences — reset on fire / no reuse', () => {
+  it('chunks 6 co-correct into two disjoint clusters, reusing no question', () => {
+    const rows = [
+      row('q1', 0, 1),
+      row('q2', 0, 2),
+      row('q3', 0, 3),
+      row('q4', 0, 4),
+      row('q5', 0, 5),
+      row('q6', 0, 6),
+    ];
+    const out = deriveConvergences('V', rows);
+    expect(out).toHaveLength(2);
+    const a = new Set(out[0].questionIds);
+    const b = new Set(out[1].questionIds);
+    // No question appears in two cards.
+    for (const id of a) expect(b.has(id)).toBe(false);
+    // Together they cover the two fresh chunks of 3.
+    const all = [...a, ...b].sort();
+    expect(all).toEqual(['q1', 'q2', 'q3', 'q4', 'q5', 'q6']);
+    // Each card carries exactly the threshold count.
+    expect(out[0].questionIds).toHaveLength(3);
+    expect(out[1].questionIds).toHaveLength(3);
+  });
+});
+
+describe('deriveConvergences — single owner', () => {
+  it('fires for exactly one of the pair (whoever answered the 3rd question first)', () => {
+    // From V's perspective the friend F answered the cluster-completing question
+    // (q3) FIRST (day 8 < day 10), so F owns it and V gets nothing.
+    const rowsFromV = [
+      row('q1', 1, 2),
+      row('q2', 1, 4),
+      row('q3', 10, 8), // viewer=day10, friend=day8 -> friend answered q3 first
+    ];
+    expect(deriveConvergences('V', rowsFromV)).toEqual([]);
+
+    // From F's perspective (timestamps swapped, friend is now 'V'), F answered
+    // q3 first -> F owns -> exactly one card surfaces.
+    const rowsFromF: ConvergenceCoCorrectRow[] = rowsFromV.map((r) => ({
+      ...r,
+      friendId: 'V',
+      viewerAnsweredAt: r.friendAnsweredAt,
+      friendAnsweredAt: r.viewerAnsweredAt,
+    }));
+    expect(deriveConvergences('F', rowsFromF)).toHaveLength(1);
+  });
+});
+
+describe('convergenceCaptionTemplate — deterministic, person-first', () => {
+  it('is stable for a given moment id and drawn from the pool', () => {
+    const id = 'converge:F:q1_q2_q3';
+    const first = convergenceCaptionTemplate(id);
+    expect(convergenceCaptionTemplate(id)).toBe(first);
+    expect(CONVERGENCE_CAPTIONS).toContain(first);
+  });
+
+  it('every caption is person-first via the {Name} token and names no domain', () => {
+    for (const caption of CONVERGENCE_CAPTIONS) {
+      expect(caption).toContain('{Name}');
+    }
+  });
+});

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -23,6 +23,7 @@ import type { ActivityItemView } from '@/server/db/queries/activity';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 import { LATELY_TIER, latelyTierForMomentDir } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
+import type { Convergence } from '@/lib/convergence';
 
 // --- Serializable model ------------------------------------------------------
 
@@ -66,6 +67,15 @@ export type StreamExpand =
       question: StreamQuestion;
       strangerId: string | null;
       strangerName: string;
+    }
+  // Convergence (B-Convergence-1): you and a friend independently answered the
+  // SAME shared questions correctly. READ-ONLY — both already answered, so the
+  // reveal just shows the cluster's questions (no answer, no send, no reaction).
+  | {
+      kind: 'same_correct';
+      friendId: string;
+      friendName: string;
+      questions: StreamQuestion[];
     };
 
 // A trailing, non-expanding utility action carried by some plain one-liners.
@@ -479,4 +489,42 @@ function breadthTail(domains: string[]): StreamLinePart[] {
   if (rest.length === 0) return [lead, cat(first), txt(' and '), cat(second)];
   const others = rest.length === 1 ? '1 other' : `${rest.length} others`;
   return [lead, cat(first), txt(', '), cat(second), txt(` and ${others}`)];
+}
+
+// --- Convergence -------------------------------------------------------------
+
+// A convergence is the quiet "same-correct overlap" line: you and a friend
+// independently got the same shared questions right. The headline is
+// PERSON-FIRST and names no domain — the caption template (assigned
+// deterministically by moment id) carries a `{Name}` token that becomes the
+// friend's first name as an actor link. It is Lately-ONLY (homeEligible: false,
+// the same slow-burn treatment as niche-match) and READ-ONLY: expanding reveals
+// the cluster's questions (domains may appear there as texture) with no answer,
+// send, or reaction affordance.
+export function convergenceToStreamItem(
+  convergence: Convergence,
+  questions: StreamQuestion[],
+  captionTemplate: string,
+): StreamItem {
+  const [before, after] = captionTemplate.split('{Name}');
+  const line: StreamLinePart[] = [];
+  if (before) line.push(txt(before));
+  line.push(act(convergence.friendFirstName, convergence.friendId));
+  if (after) line.push(txt(after));
+  return {
+    id: convergence.id,
+    sortAt: convergence.sortAt,
+    tier: LATELY_TIER.MILESTONE,
+    homeEligible: false,
+    line,
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    expand: {
+      kind: 'same_correct',
+      friendId: convergence.friendId,
+      friendName: convergence.friendName,
+      questions,
+    },
+  };
 }

--- a/src/lib/convergence.ts
+++ b/src/lib/convergence.ts
@@ -1,0 +1,164 @@
+/**
+ * Lately "Convergence" moments (B-Convergence-1) — same-correct overlap.
+ *
+ * Read-derived, additive surface: it surfaces when the viewer and a friend have
+ * INDEPENDENTLY answered the SAME shared questions correctly. It celebrates
+ * intellectual overlap ("the people who get you, getting you"), and — like
+ * `deriveLatelyMilestones` — it's a pure transform so it can be unit-tested
+ * without a DB. No write path, no migration, no points, no mastery.
+ *
+ * FIRING / RESET / OWNERSHIP (the part most likely to drift):
+ *  - A card fires when CONVERGENCE_THRESHOLD (=3) co-correct shared questions
+ *    accumulate for the pair. No rarity/difficulty gate — every co-correct
+ *    shared question is eligible.
+ *  - 14-day window, CLUSTER-RELATIVE: the 3 questions in a card must fall within
+ *    a CONVERGENCE_WINDOW_DAYS (=14) span of EACH OTHER. We replay the pair's
+ *    co-correct questions in chronological order (by the moment each became
+ *    co-correct) and chunk them into groups of 3. This makes consumption,
+ *    reset, and single-owner all deterministic from timestamps alone — so no
+ *    consumed-tracking table is needed (the chunk boundaries ARE the
+ *    consumption record, and a question is never reused across two clusters).
+ *  - Reset on fire: when a cluster of 3 is emitted the buffer clears; the next
+ *    card requires 3 fresh questions.
+ *  - Ownership — fires for ONE person only: the card belongs to whoever answered
+ *    the cluster-completing ("3rd qualifying") question FIRST. The other member
+ *    of the pair gets nothing. `deriveConvergences` is called per-viewer and
+ *    only emits the clusters that viewer owns.
+ *
+ * "Shared" excludes pair-authored questions — that exclusion happens in the
+ * query layer (a question authored by either member is covered by the existing
+ * they_got_you / you_got_them moments), so the rows handed here are already the
+ * third-party co-correct overlap.
+ */
+
+export const CONVERGENCE_WINDOW_DAYS = 14;
+export const CONVERGENCE_THRESHOLD = 3;
+
+const WINDOW_MS = CONVERGENCE_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+
+// One co-correct shared question for a (viewer, friend) pair. `qualifyingAt`
+// (the moment it became co-correct) is max(viewerAnsweredAt, friendAnsweredAt).
+export type ConvergenceCoCorrectRow = {
+  friendId: string;
+  friendName: string;
+  friendFirstName: string;
+  questionId: string;
+  viewerAnsweredAt: Date;
+  friendAnsweredAt: Date;
+};
+
+export type Convergence = {
+  kind: 'same_correct';
+  id: string;
+  friendId: string;
+  friendName: string;
+  friendFirstName: string;
+  // Exactly CONVERGENCE_THRESHOLD question ids, in the order they became
+  // co-correct (qualifyingAt asc).
+  questionIds: string[];
+  sortAt: Date;
+};
+
+function qualifyingAt(row: ConvergenceCoCorrectRow): number {
+  return Math.max(row.viewerAnsweredAt.getTime(), row.friendAnsweredAt.getTime());
+}
+
+/**
+ * Derive the convergence cards the given viewer OWNS from a flat list of the
+ * pair's co-correct shared questions. Pure + deterministic: sorting by
+ * qualifyingAt (questionId tie-break) and chunking by 3 means the same rows
+ * always yield the same cards, with no question reused across cards.
+ */
+export function deriveConvergences(
+  viewerId: string,
+  rows: ConvergenceCoCorrectRow[],
+  opts: { windowMs?: number; threshold?: number } = {},
+): Convergence[] {
+  const windowMs = opts.windowMs ?? WINDOW_MS;
+  const threshold = opts.threshold ?? CONVERGENCE_THRESHOLD;
+
+  // 1. Group by friend, deduping questionId (a question answered twice can't
+  //    count toward the threshold twice — keep the EARLIEST co-correct moment).
+  const byFriend = new Map<string, Map<string, ConvergenceCoCorrectRow>>();
+  for (const row of rows) {
+    let group = byFriend.get(row.friendId);
+    if (!group) {
+      group = new Map();
+      byFriend.set(row.friendId, group);
+    }
+    const prev = group.get(row.questionId);
+    if (!prev || qualifyingAt(row) < qualifyingAt(prev)) {
+      group.set(row.questionId, row);
+    }
+  }
+
+  const out: Convergence[] = [];
+  for (const [friendId, group] of byFriend) {
+    // 2. Chronological order by the moment each became co-correct.
+    const sorted = [...group.values()].sort((a, b) => {
+      const delta = qualifyingAt(a) - qualifyingAt(b);
+      return delta !== 0 ? delta : a.questionId.localeCompare(b.questionId);
+    });
+
+    // 3. Replay into a buffer, evicting entries that fall outside a 14-day span
+    //    of the current question, and emitting + clearing on every 3rd.
+    let buffer: ConvergenceCoCorrectRow[] = [];
+    for (const q of sorted) {
+      const cutoff = qualifyingAt(q) - windowMs;
+      while (buffer.length > 0 && qualifyingAt(buffer[0]) < cutoff) {
+        buffer.shift();
+      }
+      buffer.push(q);
+      if (buffer.length === threshold) {
+        const cluster = buffer;
+        buffer = [];
+        // 4. The cluster-completing question is the newest (last) in the buffer.
+        //    Owner = whoever answered IT first. Emit only the viewer's clusters.
+        const q3 = cluster[cluster.length - 1];
+        if (ownerOf(viewerId, friendId, q3) === viewerId) {
+          out.push(buildConvergence(friendId, cluster, q3));
+        }
+      }
+    }
+  }
+
+  // Most-recent first; id as a stable tie-break (mirrors deriveLatelyMilestones).
+  return out.sort((a, b) => {
+    const delta = b.sortAt.getTime() - a.sortAt.getTime();
+    return delta !== 0 ? delta : a.id.localeCompare(b.id);
+  });
+}
+
+// Owner = whichever of the pair answered the cluster-completing question first.
+// Tie on identical timestamps falls to the lexicographically lower user id so
+// the result is deterministic (and still assigns exactly one owner).
+function ownerOf(
+  viewerId: string,
+  friendId: string,
+  q3: ConvergenceCoCorrectRow,
+): string {
+  const viewerAt = q3.viewerAnsweredAt.getTime();
+  const friendAt = q3.friendAnsweredAt.getTime();
+  if (viewerAt < friendAt) return viewerId;
+  if (friendAt < viewerAt) return friendId;
+  return viewerId < friendId ? viewerId : friendId;
+}
+
+function buildConvergence(
+  friendId: string,
+  cluster: ConvergenceCoCorrectRow[],
+  q3: ConvergenceCoCorrectRow,
+): Convergence {
+  const questionIds = cluster.map((c) => c.questionId);
+  return {
+    kind: 'same_correct',
+    // Content-stable across renders: same pair + same 3 questions => same id,
+    // which the deterministic caption assignment keys off.
+    id: `converge:${friendId}:${[...questionIds].sort().join('_')}`,
+    friendId,
+    friendName: q3.friendName,
+    friendFirstName: q3.friendFirstName,
+    questionIds,
+    sortAt: new Date(qualifyingAt(q3)),
+  };
+}

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -71,6 +71,25 @@ export function assignCaption(
   return template.replace('{NAME}', friendFirstName.toUpperCase());
 }
 
+// Convergence (B-Convergence-1) headlines are PERSON-FIRST and never name a
+// domain — naming one of a mixed-domain cluster misrepresents the rest, and
+// naming all reads as a stats list (a brand violation). Unlike the moment
+// CAPTIONS above (all-caps chips), these are sentence-case one-liners: the
+// `{Name}` token is replaced with the friend's first name AT RENDER (as an
+// actor link), so the template is returned verbatim here. Assigned
+// deterministically by moment id, the same djb2 mechanism the moments use.
+export const CONVERGENCE_CAPTIONS = [
+  'You and {Name} keep landing in the same place.',
+  'Turns out you and {Name} think alike.',
+  'You and {Name} are on the same wavelength lately.',
+  'You and {Name} both knew these.',
+  'The people who get you, getting you — you and {Name}.',
+] as const;
+
+export function convergenceCaptionTemplate(momentId: string): string {
+  return CONVERGENCE_CAPTIONS[djb2(momentId) % CONVERGENCE_CAPTIONS.length];
+}
+
 function ymdInZone(date: Date, tz: string): string {
   // en-CA gives ISO-style YYYY-MM-DD reliably.
   return new Intl.DateTimeFormat('en-CA', {

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -13,15 +13,17 @@
 import { filterUtilityActivities } from '@/app/activities/filter-utility-activities';
 import {
   activityToStreamItem,
+  convergenceToStreamItem,
   milestoneToStreamItem,
   momentToStreamItem,
   type StreamItem,
   type StreamQuestion,
 } from '@/lib/activity-stream';
-import { sortByProminence } from '@/lib/lately';
+import { convergenceCaptionTemplate, sortByProminence } from '@/lib/lately';
 import { MILESTONE_CARD_QUESTION_CAP } from '@/lib/lately-milestones';
 import { getActivitiesForUser } from '@/server/db/queries/activity';
 import {
+  getLatelyConvergences,
   getLatelyMilestones,
   getLatelyMoments,
   getMilestoneQuestionText,
@@ -29,24 +31,29 @@ import {
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
-  const [items, moments, milestones] = await Promise.all([
+  const [items, moments, milestones, convergences] = await Promise.all([
     getActivitiesForUser(userId),
     getLatelyMoments(userId),
     getLatelyMilestones(userId),
+    getLatelyConvergences(userId),
   ]);
 
-  // Resolve every milestone's first ≤5 literal questions in one batch (text +
-  // display domain), and which of them the viewer already answered correctly.
+  // Resolve every milestone's first ≤5 literal questions and every
+  // convergence's 3 cluster questions in one batch (text + display domain), and
+  // which of them the viewer already answered correctly.
   const cappedIdsByMilestone = milestones.map((m) => ({
     id: m.id,
     ids: m.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
   }));
-  const allMilestoneIds = [
-    ...new Set(cappedIdsByMilestone.flatMap((m) => m.ids)),
+  const allQuestionIds = [
+    ...new Set([
+      ...cappedIdsByMilestone.flatMap((m) => m.ids),
+      ...convergences.flatMap((c) => c.questionIds),
+    ]),
   ];
   const [textById, answeredIds] = await Promise.all([
-    getMilestoneQuestionText(allMilestoneIds),
-    getViewerCorrectlyAnsweredIds(userId, allMilestoneIds),
+    getMilestoneQuestionText(allQuestionIds),
+    getViewerCorrectlyAnsweredIds(userId, allQuestionIds),
   ]);
 
   const utilityItems = filterUtilityActivities(items, moments).map(
@@ -65,6 +72,23 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       }));
     return milestoneToStreamItem(m, questions);
   });
+  const convergenceItems = convergences.map((c) => {
+    const questions: StreamQuestion[] = c.questionIds
+      .map((id) => textById.get(id))
+      .filter((q): q is NonNullable<typeof q> => Boolean(q))
+      .map((q) => ({
+        questionId: q.questionId,
+        text: q.text,
+        domain: q.domain,
+        answered: true, // read-only reveal: both already answered correctly
+      }));
+    return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id));
+  });
 
-  return sortByProminence([...momentItems, ...milestoneItems, ...utilityItems]);
+  return sortByProminence([
+    ...momentItems,
+    ...milestoneItems,
+    ...convergenceItems,
+    ...utilityItems,
+  ]);
 }

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -6,6 +6,11 @@ import {
   type LatelyMilestone,
   type MilestoneAnswerRow,
 } from '@/lib/lately-milestones';
+import {
+  deriveConvergences,
+  type Convergence,
+  type ConvergenceCoCorrectRow,
+} from '@/lib/convergence';
 import { resolveAuthorDisplay } from '@/lib/questions-types';
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
 import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
@@ -368,4 +373,138 @@ export async function getViewerCorrectlyAnsweredIds(
     if (row.questionId) out.add(row.questionId);
   }
   return out;
+}
+
+// --- Convergence (B-Convergence-1) -------------------------------------------
+
+// Bounds the answer scan. Generous vs. the 14-day cluster window so a recent
+// cluster's boundaries stay stable: a cluster only depends on the run of
+// co-correct questions since the last reset, which 60 days comfortably covers.
+const CONVERGENCE_LOOKBACK_DAYS = 60;
+
+const PAIR_SEP = '\u0000';
+
+// Read-time "same-correct overlap": questions the viewer AND a mutual friend
+// both answered correctly, excluding questions either of them authored (those
+// are already surfaced as the they_got_you / you_got_them moments). Derived
+// entirely from existing masteryEvents — no write path, no migration. The
+// firing / reset / single-owner rules live in `@/lib/convergence`.
+export async function getLatelyConvergences(
+  userId: string,
+): Promise<Convergence[]> {
+  const lookbackStart = new Date(
+    Date.now() - CONVERGENCE_LOOKBACK_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  // 1. The viewer's correct answers, with each question's author so we can drop
+  //    questions the viewer wrote. Keep the EARLIEST correct moment per question.
+  const viewerRows = await db
+    .select({
+      questionId: masteryEvents.questionId,
+      createdAt: masteryEvents.createdAt,
+      creatorId: questions.creatorId,
+    })
+    .from(masteryEvents)
+    .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+    .where(
+      and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.sourceType, LIVE_SOURCE_TYPES),
+        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+        isNotNull(masteryEvents.questionId),
+        gte(masteryEvents.createdAt, lookbackStart),
+      ),
+    );
+
+  const viewerByQuestion = new Map<
+    string,
+    { answeredAt: Date; creatorId: string | null }
+  >();
+  for (const row of viewerRows) {
+    if (!row.questionId) continue;
+    if (row.creatorId === userId) continue; // viewer authored it -> not "shared"
+    const prev = viewerByQuestion.get(row.questionId);
+    if (!prev || row.createdAt < prev.answeredAt) {
+      viewerByQuestion.set(row.questionId, {
+        answeredAt: row.createdAt,
+        creatorId: row.creatorId,
+      });
+    }
+  }
+  const viewerQuestionIds = [...viewerByQuestion.keys()];
+  if (viewerQuestionIds.length === 0) return [];
+
+  // 2. Mutual friends (approved follows in BOTH directions).
+  const [following, followers] = await Promise.all([
+    db
+      .select({ id: follows.followeeId })
+      .from(follows)
+      .where(and(eq(follows.followerId, userId), eq(follows.state, 'approved'))),
+    db
+      .select({ id: follows.followerId })
+      .from(follows)
+      .where(and(eq(follows.followeeId, userId), eq(follows.state, 'approved'))),
+  ]);
+  const followingIds = new Set(following.map((r) => r.id));
+  const mutualIds = [...new Set(followers.map((r) => r.id))].filter((id) =>
+    followingIds.has(id),
+  );
+  if (mutualIds.length === 0) return [];
+
+  // 3. Those friends' correct answers on the viewer's shared question set.
+  const friendRows = await db
+    .select({
+      friendId: masteryEvents.userId,
+      questionId: masteryEvents.questionId,
+      createdAt: masteryEvents.createdAt,
+    })
+    .from(masteryEvents)
+    .where(
+      and(
+        inArray(masteryEvents.userId, mutualIds),
+        inArray(masteryEvents.questionId, viewerQuestionIds),
+        inArray(masteryEvents.sourceType, LIVE_SOURCE_TYPES),
+        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+        isNotNull(masteryEvents.questionId),
+        gte(masteryEvents.createdAt, lookbackStart),
+      ),
+    );
+
+  const friendByPair = new Map<string, Date>(); // friendId\0questionId -> earliest
+  for (const row of friendRows) {
+    if (!row.questionId || !row.friendId) continue;
+    const key = `${row.friendId}${PAIR_SEP}${row.questionId}`;
+    const prev = friendByPair.get(key);
+    if (!prev || row.createdAt < prev) friendByPair.set(key, row.createdAt);
+  }
+  if (friendByPair.size === 0) return [];
+
+  // 4. Friend display names.
+  const nameRows = await db
+    .select({ id: users.id, displayName: users.displayName })
+    .from(users)
+    .where(inArray(users.id, mutualIds));
+  const nameById = new Map(nameRows.map((r) => [r.id, r.displayName]));
+
+  // 5. Build co-correct rows, excluding questions the FRIEND authored.
+  const rows: ConvergenceCoCorrectRow[] = [];
+  for (const [key, friendAnsweredAt] of friendByPair) {
+    const sep = key.indexOf(PAIR_SEP);
+    const friendId = key.slice(0, sep);
+    const questionId = key.slice(sep + 1);
+    const viewer = viewerByQuestion.get(questionId);
+    if (!viewer) continue;
+    if (viewer.creatorId === friendId) continue; // friend authored it -> not "shared"
+    const displayName = nameById.get(friendId) ?? null;
+    rows.push({
+      friendId,
+      friendName: displayName ?? 'A friend',
+      friendFirstName: firstName(displayName, 'A friend'),
+      questionId,
+      viewerAnsweredAt: viewer.answeredAt,
+      friendAnsweredAt,
+    });
+  }
+
+  return deriveConvergences(userId, rows);
 }


### PR DESCRIPTION
A new read-only Lately moment that surfaces when you and a friend have
independently answered the same shared questions correctly. Derived
entirely at read time from existing masteryEvents — no migration, no
write path, no points, no mastery.

Firing / reset / ownership (the part most likely to drift):
- Fires at 3 co-correct shared questions for a pair (N > 2), no rarity gate.
- 14-day window is cluster-relative: the 3 questions must fall within a
  14-day span of each other. Replaying co-correct answers chronologically
  and chunking by 3 makes consumption, reset, and single-owner all
  deterministic from timestamps — so no consumed-tracking table is needed
  and no question is ever reused across cards.
- The card belongs to whoever answered the cluster-completing question
  first; the other member of the pair gets nothing.
- "Shared" excludes questions either member authored (those are already
  the they_got_you / you_got_them moments).

Surface:
- New read-only `same_correct` member of the StreamExpand union, with an
  assertNever exhaustiveness guard so a new kind fails at compile time.
- Headline is person-first and names no domain; 5-variation caption pool
  assigned deterministically by moment id (the existing djb2 mechanism).
- Tap expands in place to reveal the 3 questions (domains shown only there
  as texture). No Answer, no Send Onward, no reaction.
- homeEligible: false — Lately-only, the same slow-burn treatment as
  niche-match.

Tested on both sides: pure derivation (threshold, cluster window, reset/
no-reuse, single owner, caption determinism) and the render/consumer
(one-liner renders person-first with no domain, expands to the 3
questions, read-only, excluded from the homepage top-few).

https://claude.ai/code/session_01VB5jzew9NmMXG8T9YG1dx5