### PR TITLE
Make Friends hub invite-first, simplify Friends list, and adjust nav/account UI

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import { Check, Edit3, Loader2, Plus, X } from 'lucide-react'
+import { Edit3, Loader2, Plus, X } from 'lucide-react'
 import { COUNTRIES } from '@/lib/onboarding/countries'
 import { US_STATES } from '@/lib/onboarding/us-regions'
 

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -302,7 +302,7 @@ export default function AddFriendInvite() {
         <form className="space-y-5" onSubmit={goToInterests}>
           <div>
             <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-              Add friend
+              Invite Someone
             </p>
             <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
               Who came to mind?

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -1,42 +1,40 @@
-'use client'
+'use client';
 
-import Link from 'next/link'
-
-import AddFriendInvite from '@/components/AddFriendInvite'
-import FriendsList from '@/components/FriendsList'
+import AddFriendInvite from '@/components/AddFriendInvite';
+import FriendsList from '@/components/FriendsList';
 
 export default function FriendsHubPage() {
-  function openAddFriend() {
-    window.dispatchEvent(
-      new CustomEvent('friend-invitations:create-new', { detail: {} })
-    )
+  function openInviteFlow() {
+    window.dispatchEvent(new CustomEvent('friend-invitations:create-new', { detail: {} }));
   }
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
-      <header className="mb-5 flex items-center justify-between gap-4 border-b pb-4">
-        <h1 className="text-foreground font-serif text-3xl font-semibold">
-          Friends
-        </h1>
-        <div className="flex shrink-0 items-center gap-2">
-          <Link
-            href="/friends/find"
-            className="btn-ghost min-h-10 rounded-full px-4 text-sm"
-          >
-            Find friends
-          </Link>
-          <button
-            type="button"
-            className="btn-primary min-h-10 rounded-full px-4 text-sm"
-            onClick={openAddFriend}
-          >
-            Add friend
-          </button>
-        </div>
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5 pb-24">
+      <header className="mb-5">
+        <h1 className="text-foreground font-serif text-3xl font-semibold">Friends</h1>
       </header>
+
+      <section className="border-primary/15 bg-primary/5 text-card-foreground mb-5 rounded-[2rem] border p-6 shadow-sm">
+        <p className="text-muted-foreground text-xs font-medium tracking-[0.14em] uppercase">
+          Invite
+        </p>
+        <h2 className="text-foreground mt-3 font-serif text-3xl leading-tight font-semibold">
+          Who shares your world?
+        </h2>
+        <p className="text-muted-foreground mt-3 text-base leading-7">
+          Invite someone who would enjoy the questions and discoveries happening here.
+        </p>
+        <button
+          type="button"
+          className="btn-primary mt-5 min-h-12 w-full rounded-full px-5 text-base sm:w-auto"
+          onClick={openInviteFlow}
+        >
+          Invite Someone
+        </button>
+      </section>
 
       <AddFriendInvite />
       <FriendsList />
     </main>
-  )
+  );
 }

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -1,524 +1,386 @@
-'use client'
+'use client';
 
-import Link from 'next/link'
-import PeopleYouInvited from '@/components/PeopleYouInvited'
-import { formatRelativeTime } from '@/components/feed/visual'
-import { useCallback, useEffect, useState } from 'react'
+import Link from 'next/link';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
-type Tab = 'following' | 'followers' | 'pending'
+import { formatRelativeTime } from '@/components/feed/visual';
 
 type Person = {
-  id: string
-  displayName: string
-  declaredInterests: string[]
-  sharedInterests: string[]
-  lastActiveAt: string | null
-  youFollow: boolean
-  followsYou: boolean
-}
+  id: string;
+  displayName: string;
+  declaredInterests: string[];
+  sharedInterests: string[];
+  lastActiveAt: string | null;
+  youFollow: boolean;
+  followsYou: boolean;
+};
 
 type IncomingRequest = {
-  id: string
-  requesterId: string
-  requesterName: string
-  suggestedInterests: string[]
-  personalNote: string | null
-  createdAt: string
-}
+  id: string;
+  requesterId: string;
+  requesterName: string;
+  suggestedInterests: string[];
+  personalNote: string | null;
+  createdAt: string;
+};
 
 type OutboundRequest = {
-  id: string
-  recipientId: string
-  recipientName: string
-  personalNote: string | null
-  createdAt: string
-}
-
-type FollowPrivacy = 'public' | 'approval_required'
+  id: string;
+  recipientId: string;
+  recipientName: string;
+  personalNote: string | null;
+  createdAt: string;
+};
 
 type FriendsHubResponse = {
-  ok: boolean
-  following: Person[]
-  followers: Person[]
-  incomingRequests: IncomingRequest[]
-  outboundRequests: OutboundRequest[]
-  followPrivacy: FollowPrivacy
-}
+  ok: boolean;
+  following: Person[];
+  followers: Person[];
+  incomingRequests: IncomingRequest[];
+  outboundRequests: OutboundRequest[];
+  followPrivacy: 'public' | 'approval_required';
+};
 
-type RequestAction = 'accept' | 'ignore'
+type InviteStatus = 'pending' | 'accepted' | 'expired' | 'cancelled';
+
+type OutgoingInvite = {
+  id: string;
+  inviteeDisplayName: string;
+  inviteeUserId: string | null;
+  inviteePhoneMasked: string;
+  inviteePhoneForActions: string | null;
+  suggestedInterests: string[];
+  status: InviteStatus;
+  sentAt: string;
+  acceptedAt: string | null;
+  cancelledAt: string | null;
+  expiresAt: string;
+  message: string | null;
+};
+
+type InvitationsResponse = {
+  ok: boolean;
+  invitations: OutgoingInvite[];
+};
 
 function previewInterests(interests: string[]) {
-  if (interests.length === 0) return null
-  return interests.join(', ')
+  if (interests.length === 0) return null;
+  return interests.slice(0, 3).join(', ');
 }
 
-function PersonCard({
-  person,
-  action,
+function buildSmsHref(phone: string, message: string) {
+  return `sms:${encodeURIComponent(phone)}?body=${encodeURIComponent(message)}`;
+}
+
+function invitationName(invite: OutgoingInvite) {
+  return invite.inviteeDisplayName.trim() || invite.inviteePhoneMasked || 'Invited friend';
+}
+
+function invitationTiming(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Invited recently';
+
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const invitedDay = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  const daysAgo = Math.max(0, Math.round((today.getTime() - invitedDay.getTime()) / 86_400_000));
+
+  if (daysAgo === 0) return 'Invited today';
+  if (daysAgo === 1) return 'Invited yesterday';
+  return `Invited ${daysAgo} days ago`;
+}
+
+function friendSecondary(person: Person) {
+  const sharedInterest = person.sharedInterests[0];
+  if (sharedInterest) return `Shared interest: ${sharedInterest}`;
+
+  const interests = previewInterests(person.declaredInterests);
+  if (interests) return `Into ${interests}`;
+
+  if (person.lastActiveAt) return `Active ${formatRelativeTime(person.lastActiveAt)}`;
+
+  return 'Friend on Joshing';
+}
+
+function FriendCard({ person }: { person: Person }) {
+  return (
+    <Link
+      href={`/users/${person.id}`}
+      className="group bg-card text-card-foreground hover:border-foreground/25 focus-visible:ring-ring block rounded-2xl border p-4 shadow-sm transition hover:shadow-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
+    >
+      <h3 className="text-foreground font-medium group-hover:underline group-hover:underline-offset-4">
+        {person.displayName}
+      </h3>
+      <p className="text-muted-foreground mt-1 text-sm leading-6">{friendSecondary(person)}</p>
+    </Link>
+  );
+}
+
+function PendingInviteCard({
+  invite,
+  copyingId,
+  cancellingId,
+  onCopy,
+  onCancel,
 }: {
-  person: Person
-  action?: React.ReactNode
+  invite: OutgoingInvite;
+  copyingId: string | null;
+  cancellingId: string | null;
+  onCopy: (invite: OutgoingInvite) => void;
+  onCancel: (invite: OutgoingInvite) => void;
 }) {
-  const interests = previewInterests(person.declaredInterests)
-  const sharedInterest = person.sharedInterests[0]
-  const lastActiveLabel = person.lastActiveAt ? formatRelativeTime(person.lastActiveAt) : null
+  const canMessage = invite.message && invite.inviteePhoneForActions;
 
   return (
-    <div className="bg-background hover:border-foreground/30 flex items-start justify-between gap-3 rounded-xl border p-3 transition hover:shadow-sm">
-      <Link href={`/users/${person.id}`} className="min-w-0 flex-1">
-        <h3 className="text-primary decoration-primary/40 hover:decoration-primary font-medium underline underline-offset-4">
-          {person.displayName}
-        </h3>
-        {interests ? (
-          <p className="text-muted-foreground mt-1 text-sm leading-6">A mind into {interests}</p>
-        ) : (
-          <p className="text-muted-foreground mt-1 text-sm leading-6">
-            Interests will appear here as they declare them.
-          </p>
-        )}
-        <div className="mt-1 flex flex-wrap items-center gap-2">
-          {person.followsYou && person.youFollow ? (
-            <span className="text-muted-foreground/70 text-xs">Mutual</span>
-          ) : person.followsYou ? (
-            <span className="text-muted-foreground/70 text-xs">Follows you</span>
-          ) : null}
-          {lastActiveLabel ? (
-            <span className="text-muted-foreground/70 text-xs">Active {lastActiveLabel}</span>
-          ) : null}
+    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-foreground font-medium">{invitationName(invite)}</h3>
+          <p className="text-muted-foreground mt-1 text-sm">{invitationTiming(invite.sentAt)}</p>
         </div>
-      </Link>
-      <div className="flex shrink-0 flex-col items-end gap-2">
-        {sharedInterest ? (
-          <span className="bg-muted text-foreground max-w-[12rem] rounded-full px-3 py-1 text-center text-xs font-medium break-words whitespace-normal">
-            Shared: {sharedInterest}
-          </span>
-        ) : null}
-        {action}
+        <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
+          Waiting
+        </span>
       </div>
-    </div>
-  )
+
+      {invite.suggestedInterests.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {invite.suggestedInterests.map((interest) => (
+            <span
+              key={interest}
+              className="border-primary/10 bg-primary/5 text-foreground rounded-full border px-3 py-1 text-sm"
+            >
+              {interest}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      {canMessage ? (
+        <div className="mt-4 space-y-2">
+          <a
+            className="btn-primary flex min-h-11 w-full items-center justify-center rounded-full"
+            href={buildSmsHref(invite.inviteePhoneForActions!, invite.message!)}
+          >
+            Send message
+          </a>
+          <div className="flex justify-center gap-6">
+            <button
+              type="button"
+              className="text-muted-foreground text-sm"
+              onClick={() => onCopy(invite)}
+            >
+              {copyingId === invite.id ? 'Copied ✓' : 'Copy instead'}
+            </button>
+            <button
+              type="button"
+              className="text-muted-foreground text-sm"
+              onClick={() => onCancel(invite)}
+              disabled={cancellingId === invite.id}
+            >
+              {cancellingId === invite.id ? 'Setting aside…' : 'Set aside'}
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </article>
+  );
 }
 
 export default function FriendsList() {
-  const [following, setFollowing] = useState<Person[]>([])
-  const [followers, setFollowers] = useState<Person[]>([])
-  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>([])
-  const [outboundRequests, setOutboundRequests] = useState<OutboundRequest[]>([])
-  const [followPrivacy, setFollowPrivacy] = useState<FollowPrivacy>('approval_required')
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const [pendingRequest, setPendingRequest] = useState<string | null>(null)
-  const [privacyUpdating, setPrivacyUpdating] = useState(false)
-  const [activeTab, setActiveTab] = useState<Tab>('following')
-  // Passive Pending-tab row count — null while loading, 0 when there's
-  // nothing new. Cleared after the user visits /friends/find.
-  const [newDiscoveryCount, setNewDiscoveryCount] = useState<number | null>(null)
+  const [following, setFollowing] = useState<Person[]>([]);
+  const [followers, setFollowers] = useState<Person[]>([]);
+  const [invites, setInvites] = useState<OutgoingInvite[]>([]);
+  const [friendsLoading, setFriendsLoading] = useState(true);
+  const [invitesLoading, setInvitesLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [copyingId, setCopyingId] = useState<string | null>(null);
+  const [cancellingId, setCancellingId] = useState<string | null>(null);
 
   const loadFriends = useCallback(async () => {
-    setError(null)
+    setError(null);
 
     try {
       const response = await fetch('/api/friends', {
         cache: 'no-store',
         credentials: 'include',
-      })
+      });
       const body = (await response.json().catch(() => null)) as
         | FriendsHubResponse
         | { message?: string }
-        | null
+        | null;
 
       if (!response.ok || !body || !('following' in body)) {
         throw new Error(
-          body && 'message' in body && body.message ? body.message : 'Could not load follows.',
-        )
+          body && 'message' in body && body.message ? body.message : 'Could not load friends.',
+        );
       }
 
-      setFollowing(body.following)
-      setFollowers(body.followers)
-      setIncomingRequests(body.incomingRequests)
-      setOutboundRequests(body.outboundRequests ?? [])
-      setFollowPrivacy(body.followPrivacy)
+      setFollowing(body.following);
+      setFollowers(body.followers);
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not load follows.')
+      setError(caught instanceof Error ? caught.message : 'Could not load friends.');
     } finally {
-      setLoading(false)
+      setFriendsLoading(false);
     }
-  }, [])
+  }, []);
+
+  const loadInvites = useCallback(async () => {
+    setError(null);
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        cache: 'no-store',
+        credentials: 'include',
+      });
+      const body = (await response.json().catch(() => null)) as
+        | InvitationsResponse
+        | { message?: string }
+        | null;
+
+      if (!response.ok || !body || !('invitations' in body)) {
+        throw new Error(
+          body && 'message' in body && body.message ? body.message : 'Could not load invitations.',
+        );
+      }
+
+      setInvites(body.invitations);
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : 'Could not load invitations.');
+    } finally {
+      setInvitesLoading(false);
+    }
+  }, []);
 
   useEffect(() => {
-    queueMicrotask(() => void loadFriends())
-  }, [loadFriends])
+    queueMicrotask(() => {
+      void loadFriends();
+      void loadInvites();
+    });
 
-  useEffect(() => {
-    let cancelled = false
-    void (async () => {
-      try {
-        const response = await fetch('/api/friends/has-new-discovery', {
-          credentials: 'include',
-        })
-        if (!response.ok) return
-        const body = (await response.json().catch(() => null)) as
-          | { hasNew: boolean; count: number }
-          | null
-        if (!cancelled && body) {
-          setNewDiscoveryCount(body.hasNew ? body.count : 0)
-        }
-      } catch {
-        // Swallow — passive signal, OK to skip.
-      }
-    })()
-    return () => {
-      cancelled = true
+    function refresh() {
+      void loadFriends();
+      void loadInvites();
     }
-  }, [])
 
-  async function updateRequest(requestId: string, action: RequestAction) {
-    setPendingRequest(`${requestId}:${action}`)
-    setError(null)
+    window.addEventListener('friend-invitations:refresh', refresh);
+    return () => window.removeEventListener('friend-invitations:refresh', refresh);
+  }, [loadFriends, loadInvites]);
+
+  const friends = useMemo(() => {
+    const peopleById = new Map<string, Person>();
+    for (const person of [...following, ...followers]) {
+      if (!person.youFollow || !person.followsYou) continue;
+      peopleById.set(person.id, person);
+    }
+    return Array.from(peopleById.values()).sort((a, b) =>
+      a.displayName.localeCompare(b.displayName),
+    );
+  }, [followers, following]);
+
+  const pendingInvites = useMemo(
+    () => invites.filter((invite) => invite.status === 'pending'),
+    [invites],
+  );
+
+  async function copyInvite(invite: OutgoingInvite) {
+    if (!invite.message) return;
 
     try {
-      const response = await fetch(`/api/friend-requests/${requestId}/${action}`, {
-        method: 'POST',
-        credentials: 'include',
-      })
-      const body = (await response.json().catch(() => null)) as { message?: string } | null
-
-      if (!response.ok) {
-        throw new Error(body?.message ?? 'Could not update this request.')
-      }
-
-      await loadFriends()
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not update this request.')
-    } finally {
-      setPendingRequest(null)
+      await navigator.clipboard.writeText(invite.message);
+      setCopyingId(invite.id);
+      window.setTimeout(() => setCopyingId(null), 2000);
+    } catch {
+      if (navigator.share) await navigator.share({ text: invite.message });
     }
   }
 
-  async function cancelOutbound(requestId: string) {
-    setPendingRequest(`${requestId}:cancel`)
-    setError(null)
-    const previous = outboundRequests
-    setOutboundRequests((current) => current.filter((row) => row.id !== requestId))
+  async function cancelInvite(invite: OutgoingInvite) {
+    setCancellingId(invite.id);
+    setError(null);
 
     try {
-      const response = await fetch(`/api/friend-requests/${requestId}/cancel`, {
-        method: 'POST',
+      const response = await fetch('/api/friend-invitations', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
         credentials: 'include',
-      })
+        body: JSON.stringify({ invitationId: invite.id }),
+      });
+      const body = (await response.json().catch(() => null)) as {
+        message?: string;
+      } | null;
+
       if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as { message?: string } | null
-        setOutboundRequests(previous)
-        throw new Error(body?.message ?? 'Could not cancel this request.')
+        throw new Error(body?.message ?? 'Could not set this aside.');
       }
+
+      await loadInvites();
     } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not cancel this request.')
+      setError(caught instanceof Error ? caught.message : 'Could not set this aside.');
     } finally {
-      setPendingRequest(null)
+      setCancellingId(null);
     }
   }
 
-  async function followBack(personId: string) {
-    setPendingRequest(`${personId}:follow`)
-    setError(null)
-    try {
-      const response = await fetch('/api/friend-requests', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ inviteeUserId: personId }),
-      })
-      if (!response.ok) {
-        const body = (await response.json().catch(() => null)) as { message?: string } | null
-        throw new Error(body?.message ?? 'Could not follow this person.')
-      }
-      await loadFriends()
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not follow this person.')
-    } finally {
-      setPendingRequest(null)
-    }
-  }
-
-  async function togglePrivacy(next: FollowPrivacy) {
-    setPrivacyUpdating(true)
-    setError(null)
-    const previous = followPrivacy
-    setFollowPrivacy(next)
-    try {
-      const response = await fetch('/api/users/me', {
-        method: 'PATCH',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ followPrivacy: next }),
-      })
-      if (!response.ok) {
-        setFollowPrivacy(previous)
-        const body = (await response.json().catch(() => null)) as { message?: string } | null
-        throw new Error(body?.message ?? 'Could not update your privacy setting.')
-      }
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not update your privacy setting.')
-    } finally {
-      setPrivacyUpdating(false)
-    }
-  }
+  const loading = friendsLoading || invitesLoading;
 
   return (
-    <div className="space-y-5">
-      {/* Privacy gate */}
-      <div className="bg-muted/40 flex items-start justify-between gap-3 rounded-xl border p-3">
-        <div className="min-w-0">
-          <p className="text-foreground text-sm font-medium">Who can follow you</p>
-          <p className="text-muted-foreground mt-1 text-xs">
-            {followPrivacy === 'public'
-              ? 'Anyone can follow you instantly.'
-              : 'New followers ask first — you approve each one.'}
-          </p>
-        </div>
-        <button
-          type="button"
-          className="btn-ghost min-h-9 shrink-0 rounded-full px-4 text-sm"
-          disabled={privacyUpdating}
-          onClick={() =>
-            void togglePrivacy(followPrivacy === 'public' ? 'approval_required' : 'public')
-          }
-        >
-          {privacyUpdating
-            ? 'Saving…'
-            : followPrivacy === 'public'
-              ? 'Require approval'
-              : 'Make public'}
-        </button>
-      </div>
-
-      {/* Tab bar */}
-      <div className="flex border-b">
-        <button
-          type="button"
-          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'following'
-              ? 'border-foreground text-foreground border-b-2'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-          onClick={() => setActiveTab('following')}
-        >
-          Following
-        </button>
-        <button
-          type="button"
-          className={`px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'followers'
-              ? 'border-foreground text-foreground border-b-2'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-          onClick={() => setActiveTab('followers')}
-        >
-          Followers
-        </button>
-        <button
-          type="button"
-          className={`flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium transition-colors ${
-            activeTab === 'pending'
-              ? 'border-foreground text-foreground border-b-2'
-              : 'text-muted-foreground hover:text-foreground'
-          }`}
-          onClick={() => setActiveTab('pending')}
-        >
-          Pending
-          {incomingRequests.length > 0 ? (
-            <span className="bg-primary text-primary-foreground rounded-full px-1.5 py-0.5 text-xs leading-none">
-              {incomingRequests.length}
-            </span>
-          ) : null}
-        </button>
-      </div>
-
+    <div className="space-y-8">
       {error ? <p className="text-destructive text-sm font-medium">{error}</p> : null}
 
-      {/* Following tab */}
-      {activeTab === 'following' ? (
-        <section>
-          {loading ? (
-            <p className="text-muted-foreground text-sm">Loading…</p>
-          ) : following.length > 0 ? (
-            <div className="space-y-3">
-              {following.map((person) => (
-                <PersonCard key={person.id} person={person} />
-              ))}
-            </div>
-          ) : (
-            <div className="py-2 text-center">
-              <h2 className="font-serif text-xl font-semibold">
-                Follow the people you trade facts with.
-              </h2>
-              <p className="text-muted-foreground mt-2 text-sm leading-6">
-                When you follow someone, their questions and moments start showing up for you.
-              </p>
-            </div>
-          )}
+      {loading ? <p className="text-muted-foreground text-sm">Loading friends…</p> : null}
+
+      {!loading && pendingInvites.length > 0 ? (
+        <section aria-labelledby="waiting-for-response" className="space-y-3">
+          <h2
+            id="waiting-for-response"
+            className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase"
+          >
+            Waiting for Response
+          </h2>
+          <div className="space-y-3">
+            {pendingInvites.map((invite) => (
+              <PendingInviteCard
+                key={invite.id}
+                invite={invite}
+                copyingId={copyingId}
+                cancellingId={cancellingId}
+                onCopy={copyInvite}
+                onCancel={cancelInvite}
+              />
+            ))}
+          </div>
         </section>
       ) : null}
 
-      {/* Followers tab */}
-      {activeTab === 'followers' ? (
-        <section>
-          {loading ? (
-            <p className="text-muted-foreground text-sm">Loading…</p>
-          ) : followers.length > 0 ? (
+      {!loading ? (
+        <section aria-labelledby="friends-section" className="space-y-3">
+          <h2
+            id="friends-section"
+            className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase"
+          >
+            Friends
+          </h2>
+          {friends.length > 0 ? (
             <div className="space-y-3">
-              {followers.map((person) => (
-                <PersonCard
-                  key={person.id}
-                  person={person}
-                  action={
-                    person.youFollow ? null : (
-                      <button
-                        type="button"
-                        className="btn-ghost min-h-9 rounded-full px-4 text-sm"
-                        disabled={Boolean(pendingRequest)}
-                        onClick={() => void followBack(person.id)}
-                      >
-                        {pendingRequest === `${person.id}:follow` ? 'Following…' : 'Follow back'}
-                      </button>
-                    )
-                  }
-                />
+              {friends.map((person) => (
+                <FriendCard key={person.id} person={person} />
               ))}
             </div>
-          ) : (
-            <p className="text-muted-foreground bg-muted rounded-xl px-3 py-2 text-sm">
-              No one follows you yet.
+          ) : pendingInvites.length > 0 ? (
+            <p className="bg-card text-muted-foreground rounded-2xl border p-4 text-sm shadow-sm">
+              Accepted invitations will appear here.
             </p>
+          ) : (
+            <div className="bg-card text-card-foreground rounded-2xl border p-5 shadow-sm">
+              <h3 className="font-serif text-xl font-semibold">You haven’t invited anyone yet.</h3>
+              <p className="text-muted-foreground mt-2 text-sm leading-6">
+                Start with someone who shares part of your world.
+              </p>
+            </div>
           )}
         </section>
-      ) : null}
-
-      {/* Pending tab */}
-      {activeTab === 'pending' ? (
-        <div className="space-y-6">
-          {newDiscoveryCount && newDiscoveryCount > 0 ? (
-            <Link
-              href="/friends/find"
-              className="bg-primary/5 ring-primary/20 hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm ring-1 transition"
-            >
-              <p className="text-foreground text-sm font-medium">
-                ✨ {newDiscoveryCount} new{' '}
-                {newDiscoveryCount === 1 ? 'contact is' : 'contacts are'} on Joshing.
-              </p>
-              <p className="text-muted-foreground mt-1 text-xs">→ Find friends</p>
-            </Link>
-          ) : (
-            <Link
-              href="/friends/find"
-              className="bg-card hover:border-foreground/30 text-card-foreground block rounded-2xl border p-4 shadow-sm transition"
-            >
-              <p className="text-foreground text-sm font-medium">
-                Find friends already on Joshing or invite someone new →
-              </p>
-            </Link>
-          )}
-
-          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-            <h2 className="font-serif text-lg font-semibold">Follow requests</h2>
-            {loading ? (
-              <p className="text-muted-foreground mt-2 text-sm">Loading…</p>
-            ) : incomingRequests.length > 0 ? (
-              <div className="mt-3 space-y-3">
-                {incomingRequests.map((request) => (
-                  <article key={request.id} className="bg-background rounded-xl border p-3">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div>
-                        <h3 className="text-foreground font-medium">{request.requesterName}</h3>
-                        {request.suggestedInterests.length > 0 ? (
-                          <div className="mt-3 flex flex-wrap gap-2">
-                            {request.suggestedInterests.map((interest) => (
-                              <span
-                                key={interest}
-                                className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
-                              >
-                                {interest}
-                              </span>
-                            ))}
-                          </div>
-                        ) : (
-                          <p className="text-muted-foreground mt-1 text-sm">
-                            Wants to follow you.
-                          </p>
-                        )}
-                        {request.personalNote ? (
-                          <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
-                            “{request.personalNote}”
-                          </blockquote>
-                        ) : null}
-                      </div>
-
-                      <div className="grid grid-cols-2 gap-2 sm:min-w-48">
-                        <button
-                          type="button"
-                          className="btn-primary min-h-11 rounded-full"
-                          disabled={Boolean(pendingRequest)}
-                          onClick={() => void updateRequest(request.id, 'accept')}
-                        >
-                          {pendingRequest === `${request.id}:accept` ? 'Approving…' : 'Approve'}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn-ghost min-h-11 rounded-full"
-                          disabled={Boolean(pendingRequest)}
-                          onClick={() => void updateRequest(request.id, 'ignore')}
-                        >
-                          {pendingRequest === `${request.id}:ignore` ? 'Setting aside…' : 'Not now'}
-                        </button>
-                      </div>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            ) : (
-              <p className="text-muted-foreground bg-muted mt-2 rounded-xl px-3 py-2 text-sm">
-                No follow requests right now.
-              </p>
-            )}
-          </section>
-
-          {outboundRequests.length > 0 ? (
-            <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
-              <h2 className="font-serif text-lg font-semibold">Sent requests</h2>
-              <p className="text-muted-foreground mt-1 text-sm">Waiting on their approval.</p>
-              <div className="mt-3 space-y-3">
-                {outboundRequests.map((request) => (
-                  <article key={request.id} className="bg-background rounded-xl border p-3">
-                    <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-                      <div className="min-w-0">
-                        <h3 className="text-foreground font-medium">{request.recipientName}</h3>
-                        <p className="text-muted-foreground/70 mt-1 text-xs">
-                          sent {formatRelativeTime(request.createdAt)}
-                        </p>
-                        {request.personalNote ? (
-                          <blockquote className="border-primary/30 text-muted-foreground mt-3 border-l-2 pl-3 text-sm italic">
-                            “{request.personalNote}”
-                          </blockquote>
-                        ) : null}
-                      </div>
-                      <button
-                        type="button"
-                        className="btn-ghost min-h-9 self-start rounded-full px-4 text-sm"
-                        disabled={Boolean(pendingRequest)}
-                        onClick={() => void cancelOutbound(request.id)}
-                      >
-                        {pendingRequest === `${request.id}:cancel` ? 'Cancelling…' : 'Cancel'}
-                      </button>
-                    </div>
-                  </article>
-                ))}
-              </div>
-            </section>
-          ) : null}
-
-          <PeopleYouInvited />
-        </div>
       ) : null}
     </div>
-  )
+  );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -8,10 +8,9 @@ import { CreateChooser } from '@/components/CreateChooser';
 
 const navItems = [
   { href: '/', label: 'Home', Icon: Home },
-  { href: '/friends', label: 'Friends', Icon: Users },
   { href: '/questions', label: 'Questions', Icon: Pencil },
   { href: '/knowledge', label: 'Knowledge', Icon: Brain },
-  { href: '/users/me', label: 'Profile', Icon: User },
+  { href: '/friends', label: 'Friends', Icon: Users },
 ];
 
 function initialsFor(name: string): string {
@@ -24,6 +23,30 @@ function initialsFor(name: string): string {
 function formatBadgeCount(count: number): string {
   if (count > 99) return '99+';
   return String(count);
+}
+
+function AccountIcon({
+  active,
+  initials,
+}: {
+  active: boolean;
+  initials: string | null;
+}) {
+  if (!initials) {
+    return <User className="size-5" strokeWidth={active ? 2.4 : 1.8} />;
+  }
+
+  return (
+    <span
+      className={[
+        'grid size-5 place-items-center rounded-full text-[10px] font-semibold',
+        active ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
+      ].join(' ')}
+      aria-hidden="true"
+    >
+      {initials}
+    </span>
+  );
 }
 
 export function Nav({
@@ -81,23 +104,6 @@ export function Nav({
     return null;
   }
 
-  function AccountIcon({ active }: { active: boolean }) {
-    if (!accountInitials) {
-      return <User className="size-5" strokeWidth={active ? 2.4 : 1.8} />;
-    }
-
-    return (
-      <span
-        className={[
-          'grid size-5 place-items-center rounded-full text-[10px] font-semibold',
-          active ? 'bg-foreground text-background' : 'bg-muted text-muted-foreground',
-        ].join(' ')}
-        aria-hidden="true"
-      >
-        {accountInitials}
-      </span>
-    );
-  }
 
   // The Profile tab is active for both the canonical /users/<self-id>
   // route and the /users/me alias before it redirects.
@@ -126,24 +132,34 @@ export function Nav({
           >
             Joshing
           </Link>
-          <Link
-            href="/activities"
-            aria-label={
-              showBadge ? `Activity, ${bellBadgeCount} unread` : 'Activity'
-            }
-            className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <Bell className="size-5" strokeWidth={1.9} />
-            {showBadge ? (
-              <span
-                className="absolute right-1 top-1 grid min-w-[18px] items-center rounded-full px-[5px] text-center font-mono text-[9px] font-semibold leading-[14px] text-[var(--brand-card)]"
-                style={{ backgroundColor: 'var(--destructive)' }}
-                aria-hidden="true"
-              >
-                {badgeText}
-              </span>
-            ) : null}
-          </Link>
+          <div className="flex items-center gap-1">
+            <Link
+              href="/activities"
+              aria-label={
+                showBadge ? `Activity, ${bellBadgeCount} unread` : 'Activity'
+              }
+              className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <Bell className="size-5" strokeWidth={1.9} />
+              {showBadge ? (
+                <span
+                  className="absolute right-1 top-1 grid min-w-[18px] items-center rounded-full px-[5px] text-center font-mono text-[9px] font-semibold leading-[14px] text-[var(--brand-card)]"
+                  style={{ backgroundColor: 'var(--destructive)' }}
+                  aria-hidden="true"
+                >
+                  {badgeText}
+                </span>
+              ) : null}
+            </Link>
+            <Link
+              href="/users/me"
+              aria-label="Account and settings"
+              aria-current={isProfileTabActive('/users/me') ? 'page' : undefined}
+              className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <AccountIcon active={isProfileTabActive('/users/me')} initials={accountInitials} />
+            </Link>
+          </div>
         </div>
       </header>
       {showNewGameShortcut ? (
@@ -199,7 +215,7 @@ export function Nav({
               >
                 <span aria-hidden="true" className="relative grid place-items-center">
                   {isProfile ? (
-                    <AccountIcon active={active} />
+                    <AccountIcon active={active} initials={accountInitials} />
                   ) : (
                     <Icon
                       className="size-5"

--- a/src/components/__tests__/FriendsHubPage.test.tsx
+++ b/src/components/__tests__/FriendsHubPage.test.tsx
@@ -1,44 +1,45 @@
-import React from 'react'
-import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/link', () => ({
-  default: ({
-    href,
-    children,
-    ...props
-  }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+  default: ({ href, children, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
     <a href={typeof href === 'string' ? href : String(href)} {...props}>
       {children}
     </a>
   ),
-}))
+}));
 
-import FriendsHubPage from '@/components/FriendsHubPage'
-import FriendsList from '@/components/FriendsList'
+import FriendsHubPage from '@/components/FriendsHubPage';
+import FriendsList from '@/components/FriendsList';
 
 const forbiddenGamificationCopy =
-  /leaderboard|ranking|ranked|score|points?|percent|%|timer|streak|hurry|urgent/i
+  /leaderboard|ranking|ranked|score|points?|percent|%|timer|streak|hurry|urgent/i;
+
+const forbiddenRelationshipCopy =
+  /Following|Followers|Who can follow you|Make public|Follow requests|Mutual|Follows you/i;
 
 describe('Friends page QA surface', () => {
-  it('keeps the Add Friend CTA visible and avoids leaderboard/ranking mechanics', () => {
-    const html = renderToStaticMarkup(<FriendsHubPage />)
+  it('centers the page on inviting someone without leaderboard/ranking mechanics', () => {
+    const html = renderToStaticMarkup(<FriendsHubPage />);
 
-    expect(html).toContain('Friends')
-    expect(html).toContain('Add friend')
-    expect(html).not.toContain('Joshing</p>')
-    expect(html).not.toContain('Invite your people')
-    expect(html).not.toContain('Send a warm note')
-    expect(html).not.toMatch(forbiddenGamificationCopy)
-  })
+    expect(html).toContain('Friends');
+    expect(html).toContain('Who shares your world?');
+    expect(html).toContain('Invite Someone');
+    expect(html).not.toContain('Add friend');
+    expect(html).not.toMatch(forbiddenGamificationCopy);
+    expect(html).not.toMatch(forbiddenRelationshipCopy);
+  });
 
-  it('renders the Following / Followers / Pending tab bar with following active by default', () => {
-    const html = renderToStaticMarkup(<FriendsList />)
+  it('removes social-network tabs and profile controls from the friends list shell', () => {
+    const html = renderToStaticMarkup(<FriendsList />);
 
-    expect(html).toContain('Following')
-    expect(html).toContain('Followers')
-    expect(html).toContain('Pending')
-    expect(html).toContain('Who can follow you')
-    expect(html).not.toMatch(forbiddenGamificationCopy)
-  })
-})
+    expect(html).toContain('Loading friends…');
+    expect(html).not.toContain('Following');
+    expect(html).not.toContain('Followers');
+    expect(html).not.toContain('Pending');
+    expect(html).not.toContain('Who can follow you');
+    expect(html).not.toMatch(forbiddenGamificationCopy);
+    expect(html).not.toMatch(forbiddenRelationshipCopy);
+  });
+});

--- a/src/components/friends/AddFriendButton.tsx
+++ b/src/components/friends/AddFriendButton.tsx
@@ -86,21 +86,36 @@ export function AddFriendButton({
     void runAction('ignore', relationship.friendshipId, 'Set aside.')
   }
 
+  const removeCopy =
+    relationship.state === 'friends'
+      ? {
+          action: 'Unfriend',
+          confirming: 'Unfriending…',
+          prompt: `Unfriend ${targetDisplayName}?`,
+          toast: 'Unfriended.',
+        }
+      : {
+          action: 'Unfollow',
+          confirming: 'Unfollowing…',
+          prompt: `Unfollow ${targetDisplayName}?`,
+          toast: 'Unfollowed.',
+        }
+
   function handleRemove() {
     if (!relationship.friendshipId) return
     if (confirmUnfriend) {
-      // Swap the Unfollow button for an inline Unfollow/Keep confirmation rather
-      // than punching out to native window.confirm chrome.
+      // Swap the remove button for an inline confirmation rather than punching
+      // out to native window.confirm chrome.
       setConfirmingRemove(true)
       return
     }
-    void runAction('remove', relationship.friendshipId, 'Unfollowed.')
+    void runAction('remove', relationship.friendshipId, removeCopy.toast)
   }
 
   function confirmRemove() {
     if (!relationship.friendshipId) return
     setConfirmingRemove(false)
-    void runAction('remove', relationship.friendshipId, 'Unfollowed.')
+    void runAction('remove', relationship.friendshipId, removeCopy.toast)
   }
 
   return (
@@ -170,18 +185,16 @@ export function AddFriendButton({
             <div
               className="flex flex-wrap items-center gap-2"
               role="group"
-              aria-label={`Unfollow ${targetDisplayName}?`}
+              aria-label={removeCopy.prompt}
             >
-              <span className="text-sm text-foreground">
-                Unfollow {targetDisplayName}?
-              </span>
+              <span className="text-sm text-foreground">{removeCopy.prompt}</span>
               <button
                 type="button"
                 className="btn-danger"
                 onClick={confirmRemove}
                 disabled={pendingAction !== null}
               >
-                {pendingAction === 'remove' ? 'Unfollowing…' : 'Unfollow'}
+                {pendingAction === 'remove' ? removeCopy.confirming : removeCopy.action}
               </button>
               <button
                 type="button"
@@ -203,7 +216,7 @@ export function AddFriendButton({
                 onClick={handleRemove}
                 disabled={pendingAction !== null}
               >
-                Unfollow
+                {removeCopy.action}
               </button>
             </>
           )

--- a/src/components/friends/__tests__/AddFriendButton.test.tsx
+++ b/src/components/friends/__tests__/AddFriendButton.test.tsx
@@ -1,0 +1,47 @@
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+import { AddFriendButton } from '@/components/friends/AddFriendButton';
+import type { RelationshipResult } from '@/server/db/queries/friend-requests';
+
+function relationship(state: RelationshipResult['state']): RelationshipResult {
+  return {
+    state,
+    friendshipId: state === 'friends' || state === 'following' ? 'friendship-1' : null,
+    formedAt: null,
+    isBlocked: false,
+  };
+}
+
+describe('AddFriendButton removal copy', () => {
+  it('uses unfriend language for accepted friends', () => {
+    const html = renderToStaticMarkup(
+      <AddFriendButton
+        targetUserId="friend-1"
+        targetDisplayName="Jordan"
+        relationship={relationship('friends')}
+      />,
+    );
+
+    expect(html).toContain('Friends ✓');
+    expect(html).toContain('Unfriend');
+    expect(html).not.toContain('Unfollow');
+  });
+
+  it('keeps unfollow language for one-way relationships', () => {
+    const html = renderToStaticMarkup(
+      <AddFriendButton
+        targetUserId="person-1"
+        targetDisplayName="Jordan"
+        relationship={relationship('following')}
+      />,
+    );
+
+    expect(html).toContain('Following ✓');
+    expect(html).toContain('Unfollow');
+  });
+});


### PR DESCRIPTION
### Motivation
- Shift the Friends surface away from follower-centric social mechanics toward an invite-first, private-friends experience and simplify the in-page social controls.
- Improve clarity of account controls in the top header and make the bottom nav account avatar consistent with initials.
- Unify how outbound invitations are loaded and managed separately from mutual friend lists.

### Description
- Replace the Friends hub header with an invite-focused callout and change the CTA text from `Add friend` to `Invite Someone`, plus expose an `friend-invitations:create-new` event via `openInviteFlow`.
- Heavily refactor `FriendsList` to remove Following/Followers/Pending tabs and follow-privacy controls, add types for invitations and people, fetch separate `/api/friends` and `/api/friend-invitations` endpoints, and render `FriendCard` and `PendingInviteCard` components with copy/cancel invite flows and memoized friend lists.
- Adjust `Nav` to surface account entry in the header, add an `AccountIcon` component that uses initials, reorder nav items, and keep the bell badge and profile controls grouped.
- Update `AddFriendButton` to use contextual removal copy (`Unfriend` vs `Unfollow`) and convert confirmation copy to use that message.
- Small cleanups: remove an unused icon import in `OnboardingFlow`, reformat semicolons/TS types, add helper utilities (`buildSmsHref`, `invitationTiming`, etc.), and remove or replace legacy components (`PeopleYouInvited`).
- Tests: update `FriendsHubPage` QA test expectations to match the new invite-first copy and shell, and add `AddFriendButton` unit tests validating removal copy.

### Testing
- Ran component unit tests in `src/components/__tests__` including updated `FriendsHubPage.test.tsx` and the new `friends/__tests__/AddFriendButton.test.tsx`, and they passed.
- Exercised the refactored `FriendsList` loading paths by running tests that render static markup via `renderToStaticMarkup`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23100fe9c8832e8237e428b84ec75d)