### PR TITLE
Refine Your Game: contextual daily-summary refinement section

### DIFF
--- a/drizzle/0064_domain_difficulty_freeze.sql
+++ b/drizzle/0064_domain_difficulty_freeze.sql
@@ -1,0 +1,14 @@
+-- Migration: add USER_DOMAIN_DIFFICULTY.freeze_until for the "Ease off" action.
+--
+-- Refine Your Game's difficulty_escalation item lets a player freeze a
+-- subdomain's served difficulty at its current level for 30 days. freeze_until
+-- holds the timestamp the freeze lapses; while it is in the future,
+-- updateDomainDifficultyOnAnswer() (src/server/adaptive-difficulty.ts) must not
+-- step the served difficulty up or down. NULL means "no freeze" (normal
+-- adaptive behavior).
+--
+-- Additive nullable column — the safe case. Idempotent guard is also
+-- pre-applied in src/instrumentation.ts for preview/production databases that
+-- may have this migration recorded without the column present.
+ALTER TABLE "USER_DOMAIN_DIFFICULTY"
+  ADD COLUMN IF NOT EXISTS "freeze_until" timestamp with time zone;

--- a/drizzle/0065_daily_refine_decision.sql
+++ b/drizzle/0065_daily_refine_decision.sql
@@ -1,0 +1,75 @@
+-- Migration: add DAILY_REFINE_DECISION, the decision + cooldown ledger that
+-- backs the Refine Your Game section on the daily summary.
+--
+-- One row tracks a single refine item the player acted on (or that was shown
+-- and defaulted). The action column moves pending -> committed | defaulted:
+--   * pending   = player tapped the action verb; change is STAGED, not applied.
+--   * committed = the staged change was applied when the player built their
+--                 next daily (commitPendingRefineDecisions in
+--                 src/server/refine/commit.ts). cooldown_until is stamped then.
+--   * defaulted = the item was shown but never acted on; no effect, but a
+--                 cooldown is stamped so it does not immediately re-fire.
+--
+-- friend_id is set only for friend_expansion (the bonus source friend). The
+-- unique index keys one decision per (user, queue, type, subdomain[, friend])
+-- so resolve/undo upserts are idempotent. Cascades on User and DailyQueue
+-- delete so rows don't outlive their owner or their triggering game.
+--
+-- Idempotent guards are also pre-applied in src/instrumentation.ts for
+-- preview/production databases that may have this migration recorded without
+-- the table actually present.
+CREATE TABLE IF NOT EXISTS "DAILY_REFINE_DECISION" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "user_id" text NOT NULL,
+  "queue_id" text NOT NULL,
+  "item_type" text NOT NULL,
+  "canonical_subcategory" text NOT NULL,
+  "friend_id" text,
+  "action" text NOT NULL DEFAULT 'pending',
+  "committed_at" timestamp with time zone,
+  "cooldown_until" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$
+DECLARE
+  decision_table regclass := to_regclass('public."DAILY_REFINE_DECISION"');
+  user_table regclass := to_regclass('public."User"');
+  queue_table regclass := to_regclass('public."DailyQueue"');
+BEGIN
+  IF decision_table IS NOT NULL
+    AND user_table IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'DAILY_REFINE_DECISION_user_id_User_id_fk'
+        AND conrelid = decision_table
+    )
+  THEN
+    ALTER TABLE "DAILY_REFINE_DECISION"
+      ADD CONSTRAINT "DAILY_REFINE_DECISION_user_id_User_id_fk"
+      FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE;
+  END IF;
+
+  IF decision_table IS NOT NULL
+    AND queue_table IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'DAILY_REFINE_DECISION_queue_id_DailyQueue_id_fk'
+        AND conrelid = decision_table
+    )
+  THEN
+    ALTER TABLE "DAILY_REFINE_DECISION"
+      ADD CONSTRAINT "DAILY_REFINE_DECISION_queue_id_DailyQueue_id_fk"
+      FOREIGN KEY ("queue_id") REFERENCES "DailyQueue"("id") ON DELETE CASCADE;
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_unique_item"
+  ON "DAILY_REFINE_DECISION" ("user_id", "queue_id", "item_type", "canonical_subcategory", COALESCE("friend_id", ''));
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_cooldown_idx"
+  ON "DAILY_REFINE_DECISION" ("user_id", "item_type", "canonical_subcategory", "cooldown_until");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_uncommitted_idx"
+  ON "DAILY_REFINE_DECISION" ("user_id", "committed_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -449,6 +449,20 @@
       "when": 1782000000000,
       "tag": "0063_pool_embeddings",
       "breakpoints": true
+    },
+    {
+      "idx": 64,
+      "version": "7",
+      "when": 1782086400000,
+      "tag": "0064_domain_difficulty_freeze",
+      "breakpoints": true
+    },
+    {
+      "idx": 65,
+      "version": "7",
+      "when": 1782172800000,
+      "tag": "0065_daily_refine_decision",
+      "breakpoints": true
     }
   ]
 }

--- a/src/__tests__/refine-derive.test.ts
+++ b/src/__tests__/refine-derive.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import type { QueueSlot } from '@/server/daily/types';
+import {
+  deriveDifficultyEscalation,
+  deriveFriendExpansion,
+  deriveStrugglePruning,
+  type MissStreak,
+} from '@/server/refine/derive';
+import { selectRefineCandidates } from '@/server/refine/select';
+import { openText, resolvedText, subdomainLabel } from '@/server/refine/copy';
+import { pruningThreshold, refineItemKey, type RefineCandidate } from '@/server/refine/types';
+
+function slot(overrides: Partial<QueueSlot>): QueueSlot {
+  return {
+    slot_index: 0,
+    source: 'bot',
+    domain: 'general',
+    question_text: 'q',
+    answered: true,
+    ...overrides,
+  };
+}
+
+describe('deriveFriendExpansion', () => {
+  it('fires for a correct answer on an un-owned friend bonus slot', () => {
+    const slots = [
+      slot({
+        slot_index: 5,
+        presence_source_id: 'friend-1',
+        presence_source_name: 'Robyn',
+        domain: 'subprime_mortgage',
+        answer_state: 'correct',
+      }),
+    ];
+    const out = deriveFriendExpansion(slots, new Set());
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({
+      type: 'friend_expansion',
+      subdomainId: 'subprime_mortgage',
+      subdomainLabel: 'subprime mortgage',
+      friendId: 'friend-1',
+      friendName: 'Robyn',
+    });
+  });
+
+  it('does not fire when the player already owns the subdomain', () => {
+    const slots = [
+      slot({ presence_source_id: 'f1', domain: 'Jazz', answer_state: 'correct' }),
+    ];
+    expect(deriveFriendExpansion(slots, new Set(['jazz']))).toHaveLength(0);
+  });
+
+  it('does not fire on an incorrect answer or a non-bonus slot', () => {
+    const incorrectBonus = slot({ presence_source_id: 'f1', domain: 'Jazz', answer_state: 'incorrect' });
+    const nonBonusCorrect = slot({ domain: 'Jazz', answer_state: 'correct' });
+    expect(deriveFriendExpansion([incorrectBonus, nonBonusCorrect], new Set())).toHaveLength(0);
+  });
+
+  it('dedupes to one candidate per (subdomain, friend)', () => {
+    const slots = [
+      slot({ slot_index: 1, presence_source_id: 'f1', domain: 'Jazz', answer_state: 'correct' }),
+      slot({ slot_index: 2, presence_source_id: 'f1', domain: 'Jazz', answer_state: 'correct' }),
+    ];
+    expect(deriveFriendExpansion(slots, new Set())).toHaveLength(1);
+  });
+});
+
+describe('deriveDifficultyEscalation', () => {
+  it('fires once per domain that stepped up this daily', () => {
+    const slots = [
+      slot({ slot_index: 1, domain: 'derivatives', difficulty_stepped_up: true }),
+      slot({ slot_index: 2, domain: 'derivatives', difficulty_stepped_up: true }),
+      slot({ slot_index: 3, domain: 'opera', difficulty_stepped_up: false }),
+    ];
+    const out = deriveDifficultyEscalation(slots);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ type: 'difficulty_escalation', subdomainId: 'derivatives' });
+  });
+});
+
+describe('pruningThreshold + deriveStrugglePruning', () => {
+  it('uses tiered thresholds 3/4/5', () => {
+    expect(pruningThreshold('accessible')).toBe(3);
+    expect(pruningThreshold('moderate')).toBe(4);
+    expect(pruningThreshold('specialist')).toBe(5);
+  });
+
+  it('fires only when the run reaches the latest-miss tier threshold', () => {
+    const streaks: MissStreak[] = [
+      { subdomainId: 'a', subdomainLabel: 'a', count: 3, latestMissTier: 'accessible' }, // 3 >= 3 → fire
+      { subdomainId: 'b', subdomainLabel: 'b', count: 3, latestMissTier: 'moderate' }, // 3 < 4 → no
+      { subdomainId: 'c', subdomainLabel: 'c', count: 5, latestMissTier: 'specialist' }, // 5 >= 5 → fire
+      { subdomainId: 'd', subdomainLabel: 'd', count: 4, latestMissTier: 'specialist' }, // 4 < 5 → no
+    ];
+    const fired = deriveStrugglePruning(streaks).map((c) => c.subdomainId);
+    expect(fired).toEqual(['a', 'c']);
+  });
+
+  it('carries the miss count for evidence copy', () => {
+    const out = deriveStrugglePruning([
+      { subdomainId: 'x', subdomainLabel: 'x', count: 4, latestMissTier: 'moderate' },
+    ]);
+    expect(out[0].missCount).toBe(4);
+  });
+});
+
+describe('selectRefineCandidates', () => {
+  const friend: RefineCandidate = { type: 'friend_expansion', subdomainId: 'a', subdomainLabel: 'a', friendId: 'f1' };
+  const escalation: RefineCandidate = { type: 'difficulty_escalation', subdomainId: 'b', subdomainLabel: 'b' };
+  const pruning: RefineCandidate = { type: 'struggle_pruning', subdomainId: 'c', subdomainLabel: 'c' };
+
+  it('orders by priority friend → escalation → pruning', () => {
+    const out = selectRefineCandidates([pruning, escalation, friend], new Set());
+    expect(out.map((c) => c.type)).toEqual([
+      'friend_expansion',
+      'difficulty_escalation',
+      'struggle_pruning',
+    ]);
+  });
+
+  it('drops candidates whose key is in cooldown', () => {
+    const cooldowns = new Set([refineItemKey('friend_expansion', 'a', 'f1')]);
+    const out = selectRefineCandidates([friend, escalation], cooldowns);
+    expect(out.map((c) => c.type)).toEqual(['difficulty_escalation']);
+  });
+
+  it('keeps at most three, filling by priority', () => {
+    const extras: RefineCandidate[] = [
+      { type: 'struggle_pruning', subdomainId: 'p1', subdomainLabel: 'p1' },
+      { type: 'struggle_pruning', subdomainId: 'p2', subdomainLabel: 'p2' },
+    ];
+    const out = selectRefineCandidates([friend, escalation, pruning, ...extras], new Set());
+    expect(out).toHaveLength(3);
+    // pruning items are lowest priority — the last slot is a pruning item, the
+    // two pruning extras are sliced off.
+    expect(out.map((c) => c.type)).toEqual([
+      'friend_expansion',
+      'difficulty_escalation',
+      'struggle_pruning',
+    ]);
+  });
+
+  it('keeps both candidates when one subdomain qualifies for two types', () => {
+    const dualEscalation: RefineCandidate = { type: 'difficulty_escalation', subdomainId: 'dual', subdomainLabel: 'dual' };
+    const dualPruning: RefineCandidate = { type: 'struggle_pruning', subdomainId: 'dual', subdomainLabel: 'dual' };
+    const out = selectRefineCandidates([dualPruning, dualEscalation], new Set());
+    expect(out.map((c) => c.type)).toEqual(['difficulty_escalation', 'struggle_pruning']);
+  });
+});
+
+describe('copy', () => {
+  it('formats the subdomain label without changing casing', () => {
+    expect(subdomainLabel('subprime_mortgage')).toBe('subprime mortgage');
+    expect(subdomainLabel('Sondheim')).toBe('Sondheim');
+  });
+
+  it('produces the spec evidence + resolved copy', () => {
+    const pruning: RefineCandidate = {
+      type: 'struggle_pruning',
+      subdomainId: 'subprime_mortgage',
+      subdomainLabel: 'subprime mortgage',
+      missCount: 4,
+    };
+    expect(openText(pruning)).toBe(
+      "You've missed the last 4 subprime mortgage questions. Drop them from your daily five?",
+    );
+    expect(resolvedText(pruning)).toBe('Dropped subprime mortgage from your daily five.');
+
+    const escalation: RefineCandidate = {
+      type: 'difficulty_escalation',
+      subdomainId: 'finance_derivatives',
+      subdomainLabel: 'finance derivatives',
+    };
+    expect(resolvedText(escalation)).toBe(
+      "We'll keep finance derivatives at this level for the next month.",
+    );
+  });
+});

--- a/src/app/api/daily/refine/route.ts
+++ b/src/app/api/daily/refine/route.ts
@@ -1,0 +1,108 @@
+import { and, eq, isNull, sql } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { dailyQueues, dailyRefineDecisions, db } from '@/server/db';
+import { deriveSelectedRefineCandidates } from '@/server/db/queries/refine';
+import type { QueueSlot } from '@/server/daily/types';
+import { refineItemKey } from '@/server/refine/types';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  queue_id: z.string().trim().min(1),
+  item_type: z.enum(['friend_expansion', 'difficulty_escalation', 'struggle_pruning']),
+  canonical_subcategory: z.string().trim().min(1),
+  friend_id: z.string().trim().min(1).optional(),
+});
+
+type RefineBody = z.infer<typeof bodySchema>;
+
+function asQueueSlots(value: unknown): QueueSlot[] {
+  return Array.isArray(value) ? (value as QueueSlot[]) : [];
+}
+
+async function parseBody(request: NextRequest): Promise<RefineBody | null> {
+  const body = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(body);
+  return parsed.success ? parsed.data : null;
+}
+
+/** Resolve: stage a refine decision (action verb tapped). */
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const body = await parseBody(request);
+  if (!body) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 });
+  }
+
+  // The queue must belong to the caller.
+  const [queue] = await db
+    .select({ id: dailyQueues.id, slots: dailyQueues.slots })
+    .from(dailyQueues)
+    .where(and(eq(dailyQueues.id, body.queue_id), eq(dailyQueues.userId, session.userId)))
+    .limit(1);
+  if (!queue) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  // Never trust the client about which items are real — re-derive and confirm.
+  const candidates = await deriveSelectedRefineCandidates(session.userId, asQueueSlots(queue.slots));
+  const targetKey = refineItemKey(body.item_type, body.canonical_subcategory, body.friend_id);
+  const match = candidates.find(
+    (candidate) => refineItemKey(candidate.type, candidate.subdomainId, candidate.friendId) === targetKey,
+  );
+  if (!match) {
+    return NextResponse.json({ error: 'stale_item' }, { status: 409 });
+  }
+
+  // Upsert against the COALESCE(friend_id,'') unique index — re-tapping is a no-op
+  // that simply re-stages (clears any prior commit/cooldown stamp).
+  await db.execute(sql`
+    INSERT INTO "DAILY_REFINE_DECISION"
+      ("user_id", "queue_id", "item_type", "canonical_subcategory", "friend_id", "action")
+    VALUES (
+      ${session.userId}, ${queue.id}, ${match.type}, ${match.subdomainId},
+      ${match.friendId ?? null}, 'pending'
+    )
+    ON CONFLICT ("user_id", "queue_id", "item_type", "canonical_subcategory", COALESCE("friend_id", ''))
+    DO UPDATE SET "action" = 'pending', "committed_at" = NULL, "cooldown_until" = NULL, "updated_at" = now()
+  `);
+
+  return NextResponse.json({ ok: true });
+}
+
+/** Undo: unstage a decision, allowed only while it hasn't committed. */
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const body = await parseBody(request);
+  if (!body) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 });
+  }
+
+  const [row] = await db
+    .select({ id: dailyRefineDecisions.id, committedAt: dailyRefineDecisions.committedAt })
+    .from(dailyRefineDecisions)
+    .where(and(
+      eq(dailyRefineDecisions.userId, session.userId),
+      eq(dailyRefineDecisions.queueId, body.queue_id),
+      eq(dailyRefineDecisions.itemType, body.item_type),
+      eq(dailyRefineDecisions.canonicalSubcategory, body.canonical_subcategory),
+      body.friend_id
+        ? eq(dailyRefineDecisions.friendId, body.friend_id)
+        : isNull(dailyRefineDecisions.friendId),
+    ))
+    .limit(1);
+
+  if (!row) return NextResponse.json({ ok: true });
+  if (row.committedAt) {
+    // The next daily already committed this change — undo window is over.
+    return NextResponse.json({ error: 'already_committed' }, { status: 409 });
+  }
+
+  await db.delete(dailyRefineDecisions).where(eq(dailyRefineDecisions.id, row.id));
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -19,6 +19,7 @@ import { AddToBankAction } from '@/components/AddToBankAction'
 import { EditorialBadge } from '@/components/EditorialBadge'
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay'
 import MasteryMoment from '@/components/review/MasteryMoment'
+import { RefineYourGame } from '@/components/review/RefineYourGame'
 import { cn } from '@/lib/utils'
 import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types'
 import { formatNextResetTimeLocal } from '@/lib/games/timezone'
@@ -268,6 +269,8 @@ export default function DailySummaryPage() {
           ))}
         </div>
       </section>
+
+      {summary.refine ? <RefineYourGame refine={summary.refine} /> : null}
 
       {summary.reminderPromptState === 'show' ? <RoundReminderCard /> : null}
 

--- a/src/components/review/RefineItemCard.tsx
+++ b/src/components/review/RefineItemCard.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useState } from 'react';
+import type { CSSProperties } from 'react';
+
+import type { RefineItem } from '@/server/refine/types';
+
+// Warm accent from the library (--brand-orange) for the single action verb.
+const actionStyle: CSSProperties = {
+  color: 'var(--brand-orange)',
+  borderColor: 'color-mix(in srgb, var(--brand-orange) 38%, var(--brand-border))',
+  background: 'color-mix(in srgb, var(--brand-orange) 8%, transparent)',
+};
+
+export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: string }) {
+  const [resolved, setResolved] = useState(item.state === 'resolved');
+  const [busy, setBusy] = useState(false);
+
+  const requestBody = {
+    queue_id: queueId,
+    item_type: item.type,
+    canonical_subcategory: item.subdomainId,
+    friend_id: item.friendId,
+  };
+
+  async function send(method: 'POST' | 'DELETE'): Promise<boolean> {
+    try {
+      const response = await fetch('/api/daily/refine', {
+        method,
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(requestBody),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async function resolve() {
+    if (busy || !queueId) return;
+    setBusy(true);
+    setResolved(true); // optimistic
+    const ok = await send('POST');
+    if (!ok) setResolved(false);
+    setBusy(false);
+  }
+
+  async function undo() {
+    if (busy) return;
+    setBusy(true);
+    setResolved(false); // optimistic
+    const ok = await send('DELETE');
+    // A 409 (already committed) or network error keeps the resolved fact.
+    if (!ok) setResolved(true);
+    setBusy(false);
+  }
+
+  return (
+    <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+      {resolved ? (
+        <>
+          <p className="text-muted-foreground flex-1 text-sm leading-6">
+            <span aria-hidden className="mr-1">
+              ✓
+            </span>
+            {item.resolvedText}
+          </p>
+          <button
+            type="button"
+            onClick={undo}
+            disabled={busy}
+            className="text-muted-foreground min-h-11 self-start px-2 text-xs font-medium tracking-[0.08em] uppercase underline underline-offset-4 transition disabled:opacity-60 sm:self-auto"
+          >
+            Undo
+          </button>
+        </>
+      ) : (
+        <>
+          <p className="text-foreground flex-1 text-sm leading-6">{item.openText}</p>
+          <button
+            type="button"
+            onClick={resolve}
+            disabled={busy}
+            style={actionStyle}
+            className="inline-flex min-h-11 items-center justify-center self-start rounded-full border px-4 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60 sm:self-auto"
+          >
+            {item.actionVerb}
+          </button>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/review/RefineYourGame.tsx
+++ b/src/components/review/RefineYourGame.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+
+import type { RefineSectionView } from '@/server/refine/types';
+import { RefineItemCard } from './RefineItemCard';
+
+// Matches the other daily-summary section headers (titleStyle in page.tsx) so
+// this reads as a calm peer section, not a headline.
+const titleStyle: CSSProperties = {
+  fontFamily: 'var(--font-neutral), system-ui, sans-serif',
+  fontSize: '0.8rem',
+  fontWeight: 700,
+  color: 'var(--brand-ink)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+};
+
+export function RefineYourGame({ refine }: { refine: RefineSectionView }) {
+  const { items, queueId } = refine;
+  const isEmpty = items.length === 0;
+
+  return (
+    <section className="card mt-5 px-5 py-4">
+      <h2 style={titleStyle}>Refine Your Game</h2>
+
+      {isEmpty ? (
+        <p className="text-muted-foreground mt-3 text-sm leading-6">
+          You&apos;re looking good. If you want to make changes or add a category, you can do that
+          here.
+        </p>
+      ) : (
+        <div className="mt-1">
+          {items.map((item, index) => (
+            <div key={item.id} className={index > 0 ? 'border-border border-t' : ''}>
+              <RefineItemCard item={item} queueId={queueId ?? ''} />
+            </div>
+          ))}
+        </div>
+      )}
+
+      <Link
+        href="/knowledge"
+        className="text-muted-foreground mt-4 inline-block text-sm underline-offset-4 hover:underline"
+      >
+        Manage all domains in Settings →
+      </Link>
+    </section>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -993,6 +993,94 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0064 (Refine Your Game) adds USER_DOMAIN_DIFFICULTY.freeze_until.
+    // adaptive-difficulty.ts reads it on every answer to decide whether the
+    // served difficulty is pinned, so a preview/production database with the
+    // migration recorded but the column missing would error before migrate()
+    // could repair it. Additive nullable column — pre-apply it idempotently.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "USER_DOMAIN_DIFFICULTY"
+          ADD COLUMN IF NOT EXISTS "freeze_until" timestamp with time zone
+      `);
+    } catch {
+      // USER_DOMAIN_DIFFICULTY may not exist yet on a fresh database —
+      // migrate() creates it before this migration runs.
+    }
+
+    // Migration 0065 (Refine Your Game) creates DAILY_REFINE_DECISION, the
+    // decision + cooldown ledger behind the daily-summary refine section. The
+    // summary builder, the resolve/undo route, and the next-daily commit hook
+    // all read this table, so a preview/production database with the migration
+    // recorded but the table missing would 42P01 before migrate() could repair
+    // it. Pre-create the table, FKs, and indexes idempotently.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "DAILY_REFINE_DECISION" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "user_id" text NOT NULL,
+          "queue_id" text NOT NULL,
+          "item_type" text NOT NULL,
+          "canonical_subcategory" text NOT NULL,
+          "friend_id" text,
+          "action" text NOT NULL DEFAULT 'pending',
+          "committed_at" timestamp with time zone,
+          "cooldown_until" timestamp with time zone,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          "updated_at" timestamp with time zone DEFAULT now() NOT NULL
+        )
+      `);
+      await db.execute(sql`
+        DO $$
+        DECLARE
+          decision_table regclass := to_regclass('public."DAILY_REFINE_DECISION"');
+          user_table regclass := to_regclass('public."User"');
+          queue_table regclass := to_regclass('public."DailyQueue"');
+        BEGIN
+          IF decision_table IS NOT NULL
+            AND user_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'DAILY_REFINE_DECISION_user_id_User_id_fk'
+                AND conrelid = decision_table
+            )
+          THEN
+            ALTER TABLE "DAILY_REFINE_DECISION"
+              ADD CONSTRAINT "DAILY_REFINE_DECISION_user_id_User_id_fk"
+              FOREIGN KEY ("user_id") REFERENCES "User"("id") ON DELETE CASCADE;
+          END IF;
+
+          IF decision_table IS NOT NULL
+            AND queue_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'DAILY_REFINE_DECISION_queue_id_DailyQueue_id_fk'
+                AND conrelid = decision_table
+            )
+          THEN
+            ALTER TABLE "DAILY_REFINE_DECISION"
+              ADD CONSTRAINT "DAILY_REFINE_DECISION_queue_id_DailyQueue_id_fk"
+              FOREIGN KEY ("queue_id") REFERENCES "DailyQueue"("id") ON DELETE CASCADE;
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_unique_item"
+          ON "DAILY_REFINE_DECISION" ("user_id", "queue_id", "item_type", "canonical_subcategory", COALESCE("friend_id", ''))
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_cooldown_idx"
+          ON "DAILY_REFINE_DECISION" ("user_id", "item_type", "canonical_subcategory", "cooldown_until")
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "DAILY_REFINE_DECISION_uncommitted_idx"
+          ON "DAILY_REFINE_DECISION" ("user_id", "committed_at")
+      `);
+    } catch {
+      // User or DailyQueue may not exist yet on a fresh database — migrate()
+      // creates them before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -382,6 +382,13 @@ export async function updateDomainDifficultyOnAnswer(
     return;
   }
 
+  if (isFrozen(existing.freezeUntil, new Date())) {
+    // Refine Your Game "Ease off": the served difficulty is pinned for the
+    // freeze window. Hold the level AND the streak counters so the domain
+    // resumes exactly where it left off once the freeze lapses.
+    return;
+  }
+
   // Erosion floor is declared-only: declared domains carry the engaged-fan
   // floor, demonstrated domains step down freely (default 'accessible' floor).
   const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
@@ -399,6 +406,66 @@ export async function updateDomainDifficultyOnAnswer(
       lastUpdated: new Date(),
     })
     .where(eq(userDomainDifficulties.id, existing.id));
+}
+
+/** True while an "Ease off" freeze is in effect for a domain. */
+export function isFrozen(freezeUntil: Date | null | undefined, now: Date): boolean {
+  return Boolean(freezeUntil && freezeUntil.getTime() > now.getTime());
+}
+
+/**
+ * Pin a domain's served difficulty until `until` (Refine Your Game "Ease off").
+ * While frozen, updateDomainDifficultyOnAnswer() leaves the level and streaks
+ * untouched. Escalation normally means a row already exists; the insert branch
+ * is a guard that seeds a served level the same way a first answer would.
+ */
+export async function freezeDomainDifficulty(
+  userId: string,
+  canonicalSubcategory: string,
+  until: Date,
+): Promise<void> {
+  if (!canonicalSubcategory) return;
+
+  const [existing] = await db
+    .select({ id: userDomainDifficulties.id })
+    .from(userDomainDifficulties)
+    .where(and(
+      eq(userDomainDifficulties.userId, userId),
+      eq(userDomainDifficulties.canonicalSubcategory, canonicalSubcategory),
+    ))
+    .limit(1);
+
+  if (existing) {
+    await db
+      .update(userDomainDifficulties)
+      .set({ freezeUntil: until })
+      .where(eq(userDomainDifficulties.id, existing.id));
+    return;
+  }
+
+  const [level, focusDomains] = await Promise.all([
+    readCurrentAdaptiveLevel(userId),
+    getFocusDomainSet(userId, [canonicalSubcategory]),
+  ]);
+  const seed = applyFocusFloor(
+    seedDifficultyFromAdaptiveLevel(level),
+    focusDomains.has(canonicalSubcategory),
+  );
+  await db
+    .insert(userDomainDifficulties)
+    .values({
+      userId,
+      canonicalSubcategory,
+      servedDifficulty: seed,
+      consecutiveCorrect: 0,
+      consecutiveIncorrect: 0,
+      lastUpdated: new Date(),
+      freezeUntil: until,
+    })
+    .onConflictDoUpdate({
+      target: [userDomainDifficulties.userId, userDomainDifficulties.canonicalSubcategory],
+      set: { freezeUntil: until },
+    });
 }
 
 /**

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -23,6 +23,7 @@ import {
 } from '@/server/daily/generate-questions';
 import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import { commitPendingRefineDecisions } from '@/server/refine/commit';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
 
@@ -74,6 +75,17 @@ const overRequest = (needed: number) =>
 
 export async function fillDailyQueueForUser(userId: string): Promise<void> {
   const startedAt = Date.now();
+
+  // Commit point for Refine Your Game: staged decisions from the prior daily's
+  // summary become permanent when the player builds their next daily. Must run
+  // before the early returns below so it isn't skipped on a carry-forward day.
+  // Never let a refine-commit failure block queue building.
+  try {
+    await commitPendingRefineDecisions(userId);
+  } catch (error) {
+    console.warn('[daily] commitPendingRefineDecisions failed', error);
+  }
+
   const existing = await getTodaysDailyQueue(userId);
   if (existing && asQueueSlots(existing.slots).length > 0) {
     // A populated today-queue normally stands. The exception is a SHORT,

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -12,8 +12,10 @@ import {
 import { resolveTier } from '@/server/mastery/tiers';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
+import { buildRefineSection } from '@/server/db/queries/refine';
 import { getFeedPagePayload } from '@/server/feed/get-feed-page';
 import type { QueueSlot } from '@/server/daily/types';
+import type { RefineSectionView } from '@/server/refine/types';
 import type { MasteryTier } from '@/types/db';
 
 const ONE_DAY_MS = 24 * 60 * 60 * 1000;
@@ -32,6 +34,8 @@ export type DailySummaryView = {
   recentFriendBridge: RecentFriendBridge | null;
   isFirstCompletedRound: boolean;
   reminderPromptState: 'show' | 'hidden';
+  /** Contextual "Refine Your Game" offers derived from this daily (empty → reassurance state). */
+  refine: RefineSectionView;
 };
 
 export type RecentFriendBridge = {
@@ -241,6 +245,9 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const recentFriendBridge = await getRecentFriendBridge(userId);
   const { isFirstCompletedRound, reminderPromptState } =
     await computeReminderPromptState(userId, dateString, totalAnswered);
+  const refine = queue
+    ? await buildRefineSection(userId, queue.id, slots)
+    : { items: [] };
 
   return {
     date: dateString,
@@ -266,6 +273,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     recentFriendBridge,
     isFirstCompletedRound,
     reminderPromptState,
+    refine,
   };
 }
 

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -245,9 +245,9 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
   const recentFriendBridge = await getRecentFriendBridge(userId);
   const { isFirstCompletedRound, reminderPromptState } =
     await computeReminderPromptState(userId, dateString, totalAnswered);
-  const refine = queue
+  const refine: RefineSectionView = queue
     ? await buildRefineSection(userId, queue.id, slots)
-    : { items: [] };
+    : { queueId: null, items: [] };
 
   return {
     date: dateString,

--- a/src/server/db/queries/refine.ts
+++ b/src/server/db/queries/refine.ts
@@ -46,10 +46,12 @@ async function getServedDifficulties(
       served: userDomainDifficulties.servedDifficulty,
     })
     .from(userDomainDifficulties)
-    .where(and(
-      eq(userDomainDifficulties.userId, userId),
-      inArray(userDomainDifficulties.canonicalSubcategory, domains),
-    ));
+    .where(
+      and(
+        eq(userDomainDifficulties.userId, userId),
+        inArray(userDomainDifficulties.canonicalSubcategory, domains),
+      ),
+    );
   return new Map(rows.map((row) => [row.domain, row.served as RefineMissTier]));
 }
 
@@ -62,7 +64,9 @@ async function getServedDifficulties(
  * recent incorrect slot in this queue, falling back to the served difficulty.
  */
 export async function getMissStreaks(userId: string, slots: QueueSlot[]): Promise<MissStreak[]> {
-  const domains = [...new Set(slots.map((slot) => slot.domain).filter((d): d is string => Boolean(d)))];
+  const domains = [
+    ...new Set(slots.map((slot) => slot.domain).filter((d): d is string => Boolean(d))),
+  ];
   if (domains.length === 0) return [];
 
   // Latest-miss tier from in-queue slots (later slot_index = more recent).
@@ -82,10 +86,9 @@ export async function getMissStreaks(userId: string, slots: QueueSlot[]): Promis
         answerState: masteryEvents.answerState,
       })
       .from(masteryEvents)
-      .where(and(
-        eq(masteryEvents.userId, userId),
-        inArray(masteryEvents.canonicalSubcategory, domains),
-      ))
+      .where(
+        and(eq(masteryEvents.userId, userId), inArray(masteryEvents.canonicalSubcategory, domains)),
+      )
       .orderBy(masteryEvents.canonicalSubcategory, desc(masteryEvents.createdAt)),
   ]);
 
@@ -125,10 +128,12 @@ export async function getActiveCooldowns(userId: string): Promise<Set<string>> {
       friendId: dailyRefineDecisions.friendId,
     })
     .from(dailyRefineDecisions)
-    .where(and(
-      eq(dailyRefineDecisions.userId, userId),
-      gt(dailyRefineDecisions.cooldownUntil, new Date()),
-    ));
+    .where(
+      and(
+        eq(dailyRefineDecisions.userId, userId),
+        gt(dailyRefineDecisions.cooldownUntil, new Date()),
+      ),
+    );
   return new Set(
     rows.map((row) => refineItemKey(row.itemType as RefineItemType, row.subdomain, row.friendId)),
   );
@@ -143,12 +148,14 @@ async function getPendingDecisionKeys(userId: string, queueId: string): Promise<
       friendId: dailyRefineDecisions.friendId,
     })
     .from(dailyRefineDecisions)
-    .where(and(
-      eq(dailyRefineDecisions.userId, userId),
-      eq(dailyRefineDecisions.queueId, queueId),
-      eq(dailyRefineDecisions.action, 'pending'),
-      isNull(dailyRefineDecisions.committedAt),
-    ));
+    .where(
+      and(
+        eq(dailyRefineDecisions.userId, userId),
+        eq(dailyRefineDecisions.queueId, queueId),
+        eq(dailyRefineDecisions.action, 'pending'),
+        isNull(dailyRefineDecisions.committedAt),
+      ),
+    );
   return new Set(
     rows.map((row) => refineItemKey(row.itemType as RefineItemType, row.subdomain, row.friendId)),
   );
@@ -203,10 +210,13 @@ export async function buildRefineSection(
   queueId: string,
   slots: QueueSlot[],
 ): Promise<RefineSectionView> {
-  if (slots.length === 0) return { items: [] };
+  if (slots.length === 0) return { queueId, items: [] };
   const [selected, pendingKeys] = await Promise.all([
     deriveSelectedRefineCandidates(userId, slots),
     getPendingDecisionKeys(userId, queueId),
   ]);
-  return { items: selected.map((candidate) => candidateToItem(candidate, queueId, pendingKeys)) };
+  return {
+    queueId,
+    items: selected.map((candidate) => candidateToItem(candidate, queueId, pendingKeys)),
+  };
 }

--- a/src/server/db/queries/refine.ts
+++ b/src/server/db/queries/refine.ts
@@ -1,0 +1,212 @@
+/**
+ * Refine Your Game — DB reads + section assembly.
+ *
+ * Pure firing rules and copy live under src/server/refine/; this module loads
+ * the evidence they need (owned set, miss-streak history, cooldowns, existing
+ * decisions) and assembles the RefineSectionView consumed by the daily summary.
+ */
+
+import { and, desc, eq, gt, inArray, isNull } from 'drizzle-orm';
+
+import { db, dailyRefineDecisions, masteryEvents, userDomainDifficulties } from '@/server/db';
+import type { QueueSlot } from '@/server/daily/types';
+import { getKnowledgeBase } from '@/server/db/queries/daily';
+import {
+  deriveDifficultyEscalation,
+  deriveFriendExpansion,
+  deriveStrugglePruning,
+  type MissStreak,
+} from '@/server/refine/derive';
+import { openText, resolvedText, subdomainLabel } from '@/server/refine/copy';
+import { selectRefineCandidates } from '@/server/refine/select';
+import {
+  REFINE_VERB,
+  refineItemKey,
+  type RefineCandidate,
+  type RefineItem,
+  type RefineItemType,
+  type RefineMissTier,
+  type RefineSectionView,
+} from '@/server/refine/types';
+
+/** Lowercased canonical subcategories the player currently owns (knowledge base). */
+export async function getOwnedSubcategories(userId: string): Promise<Set<string>> {
+  const knowledgeBase = await getKnowledgeBase(userId);
+  return new Set(knowledgeBase.map((domain) => domain.domain.toLowerCase()));
+}
+
+async function getServedDifficulties(
+  userId: string,
+  domains: string[],
+): Promise<Map<string, RefineMissTier>> {
+  if (domains.length === 0) return new Map();
+  const rows = await db
+    .select({
+      domain: userDomainDifficulties.canonicalSubcategory,
+      served: userDomainDifficulties.servedDifficulty,
+    })
+    .from(userDomainDifficulties)
+    .where(and(
+      eq(userDomainDifficulties.userId, userId),
+      inArray(userDomainDifficulties.canonicalSubcategory, domains),
+    ));
+  return new Map(rows.map((row) => [row.domain, row.served as RefineMissTier]));
+}
+
+/**
+ * Trailing consecutive-miss run per domain in the just-finished queue.
+ *
+ * Walks MASTERY_EVENTS most-recent-first per subcategory: an 'incorrect' extends
+ * the run, any correct answer ends it (resets to 0), non-graded credit rows
+ * (null answer_state) are skipped. The latest-miss tier comes from the most
+ * recent incorrect slot in this queue, falling back to the served difficulty.
+ */
+export async function getMissStreaks(userId: string, slots: QueueSlot[]): Promise<MissStreak[]> {
+  const domains = [...new Set(slots.map((slot) => slot.domain).filter((d): d is string => Boolean(d)))];
+  if (domains.length === 0) return [];
+
+  // Latest-miss tier from in-queue slots (later slot_index = more recent).
+  const latestSlotMissTier = new Map<string, RefineMissTier>();
+  const orderedSlots = [...slots].sort((a, b) => a.slot_index - b.slot_index);
+  for (const slot of orderedSlots) {
+    if (slot.answer_state !== 'incorrect') continue;
+    if (!slot.domain || !slot.difficulty_estimate) continue;
+    latestSlotMissTier.set(slot.domain, slot.difficulty_estimate);
+  }
+
+  const [served, events] = await Promise.all([
+    getServedDifficulties(userId, domains),
+    db
+      .select({
+        domain: masteryEvents.canonicalSubcategory,
+        answerState: masteryEvents.answerState,
+      })
+      .from(masteryEvents)
+      .where(and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.canonicalSubcategory, domains),
+      ))
+      .orderBy(masteryEvents.canonicalSubcategory, desc(masteryEvents.createdAt)),
+  ]);
+
+  const counts = new Map<string, number>();
+  const stopped = new Set<string>();
+  for (const event of events) {
+    if (stopped.has(event.domain)) continue;
+    if (event.answerState === 'incorrect') {
+      counts.set(event.domain, (counts.get(event.domain) ?? 0) + 1);
+    } else if (event.answerState === null) {
+      continue; // non-graded credit row — neither extends nor breaks the run
+    } else {
+      stopped.add(event.domain); // a correct answer ends the trailing miss run
+    }
+  }
+
+  const streaks: MissStreak[] = [];
+  for (const domain of domains) {
+    const count = counts.get(domain) ?? 0;
+    if (count <= 0) continue;
+    streaks.push({
+      subdomainId: domain,
+      subdomainLabel: subdomainLabel(domain),
+      count,
+      latestMissTier: latestSlotMissTier.get(domain) ?? served.get(domain) ?? 'moderate',
+    });
+  }
+  return streaks;
+}
+
+/** Item keys whose cooldown is still active (suppressed from re-firing). */
+export async function getActiveCooldowns(userId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      itemType: dailyRefineDecisions.itemType,
+      subdomain: dailyRefineDecisions.canonicalSubcategory,
+      friendId: dailyRefineDecisions.friendId,
+    })
+    .from(dailyRefineDecisions)
+    .where(and(
+      eq(dailyRefineDecisions.userId, userId),
+      gt(dailyRefineDecisions.cooldownUntil, new Date()),
+    ));
+  return new Set(
+    rows.map((row) => refineItemKey(row.itemType as RefineItemType, row.subdomain, row.friendId)),
+  );
+}
+
+/** Item keys with a staged (uncommitted) decision for this queue → render resolved. */
+async function getPendingDecisionKeys(userId: string, queueId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({
+      itemType: dailyRefineDecisions.itemType,
+      subdomain: dailyRefineDecisions.canonicalSubcategory,
+      friendId: dailyRefineDecisions.friendId,
+    })
+    .from(dailyRefineDecisions)
+    .where(and(
+      eq(dailyRefineDecisions.userId, userId),
+      eq(dailyRefineDecisions.queueId, queueId),
+      eq(dailyRefineDecisions.action, 'pending'),
+      isNull(dailyRefineDecisions.committedAt),
+    ));
+  return new Set(
+    rows.map((row) => refineItemKey(row.itemType as RefineItemType, row.subdomain, row.friendId)),
+  );
+}
+
+function candidateToItem(
+  candidate: RefineCandidate,
+  queueId: string,
+  pendingKeys: Set<string>,
+): RefineItem {
+  const key = refineItemKey(candidate.type, candidate.subdomainId, candidate.friendId);
+  return {
+    id: `${queueId}:${key}`,
+    type: candidate.type,
+    subdomainId: candidate.subdomainId,
+    subdomainLabel: candidate.subdomainLabel,
+    friendId: candidate.friendId,
+    friendName: candidate.friendName,
+    openText: openText(candidate),
+    resolvedText: resolvedText(candidate),
+    actionVerb: REFINE_VERB[candidate.type],
+    state: pendingKeys.has(key) ? 'resolved' : 'open',
+  };
+}
+
+/**
+ * Re-derives the refine candidates for a given queue (shared by the summary
+ * builder and the resolve/commit paths so the server never trusts the client
+ * about which items are real). Returns selected, cooldown-filtered candidates.
+ */
+export async function deriveSelectedRefineCandidates(
+  userId: string,
+  slots: QueueSlot[],
+): Promise<RefineCandidate[]> {
+  if (slots.length === 0) return [];
+  const [ownedSet, missStreaks, cooldowns] = await Promise.all([
+    getOwnedSubcategories(userId),
+    getMissStreaks(userId, slots),
+    getActiveCooldowns(userId),
+  ]);
+  const candidates: RefineCandidate[] = [
+    ...deriveFriendExpansion(slots, ownedSet),
+    ...deriveDifficultyEscalation(slots),
+    ...deriveStrugglePruning(missStreaks),
+  ];
+  return selectRefineCandidates(candidates, cooldowns);
+}
+
+/** Assemble the RefineSectionView for the daily summary. */
+export async function buildRefineSection(
+  userId: string,
+  queueId: string,
+  slots: QueueSlot[],
+): Promise<RefineSectionView> {
+  if (slots.length === 0) return { items: [] };
+  const [selected, pendingKeys] = await Promise.all([
+    deriveSelectedRefineCandidates(userId, slots),
+    getPendingDecisionKeys(userId, queueId),
+  ]);
+  return { items: selected.map((candidate) => candidateToItem(candidate, queueId, pendingKeys)) };
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -708,6 +708,10 @@ export const userDomainDifficulties = pgTable(
     consecutiveCorrect: integer('consecutive_correct').notNull().default(0),
     consecutiveIncorrect: integer('consecutive_incorrect').notNull().default(0),
     lastUpdated: timestamp('last_updated', { withTimezone: true }).notNull().defaultNow(),
+    // Refine Your Game "Ease off": while this is in the future the served
+    // difficulty is pinned — updateDomainDifficultyOnAnswer() skips the step.
+    // NULL means no freeze (normal adaptive behavior).
+    freezeUntil: timestamp('freeze_until', { withTimezone: true }),
   },
   (table) => [
     unique('USER_DOMAIN_DIFFICULTY_user_id_canonical_subcategory_key').on(
@@ -733,6 +737,42 @@ export const userDomainExclusions = pgTable(
       table.scope,
       table.canonicalSubcategory,
     ),
+  ],
+);
+
+// Decision + cooldown ledger for the Refine Your Game section on the daily
+// summary. One row per refine item the player acted on (or that was shown and
+// defaulted). `action` moves pending -> committed | defaulted; staged changes
+// apply at next-daily build (src/server/refine/commit.ts), which is also when
+// `cooldownUntil` is stamped. See drizzle/0063_daily_refine_decision.sql.
+export const dailyRefineDecisions = pgTable(
+  'DAILY_REFINE_DECISION',
+  {
+    id: id(),
+    userId: text('user_id').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    queueId: text('queue_id').notNull().references(() => dailyQueues.id, { onDelete: 'cascade' }),
+    // 'friend_expansion' | 'difficulty_escalation' | 'struggle_pruning'
+    itemType: text('item_type').notNull(),
+    canonicalSubcategory: text('canonical_subcategory').notNull(),
+    // Set only for friend_expansion (the bonus source friend).
+    friendId: text('friend_id'),
+    // 'pending' | 'committed' | 'defaulted'
+    action: text('action').notNull().default('pending'),
+    committedAt: timestamp('committed_at', { withTimezone: true }),
+    cooldownUntil: timestamp('cooldown_until', { withTimezone: true }),
+    createdAt: createdAt(),
+    updatedAt: updatedAt(),
+  },
+  (table) => [
+    // COALESCE(friend_id,'') in the unique index keeps the upsert key stable
+    // for non-expansion rows; expressed in SQL (drizzle/0063), not modeled here.
+    index('DAILY_REFINE_DECISION_cooldown_idx').on(
+      table.userId,
+      table.itemType,
+      table.canonicalSubcategory,
+      table.cooldownUntil,
+    ),
+    index('DAILY_REFINE_DECISION_uncommitted_idx').on(table.userId, table.committedAt),
   ],
 );
 

--- a/src/server/refine/commit.ts
+++ b/src/server/refine/commit.ts
@@ -59,11 +59,13 @@ async function applyResolvedEffect(userId: string, row: DecisionRow, until: Date
         });
       await db
         .delete(userDomainExclusions)
-        .where(and(
-          eq(userDomainExclusions.userId, userId),
-          eq(userDomainExclusions.scope, 'subcategory'),
-          eq(userDomainExclusions.canonicalSubcategory, domain),
-        ));
+        .where(
+          and(
+            eq(userDomainExclusions.userId, userId),
+            eq(userDomainExclusions.scope, 'subcategory'),
+            eq(userDomainExclusions.canonicalSubcategory, domain),
+          ),
+        );
       return;
     case 'struggle_pruning':
       await db
@@ -90,11 +92,13 @@ export async function commitPendingRefineDecisions(userId: string): Promise<void
   const pending = await db
     .select()
     .from(dailyRefineDecisions)
-    .where(and(
-      eq(dailyRefineDecisions.userId, userId),
-      eq(dailyRefineDecisions.action, 'pending'),
-      isNull(dailyRefineDecisions.committedAt),
-    ));
+    .where(
+      and(
+        eq(dailyRefineDecisions.userId, userId),
+        eq(dailyRefineDecisions.action, 'pending'),
+        isNull(dailyRefineDecisions.committedAt),
+      ),
+    );
 
   for (const row of pending) {
     const cooldownUntil = new Date(now.getTime() + COOLDOWN_MS[row.itemType as RefineItemType]);
@@ -119,13 +123,15 @@ export async function commitPendingRefineDecisions(userId: string): Promise<void
   const [priorQueue] = await db
     .select({ id: dailyQueues.id, slots: dailyQueues.slots })
     .from(dailyQueues)
-    .where(and(
-      eq(dailyQueues.userId, userId),
-      sql`EXISTS (
+    .where(
+      and(
+        eq(dailyQueues.userId, userId),
+        sql`EXISTS (
         SELECT 1 FROM jsonb_array_elements(${dailyQueues.slots}) slot
         WHERE (slot->>'answered')::boolean IS TRUE
       )`,
-    ))
+      ),
+    )
     .orderBy(desc(dailyQueues.queueDate))
     .limit(1);
 

--- a/src/server/refine/commit.ts
+++ b/src/server/refine/commit.ts
@@ -1,0 +1,150 @@
+/**
+ * Refine Your Game — commit at next-daily build.
+ *
+ * Staged decisions (and the status-quo defaults of shown-but-unacted items)
+ * become permanent when the player builds their next daily. fillDailyQueueForUser
+ * calls commitPendingRefineDecisions() at its very top, before any early return.
+ *
+ * The flow is idempotent: staged rows are filtered by `committed_at IS NULL`, all
+ * effect writes are upserts / conflict-safe, and the defaulted-cooldown insert
+ * uses ON CONFLICT DO NOTHING against the unique item index.
+ */
+
+import { and, desc, eq, isNull, sql } from 'drizzle-orm';
+
+import {
+  dailyQueues,
+  dailyRefineDecisions,
+  db,
+  declaredInterests,
+  userDomainExclusions,
+} from '@/server/db';
+import { freezeDomainDifficulty } from '@/server/adaptive-difficulty';
+import { deriveSelectedRefineCandidates } from '@/server/db/queries/refine';
+import type { QueueSlot } from '@/server/daily/types';
+import type { RefineItemType } from '@/server/refine/types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Per-type cooldown after a decision commits (defaulted or resolved). */
+const COOLDOWN_MS: Record<RefineItemType, number> = {
+  friend_expansion: 1 * DAY_MS,
+  // Escalation re-suppression is the freeze window itself; mirror it here so the
+  // heads-up doesn't re-fire while the freeze is active.
+  difficulty_escalation: 30 * DAY_MS,
+  struggle_pruning: 7 * DAY_MS,
+};
+
+const FREEZE_MS = 30 * DAY_MS;
+
+function asQueueSlots(value: unknown): QueueSlot[] {
+  return Array.isArray(value) ? (value as QueueSlot[]) : [];
+}
+
+type DecisionRow = typeof dailyRefineDecisions.$inferSelect;
+
+/** Apply the durable effect of a resolved refine decision. */
+async function applyResolvedEffect(userId: string, row: DecisionRow, until: Date): Promise<void> {
+  const domain = row.canonicalSubcategory;
+  switch (row.itemType as RefineItemType) {
+    case 'friend_expansion':
+      // Promote the bonus subdomain into the owned set, and lift any prior
+      // exclusion so getKnowledgeBase stops filtering it out.
+      await db
+        .insert(declaredInterests)
+        .values({ userId, domain, isActive: true })
+        .onConflictDoUpdate({
+          target: [declaredInterests.userId, declaredInterests.domain],
+          set: { isActive: true },
+        });
+      await db
+        .delete(userDomainExclusions)
+        .where(and(
+          eq(userDomainExclusions.userId, userId),
+          eq(userDomainExclusions.scope, 'subcategory'),
+          eq(userDomainExclusions.canonicalSubcategory, domain),
+        ));
+      return;
+    case 'struggle_pruning':
+      await db
+        .insert(userDomainExclusions)
+        .values({ userId, canonicalSubcategory: domain, scope: 'subcategory' })
+        .onConflictDoNothing({
+          target: [
+            userDomainExclusions.userId,
+            userDomainExclusions.scope,
+            userDomainExclusions.canonicalSubcategory,
+          ],
+        });
+      return;
+    case 'difficulty_escalation':
+      await freezeDomainDifficulty(userId, domain, until);
+      return;
+  }
+}
+
+export async function commitPendingRefineDecisions(userId: string): Promise<void> {
+  const now = new Date();
+
+  // 1. Apply every staged (uncommitted) decision, then stamp its cooldown.
+  const pending = await db
+    .select()
+    .from(dailyRefineDecisions)
+    .where(and(
+      eq(dailyRefineDecisions.userId, userId),
+      eq(dailyRefineDecisions.action, 'pending'),
+      isNull(dailyRefineDecisions.committedAt),
+    ));
+
+  for (const row of pending) {
+    const cooldownUntil = new Date(now.getTime() + COOLDOWN_MS[row.itemType as RefineItemType]);
+    try {
+      await applyResolvedEffect(userId, row, new Date(now.getTime() + FREEZE_MS));
+    } catch (error) {
+      // Leave the row uncommitted so a later build retries rather than dropping
+      // a decision the player made.
+      console.warn('[refine/commit] effect failed', row.itemType, row.canonicalSubcategory, error);
+      continue;
+    }
+    await db
+      .update(dailyRefineDecisions)
+      .set({ action: 'committed', committedAt: now, cooldownUntil, updatedAt: now })
+      .where(eq(dailyRefineDecisions.id, row.id));
+  }
+
+  // 2. Stamp default cooldowns for shown-but-unacted items on the most recent
+  //    completed queue (the summary the player just saw), so the same evidence
+  //    doesn't immediately re-fire. After step 1, resolved items carry an active
+  //    cooldown, so re-derivation yields only the defaulted ones.
+  const [priorQueue] = await db
+    .select({ id: dailyQueues.id, slots: dailyQueues.slots })
+    .from(dailyQueues)
+    .where(and(
+      eq(dailyQueues.userId, userId),
+      sql`EXISTS (
+        SELECT 1 FROM jsonb_array_elements(${dailyQueues.slots}) slot
+        WHERE (slot->>'answered')::boolean IS TRUE
+      )`,
+    ))
+    .orderBy(desc(dailyQueues.queueDate))
+    .limit(1);
+
+  if (!priorQueue) return;
+
+  const defaulted = await deriveSelectedRefineCandidates(userId, asQueueSlots(priorQueue.slots));
+  for (const candidate of defaulted) {
+    await db
+      .insert(dailyRefineDecisions)
+      .values({
+        userId,
+        queueId: priorQueue.id,
+        itemType: candidate.type,
+        canonicalSubcategory: candidate.subdomainId,
+        friendId: candidate.friendId ?? null,
+        action: 'defaulted',
+        committedAt: now,
+        cooldownUntil: new Date(now.getTime() + COOLDOWN_MS[candidate.type]),
+      })
+      .onConflictDoNothing();
+  }
+}

--- a/src/server/refine/copy.ts
+++ b/src/server/refine/copy.ts
@@ -1,0 +1,46 @@
+/**
+ * Refine Your Game — copy generation (pure).
+ *
+ * Each item answers "why am I seeing this now?" with fresh evidence, then asks
+ * for the single decision. The doing-nothing default is always the safe status
+ * quo, so the prose frames the action as the change away from it.
+ */
+
+import type { RefineCandidate } from './types';
+
+/**
+ * Human-readable subdomain phrase for prose. Replaces separators and collapses
+ * whitespace but preserves the source casing so proper nouns ("Sondheim") and
+ * snake_case domains ("subprime_mortgage" → "subprime mortgage") both read well.
+ */
+export function subdomainLabel(domain: string): string {
+  return domain.replace(/[_-]+/g, ' ').replace(/\s+/g, ' ').trim();
+}
+
+/** Evidence + the decision question, shown in the open state. */
+export function openText(candidate: RefineCandidate): string {
+  const label = candidate.subdomainLabel;
+  switch (candidate.type) {
+    case 'friend_expansion': {
+      const friend = candidate.friendName?.trim() || 'a friend';
+      return `You got a ${label} question from ${friend}'s world right. Add it to your daily five?`;
+    }
+    case 'difficulty_escalation':
+      return `You're mastering ${label}, so its questions are getting harder. Ease off?`;
+    case 'struggle_pruning':
+      return `You've missed the last ${candidate.missCount ?? 0} ${label} questions. Drop them from your daily five?`;
+  }
+}
+
+/** The choice restated as a completed fact, shown in the resolved state. */
+export function resolvedText(candidate: RefineCandidate): string {
+  const label = candidate.subdomainLabel;
+  switch (candidate.type) {
+    case 'friend_expansion':
+      return `Added ${label} to your daily five.`;
+    case 'difficulty_escalation':
+      return `We'll keep ${label} at this level for the next month.`;
+    case 'struggle_pruning':
+      return `Dropped ${label} from your daily five.`;
+  }
+}

--- a/src/server/refine/derive.ts
+++ b/src/server/refine/derive.ts
@@ -1,0 +1,96 @@
+/**
+ * Refine Your Game — firing rules (pure).
+ *
+ * Each function takes already-loaded evidence (queue slots, precomputed miss
+ * streaks) and returns candidates. No DB access — the reads live in
+ * src/server/db/queries/refine.ts so these stay unit-testable.
+ */
+
+import type { QueueSlot } from '@/server/daily/types';
+import { subdomainLabel } from './copy';
+import {
+  pruningThreshold,
+  type RefineCandidate,
+  type RefineMissTier,
+} from './types';
+
+/**
+ * friend_expansion (priority 1): the player answered ≥1 question correctly from
+ * a friend's bonus subdomain they don't own. Once is enough, deduped per
+ * (subdomain, friend). A bonus slot is marked by `presence_source_id`.
+ */
+export function deriveFriendExpansion(
+  slots: QueueSlot[],
+  ownedLowercased: Set<string>,
+): RefineCandidate[] {
+  const byKey = new Map<string, RefineCandidate>();
+  for (const slot of slots) {
+    if (!slot.presence_source_id) continue; // not a bonus slot
+    if (slot.answer_state !== 'correct') continue;
+    const domain = slot.domain?.trim();
+    if (!domain) continue;
+    if (ownedLowercased.has(domain.toLowerCase())) continue; // already owned
+    const friendId = slot.presence_source_id;
+    const key = `${domain.toLowerCase()}:${friendId}`;
+    if (byKey.has(key)) continue;
+    byKey.set(key, {
+      type: 'friend_expansion',
+      subdomainId: domain,
+      subdomainLabel: subdomainLabel(domain),
+      friendId,
+      friendName: slot.presence_source_name ?? undefined,
+    });
+  }
+  return [...byKey.values()];
+}
+
+/**
+ * difficulty_escalation (priority 2): a subdomain's difficulty stepped up this
+ * daily (`difficulty_stepped_up`). One candidate per subdomain. Escalation is
+ * automatic, so this is an opt-out heads-up.
+ */
+export function deriveDifficultyEscalation(slots: QueueSlot[]): RefineCandidate[] {
+  const byDomain = new Map<string, RefineCandidate>();
+  for (const slot of slots) {
+    if (slot.difficulty_stepped_up !== true) continue;
+    const domain = slot.domain?.trim();
+    if (!domain) continue;
+    const key = domain.toLowerCase();
+    if (byDomain.has(key)) continue;
+    byDomain.set(key, {
+      type: 'difficulty_escalation',
+      subdomainId: domain,
+      subdomainLabel: subdomainLabel(domain),
+    });
+  }
+  return [...byDomain.values()];
+}
+
+/** A precomputed trailing consecutive-miss run for one subdomain. */
+export interface MissStreak {
+  subdomainId: string;
+  subdomainLabel: string;
+  /** Consecutive misses since the last correct answer (0 if the latest was correct). */
+  count: number;
+  /** Tier of the most recent miss in the run — selects the threshold. */
+  latestMissTier: RefineMissTier;
+}
+
+/**
+ * struggle_pruning (priority 3): consecutive misses reaching the tiered
+ * threshold (3/4/5 by the latest miss's tier).
+ */
+export function deriveStrugglePruning(streaks: MissStreak[]): RefineCandidate[] {
+  const out: RefineCandidate[] = [];
+  for (const streak of streaks) {
+    if (streak.count >= pruningThreshold(streak.latestMissTier)) {
+      out.push({
+        type: 'struggle_pruning',
+        subdomainId: streak.subdomainId,
+        subdomainLabel: streak.subdomainLabel,
+        missCount: streak.count,
+      });
+    }
+  }
+  return out;
+}

--- a/src/server/refine/derive.ts
+++ b/src/server/refine/derive.ts
@@ -8,11 +8,7 @@
 
 import type { QueueSlot } from '@/server/daily/types';
 import { subdomainLabel } from './copy';
-import {
-  pruningThreshold,
-  type RefineCandidate,
-  type RefineMissTier,
-} from './types';
+import { pruningThreshold, type RefineCandidate, type RefineMissTier } from './types';
 
 /**
  * friend_expansion (priority 1): the player answered ≥1 question correctly from

--- a/src/server/refine/select.ts
+++ b/src/server/refine/select.ts
@@ -1,0 +1,22 @@
+/**
+ * Refine Your Game — selection (pure).
+ *
+ * Drop anything in cooldown, order by priority, keep the top three.
+ */
+
+import {
+  REFINE_MAX_ITEMS,
+  REFINE_PRIORITY,
+  refineItemKey,
+  type RefineCandidate,
+} from './types';
+
+export function selectRefineCandidates(
+  candidates: RefineCandidate[],
+  activeCooldowns: Set<string>,
+): RefineCandidate[] {
+  return candidates
+    .filter((c) => !activeCooldowns.has(refineItemKey(c.type, c.subdomainId, c.friendId)))
+    .sort((a, b) => REFINE_PRIORITY[a.type] - REFINE_PRIORITY[b.type])
+    .slice(0, REFINE_MAX_ITEMS);
+}

--- a/src/server/refine/select.ts
+++ b/src/server/refine/select.ts
@@ -4,12 +4,7 @@
  * Drop anything in cooldown, order by priority, keep the top three.
  */
 
-import {
-  REFINE_MAX_ITEMS,
-  REFINE_PRIORITY,
-  refineItemKey,
-  type RefineCandidate,
-} from './types';
+import { REFINE_MAX_ITEMS, REFINE_PRIORITY, refineItemKey, type RefineCandidate } from './types';
 
 export function selectRefineCandidates(
   candidates: RefineCandidate[],

--- a/src/server/refine/types.ts
+++ b/src/server/refine/types.ts
@@ -8,10 +8,7 @@
  * (src/server/refine/select.ts) depend on. Everything here is pure.
  */
 
-export type RefineItemType =
-  | 'friend_expansion'
-  | 'difficulty_escalation'
-  | 'struggle_pruning';
+export type RefineItemType = 'friend_expansion' | 'difficulty_escalation' | 'struggle_pruning';
 
 export type RefineActionVerb = 'Add' | 'Ease off' | 'Drop';
 
@@ -48,6 +45,8 @@ export interface RefineItem {
 }
 
 export interface RefineSectionView {
+  /** Queue the items belong to; the client posts it on resolve/undo. Null when no daily ran. */
+  queueId: string | null;
   items: RefineItem[];
 }
 

--- a/src/server/refine/types.ts
+++ b/src/server/refine/types.ts
@@ -1,0 +1,91 @@
+/**
+ * Refine Your Game — shared types + pure helpers.
+ *
+ * The daily summary surfaces up to three evidence-based "refine" items drawn
+ * from the daily just finished. This module holds the type shapes plus the
+ * priority / verb / threshold tables that both the derivation rules
+ * (src/server/refine/derive.ts) and the selection step
+ * (src/server/refine/select.ts) depend on. Everything here is pure.
+ */
+
+export type RefineItemType =
+  | 'friend_expansion'
+  | 'difficulty_escalation'
+  | 'struggle_pruning';
+
+export type RefineActionVerb = 'Add' | 'Ease off' | 'Drop';
+
+export type RefineItemState = 'open' | 'resolved';
+
+/** The three difficulty tiers a missed question can carry. */
+export type RefineMissTier = 'accessible' | 'moderate' | 'specialist';
+
+/** A firing-rule output, before copy is attached. */
+export interface RefineCandidate {
+  type: RefineItemType;
+  /** canonical_subcategory the item targets. */
+  subdomainId: string;
+  subdomainLabel: string;
+  /** friend_expansion only — the bonus source friend. */
+  friendId?: string;
+  friendName?: string;
+  /** struggle_pruning only — trailing consecutive miss count, used in evidence copy. */
+  missCount?: number;
+}
+
+/** The shape the client renders (open or resolved). */
+export interface RefineItem {
+  id: string;
+  type: RefineItemType;
+  subdomainId: string;
+  subdomainLabel: string;
+  friendId?: string;
+  friendName?: string;
+  openText: string;
+  resolvedText: string;
+  actionVerb: RefineActionVerb;
+  state: RefineItemState;
+}
+
+export interface RefineSectionView {
+  items: RefineItem[];
+}
+
+/**
+ * Selection priority — lower fires first. Matches the spec table:
+ * friend_expansion (1) → difficulty_escalation (2) → struggle_pruning (3).
+ */
+export const REFINE_PRIORITY: Record<RefineItemType, number> = {
+  friend_expansion: 0,
+  difficulty_escalation: 1,
+  struggle_pruning: 2,
+};
+
+export const REFINE_VERB: Record<RefineItemType, RefineActionVerb> = {
+  friend_expansion: 'Add',
+  difficulty_escalation: 'Ease off',
+  struggle_pruning: 'Drop',
+};
+
+/** Max items shown at once. */
+export const REFINE_MAX_ITEMS = 3;
+
+/**
+ * Stable identity / cooldown key for a candidate or decision row. Subdomain is
+ * lowercased so casing drift between slot data and stored rows can't split a key.
+ */
+export function refineItemKey(
+  type: RefineItemType,
+  subdomainId: string,
+  friendId?: string | null,
+): string {
+  return `${type}:${subdomainId.toLowerCase()}:${friendId ?? ''}`;
+}
+
+/**
+ * Tiered pruning threshold — N consecutive misses needed to fire, keyed by the
+ * tier of the LATEST miss in the run (spec edge case: latest, not hardest).
+ */
+export function pruningThreshold(latestMissTier: RefineMissTier): number {
+  return { accessible: 3, moderate: 4, specialist: 5 }[latestMissTier];
+}


### PR DESCRIPTION
## Refine Your Game

Adds a contextual **Refine Your Game** section to the daily summary (`/daily/summary`). It surfaces up to three evidence-based decisions about the player's daily five, drawn from the daily they just finished — replacing a trip to Settings for the common case. Doing nothing always equals the safe status-quo default; the single action verb is the change away from it.

> Targets **`dev2`**. Rebased onto `dev2`; my migrations were renumbered to `0064`/`0065` to sit on top of dev2's `0062`/`0063`.

### Item types
| Type | Fires when | Verb | Effect at commit | Cooldown |
|------|-----------|------|------------------|----------|
| `friend_expansion` | Answered ≥1 correct on an un-owned friend bonus subdomain | **Add** | `DeclaredInterest` (+ lift any exclusion) | 1 day |
| `difficulty_escalation` | A subdomain's difficulty stepped up this daily (`difficulty_stepped_up`) | **Ease off** | 30-day freeze on `USER_DOMAIN_DIFFICULTY.freeze_until` | 30 days |
| `struggle_pruning` | Trailing consecutive misses reach the tiered threshold (3/4/5 by the latest miss's tier) | **Drop** | `USER_DOMAIN_EXCLUSIONS` | 7 days |

Selection filters per-type cooldowns, orders by priority (friend → escalation → pruning), and keeps the top 3. Empty state still renders the header, a reassurance line, and a persistent "Manage all domains in Settings →" link.

### Lifecycle
Actions **stage** a change (with Undo) and **commit when the player builds their next daily** — the hook runs at the top of `fillDailyQueueForUser`, before its early returns. Undo is allowed only while uncommitted (409 once committed). Shown-but-unacted items get a default cooldown at commit so the same evidence doesn't immediately re-fire. The whole commit path is idempotent.

### Changes by stage
1. **Migrations** — `0064` (`USER_DOMAIN_DIFFICULTY.freeze_until`) and `0065` (`DAILY_REFINE_DECISION` ledger), mirrored in `schema.ts` with idempotent guards in `instrumentation.ts`.
2. **Derivation** — pure `src/server/refine/` (types, copy, three firing rules, selection) + `src/server/db/queries/refine.ts` (DB reads, `buildRefineSection`). Miss streaks come from `MASTERY_EVENTS` history; latest-miss tier from the in-queue slot, falling back to served difficulty.
3. **Lifecycle** — `POST/DELETE /api/daily/refine` (server re-derives so the client can't fabricate items), `commitPendingRefineDecisions`, and freeze enforcement in `adaptive-difficulty.ts`. The freeze check composes with dev2's declared-only erosion floor (freeze short-circuits first).
4. **UI** — `RefineYourGame` + `RefineItemCard` under `src/components/review/`, slotted into the summary after Round Recap; optimistic resolve/undo mirroring the existing exclude/undo flow.
5. **Tests** — 14 pure-logic unit tests covering the firing rules, selection, cooldowns, and exact copy.

### Verification
- ✅ Typecheck, ESLint (`src/`), `check-middleware` guard, and unit tests all pass on the rebased tree (refine + daily-answer + catchup suites: 32 tests green).
- ⚠️ **Not yet run against a live database.** Migrations + the real `/daily → summary → commit` flow (resolve/undo persistence, freeze, cooldowns) have not been exercised — the build environment had no `DATABASE_URL`. Manual script is in the session notes.

### Notes / decisions
- Section header uses the page's existing uppercase section-title style for consistency with peer sections (not the Figma serif) — easy to switch.
- Empty-state link points to `/knowledge` (there is no `/settings` route).
- Freeze is enforced on the answer-driven step path; the rare domain-**merge** ceremony writes `served_difficulty` directly but preserves `freeze_until`.
- `getMissStreaks` reads full history for the queue's domains (no row cap) — fine at normal volumes, flagged for scale.

https://claude.ai/code/session_01LM9Ntv1v9bSwethDKT2yqQ