### PR TITLE
Refine questions filter toolbar

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Plus, Search, X } from 'lucide-react';
+import { ChevronDown, Plus, Search, X } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 
@@ -383,36 +383,42 @@ function QuestionsPageContent() {
             </button>
           </header>
 
-          <section className="mb-5 grid grid-cols-2 gap-2 rounded-lg border bg-card p-2 sm:grid-cols-[1fr_1fr_2fr] sm:gap-3 sm:p-3">
-            <select
-              value={domainFilter}
-              onChange={(event) => setDomainFilter(event.target.value)}
-              className="h-11 rounded-md border bg-background px-3 text-sm"
-              aria-label="Filter by domain"
-            >
-              <option value="all">All domains</option>
-              {availableDomains.map((item) => (
-                <option key={item.domain} value={item.domain}>{item.label}</option>
-              ))}
-            </select>
-            <select
-              value={sortMode}
-              onChange={(event) => setSortMode(event.target.value as SortMode)}
-              className="h-11 rounded-md border bg-background px-3 text-sm"
-              aria-label="Sort by"
-            >
-              <option value="newest">Newest</option>
-              <option value="most_answered">Most answered</option>
-              <option value="hardest">Hardest</option>
-              <option value="easiest">Easiest</option>
-            </select>
+          <section className="mb-4 grid grid-cols-2 gap-2 rounded-md border bg-muted/30 p-2 sm:grid-cols-[1fr_1fr_2fr]" aria-label="Question filters">
+            <label className="relative">
+              <select
+                value={domainFilter}
+                onChange={(event) => setDomainFilter(event.target.value)}
+                className="h-10 w-full appearance-none rounded-md border bg-background px-3 pr-9 text-sm outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                aria-label="Filter by domain"
+              >
+                <option value="all">All domains</option>
+                {availableDomains.map((item) => (
+                  <option key={item.domain} value={item.domain}>{item.label}</option>
+                ))}
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            </label>
+            <label className="relative">
+              <select
+                value={sortMode}
+                onChange={(event) => setSortMode(event.target.value as SortMode)}
+                className="h-10 w-full appearance-none rounded-md border bg-background px-3 pr-9 text-sm outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
+                aria-label="Sort by"
+              >
+                <option value="newest">Newest</option>
+                <option value="most_answered">Most answered</option>
+                <option value="hardest">Hardest</option>
+                <option value="easiest">Easiest</option>
+              </select>
+              <ChevronDown className="pointer-events-none absolute right-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            </label>
             <label className="relative col-span-2 sm:col-span-1">
               <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
               <input
                 value={search}
                 onChange={(event) => setSearch(event.target.value)}
                 placeholder="Search questions..."
-                className="h-11 w-full rounded-md border bg-background pl-10 pr-3 text-sm outline-none focus:border-primary"
+                className="h-10 w-full rounded-md border bg-background pl-10 pr-3 text-sm outline-none focus-visible:border-primary focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2"
               />
             </label>
           </section>


### PR DESCRIPTION
### Motivation
- Make the questions filter area read more like a compact toolbar rather than a card to reduce visual weight and improve density on the page.
- Reduce control heights and spacing so the toolbar sits compactly with the rest of the header while preserving mobile-friendly layout.
- Ensure custom select carets and keyboard focus remain visible for accessibility.

### Description
- Restyled the filter container in `src/app/questions/page.tsx` from a card-like block to a compact toolbar by changing spacing (`mb-5` → `mb-4`), using `rounded-md`, reducing padding to `p-2`, and switching to a subtler `bg-muted/30` background.
- Reduced control heights from `h-11` to `h-10` for the domain select, sort select, and search input and preserved the responsive grid so two controls remain in the first mobile row and the search spans below (`sm:grid-cols-[1fr_1fr_2fr]`).
- Added `ChevronDown` icons as custom carets for the selects and added `focus-visible` ring/border styles so keyboard focus states remain visible, while keeping the same aria labels and layout.
- Minor formatting and small refactors applied by project formatter to the same file (import ordering and a few stylistic adjustments) with no behavioral changes beyond the toolbar UI.

### Testing
- Ran `npm run format` which updated the formatted file and completed successfully.
- Ran linting with `npm run lint` and `npx eslint src/app/questions/page.tsx --ext .tsx`, both completed; the repo retains its existing warnings but no new errors were introduced.
- Ran `git diff --check` to ensure no trailing whitespace or diff-check issues were reported.
- Attempted a Playwright screenshot run, but the Playwright browser binary was not installed in the environment so the visual smoke test could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d5b8b494832e9a12d4c758b55534)