### PR TITLE
fix(daily): never serve a one-question Daily Five

### DIFF
--- a/src/server/daily/__tests__/queue-floor.test.ts
+++ b/src/server/daily/__tests__/queue-floor.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE } from '@/server/daily/types';
+
+// fillDailyQueueForUser orchestrates DB pickers + LLM generation; every one of
+// those touches @/server/db, which throws at module load without a connection
+// string. Mock the whole dependency surface so this exercises ONLY the
+// orchestrator's completeness loop + minimum-size floor (the single-question
+// "Daily Five" regression). The mocks are hoisted so the vi.mock factories can
+// reference them.
+const mocks = vi.hoisted(() => ({
+  getTodaysDailyQueue: vi.fn(),
+  carryForwardUntouchedDailyQueue: vi.fn(),
+  clearStaleShortTodayQueue: vi.fn(),
+  getKnowledgeBase: vi.fn(),
+  pickEligibleAuthoredQuestions: vi.fn(),
+  pickHouseQuestions: vi.fn(),
+  createDailyQueueItem: vi.fn(),
+  createDailyQueueItemFromAuthored: vi.fn(),
+  createDailyQueueItemFromHouse: vi.fn(),
+  createDailyQueueItemFromPresence: vi.fn(),
+  getDailyPreferences: vi.fn(),
+  getFriendAndFoFUserIds: vi.fn(),
+  getFriendDomainsForBonus: vi.fn(),
+  generateDailyQuestionsFromKnowledgeBase: vi.fn(),
+  generateBonusQuestionsForDomains: vi.fn(),
+  isGenericSubcategory: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/daily', () => ({
+  getTodaysDailyQueue: mocks.getTodaysDailyQueue,
+  carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
+  clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
+  getKnowledgeBase: mocks.getKnowledgeBase,
+  pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
+  pickHouseQuestions: mocks.pickHouseQuestions,
+  createDailyQueueItem: mocks.createDailyQueueItem,
+  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
+  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
+  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+}));
+
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: mocks.getDailyPreferences,
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendAndFoFUserIds: mocks.getFriendAndFoFUserIds,
+}));
+
+vi.mock('@/server/db/queries/friend-presence-domains', () => ({
+  getFriendDomainsForBonus: mocks.getFriendDomainsForBonus,
+}));
+
+vi.mock('@/server/daily/generate-questions', () => ({
+  generateDailyQuestionsFromKnowledgeBase: mocks.generateDailyQuestionsFromKnowledgeBase,
+  generateBonusQuestionsForDomains: mocks.generateBonusQuestionsForDomains,
+}));
+
+vi.mock('@/server/questions/canonical-subcategory', () => ({
+  isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+
+const USER = 'user-1';
+
+// Minimal stand-in for a generated question row — the orchestrator only reads
+// id, questionText, and canonicalSubcategory.
+function genq(id: string, subcategory = 'Jazz') {
+  return { id, questionText: `Question ${id}`, canonicalSubcategory: subcategory } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Fresh build path: no existing queue, nothing to carry forward.
+  mocks.getTodaysDailyQueue.mockResolvedValue(null);
+  mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
+  mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
+
+  // A non-empty knowledge base in random mode; no authored or house picks, so
+  // the queue is built purely from generated questions (the path that yields
+  // the single-question regression when generation under-yields).
+  mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }]);
+  mocks.getDailyPreferences.mockResolvedValue({
+    difficulty: 'adaptive',
+    domainMode: 'random',
+    selectedDomains: [],
+  });
+  mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
+  mocks.pickHouseQuestions.mockResolvedValue([]);
+  mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+
+  // No +2 bonus domains — keep the test focused on the core slots.
+  mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+  mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+
+  mocks.isGenericSubcategory.mockReturnValue(false);
+
+  mocks.createDailyQueueItem.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+});
+
+describe('fillDailyQueueForUser — minimum-size floor', () => {
+  it('fails retryably (and persists nothing) when only one question survives the gates', async () => {
+    // The exact regression: generation yields a single usable question and the
+    // pool is tapped out, so every retry round returns the same (deduped) item.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([genq('q1')]);
+
+    await expect(fillDailyQueueForUser(USER)).rejects.toMatchObject({
+      code: 'generation_failed',
+    });
+    await expect(fillDailyQueueForUser(USER)).rejects.toBeInstanceOf(DailyQueueFillError);
+
+    // A degenerate one-question queue must never be persisted.
+    expect(mocks.createDailyQueueItem).not.toHaveBeenCalled();
+  });
+
+  it('stops topping up once a round recovers nothing (tapped-out pool)', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([genq('q1')]);
+
+    await expect(fillDailyQueueForUser(USER)).rejects.toBeInstanceOf(DailyQueueFillError);
+
+    // One initial generation + exactly one top-up round (which recovers nothing
+    // new) — not the full MAX_TOP_UP_ROUNDS — because the loop breaks early.
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(2);
+  });
+
+  it('serves a graceful-degraded short queue at the floor without failing', async () => {
+    // Three distinct questions survive; further rounds only return duplicates.
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([genq('q1'), genq('q2'), genq('q3')])
+      .mockResolvedValue([genq('q1')]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_MIN_SIZE);
+    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(1, USER, 'q1', 0);
+    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(2, USER, 'q2', 1);
+    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(3, USER, 'q3', 2);
+  });
+
+  it('loops top-up rounds until it reaches the full five', async () => {
+    // Two on the first pass, then one and two more across two top-up rounds.
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([genq('q1'), genq('q2')])
+      .mockResolvedValueOnce([genq('q3')])
+      .mockResolvedValueOnce([genq('q4'), genq('q5')]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // One initial generation + two top-up rounds reaching the target.
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(3);
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+  });
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -21,7 +21,7 @@ import {
   generateBonusQuestionsForDomains,
   generateDailyQuestionsFromKnowledgeBase,
 } from '@/server/daily/generate-questions';
-import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
@@ -37,11 +37,25 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
-// Only start a recovery top-up generation while this much of the function
-// budget is still unspent. A second generation call can take up to
-// GENERATION_TIMEOUT_MS (35s); gating it on elapsed time keeps the retry from
-// pushing the request past the route's maxDuration.
-const TOP_UP_TIME_BUDGET_MS = 30_000;
+// Quality-first completeness loop. Rather than a single recovery pass, we keep
+// generating + gating additional rounds until the core reaches DAILY_QUEUE_SIZE
+// or we run out of budget. Each round runs the SAME strict quality/factual/dedup
+// gates — we never relax them to hit the count — so a round is the honest cost of
+// trying to surface another genuinely-good question.
+//
+// Only START a new round while this much of the function budget is still unspent.
+// A round can take up to GENERATION_TIMEOUT_MS (35s); gating each round's start on
+// elapsed time, with the route's 90s maxDuration, leaves a worst-case round plus
+// slot persistence (and a degraded-but-skippable +2 bonus) comfortably inside the
+// platform ceiling. Set well below maxDuration so the request never dies mid-build.
+const TOP_UP_TIME_BUDGET_MS = 45_000;
+
+// Hard cap on top-up rounds, independent of the time budget — a backstop against
+// a pathological domain that keeps generating questions the gates fully reject.
+// Combined with the "a round that recovers nothing breaks the loop" guard below,
+// this keeps a tapped-out knowledge base from burning the whole time budget (and
+// LLM spend) on rounds that can never reach the target.
+const MAX_TOP_UP_ROUNDS = 4;
 
 // The generator's quality/factual/history-dedup gates routinely drop ~half (and
 // for some niche or deep-history domains far more) of each batch. Requesting
@@ -182,17 +196,31 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
 
   // If the first pass came up short — the LLM returned fewer usable questions
-  // than requested, or the quality/dedup gates dropped some — attempt a single
-  // bounded top-up for just the missing slots before failing. A transient slow
-  // or partial Anthropic response (e.g. prod request 9lssf-…, where one Sonnet
-  // call ran ~34s and the queue fell one slot short) otherwise 503s the entire
-  // Daily Five even though most slots generated fine. The top-up is gated on
-  // remaining time budget so the recovery can't push the request past the
-  // route's maxDuration.
+  // than requested, or the quality/dedup gates dropped some — keep topping up in
+  // bounded rounds until the core reaches DAILY_QUEUE_SIZE or we run out of
+  // budget/rounds. A transient slow or partial Anthropic response (e.g. prod
+  // request 9lssf-…, where one Sonnet call ran ~34s and the queue fell one slot
+  // short) otherwise 503s the entire Daily Five even though most slots generated
+  // fine. Each round is gated on the remaining time budget so the recovery can't
+  // push the request past the route's maxDuration.
+  //
+  // The loop is the "quality-first, willing-to-wait" lever: it never relaxes the
+  // gates to pad the count — it just spends more time/LLM calls to give more
+  // genuinely-good questions a chance to survive. It stops early (rather than
+  // burning the whole budget) the moment a round recovers nothing, which is the
+  // signal that this knowledge base is tapped out for today.
   const topUpGenerated: typeof dedupedGenerated = [];
-  const shortfall = DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length);
-  if (shortfall > 0 && Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS) {
-    const extra = await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(shortfall));
+  let topUpRounds = 0;
+  while (
+    DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length) > 0 &&
+    topUpRounds < MAX_TOP_UP_ROUNDS &&
+    Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS
+  ) {
+    topUpRounds += 1;
+    const roundShortfall =
+      DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length);
+    const extra = await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(roundShortfall));
+    let recoveredThisRound = 0;
     for (const question of extra) {
       if (isGenericSubcategory(question.canonicalSubcategory)) {
         droppedGeneric += 1;
@@ -202,35 +230,58 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       if (seenTexts.has(key)) continue;
       seenTexts.add(key);
       topUpGenerated.push(question);
+      recoveredThisRound += 1;
     }
-    if (topUpGenerated.length > 0) {
+    if (recoveredThisRound > 0) {
       console.info('[daily/queue-orchestrator] topped up short queue', {
         userId,
-        shortfall,
-        recovered: topUpGenerated.length,
+        round: topUpRounds,
+        roundShortfall,
+        recovered: recoveredThisRound,
+        topUpTotal: topUpGenerated.length,
       });
+    } else {
+      // Nothing new survived the gates this round — the domain pool is exhausted
+      // for now. Further rounds would just re-spend the budget for the same null
+      // result, so stop and let the floor/graceful-degrade below decide.
+      console.info('[daily/queue-orchestrator] top-up round recovered nothing; stopping', {
+        userId,
+        round: topUpRounds,
+        roundShortfall,
+      });
+      break;
     }
   }
 
   const generatedForQueue = [...dedupedGenerated, ...topUpGenerated];
   const achieved = authored.length + housePicks.length + generatedForQueue.length;
 
-  // Graceful degrade: persist whatever we have instead of failing on a short
-  // queue. Some niche domains have very low generation yield — the
-  // quality/factual/dedup gates correctly reject most of each batch — so even
-  // over-provisioned generation can land short. A shorter Daily Five (the good
-  // questions we did get) beats a 503; the daily cron retries for a full set on
-  // later days. The play flow and home completion are slot-driven (isRound
-  // complete + progress read the ACTUAL slot count), so an N<5 queue renders
-  // and completes correctly — no more "round ends early with blank dots".
+  // Graceful degrade WITH A FLOOR. Some niche domains have very low generation
+  // yield — the quality/factual/dedup gates correctly reject most of each batch —
+  // so even over-provisioned generation plus the top-up loop above can land short.
+  // A shorter Daily Five (the good questions we did get) beats a 503 — but only
+  // down to DAILY_QUEUE_MIN_SIZE. A one- or two-question "Daily Five" is a broken
+  // session, not a degraded one, so below the floor we fail the build instead of
+  // persisting it: /api/daily/queue surfaces a retryable 503 + the fill-error UI,
+  // and the daily cron retries for a full set on later days. The play flow and
+  // home completion are slot-driven (isRoundComplete + progress read the ACTUAL
+  // slot count), so a queue between the floor and DAILY_QUEUE_SIZE renders and
+  // completes correctly — no "round ends early with blank dots".
   //
-  // Only fail when there's nothing usable at all, so /api/daily/queue still
-  // surfaces a retryable 503 + the fill-error UI in the genuine zero case.
-  if (achieved === 0) {
-    console.warn('[daily/queue-orchestrator] generation_failed (no usable questions)', {
+  // We never relax the gates to climb to the floor: a sub-floor result means the
+  // honest, gated yield was genuinely too low, which is a retry, not filler.
+  if (achieved < DAILY_QUEUE_MIN_SIZE) {
+    console.warn('[daily/queue-orchestrator] generation_failed (below minimum usable questions)', {
       userId,
+      achieved,
+      floor: DAILY_QUEUE_MIN_SIZE,
+      authoredCount: authored.length,
+      housePicks: housePicks.length,
       knowledgeBaseDomains: knowledgeBase.length,
       generatedRaw: generated.length,
+      dedupedGenerated: dedupedGenerated.length,
+      topUpRecovered: topUpGenerated.length,
+      topUpRounds,
       droppedDuplicates,
       droppedGeneric,
       domainMode: preferences.domainMode,
@@ -250,10 +301,12 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       userId,
       achieved,
       needed: DAILY_QUEUE_SIZE,
+      floor: DAILY_QUEUE_MIN_SIZE,
       authoredCount: authored.length,
       generatedRaw: generated.length,
       dedupedGenerated: dedupedGenerated.length,
       topUpRecovered: topUpGenerated.length,
+      topUpRounds,
       droppedDuplicates,
       droppedGeneric,
       knowledgeBaseDomains: knowledgeBase.length,

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -109,6 +109,23 @@ export const PERSONAL_DAILY_SESSION_CONTEXT = 'personal_daily';
 export const DAILY_QUEUE_SIZE = 5;
 
 /**
+ * Minimum number of core slots a Daily Five may be SERVED with. The orchestrator
+ * tries hard to reach DAILY_QUEUE_SIZE (looping bounded top-up generation through
+ * the same strict quality gates), but some niche / nearly-exhausted knowledge
+ * bases genuinely can't yield five distinct, high-quality questions in one build.
+ *
+ * Graceful-degrade tolerates a short queue down to this floor — a real,
+ * multi-question session still beats a retryable 503. BELOW it, the build is
+ * treated as failed (DailyQueueFillError 'generation_failed' → retryable 503),
+ * so the player sees the retry UI and the daily cron rebuilds a full set later
+ * rather than being served a degenerate one- or two-question "Daily Five".
+ *
+ * We never pad to this floor by relaxing the quality/factual/dedup gates — a
+ * short queue is always the GOOD questions that survived, never filler.
+ */
+export const DAILY_QUEUE_MIN_SIZE = 3;
+
+/**
  * Daily Five +2 — up to this many bonus slots are appended after the core
  * DAILY_QUEUE_SIZE, each a freshly generated accessible question in a domain
  * drawn from the territory ∪ activity of people the viewer follows (D-4 §B; see


### PR DESCRIPTION
The queue orchestrator's graceful-degrade only failed the build when ZERO
questions survived the quality gates, so a badly under-yielding generation
(a single usable question) persisted and served a degenerate one-question
'Daily Five' that ended immediately at the session-close.

Two changes, both quality-first (the strict quality/factual/dedup gates are
never relaxed to pad the count):

- Loop the top-up generation instead of a single bounded pass: keep
  generating + gating additional rounds toward DAILY_QUEUE_SIZE until the
  target is met or the time/round budget is spent, breaking early the moment
  a round recovers nothing (a tapped-out pool). Trades a longer build for a
  better shot at a full five of genuinely-good questions.

- Add DAILY_QUEUE_MIN_SIZE (3): below the floor the build fails retryably
  (generation_failed -> 503 + retry UI, cron rebuilds later) instead of
  persisting a broken one- or two-question session. Graceful-degrade still
  serves 3-4 for genuinely niche/low-yield knowledge bases.

Adds an orchestrator-level test covering the floor, early-stop, and
loop-to-full-five paths.

https://claude.ai/code/session_011bunSk1wnw7uXDym5CSDUQ