### PR TITLE
Let invite-link signups reach onboarding (fix redirect loop)

### DIFF
--- a/src/app/onboarding/__tests__/page.test.ts
+++ b/src/app/onboarding/__tests__/page.test.ts
@@ -4,11 +4,18 @@ const {
   getSessionMock,
   getUserOnboardingProfileMock,
   getPreSeededInterestsForUserMock,
+  hasInviteLinkFriendshipMock,
+  friendInvitationRowsMock,
   redirectMock,
 } = vi.hoisted(() => ({
   getSessionMock: vi.fn(),
   getUserOnboardingProfileMock: vi.fn(),
   getPreSeededInterestsForUserMock: vi.fn(),
+  hasInviteLinkFriendshipMock: vi.fn(async () => false),
+  // Drives the FriendInvitation grandfather-guard query result.
+  friendInvitationRowsMock: vi.fn(
+    async () => [{ id: 'inv-1' }] as Array<{ id: string }>,
+  ),
   redirectMock: vi.fn((target: string) => {
     // Mirror Next.js: redirect() throws to short-circuit rendering.
     throw new Error(`__REDIRECT__:${target}`)
@@ -31,15 +38,15 @@ vi.mock('@/server/db/queries/users', () => ({
 // The page runs a grandfather-guard query (select FriendInvitation … limit 1)
 // directly against db. Stub the chain so it resolves without a real connection;
 // the result is discarded by the page (void hasInvitation), so [] is fine.
+// The page runs a grandfather-guard query (select FriendInvitation … limit 1)
+// directly against db. The limit() result is driven by friendInvitationRowsMock
+// so individual tests can simulate "no FriendInvitation row" (invite-link path).
 vi.mock('@/server/db', () => ({
   db: {
     select: () => ({
       from: () => ({
         where: () => ({
-          // Non-empty: the grandfather guard treats a row as "has accepted
-          // invitation" so the not-yet-onboarded case renders instead of
-          // redirecting. The redirect cases bail before reaching this query.
-          limit: async () => [{ id: 'inv-1' }],
+          limit: () => friendInvitationRowsMock(),
         }),
       }),
     }),
@@ -49,6 +56,10 @@ vi.mock('@/server/db', () => ({
     inviteeUserId: 'friendInvitations.inviteeUserId',
     acceptedAt: 'friendInvitations.acceptedAt',
   },
+}))
+
+vi.mock('@/server/friends/user-invite-token', () => ({
+  hasInviteLinkFriendship: hasInviteLinkFriendshipMock,
 }))
 
 // Stub the client component import so this test stays server-side.
@@ -80,6 +91,10 @@ describe('OnboardingPage guard', () => {
       inviterName: 'Someone',
       interests: [],
     })
+    hasInviteLinkFriendshipMock.mockReset()
+    hasInviteLinkFriendshipMock.mockResolvedValue(false)
+    friendInvitationRowsMock.mockReset()
+    friendInvitationRowsMock.mockResolvedValue([{ id: 'inv-1' }])
   })
 
   it('redirects to /login when there is no session', async () => {
@@ -114,5 +129,29 @@ describe('OnboardingPage guard', () => {
     const result = await callPage()
     expect(result).toEqual({ redirected: false })
     expect(getPreSeededInterestsForUserMock).toHaveBeenCalledWith('u1')
+  })
+
+  it('renders OnboardingFlow for an invite-link signup (no FriendInvitation row, but an invite-link friendship)', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: false,
+    })
+    friendInvitationRowsMock.mockResolvedValueOnce([]) // no SMS-style invitation
+    hasInviteLinkFriendshipMock.mockResolvedValueOnce(true) // arrived via /u/<handle>/<token>
+    const result = await callPage()
+    expect(result).toEqual({ redirected: false })
+  })
+
+  it('redirects to /login when there is neither a FriendInvitation nor an invite-link friendship', async () => {
+    getSessionMock.mockResolvedValueOnce({ userId: 'u1', id: 's1' })
+    getUserOnboardingProfileMock.mockResolvedValueOnce({
+      id: 'u1',
+      onboardingComplete: false,
+    })
+    friendInvitationRowsMock.mockResolvedValueOnce([])
+    hasInviteLinkFriendshipMock.mockResolvedValueOnce(false)
+    const result = await callPage()
+    expect(result).toEqual({ redirected: true, target: '/login' })
   })
 })

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -4,6 +4,7 @@ import { redirect } from 'next/navigation';
 import { getSession } from '@/server/auth/session';
 import { db, friendInvitations } from '@/server/db';
 import { getPreSeededInterestsForUser, getUserOnboardingProfile } from '@/server/db/queries/users';
+import { hasInviteLinkFriendship } from '@/server/friends/user-invite-token';
 
 import OnboardingFlow, { type PreSeededInterest } from './OnboardingFlow';
 
@@ -27,6 +28,12 @@ export default async function OnboardingPage() {
   // but this protects the onboarding route against any future session path
   // that bypasses the general gate (e.g. a pre-fix legacy session that was
   // grandfathered through re-login).
+  //
+  // Two valid provenances: an accepted FriendInvitation (SMS-style) OR a
+  // per-user invite-link friendship (/u/<handle>/<token>), which leaves an
+  // approved follow edge but NO FriendInvitation row. Without the second check
+  // invite-link signups fall through to redirect('/login'), which the proxy
+  // bounces back into the onboarding-claim refresh → ERR_TOO_MANY_REDIRECTS.
   const hasInvitation = await db
     .select({ id: friendInvitations.id })
     .from(friendInvitations)
@@ -36,7 +43,7 @@ export default async function OnboardingPage() {
     ))
     .limit(1);
 
-  if (hasInvitation.length === 0) {
+  if (hasInvitation.length === 0 && !(await hasInviteLinkFriendship(session.userId))) {
     redirect('/login');
   }
 

--- a/src/server/friends/user-invite-token.ts
+++ b/src/server/friends/user-invite-token.ts
@@ -1,8 +1,8 @@
 import { randomBytes } from 'node:crypto'
 
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 
-import { db, users } from '@/server/db'
+import { db, follows, users } from '@/server/db'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 
 // Match the prior-art token primitive used for FriendInvitation tokens at
@@ -120,6 +120,23 @@ export async function resolveInviteLink(handle: string, token: string): Promise<
     inviterDisplayName: row.displayName,
     inviterAvatarColor: row.avatarColor,
   }
+}
+
+// True when someone follows `userId` on an approved edge — the footprint left
+// by upsertInvitationFriendship when a per-user invite link is accepted (it
+// creates a mutual approved follow but NO FriendInvitation row). The onboarding
+// route uses this as a second invite-provenance signal so users who arrived via
+// /u/<handle>/<token> aren't bounced back to /login (which loops through the
+// onboarding-claim refresh). A brand-new user reaching onboarding can only have
+// an approved follower through an accepted invitation, so this is a safe gate.
+export async function hasInviteLinkFriendship(userId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ followerId: follows.followerId })
+    .from(follows)
+    .where(and(eq(follows.followeeId, userId), eq(follows.state, 'approved')))
+    .limit(1)
+
+  return Boolean(row)
 }
 
 // Called from verify-otp when the user arrives via /u/<handle>/<token>.


### PR DESCRIPTION
## Problem

A new user who signs up via a **per-user invite link** (`/u/<handle>/<token>`) lands on a blank `/onboarding`, and visiting `/` throws `ERR_TOO_MANY_REDIRECTS` — they can never finish onboarding.

## Cause

The onboarding page's belt-and-suspenders gate only accepted an accepted `FriendInvitation` row. A per-user invite-link signup forms a `Friendship` directly via `upsertInvitationFriendship` and leaves **no `FriendInvitation` row**, so the user was redirected to `/login` → proxy → `/api/auth/refresh-onboarding-claim` → `/onboarding` → `/login` … an infinite loop (blank `/onboarding`, too-many-redirects on `/`).

## Fix

- `src/server/friends/user-invite-token.ts` — add `hasInviteLinkFriendship(userId)`: true when an approved follow edge points at the user (the footprint invite-link acceptance leaves).
- `src/app/onboarding/page.tsx` — accept that as a second valid invite provenance alongside the `FriendInvitation` check.

A brand-new user can only have an approved follower through an accepted invitation, so the gate stays closed to genuine bypass attempts.

## Verification (live, local dev)

| Check | Before | After |
|---|---|---|
| `GET /onboarding` (invite-link session) | redirect→/login (loop) | 200, renders name/interests UI |
| `GET /` follow-redirects | loops (exhausts cap) | 2 redirects → /onboarding (200) |

## Tests

Extended `src/app/onboarding/__tests__/page.test.ts` (6 cases) — invite-link render path + no-provenance redirect. Typecheck + lint clean.

## Note

Independent of #641 (the signup-gate fix) — different files, no conflict. But the full new-user journey needs **both**: #641 lets the invite-link user past signup, this lets them through onboarding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)