### PR TITLE
Extract answer heading style and apply to correct answer

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -146,6 +146,17 @@ const monoStyle: CSSProperties = {
   letterSpacing: '0.06em',
 };
 
+// The answer, repeated as a prominent serif headline on the result card —
+// mirrors the feed reveal treatment ("eyebrow → answer as headline →
+// explanation"). Shared by the correct and wrong cards so the two stay in
+// sync; bumped up from the previous 1.4875rem so the answer reads clearly.
+const answerHeadingStyle: CSSProperties = {
+  fontFamily: 'var(--font-cormorant), Georgia, serif',
+  fontSize: '1.65rem',
+  fontWeight: 700,
+  lineHeight: 1.14,
+};
+
 // Darkened triangle-gold so warning/inside-joke labels clear AA on the cream
 // surface (raw --tri-amber #d9a82e is too light for small text). Mirrors the
 // GOLD_INK used on the feed answer sheets.
@@ -915,6 +926,11 @@ function ResultRow({
               <span style={{ color: 'var(--game-correct)', marginRight: '6px' }}>✓</span>
               {copy.headline}
             </p>
+            {correctAnswer ? (
+              <p style={{ ...answerHeadingStyle, marginTop: '8px', color: 'var(--game-correct)' }}>
+                {correctAnswer}
+              </p>
+            ) : null}
             <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '4px' }}>
               {copy.subLabel}
             </p>
@@ -954,13 +970,10 @@ function ResultRow({
             {correctAnswer ? (
               <p
                 style={{
+                  ...answerHeadingStyle,
                   marginTop: '8px',
                   // Figma question/game/answer — Cormorant Bold, scaled to match question text.
-                  fontFamily: 'var(--font-cormorant), Georgia, serif',
-                  fontSize: '1.4875rem',
-                  fontWeight: 700,
                   color: 'var(--brand-ink)',
-                  lineHeight: 1.14,
                 }}
               >
                 {correctAnswer}


### PR DESCRIPTION
## Summary
Refactors the answer heading styling in the result card by extracting repeated style properties into a reusable `answerHeadingStyle` constant, then applies it consistently across both correct and wrong answer displays. Also adds the answer heading to the correct answer card, which was previously missing.

## Changes
- **New style constant:** Created `answerHeadingStyle` with Cormorant serif font, 1.65rem size, bold weight, and 1.14 line height. Includes a detailed comment explaining the design rationale (mirrors feed reveal treatment, bumped up from 1.4875rem for clarity).
- **Correct answer card:** Added the correct answer as a prominent heading in the correct answer card (was previously absent), styled with the new constant and green color (`var(--game-correct)`).
- **Wrong answer card:** Refactored existing answer heading to use the extracted `answerHeadingStyle` constant, removing inline style duplication. Maintains the brand ink color and all other properties.

## Implementation Details
- The answer heading now appears consistently on both card types with synchronized styling
- Font size increased from 1.4875rem to 1.65rem for improved readability
- Margin and color overrides are applied locally while the base typography is centralized
- Follows the existing pattern of feed reveal treatment (eyebrow → answer as headline → explanation)

https://claude.ai/code/session_01UEDRADMrZwHpuGJXeahCxE