### PR TITLE
Add incremental declared-interest API with cap enforcement

### DIFF
--- a/src/app/api/declared-interests/route.ts
+++ b/src/app/api/declared-interests/route.ts
@@ -1,9 +1,20 @@
 import { and, asc, eq } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { db, declaredInterests } from '@/server/db';
-import { type DeclaredInterestInput, saveDeclaredInterests } from '@/server/db/queries/users';
+import {
+  addDeclaredInterest,
+  DeclaredInterestLimitError,
+  type DeclaredInterestInput,
+  saveDeclaredInterests,
+} from '@/server/db/queries/users';
+
+const addInterestSchema = z.object({
+  label: z.string().trim().min(1).max(80),
+  broadCategory: z.string().trim().max(80).optional(),
+});
 
 type DeclaredInterestsBody = {
   interests?: unknown;
@@ -66,6 +77,44 @@ export async function GET() {
       declaredAt: interest.declaredAt.toISOString(),
     })),
   });
+}
+
+// Append a single interest without replacing the existing list (PATCH replaces).
+// Backs the "add a topic" field on the daily setup screen.
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = addInterestSchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Enter a topic name (up to 80 characters).' },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await addDeclaredInterest(session.userId, {
+      label: parsed.data.label,
+      broadCategory: parsed.data.broadCategory ?? null,
+    });
+    return NextResponse.json({
+      domain: result.domain,
+      broadCategory: result.broadCategory,
+      tier: 'establishing',
+      totalPoints: 0,
+      created: result.created,
+    });
+  } catch (error) {
+    if (error instanceof DeclaredInterestLimitError) {
+      return NextResponse.json(
+        { error: 'interest_limit_reached', message: error.message },
+        { status: 409 },
+      );
+    }
+    const message = error instanceof Error ? error.message : 'Could not add that topic.';
+    return NextResponse.json({ error: 'add_failed', message }, { status: 400 });
+  }
 }
 
 export async function PATCH(request: Request) {

--- a/src/app/daily/setup/page.tsx
+++ b/src/app/daily/setup/page.tsx
@@ -94,6 +94,10 @@ function DailySetupContent() {
   const [adaptiveLabel, setAdaptiveLabel] = useState<string | null>(null);
   const [hasUnstartedQueue, setHasUnstartedQueue] = useState(false);
   const [roundComplete, setRoundComplete] = useState(false);
+  const [newTopic, setNewTopic] = useState('');
+  const [addingTopic, setAddingTopic] = useState(false);
+  const [addError, setAddError] = useState<string | null>(null);
+  const [addLimitReached, setAddLimitReached] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -183,6 +187,47 @@ function DailySetupContent() {
       return next;
     });
   }, []);
+
+  const addTopic = useCallback(async () => {
+    const label = newTopic.trim();
+    if (!label || addingTopic) return;
+    setAddingTopic(true);
+    setAddError(null);
+    setAddLimitReached(false);
+
+    try {
+      const response = await fetch('/api/declared-interests', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ label }),
+      });
+      const body = await response.json().catch(() => null);
+      if (!response.ok) {
+        setAddLimitReached(body?.error === 'interest_limit_reached');
+        throw new Error(body?.message ?? 'Could not add that topic.');
+      }
+
+      const row: DomainRow = {
+        domain: body.domain,
+        broadCategory: body.broadCategory ?? null,
+        totalPoints: typeof body.totalPoints === 'number' ? body.totalPoints : 0,
+        tier: body.tier ?? 'establishing',
+      };
+      const key = row.domain.toLocaleLowerCase('en-US');
+      setDomains((existing) =>
+        existing.some((entry) => entry.domain.toLocaleLowerCase('en-US') === key)
+          ? existing
+          : [...existing, row],
+      );
+      setSelectedDomains((existing) => new Set(existing).add(row.domain));
+      setNewTopic('');
+    } catch (caught) {
+      setAddError(caught instanceof Error ? caught.message : 'Could not add that topic.');
+    } finally {
+      setAddingTopic(false);
+    }
+  }, [addingTopic, newTopic]);
 
   const startRound = useCallback(async () => {
     if (!canStart) return;
@@ -339,6 +384,49 @@ function DailySetupContent() {
           </p>
         ) : (
           <div>
+            <form
+              onSubmit={(event) => {
+                event.preventDefault();
+                void addTopic();
+              }}
+              className="mb-5"
+            >
+              <label
+                htmlFor="add-topic"
+                className="mb-2 block text-xs font-medium uppercase tracking-[0.12em] text-muted-foreground"
+              >
+                Add a topic
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="add-topic"
+                  type="text"
+                  value={newTopic}
+                  onChange={(event) => setNewTopic(event.target.value)}
+                  placeholder="e.g. Byzantine Coinage"
+                  maxLength={80}
+                  autoComplete="off"
+                  className="min-h-11 flex-1 rounded-md border bg-card px-3 text-sm text-foreground placeholder:text-muted-foreground/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                />
+                <button type="submit" className="btn-ghost px-4" disabled={addingTopic || !newTopic.trim()}>
+                  {addingTopic ? 'Adding…' : 'Add'}
+                </button>
+              </div>
+              {addError ? (
+                <p className="mt-2 text-sm text-destructive">
+                  {addError}
+                  {addLimitReached ? (
+                    <>
+                      {' '}
+                      <Link href="/knowledge" className="underline">
+                        Manage interests
+                      </Link>
+                    </>
+                  ) : null}
+                </p>
+              ) : null}
+            </form>
+
             <div className="mb-4 inline-grid grid-cols-2 rounded-full border bg-card p-1 text-xs font-medium uppercase tracking-[0.08em]">
               {[
                 { value: 'category', label: 'By Category' },

--- a/src/server/db/queries/__tests__/add-declared-interest.test.ts
+++ b/src/server/db/queries/__tests__/add-declared-interest.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// vi.hoisted so the (hoisted) vi.mock factories below can reference these.
+const { categorizeInterestDomainMock } = vi.hoisted(() => ({
+  categorizeInterestDomainMock: vi.fn(),
+}));
+
+// Mutable fixture for the "currently active declared interests" the select
+// returns — each test sets it to drive the cap / idempotency branches.
+const state = vi.hoisted(() => ({
+  activeRows: [] as Array<{ domain: string; broadCategory: string | null }>,
+}));
+
+// Keep the real isCatchAllBroadCategory logic; only stub the LLM call.
+vi.mock('@/server/llm/interests', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/server/llm/interests')>();
+  return { ...actual, categorizeInterestDomain: categorizeInterestDomainMock };
+});
+
+const selectChain = () => {
+  const c: Record<string, unknown> = {};
+  c.from = () => c;
+  c.where = () => Promise.resolve(state.activeRows);
+  return c;
+};
+
+const txChain = () => {
+  const c: Record<string, unknown> = {};
+  c.values = () => c;
+  c.onConflictDoUpdate = () => Promise.resolve();
+  c.onConflictDoNothing = () => Promise.resolve();
+  return c;
+};
+
+vi.mock('@/server/db', () => ({
+  db: {
+    select: () => selectChain(),
+    transaction: async (cb: (tx: unknown) => Promise<unknown>) => cb({ insert: () => txChain() }),
+  },
+  declaredInterests: {
+    userId: 'declaredInterests.userId',
+    domain: 'declaredInterests.domain',
+    broadCategory: 'declaredInterests.broadCategory',
+    isActive: 'declaredInterests.isActive',
+  },
+  playerMastery: {
+    userId: 'playerMastery.userId',
+    canonicalSubcategory: 'playerMastery.canonicalSubcategory',
+  },
+  users: { id: 'users.id' },
+  friendInvitations: {},
+}));
+
+import { addDeclaredInterest, DeclaredInterestLimitError } from '../users';
+
+describe('addDeclaredInterest', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    state.activeRows = [];
+  });
+
+  it('adds a new interest when under the cap', async () => {
+    const result = await addDeclaredInterest('user-1', { label: 'Jazz', broadCategory: 'Music' });
+    expect(result).toEqual({ created: true, domain: 'Jazz', broadCategory: 'Music' });
+    expect(categorizeInterestDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('re-categorizes an uncategorized new interest', async () => {
+    categorizeInterestDomainMock.mockResolvedValue('Finance');
+    const result = await addDeclaredInterest('user-1', { label: 'Mortgage backed securities' });
+    expect(categorizeInterestDomainMock).toHaveBeenCalledWith('Mortgage backed securities');
+    expect(result).toEqual({
+      created: true,
+      domain: 'Mortgage backed securities',
+      broadCategory: 'Finance',
+    });
+  });
+
+  it('is idempotent on an already-active label (case-insensitive)', async () => {
+    state.activeRows = [{ domain: 'Jazz', broadCategory: 'Music' }];
+    const result = await addDeclaredInterest('user-1', { label: 'jazz' });
+    expect(result).toEqual({ created: false, domain: 'Jazz', broadCategory: 'Music' });
+    expect(categorizeInterestDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects with DeclaredInterestLimitError when already at the cap', async () => {
+    state.activeRows = Array.from({ length: 5 }, (_, i) => ({
+      domain: `interest-${i}`,
+      broadCategory: null,
+    }));
+    await expect(
+      addDeclaredInterest('user-1', { label: 'one too many', broadCategory: 'Music' }),
+    ).rejects.toBeInstanceOf(DeclaredInterestLimitError);
+    expect(categorizeInterestDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an empty label', async () => {
+    await expect(addDeclaredInterest('user-1', { label: '   ' })).rejects.toThrow(/topic name/);
+  });
+});

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -131,31 +131,97 @@ export function setFollowPrivacy(id: string, followPrivacy: 'public' | 'approval
     .then(([row]) => row);
 }
 
+export const MAX_ACTIVE_DECLARED_INTERESTS = 5;
+
+// Thrown when an incremental add would push the user past the declared-interest
+// cap. Callers (API routes) detect this to return a 409 rather than a generic
+// 400 so the client can offer a "manage interests" path instead of a dead end.
+export class DeclaredInterestLimitError extends Error {
+  constructor(
+    message = `A player can have at most ${MAX_ACTIVE_DECLARED_INTERESTS} active declared interests.`,
+  ) {
+    super(message);
+    this.name = 'DeclaredInterestLimitError';
+  }
+}
+
+type DeclaredInterestTx = Parameters<Parameters<typeof db.transaction>[0]>[0];
+
+// Insert (or reactivate) a single declared interest and seed its zero-point
+// PlayerMastery territory. Shared by the full-replace path (saveDeclaredInterests)
+// and the incremental path (addDeclaredInterest) so the mastery-seeding
+// invariant below lives in exactly one place — see CLAUDE.md "single chokepoint
+// for every declared-interest write".
+async function upsertDeclaredInterestRow(
+  tx: DeclaredInterestTx,
+  userId: string,
+  interest: DeclaredInterestInput,
+) {
+  await tx
+    .insert(declaredInterests)
+    .values({
+      userId,
+      domain: interest.label,
+      broadCategory: interest.broadCategory ?? null,
+      declaredAt: new Date(),
+      isActive: true,
+    })
+    .onConflictDoUpdate({
+      target: [declaredInterests.userId, declaredInterests.domain],
+      set: {
+        broadCategory: interest.broadCategory ?? null,
+        declaredAt: new Date(),
+        isActive: true,
+      },
+    });
+
+  // Seed a zero-point PlayerMastery row for the declared domain. Without
+  // this, the daily-answer route's "bot questions can only deepen existing
+  // territories" guard (src/app/api/daily/answer/route.ts) fires for the
+  // user's very first daily, so correct answers in a freshly-declared
+  // domain award 0 points and silently never open the territory.
+  await tx
+    .insert(playerMastery)
+    .values({
+      userId,
+      canonicalSubcategory: interest.label,
+      broadCategory: interest.broadCategory ?? null,
+      totalPoints: 0,
+      tier: 'establishing',
+      lifetimePointsBaseline: 0,
+      territoryType: 'declared',
+    })
+    .onConflictDoNothing({
+      target: [playerMastery.userId, playerMastery.canonicalSubcategory],
+    });
+}
+
+// Backstop categorization for a single interest. Re-runs the domain categorizer
+// for any interest that arrived uncategorized (null/empty or a catch-all) and
+// degrades to null — honest and backfillable — when categorization is
+// unavailable, since categorizeInterestDomain never throws.
+async function categorizeIfNeeded(interest: DeclaredInterestInput): Promise<DeclaredInterestInput> {
+  if (!isCatchAllBroadCategory(interest.broadCategory)) return interest;
+  const broadCategory = await categorizeInterestDomain(interest.label);
+  return { ...interest, broadCategory };
+}
+
 export async function saveDeclaredInterests(userId: string, interests: DeclaredInterestInput[]) {
   const normalized = normalizeDeclaredInterests(interests);
 
-  if (normalized.length > 5) {
-    throw new Error('A player can have at most 5 active declared interests.');
+  if (normalized.length > MAX_ACTIVE_DECLARED_INTERESTS) {
+    throw new DeclaredInterestLimitError();
   }
 
-  // Backstop categorization. This is the single chokepoint for every declared-
-  // interest write (onboarding + manual edits). The upstream categorizer
-  // (canonicalizeInterest) falls back to the "General Knowledge" catch-all
-  // whenever the Haiku call is unavailable or returns malformed JSON, and that
-  // fabricated value used to be persisted verbatim — permanently stranding the
-  // domain in the "Other interests" circle, since only later gameplay
-  // re-categorizes. Re-run the domain categorizer for any interest that arrived
-  // uncategorized (null/empty or a catch-all) and persist null — honest and
-  // backfillable — only when categorization is genuinely unavailable.
-  // categorizeInterestDomain never throws, so a transient LLM blip degrades to
-  // null rather than failing the save.
-  const categorized = await Promise.all(
-    normalized.map(async (interest) => {
-      if (!isCatchAllBroadCategory(interest.broadCategory)) return interest;
-      const broadCategory = await categorizeInterestDomain(interest.label);
-      return { ...interest, broadCategory };
-    }),
-  );
+  // Backstop categorization. saveDeclaredInterests + addDeclaredInterest are the
+  // single chokepoint for every declared-interest write (onboarding + manual
+  // edits + incremental adds). The upstream categorizer (canonicalizeInterest)
+  // falls back to the "General Knowledge" catch-all whenever the Haiku call is
+  // unavailable or returns malformed JSON, and that fabricated value used to be
+  // persisted verbatim — permanently stranding the domain in the "Other
+  // interests" circle, since only later gameplay re-categorizes. categorizeIfNeeded
+  // re-runs the domain categorizer for any interest that arrived uncategorized.
+  const categorized = await Promise.all(normalized.map(categorizeIfNeeded));
 
   await db.transaction(async (tx) => {
     await tx
@@ -164,47 +230,50 @@ export async function saveDeclaredInterests(userId: string, interests: DeclaredI
       .where(eq(declaredInterests.userId, userId));
 
     for (const interest of categorized) {
-      await tx
-        .insert(declaredInterests)
-        .values({
-          userId,
-          domain: interest.label,
-          broadCategory: interest.broadCategory ?? null,
-          declaredAt: new Date(),
-          isActive: true,
-        })
-        .onConflictDoUpdate({
-          target: [declaredInterests.userId, declaredInterests.domain],
-          set: {
-            broadCategory: interest.broadCategory ?? null,
-            declaredAt: new Date(),
-            isActive: true,
-          },
-        });
-
-      // Seed a zero-point PlayerMastery row for the declared domain. Without
-      // this, the daily-answer route's "bot questions can only deepen existing
-      // territories" guard (src/app/api/daily/answer/route.ts) fires for the
-      // user's very first daily, so correct answers in a freshly-declared
-      // domain award 0 points and silently never open the territory.
-      await tx
-        .insert(playerMastery)
-        .values({
-          userId,
-          canonicalSubcategory: interest.label,
-          broadCategory: interest.broadCategory ?? null,
-          totalPoints: 0,
-          tier: 'establishing',
-          lifetimePointsBaseline: 0,
-          territoryType: 'declared',
-        })
-        .onConflictDoNothing({
-          target: [playerMastery.userId, playerMastery.canonicalSubcategory],
-        });
+      await upsertDeclaredInterestRow(tx, userId, interest);
     }
   });
 
   return categorized;
+}
+
+// Incrementally add one declared interest without clobbering the existing list
+// (saveDeclaredInterests does a full replace). Powers the "add a topic" affordance
+// on the daily setup screen. Idempotent on an already-active label, and enforces
+// the same cap as the full-replace path.
+export async function addDeclaredInterest(
+  userId: string,
+  input: DeclaredInterestInput,
+): Promise<{ created: boolean; domain: string; broadCategory: string | null }> {
+  const clean = normalizeDeclaredInterest(input);
+  if (!clean) {
+    throw new Error('Enter a topic name.');
+  }
+
+  const active = await db
+    .select({ domain: declaredInterests.domain, broadCategory: declaredInterests.broadCategory })
+    .from(declaredInterests)
+    .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)));
+
+  const key = clean.label.toLowerCase();
+  const existing = active.find((row) => row.domain.toLowerCase() === key);
+  if (existing) {
+    return { created: false, domain: existing.domain, broadCategory: existing.broadCategory };
+  }
+
+  if (active.length >= MAX_ACTIVE_DECLARED_INTERESTS) {
+    throw new DeclaredInterestLimitError(
+      `You can track up to ${MAX_ACTIVE_DECLARED_INTERESTS} interests. Remove one on your Knowledge page to add another.`,
+    );
+  }
+
+  const interest = await categorizeIfNeeded(clean);
+
+  await db.transaction(async (tx) => {
+    await upsertDeclaredInterestRow(tx, userId, interest);
+  });
+
+  return { created: true, domain: interest.label, broadCategory: interest.broadCategory ?? null };
 }
 
 export async function markOnboardingComplete(userId: string) {


### PR DESCRIPTION
## Summary
Adds an incremental "add a topic" affordance to the daily setup screen, allowing users to add declared interests one at a time without replacing their entire list. Enforces the same 5-interest cap as the full-replace path with a 409 response code to distinguish limit errors from validation errors.

## Key Changes

- **New `addDeclaredInterest()` query function** (`src/server/db/queries/users.ts`):
  - Incremental add that checks the cap before inserting
  - Idempotent on already-active labels (case-insensitive)
  - Throws `DeclaredInterestLimitError` (409) when at capacity
  - Reuses `upsertDeclaredInterestRow()` to maintain the mastery-seeding invariant

- **Extracted shared logic** (`src/server/db/queries/users.ts`):
  - `upsertDeclaredInterestRow()`: Centralizes declared-interest + PlayerMastery seeding (used by both `saveDeclaredInterests` and `addDeclaredInterest`)
  - `categorizeIfNeeded()`: Extracted categorization logic for reuse
  - `DeclaredInterestLimitError`: Custom error class for 409 responses

- **New POST `/api/declared-interests`** (`src/app/api/declared-interests/route.ts`):
  - Validates input with Zod schema (label: 1–80 chars, optional broadCategory)
  - Returns 409 with `interest_limit_reached` error code when cap is hit
  - Returns 400 for validation failures
  - Response includes `domain`, `broadCategory`, `tier`, `totalPoints`, `created` flag

- **Daily setup UI** (`src/app/daily/setup/page.tsx`):
  - "Add a topic" form with text input and submit button
  - Detects 409 limit errors and shows "Manage interests" link to `/knowledge`
  - Idempotently adds new domains to the selection list
  - Clears input on success

- **Comprehensive test coverage** (`src/server/db/queries/__tests__/add-declared-interest.test.ts`):
  - Tests cap enforcement, idempotency, categorization, and validation
  - Mocks LLM calls while preserving real `isCatchAllBroadCategory` logic

## Implementation Details

- The `DeclaredInterestLimitError` constructor accepts a custom message, allowing the API to provide user-facing guidance ("Remove one on your Knowledge page to add another") while the query layer provides a generic fallback.
- Both `saveDeclaredInterests` and `addDeclaredInterest` are now "single chokepoints" for declared-interest writes (per CLAUDE.md guidance), ensuring the mastery-seeding invariant lives in exactly one place.
- The POST endpoint returns a 409 status code (Conflict) rather than 400 to signal that the request is valid but cannot be fulfilled due to a resource limit, enabling the client to offer a recovery path.

https://claude.ai/code/session_016sLLBWnZBew3PHVSby8dPt