### PR TITLE
B5 — Authoring UI (D9): public-by-default signpost, friends-only override, author profile links

### DIFF
--- a/src/app/daily/summary/__tests__/AuthorName.test.tsx
+++ b/src/app/daily/summary/__tests__/AuthorName.test.tsx
@@ -1,0 +1,39 @@
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+// B5/D9: summary-page author attribution. Human authors link to their profile;
+// house/editorial authors (no users.id) stay plain text. Everyone with an
+// authorId gets the link (no friend/stranger gating — per product decision).
+import { AuthorName } from '@/app/daily/summary/page'
+
+function html(node: React.ReactElement): string {
+  return renderToStaticMarkup(node)
+}
+
+describe('summary AuthorName attribution', () => {
+  it('links a human author to their profile page', () => {
+    const out = html(<AuthorName name="Robyn" authorId="user_robyn" />)
+    expect(out).toContain('href="/users/user_robyn"')
+    expect(out).toContain('Robyn')
+  })
+
+  it('renders plain text (no link) when there is no authorId (house/editorial)', () => {
+    const out = html(<AuthorName name="Joshing" authorId={null} />)
+    expect(out).not.toContain('<a')
+    expect(out).toContain('Joshing')
+  })
+
+  it('encodes the author id into the profile href', () => {
+    const out = html(<AuthorName name="A B" authorId="weird id/with?chars" />)
+    expect(out).toContain('href="/users/weird%20id%2Fwith%3Fchars"')
+  })
+})

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -320,6 +320,36 @@ function bridgeSentence(bridge: NonNullable<DailySummaryView['recentFriendBridge
   }
 }
 
+// B5/D9: on the summary page (unlike the gameplay chat, which stays plain text)
+// author names link to the author's profile. Only human authors carry an
+// authorId; house/editorial names render as plain text.
+export function AuthorName({
+  name,
+  authorId,
+  weight,
+}: {
+  name: string
+  authorId: string | null
+  weight?: number
+}) {
+  if (!authorId) {
+    return <span style={{ fontWeight: weight }}>{name}</span>
+  }
+  return (
+    <Link
+      href={`/users/${encodeURIComponent(authorId)}`}
+      style={{
+        fontWeight: weight,
+        color: 'var(--brand-link)',
+        textDecoration: 'underline',
+        textUnderlineOffset: 2,
+      }}
+    >
+      {name}
+    </Link>
+  )
+}
+
 function InterpretiveLine({ text }: { text: string }) {
   const [visible, setVisible] = useState(false)
   useEffect(() => {
@@ -484,7 +514,7 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
             >
               FROM
             </span>
-            <span style={{ fontWeight: 600 }}>{question.authorName}</span>
+            <AuthorName name={question.authorName} authorId={question.authorId} weight={600} />
             {question.authorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
             <span
               style={{
@@ -532,9 +562,17 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
       {question.authorNote ? (
         <p className="bg-muted/40 text-foreground mt-4 rounded-xl border p-3 text-sm leading-6">
           <span className="font-medium">
-            {question.authorIsHouse
-              ? 'Editor’s note:'
-              : question.authorName ? `Why ${question.authorName} asked:` : 'Why they asked:'}
+            {question.authorIsHouse ? (
+              'Editor’s note:'
+            ) : question.authorName ? (
+              <>
+                Why{' '}
+                <AuthorName name={question.authorName} authorId={question.authorId} />{' '}
+                asked:
+              </>
+            ) : (
+              'Why they asked:'
+            )}
           </span>{' '}
           {question.authorNote}
         </p>

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -226,6 +226,22 @@ function remainingCopy(state: State): string | null {
   return 'Last review for today';
 }
 
+// D9 (PRD-D-5 §5.1): authored questions are public by default — reach is a
+// reward, not a risk. The signpost states this plainly and positively; it is
+// never a cautionary or blocking warning. Friends-only is the calm exception.
+// `visibility` is the existing column the unified pool layer reads as `scope`
+// (public → public, friends → friends_only); no new field is written.
+export function scopeSignpost(visibility: 'public' | 'friends' | 'private'): string {
+  switch (visibility) {
+    case 'public':
+      return 'Others can play this. Your friends will see it’s from you.';
+    case 'friends':
+      return 'Kept to friends only — only people who follow you will see it.';
+    case 'private':
+      return 'Only you can see this — it won’t be shared.';
+  }
+}
+
 export function QuestionForm({
   mode = 'create',
   initialValues,
@@ -611,7 +627,7 @@ export function QuestionForm({
                     </button>
                   ))}
                 </div>
-                <p className="mt-2 text-xs text-muted-foreground">{state.visibility === 'public' ? 'Anyone can see this question.' : state.visibility === 'friends' ? 'Only people who follow you can see this.' : 'Only you can see this — it won’t be shared.'}</p>
+                <p className="mt-2 text-xs text-foreground">{scopeSignpost(state.visibility)}</p>
               </div>
               <label className="mb-2 flex cursor-default items-center gap-2 text-sm"><input type="checkbox" checked readOnly disabled className="rounded" /><span className="text-foreground">Save to bank</span></label>
               <label className="mb-2 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.shareToFeed} onChange={(event) => toggleShareToFeed(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING' || state.visibility === 'private'} /><span className="text-foreground">Share with all friends</span></label>

--- a/src/components/__tests__/QuestionForm.test.tsx
+++ b/src/components/__tests__/QuestionForm.test.tsx
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+
+import { scopeSignpost } from '@/components/QuestionForm';
+
+// B5 / D9 (PRD-D-5 §5.1): the authoring signpost is a feature, not a privacy
+// warning. Public is the default and reads as a reward (others can play this);
+// friends-only is the calm exception. Nothing is ever exposed outside Joshing.
+describe('scopeSignpost (D9 authoring signpost)', () => {
+  it('frames the public default as positive reach + author attribution', () => {
+    const copy = scopeSignpost('public');
+    expect(copy).toMatch(/play this/i);
+    expect(copy).toMatch(/from you/i);
+  });
+
+  it('never reads as a cautionary or alarming warning', () => {
+    for (const visibility of ['public', 'friends', 'private'] as const) {
+      expect(scopeSignpost(visibility)).not.toMatch(
+        /warning|careful|caution|danger|are you sure|cannot be undone/i,
+      );
+    }
+  });
+
+  it('never implies exposure beyond Joshing (no open web / internet / strangers)', () => {
+    for (const visibility of ['public', 'friends', 'private'] as const) {
+      expect(scopeSignpost(visibility)).not.toMatch(
+        /internet|the web|world|stranger|public web|searchable/i,
+      );
+    }
+  });
+
+  it('signposts the friends-only override as the exception path', () => {
+    expect(scopeSignpost('friends')).toMatch(/friends only/i);
+  });
+
+  it('keeps private author-only', () => {
+    expect(scopeSignpost('private')).toMatch(/only you/i);
+  });
+});

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -58,6 +58,12 @@ export type QuestionRecap = {
   isInBank: boolean;
   /** Author display name — set for friend-authored and house questions. */
   authorName: string | null;
+  /**
+   * Author's user id — only for human (friend-authored) questions, so the recap
+   * can link the name to their profile (B5/D9). Null for house/editorial and
+   * LLM-origin questions, which have no users.id to link to.
+   */
+  authorId: string | null;
   /** Author's why — commentary attached at creation, surfaced in the recap. */
   authorNote: string | null;
   /** D-3: the author is the non-human house/editorial author (Editorial badge, non-relational copy). */
@@ -231,6 +237,8 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
       domainDisplayName: displayNameForDomain(domain),
       isInBank: slot.question_id ? Boolean(bankedById[slot.question_id]) : false,
       authorName: slot.source === 'friend' || slot.source === 'house' ? (slot.author_name ?? null) : null,
+      // Only friend (human) authors have a linkable profile; house has no users.id.
+      authorId: slot.source === 'friend' ? (slot.author_id ?? null) : null,
       authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
       authorIsHouse: slot.source === 'house',
     };


### PR DESCRIPTION
Implements **B5 (Authoring UI, D9)** from `PRD-D-5` §5.1 — the surface pass on top of the B1–B4 engine — and folds the B1–B5 build outcome back into the spec of record. Frontend + docs only; no new backend fields (scope is the existing `Question.visibility`, which the unified pool layer reads as `scope`).

## Phase 1 — Authoring signpost + friends-only override (`QuestionForm`)
- Reframed the visibility helper text as the **D9 signpost**: a calm, positive statement that public questions are playable by others and that friends see the author — *"Others can play this. Your friends will see it's from you."* Not a cautionary or blocking warning (Drift Risk 1).
- **Public stays the default** (Drift Risk 3); the existing one-tap segmented control is the friends-only override (`Followers` → `visibility: 'friends'` → `scope: friends_only`). No redundant control, no new pattern.
- Extracted `scopeSignpost()` as a pure, tested helper; copy avoids any exposure-beyond-Joshing language.
- The personal/biographical answer-suggestion guardrail is left untouched.

## Phase 2 — Author attribution (Daily Five summary page)
Per the agreed model — **profile link is universal, attribution is sender-only, everyone gets full identity (no friend/stranger gating)** — the Feed and the Stream/Lately/Convergence surfaces already satisfy this (universal `/users/{id}` links, in-graph sender attribution), so they needed no change. The one gap was the **Daily Five summary recap**, where author names rendered as plain text.
- Threaded the author's user id through `QuestionRecap` (human/friend authors only; house + LLM-origin have no `users.id` and stay unlinked — house keeps its Editorial badge). Derived at read time from `author_id`; no persisted field.
- Summary page: author names (`FROM {name}` and `Why {name} asked`) now link to `/users/{id}` via a small `AuthorName` helper.
- The **gameplay chat stays plain text** (names are not links there), by design.

## Governance — fold B1–B5 into the spec of record
- **PRD-D-5 §11 (new):** build log — per-prompt status (B1–B4 engine pass shipped; B5 here), the embedding-provider choice, and the deviations from the spec as written. §4 ledger points to it.
- **Embedding provider logged:** Voyage AI `voyage-3.5-lite` (1024-dim), gated on `VOYAGE_API_KEY`, best-effort; deterministic guards (fact_key + Haiku + normalized text) remain the backstop when the key is absent.
- **Deviations logged:** (a) human-row scope stored on the existing `visibility` column and derived via `visibilityToScope`; (b) D9 attribution shipped as universal profile links / sender-only / no gating; (c) embedding dedup opt-in via env, not always-on; (d) friends-only override reuses the existing 3-way control.
- **DECISIONS.md:** notes the quality-floor build shipped and surfaces the two highest-signal deviations.

## Tests & checks
- New tests: `QuestionForm.test.tsx` (signpost copy/tone) and `summary/AuthorName.test.tsx` (human → link, house/no-id → plain text, id encoding).
- Strict typecheck: 0 errors. ESLint clean on changed files. No `src/middleware.ts` (proxy.ts preserved).
- `friends_only` invariant holds: no new path renders authored questions to non-friends (B4 still owns enforcement).

https://claude.ai/code/session_01ULMvaMqYRUBphzcWBUDi3S