### PR TITLE
Add Dismiss + inline Undo to catch-up questions

### DIFF
--- a/src/app/api/daily/catchup/undismiss/__tests__/route.test.ts
+++ b/src/app/api/daily/catchup/undismiss/__tests__/route.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { dbMock, getSessionMock, selectCallChain, updateSetMock } = vi.hoisted(() => {
+  const selectCallChain: Array<() => Promise<unknown[]>> = [];
+  const updateSetMock = vi.fn(() => ({ where: vi.fn(async () => undefined) }));
+  const dbMock = {
+    select: vi.fn(() => {
+      const handler = selectCallChain.shift() ?? (async () => []);
+      return {
+        from: () => ({
+          where: () => ({
+            limit: handler,
+          }),
+        }),
+      };
+    }),
+    update: vi.fn(() => ({ set: updateSetMock })),
+  };
+  return {
+    dbMock,
+    getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
+    selectCallChain,
+    updateSetMock,
+  };
+});
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}));
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  dailyQueues: { id: 'q.id', userId: 'q.userId' },
+  feedItems: {
+    id: 'f.id',
+    recipientUserId: 'f.recipient',
+    catchupResolvedAt: 'f.catchupResolvedAt',
+  },
+}));
+
+vi.mock('@/server/daily/catchup', () => ({
+  asQueueSlots: (v: unknown) => (Array.isArray(v) ? v : []),
+  findQueueSlotBySlotIndex: (slots: { slot_index: number }[], idx: number) =>
+    slots.find((s) => s.slot_index === idx),
+  replaceQueueSlot: (slots: { slot_index: number }[], idx: number, fn: (s: unknown) => unknown) =>
+    slots.map((s) => (s.slot_index === idx ? fn(s) : s)),
+  parseCatchupItemId: (id: string) => {
+    if (id.startsWith('feed:')) return { surface: 'feed', feedItemId: id.slice(5) };
+    const [queueId, slotIndexValue] = id.split(':');
+    if (!queueId || !Number.isInteger(Number(slotIndexValue))) return null;
+    return { surface: 'daily', queueId, slotIndex: Number(slotIndexValue) };
+  },
+}));
+
+vi.mock('@/server/play/catch-up-submit-error', () => ({
+  catchUpErrorResponse: (status: number, code: string, message?: string) =>
+    Response.json({ error: code, message }, { status }),
+}));
+
+import { POST } from '@/app/api/daily/catchup/undismiss/route';
+
+function jsonRequest(body: unknown) {
+  return new Request('http://localhost/api/daily/catchup/undismiss', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/daily/catchup/undismiss', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectCallChain.length = 0;
+    getSessionMock.mockResolvedValue({ userId: 'user-1', id: 's-1' });
+  });
+
+  it('clears dismissed_at/dismissed_reason on a daily slot', async () => {
+    selectCallChain.push(async () => [
+      {
+        id: 'queue-1',
+        userId: 'user-1',
+        slots: [
+          {
+            slot_index: 0,
+            answered: false,
+            dismissed_at: '2026-06-01T00:00:00.000Z',
+            dismissed_reason: 'not_interested',
+          },
+        ],
+      },
+    ]);
+
+    const response = await POST(jsonRequest({ dailyQueueItemId: 'queue-1:0' }) as never);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ restored: true });
+    const setArg = updateSetMock.mock.calls[0]![0] as {
+      slots: Array<{ dismissed_at?: string; dismissed_reason?: string }>;
+    };
+    expect(setArg.slots[0].dismissed_at).toBeUndefined();
+    expect(setArg.slots[0].dismissed_reason).toBeUndefined();
+  });
+
+  it('clears catchupResolvedAt on a feed item', async () => {
+    selectCallChain.push(async () => [
+      { id: 'feed-1', recipientUserId: 'user-1', catchupResolvedAt: new Date() },
+    ]);
+
+    const response = await POST(jsonRequest({ dailyQueueItemId: 'feed:feed-1' }) as never);
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ restored: true });
+    expect(updateSetMock).toHaveBeenCalledWith({ catchupResolvedAt: null });
+  });
+
+  it('401s when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null as never);
+    const response = await POST(jsonRequest({ dailyQueueItemId: 'queue-1:0' }) as never);
+    expect(response.status).toBe(401);
+    expect(updateSetMock).not.toHaveBeenCalled();
+  });
+
+  it('400s on a missing dailyQueueItemId', async () => {
+    const response = await POST(jsonRequest({}) as never);
+    expect(response.status).toBe(400);
+  });
+
+  it('404s when the daily queue belongs to another user', async () => {
+    selectCallChain.push(async () => [{ id: 'queue-1', userId: 'someone-else', slots: [] }]);
+    const response = await POST(jsonRequest({ dailyQueueItemId: 'queue-1:0' }) as never);
+    expect(response.status).toBe(404);
+    expect(updateSetMock).not.toHaveBeenCalled();
+  });
+
+  it('404s when the feed item belongs to another user', async () => {
+    selectCallChain.push(async () => [
+      { id: 'feed-1', recipientUserId: 'someone-else', catchupResolvedAt: new Date() },
+    ]);
+    const response = await POST(jsonRequest({ dailyQueueItemId: 'feed:feed-1' }) as never);
+    expect(response.status).toBe(404);
+    expect(updateSetMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/daily/catchup/undismiss/route.ts
+++ b/src/app/api/daily/catchup/undismiss/route.ts
@@ -1,0 +1,88 @@
+import { eq } from 'drizzle-orm';
+import { NextRequest } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { dailyQueues, db, feedItems } from '@/server/db';
+import {
+  asQueueSlots,
+  findQueueSlotBySlotIndex,
+  parseCatchupItemId,
+  replaceQueueSlot,
+} from '@/server/daily/catchup';
+import { type QueueSlot } from '@/server/daily/types';
+import { catchUpErrorResponse } from '@/server/play/catch-up-submit-error';
+
+export const dynamic = 'force-dynamic';
+
+function parseBody(value: unknown): { dailyQueueItemId: string } | null {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const dailyQueueItemId = (value as Record<string, unknown>).dailyQueueItemId;
+  return typeof dailyQueueItemId === 'string' ? { dailyQueueItemId } : null;
+}
+
+// Reverses POST /api/daily/catchup/dismiss, restoring a question to catch-up
+// rotation. The dismissed item is filtered out of getCatchupQuestions by the
+// eligibility gates, so the target is resolved straight from the opaque id
+// (`feed:<id>` or `<queueId>:<slotIndex>`) rather than that query.
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return catchUpErrorResponse(401, 'unauthorized');
+
+  const parsed = parseBody(await request.json().catch(() => null));
+  if (!parsed) {
+    return catchUpErrorResponse(400, 'validation', 'dailyQueueItemId is required');
+  }
+
+  const target = parseCatchupItemId(parsed.dailyQueueItemId);
+  if (!target) {
+    return catchUpErrorResponse(400, 'validation', 'dailyQueueItemId is malformed');
+  }
+
+  if (target.surface === 'feed') {
+    const [feedItem] = await db
+      .select()
+      .from(feedItems)
+      .where(eq(feedItems.id, target.feedItemId))
+      .limit(1);
+    if (!feedItem || feedItem.recipientUserId !== session.userId) {
+      return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
+    }
+
+    await db
+      .update(feedItems)
+      .set({ catchupResolvedAt: null })
+      .where(eq(feedItems.id, feedItem.id));
+
+    return Response.json({ restored: true });
+  }
+
+  const [queue] = await db
+    .select()
+    .from(dailyQueues)
+    .where(eq(dailyQueues.id, target.queueId))
+    .limit(1);
+  if (!queue || queue.userId !== session.userId) {
+    return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
+  }
+
+  const slots = asQueueSlots(queue.slots);
+  const slot = findQueueSlotBySlotIndex(slots, target.slotIndex);
+  if (!slot) {
+    return catchUpErrorResponse(404, 'assignment_not_found', 'Catch-up question not found');
+  }
+
+  const nextSlots = replaceQueueSlot(
+    slots,
+    target.slotIndex,
+    (item) =>
+      ({
+        ...item,
+        dismissed_at: undefined,
+        dismissed_reason: undefined,
+      }) satisfies QueueSlot,
+  );
+
+  await db.update(dailyQueues).set({ slots: nextSlots }).where(eq(dailyQueues.id, target.queueId));
+
+  return Response.json({ restored: true });
+}

--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -28,6 +28,7 @@ export default function DailyCatchupPage() {
     reload,
     submitCurrent,
     skipCurrent,
+    dismissCurrent,
   } = useCatchupFlow();
   const [answer, setAnswer] = useState('');
 
@@ -126,6 +127,8 @@ export default function DailyCatchupPage() {
               messages={messages}
               onGiveUp={() => skipCurrent()}
               giveUpDisabled={submitting || isResolvingTurn}
+              onDismiss={() => void dismissCurrent()}
+              dismissDisabled={submitting || isResolvingTurn}
             />
           </>
         )}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -57,9 +57,12 @@ export type ChatMessage =
       presenceSourceName?: string | null;
       presenceSourceExtraCount?: number;
       isNew?: boolean;
+      /** When true the card is shown as a dimmed, non-interactive ghost — set when the question is dismissed and the inline "Dismissed · Undo" notice takes over. */
+      faded?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
     }
+  | { id: string; kind: 'dismiss_notice'; onUndo: () => Promise<void> }
   | { id: string; kind: 'user'; text: string }
   | { id: string; kind: 'typing' }
   | {
@@ -186,6 +189,61 @@ function SystemRow({ text }: { text: string }) {
   );
 }
 
+// Inline "Dismissed · Undo" line shown after a question is dropped from
+// catch-up. Mirrors NewTerritoryUndo's self-contained optimistic state: the
+// undo is awaited, "Undoing…" shows while in flight, and a rejection surfaces
+// an inline retry hint without losing the dismissal.
+function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
+  const [state, setState] = useState<'idle' | 'undoing' | 'error'>('idle');
+
+  const handleUndo = async () => {
+    if (state === 'undoing') return;
+    setState('undoing');
+    try {
+      await onUndo();
+      // On success the hook rewinds the thread and removes this row; no further
+      // state change needed here.
+    } catch {
+      setState('error');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-0.5 py-0.5">
+      <p style={{ ...monoStyle, fontSize: '0.58rem', color: 'var(--text-muted)', textAlign: 'center' }}>
+        <span>Dismissed</span>
+        <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
+        {state === 'undoing' ? (
+          <span style={{ opacity: 0.7 }}>Undoing…</span>
+        ) : (
+          <button
+            type="button"
+            onClick={() => void handleUndo()}
+            style={{
+              ...monoStyle,
+              fontSize: '0.58rem',
+              background: 'none',
+              border: 'none',
+              padding: 0,
+              cursor: 'pointer',
+              color: 'var(--text-muted)',
+              textDecoration: 'underline',
+              textUnderlineOffset: '2px',
+            }}
+          >
+            Undo
+          </button>
+        )}
+      </p>
+      {state === 'error' ? (
+        <p style={{ ...monoStyle, fontSize: '0.54rem', color: 'var(--danger)', textAlign: 'center' }}>
+          Could not undo. Try again.
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
 function QuestionRow({
   subhead,
   badges = [],
@@ -195,8 +253,11 @@ function QuestionRow({
   presenceSourceName = null,
   presenceSourceExtraCount = 0,
   isNew = false,
+  faded = false,
   onGiveUp,
   giveUpDisabled = false,
+  onDismiss,
+  dismissDisabled = false,
 }: {
   subhead?: string | null;
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -206,8 +267,11 @@ function QuestionRow({
   presenceSourceName?: string | null;
   presenceSourceExtraCount?: number;
   isNew?: boolean;
+  faded?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
+  onDismiss?: () => void;
+  dismissDisabled?: boolean;
 }) {
   const [visible, setVisible] = useState(!isNew);
 
@@ -221,7 +285,13 @@ function QuestionRow({
   return (
     <div
       className="flex flex-col gap-0.5"
-      style={isNew ? { opacity: visible ? 1 : 0, transition: 'opacity 0.3s ease' } : undefined}
+      style={
+        faded
+          ? { opacity: 0.35, transition: 'opacity 0.4s ease', pointerEvents: 'none' }
+          : isNew
+            ? { opacity: visible ? 1 : 0, transition: 'opacity 0.3s ease' }
+            : undefined
+      }
     >
       {subhead ? (
         <div className="flex flex-wrap items-center gap-1.5 pb-1 pl-0.5">
@@ -329,35 +399,41 @@ function QuestionRow({
           </div>
         ) : null}
       </div>
-      {onGiveUp ? (
-        <button
-          type="button"
-          onClick={onGiveUp}
-          disabled={giveUpDisabled}
-          style={{
-            alignSelf: 'flex-start',
-            background: 'none',
-            border: 'none',
-            padding: 0,
-            cursor: 'pointer',
-            fontFamily: 'var(--font-mono)',
-            fontSize: '0.58rem',
-            textTransform: 'uppercase',
-            letterSpacing: '0.06em',
-            color: 'var(--text-muted)',
-            textDecoration: 'underline',
-            textUnderlineOffset: '2px',
-            opacity: 0.7,
-            marginTop: '4px',
-            paddingLeft: '2px',
-          }}
-        >
-          Show me the answer
-        </button>
+      {!faded && (onGiveUp || onDismiss) ? (
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '14px', marginTop: '4px', paddingLeft: '2px' }}>
+          {onGiveUp ? (
+            <button type="button" onClick={onGiveUp} disabled={giveUpDisabled} style={questionActionLinkStyle}>
+              Show me the answer
+            </button>
+          ) : null}
+          {onDismiss ? (
+            <button type="button" onClick={onDismiss} disabled={dismissDisabled} style={questionActionLinkStyle}>
+              Dismiss
+            </button>
+          ) : null}
+        </div>
       ) : null}
     </div>
   );
 }
+
+// Shared style for the muted mono action links beneath a question card
+// ("Show me the answer", "Dismiss").
+const questionActionLinkStyle: CSSProperties = {
+  alignSelf: 'flex-start',
+  background: 'none',
+  border: 'none',
+  padding: 0,
+  cursor: 'pointer',
+  fontFamily: 'var(--font-mono)',
+  fontSize: '0.58rem',
+  textTransform: 'uppercase',
+  letterSpacing: '0.06em',
+  color: 'var(--text-muted)',
+  textDecoration: 'underline',
+  textUnderlineOffset: '2px',
+  opacity: 0.7,
+};
 
 function UserRow({ text }: { text: string }) {
   return (
@@ -1177,14 +1253,18 @@ export function GameplayChatThread({
   messages,
   onGiveUp,
   giveUpDisabled,
+  onDismiss,
+  dismissDisabled,
 }: {
   messages: ChatMessage[];
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
+  onDismiss?: () => void;
+  dismissDisabled?: boolean;
 }) {
-  // "Show me the answer" belongs only under the active (still-unanswered)
-  // question — the last question message with no result after it. Without this
-  // gate the thread would attach onGiveUp to every historical question row.
+  // "Show me the answer" and "Dismiss" belong only under the active (still-
+  // unanswered) question — the last question message with no result after it.
+  // Without this gate the thread would attach them to every historical row.
   const lastQuestionIndex = (() => {
     for (let i = messages.length - 1; i >= 0; i -= 1) {
       if (messages[i].kind === 'question') return i;
@@ -1203,6 +1283,8 @@ export function GameplayChatThread({
         switch (m.kind) {
           case 'system':
             return <SystemRow key={m.id} text={m.text} />;
+          case 'dismiss_notice':
+            return <DismissNoticeRow key={m.id} onUndo={m.onUndo} />;
           case 'question':
             return (
               <QuestionRow
@@ -1213,10 +1295,13 @@ export function GameplayChatThread({
                 presenceSourceName={m.presenceSourceName}
                 presenceSourceExtraCount={m.presenceSourceExtraCount}
                 isNew={m.isNew}
+                faded={m.faded}
                 subhead={m.subhead}
                 badges={m.badges}
                 onGiveUp={onGiveUp && m.id === activeQuestionId ? onGiveUp : undefined}
                 giveUpDisabled={giveUpDisabled}
+                onDismiss={onDismiss && m.id === activeQuestionId ? onDismiss : undefined}
+                dismissDisabled={dismissDisabled}
               />
             );
           case 'user':

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -185,6 +185,36 @@ function questionMessage(item: CatchupQueueItem): ChatMessage {
   };
 }
 
+// Once the player engages the next turn (answers, skips, or dismisses again),
+// a lingering "Dismissed · Undo" notice is retired to a plain "Dismissed." line
+// so undo can't rewind across a resolved turn.
+function retireDismissNotices(messages: ChatMessage[]): ChatMessage[] {
+  return messages.map((message) =>
+    message.kind === 'dismiss_notice'
+      ? { id: message.id, kind: 'system' as const, text: 'Dismissed.' }
+      : message,
+  );
+}
+
+// Rebuilds the introduced/result-posted sequencing sets from a thread, used
+// after an undo rewinds (truncates) the thread: every shown question is
+// "introduced", and a question is "resolved" once it has a result after it or
+// is a dismissed (faded) card. Anything truncated away drops out of both sets
+// so it gets re-introduced cleanly when the queue reaches it again.
+function deriveCatchupRefs(messages: ChatMessage[]): { introduced: Set<string>; resultPosted: Set<string> } {
+  const introduced = new Set<string>();
+  const resultPosted = new Set<string>();
+  for (const message of messages) {
+    if (message.kind === 'question') {
+      introduced.add(message.assignmentId);
+      if (message.faded) resultPosted.add(message.assignmentId);
+    } else if (message.kind === 'result') {
+      resultPosted.add(message.assignmentId);
+    }
+  }
+  return { introduced, resultPosted };
+}
+
 export function useCatchupFlow() {
   const [items, setItems] = useState<CatchupQueueItem[]>([]);
   const [initialTotal, setInitialTotal] = useState(0);
@@ -301,7 +331,7 @@ export function useCatchupFlow() {
     resultPostedItemIdsRef.current.add(item.dailyQueueItemId);
     setIsResolvingTurn(true);
     setMessages((existing) => [
-      ...existing,
+      ...retireDismissNotices(existing),
       { id: newMessageId(), kind: 'user', text: 'i give up' },
       {
         id: newMessageId(),
@@ -334,9 +364,49 @@ export function useCatchupFlow() {
     }, 1200);
   }, [currentItem, finishTurn, isResolvingTurn, submitting]);
 
+  // Reverses a dismissal: un-dismisses server-side, then rewinds the thread back
+  // to the dismissed question (dropping the notice and the auto-introduced next
+  // card) so it becomes the active question again. Throws on failure so the
+  // notice row can surface a retry without losing the dismissal.
+  const undismissItem = useCallback(async (item: CatchupQueueItem) => {
+    const itemId = item.dailyQueueItemId;
+    setSubmitting(true);
+    try {
+      const response = await fetch('/api/daily/catchup/undismiss', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ dailyQueueItemId: itemId }),
+      });
+      if (!response.ok) {
+        const raw = await response.json().catch(() => null);
+        throw new Error(userFacingCatchUpSubmitMessage(parseCatchUpAnswerErrorBody(raw)));
+      }
+      setStats((existing) => ({ ...existing, dismissed: Math.max(0, existing.dismissed - 1) }));
+      setItems((existing) => [item, ...existing.filter((entry) => entry.dailyQueueItemId !== itemId)]);
+      setMessages((existing) => {
+        const questionId = `catchup-q-${itemId}`;
+        const index = existing.findIndex((message) => message.id === questionId);
+        if (index === -1) return existing;
+        const rewound = existing.slice(0, index + 1).map((message) =>
+          message.id === questionId && message.kind === 'question'
+            ? { ...message, faded: false }
+            : message,
+        );
+        const refs = deriveCatchupRefs(rewound);
+        introducedItemIdsRef.current = refs.introduced;
+        resultPostedItemIdsRef.current = refs.resultPosted;
+        return rewound;
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  }, []);
+
   const dismissCurrent = useCallback(async (reason: 'not_interested' | 'too_old' | 'unclear' = 'not_interested') => {
-    if (!currentItem || submitting) return;
-    const itemId = currentItem.dailyQueueItemId;
+    if (!currentItem || submitting || isResolvingTurn) return;
+    const item = currentItem;
+    const itemId = item.dailyQueueItemId;
     setSubmitting(true);
     setError(null);
     try {
@@ -348,19 +418,27 @@ export function useCatchupFlow() {
       });
       const raw = await response.json().catch(() => null);
       if (!response.ok) throw new Error(userFacingCatchUpSubmitMessage(parseCatchUpAnswerErrorBody(raw)));
+      // Mark the prompt resolved so the next question can be introduced.
       resultPostedItemIdsRef.current.add(itemId);
       setStats((existing) => ({ ...existing, dismissed: existing.dismissed + 1 }));
-      setMessages((existing) => [
-        ...existing,
-        { id: newMessageId(), kind: 'system', text: 'Dropped from catch-up.' },
-      ]);
+      setMessages((existing) => {
+        const retired = retireDismissNotices(existing).map((message) =>
+          message.kind === 'question' && message.assignmentId === itemId
+            ? { ...message, faded: true }
+            : message,
+        );
+        return [
+          ...retired,
+          { id: newMessageId(), kind: 'dismiss_notice', onUndo: () => undismissItem(item) },
+        ];
+      });
       advancePast(itemId);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not dismiss that question.');
     } finally {
       setSubmitting(false);
     }
-  }, [advancePast, currentItem, submitting]);
+  }, [advancePast, currentItem, isResolvingTurn, submitting, undismissItem]);
 
   const submitCurrent = useCallback(async (submittedAnswer: string) => {
     if (!currentItem || submitting || !submittedAnswer.trim()) return;
@@ -395,7 +473,7 @@ export function useCatchupFlow() {
         dismissed: existing.dismissed,
       }));
       setMessages((existing) => [
-        ...existing,
+        ...retireDismissNotices(existing),
         { id: newMessageId(), kind: 'user', text: trimmedAnswer },
         buildCatchupResultMessage({
           id: resultMessageId,


### PR DESCRIPTION
Surfaces a "Dismiss" link beside "Show me the answer" on the catch-up
screen. Dismissing fades the question card to a dimmed ghost, drops a
"Dismissed · Undo" line into the thread, and advances to the next
question. Undo jumps back: it un-dismisses server-side and rewinds the
thread so the question becomes the active card again.

- GameplayChat: new `dismiss_notice` message variant + `faded` flag on
  question cards; QuestionRow renders the Dismiss link (gated to the
  active question like give-up) and dims when faded; DismissNoticeRow
  mirrors NewTerritoryUndo's optimistic idle/undoing/error states.
- useCatchupFlow: dismissCurrent now fades + posts the notice + advances;
  undismissItem rewinds the thread and rebuilds the sequencing refs from
  the truncated thread; a lingering notice is retired once the next turn
  resolves so undo can't rewind across a resolved turn.
- New POST /api/daily/catchup/undismiss clears dismissed_at/
  dismissed_reason (daily) or catchupResolvedAt (feed), resolving the
  target straight from the opaque id since dismissed items are filtered
  out of getCatchupQuestions. Covered by route tests.

https://claude.ai/code/session_011PECvDt6KZELbYAUyqFKFW