### PR TITLE
Fix Common Ground to compute overlap from full mastery base

### DIFF
--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -15,6 +15,7 @@ const {
   getOrCreateInviteTokenMock,
   getFriendsMock,
   resolvePreviewAsMock,
+  getCommonGroundMock,
 } = vi.hoisted(() => ({
   getFriendPortraitDataMock: vi.fn(),
   getSessionMock: vi.fn(),
@@ -30,6 +31,7 @@ const {
   getOrCreateInviteTokenMock: vi.fn(),
   getFriendsMock: vi.fn(async () => []),
   resolvePreviewAsMock: vi.fn(async () => null),
+  getCommonGroundMock: vi.fn(),
 }))
 
 vi.mock('next/link', () => ({
@@ -71,6 +73,10 @@ vi.mock('@/server/db/queries/knowledge', () => ({
 
 vi.mock('@/server/db/queries/questions', () => ({
   getAuthoredQuestionsForUser: getAuthoredQuestionsForUserMock,
+}))
+
+vi.mock('@/server/db/queries/common-ground', () => ({
+  getCommonGround: getCommonGroundMock,
 }))
 
 vi.mock('@/server/db/queries/account', () => ({
@@ -118,6 +124,32 @@ vi.mock('@/components/profile/SharedInterestsOverlap', () => ({
       <span data-testid="friend-first-name">{friendFirstName}</span>
     </div>
   ),
+}))
+
+vi.mock('@/components/profile/CommonGround', () => ({
+  CommonGround: ({
+    data,
+    friendFirstName,
+  }: {
+    data: {
+      proven: Array<{ canonical_subcategory: string }>
+      latent: Array<{ canonical_subcategory: string }>
+      isEmpty: boolean
+    } | null
+    friendFirstName: string
+  }) =>
+    data ? (
+      <div data-testid="common-ground">
+        <span data-testid="cg-proven">
+          {data.proven.map((d) => d.canonical_subcategory).join(',')}
+        </span>
+        <span data-testid="cg-latent">
+          {data.latent.map((d) => d.canonical_subcategory).join(',')}
+        </span>
+        <span data-testid="cg-empty">{String(data.isEmpty)}</span>
+        <span data-testid="cg-friend">{friendFirstName}</span>
+      </div>
+    ) : null,
 }))
 
 vi.mock('@/components/profile/AuthoredQuestionsFeed', () => ({
@@ -207,6 +239,19 @@ describe('/users/[id] friend profile page', () => {
       expandingDomains: [],
     })
     getAuthoredQuestionsForUserMock.mockResolvedValue([])
+    getCommonGroundMock.mockResolvedValue({
+      proven: [
+        {
+          canonical_subcategory: 'Virginia Woolf',
+          broad_category: 'Literature',
+          viewer: { mastery_points: 12, current_tier: 'solid', proven: true },
+          friend: { mastery_points: 6, current_tier: 'familiar', proven: true },
+          kind: 'proven',
+        },
+      ],
+      latent: [],
+      isEmpty: false,
+    })
   })
 
   it('renders the friend profile shell and shared-interests overlap', async () => {
@@ -233,6 +278,12 @@ describe('/users/[id] friend profile page', () => {
     expect(html).toContain('Jazz piano')
     expect(html).toContain('Bauhaus design')
     expect(html).toContain('href="/friends"')
+
+    // The mastery-based common ground block renders from getCommonGround,
+    // which is called with (viewerId, profileUserId).
+    expect(getCommonGroundMock).toHaveBeenCalledWith('viewer-1', 'friend-1')
+    expect(html).toContain('common-ground')
+    expect(html).toContain('Virginia Woolf')
   })
 
   it('renders the knowledge base section with a link to the full overview', async () => {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -11,6 +11,7 @@ import { notFound } from 'next/navigation'
 
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard'
 import { AuthoredQuestionsFeed } from '@/components/profile/AuthoredQuestionsFeed'
+import { CommonGround } from '@/components/profile/CommonGround'
 import { InlineEditableField } from '@/components/profile/InlineEditableField'
 import { InlineHandleField } from '@/components/profile/InlineHandleField'
 import { MutualFriendsSection } from '@/components/profile/MutualFriendsSection'
@@ -31,6 +32,7 @@ import {
   getReminderState,
   HANDLE_CHANGE_COOLDOWN_DAYS,
 } from '@/server/db/queries/account'
+import { getCommonGround } from '@/server/db/queries/common-ground'
 import {
   getKnowledgePageData,
   getUserMasteryOverview,
@@ -125,6 +127,7 @@ export default async function UserProfilePage({
   const [
     mastery,
     pageData,
+    commonGround,
     authoredQuestions,
     editableProfile,
     discoverability,
@@ -133,6 +136,11 @@ export default async function UserProfilePage({
   ] = await Promise.all([
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
+    // Common ground compares the viewer's full mastery base to this profile's.
+    // Never rendered on the owner's own profile, so skip the reads there.
+    isOwnerView
+      ? Promise.resolve(null)
+      : getCommonGround(session.userId, portrait.user.id),
     getAuthoredQuestionsForUser({
       userId: portrait.user.id,
       limit: 25,
@@ -378,6 +386,7 @@ export default async function UserProfilePage({
 
       {!isSelf && portrait.sectionVisibleTo.friends_list ? (
         <>
+          <CommonGround data={commonGround} friendFirstName={friendFirstName} />
           <SharedInterestsOverlap
             viewerSoloInterests={portrait.viewerSoloInterests}
             friendSoloInterests={portrait.friendSoloInterests}

--- a/src/components/profile/CommonGround.tsx
+++ b/src/components/profile/CommonGround.tsx
@@ -1,0 +1,238 @@
+'use client'
+
+import type {
+  CommonGround as CommonGroundData,
+  CommonGroundDomain,
+} from '@/server/db/queries/common-ground'
+import type { MasteryTier } from '@/types/db'
+
+type CommonGroundProps = {
+  // Null when the section isn't applicable (e.g. owner self-view); renders nothing.
+  data: CommonGroundData | null
+  friendFirstName: string
+}
+
+// Circle geometry is ported from src/components/OverlapMap.tsx (CategoryItem).
+// Diameter scales with a user's mastery points in the domain; the gap between
+// the two circles encodes overlap strength. Unlike OverlapMap (whose overlap
+// ratio comes from shared correct answers), here overlap is derived from tier
+// closeness, per the profile-page spec.
+const MIN_DIAMETER = 20
+const MAX_DIAMETER = 56
+
+// Viewer = sky, friend = rose — mirrors the SharedInterestsOverlap color
+// language so the two sections read as one visual family.
+const VIEWER_FILL = '#38bdf8' // sky-400
+const FRIEND_FILL = '#fb7185' // rose-400
+const CIRCLE_OPACITY = 0.72
+
+const TIER_INDEX: Record<MasteryTier, number> = {
+  establishing: 0,
+  familiar: 1,
+  solid: 2,
+  mastery: 3,
+}
+
+function overlapRatioFromTiers(a: MasteryTier, b: MasteryTier): number {
+  return 1 - Math.abs(TIER_INDEX[a] - TIER_INDEX[b]) / 3
+}
+
+export function CommonGround({ data, friendFirstName }: CommonGroundProps) {
+  if (!data) return null
+
+  const { proven, latent, isEmpty } = data
+
+  let headline: string
+  if (proven.length === 1) {
+    headline = `You and ${friendFirstName} both know ${proven[0].canonical_subcategory}.`
+  } else if (proven.length > 1) {
+    headline = `Common ground with ${friendFirstName}.`
+  } else if (latent.length > 0) {
+    headline = `Shared ground with ${friendFirstName}, still untested.`
+  } else {
+    headline = `No overlap with ${friendFirstName} yet.`
+  }
+
+  // Scale circle diameters against the largest mastery score across everything
+  // we render, so the biggest circle is always MAX_DIAMETER. Floored at 1 to
+  // avoid divide-by-zero when every domain is latent at zero points.
+  const datasetMax = Math.max(
+    1,
+    ...[...proven, ...latent].flatMap((d) => [
+      d.viewer.mastery_points,
+      d.friend.mastery_points,
+    ]),
+  )
+
+  return (
+    <section className="mt-5" aria-label="Common ground">
+      <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+        Common ground
+      </p>
+      <h2 className="mt-1 font-serif text-2xl font-semibold">{headline}</h2>
+
+      {isEmpty ? null : (
+        <>
+          {proven.length > 0 ? (
+            <DomainGroup
+              caption="Proven together"
+              domains={proven}
+              datasetMax={datasetMax}
+              ghosted={false}
+              friendFirstName={friendFirstName}
+            />
+          ) : null}
+
+          {latent.length > 0 ? (
+            <DomainGroup
+              caption="Shared, still untested"
+              domains={latent}
+              datasetMax={datasetMax}
+              ghosted
+              friendFirstName={friendFirstName}
+            />
+          ) : null}
+
+          <div
+            className="mt-5 flex flex-wrap items-center gap-4 border-t pt-3 text-[10px] font-semibold tracking-[0.16em] uppercase"
+            style={{ borderColor: 'var(--warm-border)' }}
+          >
+            <span
+              className="inline-flex items-center gap-2"
+              style={{ color: VIEWER_FILL }}
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block size-3 rounded-full"
+                style={{ background: VIEWER_FILL }}
+              />
+              You
+            </span>
+            <span
+              className="inline-flex items-center gap-2"
+              style={{ color: FRIEND_FILL }}
+            >
+              <span
+                aria-hidden="true"
+                className="inline-block size-3 rounded-full"
+                style={{ background: FRIEND_FILL }}
+              />
+              {friendFirstName}
+            </span>
+          </div>
+        </>
+      )}
+    </section>
+  )
+}
+
+function DomainGroup({
+  caption,
+  domains,
+  datasetMax,
+  ghosted,
+  friendFirstName,
+}: {
+  caption: string
+  domains: CommonGroundDomain[]
+  datasetMax: number
+  ghosted: boolean
+  friendFirstName: string
+}) {
+  return (
+    <div className={`mt-5 ${ghosted ? 'opacity-60' : ''}`}>
+      <p
+        className="text-[11px] font-semibold tracking-[0.12em] uppercase"
+        style={{ color: 'var(--brand-ink-700)' }}
+      >
+        {caption}
+      </p>
+      <div className="mt-3 flex flex-wrap gap-x-5 gap-y-4">
+        {domains.map((domain) => (
+          <DomainCircles
+            key={domain.canonical_subcategory}
+            domain={domain}
+            datasetMax={datasetMax}
+            friendFirstName={friendFirstName}
+          />
+        ))}
+      </div>
+      {ghosted ? (
+        <p
+          className="mt-3 font-serif text-sm italic"
+          style={{ color: 'var(--brand-ink-700)' }}
+        >
+          {domains.length === 1
+            ? `You both claim ${domains[0].canonical_subcategory} — neither's been tested yet.`
+            : `Domains you both claim but neither of you has been tested on yet.`}
+        </p>
+      ) : null}
+    </div>
+  )
+}
+
+function DomainCircles({
+  domain,
+  datasetMax,
+  friendFirstName,
+}: {
+  domain: CommonGroundDomain
+  datasetMax: number
+  friendFirstName: string
+}) {
+  const dA =
+    MIN_DIAMETER +
+    (domain.viewer.mastery_points / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
+  const dB =
+    MIN_DIAMETER +
+    (domain.friend.mastery_points / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
+  const rA = dA / 2
+  const rB = dB / 2
+  const overlapRatio = overlapRatioFromTiers(
+    domain.viewer.current_tier,
+    domain.friend.current_tier,
+  )
+  const gap = (rA + rB) * (1 - overlapRatio * 0.85)
+  const svgWidth = rA + gap + rB
+  const svgHeight = Math.max(dA, dB)
+  const cy = svgHeight / 2
+
+  const label =
+    domain.kind === 'proven'
+      ? `You and ${friendFirstName} both know ${domain.canonical_subcategory}`
+      : `${domain.canonical_subcategory}: shared but not yet proven`
+
+  return (
+    <div className="flex max-w-[160px] min-w-[110px] flex-col items-center gap-1.5 px-1">
+      <svg
+        width={svgWidth}
+        height={svgHeight}
+        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+        role="img"
+        aria-label={label}
+      >
+        {/* fill via style (not the SVG attribute) to keep parity with OverlapMap */}
+        <circle
+          cx={rA}
+          cy={cy}
+          r={rA}
+          style={{ fill: VIEWER_FILL }}
+          opacity={CIRCLE_OPACITY}
+        />
+        <circle
+          cx={rA + gap}
+          cy={cy}
+          r={rB}
+          style={{ fill: FRIEND_FILL }}
+          opacity={CIRCLE_OPACITY}
+        />
+      </svg>
+      <p
+        className="text-center font-serif text-sm leading-tight"
+        style={{ color: 'var(--brand-ink)' }}
+      >
+        {domain.canonical_subcategory}
+      </p>
+    </div>
+  )
+}

--- a/src/components/profile/SharedInterestsOverlap.tsx
+++ b/src/components/profile/SharedInterestsOverlap.tsx
@@ -61,7 +61,7 @@ export function SharedInterestsOverlap({
       aria-label="Shared interests"
     >
       <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-        Common ground
+        Shared interests
       </p>
       <h2 className="mt-1 font-serif text-2xl font-semibold">{headline}</h2>
 

--- a/src/server/db/queries/__tests__/common-ground.test.ts
+++ b/src/server/db/queries/__tests__/common-ground.test.ts
@@ -1,0 +1,212 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { MasteryTier } from '@/types/db'
+
+// getCommonGround compares two users' full PLAYER_MASTERY bases and resolves
+// each shared domain into a proven (both demonstrated) or latent (shared but
+// not yet proven) tier. These tests drive the in-memory classification/ranking
+// by seeding the two DB reads it performs.
+
+type MasteryRow = {
+  userId: string
+  canonicalSubcategory: string
+  broadCategory: string | null
+  totalPoints: number
+  tier: MasteryTier
+}
+type ProvenRow = { userId: string; canonicalSubcategory: string }
+
+const { masteryRowsRef, provenRowsRef } = vi.hoisted(() => ({
+  masteryRowsRef: { rows: [] as MasteryRow[] },
+  provenRowsRef: { rows: [] as ProvenRow[] },
+}))
+
+// Spread the REAL schema so table identity (playerMastery vs masteryEvents) is
+// preserved, and stub only `db`. The select chain resolves to the seeded rows
+// for whichever table `.from()` receives. The real `.where()` source-type
+// filter isn't executed here, so `provenRowsRef` models the POST-filter result:
+// only live_correct/catchup_correct events ever land in it.
+vi.mock('@/server/db', async () => {
+  const schema =
+    await vi.importActual<typeof import('@/server/db/schema')>(
+      '@/server/db/schema',
+    )
+  return {
+    ...schema,
+    db: {
+      select: () => ({
+        from: (table: unknown) => ({
+          where: () =>
+            Promise.resolve(
+              table === schema.playerMastery
+                ? masteryRowsRef.rows
+                : provenRowsRef.rows,
+            ),
+        }),
+      }),
+    },
+  }
+})
+
+import { getCommonGround } from '../common-ground'
+
+const VIEWER = 'viewer-1'
+const FRIEND = 'friend-1'
+
+function mastery(
+  userId: string,
+  canonicalSubcategory: string,
+  totalPoints: number,
+  tier: MasteryTier = 'familiar',
+  broadCategory: string | null = 'Literature',
+): MasteryRow {
+  return { userId, canonicalSubcategory, broadCategory, totalPoints, tier }
+}
+
+function proven(userId: string, canonicalSubcategory: string): ProvenRow {
+  return { userId, canonicalSubcategory }
+}
+
+beforeEach(() => {
+  masteryRowsRef.rows = []
+  provenRowsRef.rows = []
+})
+
+describe('getCommonGround', () => {
+  it('surfaces a domain both users proved as proven', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Jazz Theory', 10, 'solid'),
+      mastery(FRIEND, 'Jazz Theory', 4, 'familiar'),
+    ]
+    provenRowsRef.rows = [
+      proven(VIEWER, 'Jazz Theory'),
+      proven(FRIEND, 'Jazz Theory'),
+    ]
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.isEmpty).toBe(false)
+    expect(result.latent).toHaveLength(0)
+    expect(result.proven).toHaveLength(1)
+    const domain = result.proven[0]
+    expect(domain.canonical_subcategory).toBe('Jazz Theory')
+    expect(domain.kind).toBe('proven')
+    expect(domain.viewer.proven).toBe(true)
+    expect(domain.friend.proven).toBe(true)
+    expect(domain.viewer.mastery_points).toBe(10)
+    expect(domain.friend.mastery_points).toBe(4)
+  })
+
+  it('classifies a shared domain neither has proven as latent', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Roman Roads', 0, 'establishing'),
+      mastery(FRIEND, 'Roman Roads', 0, 'establishing'),
+    ]
+    // No proven events for either user.
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(0)
+    expect(result.latent).toHaveLength(1)
+    expect(result.latent[0].kind).toBe('latent')
+    expect(result.latent[0].viewer.proven).toBe(false)
+    expect(result.latent[0].friend.proven).toBe(false)
+    expect(result.isEmpty).toBe(false)
+  })
+
+  it('treats a one-sided proof as latent (both must be proven)', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Virginia Woolf', 8, 'solid'),
+      mastery(FRIEND, 'Virginia Woolf', 2, 'establishing'),
+    ]
+    provenRowsRef.rows = [proven(VIEWER, 'Virginia Woolf')]
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(0)
+    expect(result.latent).toHaveLength(1)
+    expect(result.latent[0].viewer.proven).toBe(true)
+    expect(result.latent[0].friend.proven).toBe(false)
+  })
+
+  it('does not filter on depth — a master-vs-establishing proven domain still appears', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Opera', 200, 'mastery'),
+      mastery(FRIEND, 'Opera', 1, 'establishing'),
+    ]
+    provenRowsRef.rows = [proven(VIEWER, 'Opera'), proven(FRIEND, 'Opera')]
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(1)
+    expect(result.proven[0].canonical_subcategory).toBe('Opera')
+    expect(result.proven[0].viewer.current_tier).toBe('mastery')
+    expect(result.proven[0].friend.current_tier).toBe('establishing')
+  })
+
+  it('returns the top 5 proven domains ranked by combined mastery points', async () => {
+    const points = [1, 7, 3, 9, 5, 8, 2]
+    masteryRowsRef.rows = points.flatMap((p, i) => [
+      mastery(VIEWER, `Domain ${i}`, p),
+      mastery(FRIEND, `Domain ${i}`, p),
+    ])
+    provenRowsRef.rows = points.flatMap((_, i) => [
+      proven(VIEWER, `Domain ${i}`),
+      proven(FRIEND, `Domain ${i}`),
+    ])
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(5)
+    // Combined points = 2 * p. Highest p first: 9,8,7,5,3 → Domain 3,5,1,4,2.
+    expect(result.proven.map((d) => d.canonical_subcategory)).toEqual([
+      'Domain 3',
+      'Domain 5',
+      'Domain 1',
+      'Domain 4',
+      'Domain 2',
+    ])
+  })
+
+  it('reports empty when there is no shared domain', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Astronomy', 5),
+      mastery(FRIEND, 'Cricket', 5),
+    ]
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(0)
+    expect(result.latent).toHaveLength(0)
+    expect(result.isEmpty).toBe(true)
+  })
+
+  it('matches the same domain case-insensitively, keeping the viewer label', async () => {
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'star trek', 6, 'familiar'),
+      mastery(FRIEND, 'Star Trek', 6, 'familiar'),
+    ]
+    provenRowsRef.rows = [proven(VIEWER, 'star trek'), proven(FRIEND, 'Star Trek')]
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(1)
+    expect(result.proven[0].canonical_subcategory).toBe('star trek')
+  })
+
+  it('does not count non-live source types as proven (lands in latent)', async () => {
+    // A domain whose only mastery events were 'authored' is filtered out by the
+    // query's source-type WHERE, so it never appears in provenRowsRef → latent.
+    masteryRowsRef.rows = [
+      mastery(VIEWER, 'Cartography', 0, 'establishing'),
+      mastery(FRIEND, 'Cartography', 0, 'establishing'),
+    ]
+    provenRowsRef.rows = []
+
+    const result = await getCommonGround(VIEWER, FRIEND)
+
+    expect(result.proven).toHaveLength(0)
+    expect(result.latent).toHaveLength(1)
+    expect(result.isEmpty).toBe(false)
+  })
+})

--- a/src/server/db/queries/common-ground.ts
+++ b/src/server/db/queries/common-ground.ts
@@ -1,0 +1,162 @@
+import { and, inArray } from 'drizzle-orm'
+
+import { db, masteryEvents, playerMastery } from '@/server/db'
+import type { MasteryTier } from '@/types/db'
+
+// A single shared-knowledge domain between the viewer and a friend, resolved
+// from each user's FULL PLAYER_MASTERY base (not the daily-five seeds, not a
+// game scope). See src/server/db/queries/__tests__/common-ground.test.ts.
+export type CommonGroundDomain = {
+  canonical_subcategory: string
+  broad_category: string | null
+  viewer: { mastery_points: number; current_tier: MasteryTier; proven: boolean }
+  friend: { mastery_points: number; current_tier: MasteryTier; proven: boolean }
+  kind: 'proven' | 'latent'
+}
+
+export type CommonGround = {
+  // Domains both users have PROVEN. Top 5, ranked by combined mastery points.
+  proven: CommonGroundDomain[]
+  // Domains both users hold but at least one hasn't proven yet (an invitation,
+  // not a match). Declared-but-untested interests land here.
+  latent: CommonGroundDomain[]
+  // True only when there is genuinely zero shared domain across BOTH tiers.
+  isEmpty: boolean
+}
+
+// A user is "proven" in a domain when they have answered correctly on a live
+// surface: at least one MASTERY_EVENTS row with one of these source types.
+const PROVEN_SOURCE_TYPES = ['live_correct', 'catchup_correct'] as const
+
+const MAX_PROVEN = 5
+
+// PLAYER_MASTERY.canonicalSubcategory is already canonicalized, so a simple
+// case-fold is enough to match the same domain across two users. Mirrors the
+// `domainKey` convention used throughout knowledge.ts.
+function domainKey(domain: string): string {
+  return domain.trim().toLowerCase()
+}
+
+type MasteryHolding = {
+  label: string
+  broadCategory: string | null
+  points: number
+  tier: MasteryTier
+}
+
+/**
+ * Compute the common ground between two users from their full PLAYER_MASTERY
+ * bases. Resolves each shared domain into a proven tier (both demonstrated) or
+ * a latent tier (shared but at least one unproven). Depth asymmetry is NOT a
+ * disqualifier — a master-vs-curious shared domain still appears; we only sort.
+ */
+export async function getCommonGround(
+  viewerId: string,
+  friendId: string,
+): Promise<CommonGround> {
+  const userIds = [viewerId, friendId]
+
+  // Two reads: every domain each user holds, and every domain each user has
+  // proven. We explicitly enumerate the PLAYER_MASTERY columns (omitting the
+  // legacy `territory_type`) so the query can't trip the 42703 missing-column
+  // failure that getPlayerMasteryRows defends against — proven-ness is derived
+  // from MASTERY_EVENTS here, not from territory_type.
+  const [masteryRows, provenRows] = await Promise.all([
+    db
+      .select({
+        userId: playerMastery.userId,
+        canonicalSubcategory: playerMastery.canonicalSubcategory,
+        broadCategory: playerMastery.broadCategory,
+        totalPoints: playerMastery.totalPoints,
+        tier: playerMastery.tier,
+      })
+      .from(playerMastery)
+      .where(inArray(playerMastery.userId, userIds)),
+    db
+      .select({
+        userId: masteryEvents.userId,
+        canonicalSubcategory: masteryEvents.canonicalSubcategory,
+      })
+      .from(masteryEvents)
+      .where(
+        and(
+          inArray(masteryEvents.userId, userIds),
+          inArray(masteryEvents.sourceType, [...PROVEN_SOURCE_TYPES]),
+        ),
+      ),
+  ])
+
+  const viewerByKey = new Map<string, MasteryHolding>()
+  const friendByKey = new Map<string, MasteryHolding>()
+  for (const row of masteryRows) {
+    const target = row.userId === viewerId ? viewerByKey : friendByKey
+    const key = domainKey(row.canonicalSubcategory)
+    // Unique (user, canonicalSubcategory) means one row per pair; keep the
+    // first if two only differ by case.
+    if (target.has(key)) continue
+    target.set(key, {
+      label: row.canonicalSubcategory,
+      broadCategory: row.broadCategory ?? null,
+      points: Number(row.totalPoints ?? 0),
+      tier: row.tier,
+    })
+  }
+
+  const viewerProvenKeys = new Set<string>()
+  const friendProvenKeys = new Set<string>()
+  for (const row of provenRows) {
+    const target = row.userId === viewerId ? viewerProvenKeys : friendProvenKeys
+    target.add(domainKey(row.canonicalSubcategory))
+  }
+
+  const shared: CommonGroundDomain[] = []
+  for (const [key, viewerHolding] of viewerByKey) {
+    const friendHolding = friendByKey.get(key)
+    if (!friendHolding) continue
+
+    const viewerProven = viewerProvenKeys.has(key)
+    const friendProven = friendProvenKeys.has(key)
+    shared.push({
+      // Prefer the viewer's stored casing for the display label.
+      canonical_subcategory: viewerHolding.label,
+      broad_category: viewerHolding.broadCategory ?? friendHolding.broadCategory,
+      viewer: {
+        mastery_points: viewerHolding.points,
+        current_tier: viewerHolding.tier,
+        proven: viewerProven,
+      },
+      friend: {
+        mastery_points: friendHolding.points,
+        current_tier: friendHolding.tier,
+        proven: friendProven,
+      },
+      kind: viewerProven && friendProven ? 'proven' : 'latent',
+    })
+  }
+
+  const combinedPoints = (d: CommonGroundDomain) =>
+    d.viewer.mastery_points + d.friend.mastery_points
+
+  const proven = shared
+    .filter((d) => d.kind === 'proven')
+    .sort(
+      (a, b) =>
+        combinedPoints(b) - combinedPoints(a) ||
+        a.canonical_subcategory.localeCompare(b.canonical_subcategory),
+    )
+    .slice(0, MAX_PROVEN)
+
+  const latent = shared
+    .filter((d) => d.kind === 'latent')
+    .sort(
+      (a, b) =>
+        combinedPoints(b) - combinedPoints(a) ||
+        a.canonical_subcategory.localeCompare(b.canonical_subcategory),
+    )
+
+  // Invariant: if any domain is shared, the section is never empty. This is the
+  // guard that prevents "No overlap" while a domain appears in both columns.
+  const isEmpty = proven.length === 0 && latent.length === 0
+
+  return { proven, latent, isEmpty }
+}


### PR DESCRIPTION
The friend-profile COMMON GROUND section computed overlap only from
DECLARED_INTERESTS, so a domain both users proved by playing (present in
each user's PLAYER_MASTERY / Knowledge Base card) but never explicitly
declared showed "No interest overlap" — the most emotionally damaging miss
in the app.

Add getCommonGround(viewerId, friendId), which compares each user's FULL
PLAYER_MASTERY base and resolves shared domains into two tiers:
- proven: both users have a live_correct/catchup_correct mastery event
  (top 5, ranked by combined mastery points; depth asymmetry is not a
  disqualifier — master-vs-establishing still appears)
- latent: shared but at least one is unproven (declared-but-untested),
  framed as an invitation

Render a new CommonGround component (two-circle-per-domain visual ported
from OverlapMap; diameter scales with mastery points, gap encodes tier
closeness; latent domains ghosted at 60% opacity) above the existing
declared-interest Venn, which is relabeled "Shared interests" to avoid two
"Common ground" headers. The intersection-based computation guarantees the
section never reads "No overlap" while a domain appears for both users.

https://claude.ai/code/session_016hdcdHzh2twrCfX8b9HNST