### PR TITLE
Distinguish correct/incorrect milestone answers and lock missed ones

### DIFF
--- a/drizzle/0062_pool_substrate_trust_scope.sql
+++ b/drizzle/0062_pool_substrate_trust_scope.sql
@@ -1,0 +1,105 @@
+-- Migration: B1 pool substrate — trust tier, scope, perishable, provenance,
+-- empirical stats, and embedding-dedup flags (PRD-D-5 §5.1 / §6 / §8).
+--
+-- Evolves the machine bank (GeneratedQuestion) and human-authored questions
+-- (Question) into one durable, trust-tiered, dedup-aware pool. B1 adds the
+-- fields + the capability to filter by them; it does NOT switch on live
+-- trust-tier gating (that is B4) and deletes nothing.
+--
+-- Field reuse (human table): scope, n_answered and empirical_correct_rate are
+-- NOT added to Question — the unified selection layer reuses visibility,
+-- asked_count and correct_rate. Only genuinely-new columns are added there.
+--
+-- Grandfather backfill: machine rows -> machine_verified; human rows ->
+-- author_confirmed. Machine empirical stats are derived from the linked played
+-- Question row (Question.generated_question_id, unique) where one exists.
+--
+-- All additive / IF NOT EXISTS / guarded — safe and non-destructive. Matching
+-- idempotent boot guards land in src/instrumentation.ts so a preview/production
+-- database that records this migration without the pieces present can still boot.
+--
+-- Rollback: DROP the added columns (DROP COLUMN IF EXISTS) on both tables and
+-- DROP TYPE "TrustTier"/"QuestionScope"; no other data depends on them.
+DO $$ BEGIN
+  CREATE TYPE "public"."TrustTier" AS ENUM('unverified', 'machine_verified', 'human_validated', 'author_confirmed');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."QuestionScope" AS ENUM('private', 'friends_only', 'public');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+-- Human-authored questions: new-only columns.
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified';
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "suppressed_by" text;
+--> statement-breakpoint
+-- Machine bank: new-only + machine-only columns (scope/n_answered/correct-rate).
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified';
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public';
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "suppressed_by" text;
+--> statement-breakpoint
+-- Grandfather backfill: existing human rows are author_confirmed (default
+-- target only the rows still at the 'unverified' default so this is re-runnable).
+UPDATE "Question"
+  SET "trust_tier" = 'author_confirmed'
+  WHERE "trust_tier" = 'unverified';
+--> statement-breakpoint
+-- Grandfather backfill: existing machine rows are machine_verified.
+UPDATE "GeneratedQuestion"
+  SET "trust_tier" = 'machine_verified'
+  WHERE "trust_tier" = 'unverified';
+--> statement-breakpoint
+-- Empirical stats backfill (D11): derive each machine row's play stats from its
+-- linked played Question (Question.generated_question_id is unique). Machine rows
+-- with no linked play stay at 0 / NULL.
+UPDATE "GeneratedQuestion" g
+  SET "n_answered" = q."asked_count",
+      "empirical_correct_rate" = CASE
+        WHEN q."asked_count" > 0 THEN q."correct_count"::double precision / q."asked_count"
+        ELSE NULL
+      END
+  FROM "Question" q
+  WHERE q."generated_question_id" = g."id"
+    AND q."asked_count" > 0;
+--> statement-breakpoint
+-- Selection-layer filter indexes (B1). Capability only; not gated on any surface.
+CREATE INDEX IF NOT EXISTS "Question_trust_tier_idx" ON "Question" ("trust_tier");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Question_is_duplicate_idx" ON "Question" ("is_duplicate");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_trust_tier_idx" ON "GeneratedQuestion" ("trust_tier");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_is_duplicate_idx" ON "GeneratedQuestion" ("is_duplicate");

--- a/drizzle/0063_pool_embeddings.sql
+++ b/drizzle/0063_pool_embeddings.sql
@@ -1,0 +1,27 @@
+-- Migration: B1 pool substrate — pgvector embeddings for semantic dedup
+-- (PRD-D-5 §5.1 D10 / §7).
+--
+-- Enables pgvector and adds a nullable 1024-dim embedding column (Voyage
+-- voyage-3.5-lite) to both pool tables, plus HNSW cosine indexes for fast
+-- nearest-neighbour lookup. The column is populated at insert (best-effort) and
+-- by the batched backfill job; it stays NULL until VOYAGE_API_KEY is provisioned,
+-- so this migration alone changes no behavior.
+--
+-- Additive / IF NOT EXISTS throughout — safe and non-destructive. Matching
+-- idempotent boot guards land in src/instrumentation.ts.
+--
+-- Rollback: DROP INDEX the two hnsw indexes; ALTER TABLE ... DROP COLUMN IF
+-- EXISTS "embedding" on both tables. (CREATE EXTENSION is left in place.)
+CREATE EXTENSION IF NOT EXISTS vector;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "embedding" vector(1024);
+--> statement-breakpoint
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "embedding" vector(1024);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx"
+  ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops);
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx"
+  ON "Question" USING hnsw ("embedding" vector_cosine_ops);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -442,6 +442,13 @@
       "when": 1781913600000,
       "tag": "0062_pool_substrate_trust_scope",
       "breakpoints": true
+    },
+    {
+      "idx": 63,
+      "version": "7",
+      "when": 1782000000000,
+      "tag": "0063_pool_embeddings",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -435,6 +435,13 @@
       "when": 1781827200000,
       "tag": "0061_email_verification_token",
       "breakpoints": true
+    },
+    {
+      "idx": 62,
+      "version": "7",
+      "when": 1781913600000,
+      "tag": "0062_pool_substrate_trust_scope",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-pool-embeddings.ts
+++ b/scripts/backfill-pool-embeddings.ts
@@ -1,0 +1,143 @@
+// Batched backfill: populate GeneratedQuestion.embedding / Question.embedding
+// (Voyage voyage-3.5-lite, 1024-dim) for the existing pool, then run the
+// embedding-dedup collision pass over the back-filled rows.
+//
+// APPROVAL GATE (PRD-D-5 §8 B1): run the dry-run first — it reports how many
+// rows need embedding and the estimated Voyage cost. Do not --apply until that
+// estimate is approved.
+//
+// Idempotent: only rows with a NULL embedding are processed; re-running resumes.
+// Requires VOYAGE_API_KEY in the environment.
+//
+// Usage:
+//   npx tsx scripts/backfill-pool-embeddings.ts            # dry-run (count + cost)
+//   npx tsx scripts/backfill-pool-embeddings.ts --apply    # embed + dedup
+
+import 'dotenv/config';
+
+import { eq, isNull, isNotNull, and } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions, questions } from '../src/server/db';
+import { embedTexts, EMBEDDING_BATCH_SIZE, isEmbeddingEnabled } from '../src/server/llm/embeddings';
+import {
+  findNearestInPool,
+  markPoolDuplicate,
+  storePoolEmbedding,
+  type PoolOrigin,
+} from '../src/server/db/queries/pool';
+import { resolveCollision, getDedupCosineThreshold } from '../src/server/pool/dedup';
+
+const APPLY = process.argv.slice(2).includes('--apply');
+
+// voyage-3.5-lite list price (USD per 1M tokens). Adjust if Voyage repricing.
+const VOYAGE_PRICE_PER_MTOK = 0.02;
+// Cheap token proxy: ~4 chars/token.
+const estimateTokens = (text: string) => Math.ceil((text?.length ?? 0) / 4);
+
+type Pending = { id: string; text: string; origin: PoolOrigin };
+
+async function loadPending(): Promise<Pending[]> {
+  const [machine, human] = await Promise.all([
+    db
+      .select({ id: generatedQuestions.id, text: generatedQuestions.questionText })
+      .from(generatedQuestions)
+      .where(isNull(generatedQuestions.embedding)),
+    db
+      .select({ id: questions.id, text: questions.questionText })
+      .from(questions)
+      .where(and(isNull(questions.embedding), isNull(questions.deletedAt))),
+  ]);
+  return [
+    ...machine.map((r) => ({ id: r.id, text: r.text, origin: 'machine' as const })),
+    ...human.map((r) => ({ id: r.id, text: r.text, origin: 'human' as const })),
+  ];
+}
+
+async function main() {
+  console.log(`[backfill-pool-embeddings] ${APPLY ? 'APPLY' : 'DRY RUN'} mode\n`);
+
+  const pending = await loadPending();
+  const machineCount = pending.filter((p) => p.origin === 'machine').length;
+  const humanCount = pending.length - machineCount;
+  const totalTokens = pending.reduce((sum, p) => sum + estimateTokens(p.text), 0);
+  const estCost = (totalTokens / 1_000_000) * VOYAGE_PRICE_PER_MTOK;
+
+  console.log(`[backfill-pool-embeddings] rows needing embedding: ${pending.length} (machine=${machineCount}, human=${humanCount})`);
+  console.log(`[backfill-pool-embeddings] est. tokens: ~${totalTokens.toLocaleString()} → est. Voyage cost: ~$${estCost.toFixed(4)} (at $${VOYAGE_PRICE_PER_MTOK}/1M tok)`);
+  console.log(`[backfill-pool-embeddings] dedup cosine threshold: ${getDedupCosineThreshold()}`);
+
+  // Sanity check: confirm pgvector + embedding columns are actually present.
+  const haveColumns = await db
+    .select({ id: generatedQuestions.id })
+    .from(generatedQuestions)
+    .where(isNotNull(generatedQuestions.embedding))
+    .limit(1)
+    .then(() => true)
+    .catch((err) => {
+      console.warn('[backfill-pool-embeddings] embedding column not queryable yet — run migration 0063 first', { message: String(err) });
+      return false;
+    });
+  if (!haveColumns) return;
+
+  if (!APPLY) {
+    console.log('\n[backfill-pool-embeddings] dry run only — re-run with --apply once the cost is approved.');
+    return;
+  }
+  if (!isEmbeddingEnabled()) {
+    console.error('[backfill-pool-embeddings] VOYAGE_API_KEY missing — cannot --apply.');
+    process.exitCode = 1;
+    return;
+  }
+
+  // 1) Embed + store in batches.
+  let embedded = 0;
+  for (let start = 0; start < pending.length; start += EMBEDDING_BATCH_SIZE) {
+    const batch = pending.slice(start, start + EMBEDDING_BATCH_SIZE);
+    const vectors = await embedTexts(batch.map((b) => b.text), 'document');
+    if (!vectors) {
+      console.error('[backfill-pool-embeddings] embedding disabled mid-run; stopping.');
+      break;
+    }
+    for (let i = 0; i < batch.length; i += 1) {
+      const vec = vectors[i];
+      if (!vec) continue;
+      await storePoolEmbedding(batch[i].origin, batch[i].id, vec);
+      embedded += 1;
+    }
+    console.log(`[backfill-pool-embeddings] embedded ${Math.min(start + batch.length, pending.length)}/${pending.length}`);
+  }
+
+  // 2) Collision pass over the freshly back-filled rows. resolveCollision is
+  //    direction-aware (human beats machine) regardless of processing order;
+  //    findNearestInPool already excludes already-suppressed rows.
+  let suppressed = 0;
+  for (const row of pending) {
+    const [stored] = await db
+      .select({ embedding: row.origin === 'machine' ? generatedQuestions.embedding : questions.embedding })
+      .from(row.origin === 'machine' ? generatedQuestions : questions)
+      .where(eq(row.origin === 'machine' ? generatedQuestions.id : questions.id, row.id))
+      .limit(1);
+    const embedding = stored?.embedding as number[] | null | undefined;
+    if (!embedding) continue;
+    const nearest = await findNearestInPool(embedding, row.id);
+    const decision = resolveCollision({ id: row.id, origin: row.origin }, nearest, getDedupCosineThreshold());
+    if (decision.action === 'suppress_incoming') {
+      await markPoolDuplicate(row.origin, row.id, decision.survivorId);
+      suppressed += 1;
+    } else if (decision.action === 'suppress_existing') {
+      await markPoolDuplicate(decision.existingOrigin, decision.existingId, decision.survivorId);
+      suppressed += 1;
+    }
+  }
+
+  console.log(`\n[backfill-pool-embeddings] done. embedded=${embedded}, suppressed=${suppressed}`);
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-pool-embeddings] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -6,7 +6,7 @@ import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
 import { getSession } from '@/server/auth/session';
 import { db, playerMastery, questions } from '@/server/db';
-import { getSeededPlayQuestions } from '@/server/db/queries/lately';
+import { getSeededPlayQuestions, getViewerAnswerStatusByQuestionId } from '@/server/db/queries/lately';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { gradeAnswer } from '@/server/grading';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
@@ -65,6 +65,19 @@ export async function POST(request: NextRequest) {
   // is "send it onward", not "answer", under the relationship rule.
   if (question.creatorId && question.creatorId === session.userId) {
     return NextResponse.json({ error: 'forbidden' }, { status: 403 });
+  }
+
+  // One shot: a milestone question the viewer has already attempted is LOCKED —
+  // whether they got it right (no double credit) or missed it (no retry). The UI
+  // surfaces this as a CORRECT / MISSED badge instead of an ANSWER button, but we
+  // re-enforce it here so a stale client (or a direct call) can't re-submit.
+  const priorStatus = await getViewerAnswerStatusByQuestionId(session.userId, [question.id]);
+  const already = priorStatus.get(question.id);
+  if (already) {
+    return NextResponse.json(
+      { error: 'already_answered', result: already },
+      { status: 409 },
+    );
   }
 
   const domain = question.canonicalSubcategory || question.broadCategory || question.category;

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -89,36 +89,48 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
   // expanded), so the answered-state is held HERE — not inside the expansion —
   // and ticks up + persists as the viewer answers, even after the result pop-up
   // closes or the line is collapsed and reopened. Milestone lines only.
+  //
+  // We hold the viewer's per-question RESULT (correct / incorrect), not just a
+  // boolean: a correct answer ticks the "{k} of {n} answered" progress; a missed
+  // one locks the question (one shot) but does not count as answered.
   const expand = item.expand;
   const milestoneQuestions = expand && expand.kind === 'milestone' ? expand.questions : null;
-  const [answeredIds, setAnsweredIds] = useState<Set<string>>(
-    () => new Set((milestoneQuestions ?? []).filter((q) => q.answered).map((q) => q.questionId)),
-  );
+  const [resultById, setResultById] = useState<Map<string, 'correct' | 'incorrect'>>(() => {
+    const seed = new Map<string, 'correct' | 'incorrect'>();
+    for (const q of milestoneQuestions ?? []) {
+      if (q.answerStatus === 'correct' || q.answerStatus === 'incorrect') {
+        seed.set(q.questionId, q.answerStatus);
+      }
+    }
+    return seed;
+  });
 
-  function markAnswered(questionId: string) {
-    setAnsweredIds((prev) => {
-      const next = new Set(prev);
-      next.add(questionId);
+  function recordResult(questionId: string, result: 'correct' | 'incorrect') {
+    setResultById((prev) => {
+      const next = new Map(prev);
+      next.set(questionId, result);
       return next;
     });
   }
 
+  const correctCount = (milestoneQuestions ?? []).filter(
+    (q) => resultById.get(q.questionId) === 'correct',
+  ).length;
+
   const milestoneProgress =
     milestoneQuestions && milestoneQuestions.length > 0
-      ? {
-          answered: milestoneQuestions.filter((q) => answeredIds.has(q.questionId)).length,
-          total: milestoneQuestions.length,
-        }
+      ? { answered: correctCount, total: milestoneQuestions.length }
       : null;
 
   // The bundle mark (milestone) shares the row's live answered-state: as the
-  // viewer answers questions inline, solid triangles flip to hollow. Caps at 5
-  // triangles silently (the questions array is already ≤5); copy stays truthful.
+  // viewer answers questions correctly inline, solid triangles flip to hollow.
+  // Caps at 5 triangles silently (the questions array is already ≤5); copy stays
+  // truthful.
   const bundleCounts =
     item.icon === 'bundle' && milestoneQuestions
       ? (() => {
           const total = Math.min(milestoneQuestions.length, 5);
-          const answered = Math.min(answeredIds.size, total);
+          const answered = Math.min(correctCount, total);
           return { total, unanswered: total - answered };
         })()
       : null;
@@ -231,7 +243,7 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
 
       {expandable && open && expand ? (
         expand.kind === 'milestone' ? (
-          <MilestoneExpansion expand={expand} answeredIds={answeredIds} onAnswered={markAnswered} />
+          <MilestoneExpansion expand={expand} resultById={resultById} onResult={recordResult} />
         ) : expand.kind === 'same_correct' ? (
           <ConvergenceExpansion expand={expand} />
         ) : (
@@ -277,12 +289,12 @@ function ItemAction({ action }: { action: NonNullable<StreamItem['action']> }) {
 // friend's ≤5 literal questions to answer.
 function MilestoneExpansion({
   expand,
-  answeredIds,
-  onAnswered,
+  resultById,
+  onResult,
 }: {
   expand: Extract<StreamExpand, { kind: 'milestone' }>;
-  answeredIds: Set<string>;
-  onAnswered: (questionId: string) => void;
+  resultById: Map<string, 'correct' | 'incorrect'>;
+  onResult: (questionId: string, result: 'correct' | 'incorrect') => void;
 }) {
   return (
     <div
@@ -298,8 +310,8 @@ function MilestoneExpansion({
         <InlineAnswerFlow
           key={q.questionId}
           question={q}
-          answered={answeredIds.has(q.questionId)}
-          onAnswered={onAnswered}
+          status={resultById.get(q.questionId) ?? 'unanswered'}
+          onResult={onResult}
         />
       ))}
     </div>

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { AnswerFeedbackSheet } from '@/components/feed/AnswerFeedbackSheet';
 import { AnswerSheet } from '@/components/feed/AnswerSheet';
-import type { StreamQuestion } from '@/lib/activity-stream';
+import type { AnswerStatus, StreamQuestion } from '@/lib/activity-stream';
 import type { InsideJokeKind } from '@/lib/questions-types';
 
 import { FM, INK, INK2, INK3 } from '@/components/lately/tokens';
@@ -21,18 +21,25 @@ type Feedback = {
   openedTerritoryDomain: string | null;
 };
 
+// Colors borrowed from the answer-result palette so the inline badges read in
+// the same register as the feedback sheet (forest green = correct, terracotta =
+// missed).
+const CORRECT = 'var(--game-correct)';
+const WRONG = 'var(--game-wrong-strong)';
+
 // D-4 CORRECTION 2: one milestone question, answered IN PLACE via the existing
 // feed answer pop-ups (AnswerSheet -> AnswerFeedbackSheet). Full credit is
 // written by /api/lately/milestone/answer; this component only drives the UI and
-// reports a correct answer up so the milestone can track "{k} of {n} answered".
+// reports the GRADED result up so the milestone can track "{k} of {n} answered"
+// AND lock a missed question — one shot, no re-answer.
 export function InlineAnswerFlow({
   question,
-  answered,
-  onAnswered,
+  status,
+  onResult,
 }: {
   question: StreamQuestion;
-  answered: boolean;
-  onAnswered: (questionId: string) => void;
+  status: AnswerStatus;
+  onResult: (questionId: string, result: 'correct' | 'incorrect') => void;
 }) {
   const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
   const [loading, setLoading] = useState(false);
@@ -52,8 +59,17 @@ export function InlineAnswerFlow({
         | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
             masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
           })
+        | { error: string; result?: 'correct' | 'incorrect' }
         | null;
-      if (!res.ok || !body) throw new Error('Could not score that answer.');
+      // A 409 means the viewer already answered this question (a question is
+      // one-shot once attempted). Lock it to whatever the prior result was
+      // instead of inviting a retry.
+      if (res.status === 409 && body && 'result' in body && body.result) {
+        onResult(question.questionId, body.result === 'correct' ? 'correct' : 'incorrect');
+        setPhase('closed');
+        return;
+      }
+      if (!res.ok || !body || !('isCorrect' in body)) throw new Error('Could not score that answer.');
       setSubmitted(answer);
       setFeedback({
         isCorrect: body.isCorrect,
@@ -69,13 +85,19 @@ export function InlineAnswerFlow({
           : null,
       });
       setPhase('result');
-      if (body.isCorrect) onAnswered(question.questionId);
+      // Report the graded result up so the parent can tick progress (correct)
+      // and LOCK the question (correct or incorrect) — a missed milestone
+      // question can't be answered again.
+      onResult(question.questionId, body.isCorrect ? 'correct' : 'incorrect');
     } catch {
-      // Leave the input sheet open so the viewer can retry.
+      // Leave the input sheet open so the viewer can retry a transient error
+      // (network/parse) — a real grade always resolves to correct/incorrect above.
     } finally {
       setLoading(false);
     }
   }
+
+  const locked = status !== 'unanswered';
 
   return (
     <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
@@ -88,23 +110,37 @@ export function InlineAnswerFlow({
           fontStyle: 'italic',
           fontSize: 14,
           lineHeight: 1.5,
-          color: answered ? INK3 : INK2,
+          color: locked ? INK3 : INK2,
         }}
       >
         &ldquo;{question.text}&rdquo;
       </p>
 
-      {answered ? (
+      {status === 'correct' ? (
         <span
           style={{
             flexShrink: 0,
             fontFamily: FM,
             fontSize: 10,
             letterSpacing: 1.5,
-            color: INK3,
+            color: CORRECT,
           }}
         >
-          ✓ ANSWERED
+          ✓ CORRECT
+        </span>
+      ) : status === 'incorrect' ? (
+        // Missed: locked, no re-answer. Distinct terracotta badge so a wrong
+        // attempt reads differently from a correct one at a glance.
+        <span
+          style={{
+            flexShrink: 0,
+            fontFamily: FM,
+            fontSize: 10,
+            letterSpacing: 1.5,
+            color: WRONG,
+          }}
+        >
+          ✕ MISSED
         </span>
       ) : (
         <button

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -487,6 +487,24 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
+    // embedding column + HNSW cosine indexes to both pool tables. The dedup
+    // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a
+    // database that records the migration without the pieces present must still
+    // boot. Guard the extension, columns, and indexes idempotently. If pgvector
+    // is unavailable the whole block is skipped — insert-time dedup degrades to
+    // the deterministic guards.
+    try {
+      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS vector`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "embedding" vector(1024)`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "GeneratedQuestion_embedding_hnsw_idx" ON "GeneratedQuestion" USING hnsw ("embedding" vector_cosine_ops)`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Question_embedding_hnsw_idx" ON "Question" USING hnsw ("embedding" vector_cosine_ops)`);
+    } catch {
+      // pgvector may be unavailable, or the tables may not exist yet on a fresh
+      // database — migrate() handles creation; dedup is best-effort regardless.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -441,6 +441,52 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0062 (B1 pool substrate) adds the TrustTier/QuestionScope enums
+    // and the pool fields (trust_tier, scope, perishable, source_refs, empirical
+    // stats, embedding-dedup flags) to Question + GeneratedQuestion. App code
+    // (the unified selection layer, suppress-aware bank pick) reads these, so a
+    // preview/production database that records the migration without the pieces
+    // present must still boot. Enums + columns + grandfather backfill are applied
+    // idempotently; the backfills target only rows still at the 'unverified'
+    // default, so they are re-runnable no-ops once corrected.
+    try {
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."TrustTier" AS ENUM('unverified', 'machine_verified', 'human_validated', 'author_confirmed');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."QuestionScope" AS ENUM('private', 'friends_only', 'public');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
+      await db.execute(sql`UPDATE "Question" SET "trust_tier" = 'author_confirmed' WHERE "trust_tier" = 'unverified'`);
+    } catch {
+      // Question may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+    try {
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "trust_tier" "public"."TrustTier" NOT NULL DEFAULT 'unverified'`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "scope" "public"."QuestionScope" NOT NULL DEFAULT 'public'`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "perishable" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "source_refs" jsonb NOT NULL DEFAULT '[]'::jsonb`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "n_answered" integer NOT NULL DEFAULT 0`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
+      await db.execute(sql`UPDATE "GeneratedQuestion" SET "trust_tier" = 'machine_verified' WHERE "trust_tier" = 'unverified'`);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -39,13 +39,18 @@ export type StreamLinePart =
   // on the homepage "What's Happening" head (see ActivityStreamItem).
   | { t: 'category'; v: string };
 
+// The viewer's standing on a question, from their own answer history:
+//   - 'unanswered' → never attempted; still answerable (shows ANSWER →).
+//   - 'correct'    → answered correctly; counts toward the milestone
+//                    "{k} of {n} answered" progress and the no-double-credit story.
+//   - 'incorrect'  → attempted and missed; LOCKED (one shot — no re-answer).
+export type AnswerStatus = 'unanswered' | 'correct' | 'incorrect';
+
 export type StreamQuestion = {
   questionId: string;
   text: string;
   domain: string | null;
-  // True when the viewer has already answered this question correctly. Drives
-  // the milestone "{k} of {n} answered" progress and the no-double-credit story.
-  answered: boolean;
+  answerStatus: AnswerStatus;
 };
 
 // The action an expanded, question-backed item offers — determined by the
@@ -170,7 +175,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: faq.questionText,
                   domain,
-                  answered: false,
+                  answerStatus: 'unanswered',
                 },
               }
             : null,
@@ -194,7 +199,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: false,
+                  answerStatus: 'unanswered',
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -220,7 +225,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: true,
+                  answerStatus: 'correct',
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -457,7 +462,7 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
         questionId: moment.questionId,
         text: moment.questionText,
         domain: moment.category,
-        answered: true,
+        answerStatus: 'correct',
       },
     },
   };

--- a/src/server/__tests__/adaptive-difficulty.test.ts
+++ b/src/server/__tests__/adaptive-difficulty.test.ts
@@ -12,6 +12,7 @@ import {
   applyAdaptiveLevelAdjustment,
   applyFocusFloor,
   computeDomainDifficultyStep,
+  mapAdaptiveLevelToDifficultyHint,
   type DomainDifficultyState,
 } from '@/server/adaptive-difficulty';
 
@@ -131,5 +132,80 @@ describe('computeDomainDifficultyStep — per-domain streak tracking', () => {
       expect(result.consecutiveCorrect).toBe(0);
       expect(result.consecutiveIncorrect).toBe(1);
     });
+  });
+
+  // PRD-D-5 §5.2 — the declared erosion hard floor. A declared domain passes
+  // floor='moderate' (engaged-fan); a demonstrated domain passes the default
+  // 'accessible' and keeps the full range.
+  describe('declared erosion floor (engaged-fan)', () => {
+    const MODERATE_FLOOR = 'moderate' as const;
+
+    it('a declared domain never erodes below engaged-fan after repeated wrong answers', () => {
+      // Start at specialist and feed nothing but wrong answers.
+      let s = state('specialist', 0, 0);
+      for (let i = 0; i < 10; i += 1) {
+        s = computeDomainDifficultyStep(s, false, MODERATE_FLOOR);
+        expect(['moderate', 'specialist']).toContain(s.servedDifficulty);
+      }
+      // It settles at the floor and stays there — never accessible.
+      expect(s.servedDifficulty).toBe('moderate');
+    });
+
+    it('declared domain at the floor does not step down on two consecutive wrong', () => {
+      const result = computeDomainDifficultyStep(state('moderate', 0, 1), false, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('moderate');
+      expect(result.consecutiveIncorrect).toBe(2);
+    });
+
+    it('declared domain still steps DOWN from specialist to the floor', () => {
+      const result = computeDomainDifficultyStep(state('specialist', 0, 1), false, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('moderate');
+    });
+
+    it('declared domain still climbs above the floor on two consecutive correct', () => {
+      const result = computeDomainDifficultyStep(state('moderate', 1, 0), true, MODERATE_FLOOR);
+      expect(result.servedDifficulty).toBe('specialist');
+    });
+
+    it('a demonstrated domain (default floor) still erodes all the way to accessible', () => {
+      let s = state('specialist', 0, 0);
+      for (let i = 0; i < 10; i += 1) {
+        s = computeDomainDifficultyStep(s, false);
+      }
+      expect(s.servedDifficulty).toBe('accessible');
+    });
+  });
+});
+
+describe('mapAdaptiveLevelToDifficultyHint — rungs & register', () => {
+  it('accessible and engaged-fan no longer model a "casually interested person"', () => {
+    const accessible = mapAdaptiveLevelToDifficultyHint(1.0);
+    const engagedFan = mapAdaptiveLevelToDifficultyHint(2.0);
+    expect(accessible.promptHint).not.toMatch(/casually interested/i);
+    expect(engagedFan.promptHint).not.toMatch(/casually interested/i);
+    expect(accessible.targetCorrectRate).toBe(0.78);
+    expect(engagedFan.targetCorrectRate).toBe(0.62);
+  });
+
+  it('exposes a new enthusiast rung between engaged-fan and specialist (≈0.50 target)', () => {
+    const enthusiast = mapAdaptiveLevelToDifficultyHint(2.7);
+    expect(enthusiast.difficultyLabel).toBe('enthusiast');
+    expect(enthusiast.targetCorrectRate).toBe(0.5);
+    // Drift Risk 1 guardrail: the definition is the calibration anchor.
+    expect(enthusiast.promptHint).toMatch(/chose to learn/i);
+    expect(enthusiast.promptHint).toMatch(/NOT scholar- or archivist-level minutiae/);
+  });
+
+  it('the three hardest rungs all target the specialist generator tier', () => {
+    expect(mapAdaptiveLevelToDifficultyHint(2.7).estimate).toBe('specialist'); // enthusiast
+    expect(mapAdaptiveLevelToDifficultyHint(3.2).estimate).toBe('specialist'); // specialist
+    expect(mapAdaptiveLevelToDifficultyHint(4.0).estimate).toBe('specialist'); // expert
+  });
+
+  it('preserves the engaged-fan band so the per-domain moderate tier maps to 0.62', () => {
+    // SERVED_TO_PREFERENCE: moderate → 'moderate' → level 2.0 lands engaged-fan.
+    expect(mapAdaptiveLevelToDifficultyHint(2.0).targetCorrectRate).toBe(0.62);
+    // challenging → level 3.0 still lands specialist (0.35), not enthusiast.
+    expect(mapAdaptiveLevelToDifficultyHint(3.0).targetCorrectRate).toBe(0.35);
   });
 });

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -27,7 +27,7 @@ import {
   getLatelyMilestones,
   getLatelyMoments,
   getMilestoneQuestionText,
-  getViewerCorrectlyAnsweredIds,
+  getViewerAnswerStatusByQuestionId,
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
@@ -40,7 +40,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
 
   // Resolve every milestone's first ≤5 literal questions and every
   // convergence's 3 cluster questions in one batch (text + display domain), and
-  // which of them the viewer already answered correctly.
+  // the viewer's own standing on each (answered correctly, missed, or untouched).
   const cappedIdsByMilestone = milestones.map((m) => ({
     id: m.id,
     ids: m.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
@@ -51,9 +51,9 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [textById, answeredIds] = await Promise.all([
+  const [textById, statusById] = await Promise.all([
     getMilestoneQuestionText(allQuestionIds),
-    getViewerCorrectlyAnsweredIds(userId, allQuestionIds),
+    getViewerAnswerStatusByQuestionId(userId, allQuestionIds),
   ]);
 
   const utilityItems = filterUtilityActivities(items, moments).map(
@@ -68,7 +68,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: answeredIds.has(q.questionId),
+        answerStatus: statusById.get(q.questionId) ?? 'unanswered',
       }));
     return milestoneToStreamItem(m, questions);
   });
@@ -80,7 +80,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: true, // read-only reveal: both already answered correctly
+        answerStatus: 'correct' as const, // read-only reveal: both already answered correctly
       }));
     return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id));
   });

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
 import { db, declaredInterests, playerMastery, userDomainDifficulties, users } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
 
 const MIN_ADAPTIVE_LEVEL = 1.0;
 const MAX_ADAPTIVE_LEVEL = 4.0;
@@ -12,9 +13,10 @@ export type AdaptiveDifficultyHint = {
   difficultyLabel: string;
   promptHint: string;
   // The difficulty_estimate tier a question generated at this level targets.
-  // The generator only emits three tiers, so the two hardest adaptive bands
-  // both map to 'specialist'. Lets the bank-reuse path request a stored
-  // question whose tier matches what fresh generation would have produced.
+  // The generator only emits three tiers, so the three hardest adaptive bands
+  // (enthusiast, specialist, expert) all map to 'specialist'. Lets the bank-reuse
+  // path request a stored question whose tier matches what fresh generation would
+  // have produced.
   estimate: 'accessible' | 'moderate' | 'specialist';
 };
 
@@ -126,7 +128,7 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
     return {
       targetCorrectRate: 0.78,
       difficultyLabel: 'approachable trivia',
-      promptHint: 'Target roughly a 78% correct rate. Write friendly, recognizable questions a casually interested person in the domain would get — lean on well-known facts, not deep cuts.',
+      promptHint: 'Target roughly a 78% correct rate. Write questions someone with a passing interest in the domain would recognize — lean on its well-known landmarks and the facts anyone who has encountered it would have met, not deep cuts.',
       estimate: 'accessible',
     };
   }
@@ -134,9 +136,21 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
   if (normalized < 2.5) {
     return {
       targetCorrectRate: 0.62,
-      difficultyLabel: 'fair and familiar',
-      promptHint: 'Target roughly a 62% correct rate. Write questions a reasonably engaged fan of the domain should know without needing specialist depth.',
+      difficultyLabel: 'engaged fan',
+      promptHint: 'Target roughly a 62% correct rate. Write questions someone who actively follows the domain should know — the works, figures, and moments a regular fan keeps track of, without needing specialist depth.',
       estimate: 'moderate',
+    };
+  }
+
+  // Enthusiast rung — the calibration guardrail (PRD-D-5 §5.2). This text is
+  // load-bearing: it must stay "chose to learn ... NOT scholar/archivist
+  // minutiae" so the floor does not swing back to "really REALLY hard."
+  if (normalized < 3.0) {
+    return {
+      targetCorrectRate: 0.50,
+      difficultyLabel: 'enthusiast',
+      promptHint: 'Target roughly a 50% correct rate. Write questions someone who CHOSE to learn this domain would know — its structure, its famous moments, and the second-order facts enthusiasts trade — but NOT scholar- or archivist-level minutiae.',
+      estimate: 'specialist',
     };
   }
 
@@ -183,55 +197,69 @@ function seedDifficultyFromAdaptiveLevel(level: number): ServedDifficulty {
 }
 
 /**
- * Minimum first-contact difficulty for a domain the player explicitly opted
- * into — either by stating it as an area of focus during onboarding or by
- * accepting one shared by a friend. Someone who raised their hand for a topic
- * finds "Establishing" (accessible) trivia condescendingly easy, so we floor
- * the *seed* at "Familiar" (moderate). This only sets the starting point: the
- * normal two-incorrect step-down can still drop a struggling player back to
- * accessible afterwards.
+ * The "engaged-fan" rung, expressed on the per-domain served-difficulty ladder
+ * (moderate). It is the hard floor for a domain the player explicitly DECLARED:
+ * someone who raised their hand for a topic finds accessible ("tourist") trivia
+ * condescendingly easy, so a declared domain both *seeds* here and *cannot erode
+ * below* here (PRD-D-5 §5.2, D3). Demonstrated domains are NOT floored — they
+ * start low and retain the full adaptive range down to accessible.
  */
 const FOCUS_DOMAIN_MIN_DIFFICULTY: ServedDifficulty = 'moderate';
 
-export function applyFocusFloor(difficulty: ServedDifficulty, isFocusDomain: boolean): ServedDifficulty {
-  if (!isFocusDomain) return difficulty;
+export function applyFocusFloor(difficulty: ServedDifficulty, isDeclaredDomain: boolean): ServedDifficulty {
+  if (!isDeclaredDomain) return difficulty;
   return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(FOCUS_DOMAIN_MIN_DIFFICULTY)
     ? difficulty
     : FOCUS_DOMAIN_MIN_DIFFICULTY;
 }
 
 /**
- * Canonical subcategories the player has opted into: declared interests (stated
- * focus areas) plus any open territory in PLAYER_MASTERY — friend-mediated
- * acceptances and authored domains both land there. Used to decide whether a
- * first-contact difficulty seed should be floored to "Familiar". Pass the
- * `domains` filter to keep the lookup to the round being seeded.
+ * Canonical subcategories the player explicitly DECLARED — stated focus areas
+ * (`declaredInterests`) plus PLAYER_MASTERY rows whose `territoryType` is
+ * 'declared' (friend-mediated acceptances that came in as declared territory).
+ * This is the signal that keys the difficulty floor (D2/D3): declared domains
+ * seed at engaged-fan and cannot erode to accessible; demonstrated domains (the
+ * rest) get the full adaptive range. Splitting declared from demonstrated here
+ * is what stops the floor from pinning newcomer/demonstrated domains too high
+ * (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope the lookup to the round.
  */
-async function getFocusDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
-  const focus = new Set<string>();
-  if (domains.length === 0) return focus;
+async function getDeclaredDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
+  const declared = new Set<string>();
+  if (domains.length === 0) return declared;
 
-  const [declaredRows, masteryRows] = await Promise.all([
-    db
-      .select({ domain: declaredInterests.domain })
-      .from(declaredInterests)
-      .where(and(
-        eq(declaredInterests.userId, userId),
-        eq(declaredInterests.isActive, true),
-        inArray(declaredInterests.domain, domains),
-      )),
-    db
-      .select({ domain: playerMastery.canonicalSubcategory })
+  const declaredRows = await db
+    .select({ domain: declaredInterests.domain })
+    .from(declaredInterests)
+    .where(and(
+      eq(declaredInterests.userId, userId),
+      eq(declaredInterests.isActive, true),
+      inArray(declaredInterests.domain, domains),
+    ));
+  for (const row of declaredRows) declared.add(row.domain);
+
+  try {
+    const masteryRows = await db
+      .select({
+        domain: playerMastery.canonicalSubcategory,
+        territoryType: playerMastery.territoryType,
+      })
       .from(playerMastery)
       .where(and(
         eq(playerMastery.userId, userId),
         inArray(playerMastery.canonicalSubcategory, domains),
-      )),
-  ]);
+      ));
+    for (const row of masteryRows) {
+      if (row.territoryType === 'declared') declared.add(row.domain);
+    }
+  } catch (error) {
+    // territoryType is additive; on a DB where the column hasn't landed yet
+    // (42703) fall back to declaredInterests alone — the safe direction, since
+    // a missed declared mastery row only means a domain isn't floored, never
+    // that a demonstrated one is wrongly pinned.
+    if (pgErrorCode(error) !== '42703') throw error;
+  }
 
-  for (const row of declaredRows) focus.add(row.domain);
-  for (const row of masteryRows) focus.add(row.domain);
-  return focus;
+  return declared;
 }
 
 function stepDifficulty(current: ServedDifficulty, direction: 1 | -1): ServedDifficulty {
@@ -249,15 +277,23 @@ export type DomainDifficultyState = {
 export function computeDomainDifficultyStep(
   existing: DomainDifficultyState,
   isCorrect: boolean,
+  floor: ServedDifficulty = 'accessible',
 ): DomainDifficultyState {
   let nextCorrect = isCorrect ? existing.consecutiveCorrect + 1 : 0;
   let nextIncorrect = isCorrect ? 0 : existing.consecutiveIncorrect + 1;
   let nextDifficulty: ServedDifficulty = existing.servedDifficulty;
 
+  const floorIdx = DIFFICULTY_LADDER.indexOf(floor);
+
   if (isCorrect && nextCorrect >= STREAK_TO_STEP && existing.servedDifficulty !== 'specialist') {
     nextDifficulty = stepDifficulty(existing.servedDifficulty, 1);
     nextCorrect = 0;
-  } else if (!isCorrect && nextIncorrect >= STREAK_TO_STEP && existing.servedDifficulty !== 'accessible') {
+  } else if (!isCorrect && nextIncorrect >= STREAK_TO_STEP && DIFFICULTY_LADDER.indexOf(existing.servedDifficulty) > floorIdx) {
+    // Two-incorrect step-down — but never below the floor. For a declared
+    // domain the floor is the engaged-fan rung (moderate), so it erodes within
+    // the upper band but can't drop to accessible/tourist level (PRD-D-5 §5.2).
+    // Demonstrated domains pass the default 'accessible' floor and retain the
+    // full range, matching the prior behaviour exactly.
     nextDifficulty = stepDifficulty(existing.servedDifficulty, -1);
     nextIncorrect = 0;
   }
@@ -268,7 +304,9 @@ export function computeDomainDifficultyStep(
 /**
  * Update per-domain difficulty after a graded answer. Two consecutive correct →
  * step up; two consecutive incorrect → step down. Streak counter resets when
- * the level moves so a single wobble doesn't immediately yo-yo.
+ * the level moves so a single wobble doesn't immediately yo-yo. Declared domains
+ * are floored at the engaged-fan rung (moderate) on both seed and erosion;
+ * demonstrated domains seed low and retain the full range down to accessible.
  */
 export async function updateDomainDifficultyOnAnswer(
   userId: string,
@@ -287,13 +325,13 @@ export async function updateDomainDifficultyOnAnswer(
     .limit(1);
 
   if (!existing) {
-    const [level, focusDomains] = await Promise.all([
+    const [level, declaredDomains] = await Promise.all([
       readCurrentAdaptiveLevel(userId),
-      getFocusDomainSet(userId, [canonicalSubcategory]),
+      getDeclaredDomainSet(userId, [canonicalSubcategory]),
     ]);
     const seed = applyFocusFloor(
       seedDifficultyFromAdaptiveLevel(level),
-      focusDomains.has(canonicalSubcategory),
+      declaredDomains.has(canonicalSubcategory),
     );
     await db.insert(userDomainDifficulties).values({
       userId,
@@ -306,7 +344,13 @@ export async function updateDomainDifficultyOnAnswer(
     return;
   }
 
-  const next = computeDomainDifficultyStep(existing, isCorrect);
+  // Declared domains carry the engaged-fan erosion floor; demonstrated domains
+  // step down freely (default 'accessible' floor).
+  const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
+  const floor: ServedDifficulty = declaredDomains.has(canonicalSubcategory)
+    ? FOCUS_DOMAIN_MIN_DIFFICULTY
+    : 'accessible';
+  const next = computeDomainDifficultyStep(existing, isCorrect, floor);
 
   await db
     .update(userDomainDifficulties)
@@ -349,19 +393,20 @@ export async function getDomainDifficultyOverrides(
   }
 
   // Only domains without a persisted row need a first-contact seed. Pull the
-  // user's adaptive level and which of those domains are opted-in focus areas
-  // so we can floor the seed to "Familiar" for the latter.
+  // user's adaptive level and which of those domains are declared so we can
+  // floor the seed to the engaged-fan rung for the latter (demonstrated domains
+  // seed straight off the adaptive level and may start at accessible).
   const domainsNeedingSeed = domains.filter((domain) => !known.has(domain));
-  const [seedLevel, focusDomains] = domainsNeedingSeed.length === 0
+  const [seedLevel, declaredDomains] = domainsNeedingSeed.length === 0
     ? [MIN_ADAPTIVE_LEVEL, new Set<string>()]
     : await Promise.all([
         readCurrentAdaptiveLevel(userId),
-        getFocusDomainSet(userId, domainsNeedingSeed),
+        getDeclaredDomainSet(userId, domainsNeedingSeed),
       ]);
 
   for (const domain of domains) {
     const served = known.get(domain)
-      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
+      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), declaredDomains.has(domain));
     overrides.set(domain, SERVED_TO_PREFERENCE[served]);
   }
 

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -197,31 +197,68 @@ function seedDifficultyFromAdaptiveLevel(level: number): ServedDifficulty {
 }
 
 /**
- * The "engaged-fan" rung, expressed on the per-domain served-difficulty ladder
- * (moderate). It is the hard floor for a domain the player explicitly DECLARED:
- * someone who raised their hand for a topic finds accessible ("tourist") trivia
- * condescendingly easy, so a declared domain both *seeds* here and *cannot erode
- * below* here (PRD-D-5 §5.2, D3). Demonstrated domains are NOT floored — they
- * start low and retain the full adaptive range down to accessible.
+ * Minimum first-contact difficulty for a domain the player explicitly opted
+ * into — either by stating it as an area of focus or by accepting one shared by
+ * a friend. Someone who raised their hand for a topic finds "Establishing"
+ * (accessible) trivia condescendingly easy, so we floor the *seed* at "Familiar"
+ * (moderate) for ANY focus domain (declared or demonstrated). This sets only the
+ * starting point. What happens to the floor afterwards is signal-keyed: a
+ * DECLARED domain also holds this as a hard *erosion* floor (the two-incorrect
+ * step-down can't drop below it), while a DEMONSTRATED domain can still step
+ * down to accessible (PRD-D-5 §5.2, D3 — the erosion floor is declared-only).
  */
 const FOCUS_DOMAIN_MIN_DIFFICULTY: ServedDifficulty = 'moderate';
 
-export function applyFocusFloor(difficulty: ServedDifficulty, isDeclaredDomain: boolean): ServedDifficulty {
-  if (!isDeclaredDomain) return difficulty;
+export function applyFocusFloor(difficulty: ServedDifficulty, isFocusDomain: boolean): ServedDifficulty {
+  if (!isFocusDomain) return difficulty;
   return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(FOCUS_DOMAIN_MIN_DIFFICULTY)
     ? difficulty
     : FOCUS_DOMAIN_MIN_DIFFICULTY;
 }
 
 /**
+ * Canonical subcategories the player has opted into: declared interests (stated
+ * focus areas) plus any open territory in PLAYER_MASTERY — friend-mediated
+ * acceptances and authored domains both land there. Used to floor the
+ * first-contact *seed* to "Familiar" for any opted-in domain (declared OR
+ * demonstrated). The declared/demonstrated split that governs the *erosion*
+ * floor lives in `getDeclaredDomainSet`. Pass `domains` to scope the lookup.
+ */
+async function getFocusDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
+  const focus = new Set<string>();
+  if (domains.length === 0) return focus;
+
+  const [declaredRows, masteryRows] = await Promise.all([
+    db
+      .select({ domain: declaredInterests.domain })
+      .from(declaredInterests)
+      .where(and(
+        eq(declaredInterests.userId, userId),
+        eq(declaredInterests.isActive, true),
+        inArray(declaredInterests.domain, domains),
+      )),
+    db
+      .select({ domain: playerMastery.canonicalSubcategory })
+      .from(playerMastery)
+      .where(and(
+        eq(playerMastery.userId, userId),
+        inArray(playerMastery.canonicalSubcategory, domains),
+      )),
+  ]);
+
+  for (const row of declaredRows) focus.add(row.domain);
+  for (const row of masteryRows) focus.add(row.domain);
+  return focus;
+}
+
+/**
  * Canonical subcategories the player explicitly DECLARED — stated focus areas
  * (`declaredInterests`) plus PLAYER_MASTERY rows whose `territoryType` is
  * 'declared' (friend-mediated acceptances that came in as declared territory).
- * This is the signal that keys the difficulty floor (D2/D3): declared domains
- * seed at engaged-fan and cannot erode to accessible; demonstrated domains (the
- * rest) get the full adaptive range. Splitting declared from demonstrated here
- * is what stops the floor from pinning newcomer/demonstrated domains too high
- * (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope the lookup to the round.
+ * This narrower set keys the hard *erosion* floor (D2/D3): a declared domain
+ * cannot erode below engaged-fan, while a demonstrated domain — though it still
+ * *seeds* at moderate (see `getFocusDomainSet`) — keeps the full range and can
+ * step down to accessible (PRD-D-5 §5.2, DRIFT RISK 2). Pass `domains` to scope.
  */
 async function getDeclaredDomainSet(userId: string, domains: string[]): Promise<Set<string>> {
   const declared = new Set<string>();
@@ -325,13 +362,14 @@ export async function updateDomainDifficultyOnAnswer(
     .limit(1);
 
   if (!existing) {
-    const [level, declaredDomains] = await Promise.all([
+    // Seed floor is for any opted-in (focus) domain — declared or demonstrated.
+    const [level, focusDomains] = await Promise.all([
       readCurrentAdaptiveLevel(userId),
-      getDeclaredDomainSet(userId, [canonicalSubcategory]),
+      getFocusDomainSet(userId, [canonicalSubcategory]),
     ]);
     const seed = applyFocusFloor(
       seedDifficultyFromAdaptiveLevel(level),
-      declaredDomains.has(canonicalSubcategory),
+      focusDomains.has(canonicalSubcategory),
     );
     await db.insert(userDomainDifficulties).values({
       userId,
@@ -344,8 +382,8 @@ export async function updateDomainDifficultyOnAnswer(
     return;
   }
 
-  // Declared domains carry the engaged-fan erosion floor; demonstrated domains
-  // step down freely (default 'accessible' floor).
+  // Erosion floor is declared-only: declared domains carry the engaged-fan
+  // floor, demonstrated domains step down freely (default 'accessible' floor).
   const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
   const floor: ServedDifficulty = declaredDomains.has(canonicalSubcategory)
     ? FOCUS_DOMAIN_MIN_DIFFICULTY
@@ -393,20 +431,20 @@ export async function getDomainDifficultyOverrides(
   }
 
   // Only domains without a persisted row need a first-contact seed. Pull the
-  // user's adaptive level and which of those domains are declared so we can
-  // floor the seed to the engaged-fan rung for the latter (demonstrated domains
-  // seed straight off the adaptive level and may start at accessible).
+  // user's adaptive level and which of those domains are opted-in focus areas
+  // so we can floor the seed to "Familiar" for the latter (declared OR
+  // demonstrated — the erosion-floor split is applied later, on answer).
   const domainsNeedingSeed = domains.filter((domain) => !known.has(domain));
-  const [seedLevel, declaredDomains] = domainsNeedingSeed.length === 0
+  const [seedLevel, focusDomains] = domainsNeedingSeed.length === 0
     ? [MIN_ADAPTIVE_LEVEL, new Set<string>()]
     : await Promise.all([
         readCurrentAdaptiveLevel(userId),
-        getDeclaredDomainSet(userId, domainsNeedingSeed),
+        getFocusDomainSet(userId, domainsNeedingSeed),
       ]);
 
   for (const domain of domains) {
     const served = known.get(domain)
-      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), declaredDomains.has(domain));
+      ?? applyFocusFloor(seedDifficultyFromAdaptiveLevel(seedLevel), focusDomains.has(domain));
     overrides.set(domain, SERVED_TO_PREFERENCE[served]);
   }
 

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -13,6 +13,7 @@ import {
 } from '@/lib/llm';
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 import { db, generatedQuestions } from '@/server/db';
+import { embedAndResolveDuplicate } from '@/server/pool/dedup';
 import {
   getDomainDifficultyOverrides,
   mapAdaptiveLevelToDifficultyHint,
@@ -1051,6 +1052,13 @@ export async function generateDailyQuestions(
       })
       .returning();
     persisted.push(row);
+
+    // Semantic-dedup backstop (B1 pool substrate). Best-effort and no-op without
+    // VOYAGE_API_KEY, so it never blocks generation; the fact_key/Haiku/text
+    // guards above remain the cheap first pass. A new machine row that collides
+    // with an existing pool question is flagged is_duplicate (never deleted), so
+    // pickBankSource stops serving it.
+    await embedAndResolveDuplicate({ id: row.id, origin: 'machine', questionText: row.questionText });
   }
 
   return persisted;

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -66,7 +66,10 @@ BAD (multiple-choice phrasing — never produce these):
 
 GOOD (open recall):
 - "What does Sally Seton represent to the young Clarissa in Mrs. Dalloway?"
-- "In what year did Tchaikovsky premiere his Sixth Symphony?"
+- "What does the madeleine awaken in the narrator of In Search of Lost Time?"
+
+TRIVIA-OF-TRIVIA RULE:
+Prefer questions of substance — "what is X", "what does X mean", "why does X matter", "who did X" — over questions of mere recall — "what year", "what number", "what label". A date, a count, or a name is worth asking only when that specific fact is itself meaningful; a question that lands on substance is almost always the better question. Lead with the idea, not the index card.
 
 STYLE EXEMPLARS (match this register, specificity, and concision):
 These are gold-standard Joshing questions. Mimic their tone — literate, confident, and specific. Pull from comparable depth (named characters, named works, technical terms, specific years, named figures) rather than vague appreciation or "explain why" questions. Notice how they assume a cultured audience without condescension.
@@ -118,7 +121,7 @@ QUESTION SHAPE VARIETY:
 Trivia gets monotonous when every question follows the same template ("What is the name of X?"). Vary the shape across the batch. Choose from this catalog and emit the chosen shape on each question via the question_shape field:
 
 - "identification": asks for a name, term, title, or label (e.g. "What is the name of the dwarf who forges the ring?")
-- "year_or_date": asks for a year, date, or temporal ordering (e.g. "In what year did the Berlin Wall fall?")
+- "year_or_date": asks for a year, date, or temporal ordering. Use ONLY when the date itself is meaningful — a turning point, an anniversary, a deliberate juxtaposition — never as a default or filler in place of a substance question (e.g. "In what year did the Berlin Wall fall?")
 - "in_which_work": asks which work, scene, chapter, movement, or section something appears in
 - "who_did_what": asks which character/person performs a specific act (e.g. "Who kills Polonius?")
 - "sequence_or_order": asks for ordering of events, items, or steps
@@ -233,6 +236,8 @@ function difficultyInstruction(preference: string | undefined, adaptiveLevel?: n
 type AvoidQuestionEntry = RecentDailyQuestionEntry;
 type AvoidFactKeyEntry = RecentFactKeyEntry;
 
+type TerritoryType = 'declared' | 'demonstrated';
+
 function buildUserPrompt(
   domains: string[],
   count: number,
@@ -243,6 +248,7 @@ function buildUserPrompt(
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): string {
   const prevBlock = prev.length > 0
     ? prev
@@ -296,6 +302,28 @@ ${lines.join('\n')}`;
     if (instruction) difficultyHint = `\n\nDifficulty instruction: ${instruction}`;
   }
 
+  // Territory register (PRD-D-5 §5.2). A DECLARED domain is one the player chose
+  // — they hold a floor at the engaged-fan rung, so questions must read for
+  // someone who actively follows it, never tourist-level recognition trivia. A
+  // DEMONSTRATED domain surfaced from play; meet a newcomer at an accessible
+  // register and let depth climb. This mirrors the floor the difficulty mapper
+  // already applies, so the prose register and the target rate stay aligned.
+  let territoryHint = '';
+  if (domainTerritoryTypes && domainTerritoryTypes.size > 0) {
+    const declaredDomains = domains.filter((d) => domainTerritoryTypes.get(d) === 'declared');
+    const introducedDomains = domains.filter((d) => domainTerritoryTypes.get(d) === 'demonstrated');
+    const lines: string[] = [];
+    if (declaredDomains.length > 0) {
+      lines.push(`- DECLARED (the player chose to learn these — write for an engaged enthusiast who actively follows the domain; assume real familiarity and never ask tourist-level "who composed it" recognition trivia): ${declaredDomains.join(', ')}`);
+    }
+    if (introducedDomains.length > 0) {
+      lines.push(`- INTRODUCED (surfaced from the player's activity — meet a curious newcomer at an accessible register and let difficulty climb with play): ${introducedDomains.join(', ')}`);
+    }
+    if (lines.length > 0) {
+      territoryHint = `\n\nDomain familiarity:\n${lines.join('\n')}`;
+    }
+  }
+
   const domainSection =
     domains.length === count && count > 1
       ? `Generate exactly one trivia question for each of the following ${count} domains:\n${domains.map((d, i) => `${i + 1}. ${d}`).join('\n')}`
@@ -316,7 +344,7 @@ ${perDomain.join('\n')}`;
     }
   }
 
-  return `${domainSection}${calibration}${difficultyHint}${subAnglesHint}
+  return `${domainSection}${calibration}${difficultyHint}${territoryHint}${subAnglesHint}
 
 Previously generated questions to avoid repeating (do not re-ask any of these facts, even rephrased). Each entry is prefixed with [<source domain>]. The user's domains may overlap in subject matter — for example, a fact about Mrs. Dalloway already asked under "Virginia Woolf's Novels and Essays" is still off limits when generating for "Mrs. Dalloway", and vice versa. A fact already covered under ANY of the user's domains must not be re-asked under ANY domain:
 ${wrapUserInput('recent_questions', prevBlock)}
@@ -761,6 +789,7 @@ async function callLlmOnce(
   domainDifficultyOverrides?: ReadonlyMap<string, string>,
   adaptiveLevel?: number | null,
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): Promise<LlmQuestion[]> {
   const client = getAnthropicClient();
   if (!client) return [];
@@ -787,6 +816,7 @@ async function callLlmOnce(
           domainDifficultyOverrides,
           adaptiveLevel,
           subAnglesByDomain,
+          domainTerritoryTypes,
         ),
       },
     ],
@@ -808,6 +838,7 @@ export async function generateDailyQuestions(
   adaptiveLevel?: number | null,
   previousFactKeys: AvoidFactKeyEntry[] = [],
   subAnglesByDomain?: ReadonlyMap<string, string[]>,
+  domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
 ): Promise<GeneratedQuestionRow[]> {
   if (count <= 0 || domains.length === 0) return [];
 
@@ -841,6 +872,7 @@ export async function generateDailyQuestions(
         domainDifficultyOverrides,
         adaptiveLevel,
         subAnglesByDomain,
+        domainTerritoryTypes,
       );
       if (out.length > 0) return out;
       console.warn('[daily/generate-questions] chunk returned no usable questions, retrying', {
@@ -856,6 +888,7 @@ export async function generateDailyQuestions(
         domainDifficultyOverrides,
         adaptiveLevel,
         subAnglesByDomain,
+        domainTerritoryTypes,
       );
     } catch (err) {
       // A single chunk failing (timeout / aborted) must not sink the batch —
@@ -1204,6 +1237,14 @@ export async function generateDailyQuestionsFromKnowledgeBase(
     ? await getDomainDifficultyOverrides(userId, domainsForRound).catch(() => undefined)
     : undefined;
 
+  // territoryType (declared | demonstrated) per selected domain — threaded into
+  // the generation prompt so its register matches the difficulty floor (PRD-D-5
+  // §5.2): declared domains read for an enthusiast, demonstrated for a newcomer.
+  const territoryByDomain = new Map<string, TerritoryType>();
+  for (const entry of knowledgeBase) {
+    territoryByDomain.set(entry.domain, entry.territoryType);
+  }
+
   const subAnglesByDomain = await getRecentSubAnglesByDomain(userId, domainsForRound).catch(() => undefined);
 
   // Try to fill slots from the cross-user bank (previously-generated questions
@@ -1239,6 +1280,7 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       adaptiveLevel,
       previousFactKeys,
       subAnglesByDomain,
+      territoryByDomain,
     );
   }
 

--- a/src/server/db/queries/__tests__/pool.test.ts
+++ b/src/server/db/queries/__tests__/pool.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  empiricalRate,
+  filterPooledQuestions,
+  normalizeHumanRow,
+  normalizeMachineRow,
+  visibilityToScope,
+  type PooledQuestion,
+} from '@/server/db/queries/pool';
+import { generatedQuestions, questions } from '@/server/db/schema';
+
+type MachineRow = typeof generatedQuestions.$inferSelect;
+type HumanRow = typeof questions.$inferSelect;
+
+let seq = 0;
+
+function machineRow(over: Partial<MachineRow> = {}): MachineRow {
+  seq += 1;
+  return {
+    id: `gen-${seq}`,
+    userId: 'recipient-user',
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    questionText: `Machine question ${seq}`,
+    answer: `Machine answer ${seq}`,
+    explainer: `Machine explainer ${seq}`,
+    difficultyEstimate: 'moderate',
+    basePoints: 10,
+    factKey: `fact-${seq}`,
+    subAngles: [],
+    insideJoke: null,
+    createdAt: new Date(2026, 0, seq + 1),
+    expiresAt: new Date(2026, 1, seq + 1),
+    usedInQueue: false,
+    trustTier: 'machine_verified',
+    scope: 'public',
+    perishable: false,
+    sourceRefs: [],
+    nAnswered: 0,
+    empiricalCorrectRate: null,
+    isDuplicate: false,
+    suppressedBy: null,
+    ...over,
+  } as MachineRow;
+}
+
+function humanRow(over: Partial<HumanRow> = {}): HumanRow {
+  seq += 1;
+  return {
+    id: `q-${seq}`,
+    creatorId: 'author-user',
+    questionText: `Human question ${seq}`,
+    answerText: `Human answer ${seq}`,
+    factualExplanation: `Human explainer ${seq}`,
+    explainerFull: null,
+    canonicalSubcategory: 'Bowie-era Glam Rock',
+    broadCategory: 'music',
+    difficultyEstimate: 'moderate',
+    visibility: 'public',
+    askedCount: 0,
+    correctCount: 0,
+    correctRate: null,
+    createdAt: new Date(2026, 0, seq + 1),
+    deletedAt: null,
+    trustTier: 'author_confirmed',
+    perishable: false,
+    sourceRefs: [],
+    isDuplicate: false,
+    suppressedBy: null,
+    ...over,
+  } as unknown as HumanRow;
+}
+
+describe('visibilityToScope', () => {
+  it('maps friends -> friends_only and passes private/public through', () => {
+    expect(visibilityToScope('friends')).toBe('friends_only');
+    expect(visibilityToScope('private')).toBe('private');
+    expect(visibilityToScope('public')).toBe('public');
+  });
+});
+
+describe('empiricalRate', () => {
+  it('computes correct/asked when there is play history', () => {
+    expect(empiricalRate(4, 3, null)).toBeCloseTo(0.75);
+  });
+  it('falls back to the stored rate, then null, when nothing was asked', () => {
+    expect(empiricalRate(0, 0, 0.5)).toBe(0.5);
+    expect(empiricalRate(0, 0, null)).toBeNull();
+  });
+});
+
+describe('normalizeMachineRow', () => {
+  it('produces the unified shape with no author and scope from the column', () => {
+    const row = normalizeMachineRow(machineRow({ scope: 'friends_only', nAnswered: 2, empiricalCorrectRate: 0.5 }));
+    expect(row.origin).toBe('machine');
+    expect(row.authorId).toBeNull();
+    expect(row.scope).toBe('friends_only');
+    expect(row.answer).toContain('Machine answer');
+    expect(row.nAnswered).toBe(2);
+    expect(row.empiricalCorrectRate).toBe(0.5);
+  });
+});
+
+describe('normalizeHumanRow', () => {
+  it('reuses visibility/askedCount/counts and exposes the author', () => {
+    const row = normalizeHumanRow(humanRow({
+      creatorId: 'jane',
+      visibility: 'friends',
+      askedCount: 10,
+      correctCount: 6,
+    }));
+    expect(row.origin).toBe('human');
+    expect(row.authorId).toBe('jane');
+    expect(row.scope).toBe('friends_only');
+    expect(row.answer).toContain('Human answer');
+    expect(row.nAnswered).toBe(10);
+    expect(row.empiricalCorrectRate).toBeCloseTo(0.6);
+  });
+});
+
+describe('filterPooledQuestions — unified pool, default path unchanged', () => {
+  function pool(): PooledQuestion[] {
+    return [
+      normalizeMachineRow(machineRow({ trustTier: 'machine_verified', scope: 'public' })),
+      normalizeHumanRow(humanRow({ trustTier: 'author_confirmed', visibility: 'public' })),
+    ];
+  }
+
+  it('returns BOTH machine and human questions by default (today\'s union)', () => {
+    const result = filterPooledQuestions(pool());
+    expect(result.map((r) => r.origin).sort()).toEqual(['human', 'machine']);
+  });
+
+  it('excludes suppressed (is_duplicate) rows by default', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ isDuplicate: true })),
+      normalizeHumanRow(humanRow({ isDuplicate: false })),
+    ];
+    const result = filterPooledQuestions(rows);
+    expect(result.map((r) => r.origin)).toEqual(['human']);
+  });
+
+  it('includes suppressed rows only when explicitly asked', () => {
+    const rows = [normalizeMachineRow(machineRow({ isDuplicate: true }))];
+    expect(filterPooledQuestions(rows)).toHaveLength(0);
+    expect(filterPooledQuestions(rows, { includeSuppressed: true })).toHaveLength(1);
+  });
+
+  it('can filter by trust tier (capability — not wired into any live surface)', () => {
+    const result = filterPooledQuestions(pool(), { trustTiers: ['author_confirmed'] });
+    expect(result.map((r) => r.origin)).toEqual(['human']);
+    const machineOnly = filterPooledQuestions(pool(), { trustTiers: ['machine_verified'] });
+    expect(machineOnly.map((r) => r.origin)).toEqual(['machine']);
+  });
+
+  it('can filter by scope', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ scope: 'public' })),
+      normalizeHumanRow(humanRow({ visibility: 'friends' })),
+    ];
+    const friendsOnly = filterPooledQuestions(rows, { scopes: ['friends_only'] });
+    expect(friendsOnly.map((r) => r.origin)).toEqual(['human']);
+  });
+
+  it('can filter by origin and domain', () => {
+    const rows = [
+      normalizeMachineRow(machineRow({ canonicalSubcategory: 'Jazz' })),
+      normalizeMachineRow(machineRow({ canonicalSubcategory: 'Opera' })),
+      normalizeHumanRow(humanRow({ canonicalSubcategory: 'Jazz' })),
+    ];
+    expect(filterPooledQuestions(rows, { origins: ['machine'] })).toHaveLength(2);
+    expect(filterPooledQuestions(rows, { domains: ['Jazz'] })).toHaveLength(2);
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1334,20 +1334,25 @@ export type BankDifficulty = 'accessible' | 'moderate' | 'specialist';
 //
 // Restrictions:
 // - fact_key must be present (predates 2026-05-24; older rows lack it)
-// - created within the last 30 days (filters out the worst pre-quality-gate
-//   historical drift)
 // - not authored by the viewer
+// - not suppressed as an embedding near-duplicate (is_duplicate; B3)
 // - fact_key not already in the viewer's recent avoid set
+//
+// Durability (B1 pool substrate / PRD-D-5 §5.1, D8): the bank no longer excludes
+// questions by age — nothing decays out, so thin domains stop drying up. Recency
+// still *ranks*: we draw a newest-first window and shuffle within it, so when a
+// domain has plenty of recent rows the result matches the prior "random among
+// recent" behavior, and only falls back to older rows when recent ones run out.
 //
 // Returns null when the bank is empty for this domain+difficulty — caller
 // falls back to fresh LLM generation, which incidentally grows the bank.
+const BANK_RECENCY_WINDOW = 50;
 export async function pickBankSource(
   userId: string,
   domain: string,
   difficulty: BankDifficulty,
   avoidFactKeys: ReadonlySet<string>,
 ): Promise<BankSource | null> {
-  const since = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
     candidates = await db
@@ -1358,16 +1363,23 @@ export async function pickBankSource(
         eq(generatedQuestions.difficultyEstimate, difficulty),
         isNotNull(generatedQuestions.factKey),
         sql`${generatedQuestions.userId} <> ${userId}`,
-        gte(generatedQuestions.createdAt, since),
+        eq(generatedQuestions.isDuplicate, false),
       ))
-      .orderBy(sql`random()`)
-      .limit(8);
+      .orderBy(desc(generatedQuestions.createdAt))
+      .limit(BANK_RECENCY_WINDOW);
   } catch (error) {
-    // Tolerate the brief window where the sub_angles column is missing
-    // (migration 0055): a hard failure here would silently disable the
-    // entire bank-pick path until the migration lands.
+    // Tolerate the brief window where a newly-added column is missing
+    // (sub_angles in 0055; is_duplicate in 0062): a hard failure here would
+    // silently disable the entire bank-pick path until the migration lands.
     if (pgErrorCode(error) === '42703') return null;
     throw error;
+  }
+
+  // Shuffle the recency window (Fisher–Yates) so selection within it stays
+  // varied; recency already biases which rows land in the window.
+  for (let i = candidates.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [candidates[i], candidates[j]] = [candidates[j], candidates[i]];
   }
 
   for (const row of candidates) {

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -349,28 +349,43 @@ export async function getMilestoneQuestionText(
   return out;
 }
 
-// Which of the given questions the viewer has ALREADY answered correctly. Drives
-// the milestone expansion's "{k} of {n} answered" progress on first render and
-// makes the no-double-credit reality visible (a question already in the viewer's
-// mastery history won't earn new credit on re-answer — it becomes repeat_correct).
-export async function getViewerCorrectlyAnsweredIds(
+export type ViewerAnswerStatus = 'correct' | 'incorrect';
+
+// The viewer's own standing on each of the given questions, from their answer
+// history. A question the viewer answered correctly counts toward the milestone
+// "{k} of {n} answered" progress and makes the no-double-credit reality visible
+// (re-answering becomes repeat_correct, 0 points). A question they MISSED is
+// surfaced as 'incorrect' so the expansion can lock it — one shot, no re-answer.
+//
+// Scoped to the viewer's OWN attempts (answeredByUserId = userId) and to rows
+// that actually carry an answer_state, which excludes author/curator credit
+// (those store a null answer_state). Any correct attempt wins; otherwise the
+// question is reported as the incorrect attempt we saw.
+export async function getViewerAnswerStatusByQuestionId(
   userId: string,
   ids: string[],
-): Promise<Set<string>> {
-  const out = new Set<string>();
+): Promise<Map<string, ViewerAnswerStatus>> {
+  const out = new Map<string, ViewerAnswerStatus>();
   if (ids.length === 0) return out;
   const rows = await db
-    .select({ questionId: masteryEvents.questionId })
+    .select({ questionId: masteryEvents.questionId, answerState: masteryEvents.answerState })
     .from(masteryEvents)
     .where(
       and(
         eq(masteryEvents.userId, userId),
+        eq(masteryEvents.answeredByUserId, userId),
         inArray(masteryEvents.questionId, ids),
-        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+        isNotNull(masteryEvents.answerState),
       ),
     );
   for (const row of rows) {
-    if (row.questionId) out.add(row.questionId);
+    if (!row.questionId) continue;
+    const correct = row.answerState !== 'incorrect';
+    if (correct) {
+      out.set(row.questionId, 'correct');
+    } else if (!out.has(row.questionId)) {
+      out.set(row.questionId, 'incorrect');
+    }
   }
   return out;
 }

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -1,0 +1,200 @@
+import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { generatedQuestions, questions } from '@/server/db/schema';
+
+// B1 pool substrate — unified selection layer (PRD-D-5 §5.1 / §8).
+//
+// The machine bank (GeneratedQuestion) and the human-authored questions
+// (Question) stay as separate tables; this layer is the seam that treats them as
+// ONE pool — normalizing both into a single shape and exposing trust_tier / scope
+// as optional filters.
+//
+// DRIFT GUARD (B1): this is *capability only*. Nothing here is wired into a live
+// surface, and the default filter reproduces today's served set — all trust
+// tiers, suppressed rows excluded, soft-deleted human rows excluded. Live
+// trust-tier gating is B4's job. Existing callers (pickBankSource,
+// pickEligibleAuthoredQuestions, pickHouseQuestions) are untouched.
+
+export type PoolOrigin = 'machine' | 'human';
+export type TrustTier = 'unverified' | 'machine_verified' | 'human_validated' | 'author_confirmed';
+export type PoolScope = 'private' | 'friends_only' | 'public';
+
+export interface PooledQuestion {
+  id: string;
+  origin: PoolOrigin;
+  questionText: string;
+  answer: string;
+  explainer: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+  difficultyEstimate: string | null;
+  trustTier: TrustTier;
+  scope: PoolScope;
+  /** Author for human rows (creatorId); null for machine (no author — the
+   *  GeneratedQuestion.userId is the recipient, not the author). */
+  authorId: string | null;
+  perishable: boolean;
+  sourceRefs: string[];
+  nAnswered: number;
+  empiricalCorrectRate: number | null;
+  isDuplicate: boolean;
+  suppressedBy: string | null;
+  createdAt: Date;
+}
+
+export interface PoolFilter {
+  trustTiers?: TrustTier[];
+  scopes?: PoolScope[];
+  origins?: PoolOrigin[];
+  /** canonical_subcategory match. */
+  domains?: string[];
+  difficulty?: string[];
+  /** Include embedding-dedup-suppressed rows. Default false (reproduces today). */
+  includeSuppressed?: boolean;
+}
+
+type MachineRow = typeof generatedQuestions.$inferSelect;
+type HumanRow = typeof questions.$inferSelect;
+
+/** Human Question.visibility → unified pool scope. */
+export function visibilityToScope(visibility: 'private' | 'public' | 'friends'): PoolScope {
+  return visibility === 'friends' ? 'friends_only' : visibility;
+}
+
+/** Empirical played rate, uniform across origins: correct/asked when there is
+ *  play history, falling back to the stored rate, else null. Matches the machine
+ *  backfill in migration 0062 (correct_count / asked_count). */
+export function empiricalRate(
+  asked: number,
+  correct: number,
+  storedRate: number | null,
+): number | null {
+  if (asked > 0) return correct / asked;
+  return storedRate ?? null;
+}
+
+export function normalizeMachineRow(row: MachineRow): PooledQuestion {
+  return {
+    id: row.id,
+    origin: 'machine',
+    questionText: row.questionText,
+    answer: row.answer,
+    explainer: row.explainer,
+    canonicalSubcategory: row.canonicalSubcategory,
+    broadCategory: row.broadCategory,
+    difficultyEstimate: row.difficultyEstimate,
+    trustTier: row.trustTier as TrustTier,
+    scope: row.scope as PoolScope,
+    authorId: null,
+    perishable: row.perishable,
+    sourceRefs: row.sourceRefs ?? [],
+    nAnswered: row.nAnswered,
+    empiricalCorrectRate: row.empiricalCorrectRate ?? null,
+    isDuplicate: row.isDuplicate,
+    suppressedBy: row.suppressedBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+export function normalizeHumanRow(row: HumanRow): PooledQuestion {
+  return {
+    id: row.id,
+    origin: 'human',
+    questionText: row.questionText,
+    answer: row.answerText,
+    // Human rows carry several explainer variants; prefer the factual one, then
+    // the full default, mirroring the existing question-view fallback order.
+    explainer: row.factualExplanation ?? row.explainerFull ?? null,
+    canonicalSubcategory: row.canonicalSubcategory,
+    broadCategory: row.broadCategory,
+    difficultyEstimate: row.difficultyEstimate,
+    trustTier: row.trustTier as TrustTier,
+    // Reused field: scope is derived from the existing visibility column.
+    scope: visibilityToScope(row.visibility),
+    authorId: row.creatorId,
+    perishable: row.perishable,
+    sourceRefs: row.sourceRefs ?? [],
+    // Reused fields: n_answered ← asked_count, empirical rate ← play history.
+    nAnswered: row.askedCount,
+    empiricalCorrectRate: empiricalRate(row.askedCount, row.correctCount, row.correctRate),
+    isDuplicate: row.isDuplicate,
+    suppressedBy: row.suppressedBy ?? null,
+    createdAt: row.createdAt,
+  };
+}
+
+/**
+ * Pure filter over normalized pool rows — the single source of truth for filter
+ * semantics. Defaults reproduce today's served set: suppressed rows excluded,
+ * no tier/scope narrowing.
+ */
+export function filterPooledQuestions(
+  rows: PooledQuestion[],
+  filter: PoolFilter = {},
+): PooledQuestion[] {
+  const { trustTiers, scopes, origins, domains, difficulty, includeSuppressed } = filter;
+  return rows.filter((row) => {
+    if (!includeSuppressed && row.isDuplicate) return false;
+    if (origins && !origins.includes(row.origin)) return false;
+    if (trustTiers && !trustTiers.includes(row.trustTier)) return false;
+    if (scopes && !scopes.includes(row.scope)) return false;
+    if (domains && (row.canonicalSubcategory == null || !domains.includes(row.canonicalSubcategory))) {
+      return false;
+    }
+    if (difficulty && (row.difficultyEstimate == null || !difficulty.includes(row.difficultyEstimate))) {
+      return false;
+    }
+    return true;
+  });
+}
+
+/**
+ * Draw candidates from BOTH tables as one pool. The selective predicates
+ * (domain, difficulty, suppressed, soft-delete) are pushed to SQL for
+ * efficiency; the full, authoritative filter is re-applied in-memory via
+ * filterPooledQuestions so SQL and pure paths can never diverge.
+ */
+export async function selectFromPool(filter: PoolFilter = {}): Promise<PooledQuestion[]> {
+  const includeMachine = !filter.origins || filter.origins.includes('machine');
+  const includeHuman = !filter.origins || filter.origins.includes('human');
+
+  const [machineRows, humanRows] = await Promise.all([
+    includeMachine
+      ? db.select().from(generatedQuestions).where(buildMachineWhere(filter))
+      : Promise.resolve([] as MachineRow[]),
+    includeHuman
+      ? db.select().from(questions).where(buildHumanWhere(filter))
+      : Promise.resolve([] as HumanRow[]),
+  ]);
+
+  const pooled = [
+    ...machineRows.map(normalizeMachineRow),
+    ...humanRows.map(normalizeHumanRow),
+  ];
+  return filterPooledQuestions(pooled, filter);
+}
+
+function buildMachineWhere(filter: PoolFilter) {
+  const clauses = [];
+  if (!filter.includeSuppressed) clauses.push(eq(generatedQuestions.isDuplicate, false));
+  if (filter.domains?.length) clauses.push(inArray(generatedQuestions.canonicalSubcategory, filter.domains));
+  if (filter.difficulty?.length) clauses.push(inArray(generatedQuestions.difficultyEstimate, filter.difficulty));
+  return clauses.length ? and(...clauses) : sql`true`;
+}
+
+function buildHumanWhere(filter: PoolFilter) {
+  // Default reproduces today: soft-deleted authored rows are never served.
+  const clauses = [isNull(questions.deletedAt)];
+  if (!filter.includeSuppressed) clauses.push(eq(questions.isDuplicate, false));
+  if (filter.domains?.length) clauses.push(inArray(questions.canonicalSubcategory, filter.domains));
+  if (filter.difficulty?.length) {
+    // questions.difficultyEstimate is enum-typed; the authoritative narrowing
+    // happens in filterPooledQuestions, so a value outside the enum simply
+    // matches nothing here. Cast to satisfy the column's literal union.
+    clauses.push(inArray(questions.difficultyEstimate, filter.difficulty as HumanDifficulty[]));
+  }
+  return and(...clauses);
+}
+
+type HumanDifficulty = NonNullable<HumanRow['difficultyEstimate']>;

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, cosineDistance, eq, inArray, isNotNull, isNull, sql } from 'drizzle-orm';
 
 import { db } from '@/server/db';
 import { generatedQuestions, questions } from '@/server/db/schema';
@@ -198,3 +198,94 @@ function buildHumanWhere(filter: PoolFilter) {
 }
 
 type HumanDifficulty = NonNullable<HumanRow['difficultyEstimate']>;
+
+// ─── Embedding dedup helpers (B3) ───────────────────────────────────────────
+
+export interface NearestPoolMatch {
+  id: string;
+  origin: PoolOrigin;
+  /** Cosine similarity in [0,1]; 1 = identical. */
+  similarity: number;
+}
+
+/**
+ * Nearest non-suppressed neighbour across BOTH tables by cosine similarity,
+ * excluding the given id. Returns null when nothing has an embedding yet.
+ */
+export async function findNearestInPool(
+  embedding: number[],
+  excludeId: string,
+): Promise<NearestPoolMatch | null> {
+  // cosineDistance returns 1 - similarity; ORDER BY it ascending for nearest.
+  const machineDistance = cosineDistance(generatedQuestions.embedding, embedding);
+  const humanDistance = cosineDistance(questions.embedding, embedding);
+
+  const [machineNearest, humanNearest] = await Promise.all([
+    db
+      .select({ id: generatedQuestions.id, distance: machineDistance })
+      .from(generatedQuestions)
+      .where(and(
+        isNotNull(generatedQuestions.embedding),
+        eq(generatedQuestions.isDuplicate, false),
+        sql`${generatedQuestions.id} <> ${excludeId}`,
+      ))
+      .orderBy(machineDistance)
+      .limit(1),
+    db
+      .select({ id: questions.id, distance: humanDistance })
+      .from(questions)
+      .where(and(
+        isNotNull(questions.embedding),
+        eq(questions.isDuplicate, false),
+        isNull(questions.deletedAt),
+        sql`${questions.id} <> ${excludeId}`,
+      ))
+      .orderBy(humanDistance)
+      .limit(1),
+  ]);
+
+  const candidates: NearestPoolMatch[] = [];
+  if (machineNearest[0]) {
+    candidates.push({ id: machineNearest[0].id, origin: 'machine', similarity: 1 - Number(machineNearest[0].distance) });
+  }
+  if (humanNearest[0]) {
+    candidates.push({ id: humanNearest[0].id, origin: 'human', similarity: 1 - Number(humanNearest[0].distance) });
+  }
+  if (!candidates.length) return null;
+  return candidates.reduce((best, c) => (c.similarity > best.similarity ? c : best));
+}
+
+/** Persist an embedding onto a pool row in the table indicated by origin. */
+export async function storePoolEmbedding(
+  origin: PoolOrigin,
+  id: string,
+  embedding: number[],
+): Promise<void> {
+  if (origin === 'machine') {
+    await db.update(generatedQuestions).set({ embedding }).where(eq(generatedQuestions.id, id));
+  } else {
+    await db.update(questions).set({ embedding }).where(eq(questions.id, id));
+  }
+}
+
+/**
+ * Flag a row as a suppressed near-duplicate (never delete). suppressedBy points
+ * at the surviving question, which may live in either table.
+ */
+export async function markPoolDuplicate(
+  origin: PoolOrigin,
+  id: string,
+  survivorId: string,
+): Promise<void> {
+  if (origin === 'machine') {
+    await db
+      .update(generatedQuestions)
+      .set({ isDuplicate: true, suppressedBy: survivorId })
+      .where(eq(generatedQuestions.id, id));
+  } else {
+    await db
+      .update(questions)
+      .set({ isDuplicate: true, suppressedBy: survivorId })
+      .where(eq(questions.id, id));
+  }
+}

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -12,6 +12,7 @@ import {
 } from '@/server/db';
 import { broadCategoryDisplayName } from '@/lib/question-categorization';
 import { pgErrorCode } from '@/server/db/pg-error';
+import { embedAndResolveDuplicate } from '@/server/pool/dedup';
 
 export type QuestionView = {
   id: string;
@@ -129,7 +130,7 @@ export const bankQuestionSelectColumns = questionViewColumns;
 // (e.g. bankQuestionSelectColumns) need not fetch them.
 type QuestionViewNonViewKey =
   | 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'
-  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy';
+  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy' | 'embedding';
 type QuestionViewRow = Omit<QuestionRow, QuestionViewNonViewKey>
   & Partial<Pick<QuestionRow, QuestionViewNonViewKey>>;
 
@@ -537,6 +538,13 @@ export async function createQuestion(params: {
     .onConflictDoNothing({
       target: [userQuestionBank.userId, userQuestionBank.questionId],
     });
+
+  // Semantic-dedup backstop (B1 pool substrate). Best-effort, no-op without a
+  // VOYAGE_API_KEY. A human-authored question that collides with an existing
+  // MACHINE pool row suppresses the *machine* row (human beats machine); a
+  // collision with another human row suppresses this new one. Always flags,
+  // never deletes.
+  await embedAndResolveDuplicate({ id: created.id, origin: 'human', questionText: params.text });
 
   return { id: created.id };
 }

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -124,8 +124,14 @@ const questionViewColumns = {
 
 export const bankQuestionSelectColumns = questionViewColumns;
 
-type QuestionViewRow = Omit<QuestionRow, 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'>
-  & Partial<Pick<QuestionRow, 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'>>;
+// The pool-substrate fields (B1) are not part of the rendered question view, so
+// they are excluded here like the other non-view columns — partial selects
+// (e.g. bankQuestionSelectColumns) need not fetch them.
+type QuestionViewNonViewKey =
+  | 'verified' | 'llmSuggestedAnswer' | 'critiqueIterations' | 'surfacePriorityScore'
+  | 'trustTier' | 'perishable' | 'sourceRefs' | 'isDuplicate' | 'suppressedBy';
+type QuestionViewRow = Omit<QuestionRow, QuestionViewNonViewKey>
+  & Partial<Pick<QuestionRow, QuestionViewNonViewKey>>;
 
 function difficultyToNumber(value: QuestionRow['difficultyEstimate']): number {
   if (value === 'accessible') return 1;

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -17,6 +17,7 @@ import {
   unique,
   uniqueIndex,
   uuid,
+  vector,
 } from 'drizzle-orm/pg-core';
 
 const id = (name = 'id') => text(name).primaryKey().default(sql`gen_random_uuid()::text`);
@@ -329,6 +330,9 @@ export const questions = pgTable(
     // question id (may live in either table, so not a hard FK).
     isDuplicate: boolean('is_duplicate').notNull().default(false),
     suppressedBy: text('suppressed_by'),
+    // Voyage voyage-3.5-lite embedding (1024-dim) — semantic-dedup backstop.
+    // Nullable: populated at insert and by the batched backfill (B3).
+    embedding: vector('embedding', { dimensions: 1024 }),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
@@ -592,6 +596,8 @@ export const generatedQuestions = pgTable(
     // row is the loser: is_duplicate=true, suppressed_by=<human id>. Never deleted.
     isDuplicate: boolean('is_duplicate').notNull().default(false),
     suppressedBy: text('suppressed_by'),
+    // Voyage voyage-3.5-lite embedding (1024-dim) — semantic-dedup backstop.
+    embedding: vector('embedding', { dimensions: 1024 }),
   },
   (table) => [
     index('GeneratedQuestion_user_id_idx').on(table.userId),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -39,6 +39,24 @@ export const categoryEnum = pgEnum('Category', [
 
 export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends']);
 
+// B1 pool substrate (PRD-D-5 §5.1 / §6). Trust climbs as a question earns it:
+// unverified (fresh, pre-checks) → machine_verified (retrieval + ask-to-answer,
+// B3/B4) → human_validated (N humans correct in play) → author_confirmed
+// (human-authored, answer asserted by author). B1 only adds the field + the
+// grandfather backfill; live tier-gating stays OFF until B4.
+export const trustTierEnum = pgEnum('TrustTier', [
+  'unverified',
+  'machine_verified',
+  'human_validated',
+  'author_confirmed',
+]);
+// Pool scope (PRD-D-5 §5.1 / D9). The spec models scope as friends_only | public
+// (machine default public; human authored public with a one-tap friends_only
+// override). We carry a third `private` value so the unified selection layer can
+// represent the human Question.visibility 'private' losslessly; machine rows only
+// ever use friends_only | public.
+export const questionScopeEnum = pgEnum('QuestionScope', ['private', 'friends_only', 'public']);
+
 // D-1 Stage 3 — directional follow model.
 // `state` on a follow edge: a follow targeting an approval_required user lands
 // as `pending` (a request the followee approves); a follow targeting a public
@@ -296,6 +314,21 @@ export const questions = pgTable(
     askedCount: integer('asked_count').notNull().default(0),
     correctCount: integer('correct_count').notNull().default(0),
     surfacePriorityScore: doublePrecision('surface_priority_score').notNull().default(0),
+    // B1 pool substrate (PRD-D-5 §5.1). Human-authored rows grandfather to
+    // author_confirmed. Scope, n_answered and empirical_correct_rate are NOT
+    // duplicated here — the unified selection layer reuses visibility, askedCount
+    // and correctRate (see src/server/db/queries/pool.ts).
+    trustTier: trustTierEnum('trust_tier').notNull().default('unverified'),
+    // Perishable = time-relative facts ("the latest…", "who currently…") flagged
+    // for re-grounding (B3); evergreen by default (no decay — D8).
+    perishable: boolean('perishable').notNull().default(false),
+    // Provenance refs from retrieval-grounded generation; populated in B3.
+    sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // Embedding-dedup flags (B3). Human beats machine on collision; the loser is
+    // suppressed (flagged), never deleted. suppressedBy holds the surviving
+    // question id (may live in either table, so not a hard FK).
+    isDuplicate: boolean('is_duplicate').notNull().default(false),
+    suppressedBy: text('suppressed_by'),
     createdAt: createdAt(),
     updatedAt: updatedAt(),
     deletedAt: timestamp('deleted_at', { withTimezone: true }),
@@ -309,6 +342,10 @@ export const questions = pgTable(
     index('Question_source_question_id_idx').on(table.sourceQuestionId),
     index('Question_source_creator_id_idx').on(table.sourceCreatorId),
     uniqueIndex('Question_generated_question_id_key').on(table.generatedQuestionId),
+    // Selection-layer filters (B1 pool substrate). Filter capability only — no
+    // live tier-gating yet (B4 owns enforcement).
+    index('Question_trust_tier_idx').on(table.trustTier),
+    index('Question_is_duplicate_idx').on(table.isDuplicate),
   ],
 );
 
@@ -539,11 +576,31 @@ export const generatedQuestions = pgTable(
     createdAt: createdAt(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     usedInQueue: boolean('used_in_queue').notNull().default(false),
+    // B1 pool substrate (PRD-D-5 §5.1). Machine rows grandfather to
+    // machine_verified; scope defaults public. Unlike the human table, the
+    // machine bank has no native scope/answered/correct-rate columns, so these
+    // are added here (the selection layer reads them directly).
+    trustTier: trustTierEnum('trust_tier').notNull().default('unverified'),
+    scope: questionScopeEnum('scope').notNull().default('public'),
+    perishable: boolean('perishable').notNull().default(false),
+    sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // Empirical play stats (D11 / "nobody got it" smell). Back-filled from answer
+    // history where a join exists; machine rows usually start 0 / null.
+    nAnswered: integer('n_answered').notNull().default(0),
+    empiricalCorrectRate: doublePrecision('empirical_correct_rate'),
+    // Embedding-dedup flags (B3). On a human-beats-machine collision, the machine
+    // row is the loser: is_duplicate=true, suppressed_by=<human id>. Never deleted.
+    isDuplicate: boolean('is_duplicate').notNull().default(false),
+    suppressedBy: text('suppressed_by'),
   },
   (table) => [
     index('GeneratedQuestion_user_id_idx').on(table.userId),
     index('GeneratedQuestion_user_id_used_in_queue_idx').on(table.userId, table.usedInQueue),
     index('GeneratedQuestion_user_id_fact_key_idx').on(table.userId, table.factKey),
+    // Selection-layer filters (B1): tier/scope filter capability + suppress-aware
+    // bank pick. Not gated on any live surface yet (B4 owns enforcement).
+    index('GeneratedQuestion_trust_tier_idx').on(table.trustTier),
+    index('GeneratedQuestion_is_duplicate_idx').on(table.isDuplicate),
   ],
 );
 

--- a/src/server/llm/embeddings.ts
+++ b/src/server/llm/embeddings.ts
@@ -1,0 +1,118 @@
+/**
+ * Joshing embeddings — Voyage AI client (B1 pool substrate, PRD-D-5 §5.1/§7).
+ *
+ * The rest of the pipeline is Anthropic-only and Anthropic ships no first-party
+ * embedding model, so the pool's semantic-dedup backstop uses Voyage AI
+ * (Anthropic's recommended embeddings partner). Model: voyage-3.5-lite,
+ * 1024-dim. All calls are server-side only.
+ *
+ * Graceful by design (mirrors getAnthropicClient): with no VOYAGE_API_KEY — or
+ * LLM_ENABLED=false — every entry point returns null and callers fall back to
+ * the cheap deterministic guards (fact_key + Haiku + normalized text). This is
+ * what keeps embedding dedup OFF until the key is provisioned, so B1 ships with
+ * no behavior change.
+ */
+
+export const VOYAGE_EMBEDDING_MODEL = 'voyage-3.5-lite';
+export const EMBEDDING_DIMENSIONS = 1024;
+const VOYAGE_URL = 'https://api.voyageai.com/v1/embeddings';
+// Voyage caps batches at 1000 inputs / 120k tokens; stay well under for safety.
+export const EMBEDDING_BATCH_SIZE = 128;
+
+let hasLoggedMissingKey = false;
+
+export function isEmbeddingEnabled(): boolean {
+  if (process.env.LLM_ENABLED === 'false') return false;
+  return Boolean(process.env.VOYAGE_API_KEY?.trim());
+}
+
+type VoyageResponse = {
+  data?: Array<{ embedding?: number[]; index?: number }>;
+};
+
+async function callVoyage(
+  inputs: string[],
+  inputType: 'query' | 'document',
+): Promise<number[][] | null> {
+  const apiKey = process.env.VOYAGE_API_KEY?.trim();
+  if (process.env.LLM_ENABLED === 'false' || !apiKey) {
+    if (!hasLoggedMissingKey) {
+      console.warn('[embeddings] Voyage disabled: VOYAGE_API_KEY missing — dedup falls back to deterministic guards');
+      hasLoggedMissingKey = true;
+    }
+    return null;
+  }
+  hasLoggedMissingKey = false;
+
+  try {
+    const res = await fetch(VOYAGE_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        input: inputs,
+        model: VOYAGE_EMBEDDING_MODEL,
+        input_type: inputType,
+        output_dimension: EMBEDDING_DIMENSIONS,
+      }),
+    });
+    if (!res.ok) {
+      console.warn('[embeddings] Voyage request failed', { status: res.status });
+      return null;
+    }
+    const json = (await res.json()) as VoyageResponse;
+    const data = json.data;
+    if (!data?.length) return null;
+    // Preserve request order (Voyage returns an index per item).
+    const ordered = [...data].sort((a, b) => (a.index ?? 0) - (b.index ?? 0));
+    const vectors = ordered.map((d) => d.embedding);
+    if (vectors.some((v) => !Array.isArray(v) || v.length !== EMBEDDING_DIMENSIONS)) {
+      console.warn('[embeddings] Voyage returned unexpected vector shape');
+      return null;
+    }
+    return vectors as number[][];
+  } catch (error) {
+    console.warn('[embeddings] Voyage call threw', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/** Embed a single text. Returns null when disabled or on any failure. */
+export async function embedText(
+  text: string,
+  inputType: 'query' | 'document' = 'document',
+): Promise<number[] | null> {
+  const trimmed = text?.trim();
+  if (!trimmed) return null;
+  const vectors = await callVoyage([trimmed], inputType);
+  return vectors?.[0] ?? null;
+}
+
+/**
+ * Embed many texts in batches. Returns one entry per input (null for blanks),
+ * or null overall when embedding is disabled. Used by the backfill job.
+ */
+export async function embedTexts(
+  texts: string[],
+  inputType: 'query' | 'document' = 'document',
+): Promise<Array<number[] | null> | null> {
+  if (!isEmbeddingEnabled()) return null;
+  const out: Array<number[] | null> = new Array(texts.length).fill(null);
+  for (let start = 0; start < texts.length; start += EMBEDDING_BATCH_SIZE) {
+    const slice = texts.slice(start, start + EMBEDDING_BATCH_SIZE);
+    const nonBlank = slice
+      .map((t, i) => ({ t: t?.trim() ?? '', i }))
+      .filter((x) => x.t.length > 0);
+    if (!nonBlank.length) continue;
+    const vectors = await callVoyage(nonBlank.map((x) => x.t), inputType);
+    if (!vectors) return null;
+    nonBlank.forEach((x, k) => {
+      out[start + x.i] = vectors[k] ?? null;
+    });
+  }
+  return out;
+}

--- a/src/server/pool/__tests__/dedup.test.ts
+++ b/src/server/pool/__tests__/dedup.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_DEDUP_COSINE_THRESHOLD,
+  resolveCollision,
+} from '@/server/pool/dedup';
+import type { NearestPoolMatch } from '@/server/db/queries/pool';
+
+const T = DEFAULT_DEDUP_COSINE_THRESHOLD;
+const near = (over: Partial<NearestPoolMatch> & Pick<NearestPoolMatch, 'origin'>): NearestPoolMatch => ({
+  id: 'existing-1',
+  similarity: 0.99,
+  ...over,
+});
+
+describe('resolveCollision — the collision matrix (Drift Risk 2)', () => {
+  // Row 1: new machine vs existing machine → suppress the NEW one.
+  it('machine vs machine → suppress incoming, survivor is the existing row', () => {
+    const d = resolveCollision({ id: 'new-m', origin: 'machine' }, near({ id: 'old-m', origin: 'machine' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-m' });
+  });
+
+  // Row 2: new machine vs existing human → suppress the NEW (machine) one.
+  it('machine vs human → suppress incoming (machine), human survives', () => {
+    const d = resolveCollision({ id: 'new-m', origin: 'machine' }, near({ id: 'old-h', origin: 'human' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+
+  // Row 3 (THE one that must not be backwards): new human vs existing machine →
+  // keep the HUMAN, suppress the EXISTING machine row.
+  it('human vs machine → suppress the EXISTING machine row, human survives', () => {
+    const d = resolveCollision({ id: 'new-h', origin: 'human' }, near({ id: 'old-m', origin: 'machine' }), T);
+    expect(d).toEqual({
+      action: 'suppress_existing',
+      existingId: 'old-m',
+      existingOrigin: 'machine',
+      survivorId: 'new-h',
+    });
+  });
+
+  // Row 4: new human vs existing human → suppress the NEW one.
+  it('human vs human → suppress incoming, survivor is the existing row', () => {
+    const d = resolveCollision({ id: 'new-h', origin: 'human' }, near({ id: 'old-h', origin: 'human' }), T);
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
+  });
+
+  it('never suppresses below the similarity threshold', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-m', origin: 'machine', similarity: T - 0.01 }),
+      T,
+    );
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('does nothing when there is no neighbour', () => {
+    expect(resolveCollision({ id: 'new-m', origin: 'machine' }, null, T)).toEqual({ action: 'none' });
+  });
+
+  it('suppresses exactly at the threshold (>= is a collision)', () => {
+    const d = resolveCollision(
+      { id: 'new-h', origin: 'human' },
+      near({ id: 'old-m', origin: 'machine', similarity: T }),
+      T,
+    );
+    expect(d.action).toBe('suppress_existing');
+  });
+});

--- a/src/server/pool/dedup.ts
+++ b/src/server/pool/dedup.ts
@@ -1,0 +1,120 @@
+/**
+ * Pool embedding dedup — collision matrix + insert-time orchestration
+ * (B1 pool substrate, PRD-D-5 §5.1 D10 / §7).
+ *
+ * The deterministic guards (fact_key + Haiku + normalized text) remain the cheap
+ * first pass; this is the semantic backstop. The cardinal rule (Drift Risk 2):
+ * a HUMAN-authored question BEATS a machine near-duplicate. Suppression always
+ * flags (is_duplicate + suppressed_by), NEVER deletes — decay is gone, so every
+ * suppression must be reversible.
+ *
+ *   incoming \ nearest │ machine            │ human
+ *   ───────────────────┼────────────────────┼────────────────────
+ *   machine            │ suppress incoming  │ suppress incoming
+ *   human              │ suppress EXISTING  │ suppress incoming
+ *
+ * Only the human-over-machine cell suppresses the row already in the pool.
+ */
+
+import type { PoolOrigin } from '@/server/db/queries/pool';
+import {
+  findNearestInPool,
+  markPoolDuplicate,
+  storePoolEmbedding,
+  type NearestPoolMatch,
+} from '@/server/db/queries/pool';
+import { embedText, isEmbeddingEnabled } from '@/server/llm/embeddings';
+
+// Cosine *similarity* threshold (1 = identical). Start strict per §7 (the spec's
+// knob table does not pin a number); override via env without a deploy.
+export const DEFAULT_DEDUP_COSINE_THRESHOLD = 0.92;
+
+export function getDedupCosineThreshold(): number {
+  const raw = process.env.POOL_DEDUP_COSINE_THRESHOLD?.trim();
+  if (!raw) return DEFAULT_DEDUP_COSINE_THRESHOLD;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return DEFAULT_DEDUP_COSINE_THRESHOLD;
+  }
+  return parsed;
+}
+
+export type CollisionDecision =
+  | { action: 'none' }
+  | { action: 'suppress_incoming'; survivorId: string }
+  | { action: 'suppress_existing'; existingId: string; existingOrigin: PoolOrigin; survivorId: string };
+
+/**
+ * Pure collision matrix. `incomingId` is the row just inserted; `nearest` is the
+ * closest existing pool row (excluding self), or null if none within reach.
+ */
+export function resolveCollision(
+  incoming: { id: string; origin: PoolOrigin },
+  nearest: NearestPoolMatch | null,
+  threshold: number,
+): CollisionDecision {
+  if (!nearest) return { action: 'none' };
+  if (nearest.similarity < threshold) return { action: 'none' };
+
+  // Human beats machine: the only case where the EXISTING row is suppressed.
+  if (incoming.origin === 'human' && nearest.origin === 'machine') {
+    return {
+      action: 'suppress_existing',
+      existingId: nearest.id,
+      existingOrigin: 'machine',
+      survivorId: incoming.id,
+    };
+  }
+
+  // Every other collision (machine vs *, human vs human): suppress the new one.
+  return { action: 'suppress_incoming', survivorId: nearest.id };
+}
+
+/**
+ * Insert-time dedup, best-effort. Embeds the freshly-inserted row, stores the
+ * vector, finds its nearest pool neighbour, and applies the collision matrix.
+ * Any failure (no key, API error, missing column pre-migration) is swallowed so
+ * generation/authoring is never blocked — the deterministic guards still ran.
+ */
+export async function embedAndResolveDuplicate(args: {
+  id: string;
+  origin: PoolOrigin;
+  questionText: string;
+}): Promise<void> {
+  if (!isEmbeddingEnabled()) return;
+  try {
+    const embedding = await embedText(args.questionText, 'document');
+    if (!embedding) return;
+
+    await storePoolEmbedding(args.origin, args.id, embedding);
+
+    const nearest = await findNearestInPool(embedding, args.id);
+    const decision = resolveCollision(
+      { id: args.id, origin: args.origin },
+      nearest,
+      getDedupCosineThreshold(),
+    );
+
+    if (decision.action === 'suppress_incoming') {
+      await markPoolDuplicate(args.origin, args.id, decision.survivorId);
+      console.info('[pool/dedup] suppressed new near-duplicate', {
+        origin: args.origin,
+        id: args.id,
+        survivor: decision.survivorId,
+      });
+    } else if (decision.action === 'suppress_existing') {
+      // Human beat an existing machine row.
+      await markPoolDuplicate(decision.existingOrigin, decision.existingId, decision.survivorId);
+      console.info('[pool/dedup] human beat machine; suppressed existing machine row', {
+        existing: decision.existingId,
+        survivor: decision.survivorId,
+      });
+    }
+  } catch (error) {
+    console.warn('[pool/dedup] insert-time dedup skipped (non-fatal)', {
+      id: args.id,
+      origin: args.origin,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}


### PR DESCRIPTION
## What & why

Milestone questions in the activity stream ("Robyn went deep on…", rendered by `InlineAnswerFlow`) previously collapsed to a single `answered` boolean that **only flipped on a correct answer**. As a result:

- A **wrong answer** left the question showing `ANSWER →` and re-answerable.
- A viewer **couldn't tell a correct answer from a missed one** — both non-answered and incorrect looked the same.

This PR replaces the boolean with a per-question `AnswerStatus` (`'unanswered' | 'correct' | 'incorrect'`) threaded from the server through to the inline card.

## Changes

- **Distinguish correct vs. incorrect** — the inline badge now renders a green `✓ CORRECT`, a terracotta `✕ MISSED`, or the `ANSWER →` button.
- **Lock missed questions** — `InlineAnswerFlow` reports the graded result up for *both* outcomes (previously correct-only), so a wrong answer immediately locks the question (one shot, no retry). This persists across reload because the route already writes a `masteryEvents` row on a wrong answer.
- **Server-side enforcement** — `/api/lately/milestone/answer` re-checks via the new `getViewerAnswerStatusByQuestionId` and returns `409 { error: 'already_answered', result }` so a stale client (or direct call) can't re-submit.
- `getViewerCorrectlyAnsweredIds` → `getViewerAnswerStatusByQuestionId` (now reports correct **and** incorrect standing, scoped to the viewer's own graded events).

The `{k} of {n} answered` progress and bundle triangles keep counting **correct** answers only — a miss doesn't count as "answered".

## Note on scope

The lock applies to **both** correct and incorrect re-answers on this surface, which removes the `first_correct_after_wrong` recovery re-answer path the milestone route originally allowed here. This matches the "shouldn't be able to answer it again" intent and keeps the server consistent with the locked UI. If a retry-after-wrong (but not after-correct) is preferred, the lock can be scoped to incorrect-only.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean on changed files
- `npm run lint` — 0 errors
- `npx vitest run src/app/activities src/server/activity` — 16/16 pass

https://claude.ai/code/session_0139h7stN5nT3iQnCjMXXQQU

---
_Generated by [Claude Code](https://claude.ai/code/session_0139h7stN5nT3iQnCjMXXQQU)_