### PR TITLE
B2 — Difficulty floor + register (enthusiast rung, declared-only floor, prompt fixes)

### DIFF
--- a/src/server/__tests__/adaptive-difficulty.test.ts
+++ b/src/server/__tests__/adaptive-difficulty.test.ts
@@ -12,6 +12,7 @@ import {
   applyAdaptiveLevelAdjustment,
   applyFocusFloor,
   computeDomainDifficultyStep,
+  mapAdaptiveLevelToDifficultyHint,
   type DomainDifficultyState,
 } from '@/server/adaptive-difficulty';
 
@@ -131,5 +132,80 @@ describe('computeDomainDifficultyStep — per-domain streak tracking', () => {
       expect(result.consecutiveCorrect).toBe(0);
       expect(result.consecutiveIncorrect).toBe(1);
     });
+  });
+
+  // PRD-D-5 §5.2 — the declared erosion hard floor. A declared domain passes
+  // floor='moderate' (engaged-fan); a demonstrated domain passes the default
+  // 'accessible' and keeps the full range.
+  describe('declared erosion floor (engaged-fan)', () => {
+    const MODERATE_FLOOR = 'moderate' as const;
+
+    it('a declared domain never erodes below engaged-fan after repeated wrong answers', () => {
+      // Start at specialist and feed nothing but wrong answers.
+      let s = state('specialist', 0, 0);
+      for (let i = 0; i < 10; i += 1) {
+        s = computeDomainDifficultyStep(s, false, MODERATE_FLOOR);
+        expect(['moderate', 'specialist']).toContain(s.servedDifficulty);
+      }
+      // It settles at the floor and stays there — never accessible.
+      expect(s.servedDifficulty).toBe('moderate');
+    });
+
+    it('declared domain at the floor does not step down on two consecutive wrong', () => {
+      const result = computeDomainDifficultyStep(state('moderate', 0, 1), false, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('moderate');
+      expect(result.consecutiveIncorrect).toBe(2);
+    });
+
+    it('declared domain still steps DOWN from specialist to the floor', () => {
+      const result = computeDomainDifficultyStep(state('specialist', 0, 1), false, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('moderate');
+    });
+
+    it('declared domain still climbs above the floor on two consecutive correct', () => {
+      const result = computeDomainDifficultyStep(state('moderate', 1, 0), true, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('specialist');
+    });
+
+    it('a demonstrated domain (default floor) still erodes all the way to accessible', () => {
+      let s = state('specialist', 0, 0);
+      for (let i = 0; i < 10; i += 1) {
+        s = computeDomainDifficultyStep(s, false);
+      }
+      expect(s.servedDifficulty).toBe('accessible');
+    });
+  });
+});
+
+describe('mapAdaptiveLevelToDifficultyHint — rungs & register', () => {
+  it('accessible and engaged-fan no longer model a "casually interested person"', () => {
+    const accessible = mapAdaptiveLevelToDifficultyHint(1.0);
+    const engagedFan = mapAdaptiveLevelToDifficultyHint(2.0);
+    expect(accessible.promptHint).not.toMatch(/casually interested/i);
+    expect(engagedFan.promptHint).not.toMatch(/casually interested/i);
+    expect(accessible.targetCorrectRate).toBe(0.78);
+    expect(engagedFan.targetCorrectRate).toBe(0.62);
+  });
+
+  it('exposes a new enthusiast rung between engaged-fan and specialist (≈0.50 target)', () => {
+    const enthusiast = mapAdaptiveLevelToDifficultyHint(2.7);
+    expect(enthusiast.difficultyLabel).toBe('enthusiast');
+    expect(enthusiast.targetCorrectRate).toBe(0.5);
+    // Drift Risk 1 guardrail: the definition is the calibration anchor.
+    expect(enthusiast.promptHint).toMatch(/chose to learn/i);
+    expect(enthusiast.promptHint).toMatch(/NOT scholar- or archivist-level minutiae/);
+  });
+
+  it('the three hardest rungs all target the specialist generator tier', () => {
+    expect(mapAdaptiveLevelToDifficultyHint(2.7).estimate).toBe('specialist'); // enthusiast
+    expect(mapAdaptiveLevelToDifficultyHint(3.2).estimate).toBe('specialist'); // specialist
+    expect(mapAdaptiveLevelToDifficultyHint(4.0).estimate).toBe('specialist'); // expert
+  });
+
+  it('preserves the engaged-fan band so the per-domain moderate tier maps to 0.62', () => {
+    // SERVED_TO_PREFERENCE: moderate → 'moderate' → level 2.0 lands engaged-fan.
+    expect(mapAdaptiveLevelToDifficultyHint(2.0).targetCorrectRate).toBe(0.62);
+    // challenging → level 3.0 still lands specialist (0.35), not enthusiast.
+    expect(mapAdaptiveLevelToDifficultyHint(3.0).targetCorrectRate).toBe(0.35);
   });
 });

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { db, declaredInterests, playerMastery, userDomainDifficulties, users } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
 
 const MIN_ADAPTIVE_LEVEL = 1.0;
 const MAX_ADAPTIVE_LEVEL = 4.0;
@@ -12,9 +13,10 @@ export type AdaptiveDifficultyHint = {
   difficultyLabel: string;
   promptHint: string;
   // The difficulty_estimate tier a question generated at this level targets.
-  // The generator only emits three tiers, so the two hardest adaptive bands
-  // both map to 'specialist'. Lets the bank-reuse path request a stored
-  // question whose tier matches what fresh generation would have produced.
+  // The generator only emits three tiers, so the three hardest adaptive bands
+  // (enthusiast, specialist, expert) all map to 'specialist'. Lets the bank-reuse
+  // path request a stored question whose tier matches what fresh generation would
+  // have produced.
   estimate: 'accessible' | 'moderate' | 'specialist';
 };
 
@@ -126,7 +128,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
     return {
       targetCorrectRate: 0.78,
       difficultyLabel: 'approachable trivia',
-      promptHint: 'Target roughly a 78% correct rate. Write friendly, recognizable questions a casually interested person in the domain would get — lean on well-known facts, not deep cuts.',
+      promptHint: 'Target roughly a 78% correct rate. Write questions someone with a passing interest in the domain would recognize — lean on its well-known landmarks and the facts anyone who has encountered it would have met, not deep cuts.',
       estimate: 'accessible',
     };
   }
@@ -134,9 +136,21 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
   if (normalized < 2.5) {
     return {
       targetCorrectRate: 0.62,
-      difficultyLabel: 'fair and familiar',
-      promptHint: 'Target roughly a 62% correct rate. Write questions a reasonably engaged fan of the domain should know without needing specialist depth.',
+      difficultyLabel: 'engaged fan',
+      promptHint: 'Target roughly a 62% correct rate. Write questions someone who actively follows the domain should know — the works, figures, and moments a regular fan keeps track of, without needing specialist depth.',
       estimate: 'moderate',
+    };
+  }
+
+  // Enthusiast rung — the calibration guardrail (PRD-D-5 §5.2). This text is
+  // load-bearing: it must stay "chose to learn ... NOT scholar/archivist
+  // minutiae" so the floor does not swing back to "really REALLY hard."
+  if (normalized < 3.0) {
+    return {
+      targetCorrectRate: 0.50,
+      difficultyLabel: 'enthusiast',
+      promptHint: 'Target roughly a 50% correct rate. Write questions someone who CHOSE to learn this domain would know — its structure, its famous moments, and the second-order facts enthusiasts trade — but NOT scholar- or archivist-level minutiae.',
+      estimate: 'specialist',
     };
   }
 
@@ -183,55 +197,69 @@ function seedDifficultyFromAdaptiveLevel(level: number): ServedDifficulty {
 }
 
 /**
- * Minimum first-contact difficulty for a domain the player explicitly opted
- * into — either by stating it as an area of focus during onboarding or by
- * accepting one shared by a friend. Someone who raised their hand for a topic
- * finds "Establishing" (accessible) trivia condescendingly easy, so we floor
- * the *seed* at "Familiar" (moderate). This only sets the starting point: the
- * normal two-incorrect step-down can still drop a struggling player back to
- * accessible afterwards.
+ * The "engaged-fan" rung, expressed on the per-domain served-difficulty ladder
+ * (moderate). It is the hard floor for a domain the player explicitly DECLARED:
+ * someone who raised their hand for a topic finds accessible ("tourist") trivia
+ * condescendingly easy, so a declared domain both *seeds* here and *cannot erode
+ * below* here (PRD-D-5 §5.2, D3). Demonstrated domains are NOT floored — they
+ * start low and retain the full adaptive range down to accessible.
  */
 const FOCUS_DOMAIN_MIN_DIFFICULTY: ServedDifficulty = 'moderate';
 
-export function applyFocusFloor(difficulty: ServedDifficulty, isFocusDomain: boolean): ServedDifficulty {
-  if (!isFocusDomain) return difficulty;
+export function applyFocusFloor(difficulty: ServedDifficulty, isDeclaredDomain: boolean): ServedDifficulty {
+  if (!isDeclaredDomain) return difficulty;
   return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(FOCUS_DOMAIN_MIN_DIFFICULTY)
     ? difficulty
     : FOCUS_DOMAIN_MIN_DIFFICULTY;
 }
 
 /**
- * Canonical subcategories the player has opted into: declared interests (stated
- * focus areas) plus any open territory in PLAYER_MASTERY — friend-mediated
- * acceptances and authored domains both land there. Used to decide whether a
- * first-contact difficulty seed should be floored to "Familiar". Pass the
- * `domains` filter to keep the lookup to the round being seeded.
+ * Canonical subcategories the player explicitly DECLARED — stated focus areas
+ * (`declaredInterests`) plus PLAYER_MASTERY rows whose `territoryType` is
+ * 'declared' (friend-mediated acceptances that came in as declared territory).
+ * This is the signal that keys the difficulty floor (D2/D3): declared domains
+ * seed at engaged-fan and cannot erode to accessible; demonstrated domains (the
+ * rest) get the full adaptive range. Splitting declared from demonstrated here
+ * is what stops the floor from pinning newcomer/demonstrated domains too high
+ * (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope the lookup to the round.
  */
-async function getFocusDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
-  const focus = new Set<string>();
-  if (domains.length === 0) return focus;
+async function getDeclaredDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
+  const declared = new Set<string>();
+  if (domains.length === 0) return declared;
 
-  const [declaredRows, masteryRows] = await Promise.all([
-    db
-      .select({ domain: declaredInterests.domain })
-      .from(declaredInterests)
-      .where(and(
-        eq(declaredInterests.userId, userId),
-        eq(declaredInterests.isActive, true),
-        inArray(declaredInterests.domain, domains),
-      )),
-    db
-      .select({ domain: playerMastery.canonicalSubcategory })
+  const declaredRows = await db
+    .select({ domain: declaredInterests.domain })
+    .from(declaredInterests)
+    .where(and(
+      eq(declaredInterests.userId, userId),
+      eq(declaredInterests.isActive, true),
+      inArray(declaredInterests.domain, domains),
+    ));
+  for (const row of declaredRows) declared.add(row.domain);
+
+  try {
+    const masteryRows = await db
+      .select({
+        domain: playerMastery.canonicalSubcategory,
+        territoryType: playerMastery.territoryType,
+      })
       .from(playerMastery)
       .where(and(
         eq(playerMastery.userId, userId),
         inArray(playerMastery.canonicalSubcategory, domains),
-      )),
-  ]);
+      ));
+    for (const row of masteryRows) {
+      if (row.territoryType === 'declared') declared.add(row.domain);
+    }
+  } catch (error) {
+    // territoryType is additive; on a DB where the column hasn't landed yet
+    // (42703) fall back to declaredInterests alone — the safe direction, since
+    // a missed declared mastery row only means a domain isn't floored, never
+    // that a demonstrated one is wrongly pinned.
+    if (pgErrorCode(error) !== '42703') throw error;
+  }
 
-  for (const row of declaredRows) focus.add(row.domain);
-  for (const row of masteryRows) focus.add(row.domain);
-  return focus;
+  return declared;
 }
 
 function stepDifficulty(current: ServedDifficulty, direction: 1 | -1): ServedDifficulty {
@@ -249,15 +277,23 @@ export type DomainDifficultyState = {
 export function computeDomainDifficultyStep(
   existing: DomainDifficultyState,
   isCorrect: boolean,
+  floor: ServedDifficulty = 'accessible',
 ): DomainDifficultyState {
   let nextCorrect = isCorrect ? existing.consecutiveCorrect + 1 : 0;
   let nextIncorrect = isCorrect ? 0 : existing.consecutiveIncorrect + 1;
   let nextDifficulty: ServedDifficulty = existing.servedDifficulty;
 
+  const floorIdx = DIFFICULTY_LADDER.indexOf(floor);
+
   if (isCorrect && nextCorrect >= STREAK_TO_STEP && existing.servedDifficulty !== 'specialist') {
     nextDifficulty = stepDifficulty(existing.servedDifficulty, 1);
     nextCorrect = 0;
-  } else if (!isCorrect && nextIncorrect >= STREAK_TO_STEP && existing.servedDifficulty !== 'accessible') {
+  } else if (!isCorrect && nextIncorrect >= STREAK_TO_STEP && DIFFICULTY_LADDER.indexOf(existing.servedDifficulty) > floorIdx) {
+    // Two-incorrect step-down — but never below the floor. For a declared
+    // domain the floor is the engaged-fan rung (moderate), so it erodes within
+    // the upper band but can't drop to accessible/tourist level (PRD-D-5 §5.2).
+    // Demonstrated domains pass the default 'accessible' floor and retain the
+    // full range, matching the prior behaviour exactly.
     nextDifficulty = stepDifficulty(existing.servedDifficulty, -1);
     nextIncorrect = 0;
   }
@@ -268,7 +304,9 @@ export function computeDomainDifficultyStep(
 /**
  * Update per-domain difficulty after a graded answer. Two consecutive correct →
  * step up; two consecutive incorrect → step down. Streak counter resets when
- * the level moves so a single wobble doesn't immediately yo-yo.
+ * the level moves so a single wobble doesn't immediately yo-yo. Declared domains
+ * are floored at the engaged-fan rung (moderate) on both seed and erosion;
+ * demonstrated domains seed low and retain the full range down to accessible.
  */
 export async function updateDomainDifficultyOnAnswer(
   userId: string,
@@ -287,13 +325,13 @@ export async function updateDomainDifficultyOnAnswer(
     .limit(1);
 
   if (!existing) {
-    const [level, focusDomains] = await Promise.all([
+    const [level, declaredDomains] = await Promise.all([
       readCurrentAdaptiveLevel(userId),
-      getFocusDomainSet(userId, [canonicalSubcategory]),
+      getDeclaredDomainSet(userId, [canonicalSubcategory]),
     ]);
     const seed = applyFocusFloor(
       seedDifficultyFromAdaptiveLevel(level),
-      focusDomains.has(canonicalSubcategory),
+      declaredDomains.has(canonicalSubcategory),
     );
     await db.insert(userDomainDifficulties).values({
       userId,
@@ -306,7 +344,13 @@ export async function updateDomainDifficultyOnAnswer(
     return;
   }
 
-  const next = computeDomainDifficultyStep(existing, isCorrect);
+  // Declared domains carry the engaged-fan erosion floor; demonstrated domains
+  // step down freely (default 'accessible' floor).
+  const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
+  const floor: ServedDifficulty = declaredDomains.has(canonicalSubcategory)
+    ? FOCUS_DOMAIN_MIN_DIFFICULTY
+    : 'accessible';
+  const next = computeDomainDifficultyStep(existing, isCorrect, floor);
 
   await db
     .update(userDomainDifficulties)
@@ -349,19 +393,20 @@ export async function getDomainDifficultyOverrides(
   }
 
   // Only domains without a persisted row need a first-contact seed. Pull the
-  // user's adaptive level and which of those domains are opted-in focus areas
-  // so we can floor the seed to "Familiar" for the latter.
+  // user's adaptive level and which of those domains are declared so we can
+  // floor the seed to the engaged-fan rung for the latter (demonstrated domains
+  // seed straight off the adaptive level and may start at accessible).
   const domainsNeedingSeed = domains.filter((domain) => !known.has(domain));
-  const [seedLevel, focusDomains] = domainsNeedingSeed.length === 0
+  const [seedLevel, declaredDomains] = domainsNeedingSeed.length === 0
     ? [MIN_ADAPTIVE_LEVEL, new Set<string>()]
     : await Promise.all([
         readCurrentAdaptiveLevel(userId),
-        getFocusDomainSet(userId, domainsNeedingSeed),
+        getDeclaredDomainSet(userId, domainsNeedingSeed),
       ]);
 
   for (const domain of domains) {
     const served = known.get(domain)
-      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
+      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), declaredDomains.has(domain));
     overrides.set(domain, SERVED_TO_PREFERENCE[served]);
   }
 

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -197,31 +197,68 @@ function seedDifficultyFromAdaptiveLevel(level: number): ServedDifficulty {
 }
 
 /**
- * The "engaged-fan" rung, expressed on the per-domain served-difficulty ladder
- * (moderate). It is the hard floor for a domain the player explicitly DECLARED:
- * someone who raised their hand for a topic finds accessible ("tourist") trivia
- * condescendingly easy, so a declared domain both *seeds* here and *cannot erode
- * below* here (PRD-D-5 §5.2, D3). Demonstrated domains are NOT floored — they
- * start low and retain the full adaptive range down to accessible.
+ * Minimum first-contact difficulty for a domain the player explicitly opted
+ * into — either by stating it as an area of focus or by accepting one shared by
+ * a friend. Someone who raised their hand for a topic finds "Establishing"
+ * (accessible) trivia condescendingly easy, so we floor the *seed* at "Familiar"
+ * (moderate) for ANY focus domain (declared or demonstrated). This sets only the
+ * starting point. What happens to the floor afterwards is signal-keyed: a
+ * DECLARED domain also holds this as a hard *erosion* floor (the two-incorrect
+ * step-down can't drop below it), while a DEMONSTRATED domain can still step
+ * down to accessible (PRD-D-5 §5.2, D3 — the erosion floor is declared-only).
  */
 const FOCUS_DOMAIN_MIN_DIFFICULTY: ServedDifficulty = 'moderate';
 
-export function applyFocusFloor(difficulty: ServedDifficulty, isDeclaredDomain: boolean): ServedDifficulty {
-  if (!isDeclaredDomain) return difficulty;
+export function applyFocusFloor(difficulty: ServedDifficulty, isFocusDomain: boolean): ServedDifficulty {
+  if (!isFocusDomain) return difficulty;
   return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(FOCUS_DOMAIN_MIN_DIFFICULTY)
     ? difficulty
     : FOCUS_DOMAIN_MIN_DIFFICULTY;
 }
 
 /**
+ * Canonical subcategories the player has opted into: declared interests (stated
+ * focus areas) plus any open territory in PLAYER_MASTERY — friend-mediated
+ * acceptances and authored domains both land there. Used to floor the
+ * first-contact *seed* to "Familiar" for any opted-in domain (declared OR
+ * demonstrated). The declared/demonstrated split that governs the *erosion*
+ * floor lives in `getDeclaredDomainSet`. Pass `domains` to scope the lookup.
+ */
+async function getFocusDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
+  const focus = new Set<string>();
+  if (domains.length === 0) return focus;
+
+  const [declaredRows, masteryRows] = await Promise.all([
+    db
+      .select({ domain: declaredInterests.domain })
+      .from(declaredInterests)
+      .where(and(
+        eq(declaredInterests.userId, userId),
+        eq(declaredInterests.isActive, true),
+        inArray(declaredInterests.domain, domains),
+      )),
+    db
+      .select({ domain: playerMastery.canonicalSubcategory })
+      .from(playerMastery)
+      .where(and(
+        eq(playerMastery.userId, userId),
+        inArray(playerMastery.canonicalSubcategory, domains),
+      )),
+  ]);
+
+  for (const row of declaredRows) focus.add(row.domain);
+  for (const row of masteryRows) focus.add(row.domain);
+  return focus;
+}
+
+/**
  * Canonical subcategories the player explicitly DECLARED — stated focus areas
  * (`declaredInterests`) plus PLAYER_MASTERY rows whose `territoryType` is
  * 'declared' (friend-mediated acceptances that came in as declared territory).
- * This is the signal that keys the difficulty floor (D2/D3): declared domains
- * seed at engaged-fan and cannot erode to accessible; demonstrated domains (the
- * rest) get the full adaptive range. Splitting declared from demonstrated here
- * is what stops the floor from pinning newcomer/demonstrated domains too high
- * (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope the lookup to the round.
+ * This narrower set keys the hard *erosion* floor (D2/D3): a declared domain
+ * cannot erode below engaged-fan, while a demonstrated domain — though it still
+ * *seeds* at moderate (see `getFocusDomainSet`) — keeps the full range and can
+ * step down to accessible (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope.
  */
 async function getDeclaredDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
   const declared = new Set<string>();
@@ -325,13 +362,14 @@ export async function updateDomainDifficultyOnAnswer(
     .limit(1);
 
   if (!existing) {
-    const [level, declaredDomains] = await Promise.all([
+    // Seed floor is for any opted-in (focus) domain — declared or demonstrated.
+    const [level, focusDomains] = await Promise.all([
       readCurrentAdaptiveLevel(userId),
-      getDeclaredDomainSet(userId, [canonicalSubcategory]),
+      getFocusDomainSet(userId, [canonicalSubcategory]),
     ]);
     const seed = applyFocusFloor(
       seedDifficultyFromAdaptiveLevel(level),
-      declaredDomains.has(canonicalSubcategory),
+      focusDomains.has(canonicalSubcategory),
     );
     await db.insert(userDomainDifficulties).values({
       userId,
@@ -344,8 +382,8 @@ export async function updateDomainDifficultyOnAnswer(
     return;
   }
 
-  // Declared domains carry the engaged-fan erosion floor; demonstrated domains
-  // step down freely (default 'accessible' floor).
+  // Erosion floor is declared-only: declared domains carry the engaged-fan
+  // floor, demonstrated domains step down freely (default 'accessible' floor).
   const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
   const floor: ServedDifficulty = declaredDomains.has(canonicalSubcategory)
     ? FOCUS_DOMAIN_MIN_DIFFICULTY
@@ -393,20 +431,20 @@ export async function getDomainDifficultyOverrides(
   }
 
   // Only domains without a persisted row need a first-contact seed. Pull the
-  // user's adaptive level and which of those domains are declared so we can
-  // floor the seed to the engaged-fan rung for the latter (demonstrated domains
-  // seed straight off the adaptive level and may start at accessible).
+  // user's adaptive level and which of those domains are opted-in focus areas
+  // so we can floor the seed to "Familiar" for the latter (declared OR
+  // demonstrated — the erosion-floor split is applied later, on answer).
   const domainsNeedingSeed = domains.filter((domain) => !known.has(domain));
-  const [seedLevel, declaredDomains] = domainsNeedingSeed.length === 0
+  const [seedLevel, focusDomains] = domainsNeedingSeed.length === 0
     ? [MIN_ADAPTIVE_LEVEL, new Set<string>()]
     : await Promise.all([
         readCurrentAdaptiveLevel(userId),
-        getDeclaredDomainSet(userId, domainsNeedingSeed),
+        getFocusDomainSet(userId, domainsNeedingSeed),
       ]);
 
   for (const domain of domains) {
     const served = known.get(domain)
-      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), declaredDomains.has(domain));
+      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
     overrides.set(domain, SERVED_TO_PREFERENCE[served]);
   }
 

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -66,7 +66,10 @@ BAD (multiple-choice phrasing — never produce these):
 
 GOOD (open recall):
 - "What does Sally Seton represent to the young Clarissa in Mrs. Dalloway?"
-- "In what year did Tchaikovsky premiere his Sixth Symphony?"
+- "What does the madeleine awaken in the narrator of In Search of Lost Time?"
+
+TRIVIA-OF-TRIVIA RULE:
+Prefer questions of substance — "what is X", "what does X mean", "why does X matter", "who did X" — over questions of mere recall — "what year", "what number", "what label". A date, a count, or a name is worth asking only when that specific fact is itself meaningful; a question that lands on substance is almost always the better question. Lead with the idea, not the index card.
 
 STYLE EXEMPLARS (match this register, specificity, and concision):
 These are gold-standard Joshing questions. Mimic their tone — literate, confident, and specific. Pull from comparable depth (named characters, named works, technical terms, specific years, named figures) rather than vague appreciation or "explain why" questions. Notice how they assume a cultured audience without condescension.
@@ -118,7 +121,7 @@ QUESTION SHAPE VARIETY:
 Trivia gets monotonous when every question follows the same template ("What is the name of X?"). Vary the shape across the batch. Choose from this catalog and emit the chosen shape on each question via the question_shape field:
 
 - "identification": asks for a name, term, title, or label (e.g. "What is the name of the dwarf who forges the ring?")
-- "year_or_date": asks for a year, date, or temporal ordering (e.g. "In what year did the Berlin Wall fall?")
+- "year_or_date": asks for a year, date, or temporal ordering. Use ONLY when the date itself is meaningful — a turning point, an anniversary, a deliberate juxtaposition — never as a default or filler in place of a substance question (e.g. "In what year did the Berlin Wall fall?")
 - "in_which_work": asks which work, scene, chapter, movement, or section something appears in
 - "who_did_what": asks which character/person performs a specific act (e.g. "Who kills Polonius?")
 - "sequence_or_order": asks for ordering of events, items, or steps
@@ -233,6 +236,8 @@ function difficultyInstruction(preference: string | undefined, adaptiveLevel?: n
 type AvoidQuestionEntry = RecentDailyQuestionEntry;
 type AvoidFactKeyEntry = RecentFactKeyEntry;
 
+type TerritoryType = 'declared' | 'demonstrated';
+
 function buildUserPrompt(
   domains: string[],
   count: number,
@@ -243,6 +248,7 @@ function buildUserPrompt(
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): string {
   const prevBlock = prev.length > 0
     ? prev
@@ -296,6 +302,28 @@ ${lines.join('\n')}`;
     if (instruction) difficultyHint = `\n\nDifficulty instruction: ${instruction}`;
   }
 
+  // Territory register (PRD-D-5 §5.2). A DECLARED domain is one the player chose
+  // — they hold a floor at the engaged-fan rung, so questions must read for
+  // someone who actively follows it, never tourist-level recognition trivia. A
+  // DEMONSTRATED domain surfaced from play; meet a newcomer at an accessible
+  // register and let depth climb. This mirrors the floor the difficulty mapper
+  // already applies, so the prose register and the target rate stay aligned.
+  let territoryHint = '';
+  if (domainTerritoryTypes && domainTerritoryTypes.size > 0) {
+    const declaredDomains = domains.filter((d) => domainTerritoryTypes.get(d) === 'declared');
+    const introducedDomains = domains.filter((d) => domainTerritoryTypes.get(d) === 'demonstrated');
+    const lines: string[] = [];
+    if (declaredDomains.length > 0) {
+      lines.push(`- DECLARED (the player chose to learn these — write for an engaged enthusiast who actively follows the domain; assume real familiarity and never ask tourist-level "who composed it" recognition trivia): ${declaredDomains.join(', ')}`);
+    }
+    if (introducedDomains.length > 0) {
+      lines.push(`- INTRODUCED (surfaced from the player's activity — meet a curious newcomer at an accessible register and let difficulty climb with play): ${introducedDomains.join(', ')}`);
+    }
+    if (lines.length > 0) {
+      territoryHint = `\n\nDomain familiarity:\n${lines.join('\n')}`;
+    }
+  }
+
   const domainSection =
     domains.length === count && count > 1
       ? `Generate exactly one trivia question for each of the following ${count} domains:\n${domains.map((d, i) => `${i + 1}. ${d}`).join('\n')}`
@@ -316,7 +344,7 @@ ${perDomain.join('\n')}`;
     }
   }
 
-  return `${domainSection}${calibration}${difficultyHint}${subAnglesHint}
+  return `${domainSection}${calibration}${difficultyHint}${territoryHint}${subAnglesHint}
 
 Previously generated questions to avoid repeating (do not re-ask any of these facts, even rephrased). Each entry is prefixed with [<source domain>]. The user's domains may overlap in subject matter — for example, a fact about Mrs. Dalloway already asked under "Virginia Woolf's Novels and Essays" is still off limits when generating for "Mrs. Dalloway", and vice versa. A fact already covered under ANY of the user's domains must not be re-asked under ANY domain:
 ${wrapUserInput('recent_questions', prevBlock)}
@@ -761,6 +789,7 @@ async function callLlmOnce(
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): Promise<LlmQuestion[]> {
   const client = getAnthropicClient();
   if (!client) return [];
@@ -787,6 +816,7 @@ async function callLlmOnce(
           domainDifficultyOverrides,
           adaptiveLevel,
           subAnglesByDomain,
+          domainTerritoryTypes,
         ),
       },
     ],
@@ -808,6 +838,7 @@ export async function generateDailyQuestions(
   adaptiveLevel?: number | null,
   previousFactKeys: AvoidFactKeyEntry[] = [],
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): Promise<GeneratedQuestionRow[]> {
   if (count <= 0 || domains.length === 0) return [];
 
@@ -841,6 +872,7 @@ export async function generateDailyQuestions(
         domainDifficultyOverrides,
         adaptiveLevel,
         subAnglesByDomain,
+        domainTerritoryTypes,
       );
       if (out.length > 0) return out;
       console.warn('[daily/generate-questions] chunk returned no usable questions, retrying', {
@@ -856,6 +888,7 @@ export async function generateDailyQuestions(
         domainDifficultyOverrides,
         adaptiveLevel,
         subAnglesByDomain,
+        domainTerritoryTypes,
       );
     } catch (err) {
       // A single chunk failing (timeout / aborted) must not sink the batch —
@@ -1204,6 +1237,14 @@ export async function generateDailyQuestionsFromKnowledgeBase(
     ? await getDomainDifficultyOverrides(userId, domainsForRound).catch(() => undefined)
     : undefined;
 
+  // territoryType (declared | demonstrated) per selected domain — threaded into
+  // the generation prompt so its register matches the difficulty floor (PRD-D-5
+  // §5.2): declared domains read for an enthusiast, demonstrated for a newcomer.
+  const territoryByDomain = new Map<string, TerritoryType>();
+  for (const entry of knowledgeBase) {
+    territoryByDomain.set(entry.domain, entry.territoryType);
+  }
+
   const subAnglesByDomain = await getRecentSubAnglesByDomain(userId, domainsForRound).catch(() => undefined);
 
   // Try to fill slots from the cross-user bank (previously-generated questions
@@ -1239,6 +1280,7 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       adaptiveLevel,
       previousFactKeys,
       subAnglesByDomain,
+      territoryByDomain,
     );
   }
 


### PR DESCRIPTION
Implements **B2** of the D-5 quality-floor series (B1 pool ✓ → **B2 floor** → B3 retrieval → B4 verification). Makes declared interests start higher and fixes what the generation prompt *teaches*. Touches the difficulty mapper and the generation prompt only — no pool/schema, retrieval, grading, or surface-gating changes.

## Phase 1 — Difficulty ladder + signal-keyed floor (`adaptive-difficulty.ts`)
- **Enthusiast rung** inserted between engaged-fan (0.62) and specialist (0.35) in `mapAdaptiveLevelToDifficultyHint` — level band `[2.5, 3.0)`, target **0.50**, with the calibration-guardrail text verbatim ("Questions someone who **chose to learn** this domain would know … but **NOT** scholar- or archivist-level minutiae"). Estimate maps to `specialist` (the three hardest rungs collapse to the specialist generator tier).
- **Rewrote the accessible / engaged-fan hint strings** so neither models a "casually interested person" ("passing interest" / "actively follows").
- **Signal-keyed floor:** `getFocusDomainSet` → `getDeclaredDomainSet` (active declared interests ∪ `playerMastery` rows with `territoryType='declared'`, 42703-guarded). Declared domains seed at engaged-fan and gain a **hard erosion floor** — `computeDomainDifficultyStep` now takes a `floor` arg so two-incorrect step-downs never reach accessible. Demonstrated domains pass the default `accessible` floor and retain the full existing range.

## Phase 2 — Prompt register (`generate-questions.ts`)
- **Threaded `territoryType`** from the knowledge base through `generateDailyQuestions → callLlmOnce → buildUserPrompt` as a "Domain familiarity" block: declared → engaged-enthusiast register (no tourist-level "who composed it"); introduced → curious-newcomer register. Mirrors the difficulty floor.
- **Demoted the year-question GOOD example** to a substance exemplar (the madeleine in *In Search of Lost Time*).
- **Added the trivia-of-trivia rule** (prefer "what is X / why does X matter" over "what year / what number / what label").
- **Demoted `year_or_date`** in the shape catalog ("use only when the date itself is meaningful") — kept, not removed.

## Drift-risk guardrails honored
- Enthusiast rung text is the "chose to learn … not scholar/archivist" definition, not deep-cut difficulty.
- Hard floor is **declared-only**; demonstrated domains keep the full adaptive range incl. accessible.
- `year_or_date` demoted, not banned.

## Tests
- New unit tests: a declared domain never erodes below engaged-fan after repeated wrong answers; a demonstrated domain still reaches accessible; enthusiast rung + register assertions.
- `npx tsc -p tsconfig.typecheck.json` clean · ESLint clean · **full suite 736 passed / 3 skipped**.

## Not done here (flagged)
- **WTC calibration** ("Well-Tempered Clavier" as a declared domain) is verified by prompt construction, **not** a live Sonnet generation run — worth a real eval pass before relying on it.
- **Scoping change:** demonstrated-mastery domains previously got a moderate seed-floor (they were lumped into the old focus set); per §5.2 / DRIFT RISK 2 ("demonstrated → starts low") this PR **removes** that seed-floor for demonstrated. Flagging for review since it's a behavior change at first contact.

https://claude.ai/code/session_012MiXiniPQt6wdXDrJLKvG7

---
_Generated by [Claude Code](https://claude.ai/code/session_012MiXiniPQt6wdXDrJLKvG7)_