### PR TITLE
Make question composer URL-driven for consistent FAB behavior

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Plus, Search, X } from 'lucide-react';
-import { useSearchParams } from 'next/navigation';
+import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
@@ -124,6 +124,8 @@ export default function QuestionsPage() {
 
 function QuestionsPageContent() {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const pathname = usePathname();
   const [tab, setTab] = useState<Tab>('authored');
   const [questions, setQuestions] = useState<QuestionView[]>([]);
   const [loading, setLoading] = useState(true);
@@ -134,13 +136,23 @@ function QuestionsPageContent() {
   const [domainFilter, setDomainFilter] = useState('all');
   const [sortMode, setSortMode] = useState<SortMode>('newest');
   const [search, setSearch] = useState('');
-  const [drawer, setDrawer] = useState<DrawerState>(() => {
-    if (searchParams.get('create') !== '1') return { mode: 'closed' };
-    // The feed's "what would you like to be asked?" prompt rides the idea in
-    // via ?text= so the composer opens pre-filled with the reader's words.
-    const prefillText = searchParams.get('text')?.trim() || undefined;
-    return { mode: 'create', intent: parseIntent(searchParams.get('intent')), prefillText };
-  });
+  // The composer (create) drawer is driven by the URL so the global Nav FAB,
+  // the CreateChooser, and the feed footer can all open it by navigating to
+  // ?create=1 — including when we're already on /questions, where the page
+  // doesn't remount. The editor (edit) drawer is local, opened by a card.
+  const [editingQuestion, setEditingQuestion] = useState<QuestionView | null>(null);
+  const createRequested = searchParams.get('create') === '1';
+  const drawer: DrawerState = editingQuestion
+    ? { mode: 'edit', question: editingQuestion }
+    : createRequested
+      ? {
+          mode: 'create',
+          intent: parseIntent(searchParams.get('intent')),
+          // The feed's "what would you like to be asked?" prompt rides the idea
+          // in via ?text= so the composer opens pre-filled with the reader's words.
+          prefillText: searchParams.get('text')?.trim() || undefined,
+        }
+      : { mode: 'closed' };
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
   const [cardError, setCardError] = useState<Record<string, string>>({});
   const [removingId, setRemovingId] = useState<string | null>(null);
@@ -198,6 +210,31 @@ function QuestionsPageContent() {
     return () => window.clearTimeout(timer);
   }, [toast]);
 
+  // Strip the composer params from the URL (no-op if none are present). Keeping
+  // this separate lets the FAB reopen the composer with a fresh ?create=1 push —
+  // a same-URL push would otherwise be a no-op and leave the drawer closed.
+  const clearComposerParams = useCallback(() => {
+    if (searchParams.has('create') || searchParams.has('intent') || searchParams.has('text')) {
+      router.replace(pathname, { scroll: false });
+    }
+  }, [pathname, router, searchParams]);
+
+  const openComposer = useCallback(() => {
+    router.push('/questions?create=1', { scroll: false });
+  }, [router]);
+
+  const openEditor = useCallback((question: QuestionView) => {
+    setEditingQuestion(question);
+    // The editor takes precedence over a URL-driven composer; clear the params
+    // so closing the editor returns to the list instead of reopening it.
+    clearComposerParams();
+  }, [clearComposerParams]);
+
+  const closeDrawer = useCallback(() => {
+    setEditingQuestion(null);
+    clearComposerParams();
+  }, [clearComposerParams]);
+
   const availableDomains = useMemo(() => (
     [...new Map(questions.map((question) => [question.domain, question.domainDisplayName] as const)).entries()]
       .map(([domain, label]) => ({ domain, label }))
@@ -234,7 +271,7 @@ function QuestionsPageContent() {
     const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
     if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not save that question.');
     setQuestions((current) => [body.question!, ...current]);
-    setDrawer({ mode: 'closed' });
+    closeDrawer();
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
@@ -258,7 +295,7 @@ function QuestionsPageContent() {
     const body = await response.json().catch(() => null) as { question?: QuestionView; error?: string; message?: string } | null;
     if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not update that question.');
     setQuestions((current) => current.map((question) => question.id === questionId ? body.question! : question));
-    setDrawer({ mode: 'closed' });
+    closeDrawer();
     setToast('Question updated.');
   }
 
@@ -340,7 +377,7 @@ function QuestionsPageContent() {
               <h1 className="font-serif text-3xl font-semibold">Your Questions</h1>
               <p className="mt-1 text-sm text-muted-foreground">{questions.length} questions</p>
             </div>
-            <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={() => setDrawer({ mode: 'create', intent: null })}>
+            <button className="btn-primary inline-flex items-center gap-2" type="button" onClick={openComposer}>
               <Plus className="size-4" />
               Write a question
             </button>
@@ -386,7 +423,7 @@ function QuestionsPageContent() {
               <p className="mt-2 max-w-sm text-sm text-muted-foreground">
                 You haven&apos;t written any questions yet. Write one to get started.
               </p>
-              <button className="btn-primary mt-5" type="button" onClick={() => setDrawer({ mode: 'create', intent: null })}>
+              <button className="btn-primary mt-5" type="button" onClick={openComposer}>
                 Write a question
               </button>
             </section>
@@ -406,7 +443,7 @@ function QuestionsPageContent() {
                   confirming={confirmingId === question.id}
                   cardError={cardError[question.id]}
                   deleting={removingId === question.id}
-                  onEdit={() => setDrawer({ mode: 'edit', question })}
+                  onEdit={() => openEditor(question)}
                   onDeleteRequest={() => setConfirmingId(question.id)}
                   onConfirmDelete={() => void confirmDelete(question)}
                   onCancelConfirm={() => setConfirmingId(null)}
@@ -446,14 +483,14 @@ function QuestionsPageContent() {
 
       {drawer.mode !== 'closed' ? (
         <div className="fixed inset-0 z-[60] flex items-end bg-black/35 md:items-stretch md:justify-end" role="dialog" aria-modal="true">
-          <button className="absolute inset-0 cursor-default" type="button" aria-label="Close" onClick={() => setDrawer({ mode: 'closed' })} />
+          <button className="absolute inset-0 cursor-default" type="button" aria-label="Close" onClick={closeDrawer} />
           <aside className="relative max-h-[92dvh] w-full overflow-y-auto rounded-t-lg bg-background px-5 pt-5 shadow-xl md:h-full md:max-h-none md:w-[440px] md:rounded-none">
             <div className="mb-5 flex items-center justify-between gap-3">
               <div>
                 <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">{drawer.mode === 'edit' ? 'Edit' : 'Create'}</p>
                 <h2 className="font-serif text-2xl font-semibold">{drawer.mode === 'edit' ? 'Edit question' : 'Write a question'}</h2>
               </div>
-              <button className="rounded-md border p-2 hover:bg-muted" type="button" onClick={() => setDrawer({ mode: 'closed' })} title="Close">
+              <button className="rounded-md border p-2 hover:bg-muted" type="button" onClick={closeDrawer} title="Close">
                 <X className="size-4" />
               </button>
             </div>
@@ -464,7 +501,7 @@ function QuestionsPageContent() {
                 : { ...createFormProps(drawer.intent).initialValues, ...(drawer.prefillText ? { text: drawer.prefillText } : {}) }}
               initialSpecificMode={drawer.mode === 'create' ? createFormProps(drawer.intent).initialSpecificMode : undefined}
               onSubmit={drawer.mode === 'edit' ? (values) => saveEdit(drawer.question.id, values) : saveCreate}
-              onCancel={() => setDrawer({ mode: 'closed' })}
+              onCancel={closeDrawer}
             />
           </aside>
         </div>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import { Bell, Brain, Home, Pencil, Plus, User, Users } from 'lucide-react';
 import { CreateChooser } from '@/components/CreateChooser';
 
@@ -38,9 +38,16 @@ export function Nav({
   friendsDotVisible?: boolean;
 }) {
   const pathname = usePathname();
+  const router = useRouter();
   const accountInitials = initialDisplayName ? initialsFor(initialDisplayName) || null : null;
   const currentUserId = initialUserId;
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
+  // On Home and the Questions page the FAB is a dedicated "add a question"
+  // shortcut: it drops straight into the composer (?create=1) rather than the
+  // generic three-way Create chooser. The composer still surfaces every
+  // destination control, so nothing is lost by skipping the chooser here. The
+  // chooser stays as the FAB action on the other surfaces.
+  const isQuestionComposerShortcut = pathname === '/' || pathname.startsWith('/questions');
   const isOtherUserProfilePath = (() => {
     if (!pathname.startsWith('/users/')) return false;
     const rest = pathname.slice('/users/'.length);
@@ -142,9 +149,18 @@ export function Nav({
       {showNewGameShortcut ? (
         <button
           type="button"
-          className="fixed bottom-24 right-5 z-50 grid size-14 place-items-center rounded-full bg-primary text-primary-foreground shadow-lg md:hidden"
-          aria-label="Create"
-          onClick={() => setCreateChooserOpen(true)}
+          className={[
+            'fixed bottom-24 right-5 z-50 grid size-14 place-items-center rounded-full bg-primary text-primary-foreground shadow-lg',
+            // The dedicated add-a-question FAB shows on every viewport; the
+            // generic Create chooser FAB stays mobile-only as before.
+            isQuestionComposerShortcut ? '' : 'md:hidden',
+          ].join(' ')}
+          aria-label={isQuestionComposerShortcut ? 'Add a question' : 'Create'}
+          onClick={() =>
+            isQuestionComposerShortcut
+              ? router.push('/questions?create=1')
+              : setCreateChooserOpen(true)
+          }
         >
           <Plus className="size-6" />
         </button>


### PR DESCRIPTION
## Summary
Refactors the question composer drawer to be driven by URL state (`?create=1`) rather than local React state, enabling the global Nav FAB, CreateChooser, and feed footer to consistently open the composer by navigating to `/questions?create=1`. This ensures the composer reopens correctly even when already on the questions page (where the component doesn't remount).

## Key Changes
- **Questions page (`src/app/questions/page.tsx`)**
  - Replaced local `drawer` state initialization with URL-driven logic: `createRequested = searchParams.get('create') === '1'`
  - Separated edit drawer (local state via `editingQuestion`) from create drawer (URL-driven)
  - Added `clearComposerParams()` callback to strip `?create=1`, `?intent=`, and `?text=` from URL
  - Added `openComposer()` callback to navigate to `/questions?create=1`
  - Added `openEditor()` callback that opens edit drawer and clears composer params (so closing editor returns to list, not reopening composer)
  - Added `closeDrawer()` callback that closes either drawer type and clears composer params
  - Updated all drawer state mutations to use the new callbacks instead of direct `setDrawer()` calls

- **Nav component (`src/components/Nav.tsx`)**
  - Added `useRouter` hook
  - Introduced `isQuestionComposerShortcut` flag: FAB becomes a dedicated "add a question" button on Home (`/`) and Questions pages (`/questions*`)
  - On those pages, FAB navigates directly to `/questions?create=1` instead of opening the generic CreateChooser
  - FAB now shows on all viewports when it's the question composer shortcut (previously mobile-only for CreateChooser)
  - Updated FAB aria-label and click handler based on shortcut mode

## Implementation Details
- The composer params are cleared separately from drawer closure to allow the FAB to reopen the composer with a fresh `?create=1` push—a same-URL push would otherwise be a no-op
- Edit drawer takes precedence over URL-driven composer; opening an editor clears composer params so the drawer stack is unambiguous
- The feed's "what would you like to be asked?" prompt continues to prefill the composer via `?text=` parameter

https://claude.ai/code/session_01TNNzb4LLegR33yP2ygyHrK