### PR TITLE
Improve interest suggestion UX and messaging

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -392,6 +392,7 @@ export default function OnboardingFlow({
           broadCategory: data.broadCategory ?? 'General Knowledge',
           explanation: data.explanation ?? null,
         })
+        setCustomChoice('suggested')
       } catch (fetchError) {
         if (
           !(
@@ -1281,30 +1282,30 @@ export default function OnboardingFlow({
                         </p>
                       ) : null}
                       {canonicalSuggestion ? (
-                        <div className="bg-background space-y-3 rounded-md border p-3">
-                          <p>
-                            Suggested:{' '}
-                            <span className="font-medium">
-                              {canonicalSuggestion.suggested}
-                            </span>
+                        <div className="bg-background space-y-2 rounded-md border p-3">
+                          <p className="text-muted-foreground text-xs">
+                            Refined for better trivia:
                           </p>
-                          <div className="flex flex-wrap gap-2">
+                          <p className="font-medium">
+                            {customChoice === 'mine'
+                              ? canonicalSuggestion.original
+                              : canonicalSuggestion.suggested}
+                          </p>
+                          {canonicalSuggestion.suggested !== canonicalSuggestion.original ? (
                             <button
                               type="button"
-                              className="btn-primary h-9"
-                              onClick={() => setCustomChoice('suggested')}
+                              className="btn-ghost h-8 text-xs"
+                              onClick={() =>
+                                setCustomChoice(
+                                  customChoice === 'mine' ? 'suggested' : 'mine'
+                                )
+                              }
                             >
-                              <Check className="size-4" />
-                              Use this
+                              {customChoice === 'mine'
+                                ? `Use refined: "${canonicalSuggestion.suggested}"`
+                                : `Use original: "${canonicalSuggestion.original}"`}
                             </button>
-                            <button
-                              type="button"
-                              className="btn-ghost h-9"
-                              onClick={() => setCustomChoice('mine')}
-                            >
-                              Keep mine
-                            </button>
-                          </div>
+                          ) : null}
                         </div>
                       ) : null}
                     </div>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -1338,10 +1338,10 @@ export default function OnboardingFlow({
                   </span>
                   <span className="text-muted-foreground">
                     {selectedInterests.length === 0
-                      ? 'Pick at least 1 to continue'
+                      ? 'Pick up to 5 to continue'
                       : null}
                     {selectedInterests.length === 5
-                      ? '5 max - deselect one to add another'
+                      ? '5 max - deselect one to swap'
                       : null}
                   </span>
                 </div>


### PR DESCRIPTION
## Summary
Refines the onboarding flow's interest suggestion UI and user guidance messaging. Improves the presentation of refined interest suggestions and clarifies the selection limits for users.

## Key Changes
- **Auto-select refined suggestion**: When a refined interest suggestion is fetched, automatically set `customChoice` to `'suggested'` to pre-select the refined option
- **Redesigned suggestion card**: 
  - Changed layout from two-button approach to a single toggle button
  - Added descriptive label "Refined for better trivia" with muted styling
  - Display the currently selected choice (original or refined) prominently
  - Only show the toggle button if the refined suggestion differs from the original
  - Updated button text to clearly indicate which version will be used
- **Improved user messaging**:
  - Changed "Pick at least 1 to continue" to "Pick up to 5 to continue" for clarity
  - Changed "5 max - deselect one to add another" to "5 max - deselect one to swap" for better UX language
- **Minor styling adjustments**: Reduced spacing (`space-y-3` → `space-y-2`) and button height (`h-9` → `h-8`) in the suggestion card

## Implementation Details
The suggestion card now uses a conditional toggle pattern rather than separate accept/reject buttons, making it clearer that users are choosing between two versions of the same interest. The auto-selection of the refined suggestion on fetch aligns with the improved UX by defaulting to the better option while still allowing users to override if preferred.

https://claude.ai/code/session_01DMcNpPjAdt5zfSKkMoVTop