### PR TITLE
Add declared-interest specificity guard (Workstream 1)

### DIFF
--- a/src/app/api/declared-interests/route.ts
+++ b/src/app/api/declared-interests/route.ts
@@ -10,6 +10,7 @@ import {
   type DeclaredInterestInput,
   saveDeclaredInterests,
 } from '@/server/db/queries/users';
+import { TooBroadInterestError } from '@/lib/knowledge/interest-specificity';
 
 const addInterestSchema = z.object({
   label: z.string().trim().min(1).max(80),
@@ -110,6 +111,18 @@ export async function POST(request: Request) {
       return NextResponse.json(
         { error: 'interest_limit_reached', message: error.message },
         { status: 409 },
+      );
+    }
+    // The topic is a broad category, not a specific interest. Signal the client
+    // to expand it into specific choices instead of saving it as-is.
+    if (error instanceof TooBroadInterestError) {
+      return NextResponse.json(
+        {
+          error: 'too_broad',
+          topic: error.attempted,
+          message: `"${error.attempted}" is a whole category. Pick something more specific within it.`,
+        },
+        { status: 422 },
       );
     }
     const message = error instanceof Error ? error.message : 'Could not add that topic.';

--- a/src/app/api/interests/expand/route.ts
+++ b/src/app/api/interests/expand/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { expandBroadInterest } from '@/server/llm/interests';
+
+// Inline Haiku call; keep a modest budget above the default so a slow expansion
+// completes rather than being platform-killed.
+export const maxDuration = 30;
+
+const bodySchema = z.object({
+  topic: z.string().trim().min(1).max(80),
+});
+
+// Break a too-broad topic ("Music", "Technology") into specific, passion-level
+// choices for the add-topic field's expand-into-choices flow.
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Enter a topic (up to 80 characters).' },
+      { status: 400 },
+    );
+  }
+
+  const candidates = await expandBroadInterest(parsed.data.topic);
+  return NextResponse.json({ topic: parsed.data.topic, candidates });
+}

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -14,6 +14,7 @@ import { useRouter } from 'next/navigation';
 import { Plus } from 'lucide-react';
 
 import { KnowledgeBubble } from '@/components/knowledge/KnowledgeBubble';
+import { AddTopicField } from '@/components/interests/AddTopicField';
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { getPortraitCircleSize, type CircleSizingTier } from '@/lib/knowledge/circle-sizing';
@@ -125,7 +126,6 @@ export function TerritorySetupClient({
   const [domains, setDomains] = useState<TerritoryDomain[]>(initialDomains);
   const [frequencyByDomain, setFrequencyByDomain] =
     useState<DomainPreferenceFrequency>(initialFrequencyByDomain);
-  const [newTopic, setNewTopic] = useState('');
   const [addingTopic, setAddingTopic] = useState(false);
   const [addError, setAddError] = useState<string | null>(null);
   const [addLimitReached, setAddLimitReached] = useState(false);
@@ -245,8 +245,12 @@ export function TerritorySetupClient({
       });
       const body = await response.json().catch(() => null);
       if (!response.ok) {
-        setAddLimitReached(body?.error === 'interest_limit_reached');
-        throw new Error(body?.message ?? 'Could not add that topic.');
+        const error = new Error(
+          body?.message ?? 'Could not add that topic.',
+        ) as Error & { code?: 'limit_reached' | 'too_broad' };
+        if (body?.error === 'interest_limit_reached') error.code = 'limit_reached';
+        else if (body?.error === 'too_broad') error.code = 'too_broad';
+        throw error;
       }
       const row: TerritoryDomain = {
         domain: body.domain,
@@ -269,23 +273,6 @@ export function TerritorySetupClient({
     input.focus({ preventScroll: true });
   }, []);
 
-  const addTopic = useCallback(async () => {
-    const label = newTopic.trim();
-    if (!label || addingTopic) return;
-    setAddingTopic(true);
-    setAddError(null);
-    setAddLimitReached(false);
-
-    try {
-      await adoptTopic(label);
-      setNewTopic('');
-    } catch (caught) {
-      setAddError(caught instanceof Error ? caught.message : 'Could not add that topic.');
-    } finally {
-      setAddingTopic(false);
-    }
-  }, [addingTopic, adoptTopic, newTopic]);
-
   const addNearbyTerritory = useCallback(
     async (territory: NearbyTerritory) => {
       if (addingTopic) return;
@@ -295,6 +282,8 @@ export function TerritorySetupClient({
       try {
         await adoptTopic(territory.domain, territory.broadCategory);
       } catch (caught) {
+        const coded = caught as Error & { code?: string };
+        setAddLimitReached(coded?.code === 'limit_reached');
         setAddError(caught instanceof Error ? caught.message : 'Could not add that territory.');
       } finally {
         setAddingTopic(false);
@@ -502,6 +491,19 @@ export function TerritorySetupClient({
             ))}
             <CreateYourOwnCircle disabled={addingTopic} onClick={focusCreateTopic} />
           </div>
+          {addError ? (
+            <p className="text-destructive mt-3 text-sm">
+              {addError}
+              {addLimitReached ? (
+                <>
+                  {' '}
+                  <Link href="/knowledge" className="underline">
+                    Manage interests
+                  </Link>
+                </>
+              ) : null}
+            </p>
+          ) : null}
         </section>
 
         <section className="space-y-5" aria-label="Round territory frequency zones">
@@ -529,52 +531,20 @@ export function TerritorySetupClient({
         </section>
 
         <section className="mt-8 rounded-[2rem] border border-[var(--border-warm)] bg-[var(--cream-warm)] p-5">
-          <form
-            onSubmit={(event) => {
-              event.preventDefault();
-              void addTopic();
+          <AddTopicField
+            heading="Explore something new"
+            inputRef={newTopicInputRef}
+            existingLabels={domains.map((domain) => domain.domain)}
+            disabled={addingTopic}
+            limitReachedNode={
+              <Link href="/knowledge" className="underline">
+                Manage interests
+              </Link>
+            }
+            onAdd={async (topic) => {
+              await adoptTopic(topic.label, topic.broadCategory ?? null);
             }}
-          >
-            <label
-              htmlFor="add-topic"
-              className="block font-serif text-2xl font-semibold text-[var(--ink)]"
-            >
-              Explore something new
-            </label>
-            <div className="mt-4 flex gap-2">
-              <input
-                ref={newTopicInputRef}
-                id="add-topic"
-                type="text"
-                value={newTopic}
-                onChange={(event) => setNewTopic(event.target.value)}
-                placeholder="e.g. Byzantine Coinage"
-                maxLength={80}
-                autoComplete="off"
-                className="min-h-12 flex-1 rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus-visible:ring-2 focus-visible:ring-[var(--ink)] focus-visible:ring-offset-2 focus-visible:outline-none"
-              />
-              <button
-                type="submit"
-                className="btn-ghost min-h-12 px-5"
-                disabled={addingTopic || !newTopic.trim()}
-              >
-                {addingTopic ? 'Adding…' : 'Add'}
-              </button>
-            </div>
-            {addError ? (
-              <p className="text-destructive mt-3 text-sm">
-                {addError}
-                {addLimitReached ? (
-                  <>
-                    {' '}
-                    <Link href="/knowledge" className="underline">
-                      Manage interests
-                    </Link>
-                  </>
-                ) : null}
-              </p>
-            ) : null}
-          </form>
+          />
         </section>
 
         {error ? (

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -12,6 +12,7 @@ import { RecentlyExpanding, type ExpandingDomain } from '@/components/knowledge/
 import { AskFriendForDomain } from '@/components/knowledge/AskFriendForDomain';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 import { domainKey } from '@/lib/knowledge/domain-key';
 import type { MasteryTier } from '@/types/db';
 
@@ -160,6 +161,8 @@ function KnowledgePageContent() {
   const [selectedInterest, setSelectedInterest] = useState<ProposedInterest | null>(null);
   const [customInterest, setCustomInterest] = useState('');
   const [canonicalizing, setCanonicalizing] = useState(false);
+  // Specific choices a too-broad written interest expanded into (null = none).
+  const [interestChoices, setInterestChoices] = useState<ProposedInterest[] | null>(null);
   const [savingInterests, setSavingInterests] = useState(false);
   const [interestError, setInterestError] = useState<string | null>(null);
   const [tidying, setTidying] = useState(false);
@@ -322,6 +325,7 @@ function KnowledgePageContent() {
     setActiveModal({ type: 'interests', slotIndex, currentDomain });
     setSelectedInterest(null);
     setCustomInterest('');
+    setInterestChoices(null);
     setInterestError(null);
   };
 
@@ -330,28 +334,41 @@ function KnowledgePageContent() {
     setActiveModal({ type: 'manage-interests' });
     setSelectedInterest(null);
     setCustomInterest('');
+    setInterestChoices(null);
     setInterestError(null);
   };
 
+  // Stage a written interest into the slot. A specific topic is selected as-is;
+  // a too-broad one ("Music", "Technology") expands into specific choices the
+  // player picks from instead, so a slot never gets a bucket-level label.
   const proposeCustomInterest = async () => {
     const raw = customInterest.trim();
     if (!raw) return;
     setCanonicalizing(true);
     setInterestError(null);
+    setInterestChoices(null);
     try {
-      const response = await fetch('/api/onboarding/propose-interests', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ warmupAnswers: [raw] }),
-      });
-      const body = await response.json().catch(() => null) as { interests?: ProposedInterest[]; message?: string } | null;
-      if (!response.ok) throw new Error(body?.message ?? 'Could not refine that interest.');
-      const proposal = body?.interests?.[0];
-      setSelectedInterest(proposal?.label ? proposal : { label: raw });
-    } catch (caught) {
-      setInterestError(caught instanceof Error ? caught.message : 'Could not refine that interest.');
+      if (isTooBroadInterest(raw)) {
+        const response = await fetch('/api/interests/expand', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ topic: raw }),
+        });
+        const body = await response.json().catch(() => null) as { candidates?: ProposedInterest[]; message?: string } | null;
+        if (!response.ok) throw new Error(body?.message ?? 'Could not break that down.');
+        const choices = Array.isArray(body?.candidates) ? body.candidates : [];
+        if (choices.length === 0) {
+          setInterestError(`“${raw}” is a whole category. Try something more specific — a person, era, scene, or work.`);
+        } else {
+          setSelectedInterest(null);
+          setInterestChoices(choices);
+        }
+        return;
+      }
       setSelectedInterest({ label: raw });
+    } catch (caught) {
+      setInterestError(caught instanceof Error ? caught.message : 'Could not add that interest.');
     } finally {
       setCanonicalizing(false);
     }
@@ -359,6 +376,11 @@ function KnowledgePageContent() {
 
   const confirmInterestChange = async () => {
     if (activeModal?.type !== 'interests' || !selectedInterest?.label) return;
+    // Backstop the "Use my wording" path: never let a bucket-level label save.
+    if (isTooBroadInterest(selectedInterest.label)) {
+      setInterestError(`“${selectedInterest.label.trim()}” is a whole category. Pick something more specific.`);
+      return;
+    }
     const modal = activeModal;
     setSavingInterests(true);
     setInterestError(null);
@@ -682,6 +704,26 @@ function KnowledgePageContent() {
                     {canonicalizing ? 'Refining...' : 'Refine'}
                   </button>
                 </div>
+                {interestChoices ? (
+                  <div className="mt-3">
+                    <p className="m-0 text-[var(--text-muted-warm)] text-[0.82rem]">That&rsquo;s a whole category — pick what you&rsquo;re into:</p>
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      {interestChoices.map((choice) => (
+                        <button
+                          key={choice.label}
+                          type="button"
+                          className="border border-[var(--border-warm)] bg-white text-[var(--ink)] px-3 py-1.5 text-[0.82rem] cursor-pointer hover:bg-[var(--cream-warm)]"
+                          onClick={() => {
+                            setSelectedInterest({ label: choice.label, broadCategory: choice.broadCategory ?? undefined });
+                            setInterestChoices(null);
+                          }}
+                        >
+                          {choice.label}
+                        </button>
+                      ))}
+                    </div>
+                  </div>
+                ) : null}
                 {selectedInterest ? (
                   <div className="mt-3 border border-[var(--border-light)] bg-[var(--cream)] p-3">
                     <p className="m-0 font-semibold">{selectedInterest.label}</p>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -693,7 +693,20 @@ export default function OnboardingFlow({
         return
       }
 
-      router.push('/')
+      // Kick off first-round generation in the background so it's ready (or
+      // nearly) when the player lands in /daily, then take them straight into
+      // gameplay instead of the homepage. keepalive lets the POST survive the
+      // client navigation; the queue route is idempotent, so /daily's own load
+      // won't double-generate. A freshly-declared interest list guarantees a
+      // knowledge base, so /daily won't bounce to setup.
+      void fetch('/api/daily/queue', {
+        method: 'POST',
+        credentials: 'include',
+        cache: 'no-store',
+        keepalive: true,
+      }).catch(() => {})
+
+      router.push('/daily')
     } catch {
       setError('Unable to save interests.')
     } finally {

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -3,17 +3,12 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import { Edit3, Loader2, Plus, X } from 'lucide-react'
-import { COUNTRIES } from '@/lib/onboarding/countries'
-import { US_STATES } from '@/lib/onboarding/us-regions'
+import { Edit3, Loader2, X } from 'lucide-react'
+import { AddTopicField, type AddTopicError } from '@/components/interests/AddTopicField'
 
-type CurrentStep =
-  | 'display-name'
-  | 'handle'
-  | 'invite-suggestions'
-  | 'background'
-  | 'warmup'
-  | 'review'
+// Condensed onboarding: name → handle → one interests screen (warm-up is an
+// optional expander there; the cultural-anchor/background step was removed).
+type CurrentStep = 'display-name' | 'handle' | 'review'
 
 export type WarmupAnswers = {
   deepDive?: string
@@ -56,13 +51,6 @@ function sanitizeForHandle(input: string): string {
     .slice(0, HANDLE_MAX)
 }
 
-type CanonicalSuggestion = {
-  original: string
-  suggested: string
-  broadCategory: string
-  explanation: string | null
-}
-
 const WARMUP_FIELDS: Array<{
   field: keyof WarmupAnswers
   label: string
@@ -95,10 +83,13 @@ const LOADING_COPY = [
 ]
 
 const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
-  { step: 'background', label: 'About You' },
-  { step: 'warmup', label: 'Warmup' },
-  { step: 'review', label: 'Review' },
+  { step: 'display-name', label: 'Name' },
+  { step: 'handle', label: 'Handle' },
+  { step: 'review', label: 'Interests' },
 ]
+
+const MIN_INTERESTS = 3
+const MAX_INTERESTS = 5
 
 function normalizeDomain(domain: string) {
   return domain.trim().replace(/\s+/g, ' ')
@@ -141,13 +132,10 @@ function Spinner({ small = false }: { small?: boolean }) {
 }
 
 function ProgressDots({ currentStep }: { currentStep: CurrentStep }) {
-  const activeIndex =
-    currentStep === 'invite-suggestions'
-      ? -1
-      : Math.max(
-          0,
-          STEP_DOTS.findIndex((item) => item.step === currentStep)
-        )
+  const activeIndex = Math.max(
+    0,
+    STEP_DOTS.findIndex((item) => item.step === currentStep)
+  )
 
   return (
     <div
@@ -199,7 +187,7 @@ export default function OnboardingFlow({
   const [currentStep, setCurrentStep] = useState<CurrentStep>(() => {
     if (!hasInitialDisplayName) return 'display-name'
     if (!hasInitialHandle) return 'handle'
-    return preSeededInterests.length > 0 ? 'invite-suggestions' : 'background'
+    return 'review'
   })
   const [displayName, setDisplayName] = useState<string>(() =>
     (initialDisplayName ?? inviteeDisplayName ?? '')
@@ -222,9 +210,7 @@ export default function OnboardingFlow({
   >({ state: 'idle' })
   const [isSavingHandle, setIsSavingHandle] = useState(false)
   const [handleError, setHandleError] = useState<string | null>(null)
-  const [birthYear, setBirthYear] = useState('')
-  const [grewUpCountry, setGrewUpCountry] = useState('')
-  const [grewUpRegion, setGrewUpRegion] = useState('')
+  const [showWarmup, setShowWarmup] = useState(false)
   const [warmupAnswers, setWarmupAnswers] = useState<WarmupAnswers>({})
   const [proposedInterests, setProposedInterests] = useState<
     ProposedInterest[] | null
@@ -243,33 +229,15 @@ export default function OnboardingFlow({
       .slice(0, 5)
   )
   const [isLoading, setIsLoading] = useState(false)
-  const [isCanonicalizing, setIsCanonicalizing] = useState(false)
+  const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loadingCopyIndex, setLoadingCopyIndex] = useState(0)
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [editingDomain, setEditingDomain] = useState('')
-  const [showComposer, setShowComposer] = useState(false)
-  const [customInput, setCustomInput] = useState('')
-  const [canonicalSuggestion, setCanonicalSuggestion] =
-    useState<CanonicalSuggestion | null>(null)
-  const [customChoice, setCustomChoice] = useState<'suggested' | 'mine' | null>(
-    null
-  )
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
   const displayInviterName = inviterName?.trim()
     ? inviterName.trim()
     : 'A friend'
-
-  const parsedBirthYear = parseInt(birthYear, 10)
-  const maxBirthYear = new Date().getFullYear() - 13
-  const birthYearValid =
-    birthYear.length === 4 &&
-    parsedBirthYear >= 1920 &&
-    parsedBirthYear <= maxBirthYear
-  const canAdvanceBackground =
-    birthYearValid &&
-    grewUpCountry !== '' &&
-    (grewUpCountry !== 'US' || grewUpRegion !== '')
 
   const canGenerate =
     normalizeDomain(warmupAnswers.deepDive ?? '').length > 0 &&
@@ -351,68 +319,14 @@ export default function OnboardingFlow({
   }, [currentStep, handle])
 
   useEffect(() => {
-    if (!isLoading || currentStep !== 'warmup') return
+    if (!isGenerating) return
 
     const interval = window.setInterval(() => {
       setLoadingCopyIndex((current) => (current + 1) % LOADING_COPY.length)
     }, 3000)
 
     return () => window.clearInterval(interval)
-  }, [currentStep, isLoading])
-
-  useEffect(() => {
-    const rawInput = normalizeDomain(customInput)
-    const resetTimer = window.setTimeout(() => {
-      setCanonicalSuggestion(null)
-      setCustomChoice(null)
-      if (!showComposer || rawInput.length <= 3) setIsCanonicalizing(false)
-    }, 0)
-
-    if (!showComposer || rawInput.length <= 3) {
-      return () => window.clearTimeout(resetTimer)
-    }
-
-    const controller = new AbortController()
-    const timer = window.setTimeout(async () => {
-      setIsCanonicalizing(true)
-      try {
-        const response = await fetch('/api/onboarding/canonicalize', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ rawInput }),
-          signal: controller.signal,
-        })
-        const data = await response.json().catch(() => ({}))
-
-        if (!response.ok || typeof data?.suggested !== 'string') return
-
-        setCanonicalSuggestion({
-          original: data.original ?? rawInput,
-          suggested: data.suggested,
-          broadCategory: data.broadCategory ?? 'General Knowledge',
-          explanation: data.explanation ?? null,
-        })
-        setCustomChoice('suggested')
-      } catch (fetchError) {
-        if (
-          !(
-            fetchError instanceof DOMException &&
-            fetchError.name === 'AbortError'
-          )
-        ) {
-          setCanonicalSuggestion(null)
-        }
-      } finally {
-        if (!controller.signal.aborted) setIsCanonicalizing(false)
-      }
-    }, 800)
-
-    return () => {
-      controller.abort()
-      window.clearTimeout(resetTimer)
-      window.clearTimeout(timer)
-    }
-  }, [customInput, showComposer])
+  }, [isGenerating])
 
   function updateWarmupAnswer(field: keyof WarmupAnswers, value: string) {
     setWarmupAnswers((current) => ({
@@ -496,24 +410,16 @@ export default function OnboardingFlow({
     if (!canGenerate) return
 
     setError(null)
-    setIsLoading(true)
+    setIsGenerating(true)
     setLoadingCopyIndex(0)
 
     try {
+      // Cultural anchor was removed from onboarding; the endpoint generates
+      // from warm-up answers alone.
       const response = await fetch('/api/onboarding/propose-interests', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          warmupAnswers,
-          culturalAnchor:
-            birthYearValid && grewUpCountry
-              ? {
-                  birthYear: parsedBirthYear,
-                  grewUpCountry,
-                  grewUpRegion: grewUpRegion || undefined,
-                }
-              : undefined,
-        }),
+        body: JSON.stringify({ warmupAnswers }),
       })
       const data = await response.json().catch(() => ({}))
 
@@ -525,14 +431,40 @@ export default function OnboardingFlow({
       }
 
       setProposedInterests(data.proposedInterests)
-      setCurrentStep('review')
+      setShowWarmup(false)
     } catch {
       setError(
         "We couldn't generate suggestions. You can try again or write your own."
       )
     } finally {
-      setIsLoading(false)
+      setIsGenerating(false)
     }
+  }
+
+  // Stage a chosen topic (from the add-topic field) into the selected list.
+  async function addSelectedInterest(topic: { label: string; broadCategory?: string | null }) {
+    const selected = toSelected({
+      domain: topic.label,
+      broadCategory: topic.broadCategory ?? 'General Knowledge',
+    })
+    if (!selected) throw new Error('Enter a topic name.')
+    if (selectedInterests.length >= MAX_INTERESTS) {
+      const limit = new Error(`That's the max — ${MAX_INTERESTS} interests.`) as AddTopicError
+      limit.code = 'limit_reached'
+      throw limit
+    }
+    setError(null)
+    setSelectedInterests((current) =>
+      current.some((item) => selectedKey(item) === selectedKey(selected))
+        ? current
+        : [...current, selected].slice(0, MAX_INTERESTS)
+    )
+  }
+
+  function removeSelectedInterest(target: SelectedInterest) {
+    setSelectedInterests((current) =>
+      current.filter((item) => selectedKey(item) !== selectedKey(target))
+    )
   }
 
   async function submitDisplayName() {
@@ -568,16 +500,12 @@ export default function OnboardingFlow({
       if (!handle && !hasInitialHandle) {
         setHandle(sanitizeForHandle(trimmed))
       }
-      setCurrentStep(hasInitialHandle ? nextStepAfterHandle() : 'handle')
+      setCurrentStep(hasInitialHandle ? 'review' : 'handle')
     } catch {
       setDisplayNameError("We couldn't save that name. Try again.")
     } finally {
       setIsSavingDisplayName(false)
     }
-  }
-
-  function nextStepAfterHandle(): CurrentStep {
-    return inviteInterests.length > 0 ? 'invite-suggestions' : 'background'
   }
 
   async function submitHandle() {
@@ -610,43 +538,12 @@ export default function OnboardingFlow({
       }
 
       setHandle(candidate)
-      setCurrentStep(nextStepAfterHandle())
+      setCurrentStep('review')
     } catch {
       setHandleError("We couldn't save that handle. Try again.")
     } finally {
       setIsSavingHandle(false)
     }
-  }
-
-  function keepInviteInterests() {
-    setError(null)
-    const toSave = inviteInterests
-      .flatMap((interest) => {
-        const selected = toSelected(interest)
-        return selected ? [selected] : []
-      })
-      .slice(0, 5)
-    saveInterests(toSave)
-  }
-
-  function reviewInviteInterests() {
-    setError(null)
-    setSelectedInterests(
-      inviteInterests
-        .flatMap((interest) => {
-          const selected = toSelected(interest)
-          return selected ? [selected] : []
-        })
-        .slice(0, 5)
-    )
-    setCurrentStep('background')
-  }
-
-  function skipInviteInterests() {
-    setError(null)
-    setSelectedInterests([])
-    setInviteInterests([])
-    setCurrentStep('background')
   }
 
   async function saveInterests(interestsOverride?: SelectedInterest[]) {
@@ -655,7 +552,7 @@ export default function OnboardingFlow({
         const selected = toSelected(interest)
         return selected ? [selected] : []
       })
-      .slice(0, 5)
+      .slice(0, MAX_INTERESTS)
 
     const inviteSelectedCount = inviteInterests.filter((interest) => {
       const selected = toSelected(interest)
@@ -666,8 +563,8 @@ export default function OnboardingFlow({
         : false
     }).length
 
-    if (cleanSelected.length === 0) {
-      setError('Pick at least 1 to continue.')
+    if (cleanSelected.length < MIN_INTERESTS) {
+      setError(`Pick at least ${MIN_INTERESTS} to continue.`)
       return
     }
 
@@ -714,35 +611,7 @@ export default function OnboardingFlow({
     }
   }
 
-  function skipSuggestions() {
-    setError(null)
-    setProposedInterests([])
-    setShowComposer(true)
-    setCurrentStep('review')
-  }
-
-  function addCustomInterest() {
-    const rawInput = normalizeDomain(customInput)
-    const chosenDomain =
-      customChoice === 'suggested' && canonicalSuggestion
-        ? canonicalSuggestion.suggested
-        : rawInput
-    const broadCategory = canonicalSuggestion?.broadCategory ?? 'General Knowledge'
-    const selected = toSelected({ domain: chosenDomain, broadCategory })
-
-    if (!selected || selectedInterests.length >= 5) return
-
-    setSelectedInterests((current) => {
-      if (current.some((item) => selectedKey(item) === selectedKey(selected)))
-        return current
-      return [...current, selected].slice(0, 5)
-    })
-    setCustomInput('')
-    setCanonicalSuggestion(null)
-    setCustomChoice(null)
-  }
-
-  if (isLoading && currentStep === 'warmup') {
+  if (isGenerating) {
     return (
       <main className="bg-background text-foreground grid min-h-screen place-items-center px-5 py-12">
         <div className="flex max-w-sm flex-col items-center gap-5 text-center">
@@ -902,439 +771,194 @@ export default function OnboardingFlow({
             </div>
           ) : null}
 
-          {currentStep === 'invite-suggestions' ? (
-            <div className="flex flex-1 flex-col justify-center gap-8">
-              <StepHeader
-                title={`${displayInviterName} suggested these for you.`}
-                subtitle="Keep the ones that fit. You can edit or skip them."
-              />
-
-              <ul className="space-y-3">
-                {inviteInterests.map((interest) => (
-                  <li
-                    key={`${interest.domain}-${interest.broadCategory}`}
-                    className="bg-card rounded-lg border p-4"
-                  >
-                    <span className="block text-xl font-semibold tracking-normal">
-                      {interest.domain}
-                    </span>
-                    <span className="text-muted-foreground mt-1 block text-xs font-medium uppercase">
-                      {interest.broadCategory}
-                    </span>
-                    {interest.rationale ? (
-                      <span className="text-muted-foreground mt-3 block text-sm leading-6 italic">
-                        {interest.rationale}
-                      </span>
-                    ) : null}
-                  </li>
-                ))}
-              </ul>
-
-              <div className="space-y-3">
-                <button
-                  type="button"
-                  className="btn-primary h-12 w-full"
-                  onClick={keepInviteInterests}
-                  disabled={isLoading}
-                >
-                  {isLoading ? 'Saving...' : 'These look good'}
-                </button>
-                <button
-                  type="button"
-                  className="btn-ghost h-12 w-full"
-                  onClick={reviewInviteInterests}
-                  disabled={isLoading}
-                >
-                  Let me adjust them
-                </button>
-                <button
-                  type="button"
-                  className="btn-ghost h-12 w-full"
-                  onClick={skipInviteInterests}
-                  disabled={isLoading}
-                >
-                  Start fresh
-                </button>
-              </div>
-            </div>
-          ) : null}
-
-          {currentStep === 'background' ? (
-            <div className="flex flex-1 flex-col gap-7">
-              <StepHeader
-                title="Welcome to Joshing"
-                subtitle="Two quick facts to calibrate your daily round. We won't share these."
-              />
-
-              <div className="space-y-5">
-                <label className="block">
-                  <span className="text-sm font-medium">
-                    What year were you born?
-                  </span>
-                  <input
-                    type="number"
-                    className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
-                    placeholder="e.g. 1978"
-                    min={1920}
-                    max={2010}
-                    value={birthYear}
-                    onChange={(e) => setBirthYear(e.target.value.slice(0, 4))}
-                  />
-                  {birthYear.length === 4 && !birthYearValid ? (
-                    <span className="text-destructive mt-1 block text-xs">
-                      Please enter a year between 1920 and {maxBirthYear}.
-                    </span>
-                  ) : null}
-                </label>
-
-                <label className="block">
-                  <span className="text-sm font-medium">
-                    Where did you grow up?
-                  </span>
-                  <select
-                    className="bg-card focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
-                    value={grewUpCountry}
-                    onChange={(e) => {
-                      setGrewUpCountry(e.target.value)
-                      setGrewUpRegion('')
-                    }}
-                  >
-                    <option value="">Select a country</option>
-                    {COUNTRIES.map((c) => (
-                      <option key={c.code} value={c.code}>
-                        {c.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-
-                {grewUpCountry === 'US' ? (
-                  <label className="block">
-                    <span className="text-sm font-medium">Which state?</span>
-                    <select
-                      className="bg-card focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
-                      value={grewUpRegion}
-                      onChange={(e) => setGrewUpRegion(e.target.value)}
-                    >
-                      <option value="">Select a state</option>
-                      {US_STATES.map((s) => (
-                        <option key={s.code} value={s.name}>
-                          {s.name}
-                        </option>
-                      ))}
-                    </select>
-                  </label>
-                ) : null}
-              </div>
-
-              <div className="mt-auto space-y-3 pt-2">
-                <button
-                  type="button"
-                  className="btn-primary h-12 w-full"
-                  onClick={() => setCurrentStep('warmup')}
-                  disabled={!canAdvanceBackground}
-                >
-                  Continue
-                </button>
-                {inviteInterests.length > 0 ? (
-                  <button
-                    type="button"
-                    className="btn-ghost h-12 w-full"
-                    onClick={() => setCurrentStep('invite-suggestions')}
-                  >
-                    Back
-                  </button>
-                ) : null}
-              </div>
-            </div>
-          ) : null}
-
-          {currentStep === 'warmup' ? (
-            <div className="flex flex-1 flex-col gap-7">
-              <StepHeader
-                title="Tell us about your interests"
-                subtitle="Free text. The more specific, the better."
-              />
-
-              <div className="space-y-4">
-                {WARMUP_FIELDS.map(
-                  ({ field, label, placeholder, optional }) => {
-                    const value = warmupAnswers[field] ?? ''
-                    return (
-                      <label key={field} className="block">
-                        <span className="text-sm font-medium">
-                          {label}
-                          {optional ? (
-                            <span className="text-muted-foreground">
-                              {' '}
-                              optional
-                            </span>
-                          ) : null}
-                        </span>
-                        <input
-                          className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
-                          maxLength={200}
-                          placeholder={placeholder}
-                          value={value}
-                          onChange={(event) =>
-                            updateWarmupAnswer(field, event.target.value)
-                          }
-                        />
-                        {value.length > 150 ? (
-                          <span className="text-muted-foreground mt-1 block text-right text-xs">
-                            {value.length}/200
-                          </span>
-                        ) : null}
-                      </label>
-                    )
-                  }
-                )}
-              </div>
-
-              {error ? (
-                <ErrorPanel
-                  message={error}
-                  actions={
-                    <>
-                      <button
-                        type="button"
-                        className="btn-primary h-10"
-                        onClick={generateProposals}
-                      >
-                        Try again
-                      </button>
-                      <button
-                        type="button"
-                        className="btn-ghost h-10"
-                        onClick={skipSuggestions}
-                      >
-                        Skip suggestions
-                      </button>
-                    </>
-                  }
-                />
-              ) : null}
-
-              <div className="mt-auto grid grid-cols-2 gap-3 pt-2">
-                <button
-                  type="button"
-                  className="btn-ghost h-12"
-                  onClick={() => setCurrentStep('background')}
-                >
-                  Back
-                </button>
-                <button
-                  type="button"
-                  className="btn-primary h-12"
-                  onClick={generateProposals}
-                  disabled={!canGenerate || isLoading}
-                >
-                  See suggestions
-                </button>
-              </div>
-            </div>
-          ) : null}
-
           {currentStep === 'review' ? (
             <div className="flex flex-1 flex-col gap-7">
               <StepHeader
-                title="Here's what we found"
-                subtitle="Pick up to 5. You can edit any of them, or write your own."
+                title="What are you into?"
+                subtitle={`Add at least ${MIN_INTERESTS} things you'd love to be asked about. Tap a suggestion, write your own, or get ideas from the prompts.`}
               />
 
               <div className="space-y-3">
-                {reviewInterests.map((interest) => {
-                  const selected = isSelected(selectedInterests, interest)
-                  const normalized = toSelected(interest)
-                  const atCap = selectedInterests.length >= 5 && !selected
-                  const fromInvite = inviteInterests.some(
-                    (seeded) =>
-                      selectedKey(
-                        toSelected(seeded) ?? { domain: '', broadCategory: '' }
-                      ) ===
-                      selectedKey(
-                        normalized ?? { domain: '', broadCategory: '' }
-                      )
-                  )
-                  const key = `${interest.domain}-${interest.broadCategory}`
-                  const editing = normalized
-                    ? editingKey === selectedKey(normalized)
-                    : false
-
-                  return (
-                    <div
-                      key={key}
-                      className={[
-                        'rounded-lg border p-4 transition',
-                        selected
-                          ? 'border-foreground bg-foreground text-background'
-                          : 'bg-card',
-                        atCap ? 'opacity-45' : '',
-                      ].join(' ')}
-                      title={
-                        atCap
-                          ? '5 max - deselect one to add another'
-                          : undefined
-                      }
-                      onPointerDown={() => startLongPress(interest)}
-                      onPointerUp={clearLongPress}
-                      onPointerLeave={clearLongPress}
-                    >
-                      {editing ? (
-                        <div className="space-y-3">
-                          <input
-                            className="bg-background text-foreground focus:ring-ring h-11 w-full rounded-md border px-3 text-base outline-none focus:ring-2"
-                            value={editingDomain}
-                            maxLength={100}
-                            onChange={(event) =>
-                              setEditingDomain(event.target.value)
-                            }
-                          />
-                          <div className="flex gap-2">
-                            <button
-                              type="button"
-                              className="btn-primary h-9"
-                              onClick={() => saveEdit(interest)}
-                            >
-                              Save
-                            </button>
-                            <button
-                              type="button"
-                              className="btn-ghost h-9"
-                              onClick={() => setEditingKey(null)}
-                            >
-                              Cancel
-                            </button>
-                          </div>
-                        </div>
-                      ) : (
-                        <div className="flex gap-3">
-                          <button
-                            type="button"
-                            className="min-w-0 flex-1 text-left"
-                            onClick={() => toggleInterest(interest)}
-                            disabled={atCap}
-                          >
-                            <span className="block text-xl font-semibold tracking-normal">
-                              {interest.domain}
-                            </span>
-                            <span
-                              className={`mt-1 block text-xs font-medium uppercase ${selected ? 'text-background/70' : 'text-muted-foreground'}`}
-                            >
-                              {interest.broadCategory}
-                            </span>
-                            {interest.rationale ? (
-                              <span
-                                className={`mt-3 block text-sm leading-6 italic ${selected ? 'text-background/80' : 'text-muted-foreground'}`}
-                              >
-                                {interest.rationale}
-                              </span>
-                            ) : null}
-                            {fromInvite ? (
-                              <span
-                                className={`mt-3 inline-flex rounded-sm border px-2 py-1 text-[11px] font-semibold uppercase ${selected ? 'border-background/30 text-background/80' : 'text-muted-foreground'}`}
-                              >
-                                From {displayInviterName}
-                              </span>
-                            ) : null}
-                          </button>
-                          <button
-                            type="button"
-                            className={`grid size-9 shrink-0 place-items-center rounded-md border ${selected ? 'border-background/30' : 'hover:bg-muted'}`}
-                            aria-label={`Edit ${interest.domain}`}
-                            title="Edit"
-                            onClick={() => beginEdit(interest)}
-                          >
-                            <Edit3 className="size-4" />
-                          </button>
-                        </div>
-                      )}
-                    </div>
-                  )
-                })}
+                <p className="text-sm font-medium">
+                  Your interests · {selectedInterests.length}/{MAX_INTERESTS}
+                </p>
+                {selectedInterests.length === 0 ? (
+                  <p className="text-muted-foreground text-sm">
+                    Nothing yet — add at least {MIN_INTERESTS} below.
+                  </p>
+                ) : (
+                  <div className="flex flex-wrap gap-2">
+                    {selectedInterests.map((interest) => (
+                      <button
+                        key={selectedKey(interest)}
+                        type="button"
+                        className="bg-foreground text-background inline-flex items-center gap-2 rounded-full px-3 py-1.5 text-sm font-medium"
+                        onClick={() => removeSelectedInterest(interest)}
+                        aria-label={`Remove ${interest.domain}`}
+                      >
+                        {interest.domain}
+                        <X className="size-3.5" />
+                      </button>
+                    ))}
+                  </div>
+                )}
               </div>
 
+              <AddTopicField
+                heading="Add your own"
+                placeholder="e.g. Byzantine Coinage"
+                maxLength={100}
+                disabled={selectedInterests.length >= MAX_INTERESTS}
+                existingLabels={selectedInterests.map((item) => item.domain)}
+                onAdd={addSelectedInterest}
+                inputClassName="bg-background focus:ring-ring h-11 min-w-0 flex-1 rounded-md border px-3 text-base outline-none focus:ring-2 disabled:opacity-60"
+                buttonClassName="btn-primary h-11 px-5"
+                chipClassName="rounded-md border bg-card px-3 py-1.5 text-sm transition-colors hover:bg-muted disabled:opacity-50"
+                mutedClassName="text-muted-foreground text-sm"
+                errorClassName="text-destructive mt-3 text-sm"
+              />
+
+              {reviewInterests.some(
+                (interest) => !isSelected(selectedInterests, interest)
+              ) ? (
+                <div className="space-y-3">
+                  <p className="text-sm font-medium">Suggestions</p>
+                  {reviewInterests
+                    .filter((interest) => !isSelected(selectedInterests, interest))
+                    .map((interest) => {
+                      const normalized = toSelected(interest)
+                      const atCap = selectedInterests.length >= MAX_INTERESTS
+                      const fromInvite = inviteInterests.some(
+                        (seeded) =>
+                          selectedKey(
+                            toSelected(seeded) ?? { domain: '', broadCategory: '' }
+                          ) ===
+                          selectedKey(normalized ?? { domain: '', broadCategory: '' })
+                      )
+                      const key = `${interest.domain}-${interest.broadCategory}`
+                      const editing = normalized
+                        ? editingKey === selectedKey(normalized)
+                        : false
+
+                      return (
+                        <div
+                          key={key}
+                          className={[
+                            'bg-card rounded-lg border p-4 transition',
+                            atCap ? 'opacity-45' : '',
+                          ].join(' ')}
+                          title={atCap ? `${MAX_INTERESTS} max - remove one to add another` : undefined}
+                          onPointerDown={() => startLongPress(interest)}
+                          onPointerUp={clearLongPress}
+                          onPointerLeave={clearLongPress}
+                        >
+                          {editing ? (
+                            <div className="space-y-3">
+                              <input
+                                className="bg-background text-foreground focus:ring-ring h-11 w-full rounded-md border px-3 text-base outline-none focus:ring-2"
+                                value={editingDomain}
+                                maxLength={100}
+                                onChange={(event) => setEditingDomain(event.target.value)}
+                              />
+                              <div className="flex gap-2">
+                                <button type="button" className="btn-primary h-9" onClick={() => saveEdit(interest)}>
+                                  Save
+                                </button>
+                                <button type="button" className="btn-ghost h-9" onClick={() => setEditingKey(null)}>
+                                  Cancel
+                                </button>
+                              </div>
+                            </div>
+                          ) : (
+                            <div className="flex gap-3">
+                              <button
+                                type="button"
+                                className="min-w-0 flex-1 text-left"
+                                onClick={() => toggleInterest(interest)}
+                                disabled={atCap}
+                              >
+                                <span className="block text-xl font-semibold tracking-normal">
+                                  {interest.domain}
+                                </span>
+                                <span className="text-muted-foreground mt-1 block text-xs font-medium uppercase">
+                                  {interest.broadCategory}
+                                </span>
+                                {interest.rationale ? (
+                                  <span className="text-muted-foreground mt-3 block text-sm leading-6 italic">
+                                    {interest.rationale}
+                                  </span>
+                                ) : null}
+                                {fromInvite ? (
+                                  <span className="text-muted-foreground mt-3 inline-flex rounded-sm border px-2 py-1 text-[11px] font-semibold uppercase">
+                                    From {displayInviterName}
+                                  </span>
+                                ) : null}
+                              </button>
+                              <button
+                                type="button"
+                                className="hover:bg-muted grid size-9 shrink-0 place-items-center rounded-md border"
+                                aria-label={`Edit ${interest.domain}`}
+                                title="Edit"
+                                onClick={() => beginEdit(interest)}
+                              >
+                                <Edit3 className="size-4" />
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      )
+                    })}
+                </div>
+              ) : null}
+
               <div className="space-y-3">
-                {!showComposer ? (
+                {!showWarmup ? (
                   <button
                     type="button"
-                    className="btn-ghost h-11 w-full gap-2"
-                    onClick={() => setShowComposer(true)}
-                    disabled={selectedInterests.length >= 5}
+                    className="btn-ghost h-11 w-full"
+                    onClick={() => setShowWarmup(true)}
                   >
-                    <Plus className="size-4" />
-                    Write your own
+                    Need ideas? Answer a couple quick questions
                   </button>
                 ) : (
-                  <div className="bg-card rounded-lg border p-4">
-                    <div className="flex items-center gap-2">
-                      <input
-                        className="bg-background focus:ring-ring h-11 min-w-0 flex-1 rounded-md border px-3 text-base outline-none focus:ring-2"
-                        placeholder="Write an interest"
-                        value={customInput}
-                        maxLength={100}
-                        onChange={(event) => setCustomInput(event.target.value)}
-                        disabled={selectedInterests.length >= 5}
-                      />
+                  <div className="bg-card space-y-4 rounded-lg border p-4">
+                    {WARMUP_FIELDS.map(({ field, label, placeholder, optional }) => {
+                      const value = warmupAnswers[field] ?? ''
+                      return (
+                        <label key={field} className="block">
+                          <span className="text-sm font-medium">
+                            {label}
+                            {optional ? (
+                              <span className="text-muted-foreground"> optional</span>
+                            ) : null}
+                          </span>
+                          <input
+                            className="bg-background placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
+                            maxLength={200}
+                            placeholder={placeholder}
+                            value={value}
+                            onChange={(event) => updateWarmupAnswer(field, event.target.value)}
+                          />
+                        </label>
+                      )
+                    })}
+                    <div className="flex gap-2">
                       <button
                         type="button"
-                        className="hover:bg-muted grid size-11 place-items-center rounded-md border"
-                        aria-label="Close composer"
-                        title="Close"
-                        onClick={() => setShowComposer(false)}
+                        className="btn-primary h-11 flex-1"
+                        onClick={generateProposals}
+                        disabled={!canGenerate || isGenerating}
                       >
-                        <X className="size-4" />
+                        See suggestions
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-ghost h-11 px-4"
+                        onClick={() => setShowWarmup(false)}
+                      >
+                        Hide
                       </button>
                     </div>
-
-                    <div className="mt-3 min-h-11 text-sm">
-                      {isCanonicalizing ? (
-                        <p className="text-muted-foreground flex items-center gap-2">
-                          <Spinner small />
-                          Checking wording...
-                        </p>
-                      ) : null}
-                      {canonicalSuggestion ? (
-                        <div className="bg-background space-y-2 rounded-md border p-3">
-                          <p className="text-muted-foreground text-xs">
-                            Refined for better trivia:
-                          </p>
-                          <p className="font-medium">
-                            {customChoice === 'mine'
-                              ? canonicalSuggestion.original
-                              : canonicalSuggestion.suggested}
-                          </p>
-                          {canonicalSuggestion.suggested !== canonicalSuggestion.original ? (
-                            <button
-                              type="button"
-                              className="btn-ghost h-8 text-xs"
-                              onClick={() =>
-                                setCustomChoice(
-                                  customChoice === 'mine' ? 'suggested' : 'mine'
-                                )
-                              }
-                            >
-                              {customChoice === 'mine'
-                                ? `Use refined: "${canonicalSuggestion.suggested}"`
-                                : `Use original: "${canonicalSuggestion.original}"`}
-                            </button>
-                          ) : null}
-                        </div>
-                      ) : null}
-                    </div>
-
-                    <button
-                      type="button"
-                      className="btn-primary mt-3 h-11 w-full"
-                      onClick={addCustomInterest}
-                      disabled={
-                        normalizeDomain(customInput).length < 2 ||
-                        selectedInterests.length >= 5 ||
-                        (canonicalSuggestion !== null && customChoice === null)
-                      }
-                    >
-                      Add
-                    </button>
                   </div>
                 )}
               </div>
@@ -1345,37 +969,19 @@ export default function OnboardingFlow({
                     <ErrorPanel message={error} />
                   </div>
                 ) : null}
-                <div className="mb-3 flex items-center justify-between text-sm">
-                  <span className="font-medium">
-                    {selectedInterests.length} of 5 selected
-                  </span>
-                  <span className="text-muted-foreground">
-                    {selectedInterests.length === 0
-                      ? 'Pick up to 5 to continue'
-                      : null}
-                    {selectedInterests.length === 5
-                      ? '5 max - deselect one to swap'
-                      : null}
-                  </span>
-                </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <button
-                    type="button"
-                    className="btn-ghost h-12"
-                    onClick={() => setCurrentStep('warmup')}
-                    disabled={isLoading}
-                  >
-                    Back
-                  </button>
-                  <button
-                    type="button"
-                    className="btn-primary h-12"
-                    onClick={() => saveInterests()}
-                    disabled={selectedInterests.length === 0 || isLoading}
-                  >
-                    {isLoading ? 'Saving...' : 'Lock it in'}
-                  </button>
-                </div>
+                <p className="text-muted-foreground mb-3 text-sm">
+                  {selectedInterests.length < MIN_INTERESTS
+                    ? `Pick at least ${MIN_INTERESTS} to continue (${selectedInterests.length}/${MIN_INTERESTS}).`
+                    : `${selectedInterests.length} selected.`}
+                </p>
+                <button
+                  type="button"
+                  className="btn-primary h-12 w-full"
+                  onClick={() => saveInterests()}
+                  disabled={selectedInterests.length < MIN_INTERESTS || isLoading}
+                >
+                  {isLoading ? 'Saving...' : 'Lock it in'}
+                </button>
               </div>
             </div>
           ) : null}

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -8,8 +8,8 @@ vi.mock('next/navigation', () => ({
   useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
 }))
 
-describe('OnboardingFlow invited-interest copy', () => {
-  it('names the inviter when available', () => {
+describe('OnboardingFlow invited interests', () => {
+  it('pre-selects a seeded interest on the interests step', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         inviterName="Alex Inviter"
@@ -21,11 +21,12 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('Alex Inviter suggested these for you.')
+    expect(html).toContain('What are you into?')
+    expect(html).toContain('Your interests · 1/5')
     expect(html).toContain('Sondheim')
   })
 
-  it("renders Josh as Jaime's inviter with all three suggested interests", () => {
+  it('pre-selects all three seeded interests', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         inviterName="Josh"
@@ -39,28 +40,13 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('Josh suggested these for you.')
+    expect(html).toContain('Your interests · 3/5')
     expect(html).toContain('Sondheim')
     expect(html).toContain('Jazz')
     expect(html).toContain('Poetry')
   })
 
-  it('uses friend fallback when inviter name is unavailable', () => {
-    const html = renderToStaticMarkup(
-      <OnboardingFlow
-        inviterName={null}
-        initialDisplayName="Returning User"
-        initialHandle="returninguser"
-        preSeededInterests={[
-          { domain: 'Jazz', broadCategory: 'Music', rationale: null },
-        ]}
-      />
-    )
-
-    expect(html).toContain('A friend suggested these for you.')
-  })
-
-  it('still renders regular onboarding with no invite', () => {
+  it('lands setup-skipping users on the interests step with nothing seeded', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         preSeededInterests={[]}
@@ -69,7 +55,8 @@ describe('OnboardingFlow invited-interest copy', () => {
       />
     )
 
-    expect(html).toContain('Welcome to Joshing')
+    expect(html).toContain('What are you into?')
+    expect(html).toContain('Your interests · 0/5')
     expect(html).not.toContain('suggested these for you.')
   })
 })
@@ -122,6 +109,6 @@ describe('OnboardingFlow display-name gate', () => {
     )
 
     expect(html).not.toContain('What should we call you?')
-    expect(html).toContain('Welcome to Joshing')
+    expect(html).toContain('What are you into?')
   })
 })

--- a/src/components/daily/TopUpAreasModal.tsx
+++ b/src/components/daily/TopUpAreasModal.tsx
@@ -2,6 +2,8 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
+import { AddTopicField, type AddTopicError } from '@/components/interests/AddTopicField';
+
 export type TopUpInterest = {
   label: string;
   broadCategory: string | null;
@@ -15,11 +17,6 @@ type Suggestion = {
 
 type SuggestionsResponse = {
   suggestions?: Suggestion[];
-};
-
-type CanonicalizeResponse = {
-  suggested?: string;
-  broadCategory?: string;
 };
 
 // One-time prompt offering invite-seeded users (who sit at exactly three
@@ -45,8 +42,6 @@ export function TopUpAreasModal({
   const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
   const [loadingSuggestions, setLoadingSuggestions] = useState(true);
   const [selected, setSelected] = useState<TopUpInterest[]>([]);
-  const [customInput, setCustomInput] = useState('');
-  const [addingCustom, setAddingCustom] = useState(false);
   const [saving, setSaving] = useState(false);
   const [dismissing, setDismissing] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -95,45 +90,26 @@ export function TopUpAreasModal({
     [maxNew],
   );
 
-  const addCustom = useCallback(async () => {
-    const raw = customInput.trim();
-    if (raw.length < 2) return;
-    if (selected.length >= maxNew) {
-      setError(`You can add ${maxNew} more.`);
-      return;
-    }
-    if (isSelected(raw)) {
-      setCustomInput('');
-      return;
-    }
-    setAddingCustom(true);
-    setError(null);
-    try {
-      const response = await fetch('/api/onboarding/canonicalize', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ rawInput: raw }),
-      });
-      const body = (await response.json().catch(() => null)) as CanonicalizeResponse | null;
-      const label = body?.suggested?.trim() || raw;
-      const broadCategory = body?.broadCategory?.trim() || 'General Knowledge';
-      if (!isSelected(label)) {
-        setSelected((current) =>
-          current.length >= maxNew ? current : [...current, { label, broadCategory }],
-        );
+  // Stage a chosen topic into the local selection (the modal persists the union
+  // on save). The shared field handles the type → add / expand-into-choices UX
+  // and the specificity gate, so a broad word like "Music" becomes specific
+  // choices here instead of being staged verbatim.
+  const stageTopic = useCallback(
+    async (topic: { label: string; broadCategory?: string | null }) => {
+      if (selected.length >= maxNew) {
+        const error = new Error(`That's the max — ${maxNew} added.`) as AddTopicError;
+        error.code = 'limit_reached';
+        throw error;
       }
-      setCustomInput('');
-    } catch {
-      // Fall back to the raw input if canonicalization fails.
+      setError(null);
       setSelected((current) =>
-        current.length >= maxNew ? current : [...current, { label: raw, broadCategory: 'General Knowledge' }],
+        current.length >= maxNew
+          ? current
+          : [...current, { label: topic.label, broadCategory: topic.broadCategory ?? 'General Knowledge' }],
       );
-      setCustomInput('');
-    } finally {
-      setAddingCustom(false);
-    }
-  }, [customInput, isSelected, maxNew, selected.length]);
+    },
+    [maxNew, selected.length],
+  );
 
   const dismissPrompt = useCallback(async () => {
     try {
@@ -275,32 +251,21 @@ export function TopUpAreasModal({
           )}
         </div>
 
-        <div className="mt-3 flex gap-2">
-          <input
-            value={customInput}
-            onChange={(event) => setCustomInput(event.target.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter') {
-                event.preventDefault();
-                void addCustom();
-              }
-            }}
-            maxLength={100}
-            disabled={busy || selected.length >= maxNew}
-            placeholder="Or write your own…"
-            className="min-h-10 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-3 text-sm text-[var(--text)] outline-none"
-            style={{ borderColor: 'var(--border)' }}
-          />
-          <button
-            type="button"
-            className="shrink-0 rounded-[var(--radius-md)] border px-3 py-2 text-sm font-medium text-[var(--text)] transition-colors hover:bg-[var(--surface-raised)] disabled:opacity-50"
-            style={{ borderColor: 'var(--border)' }}
-            disabled={busy || addingCustom || selected.length >= maxNew || customInput.trim().length < 2}
-            onClick={() => void addCustom()}
-          >
-            {addingCustom ? '…' : 'Add'}
-          </button>
-        </div>
+        <AddTopicField
+          className="mt-3"
+          placeholder="Or write your own…"
+          disabled={busy || remaining <= 0}
+          existingLabels={[
+            ...existing.map((item) => item.label),
+            ...selected.map((item) => item.label),
+          ]}
+          onAdd={stageTopic}
+          inputClassName="min-h-10 min-w-0 flex-1 rounded-[var(--radius-md)] border border-[var(--border)] bg-[var(--bg)] px-3 text-sm text-[var(--text)] outline-none disabled:opacity-50"
+          buttonClassName="shrink-0 rounded-[var(--radius-md)] border border-[var(--border)] px-3 py-2 text-sm font-medium text-[var(--text)] transition-colors hover:bg-[var(--surface-raised)] disabled:opacity-50"
+          chipClassName="rounded-full border border-[var(--border)] px-3 py-1 text-xs font-medium text-[var(--text)] transition-colors hover:bg-[var(--surface-raised)] disabled:opacity-50"
+          mutedClassName="text-sm text-[var(--text-muted)]"
+          errorClassName="mt-2 text-sm text-[var(--danger)]"
+        />
 
         {selected.length > 0 ? (
           <div className="mt-3 flex flex-wrap gap-2">

--- a/src/components/interests/AddTopicField.tsx
+++ b/src/components/interests/AddTopicField.tsx
@@ -17,6 +17,16 @@ export type AddTopicCandidate = { label: string; broadCategory?: string | null }
 // outcomes: re-expand on a too-broad backstop, or show the cap affordance.
 export type AddTopicError = Error & { code?: 'limit_reached' | 'too_broad' };
 
+// Cream / Ink-on-Cream defaults (the daily-setup surface). Overridable so the
+// same field matches differently-themed surfaces (e.g. the top-up modal).
+const DEFAULT_INPUT_CLASS =
+  'min-h-12 flex-1 rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus-visible:ring-2 focus-visible:ring-[var(--ink)] focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-60';
+const DEFAULT_BUTTON_CLASS = 'btn-ghost min-h-12 px-5';
+const DEFAULT_CHIP_CLASS =
+  'rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-3 py-1.5 text-sm text-[var(--ink)] transition-colors hover:bg-[var(--cream-warm)] disabled:opacity-50';
+const DEFAULT_MUTED_CLASS = 'text-sm text-[var(--text-muted-warm)]';
+const DEFAULT_ERROR_CLASS = 'text-destructive mt-3 text-sm';
+
 type AddTopicFieldProps = {
   /** Persist the chosen topic. Throw an AddTopicError to signal a known outcome. */
   onAdd: (topic: AddTopicCandidate) => Promise<void>;
@@ -30,6 +40,13 @@ type AddTopicFieldProps = {
   limitReachedNode?: ReactNode;
   /** Lets a parent focus the input (e.g. a "create your own" CTA). */
   inputRef?: RefObject<HTMLInputElement | null>;
+  // Style overrides so the field can match each surface's palette.
+  className?: string;
+  inputClassName?: string;
+  buttonClassName?: string;
+  chipClassName?: string;
+  mutedClassName?: string;
+  errorClassName?: string;
 };
 
 /**
@@ -47,6 +64,12 @@ export function AddTopicField({
   disabled = false,
   limitReachedNode,
   inputRef,
+  className,
+  inputClassName = DEFAULT_INPUT_CLASS,
+  buttonClassName = DEFAULT_BUTTON_CLASS,
+  chipClassName = DEFAULT_CHIP_CLASS,
+  mutedClassName = DEFAULT_MUTED_CLASS,
+  errorClassName = DEFAULT_ERROR_CLASS,
 }: AddTopicFieldProps) {
   const inputId = useId();
   const internalRef = useRef<HTMLInputElement | null>(null);
@@ -163,7 +186,7 @@ export function AddTopicField({
   }, [busy, disabled, value, isDuplicate, expand, commit]);
 
   return (
-    <div>
+    <div className={className}>
       {heading ? (
         <label
           htmlFor={inputId}
@@ -190,11 +213,11 @@ export function AddTopicField({
             maxLength={maxLength}
             autoComplete="off"
             disabled={disabled}
-            className="min-h-12 flex-1 rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus-visible:ring-2 focus-visible:ring-[var(--ink)] focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-60"
+            className={inputClassName}
           />
           <button
             type="submit"
-            className="btn-ghost min-h-12 px-5"
+            className={buttonClassName}
             disabled={disabled || busy || !value.trim()}
           >
             {busy ? 'Working…' : 'Add'}
@@ -204,7 +227,7 @@ export function AddTopicField({
 
       {candidates ? (
         <div className="mt-4">
-          <p className="text-sm text-[var(--text-muted-warm)]">
+          <p className={mutedClassName}>
             {expandedFrom
               ? `“${expandedFrom}” is a whole category — pick what you’re into:`
               : 'Pick what you’re into:'}
@@ -216,7 +239,7 @@ export function AddTopicField({
                 type="button"
                 onClick={() => void commit(candidate)}
                 disabled={busy}
-                className="rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-3 py-1.5 text-sm text-[var(--ink)] transition-colors hover:bg-[var(--cream-warm)] disabled:opacity-50"
+                className={chipClassName}
               >
                 {pendingLabel === candidate.label.trim() ? 'Adding…' : candidate.label}
               </button>
@@ -226,7 +249,7 @@ export function AddTopicField({
       ) : null}
 
       {error ? (
-        <p className="text-destructive mt-3 text-sm">
+        <p className={errorClassName}>
           {error}
           {limitReached && limitReachedNode ? <> {limitReachedNode}</> : null}
         </p>

--- a/src/components/interests/AddTopicField.tsx
+++ b/src/components/interests/AddTopicField.tsx
@@ -1,0 +1,238 @@
+'use client';
+
+import {
+  useCallback,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+  type RefObject,
+} from 'react';
+
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
+
+export type AddTopicCandidate = { label: string; broadCategory?: string | null };
+
+// Callers throw this from onAdd so the field can react to known persistence
+// outcomes: re-expand on a too-broad backstop, or show the cap affordance.
+export type AddTopicError = Error & { code?: 'limit_reached' | 'too_broad' };
+
+type AddTopicFieldProps = {
+  /** Persist the chosen topic. Throw an AddTopicError to signal a known outcome. */
+  onAdd: (topic: AddTopicCandidate) => Promise<void>;
+  /** Existing labels for case-insensitive dedup. */
+  existingLabels?: string[];
+  heading?: string;
+  placeholder?: string;
+  maxLength?: number;
+  disabled?: boolean;
+  /** Rendered after the error text when the interest cap is reached. */
+  limitReachedNode?: ReactNode;
+  /** Lets a parent focus the input (e.g. a "create your own" CTA). */
+  inputRef?: RefObject<HTMLInputElement | null>;
+};
+
+/**
+ * Shared "add a topic" field. Type a topic and Add it; if it's a broad category
+ * ("Technology", "Music") it expands into specific, passion-level choices to pick
+ * from instead of saving the bucket. The caller owns persistence via onAdd, so
+ * the same field backs onboarding, daily setup, the knowledge modal, and top-up.
+ */
+export function AddTopicField({
+  onAdd,
+  existingLabels,
+  heading,
+  placeholder = 'e.g. Byzantine Coinage',
+  maxLength = 80,
+  disabled = false,
+  limitReachedNode,
+  inputRef,
+}: AddTopicFieldProps) {
+  const inputId = useId();
+  const internalRef = useRef<HTMLInputElement | null>(null);
+  const ref = inputRef ?? internalRef;
+
+  const [value, setValue] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [limitReached, setLimitReached] = useState(false);
+  const [candidates, setCandidates] = useState<AddTopicCandidate[] | null>(null);
+  const [expandedFrom, setExpandedFrom] = useState<string | null>(null);
+  const [pendingLabel, setPendingLabel] = useState<string | null>(null);
+
+  const isDuplicate = useCallback(
+    (label: string) =>
+      (existingLabels ?? []).some(
+        (existing) => existing.trim().toLowerCase() === label.trim().toLowerCase(),
+      ),
+    [existingLabels],
+  );
+
+  const expand = useCallback(
+    async (topic: string) => {
+      setBusy(true);
+      setError(null);
+      setLimitReached(false);
+      setCandidates(null);
+      setExpandedFrom(null);
+      setPendingLabel(null);
+      try {
+        const response = await fetch('/api/interests/expand', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ topic }),
+        });
+        const body = await response.json().catch(() => null);
+        if (!response.ok) throw new Error(body?.message ?? 'Could not break that down.');
+        const list: AddTopicCandidate[] = Array.isArray(body?.candidates) ? body.candidates : [];
+        const fresh = list.filter(
+          (candidate) =>
+            typeof candidate?.label === 'string' &&
+            candidate.label.trim() &&
+            !isDuplicate(candidate.label),
+        );
+        if (fresh.length === 0) {
+          setError(
+            `“${topic}” is a whole category. Try something more specific — a person, era, scene, or work.`,
+          );
+        } else {
+          setCandidates(fresh);
+          setExpandedFrom(topic);
+        }
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Could not break that down.');
+      } finally {
+        setBusy(false);
+      }
+    },
+    [isDuplicate],
+  );
+
+  const commit = useCallback(
+    async (candidate: AddTopicCandidate) => {
+      const label = candidate.label.trim();
+      if (!label || busy) return;
+      if (isDuplicate(label)) {
+        setError('You already added that one.');
+        return;
+      }
+      setBusy(true);
+      setError(null);
+      setLimitReached(false);
+      setPendingLabel(label);
+      try {
+        await onAdd({ label, broadCategory: candidate.broadCategory ?? null });
+        setValue('');
+        setCandidates((prev) => {
+          if (!prev) return prev;
+          const next = prev.filter(
+            (item) => item.label.trim().toLowerCase() !== label.toLowerCase(),
+          );
+          return next.length > 0 ? next : null;
+        });
+      } catch (caught) {
+        const coded = caught as AddTopicError;
+        if (coded?.code === 'too_broad') {
+          await expand(label);
+          return;
+        }
+        if (coded?.code === 'limit_reached') setLimitReached(true);
+        setError(caught instanceof Error ? caught.message : 'Could not add that topic.');
+      } finally {
+        setBusy(false);
+        setPendingLabel(null);
+      }
+    },
+    [busy, isDuplicate, onAdd, expand],
+  );
+
+  const submit = useCallback(async () => {
+    if (busy || disabled) return;
+    const label = value.trim();
+    if (!label) return;
+    if (isDuplicate(label)) {
+      setError('You already added that one.');
+      return;
+    }
+    if (isTooBroadInterest(label)) {
+      await expand(label);
+      return;
+    }
+    await commit({ label });
+  }, [busy, disabled, value, isDuplicate, expand, commit]);
+
+  return (
+    <div>
+      {heading ? (
+        <label
+          htmlFor={inputId}
+          className="block font-serif text-2xl font-semibold text-[var(--ink)]"
+        >
+          {heading}
+        </label>
+      ) : null}
+      <form
+        onSubmit={(event) => {
+          event.preventDefault();
+          void submit();
+        }}
+        className={heading ? 'mt-4' : undefined}
+      >
+        <div className="flex gap-2">
+          <input
+            ref={ref}
+            id={inputId}
+            type="text"
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder={placeholder}
+            maxLength={maxLength}
+            autoComplete="off"
+            disabled={disabled}
+            className="min-h-12 flex-1 rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus-visible:ring-2 focus-visible:ring-[var(--ink)] focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-60"
+          />
+          <button
+            type="submit"
+            className="btn-ghost min-h-12 px-5"
+            disabled={disabled || busy || !value.trim()}
+          >
+            {busy ? 'Working…' : 'Add'}
+          </button>
+        </div>
+      </form>
+
+      {candidates ? (
+        <div className="mt-4">
+          <p className="text-sm text-[var(--text-muted-warm)]">
+            {expandedFrom
+              ? `“${expandedFrom}” is a whole category — pick what you’re into:`
+              : 'Pick what you’re into:'}
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {candidates.map((candidate) => (
+              <button
+                key={candidate.label}
+                type="button"
+                onClick={() => void commit(candidate)}
+                disabled={busy}
+                className="rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-3 py-1.5 text-sm text-[var(--ink)] transition-colors hover:bg-[var(--cream-warm)] disabled:opacity-50"
+              >
+                {pendingLabel === candidate.label.trim() ? 'Adding…' : candidate.label}
+              </button>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {error ? (
+        <p className="text-destructive mt-3 text-sm">
+          {error}
+          {limitReached && limitReachedNode ? <> {limitReachedNode}</> : null}
+        </p>
+      ) : null}
+    </div>
+  );
+}
+
+export default AddTopicField;

--- a/src/lib/knowledge/broad-category.ts
+++ b/src/lib/knowledge/broad-category.ts
@@ -13,7 +13,9 @@ const BROAD_CATEGORY_ALIASES: Record<string, string> = {
   'potpourri': 'General Knowledge',
 };
 
-const STABLE_BROAD_CATEGORIES = new Set([
+// The top-level portrait buckets. "General Knowledge" is the catch-all and is
+// intentionally last.
+export const STABLE_BROAD_CATEGORIES = [
   'Literature',
   'Music',
   'Film & Television',
@@ -27,7 +29,7 @@ const STABLE_BROAD_CATEGORIES = new Set([
   'Pop Culture',
   'Language',
   'General Knowledge',
-]);
+] as const;
 
 const LITERATURE_BROAD_CATEGORY_PATTERNS = [
   /\bliterat(?:ure|ary)\b/i,
@@ -44,6 +46,35 @@ const LITERATURE_BROAD_CATEGORY_PATTERNS = [
 
 function cleanBroadCategory(value: string): string {
   return value.trim().replace(/\s+/g, ' ');
+}
+
+// Fold to a stable comparison form: lowercase, unify "&"/"and", and collapse
+// separators so "Architecture & Design", "architecture and design", and
+// "architecture_design" all match the same bucket.
+function foldForBucketMatch(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s*&\s*/g, ' and ')
+    .replace(/[_-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+const BROAD_CATEGORY_LABELS_FOLDED = new Set<string>(
+  [...STABLE_BROAD_CATEGORIES, ...Object.keys(BROAD_CATEGORY_ALIASES)].map(foldForBucketMatch),
+);
+
+/**
+ * True when `value` is itself a top-level broad-category bucket or a direct alias
+ * of one (e.g. "Technology", "film & tv", "world history"). Unlike
+ * normalizeBroadCategory, this does NOT apply the territory→Literature pattern
+ * folding, so a specific label such as "James Joyce" returns false. Used by the
+ * declared-interest specificity guard to reject bucket-level topics.
+ */
+export function isBroadCategoryLabel(value: string | null | undefined): boolean {
+  if (typeof value !== 'string') return false;
+  const folded = foldForBucketMatch(value);
+  return folded.length > 0 && BROAD_CATEGORY_LABELS_FOLDED.has(folded);
 }
 
 /**

--- a/src/lib/knowledge/interest-specificity.test.ts
+++ b/src/lib/knowledge/interest-specificity.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { STABLE_BROAD_CATEGORIES } from '@/lib/knowledge/broad-category';
+import {
+  assertSpecificInterest,
+  isTooBroadInterest,
+  TooBroadInterestError,
+} from '@/lib/knowledge/interest-specificity';
+
+describe('isTooBroadInterest', () => {
+  it('rejects every top-level broad-category bucket', () => {
+    for (const bucket of STABLE_BROAD_CATEGORIES) {
+      expect(isTooBroadInterest(bucket)).toBe(true);
+    }
+  });
+
+  it('rejects broad-category aliases and case/separator variants', () => {
+    expect(isTooBroadInterest('Film & TV')).toBe(true);
+    expect(isTooBroadInterest('television')).toBe(true);
+    expect(isTooBroadInterest('world history')).toBe(true);
+    expect(isTooBroadInterest('architecture and design')).toBe(true);
+    expect(isTooBroadInterest('TECHNOLOGY')).toBe(true);
+  });
+
+  it('rejects generic catch-all fillers', () => {
+    expect(isTooBroadInterest('general')).toBe(true);
+    expect(isTooBroadInterest('general knowledge')).toBe(true);
+    expect(isTooBroadInterest('trivia')).toBe(true);
+    expect(isTooBroadInterest('other')).toBe(true);
+    expect(isTooBroadInterest('miscellaneous')).toBe(true);
+  });
+
+  it('rejects empty/whitespace input', () => {
+    expect(isTooBroadInterest('')).toBe(true);
+    expect(isTooBroadInterest('   ')).toBe(true);
+    expect(isTooBroadInterest(null)).toBe(true);
+    expect(isTooBroadInterest(undefined)).toBe(true);
+  });
+
+  it('allows hyper-specific, passion-level topics', () => {
+    expect(isTooBroadInterest('Byzantine Coinage')).toBe(false);
+    expect(isTooBroadInterest('Late Tchaikovsky')).toBe(false);
+    expect(isTooBroadInterest('James Joyce')).toBe(false);
+    expect(isTooBroadInterest('Weimar-Era Cinema')).toBe(false);
+    expect(isTooBroadInterest('90s Bollywood')).toBe(false);
+    // Short but specific acronyms are not "broad".
+    expect(isTooBroadInterest('AI alignment')).toBe(false);
+  });
+});
+
+describe('assertSpecificInterest', () => {
+  it('throws TooBroadInterestError for a bucket', () => {
+    expect(() => assertSpecificInterest('Music')).toThrow(TooBroadInterestError);
+  });
+
+  it('does not throw for a specific topic', () => {
+    expect(() => assertSpecificInterest('Delta Blues')).not.toThrow();
+  });
+});

--- a/src/lib/knowledge/interest-specificity.ts
+++ b/src/lib/knowledge/interest-specificity.ts
@@ -1,0 +1,77 @@
+/**
+ * Granularity guard for declared interests.
+ *
+ * A declared interest must be hyper-specific — the thing a player is actually
+ * passionate about — not a top-level category. "Technology", "Music", "general"
+ * are exactly what we reject here so the add-topic field can expand them into
+ * specific choices instead of saving the bucket verbatim.
+ *
+ * This is intentionally STRICTER than the question-subcategory guard
+ * (src/server/questions/canonical-subcategory.ts), which deliberately ALLOWS
+ * broad-category words like "music"/"history" in other columns. For interests
+ * those bucket words are precisely what's too broad.
+ *
+ * Pure (no server/LLM imports) so it can run on both the client add-topic field
+ * and the server write boundary.
+ */
+import { isBroadCategoryLabel } from '@/lib/knowledge/broad-category';
+
+// Catch-all fillers that aren't broad-category buckets but are still too generic
+// to be a passion-level interest. Mirrors FORBIDDEN_CANONICAL_SUBCATEGORIES
+// (canonical-subcategory.ts) plus a few interest-specific fillers.
+const GENERIC_INTEREST_LABELS = new Set<string>([
+  'other',
+  'general',
+  'general knowledge',
+  'trivia',
+  'potpourri',
+  'miscellaneous',
+  'misc',
+  'random',
+  'stuff',
+  'things',
+  'everything',
+  'anything',
+]);
+
+function normalizeForCheck(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s*&\s*/g, ' and ')
+    .replace(/[_-]/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+/**
+ * True when a typed interest is too broad to stand on its own — a top-level
+ * category bucket (or alias) or a generic catch-all. Callers should expand it
+ * into specific choices rather than saving it as-is.
+ */
+export function isTooBroadInterest(topic: string | null | undefined): boolean {
+  if (!topic) return true;
+  const normalized = normalizeForCheck(topic);
+  if (!normalized) return true;
+  if (GENERIC_INTEREST_LABELS.has(normalized)) return true;
+  return isBroadCategoryLabel(topic);
+}
+
+export class TooBroadInterestError extends Error {
+  constructor(public readonly attempted: string) {
+    super(
+      `Refusing to save "${attempted}" as a declared interest: it is a broad category, not a specific topic.`,
+    );
+    this.name = 'TooBroadInterestError';
+  }
+}
+
+/**
+ * Throw if the topic is too broad to be a declared interest. Use at the
+ * declared-interest write boundary as a last line of defense behind the
+ * client-side add-topic field.
+ */
+export function assertSpecificInterest(topic: string): void {
+  if (isTooBroadInterest(topic)) {
+    throw new TooBroadInterestError(topic);
+  }
+}

--- a/src/server/db/queries/__tests__/add-declared-interest.test.ts
+++ b/src/server/db/queries/__tests__/add-declared-interest.test.ts
@@ -51,6 +51,8 @@ vi.mock('@/server/db', () => ({
   friendInvitations: {},
 }));
 
+import { TooBroadInterestError } from '@/lib/knowledge/interest-specificity';
+
 import { addDeclaredInterest, DeclaredInterestLimitError } from '../users';
 
 describe('addDeclaredInterest', () => {
@@ -96,5 +98,12 @@ describe('addDeclaredInterest', () => {
 
   it('rejects an empty label', async () => {
     await expect(addDeclaredInterest('user-1', { label: '   ' })).rejects.toThrow(/topic name/);
+  });
+
+  it('rejects a broad-category label so the field expands it instead', async () => {
+    await expect(
+      addDeclaredInterest('user-1', { label: 'Technology' }),
+    ).rejects.toBeInstanceOf(TooBroadInterestError);
+    expect(categorizeInterestDomainMock).not.toHaveBeenCalled();
   });
 });

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -5,6 +5,7 @@ import { cache } from 'react';
 import { db, declaredInterests, friendInvitations, playerMastery, users } from '@/server/db';
 import { categorizeInterestDomain, isCatchAllBroadCategory } from '@/server/llm/interests';
 import { foldDomainPunctuation } from '@/lib/knowledge/domain-key';
+import { assertSpecificInterest } from '@/lib/knowledge/interest-specificity';
 
 type User = InferSelectModel<typeof users>;
 
@@ -249,6 +250,13 @@ export async function addDeclaredInterest(
   if (!clean) {
     throw new Error('Enter a topic name.');
   }
+
+  // Last line of defense behind the client add-topic field: a bucket-level or
+  // catch-all label ("Technology", "general") must never persist as a declared
+  // interest. The field expands these into specific choices; this guard refuses
+  // any that slip past it. (The full-replace saveDeclaredInterests path is left
+  // lenient so legacy/pre-seeded rows can still be re-saved during an edit.)
+  assertSpecificInterest(clean.label);
 
   const active = await db
     .select({ domain: declaredInterests.domain, broadCategory: declaredInterests.broadCategory })

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -9,6 +9,7 @@ import {
   wrapUserInput,
 } from '@/lib/llm';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 
 export type WarmupAnswers = {
   deepDive?: string;
@@ -325,6 +326,71 @@ Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation
         : null,
     explanation: explanation.slice(0, 180),
   };
+}
+
+export type ExpandedInterest = {
+  label: string;
+  // null when categorization is unavailable or the model returns a catch-all;
+  // the save path re-categorizes before persisting (same contract as canonicalize).
+  broadCategory: string | null;
+};
+
+/**
+ * Break a too-broad topic ("Music", "Technology") into specific, passion-level
+ * sub-topics the player can pick from. Powers the add-topic field's
+ * expand-into-choices flow. Uses Haiku for low latency (this runs inline as the
+ * user adds a topic) and filters out any candidate that is itself still broad
+ * (isTooBroadInterest), so the menu is always actionable.
+ */
+export async function expandBroadInterest(topic: string): Promise<ExpandedInterest[]> {
+  const cleanTopic = topic.trim().replace(/\s+/g, ' ').slice(0, 80);
+  if (!cleanTopic) return [];
+
+  const client = getAnthropicClient();
+  if (!client) return [];
+
+  const systemPrompt = `A player typed a broad trivia category. Break it into 8 hyper-specific sub-topics they might be passionate about, each useful for trivia.
+Rules:
+- Every item must be hyper-specific — a person, era, movement, work, scene, or sub-field — never another broad category.
+- Good for "Music": "Late Beethoven String Quartets", "Delta Blues", "1990s Hip-Hop", "Film Scores of Ennio Morricone".
+- Bad for "Music": "Classical Music", "Rock", "Jazz" (still too broad).
+- broadCategory is a stable top-level bucket such as Music, Literature, Film & Television, History, Science, Philosophy, Sports, Pop Culture, Language, Technology, Food & Cuisine, Architecture & Design. Never "Other" or "General".
+Respond in JSON array only, no markdown: [ { "label": "...", "broadCategory": "..." } ]${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+  const response = await loggedMessagesCreate(client, 'interests-expand', {
+    model: CANONICALIZE_MODEL,
+    max_tokens: 600,
+    temperature: 0.6,
+    system: systemPrompt,
+    messages: [{ role: 'user', content: wrapUserInput('broad_topic', cleanTopic) }],
+  });
+
+  const parsed = parseJsonArray(extractTextContent(response.content));
+  if (!parsed) return [];
+
+  const seen = new Set<string>();
+  const candidates: ExpandedInterest[] = [];
+  for (const item of parsed) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) continue;
+    const record = item as Record<string, unknown>;
+    const label = asTrimmedString(record.label ?? record.domain);
+    if (!label) continue;
+    // Drop candidates that are still bucket-level — the menu must be actionable.
+    if (isTooBroadInterest(label)) continue;
+    const key = label.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+
+    const rawBroad = asTrimmedString(record.broadCategory ?? record.broad_category);
+    const normalized = rawBroad ? normalizeBroadCategory(rawBroad) : null;
+    candidates.push({
+      label: label.slice(0, 80),
+      broadCategory:
+        normalized && normalized !== 'General Knowledge' ? normalized.slice(0, 80) : null,
+    });
+  }
+
+  return candidates.slice(0, 8);
 }
 
 /**


### PR DESCRIPTION
Reject bucket-level and catch-all labels ("Technology", "general") as
declared interests so the add-topic field can expand them into specific,
passion-level choices instead of saving the broad word.

- isTooBroadInterest / assertSpecificInterest in a pure lib (client- and
  server-safe), built on a new isBroadCategoryLabel predicate over the
  existing broad-category taxonomy.
- Enforce at the incremental write boundary (addDeclaredInterest); the
  full-replace path stays lenient so legacy/pre-seeded rows still re-save.
- POST /api/declared-interests maps the guard to a 422 too_broad signal
  the client uses to trigger the expand-into-choices flow.

https://claude.ai/code/session_01NQkST6A26Xjh67pH7YTASq