### PR TITLE
Lift resend prohibition on friend invites for now

### DIFF
--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -22,7 +22,10 @@ const MAX_SUGGESTED_INTEREST_LENGTH = 60
 const INVITES_PER_USER_WINDOW = 12
 const INVITES_PER_PHONE_WINDOW = 4
 const INVITE_WINDOW_MS = 1000 * 60 * 60
-const SAME_PHONE_COOLDOWN_MS = 1000 * 60 * 10
+// Resend prohibition temporarily lifted: this same-phone cooldown previously
+// blocked re-inviting the same person for 10 minutes. Restore `1000 * 60 * 10`
+// to bring the resend prohibition back.
+const SAME_PHONE_COOLDOWN_MS = 0
 const CANCELLED_PHONE_COOLDOWN_MS = 1000 * 60 * 20
 const IGNORED_PHONE_COOLDOWN_MS = 1000 * 60 * 60 * 24
 


### PR DESCRIPTION
Neutralize the same-phone invite cooldown (SAME_PHONE_COOLDOWN_MS) so users
can resend an invite to the same person without hitting the 'give this invite
a little breathing room' 429. Other abuse guards (per-user/per-phone hourly
caps, cancelled and ignored cooldowns) remain in place. Restore the 10-minute
value to bring the prohibition back.

https://claude.ai/code/session_01EgmZX3SneQJyJD1QzBC85t