### PR TITLE
Update "Play Missed Questions" button to light-teal styling

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -316,11 +316,12 @@ export default function TodaysFiveCard({
           {missedCount > 0 ? (
             // Branch A — outstanding catch-up questions own the only button here;
             // the home page suppresses the standalone Catch up card to match.
-            // Outline (orange border / link-slate text) per the Figma "Play
-            // Missed Questions" treatment — secondary to the day's primary Play.
+            // Light-teal treatment (teal border + soft teal fill / teal text)
+            // from the triangle palette — secondary to the day's primary Play,
+            // and distinct from the orange accent used for links.
             <Link
               href="/daily/catchup"
-              className="flex min-h-12 w-full items-center justify-center rounded-[4px] border border-[var(--brand-orange)] bg-transparent text-base font-bold tracking-[0.04em] text-[var(--brand-link)] transition-colors hover:bg-[color-mix(in_srgb,var(--brand-orange)_8%,transparent)]"
+              className="flex min-h-12 w-full items-center justify-center rounded-[4px] border border-[var(--tri-darkteal)] bg-[color-mix(in_srgb,var(--tri-darkteal)_10%,transparent)] text-base font-bold tracking-[0.04em] text-[color-mix(in_srgb,var(--tri-darkteal)_55%,var(--brand-ink))] transition-colors hover:bg-[color-mix(in_srgb,var(--tri-darkteal)_18%,transparent)]"
             >
               Play Missed Questions
             </Link>


### PR DESCRIPTION
## Summary
Updates the "Play Missed Questions" button styling in the TodaysFiveCard component from an orange-outlined secondary treatment to a light-teal design that aligns with the triangle palette.

## Changes
- **Button styling:** Changed from orange border with transparent background to teal border with soft teal fill
  - Border: `var(--brand-orange)` → `var(--tri-darkteal)`
  - Background: transparent → `color-mix(in_srgb,var(--tri-darkteal)_10%,transparent)`
  - Text color: `var(--brand-link)` → `color-mix(in_srgb,var(--tri-darkteal)_55%,var(--brand-ink))`
  - Hover state: orange-tinted → `color-mix(in_srgb,var(--tri-darkteal)_18%,transparent)`

- **Documentation:** Updated inline comments to clarify the new light-teal treatment and its distinction from the orange accent used for links

## Implementation Details
The new styling uses the triangle palette's dark teal color with a soft fill (10% opacity) and teal-tinted text (55% teal mixed with brand ink). This creates a secondary button treatment that is visually distinct from the primary Play button while maintaining consistency with the design system's color palette.

https://claude.ai/code/session_017yYeZAkjrK7GZYJcJBtJGY