### PR TITLE
Compact authored question rows

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -435,7 +435,7 @@ function QuestionsPageContent() {
               </button>
             </section>
           ) : (
-            <section className="space-y-3">
+            <section className="space-y-2">
               {filteredQuestions.map((question) => (
                 <MyQuestionCard
                   key={question.id}

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -3,11 +3,10 @@
 import { Lock, MoreHorizontal, Pencil, Trash2 } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
-import { FeedCard } from '@/components/feed/FeedCard';
 import { visibleFeedCategory } from '@/components/feed/category';
-import type { FeedCardBaseItem } from '@/components/feed/types';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
+import { cn } from '@/lib/utils';
 import type { QuestionView } from '@/server/db/queries/questions';
 
 type MyQuestionCardProps = {
@@ -34,121 +33,134 @@ export function MyQuestionCard({
   const inUse = question.usedInGamesCount > 0;
   const difficultyLabel = difficultyCopyFromValue(question.difficulty) ?? 'Unrated';
   const visibleCategory = visibleFeedCategory(question.domainDisplayName);
-  const answerersLine = question.isOwnAuthored && question.answerers
-    ? formatAnswerersLine(question.answerers)
-    : null;
-
-  const item: FeedCardBaseItem = {
-    id: question.id,
-    metadata: null,
-    question: question.text,
-    category: question.domainDisplayName,
-    viewerIsAuthor: true,
-  };
+  const answerersLine =
+    question.isOwnAuthored && question.answerers ? formatAnswerersLine(question.answerers) : null;
 
   return (
-    <FeedCard
-      item={item}
-      className={`transition duration-200 ${deleting ? 'scale-[0.98] opacity-0' : 'opacity-100'}`}
-      overflow={
-        <CardOverflowMenu
-          inUse={inUse}
-          onEdit={onEdit}
-          onDelete={onDeleteRequest}
-        />
-      }
-      headerContent={
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          {visibleCategory ? (
+    <article
+      className={cn(
+        'bg-card rounded-md border px-4 py-3 transition duration-200',
+        deleting ? 'scale-[0.98] opacity-0' : 'opacity-100',
+      )}
+    >
+      <div className="flex items-start gap-3 sm:gap-4">
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2 pr-2">
+            {visibleCategory ? (
+              <span
+                className="truncate text-[12px] leading-tight italic"
+                style={{
+                  fontFamily: 'var(--font-literata)',
+                  color: 'var(--ink)',
+                  opacity: 0.7,
+                }}
+              >
+                {visibleCategory}
+              </span>
+            ) : null}
             <span
-              className="truncate text-[12px] italic leading-tight"
-              style={{
-                fontFamily: 'var(--font-literata)',
-                color: 'var(--ink)',
-                opacity: 0.7,
-              }}
+              className="rounded-full bg-[rgba(0,0,0,0.06)] px-2 py-0.5 text-[10px] font-medium tracking-wide uppercase"
+              style={{ color: 'var(--ink)', opacity: 0.7 }}
+              aria-label={`LLM-rated difficulty: ${difficultyLabel}`}
             >
-              {visibleCategory}
+              {difficultyLabel}
             </span>
-          ) : null}
-          <span
-            className="rounded-full bg-[rgba(0,0,0,0.06)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
-            style={{ color: 'var(--ink)', opacity: 0.7 }}
-            aria-label={`LLM-rated difficulty: ${difficultyLabel}`}
-          >
-            {difficultyLabel}
-          </span>
-        </div>
-      }
-      footer={
-        <>
-          <p
-            className="text-[13px] leading-snug"
-            style={{ color: 'var(--ink)', opacity: 0.65 }}
-          >
-            {question.timesAnswered} answers · {question.correctRate}% correct · {question.usedInGamesCount} games
-          </p>
-          {question.nobody_correct_flag ? (
-            // "Nobody got it" review smell (B4 Phase 2): a QA signal that enough
-            // players have tried with none correct — likely a bad answer, not a
-            // hard question. Flagged for review, never auto-removed.
-            <p
-              className="mt-1 inline-flex items-center gap-1 text-[12px] font-medium leading-snug"
-              style={{ color: 'var(--ink)', opacity: 0.8 }}
-            >
-              ⚠ Nobody&apos;s gotten this right — flagged for review
-            </p>
-          ) : null}
-          {answerersLine ? (
-            <p
-              className="mt-1 text-[13px] leading-snug"
-              style={{ color: 'var(--ink)', opacity: 0.65 }}
-            >
-              {answerersLine}
-            </p>
-          ) : null}
-          {cardError ? (
-            <p className="mt-2 text-[13px] text-destructive">{cardError}</p>
-          ) : null}
-          <div className="mt-3 flex items-center gap-2">
-            {confirming ? (
-              <>
-                <span
-                  className="mr-auto text-[13px] font-medium"
-                  style={{ color: 'var(--ink)' }}
-                >
-                  Delete this question?
-                </span>
-                <button
-                  className="rounded-md border border-destructive px-3 py-2 text-sm text-destructive"
-                  type="button"
-                  onClick={onConfirmDelete}
-                >
-                  Confirm
-                </button>
-                <button
-                  className="rounded-md border px-3 py-2 text-sm"
-                  type="button"
-                  onClick={onCancelConfirm}
-                >
-                  Cancel
-                </button>
-              </>
-            ) : (
-              <div className="ml-auto">
-                <SendQuestionAction
-                  question={{
-                    id: question.id,
-                    text: question.text,
-                    domain: question.domainDisplayName,
-                  }}
-                />
-              </div>
-            )}
           </div>
-        </>
-      }
-    />
+
+          <p
+            className="mt-1.5 font-serif text-[18px] leading-6 font-semibold tracking-[0.02em]"
+            style={{ color: 'var(--ink)' }}
+          >
+            {question.text}
+          </p>
+
+          <div className="mt-2 flex flex-col gap-1 text-[13px] leading-snug sm:flex-row sm:flex-wrap sm:items-center sm:gap-x-3">
+            <p style={{ color: 'var(--ink)', opacity: 0.65 }}>
+              {question.timesAnswered} answers · {question.correctRate}% correct ·{' '}
+              {question.usedInGamesCount} games
+            </p>
+            {question.nobody_correct_flag ? (
+              // "Nobody got it" review smell (B4 Phase 2): a QA signal that enough
+              // players have tried with none correct — likely a bad answer, not a
+              // hard question. Flagged for review, never auto-removed.
+              <p
+                className="inline-flex items-center gap-1 font-medium"
+                style={{ color: 'var(--ink)', opacity: 0.8 }}
+              >
+                ⚠ Nobody&apos;s gotten this right — flagged for review
+              </p>
+            ) : null}
+            {answerersLine ? (
+              <p style={{ color: 'var(--ink)', opacity: 0.65 }}>{answerersLine}</p>
+            ) : null}
+          </div>
+
+          {cardError ? <p className="text-destructive mt-2 text-[13px]">{cardError}</p> : null}
+
+          {confirming ? (
+            <DeleteConfirmation
+              onConfirmDelete={onConfirmDelete}
+              onCancelConfirm={onCancelConfirm}
+            />
+          ) : (
+            <div className="mt-3 sm:hidden">
+              <SendQuestionAction
+                question={{
+                  id: question.id,
+                  text: question.text,
+                  domain: question.domainDisplayName,
+                }}
+              />
+            </div>
+          )}
+        </div>
+
+        <div className="flex shrink-0 items-start gap-2">
+          {!confirming ? (
+            <div className="hidden sm:block">
+              <SendQuestionAction
+                question={{
+                  id: question.id,
+                  text: question.text,
+                  domain: question.domainDisplayName,
+                }}
+              />
+            </div>
+          ) : null}
+          <CardOverflowMenu inUse={inUse} onEdit={onEdit} onDelete={onDeleteRequest} />
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function DeleteConfirmation({
+  onConfirmDelete,
+  onCancelConfirm,
+}: {
+  onConfirmDelete: () => void;
+  onCancelConfirm: () => void;
+}) {
+  return (
+    <div className="mt-3 flex flex-wrap items-center gap-2">
+      <span className="mr-auto text-[13px] font-medium" style={{ color: 'var(--ink)' }}>
+        Delete this question?
+      </span>
+      <button
+        className="border-destructive text-destructive rounded-md border px-3 py-2 text-sm"
+        type="button"
+        onClick={onConfirmDelete}
+      >
+        Confirm
+      </button>
+      <button
+        className="rounded-md border px-3 py-2 text-sm"
+        type="button"
+        onClick={onCancelConfirm}
+      >
+        Cancel
+      </button>
+    </div>
   );
 }
 
@@ -192,7 +204,7 @@ function CardOverflowMenu({
         aria-expanded={open}
         aria-controls={open ? menuId : undefined}
         onClick={() => setOpen((current) => !current)}
-        className="-mr-1 inline-flex size-8 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground"
+        className="text-muted-foreground hover:bg-muted hover:text-foreground -mr-1 inline-flex size-8 items-center justify-center rounded-md transition"
       >
         <MoreHorizontal className="size-4" />
       </button>
@@ -200,7 +212,7 @@ function CardOverflowMenu({
         <div
           id={menuId}
           role="menu"
-          className="absolute right-0 top-full z-30 mt-1 w-44 rounded-md border bg-background p-1 shadow-md"
+          className="bg-background absolute top-full right-0 z-30 mt-1 w-44 rounded-md border p-1 shadow-md"
         >
           <button
             type="button"
@@ -211,7 +223,7 @@ function CardOverflowMenu({
               setOpen(false);
               onEdit();
             }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            className="hover:bg-muted flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {inUse ? <Lock className="size-4" /> : <Pencil className="size-4" />}
             Edit
@@ -225,7 +237,7 @@ function CardOverflowMenu({
               setOpen(false);
               onDelete();
             }}
-            className="flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-destructive hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50"
+            className="text-destructive hover:bg-muted flex w-full items-center gap-2 rounded-sm px-2 py-1.5 text-sm disabled:cursor-not-allowed disabled:opacity-50"
           >
             {inUse ? <Lock className="size-4" /> : <Trash2 className="size-4" />}
             Delete


### PR DESCRIPTION
### Motivation
- Render the authored questions list as a denser, page-specific compact row instead of reusing the feed `FeedCard` so management actions are clearer and the list reads more tightly.
- Surface category, LLM difficulty, inline metadata, errors, delete confirmation, and send behavior in a compact horizontal layout that adapts between mobile and desktop.

### Description
- Replaced `FeedCard` usage with a compact `<article>` row in `src/components/questions/MyQuestionCard.tsx` and added `cn` utility import for class merging and conditional opacity/scale handling.
- Kept the category display, difficulty badge, overflow edit/delete menu, card error display, answerer/review signals, and all external callbacks/props (`onEdit`, `onDeleteRequest`, `onConfirmDelete`, `onCancelConfirm`, `confirming`, `deleting`, `cardError`).
- Moved `SendQuestionAction` into the right-side desktop row actions and preserved it below the metadata on small screens; added an inline `DeleteConfirmation` component for the compact row flow.
- Tightened the authored list spacing by changing the wrapper in `src/app/questions/page.tsx` from `space-y-3` to `space-y-2` and applied minor style/formatting cleanups in that file.

### Testing
- Ran formatting on changed files with `npm run format -- src/components/questions/MyQuestionCard.tsx src/app/questions/page.tsx` which completed successfully.
- Ran lint with `npm run lint`, which completed (repo baseline shows 44 existing warnings unrelated to this change).
- Type check with `npx tsc --noEmit` completed without errors.
- `npm run build` failed in this environment due to `next/font` failing to fetch Google Fonts (external network font fetch), not due to the component changes.
- `npm test` (Vitest) did not produce stable output within the environment timeout (timed out).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22d5ab4474832e89765b73e90aeb3c)