### PR TITLE
fix(feed): show directly-sent questions regardless of question visibility

### DIFF
--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/server/db/queries/feed', () => ({
   getFeedForUser: getFeedForUserMock,
   visibleFeedSourcePredicate: { op: 'visibleFeedSourcePredicate' },
   questionVisibilityPredicate: vi.fn((viewerUserId) => ({ op: 'questionVisibilityPredicate', viewerUserId })),
+  feedItemVisibilityPredicate: vi.fn((viewerUserId) => ({ op: 'feedItemVisibilityPredicate', viewerUserId })),
 }));
 vi.mock('@/server/db', () => ({
   db: dbMock,

--- a/src/server/db/queries/__tests__/question-visibility.test.ts
+++ b/src/server/db/queries/__tests__/question-visibility.test.ts
@@ -44,7 +44,28 @@ vi.mock('@/server/db', () => ({
   users: { id: 'users.id' },
 }));
 
-import { questionVisibilityPredicate } from '@/server/db/queries/feed';
+import { feedItemVisibilityPredicate, questionVisibilityPredicate } from '@/server/db/queries/feed';
+
+describe('feedItemVisibilityPredicate (direct_sent exemption)', () => {
+  it('admits a feed item when it is direct_sent OR the question visibility gate passes', () => {
+    const predicate = feedItemVisibilityPredicate('viewer-1') as { op: string; parts: unknown[] };
+
+    expect(predicate.op).toBe('or');
+
+    // A question addressed directly to the viewer renders regardless of the
+    // question's visibility — otherwise a 'friends' send to a non-follower is
+    // silently filtered out of the recipient's feed.
+    expect(predicate.parts).toContainEqual({ op: 'eq', column: 'feedItems.sourceType', value: 'direct_sent' });
+
+    // The broadcast/feed visibility gate is still the other branch.
+    const visibilityBranch = predicate.parts.find(
+      (p): p is { op: string; parts: unknown[] } =>
+        typeof p === 'object' && p !== null && (p as { op?: string }).op === 'or',
+    );
+    expect(visibilityBranch).toBeDefined();
+    expect(visibilityBranch!.parts).toContainEqual({ op: 'eq', column: 'questions.visibility', value: 'public' });
+  });
+});
 
 describe('questionVisibilityPredicate (D-1 Stage 4)', () => {
   it('admits public questions unconditionally and gates friends on an approved viewer→author follow', () => {

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -269,9 +269,25 @@ export function questionVisibilityPredicate(viewerUserId: string) {
   )!;
 }
 
+// A question's visibility ('public'/'friends'/'private') gates broadcast/feed
+// items, but NOT items addressed directly to the viewer: a direct_sent question
+// always renders for its recipient regardless of the question's visibility.
+// Without this exemption a 'friends'-visibility question sent straight to a
+// recipient who doesn't (yet) follow the author is silently filtered out of
+// their feed even though a feed row was written. Mirrors the direct_sent
+// special-case in viewerNotAlreadyAnsweredPredicate. Exported so get-feed-page's
+// diagnostic/badge counts apply the identical rule and stay in sync with what
+// actually renders.
+export function feedItemVisibilityPredicate(viewerUserId: string) {
+  return or(
+    eq(feedItems.sourceType, 'direct_sent'),
+    questionVisibilityPredicate(viewerUserId),
+  )!;
+}
+
 function visibleQuestionPredicate(viewerUserId: string, dismissedDomains: string[]) {
   const predicates = [
-    questionVisibilityPredicate(viewerUserId),
+    feedItemVisibilityPredicate(viewerUserId),
     isNull(questions.deletedAt),
   ];
 

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -12,9 +12,9 @@ import { and, count, eq, inArray, isNull, ne, notExists, or } from 'drizzle-orm'
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import {
+  feedItemVisibilityPredicate,
   getDismissedDomains,
   getFeedForUser,
-  questionVisibilityPredicate,
   type CollapsedFeedItem,
   type FeedCursor,
   type FeedFilter,
@@ -147,7 +147,7 @@ function surfaceActionableCount(viewerUserId: string, filter: FeedFilter): Promi
       visibleSourcePredicate,
       feedFilterSourcePredicate(filter),
       inArray(feedItems.state, ['active', 'skipped']),
-      questionVisibilityPredicate(viewerUserId),
+      feedItemVisibilityPredicate(viewerUserId),
       or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
       or(
         eq(feedItems.sourceType, 'direct_sent'),
@@ -201,7 +201,7 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         eq(feedItems.recipientUserId, viewerUserId),
         visibleSourcePredicate,
         feedFilterSourcePredicate(filter),
-        questionVisibilityPredicate(viewerUserId),
+        feedItemVisibilityPredicate(viewerUserId),
         or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
       ))
       .then((rows) => rows[0]?.value ?? 0),


### PR DESCRIPTION
A question sent straight to a recipient (sourceType='direct_sent') was still
gated by the broadcast visibility predicate. A 'friends'-visibility question
sent to someone who didn't have an approved follow edge to the author had a
feed row written but was silently filtered out of their feed on read.

Exempt direct_sent items from the visibility gate in feed.ts via a new exported
feedItemVisibilityPredicate, mirroring the existing direct_sent special-case in
viewerNotAlreadyAnsweredPredicate. Reuse it in get-feed-page's diagnostic/badge
counts so they stay in sync with what actually renders.