### PR TITLE
Order homepage "What's Happening" head by recency

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -129,9 +129,17 @@ const HOME_HEAD_LIMIT = 3
 
 async function RecentActivityServerSection({ userId }: { userId: string }) {
   // The homepage head is the curated top of the one unified stream (same source
-  // as Lately): take the home-eligible items, already prominence-sorted.
+  // as Lately): take the home-eligible items. Lately's prominence sort puts
+  // higher tiers before recency, which let older "got your question" moments
+  // outrank genuinely newer home-eligible items (e.g. a recent milestone) and
+  // hide them below the head's slice. The homepage is a "what's happening NOW"
+  // surface, so re-sort the home-eligible items by recency before taking the
+  // head — Lately keeps its prominence ordering.
   const stream = await buildActivityStream(userId)
-  const items = stream.filter((item) => item.homeEligible).slice(0, HOME_HEAD_LIMIT)
+  const items = stream
+    .filter((item) => item.homeEligible)
+    .sort((a, b) => b.sortAt.getTime() - a.sortAt.getTime())
+    .slice(0, HOME_HEAD_LIMIT)
   return <RecentActivitySection items={items} />
 }
 


### PR DESCRIPTION
## Problem

The homepage "What's Happening" section showed staler activity than the Lately page, even though both are fed by the same `buildActivityStream()`.

That stream is sorted by **prominence tier first, recency second** (`src/lib/lately.ts:25`). The homepage then sliced the top 3 home-eligible items off that ordering:

```ts
stream.filter((item) => item.homeEligible).slice(0, HOME_HEAD_LIMIT)
```

So the head showed the 3 *highest-tier* items, not the 3 *newest*. "Robyn got your question" moments are tier 0 (most prominent), so they filled all three slots — and a genuinely newer home-eligible item (e.g. a recent milestone, tier 2) got pushed below the slice and never appeared on the homepage, even though Lately showed it.

## Fix

Re-sort the home-eligible items by recency before taking the head, so "What's Happening" reflects the most recent activity:

```ts
const items = stream
  .filter((item) => item.homeEligible)
  .sort((a, b) => b.sortAt.getTime() - a.sortAt.getTime())
  .slice(0, HOME_HEAD_LIMIT)
```

`.filter()` returns a fresh array, so the in-place `.sort()` does not disturb Lately, which keeps its prominence ordering unchanged.

## Scope

This keeps the existing home-eligible curation. Item types intentionally marked Lately-only — `you got them` moments, convergences, and niche-matches (`src/lib/activity-stream.ts:444-446,518`) — still do not appear on the homepage head. Any recent milestone / got-your-question / reaction / domain-opened activity will now surface.

## Testing

- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- No `src/middleware.ts` regression (repo uses `src/proxy.ts`)

https://claude.ai/code/session_018gzgKtjay7PFK3EeDfnQXj

---
_Generated by [Claude Code](https://claude.ai/code/session_018gzgKtjay7PFK3EeDfnQXj)_