### PR TITLE
Fix per-user invite link signup blocked by invite-only gate

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -31,6 +31,16 @@ describe('proxy unauthenticated route preservation', () => {
     expect(response.headers.get('location')).toBeNull()
   })
 
+  it('passes the per-user invite landing (/u/<handle>/<token>) through logged-out so the invite params survive to /login', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce(null)
+
+    const response = await proxy(makeRequest('/u/josh/keep-this-token'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('location')).toBeNull()
+  })
+
   it('redirects other unauthenticated pages to login, preserving the original path via next', async () => {
     readSessionClaimsMock.mockResolvedValueOnce(null)
 

--- a/src/app/api/auth/request-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/request-otp/__tests__/route.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  findUserSelectMock,
+  hasValidPendingInvitationForPhoneMock,
+  requestOtpMock,
+  resolveInviteLinkMock,
+} = vi.hoisted(() => {
+  const findUserSelectMock = vi.fn(
+    async () => [] as Array<Record<string, unknown>>,
+  )
+  return {
+    findUserSelectMock,
+    hasValidPendingInvitationForPhoneMock: vi.fn(async () => false),
+    requestOtpMock: vi.fn(async () => ({ code: '424242' })),
+    resolveInviteLinkMock: vi.fn(async () => null as unknown),
+  }
+})
+
+vi.mock('@/server/auth', () => ({
+  isUsPhoneNumber: (value: string) => /^\+1\d{10}$/.test(value),
+  normalizePhone: (value: string) => value,
+  requestOtp: requestOtpMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: vi.fn(() => findUserSelectMock()),
+        })),
+      })),
+    })),
+  },
+  users: { id: 'users.id', phoneNumber: 'users.phoneNumber' },
+}))
+
+vi.mock('@/server/friends/invitations', () => ({
+  hasValidPendingInvitationForPhone: hasValidPendingInvitationForPhoneMock,
+  INVITE_REQUIRED_MESSAGE:
+    "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.",
+}))
+
+vi.mock('@/server/friends/user-invite-token', () => ({
+  resolveInviteLink: resolveInviteLinkMock,
+}))
+
+import { POST } from '@/app/api/auth/request-otp/route'
+
+function jsonRequest(body: unknown) {
+  return new Request('http://localhost/api/auth/request-otp', {
+    method: 'POST',
+    body: JSON.stringify(body),
+  })
+}
+
+const NEW_PHONE = '+15551230001'
+const USER_INVITE = { handle: 'jpalay', token: 'real-token' }
+
+describe('/api/auth/request-otp invite gate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findUserSelectMock.mockReset()
+    // Default: phone belongs to no existing user (new-signup path).
+    findUserSelectMock.mockResolvedValue([])
+    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false)
+    resolveInviteLinkMock.mockResolvedValue(null)
+    requestOtpMock.mockResolvedValue({ code: '424242' })
+  })
+
+  it('blocks a brand-new phone with no invitation (403, no OTP sent)', async () => {
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }))
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({ error: 'invite_required' })
+    expect(requestOtpMock).not.toHaveBeenCalled()
+  })
+
+  it('lets a brand-new phone through when a valid per-user invite link is supplied', async () => {
+    resolveInviteLinkMock.mockResolvedValue({
+      inviterUserId: 'inviter-1',
+      inviterHandle: 'jpalay',
+      inviterDisplayName: 'Joshua P',
+      inviterAvatarColor: null,
+    })
+
+    const response = await POST(
+      jsonRequest({ phone: NEW_PHONE, userInvite: USER_INVITE }),
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({ ok: true })
+    expect(resolveInviteLinkMock).toHaveBeenCalledWith('jpalay', 'real-token')
+    expect(requestOtpMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('still blocks a brand-new phone when the invite link does not resolve', async () => {
+    resolveInviteLinkMock.mockResolvedValue(null)
+
+    const response = await POST(
+      jsonRequest({
+        phone: NEW_PHONE,
+        userInvite: { handle: 'jpalay', token: 'bogus' },
+      }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(requestOtpMock).not.toHaveBeenCalled()
+  })
+
+  it('does not require an invitation for an existing user', async () => {
+    findUserSelectMock.mockResolvedValue([{ id: 'user-1' }])
+
+    const response = await POST(jsonRequest({ phone: NEW_PHONE }))
+
+    expect(response.status).toBe(200)
+    expect(resolveInviteLinkMock).not.toHaveBeenCalled()
+    expect(requestOtpMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -8,8 +8,22 @@ import {
   hasValidPendingInvitationForPhone,
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations';
+import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
-const bodySchema = z.object({ phone: z.string().trim().min(1) });
+const bodySchema = z.object({
+  phone: z.string().trim().min(1),
+  // Per-user evergreen invite link (B-Friends-3). When a brand-new phone
+  // arrives via /u/<handle>/<token>, the invitation is NOT phone-targeted, so
+  // hasValidPendingInvitationForPhone() can't see it. The link itself is the
+  // invitation credential — a valid {handle, token} satisfies the gate and
+  // lets us send the OTP. verify-otp re-validates and forms the friendship.
+  userInvite: z
+    .object({
+      handle: z.string().trim().min(1),
+      token: z.string().trim().min(1),
+    })
+    .nullish(),
+});
 
 export async function POST(request: Request) {
   try {
@@ -39,8 +53,12 @@ export async function POST(request: Request) {
       .limit(1);
 
     if (!existingUser) {
-      const hasInvite = await hasValidPendingInvitationForPhone(phone);
-      if (!hasInvite) {
+      const invitedByPhone = await hasValidPendingInvitationForPhone(phone);
+      const userInvite = parsed.data.userInvite;
+      const invitedByLink = userInvite
+        ? Boolean(await resolveInviteLink(userInvite.handle, userInvite.token))
+        : false;
+      if (!invitedByPhone && !invitedByLink) {
         return NextResponse.json(
           { error: 'invite_required', message: INVITE_REQUIRED_MESSAGE },
           { status: 403 },

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -101,7 +101,10 @@ export default function LoginPanel() {
       const response = await fetch('/api/auth/request-otp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ phone: normalized }),
+        // Forward the per-user invite link so request-otp can satisfy the
+        // invite gate for a brand-new phone that arrived via /u/<handle>/<token>
+        // (the invitation isn't phone-targeted, so the gate can't infer it).
+        body: JSON.stringify({ phone: normalized, userInvite }),
       });
       const data = await response.json().catch(() => ({}));
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -32,7 +32,14 @@ export async function middleware(request: NextRequest) {
   const { pathname, search } = request.nextUrl
   const isApi = pathname.startsWith('/api/')
   const isLoginPage = pathname === '/login'
-  const isInvitePage = pathname.startsWith('/invite/')
+  // Both invite landing surfaces must be reachable logged-out so the invitee
+  // can carry their invite into /login: /invite/<token> (FriendInvitation,
+  // SMS-style) and /u/<handle>/<token> (per-user evergreen invite link,
+  // B-Friends-3). Without /u/ here the proxy bounces the invitee to /login
+  // and drops the invite params, so brand-new accounts hit the invite-only
+  // gate at verify-otp and can never sign up.
+  const isInvitePage =
+    pathname.startsWith('/invite/') || pathname.startsWith('/u/')
 
   const token = request.cookies.get(SESSION_COOKIE_NAME)?.value
   const claims = await readSessionClaims(token)


### PR DESCRIPTION
## Problem

Brand-new accounts arriving via a **per-user evergreen invite link** (`/u/<handle>/<token>` — the link the profile page generates) were blocked with the invite-only message, even with a valid URL. Two gates both ignored per-user links:

1. **Proxy** (`src/proxy.ts`) only allow-listed `/invite/` pre-auth. A logged-out invitee on `/u/<handle>/<token>` was redirected to `/login`, **dropping the `inviteHandle`/`inviteUserToken` params**, so the invite never reached the OTP request.
2. **`request-otp`** gated new phones with `hasValidPendingInvitationForPhone`, which only matches phone-targeted `FriendInvitation` rows. Per-user links aren't phone-keyed, so the **OTP was refused before being sent** (403). `/invite/<token>` worked only because those invitations *are* phone-targeted.

`verify-otp` already accepted `userInvite`, so no change there.

## Fix

- `src/proxy.ts` — allow `/u/` through pre-auth alongside `/invite/`.
- `src/app/api/auth/request-otp/route.ts` — accept optional `userInvite`; a link that resolves via `resolveInviteLink` satisfies the gate.
- `src/app/login/LoginPanel.tsx` — forward `userInvite` into the `request-otp` call.

Uninvited and bogus-token paths still return 403, so no OTP SMS goes to uninvited numbers.

## Verification (live, against running dev server)

| Step | Result |
|---|---|
| `GET /u/jpalay/<token>` logged-out | 200, no redirect (was 307→/login) |
| `request-otp` new phone, no invite | 403 — gate still closed |
| `request-otp` new phone + valid link | 200 + OTP sent |
| `request-otp` new phone + bogus token | 403 — fake links don't unlock |
| `verify-otp` new phone + code + link | account created, `invitation.accepted: true`, session set |

## Tests

- New `request-otp/__tests__/route.test.ts` (block-no-invite, allow-valid-link, block-bogus-link, existing-user-bypass).
- New proxy case asserting `/u/<handle>/<token>` passes through logged-out.
- Full run green (26 tests); typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)