### PR TITLE
Refactor milestone expansion to show active question + answered history

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -15,7 +15,7 @@ import type {
 
 import { InlineAnswerFlow } from './InlineAnswerFlow';
 import { ActivityIcon, specForIcon } from './ActivityIcon';
-import { FM, INK, INK2, INK3, RULE } from '@/components/lately/tokens';
+import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
 
 // Friend names render in the activity-blue from Figma (--brand-link #4a5d75),
@@ -81,34 +81,49 @@ function questionBacked(expand: StreamExpand | null): boolean {
   }
 }
 
+// One in-session answer to a milestone question: what the viewer typed and
+// whether it was scored correct. Drives the calm "Answered" history copy.
+type Resolution = { submitted: string; isCorrect: boolean };
+
 export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; timestamp: string }) {
   const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
 
-  // CORRECTION 3: the answered-of-total counter lives on the LINE (collapsed and
-  // expanded), so the answered-state is held HERE — not inside the expansion —
-  // and ticks up + persists as the viewer answers, even after the result pop-up
-  // closes or the line is collapsed and reopened. Milestone lines only.
+  // CORRECTION 3 (revised): the answered-of-total counter lives on the LINE
+  // (collapsed and expanded), so the answered-state is held HERE — not inside
+  // the expansion — and ticks up + persists as the viewer answers, even after
+  // the result pop-up closes or the line is collapsed and reopened. We also keep
+  // each in-session resolution (submitted answer + correctness) here so the
+  // expanded "Answered" history can read it back. Milestone lines only.
   const expand = item.expand;
   const milestoneQuestions = expand && expand.kind === 'milestone' ? expand.questions : null;
-  const [answeredIds, setAnsweredIds] = useState<Set<string>>(
+  // Questions the server already records as answered (correctly) on load. We
+  // don't have the original submitted text for these, so the history shows a
+  // calm "Correct" without the "You answered:" clause for them.
+  const [serverAnswered] = useState<Set<string>>(
     () => new Set((milestoneQuestions ?? []).filter((q) => q.answered).map((q) => q.questionId)),
   );
+  // Resolutions captured this session — both correct and "not quite" — keyed by
+  // questionId, carrying what the viewer typed so the history can echo it.
+  const [resolutions, setResolutions] = useState<Map<string, Resolution>>(() => new Map());
 
-  function markAnswered(questionId: string) {
-    setAnsweredIds((prev) => {
-      const next = new Set(prev);
-      next.add(questionId);
+  function isResolved(questionId: string): boolean {
+    return serverAnswered.has(questionId) || resolutions.has(questionId);
+  }
+
+  function resolve(questionId: string, submitted: string, isCorrect: boolean) {
+    setResolutions((prev) => {
+      const next = new Map(prev);
+      next.set(questionId, { submitted, isCorrect });
       return next;
     });
   }
 
+  const answeredCount = (milestoneQuestions ?? []).filter((q) => isResolved(q.questionId)).length;
+
   const milestoneProgress =
     milestoneQuestions && milestoneQuestions.length > 0
-      ? {
-          answered: milestoneQuestions.filter((q) => answeredIds.has(q.questionId)).length,
-          total: milestoneQuestions.length,
-        }
+      ? { answered: answeredCount, total: milestoneQuestions.length }
       : null;
 
   // The bundle mark (milestone) shares the row's live answered-state: as the
@@ -118,7 +133,7 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
     item.icon === 'bundle' && milestoneQuestions
       ? (() => {
           const total = Math.min(milestoneQuestions.length, 5);
-          const answered = Math.min(answeredIds.size, total);
+          const answered = Math.min(answeredCount, total);
           return { total, unanswered: total - answered };
         })()
       : null;
@@ -136,13 +151,28 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
     }
   }
 
+  // Opened milestone clusters read as a distinct, quiet "opened" state: a touch
+  // more vertical room, a faint inset (slightly lifted paper + a gentle inset of
+  // the side padding) and top/bottom hairlines — never a heavy card shadow or
+  // loud fill, so the item still sits inside the feed.
+  const opened = expandable && open;
+
   return (
     <div
       id={item.anchorId ?? undefined}
-      style={{
-        borderBottom: `1px solid ${RULE}`,
-        padding: '12px 2px',
-      }}
+      style={
+        opened
+          ? {
+              borderTop: `1px solid ${RULE}`,
+              borderBottom: `1px solid ${RULE}`,
+              padding: '18px 10px',
+              background: PAPER,
+            }
+          : {
+              borderBottom: `1px solid ${RULE}`,
+              padding: '12px 2px',
+            }
+      }
     >
       <div
         role={expandable ? 'button' : undefined}
@@ -198,7 +228,7 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
                 color: INK3,
               }}
             >
-              {milestoneProgress.answered} of {milestoneProgress.total}
+              {milestoneProgress.answered} of {milestoneProgress.total} questions
             </p>
           ) : null}
         </div>
@@ -231,7 +261,12 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
 
       {expandable && open && expand ? (
         expand.kind === 'milestone' ? (
-          <MilestoneExpansion expand={expand} answeredIds={answeredIds} onAnswered={markAnswered} />
+          <MilestoneExpansion
+            expand={expand}
+            isResolved={isResolved}
+            resolutions={resolutions}
+            onResolved={resolve}
+          />
         ) : expand.kind === 'same_correct' ? (
           <ConvergenceExpansion expand={expand} />
         ) : (
@@ -270,38 +305,116 @@ function ItemAction({ action }: { action: NonNullable<StreamItem['action']> }) {
   );
 }
 
-// CORRECTION 3: the expanded milestone questions render at the homepage's FULL
-// width — no narrow inset (the old left-rule/indent is gone) — matching the
-// one-liner register. The answered-state is owned by the parent so the line's
-// quiet "{answered} of {total}" counter ticks up here; this only lists the
-// friend's ≤5 literal questions to answer.
+// CORRECTION 3 (revised): the opened milestone reads as a cluster with ONE
+// playable question. The active (first still-unanswered) question leads —
+// directly under the header — as the single focal point and single action.
+// Everything already answered drops into a quiet "Answered" history below it,
+// so the viewer never scans past settled questions to find the thing they can
+// do now. The answered-state is owned by the parent so the line's quiet
+// "{answered} of {total}" counter and the triangle mark stay in lockstep.
 function MilestoneExpansion({
   expand,
-  answeredIds,
-  onAnswered,
+  isResolved,
+  resolutions,
+  onResolved,
 }: {
   expand: Extract<StreamExpand, { kind: 'milestone' }>;
-  answeredIds: Set<string>;
-  onAnswered: (questionId: string) => void;
+  isResolved: (questionId: string) => boolean;
+  resolutions: Map<string, Resolution>;
+  onResolved: (questionId: string, submitted: string, isCorrect: boolean) => void;
 }) {
+  const active = expand.questions.find((q) => !isResolved(q.questionId)) ?? null;
+  const answered = expand.questions.filter((q) => isResolved(q.questionId));
+
   return (
     <div
       onClick={(e) => e.stopPropagation()}
       style={{
-        marginTop: 12,
+        marginTop: 14,
         display: 'flex',
         flexDirection: 'column',
-        gap: 12,
+        gap: 20,
       }}
     >
-      {expand.questions.map((q) => (
-        <InlineAnswerFlow
-          key={q.questionId}
-          question={q}
-          answered={answeredIds.has(q.questionId)}
-          onAnswered={onAnswered}
-        />
-      ))}
+      {active ? (
+        <InlineAnswerFlow key={active.questionId} question={active} onResolved={onResolved} />
+      ) : null}
+      {answered.length > 0 ? (
+        <AnsweredHistory questions={answered} resolutions={resolutions} />
+      ) : null}
+    </div>
+  );
+}
+
+// The quiet history beneath the active question: each settled question shows a
+// calm, descriptive result ("Correct" / "Not quite") with what the viewer
+// typed, then the original question in a lighter, smaller serif. No bright
+// success/failure colors, no punitive "wrong" — it's available but secondary.
+function AnsweredHistory({
+  questions,
+  resolutions,
+}: {
+  questions: StreamQuestion[];
+  resolutions: Map<string, Resolution>;
+}) {
+  return (
+    <div>
+      <p
+        style={{
+          margin: 0,
+          fontFamily: FM,
+          fontSize: 10,
+          letterSpacing: 1.5,
+          color: INK3,
+        }}
+      >
+        ANSWERED
+      </p>
+      <div
+        style={{
+          marginTop: 10,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 14,
+        }}
+      >
+        {questions.map((q) => {
+          const r = resolutions.get(q.questionId);
+          // No in-session resolution means the server already had it on load as
+          // a correct answer; we lack the original text, so we stay calm and
+          // drop the "You answered:" clause rather than invent one.
+          const isCorrect = r ? r.isCorrect : true;
+          return (
+            <div key={q.questionId}>
+              <p
+                style={{
+                  margin: 0,
+                  fontFamily: FF,
+                  fontSize: 12.5,
+                  lineHeight: 1.45,
+                  letterSpacing: 0.2,
+                  color: INK2,
+                }}
+              >
+                <span style={{ fontWeight: 600 }}>{isCorrect ? 'Correct' : 'Not quite'}</span>
+                {r ? ` · You answered: ${r.submitted}` : null}
+              </p>
+              <p
+                style={{
+                  margin: '3px 0 0',
+                  fontFamily: 'Georgia, serif',
+                  fontStyle: 'italic',
+                  fontSize: 13,
+                  lineHeight: 1.5,
+                  color: INK3,
+                }}
+              >
+                &ldquo;{q.text}&rdquo;
+              </p>
+            </div>
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -7,7 +7,7 @@ import { AnswerSheet } from '@/components/feed/AnswerSheet';
 import type { StreamQuestion } from '@/lib/activity-stream';
 import type { InsideJokeKind } from '@/lib/questions-types';
 
-import { FM, INK, INK2, INK3 } from '@/components/lately/tokens';
+import { FM, INK, INK2 } from '@/components/lately/tokens';
 
 type Feedback = {
   isCorrect: boolean;
@@ -21,18 +21,20 @@ type Feedback = {
   openedTerritoryDomain: string | null;
 };
 
-// D-4 CORRECTION 2: one milestone question, answered IN PLACE via the existing
-// feed answer pop-ups (AnswerSheet -> AnswerFeedbackSheet). Full credit is
-// written by /api/lately/milestone/answer; this component only drives the UI and
-// reports a correct answer up so the milestone can track "{k} of {n} answered".
+// D-4 CORRECTION 2 (revised): this drives the ONE active (still-unanswered)
+// milestone question — the expanded item's single focal point and single
+// action. The question reads as the live, playable one (upright navy serif,
+// slightly larger, behind a thin left rule); the action is an inline text
+// affordance, not a boxed button. The result is reported up only AFTER the
+// feedback pop-up closes, so the parent can retire the question into the quiet
+// "Answered" history (carrying the submitted answer + correctness) and promote
+// the next unanswered question — keeping exactly one active question on screen.
 export function InlineAnswerFlow({
   question,
-  answered,
-  onAnswered,
+  onResolved,
 }: {
   question: StreamQuestion;
-  answered: boolean;
-  onAnswered: (questionId: string) => void;
+  onResolved: (questionId: string, submitted: string, isCorrect: boolean) => void;
 }) {
   const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
   const [loading, setLoading] = useState(false);
@@ -69,7 +71,6 @@ export function InlineAnswerFlow({
           : null,
       });
       setPhase('result');
-      if (body.isCorrect) onAnswered(question.questionId);
     } catch {
       // Leave the input sheet open so the viewer can retry.
     } finally {
@@ -77,54 +78,53 @@ export function InlineAnswerFlow({
     }
   }
 
+  // Hand the resolution up only once the viewer dismisses the result pop-up, so
+  // this block stays mounted (and the sheet visible) through the reveal, then
+  // the parent moves the question into the answered history.
+  function finish() {
+    setPhase('closed');
+    if (feedback) onResolved(question.questionId, submitted, feedback.isCorrect);
+  }
+
   return (
-    <div style={{ display: 'flex', alignItems: 'flex-start', gap: 12 }}>
+    <div
+      style={{
+        borderLeft: `2px solid ${INK2}`,
+        paddingLeft: 14,
+      }}
+    >
       <p
         style={{
-          flex: 1,
-          minWidth: 0,
           margin: 0,
           fontFamily: 'Georgia, serif',
-          fontStyle: 'italic',
-          fontSize: 14,
+          fontSize: 17,
           lineHeight: 1.5,
-          color: answered ? INK3 : INK2,
+          color: INK,
         }}
       >
         &ldquo;{question.text}&rdquo;
       </p>
 
-      {answered ? (
-        <span
-          style={{
-            flexShrink: 0,
-            fontFamily: FM,
-            fontSize: 10,
-            letterSpacing: 1.5,
-            color: INK3,
-          }}
-        >
-          ✓ ANSWERED
-        </span>
-      ) : (
-        <button
-          type="button"
-          onClick={() => setPhase('input')}
-          style={{
-            flexShrink: 0,
-            background: 'transparent',
-            border: `1.5px solid ${INK}`,
-            color: INK,
-            fontFamily: FM,
-            fontSize: 10,
-            letterSpacing: 2,
-            padding: '6px 12px',
-            cursor: 'pointer',
-          }}
-        >
-          ANSWER →
-        </button>
-      )}
+      <button
+        type="button"
+        onClick={() => setPhase('input')}
+        style={{
+          marginTop: 10,
+          display: 'inline-flex',
+          alignItems: 'center',
+          background: 'transparent',
+          border: 'none',
+          borderBottom: `1px solid ${INK}`,
+          color: INK,
+          fontFamily: FM,
+          fontSize: 11,
+          letterSpacing: 1.5,
+          padding: '0 0 2px',
+          cursor: 'pointer',
+        }}
+      >
+        ANSWER THIS ONE →
+      </button>
 
       {phase === 'input' ? (
         <AnswerSheet
@@ -152,7 +152,7 @@ export function InlineAnswerFlow({
           openedTerritoryDomain={feedback.openedTerritoryDomain}
           questionId={question.questionId}
           feedItemId={`milestone:${question.questionId}`}
-          onClose={() => setPhase('closed')}
+          onClose={finish}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
Restructures the milestone question expansion UI to display one active (unanswered) question as the focal point, with all previously answered questions moved into a quiet "Answered" history section below. This keeps the viewer focused on the next actionable question rather than scanning past settled answers.

## Key Changes

- **Resolution tracking**: Replaced `answeredIds` Set with a `resolutions` Map that captures both the submitted answer text and correctness for each question answered in-session. This allows the history to echo back what the viewer typed.

- **Separation of concerns**: Split milestone questions into `active` (first unanswered) and `answered` (all resolved) arrays. Only the active question renders as an `InlineAnswerFlow`; answered questions render in a new `AnsweredHistory` component.

- **InlineAnswerFlow refactor**: 
  - Removed `answered` prop and conditional rendering of "✓ ANSWERED" badge
  - Changed `onAnswered` callback to `onResolved(questionId, submitted, isCorrect)` 
  - Deferred resolution reporting until the feedback pop-up closes (via new `finish()` method), allowing the parent to move the question into history and promote the next active question
  - Updated styling: added left border rule, larger serif font (17px), inline text affordance button ("ANSWER THIS ONE →") instead of boxed button

- **AnsweredHistory component**: New quiet history section showing each settled question with:
  - Result label ("Correct" / "Not quite") + submitted answer (if captured in-session)
  - Original question text in smaller, lighter serif (Georgia italic)
  - No bright success/failure colors; calm, secondary presentation

- **Opened state styling**: Added distinct visual treatment for expanded milestone clusters—faint inset with top/bottom hairlines, lifted paper background, and increased padding—to signal the item sits inside the feed rather than as a heavy card.

- **Progress counter**: Updated to include "questions" label and use the new `answeredCount` derived from both server-answered and in-session resolutions.

- **Token imports**: Added `FF` (serif font family) and `PAPER` (background color) to support the new history styling.

## Implementation Details

- `isResolved()` helper checks both `serverAnswered` (questions the server already had on load) and `resolutions` (in-session answers), allowing the history to distinguish between them: server-answered questions show "Correct" without the "You answered:" clause since the original text is unavailable.
- The `opened` state variable consolidates the expanded milestone styling logic, making the conditional styling more readable.
- All three milestone expansion props (`isResolved`, `resolutions`, `onResolved`) are passed down from the parent to maintain the single source of truth for answered state.

https://claude.ai/code/session_015QqY5aMCB5358SPDnAgjj8