### PR TITLE
Distinguish correct/incorrect milestone answers and lock missed ones

### DIFF
--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -6,7 +6,7 @@ import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
 import { getSession } from '@/server/auth/session';
 import { db, playerMastery, questions } from '@/server/db';
-import { getSeededPlayQuestions } from '@/server/db/queries/lately';
+import { getSeededPlayQuestions, getViewerAnswerStatusByQuestionId } from '@/server/db/queries/lately';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { gradeAnswer } from '@/server/grading';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
@@ -65,6 +65,19 @@ export async function POST(request: NextRequest) {
   // is "send it onward", not "answer", under the relationship rule.
   if (question.creatorId && question.creatorId === session.userId) {
     return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  // One shot: a milestone question the viewer has already attempted is LOCKED —
+  // whether they got it right (no double credit) or missed it (no retry). The UI
+  // surfaces this as a CORRECT / MISSED badge instead of an ANSWER button, but we
+  // re-enforce it here so a stale client (or a direct call) can't re-submit.
+  const priorStatus = await getViewerAnswerStatusByQuestionId(session.userId, [question.id]);
+  const already = priorStatus.get(question.id);
+  if (already) {
+    return NextResponse.json(
+      { error: 'already_answered', result: already },
+      { status: 409 },
+    );
   }
 
   const domain = question.canonicalSubcategory || question.broadCategory || question.category;

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -89,36 +89,48 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
   // expanded), so the answered-state is held HERE — not inside the expansion —
   // and ticks up + persists as the viewer answers, even after the result pop-up
   // closes or the line is collapsed and reopened. Milestone lines only.
+  //
+  // We hold the viewer's per-question RESULT (correct / incorrect), not just a
+  // boolean: a correct answer ticks the "{k} of {n} answered" progress; a missed
+  // one locks the question (one shot) but does not count as answered.
   const expand = item.expand;
   const milestoneQuestions = expand && expand.kind === 'milestone' ? expand.questions : null;
-  const [answeredIds, setAnsweredIds] = useState<Set<string>>(
-    () => new Set((milestoneQuestions ?? []).filter((q) => q.answered).map((q) => q.questionId)),
-  );
+  const [resultById, setResultById] = useState<Map<string, 'correct' | 'incorrect'>>(() => {
+    const seed = new Map<string, 'correct' | 'incorrect'>();
+    for (const q of milestoneQuestions ?? []) {
+      if (q.answerStatus === 'correct' || q.answerStatus === 'incorrect') {
+        seed.set(q.questionId, q.answerStatus);
+      }
+    }
+    return seed;
+  });
 
-  function markAnswered(questionId: string) {
-    setAnsweredIds((prev) => {
-      const next = new Set(prev);
-      next.add(questionId);
+  function recordResult(questionId: string, result: 'correct' | 'incorrect') {
+    setResultById((prev) => {
+      const next = new Map(prev);
+      next.set(questionId, result);
       return next;
     });
   }
 
+  const correctCount = (milestoneQuestions ?? []).filter(
+    (q) => resultById.get(q.questionId) === 'correct',
+  ).length;
+
   const milestoneProgress =
     milestoneQuestions && milestoneQuestions.length > 0
-      ? {
-          answered: milestoneQuestions.filter((q) => answeredIds.has(q.questionId)).length,
-          total: milestoneQuestions.length,
-        }
+      ? { answered: correctCount, total: milestoneQuestions.length }
       : null;
 
   // The bundle mark (milestone) shares the row's live answered-state: as the
-  // viewer answers questions inline, solid triangles flip to hollow. Caps at 5
-  // triangles silently (the questions array is already ≤5); copy stays truthful.
+  // viewer answers questions correctly inline, solid triangles flip to hollow.
+  // Caps at 5 triangles silently (the questions array is already ≤5); copy stays
+  // truthful.
   const bundleCounts =
     item.icon === 'bundle' && milestoneQuestions
       ? (() => {
           const total = Math.min(milestoneQuestions.length, 5);
-          const answered = Math.min(answeredIds.size, total);
+          const answered = Math.min(correctCount, total);
           return { total, unanswered: total - answered };
         })()
       : null;
@@ -231,7 +243,7 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
 
       {expandable && open && expand ? (
         expand.kind === 'milestone' ? (
-          <MilestoneExpansion expand={expand} answeredIds={answeredIds} onAnswered={markAnswered} />
+          <MilestoneExpansion expand={expand} resultById={resultById} onResult={recordResult} />
         ) : expand.kind === 'same_correct' ? (
           <ConvergenceExpansion expand={expand} />
         ) : (
@@ -277,12 +289,12 @@ function ItemAction({ action }: { action: NonNullable<StreamItem['action']> }) {
 // friend's ≤5 literal questions to answer.
 function MilestoneExpansion({
   expand,
-  answeredIds,
-  onAnswered,
+  resultById,
+  onResult,
 }: {
   expand: Extract<StreamExpand, { kind: 'milestone' }>;
-  answeredIds: Set<string>;
-  onAnswered: (questionId: string) => void;
+  resultById: Map<string, 'correct' | 'incorrect'>;
+  onResult: (questionId: string, result: 'correct' | 'incorrect') => void;
 }) {
   return (
     <div
@@ -298,8 +310,8 @@ function MilestoneExpansion({
         <InlineAnswerFlow
           key={q.questionId}
           question={q}
-          answered={answeredIds.has(q.questionId)}
-          onAnswered={onAnswered}
+          status={resultById.get(q.questionId) ?? 'unanswered'}
+          onResult={onResult}
         />
       ))}
     </div>

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { AnswerFeedbackSheet } from '@/components/feed/AnswerFeedbackSheet';
 import { AnswerSheet } from '@/components/feed/AnswerSheet';
-import type { StreamQuestion } from '@/lib/activity-stream';
+import type { AnswerStatus, StreamQuestion } from '@/lib/activity-stream';
 import type { InsideJokeKind } from '@/lib/questions-types';
 
 import { FM, INK, INK2, INK3 } from '@/components/lately/tokens';
@@ -21,18 +21,25 @@ type Feedback = {
   openedTerritoryDomain: string | null;
 };
 
+// Colors borrowed from the answer-result palette so the inline badges read in
+// the same register as the feedback sheet (forest green = correct, terracotta =
+// missed).
+const CORRECT = 'var(--game-correct)';
+const WRONG = 'var(--game-wrong-strong)';
+
 // D-4 CORRECTION 2: one milestone question, answered IN PLACE via the existing
 // feed answer pop-ups (AnswerSheet -> AnswerFeedbackSheet). Full credit is
 // written by /api/lately/milestone/answer; this component only drives the UI and
-// reports a correct answer up so the milestone can track "{k} of {n} answered".
+// reports the GRADED result up so the milestone can track "{k} of {n} answered"
+// AND lock a missed question — one shot, no re-answer.
 export function InlineAnswerFlow({
   question,
-  answered,
-  onAnswered,
+  status,
+  onResult,
 }: {
   question: StreamQuestion;
-  answered: boolean;
-  onAnswered: (questionId: string) => void;
+  status: AnswerStatus;
+  onResult: (questionId: string, result: 'correct' | 'incorrect') => void;
 }) {
   const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
   const [loading, setLoading] = useState(false);
@@ -52,8 +59,17 @@ export function InlineAnswerFlow({
         | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
             masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
           })
+        | { error: string; result?: 'correct' | 'incorrect' }
         | null;
-      if (!res.ok || !body) throw new Error('Could not score that answer.');
+      // A 409 means the viewer already answered this question (a question is
+      // one-shot once attempted). Lock it to whatever the prior result was
+      // instead of inviting a retry.
+      if (res.status === 409 && body && 'result' in body && body.result) {
+        onResult(question.questionId, body.result === 'correct' ? 'correct' : 'incorrect');
+        setPhase('closed');
+        return;
+      }
+      if (!res.ok || !body || !('isCorrect' in body)) throw new Error('Could not score that answer.');
       setSubmitted(answer);
       setFeedback({
         isCorrect: body.isCorrect,
@@ -69,13 +85,19 @@ export function InlineAnswerFlow({
           : null,
       });
       setPhase('result');
-      if (body.isCorrect) onAnswered(question.questionId);
+      // Report the graded result up so the parent can tick progress (correct)
+      // and LOCK the question (correct or incorrect) — a missed milestone
+      // question can't be answered again.
+      onResult(question.questionId, body.isCorrect ? 'correct' : 'incorrect');
     } catch {
-      // Leave the input sheet open so the viewer can retry.
+      // Leave the input sheet open so the viewer can retry a transient error
+      // (network/parse) — a real grade always resolves to correct/incorrect above.
     } finally {
       setLoading(false);
     }
   }
+
+  const locked = status !== 'unanswered';
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
@@ -88,23 +110,37 @@ export function InlineAnswerFlow({
           fontStyle: 'italic',
           fontSize: 14,
           lineHeight: 1.5,
-          color: answered ? INK3 : INK2,
+          color: locked ? INK3 : INK2,
         }}
       >
         &ldquo;{question.text}&rdquo;
       </p>
 
-      {answered ? (
+      {status === 'correct' ? (
         <span
           style={{
             flexShrink: 0,
             fontFamily: FM,
             fontSize: 10,
             letterSpacing: 1.5,
-            color: INK3,
+            color: CORRECT,
           }}
         >
-          ✓ ANSWERED
+          ✓ CORRECT
+        </span>
+      ) : status === 'incorrect' ? (
+        // Missed: locked, no re-answer. Distinct terracotta badge so a wrong
+        // attempt reads differently from a correct one at a glance.
+        <span
+          style={{
+            flexShrink: 0,
+            fontFamily: FM,
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: WRONG,
+          }}
+        >
+          ✕ MISSED
         </span>
       ) : (
         <button

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -39,13 +39,18 @@ export type StreamLinePart =
   // on the homepage "What's Happening" head (see ActivityStreamItem).
   | { t: 'category'; v: string };
 
+// The viewer's standing on a question, from their own answer history:
+//   - 'unanswered' → never attempted; still answerable (shows ANSWER →).
+//   - 'correct'    → answered correctly; counts toward the milestone
+//                    "{k} of {n} answered" progress and the no-double-credit story.
+//   - 'incorrect'  → attempted and missed; LOCKED (one shot — no re-answer).
+export type AnswerStatus = 'unanswered' | 'correct' | 'incorrect';
+
 export type StreamQuestion = {
   questionId: string;
   text: string;
   domain: string | null;
-  // True when the viewer has already answered this question correctly. Drives
-  // the milestone "{k} of {n} answered" progress and the no-double-credit story.
-  answered: boolean;
+  answerStatus: AnswerStatus;
 };
 
 // The action an expanded, question-backed item offers — determined by the
@@ -170,7 +175,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: faq.questionText,
                   domain,
-                  answered: false,
+                  answerStatus: 'unanswered',
                 },
               }
             : null,
@@ -194,7 +199,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: false,
+                  answerStatus: 'unanswered',
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -220,7 +225,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: true,
+                  answerStatus: 'correct',
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -457,7 +462,7 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
         questionId: moment.questionId,
         text: moment.questionText,
         domain: moment.category,
-        answered: true,
+        answerStatus: 'correct',
       },
     },
   };

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -27,7 +27,7 @@ import {
   getLatelyMilestones,
   getLatelyMoments,
   getMilestoneQuestionText,
-  getViewerCorrectlyAnsweredIds,
+  getViewerAnswerStatusByQuestionId,
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
@@ -40,7 +40,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
 
   // Resolve every milestone's first ≤5 literal questions and every
   // convergence's 3 cluster questions in one batch (text + display domain), and
-  // which of them the viewer already answered correctly.
+  // the viewer's own standing on each (answered correctly, missed, or untouched).
   const cappedIdsByMilestone = milestones.map((m) => ({
     id: m.id,
     ids: m.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
@@ -51,9 +51,9 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [textById, answeredIds] = await Promise.all([
+  const [textById, statusById] = await Promise.all([
     getMilestoneQuestionText(allQuestionIds),
-    getViewerCorrectlyAnsweredIds(userId, allQuestionIds),
+    getViewerAnswerStatusByQuestionId(userId, allQuestionIds),
   ]);
 
   const utilityItems = filterUtilityActivities(items, moments).map(
@@ -68,7 +68,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: answeredIds.has(q.questionId),
+        answerStatus: statusById.get(q.questionId) ?? 'unanswered',
       }));
     return milestoneToStreamItem(m, questions);
   });
@@ -80,7 +80,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: true, // read-only reveal: both already answered correctly
+        answerStatus: 'correct' as const, // read-only reveal: both already answered correctly
       }));
     return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id));
   });

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -349,28 +349,43 @@ export async function getMilestoneQuestionText(
   return out;
 }
 
-// Which of the given questions the viewer has ALREADY answered correctly. Drives
-// the milestone expansion's "{k} of {n} answered" progress on first render and
-// makes the no-double-credit reality visible (a question already in the viewer's
-// mastery history won't earn new credit on re-answer — it becomes repeat_correct).
-export async function getViewerCorrectlyAnsweredIds(
+export type ViewerAnswerStatus = 'correct' | 'incorrect';
+
+// The viewer's own standing on each of the given questions, from their answer
+// history. A question the viewer answered correctly counts toward the milestone
+// "{k} of {n} answered" progress and makes the no-double-credit reality visible
+// (re-answering becomes repeat_correct, 0 points). A question they MISSED is
+// surfaced as 'incorrect' so the expansion can lock it — one shot, no re-answer.
+//
+// Scoped to the viewer's OWN attempts (answeredByUserId = userId) and to rows
+// that actually carry an answer_state, which excludes author/curator credit
+// (those store a null answer_state). Any correct attempt wins; otherwise the
+// question is reported as the incorrect attempt we saw.
+export async function getViewerAnswerStatusByQuestionId(
   userId: string,
   ids: string[],
-): Promise<Set<string>> {
-  const out = new Set<string>();
+): Promise<Map<string, ViewerAnswerStatus>> {
+  const out = new Map<string, ViewerAnswerStatus>();
   if (ids.length === 0) return out;
   const rows = await db
-    .select({ questionId: masteryEvents.questionId })
+    .select({ questionId: masteryEvents.questionId, answerState: masteryEvents.answerState })
     .from(masteryEvents)
     .where(
       and(
         eq(masteryEvents.userId, userId),
+        eq(masteryEvents.answeredByUserId, userId),
         inArray(masteryEvents.questionId, ids),
-        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+        isNotNull(masteryEvents.answerState),
       ),
     );
   for (const row of rows) {
-    if (row.questionId) out.add(row.questionId);
+    if (!row.questionId) continue;
+    const correct = row.answerState !== 'incorrect';
+    if (correct) {
+      out.set(row.questionId, 'correct');
+    } else if (!out.has(row.questionId)) {
+      out.set(row.questionId, 'incorrect');
+    }
   }
   return out;
 }


### PR DESCRIPTION
Milestone questions in the activity stream previously collapsed to a single
"answered" boolean that only flipped on a correct answer, so a wrong answer
left the question showing "ANSWER →" and re-answerable, and a viewer couldn't
tell a correct answer from a missed one.

Replace the boolean with a per-question AnswerStatus ('unanswered' | 'correct'
| 'incorrect') threaded from the server through to the inline card:

- getViewerAnswerStatusByQuestionId reports the viewer's own standing on each
  question (any correct attempt wins; otherwise the missed attempt), scoped to
  their own graded events.
- InlineAnswerFlow renders a green "✓ CORRECT" badge, a terracotta "✕ MISSED"
  badge, or the ANSWER button, and reports the graded result up for both
  outcomes so a missed question locks (one shot, no retry).
- The milestone answer route re-enforces the lock server-side, returning 409
  for an already-attempted question so a stale client can't re-submit.

The "{k} of {n} answered" progress and bundle triangles keep counting correct
answers only.