### PR TITLE
Codebase audit remediation: Zod input validation, lint ratchet, +2 visibility & doc fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,10 +25,9 @@ Thumbs.db
 dev-out.txt
 dev-stderr.txt
 .drizzle-tmp/
-/{
- 
-# TypeScript incremental build cache 
-*.tsbuildinfo 
+
+# TypeScript incremental build cache
+*.tsbuildinfo
 
 # Local Claude overrides & scratch
 .claude/settings.local.json

--- a/DECISIONS.md
+++ b/DECISIONS.md
@@ -31,6 +31,11 @@ Execution scaffolding (kept separate, not product spec): [`docs/build-prompts/`]
 - **Authored-vs-curated provenance is honest.** Forwarded LLM questions get `creatorId: null`, `source: 'curated_sent'`; credit never accrues to the forwarder. (Conformance audit §2.1.)
 - **Send difficulty travels with the question.** The forwarded question keeps its own `difficultyEstimate`. (`PRD-D-0` §4.1.)
 - **Broadcast rolls off after unfollow — won't fix.** Already-surfaced broadcasts are not retroactively purged on unfollow. (`PRD-D-0` §4.2.)
+- **Zod-validation convention applies to structured request bodies.** The CLAUDE.md rule ("Zod on every API input") was reconciled across the API surface (audit finding E, 2026-06-04): the JSON request-body handlers now validate with Zod. Four routes are a deliberate, documented carve-out and keep their existing validators because converting them is high-churn with no safety gain:
+  - `GET /api/archive`, `GET /api/feed`, `GET|POST /api/feed/backfill-missing-feed-items`, `GET /api/handle/check` — these take **query params** (always `string | null`), already coerced/clamped/enum-checked inline or routed through purpose-built validators (`decodeFeedCursor`, `handle-validation`).
+  - `POST /api/questions` delegates body validation to `readCreateQuestionPayload` (`src/server/questions/create-payload.ts`), a **centralized, unit-tested** validator — already the spirit of the convention, just not literally Zod.
+  - `POST /api/onboarding/propose-interests` and `POST|DELETE /api/friend-invitations` retain their hand-rolled validators: both emit several **distinct, field-specific error codes/messages** that a single Zod schema would flatten, and `validateCreateFriendInvitationBody` is exported and covered by its own test suite. Converting later is safe-but-optional; the tests would catch drift.
+  - `PATCH /api/declared-interests` retains its parser: each item is a lenient `string`-or-`object` union where **invalid items are dropped, not rejected** (1–5 must survive). Zod can only express that by wrapping the existing per-item parser, which adds ceremony without added safety.
 
 ## Open — pick these up
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ shared with friends.
 
 ## Stack
 
-Next.js 16 · TypeScript · Tailwind CSS 4 · Prisma 5 · Supabase (Postgres) · Anthropic API
+Next.js 16 · TypeScript · Tailwind CSS 4 · Drizzle ORM · Supabase (Postgres) · Anthropic API
 
 ## Local setup
 
@@ -62,5 +62,5 @@ Open [http://localhost:3000](http://localhost:3000).
 npm run build      # production build
 npm run lint       # ESLint
 npm run format     # Prettier
-npx prisma studio  # browse the database (read-only; Drizzle migrations are authoritative)
+npx drizzle-kit studio  # browse the database (Drizzle migrations are authoritative)
 ```

--- a/_docs/ARCHITECTURAL-DECISIONS.md
+++ b/_docs/ARCHITECTURAL-DECISIONS.md
@@ -10,8 +10,8 @@ Every Claude Code session should reference this to stay consistent.
 - **Database:** Postgres 15+, hosted on Supabase
   - Used as Postgres-only — NOT using Supabase Auth, Storage, Realtime, or RLS
   - Connection: pooled (port 6543) for app, direct (port 5432) for migrations
-- **ORM:** Prisma 5.x
-- **Migrations:** Prisma Migrate
+- **ORM:** Drizzle ORM (`drizzle-orm` + `drizzle-kit`)
+- **Migrations:** Drizzle Kit — `npm run db:migrate`; also auto-applied at boot via `src/instrumentation.ts`
 - **Styling:** Tailwind CSS 4 with @tailwindcss/postcss
 - **Components:** shadcn/ui (CLI-installed; source in src/components/ui/)
 - **Auth (dev):** Hardcoded sign-in (no SMS, no OTP) — see SMS section below
@@ -66,8 +66,8 @@ written normally from Phase 1 onward** — only the implementations change later
 ## Environment Variables
 
 Required for local + production:
-- `DATABASE_URL` — Supabase pooled connection (Prisma runtime)
-- `DIRECT_URL` — Supabase direct connection (Prisma Migrate)
+- `DATABASE_URL` — Supabase pooled connection (app runtime + drizzle-kit migrations)
+- `DIRECT_URL` — Supabase direct connection (port 5432; retained for tooling/tests)
 - `ANTHROPIC_API_KEY`
 - `JWT_SECRET` — 32+ random bytes, base64
 - `NEXT_PUBLIC_APP_URL` — base URL for invitation links

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -33,7 +33,10 @@ const TOKEN_LINT_RULE = {
 // Files that predate the rule and still carry off-system colors. Grandfathered to
 // a warning so the build stays green while the backlog is worked down — new files
 // (and any cleaned file removed from this list) are held at error. Shrink this
-// list; don't add to it.
+// list; don't add to it. These warnings are the *only* ones `npm run lint`
+// tolerates: the script pins `--max-warnings` to their current count (44), so the
+// warning lane can't silently grow. When you clean a file off this list, drop the
+// `--max-warnings` ceiling in package.json by the number of warnings it removed.
 const TOKEN_LINT_GRANDFATHERED = [
   "src/components/AddToBankAction.tsx",
   "src/components/CreateChooser.tsx",
@@ -74,6 +77,22 @@ const eslintConfig = defineConfig([
     ".drizzle-tmp/**",
     "next-env.d.ts",
   ]),
+  // Honor the repo-wide `_`-prefix convention for intentionally-unused bindings
+  // (e.g. `(..._args) => …`, a parked `_legacyInsertDeclared`). Without this the
+  // default rule warns on them, polluting the warning lane that the
+  // `--max-warnings` ratchet (see the `lint` script) is meant to hold flat.
+  {
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          argsIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
   {
     files: ["src/components/**/*.tsx"],
     rules: TOKEN_LINT_RULE,

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run src/lib/llm.grading.eval.test.ts",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 44",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/src/app/api/account/route.ts
+++ b/src/app/api/account/route.ts
@@ -1,9 +1,12 @@
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { destroySession, getSession } from '@/server/auth/session';
 import { deleteUserAccount, getUserProfile, updateDisplayName } from '@/server/db/queries/account';
 
 const DISPLAY_NAME_ERROR = 'Display name must be 2-30 characters.';
+
+const patchBodySchema = z.object({ displayName: z.string() });
 
 export async function GET() {
   const session = await getSession();
@@ -28,8 +31,8 @@ export async function PATCH(request: Request) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
-  const body = await request.json().catch(() => null) as { displayName?: unknown } | null;
-  const displayName = typeof body?.displayName === 'string' ? body.displayName.trim() : '';
+  const parsed = patchBodySchema.safeParse(await request.json().catch(() => null));
+  const displayName = parsed.success ? parsed.data.displayName.trim() : '';
 
   if (displayName.length < 2 || displayName.length > 30) {
     return NextResponse.json({ error: DISPLAY_NAME_ERROR }, { status: 400 });

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { isUsPhoneNumber, normalizePhone, requestOtp } from '@/server/auth';
 import { db, users } from '@/server/db';
@@ -8,17 +9,19 @@ import {
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations';
 
+const bodySchema = z.object({ phone: z.string().trim().min(1) });
+
 export async function POST(request: Request) {
   try {
-    const body = (await request.json().catch(() => null)) as { phone?: unknown } | null;
-    const rawPhone = typeof body?.phone === 'string' ? body.phone.trim() : '';
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
 
-    if (!rawPhone) {
+    if (!parsed.success) {
       return NextResponse.json(
         { error: 'invalid_request', message: 'phone is required' },
         { status: 400 },
       );
     }
+    const rawPhone = parsed.data.phone;
 
     if (!isUsPhoneNumber(rawPhone)) {
       return NextResponse.json(

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -76,7 +76,6 @@ vi.mock('@/server/friends/invitations', () => ({
 }))
 
 import { POST } from '@/app/api/auth/verify-otp/route'
-import { INVITE_REQUIRED_MESSAGE } from '@/server/friends/invitations'
 
 const EXISTING_USER = {
   id: 'user-1',

--- a/src/app/api/bank/check/route.ts
+++ b/src/app/api/bank/check/route.ts
@@ -1,18 +1,25 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 
 export const dynamic = 'force-dynamic';
 
+// Tolerant of a missing/non-array body and of non-string elements (which are
+// filtered out, matching the prior hand-rolled parser) rather than 400-ing.
+const bodySchema = z.object({
+  questionIds: z.array(z.unknown()).optional().catch(undefined),
+});
+
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as { questionIds?: unknown } | null;
-  const questionIds = Array.isArray(body?.questionIds)
-    ? body.questionIds.filter((id): id is string => typeof id === 'string')
-    : [];
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  const questionIds = (parsed.success ? parsed.data.questionIds ?? [] : []).filter(
+    (id): id is string => typeof id === 'string',
+  );
 
   return NextResponse.json(await checkBankedQuestions(session.userId, questionIds));
 }

--- a/src/app/api/bank/route.ts
+++ b/src/app/api/bank/route.ts
@@ -1,16 +1,28 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
-import { addToBank, getBankedQuestions, removeFromBank, type BankContextType } from '@/server/db/queries/bank';
+import { addToBank, getBankedQuestions, removeFromBank } from '@/server/db/queries/bank';
 
 export const dynamic = 'force-dynamic';
 
-function parseContextType(value: unknown): BankContextType | undefined {
-  return value === 'feed' || value === 'joshing_game' || value === 'manual' ? value : undefined;
+const bodySchema = z.object({
+  questionId: z.string().optional().catch(undefined),
+  // Unrecognized context types / non-string contextId are coerced away rather
+  // than rejected, matching the prior hand-rolled parser.
+  contextType: z.enum(['feed', 'joshing_game', 'manual']).optional().catch(undefined),
+  contextId: z.string().optional().catch(undefined),
+});
+
+function parseBody(value: unknown): z.infer<typeof bodySchema> | null {
+  const parsed = bodySchema.safeParse(value);
+  return parsed.success ? parsed.data : null;
 }
 
-function parseQuestionId(body: Record<string, unknown> | null): string | null {
-  return typeof body?.questionId === 'string' && body.questionId.trim() ? body.questionId.trim() : null;
+function questionIdFrom(body: z.infer<typeof bodySchema> | null): string | null {
+  return body && typeof body.questionId === 'string' && body.questionId.trim()
+    ? body.questionId.trim()
+    : null;
 }
 
 export async function GET() {
@@ -24,15 +36,15 @@ export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as Record<string, unknown> | null;
-  const questionId = parseQuestionId(body);
+  const body = parseBody(await request.json().catch(() => null));
+  const questionId = questionIdFrom(body);
   if (!questionId) return NextResponse.json({ error: 'validation', message: 'questionId is required' }, { status: 400 });
 
   const result = await addToBank({
     userId: session.userId,
     questionId,
-    contextType: parseContextType(body?.contextType),
-    contextId: typeof body?.contextId === 'string' ? body.contextId : undefined,
+    contextType: body?.contextType,
+    contextId: body?.contextId,
   });
 
   if (!result.ok) return NextResponse.json({ error: 'not_found' }, { status: 404 });
@@ -43,8 +55,8 @@ export async function DELETE(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as Record<string, unknown> | null;
-  const questionId = parseQuestionId(body);
+  const body = parseBody(await request.json().catch(() => null));
+  const questionId = questionIdFrom(body);
   if (!questionId) return NextResponse.json({ error: 'validation', message: 'questionId is required' }, { status: 400 });
 
   await removeFromBank(session.userId, questionId);

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { after, NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { gradeAnswer } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
@@ -75,23 +76,30 @@ async function resolveCanonicalAnswer(question: typeof generatedQuestions.$infer
   return repairedAnswer;
 }
 
-function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string; gaveUp: boolean } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const queueId = typeof record.queue_id === 'string' ? record.queue_id : null;
-  const slotIndex = typeof record.slot_index === 'number' && Number.isInteger(record.slot_index)
-    ? record.slot_index
-    : null;
-  const gaveUp = record.gave_up === true;
-  const submittedAnswer = typeof record.submitted_answer === 'string'
-    ? record.submitted_answer.trim()
-    : typeof record.answer === 'string'
-      ? record.answer.trim()
-      : '';
+const bodySchema = z.object({
+  queue_id: z.string().min(1),
+  slot_index: z.number().int(),
+  // gave_up / submitted_answer / answer are permissive: a malformed type is
+  // coerced away (matching the prior hand-rolled parser) rather than 400-ing.
+  gave_up: z.boolean().optional().catch(undefined),
+  submitted_answer: z.string().optional().catch(undefined),
+  answer: z.string().optional().catch(undefined),
+});
 
-  if (!queueId || slotIndex === null) return null;
+function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string; gaveUp: boolean } | null {
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { queue_id, slot_index, gave_up, submitted_answer, answer } = parsed.data;
+  const gaveUp = gave_up === true;
+  const submittedAnswer = (
+    typeof submitted_answer === 'string'
+      ? submitted_answer
+      : typeof answer === 'string'
+        ? answer
+        : ''
+  ).trim();
   if (!gaveUp && !submittedAnswer) return null;
-  return { queueId, slotIndex, submittedAnswer, gaveUp };
+  return { queueId: queue_id, slotIndex: slot_index, submittedAnswer, gaveUp };
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { after, NextRequest } from 'next/server';
+import { z } from 'zod';
 
 import { gradeAnswer } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
@@ -29,13 +30,17 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+const bodySchema = z.object({
+  dailyQueueItemId: z.string().min(1),
+  submittedAnswer: z.string(),
+});
+
 function parseBody(value: unknown): { dailyQueueItemId: string; submittedAnswer: string } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const dailyQueueItemId = typeof record.dailyQueueItemId === 'string' ? record.dailyQueueItemId : null;
-  const submittedAnswer = typeof record.submittedAnswer === 'string' ? record.submittedAnswer.trim() : null;
-  if (!dailyQueueItemId || !submittedAnswer) return null;
-  return { dailyQueueItemId, submittedAnswer };
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const submittedAnswer = parsed.data.submittedAnswer.trim();
+  if (!submittedAnswer) return null;
+  return { dailyQueueItemId: parsed.data.dailyQueueItemId, submittedAnswer };
 }
 
 function nextItemPayload(item: CatchupQuestion | null) {

--- a/src/app/api/daily/catchup/dismiss/route.ts
+++ b/src/app/api/daily/catchup/dismiss/route.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { NextRequest } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, feedItems } from '@/server/db';
@@ -12,21 +13,17 @@ export const dynamic = 'force-dynamic';
 
 type DismissReason = 'not_interested' | 'too_old' | 'unclear';
 
-const DISMISS_REASONS = new Set<DismissReason>(['not_interested', 'too_old', 'unclear']);
+const bodySchema = z.object({
+  dailyQueueItemId: z.string(),
+  // An unrecognized reason is dropped to undefined rather than rejected,
+  // preserving the prior hand-rolled parser's behavior.
+  reason: z.enum(['not_interested', 'too_old', 'unclear']).optional().catch(undefined),
+});
 
 function parseBody(value: unknown): { dailyQueueItemId: string; reason?: DismissReason } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const dailyQueueItemId = record.dailyQueueItemId;
-  const reason = record.reason;
-  return typeof dailyQueueItemId === 'string'
-    ? {
-        dailyQueueItemId,
-        reason: typeof reason === 'string' && DISMISS_REASONS.has(reason as DismissReason)
-          ? reason as DismissReason
-          : undefined,
-      }
-    : null;
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  return { dailyQueueItemId: parsed.data.dailyQueueItemId, reason: parsed.data.reason };
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/daily/feedback/route.ts
+++ b/src/app/api/daily/feedback/route.ts
@@ -1,32 +1,30 @@
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { db, generatedQuestions, questionFeedback, questions } from '@/server/db';
 
 export const dynamic = 'force-dynamic';
 
-type FeedbackSignal = 'thumbs_up' | 'thumbs_down';
-
-function parseSignal(value: unknown): FeedbackSignal | null {
-  return value === 'thumbs_up' || value === 'thumbs_down' ? value : null;
-}
+const bodySchema = z.object({
+  question_id: z.string().optional().catch(undefined),
+  generated_question_id: z.string().optional().catch(undefined),
+  signal: z.enum(['thumbs_up', 'thumbs_down']).optional().catch(undefined),
+});
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as {
-    question_id?: unknown;
-    generated_question_id?: unknown;
-    signal?: unknown;
-  } | null;
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  const body = parsed.success ? parsed.data : null;
 
   const questionId = typeof body?.question_id === 'string' && body.question_id ? body.question_id : null;
   const generatedQuestionId = typeof body?.generated_question_id === 'string' && body.generated_question_id
     ? body.generated_question_id
     : null;
-  const signal = parseSignal(body?.signal);
+  const signal = body?.signal ?? null;
 
   if (!signal) {
     return NextResponse.json(

--- a/src/app/api/daily/preferences/add-domain/route.ts
+++ b/src/app/api/daily/preferences/add-domain/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { getKnowledgeBase } from '@/server/db/queries/daily';
@@ -6,9 +7,12 @@ import { getDailyPreferences, updateDailyPreferences } from '@/server/db/queries
 
 export const dynamic = 'force-dynamic';
 
+const bodySchema = z.object({ domain: z.string().optional().catch(undefined) });
+
 function parseDomain(value: unknown): string | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const domain = (value as Record<string, unknown>).domain;
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const domain = parsed.data.domain;
   return typeof domain === 'string' && domain.trim() ? domain.trim() : null;
 }
 

--- a/src/app/api/daily/preferences/route.ts
+++ b/src/app/api/daily/preferences/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { getKnowledgeBase, invalidateUntouchedDailyQueues } from '@/server/db/queries/daily';
@@ -13,23 +14,21 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+const difficultySchema = z.enum(DAILY_DIFFICULTIES);
+const domainModeSchema = z.enum(DAILY_DOMAIN_MODES);
+
 function isValidDifficulty(value: unknown): value is DailyDifficulty {
-  return DAILY_DIFFICULTIES.includes(value as DailyDifficulty);
+  return difficultySchema.safeParse(value).success;
 }
 
 function isValidDomainMode(value: unknown): value is DailyDomainMode {
-  return DAILY_DOMAIN_MODES.includes(value as DailyDomainMode);
+  return domainModeSchema.safeParse(value).success;
 }
 
 function parseStringArray(value: unknown): string[] | null {
-  if (!Array.isArray(value)) return null;
-  const result: string[] = [];
-  for (const item of value) {
-    if (typeof item !== 'string') return null;
-    const trimmed = item.trim();
-    if (trimmed) result.push(trimmed);
-  }
-  return [...new Set(result)];
+  const parsed = z.array(z.string()).safeParse(value);
+  if (!parsed.success) return null;
+  return [...new Set(parsed.data.map((item) => item.trim()).filter(Boolean))];
 }
 
 // Order-insensitive comparison; both inputs are already de-duped upstream

--- a/src/app/api/daily/recheck/route.ts
+++ b/src/app/api/daily/recheck/route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { after, NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
 import { getSession } from '@/server/auth/session';
@@ -24,15 +25,15 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+const bodySchema = z.object({
+  queue_id: z.string().min(1),
+  slot_index: z.number().int(),
+});
+
 function parseBody(value: unknown): { queueId: string; slotIndex: number } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const queueId = typeof record.queue_id === 'string' ? record.queue_id : null;
-  const slotIndex = typeof record.slot_index === 'number' && Number.isInteger(record.slot_index)
-    ? record.slot_index
-    : null;
-  if (!queueId || slotIndex === null) return null;
-  return { queueId, slotIndex };
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  return { queueId: parsed.data.queue_id, slotIndex: parsed.data.slot_index };
 }
 
 async function resolveCanonicalAnswer(question: typeof generatedQuestions.$inferSelect): Promise<string> {

--- a/src/app/api/daily/skip/route.ts
+++ b/src/app/api/daily/skip/route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { dailyQueues, db, skippedDailyQuestions } from '@/server/db';
@@ -13,14 +14,15 @@ function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
 }
 
+const bodySchema = z.object({
+  queue_id: z.string().min(1),
+  slot_index: z.number().int(),
+});
+
 function parseBody(value: unknown): { queueId: string; slotIndex: number } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const queueId = typeof record.queue_id === 'string' ? record.queue_id : null;
-  const slotIndex = typeof record.slot_index === 'number' && Number.isInteger(record.slot_index)
-    ? record.slot_index
-    : null;
-  return queueId && slotIndex !== null ? { queueId, slotIndex } : null;
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  return { queueId: parsed.data.queue_id, slotIndex: parsed.data.slot_index };
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/feed/dismiss-domain/route.ts
+++ b/src/app/api/feed/dismiss-domain/route.ts
@@ -1,13 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { dismissDomain, reinstateDomain } from '@/server/db/queries/feed';
 
 export const dynamic = 'force-dynamic';
 
+const bodySchema = z.object({ domain: z.string().optional().catch(undefined) });
+
 function parseDomain(value: unknown): string | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const domain = (value as Record<string, unknown>).domain;
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const domain = parsed.data.domain;
   return typeof domain === 'string' && domain.trim() ? domain.trim() : null;
 }
 

--- a/src/app/api/joshing-games/route.ts
+++ b/src/app/api/joshing-games/route.ts
@@ -1,5 +1,6 @@
 import { and, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { db, questions, userQuestionBank, users } from '@/server/db';
@@ -25,24 +26,19 @@ function getBaseUrl(request: NextRequest): string {
   return host ? `${protocol}://${host}` : request.nextUrl.origin;
 }
 
+const bodySchema = z.object({
+  title: z.string(),
+  recipientIds: z.array(z.string()),
+  questionIds: z.array(z.string()),
+});
+
 function parseBody(value: unknown): CreateJoshingGameBody | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-
-  if (
-    typeof record.title !== 'string'
-    || !Array.isArray(record.recipientIds)
-    || !Array.isArray(record.questionIds)
-    || !record.recipientIds.every((id) => typeof id === 'string')
-    || !record.questionIds.every((id) => typeof id === 'string')
-  ) {
-    return null;
-  }
-
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
   return {
-    title: record.title.trim(),
-    recipientIds: record.recipientIds,
-    questionIds: record.questionIds,
+    title: parsed.data.title.trim(),
+    recipientIds: parsed.data.recipientIds,
+    questionIds: parsed.data.questionIds,
   };
 }
 

--- a/src/app/api/knowledge/[domain]/route.ts
+++ b/src/app/api/knowledge/[domain]/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import {
   getDomainDetail,
   removeKnowledgeDomain,
   setDomainVisibility,
-  type DomainVisibility,
 } from '@/server/db/queries/knowledge';
 
 export const dynamic = 'force-dynamic';
@@ -14,9 +14,9 @@ type RouteContext = {
   params: Promise<{ domain: string }>;
 };
 
-function parseVisibility(value: unknown): DomainVisibility | null {
-  return value === 'public' || value === 'friends' || value === 'private' ? value : null;
-}
+const patchBodySchema = z.object({
+  visibility: z.enum(['public', 'friends', 'private']).optional().catch(undefined),
+});
 
 export async function GET(_request: NextRequest, context: RouteContext) {
   const session = await getSession();
@@ -34,8 +34,8 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as { visibility?: unknown } | null;
-  const visibility = parseVisibility(body?.visibility);
+  const parsed = patchBodySchema.safeParse(await request.json().catch(() => null));
+  const visibility = parsed.success ? parsed.data.visibility : undefined;
   if (!visibility) {
     return NextResponse.json(
       { error: 'validation', message: 'visibility must be public, friends, or private' },

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNull, sql } from 'drizzle-orm';
 import { after, NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { gradeAnswer } from '@/server/grading';
 import { getSession } from '@/server/auth/session';
@@ -20,15 +21,24 @@ type RouteContext = {
 
 type MasteryTier = 'establishing' | 'familiar' | 'solid' | 'mastery';
 
-function parseBody(value: unknown): { submittedAnswer: string } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const submittedAnswer = typeof record.submitted_answer === 'string'
-    ? record.submitted_answer.trim()
-    : typeof record.answer === 'string'
-      ? record.answer.trim()
-      : null;
+const bodySchema = z.object({
+  // Permissive: a malformed type is coerced away (matching the prior parser)
+  // rather than 400-ing; the required-non-empty check happens below.
+  submitted_answer: z.string().optional().catch(undefined),
+  answer: z.string().optional().catch(undefined),
+});
 
+function parseBody(value: unknown): { submittedAnswer: string } | null {
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { submitted_answer, answer } = parsed.data;
+  const submittedAnswer = (
+    typeof submitted_answer === 'string'
+      ? submitted_answer
+      : typeof answer === 'string'
+        ? answer
+        : ''
+  ).trim();
   return submittedAnswer ? { submittedAnswer } : null;
 }
 

--- a/src/app/api/questions/[id]/rating/route.ts
+++ b/src/app/api/questions/[id]/rating/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { getRatingCounts, getRatingForUser, setRating } from '@/server/db/queries/ratings';
@@ -9,10 +10,9 @@ type RouteContext = {
   params: Promise<{ id: string }>;
 };
 
-function parseRating(value: unknown): 'up' | 'down' | null | undefined {
-  if (value === null || value === 'up' || value === 'down') return value;
-  return undefined;
-}
+const bodySchema = z.object({
+  rating: z.union([z.literal('up'), z.literal('down'), z.null()]),
+});
 
 export async function GET(_request: Request, context: RouteContext) {
   const session = await getSession();
@@ -31,14 +31,13 @@ export async function POST(request: NextRequest, context: RouteContext) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as { rating?: unknown } | null;
-  const rating = parseRating(body?.rating);
-  if (rating === undefined) {
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
     return NextResponse.json({ error: 'rating must be up, down, or null' }, { status: 400 });
   }
 
   const { id } = await context.params;
-  await setRating(session.userId, id, rating);
+  await setRating(session.userId, id, parsed.data.rating);
 
   return NextResponse.json({ ok: true });
 }

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -1,5 +1,6 @@
 import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion } from '@/lib/llm';
@@ -28,39 +29,48 @@ function splitAlternates(value: unknown): string[] | undefined {
   return undefined;
 }
 
-function validatePatchPayload(body: Record<string, unknown> | null) {
-  const values: {
-    text?: string;
-    correctAnswer?: string;
-    alternateAnswers?: string[];
-    explanation?: string;
-    category?: string;
-    broadCategory?: string | null;
-    subcategory?: string;
-    canonicalSubcategory?: string;
-    difficulty?: number;
-  } = {};
-  const errors: string[] = [];
+type PatchValues = {
+  text?: string;
+  correctAnswer?: string;
+  alternateAnswers?: string[];
+  explanation?: string;
+  category?: string;
+  broadCategory?: string | null;
+  subcategory?: string;
+  canonicalSubcategory?: string;
+  difficulty?: number;
+};
 
-  if (body?.text !== undefined) {
-    values.text = typeof body.text === 'string' ? body.text.trim() : '';
-    if (!values.text || values.text.length > 300) errors.push('text');
+// Field order for the `fields` error array, preserved from the prior
+// hand-rolled validator so clients keep highlighting fields in the same order.
+const PATCH_FIELD_ORDER = ['text', 'correctAnswer', 'alternateAnswers', 'explanation'] as const;
+
+// Only the fields actually present in the body are validated (partial update).
+// `explanation` tolerates a non-string (coerced to '') to match the prior
+// parser, which only ever flagged it for exceeding the length cap.
+// `alternateAnswers` keeps its lenient split (non-strings dropped, trimmed,
+// empties removed) via preprocess, and an absent value stays undefined so an
+// unrelated edit never clears stored alternates.
+const patchSchema = z.object({
+  text: z.string().transform((s) => s.trim()).pipe(z.string().min(1).max(300)).optional(),
+  correctAnswer: z.string().transform((s) => s.trim()).pipe(z.string().min(1).max(200)).optional(),
+  alternateAnswers: z
+    .preprocess((v) => (v === undefined ? undefined : splitAlternates(v) ?? []), z.array(z.string().max(200)).max(5))
+    .optional(),
+  explanation: z.string().catch('').transform((s) => s.trim()).pipe(z.string().max(500)).optional(),
+});
+
+function validatePatchPayload(body: Record<string, unknown> | null): { values: PatchValues; errors: string[] } {
+  const parsed = patchSchema.safeParse(body ?? {});
+  if (parsed.success) {
+    return { values: { ...parsed.data }, errors: [] };
   }
-  if (body?.correctAnswer !== undefined) {
-    values.correctAnswer = typeof body.correctAnswer === 'string' ? body.correctAnswer.trim() : '';
-    if (!values.correctAnswer || values.correctAnswer.length > 200) errors.push('correctAnswer');
-  }
-  if (body?.alternateAnswers !== undefined) {
-    values.alternateAnswers = splitAlternates(body.alternateAnswers) ?? [];
-    if (values.alternateAnswers.length > 5 || values.alternateAnswers.some((answer) => answer.length > 200)) {
-      errors.push('alternateAnswers');
-    }
-  }
-  if (body?.explanation !== undefined) {
-    values.explanation = typeof body.explanation === 'string' ? body.explanation.trim() : '';
-    if (values.explanation.length > 500) errors.push('explanation');
-  }
-  return { values, errors };
+  const errors = [...new Set(parsed.error.issues.map((issue) => String(issue.path[0])))].sort(
+    (a, b) =>
+      PATCH_FIELD_ORDER.indexOf(a as (typeof PATCH_FIELD_ORDER)[number]) -
+      PATCH_FIELD_ORDER.indexOf(b as (typeof PATCH_FIELD_ORDER)[number]),
+  );
+  return { values: {}, errors };
 }
 
 async function questionExistsForAnotherUser(questionId: string, userId: string): Promise<boolean> {

--- a/src/app/api/questions/critique/route.ts
+++ b/src/app/api/questions/critique/route.ts
@@ -1,5 +1,6 @@
 import { and, eq, sql } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { db, critiqueUsageDaily } from '@/server/db';
@@ -8,6 +9,8 @@ import { critiqueQuestion } from '@/server/llm/critique';
 export const dynamic = 'force-dynamic';
 
 const DAILY_LIMIT = 5;
+
+const bodySchema = z.object({ questionText: z.string().optional().catch(undefined) });
 
 type CritiqueResponse = {
   ok: boolean;
@@ -30,8 +33,10 @@ export async function POST(request: NextRequest) {
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
   try {
-    const body = await request.json().catch(() => null) as { questionText?: unknown } | null;
-    const questionText = typeof body?.questionText === 'string' ? body.questionText.trim() : '';
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    const questionText = parsed.success && typeof parsed.data.questionText === 'string'
+      ? parsed.data.questionText.trim()
+      : '';
     if (!questionText) return NextResponse.json(passResponse({ remaining: null }));
 
     const usageDate = utcDateString();

--- a/src/app/api/questions/suggest-answer/route.ts
+++ b/src/app/api/questions/suggest-answer/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { suggestAnswer } from '@/lib/llm';
 import { getSession } from '@/server/auth/session';
+
+const bodySchema = z.object({ question: z.string() });
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as { question?: unknown } | null;
-  const question = typeof body?.question === 'string' ? body.question.trim() : '';
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  const question = parsed.success ? parsed.data.question.trim() : '';
   if (question.length < 5) return NextResponse.json({ error: 'question too short' }, { status: 400 });
 
   return NextResponse.json(await suggestAnswer(question));

--- a/src/app/api/questions/suggest/route.ts
+++ b/src/app/api/questions/suggest/route.ts
@@ -1,14 +1,17 @@
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { suggestQuestionAnswer } from '@/server/llm/suggest-question';
+
+const bodySchema = z.object({ questionText: z.string() });
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const body = await request.json().catch(() => null) as { questionText?: unknown } | null;
-  const questionText = typeof body?.questionText === 'string' ? body.questionText.trim() : '';
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  const questionText = parsed.success ? parsed.data.questionText.trim() : '';
   if (!questionText) return NextResponse.json({ error: 'questionText is required' }, { status: 400 });
 
   try {

--- a/src/app/api/reactions/route.ts
+++ b/src/app/api/reactions/route.ts
@@ -1,5 +1,6 @@
 import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { isReactionKey, isWrongAnswerReactionKey, type ReactionKey } from '@/lib/reactions';
 import { getSession } from '@/server/auth/session';
@@ -22,21 +23,32 @@ type ReactionBody = {
   includeSubmittedAnswer: boolean;
 };
 
+// Raw shape only; unrecognized types are coerced away (matching the prior
+// hand-rolled parser). The business rules (trim, isReactionKey, the §8.22
+// wrong-answer gate) are applied after parsing.
+const bodySchema = z.object({
+  questionId: z.string().optional().catch(undefined),
+  contextType: z.enum(['feed', 'joshing_game']).optional().catch(undefined),
+  contextId: z.string().optional().catch(undefined),
+  reactionType: z.string().optional().catch(undefined),
+  customMessage: z.string().optional().catch(undefined),
+  includeSubmittedAnswer: z.boolean().optional().catch(undefined),
+});
+
 function parseBody(value: unknown): ReactionBody | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const questionId = typeof record.questionId === 'string' ? record.questionId.trim() : '';
-  const contextType = record.contextType === 'feed' || record.contextType === 'joshing_game'
-    ? record.contextType
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const data = parsed.data;
+  const questionId = typeof data.questionId === 'string' ? data.questionId.trim() : '';
+  const contextType = data.contextType ?? null;
+  const contextId = typeof data.contextId === 'string' && data.contextId.trim()
+    ? data.contextId.trim()
     : null;
-  const contextId = typeof record.contextId === 'string' && record.contextId.trim()
-    ? record.contextId.trim()
-    : null;
-  const reactionType = typeof record.reactionType === 'string' ? record.reactionType.trim() : '';
-  const customMessage = typeof record.customMessage === 'string' ? record.customMessage.trim().slice(0, 160) : null;
+  const reactionType = typeof data.reactionType === 'string' ? data.reactionType.trim() : '';
+  const customMessage = typeof data.customMessage === 'string' ? data.customMessage.trim().slice(0, 160) : null;
   // §8.22: only wrong-answer reactions are eligible to attach submitted text.
   // For any other reactionType we coerce to false even if the client asks.
-  const includeSubmittedAnswerRequested = record.includeSubmittedAnswer === true;
+  const includeSubmittedAnswerRequested = data.includeSubmittedAnswer === true;
   const includeSubmittedAnswer = includeSubmittedAnswerRequested && isWrongAnswerReactionKey(reactionType);
 
   if (!questionId || !contextType || !isReactionKey(reactionType)) return null;

--- a/src/app/api/replay/grade/route.ts
+++ b/src/app/api/replay/grade/route.ts
@@ -1,5 +1,6 @@
 import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { asQueueSlots, findQueueSlotBySlotIndex, replaceQueueSlot } from '@/server/daily/catchup';
@@ -12,17 +13,24 @@ import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 
 export const dynamic = 'force-dynamic';
 
+const bodySchema = z.object({
+  dailyQueueItemId: z.string().optional().catch(undefined),
+  assignmentId: z.string().optional().catch(undefined),
+  submittedAnswer: z.string().optional().catch(undefined),
+});
+
 function parseBody(value: unknown): { dailyQueueItemId: string; submittedAnswer: string } | null {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
-  const record = value as Record<string, unknown>;
-  const dailyQueueItemId = typeof record.dailyQueueItemId === 'string'
-    ? record.dailyQueueItemId
-    : typeof record.assignmentId === 'string'
-      ? record.assignmentId
+  const parsed = bodySchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { dailyQueueItemId, assignmentId, submittedAnswer } = parsed.data;
+  const id = typeof dailyQueueItemId === 'string'
+    ? dailyQueueItemId
+    : typeof assignmentId === 'string'
+      ? assignmentId
       : null;
-  const submittedAnswer = typeof record.submittedAnswer === 'string' ? record.submittedAnswer.trim() : null;
-  if (!dailyQueueItemId || !submittedAnswer) return null;
-  return { dailyQueueItemId, submittedAnswer };
+  const answer = typeof submittedAnswer === 'string' ? submittedAnswer.trim() : null;
+  if (!id || !answer) return null;
+  return { dailyQueueItemId: id, submittedAnswer: answer };
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -1,21 +1,22 @@
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
 
 import { getSession } from '@/server/auth/session'
 import { logTelemetry, type TelemetryEventName } from '@/server/telemetry'
 
 export const dynamic = 'force-dynamic'
 
-const CLIENT_TELEMETRY_EVENTS = new Set<TelemetryEventName>([
+const CLIENT_TELEMETRY_EVENTS = [
   'add_friend_started',
   'add_friend_message_copied',
   'add_friend_sms_handoff_opened',
   'friend_invite_auth_started',
-])
+] as const satisfies readonly TelemetryEventName[]
 
-type TelemetryBody = {
-  event?: unknown
-  metadata?: unknown
-}
+const bodySchema = z.object({
+  event: z.enum(CLIENT_TELEMETRY_EVENTS),
+  metadata: z.unknown().optional(),
+})
 
 function parseMetadata(value: unknown) {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return {}
@@ -37,10 +38,9 @@ function parseMetadata(value: unknown) {
 }
 
 export async function POST(request: Request) {
-  const body = (await request.json().catch(() => null)) as TelemetryBody | null
-  const event = typeof body?.event === 'string' ? body.event : ''
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
 
-  if (!CLIENT_TELEMETRY_EVENTS.has(event as TelemetryEventName)) {
+  if (!parsed.success) {
     return NextResponse.json(
       { error: 'invalid_event', message: 'Unsupported telemetry event.' },
       { status: 400 }
@@ -48,8 +48,8 @@ export async function POST(request: Request) {
   }
 
   const session = await getSession()
-  logTelemetry(event as TelemetryEventName, {
-    ...parseMetadata(body?.metadata),
+  logTelemetry(parsed.data.event, {
+    ...parseMetadata(parsed.data.metadata),
     user_id: session?.userId ?? null,
   })
 

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -168,6 +168,9 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
   // we just re-assert it when the field becomes editable again.
   useEffect(() => {
     if (currentQuestion && !pending) answerInputRef.current?.focus();
+    // Keyed on the stable question id, not the derived `currentQuestion` object
+    // (recomputed every render via .find(), which would re-fire focus constantly).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentQuestion?.questionId, pending]);
 
   async function submitAnswer() {

--- a/src/components/QuestionBankPicker.tsx
+++ b/src/components/QuestionBankPicker.tsx
@@ -49,6 +49,9 @@ export function QuestionBankPicker({ onSelect, onQuestionsLoaded, maxSelect = 5,
       })
       .catch(() => setError('Could not load your question bank'))
       .finally(() => setLoading(false));
+    // Mount-only fetch: `onQuestionsLoaded` is a parent callback that may not be
+    // memoized, so depending on it would risk re-fetching on every parent render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const toggle = (id: string) => {

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -1,6 +1,6 @@
 import { assertNever } from '@/lib/assert-never';
 
-/** Question shape returned by /api/questions (matches Prisma Question) */
+/** Question shape returned by /api/questions (matches the Drizzle `questions` row) */
 export type QuestionRecord = {
   id: string;
   creator_id: string;

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -1,5 +1,5 @@
 /**
- * Session creation and validation using UserSession (Prisma).
+ * Session creation and validation using the UserSession table (Drizzle).
  * A signed JWT is stored in an httpOnly cookie; PRD: 90-day persistence.
  */
 

--- a/src/server/ceremony/__tests__/payload-validation.test.ts
+++ b/src/server/ceremony/__tests__/payload-validation.test.ts
@@ -75,7 +75,6 @@ describe('beatsPayloadSchema (F3.5)', () => {
   })
 
   it('rejects a payload missing cycleStart', () => {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const { cycleStart: _cycleStart, ...rest } = WELL_FORMED
     const result = beatsPayloadSchema.safeParse(rest)
     expect(result.success).toBe(false)

--- a/src/server/mastery/category-label.ts
+++ b/src/server/mastery/category-label.ts
@@ -53,7 +53,7 @@ export function resolveCanonicalSubcategoryLabel(input: ResolveCategoryLabelInpu
 }
 
 export type ResolveReviewCategoryDisplayInput = ResolveCategoryLabelInput & {
-  /** Prisma `Question.category` when hyper-specific fields are empty */
+  /** The question's `category` column when hyper-specific fields are empty */
   broad_category_key?: string | null;
 };
 


### PR DESCRIPTION
Remediation pass from the 2026-06 codebase audit. All commits are behavior-preserving unless noted, and each was gated on a clean `tsc`, the lint warning ratchet holding, and the full test suite passing.

## Finding E — Zod input-validation reconciliation (the bulk)
The CLAUDE.md convention is "Zod on every API input," but a chunk of the API surface still used hand-rolled `typeof` validators. **24 of 32 handlers** were converted to Zod schemas, preserving exact status codes, error shapes, and input coercion (permissive fields that the old parsers *coerced* rather than *rejected* use `.optional().catch(undefined)`, so no new 400s are introduced).

- `81ec10a` — batch 1: request-otp, daily/answer, daily/skip, daily/recheck, catchup/answer, catchup/dismiss, account, questions/[id]/answer, questions/[id]/rating
- `7775528` — batch 2: reactions, telemetry, bank, bank/check, feed/dismiss-domain, knowledge/[domain]
- `a72bb88` — batch 3: daily/feedback, preferences/add-domain, questions/suggest, suggest-answer, critique, replay/grade
- `6200698` — joshing-games
- `4d1b8fd` — daily/preferences, questions/[id] PATCH

`questions/[id]` PATCH has no test of its own, so its candidate schema was verified identical to the prior `validatePatchPayload` across 24 representative inputs (including the dangerous absent-`alternateAnswers`→`undefined` case) before the swap.

**8 routes are a deliberate, documented carve-out** (recorded in `DECISIONS.md`): the 4 query-param GETs (params already coerced/validated), `questions` POST (delegates to the unit-tested `readCreateQuestionPayload`), and `onboarding` / `friend-invitations` / `declared-interests` (distinct-error or lenient-union validators where a Zod rewrite is high-churn with no safety gain). Note: the CLAUDE.md rule reads "No exceptions," and this PR formally carves out those 8 — flag if you'd rather keep it absolute and I'll convert the tail too.

## Other audit findings
- `1e9f653` — Make the lint warning lane a real gate: `--max-warnings` ratchet, honoring the `_` prefix.
- `667a454` — Fix Prisma→Drizzle doc drift and a malformed `.gitignore` entry.
- `96465f4` — Reword +2 attribution to name the bonus and the friend's knowledge.
- `eeb2384` — Honor `knowledge_base` visibility in the +2 pool; label bonus slots (includes a new `friend-presence-domains.visibility` test).

## Verification
`tsc` clean · lint ratchet holds (44 warnings, 0 errors) · full suite **699 passed / 3 skipped**.

https://claude.ai/code/session_01LqEL1p6DxgE969LkpFLaen

---
_Generated by [Claude Code](https://claude.ai/code/session_01LqEL1p6DxgE969LkpFLaen)_