### PR TITLE
Refactor grading to distinguish scored verdicts from infrastructure failures

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -370,14 +370,12 @@ describe('POST /api/daily/answer grader outage (#6 — never score wrong on LLM 
 
   it('holds the answer for retry (503) and persists nothing when the grader is unreachable', async () => {
     setupDbChain()
-    // gradeAnswer signals an unreachable LLM grader via gradedVia: 'fallback'.
-    // Its result is a deterministic 'wrong' placeholder, NOT a real verdict —
-    // the route must refuse to score it rather than penalise an infra outage.
+    // gradeAnswer signals an unreachable LLM grader via status: 'unscored'.
+    // There is NO result field — the route must refuse to score it rather than
+    // penalise an infra outage.
     gradeAnswerMock.mockResolvedValueOnce({
-      result: 'wrong',
-      consolation: null,
-      confidence: 0,
-      gradedVia: 'fallback',
+      status: 'unscored',
+      reason: 'llm_error',
     })
 
     const res = await POST(jsonRequest(VALID_BODY) as never)

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -2,7 +2,7 @@ import { and, eq } from 'drizzle-orm';
 import { after, NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
-import { gradeAnswer } from '@/server/grading';
+import { gradeAnswer, type GradeOutcome } from '@/server/grading';
 import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
 import { getSession } from '@/server/auth/session';
 import {
@@ -221,8 +221,10 @@ export async function POST(request: NextRequest) {
 
     const canonicalAnswer = question.answer;
 
-    const grade = parsed.gaveUp
-      ? { result: 'wrong' as const, consolation: null, confidence: 1, gradedVia: 'exact' as const }
+    // Give-up is a deliberate, real wrong — a genuine scored verdict, not an infra
+    // failure — so it's constructed as a scored outcome and never held for retry.
+    const grade: GradeOutcome = parsed.gaveUp
+      ? { status: 'scored', result: 'wrong', consolation: null, confidence: 1, gradedVia: 'exact' }
       : await gradeAnswer(
           parsed.submittedAnswer,
           canonicalAnswer,
@@ -230,15 +232,15 @@ export async function POST(request: NextRequest) {
           question.questionText,
           'factual',
         );
-    // The LLM grader was unreachable (timeout, parse error, no client), so its
-    // 'wrong' verdict is not a real judgement of the answer — it's a deterministic
-    // placeholder. Scoring the player wrong for an Anthropic outage is the most
-    // off-brand failure mode in a product whose thesis is "wrong answers are
-    // connection events, not penalties." Instead of persisting anything, hold the
-    // answer in a non-scored retry state: leave the slot untouched (unanswered) and
-    // return a transparent, retryable error so the player can simply resubmit.
-    // Give-ups skip the grader entirely (gradedVia: 'exact'), so they're never held.
-    if (grade.gradedVia === 'fallback') {
+    // The LLM grader was unreachable (timeout, parse error, no client), so there is
+    // no verdict at all — the outcome is `unscored`, never a 'wrong'. Scoring the
+    // player wrong for an Anthropic outage is the most off-brand failure mode in a
+    // product whose thesis is "wrong answers are connection events, not penalties."
+    // Instead of persisting anything, hold the answer in a non-scored retry state:
+    // leave the slot untouched (unanswered) and return a transparent, retryable
+    // error so the player can simply resubmit. Give-ups are scored above, so they
+    // are never held here.
+    if (grade.status === 'unscored') {
       console.warn('[daily/answer] grader unavailable; holding answer for retry', {
         queueId: parsed.queueId,
         slotIndex: parsed.slotIndex,

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -144,7 +144,7 @@ async function handleDailyCatchupAnswer({
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): a grader outage is not a
   // real verdict — never persist 'wrong'. Hold for retry.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return catchUpErrorResponse(
       503,
       'grader_unavailable',
@@ -428,7 +428,7 @@ async function handleFeedCatchupAnswer({
     feedRow.question.questionType,
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return catchUpErrorResponse(
       503,
       'grader_unavailable',

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -104,7 +104,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): a grader outage is not a
   // real verdict — never mark a friend's question wrong. Return a retryable 503.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return NextResponse.json(
       {
         error: 'grader_unavailable',

--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest) {
     question.questionType,
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return NextResponse.json(
       {
         error: 'grader_unavailable',

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -82,7 +82,7 @@ export async function POST(request: NextRequest, context: RouteContext) {
     question.questionType,
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return NextResponse.json(
       {
         error: 'grader_unavailable',

--- a/src/app/api/replay/grade/route.ts
+++ b/src/app/api/replay/grade/route.ts
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
     'factual',
   );
   // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     return NextResponse.json(
       {
         error: 'grader_unavailable',

--- a/src/lib/llm.grading.test.ts
+++ b/src/lib/llm.grading.test.ts
@@ -62,6 +62,8 @@ describe('gradeAnswerWithLLM', () => {
       'factual',
     )
 
+    expect(outcome.status).toBe('scored')
+    if (outcome.status !== 'scored') throw new Error('expected scored')
     expect(outcome.result).toBe('correct')
     expect(outcome.consolation).toBeNull()
   })

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -23,18 +23,28 @@ import { textContainsAnswer } from '@/server/questions/self-answering';
 
 export type GradeResult = 'correct' | 'wrong';
 
-export type GradingResponse = {
+// A genuine model verdict: the answer was actually graded. Carries `result`.
+export type ScoredGradingResponse = {
+  status: 'scored';
   result: GradeResult;
   confidence: number;
   reason: string;
   // "Snarky but Sweet" — a short, warm quip when the answer is wrong but thematically close.
   // null if the answer is simply off-base or unrelated.
   consolation: string | null;
-  // Set to true when the response is a deterministic fallback (timeout, parse
-  // failure, missing client) rather than an actual model verdict. Callers that
-  // care about "wrong vs. couldn't-grade" should branch on this.
-  fallback?: boolean;
 };
+
+// An infrastructure failure — timeout, parse failure, missing client, malformed
+// result field. This is NOT a judgement of the answer, so it deliberately has no
+// `result` field: reading a verdict off an outage is a type error, by design.
+// The product thesis is "wrong answers are connection events," so a player must
+// never be scored wrong because Anthropic was unreachable.
+export type UnscoredGradingResponse = {
+  status: 'unscored';
+  reason: string;
+};
+
+export type GradingResponse = ScoredGradingResponse | UnscoredGradingResponse;
 
 export type CategoryResult = {
   subcategory: string;
@@ -474,8 +484,8 @@ export function parseJsonObject(rawText: string): Record<string, unknown> | null
   return null;
 }
 
-function fallbackGrading(reason: string = 'llm_error'): GradingResponse {
-  return { result: 'wrong', confidence: 0, reason, consolation: null, fallback: true };
+function fallbackGrading(reason: string = 'llm_error'): UnscoredGradingResponse {
+  return { status: 'unscored', reason };
 }
 
 // "General Knowledge" and "Other" must never reach the UI as a broad_category.
@@ -602,7 +612,7 @@ Return only valid JSON with keys: result, confidence, reason, consolation. No ex
     const reason = asTrimmedString(parsed.reason) ?? 'llm_invalid_response';
     const consolation = result === 'wrong' ? asNullableString(parsed.consolation) : null;
 
-    return { result, confidence, reason, consolation };
+    return { status: 'scored', result, confidence, reason, consolation };
   } catch (error) {
     logFallback('gradeAnswerWithLLM', 'request_failed', summarizeError(error));
     return fallbackGrading('request_failed');

--- a/src/server/__tests__/grading-fail-toward-player.test.ts
+++ b/src/server/__tests__/grading-fail-toward-player.test.ts
@@ -19,6 +19,8 @@ describe('gradeAnswer — acceptable variants (B4 Phase 4)', () => {
       ['J.S. Bach', 'Bach'],
       'Who composed the Well-Tempered Clavier?',
     );
+    expect(result.status).toBe('scored');
+    if (result.status !== 'scored') throw new Error('expected scored');
     expect(result.result).toBe('correct');
     expect(result.gradedVia).toBe('exact');
     expect(llmMock.gradeAnswerWithLLM).not.toHaveBeenCalled();
@@ -26,29 +28,41 @@ describe('gradeAnswer — acceptable variants (B4 Phase 4)', () => {
 
   it('is case-insensitive on the variant match', async () => {
     const result = await gradeAnswer('bach', 'Johann Sebastian Bach', ['Bach'], 'q');
+    expect(result.status).toBe('scored');
+    if (result.status !== 'scored') throw new Error('expected scored');
     expect(result.result).toBe('correct');
   });
 });
 
 describe('gradeAnswer — fail toward the player on outage (Drift Risk 2)', () => {
-  it('tags the verdict gradedVia="fallback" when the grader throws', async () => {
-    // gradeAnswer catches the throw and returns the deterministic placeholder.
+  it('returns an UNSCORED outcome (no result field) when the grader throws', async () => {
+    // gradeAnswer catches the throw and returns the unscored outcome.
     llmMock.gradeAnswerWithLLM.mockRejectedValue(new Error('anthropic 529'));
     const result = await gradeAnswer('some answer', 'the real answer', [], 'q');
-    // The sentinel every answer route now branches on to defer instead of
-    // persisting a wrong. The result field is a placeholder, NOT a real verdict.
-    expect(result.gradedVia).toBe('fallback');
-    expect(result.confidence).toBe(0);
+    // The discriminant every answer route now branches on to defer instead of
+    // persisting a wrong. There is NO result field — reading a verdict is impossible.
+    expect(result.status).toBe('unscored');
+    expect(result).not.toHaveProperty('result');
   });
 
-  it('passes through a genuine LLM verdict as gradedVia="llm"', async () => {
+  it('propagates an unscored outcome when the LLM returns one', async () => {
+    llmMock.gradeAnswerWithLLM.mockResolvedValue({ status: 'unscored', reason: 'invalid_json' });
+    const result = await gradeAnswer('some answer', 'the real answer', [], 'q');
+    expect(result.status).toBe('unscored');
+    expect(result).not.toHaveProperty('result');
+  });
+
+  it('passes through a genuine LLM verdict as a scored gradedVia="llm"', async () => {
     llmMock.gradeAnswerWithLLM.mockResolvedValue({
+      status: 'scored',
       result: 'wrong',
       confidence: 0.9,
       reason: 'different person',
       consolation: 'close!',
     });
     const result = await gradeAnswer('wrong answer', 'right answer', [], 'q');
+    expect(result.status).toBe('scored');
+    if (result.status !== 'scored') throw new Error('expected scored');
     expect(result.gradedVia).toBe('llm');
     expect(result.result).toBe('wrong'); // a REAL wrong is a connection event — allowed
   });

--- a/src/server/db/queries/joshing-game.ts
+++ b/src/server/db/queries/joshing-game.ts
@@ -489,7 +489,7 @@ export async function submitJoshingGameResponse(params: {
   );
   // Never persist an outage 'wrong' (Drift Risk 2): bail before any write so the
   // turn is retryable. No response row, no mastery, no asked_count bump.
-  if (grade.gradedVia === 'fallback') {
+  if (grade.status === 'unscored') {
     throw new JoshingGameGraderUnavailableError();
   }
   const isCorrect = grade.result === 'correct';

--- a/src/server/grading.ts
+++ b/src/server/grading.ts
@@ -2,26 +2,40 @@
  * Answer grading — LLM primary, exact-match fast-path for obvious hits.
  * PRD 8.9: answers graded immediately on submission; result shown in session UI.
  * PRD 9.3: case insensitivity, accepted_alternatives treated as correct.
- * PRD 9 / Prompt 1: lenient grader via claude-sonnet-4-6, fallback to 'wrong' on error.
+ * PRD 9 / Prompt 1: lenient grader via claude-sonnet-4-6; on infra failure the
+ * grader returns an UNSCORED outcome (no `result`), never a 'wrong' verdict.
  */
 
 import { gradeAnswerWithLLM } from '@/lib/llm';
 
 export type GradeResult = 'correct' | 'wrong';
 
-export type GradeOutcome = {
+// A genuine, scored verdict — exact-match hit/miss or a real model judgement.
+// `result` is meaningful and may be acted on: a 'wrong' here is a real wrong.
+export type ScoredGrade = {
+  status: 'scored';
   result: GradeResult;
   // "Snarky but Sweet" consolation for thematically-close wrong answers (null otherwise)
   consolation: string | null;
-  // 0..1 from the LLM, or 1 for exact-match. 0 when grading fell back to a
-  // deterministic 'wrong' verdict due to an LLM error.
+  // 0..1 from the LLM, or 1 for exact-match.
   confidence: number;
-  // 'exact' — exact-match fast-path; 'llm' — model verdict;
-  // 'fallback' — model couldn't be reached (timeout, parse error, no client).
-  // Consumers wanting to soften UX on LLM outages should branch on 'fallback'
-  // (e.g. auto-route to /api/daily/recheck, or hold scoring pending review).
-  gradedVia: 'exact' | 'llm' | 'fallback';
+  // 'exact' — exact-match fast-path; 'llm' — model verdict. Retained for
+  // analytics; it is NO LONGER the only thing standing between an outage and a
+  // wrong score (that is now the `status` discriminant below).
+  gradedVia: 'exact' | 'llm';
 };
+
+// The grader could not reach a verdict (timeout, parse error, no client). This
+// is an infrastructure event, NOT a judgement of the answer, so it carries no
+// `result` field — accessing `.result` here is a compile error. Routes MUST
+// branch on `status === 'unscored'` and hold the answer for retry rather than
+// persist a verdict the model never gave.
+export type UnscoredGrade = {
+  status: 'unscored';
+  reason: string;
+};
+
+export type GradeOutcome = ScoredGrade | UnscoredGrade;
 
 /**
  * Fast-path exact match before calling the LLM.
@@ -50,13 +64,16 @@ export async function gradeAnswer(
   questionText: string,
   questionType: string = 'factual'
 ): Promise<GradeOutcome> {
+  // An empty submission is a genuine, deliberate wrong — a real scored verdict,
+  // not an infra failure. (The daily give-up path is the analogous deliberate
+  // wrong on its own route.)
   if (!submitted.trim()) {
-    return { result: 'wrong', consolation: null, confidence: 1, gradedVia: 'exact' };
+    return { status: 'scored', result: 'wrong', consolation: null, confidence: 1, gradedVia: 'exact' };
   }
 
   // Fast-path: skip the LLM for obvious exact matches and accepted alternatives
   if (exactMatch(submitted, canonicalAnswer, acceptedAlternatives)) {
-    return { result: 'correct', consolation: null, confidence: 1, gradedVia: 'exact' };
+    return { status: 'scored', result: 'correct', consolation: null, confidence: 1, gradedVia: 'exact' };
   }
 
   const llmResult = await gradeAnswerWithLLM(
@@ -64,23 +81,24 @@ export async function gradeAnswer(
     canonicalAnswer,
     submitted,
     questionType
-  ).catch((error) => {
-    console.warn('[grading] LLM grading call failed; using deterministic fallback', {
+  ).catch((error): UnscoredGrade => {
+    console.warn('[grading] LLM grading call failed; holding answer unscored', {
       name: error instanceof Error ? error.name : undefined,
       message: error instanceof Error ? error.message : String(error),
     });
-    return {
-      result: 'wrong' as const,
-      confidence: 0,
-      reason: 'llm_error',
-      consolation: null,
-      fallback: true,
-    };
+    return { status: 'unscored', reason: 'llm_error' };
   });
+
+  // Infra failure (timeout, parse error, no client) — never a scored verdict.
+  if (llmResult.status === 'unscored') {
+    return { status: 'unscored', reason: llmResult.reason };
+  }
+
   return {
+    status: 'scored',
     result: llmResult.result,
     consolation: llmResult.consolation ?? null,
     confidence: llmResult.confidence,
-    gradedVia: llmResult.fallback ? 'fallback' : 'llm',
+    gradedVia: 'llm',
   };
 }


### PR DESCRIPTION
## Summary
Restructure the grading system to use a discriminated union (`status: 'scored' | 'unscored'`) instead of relying on a `gradedVia: 'fallback'` sentinel to detect infrastructure failures. This makes it impossible to accidentally treat an outage as a real 'wrong' verdict, aligning with the product thesis that "wrong answers are connection events, not penalties."

## Key Changes

- **Type system overhaul:**
  - Split `GradeOutcome` into `ScoredGrade` (with `result` field) and `UnscoredGrade` (without `result`), combined as a discriminated union
  - Split `GradingResponse` similarly into `ScoredGradingResponse` and `UnscoredGradingResponse`
  - Removed `fallback` boolean flag and `gradedVia: 'fallback'` sentinel; now only `'exact' | 'llm'` are valid
  - Added `status: 'scored' | 'unscored'` discriminant to both types

- **Grading logic (`src/server/grading.ts`):**
  - Empty submissions and exact matches now explicitly return `{ status: 'scored', ... }`
  - LLM errors caught in `.catch()` now return `{ status: 'unscored', reason: 'llm_error' }` instead of a placeholder 'wrong'
  - Added explicit check for `llmResult.status === 'unscored'` to propagate unscored outcomes
  - Removed confidence=0 and reason fields from fallback path (now only in unscored)

- **LLM layer (`src/lib/llm.ts`):**
  - `fallbackGrading()` now returns `UnscoredGradingResponse` with only `status` and `reason`
  - Successful parses return `{ status: 'scored', result, confidence, reason, consolation }`
  - Parse failures and request errors return `{ status: 'unscored', reason }` instead of a deterministic 'wrong'

- **Route handlers (all answer endpoints):**
  - Changed all checks from `grade.gradedVia === 'fallback'` to `grade.status === 'unscored'`
  - Updated comments to reflect that unscored outcomes are infrastructure events, not verdicts
  - Give-up paths explicitly construct `{ status: 'scored', result: 'wrong', ... }` to distinguish from outages

- **Tests:**
  - Updated test assertions to check `status` discriminant and verify absence of `result` field on unscored outcomes
  - Added type guards (`if (result.status !== 'scored') throw ...`) to narrow types in tests

## Implementation Details

The change is **purely structural** — no grading logic or behavior changes. The key insight is that by making `result` inaccessible on unscored outcomes (via TypeScript's type system), we prevent accidental scoring of outages as wrong. All route handlers already had the correct retry logic; this change makes it impossible to bypass that logic by accident.

The `gradedVia` field is retained on scored outcomes for analytics but is no longer the discriminant between "real verdict" and "outage."

https://claude.ai/code/session_011JmJTr6g1DqEgGXiXUjjWs