### PR TITLE
Cycle placeholder examples in question composer

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -532,9 +532,28 @@ export function buildQuestionWriterHref(idea: string): string {
     : '/questions?create=1&intent=bank'
 }
 
+// Example questions the composer placeholder cycles through, one every few
+// seconds, so the prompt keeps suggesting the kind of thing worth asking.
+const CONTRIBUTE_PLACEHOLDER_EXAMPLES = [
+  'Who was the main character in Catch 22?',
+  'Who starred in the Tim Burton Batman films?',
+  'Who was the 16th president of the United States?',
+] as const
+
+const CONTRIBUTE_PLACEHOLDER_INTERVAL_MS = 4000
+
 function FeedContributeFooter() {
   const router = useRouter()
   const [idea, setIdea] = useState('')
+  const [placeholderIndex, setPlaceholderIndex] = useState(0)
+
+  // Circulate the placeholder through the example questions every few seconds.
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setPlaceholderIndex((index) => (index + 1) % CONTRIBUTE_PLACEHOLDER_EXAMPLES.length)
+    }, CONTRIBUTE_PLACEHOLDER_INTERVAL_MS)
+    return () => clearInterval(timer)
+  }, [])
 
   function handleSubmit(event: React.FormEvent) {
     event.preventDefault()
@@ -581,7 +600,7 @@ function FeedContributeFooter() {
               <textarea
                 value={idea}
                 onChange={(event) => setIdea(event.target.value)}
-                placeholder="Who was the main character in Catch 22?"
+                placeholder={CONTRIBUTE_PLACEHOLDER_EXAMPLES[placeholderIndex]}
                 aria-label="What question would you like to be asked?"
                 rows={5}
                 className="min-h-[200px] w-full resize-none rounded-[8px] border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-3 text-base text-[var(--brand-ink)] placeholder:text-[var(--brand-ink-400)] outline-none focus:border-[var(--brand-link)]"


### PR DESCRIPTION
## Summary
Updated the question composer footer to cycle through multiple example placeholder texts instead of showing a static prompt. This provides better UX by continuously suggesting different types of questions users can ask.

## Changes
- Added `CONTRIBUTE_PLACEHOLDER_EXAMPLES` constant with three example questions
- Added `CONTRIBUTE_PLACEHOLDER_INTERVAL_MS` constant (4 seconds) to control rotation speed
- Introduced `placeholderIndex` state to track the current example
- Added `useEffect` hook to rotate through examples on a timer, cycling back to the start when reaching the end
- Updated the textarea placeholder binding to use the dynamic example instead of the hardcoded "Who was the main character in Catch 22?" text

## Implementation details
- The interval timer is properly cleaned up on component unmount to prevent memory leaks
- The placeholder index cycles using modulo arithmetic: `(index + 1) % CONTRIBUTE_PLACEHOLDER_EXAMPLES.length`
- Examples cover different question types (literature, film, history) to demonstrate the range of acceptable queries

https://claude.ai/code/session_01GX9pEfrt3nnLcp2jf45kJ9