### PR TITLE
Change struggle_pruning to rest domains instead of excluding them

### DIFF
--- a/src/__tests__/refine-derive.test.ts
+++ b/src/__tests__/refine-derive.test.ts
@@ -163,9 +163,9 @@ describe('copy', () => {
       missCount: 4,
     };
     expect(openText(pruning)).toBe(
-      "You've missed the last 4 subprime mortgage questions. Drop them from your daily five?",
+      "You've missed the last 4 subprime mortgage questions. Rest them for now?",
     );
-    expect(resolvedText(pruning)).toBe('Dropped subprime mortgage from your daily five.');
+    expect(resolvedText(pruning)).toBe("Resting subprime mortgage for now — it won't be asked.");
 
     const escalation: RefineCandidate = {
       type: 'difficulty_escalation',

--- a/src/components/review/RefineYourGame.tsx
+++ b/src/components/review/RefineYourGame.tsx
@@ -27,7 +27,7 @@ export function RefineYourGame({ refine }: { refine: RefineSectionView }) {
 
       {isEmpty ? (
         <p className="text-muted-foreground mt-3 text-sm leading-6">
-          You&apos;re looking good. If you want to make changes or add a category, you can do that
+          You&apos;re looking good. If you want to make changes or add a territory, you can do that
           here.
         </p>
       ) : (
@@ -41,10 +41,10 @@ export function RefineYourGame({ refine }: { refine: RefineSectionView }) {
       )}
 
       <Link
-        href="/knowledge"
+        href="/daily/setup"
         className="text-muted-foreground mt-4 inline-block text-sm underline-offset-4 hover:underline"
       >
-        Manage all domains in Settings →
+        Manage your territories in Settings →
       </Link>
     </section>
   );

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -1303,7 +1303,21 @@ export async function generateDailyQuestionsFromKnowledgeBase(
   } else {
     // Random mode: pick one domain per category for cross-category variety,
     // with a soft per-domain frequency cap applied via recentDomainCounts.
-    domainsForRound = selectDiverseDomains(knowledgeBase, count, recentDomainCounts);
+    // 'resting' domains are honored here too (custom mode filters them out of
+    // selectedDomains upstream) so "Resting" means "won't be asked" in both
+    // modes; fall back to the full base if everything has been rested.
+    const frequencyByDomain = preferences.domainPreferenceFrequency ?? {};
+    const resting = new Set(
+      Object.entries(frequencyByDomain)
+        .filter(([, frequency]) => frequency === 'resting')
+        .map(([domain]) => domain.toLowerCase()),
+    );
+    const eligible = knowledgeBase.filter((domain) => !resting.has(domain.domain.toLowerCase()));
+    domainsForRound = selectDiverseDomains(
+      eligible.length > 0 ? eligible : knowledgeBase,
+      count,
+      recentDomainCounts,
+    );
   }
 
   const domainDifficultyOverrides = preferences.difficulty === 'adaptive'

--- a/src/server/refine/commit.ts
+++ b/src/server/refine/commit.ts
@@ -20,6 +20,10 @@ import {
   userDomainExclusions,
 } from '@/server/db';
 import { freezeDomainDifficulty } from '@/server/adaptive-difficulty';
+import {
+  getDailyPreferences,
+  updateDailyPreferences,
+} from '@/server/db/queries/daily-preferences';
 import { deriveSelectedRefineCandidates } from '@/server/db/queries/refine';
 import type { QueueSlot } from '@/server/daily/types';
 import type { RefineItemType } from '@/server/refine/types';
@@ -67,18 +71,23 @@ async function applyResolvedEffect(userId: string, row: DecisionRow, until: Date
           ),
         );
       return;
-    case 'struggle_pruning':
-      await db
-        .insert(userDomainExclusions)
-        .values({ userId, canonicalSubcategory: domain, scope: 'subcategory' })
-        .onConflictDoNothing({
-          target: [
-            userDomainExclusions.userId,
-            userDomainExclusions.scope,
-            userDomainExclusions.canonicalSubcategory,
-          ],
-        });
+    case 'struggle_pruning': {
+      // Move the struggling domain into the Resting bucket rather than hiding it
+      // behind an exclusion: it stays on the player's map (visible + draggable in
+      // /daily/setup), so resting it here mirrors what they'd do in settings.
+      // domainMode is left untouched on purpose — we only rest this one domain and
+      // don't want to re-infer custom/random mode from a possibly-partial map.
+      const prefs = await getDailyPreferences(userId);
+      const nextFreq = { ...prefs.domainPreferenceFrequency, [domain]: 'resting' as const };
+      const nextSelected = prefs.selectedDomains.filter(
+        (selected) => selected.toLowerCase() !== domain.toLowerCase(),
+      );
+      await updateDailyPreferences(userId, {
+        domainPreferenceFrequency: nextFreq,
+        selectedDomains: nextSelected,
+      });
       return;
+    }
     case 'difficulty_escalation':
       await freezeDomainDifficulty(userId, domain, until);
       return;

--- a/src/server/refine/copy.ts
+++ b/src/server/refine/copy.ts
@@ -23,12 +23,12 @@ export function openText(candidate: RefineCandidate): string {
   switch (candidate.type) {
     case 'friend_expansion': {
       const friend = candidate.friendName?.trim() || 'a friend';
-      return `You got a ${label} question from ${friend}'s world right. Add it to your daily five?`;
+      return `You got a ${label} question from ${friend}'s world right. Add it to your rotation?`;
     }
     case 'difficulty_escalation':
       return `You're mastering ${label}, so its questions are getting harder. Ease off?`;
     case 'struggle_pruning':
-      return `You've missed the last ${candidate.missCount ?? 0} ${label} questions. Drop them from your daily five?`;
+      return `You've missed the last ${candidate.missCount ?? 0} ${label} questions. Rest them for now?`;
   }
 }
 
@@ -37,10 +37,10 @@ export function resolvedText(candidate: RefineCandidate): string {
   const label = candidate.subdomainLabel;
   switch (candidate.type) {
     case 'friend_expansion':
-      return `Added ${label} to your daily five.`;
+      return `Added ${label} to your rotation.`;
     case 'difficulty_escalation':
       return `We'll keep ${label} at this level for the next month.`;
     case 'struggle_pruning':
-      return `Dropped ${label} from your daily five.`;
+      return `Resting ${label} for now — it won't be asked.`;
   }
 }

--- a/src/server/refine/types.ts
+++ b/src/server/refine/types.ts
@@ -10,7 +10,7 @@
 
 export type RefineItemType = 'friend_expansion' | 'difficulty_escalation' | 'struggle_pruning';
 
-export type RefineActionVerb = 'Add' | 'Ease off' | 'Drop';
+export type RefineActionVerb = 'Add' | 'Ease off' | 'Rest';
 
 export type RefineItemState = 'open' | 'resolved';
 
@@ -63,7 +63,7 @@ export const REFINE_PRIORITY: Record<RefineItemType, number> = {
 export const REFINE_VERB: Record<RefineItemType, RefineActionVerb> = {
   friend_expansion: 'Add',
   difficulty_escalation: 'Ease off',
-  struggle_pruning: 'Drop',
+  struggle_pruning: 'Rest',
 };
 
 /** Max items shown at once. */


### PR DESCRIPTION
## Summary
Refactors the "struggle_pruning" refine action to rest struggling domains instead of permanently excluding them. This keeps domains visible and draggable in `/daily/setup` while preventing them from being asked, mirroring the user experience of manually resting a domain in settings.

## Key Changes

- **Refine action behavior** (`src/server/refine/commit.ts`):
  - Replaced `userDomainExclusions` insert with calls to `getDailyPreferences` and `updateDailyPreferences`
  - Sets the struggling domain's frequency to `'resting'` and removes it from `selectedDomains`
  - Leaves `domainMode` untouched to preserve custom/random mode inference

- **Daily question generation** (`src/server/daily/generate-questions.ts`):
  - Added filtering logic to honor `'resting'` domains in random mode
  - Builds a set of resting domains from `domainPreferenceFrequency` and excludes them from selection
  - Falls back to full knowledge base if all domains are resting

- **User-facing copy** (`src/server/refine/copy.ts`):
  - Updated prompt: "Drop them from your daily five?" → "Rest them for now?"
  - Updated confirmation: "Dropped X from your daily five." → "Resting X for now — it won't be asked."
  - Updated other refine action copy to use "rotation" instead of "daily five"

- **UI updates** (`src/components/review/RefineYourGame.tsx`):
  - Changed link destination from `/knowledge` to `/daily/setup`
  - Updated terminology: "category" → "territory", "Manage all domains" → "Manage your territories"

- **Type and test updates**:
  - Changed `RefineActionVerb` from `'Drop'` to `'Rest'` in `src/server/refine/types.ts`
  - Updated test expectations in `src/__tests__/refine-derive.test.ts`

## Implementation Details
The change preserves domain visibility on the player's map while preventing them from being asked. The `domainMode` is intentionally left untouched to avoid re-inferring custom/random mode from a possibly-partial map state.

https://claude.ai/code/session_012nWsB16HQFGKg8MvBS7tHJ