### PR TITLE
Refresh bell badge after marking activities read

### DIFF
--- a/src/app/activities/MarkActivitiesRead.tsx
+++ b/src/app/activities/MarkActivitiesRead.tsx
@@ -1,8 +1,11 @@
 'use client';
 
 import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
 
 export function MarkActivitiesRead() {
+  const router = useRouter();
+
   useEffect(() => {
     void Promise.allSettled([
       fetch('/api/activities/read', {
@@ -13,8 +16,16 @@ export function MarkActivitiesRead() {
         method: 'POST',
         credentials: 'include',
       }),
-    ]);
-  }, []);
+    ]).then(() => {
+      // The bell badge count is computed server-side in the root layout
+      // (getBellBadgeCount in layout.tsx) and passed into Nav as a prop. The
+      // root layout is preserved across navigations and does not re-run after
+      // these POSTs, so without an explicit refresh the badge keeps showing
+      // the stale pre-open count until the next hard render. Refresh re-runs
+      // the server layout so the badge clears in place.
+      router.refresh();
+    });
+  }, [router]);
 
   return null;
 }


### PR DESCRIPTION
The activity bell badge count is computed server-side in the root layout
(getBellBadgeCount in layout.tsx) and passed to Nav as a prop. Visiting
/activities fires the mark-read/mark-opened POSTs, but the root layout is
preserved across navigations and never re-runs, so the badge kept showing
the stale pre-open count until a hard refresh.

Call router.refresh() once the POSTs settle so the server layout re-renders
and the badge clears in place.