### PR TITLE
Hard-block safety-failed questions from all surfaces

### DIFF
--- a/drizzle/0069_question_visibility_blocked.sql
+++ b/drizzle/0069_question_visibility_blocked.sql
@@ -1,0 +1,17 @@
+-- Migration: QuestionVisibility 'blocked' terminal state.
+--
+-- Adds a 'blocked' value to QuestionVisibility for questions that fail the
+-- safety vet (slurs, harassment, sexual content involving minors, doxxing).
+-- Unlike 'rejected' publicStatus — which only keeps a question out of the
+-- public pool while leaving it shareable to friends — 'blocked' is a hard
+-- block: questionVisibilityPredicate and every bank/send/game read path
+-- already exclude any visibility outside ('public','friends'), so a blocked
+-- question can never reach a recipient feed, a direct send, a Joshing Game,
+-- or the daily pool, and can never be flipped back to a shareable state.
+--
+-- An idempotent guard mirroring this enum addition also lands in
+-- src/instrumentation.ts so preview/production databases that may have this
+-- migration recorded without the value actually present can still boot
+-- (Postgres forbids referencing a newly-added enum value inside the same
+-- transaction that adds it, and Drizzle wraps the migrator in a transaction).
+ALTER TYPE "public"."QuestionVisibility" ADD VALUE IF NOT EXISTS 'blocked';

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -484,6 +484,13 @@
       "when": 1782432000000,
       "tag": "0068_acceptable_variants",
       "breakpoints": true
+    },
+    {
+      "idx": 69,
+      "version": "7",
+      "when": 1782518400000,
+      "tag": "0069_question_visibility_blocked",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/vet-questions/route.ts
+++ b/src/app/api/cron/vet-questions/route.ts
@@ -4,6 +4,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { db, questions } from '@/server/db';
 import { runWithConcurrency } from '@/server/lib/concurrency';
 import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
+import { verdictToBlockedVisibility } from '@/server/llm/vet-verdict';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -69,6 +70,12 @@ export async function GET(request: NextRequest) {
         canonicalSubcategory: row.canonicalSubcategory,
       });
       const scoring = verdictToPublicStatus(verdict);
+      // This sweep only scans visibility='public' rows (see query above), so it
+      // never re-vets an already-blocked question and can never flip one back to
+      // shareable. But it CAN be the first place a safety-fail is detected (when
+      // the inline create vet returned needs_review on a Haiku error/unknown).
+      // In that case apply the same hard-block the create route does.
+      const blockedVisibility = verdictToBlockedVisibility(verdict);
 
       // Skip the update when we'd just re-write 'not_scored' with the same
       // null score — the row was already in that state and nothing changed.
@@ -82,6 +89,7 @@ export async function GET(request: NextRequest) {
             publicStatus: scoring.publicStatus,
             publicEligibilityScore: scoring.publicEligibilityScore,
             publicEligibilityReason: scoring.publicEligibilityReason,
+            ...(blockedVisibility ? { visibility: blockedVisibility } : {}),
             updatedAt: new Date(),
           })
           .where(eq(questions.id, row.id));

--- a/src/app/api/joshing-games/route.ts
+++ b/src/app/api/joshing-games/route.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, isNotNull, isNull, or } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, isNull, ne, or } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
@@ -108,6 +108,11 @@ export async function POST(request: NextRequest) {
       .where(and(
         inArray(questions.id, uniqueQuestionIds),
         isNull(questions.deletedAt),
+        // Safety hard-block: a question that failed the safety vet
+        // (visibility='blocked') can never be added to a Joshing Game, even
+        // one the author owns. Excluding it here drops it from allowedQuestionIds
+        // so the size check below 400s the request.
+        ne(questions.visibility, 'blocked'),
         or(eq(questions.creatorId, session.userId), isNotNull(userQuestionBank.id)),
       )),
   ]);

--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -518,6 +518,34 @@ describe('POST /api/questions category leak handling', () => {
     expect(createArgs.publicStatus).toBe('eligible_pending')
   })
 
+  it('hard-blocks a safety-fail verdict: saves as visibility blocked, skips all fan-out, returns a non-graphic content-check error', async () => {
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'Victorian Literature',
+    })
+    // Real verdictToBlockedVisibility (vet-verdict is not mocked) keys off rejectionKind.
+    vetQuestionMock.mockResolvedValue({ status: 'rejected', score: 0.1, reason: 'safety: …', rejectionKind: 'safety' })
+    getFriendsMock.mockResolvedValue([{ id: 'friend-1', displayName: 'Friend One' }])
+
+    const response = await POST(questionRequest({ shareToFeed: true, sendToFriendIds: [] }))
+    const body = await response.json()
+
+    expect(response.status).toBe(422)
+    expect(body.error).toBe('failed_content_check')
+    // Must not echo or name the triggered safety category.
+    expect(JSON.stringify(body)).not.toMatch(/slur|harass|minor|doxx|safety/i)
+
+    // Persisted as blocked so it can never be re-shared, even from the bank.
+    expect(createQuestionMock).toHaveBeenCalledTimes(1)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { visibility?: string; publicStatus: string }
+    expect(createArgs.visibility).toBe('blocked')
+    expect(createArgs.publicStatus).toBe('rejected')
+
+    // No fan-out: no broadcast or direct-send feed rows in the same request.
+    expect(state.feedInsertValues).toEqual([])
+    expect(state.questionUpdateValues).toEqual([])
+  })
+
   it('returns 500 with a friendly message when an enrichment step throws', async () => {
     categorizeQuestionMock.mockResolvedValue({
       broad_category: 'Arts & Literature',

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -4,6 +4,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { broadCategoryDisplayName, normalizeBroadQuestionCategoryOrDefault, normalizeCanonicalSubcategory } from '@/lib/question-categorization';
 import { categorizeQuestion, generateInsideJoke } from '@/lib/llm';
 import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
+// Imported from vet-verdict (not vet-question) so it resolves to the real
+// pure mapper even where vet-question is mocked.
+import { verdictToBlockedVisibility } from '@/server/llm/vet-verdict';
 import { getSession } from '@/server/auth/session';
 import { db, feedDismissedDomains, feedItems, questions, users } from '@/server/db';
 import {
@@ -188,6 +191,12 @@ export async function POST(request: NextRequest) {
     );
   }
   let publicScoring = verdictToPublicStatus(verdict);
+  // Safety-fail verdicts are hard-blocked from every surface: we override the
+  // saved visibility to 'blocked' (a state questionVisibilityPredicate and all
+  // bank/send/game read paths exclude) and skip ALL fan-out below. This is
+  // safety-only — factual/quality/answer-leaked rejections stay publicStatus
+  // signals and remain shareable to friends.
+  const blockedVisibility = verdictToBlockedVisibility(verdict);
   if (categoryLeaksAnswer && publicScoring.publicStatus !== 'rejected') {
     publicScoring = {
       publicStatus: 'rejected',
@@ -228,8 +237,27 @@ export async function POST(request: NextRequest) {
     publicStatus: publicScoring.publicStatus,
     publicEligibilityScore: publicScoring.publicEligibilityScore,
     publicEligibilityReason: publicScoring.publicEligibilityReason,
+    // Override any user-chosen visibility on a safety hard-block. Placed after
+    // the spread so it wins over categorizedQuestionFields.visibility.
+    ...(blockedVisibility ? { visibility: blockedVisibility } : {}),
   });
   console.info('[questions/create]', { questionId: created.id, userId: session.userId, verified: categorizedQuestionFields.verified, category: categorizedQuestionFields.category, canonicalSubcategory: categorizedQuestionFields.canonicalSubcategory, difficultyTier: difficultyAssessment.tier });
+
+  // Safety hard-block: short-circuit BEFORE any fan-out (broadcast + direct
+  // send), KB-domain opening, and the success payload. The question is saved
+  // as 'blocked' (in the author's bank, but unshareable) and must not reach any
+  // recipient feed even in this same request. We do not name the triggered
+  // category. Matches the existing creation-error response shape.
+  if (blockedVisibility) {
+    console.info('[questions/create] safety_blocked', { questionId: created.id, userId: session.userId });
+    return NextResponse.json(
+      {
+        error: 'failed_content_check',
+        message: "We couldn't publish or share that question because it didn't pass a content check.",
+      },
+      { status: 422 },
+    );
+  }
   const feedShare = {
     requested: shareToFeed,
     createdCount: 0,

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -59,6 +59,17 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // Safety hard-block: a question that failed the safety vet is marked
+  // visibility='blocked' and can never be sent to a recipient, even by its
+  // author. The feed render predicate would hide it anyway, but reject at the
+  // entry point so no feed row is written. Non-graphic message; category not named.
+  if (question[0].visibility === 'blocked') {
+    return NextResponse.json(
+      { error: 'invalid_question', message: "That question can't be sent because it didn't pass a content check." },
+      { status: 400 },
+    );
+  }
+
   const [alreadyCorrect, alreadyInFeed] = await Promise.all([
     userAnsweredQuestionCorrectly(parsed.recipientUserId, sendableQuestionId!),
     userHasQuestionInBlockingFeed(parsed.recipientUserId, sendableQuestionId!),

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -794,6 +794,18 @@ export async function register() {
       // QuestionVisibility may not exist yet on a fresh database — migrate()
       // creates it before this migration runs.
     }
+    // Migration 0069 adds a 'blocked' value to QuestionVisibility for questions
+    // that fail the safety vet. Pre-applied here for the same reason as 'friends'
+    // above: code paths that read/compare 'blocked' from a preview database where
+    // 0069 is recorded-but-not-fully-applied would 22P02 without this guard.
+    try {
+      await db.execute(sql`
+        ALTER TYPE "public"."QuestionVisibility" ADD VALUE IF NOT EXISTS 'blocked'
+      `);
+    } catch {
+      // QuestionVisibility may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
     try {
       await db.execute(sql`
         DO $$

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -58,8 +58,13 @@ type MachineRow = typeof generatedQuestions.$inferSelect;
 type HumanRow = typeof questions.$inferSelect;
 
 /** Human Question.visibility → unified pool scope. */
-export function visibilityToScope(visibility: 'private' | 'public' | 'friends'): PoolScope {
-  return visibility === 'friends' ? 'friends_only' : visibility;
+export function visibilityToScope(visibility: 'private' | 'public' | 'friends' | 'blocked'): PoolScope {
+  if (visibility === 'friends') return 'friends_only';
+  // 'blocked' is a safety hard-block and is never poolable; collapse it to the
+  // most restrictive scope so it can never widen reach even if a future caller
+  // wires selectFromPool without an explicit scope filter.
+  if (visibility === 'blocked') return 'private';
+  return visibility;
 }
 
 /** Empirical played rate, uniform across origins: correct/asked when there is

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -412,7 +412,9 @@ export async function createQuestion(params: {
   publicStatus?: 'not_scored' | 'eligible_pending' | 'rejected' | 'opted_out' | 'migrated';
   publicEligibilityScore?: number | null;
   publicEligibilityReason?: string | null;
-  visibility?: 'public' | 'friends' | 'private';
+  // 'blocked' is set by the create route on a safety-fail vet verdict; it is
+  // not user-selectable. See verdictToBlockedVisibility.
+  visibility?: 'public' | 'friends' | 'private' | 'blocked';
 }): Promise<{ id: string }> {
   await ensureQuestionSurfacePriorityColumn();
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -38,7 +38,10 @@ export const categoryEnum = pgEnum('Category', [
   'general_knowledge',
 ]);
 
-export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends']);
+// 'blocked' is a safety hard-block terminal state (see verdictToBlockedVisibility):
+// a question that failed the safety vet. It is NOT user-selectable and is excluded
+// by questionVisibilityPredicate and every bank/send/game read path.
+export const questionVisibilityEnum = pgEnum('QuestionVisibility', ['private', 'public', 'friends', 'blocked']);
 
 // B1 pool substrate (PRD-D-5 §5.1 / §6). Trust climbs as a question earns it:
 // unverified (fresh, pre-checks) → machine_verified (retrieval + ask-to-answer,

--- a/src/server/llm/vet-question.ts
+++ b/src/server/llm/vet-question.ts
@@ -140,12 +140,14 @@ export async function vetQuestion(input: VetQuestionInput): Promise<VetVerdict> 
   const answerLeaked = parsed.answer_leaked === true;
   const reason = trimmed(parsed.reason, 'vetted');
 
-  // Hard rejects first.
-  if (factual === 'fail') return { status: 'rejected', score: overall, reason: `factual: ${reason}` };
-  if (safety === 'fail') return { status: 'rejected', score: overall, reason: `safety: ${reason}` };
-  if (answerLeaked) return { status: 'rejected', score: overall, reason: `answer in question: ${reason}` };
+  // Hard rejects first. rejectionKind discriminates which dimension failed;
+  // only 'safety' triggers the visibility hard-block downstream (the others
+  // stay public-pool signals that remain shareable to friends).
+  if (factual === 'fail') return { status: 'rejected', score: overall, reason: `factual: ${reason}`, rejectionKind: 'factual' };
+  if (safety === 'fail') return { status: 'rejected', score: overall, reason: `safety: ${reason}`, rejectionKind: 'safety' };
+  if (answerLeaked) return { status: 'rejected', score: overall, reason: `answer in question: ${reason}`, rejectionKind: 'answer_leaked' };
   if (quality < QUALITY_APPROVAL_THRESHOLD) {
-    return { status: 'rejected', score: overall, reason: `quality ${quality.toFixed(2)}: ${reason}` };
+    return { status: 'rejected', score: overall, reason: `quality ${quality.toFixed(2)}: ${reason}`, rejectionKind: 'quality' };
   }
 
   // Cannot verify the fact, but no other red flags — let a human (or a later

--- a/src/server/llm/vet-verdict.ts
+++ b/src/server/llm/vet-verdict.ts
@@ -5,9 +5,14 @@
  * pulling in the Anthropic SDK.
  */
 
+// Which dimension caused a rejection. Only 'safety' is a hard block (see
+// verdictToBlockedVisibility); the rest stay public-pool-eligibility signals
+// that remain shareable to friends.
+export type VetRejectionKind = 'factual' | 'safety' | 'quality' | 'answer_leaked';
+
 export type VetVerdict =
   | { status: 'approved'; score: number; reason: string }
-  | { status: 'rejected'; score: number; reason: string }
+  | { status: 'rejected'; score: number; reason: string; rejectionKind: VetRejectionKind }
   | { status: 'needs_review'; score: number | null; reason: string };
 
 export function verdictToPublicStatus(verdict: VetVerdict): {
@@ -35,4 +40,21 @@ export function verdictToPublicStatus(verdict: VetVerdict): {
         publicEligibilityReason: verdict.reason,
       };
   }
+}
+
+/**
+ * Safety-failed questions (slurs, harassment, sexual content involving minors,
+ * doxxing) must be hard-blocked from every surface, not merely kept out of the
+ * public pool: the harm is to the recipient and friend-trust is not a defense.
+ * We map them to visibility = 'blocked', a terminal state excluded by
+ * questionVisibilityPredicate and every bank/send/game read path, so the
+ * question can never reach a recipient or be re-shared — even by its author,
+ * and even if it remains in the author's bank. publicStatus is independently
+ * still set to 'rejected' by verdictToPublicStatus.
+ *
+ * Factual / quality / answer-leaked rejections are deliberately NOT blocked:
+ * they remain publicStatus-only signals and stay shareable to friends.
+ */
+export function verdictToBlockedVisibility(verdict: VetVerdict): 'blocked' | null {
+  return verdict.status === 'rejected' && verdict.rejectionKind === 'safety' ? 'blocked' : null;
 }


### PR DESCRIPTION
## Summary
Implements a safety hard-block mechanism for questions that fail the safety vet (slurs, harassment, sexual content involving minors, doxxing). These questions are now marked with `visibility='blocked'` — a terminal state that prevents them from reaching any recipient surface, even when shared by their author to friends.

## Key Changes

- **New `VetRejectionKind` type** (`vet-verdict.ts`): Discriminates rejection dimensions (`'factual'`, `'safety'`, `'quality'`, `'answer_leaked'`). Only `'safety'` triggers the hard-block; other rejections remain public-pool-eligibility signals and stay shareable to friends.

- **`verdictToBlockedVisibility()` mapper** (`vet-verdict.ts`): Pure function that returns `'blocked'` for safety-failed verdicts, `null` otherwise. Imported directly from `vet-verdict` (not `vet-question`) so it resolves to the real implementation even where `vet-question` is mocked in tests.

- **Question creation hard-block** (`questions/route.ts`): When a safety-fail verdict is detected, the question is persisted with `visibility='blocked'` and the response short-circuits before any fan-out (broadcast, direct send, KB-domain opening). Returns a non-graphic 422 error (`failed_content_check`) that does not name the triggered safety category.

- **Question send rejection** (`questions/send/route.ts`): Rejects attempts to send a blocked question with a 400 error, preventing feed rows from being written.

- **Joshing Game exclusion** (`joshing-games/route.ts`): Blocked questions are excluded from game candidate pools via `ne(questions.visibility, 'blocked')`.

- **Pool scope mapping** (`pool.ts`): `visibilityToScope()` collapses `'blocked'` to `'private'` so blocked questions can never widen reach even if a future caller wires `selectFromPool` without an explicit scope filter.

- **Cron vet sweep** (`cron/vet-questions/route.ts`): When the background vet sweep detects a safety-fail on a previously-unvetted question (e.g., when inline create returned `needs_review` on a Haiku error), it applies the same hard-block the create route does.

- **Database migration** (`0069_question_visibility_blocked.sql`): Adds `'blocked'` value to the `QuestionVisibility` enum. Idempotent guard pre-applied in `src/instrumentation.ts` to handle preview/production databases where the migration is recorded but not fully applied.

- **Schema and type updates**: `questionVisibilityEnum` extended to include `'blocked'`; `createQuestion()` parameter type updated to accept `'blocked'` visibility.

## Notable Implementation Details

- **Safety-only hard-block**: Factual, quality, and answer-leaked rejections deliberately remain shareable to friends. Only safety failures trigger the visibility hard-block.

- **Non-graphic error messaging**: The 422 and 400 responses use generic language (`"didn't pass a content check"`) and do not echo or name the triggered safety category (verified by test regex).

- **Terminal state**: `'blocked'` is excluded by `questionVisibilityPredicate` and every bank/send/game read path, so a blocked question can never be re-shared or flipped back to a shareable state, even by its author.

- **Test coverage**: New test case verifies the hard-block flow: safety-fail verdict → 422 response with non-graphic error → question persisted as `visibility='blocked'` and `publicStatus='rejected'` → no fan-out feed rows written.

https://claude.ai/code/session_01AbQrhoyJADo48oatf8wyXL