### PR TITLE
B1 pool substrate: unified question selection, trust tiers, and embedding dedup

### DIFF
--- a/drizzle/0062_pool_substrate_trust_scope.sql
+++ b/drizzle/0062_pool_substrate_trust_scope.sql
@@ -1,0 +1,105 @@
+-- Migration: B1 pool substrate — trust tier, scope, perishable, provenance,
+-- empirical stats, and embedding-dedup flags (PRD-D-5 §5.1 / §6 / §8).
+--
+-- Evolves the machine bank (GeneratedQuestion) and human-authored questions
+-- (Question) into one durable, trust-tiered, dedup-aware pool. B1 adds the
+-- fields + the capability to filter by them; it does NOT switch on live
+-- trust-tier gating (that is B4) and deletes nothing.
+--
+-- Field reuse (human table): scope, n_answered and empirical_correct_rate are
+-- NOT added to Question — the unified selection layer reuses visibility,
+-- asked_count and correct_rate. Only genuinely-new columns are added there.
+--
+-- Grandfather backfill: machine rows -> machine_verified; human rows ->
+-- author_confirmed. Machine empirical stats are derived from the linked played
+-- Question row (Question.generated_question_id, unique) where one exists.
+--
+-- All additive / IF NOT EXISTS / guarded — safe and non-destructive. Matching
+-- idempotent boot guards land in src/instrumentation.ts so a preview/production
+-- database that records this migration without the pieces present can still boot.
+--
+-- Rollback: DROP the added columns (DROP COLUMN IF EXISTS) on both tables and
+-- DROP TYPE "TrustTier"/"QuestionScope"; no other data depends on them.
+DO $$ BEGIN
+  CREATE TYPE "public"."TrustTier" AS ENUM('unverified', 'machine_verified', 'human_validated', 'author_confirmed');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."QuestionScope" AS ENUM('private', 'friends_only', 'public');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+-- Human-authored questions: new-only columns.
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified';
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "suppressed_by" text;
+--> statement-breakpoint
+-- Machine bank: new-only + machine-only columns (scope/n_answered/correct-rate).
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified';
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public';
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "suppressed_by" text;
+--> statement-breakpoint
+-- Grandfather backfill: existing human rows are author_confirmed (default
+-- target only the rows still at the 'unverified' default so this is re-runnable).
+UPDATE "Question"
+  SET "trust_tier" = 'author_confirmed'
+  WHERE "trust_tier" = 'unverified';
+--> statement-breakpoint
+-- Grandfather backfill: existing machine rows are machine_verified.
+UPDATE "GeneratedQuestion"
+  SET "trust_tier" = 'machine_verified'
+  WHERE "trust_tier" = 'unverified';
+--> statement-breakpoint
+-- Empirical stats backfill (D11): derive each machine row's play stats from its
+-- linked played Question (Question.generated_question_id is unique). Machine rows
+-- with no linked play stay at 0 / NULL.
+UPDATE "GeneratedQuestion" g
+  SET "n_answered" = q."asked_count",
+      "empirical_correct_rate" = CASE
+        WHEN q."asked_count" > 0 THEN q."correct_count"::double precision / q."asked_count"
+        ELSE NULL
+      END
+  FROM "Question" q
+  WHERE q."generated_question_id" = g."id"
+    AND q."asked_count" > 0;
+--> statement-breakpoint
+-- Selection-layer filter indexes (B1). Capability only; not gated on any surface.
+CREATE INDEX IF NOT EXISTS "Question_trust_tier_idx" ON "Question" ("trust_tier");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Question_is_duplicate_idx" ON "Question" ("is_duplicate");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_trust_tier_idx" ON "GeneratedQuestion" ("trust_tier");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_is_duplicate_idx" ON "GeneratedQuestion" ("is_duplicate");

--- a/drizzle/0063_pool_embeddings.sql
+++ b/drizzle/0063_pool_embeddings.sql
@@ -1,0 +1,27 @@
+-- Migration: B1 pool substrate — pgvector embeddings for semantic dedup
+-- (PRD-D-5 §5.1 D10 / §7).
+--
+-- Enables pgvector and adds a nullable 1024-dim embedding column (Voyage
+-- voyage-3.5-lite) to both pool tables, plus HNSW cosine indexes for fast
+-- nearest-neighbour lookup. The column is populated at insert (best-effort) and
+-- by the batched backfill job; it stays NULL until VOYAGE_API_KEY is provisioned,
+-- so this migration alone changes no behavior.
+--
+-- Additive / IF NOT EXISTS throughout — safe and non-destructive. Matching
+-- idempotent boot guards land in src/instrumentation.ts.
+--
+-- Rollback: DROP INDEX the two hnsw indexes; ALTER TABLE ... DROP COLUMN IF
+-- EXISTS "embedding" on both tables. (CREATE EXTENSION is left in place.)
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "embedding" vector(1024);
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "embedding" vector(1024);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx"
+  ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx"
+  ON "Question" USING hnsw ("embedding" vector_cosine_ops);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1781913600000,
       "tag": "0062_pool_substrate_trust_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1782000000000,
+      "tag": "0063_pool_embeddings",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781827200000,
       "tag": "0061_email_verification_token",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781913600000,
+      "tag": "0062_pool_substrate_trust_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-pool-embeddings.ts
+++ b/scripts/backfill-pool-embeddings.ts
@@ -1,0 +1,143 @@
+// Batched backfill: populate GeneratedQuestion.embedding / Question.embedding
+// (Voyage voyage-3.5-lite, 1024-dim) for the existing pool, then run the
+// embedding-dedup collision pass over the back-filled rows.
+//
+// APPROVAL GATE (PRD-D-5 §8 B1): run the dry-run first — it reports how many
+// rows need embedding and the estimated Voyage cost. Do not --apply until that
+// estimate is approved.
+//
+// Idempotent: only rows with a NULL embedding are processed; re-running resumes.
+// Requires VOYAGE_API_KEY in the environment.
+//
+// Usage:
+//   npx tsx scripts/backfill-pool-embeddings.ts            # dry-run (count + cost)
+//   npx tsx scripts/backfill-pool-embeddings.ts --apply    # embed + dedup
+
+import 'dotenv/config';
+
+import { eq, isNull, isNotNull, and } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions, questions } from '../src/server/db';
+import { embedTexts, EMBEDDING_BATCH_SIZE, isEmbeddingEnabled } from '../src/server/llm/embeddings';
+import {
+  findNearestInPool,
+  markPoolDuplicate,
+  storePoolEmbedding,
+  type PoolOrigin,
+} from '../src/server/db/queries/pool';
+import { resolveCollision, getDedupCosineThreshold } from '../src/server/pool/dedup';
+
+const APPLY = process.argv.slice(2).includes('--apply');
+
+// voyage-3.5-lite list price (USD per 1M tokens). Adjust if Voyage repricing.
+const VOYAGE_PRICE_PER_MTOK = 0.02;
+// Cheap token proxy: ~4 chars/token.
+const estimateTokens = (text: string) => Math.ceil((text?.length ?? 0) / 4);
+
+type Pending = { id: string; text: string; origin: PoolOrigin };
+
+async function loadPending(): Promise<Pending[]> {
+  const [machine, human] = await Promise.all([
+    db
+      .select({ id: generatedQuestions.id, text: generatedQuestions.questionText })
+      .from(generatedQuestions)
+      .where(isNull(generatedQuestions.embedding)),
+    db
+      .select({ id: questions.id, text: questions.questionText })
+      .from(questions)
+      .where(and(isNull(questions.embedding), isNull(questions.deletedAt))),
+  ]);
+  return [
+    ...machine.map((r) => ({ id: r.id, text: r.text, origin: 'machine' as const })),
+    ...human.map((r) => ({ id: r.id, text: r.text, origin: 'human' as const })),
+  ];
+}
+
+async function main() {
+  console.log(`[backfill-pool-embeddings] ${APPLY ? 'APPLY' : 'DRY RUN'} mode\n`);
+
+  const pending = await loadPending();
+  const machineCount = pending.filter((p) => p.origin === 'machine').length;
+  const humanCount = pending.length - machineCount;
+  const totalTokens = pending.reduce((sum, p) => sum + estimateTokens(p.text), 0);
+  const estCost = (totalTokens / 1_000_000) * VOYAGE_PRICE_PER_MTOK;
+
+  console.log(`[backfill-pool-embeddings] rows needing embedding: ${pending.length} (machine=${machineCount}, human=${humanCount})`);
+  console.log(`[backfill-pool-embeddings] est. tokens: ~${totalTokens.toLocaleString()} → est. Voyage cost: ~$${estCost.toFixed(4)} (at $${VOYAGE_PRICE_PER_MTOK}/1M tok)`);
+  console.log(`[backfill-pool-embeddings] dedup cosine threshold: ${getDedupCosineThreshold()}`);
+
+  // Sanity check: confirm pgvector + embedding columns are actually present.
+  const haveColumns = await db
+    .select({ id: generatedQuestions.id })
+    .from(generatedQuestions)
+    .where(isNotNull(generatedQuestions.embedding))
+    .limit(1)
+    .then(() => true)
+    .catch((err) => {
+      console.warn('[backfill-pool-embeddings] embedding column not queryable yet — run migration 0063 first', { message: String(err) });
+      return false;
+    });
+  if (!haveColumns) return;
+
+  if (!APPLY) {
+    console.log('\n[backfill-pool-embeddings] dry run only — re-run with --apply once the cost is approved.');
+    return;
+  }
+  if (!isEmbeddingEnabled()) {
+    console.error('[backfill-pool-embeddings] VOYAGE_API_KEY missing — cannot --apply.');
+    process.exitCode = 1;
+    return;
+  }
+
+  // 1) Embed + store in batches.
+  let embedded = 0;
+  for (let start = 0; start < pending.length; start += EMBEDDING_BATCH_SIZE) {
+    const batch = pending.slice(start, start + EMBEDDING_BATCH_SIZE);
+    const vectors = await embedTexts(batch.map((b) => b.text), 'document');
+    if (!vectors) {
+      console.error('[backfill-pool-embeddings] embedding disabled mid-run; stopping.');
+      break;
+    }
+    for (let i = 0; i < batch.length; i += 1) {
+      const vec = vectors[i];
+      if (!vec) continue;
+      await storePoolEmbedding(batch[i].origin, batch[i].id, vec);
+      embedded += 1;
+    }
+    console.log(`[backfill-pool-embeddings] embedded ${Math.min(start + batch.length, pending.length)}/${pending.length}`);
+  }
+
+  // 2) Collision pass over the freshly back-filled rows. resolveCollision is
+  //    direction-aware (human beats machine) regardless of processing order;
+  //    findNearestInPool already excludes already-suppressed rows.
+  let suppressed = 0;
+  for (const row of pending) {
+    const [stored] = await db
+      .select({ embedding: row.origin === 'machine' ? generatedQuestions.embedding : questions.embedding })
+      .from(row.origin === 'machine' ? generatedQuestions : questions)
+      .where(eq(row.origin === 'machine' ? generatedQuestions.id : questions.id, row.id))
+      .limit(1);
+    const embedding = stored?.embedding as number[] | null | undefined;
+    if (!embedding) continue;
+    const nearest = await findNearestInPool(embedding, row.id);
+    const decision = resolveCollision({ id: row.id, origin: row.origin }, nearest, getDedupCosineThreshold());
+    if (decision.action === 'suppress_incoming') {
+      await markPoolDuplicate(row.origin, row.id, decision.survivorId);
+      suppressed += 1;
+    } else if (decision.action === 'suppress_existing') {
+      await markPoolDuplicate(decision.existingOrigin, decision.existingId, decision.survivorId);
+      suppressed += 1;
+    }
+  }
+
+  console.log(`\n[backfill-pool-embeddings] done. embedded=${embedded}, suppressed=${suppressed}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-pool-embeddings] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -487,6 +487,24 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
+    // embedding column + HNSW cosine indexes to both pool tables. The dedup
+    // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a
+    // database that records the migration without the pieces present must still
+    // boot. Guard the extension, columns, and indexes idempotently. If pgvector
+    // is unavailable the whole block is skipped — insert-time dedup degrades to
+    // the deterministic guards.
+    try {
+      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx" ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops)`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx" ON "Question" USING hnsw ("embedding" vector_cosine_ops)`);
+    } catch {
+      // pgvector may be unavailable, or the tables may not exist yet on a fresh
+      // database — migrate() handles creation; dedup is best-effort regardless.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -441,6 +441,52 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0062 (B1 pool substrate) adds the TrustTier/QuestionScope enums
+    // and the pool fields (trust_tier, scope, perishable, source_refs, empirical
+    // stats, embedding-dedup flags) to Question + GeneratedQuestion. App code
+    // (the unified selection layer, suppress-aware bank pick) reads these, so a
+    // preview/production database that records the migration without the pieces
+    // present must still boot. Enums + columns + grandfather backfill are applied
+    // idempotently; the backfills target only rows still at the 'unverified'
+    // default, so they are re-runnable no-ops once corrected.
+    try {
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."TrustTier" AS ENUM('unverified', 'machine_verified', 'human_validated', 'author_confirmed');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."QuestionScope" AS ENUM('private', 'friends_only', 'public');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
+      await db.execute(sql`UPDATE "Question" SET "trust_tier" = 'author_confirmed' WHERE "trust_tier" = 'unverified'`);
+    } catch {
+      // Question may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+    try {
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public'`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
+      await db.execute(sql`UPDATE "GeneratedQuestion" SET "trust_tier" = 'machine_verified' WHERE "trust_tier" = 'unverified'`);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/llm';
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 import { db, generatedQuestions } from '@/server/db';
+import { embedAndResolveDuplicate } from '@/server/pool/dedup';
 import {
   getDomainDifficultyOverrides,
   mapAdaptiveLevelToDifficultyHint,
@@ -1051,6 +1052,13 @@ export async function generateDailyQuestions(
       })
       .returning();
     persisted.push(row);
+
+    // Semantic-dedup backstop (B1 pool substrate). Best-effort and no-op without
+    // VOYAGE_API_KEY, so it never blocks generation; the fact_key/Haiku/text
+    // guards above remain the cheap first pass. A new machine row that collides
+    // with an existing pool question is flagged is_duplicate (never deleted), so
+    // pickBankSource stops serving it.
+    await embedAndResolveDuplicate({ id: row.id, origin: 'machine', questionText: row.questionText });
   }
 
   return persisted;

--- a/src/server/db/queries/__tests__/pool.test.ts
+++ b/src/server/db/queries/__tests__/pool.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  empiricalRate,
+  filterPooledQuestions,
+  normalizeHumanRow,
+  normalizeMachineRow,
+  visibilityToScope,
+  type PooledQuestion,
+} from '@/server/db/queries/pool';
+import { generatedQuestions, questions } from '@/server/db/schema';
+
+type MachineRow = typeof generatedQuestions.$inferSelect;
+type HumanRow = typeof questions.$inferSelect;
+
+let seq = 0;
+
+function machineRow(over: Partial<MachineRow> = {}): MachineRow {
+  seq += 1;
+  return {
+    id: `gen-${seq}`,
+    userId: 'recipient-user',
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    questionText: `Machine question ${seq}`,
+    answer: `Machine answer ${seq}`,
+    explainer: `Machine explainer ${seq}`,
+    difficultyEstimate: 'moderate',
+    basePoints: 10,
+    factKey: `fact-${seq}`,
+    subAngles: [],
+    insideJoke: null,
+    createdAt: new Date(2026, 0, seq + 1),
+    expiresAt: new Date(2026, 1, seq + 1),
+    usedInQueue: false,
+    trustTier: 'machine_verified',
+    scope: 'public',
+    perishable: false,
+    sourceRefs: [],
+    nAnswered: 0,
+    empiricalCorrectRate: null,
+    isDuplicate: false,
+    suppressedBy: null,
+    ...over,
+  } as MachineRow;
+}
+
+function humanRow(over: Partial<HumanRow> = {}): HumanRow {
+  seq += 1;
+  return {
+    id: `q-${seq}`,
+    creatorId: 'author-user',
+    questionText: `Human question ${seq}`,
+    answerText: `Human answer ${seq}`,
+    factualExplanation: `Human explainer ${seq}`,
+    explainerFull: null,
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    difficultyEstimate: 'moderate',
+    visibility: 'public',
+    askedCount: 0,
+    correctCount: 0,
+    correctRate: null,
+    createdAt: new Date(2026, 0, seq + 1),
+    deletedAt: null,
+    trustTier: 'author_confirmed',
+    perishable: false,
+    sourceRefs: [],
+    isDuplicate: false,
+    suppressedBy: null,
+    ...over,
+  } as unknown as HumanRow;
+}
+
+describe('visibilityToScope', () => {
+  it('maps friends -> friends_only and passes private/public through', () => {
+    expect(visibilityToScope('friends')).toBe('friends_only');
+    expect(visibilityToScope('private')).toBe('private');
+    expect(visibilityToScope('public')).toBe('public');
+  });
+});
+
+describe('empiricalRate', () => {
+  it('computes correct/asked when there is play history', () => {
+    expect(empiricalRate(4, 3, null)).toBeCloseTo(0.75);
+  });
+  it('falls back to the stored rate, then null, when nothing was asked', () => {
+    expect(empiricalRate(0, 0, 0.5)).toBe(0.5);
+    expect(empiricalRate(0, 0, null)).toBeNull();
+  });
+});
+
+describe('normalizeMachineRow', () => {
+  it('produces the unified shape with no author and scope from the column', () => {
+    const row = normalizeMachineRow(machineRow({ scope: 'friends_only', nAnswered: 2, empiricalCorrectRate: 0.5 }));
+    expect(row.origin).toBe('machine');
+    expect(row.authorId).toBeNull();
+    expect(row.scope).toBe('friends_only');
+    expect(row.answer).toContain('Machine answer');
+    expect(row.nAnswered).toBe(2);
+    expect(row.empiricalCorrectRate).toBe(0.5);
+  });
+});
+
+describe('normalizeHumanRow', () => {
+  it('reuses visibility/askedCount/counts and exposes the author', () => {
+    const row = normalizeHumanRow(humanRow({
+      creatorId: 'jane',
+      visibility: 'friends',
+      askedCount: 10,
+      correctCount: 6,
+    }));
+    expect(row.origin).toBe('human');
+    expect(row.authorId).toBe('jane');
+    expect(row.scope).toBe('friends_only');
+    expect(row.answer).toContain('Human answer');
+    expect(row.nAnswered).toBe(10);
+    expect(row.empiricalCorrectRate).toBeCloseTo(0.6);
+  });
+});
+
+describe('filterPooledQuestions — unified pool, default path unchanged', () => {
+  function pool(): PooledQuestion[] {
+    return [
+      normalizeMachineRow(machineRow({ trustTier: 'machine_verified', scope: 'public' })),
+      normalizeHumanRow(humanRow({ trustTier: 'author_confirmed', visibility: 'public' })),
+    ];
+  }
+
+  it('returns BOTH machine and human questions by default (today\'s union)', () => {
+    const result = filterPooledQuestions(pool());
+    expect(result.map((r) => r.origin).sort()).toEqual(['human', 'machine']);
+  });
+
+  it('excludes suppressed (is_duplicate) rows by default', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ isDuplicate: true })),
+      normalizeHumanRow(humanRow({ isDuplicate: false })),
+    ];
+    const result = filterPooledQuestions(rows);
+    expect(result.map((r) => r.origin)).toEqual(['human']);
+  });
+
+  it('includes suppressed rows only when explicitly asked', () => {
+    const rows = [normalizeMachineRow(machineRow({ isDuplicate: true }))];
+    expect(filterPooledQuestions(rows)).toHaveLength(0);
+    expect(filterPooledQuestions(rows, { includeSuppressed: true })).toHaveLength(1);
+  });
+
+  it('can filter by trust tier (capability — not wired into any live surface)', () => {
+    const result = filterPooledQuestions(pool(), { trustTiers: ['author_confirmed'] });
+    expect(result.map((r) => r.origin)).toEqual(['human']);
+    const machineOnly = filterPooledQuestions(pool(), { trustTiers: ['machine_verified'] });
+    expect(machineOnly.map((r) => r.origin)).toEqual(['machine']);
+  });
+
+  it('can filter by scope', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ scope: 'public' })),
+      normalizeHumanRow(humanRow({ visibility: 'friends' })),
+    ];
+    const friendsOnly = filterPooledQuestions(rows, { scopes: ['friends_only'] });
+    expect(friendsOnly.map((r) => r.origin)).toEqual(['human']);
+  });
+
+  it('can filter by origin and domain', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ canonicalSubcategory: 'Jazz' })),
+      normalizeMachineRow(machineRow({ canonicalSubcategory: 'Opera' })),
+      normalizeHumanRow(humanRow({ canonicalSubcategory: 'Jazz' })),
+    ];
+    expect(filterPooledQuestions(rows, { origins: ['machine'] })).toHaveLength(2);
+    expect(filterPooledQuestions(rows, { domains: ['Jazz'] })).toHaveLength(2);
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1334,20 +1334,25 @@ export type BankDifficulty = 'accessible' | 'moderate' | 'specialist';
 //
 // Restrictions:
 // - fact_key must be present (predates 2026-05-24; older rows lack it)
-// - created within the last 30 days (filters out the worst pre-quality-gate
-//   historical drift)
 // - not authored by the viewer
+// - not suppressed as an embedding near-duplicate (is_duplicate; B3)
 // - fact_key not already in the viewer's recent avoid set
+//
+// Durability (B1 pool substrate / PRD-D-5 §5.1, D8): the bank no longer excludes
+// questions by age — nothing decays out, so thin domains stop drying up. Recency
+// still *ranks*: we draw a newest-first window and shuffle within it, so when a
+// domain has plenty of recent rows the result matches the prior "random among
+// recent" behavior, and only falls back to older rows when recent ones run out.
 //
 // Returns null when the bank is empty for this domain+difficulty — caller
 // falls back to fresh LLM generation, which incidentally grows the bank.
+const BANK_RECENCY_WINDOW = 50;
 export async function pickBankSource(
   userId: string,
   domain: string,
   difficulty: BankDifficulty,
   avoidFactKeys: ReadonlySet<string>,
 ): Promise<BankSource | null> {
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
     candidates = await db
@@ -1358,16 +1363,23 @@ export async function pickBankSource(
         eq(generatedQuestions.difficultyEstimate, difficulty),
         isNotNull(generatedQuestions.factKey),
         sql`${generatedQuestions.userId} <> ${userId}`,
-        gte(generatedQuestions.createdAt, since),
+        eq(generatedQuestions.isDuplicate, false),
       ))
-      .orderBy(sql`random()`)
-      .limit(8);
+      .orderBy(desc(generatedQuestions.createdAt))
+      .limit(BANK_RECENCY_WINDOW);
   } catch (error) {
-    // Tolerate the brief window where the sub_angles column is missing
-    // (migration 0055): a hard failure here would silently disable the
-    // entire bank-pick path until the migration lands.
+    // Tolerate the brief window where a newly-added column is missing
+    // (sub_angles in 0055; is_duplicate in 0062): a hard failure here would
+    // silently disable the entire bank-pick path until the migration lands.
     if (pgErrorCode(error) === '42703') return null;
     throw error;
+  }
+
+  // Shuffle the recency window (Fisher–Yates) so selection within it stays
+  // varied; recency already biases which rows land in the window.
+  for (let i = candidates.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
   }
 
   for (const row of candidates) {

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -1,0 +1,200 @@
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { generatedQuestions, questions } from '@/server/db/schema';
+
+// B1 pool substrate — unified selection layer (PRD-D-5 §5.1 / §8).
+//
+// The machine bank (GeneratedQuestion) and the human-authored questions
+// (Question) stay as separate tables; this layer is the seam that treats them as
+// ONE pool — normalizing both into a single shape and exposing trust_tier / scope
+// as optional filters.
+//
+// DRIFT GUARD (B1): this is *capability only*. Nothing here is wired into a live
+// surface, and the default filter reproduces today's served set — all trust
+// tiers, suppressed rows excluded, soft-deleted human rows excluded. Live
+// trust-tier gating is B4's job. Existing callers (pickBankSource,
+// pickEligibleAuthoredQuestions, pickHouseQuestions) are untouched.
+
+export type PoolOrigin = 'machine' | 'human';
+export type TrustTier = 'unverified' | 'machine_verified' | 'human_validated' | 'author_confirmed';
+export type PoolScope = 'private' | 'friends_only' | 'public';
+
+export interface PooledQuestion {
+  id: string;
+  origin: PoolOrigin;
+  questionText: string;
+  answer: string;
+  explainer: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  difficultyEstimate: string | null;
+  trustTier: TrustTier;
+  scope: PoolScope;
+  /** Author for human rows (creatorId); null for machine (no author — the
+   *  GeneratedQuestion.userId is the recipient, not the author). */
+  authorId: string | null;
+  perishable: boolean;
+  sourceRefs: string[];
+  nAnswered: number;
+  empiricalCorrectRate: number | null;
+  isDuplicate: boolean;
+  suppressedBy: string | null;
+  createdAt: Date;
+}
+
+export interface PoolFilter {
+  trustTiers?: TrustTier[];
+  scopes?: PoolScope[];
+  origins?: PoolOrigin[];
+  /** canonical_subcategory match. */
+  domains?: string[];
+  difficulty?: string[];
+  /** Include embedding-dedup-suppressed rows. Default false (reproduces today). */
+  includeSuppressed?: boolean;
+}
+
+type MachineRow = typeof generatedQuestions.$inferSelect;
+type HumanRow = typeof questions.$inferSelect;
+
+/** Human Question.visibility → unified pool scope. */
+export function visibilityToScope(visibility: 'private' | 'public' | 'friends'): PoolScope {
+  return visibility === 'friends' ? 'friends_only' : visibility;
+}
+
+/** Empirical played rate, uniform across origins: correct/asked when there is
+ *  play history, falling back to the stored rate, else null. Matches the machine
+ *  backfill in migration 0062 (correct_count / asked_count). */
+export function empiricalRate(
+  asked: number,
+  correct: number,
+  storedRate: number | null,
+): number | null {
+  if (asked > 0) return correct / asked;
+  return storedRate ?? null;
+}
+
+export function normalizeMachineRow(row: MachineRow): PooledQuestion {
+  return {
+    id: row.id,
+    origin: 'machine',
+    questionText: row.questionText,
+    answer: row.answer,
+    explainer: row.explainer,
+    canonicalSubcategory: row.canonicalSubcategory,
+    broadCategory: row.broadCategory,
+    difficultyEstimate: row.difficultyEstimate,
+    trustTier: row.trustTier as TrustTier,
+    scope: row.scope as PoolScope,
+    authorId: null,
+    perishable: row.perishable,
+    sourceRefs: row.sourceRefs ?? [],
+    nAnswered: row.nAnswered,
+    empiricalCorrectRate: row.empiricalCorrectRate ?? null,
+    isDuplicate: row.isDuplicate,
+    suppressedBy: row.suppressedBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+export function normalizeHumanRow(row: HumanRow): PooledQuestion {
+  return {
+    id: row.id,
+    origin: 'human',
+    questionText: row.questionText,
+    answer: row.answerText,
+    // Human rows carry several explainer variants; prefer the factual one, then
+    // the full default, mirroring the existing question-view fallback order.
+    explainer: row.factualExplanation ?? row.explainerFull ?? null,
+    canonicalSubcategory: row.canonicalSubcategory,
+    broadCategory: row.broadCategory,
+    difficultyEstimate: row.difficultyEstimate,
+    trustTier: row.trustTier as TrustTier,
+    // Reused field: scope is derived from the existing visibility column.
+    scope: visibilityToScope(row.visibility),
+    authorId: row.creatorId,
+    perishable: row.perishable,
+    sourceRefs: row.sourceRefs ?? [],
+    // Reused fields: n_answered ← asked_count, empirical rate ← play history.
+    nAnswered: row.askedCount,
+    empiricalCorrectRate: empiricalRate(row.askedCount, row.correctCount, row.correctRate),
+    isDuplicate: row.isDuplicate,
+    suppressedBy: row.suppressedBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Pure filter over normalized pool rows — the single source of truth for filter
+ * semantics. Defaults reproduce today's served set: suppressed rows excluded,
+ * no tier/scope narrowing.
+ */
+export function filterPooledQuestions(
+  rows: PooledQuestion[],
+  filter: PoolFilter = {},
+): PooledQuestion[] {
+  const { trustTiers, scopes, origins, domains, difficulty, includeSuppressed } = filter;
+  return rows.filter((row) => {
+    if (!includeSuppressed && row.isDuplicate) return false;
+    if (origins && !origins.includes(row.origin)) return false;
+    if (trustTiers && !trustTiers.includes(row.trustTier)) return false;
+    if (scopes && !scopes.includes(row.scope)) return false;
+    if (domains && (row.canonicalSubcategory == null || !domains.includes(row.canonicalSubcategory))) {
+      return false;
+    }
+    if (difficulty && (row.difficultyEstimate == null || !difficulty.includes(row.difficultyEstimate))) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Draw candidates from BOTH tables as one pool. The selective predicates
+ * (domain, difficulty, suppressed, soft-delete) are pushed to SQL for
+ * efficiency; the full, authoritative filter is re-applied in-memory via
+ * filterPooledQuestions so SQL and pure paths can never diverge.
+ */
+export async function selectFromPool(filter: PoolFilter = {}): Promise<PooledQuestion[]> {
+  const includeMachine = !filter.origins || filter.origins.includes('machine');
+  const includeHuman = !filter.origins || filter.origins.includes('human');
+
+  const [machineRows, humanRows] = await Promise.all([
+    includeMachine
+      ? db.select().from(generatedQuestions).where(buildMachineWhere(filter))
+      : Promise.resolve([] as MachineRow[]),
+    includeHuman
+      ? db.select().from(questions).where(buildHumanWhere(filter))
+      : Promise.resolve([] as HumanRow[]),
+  ]);
+
+  const pooled = [
+    ...machineRows.map(normalizeMachineRow),
+    ...humanRows.map(normalizeHumanRow),
+  ];
+  return filterPooledQuestions(pooled, filter);
+}
+
+function buildMachineWhere(filter: PoolFilter) {
+  const clauses = [];
+  if (!filter.includeSuppressed) clauses.push(eq(generatedQuestions.isDuplicate, false));
+  if (filter.domains?.length) clauses.push(inArray(generatedQuestions.canonicalSubcategory, filter.domains));
+  if (filter.difficulty?.length) clauses.push(inArray(generatedQuestions.difficultyEstimate, filter.difficulty));
+  return clauses.length ? and(...clauses) : sql`true`;
+}
+
+function buildHumanWhere(filter: PoolFilter) {
+  // Default reproduces today: soft-deleted authored rows are never served.
+  const clauses = [isNull(questions.deletedAt)];
+  if (!filter.includeSuppressed) clauses.push(eq(questions.isDuplicate, false));
+  if (filter.domains?.length) clauses.push(inArray(questions.canonicalSubcategory, filter.domains));
+  if (filter.difficulty?.length) {
+    // questions.difficultyEstimate is enum-typed; the authoritative narrowing
+    // happens in filterPooledQuestions, so a value outside the enum simply
+    // matches nothing here. Cast to satisfy the column's literal union.
+    clauses.push(inArray(questions.difficultyEstimate, filter.difficulty as HumanDifficulty[]));
+  }
+  return and(...clauses);
+}
+
+type HumanDifficulty = NonNullable<HumanRow['difficultyEstimate']>;

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, cosineDistance, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 
 import { db } from '@/server/db';
 import { generatedQuestions, questions } from '@/server/db/schema';
@@ -198,3 +198,94 @@ function buildHumanWhere(filter: PoolFilter) {
 }
 
 type HumanDifficulty = NonNullable<HumanRow['difficultyEstimate']>;
+
+// ─── Embedding dedup helpers (B3) ───────────────────────────────────────────
+
+export interface NearestPoolMatch {
+  id: string;
+  origin: PoolOrigin;
+  /** Cosine similarity in [0,1]; 1 = identical. */
+  similarity: number;
+}
+
+/**
+ * Nearest non-suppressed neighbour across BOTH tables by cosine similarity,
+ * excluding the given id. Returns null when nothing has an embedding yet.
+ */
+export async function findNearestInPool(
+  embedding: number[],
+  excludeId: string,
+): Promise<NearestPoolMatch | null> {
+  // cosineDistance returns 1 - similarity; ORDER BY it ascending for nearest.
+  const machineDistance = cosineDistance(generatedQuestions.embedding, embedding);
+  const humanDistance = cosineDistance(questions.embedding, embedding);
+
+  const [machineNearest, humanNearest] = await Promise.all([
+    db
+      .select({ id: generatedQuestions.id, distance: machineDistance })
+      .from(generatedQuestions)
+      .where(and(
+        isNotNull(generatedQuestions.embedding),
+        eq(generatedQuestions.isDuplicate, false),
+        sql`${generatedQuestions.id} <> ${excludeId}`,
+      ))
+      .orderBy(machineDistance)
+      .limit(1),
+    db
+      .select({ id: questions.id, distance: humanDistance })
+      .from(questions)
+      .where(and(
+        isNotNull(questions.embedding),
+        eq(questions.isDuplicate, false),
+        isNull(questions.deletedAt),
+        sql`${questions.id} <> ${excludeId}`,
+      ))
+      .orderBy(humanDistance)
+      .limit(1),
+  ]);
+
+  const candidates: NearestPoolMatch[] = [];
+  if (machineNearest[0]) {
+    candidates.push({ id: machineNearest[0].id, origin: 'machine', similarity: 1 - Number(machineNearest[0].distance) });
+  }
+  if (humanNearest[0]) {
+    candidates.push({ id: humanNearest[0].id, origin: 'human', similarity: 1 - Number(humanNearest[0].distance) });
+  }
+  if (!candidates.length) return null;
+  return candidates.reduce((best, c) => (c.similarity > best.similarity ? c : best));
+}
+
+/** Persist an embedding onto a pool row in the table indicated by origin. */
+export async function storePoolEmbedding(
+  origin: PoolOrigin,
+  id: string,
+  embedding: number[],
+): Promise<void> {
+  if (origin === 'machine') {
+    await db.update(generatedQuestions).set({ embedding }).where(eq(generatedQuestions.id, id));
+  } else {
+    await db.update(questions).set({ embedding }).where(eq(questions.id, id));
+  }
+}
+
+/**
+ * Flag a row as a suppressed near-duplicate (never delete). suppressedBy points
+ * at the surviving question, which may live in either table.
+ */
+export async function markPoolDuplicate(
+  origin: PoolOrigin,
+  id: string,
+  survivorId: string,
+): Promise<void> {
+  if (origin === 'machine') {
+    await db
+      .update(generatedQuestions)
+      .set({ isDuplicate: true, suppressedBy: survivorId })
+      .where(eq(generatedQuestions.id, id));
+  } else {
+    await db
+      .update(questions)
+      .set({ isDuplicate: true, suppressedBy: survivorId })
+      .where(eq(questions.id, id));
+  }
+}

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -12,6 +12,7 @@ import {
 } from '@/server/db';
 import { broadCategoryDisplayName } from '@/lib/question-categorization';
 import { pgErrorCode } from '@/server/db/pg-error';
+import { embedAndResolveDuplicate } from '@/server/pool/dedup';
 
 export type QuestionView = {
   id: string;
@@ -129,7 +130,7 @@ export const bankQuestionSelectColumns = questionViewColumns;
 // (e.g. bankQuestionSelectColumns) need not fetch them.
 type QuestionViewNonViewKey =
   | 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'
-  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy';
+  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy' | 'embedding';
 type QuestionViewRow = Omit<QuestionRow, QuestionViewNonViewKey>
   & Partial<Pick<QuestionRow, QuestionViewNonViewKey>>;
 
@@ -537,6 +538,13 @@ export async function createQuestion(params: {
     .onConflictDoNothing({
       target: [userQuestionBank.userId, userQuestionBank.questionId],
     });
+
+  // Semantic-dedup backstop (B1 pool substrate). Best-effort, no-op without a
+  // VOYAGE_API_KEY. A human-authored question that collides with an existing
+  // MACHINE pool row suppresses the *machine* row (human beats machine); a
+  // collision with another human row suppresses this new one. Always flags,
+  // never deletes.
+  await embedAndResolveDuplicate({ id: created.id, origin: 'human', questionText: params.text });
 
   return { id: created.id };
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -124,8 +124,14 @@ const questionViewColumns = {
 
 export const bankQuestionSelectColumns = questionViewColumns;
 
-type QuestionViewRow = Omit<QuestionRow, 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'>
-  & Partial<Pick<QuestionRow, 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'>>;
+// The pool-substrate fields (B1) are not part of the rendered question view, so
+// they are excluded here like the other non-view columns — partial selects
+// (e.g. bankQuestionSelectColumns) need not fetch them.
+type QuestionViewNonViewKey =
+  | 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'
+  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy';
+type QuestionViewRow = Omit<QuestionRow, QuestionViewNonViewKey>
+  & Partial<Pick<QuestionRow, QuestionViewNonViewKey>>;
 
 function difficultyToNumber(value: QuestionRow['difficultyEstimate']): number {
   if (value === 'accessible') return 1;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -17,6 +17,7 @@ import {
   unique,
   uniqueIndex,
   uuid,
+  vector,
 } from 'drizzle-orm/pg-core';
 
 const id = (name = 'id') => text(name).primaryKey().default(sql`gen_random_uuid()::text`);
@@ -329,6 +330,9 @@ export const questions = pgTable(
     // question id (may live in either table, so not a hard FK).
     isDuplicate: boolean('is_duplicate').notNull().default(false),
     suppressedBy: text('suppressed_by'),
+    // Voyage voyage-3.5-lite embedding (1024-dim) — semantic-dedup backstop.
+    // Nullable: populated at insert and by the batched backfill (B3).
+    embedding: vector('embedding', { dimensions: 1024 }),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
@@ -592,6 +596,8 @@ export const generatedQuestions = pgTable(
     // row is the loser: is_duplicate=true, suppressed_by=<human id>. Never deleted.
     isDuplicate: boolean('is_duplicate').notNull().default(false),
     suppressedBy: text('suppressed_by'),
+    // Voyage voyage-3.5-lite embedding (1024-dim) — semantic-dedup backstop.
+    embedding: vector('embedding', { dimensions: 1024 }),
   },
   (table) => [
     index('GeneratedQuestion_user_id_idx').on(table.userId),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -39,6 +39,24 @@ export const categoryEnum = pgEnum('Category', [
 
 export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends']);
 
+// B1 pool substrate (PRD-D-5 §5.1 / §6). Trust climbs as a question earns it:
+// unverified (fresh, pre-checks) → machine_verified (retrieval + ask-to-answer,
+// B3/B4) → human_validated (N humans correct in play) → author_confirmed
+// (human-authored, answer asserted by author). B1 only adds the field + the
+// grandfather backfill; live tier-gating stays OFF until B4.
+export const trustTierEnum = pgEnum('TrustTier', [
+  'unverified',
+  'machine_verified',
+  'human_validated',
+  'author_confirmed',
+]);
+// Pool scope (PRD-D-5 §5.1 / D9). The spec models scope as friends_only | public
+// (machine default public; human authored public with a one-tap friends_only
+// override). We carry a third `private` value so the unified selection layer can
+// represent the human Question.visibility 'private' losslessly; machine rows only
+// ever use friends_only | public.
+export const questionScopeEnum = pgEnum('QuestionScope', ['private', 'friends_only', 'public']);
+
 // D-1 Stage 3 — directional follow model.
 // `state` on a follow edge: a follow targeting an approval_required user lands
 // as `pending` (a request the followee approves); a follow targeting a public
@@ -296,6 +314,21 @@ export const questions = pgTable(
     askedCount: integer('asked_count').notNull().default(0),
     correctCount: integer('correct_count').notNull().default(0),
     surfacePriorityScore: doublePrecision('surface_priority_score').notNull().default(0),
+    // B1 pool substrate (PRD-D-5 §5.1). Human-authored rows grandfather to
+    // author_confirmed. Scope, n_answered and empirical_correct_rate are NOT
+    // duplicated here — the unified selection layer reuses visibility, askedCount
+    // and correctRate (see src/server/db/queries/pool.ts).
+    trustTier: trustTierEnum('trust_tier').notNull().default('unverified'),
+    // Perishable = time-relative facts ("the latest…", "who currently…") flagged
+    // for re-grounding (B3); evergreen by default (no decay — D8).
+    perishable: boolean('perishable').notNull().default(false),
+    // Provenance refs from retrieval-grounded generation; populated in B3.
+    sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // Embedding-dedup flags (B3). Human beats machine on collision; the loser is
+    // suppressed (flagged), never deleted. suppressedBy holds the surviving
+    // question id (may live in either table, so not a hard FK).
+    isDuplicate: boolean('is_duplicate').notNull().default(false),
+    suppressedBy: text('suppressed_by'),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
@@ -309,6 +342,10 @@ export const questions = pgTable(
     index('Question_source_question_id_idx').on(table.sourceQuestionId),
     index('Question_source_creator_id_idx').on(table.sourceCreatorId),
     uniqueIndex('Question_generated_question_id_key').on(table.generatedQuestionId),
+    // Selection-layer filters (B1 pool substrate). Filter capability only — no
+    // live tier-gating yet (B4 owns enforcement).
+    index('Question_trust_tier_idx').on(table.trustTier),
+    index('Question_is_duplicate_idx').on(table.isDuplicate),
   ],
 );
 
@@ -539,11 +576,31 @@ export const generatedQuestions = pgTable(
     createdAt: createdAt(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     usedInQueue: boolean('used_in_queue').notNull().default(false),
+    // B1 pool substrate (PRD-D-5 §5.1). Machine rows grandfather to
+    // machine_verified; scope defaults public. Unlike the human table, the
+    // machine bank has no native scope/answered/correct-rate columns, so these
+    // are added here (the selection layer reads them directly).
+    trustTier: trustTierEnum('trust_tier').notNull().default('unverified'),
+    scope: questionScopeEnum('scope').notNull().default('public'),
+    perishable: boolean('perishable').notNull().default(false),
+    sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // Empirical play stats (D11 / "nobody got it" smell). Back-filled from answer
+    // history where a join exists; machine rows usually start 0 / null.
+    nAnswered: integer('n_answered').notNull().default(0),
+    empiricalCorrectRate: doublePrecision('empirical_correct_rate'),
+    // Embedding-dedup flags (B3). On a human-beats-machine collision, the machine
+    // row is the loser: is_duplicate=true, suppressed_by=<human id>. Never deleted.
+    isDuplicate: boolean('is_duplicate').notNull().default(false),
+    suppressedBy: text('suppressed_by'),
   },
   (table) => [
     index('GeneratedQuestion_user_id_idx').on(table.userId),
     index('GeneratedQuestion_user_id_used_in_queue_idx').on(table.userId, table.usedInQueue),
     index('GeneratedQuestion_user_id_fact_key_idx').on(table.userId, table.factKey),
+    // Selection-layer filters (B1): tier/scope filter capability + suppress-aware
+    // bank pick. Not gated on any live surface yet (B4 owns enforcement).
+    index('GeneratedQuestion_trust_tier_idx').on(table.trustTier),
+    index('GeneratedQuestion_is_duplicate_idx').on(table.isDuplicate),
   ],
 );
 

--- a/src/server/llm/embeddings.ts
+++ b/src/server/llm/embeddings.ts
@@ -1,0 +1,118 @@
+/**
+ * Joshing embeddings — Voyage AI client (B1 pool substrate, PRD-D-5 §5.1/§7).
+ *
+ * The rest of the pipeline is Anthropic-only and Anthropic ships no first-party
+ * embedding model, so the pool's semantic-dedup backstop uses Voyage AI
+ * (Anthropic's recommended embeddings partner). Model: voyage-3.5-lite,
+ * 1024-dim. All calls are server-side only.
+ *
+ * Graceful by design (mirrors getAnthropicClient): with no VOYAGE_API_KEY — or
+ * LLM_ENABLED=false — every entry point returns null and callers fall back to
+ * the cheap deterministic guards (fact_key + Haiku + normalized text). This is
+ * what keeps embedding dedup OFF until the key is provisioned, so B1 ships with
+ * no behavior change.
+ */
+
+export const VOYAGE_EMBEDDING_MODEL = 'voyage-3.5-lite';
+export const EMBEDDING_DIMENSIONS = 1024;
+const VOYAGE_URL = 'https://api.voyageai.com/v1/embeddings';
+// Voyage caps batches at 1000 inputs / 120k tokens; stay well under for safety.
+export const EMBEDDING_BATCH_SIZE = 128;
+
+let hasLoggedMissingKey = false;
+
+export function isEmbeddingEnabled(): boolean {
+  if (process.env.LLM_ENABLED === 'false') return false;
+  return Boolean(process.env.VOYAGE_API_KEY?.trim());
+}
+
+type VoyageResponse = {
+  data?: Array<{ embedding?: number[]; index?: number }>;
+};
+
+async function callVoyage(
+  inputs: string[],
+  inputType: 'query' | 'document',
+): Promise<number[][] | null> {
+  const apiKey = process.env.VOYAGE_API_KEY?.trim();
+  if (process.env.LLM_ENABLED === 'false' || !apiKey) {
+    if (!hasLoggedMissingKey) {
+      console.warn('[embeddings] Voyage disabled: VOYAGE_API_KEY missing — dedup falls back to deterministic guards');
+      hasLoggedMissingKey = true;
+    }
+    return null;
+  }
+  hasLoggedMissingKey = false;
+
+  try {
+    const res = await fetch(VOYAGE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        input: inputs,
+        model: VOYAGE_EMBEDDING_MODEL,
+        input_type: inputType,
+        output_dimension: EMBEDDING_DIMENSIONS,
+      }),
+    });
+    if (!res.ok) {
+      console.warn('[embeddings] Voyage request failed', { status: res.status });
+      return null;
+    }
+    const json = (await res.json()) as VoyageResponse;
+    const data = json.data;
+    if (!data?.length) return null;
+    // Preserve request order (Voyage returns an index per item).
+    const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    const vectors = ordered.map((d) => d.embedding);
+    if (vectors.some((v) => !Array.isArray(v) || v.length !== EMBEDDING_DIMENSIONS)) {
+      console.warn('[embeddings] Voyage returned unexpected vector shape');
+      return null;
+    }
+    return vectors as number[][];
+  } catch (error) {
+    console.warn('[embeddings] Voyage call threw', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/** Embed a single text. Returns null when disabled or on any failure. */
+export async function embedText(
+  text: string,
+  inputType: 'query' | 'document' = 'document',
+): Promise<number[] | null> {
+  const trimmed = text?.trim();
+  if (!trimmed) return null;
+  const vectors = await callVoyage([trimmed], inputType);
+  return vectors?.[0] ?? null;
+}
+
+/**
+ * Embed many texts in batches. Returns one entry per input (null for blanks),
+ * or null overall when embedding is disabled. Used by the backfill job.
+ */
+export async function embedTexts(
+  texts: string[],
+  inputType: 'query' | 'document' = 'document',
+): Promise<Array<number[] | null> | null> {
+  if (!isEmbeddingEnabled()) return null;
+  const out: Array<number[] | null> = new Array(texts.length).fill(null);
+  for (let start = 0; start < texts.length; start += EMBEDDING_BATCH_SIZE) {
+    const slice = texts.slice(start, start + EMBEDDING_BATCH_SIZE);
+    const nonBlank = slice
+      .map((t, i) => ({ t: t?.trim() ?? '', i }))
+      .filter((x) => x.t.length > 0);
+    if (!nonBlank.length) continue;
+    const vectors = await callVoyage(nonBlank.map((x) => x.t), inputType);
+    if (!vectors) return null;
+    nonBlank.forEach((x, k) => {
+      out[start + x.i] = vectors[k] ?? null;
+    });
+  }
+  return out;
+}

--- a/src/server/pool/__tests__/dedup.test.ts
+++ b/src/server/pool/__tests__/dedup.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DEDUP_COSINE_THRESHOLD,
+  resolveCollision,
+} from '@/server/pool/dedup';
+import type { NearestPoolMatch } from '@/server/db/queries/pool';
+
+const T = DEFAULT_DEDUP_COSINE_THRESHOLD;
+const near = (over: Partial<NearestPoolMatch> & Pick<NearestPoolMatch, 'origin'>): NearestPoolMatch => ({
+  id: 'existing-1',
+  similarity: 0.99,
+  ...over,
+});
+
+describe('resolveCollision — the collision matrix (Drift Risk 2)', () => {
+  // Row 1: new machine vs existing machine → suppress the NEW one.
+  it('machine vs machine → suppress incoming, survivor is the existing row', () => {
+    const d = resolveCollision({ id: 'new-m', origin: 'machine' }, near({ id: 'old-m', origin: 'machine' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-m' });
+  });
+
+  // Row 2: new machine vs existing human → suppress the NEW (machine) one.
+  it('machine vs human → suppress incoming (machine), human survives', () => {
+    const d = resolveCollision({ id: 'new-m', origin: 'machine' }, near({ id: 'old-h', origin: 'human' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+
+  // Row 3 (THE one that must not be backwards): new human vs existing machine →
+  // keep the HUMAN, suppress the EXISTING machine row.
+  it('human vs machine → suppress the EXISTING machine row, human survives', () => {
+    const d = resolveCollision({ id: 'new-h', origin: 'human' }, near({ id: 'old-m', origin: 'machine' }), T);
+    expect(d).toEqual({
+      action: 'suppress_existing',
+      existingId: 'old-m',
+      existingOrigin: 'machine',
+      survivorId: 'new-h',
+    });
+  });
+
+  // Row 4: new human vs existing human → suppress the NEW one.
+  it('human vs human → suppress incoming, survivor is the existing row', () => {
+    const d = resolveCollision({ id: 'new-h', origin: 'human' }, near({ id: 'old-h', origin: 'human' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+
+  it('never suppresses below the similarity threshold', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-m', origin: 'machine', similarity: T - 0.01 }),
+      T,
+    );
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('does nothing when there is no neighbour', () => {
+    expect(resolveCollision({ id: 'new-m', origin: 'machine' }, null, T)).toEqual({ action: 'none' });
+  });
+
+  it('suppresses exactly at the threshold (>= is a collision)', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-m', origin: 'machine', similarity: T }),
+      T,
+    );
+    expect(d.action).toBe('suppress_existing');
+  });
+});

--- a/src/server/pool/dedup.ts
+++ b/src/server/pool/dedup.ts
@@ -1,0 +1,120 @@
+/**
+ * Pool embedding dedup — collision matrix + insert-time orchestration
+ * (B1 pool substrate, PRD-D-5 §5.1 D10 / §7).
+ *
+ * The deterministic guards (fact_key + Haiku + normalized text) remain the cheap
+ * first pass; this is the semantic backstop. The cardinal rule (Drift Risk 2):
+ * a HUMAN-authored question BEATS a machine near-duplicate. Suppression always
+ * flags (is_duplicate + suppressed_by), NEVER deletes — decay is gone, so every
+ * suppression must be reversible.
+ *
+ *   incoming \ nearest │ machine            │ human
+ *   ───────────────────┼────────────────────┼────────────────────
+ *   machine            │ suppress incoming  │ suppress incoming
+ *   human              │ suppress EXISTING  │ suppress incoming
+ *
+ * Only the human-over-machine cell suppresses the row already in the pool.
+ */
+
+import type { PoolOrigin } from '@/server/db/queries/pool';
+import {
+  findNearestInPool,
+  markPoolDuplicate,
+  storePoolEmbedding,
+  type NearestPoolMatch,
+} from '@/server/db/queries/pool';
+import { embedText, isEmbeddingEnabled } from '@/server/llm/embeddings';
+
+// Cosine *similarity* threshold (1 = identical). Start strict per §7 (the spec's
+// knob table does not pin a number); override via env without a deploy.
+export const DEFAULT_DEDUP_COSINE_THRESHOLD = 0.92;
+
+export function getDedupCosineThreshold(): number {
+  const raw = process.env.POOL_DEDUP_COSINE_THRESHOLD?.trim();
+  if (!raw) return DEFAULT_DEDUP_COSINE_THRESHOLD;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return DEFAULT_DEDUP_COSINE_THRESHOLD;
+  }
+  return parsed;
+}
+
+export type CollisionDecision =
+  | { action: 'none' }
+  | { action: 'suppress_incoming'; survivorId: string }
+  | { action: 'suppress_existing'; existingId: string; existingOrigin: PoolOrigin; survivorId: string };
+
+/**
+ * Pure collision matrix. `incomingId` is the row just inserted; `nearest` is the
+ * closest existing pool row (excluding self), or null if none within reach.
+ */
+export function resolveCollision(
+  incoming: { id: string; origin: PoolOrigin },
+  nearest: NearestPoolMatch | null,
+  threshold: number,
+): CollisionDecision {
+  if (!nearest) return { action: 'none' };
+  if (nearest.similarity < threshold) return { action: 'none' };
+
+  // Human beats machine: the only case where the EXISTING row is suppressed.
+  if (incoming.origin === 'human' && nearest.origin === 'machine') {
+    return {
+      action: 'suppress_existing',
+      existingId: nearest.id,
+      existingOrigin: 'machine',
+      survivorId: incoming.id,
+    };
+  }
+
+  // Every other collision (machine vs *, human vs human): suppress the new one.
+  return { action: 'suppress_incoming', survivorId: nearest.id };
+}
+
+/**
+ * Insert-time dedup, best-effort. Embeds the freshly-inserted row, stores the
+ * vector, finds its nearest pool neighbour, and applies the collision matrix.
+ * Any failure (no key, API error, missing column pre-migration) is swallowed so
+ * generation/authoring is never blocked — the deterministic guards still ran.
+ */
+export async function embedAndResolveDuplicate(args: {
+  id: string;
+  origin: PoolOrigin;
+  questionText: string;
+}): Promise<void> {
+  if (!isEmbeddingEnabled()) return;
+  try {
+    const embedding = await embedText(args.questionText, 'document');
+    if (!embedding) return;
+
+    await storePoolEmbedding(args.origin, args.id, embedding);
+
+    const nearest = await findNearestInPool(embedding, args.id);
+    const decision = resolveCollision(
+      { id: args.id, origin: args.origin },
+      nearest,
+      getDedupCosineThreshold(),
+    );
+
+    if (decision.action === 'suppress_incoming') {
+      await markPoolDuplicate(args.origin, args.id, decision.survivorId);
+      console.info('[pool/dedup] suppressed new near-duplicate', {
+        origin: args.origin,
+        id: args.id,
+        survivor: decision.survivorId,
+      });
+    } else if (decision.action === 'suppress_existing') {
+      // Human beat an existing machine row.
+      await markPoolDuplicate(decision.existingOrigin, decision.existingId, decision.survivorId);
+      console.info('[pool/dedup] human beat machine; suppressed existing machine row', {
+        existing: decision.existingId,
+        survivor: decision.survivorId,
+      });
+    }
+  } catch (error) {
+    console.warn('[pool/dedup] insert-time dedup skipped (non-fatal)', {
+      id: args.id,
+      origin: args.origin,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## Summary

Implements the B1 pool substrate (PRD-D-5 §5.1, §6–8): a unified selection layer that treats the machine-generated question bank and human-authored questions as a single pool with trust tiers, scope filtering, and semantic deduplication via embeddings.

## Key Changes

**Core pool abstraction** (`src/server/db/queries/pool.ts`):
- Unified `PooledQuestion` type normalizing both `GeneratedQuestion` and `Question` rows into a single shape
- `selectFromPool()` draws candidates from both tables and applies authoritative filtering
- `filterPooledQuestions()` implements the pure filter semantics (trust tier, scope, origin, domain, difficulty, suppression)
- Helper functions: `normalizeMachineRow()`, `normalizeHumanRow()`, `visibilityToScope()`, `empiricalRate()`
- Embedding dedup support: `findNearestInPool()`, `storePoolEmbedding()`, `markPoolDuplicate()`

**Embedding & dedup** (`src/server/llm/embeddings.ts`, `src/server/pool/dedup.ts`):
- Voyage AI client (voyage-3.5-lite, 1024-dim) for semantic embeddings
- Graceful degradation: returns null when `VOYAGE_API_KEY` is missing or `LLM_ENABLED=false`
- Collision matrix (`resolveCollision()`): human-authored questions beat machine near-duplicates; all other collisions suppress the incoming row
- Insert-time dedup (`embedAndResolveDuplicate()`): best-effort, non-blocking

**Database schema & migrations**:
- Migration 0062: adds `TrustTier` and `QuestionScope` enums; new columns to both tables:
  - `Question`: `trust_tier`, `perishable`, `source_refs`, `is_duplicate`, `suppressed_by`
  - `GeneratedQuestion`: `trust_tier`, `scope`, `perishable`, `source_refs`, `n_answered`, `empirical_correct_rate`, `is_duplicate`, `suppressed_by`
  - Grandfather backfill: human rows → `author_confirmed`, machine rows → `machine_verified`
- Migration 0063: pgvector extension, 1024-dim `embedding` columns on both tables, HNSW cosine indexes
- Idempotent boot guards in `src/instrumentation.ts` for preview/production databases that record migrations without the pieces present

**Integration**:
- `src/server/db/queries/questions.ts`: calls `embedAndResolveDuplicate()` on human question creation
- `src/server/daily/generate-questions.ts`: calls `embedAndResolveDuplicate()` on machine question generation
- `src/server/db/queries/daily.ts`: `pickBankSource()` now excludes suppressed rows and removes the 30-day age filter (durability: no decay, thin domains no longer dry up)

**Backfill & testing**:
- `scripts/backfill-pool-embeddings.ts`: batched embedding backfill with dry-run cost estimation and collision pass
- Comprehensive unit tests for normalization, filtering, and collision resolution

## Notable Implementation Details

- **Drift guard (B1)**: capability-only. No live trust-tier gating yet (that is B4). Default filter reproduces today's served set (all tiers, suppressed rows excluded, soft-deleted human rows excluded).
- **Field reuse**: human table does not duplicate `scope`, `n_answered`, or `empirical_correct_rate` — the unified selection layer reuses `visibility`, `askedCount`, and `correctRate` (see `normalizeHumanRow()`).
- **Suppression is reversible**: rows are flagged `is_duplicate + suppressed_by`, never deleted. Decay is gone.
- **Deterministic guards first**: fact_key + Haiku + normalized text remain the cheap first pass; embeddings are the semantic backstop.
- **Threshold tunable**: `POOL_DEDUP_COSINE_

https://claude.ai/code/session_01XU5fUqoPLayu46H6K4qy9v