### PR TITLE
Add 10 calibration exemplars to broaden generator domain and shape range

### DIFF
--- a/src/server/daily/exemplars.ts
+++ b/src/server/daily/exemplars.ts
@@ -57,6 +57,18 @@ export const STYLE_EXEMPLARS: readonly StyleExemplar[] = [
   { q: "Which famous piano work by Debussy quotes and mocks a theme from Wagner's Tristan und Isolde?", a: "Golliwogg's Cakewalk", shape: 'in_which_work' },
   { q: "Kitty O'Shea had an affair with what famous Irish statesman?", a: "Charles Stewart Parnell", shape: 'identification' },
   { q: "What is the name of the rope that raises or lowers a sail on a sailboat?", a: "halyard", shape: 'identification' },
+  // Calibration additions (Section 20, questions 35–63) — broaden domain and
+  // shape range beyond the founding literary/classical set.
+  { q: "In what song does Weird Al churn butter once or twice?", a: "Amish Paradise", shape: 'in_which_work' },
+  { q: "In Star Trek: The Next Generation, who was not a Merry Man?", a: "Worf", shape: 'who_did_what' },
+  { q: "In Frigaliment Importing Co. v. B.N.S. International Sales Corp. (1960), Judge Henry Friendly opened his ruling with what famous question?", a: "What is chicken?", shape: 'complete_the_quote' },
+  { q: "What is the name of the opera singer who was supposed to sing the National Anthem in The Naked Gun?", a: "Enrico Pallazzo", shape: 'identification' },
+  { q: "If I wanted to talk to Galadriel in her native language, what would it be?", a: "Quenya", shape: 'identification' },
+  { q: "If you have a date in Constantinople, where will she be waiting?", a: "Istanbul", shape: 'complete_the_quote' },
+  { q: "Which architect designed a building in Berlin that has a gigantic fish sculpture inside it?", a: "Frank Gehry", shape: 'identification' },
+  { q: "What was the name of the evil business tycoon in the animated series Gargoyles?", a: "David Xanatos", shape: 'identification' },
+  { q: "What chords make up a plagal cadence?", a: "IV to I", shape: 'technique_or_term' },
+  { q: "What is the main character's name in the Metroid video game series?", a: "Samus Aran", shape: 'identification' },
 ];
 
 export const STYLE_EXEMPLAR_BLOCK: string = STYLE_EXEMPLARS


### PR DESCRIPTION
## What

Appends 10 hand-picked questions from the Section 20 calibration set (questions 35–63) to `STYLE_EXEMPLARS` in `src/server/daily/exemplars.ts`, taking the founding set from 34 → 44.

## Why

The existing 34 exemplars are heavily literary/classical (Joyce, Wagner, Rawls, Tchaikovsky…). Since the exemplar block is the daily generator's taste reference, that skews what it produces toward highbrow trivia. These additions re-signal that fan-salient pop-culture depth — sci-fi, gaming, comedy music, architecture, law, music theory — is equally in scope, and add underused question shapes (`who_did_what`, `in_which_work`, `technique_or_term`) to counter the existing `identification` lean.

Both the daily generator (`SYSTEM_PROMPT`) and the quality-gate prompt (`QUALITY_GATE_SYSTEM_PROMPT`) consume these automatically via `STYLE_EXEMPLAR_BLOCK` — no other wiring needed.

## The 10 added

| Question | Answer | Shape | Domain it opens |
|---|---|---|---|
| Weird Al churns butter | Amish Paradise | `in_which_work` | Comedy music |
| TNG: who was not a Merry Man | Worf | `who_did_what` | Sci-fi TV |
| Frigaliment ruling's famous question | What is chicken? | `complete_the_quote` | Law |
| Naked Gun anthem singer | Enrico Pallazzo | `identification` | Film comedy |
| Galadriel's native language | Quenya | `identification` | Fantasy lit / Tolkien |
| Date in Constantinople | Istanbul | `complete_the_quote` | Indie/alt music |
| Berlin building w/ giant fish | Frank Gehry | `identification` | Architecture |
| Gargoyles tycoon | David Xanatos | `identification` | Western animation |
| Plagal cadence chords | IV to I | `technique_or_term` | Music theory |
| Metroid main character | Samus Aran | `identification` | Video games |

## Notes

- The exemplar type is `{ q, a, shape }` only — the `acceptable_variants` / `domain` metadata from the source doc is **not** carried here (that belongs in the seed question library, a separate follow-up).
- Skipped entries that were redundant with the existing set (opera, Joyce, Beethoven, a second Richard III quote) or low fan-salience as *style* models; #45 (Lou Reed / Poe's Raven) held pending the "10 minutes" qualifier flagged in the source doc.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean for `exemplars.ts`.

https://claude.ai/code/session_016EHHWg2FG3UQ282vHmFGbN

---
_Generated by [Claude Code](https://claude.ai/code/session_016EHHWg2FG3UQ282vHmFGbN)_