### PR TITLE
Add fan-salience and strip-the-domain rules to question generation

### DIFF
--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -72,6 +72,26 @@ GOOD (open recall):
 TRIVIA-OF-TRIVIA RULE:
 Prefer questions of substance — "what is X", "what does X mean", "why does X matter", "who did X" — over questions of mere recall — "what year", "what number", "what label". A date, a count, or a name is worth asking only when that specific fact is itself meaningful; a question that lands on substance is almost always the better question. Lead with the idea, not the index card.
 
+FAN-SALIENCE RULE (Rule 1 — tier-dependent):
+Do NOT default to the most nameable entity in a work — the character roster, the title, the principal location. Those are wiki-salient (easy to look up, dull to be asked). Chase fan-salient facts instead: the thing a devoted fan of THIS specific work would be delighted to be recognized for knowing — the rewatch-catch, the running joke, the exact wording of a famous line, the specific beat or object fans hold onto. Apply by difficulty tier:
+- specialist and moderate: the question MUST clear fan-salience. A generic "name the entity" question is a FAILURE at these tiers, even if factually correct.
+- accessible: fan-salience is PREFERRED but NOT required. Easy facts are allowed to stay simple — forcing delight onto a trivially easy fact produces strained, contorted questions. An accessible question need only clear Rule 2 below. Do not make accessible questions harder to satisfy this rule.
+
+STRIP-THE-DOMAIN TEST (Rule 2 — hard floor, ALL tiers including accessible):
+Before emitting, mentally remove the work's title from the question. If what remains could appear in any generic trivia app, the question is too generic — revise it. The angle, not just the subject, must be specific to the work.
+- PASSES: "In American Psycho, what color is Paul Allen's business card?" — strip the title and the angle is still specific to the work.
+- FAILS: "In Gilmore Girls, what is the name of Rory's first boyfriend?" — strip the title and it is generic teen-romance trivia.
+
+ONE CLEAN ANSWER (Rule 3 — ALL tiers):
+The answer must be a single short, checkable response — a name, a title, a word, a short phrase. NEVER a sentence or paragraph that explains the answer. If the natural answer is explanatory (e.g. "he understands the language of birds"), re-aim the question so the answer is crisp (e.g. ask what specific ability the potion grants → "birdsong"). Paragraph-length answers grade unpredictably and must not be produced. (This sharpens, but does not relax, the single-answer factual-recall and no-answer-leak rules above — a cleverer setup still must not name its own answer.)
+
+CALIBRATION PAIRS (generic → fan-salient; study these — concrete pairs calibrate harder than abstract principles):
+- BAD (generic, roster): "In Gilmore Girls, what is the name of Lorelai's dog?" → GOOD (fan-salient, same answer): "Lorelai names her dog after a Canadian crooner — a running gag, since the real musician also haunts her dreams. What's the dog called?" → "Paul Anka"
+- BAD (generic location): "In what city is the Dragonfly Inn located?" → GOOD (accessible, clears strip-the-domain): "Lorelai and Sookie's inn shares the town's quirk of naming businesses after insects. What's it called?" → "the Dragonfly Inn"
+- BAD (generic, title): "In American Psycho, what is the protagonist's name?" → GOOD (specialist, fan-salient): "In American Psycho, what color is Paul Allen's business card?" → "bone"
+- BAD (paragraph answer): "What does Siegfried gain after tasting the dragon's blood?" → "He suddenly understands the language of the birds." → GOOD (one clean answer): "After tasting Fafner's blood, Siegfried can suddenly understand the song of which creatures?" → "birds"
+- GOOD reference (already on-target, specialist): the unproduced Dungeons & Dragons animated finale that fans still trade the script of → "Requiem"
+
 STYLE EXEMPLARS (match this register, specificity, and concision):
 These are gold-standard Joshing questions. Mimic their tone — literate, confident, and specific. Pull from comparable depth (named characters, named works, technical terms, specific years, named figures) rather than vague appreciation or "explain why" questions. Notice how they assume a cultured audience without condescension.
 


### PR DESCRIPTION
## Summary
Expanded the question generation prompt with three new calibration rules to improve question quality by prioritizing fan-specific knowledge over generic trivia, ensuring questions remain work-specific after removing the title, and enforcing crisp single-answer responses.

## Changes
- **FAN-SALIENCE RULE (Rule 1):** Added tier-dependent guidance to prefer questions that devoted fans would recognize — rewatch-catches, running jokes, exact phrasings — over generic roster/location/title questions. Mandatory for specialist and moderate tiers; preferred but not required for accessible tier.
- **STRIP-THE-DOMAIN TEST (Rule 2):** Introduced a hard-floor validation rule across all tiers: questions must remain work-specific even when the title is removed. Prevents generic trivia that could appear in any app.
- **ONE CLEAN ANSWER (Rule 3):** Clarified that answers must be single, short, checkable responses (name, word, phrase) — never sentences or paragraphs. Includes guidance on re-aiming questions to produce crisp answers.
- **CALIBRATION PAIRS:** Added five concrete before/after examples showing the progression from generic to fan-salient questions, with specific Gilmore Girls and American Psycho examples that illustrate the rules in practice.

## Implementation Details
- Rules are presented in order of application: Rule 1 (fan-salience) is tier-dependent, Rule 2 (strip-the-domain) is a universal floor, Rule 3 (clean answers) applies everywhere.
- Calibration pairs use real show/book examples to make the principles concrete and actionable for the LLM.
- The examples show both the transformation (BAD → GOOD) and the final answer, making it clear what the expected output should be.

https://claude.ai/code/session_01ARCm7HnBavJHBJsW8FMmvP