### PR TITLE
Add B3 retrieval-grounded pool refill batch

### DIFF
--- a/src/app/api/cron/pool-refill/route.ts
+++ b/src/app/api/cron/pool-refill/route.ts
@@ -23,13 +23,25 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 
-  const report = await runPoolRefill();
+  // ?dryRun=1 (or ?dry_run / ?preview) derives demand and PROJECTS worst-case
+  // search spend without issuing any searches or persisting anything — for
+  // sanity-checking which domains would be refilled and the cost before turning
+  // the feature on. Projected usdSpent/webSearches cover search cost only; actual
+  // runs also incur token deltas.
+  const params = request.nextUrl.searchParams;
+  const dryRun = ['dryRun', 'dry_run', 'preview'].some((key) => {
+    const value = params.get(key);
+    return value !== null && value !== 'false' && value !== '0';
+  });
+
+  const report = await runPoolRefill({ dryRun });
 
   // The report IS the "what's happening" deliverable: structured log line +
   // returned JSON. Spend vs. ceiling and backlogRemaining are the two numbers to
   // watch — a persistent backlog means the ceiling is below demand.
   console.info('[cron/pool-refill] run complete', {
     enabled: report.enabled,
+    dryRun: report.dryRun,
     reason: report.reason,
     usdSpent: Number(report.usdSpent.toFixed(4)),
     usdCeiling: report.usdCeiling,

--- a/src/app/api/cron/pool-refill/route.ts
+++ b/src/app/api/cron/pool-refill/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { runPoolRefill } from '@/server/daily/retrieval-grounded';
+
+export const dynamic = 'force-dynamic';
+// B3 retrieval-grounded pool refill (PRD-D-5 §5.3). Heavy, off the user's
+// critical path: it deepens the shared durable bank for thin-but-active domains
+// so per-user builds keep serving from the pool. Spend is hard-capped per run by
+// RETRIEVAL_DAILY_USD_CEILING; demand is derived (thin + active domains), so most
+// runs spend far less. Give it the plan maximum since a run may issue many
+// retrieval calls.
+export const maxDuration = 300;
+
+function isAuthorized(request: NextRequest): boolean {
+  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
+  if (!secret) return true;
+  const authHeader = request.headers.get('authorization');
+  return authHeader === `Bearer ${secret}`;
+}
+
+export async function GET(request: NextRequest) {
+  if (!isAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const report = await runPoolRefill();
+
+  // The report IS the "what's happening" deliverable: structured log line +
+  // returned JSON. Spend vs. ceiling and backlogRemaining are the two numbers to
+  // watch — a persistent backlog means the ceiling is below demand.
+  console.info('[cron/pool-refill] run complete', {
+    enabled: report.enabled,
+    reason: report.reason,
+    usdSpent: Number(report.usdSpent.toFixed(4)),
+    usdCeiling: report.usdCeiling,
+    webSearches: report.webSearches,
+    domainsConsidered: report.domainsConsidered,
+    domainsProcessed: report.domainsProcessed,
+    questionsPersisted: report.questionsPersisted,
+    dropped: report.dropped,
+    backlogRemaining: report.backlogRemaining,
+  });
+
+  return NextResponse.json(report);
+}

--- a/src/server/daily/__tests__/retrieval-grounded.test.ts
+++ b/src/server/daily/__tests__/retrieval-grounded.test.ts
@@ -1,0 +1,114 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// generate-questions.ts and retrieval-config import @/server/db, which throws at
+// module load without a connection string. The helpers under test are pure; a
+// dummy URL plus dynamic import (repo convention) keeps the units pure.
+let mod: typeof import('@/server/daily/generate-questions');
+let cfg: typeof import('@/server/daily/retrieval-config');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/daily/generate-questions');
+  cfg = await import('@/server/daily/retrieval-config');
+});
+
+describe('normalizeSourceRefs', () => {
+  it('keeps http(s) URL strings and dedupes case-insensitively', () => {
+    const refs = mod.normalizeSourceRefs([
+      'https://www.britannica.com/x',
+      'HTTPS://WWW.BRITANNICA.COM/X',
+      'https://en.wikipedia.org/y',
+    ]);
+    expect(refs).toEqual(['https://www.britannica.com/x', 'https://en.wikipedia.org/y']);
+  });
+
+  it('extracts url from object form and drops non-http / junk entries', () => {
+    const refs = mod.normalizeSourceRefs([
+      { url: 'https://example.edu/a', name: 'Example' },
+      { name: 'no url' },
+      'ftp://nope',
+      'not a url',
+      42,
+    ]);
+    expect(refs).toEqual(['https://example.edu/a']);
+  });
+
+  it('returns [] for non-array input', () => {
+    expect(mod.normalizeSourceRefs(undefined)).toEqual([]);
+    expect(mod.normalizeSourceRefs('https://x.com')).toEqual([]);
+  });
+});
+
+describe('distinctSourceHostCount', () => {
+  it('counts distinct registrable hosts, ignoring www and path', () => {
+    expect(
+      mod.distinctSourceHostCount([
+        'https://www.britannica.com/a',
+        'https://britannica.com/b',
+        'https://en.wikipedia.org/c',
+      ]),
+    ).toBe(2);
+  });
+
+  it('mirrors of the same host count once (the corroboration trap)', () => {
+    expect(
+      mod.distinctSourceHostCount([
+        'https://site.com/page1',
+        'https://site.com/page2',
+      ]),
+    ).toBe(1);
+  });
+});
+
+describe('parseGroundedQuestions', () => {
+  const valid = {
+    questions: [
+      {
+        canonical_subcategory: 'Late Tchaikovsky',
+        broad_category: 'Music',
+        question_text: 'What tempo marking closes the Pathétique?',
+        answer: 'Adagio lamentoso',
+        explainer: 'The finale is marked Adagio lamentoso, an unusual slow close.',
+        difficulty_estimate: 'moderate',
+        fact_key: 'tchaikovsky-pathetique-final-tempo',
+        sub_angles: ['Pathétique', 'finale'],
+        question_shape: 'technique_or_term',
+        source_refs: ['https://en.wikipedia.org/wiki/x', 'https://www.britannica.com/y'],
+      },
+    ],
+  };
+
+  it('parses questions and attaches normalized source_refs', () => {
+    const out = mod.parseGroundedQuestions(JSON.stringify(valid));
+    expect(out).toHaveLength(1);
+    expect(out[0].answer).toBe('Adagio lamentoso');
+    expect(out[0].source_refs).toHaveLength(2);
+  });
+
+  it('defaults source_refs to [] when the model omits them', () => {
+    const noRefs = JSON.parse(JSON.stringify(valid));
+    delete noRefs.questions[0].source_refs;
+    const out = mod.parseGroundedQuestions(JSON.stringify(noRefs));
+    expect(out[0].source_refs).toEqual([]);
+  });
+
+  it('drops items that fail the base contract (generic subcategory)', () => {
+    const generic = JSON.parse(JSON.stringify(valid));
+    generic.questions[0].canonical_subcategory = 'General Knowledge';
+    expect(mod.parseGroundedQuestions(JSON.stringify(generic))).toHaveLength(0);
+  });
+});
+
+describe('estimateCallUsd', () => {
+  it('prices searches and tokens additively', () => {
+    const usd = cfg.estimateCallUsd({
+      webSearches: 10,
+      inputTokens: 1_000_000,
+      outputTokens: 0,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+    // 10 * $0.01 + 1M * $3/M = $0.10 + $3.00
+    expect(usd).toBeCloseTo(3.1, 5);
+  });
+});

--- a/src/server/daily/__tests__/source-reputation.test.ts
+++ b/src/server/daily/__tests__/source-reputation.test.ts
@@ -1,0 +1,115 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// source-reputation imports generate-questions → @/server/db, which throws at
+// module load without a connection string. The functions under test are pure;
+// dummy URL + dynamic import (repo convention) keeps the units pure.
+let rep: typeof import('@/server/daily/source-reputation');
+
+const lists = () => rep.getReputationLists();
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  rep = await import('@/server/daily/source-reputation');
+});
+
+describe('classifySource', () => {
+  it('treats allow-listed references and their subdomains as reputable', () => {
+    expect(rep.classifySource('https://en.wikipedia.org/wiki/x', lists())).toBe('reputable');
+    expect(rep.classifySource('https://www.britannica.com/y', lists())).toBe('reputable');
+  });
+
+  it('treats .edu / .gov / .ac.* TLDs as reputable', () => {
+    expect(rep.classifySource('https://plato.stanford.edu/entries/z', lists())).toBe('reputable');
+    expect(rep.classifySource('https://www.nasa.gov/mission', lists())).toBe('reputable');
+    expect(rep.classifySource('https://www.ox.ac.uk/page', lists())).toBe('reputable');
+  });
+
+  it('treats forums / Q&A / content farms as denied', () => {
+    expect(rep.classifySource('https://www.reddit.com/r/x', lists())).toBe('denied');
+    expect(rep.classifySource('https://www.quora.com/q', lists())).toBe('denied');
+    expect(rep.classifySource('https://somegame.fandom.com/wiki/x', lists())).toBe('denied');
+  });
+
+  it('treats unknown sites as neutral', () => {
+    expect(rep.classifySource('https://some-random-blog.example/post', lists())).toBe('neutral');
+  });
+});
+
+describe('assessCorroboration', () => {
+  const opts = () => ({ minTotal: 2, minReputable: 1, lists: lists() });
+
+  it('passes with two distinct reputable hosts', () => {
+    const a = rep.assessCorroboration(
+      ['https://en.wikipedia.org/a', 'https://www.britannica.com/b'],
+      opts(),
+    );
+    expect(a.corroborated).toBe(true);
+    expect(a.distinctReputableHosts).toBe(2);
+  });
+
+  it('passes with one reputable + one neutral (default minReputable=1)', () => {
+    const a = rep.assessCorroboration(
+      ['https://www.britannica.com/b', 'https://unknown-ref.example/c'],
+      opts(),
+    );
+    expect(a.corroborated).toBe(true);
+  });
+
+  it('fails with two neutral sources (no editorially-accountable anchor)', () => {
+    const a = rep.assessCorroboration(
+      ['https://blog-one.example/a', 'https://blog-two.example/b'],
+      opts(),
+    );
+    expect(a.corroborated).toBe(false);
+  });
+
+  it('does not count mirrors of the same host (the corroboration trap)', () => {
+    const a = rep.assessCorroboration(
+      ['https://en.wikipedia.org/page1', 'https://en.wikipedia.org/page2'],
+      opts(),
+    );
+    expect(a.distinctReputableHosts).toBe(1);
+    expect(a.corroborated).toBe(false);
+  });
+
+  it('strips denied sources and they never count toward corroboration', () => {
+    const a = rep.assessCorroboration(
+      ['https://www.britannica.com/b', 'https://www.reddit.com/r/x'],
+      opts(),
+    );
+    // Only one non-denied host remains → below minTotal.
+    expect(a.corroborated).toBe(false);
+    expect(a.deniedRefs).toContain('https://www.reddit.com/r/x');
+    expect(a.orderedRefs).not.toContain('https://www.reddit.com/r/x');
+  });
+
+  it('orders surviving refs reputable-first', () => {
+    const a = rep.assessCorroboration(
+      ['https://unknown-ref.example/c', 'https://www.britannica.com/b'],
+      opts(),
+    );
+    expect(a.orderedRefs[0]).toBe('https://www.britannica.com/b');
+  });
+
+  it('honors the strict reading when minReputable equals minTotal', () => {
+    const strict = { minTotal: 2, minReputable: 2, lists: lists() };
+    const oneReputable = rep.assessCorroboration(
+      ['https://www.britannica.com/b', 'https://unknown-ref.example/c'],
+      strict,
+    );
+    expect(oneReputable.corroborated).toBe(false);
+  });
+
+  it('thin-domain degrade: an uncorroborated batch yields nothing to persist', () => {
+    // The checkpoint guarantee: when sources are junk-only, NOTHING qualifies, so
+    // the batch persists no fresh question and the per-user path keeps serving
+    // from the durable bank — never an uncorroborated fresh question.
+    const junkBatch = [
+      ['https://www.reddit.com/r/a'],
+      ['https://www.quora.com/q', 'https://random.example/x'],
+      [],
+    ];
+    const survivors = junkBatch.filter((refs) => rep.assessCorroboration(refs, opts()).corroborated);
+    expect(survivors).toHaveLength(0);
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -1480,6 +1480,7 @@ You have a web_search tool. You MUST use it BEFORE writing each question. The qu
 - Anchor the answer to the sources, not to your prior knowledge. If retrieval contradicts what you "remember", trust the sources or drop the question.
 - The explainer must be consistent with the retrieved sources and written IN YOUR OWN WORDS — paraphrase, never copy passages verbatim.
 - Corroboration: only keep a question whose answer is supported by AT LEAST TWO independent, reputable sources on DIFFERENT domains (e.g. an encyclopedia plus a university or institutional page). Two pages that copy the same text are NOT independent.
+- Prefer editorially-accountable sources: encyclopedias (Wikipedia with citations, Britannica), university/.edu and government/.gov/.mil pages, museums, primary institutional sources, and established reference works. AVOID forums, Q&A/homework sites, social media, wikis-of-fandom, content farms, and AI-generated content mills — these do not count as corroboration.
 
 Add ONE extra field to each question object in the return JSON:
   "source_refs": ["https://full-url-of-supporting-source-1", "https://full-url-of-supporting-source-2", ...]

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -49,7 +49,7 @@ const RECENT_FACT_KEY_LIMIT = 200;
 
 export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
 
-const SYSTEM_PROMPT = `You are generating trivia questions for Joshing, a social trivia game played among friends.
+export const SYSTEM_PROMPT = `You are generating trivia questions for Joshing, a social trivia game played among friends.
 Questions must be:
 - Factual with a single objectively correct answer, or — for the "name_multiple" shape only — a small fixed set of correct answers (typically 2–4)
 - Drawn from the intellectual and cultural world of the domain, not biographical trivia
@@ -182,7 +182,7 @@ function asQuestionShape(value: unknown): QuestionShape | null {
     : null;
 }
 
-type LlmQuestion = {
+export type LlmQuestion = {
   canonical_subcategory: string;
   broad_category: string;
   question_text: string;
@@ -238,7 +238,7 @@ type AvoidFactKeyEntry = RecentFactKeyEntry;
 
 type TerritoryType = 'declared' | 'demonstrated';
 
-function buildUserPrompt(
+export function buildUserPrompt(
   domains: string[],
   count: number,
   prev: AvoidQuestionEntry[],
@@ -366,6 +366,63 @@ function asDifficulty(value: unknown): LlmQuestion['difficulty_estimate'] | null
   return null;
 }
 
+// Parse a single question object from the model's JSON array into the validated
+// LlmQuestion shape, or null if it fails the structural / generic-label guards.
+// Shared by parseQuestions (per-user path) and parseGroundedQuestions (the B3
+// retrieval batch path) so both honour exactly the same field contract.
+function parseBaseQuestion(item: unknown): LlmQuestion | null {
+  if (!item || typeof item !== 'object') return null;
+  const rec = item as Record<string, unknown>;
+  const canonical = asString(rec.canonical_subcategory);
+  const broad = asString(rec.broad_category);
+  const questionText = asString(rec.question_text);
+  const answer = asString(rec.answer);
+  const explainer = asString(rec.explainer);
+  const difficulty = asDifficulty(rec.difficulty_estimate);
+  if (!canonical || !broad || !questionText || !answer || !explainer || !difficulty) {
+    return null;
+  }
+  if (isGenericCanonicalAnswer(answer)) {
+    return null;
+  }
+  // Reject LLM responses that pick a bucket-level subcategory ("general",
+  // "general knowledge", "trivia", etc.) — those questions are not tied
+  // to any of the user's declared/demonstrated domains and must not be
+  // served. This is the upstream guard on the generated_questions write
+  // boundary; the LLM is told to use the exact domain it was given, so
+  // anything generic here is a prompt violation we discard.
+  if (isGenericSubcategory(canonical)) {
+    return null;
+  }
+  const factKeyRaw = rec.fact_key;
+  const factKeyStr = asString(factKeyRaw);
+  const factKey = normalizeFactKey(factKeyStr);
+  if (!factKey) {
+    // The fact-key dedup pipeline (avoid list + persist-time guard) is
+    // load-bearing for question variety; a null fact_key silently disables
+    // it for this row. Log enough detail to tell whether the LLM omitted
+    // the field, returned a non-string, or emitted a string that
+    // normalizeFactKey rejected.
+    console.warn('[daily/generate-questions] fact_key missing or unnormalizable', {
+      domain: canonical,
+      rawType: factKeyRaw === undefined ? 'undefined' : factKeyRaw === null ? 'null' : typeof factKeyRaw,
+      rawValue: typeof factKeyRaw === 'string' ? factKeyRaw.slice(0, 120) : null,
+      questionPreview: questionText.slice(0, 80),
+    });
+  }
+  return {
+    canonical_subcategory: canonical,
+    broad_category: broad,
+    question_text: questionText,
+    answer: normalizeCanonicalAnswerLabel(answer),
+    explainer,
+    difficulty_estimate: difficulty,
+    fact_key: factKey,
+    sub_angles: normalizeSubAngles(rec.sub_angles),
+    question_shape: asQuestionShape(rec.question_shape),
+  };
+}
+
 function parseQuestions(raw: string): LlmQuestion[] {
   const parsed = parseJsonObject(raw);
   if (!parsed) return [];
@@ -374,56 +431,8 @@ function parseQuestions(raw: string): LlmQuestion[] {
 
   const result: LlmQuestion[] = [];
   for (const item of rawList) {
-    if (!item || typeof item !== 'object') continue;
-    const rec = item as Record<string, unknown>;
-    const canonical = asString(rec.canonical_subcategory);
-    const broad = asString(rec.broad_category);
-    const questionText = asString(rec.question_text);
-    const answer = asString(rec.answer);
-    const explainer = asString(rec.explainer);
-    const difficulty = asDifficulty(rec.difficulty_estimate);
-    if (!canonical || !broad || !questionText || !answer || !explainer || !difficulty) {
-      continue;
-    }
-    if (isGenericCanonicalAnswer(answer)) {
-      continue;
-    }
-    // Reject LLM responses that pick a bucket-level subcategory ("general",
-    // "general knowledge", "trivia", etc.) — those questions are not tied
-    // to any of the user's declared/demonstrated domains and must not be
-    // served. This is the upstream guard on the generated_questions write
-    // boundary; the LLM is told to use the exact domain it was given, so
-    // anything generic here is a prompt violation we discard.
-    if (isGenericSubcategory(canonical)) {
-      continue;
-    }
-    const factKeyRaw = rec.fact_key;
-    const factKeyStr = asString(factKeyRaw);
-    const factKey = normalizeFactKey(factKeyStr);
-    if (!factKey) {
-      // The fact-key dedup pipeline (avoid list + persist-time guard) is
-      // load-bearing for question variety; a null fact_key silently disables
-      // it for this row. Log enough detail to tell whether the LLM omitted
-      // the field, returned a non-string, or emitted a string that
-      // normalizeFactKey rejected.
-      console.warn('[daily/generate-questions] fact_key missing or unnormalizable', {
-        domain: canonical,
-        rawType: factKeyRaw === undefined ? 'undefined' : factKeyRaw === null ? 'null' : typeof factKeyRaw,
-        rawValue: typeof factKeyRaw === 'string' ? factKeyRaw.slice(0, 120) : null,
-        questionPreview: questionText.slice(0, 80),
-      });
-    }
-    result.push({
-      canonical_subcategory: canonical,
-      broad_category: broad,
-      question_text: questionText,
-      answer: normalizeCanonicalAnswerLabel(answer),
-      explainer,
-      difficulty_estimate: difficulty,
-      fact_key: factKey,
-      sub_angles: normalizeSubAngles(rec.sub_angles),
-      question_shape: asQuestionShape(rec.question_shape),
-    });
+    const question = parseBaseQuestion(item);
+    if (question) result.push(question);
   }
   return result;
 }
@@ -1448,4 +1457,125 @@ async function pickBankPicksForDomains(
     }
   }
   return picks;
+}
+
+// ─── B3: Retrieval-grounded generation (batch path) ─────────────────────────
+//
+// The pieces below are consumed by the pool-refill batch (src/server/daily/
+// retrieval-grounded.ts + the /api/cron/pool-refill route). They layer ON TOP of
+// the B2 SYSTEM_PROMPT / buildUserPrompt above — same exemplars, difficulty and
+// register rules — and only ADD the requirement that every question be written
+// FROM retrieved web sources, with the supporting URLs returned as provenance.
+// Nothing here runs on the per-user critical path.
+
+// Appended to SYSTEM_PROMPT for the retrieval-grounded call. Keeps the base
+// prompt's return schema and adds the source_refs field + the retrieve-first
+// contract (Drift Risk 1: never write from memory and search to justify).
+export const GROUNDING_SYSTEM_ADDENDUM = `
+
+RETRIEVAL-GROUNDED MODE (this call only):
+You have a web_search tool. You MUST use it BEFORE writing each question. The question and its answer must be drawn FROM what you retrieve — never from memory. If you cannot find the answer in retrieved sources, do not invent the question; produce fewer questions instead.
+
+- Search first, then write the question and answer out of the retrieved text.
+- Anchor the answer to the sources, not to your prior knowledge. If retrieval contradicts what you "remember", trust the sources or drop the question.
+- The explainer must be consistent with the retrieved sources and written IN YOUR OWN WORDS — paraphrase, never copy passages verbatim.
+- Corroboration: only keep a question whose answer is supported by AT LEAST TWO independent, reputable sources on DIFFERENT domains (e.g. an encyclopedia plus a university or institutional page). Two pages that copy the same text are NOT independent.
+
+Add ONE extra field to each question object in the return JSON:
+  "source_refs": ["https://full-url-of-supporting-source-1", "https://full-url-of-supporting-source-2", ...]
+List the actual URLs you retrieved that support THIS question's answer — at least two, on distinct sites. Do not fabricate URLs; only list pages you actually retrieved.`;
+
+export type SourceRef = string;
+
+export type GroundedLlmQuestion = LlmQuestion & {
+  // Provenance URLs (B1 source_refs is typed string[]). Persisted onto
+  // generatedQuestions.sourceRefs. The supporting sources for THIS answer.
+  source_refs: SourceRef[];
+};
+
+// Normalize a raw source_refs value into a deduped list of http(s) URL strings.
+// Accepts either an array of URL strings or an array of { url, name } objects
+// (the model occasionally emits the richer form even when asked for strings).
+export function normalizeSourceRefs(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const item of value) {
+    let url: string | null = null;
+    if (typeof item === 'string') {
+      url = item.trim();
+    } else if (item && typeof item === 'object') {
+      const rec = item as Record<string, unknown>;
+      url = asString(rec.url) ?? asString(rec.href) ?? asString(rec.link);
+    }
+    if (!url) continue;
+    if (!/^https?:\/\//i.test(url)) continue;
+    const key = url.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(url);
+  }
+  return out;
+}
+
+// Registrable-ish host for a URL, lowercased, www stripped. Used to count
+// DISTINCT source domains for the corroboration check. Phase 2 replaces this
+// with the reputation allow/deny list + true mirror detection; for Phase 1 it
+// is the minimal "≥2 independent sites" guard so we never persist an
+// uncorroborated fresh question into the shared pool (Drift Risk 3).
+export function sourceHost(url: string): string | null {
+  try {
+    return new URL(url).hostname.replace(/^www\./i, '').toLowerCase();
+  } catch {
+    return null;
+  }
+}
+
+export function distinctSourceHostCount(refs: readonly string[]): number {
+  const hosts = new Set<string>();
+  for (const ref of refs) {
+    const host = sourceHost(ref);
+    if (host) hosts.add(host);
+  }
+  return hosts.size;
+}
+
+// Parse a retrieval-grounded generation reply. Same base contract as
+// parseQuestions, plus the source_refs provenance array.
+export function parseGroundedQuestions(raw: string): GroundedLlmQuestion[] {
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return [];
+  const rawList = parsed.questions;
+  if (!Array.isArray(rawList)) return [];
+
+  const result: GroundedLlmQuestion[] = [];
+  for (const item of rawList) {
+    const base = parseBaseQuestion(item);
+    if (!base) continue;
+    const rec = item as Record<string, unknown>;
+    result.push({ ...base, source_refs: normalizeSourceRefs(rec.source_refs) });
+  }
+  return result;
+}
+
+// Run the existing quality gates over a batch and return the union of indices to
+// drop. Reuses the SAME gates the per-user path applies (intra-batch dupes,
+// LLM quality, factual-correctness, deterministic answer-leak) so grounded
+// questions are held to the same bar — without modifying the hot per-user path.
+// Fails open per gate (each catch returns an empty set internally), matching the
+// per-user behaviour.
+export async function screenGroundedBatch(questions: LlmQuestion[]): Promise<Set<number>> {
+  if (questions.length === 0) return new Set();
+  const [batchDuplicates, qualityResult, factualResult] = await Promise.all([
+    findBatchDuplicates(questions),
+    findQualityFailures(questions),
+    findFactualFailures(questions),
+  ]);
+  const answerLeaks = findAnswerLeaks(questions);
+  return new Set<number>([
+    ...batchDuplicates,
+    ...qualityResult.toDrop,
+    ...factualResult.toDrop,
+    ...answerLeaks.toDrop,
+  ]);
 }

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -43,9 +43,13 @@ export type RetrievalConfig = {
   /** Cap on domains processed in a single run (belt-and-braces alongside the
    *  USD ceiling). */
   maxDomainsPerRun: number;
-  /** Minimum distinct source hosts required to keep a grounded question
-   *  (corroboration floor; Drift Risk 2). */
+  /** Minimum distinct non-denied source hosts required to keep a grounded
+   *  question (corroboration floor; Drift Risk 2). */
   minCorroboratingSources: number;
+  /** Of the corroborating sources, how many must be editorially-accountable
+   *  (allow-listed / .edu / .gov / .mil / .ac.*). Default 1 — set equal to
+   *  minCorroboratingSources for the strict "all reputable" reading. */
+  minReputableSources: number;
 };
 
 // Anthropic server-side web search billing: ~$10 / 1,000 searches.
@@ -68,6 +72,7 @@ export function getRetrievalConfig(): RetrievalConfig {
     activeLookbackDays: Math.max(1, Math.round(numEnv('RETRIEVAL_ACTIVE_LOOKBACK_DAYS', 14))),
     maxDomainsPerRun: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_DOMAINS_PER_RUN', 50))),
     minCorroboratingSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_CORROBORATING_SOURCES', 2))),
+    minReputableSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_REPUTABLE_SOURCES', 1))),
   };
 }
 

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -1,0 +1,90 @@
+// Server-configurable knobs for B3 retrieval-grounded pool refill.
+//
+// Everything here is read from the environment with a SAFE, LOW default so the
+// feature is off (and cheap) until an operator deliberately turns it on. The
+// daily USD ceiling is a hard runaway guard, not a target: the batch derives
+// demand (thin + active domains) and usually spends far less. See PRD-D-5 §5.3 /
+// §7 and the B3 build prompt's cost gate.
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return fallback;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+export type RetrievalConfig = {
+  /** Master switch. Off by default — the batch no-ops until enabled. */
+  enabled: boolean;
+  /** Owning user id for batch-generated pool rows (generatedQuestions.userId is
+   *  a NOT NULL FK; pickBankSource serves rows where userId <> viewer, so a
+   *  dedicated account becomes pool fodder for everyone else). No-op if unset. */
+  systemUserId: string | null;
+  /** Hard ceiling on retrieval spend per cron run, in USD. Stops issuing new
+   *  retrieval calls once the next call's worst case would cross it. */
+  dailyUsdCeiling: number;
+  /** Searches the model may run per generated question (maps to web_search
+   *  max_uses, multiplied by questions-per-call). */
+  maxSearchesPerQuestion: number;
+  /** How many questions to ask for per domain in a single grounded call. */
+  questionsPerDomain: number;
+  /** A domain is "thin" (eligible for refill) when its durable pool depth — the
+   *  count of non-duplicate, fact-keyed machine rows — is below this. */
+  poolDepthThreshold: number;
+  /** "Active" lookback: a domain qualifies only if it saw machine-pool activity
+   *  within this many days (a proxy for real users being served it). */
+  activeLookbackDays: number;
+  /** Cap on domains processed in a single run (belt-and-braces alongside the
+   *  USD ceiling). */
+  maxDomainsPerRun: number;
+  /** Minimum distinct source hosts required to keep a grounded question
+   *  (corroboration floor; Drift Risk 2). */
+  minCorroboratingSources: number;
+};
+
+// Anthropic server-side web search billing: ~$10 / 1,000 searches.
+export const USD_PER_WEB_SEARCH = 0.01;
+// claude-sonnet-4-6 token pricing (USD per token) for the spend estimate. Input
+// includes the retrieved-source tokens the search tool injects.
+export const USD_PER_INPUT_TOKEN = 3 / 1_000_000;
+export const USD_PER_OUTPUT_TOKEN = 15 / 1_000_000;
+export const USD_PER_CACHE_READ_TOKEN = 0.3 / 1_000_000;
+export const USD_PER_CACHE_WRITE_TOKEN = 3.75 / 1_000_000;
+
+export function getRetrievalConfig(): RetrievalConfig {
+  return {
+    enabled: boolEnv('RETRIEVAL_GROUNDING_ENABLED', false),
+    systemUserId: process.env.RETRIEVAL_SYSTEM_USER_ID?.trim() || null,
+    dailyUsdCeiling: numEnv('RETRIEVAL_DAILY_USD_CEILING', 2),
+    maxSearchesPerQuestion: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_SEARCHES_PER_QUESTION', 3))),
+    questionsPerDomain: Math.max(1, Math.round(numEnv('RETRIEVAL_QUESTIONS_PER_DOMAIN', 3))),
+    poolDepthThreshold: Math.max(1, Math.round(numEnv('RETRIEVAL_POOL_DEPTH_THRESHOLD', 8))),
+    activeLookbackDays: Math.max(1, Math.round(numEnv('RETRIEVAL_ACTIVE_LOOKBACK_DAYS', 14))),
+    maxDomainsPerRun: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_DOMAINS_PER_RUN', 50))),
+    minCorroboratingSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_CORROBORATING_SOURCES', 2))),
+  };
+}
+
+// Convert an Anthropic usage object + web-search count into an estimated USD
+// cost. Used both to enforce the ceiling and to populate the run report.
+export function estimateCallUsd(args: {
+  webSearches: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}): number {
+  return (
+    args.webSearches * USD_PER_WEB_SEARCH +
+    args.inputTokens * USD_PER_INPUT_TOKEN +
+    args.outputTokens * USD_PER_OUTPUT_TOKEN +
+    args.cacheReadTokens * USD_PER_CACHE_READ_TOKEN +
+    args.cacheWriteTokens * USD_PER_CACHE_WRITE_TOKEN
+  );
+}

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -1,0 +1,310 @@
+import type Anthropic from '@anthropic-ai/sdk';
+
+import {
+  ANTHROPIC_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+} from '@/lib/llm';
+import { db, generatedQuestions } from '@/server/db';
+import { embedAndResolveDuplicate } from '@/server/pool/dedup';
+import {
+  GROUNDING_SYSTEM_ADDENDUM,
+  SYSTEM_PROMPT,
+  buildUserPrompt,
+  distinctSourceHostCount,
+  parseGroundedQuestions,
+  screenGroundedBatch,
+  type GroundedLlmQuestion,
+} from '@/server/daily/generate-questions';
+import { resolveDailyBasePoints } from '@/server/daily/types';
+import {
+  getDomainPoolAvoidLists,
+  getThinActiveDomains,
+} from '@/server/db/queries/retrieval-demand';
+import {
+  estimateCallUsd,
+  getRetrievalConfig,
+  type RetrievalConfig,
+} from '@/server/daily/retrieval-config';
+
+// Web search adds round-trips inside the single (server-tool) generation call,
+// so it tolerates more latency than a plain generation batch. Still bounded so a
+// stalled call can't eat the cron's whole budget.
+const RETRIEVAL_CALL_TIMEOUT_MS = 60_000;
+// Durable pool content (B1 §5.1, D8): machine bank no longer expires by age, so
+// seed rows get a far-future expiry rather than the per-user daily-reset value —
+// the bank ignores expiry for serving, and this keeps any age-based cleanup from
+// sweeping durable seeds.
+const DURABLE_EXPIRY = new Date('2999-01-01T00:00:00.000Z');
+// How many existing pool facts per domain to feed the avoid list.
+const AVOID_LIST_LIMIT = 60;
+
+export type DomainRefillResult = {
+  domain: string;
+  persisted: number;
+  webSearches: number;
+  usd: number;
+  generated: number;
+  droppedUncorroborated: number;
+  droppedQualityGate: number;
+  droppedDuplicateFact: number;
+};
+
+export type PoolRefillReport = {
+  enabled: boolean;
+  ranAt: string;
+  reason?: string;
+  usdCeiling: number;
+  usdSpent: number;
+  webSearches: number;
+  domainsConsidered: number;
+  domainsProcessed: number;
+  questionsPersisted: number;
+  dropped: {
+    uncorroborated: number;
+    qualityGate: number;
+    duplicateFact: number;
+  };
+  // Domains that wanted refill but the USD ceiling / per-run cap cut off — the
+  // signal that the budget is too low for current demand.
+  backlogRemaining: number;
+  perDomain: DomainRefillResult[];
+};
+
+type GroundedCallResult = {
+  questions: GroundedLlmQuestion[];
+  webSearches: number;
+  usd: number;
+};
+
+// One retrieval-grounded generation call for a single domain. Returns the parsed
+// questions plus the metered cost (searches + tokens) of THIS call.
+async function generateGroundedForDomain(
+  client: Anthropic,
+  domain: string,
+  config: RetrievalConfig,
+): Promise<GroundedCallResult> {
+  const { questionTexts, factKeys } = await getDomainPoolAvoidLists(domain, AVOID_LIST_LIMIT);
+
+  const userPrompt = buildUserPrompt(
+    [domain],
+    config.questionsPerDomain,
+    questionTexts,
+    factKeys,
+    undefined,
+  );
+
+  const maxUses = config.maxSearchesPerQuestion * config.questionsPerDomain;
+  const params = {
+    model: ANTHROPIC_MODEL,
+    max_tokens: 3000,
+    // Low temperature: fact anchoring, not question-shape variety (§7).
+    temperature: 0.2,
+    system: [
+      { type: 'text', text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: GROUNDING_SYSTEM_ADDENDUM },
+    ],
+    messages: [{ role: 'user', content: userPrompt }],
+    tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: maxUses }],
+  } as unknown as Anthropic.MessageCreateParamsNonStreaming;
+
+  const response = await loggedMessagesCreate(client, 'pool-refill-generate', params, {
+    timeoutMs: RETRIEVAL_CALL_TIMEOUT_MS,
+  });
+
+  const usage = response.usage as
+    | (Anthropic.Usage & { server_tool_use?: { web_search_requests?: number } })
+    | undefined;
+  const webSearches = usage?.server_tool_use?.web_search_requests ?? 0;
+  const usd = estimateCallUsd({
+    webSearches,
+    inputTokens: usage?.input_tokens ?? 0,
+    outputTokens: usage?.output_tokens ?? 0,
+    cacheReadTokens: usage?.cache_read_input_tokens ?? 0,
+    cacheWriteTokens: usage?.cache_creation_input_tokens ?? 0,
+  });
+
+  const questions = parseGroundedQuestions(extractTextContent(response.content));
+  return { questions, webSearches, usd };
+}
+
+// Generate, screen, corroborate, dedup, and persist grounded questions for one
+// domain. Returns the per-domain metrics for the run report.
+async function refillDomain(
+  client: Anthropic,
+  domain: string,
+  config: RetrievalConfig,
+  systemUserId: string,
+): Promise<DomainRefillResult> {
+  const result: DomainRefillResult = {
+    domain,
+    persisted: 0,
+    webSearches: 0,
+    usd: 0,
+    generated: 0,
+    droppedUncorroborated: 0,
+    droppedQualityGate: 0,
+    droppedDuplicateFact: 0,
+  };
+
+  const { questions, webSearches, usd } = await generateGroundedForDomain(client, domain, config);
+  result.webSearches = webSearches;
+  result.usd = usd;
+  result.generated = questions.length;
+  if (questions.length === 0) return result;
+
+  // Corroboration floor (Drift Risk 2/3): drop anything below the distinct-host
+  // threshold BEFORE the quality gates so we never persist — or even spend gate
+  // calls on — an uncorroborated fresh question. Phase 2 layers reputation
+  // ranking + true mirror detection on top of this minimal "≥2 distinct sites".
+  const corroborated: GroundedLlmQuestion[] = [];
+  for (const q of questions) {
+    if (distinctSourceHostCount(q.source_refs) >= config.minCorroboratingSources) {
+      corroborated.push(q);
+    } else {
+      result.droppedUncorroborated += 1;
+    }
+  }
+  if (corroborated.length === 0) return result;
+
+  // Same quality bar as the per-user path (intra-batch dupe, quality, factual,
+  // answer-leak). Fails open per gate.
+  const drops = await screenGroundedBatch(corroborated);
+  const screened = corroborated.filter((_, i) => !drops.has(i));
+  result.droppedQualityGate = corroborated.length - screened.length;
+  if (screened.length === 0) return result;
+
+  const seenFactKeys = new Set<string>();
+  for (const q of screened) {
+    if (q.fact_key) {
+      if (seenFactKeys.has(q.fact_key)) {
+        result.droppedDuplicateFact += 1;
+        continue;
+      }
+      seenFactKeys.add(q.fact_key);
+    }
+
+    try {
+      const [row] = await db
+        .insert(generatedQuestions)
+        .values({
+          userId: systemUserId,
+          canonicalSubcategory: q.canonical_subcategory,
+          broadCategory: q.broad_category,
+          questionText: q.question_text,
+          answer: q.answer,
+          explainer: q.explainer,
+          difficultyEstimate: q.difficulty_estimate,
+          basePoints: resolveDailyBasePoints(q.difficulty_estimate),
+          factKey: q.fact_key,
+          subAngles: q.sub_angles,
+          sourceRefs: q.source_refs,
+          expiresAt: DURABLE_EXPIRY,
+          usedInQueue: false,
+        })
+        .returning();
+      result.persisted += 1;
+
+      // Semantic-dedup backstop (B1). Best-effort; never blocks the refill.
+      await embedAndResolveDuplicate({
+        id: row.id,
+        origin: 'machine',
+        questionText: row.questionText,
+      }).catch(() => undefined);
+    } catch (err) {
+      console.warn('[pool-refill] persist failed', {
+        domain,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}
+
+// Drive a single capped pool-refill run. Derives demand (thin + active domains),
+// spends up to the USD ceiling generating corroborated questions into the shared
+// pool, and returns a structured report. Never throws on per-domain failure.
+export async function runPoolRefill(): Promise<PoolRefillReport> {
+  const config = getRetrievalConfig();
+  const report: PoolRefillReport = {
+    enabled: config.enabled,
+    ranAt: new Date().toISOString(),
+    usdCeiling: config.dailyUsdCeiling,
+    usdSpent: 0,
+    webSearches: 0,
+    domainsConsidered: 0,
+    domainsProcessed: 0,
+    questionsPersisted: 0,
+    dropped: { uncorroborated: 0, qualityGate: 0, duplicateFact: 0 },
+    backlogRemaining: 0,
+    perDomain: [],
+  };
+
+  if (!config.enabled) {
+    report.reason = 'RETRIEVAL_GROUNDING_ENABLED is not set';
+    return report;
+  }
+  const client = getAnthropicClient();
+  if (!client) {
+    report.reason = 'Anthropic client unavailable (missing/invalid ANTHROPIC_API_KEY or LLM disabled)';
+    return report;
+  }
+  if (!config.systemUserId) {
+    report.reason = 'RETRIEVAL_SYSTEM_USER_ID is not set — no owning user for pool rows';
+    return report;
+  }
+
+  const domains = await getThinActiveDomains({
+    depthThreshold: config.poolDepthThreshold,
+    activeLookbackDays: config.activeLookbackDays,
+    limit: config.maxDomainsPerRun,
+  });
+  report.domainsConsidered = domains.length;
+
+  // Worst-case cost of one call (all searches used) — used to stop BEFORE a call
+  // that could cross the ceiling rather than after, so the cap never overshoots
+  // by more than rounding. Token cost is added from the actual usage afterwards.
+  const perCallWorstCaseUsd =
+    config.maxSearchesPerQuestion * config.questionsPerDomain * 0.01;
+
+  for (let i = 0; i < domains.length; i += 1) {
+    if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
+      // Ceiling reached — everything still in the list is unserved demand.
+      report.backlogRemaining = domains.length - i;
+      break;
+    }
+
+    const { domain } = domains[i];
+    try {
+      const domainResult = await refillDomain(client, domain, config, config.systemUserId);
+      report.perDomain.push(domainResult);
+      report.domainsProcessed += 1;
+      report.usdSpent += domainResult.usd;
+      report.webSearches += domainResult.webSearches;
+      report.questionsPersisted += domainResult.persisted;
+      report.dropped.uncorroborated += domainResult.droppedUncorroborated;
+      report.dropped.qualityGate += domainResult.droppedQualityGate;
+      report.dropped.duplicateFact += domainResult.droppedDuplicateFact;
+    } catch (err) {
+      // A single domain failing (timeout / parse / API) must not sink the run.
+      console.warn('[pool-refill] domain refill failed', {
+        domain,
+        error: err instanceof Error ? err.message : String(err),
+      });
+      report.perDomain.push({
+        domain,
+        persisted: 0,
+        webSearches: 0,
+        usd: 0,
+        generated: 0,
+        droppedUncorroborated: 0,
+        droppedQualityGate: 0,
+        droppedDuplicateFact: 0,
+      });
+    }
+  }
+
+  return report;
+}

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -23,6 +23,7 @@ import {
   getThinActiveDomains,
 } from '@/server/db/queries/retrieval-demand';
 import {
+  USD_PER_WEB_SEARCH,
   estimateCallUsd,
   getRetrievalConfig,
   type RetrievalConfig,
@@ -53,6 +54,9 @@ export type DomainRefillResult = {
 
 export type PoolRefillReport = {
   enabled: boolean;
+  // True when this was a preview: demand derived + spend projected, but no
+  // searches issued and nothing persisted. usdSpent/webSearches are projections.
+  dryRun: boolean;
   ranAt: string;
   reason?: string;
   usdCeiling: number;
@@ -234,10 +238,12 @@ async function refillDomain(
 // Drive a single capped pool-refill run. Derives demand (thin + active domains),
 // spends up to the USD ceiling generating corroborated questions into the shared
 // pool, and returns a structured report. Never throws on per-domain failure.
-export async function runPoolRefill(): Promise<PoolRefillReport> {
+export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<PoolRefillReport> {
+  const dryRun = opts.dryRun ?? false;
   const config = getRetrievalConfig();
   const report: PoolRefillReport = {
     enabled: config.enabled,
+    dryRun,
     ranAt: new Date().toISOString(),
     usdCeiling: config.dailyUsdCeiling,
     usdSpent: 0,
@@ -250,18 +256,19 @@ export async function runPoolRefill(): Promise<PoolRefillReport> {
     perDomain: [],
   };
 
-  if (!config.enabled) {
-    report.reason = 'RETRIEVAL_GROUNDING_ENABLED is not set';
-    return report;
-  }
   const client = getAnthropicClient();
-  if (!client) {
-    report.reason = 'Anthropic client unavailable (missing/invalid ANTHROPIC_API_KEY or LLM disabled)';
-    return report;
-  }
-  if (!config.systemUserId) {
-    report.reason = 'RETRIEVAL_SYSTEM_USER_ID is not set — no owning user for pool rows';
-    return report;
+
+  // A real run requires all three preconditions; a dry run previews regardless
+  // (that's its purpose — sanity-check demand BEFORE flipping the switches) and
+  // just records which precondition would block the real run.
+  const blockers: string[] = [];
+  if (!config.enabled) blockers.push('RETRIEVAL_GROUNDING_ENABLED is not set');
+  if (!client) blockers.push('Anthropic client unavailable (missing/invalid ANTHROPIC_API_KEY or LLM disabled)');
+  if (!config.systemUserId) blockers.push('RETRIEVAL_SYSTEM_USER_ID is not set — no owning user for pool rows');
+
+  if (blockers.length > 0) {
+    report.reason = blockers.join('; ');
+    if (!dryRun) return report;
   }
 
   const domains = await getThinActiveDomains({
@@ -271,11 +278,12 @@ export async function runPoolRefill(): Promise<PoolRefillReport> {
   });
   report.domainsConsidered = domains.length;
 
-  // Worst-case cost of one call (all searches used) — used to stop BEFORE a call
-  // that could cross the ceiling rather than after, so the cap never overshoots
-  // by more than rounding. Token cost is added from the actual usage afterwards.
-  const perCallWorstCaseUsd =
-    config.maxSearchesPerQuestion * config.questionsPerDomain * 0.01;
+  // Worst-case search cost of one call (all max_uses searches) — used to stop
+  // BEFORE a call that could cross the ceiling rather than after, so the cap
+  // never overshoots by more than rounding. Token cost is added from actual
+  // usage afterwards (and is NOT projected in a dry run — flagged in the route).
+  const maxSearchesPerCall = config.maxSearchesPerQuestion * config.questionsPerDomain;
+  const perCallWorstCaseUsd = maxSearchesPerCall * USD_PER_WEB_SEARCH;
 
   for (let i = 0; i < domains.length; i += 1) {
     if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
@@ -285,6 +293,28 @@ export async function runPoolRefill(): Promise<PoolRefillReport> {
     }
 
     const { domain } = domains[i];
+
+    if (dryRun) {
+      // Preview only: project this call's worst-case search spend, issue nothing.
+      report.perDomain.push({
+        domain,
+        persisted: 0,
+        webSearches: maxSearchesPerCall,
+        usd: perCallWorstCaseUsd,
+        generated: 0,
+        droppedUncorroborated: 0,
+        droppedQualityGate: 0,
+        droppedDuplicateFact: 0,
+      });
+      report.domainsProcessed += 1;
+      report.usdSpent += perCallWorstCaseUsd;
+      report.webSearches += maxSearchesPerCall;
+      continue;
+    }
+
+    // Preconditions are guaranteed by the early return above on a real run;
+    // narrow them for the type checker (and stay defensive).
+    if (!client || !config.systemUserId) continue;
     try {
       const domainResult = await refillDomain(client, domain, config, config.systemUserId);
       report.perDomain.push(domainResult);

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -12,11 +12,11 @@ import {
   GROUNDING_SYSTEM_ADDENDUM,
   SYSTEM_PROMPT,
   buildUserPrompt,
-  distinctSourceHostCount,
   parseGroundedQuestions,
   screenGroundedBatch,
   type GroundedLlmQuestion,
 } from '@/server/daily/generate-questions';
+import { assessCorroboration, getReputationLists } from '@/server/daily/source-reputation';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import {
   getDomainPoolAvoidLists,
@@ -154,14 +154,22 @@ async function refillDomain(
   result.generated = questions.length;
   if (questions.length === 0) return result;
 
-  // Corroboration floor (Drift Risk 2/3): drop anything below the distinct-host
-  // threshold BEFORE the quality gates so we never persist — or even spend gate
-  // calls on — an uncorroborated fresh question. Phase 2 layers reputation
-  // ranking + true mirror detection on top of this minimal "≥2 distinct sites".
+  // Corroboration + reputation gate (Phase 2; DR2/DR3): drop anything not backed
+  // by ≥minCorroboratingSources independent non-denied hosts with
+  // ≥minReputableSources editorially-accountable anchors, BEFORE the quality
+  // gates — so we never persist (or spend gate calls on) an uncorroborated fresh
+  // question, and circular/junk sources can't fake corroboration. Surviving
+  // questions keep only their non-denied refs, reputable-first.
+  const lists = getReputationLists();
   const corroborated: GroundedLlmQuestion[] = [];
   for (const q of questions) {
-    if (distinctSourceHostCount(q.source_refs) >= config.minCorroboratingSources) {
-      corroborated.push(q);
+    const assessment = assessCorroboration(q.source_refs, {
+      minTotal: config.minCorroboratingSources,
+      minReputable: config.minReputableSources,
+      lists,
+    });
+    if (assessment.corroborated) {
+      corroborated.push({ ...q, source_refs: assessment.orderedRefs });
     } else {
       result.droppedUncorroborated += 1;
     }

--- a/src/server/daily/source-reputation.ts
+++ b/src/server/daily/source-reputation.ts
@@ -1,0 +1,200 @@
+import { sourceHost } from '@/server/daily/generate-questions';
+
+// B3 Phase 2 — source reputation + corroboration (PRD-D-5 §5.3 trust layer, §7).
+//
+// The defense against AI-contaminated / circular web content: a fresh question
+// is only allowed into the pool when its answer is backed by independent,
+// editorially-accountable sources. This module is pure (no DB, no LLM) so the
+// trust rules are unit-testable in isolation.
+
+export type SourceTier = 'reputable' | 'neutral' | 'denied';
+
+// Editorially-accountable reference / primary / institutional domains. This is a
+// SEED (spec §7) — deliberately small and expanded empirically. Most authority
+// is carried by the TLD heuristics below (.edu/.gov/.mil/.ac.*), so the list
+// only needs the high-value non-institutional references.
+const ALLOW_SEED = [
+  'wikipedia.org',
+  'britannica.com',
+  'merriam-webster.com',
+  'oed.com',
+  'oxfordreference.com',
+  'encyclopedia.com',
+  'bbc.com',
+  'bbc.co.uk',
+  'nationalgeographic.com',
+  'smithsonianmag.com',
+  'nature.com',
+  'science.org',
+  'scientificamerican.com',
+  'jstor.org',
+  'poetryfoundation.org',
+  'metmuseum.org',
+  'moma.org',
+  'tate.org.uk',
+  'britishmuseum.org',
+  'guggenheim.org',
+  'pbs.org',
+  'npr.org',
+  'reuters.com',
+  'apnews.com',
+  'nytimes.com',
+  'theguardian.com',
+];
+
+// Content farms, open-UGC, forums, Q&A mills, social, and known AI-content
+// mills. Pages here NEVER count toward corroboration and are stripped from the
+// stored provenance — they're the circular/contaminated-source risk (DR2).
+const DENY_SEED = [
+  'reddit.com',
+  'quora.com',
+  'answers.com',
+  'answers.yahoo.com',
+  'ehow.com',
+  'wikihow.com',
+  'pinterest.com',
+  'facebook.com',
+  'instagram.com',
+  'twitter.com',
+  'x.com',
+  'tiktok.com',
+  'tumblr.com',
+  'medium.com',
+  'blogspot.com',
+  'wordpress.com',
+  'fandom.com',
+  'wikia.com',
+  'coursehero.com',
+  'chegg.com',
+  'studocu.com',
+  'scribd.com',
+  'slideshare.net',
+  'brainly.com',
+  'enotes.com',
+];
+
+// Academic / governmental / military TLDs (and their country-coded forms) are
+// treated as reputable without needing an explicit allow-list entry.
+const REPUTABLE_TLD_PATTERNS: RegExp[] = [
+  /\.edu$/,
+  /\.edu\.[a-z]{2}$/,
+  /\.gov$/,
+  /\.gov\.[a-z]{2}$/,
+  /\.mil$/,
+  /\.mil\.[a-z]{2}$/,
+  /\.ac\.[a-z]{2}$/,
+];
+
+export type ReputationLists = {
+  allow: ReadonlySet<string>;
+  deny: ReadonlySet<string>;
+};
+
+function parseHostListEnv(name: string): string[] {
+  const raw = process.env[name];
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((h) => h.trim().toLowerCase().replace(/^www\./, ''))
+    .filter(Boolean);
+}
+
+// Built-in seeds merged with comma-separated env overrides
+// (RETRIEVAL_SOURCE_ALLOW / RETRIEVAL_SOURCE_DENY). Deny wins ties: a host on
+// both lists is treated as denied.
+export function getReputationLists(): ReputationLists {
+  const allow = new Set<string>([...ALLOW_SEED, ...parseHostListEnv('RETRIEVAL_SOURCE_ALLOW')]);
+  const deny = new Set<string>([...DENY_SEED, ...parseHostListEnv('RETRIEVAL_SOURCE_DENY')]);
+  return { allow, deny };
+}
+
+// True when `host` equals `listed` or is a subdomain of it
+// (e.g. "plato.stanford.edu" matches "stanford.edu").
+function hostMatches(host: string, listed: string): boolean {
+  return host === listed || host.endsWith(`.${listed}`);
+}
+
+function inList(host: string, list: ReadonlySet<string>): boolean {
+  if (list.has(host)) return true;
+  for (const listed of list) {
+    if (hostMatches(host, listed)) return true;
+  }
+  return false;
+}
+
+export function classifyHost(host: string, lists: ReputationLists): SourceTier {
+  // Deny wins — a junk source is never rescued by also matching an allow rule.
+  if (inList(host, lists.deny)) return 'denied';
+  if (inList(host, lists.allow)) return 'reputable';
+  if (REPUTABLE_TLD_PATTERNS.some((re) => re.test(host))) return 'reputable';
+  return 'neutral';
+}
+
+export function classifySource(url: string, lists: ReputationLists): SourceTier {
+  const host = sourceHost(url);
+  if (!host) return 'denied';
+  return classifyHost(host, lists);
+}
+
+export type CorroborationAssessment = {
+  corroborated: boolean;
+  // Non-denied refs, reordered reputable-first (stable within tier) — what we
+  // persist as provenance. Denied sources are stripped.
+  orderedRefs: string[];
+  distinctReputableHosts: number;
+  distinctNonDeniedHosts: number;
+  deniedRefs: string[];
+};
+
+// The corroboration gate (DR2/DR3). A question is corroborated when it has at
+// least `minTotal` independent (distinct-host) non-denied sources AND at least
+// `minReputable` of those are editorially-accountable. Denied sources never
+// count and are stripped from provenance. Mirrors collapse to one host, so two
+// copies of the same page can't fake independence.
+//
+// `minReputable` defaults to 1 (≥2 independent sources with ≥1 authoritative
+// anchor) rather than requiring BOTH to be allow-listed — the strict reading
+// would tank yield on the thin domains B3 exists to refill. Set
+// RETRIEVAL_MIN_REPUTABLE_SOURCES equal to RETRIEVAL_MIN_CORROBORATING_SOURCES
+// for the strict "all reputable" interpretation.
+export function assessCorroboration(
+  refs: readonly string[],
+  opts: { minTotal: number; minReputable: number; lists: ReputationLists },
+): CorroborationAssessment {
+  const reputableHosts = new Set<string>();
+  const nonDeniedHosts = new Set<string>();
+  const reputableRefs: string[] = [];
+  const neutralRefs: string[] = [];
+  const deniedRefs: string[] = [];
+
+  for (const ref of refs) {
+    const host = sourceHost(ref);
+    if (!host) {
+      deniedRefs.push(ref);
+      continue;
+    }
+    const tier = classifyHost(host, opts.lists);
+    if (tier === 'denied') {
+      deniedRefs.push(ref);
+      continue;
+    }
+    nonDeniedHosts.add(host);
+    if (tier === 'reputable') {
+      reputableHosts.add(host);
+      reputableRefs.push(ref);
+    } else {
+      neutralRefs.push(ref);
+    }
+  }
+
+  const corroborated =
+    nonDeniedHosts.size >= opts.minTotal && reputableHosts.size >= opts.minReputable;
+
+  return {
+    corroborated,
+    orderedRefs: [...reputableRefs, ...neutralRefs],
+    distinctReputableHosts: reputableHosts.size,
+    distinctNonDeniedHosts: nonDeniedHosts.size,
+    deniedRefs,
+  };
+}

--- a/src/server/db/queries/retrieval-demand.ts
+++ b/src/server/db/queries/retrieval-demand.ts
@@ -1,0 +1,83 @@
+import { and, desc, eq, isNotNull, sql } from 'drizzle-orm';
+
+import { db, generatedQuestions } from '@/server/db';
+import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import type { RecentDailyQuestionEntry, RecentFactKeyEntry } from '@/server/db/queries/daily';
+
+export type ThinActiveDomain = {
+  domain: string;
+  /** Distinct facts currently in the durable machine pool for this domain. */
+  depth: number;
+  /** Most recent machine-pool activity for the domain (the "active" proxy). */
+  lastActivity: Date;
+};
+
+// Derive the demand signal for B3 pool refill WITHOUT a new backlog table: the
+// domains real users are being served (recent machine-pool activity) whose
+// durable pool is THIN (few distinct facts). This is the reconstructed "on-miss"
+// set — exactly the domains a per-user build keeps falling through to fresh
+// generation on because pickBankSource can't satisfy them. Thinnest-first so a
+// capped run spends on the domains that need it most.
+export async function getThinActiveDomains(opts: {
+  depthThreshold: number;
+  activeLookbackDays: number;
+  limit: number;
+}): Promise<ThinActiveDomain[]> {
+  const sinceMs = Date.now() - opts.activeLookbackDays * 24 * 60 * 60 * 1000;
+  const since = new Date(sinceMs);
+
+  const rows = await db
+    .select({
+      domain: generatedQuestions.canonicalSubcategory,
+      depth: sql<number>`count(distinct ${generatedQuestions.factKey})`,
+      lastActivity: sql<Date>`max(${generatedQuestions.createdAt})`,
+    })
+    .from(generatedQuestions)
+    .where(and(
+      eq(generatedQuestions.isDuplicate, false),
+      isNotNull(generatedQuestions.factKey),
+    ))
+    .groupBy(generatedQuestions.canonicalSubcategory)
+    .having(
+      sql`max(${generatedQuestions.createdAt}) >= ${since} and count(distinct ${generatedQuestions.factKey}) < ${opts.depthThreshold}`,
+    );
+
+  return rows
+    .map((row) => ({
+      domain: row.domain,
+      depth: Number(row.depth),
+      lastActivity: row.lastActivity instanceof Date ? row.lastActivity : new Date(row.lastActivity),
+    }))
+    .filter((row) => !isGenericSubcategory(row.domain))
+    .sort((a, b) => a.depth - b.depth || b.lastActivity.getTime() - a.lastActivity.getTime())
+    .slice(0, opts.limit);
+}
+
+// Existing pool facts for a domain, shaped as the avoid lists buildUserPrompt
+// expects, so the grounded call doesn't re-mint a fact the pool already holds.
+export async function getDomainPoolAvoidLists(
+  domain: string,
+  limit: number,
+): Promise<{ questionTexts: RecentDailyQuestionEntry[]; factKeys: RecentFactKeyEntry[] }> {
+  const rows = await db
+    .select({
+      questionText: generatedQuestions.questionText,
+      factKey: generatedQuestions.factKey,
+    })
+    .from(generatedQuestions)
+    .where(and(
+      eq(generatedQuestions.canonicalSubcategory, domain),
+      eq(generatedQuestions.isDuplicate, false),
+      isNotNull(generatedQuestions.factKey),
+    ))
+    .orderBy(desc(generatedQuestions.createdAt))
+    .limit(limit);
+
+  const questionTexts: RecentDailyQuestionEntry[] = [];
+  const factKeys: RecentFactKeyEntry[] = [];
+  for (const row of rows) {
+    questionTexts.push({ domain, text: row.questionText });
+    if (row.factKey) factKeys.push({ domain, factKey: row.factKey });
+  }
+  return { questionTexts, factKeys };
+}

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,10 @@
     {
       "path": "/api/cron/expire-friend-requests",
       "schedule": "30 6 * * *"
+    },
+    {
+      "path": "/api/cron/pool-refill",
+      "schedule": "0 9 * * *"
     }
   ]
 }


### PR DESCRIPTION
Implements B3 retrieval-grounded generation for the durable question pool (PRD-D-5 §5.3). This adds a new cron job that automatically deepens the shared pool for thin-but-active domains by generating corroborated questions from web search results, reducing per-user generation load on those domains.

## Key changes

- **New retrieval-grounded generation pipeline** (`src/server/daily/retrieval-grounded.ts`):
  - `runPoolRefill()`: Main entry point for the cron job; derives demand (thin + active domains), generates grounded questions up to a USD ceiling, and persists corroborated results
  - `refillDomain()`: Per-domain generation, screening, corroboration assessment, dedup, and persistence
  - `generateGroundedForDomain()`: Single LLM call with web_search tool, metered for cost

- **Source reputation & corroboration module** (`src/server/daily/source-reputation.ts`):
  - `classifySource()` / `classifyHost()`: Tier sources as reputable (allow-list + .edu/.gov/.mil/.ac.*), neutral, or denied (forums, Q&A, content farms)
  - `assessCorroboration()`: Gate that requires ≥minTotal distinct non-denied hosts with ≥minReputable editorially-accountable anchors; strips denied refs from provenance
  - Configurable allow/deny lists via `RETRIEVAL_SOURCE_ALLOW` / `RETRIEVAL_SOURCE_DENY` env vars

- **Retrieval configuration** (`src/server/daily/retrieval-config.ts`):
  - Safe defaults (feature off, $2/day ceiling) until explicitly enabled
  - Knobs for search budget, questions per domain, pool depth threshold, active lookback, corroboration minimums
  - Token pricing for spend estimation (Sonnet 4.6 rates)

- **Demand derivation** (`src/server/db/queries/retrieval-demand.ts`):
  - `getThinActiveDomains()`: Reconstructs "on-miss" set — domains with recent machine-pool activity but shallow durable depth
  - `getDomainPoolAvoidLists()`: Feeds existing facts to the LLM to prevent re-minting

- **Cron route** (`src/app/api/cron/pool-refill/route.ts`):
  - GET endpoint with CRON_SECRET auth
  - `?dryRun=1` mode: projects worst-case spend without issuing searches or persisting
  - Returns structured report (spend, searches, per-domain metrics, drops)
  - Scheduled daily at 9 AM UTC (vercel.json)

- **Grounded question parsing & screening** (extensions to `src/server/daily/generate-questions.ts`):
  - `GROUNDING_SYSTEM_ADDENDUM`: Appended to SYSTEM_PROMPT; requires web_search before writing, corroboration from ≥2 independent sources, and source_refs field
  - `parseGroundedQuestions()`: Parses LLM JSON with source_refs; reuses `parseBaseQuestion()` for field validation
  - `normalizeSourceRefs()`: Dedupes and validates URLs; extracts from object form
  - `distinctSourceHostCount()`: Counts distinct registrable hosts (mirrors collapse to one)
  - `screenGroundedBatch()`: Same quality gates as per-user path (intra-batch dupe, quality, factual, answer-leak)
  - Exported `SYSTEM_PROMPT`, `buildUserPrompt()`, `LlmQuestion` type for reuse

## Notable implementation details

- **Drift Risk mitigation** (DR1/DR2/DR3):
  - DR1 (memory-only answers): Enforced by GROUNDING_SYSTEM_ADDENDUM requiring search-first
  - DR2 (circular sources): Corroboration gate strips denied refs and requires ≥1 reputable anchor
  - DR3 (thin-domain junk): Batch yields nothing if all sources are junk-only

- **Cost control**:
  - Hard

https://claude.ai/code/session_013zTPbfAm3h9HhrRBujHzLc