### PR TITLE
B4 — Verification Stack + Switch-On

### DIFF
--- a/drizzle/0066_ask_to_answer_verified.sql
+++ b/drizzle/0066_ask_to_answer_verified.sql
@@ -1,0 +1,20 @@
+-- Migration: ask-to-answer verification record (B4 Phase 1, PRD-D-5 §5.3 layer 2).
+--
+-- Adds GeneratedQuestion.ask_to_answer_verified — true when an independent cold
+-- solver (Haiku, separate from the Sonnet generator) corroborated the stored
+-- answer at generation time. Together with B3 retrieval corroboration this is
+-- what earns the machine_verified trust tier (see resolveMachineTrustTier in
+-- src/server/daily/ask-to-answer.ts).
+--
+-- Only the machine bank gets this column: human-authored questions are
+-- author_confirmed by their author and never pass through ask-to-answer.
+--
+-- Additive, IF NOT EXISTS, non-destructive. Existing rows default false; the B1
+-- grandfather backfill already promoted the pre-existing machine backlog to
+-- machine_verified, so a false here does not demote anything. Matching idempotent
+-- boot guard lands in src/instrumentation.ts.
+--
+-- Rollback: ALTER TABLE "GeneratedQuestion" DROP COLUMN IF EXISTS
+-- "ask_to_answer_verified"; nothing else depends on it.
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "ask_to_answer_verified" boolean NOT NULL DEFAULT false;

--- a/drizzle/0067_human_validated_backfill.sql
+++ b/drizzle/0067_human_validated_backfill.sql
@@ -1,0 +1,84 @@
+-- Migration: human-play trust promotion back-fill + "nobody got it" flag
+-- (B4 Phase 2, PRD-D-5 §5.3 layer 3 / §6 / §7).
+--
+-- 1. Adds Question.nobody_correct_flag (the review smell; never auto-deletes).
+-- 2. Corrects a B1 grandfather artifact: migration 0062 promoted ALL existing
+--    Question rows to author_confirmed, including null-creator daily_generated
+--    rows that are machine-origin, not author-asserted. author_confirmed is a
+--    friend-facing + public-per-D9 tier that must mean "a human authored this",
+--    so machine-origin rows are corrected back to machine_verified BEFORE the
+--    human_validated back-fill (so they become eligible for it).
+-- 3. Back-fills human_validated for questions whose play history already meets
+--    the §7 threshold (N=3 distinct humans correct), Drift Risk 1 step 1.
+-- 4. Back-fills the nobody_correct_flag for questions ≥5 distinct holders tried
+--    with zero correct.
+--
+-- "Correct" = any non-incorrect MASTERY_EVENTS.answer_state. An answerer may have
+-- more than one row per question (the unique key includes source_type), so
+-- count(DISTINCT answered_by_user_id) is what collapses them to distinct humans.
+--
+-- Additive + idempotent (column IF NOT EXISTS; UPDATEs are re-runnable, each
+-- guarded on the source tier / current flag). Matching boot guards land in
+-- src/instrumentation.ts. Emits RAISE NOTICE counts for the Phase 2 checkpoint
+-- report.
+--
+-- Rollback: ALTER TABLE "Question" DROP COLUMN IF EXISTS "nobody_correct_flag".
+-- The trust_tier corrections are not auto-reverted (they restore correct
+-- semantics); no other data depends on the flag column.
+ALTER TABLE "Question"
+  ADD COLUMN IF NOT EXISTS "nobody_correct_flag" boolean NOT NULL DEFAULT false;
+--> statement-breakpoint
+-- Correct mis-grandfathered machine-origin rows (null author, daily_generated).
+UPDATE "Question"
+  SET "trust_tier" = 'machine_verified'
+  WHERE "creator_id" IS NULL
+    AND "source" = 'daily_generated'
+    AND "trust_tier" = 'author_confirmed';
+--> statement-breakpoint
+-- Promote machine_verified rows that already have ≥3 distinct humans correct.
+UPDATE "Question" q
+  SET "trust_tier" = 'human_validated'
+  WHERE q."trust_tier" = 'machine_verified'
+    AND q."id" IN (
+      SELECT m."question_id"
+      FROM "MASTERY_EVENTS" m
+      WHERE m."question_id" IS NOT NULL
+        AND m."answer_state" IN ('first_correct', 'first_correct_after_wrong', 'repeat_correct')
+      GROUP BY m."question_id"
+      HAVING count(DISTINCT m."answered_by_user_id") >= 3
+    );
+--> statement-breakpoint
+-- Flag "nobody got it" rows: ≥5 distinct holders answered, none correctly.
+UPDATE "Question" q
+  SET "nobody_correct_flag" = true
+  WHERE q."nobody_correct_flag" = false
+    AND q."id" IN (
+      SELECT m."question_id"
+      FROM "MASTERY_EVENTS" m
+      WHERE m."question_id" IS NOT NULL
+        AND m."answer_state" IS NOT NULL
+      GROUP BY m."question_id"
+      HAVING count(DISTINCT m."answered_by_user_id") >= 5
+        AND count(DISTINCT m."answered_by_user_id") FILTER (
+          WHERE m."answer_state" IN ('first_correct', 'first_correct_after_wrong', 'repeat_correct')
+        ) = 0
+    );
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "Question_nobody_correct_flag_idx"
+  ON "Question" ("nobody_correct_flag") WHERE "nobody_correct_flag" = true;
+--> statement-breakpoint
+-- Checkpoint report (visible in migration logs).
+DO $$
+DECLARE
+  v_human_validated bigint;
+  v_machine_verified bigint;
+  v_author_confirmed bigint;
+  v_nobody_flagged bigint;
+BEGIN
+  SELECT count(*) INTO v_human_validated FROM "Question" WHERE "trust_tier" = 'human_validated';
+  SELECT count(*) INTO v_machine_verified FROM "Question" WHERE "trust_tier" = 'machine_verified';
+  SELECT count(*) INTO v_author_confirmed FROM "Question" WHERE "trust_tier" = 'author_confirmed';
+  SELECT count(*) INTO v_nobody_flagged FROM "Question" WHERE "nobody_correct_flag" = true;
+  RAISE NOTICE 'B4 Phase 2 back-fill: Question human_validated=%, machine_verified=%, author_confirmed=%, nobody_correct_flag=%',
+    v_human_validated, v_machine_verified, v_author_confirmed, v_nobody_flagged;
+END $$;

--- a/drizzle/0068_acceptable_variants.sql
+++ b/drizzle/0068_acceptable_variants.sql
@@ -1,0 +1,19 @@
+-- Migration: acceptable answer variants on the machine bank (B4 Phase 4,
+-- PRD-D-5 §5.3).
+--
+-- Adds GeneratedQuestion.acceptable_variants — equivalent phrasings of the answer
+-- that the ask-to-answer cold solver produced and the judge accepted. Honored in
+-- grading (exact-match fast path) so a right-but-rephrased answer is never marked
+-- wrong, and carried to Question.accepted_alternatives when a machine row is
+-- promoted to canonical (persistGeneratedQuestion).
+--
+-- The human-authored table already has accepted_alternatives, so this only adds
+-- the machine-side column.
+--
+-- Additive, IF NOT EXISTS, non-destructive; default empty array. Matching boot
+-- guard lands in src/instrumentation.ts.
+--
+-- Rollback: ALTER TABLE "GeneratedQuestion" DROP COLUMN IF EXISTS
+-- "acceptable_variants"; nothing else depends on it.
+ALTER TABLE "GeneratedQuestion"
+  ADD COLUMN IF NOT EXISTS "acceptable_variants" text[] NOT NULL DEFAULT '{}';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -463,6 +463,13 @@
       "when": 1782172800000,
       "tag": "0065_daily_refine_decision",
       "breakpoints": true
+    },
+    {
+      "idx": 66,
+      "version": "7",
+      "when": 1782259200000,
+      "tag": "0066_ask_to_answer_verified",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -470,6 +470,13 @@
       "when": 1782259200000,
       "tag": "0066_ask_to_answer_verified",
       "breakpoints": true
+    },
+    {
+      "idx": 67,
+      "version": "7",
+      "when": 1782345600000,
+      "tag": "0067_human_validated_backfill",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -477,6 +477,13 @@
       "when": 1782345600000,
       "tag": "0067_human_validated_backfill",
       "breakpoints": true
+    },
+    {
+      "idx": 68,
+      "version": "7",
+      "when": 1782432000000,
+      "tag": "0068_acceptable_variants",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -150,6 +150,7 @@ export async function POST(request: NextRequest) {
       canonicalSubcategory: string;
       broadCategory: string | null;
       basePoints: number;
+      acceptedAlternatives: string[];
     };
 
     let question: DailyAnswerQuestion;
@@ -174,6 +175,8 @@ export async function POST(request: NextRequest) {
         canonicalSubcategory: row.canonicalSubcategory,
         broadCategory: row.broadCategory,
         basePoints: Math.round(row.basePoints),
+        // acceptable_variants (B4 Phase 4): right-but-rephrased answers grade correct.
+        acceptedAlternatives: row.acceptableVariants ?? [],
       };
     } else {
       const [row] = await db
@@ -198,6 +201,7 @@ export async function POST(request: NextRequest) {
         canonicalSubcategory: row.canonicalSubcategory ?? slot.domain,
         broadCategory: row.broadCategory,
         basePoints: resolveDailyBasePoints(difficulty),
+        acceptedAlternatives: row.acceptedAlternatives ?? [],
       };
     }
 
@@ -208,7 +212,7 @@ export async function POST(request: NextRequest) {
       : await gradeAnswer(
           parsed.submittedAnswer,
           canonicalAnswer,
-          [],
+          question.acceptedAlternatives,
           question.questionText,
           'factual',
         );

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -20,6 +20,7 @@ import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { type QueueSlot } from '@/server/daily/types';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
+import { resolveEffectiveDifficulty } from '@/server/daily/empirical-difficulty';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { suggestAnswer } from '@/lib/llm';
 import { computeAnswerState } from '@/server/answer-state';
@@ -166,6 +167,19 @@ export async function POST(request: NextRequest) {
       if (!row) {
         return dailyAnswerErrorResponse(404, 'question_not_found', 'We could not find that Daily Five question.');
       }
+      // D11 (B4 Phase 5): once a bank question has real play history, its measured
+      // correct rate overrides the model's difficulty_estimate for scoring — the
+      // pool teaches the floor what is actually easy. Falls back to the stored
+      // basePoints when there isn't enough play yet.
+      const effective = resolveEffectiveDifficulty({
+        estimate: row.difficultyEstimate,
+        empiricalRate: row.empiricalCorrectRate,
+        nAnswered: row.nAnswered,
+      });
+      const basePoints =
+        effective.source === 'empirical'
+          ? resolveDailyBasePoints(effective.difficulty)
+          : Math.round(row.basePoints);
       question = {
         generatedId: row.id,
         canonicalId: null,
@@ -174,7 +188,7 @@ export async function POST(request: NextRequest) {
         explainer: row.explainer,
         canonicalSubcategory: row.canonicalSubcategory,
         broadCategory: row.broadCategory,
-        basePoints: Math.round(row.basePoints),
+        basePoints,
         // acceptable_variants (B4 Phase 4): right-but-rephrased answers grade correct.
         acceptedAlternatives: row.acceptableVariants ?? [],
       };

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -142,6 +142,16 @@ async function handleDailyCatchupAnswer({
     catchupItem.questionText,
     'factual',
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): a grader outage is not a
+  // real verdict — never persist 'wrong'. Hold for retry.
+  if (grade.gradedVia === 'fallback') {
+    return catchUpErrorResponse(
+      503,
+      'grader_unavailable',
+      "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      { refresh_required: false, next_action: 'retry' },
+    );
+  }
   const isCorrect = grade.result === 'correct';
   const answerState = isCorrect ? 'correct' : 'incorrect';
 
@@ -417,6 +427,15 @@ async function handleFeedCatchupAnswer({
     catchupItem.questionText,
     feedRow.question.questionType,
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
+  if (grade.gradedVia === 'fallback') {
+    return catchUpErrorResponse(
+      503,
+      'grader_unavailable',
+      "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      { refresh_required: false, next_action: 'retry' },
+    );
+  }
   const isCorrect = grade.result === 'correct';
   const answerState = isCorrect ? 'correct' : 'incorrect';
 

--- a/src/app/api/dev/pool-report/route.ts
+++ b/src/app/api/dev/pool-report/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getPoolReport } from '@/server/db/queries/pool-report';
+import { isTierGatingEnabled } from '@/server/daily/verification-gating';
+
+export const dynamic = 'force-dynamic';
+
+// B4 Phase 3 reporting: eligible pool sizes per serving surface under the §6 tier
+// rules, plus the current enforcement-flag state. Read-only. Used to confirm
+// pools are healthy BEFORE flipping VERIFICATION_TIER_GATING_ENABLED.
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const report = await getPoolReport();
+  return NextResponse.json({
+    tierGatingEnforced: isTierGatingEnabled(),
+    ...report,
+  });
+}

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -102,6 +102,18 @@ export async function POST(request: NextRequest, context: RouteContext) {
     question.questionText,
     question.questionType,
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): a grader outage is not a
+  // real verdict — never mark a friend's question wrong. Return a retryable 503.
+  if (grade.gradedVia === 'fallback') {
+    return NextResponse.json(
+      {
+        error: 'grader_unavailable',
+        message:
+          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      },
+      { status: 503 },
+    );
+  }
   const isCorrect = grade.result === 'correct';
 
   // F2.3: compute answer_state against the user's prior history on this

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -7,6 +7,7 @@ import { db, feedItems, users } from '@/server/db';
 import {
   checkJoshingGameCompletion,
   getJoshingGame,
+  JoshingGameGraderUnavailableError,
   JoshingGameValidationError,
   submitJoshingGameResponse,
 } from '@/server/db/queries/joshing-game';
@@ -178,6 +179,16 @@ export async function POST(request: NextRequest, context: RouteContext) {
       insideJokeKind: insideJoke?.kind ?? null,
     });
   } catch (error) {
+    if (error instanceof JoshingGameGraderUnavailableError) {
+      return NextResponse.json(
+        {
+          error: 'grader_unavailable',
+          message:
+            "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+        },
+        { status: error.status },
+      );
+    }
     if (error instanceof JoshingGameValidationError) {
       const status = error.message === 'userId is not a recipient or creator of this game' ? 403 : error.status;
       return NextResponse.json({ error: 'validation', message: error.message }, { status });

--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -75,6 +75,17 @@ export async function POST(request: NextRequest) {
     question.questionText,
     question.questionType,
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
+  if (grade.gradedVia === 'fallback') {
+    return NextResponse.json(
+      {
+        error: 'grader_unavailable',
+        message:
+          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      },
+      { status: 503 },
+    );
+  }
   const isCorrect = grade.result === 'correct';
 
   // F2.3 parity with the feed route: state-adjusted credit against prior history

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -81,6 +81,17 @@ export async function POST(request: NextRequest, context: RouteContext) {
     question.questionText,
     question.questionType,
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
+  if (grade.gradedVia === 'fallback') {
+    return NextResponse.json(
+      {
+        error: 'grader_unavailable',
+        message:
+          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      },
+      { status: 503 },
+    );
+  }
   const isCorrect = grade.result === 'correct';
 
   const priorAnswers = await readPriorAnswersForQuestion(session.userId, question.id);

--- a/src/app/api/replay/grade/route.ts
+++ b/src/app/api/replay/grade/route.ts
@@ -73,6 +73,17 @@ export async function POST(request: NextRequest) {
     replayItem.questionText,
     'factual',
   );
+  // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
+  if (grade.gradedVia === 'fallback') {
+    return NextResponse.json(
+      {
+        error: 'grader_unavailable',
+        message:
+          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      },
+      { status: 503 },
+    );
+  }
   const isCorrect = grade.result === 'correct';
   const breadcrumb = await generateBreadcrumb({
     questionId: replayItem.questionId,

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -88,6 +88,17 @@ export function MyQuestionCard({
           >
             {question.timesAnswered} answers · {question.correctRate}% correct · {question.usedInGamesCount} games
           </p>
+          {question.nobody_correct_flag ? (
+            // "Nobody got it" review smell (B4 Phase 2): a QA signal that enough
+            // players have tried with none correct — likely a bad answer, not a
+            // hard question. Flagged for review, never auto-removed.
+            <p
+              className="mt-1 inline-flex items-center gap-1 text-[12px] font-medium leading-snug"
+              style={{ color: 'var(--ink)', opacity: 0.8 }}
+            >
+              ⚠ Nobody&apos;s gotten this right — flagged for review
+            </p>
+          ) : null}
           {answerersLine ? (
             <p
               className="mt-1 text-[13px] leading-snug"

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -531,6 +531,17 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0068 (B4 Phase 4) adds GeneratedQuestion.acceptable_variants —
+    // equivalent answer phrasings honored in grading. App code (generation persist
+    // + the daily/catchup answer routes) reads it, so a database that records the
+    // migration without the column present must still boot.
+    try {
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "acceptable_variants" text[] NOT NULL DEFAULT '{}'`);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
     // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
     // embedding column + HNSW cosine indexes to both pool tables. The dedup
     // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -481,7 +481,35 @@ export async function register() {
       await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "empirical_correct_rate" double precision`);
       await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "is_duplicate" boolean NOT NULL DEFAULT false`);
       await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "suppressed_by" text`);
-      await db.execute(sql`UPDATE "GeneratedQuestion" SET "trust_tier" = 'machine_verified' WHERE "trust_tier" = 'unverified'`);
+      // Grandfather-promote the pre-existing machine backlog — but ONLY while the
+      // database is still pre-B4. Once migration 0066 adds ask_to_answer_verified,
+      // we are in the B4 world where fresh rows are promoted explicitly by the
+      // ask-to-answer gate (resolveMachineTrustTier); a blanket boot-time promotion
+      // would then wrongly bump rows the gate deliberately left 'unverified'
+      // (failed/skipped ask-to-answer). The one-time grandfather already ran in the
+      // 0062 migration SQL; this guard only re-applies it for a recovering pre-B4 DB.
+      await db.execute(sql`
+        DO $$ BEGIN
+          IF NOT EXISTS (
+            SELECT 1 FROM information_schema.columns
+            WHERE table_name = 'GeneratedQuestion' AND column_name = 'ask_to_answer_verified'
+          ) THEN
+            UPDATE "GeneratedQuestion" SET "trust_tier" = 'machine_verified' WHERE "trust_tier" = 'unverified';
+          END IF;
+        END $$
+      `);
+    } catch {
+      // GeneratedQuestion may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
+
+    // Migration 0066 (B4 Phase 1) adds GeneratedQuestion.ask_to_answer_verified —
+    // the ask-to-answer corroboration record that (with B3 retrieval) earns the
+    // machine_verified tier. App code reads it via resolveMachineTrustTier, so a
+    // preview/production database that records the migration without the column
+    // present must still boot.
+    try {
+      await db.execute(sql`ALTER TABLE "GeneratedQuestion" ADD COLUMN IF NOT EXISTS "ask_to_answer_verified" boolean NOT NULL DEFAULT false`);
     } catch {
       // GeneratedQuestion may not exist yet on a fresh database — migrate()
       // creates it before this migration runs.

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -515,6 +515,22 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0067 (B4 Phase 2) adds Question.nobody_correct_flag (the "nobody
+    // got it" review smell) + its partial index. App code (the questions view,
+    // evaluateQuestionTrustOnPlay) reads the column, so a database that records
+    // the migration without it present must still boot. The one-time trust
+    // back-fills (author_confirmed correction + human_validated promotion) are
+    // applied by the migration only — not re-run here — because they are pure data
+    // back-fill (a missing promotion is safe/conservative, never a boot blocker)
+    // and re-aggregating MASTERY_EVENTS on every boot would be wasteful.
+    try {
+      await db.execute(sql`ALTER TABLE "Question" ADD COLUMN IF NOT EXISTS "nobody_correct_flag" boolean NOT NULL DEFAULT false`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "Question_nobody_correct_flag_idx" ON "Question" ("nobody_correct_flag") WHERE "nobody_correct_flag" = true`);
+    } catch {
+      // Question may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     // Migration 0063 (B1) enables pgvector and adds the nullable 1024-dim
     // embedding column + HNSW cosine indexes to both pool tables. The dedup
     // helpers read/write GeneratedQuestion.embedding / Question.embedding, so a

--- a/src/server/__tests__/grading-fail-toward-player.test.ts
+++ b/src/server/__tests__/grading-fail-toward-player.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// gradeAnswer wraps gradeAnswerWithLLM (@/lib/llm). Mock the LLM so we can drive
+// the outage path and the accepted-variant fast path deterministically.
+const llmMock = vi.hoisted(() => ({ gradeAnswerWithLLM: vi.fn() }));
+vi.mock('@/lib/llm', () => ({ gradeAnswerWithLLM: llmMock.gradeAnswerWithLLM }));
+
+const { gradeAnswer } = await import('@/server/grading');
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('gradeAnswer — acceptable variants (B4 Phase 4)', () => {
+  it('marks a known acceptable variant correct WITHOUT calling the LLM', async () => {
+    const result = await gradeAnswer(
+      'J.S. Bach',
+      'Johann Sebastian Bach',
+      ['J.S. Bach', 'Bach'],
+      'Who composed the Well-Tempered Clavier?',
+    );
+    expect(result.result).toBe('correct');
+    expect(result.gradedVia).toBe('exact');
+    expect(llmMock.gradeAnswerWithLLM).not.toHaveBeenCalled();
+  });
+
+  it('is case-insensitive on the variant match', async () => {
+    const result = await gradeAnswer('bach', 'Johann Sebastian Bach', ['Bach'], 'q');
+    expect(result.result).toBe('correct');
+  });
+});
+
+describe('gradeAnswer — fail toward the player on outage (Drift Risk 2)', () => {
+  it('tags the verdict gradedVia="fallback" when the grader throws', async () => {
+    // gradeAnswer catches the throw and returns the deterministic placeholder.
+    llmMock.gradeAnswerWithLLM.mockRejectedValue(new Error('anthropic 529'));
+    const result = await gradeAnswer('some answer', 'the real answer', [], 'q');
+    // The sentinel every answer route now branches on to defer instead of
+    // persisting a wrong. The result field is a placeholder, NOT a real verdict.
+    expect(result.gradedVia).toBe('fallback');
+    expect(result.confidence).toBe(0);
+  });
+
+  it('passes through a genuine LLM verdict as gradedVia="llm"', async () => {
+    llmMock.gradeAnswerWithLLM.mockResolvedValue({
+      result: 'wrong',
+      confidence: 0.9,
+      reason: 'different person',
+      consolation: 'close!',
+    });
+    const result = await gradeAnswer('wrong answer', 'right answer', [], 'q');
+    expect(result.gradedVia).toBe('llm');
+    expect(result.result).toBe('wrong'); // a REAL wrong is a connection event — allowed
+  });
+});

--- a/src/server/daily/__tests__/ask-to-answer.test.ts
+++ b/src/server/daily/__tests__/ask-to-answer.test.ts
@@ -1,0 +1,137 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ask-to-answer.ts only depends on @/lib/llm (no DB), so we mock that module to
+// drive the cold-solver + judge calls deterministically. loggedMessagesCreate is
+// dispatched by the `scope` argument: cold answers vs the batched judge verdict.
+const llmMock = vi.hoisted(() => ({
+  loggedMessagesCreate: vi.fn(),
+  getAnthropicClient: vi.fn(() => ({}) as unknown),
+}));
+
+vi.mock('@/lib/llm', () => ({
+  HAIKU_GATE_TIMEOUT_MS: 1000,
+  HAIKU_MODEL: 'claude-haiku-test',
+  INSTRUCTION_USER_INPUT_GUIDANCE: '',
+  extractTextContent: (content: unknown) => String((content as { text: string }).text),
+  parseJsonObject: (raw: string) => {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  },
+  wrapUserInput: (_tag: string, body: string) => body,
+  getAnthropicClient: llmMock.getAnthropicClient,
+  loggedMessagesCreate: llmMock.loggedMessagesCreate,
+}));
+
+const {
+  askToAnswerBatch,
+  parseJudgeResponse,
+  resolveMachineTrustTier,
+} = await import('@/server/daily/ask-to-answer');
+
+const CONFIG = { enabled: true, samples: 3, coldTemperature: 0.7 };
+
+function judgeResponse(json: object) {
+  return { content: { text: JSON.stringify(json) } };
+}
+
+beforeEach(() => {
+  llmMock.getAnthropicClient.mockReturnValue({});
+  llmMock.loggedMessagesCreate.mockReset();
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('parseJudgeResponse', () => {
+  it('collects pass and drop indices and reasons', () => {
+    const r = parseJudgeResponse(
+      '{"pass_indices":[0],"drop_indices":[1],"reasons":{"1":"cold solver said Paris, not Berlin"}}',
+      2,
+    );
+    expect([...r.verified]).toEqual([0]);
+    expect([...r.toDrop]).toEqual([1]);
+    expect(r.reasons[1]).toContain('Paris');
+  });
+
+  it('lets a clear DROP win over a contradictory PASS for the same index', () => {
+    const r = parseJudgeResponse('{"pass_indices":[0],"drop_indices":[0]}', 1);
+    expect(r.toDrop.has(0)).toBe(true);
+    expect(r.verified.has(0)).toBe(false);
+  });
+
+  it('ignores out-of-range / non-integer indices and malformed input', () => {
+    expect(parseJudgeResponse('{"pass_indices":[5,-1,1.5]}', 2).verified.size).toBe(0);
+    for (const raw of ['not json', '[]', '{}']) {
+      const r = parseJudgeResponse(raw, 2);
+      expect(r.verified.size).toBe(0);
+      expect(r.toDrop.size).toBe(0);
+    }
+  });
+});
+
+describe('resolveMachineTrustTier', () => {
+  it('promotes to machine_verified on either positive signal', () => {
+    expect(resolveMachineTrustTier({ askToAnswerVerified: true, corroborated: false })).toBe('machine_verified');
+    expect(resolveMachineTrustTier({ askToAnswerVerified: false, corroborated: true })).toBe('machine_verified');
+    expect(resolveMachineTrustTier({ askToAnswerVerified: true, corroborated: true })).toBe('machine_verified');
+  });
+
+  it('leaves a row with no positive signal unverified', () => {
+    expect(resolveMachineTrustTier({ askToAnswerVerified: false, corroborated: false })).toBe('unverified');
+  });
+});
+
+describe('askToAnswerBatch (checkpoint)', () => {
+  it('drops a fabricated-answer question and passes a solid one', async () => {
+    // Cold calls always succeed (so the batch is evaluated); the judge renders the
+    // verdict: index 0 (solid) passes, index 1 (fabricated stored answer) drops.
+    llmMock.loggedMessagesCreate.mockImplementation(async (_client, scope) => {
+      if (scope === 'ask-to-answer-cold') return { content: { text: 'some cold answer' } };
+      return judgeResponse({ pass_indices: [0], drop_indices: [1], reasons: { 1: 'cold solver disagreed' } });
+    });
+
+    const result = await askToAnswerBatch(
+      [
+        { questionText: 'What is 2 + 2?', answer: '4' },
+        { questionText: 'What is the capital of France?', answer: 'Berlin' },
+      ],
+      CONFIG,
+    );
+
+    expect([...result.verified]).toEqual([0]);
+    expect([...result.toDrop]).toEqual([1]);
+    // 3 samples × 2 questions cold calls + 1 judge call.
+    expect(llmMock.loggedMessagesCreate).toHaveBeenCalledTimes(7);
+  });
+
+  it('fails open (drops/verifies nothing) when no client is configured', async () => {
+    llmMock.getAnthropicClient.mockReturnValue(null);
+    const result = await askToAnswerBatch([{ questionText: 'q', answer: 'a' }], CONFIG);
+    expect(result.toDrop.size).toBe(0);
+    expect(result.verified.size).toBe(0);
+    expect(llmMock.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('fails open when every cold attempt errors (LLM outage)', async () => {
+    llmMock.loggedMessagesCreate.mockRejectedValue(new Error('timeout'));
+    const result = await askToAnswerBatch([{ questionText: 'q', answer: 'a' }], CONFIG);
+    expect(result.toDrop.size).toBe(0);
+    expect(result.verified.size).toBe(0);
+    // Judge is never reached when all cold attempts fail.
+    expect(llmMock.loggedMessagesCreate).toHaveBeenCalledTimes(CONFIG.samples);
+  });
+
+  it('is a no-op when disabled', async () => {
+    const result = await askToAnswerBatch([{ questionText: 'q', answer: 'a' }], {
+      ...CONFIG,
+      enabled: false,
+    });
+    expect(result.toDrop.size).toBe(0);
+    expect(llmMock.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/daily/__tests__/ask-to-answer.test.ts
+++ b/src/server/daily/__tests__/ask-to-answer.test.ts
@@ -28,6 +28,7 @@ vi.mock('@/lib/llm', () => ({
 
 const {
   askToAnswerBatch,
+  extractVariants,
   parseJudgeResponse,
   resolveMachineTrustTier,
 } = await import('@/server/daily/ask-to-answer');
@@ -71,6 +72,35 @@ describe('parseJudgeResponse', () => {
       expect(r.verified.size).toBe(0);
       expect(r.toDrop.size).toBe(0);
     }
+  });
+});
+
+describe('extractVariants (B4 Phase 4)', () => {
+  const items = [
+    { questionText: 'q0', answer: 'Johann Sebastian Bach' },
+    { questionText: 'q1', answer: 'Paris' },
+  ];
+
+  it('collects distinct cold answers minus the stored answer, for verified items only', () => {
+    const cold = [
+      ['J.S. Bach', 'Johann Sebastian Bach', 'Bach'], // index 0 (verified)
+      ['Lyon', 'Lyon', 'Lyon'], // index 1 (NOT verified — excluded)
+    ];
+    const variants = extractVariants(new Set([0]), items, cold);
+    expect(variants.get(0)).toEqual(['J.S. Bach', 'Bach']); // stored form dropped, deduped
+    expect(variants.has(1)).toBe(false);
+  });
+
+  it('drops UNSURE, empties, and case-dupes; never emits an empty list', () => {
+    const cold = [['UNSURE', '', 'bach', 'BACH']];
+    const variants = extractVariants(new Set([0]), items, cold);
+    expect(variants.get(0)).toEqual(['bach']);
+  });
+
+  it('omits an index entirely when no usable variant remains', () => {
+    const cold = [['Johann Sebastian Bach', 'UNSURE']];
+    const variants = extractVariants(new Set([0]), items, cold);
+    expect(variants.has(0)).toBe(false);
   });
 });
 

--- a/src/server/daily/__tests__/empirical-difficulty.test.ts
+++ b/src/server/daily/__tests__/empirical-difficulty.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  empiricalDifficultyTier,
+  resolveEffectiveDifficulty,
+} from '@/server/daily/empirical-difficulty';
+
+describe('empiricalDifficultyTier', () => {
+  it('maps high rate → accessible, mid → moderate, low → specialist', () => {
+    expect(empiricalDifficultyTier(0.9)).toBe('accessible');
+    expect(empiricalDifficultyTier(0.7)).toBe('accessible'); // boundary inclusive
+    expect(empiricalDifficultyTier(0.6)).toBe('moderate');
+    expect(empiricalDifficultyTier(0.45)).toBe('moderate'); // boundary inclusive
+    expect(empiricalDifficultyTier(0.2)).toBe('specialist');
+    expect(empiricalDifficultyTier(0)).toBe('specialist');
+  });
+});
+
+describe('resolveEffectiveDifficulty (D11)', () => {
+  const MIN = 5;
+
+  it('keeps the model estimate below the sample threshold', () => {
+    const r = resolveEffectiveDifficulty({
+      estimate: 'specialist',
+      empiricalRate: 0.95,
+      nAnswered: 4, // not enough play yet
+      minSamples: MIN,
+    });
+    expect(r).toEqual({ difficulty: 'specialist', source: 'estimate' });
+  });
+
+  it('overrides with the measured rate once enough humans have played', () => {
+    // A "specialist"-estimated question almost everyone nails is really accessible.
+    const r = resolveEffectiveDifficulty({
+      estimate: 'specialist',
+      empiricalRate: 0.85,
+      nAnswered: 12,
+      minSamples: MIN,
+    });
+    expect(r).toEqual({ difficulty: 'accessible', source: 'empirical' });
+  });
+
+  it('CHECKPOINT: a measured rate that diverges from the estimate resolves by the measured rate', () => {
+    // Estimated accessible, but nobody actually gets it → resolves specialist.
+    const r = resolveEffectiveDifficulty({
+      estimate: 'accessible',
+      empiricalRate: 0.1,
+      nAnswered: 10,
+      minSamples: MIN,
+    });
+    expect(r.source).toBe('empirical');
+    expect(r.difficulty).toBe('specialist');
+    expect(r.difficulty).not.toBe('accessible'); // the estimate did NOT win
+  });
+
+  it('falls back to the estimate when there is no empirical rate', () => {
+    expect(
+      resolveEffectiveDifficulty({ estimate: 'moderate', empiricalRate: null, nAnswered: 99, minSamples: MIN }),
+    ).toEqual({ difficulty: 'moderate', source: 'estimate' });
+  });
+
+  it('defaults a missing/invalid estimate to moderate', () => {
+    expect(
+      resolveEffectiveDifficulty({ estimate: null, empiricalRate: null, nAnswered: 0, minSamples: MIN }).difficulty,
+    ).toBe('moderate');
+  });
+});

--- a/src/server/daily/__tests__/verification-gating.test.ts
+++ b/src/server/daily/__tests__/verification-gating.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  FRIEND_FACING_TIERS,
+  SELF_PRACTICE_TIERS,
+  applyTierGate,
+  isTierGatingEnabled,
+  type TrustTier,
+} from '@/server/daily/verification-gating';
+
+type Row = { id: string; tier: TrustTier };
+const rows: Row[] = [
+  { id: 'a', tier: 'unverified' },
+  { id: 'b', tier: 'machine_verified' },
+  { id: 'c', tier: 'human_validated' },
+  { id: 'd', tier: 'author_confirmed' },
+];
+const tierOf = (r: Row) => r.tier;
+
+afterEach(() => {
+  delete process.env.VERIFICATION_TIER_GATING_ENABLED;
+});
+
+describe('isTierGatingEnabled', () => {
+  it('defaults OFF', () => {
+    expect(isTierGatingEnabled()).toBe(false);
+  });
+  it('reads truthy env values', () => {
+    for (const v of ['true', '1', 'yes', 'on']) {
+      process.env.VERIFICATION_TIER_GATING_ENABLED = v;
+      expect(isTierGatingEnabled()).toBe(true);
+    }
+    process.env.VERIFICATION_TIER_GATING_ENABLED = 'false';
+    expect(isTierGatingEnabled()).toBe(false);
+  });
+});
+
+describe('applyTierGate — shadow (flag off)', () => {
+  it('serves ALL rows unchanged but reports the would-filter count', () => {
+    const r = applyTierGate('self-practice/bank', rows, tierOf, SELF_PRACTICE_TIERS);
+    expect(r.enforced).toBe(false);
+    expect(r.rows).toHaveLength(4); // unchanged — today's behavior preserved
+    expect(r.wouldFilter).toBe(1); // the unverified row would be dropped
+    expect(r.candidateCount).toBe(4);
+  });
+});
+
+describe('applyTierGate — enforcing (flag on)', () => {
+  it('drops below-bar rows for self-practice (≥ machine_verified)', () => {
+    process.env.VERIFICATION_TIER_GATING_ENABLED = 'true';
+    const r = applyTierGate('self-practice/bank', rows, tierOf, SELF_PRACTICE_TIERS);
+    expect(r.enforced).toBe(true);
+    expect(r.rows.map((x) => x.id)).toEqual(['b', 'c', 'd']);
+  });
+
+  it('drops everything below human_validated for friend-facing', () => {
+    process.env.VERIFICATION_TIER_GATING_ENABLED = 'true';
+    const r = applyTierGate('friend-facing/authored', rows, tierOf, FRIEND_FACING_TIERS);
+    expect(r.rows.map((x) => x.id)).toEqual(['c', 'd']);
+    expect(r.wouldFilter).toBe(2);
+  });
+});
+
+describe('tier bands', () => {
+  it('self-practice excludes only unverified; friend-facing is the higher pair', () => {
+    expect(SELF_PRACTICE_TIERS).not.toContain('unverified');
+    expect(SELF_PRACTICE_TIERS).toContain('machine_verified');
+    expect(FRIEND_FACING_TIERS).toEqual(['human_validated', 'author_confirmed']);
+  });
+});

--- a/src/server/daily/ask-to-answer.ts
+++ b/src/server/daily/ask-to-answer.ts
@@ -1,0 +1,233 @@
+// Ask-to-answer gate (PRD-D-5 §5.3 layer 2 / §7 / B4 Phase 1).
+//
+// The secondary verification net. For a generated question we STRIP the stored
+// answer and ask a separate, cheaper model (Haiku — different from the Sonnet
+// generator, per spec "ideally a different model") the question COLD, several
+// times. A question passes only when the cold attempts agree with each other AND
+// with the stored answer; otherwise it is dropped. This catches the generator
+// misreading its own source. Its blind spot — a *stable* hallucination the cold
+// model shares — is by design covered by B3 retrieval corroboration, NOT here
+// (Drift Risk 3): never lean on ask-to-answer to wave through a retrieval gap.
+//
+// Fail direction: this gate DROPS questions, never serves them. On an LLM outage
+// (no client, timeout, parse failure) it FAILS OPEN — drops nothing, verifies
+// nothing — exactly like the other generation gates in generate-questions.ts. A
+// question it can't evaluate simply stays `unverified` (it is not falsely
+// promoted, and it is not falsely dropped).
+
+import {
+  HAIKU_GATE_TIMEOUT_MS,
+  HAIKU_MODEL,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return fallback;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+export interface AskToAnswerConfig {
+  /** Master switch. On by default — this is a live generation gate (B4 Phase 1),
+   *  but it fails open and is a no-op without an Anthropic client. */
+  enabled: boolean;
+  /** Cold samples per question (§7 recommends 3, unanimous + match stored). */
+  samples: number;
+  /** Temperature for the cold attempts. Non-zero so genuine instability in the
+   *  answer surfaces across samples; the equivalence judge runs at temp 0. */
+  coldTemperature: number;
+}
+
+export function getAskToAnswerConfig(): AskToAnswerConfig {
+  return {
+    enabled: boolEnv('ASK_TO_ANSWER_ENABLED', true),
+    samples: Math.max(1, Math.round(numEnv('ASK_TO_ANSWER_SAMPLES', 3))),
+    coldTemperature: numEnv('ASK_TO_ANSWER_COLD_TEMPERATURE', 0.7),
+  };
+}
+
+export interface AskToAnswerItem {
+  questionText: string;
+  answer: string;
+}
+
+export interface AskToAnswerResult {
+  /** Indices to drop: the cold attempts clearly did NOT support the stored
+   *  answer (disagreed with each other or converged on something else). */
+  toDrop: Set<number>;
+  /** Indices that affirmatively passed — cold attempts agreed with each other
+   *  and matched the stored answer. These earn `machine_verified`. */
+  verified: Set<number>;
+  reasons: Record<number, string>;
+}
+
+const COLD_ANSWER_SYSTEM_PROMPT = `You are answering a single trivia question COLD, with no answer key. Reply with ONLY your best short answer — the name, term, phrase, date, or number the question asks for. No explanation, no preamble, no punctuation beyond what the answer itself needs. If you genuinely do not know, reply with exactly: UNSURE.${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+// The equivalence judge compares, per question, the stored answer against the
+// cold attempts. It decides PASS / DROP for each. Conservative by construction:
+// PASS demands affirmative agreement, DROP demands a clear contradiction, and
+// it leaves genuinely-ambiguous items in neither set (they stay `unverified`).
+const JUDGE_SYSTEM_PROMPT = `You are auditing trivia questions. For each item you are given the stored answer the game treats as correct, plus several COLD answers an independent solver produced for the same question without seeing the stored answer.
+
+For each item decide one of:
+- PASS — the cold answers agree with EACH OTHER and all match the stored answer (allowing equivalent forms: "J.S. Bach" = "Johann Sebastian Bach"; "1969" = "the year 1969"; abbreviations, word order, articles). This means the stored answer is corroborated by an independent solver.
+- DROP — the cold answers clearly do NOT support the stored answer: they agree with each other on a DIFFERENT answer, or they are mutually inconsistent (no stable answer exists), indicating the stored answer is likely wrong or the question is unanswerable. Treat UNSURE attempts as "no support".
+- SKIP — you cannot tell (e.g. all attempts UNSURE on a genuinely obscure-but-plausible fact). Do not pass and do not drop.
+
+Be strict about PASS and conservative about DROP: only DROP when the cold answers actively contradict the stored answer. When in doubt between SKIP and DROP, choose SKIP.
+
+Return JSON only:
+{ "pass_indices": [..], "drop_indices": [..], "reasons": { "<index>": "<short reason naming the answer the cold solver gave>" } }${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+/** One cold attempt at a question. Returns the trimmed answer, or null on any
+ *  failure (treated upstream as a missing/UNSURE attempt — never a drop). */
+async function coldAnswerOnce(
+  client: NonNullable<ReturnType<typeof getAnthropicClient>>,
+  questionText: string,
+  temperature: number,
+): Promise<string | null> {
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'ask-to-answer-cold',
+      {
+        model: HAIKU_MODEL,
+        max_tokens: 60,
+        temperature,
+        system: COLD_ANSWER_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: wrapUserInput('question', questionText) }],
+      },
+      { timeoutMs: HAIKU_GATE_TIMEOUT_MS },
+    );
+    const text = extractTextContent(response.content).trim();
+    return text.length > 0 ? text.slice(0, 200) : null;
+  } catch {
+    return null;
+  }
+}
+
+export function parseJudgeResponse(
+  raw: string,
+  batchSize: number,
+): { verified: Set<number>; toDrop: Set<number>; reasons: Record<number, string> } {
+  const verified = new Set<number>();
+  const toDrop = new Set<number>();
+  const reasons: Record<number, string> = {};
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return { verified, toDrop, reasons };
+
+  const collect = (value: unknown, into: Set<number>) => {
+    if (!Array.isArray(value)) return;
+    for (const v of value) {
+      if (typeof v === 'number' && Number.isInteger(v) && v >= 0 && v < batchSize) into.add(v);
+    }
+  };
+  collect(parsed.pass_indices, verified);
+  collect(parsed.drop_indices, toDrop);
+  // A clear DROP wins over a contradictory PASS for the same index (fail toward
+  // not-serving a question whose correctness the judge doubts).
+  for (const idx of toDrop) verified.delete(idx);
+
+  const rawReasons = parsed.reasons;
+  if (rawReasons && typeof rawReasons === 'object' && !Array.isArray(rawReasons)) {
+    for (const [key, value] of Object.entries(rawReasons as Record<string, unknown>)) {
+      const idx = Number.parseInt(key, 10);
+      if (Number.isInteger(idx) && idx >= 0 && idx < batchSize && typeof value === 'string') {
+        reasons[idx] = value.slice(0, 200);
+      }
+    }
+  }
+  return { verified, toDrop, reasons };
+}
+
+/**
+ * Run the ask-to-answer gate over a batch. Cold answers are sampled per question
+ * in parallel; a single batched judge call then renders the per-item verdict.
+ *
+ * Fail-open contract: returns empty sets (drop nothing, verify nothing) when the
+ * gate is disabled, no client is configured, or the judge call fails.
+ */
+export async function askToAnswerBatch(
+  items: AskToAnswerItem[],
+  config: AskToAnswerConfig = getAskToAnswerConfig(),
+): Promise<AskToAnswerResult> {
+  const empty: AskToAnswerResult = { toDrop: new Set(), verified: new Set(), reasons: {} };
+  if (!config.enabled || items.length === 0) return empty;
+  const client = getAnthropicClient();
+  if (!client) return empty;
+
+  // Cold attempts: items × samples, all in parallel.
+  const coldByItem = await Promise.all(
+    items.map((item) =>
+      Promise.all(
+        Array.from({ length: config.samples }, () =>
+          coldAnswerOnce(client, item.questionText, config.coldTemperature),
+        ),
+      ),
+    ),
+  );
+
+  // If every cold attempt failed (full outage), fail open — don't drop anything.
+  const anyColdSucceeded = coldByItem.some((attempts) => attempts.some((a) => a !== null));
+  if (!anyColdSucceeded) return empty;
+
+  const body = items
+    .map((item, i) => {
+      const attempts = coldByItem[i]
+        .map((a, j) => `      cold_${j + 1}=${a ?? 'UNSURE'}`)
+        .join('\n');
+      return `[${i}] question=${item.questionText}\n    stored_answer=${item.answer}\n${attempts}`;
+    })
+    .join('\n\n');
+
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'ask-to-answer-judge',
+      {
+        model: HAIKU_MODEL,
+        max_tokens: 600,
+        temperature: 0,
+        system: JUDGE_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: wrapUserInput('batch', body) }],
+      },
+      { timeoutMs: HAIKU_GATE_TIMEOUT_MS },
+    );
+    return parseJudgeResponse(extractTextContent(response.content), items.length);
+  } catch (err) {
+    // Fail open: a judge outage must not drop questions. They stay unverified.
+    console.warn('[daily/ask-to-answer] judge call failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return empty;
+  }
+}
+
+/**
+ * Resolve the trust tier a freshly-generated machine row should enter at
+ * (PRD-D-5 §6). A row earns `machine_verified` when an independent signal
+ * corroborates its answer: it passed ask-to-answer agreement, OR it is
+ * retrieval-corroborated (B3 source corroboration floor met). Either positive
+ * signal alone promotes — requiring BOTH would starve self-practice whenever
+ * retrieval grounding is disabled (Drift Risk 1), and is strictly stronger than
+ * B1's grandfather baseline (which promoted rows with neither signal). Rows with
+ * no positive signal stay `unverified`.
+ */
+export function resolveMachineTrustTier(args: {
+  askToAnswerVerified: boolean;
+  corroborated: boolean;
+}): 'unverified' | 'machine_verified' {
+  return args.askToAnswerVerified || args.corroborated ? 'machine_verified' : 'unverified';
+}

--- a/src/server/daily/ask-to-answer.ts
+++ b/src/server/daily/ask-to-answer.ts
@@ -70,6 +70,11 @@ export interface AskToAnswerResult {
   /** Indices that affirmatively passed — cold attempts agreed with each other
    *  and matched the stored answer. These earn `machine_verified`. */
   verified: Set<number>;
+  /** Distinct cold answers per verified index, normalized and minus the stored
+   *  answer — acceptable_variant seeds (B4 Phase 4). The judge already deemed
+   *  these equivalent to the stored answer, so they are safe to honor in grading.
+   *  Only populated for verified indices. */
+  variantsByIndex: Map<number, string[]>;
   reasons: Record<number, string>;
 }
 
@@ -163,7 +168,12 @@ export async function askToAnswerBatch(
   items: AskToAnswerItem[],
   config: AskToAnswerConfig = getAskToAnswerConfig(),
 ): Promise<AskToAnswerResult> {
-  const empty: AskToAnswerResult = { toDrop: new Set(), verified: new Set(), reasons: {} };
+  const empty: AskToAnswerResult = {
+    toDrop: new Set(),
+    verified: new Set(),
+    variantsByIndex: new Map(),
+    reasons: {},
+  };
   if (!config.enabled || items.length === 0) return empty;
   const client = getAnthropicClient();
   if (!client) return empty;
@@ -205,7 +215,11 @@ export async function askToAnswerBatch(
       },
       { timeoutMs: HAIKU_GATE_TIMEOUT_MS },
     );
-    return parseJudgeResponse(extractTextContent(response.content), items.length);
+    const parsed = parseJudgeResponse(extractTextContent(response.content), items.length);
+    return {
+      ...parsed,
+      variantsByIndex: extractVariants(parsed.verified, items, coldByItem),
+    };
   } catch (err) {
     // Fail open: a judge outage must not drop questions. They stay unverified.
     console.warn('[daily/ask-to-answer] judge call failed', {
@@ -213,6 +227,37 @@ export async function askToAnswerBatch(
     });
     return empty;
   }
+}
+
+const MAX_VARIANTS = 4;
+
+/**
+ * For each verified item, the distinct cold answers minus the stored answer form
+ * acceptable_variant seeds (the judge already deemed them equivalent). Normalized
+ * (trimmed), case-insensitively deduped, UNSURE/empty dropped, capped.
+ */
+export function extractVariants(
+  verified: Set<number>,
+  items: AskToAnswerItem[],
+  coldByItem: (string | null)[][],
+): Map<number, string[]> {
+  const out = new Map<number, string[]>();
+  for (const i of verified) {
+    const stored = items[i].answer.trim().toLowerCase();
+    const seen = new Set<string>([stored]);
+    const variants: string[] = [];
+    for (const raw of coldByItem[i] ?? []) {
+      if (!raw) continue;
+      const trimmed = raw.trim();
+      const key = trimmed.toLowerCase();
+      if (!trimmed || key === 'unsure' || seen.has(key)) continue;
+      seen.add(key);
+      variants.push(trimmed);
+      if (variants.length >= MAX_VARIANTS) break;
+    }
+    if (variants.length > 0) out.set(i, variants);
+  }
+  return out;
 }
 
 /**

--- a/src/server/daily/empirical-difficulty.ts
+++ b/src/server/daily/empirical-difficulty.ts
@@ -1,0 +1,75 @@
+// D11 — empirical correct-rate overrides the model's difficulty_estimate and
+// feeds B2's calibration (PRD-D-5 §5.2 D11 / §7 / B4 Phase 5).
+//
+// The model's difficulty_estimate is a guess made at generation time. Once enough
+// humans have actually played a question, the MEASURED correct rate is ground
+// truth: a "specialist" question 80% of players nail is really accessible; a
+// "moderate" one almost nobody gets is really specialist. The pool teaches the
+// floor what is actually easy — the loop that makes the floor self-correcting.
+//
+// This is the per-question override. The resolved tier is written to
+// Question.calibrated_difficulty (the value serving + base-points already read),
+// so the correction flows into points and difficulty matching automatically.
+
+export type DifficultyTier = 'accessible' | 'moderate' | 'specialist';
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+/** Real human plays required before measured rate is trusted to override the
+ *  model's estimate (§7). Below this, the estimate stands. */
+export function empiricalMinSamples(): number {
+  return Math.max(1, Math.round(numEnv('EMPIRICAL_DIFFICULTY_MIN_SAMPLES', 5)));
+}
+
+// Rate → tier cut points, aligned with the generator's per-tier target rates
+// (accessible ≈ 0.78, moderate ≈ 0.62, enthusiast/specialist ≈ 0.50): a question
+// most players get is accessible; one few get is specialist.
+function accessibleMinRate(): number {
+  return numEnv('EMPIRICAL_DIFFICULTY_ACCESSIBLE_MIN_RATE', 0.7);
+}
+function moderateMinRate(): number {
+  return numEnv('EMPIRICAL_DIFFICULTY_MODERATE_MIN_RATE', 0.45);
+}
+
+function toTier(value: string | null | undefined): DifficultyTier {
+  return value === 'accessible' || value === 'moderate' || value === 'specialist' ? value : 'moderate';
+}
+
+/** Map a measured correct rate (0..1) to a difficulty tier. */
+export function empiricalDifficultyTier(
+  rate: number,
+  accessibleMin: number = accessibleMinRate(),
+  moderateMin: number = moderateMinRate(),
+): DifficultyTier {
+  if (rate >= accessibleMin) return 'accessible';
+  if (rate >= moderateMin) return 'moderate';
+  return 'specialist';
+}
+
+export interface EffectiveDifficulty {
+  difficulty: DifficultyTier;
+  /** Which signal won — measured play vs the model's estimate. */
+  source: 'empirical' | 'estimate';
+}
+
+/**
+ * D11 resolution: the measured rate overrides the model's estimate once at least
+ * `minSamples` humans have played; otherwise the estimate stands. Pure.
+ */
+export function resolveEffectiveDifficulty(args: {
+  estimate: string | null | undefined;
+  empiricalRate: number | null | undefined;
+  nAnswered: number;
+  minSamples?: number;
+}): EffectiveDifficulty {
+  const minSamples = args.minSamples ?? empiricalMinSamples();
+  if (args.empiricalRate != null && Number.isFinite(args.empiricalRate) && args.nAnswered >= minSamples) {
+    return { difficulty: empiricalDifficultyTier(args.empiricalRate), source: 'empirical' };
+  }
+  return { difficulty: toTier(args.estimate), source: 'estimate' };
+}

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -1120,6 +1120,7 @@ export async function generateDailyQuestions(
         insideJoke: insideJokeByQuestion.get(question) ?? null,
         trustTier,
         askToAnswerVerified,
+        acceptableVariants: askResult.variantsByIndex.get(persistIndex) ?? [],
         expiresAt,
         usedInQueue: false,
       })

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -38,6 +38,7 @@ import { normalizeFactKey } from '@/server/questions/fact-key';
 import { textContainsAnswer } from '@/server/questions/self-answering';
 import { resolveDailyBasePoints } from './types';
 import { STYLE_EXEMPLAR_BLOCK } from './exemplars';
+import { askToAnswerBatch, resolveMachineTrustTier } from './ask-to-answer';
 
 // Cap the recent question-text block at this many entries inside the prompt.
 // The full recent history (up to 200) is still used to derive the fact-key
@@ -1033,19 +1034,41 @@ export async function generateDailyQuestions(
   // aside. Mirrors the parallel/fail-open pattern of the LLM gates above.
   const toPersist = generated.slice(0, count);
   const insideJokeByQuestion = new Map<(typeof toPersist)[number], string | null>();
-  await Promise.all(
-    toPersist.map(async (question) => {
-      const aside = await generateInsideJoke({
-        questionText: question.question_text,
-        correctAnswer: question.answer,
-        broadCategory: question.broad_category,
-        canonicalSubcategory: question.canonical_subcategory,
-      }).catch(() => null);
-      insideJokeByQuestion.set(question, aside);
-    }),
-  );
+  // Ask-to-answer gate (B4 Phase 1): strip the answer and ask a separate cold
+  // solver; a question whose cold answers contradict the stored answer is dropped,
+  // one they corroborate earns machine_verified. Runs in parallel with the aside
+  // precompute; fails open (drops/verifies nothing on an LLM outage). Scoped to
+  // the rows we will actually persist rather than the full generated batch.
+  const [, askResult] = await Promise.all([
+    Promise.all(
+      toPersist.map(async (question) => {
+        const aside = await generateInsideJoke({
+          questionText: question.question_text,
+          correctAnswer: question.answer,
+          broadCategory: question.broad_category,
+          canonicalSubcategory: question.canonical_subcategory,
+        }).catch(() => null);
+        insideJokeByQuestion.set(question, aside);
+      }),
+    ),
+    askToAnswerBatch(
+      toPersist.map((q) => ({ questionText: q.question_text, answer: q.answer })),
+    ),
+  ]);
+  if (askResult.toDrop.size > 0) {
+    console.warn('[daily/generate-questions] dropping ask-to-answer failures', {
+      droppedCount: askResult.toDrop.size,
+      droppedIndices: [...askResult.toDrop].sort((a, b) => a - b),
+      reasons: askResult.reasons,
+      originalCount: toPersist.length,
+    });
+  }
 
-  for (const question of toPersist) {
+  for (let persistIndex = 0; persistIndex < toPersist.length; persistIndex += 1) {
+    const question = toPersist[persistIndex];
+    // Drop ask-to-answer failures: the cold solver contradicted the stored answer.
+    if (askResult.toDrop.has(persistIndex)) continue;
+
     const { canonicalDomain } = await reconcileProposedDomain(
       question.canonical_subcategory,
       userId,
@@ -1075,6 +1098,12 @@ export async function generateDailyQuestions(
     }
 
     const basePoints = resolveDailyBasePoints(question.difficulty_estimate);
+    // Trust tier (B4 Phase 1 / §6): ask-to-answer corroboration promotes to
+    // machine_verified. This non-grounded path has no retrieval corroboration,
+    // so the tier hinges on the ask-to-answer verdict; an unevaluated row (gate
+    // disabled or failed open) stays unverified.
+    const askToAnswerVerified = askResult.verified.has(persistIndex);
+    const trustTier = resolveMachineTrustTier({ askToAnswerVerified, corroborated: false });
     const [row] = await db
       .insert(generatedQuestions)
       .values({
@@ -1089,6 +1118,8 @@ export async function generateDailyQuestions(
         factKey,
         subAngles: question.sub_angles,
         insideJoke: insideJokeByQuestion.get(question) ?? null,
+        trustTier,
+        askToAnswerVerified,
         expiresAt,
         usedInQueue: false,
       })

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -16,6 +16,7 @@ import {
   screenGroundedBatch,
   type GroundedLlmQuestion,
 } from '@/server/daily/generate-questions';
+import { askToAnswerBatch, resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
 import { assessCorroboration, getReputationLists } from '@/server/daily/source-reputation';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import {
@@ -187,8 +188,19 @@ async function refillDomain(
   result.droppedQualityGate = corroborated.length - screened.length;
   if (screened.length === 0) return result;
 
+  // Ask-to-answer secondary net (B4 Phase 1 / §5.3 layer 2): even corroborated
+  // grounded questions get the cold-solver check — its job is to catch the model
+  // MISREADING its own retrieved source. A clear contradiction drops the row;
+  // otherwise the row keeps its corroborated → machine_verified entry tier.
+  const askResult = await askToAnswerBatch(
+    screened.map((q) => ({ questionText: q.question_text, answer: q.answer })),
+  );
+  result.droppedQualityGate += askResult.toDrop.size;
+
   const seenFactKeys = new Set<string>();
-  for (const q of screened) {
+  for (let i = 0; i < screened.length; i += 1) {
+    const q = screened[i];
+    if (askResult.toDrop.has(i)) continue;
     if (q.fact_key) {
       if (seenFactKeys.has(q.fact_key)) {
         result.droppedDuplicateFact += 1;
@@ -197,6 +209,11 @@ async function refillDomain(
       seenFactKeys.add(q.fact_key);
     }
 
+    // Corroborated by construction (passed the corroboration gate above), so the
+    // row enters machine_verified regardless of the ask-to-answer outcome; the
+    // ask-to-answer flag is still recorded for provenance.
+    const askToAnswerVerified = askResult.verified.has(i);
+    const trustTier = resolveMachineTrustTier({ askToAnswerVerified, corroborated: true });
     try {
       const [row] = await db
         .insert(generatedQuestions)
@@ -212,6 +229,8 @@ async function refillDomain(
           factKey: q.fact_key,
           subAngles: q.sub_angles,
           sourceRefs: q.source_refs,
+          trustTier,
+          askToAnswerVerified,
           expiresAt: DURABLE_EXPIRY,
           usedInQueue: false,
         })

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -231,6 +231,7 @@ async function refillDomain(
           sourceRefs: q.source_refs,
           trustTier,
           askToAnswerVerified,
+          acceptableVariants: askResult.variantsByIndex.get(i) ?? [],
           expiresAt: DURABLE_EXPIRY,
           usedInQueue: false,
         })

--- a/src/server/daily/verification-gating.ts
+++ b/src/server/daily/verification-gating.ts
@@ -1,0 +1,83 @@
+// Verification tier-gating switch (B4 Phase 3, PRD-D-5 §6).
+//
+// Turns the B1 selection-layer tier filters from "capability" into live
+// enforcement — BEHIND A FLAG, OFF BY DEFAULT (Drift Risk 1). With the flag off,
+// every serving surface logs what it WOULD filter (and the candidate counts) but
+// serves exactly today's set. Only after the per-surface eligible pools are
+// confirmed healthy (the Phase 3 approval gate) does an operator flip the flag.
+//
+// §6 surface eligibility:
+//   self-practice (Daily Five)   → tier ≥ machine_verified (everything but unverified)
+//   friend-facing / Convergence  → human_validated OR author_confirmed
+//   house (editorial, D9 public) → human_validated OR author_confirmed (author_confirmed in practice)
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return fallback;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+/** Master enforcement switch. OFF by default — shadow-log only until flipped. */
+export function isTierGatingEnabled(): boolean {
+  return boolEnv('VERIFICATION_TIER_GATING_ENABLED', false);
+}
+
+export type TrustTier = 'unverified' | 'machine_verified' | 'human_validated' | 'author_confirmed';
+
+/** Self-practice floor: anything that has earned at least machine_verified. */
+export const SELF_PRACTICE_TIERS: readonly TrustTier[] = [
+  'machine_verified',
+  'human_validated',
+  'author_confirmed',
+];
+
+/** Friend-facing / Convergence / house: human-validated or author-asserted. */
+export const FRIEND_FACING_TIERS: readonly TrustTier[] = ['human_validated', 'author_confirmed'];
+
+export interface TierGateResult<T> {
+  /** Rows to actually serve: filtered when enforcing, unchanged when shadowing. */
+  rows: T[];
+  /** Whether enforcement was on for this call. */
+  enforced: boolean;
+  /** How many candidates fall below the surface's tier bar. */
+  wouldFilter: number;
+  /** Candidates considered. */
+  candidateCount: number;
+}
+
+/**
+ * Apply (or shadow-evaluate) a surface's tier bar over candidate rows.
+ *
+ * Enforcing → returns only eligible rows. Shadowing (flag off) → returns ALL rows
+ * unchanged so live behavior is byte-identical to today, but logs the would-filter
+ * count so we can measure impact before flipping. Either way it logs when any
+ * candidate is below the bar, tagged with the surface for the Phase 3 report.
+ */
+export function applyTierGate<T>(
+  surface: string,
+  rows: T[],
+  tierOf: (row: T) => TrustTier,
+  allowed: readonly TrustTier[],
+): TierGateResult<T> {
+  const enforced = isTierGatingEnabled();
+  const kept = rows.filter((row) => allowed.includes(tierOf(row)));
+  const wouldFilter = rows.length - kept.length;
+
+  if (wouldFilter > 0) {
+    console.info('[verification-gating]', {
+      surface,
+      enforced,
+      candidateCount: rows.length,
+      eligible: kept.length,
+      wouldFilter,
+      allowed,
+    });
+  }
+
+  return {
+    rows: enforced ? kept : rows,
+    enforced,
+    wouldFilter,
+    candidateCount: rows.length,
+  };
+}

--- a/src/server/db/queries/__tests__/trust-promotion.test.ts
+++ b/src/server/db/queries/__tests__/trust-promotion.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import { decideTrustOnPlay } from '@/server/db/queries/trust-promotion';
+
+const MIN_CORRECT = 3;
+const MIN_HOLDERS = 5;
+
+describe('decideTrustOnPlay', () => {
+  it('promotes machine_verified to human_validated at N=3 distinct correct', () => {
+    const d = decideTrustOnPlay(
+      { distinctCorrect: 3, distinctAnswerers: 4 },
+      'machine_verified',
+      MIN_CORRECT,
+      MIN_HOLDERS,
+    );
+    expect(d.promoteTo).toBe('human_validated');
+    expect(d.nobodyCorrectFlag).toBe(false);
+  });
+
+  it('tolerates a wrong answer in the mix (counts correct, not rate)', () => {
+    // 3 correct + 2 wrong = 5 holders, still promotes.
+    const d = decideTrustOnPlay(
+      { distinctCorrect: 3, distinctAnswerers: 5 },
+      'machine_verified',
+      MIN_CORRECT,
+      MIN_HOLDERS,
+    );
+    expect(d.promoteTo).toBe('human_validated');
+  });
+
+  it('does not promote below the threshold', () => {
+    expect(
+      decideTrustOnPlay({ distinctCorrect: 2, distinctAnswerers: 2 }, 'machine_verified', MIN_CORRECT, MIN_HOLDERS)
+        .promoteTo,
+    ).toBeNull();
+  });
+
+  it('only promotes machine_verified — never unverified or higher tiers', () => {
+    for (const tier of ['unverified', 'human_validated', 'author_confirmed'] as const) {
+      expect(
+        decideTrustOnPlay({ distinctCorrect: 9, distinctAnswerers: 9 }, tier, MIN_CORRECT, MIN_HOLDERS).promoteTo,
+      ).toBeNull();
+    }
+  });
+
+  it('flags "nobody got it" at >=5 holders with zero correct', () => {
+    const d = decideTrustOnPlay(
+      { distinctCorrect: 0, distinctAnswerers: 5 },
+      'machine_verified',
+      MIN_CORRECT,
+      MIN_HOLDERS,
+    );
+    expect(d.nobodyCorrectFlag).toBe(true);
+    expect(d.promoteTo).toBeNull();
+  });
+
+  it('does not flag before enough holders have tried', () => {
+    expect(
+      decideTrustOnPlay({ distinctCorrect: 0, distinctAnswerers: 4 }, 'machine_verified', MIN_CORRECT, MIN_HOLDERS)
+        .nobodyCorrectFlag,
+    ).toBe(false);
+  });
+
+  it('clears the flag the moment one human gets it right (hard, not broken)', () => {
+    const d = decideTrustOnPlay(
+      { distinctCorrect: 1, distinctAnswerers: 8 },
+      'human_validated',
+      MIN_CORRECT,
+      MIN_HOLDERS,
+    );
+    expect(d.nobodyCorrectFlag).toBe(false);
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -20,6 +20,12 @@ import { CATEGORIES, categoryLabel, HOUSE_AUTHOR, resolveAuthorDisplay } from '@
 import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
 import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import {
+  FRIEND_FACING_TIERS,
+  SELF_PRACTICE_TIERS,
+  applyTierGate,
+  type TrustTier,
+} from '@/server/daily/verification-gating';
+import {
   catchUpExpiresAt,
   expiresWithin24Hours,
   isCatchUpQueueDateEligible,
@@ -952,6 +958,7 @@ export async function pickEligibleAuthoredQuestions(
       difficultyEstimate: canonicalQuestions.difficultyEstimate,
       creatorNote: canonicalQuestions.creatorNote,
       publicEligibilityScore: canonicalQuestions.publicEligibilityScore,
+      trustTier: canonicalQuestions.trustTier,
       createdAt: canonicalQuestions.createdAt,
     })
     .from(canonicalQuestions)
@@ -969,6 +976,15 @@ export async function pickEligibleAuthoredQuestions(
     )
     .limit(overFetch);
 
+  // Tier-gate (B4 Phase 3): friend-facing requires human_validated|author_confirmed.
+  // Off by default — shadow-logs and serves today's set until the flag is flipped.
+  const tierGated = applyTierGate(
+    'friend-facing/authored',
+    candidates,
+    (row) => row.trustTier as TrustTier,
+    FRIEND_FACING_TIERS,
+  ).rows;
+
   const tierOf = (creatorId: string | null): number => {
     if (!creatorId) return 3;
     if (socialGraph.direct.has(creatorId)) return 0;
@@ -976,7 +992,7 @@ export async function pickEligibleAuthoredQuestions(
     return 2;
   };
 
-  const filtered = candidates
+  const filtered = tierGated
     .filter((row) => row.creatorId && row.creatorId !== viewerUserId)
     .filter((row) => !seenQuestionIds.has(row.id))
     .filter((row) => row.canonicalSubcategory && !isGenericSubcategory(row.canonicalSubcategory))
@@ -1184,6 +1200,7 @@ export async function pickHouseQuestions(
       category: canonicalQuestions.category,
       difficultyEstimate: canonicalQuestions.difficultyEstimate,
       creatorNote: canonicalQuestions.creatorNote,
+      trustTier: canonicalQuestions.trustTier,
       createdAt: canonicalQuestions.createdAt,
     })
     .from(canonicalQuestions)
@@ -1198,7 +1215,16 @@ export async function pickHouseQuestions(
     .orderBy(desc(canonicalQuestions.createdAt))
     .limit(Math.max(limit * 4, 20));
 
-  return selectHousePicks(candidates, seenQuestionIds, limit);
+  // Tier-gate (B4 Phase 3): house editorial is the friend-facing bucket
+  // (author-asserted, public per D9). Off by default — shadow-logs only.
+  const gatedCandidates = applyTierGate(
+    'house/editorial',
+    candidates,
+    (row) => row.trustTier as TrustTier,
+    FRIEND_FACING_TIERS,
+  ).rows;
+
+  return selectHousePicks(gatedCandidates, seenQuestionIds, limit);
 }
 
 /**
@@ -1374,6 +1400,16 @@ export async function pickBankSource(
     if (pgErrorCode(error) === '42703') return null;
     throw error;
   }
+
+  // Tier-gate (B4 Phase 3): self-practice may only serve tier ≥ machine_verified.
+  // Off by default — shadow-logs the would-filter count and serves today's set
+  // until the enforcement flag is flipped.
+  candidates = applyTierGate(
+    'self-practice/bank',
+    candidates,
+    (row) => row.trustTier as TrustTier,
+    SELF_PRACTICE_TIERS,
+  ).rows;
 
   // Shuffle the recency window (Fisher–Yates) so selection within it stays
   // varied; recency already biases which rows land in the window.

--- a/src/server/db/queries/joshing-game.ts
+++ b/src/server/db/queries/joshing-game.ts
@@ -161,6 +161,18 @@ export class JoshingGameValidationError extends Error {
   }
 }
 
+// Fail toward the player (B4 Phase 4 / Drift Risk 2): the LLM grader was
+// unreachable, so its 'wrong' verdict is not a real judgement. Thrown BEFORE any
+// response is persisted so the turn can be retried rather than scored wrong.
+export class JoshingGameGraderUnavailableError extends Error {
+  readonly status = 503;
+
+  constructor() {
+    super('grader unavailable; answer not scored');
+    this.name = 'JoshingGameGraderUnavailableError';
+  }
+}
+
 function assertValidCreateParams(params: {
   title: string;
   recipientIds: string[];
@@ -475,6 +487,11 @@ export async function submitJoshingGameResponse(params: {
     question.questionText,
     question.questionType,
   );
+  // Never persist an outage 'wrong' (Drift Risk 2): bail before any write so the
+  // turn is retryable. No response row, no mastery, no asked_count bump.
+  if (grade.gradedVia === 'fallback') {
+    throw new JoshingGameGraderUnavailableError();
+  }
   const isCorrect = grade.result === 'correct';
   const isPartial = false;
   const priorAnswers = await readPriorAnswers(params.userId, params.questionId);

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -12,6 +12,11 @@ import {
   type ConvergenceCoCorrectRow,
 } from '@/lib/convergence';
 import { resolveAuthorDisplay } from '@/lib/questions-types';
+import {
+  FRIEND_FACING_TIERS,
+  applyTierGate,
+  type TrustTier,
+} from '@/server/daily/verification-gating';
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
 import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
@@ -398,11 +403,12 @@ export async function getLatelyConvergences(
 
   // 1. The viewer's correct answers, with each question's author so we can drop
   //    questions the viewer wrote. Keep the EARLIEST correct moment per question.
-  const viewerRows = await db
+  const viewerRowsRaw = await db
     .select({
       questionId: masteryEvents.questionId,
       createdAt: masteryEvents.createdAt,
       creatorId: questions.creatorId,
+      trustTier: questions.trustTier,
     })
     .from(masteryEvents)
     .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
@@ -415,6 +421,15 @@ export async function getLatelyConvergences(
         gte(masteryEvents.createdAt, lookbackStart),
       ),
     );
+
+  // Tier-gate (B4 Phase 3): a Convergence moment only forms from human_validated|
+  // author_confirmed questions. Off by default — shadow-logs and keeps today's set.
+  const viewerRows = applyTierGate(
+    'convergence',
+    viewerRowsRaw,
+    (row) => row.trustTier as TrustTier,
+    FRIEND_FACING_TIERS,
+  ).rows;
 
   const viewerByQuestion = new Map<
     string,

--- a/src/server/db/queries/pool-report.ts
+++ b/src/server/db/queries/pool-report.ts
@@ -1,0 +1,105 @@
+// Trust-tier pool reporting (B4 Phase 2 checkpoint + Phase 3 flag-off logging,
+// PRD-D-5 §6).
+//
+// Counts the eligible pool per serving surface under the §6 tier rules WITHOUT
+// enforcing anything — so we can confirm pools are healthy before flipping the
+// enforcement flag (Drift Risk 1, step 3). Read-only.
+//
+//   self-practice (Daily Five)   → machine bank rows tier ≥ machine_verified
+//   friend-facing / Convergence  → human_validated OR author_confirmed
+//   author_confirmed (D9)        → author-asserted, friend-graph + public
+//
+// "tier ≥ machine_verified" excludes only `unverified`; higher tiers always
+// remain eligible for a lower-bar surface.
+
+import { and, count, eq, isNull } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { generatedQuestions, questions } from '@/server/db/schema';
+
+export interface TrustTierBreakdown {
+  unverified: number;
+  machine_verified: number;
+  human_validated: number;
+  author_confirmed: number;
+}
+
+export interface PoolReport {
+  /** Non-duplicate machine bank rows by tier. */
+  machineBank: TrustTierBreakdown;
+  /** Non-duplicate, non-deleted human-authored rows by tier. */
+  humanAuthored: TrustTierBreakdown;
+  /** Eligible counts under §6 tier rules. */
+  eligible: {
+    /** Machine rows eligible for self-practice (tier ≥ machine_verified). */
+    selfPractice: number;
+    /** Human rows eligible for friend-facing (human_validated|author_confirmed). */
+    friendFacing: number;
+  };
+  /** Questions flagged "nobody got it" for review. */
+  nobodyCorrectFlagged: number;
+}
+
+const EMPTY: TrustTierBreakdown = {
+  unverified: 0,
+  machine_verified: 0,
+  human_validated: 0,
+  author_confirmed: 0,
+};
+
+async function machineBankBreakdown(): Promise<TrustTierBreakdown> {
+  const rows = await db
+    .select({ tier: generatedQuestions.trustTier, n: count() })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.isDuplicate, false))
+    .groupBy(generatedQuestions.trustTier);
+  const out = { ...EMPTY };
+  for (const r of rows) out[r.tier as keyof TrustTierBreakdown] = Number(r.n);
+  return out;
+}
+
+async function humanAuthoredBreakdown(): Promise<TrustTierBreakdown> {
+  const rows = await db
+    .select({ tier: questions.trustTier, n: count() })
+    .from(questions)
+    .where(and(eq(questions.isDuplicate, false), isNull(questions.deletedAt)))
+    .groupBy(questions.trustTier);
+  const out = { ...EMPTY };
+  for (const r of rows) out[r.tier as keyof TrustTierBreakdown] = Number(r.n);
+  return out;
+}
+
+export async function getPoolReport(): Promise<PoolReport> {
+  const [machineBank, humanAuthored, flaggedRows] = await Promise.all([
+    machineBankBreakdown(),
+    humanAuthoredBreakdown(),
+    db
+      .select({ n: count() })
+      .from(questions)
+      .where(and(eq(questions.nobodyCorrectFlag, true), isNull(questions.deletedAt))),
+  ]);
+
+  const selfPractice =
+    machineBank.machine_verified + machineBank.human_validated + machineBank.author_confirmed;
+  const friendFacing = humanAuthored.human_validated + humanAuthored.author_confirmed;
+
+  return {
+    machineBank,
+    humanAuthored,
+    eligible: { selfPractice, friendFacing },
+    nobodyCorrectFlagged: Number(flaggedRows[0]?.n ?? 0),
+  };
+}
+
+/** Convenience: log the pool report (used by the Phase 3 flag-off path). */
+export async function logPoolReport(context: string): Promise<PoolReport> {
+  const report = await getPoolReport();
+  console.info(`[pool-report] ${context}`, {
+    machineBank: report.machineBank,
+    humanAuthored: report.humanAuthored,
+    eligibleSelfPractice: report.eligible.selfPractice,
+    eligibleFriendFacing: report.eligible.friendFacing,
+    nobodyCorrectFlagged: report.nobodyCorrectFlagged,
+  });
+  return report;
+}

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -51,6 +51,8 @@ export type QuestionView = {
   tags: string[];
   asked_count: number;
   correct_count: number;
+  // "Nobody got it" QA signal (B4 Phase 2): ≥N holders tried, none correct.
+  nobody_correct_flag: boolean;
   isInBank?: boolean;
   isOwnAuthored?: boolean;
   authorName?: string;
@@ -118,6 +120,8 @@ const questionViewColumns = {
   sharedToFriendsFeed: questionTableColumns.sharedToFriendsFeed,
   askedCount: questionTableColumns.askedCount,
   correctCount: questionTableColumns.correctCount,
+  // "Nobody got it" review smell (B4 Phase 2) — surfaced as a QA signal.
+  nobodyCorrectFlag: questionTableColumns.nobodyCorrectFlag,
   createdAt: questionTableColumns.createdAt,
   updatedAt: questionTableColumns.updatedAt,
   deletedAt: questionTableColumns.deletedAt,
@@ -253,6 +257,7 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
     tags: [],
     asked_count: row.askedCount,
     correct_count: row.correctCount,
+    nobody_correct_flag: row.nobodyCorrectFlag ?? false,
     verified: row.verified ?? true,
     llmSuggestedAnswer: row.llmSuggestedAnswer ?? null,
     critiqueIterations: row.critiqueIterations ?? 0,

--- a/src/server/db/queries/trust-promotion.ts
+++ b/src/server/db/queries/trust-promotion.ts
@@ -16,6 +16,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { db } from '@/server/db';
 import { masteryEvents, questions } from '@/server/db/schema';
+import { empiricalMinSamples, resolveEffectiveDifficulty } from '@/server/daily/empirical-difficulty';
 
 function numEnv(name: string, fallback: number): number {
   const raw = process.env[name];
@@ -101,12 +102,25 @@ export async function evaluateQuestionTrustOnPlay(questionId: string): Promise<v
   const agg = await readPlayAggregate(questionId);
   const minCorrect = humanValidatedMinCorrect();
   const minHolders = nobodyCorrectMinHolders();
+  const minSamples = empiricalMinSamples();
 
-  // Cheap exit: nothing to do until either threshold is in reach.
-  if (agg.distinctCorrect < minCorrect && !(agg.distinctAnswerers >= minHolders)) return;
+  // Cheap exit: nothing to do until a promotion, a flag, or an empirical
+  // difficulty recompute is in reach.
+  if (
+    agg.distinctCorrect < minCorrect &&
+    agg.distinctAnswerers < minHolders &&
+    agg.distinctAnswerers < minSamples
+  ) {
+    return;
+  }
 
   const [current] = await db
-    .select({ trustTier: questions.trustTier, nobodyCorrectFlag: questions.nobodyCorrectFlag })
+    .select({
+      trustTier: questions.trustTier,
+      nobodyCorrectFlag: questions.nobodyCorrectFlag,
+      calibratedDifficulty: questions.calibratedDifficulty,
+      difficultyEstimate: questions.difficultyEstimate,
+    })
     .from(questions)
     .where(eq(questions.id, questionId))
     .limit(1);
@@ -131,5 +145,24 @@ export async function evaluateQuestionTrustOnPlay(questionId: string): Promise<v
       .update(questions)
       .set({ nobodyCorrectFlag: decision.nobodyCorrectFlag })
       .where(eq(questions.id, questionId));
+  }
+
+  // D11 (B4 Phase 5): once enough humans have played, the measured correct rate
+  // overrides the model's difficulty_estimate. Persist it to calibrated_difficulty
+  // — the value serving + base-points already read — so the floor self-corrects.
+  if (agg.distinctAnswerers >= minSamples) {
+    const empiricalRate = agg.distinctCorrect / agg.distinctAnswerers;
+    const effective = resolveEffectiveDifficulty({
+      estimate: current.difficultyEstimate,
+      empiricalRate,
+      nAnswered: agg.distinctAnswerers,
+      minSamples,
+    });
+    if (effective.source === 'empirical' && effective.difficulty !== current.calibratedDifficulty) {
+      await db
+        .update(questions)
+        .set({ calibratedDifficulty: effective.difficulty })
+        .where(eq(questions.id, questionId));
+    }
   }
 }

--- a/src/server/db/queries/trust-promotion.ts
+++ b/src/server/db/queries/trust-promotion.ts
@@ -1,0 +1,135 @@
+// Human-play trust promotion + "nobody got it" smell (PRD-D-5 §5.3 layer 3 / §6 /
+// §7 / B4 Phase 2).
+//
+// Trust climbs with real play: a machine_verified question that N humans answer
+// correctly earns human_validated (friend-facing eligible, §6). The inverse is a
+// hallucination smell, not a hard question — a question that ENOUGH domain-holders
+// answer with NOBODY getting it right is flagged for review (never auto-deleted —
+// no decay, D8).
+//
+// The authoritative play log is MASTERY_EVENTS, keyed by the canonical Question
+// id (question_id). "Correct" is any non-incorrect answer_state. An answerer can
+// have more than one row for a question (the unique key includes source_type), so
+// count(DISTINCT answered_by_user_id) is what collapses those to distinct humans.
+
+import { and, eq, sql } from 'drizzle-orm';
+
+import { db } from '@/server/db';
+import { masteryEvents, questions } from '@/server/db/schema';
+
+function numEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined) return fallback;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : fallback;
+}
+
+/** §7: human_validated after N=3 correct (with ≥1 wrong tolerated — we count
+ *  correct distinct humans, so a mixed-in wrong answer never blocks promotion). */
+export function humanValidatedMinCorrect(): number {
+  return Math.max(1, Math.round(numEnv('TRUST_HUMAN_VALIDATED_MIN_CORRECT', 3)));
+}
+
+/** §7: "nobody got it" smell — 0% correct over ≥5 domain-holders. */
+export function nobodyCorrectMinHolders(): number {
+  return Math.max(1, Math.round(numEnv('TRUST_NOBODY_CORRECT_MIN_HOLDERS', 5)));
+}
+
+export interface PlayAggregate {
+  /** Distinct humans whose recorded answer was correct (non-incorrect). */
+  distinctCorrect: number;
+  /** Distinct humans who answered at all (any scored state). */
+  distinctAnswerers: number;
+}
+
+export type TrustTierValue = 'unverified' | 'machine_verified' | 'human_validated' | 'author_confirmed';
+
+export interface TrustDecision {
+  /** Tier to promote to, or null to leave the tier unchanged. */
+  promoteTo: 'human_validated' | null;
+  /** Desired value of nobody_correct_flag after this play. */
+  nobodyCorrectFlag: boolean;
+}
+
+/**
+ * Pure decision from a play aggregate + current tier. Fails toward NOT flagging
+ * and NOT demoting:
+ *  - Promote machine_verified → human_validated once enough distinct humans are
+ *    correct. Only machine_verified is promoted (unverified hasn't earned its
+ *    first tier; human_validated/author_confirmed are already at/above it).
+ *  - Flag "nobody correct" only once enough distinct holders have tried AND none
+ *    succeeded; the moment one human gets it right the flag clears (it was a hard
+ *    question, not a broken one).
+ */
+export function decideTrustOnPlay(
+  agg: PlayAggregate,
+  currentTier: TrustTierValue,
+  minCorrect: number = humanValidatedMinCorrect(),
+  minHolders: number = nobodyCorrectMinHolders(),
+): TrustDecision {
+  const promoteTo =
+    currentTier === 'machine_verified' && agg.distinctCorrect >= minCorrect ? 'human_validated' : null;
+  const nobodyCorrectFlag = agg.distinctAnswerers >= minHolders && agg.distinctCorrect === 0;
+  return { promoteTo, nobodyCorrectFlag };
+}
+
+/** A correct answer_state is any scored, non-incorrect state. */
+const CORRECT_STATES = sql`('first_correct','first_correct_after_wrong','repeat_correct')`;
+
+/** Read distinct-human play aggregates for a single canonical question. */
+export async function readPlayAggregate(questionId: string): Promise<PlayAggregate> {
+  const [row] = await db
+    .select({
+      distinctCorrect: sql<number>`count(distinct ${masteryEvents.answeredByUserId}) filter (where ${masteryEvents.answerState} in ${CORRECT_STATES})`,
+      distinctAnswerers: sql<number>`count(distinct ${masteryEvents.answeredByUserId}) filter (where ${masteryEvents.answerState} is not null)`,
+    })
+    .from(masteryEvents)
+    .where(eq(masteryEvents.questionId, questionId));
+  return {
+    distinctCorrect: Number(row?.distinctCorrect ?? 0),
+    distinctAnswerers: Number(row?.distinctAnswerers ?? 0),
+  };
+}
+
+/**
+ * Evaluate + apply trust promotion / "nobody got it" flag for a question after a
+ * scored answer. Best-effort and idempotent: the promotion UPDATE is guarded on
+ * the current tier so a re-run never re-promotes, and the flag converges to the
+ * decision. Callers invoke this fire-and-forget after writeMasteryEvent.
+ */
+export async function evaluateQuestionTrustOnPlay(questionId: string): Promise<void> {
+  const agg = await readPlayAggregate(questionId);
+  const minCorrect = humanValidatedMinCorrect();
+  const minHolders = nobodyCorrectMinHolders();
+
+  // Cheap exit: nothing to do until either threshold is in reach.
+  if (agg.distinctCorrect < minCorrect && !(agg.distinctAnswerers >= minHolders)) return;
+
+  const [current] = await db
+    .select({ trustTier: questions.trustTier, nobodyCorrectFlag: questions.nobodyCorrectFlag })
+    .from(questions)
+    .where(eq(questions.id, questionId))
+    .limit(1);
+  if (!current) return;
+
+  const decision = decideTrustOnPlay(
+    agg,
+    current.trustTier as TrustTierValue,
+    minCorrect,
+    minHolders,
+  );
+
+  if (decision.promoteTo) {
+    // Guard on machine_verified so concurrent evaluations and re-runs are no-ops.
+    await db
+      .update(questions)
+      .set({ trustTier: 'human_validated' })
+      .where(and(eq(questions.id, questionId), eq(questions.trustTier, 'machine_verified')));
+  }
+  if (decision.nobodyCorrectFlag !== current.nobodyCorrectFlag) {
+    await db
+      .update(questions)
+      .set({ nobodyCorrectFlag: decision.nobodyCorrectFlag })
+      .where(eq(questions.id, questionId));
+  }
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -325,6 +325,10 @@ export const questions = pgTable(
     perishable: boolean('perishable').notNull().default(false),
     // Provenance refs from retrieval-grounded generation; populated in B3.
     sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // "Nobody got it" smell (B4 Phase 2, §5.3 layer 3 / §7). True when ≥N distinct
+    // domain-holders have answered and NONE got it right — a hallucination smell,
+    // not a hard question. Flags for review; never auto-deletes (no decay, D8).
+    nobodyCorrectFlag: boolean('nobody_correct_flag').notNull().default(false),
     // Embedding-dedup flags (B3). Human beats machine on collision; the loser is
     // suppressed (flagged), never deleted. suppressedBy holds the surviving
     // question id (may live in either table, so not a hard FK).
@@ -350,6 +354,11 @@ export const questions = pgTable(
     // live tier-gating yet (B4 owns enforcement).
     index('Question_trust_tier_idx').on(table.trustTier),
     index('Question_is_duplicate_idx').on(table.isDuplicate),
+    // Partial index for the "nobody got it" review queue (B4 Phase 2): the flag is
+    // true for a tiny minority of rows, so a partial index keeps the scan cheap.
+    index('Question_nobody_correct_flag_idx')
+      .on(table.nobodyCorrectFlag)
+      .where(sql`${table.nobodyCorrectFlag} = true`),
   ],
 );
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -588,6 +588,10 @@ export const generatedQuestions = pgTable(
     scope: questionScopeEnum('scope').notNull().default('public'),
     perishable: boolean('perishable').notNull().default(false),
     sourceRefs: jsonb('source_refs').$type<string[]>().notNull().default([]),
+    // Ask-to-answer record (B4 Phase 1, PRD-D-5 §5.3 layer 2). True when an
+    // independent cold solver corroborated the stored answer at generation time.
+    // This + B3 corroboration is what earns the machine_verified trust tier.
+    askToAnswerVerified: boolean('ask_to_answer_verified').notNull().default(false),
     // Empirical play stats (D11 / "nobody got it" smell). Back-filled from answer
     // history where a join exists; machine rows usually start 0 / null.
     nAnswered: integer('n_answered').notNull().default(0),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -601,6 +601,11 @@ export const generatedQuestions = pgTable(
     // independent cold solver corroborated the stored answer at generation time.
     // This + B3 corroboration is what earns the machine_verified trust tier.
     askToAnswerVerified: boolean('ask_to_answer_verified').notNull().default(false),
+    // Acceptable answer variants (B4 Phase 4, §5.3). Equivalent phrasings the cold
+    // solver produced that the judge accepted; honored in grading so a right-but-
+    // rephrased answer is marked correct. Carried to Question.accepted_alternatives
+    // when a machine row is promoted to canonical.
+    acceptableVariants: text('acceptable_variants').array().notNull().default([]),
     // Empirical play stats (D11 / "nobody got it" smell). Back-filled from answer
     // history where a join exists; machine rows usually start 0 / null.
     nAnswered: integer('n_answered').notNull().default(0),

--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -2,6 +2,7 @@ import { and, eq, sql } from 'drizzle-orm';
 
 import { db, masteryEvents, playerMastery } from '@/server/db';
 import { maybeNotifyInviterOfFirstFive } from '@/server/activity/invite-onboarding';
+import { evaluateQuestionTrustOnPlay } from '@/server/db/queries/trust-promotion';
 import { effectiveTier } from '@/server/mastery/tiers';
 import type { AnswerState, MasteryTier } from '@/types/db';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
@@ -184,6 +185,26 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
       previousTier,
       newTier: nextTier,
     });
+  }
+
+  // Human-play trust promotion + "nobody got it" smell (B4 Phase 2). Best-effort
+  // and fire-after-write: a freshly-recorded human answer may push the canonical
+  // question over the human_validated threshold or the nobody-correct smell.
+  // Skipped for author/curator credit (no real answer_state) and when there is no
+  // canonical question id to evaluate. Never blocks the mastery write.
+  if (
+    params.eventQuestionId &&
+    params.sourceType !== 'author_credit' &&
+    params.sourceType !== 'curator_credit'
+  ) {
+    try {
+      await evaluateQuestionTrustOnPlay(params.eventQuestionId);
+    } catch (error) {
+      console.warn('[mastery] trust-on-play evaluation failed', {
+        questionId: params.eventQuestionId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   // Only the surfaces a new user actually plays count toward the invited-friend

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -133,7 +133,9 @@ export async function persistGeneratedQuestion(generatedQuestionId: string, slot
         questionText: generated.questionText,
         answerText: generated.answer,
         factualExplanation: generated.explainer,
-        acceptedAlternatives: [],
+        // Carry the machine row's acceptable_variants (B4 Phase 4) onto the
+        // canonical row so grading honors right-but-rephrased answers everywhere.
+        acceptedAlternatives: generated.acceptableVariants ?? [],
         answerSource: 'llm_suggested',
         questionType: 'factual',
         category: 'general_knowledge',

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -145,6 +145,13 @@ export async function persistGeneratedQuestion(generatedQuestionId: string, slot
         calibratedDifficulty: asDifficulty(generated.difficultyEstimate),
         status: 'verified',
         visibility: 'public',
+        // Carry the machine row's earned trust tier onto the canonical row (B4
+        // Phase 2): a machine_verified generated question yields a machine_verified
+        // Question, which human play can then promote to human_validated. Without
+        // this the canonical row would default to 'unverified' and never promote.
+        // Null-creator daily_generated rows are machine-origin, so they must NOT
+        // default to author_confirmed (that tier means a human authored it).
+        trustTier: generated.trustTier,
         // Carry the precomputed aside through; the editorial label is applied at
         // display time (selectInsideJokeForViewer) for these null-creator rows.
         insideJoke: generated.insideJoke,


### PR DESCRIPTION
Implements **B4 — Verification Stack + Switch-On** (PRD-D-5 §5.3 / §6 / §7 / §9), the last of the four-prompt engine (B1 pool → B2 floor → B3 retrieval → **B4 verification**). It activates the trust tiers, turns on surface gating (behind a flag), and fixes grading so a wrong call is never falsely assigned.

Built in five phases, each behind its own checkpoint/approval gate.

## What shipped

| Phase | What |
|---|---|
| **1 — Ask-to-answer gate** | Strip the answer, ask a separate cold solver (Haiku, distinct from the Sonnet generator) the question 3×; cold answers must agree with each other and the stored answer or the question is dropped. Earns `machine_verified` (with B3 corroboration). Fail-open on outage. |
| **2 — Human-play promotion** | `machine_verified` → `human_validated` after N=3 distinct humans correct. "Nobody got it" smell (≥5 holders, 0 correct) flags for review (never auto-deletes). Back-fills `human_validated` from existing play history. |
| **3 — Tier-gating** | Live enforcement of the §6 surface bars across self-practice, friend-facing, house, and Convergence — **behind `VERIFICATION_TIER_GATING_ENABLED`, OFF by default**. With the flag off every surface shadow-logs what it *would* filter and serves today's exact set. Adds `GET /api/dev/pool-report` to confirm pool health before any flip. |
| **4 — Grading fails toward the player** | Every answer route now defers (retryable 503) instead of persisting `wrong` when the grader is unreachable — never a machine-manufactured wrong. A genuine LLM `wrong` is untouched. Builds `acceptable_variants` (reusing the Phase-1 cold answers, zero new LLM calls) and honors them in grading. |
| **5 — D11 empirical override** | Once enough humans play a question, its measured correct rate overrides the model's `difficulty_estimate` and is persisted to `calibrated_difficulty` — the floor self-corrects from real play. |

## Drift risks (all honored)
- **DR1 — don't starve surfaces:** tier-gating is flag-gated + off; `human_validated` back-filled from history; pool report added to measure before enforcing. Flag NOT flipped — held at the Phase 3 approval gate.
- **DR2 — grading fails toward the player:** outage/uncertainty never marks wrong; defers/retries. Tested across all 7 grading call sites incl. multiplayer.
- **DR3 — fail-open ≠ serve known-wrong:** known-wrong dropped by the verification stack; ask-to-answer is the secondary net, never the primary correctness mechanism.

## Migrations (additive, idempotent, with boot guards)
- `0066_ask_to_answer_verified` — `GeneratedQuestion.ask_to_answer_verified`
- `0067_human_validated_backfill` — `Question.nobody_correct_flag` + partial index; corrects a B1 grandfather artifact (null-creator daily rows wrongly `author_confirmed` → `machine_verified`); back-fills `human_validated` from play
- `0068_acceptable_variants` — `GeneratedQuestion.acceptable_variants`

## Notable decisions
1. **`machine_verified` = ask-to-answer OR corroboration** (not strict AND) — requiring both would starve self-practice when retrieval is off; strictly stronger than B1's grandfather baseline.
2. **Corrected a B1 artifact:** null-creator `daily_generated` rows had been grandfathered to `author_confirmed`; re-tiered to `machine_verified` so they don't pass the friend-facing/public gate as if authored.
3. **Uniform defer-on-outage** for grading (the daily route's existing pattern) rather than self-practice auto-credit — never wrong, never falsely credits, corrupts no mastery data.

## Switch-on (operator, post-merge — no code)
The enforcement flag is **off**. To flip: deploy, read `GET /api/dev/pool-report` + the `[verification-gating]` shadow logs from real data, confirm `eligible.selfPractice` / `eligible.friendFacing` are healthy, then set `VERIFICATION_TIER_GATING_ENABLED=true`. The `0067` migration's `RAISE NOTICE` prints back-fill counts at deploy.

## Verification
- Full suite: **806 passed**, 3 pre-existing skips.
- Typecheck (`tsconfig.typecheck.json`): **0 errors**.
- Lint clean on all touched files; no `src/middleware.ts`.
- All three migrations reviewed and approved.

Out of scope (remaining follow-ups per the build prompt): B5 (authoring UI) and the PRD/governance update.

https://claude.ai/code/session_01M3PUM7AK8aC5Upa1hW2hKD

---
_Generated by [Claude Code](https://claude.ai/code/session_01M3PUM7AK8aC5Upa1hW2hKD)_