### PR TITLE
Uncap declared interests + answerability guard for new-player onboarding

### DIFF
--- a/src/app/api/declared-interests/route.ts
+++ b/src/app/api/declared-interests/route.ts
@@ -8,9 +8,11 @@ import {
   addDeclaredInterest,
   DeclaredInterestLimitError,
   type DeclaredInterestInput,
+  MAX_ACTIVE_DECLARED_INTERESTS,
   saveDeclaredInterests,
 } from '@/server/db/queries/users';
 import { TooBroadInterestError } from '@/lib/knowledge/interest-specificity';
+import { UnanswerableInterestError } from '@/server/llm/interests';
 
 const addInterestSchema = z.object({
   label: z.string().trim().min(1).max(80),
@@ -51,7 +53,8 @@ function parseInterests(value: unknown): DeclaredInterestInput[] | null {
     return parsed ? [parsed] : [];
   });
 
-  if (interests.length < 1 || interests.length > 5) return null;
+  // No product cap — only the defensive sanity bound shared with the DB layer.
+  if (interests.length < 1 || interests.length > MAX_ACTIVE_DECLARED_INTERESTS) return null;
   return interests;
 }
 
@@ -68,7 +71,7 @@ export async function GET() {
     .from(declaredInterests)
     .where(and(eq(declaredInterests.userId, session.userId), eq(declaredInterests.isActive, true)))
     .orderBy(asc(declaredInterests.declaredAt))
-    .limit(5);
+    .limit(MAX_ACTIVE_DECLARED_INTERESTS);
 
   return NextResponse.json({
     interests: interests.map((interest) => ({
@@ -125,6 +128,14 @@ export async function POST(request: Request) {
         { status: 422 },
       );
     }
+    // The topic has no public factual basis (e.g. "my cat", gibberish). Signal
+    // the client to surface the reason inline rather than save an empty domain.
+    if (error instanceof UnanswerableInterestError) {
+      return NextResponse.json(
+        { error: 'unanswerable', topic: error.attempted, message: error.message },
+        { status: 422 },
+      );
+    }
     const message = error instanceof Error ? error.message : 'Could not add that topic.';
     return NextResponse.json({ error: 'add_failed', message }, { status: 400 });
   }
@@ -139,7 +150,7 @@ export async function PATCH(request: Request) {
 
   if (!interests) {
     return NextResponse.json(
-      { error: 'invalid_request', message: 'Send 1 to 5 interests.' },
+      { error: 'invalid_request', message: 'Send at least 1 interest.' },
       { status: 400 },
     );
   }

--- a/src/app/api/interests/check/route.ts
+++ b/src/app/api/interests/check/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
+import { assessInterestAnswerability } from '@/server/llm/interests';
+
+// Inline Haiku call; keep a modest budget above the default so a slow check
+// completes rather than being platform-killed.
+export const maxDuration = 30;
+
+const bodySchema = z.object({
+  topic: z.string().trim().min(1).max(100),
+});
+
+// Up-front validation for a typed declared interest, used by surfaces that stage
+// a topic client-side before the batch save (onboarding) or before opening a
+// confirm step (the knowledge "use my wording" path). Mirrors the two write-path
+// guards: too-broad (expand into specifics) and unanswerable (no factual basis).
+// Answerability fails open inside assessInterestAnswerability, so an LLM outage
+// returns ok and never blocks a real user.
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Enter a topic (up to 100 characters).' },
+      { status: 400 },
+    );
+  }
+
+  const topic = parsed.data.topic;
+
+  if (isTooBroadInterest(topic)) {
+    return NextResponse.json({
+      ok: false,
+      code: 'too_broad',
+      message: `"${topic}" is a whole category. Pick something more specific within it.`,
+    });
+  }
+
+  const answerability = await assessInterestAnswerability(topic);
+  if (!answerability.answerable) {
+    return NextResponse.json({
+      ok: false,
+      code: 'unanswerable',
+      message: answerability.reason,
+    });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -10,6 +10,7 @@ import {
   type DeclaredInterestInput,
   getUserOnboardingProfile,
   markOnboardingComplete,
+  MAX_ACTIVE_DECLARED_INTERESTS,
   saveDeclaredInterests,
 } from '@/server/db/queries/users';
 
@@ -54,7 +55,8 @@ function parseOnboardingTelemetry(value: unknown) {
 }
 
 function parseInterests(value: unknown): DeclaredInterestInput[] | null {
-  if (!Array.isArray(value) || value.length > 5) return null;
+  // No product cap — only the defensive sanity bound shared with the DB layer.
+  if (!Array.isArray(value) || value.length > MAX_ACTIVE_DECLARED_INTERESTS) return null;
 
   const interests = value.map(parseInterest);
   if (interests.some((interest) => !interest)) return null;
@@ -81,7 +83,7 @@ export async function POST(request: Request) {
 
   if (!interests || (interests.length === 0 && !isInviteSkip)) {
     return NextResponse.json(
-      { error: 'invalid_request', message: 'Save 1 to 5 interests, or skip invite suggestions. Domains must be 2 to 100 characters.' },
+      { error: 'invalid_request', message: 'Save at least 1 interest, or skip invite suggestions. Domains must be 2 to 100 characters.' },
       { status: 400 },
     );
   }

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -2,7 +2,7 @@
 
 import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
-import { Combine, Plus, Repeat2, X } from 'lucide-react';
+import { Combine, Plus, Repeat2, Trash2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
@@ -268,11 +268,13 @@ function KnowledgePageContent() {
     [annotatedDomains, visibleDomains, editMode],
   );
   const sharePortraitEntries = useMemo(() => visibleDomains.map(toPortraitEntry), [visibleDomains]);
-  const declaredSlots = useMemo(() => {
+  // One entry per declared interest — no fixed slot count and no cap. The manage
+  // modal renders these plus a trailing "add interest" affordance, so the list
+  // grows and shrinks with the player. (MAX_ACTIVE only bounds the write path.)
+  const declaredSlots = useMemo<DomainMastery[]>(() => {
     if (!data) return [];
     const byKey = new Map(data.pageData.allDomains.map((domain) => [domainKey(domain.domain), domain]));
-    const filled = data.pageData.declaredInterests.slice(0, 5).map((domain) => byKey.get(domainKey(domain)) ?? emptyDomain(domain));
-    return Array.from({ length: 5 }, (_, index) => filled[index] ?? null);
+    return data.pageData.declaredInterests.map((domain) => byKey.get(domainKey(domain)) ?? emptyDomain(domain));
   }, [data]);
   const declaredKeys = useMemo(() => new Set((data?.pageData.declaredInterests ?? []).map(domainKey)), [data]);
   const demonstratedChoices = useMemo(() => {
@@ -366,6 +368,21 @@ function KnowledgePageContent() {
         }
         return;
       }
+      // Specific enough to stand on its own — now validate answerability up front
+      // so a topic with no factual basis ("my cat") is caught before the confirm
+      // step rather than silently producing nothing. The check fails open
+      // server-side, so an LLM outage still lets the player proceed.
+      const check = await fetch('/api/interests/check', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ topic: raw }),
+      });
+      const checkBody = await check.json().catch(() => null) as { ok?: boolean; message?: string } | null;
+      if (check.ok && checkBody?.ok === false) {
+        setInterestError(checkBody.message ?? 'We could not find real questions for that topic.');
+        return;
+      }
       setSelectedInterest({ label: raw });
     } catch (caught) {
       setInterestError(caught instanceof Error ? caught.message : 'Could not add that interest.');
@@ -384,22 +401,29 @@ function KnowledgePageContent() {
     const modal = activeModal;
     setSavingInterests(true);
     setInterestError(null);
-    const nextInterests = (declaredSlots
-      .map((slot, index) => {
-        if (index === modal.slotIndex) {
-          return {
-            label: selectedInterest.label.trim(),
-            description: selectedInterest.description,
-            broadCategory: selectedInterest.broadCategory,
-          };
-        }
-        return slot ? { label: slot.domain, broadCategory: slot.broadCategory } : null;
-      }) as Array<ProposedInterest | null>)
-      .filter((interest): interest is ProposedInterest => Boolean(interest?.label.trim()))
-      .slice(0, 5);
+    // Full replace: start from the current declared list, then either swap the
+    // chosen slot or append (slotIndex === declaredSlots.length signals an add).
+    const entry: ProposedInterest = {
+      label: selectedInterest.label.trim(),
+      description: selectedInterest.description,
+      broadCategory: selectedInterest.broadCategory,
+    };
+    const base: ProposedInterest[] = declaredSlots.map((slot) => ({
+      label: slot.domain,
+      broadCategory: slot.broadCategory,
+    }));
+    if (modal.slotIndex >= 0 && modal.slotIndex < base.length) {
+      base[modal.slotIndex] = entry;
+    } else {
+      base.push(entry);
+    }
+    const nextInterests = base.filter((interest) => Boolean(interest.label.trim()));
 
     try {
-      const response = await fetch('/api/onboarding/save-interests', {
+      // PATCH /api/declared-interests is the full-replace endpoint
+      // (saveDeclaredInterests). The old call hit /api/onboarding/save-interests
+      // with PATCH, which has no PATCH handler — a 405 that silently failed.
+      const response = await fetch('/api/declared-interests', {
         method: 'PATCH',
         credentials: 'include',
         headers: { 'content-type': 'application/json' },
@@ -411,6 +435,36 @@ function KnowledgePageContent() {
       closeInterestModal();
     } catch (caught) {
       setInterestError(caught instanceof Error ? caught.message : 'Could not save your interests.');
+    } finally {
+      setSavingInterests(false);
+    }
+  };
+
+  // Drop a declared interest via the same full-replace endpoint. Blocked at the
+  // last one (the route also rejects an empty list) so a player always keeps at
+  // least one interest seeding their Daily Five.
+  const removeDeclaredInterest = async (domain: string) => {
+    const remaining = declaredSlots
+      .filter((slot) => slot.domain !== domain)
+      .map((slot) => ({ label: slot.domain, broadCategory: slot.broadCategory }));
+    if (remaining.length < 1) {
+      setInterestError('Keep at least one interest — swap it instead of removing the last one.');
+      return;
+    }
+    setSavingInterests(true);
+    setInterestError(null);
+    try {
+      const response = await fetch('/api/declared-interests', {
+        method: 'PATCH',
+        credentials: 'include',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ interests: remaining }),
+      });
+      const body = await response.json().catch(() => null) as { message?: string } | null;
+      if (!response.ok) throw new Error(body?.message ?? 'Could not remove that interest.');
+      await loadKnowledge();
+    } catch (caught) {
+      setInterestError(caught instanceof Error ? caught.message : 'Could not remove that interest.');
     } finally {
       setSavingInterests(false);
     }
@@ -786,7 +840,7 @@ function KnowledgePageContent() {
             <div className="flex justify-between gap-4">
               <div>
                 <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Manage interests</h2>
-                <p className="mt-[0.45rem] text-[var(--text-muted-warm)] text-[0.88rem] leading-[1.5]">Your five declared interests seed your Daily Five questions.</p>
+                <p className="mt-[0.45rem] text-[var(--text-muted-warm)] text-[0.88rem] leading-[1.5]">Your declared interests seed your Daily Five questions. Add as many as you like.</p>
               </div>
               <button type="button" className="w-[34px] h-[34px] border-none bg-transparent text-[var(--text-muted-warm)] grid place-items-center cursor-pointer" onClick={() => setActiveModal(null)} aria-label="Close">
                 <X className="size-4" />
@@ -794,26 +848,28 @@ function KnowledgePageContent() {
             </div>
             <div className="grid grid-cols-[repeat(auto-fit,minmax(118px,1fr))] gap-[0.6rem] mt-5">
               {declaredSlots.map((slot, index) => (
-                <div key={slot?.domain ?? `empty-${index}`} className="min-h-[132px] border border-[var(--border-light)] rounded-lg p-3 flex flex-col justify-between bg-[var(--cream)]">
-                  {slot ? (
-                    <>
-                      <div className="min-w-0">
-                        <h3 className="m-0 text-[0.9rem] leading-[1.25] text-[var(--ink)]">{slot.displayName}</h3>
-                        <p className="mt-1 text-[var(--text-muted-warm)] text-[0.72rem]">{slot.broadCategory ?? asTier(slot.tier)}</p>
-                      </div>
-                      <button type="button" className="min-h-[34px] border border-[var(--border-warm)] bg-white text-[var(--text-muted-warm)] inline-flex items-center justify-center gap-[6px] text-[0.68rem] uppercase tracking-[0.08em] cursor-pointer" onClick={() => openInterestModal(index, slot.domain)}>
-                        <Repeat2 className="size-3.5" />
-                        Swap
-                      </button>
-                    </>
-                  ) : (
-                    <button type="button" className="min-h-[104px] border border-dashed border-[#c8c0b0] bg-transparent text-[var(--text-muted-warm)] flex flex-col items-center justify-center gap-2 text-[0.82rem] cursor-pointer w-full" onClick={() => openInterestModal(index, null)}>
-                      <Plus className="size-4" />
-                      Add interest
+                <div key={slot.domain} className="min-h-[132px] border border-[var(--border-light)] rounded-lg p-3 flex flex-col justify-between bg-[var(--cream)]">
+                  <div className="min-w-0">
+                    <h3 className="m-0 text-[0.9rem] leading-[1.25] text-[var(--ink)]">{slot.displayName}</h3>
+                    <p className="mt-1 text-[var(--text-muted-warm)] text-[0.72rem]">{slot.broadCategory ?? asTier(slot.tier)}</p>
+                  </div>
+                  <div className="flex gap-[6px] mt-2">
+                    <button type="button" className="flex-1 min-h-[34px] border border-[var(--border-warm)] bg-white text-[var(--text-muted-warm)] inline-flex items-center justify-center gap-[6px] text-[0.68rem] uppercase tracking-[0.08em] cursor-pointer" onClick={() => openInterestModal(index, slot.domain)}>
+                      <Repeat2 className="size-3.5" />
+                      Swap
                     </button>
-                  )}
+                    <button type="button" className="min-h-[34px] w-[34px] border border-[var(--border-warm)] bg-white text-[var(--text-muted-warm)] inline-flex items-center justify-center cursor-pointer disabled:opacity-40 disabled:cursor-not-allowed" onClick={() => void removeDeclaredInterest(slot.domain)} disabled={savingInterests || declaredSlots.length <= 1} aria-label={`Remove ${slot.displayName}`} title={declaredSlots.length <= 1 ? 'Keep at least one interest' : `Remove ${slot.displayName}`}>
+                      <Trash2 className="size-3.5" />
+                    </button>
+                  </div>
                 </div>
               ))}
+              <div className="min-h-[132px] border border-[var(--border-light)] rounded-lg p-3 flex flex-col justify-between bg-[var(--cream)]">
+                <button type="button" className="min-h-[104px] border border-dashed border-[#c8c0b0] bg-transparent text-[var(--text-muted-warm)] flex flex-col items-center justify-center gap-2 text-[0.82rem] cursor-pointer w-full h-full" onClick={() => openInterestModal(declaredSlots.length, null)}>
+                  <Plus className="size-4" />
+                  Add interest
+                </button>
+              </div>
             </div>
             <div className="flex justify-start gap-2 mt-4">
               <button type="button" className="min-h-10 border border-[var(--border-warm)] bg-white text-[var(--text-muted-warm)] px-4 cursor-pointer" onClick={() => setActiveModal(null)}>Done</button>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -89,7 +89,10 @@ const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
 ]
 
 const MIN_INTERESTS = 3
-const MAX_INTERESTS = 5
+// No upper product cap — players pick as many interests as they like. This is a
+// defensive sanity bound only (the save path fans out into per-interest LLM
+// work); no real user reaches it, and the UI never shows it as a ceiling.
+const MAX_INTERESTS = 100
 
 function normalizeDomain(domain: string) {
   return domain.trim().replace(/\s+/g, ' ')
@@ -226,7 +229,7 @@ export default function OnboardingFlow({
         const selected = toSelected(interest)
         return selected ? [selected] : []
       })
-      .slice(0, 5)
+      .slice(0, MAX_INTERESTS)
   )
   const [isLoading, setIsLoading] = useState(false)
   const [isGenerating, setIsGenerating] = useState(false)
@@ -347,7 +350,7 @@ export default function OnboardingFlow({
         return current.filter(
           (item) => selectedKey(item) !== selectedKey(selected)
         )
-      if (current.length >= 5) return current
+      if (current.length >= MAX_INTERESTS) return current
       return [...current, selected]
     })
   }
@@ -453,6 +456,29 @@ export default function OnboardingFlow({
       limit.code = 'limit_reached'
       throw limit
     }
+
+    // Validate answerability up front: interests are staged client-side and not
+    // persisted until "Lock it in", so without this a topic with no factual
+    // basis ("my cat") would only be caught at the very end. The check fails
+    // open server-side, so an LLM outage never blocks staging.
+    const check = await fetch('/api/interests/check', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ topic: selected.domain }),
+    })
+    const checkBody = await check.json().catch(() => null)
+    if (check.ok && checkBody?.ok === false) {
+      if (checkBody.code === 'too_broad') {
+        const broad = new Error(checkBody.message) as AddTopicError
+        broad.code = 'too_broad'
+        throw broad
+      }
+      throw new Error(
+        checkBody.message ?? 'We could not find real questions for that topic.'
+      )
+    }
+
     setError(null)
     setSelectedInterests((current) =>
       current.some((item) => selectedKey(item) === selectedKey(selected))
@@ -780,7 +806,7 @@ export default function OnboardingFlow({
 
               <div className="space-y-3">
                 <p className="text-sm font-medium">
-                  Your interests · {selectedInterests.length}/{MAX_INTERESTS}
+                  Your interests · {selectedInterests.length}
                 </p>
                 {selectedInterests.length === 0 ? (
                   <p className="text-muted-foreground text-sm">

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -238,6 +238,7 @@ export default function OnboardingFlow({
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [editingDomain, setEditingDomain] = useState('')
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const seedsCheckedRef = useRef(false)
   const displayInviterName = inviterName?.trim()
     ? inviterName.trim()
     : 'A friend'
@@ -330,6 +331,68 @@ export default function OnboardingFlow({
 
     return () => window.clearInterval(interval)
   }, [isGenerating])
+
+  // Run the answerability check over the friend's pre-seeded suggestions, then
+  // let only the positive results stand as the pre-selected interests. A friend
+  // can seed anything ("your mom"), and these auto-populate the selection and
+  // appear as tappable cards — so without this, junk would reach the daily
+  // generator unchecked. We pre-fill optimistically (good for SSR and the common
+  // all-valid case), then prune any seed the check explicitly rejects. Fails open
+  // per-seed, so an LLM outage leaves the friend's picks intact.
+  useEffect(() => {
+    if (seedsCheckedRef.current || preSeededInterests.length === 0) return
+    seedsCheckedRef.current = true
+    let cancelled = false
+
+    void (async () => {
+      const results = await Promise.all(
+        preSeededInterests.map(async (seed) => {
+          const domain = normalizeDomain(seed.domain)
+          if (domain.length < 2) return { seed, answerable: false }
+          try {
+            const res = await fetch('/api/interests/check', {
+              method: 'POST',
+              credentials: 'include',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ topic: domain }),
+            })
+            const body = await res.json().catch(() => null)
+            // Only drop a seed when the check explicitly returns a negative.
+            return { seed, answerable: !(res.ok && body?.ok === false) }
+          } catch {
+            return { seed, answerable: true }
+          }
+        })
+      )
+      if (cancelled) return
+
+      const rejectedKeys = new Set(
+        results
+          .filter((result) => !result.answerable)
+          .map((result) =>
+            selectedKey(toSelected(result.seed) ?? { domain: '', broadCategory: '' })
+          )
+      )
+      rejectedKeys.delete('')
+      if (rejectedKeys.size === 0) return
+
+      // Remove rejected seeds everywhere: they neither pre-populate the selected
+      // interests nor remain as tappable "From <friend>" suggestion cards.
+      setInviteInterests((current) =>
+        current.filter(
+          (seed) =>
+            !rejectedKeys.has(selectedKey(toSelected(seed) ?? { domain: '', broadCategory: '' }))
+        )
+      )
+      setSelectedInterests((current) =>
+        current.filter((item) => !rejectedKeys.has(selectedKey(item)))
+      )
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [preSeededInterests])
 
   function updateWarmupAnswer(field: keyof WarmupAnswers, value: string) {
     setWarmupAnswers((current) => ({

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -238,7 +238,6 @@ export default function OnboardingFlow({
   const [editingKey, setEditingKey] = useState<string | null>(null)
   const [editingDomain, setEditingDomain] = useState('')
   const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const seedsCheckedRef = useRef(false)
   const displayInviterName = inviterName?.trim()
     ? inviterName.trim()
     : 'A friend'
@@ -331,68 +330,6 @@ export default function OnboardingFlow({
 
     return () => window.clearInterval(interval)
   }, [isGenerating])
-
-  // Run the answerability check over the friend's pre-seeded suggestions, then
-  // let only the positive results stand as the pre-selected interests. A friend
-  // can seed anything ("your mom"), and these auto-populate the selection and
-  // appear as tappable cards — so without this, junk would reach the daily
-  // generator unchecked. We pre-fill optimistically (good for SSR and the common
-  // all-valid case), then prune any seed the check explicitly rejects. Fails open
-  // per-seed, so an LLM outage leaves the friend's picks intact.
-  useEffect(() => {
-    if (seedsCheckedRef.current || preSeededInterests.length === 0) return
-    seedsCheckedRef.current = true
-    let cancelled = false
-
-    void (async () => {
-      const results = await Promise.all(
-        preSeededInterests.map(async (seed) => {
-          const domain = normalizeDomain(seed.domain)
-          if (domain.length < 2) return { seed, answerable: false }
-          try {
-            const res = await fetch('/api/interests/check', {
-              method: 'POST',
-              credentials: 'include',
-              headers: { 'Content-Type': 'application/json' },
-              body: JSON.stringify({ topic: domain }),
-            })
-            const body = await res.json().catch(() => null)
-            // Only drop a seed when the check explicitly returns a negative.
-            return { seed, answerable: !(res.ok && body?.ok === false) }
-          } catch {
-            return { seed, answerable: true }
-          }
-        })
-      )
-      if (cancelled) return
-
-      const rejectedKeys = new Set(
-        results
-          .filter((result) => !result.answerable)
-          .map((result) =>
-            selectedKey(toSelected(result.seed) ?? { domain: '', broadCategory: '' })
-          )
-      )
-      rejectedKeys.delete('')
-      if (rejectedKeys.size === 0) return
-
-      // Remove rejected seeds everywhere: they neither pre-populate the selected
-      // interests nor remain as tappable "From <friend>" suggestion cards.
-      setInviteInterests((current) =>
-        current.filter(
-          (seed) =>
-            !rejectedKeys.has(selectedKey(toSelected(seed) ?? { domain: '', broadCategory: '' }))
-        )
-      )
-      setSelectedInterests((current) =>
-        current.filter((item) => !rejectedKeys.has(selectedKey(item)))
-      )
-    })()
-
-    return () => {
-      cancelled = true
-    }
-  }, [preSeededInterests])
 
   function updateWarmupAnswer(field: keyof WarmupAnswers, value: string) {
     setWarmupAnswers((current) => ({

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -22,7 +22,7 @@ describe('OnboardingFlow invited interests', () => {
     )
 
     expect(html).toContain('What are you into?')
-    expect(html).toContain('Your interests · 1/5')
+    expect(html).toContain('Your interests · 1')
     expect(html).toContain('Sondheim')
   })
 
@@ -40,7 +40,7 @@ describe('OnboardingFlow invited interests', () => {
       />
     )
 
-    expect(html).toContain('Your interests · 3/5')
+    expect(html).toContain('Your interests · 3')
     expect(html).toContain('Sondheim')
     expect(html).toContain('Jazz')
     expect(html).toContain('Poetry')
@@ -56,7 +56,7 @@ describe('OnboardingFlow invited interests', () => {
     )
 
     expect(html).toContain('What are you into?')
-    expect(html).toContain('Your interests · 0/5')
+    expect(html).toContain('Your interests · 0')
     expect(html).not.toContain('suggested these for you.')
   })
 })

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -5,6 +5,8 @@ import { getSession } from '@/server/auth/session';
 import { db, friendInvitations } from '@/server/db';
 import { getPreSeededInterestsForUser, getUserOnboardingProfile } from '@/server/db/queries/users';
 import { hasInviteLinkFriendship } from '@/server/friends/user-invite-token';
+import { assessInterestAnswerability } from '@/server/llm/interests';
+import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 
 import OnboardingFlow, { type PreSeededInterest } from './OnboardingFlow';
 
@@ -48,11 +50,28 @@ export default async function OnboardingPage() {
   }
 
   const seeded = await getPreSeededInterestsForUser(session.userId);
-  const preSeededInterests: PreSeededInterest[] = seeded.interests.map((interest) => ({
-    domain: interest.label,
-    broadCategory: interest.broadCategory ?? 'General Knowledge',
-    rationale: interest.description ?? null,
-  }));
+
+  // Validate the inviter's free-text suggestions at the invitee's first login,
+  // before the interests step renders. The inviter can seed anything ("your
+  // mom"), so only the answerable, specific-enough seeds reach Jesse and
+  // pre-populate his selection — he never sees the rejects. This reads the
+  // stored invite without modifying it, and assessInterestAnswerability fails
+  // open, so an LLM outage leaves the friend's picks intact. Seeds are capped at
+  // 3, so this is at most a few parallel Haiku checks on a one-time page load.
+  const checkedSeeds = await Promise.all(
+    seeded.interests.map(async (interest) => {
+      if (isTooBroadInterest(interest.label)) return null;
+      const { answerable } = await assessInterestAnswerability(interest.label);
+      return answerable ? interest : null;
+    }),
+  );
+  const preSeededInterests: PreSeededInterest[] = checkedSeeds
+    .filter((interest): interest is NonNullable<typeof interest> => interest !== null)
+    .map((interest) => ({
+      domain: interest.label,
+      broadCategory: interest.broadCategory ?? 'General Knowledge',
+      rationale: interest.description ?? null,
+    }));
 
   return (
     <OnboardingFlow

--- a/src/server/db/queries/__tests__/save-declared-interests.test.ts
+++ b/src/server/db/queries/__tests__/save-declared-interests.test.ts
@@ -46,13 +46,16 @@ describe('saveDeclaredInterests categorization backstop', () => {
     vi.clearAllMocks();
   });
 
-  it('rejects more than 5 interests before any categorization', async () => {
+  // There is no product cap on declared interests, only a defensive sanity
+  // bound (MAX_ACTIVE_DECLARED_INTERESTS) that no real user reaches; exceeding it
+  // still short-circuits before any per-interest categorization.
+  it('rejects past the sanity bound before any categorization', async () => {
     await expect(
       saveDeclaredInterests(
         'user-1',
-        Array.from({ length: 6 }, (_, i) => ({ label: `interest-${i}` })),
+        Array.from({ length: 101 }, (_, i) => ({ label: `interest-${i}` })),
       ),
-    ).rejects.toThrow(/at most 5/);
+    ).rejects.toThrow(/at most 100/);
     expect(categorizeInterestDomainMock).not.toHaveBeenCalled();
   });
 

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -3,7 +3,11 @@ import { and, desc, eq, isNotNull } from 'drizzle-orm';
 import { cache } from 'react';
 
 import { db, declaredInterests, friendInvitations, playerMastery, users } from '@/server/db';
-import { categorizeInterestDomain, isCatchAllBroadCategory } from '@/server/llm/interests';
+import {
+  assertAnswerableInterest,
+  categorizeInterestDomain,
+  isCatchAllBroadCategory,
+} from '@/server/llm/interests';
 import { foldDomainPunctuation } from '@/lib/knowledge/domain-key';
 import { assertSpecificInterest } from '@/lib/knowledge/interest-specificity';
 
@@ -132,14 +136,20 @@ export function setFollowPrivacy(id: string, followPrivacy: 'public' | 'approval
     .then(([row]) => row);
 }
 
-export const MAX_ACTIVE_DECLARED_INTERESTS = 5;
+// There is no product cap on declared interests — players may declare as many as
+// they like. This is a defensive *sanity* bound only: every save fans out into
+// per-interest Haiku categorization (categorizeIfNeeded) and seeds a mastery row,
+// so an unbounded array from a client would be a cost/DoS vector. No real user
+// reaches it. (The separate "3 → 5" one-time top-up nudge lives in
+// src/server/area-top-up/rules.ts and is unaffected.)
+export const MAX_ACTIVE_DECLARED_INTERESTS = 100;
 
-// Thrown when an incremental add would push the user past the declared-interest
-// cap. Callers (API routes) detect this to return a 409 rather than a generic
-// 400 so the client can offer a "manage interests" path instead of a dead end.
+// Thrown when a write would push the user past the sanity bound above. Callers
+// (API routes) detect this to return a 409 rather than a generic 400 so the
+// client can react instead of hitting a dead end.
 export class DeclaredInterestLimitError extends Error {
   constructor(
-    message = `A player can have at most ${MAX_ACTIVE_DECLARED_INTERESTS} active declared interests.`,
+    message = `A player can declare at most ${MAX_ACTIVE_DECLARED_INTERESTS} interests.`,
   ) {
     super(message);
     this.name = 'DeclaredInterestLimitError';
@@ -258,6 +268,13 @@ export async function addDeclaredInterest(
   // lenient so legacy/pre-seeded rows can still be re-saved during an edit.)
   assertSpecificInterest(clean.label);
 
+  // Companion answerability guard: refuse topics with no public factual basis
+  // ("my cat", gibberish) so they never reach the daily generator. Fails open if
+  // the LLM is unavailable (see assessInterestAnswerability), so an outage never
+  // blocks a real add. The lenient full-replace path (saveDeclaredInterests) is
+  // intentionally NOT gated, so legacy/pre-seeded rows can always be re-saved.
+  await assertAnswerableInterest(clean.label);
+
   const active = await db
     .select({ domain: declaredInterests.domain, broadCategory: declaredInterests.broadCategory })
     .from(declaredInterests)
@@ -271,7 +288,7 @@ export async function addDeclaredInterest(
 
   if (active.length >= MAX_ACTIVE_DECLARED_INTERESTS) {
     throw new DeclaredInterestLimitError(
-      `You can track up to ${MAX_ACTIVE_DECLARED_INTERESTS} interests. Remove one on your Knowledge page to add another.`,
+      `You've reached the maximum of ${MAX_ACTIVE_DECLARED_INTERESTS} interests. Remove one on your Knowledge page to add another.`,
     );
   }
 

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -393,6 +393,83 @@ Respond in JSON array only, no markdown: [ { "label": "...", "broadCategory": ".
   return candidates.slice(0, 8);
 }
 
+export type InterestAnswerability = { answerable: boolean; reason: string | null };
+
+const UNANSWERABLE_FALLBACK_REASON =
+  'We could not find real questions for that topic. Try something more specific or more widely known.';
+
+/**
+ * Judge whether a daily trivia game could write real, factual questions about a
+ * typed interest. This is the "answerability" guard — a companion to the
+ * specificity guard (isTooBroadInterest), which rejects bucket-level labels.
+ * Answerability instead rejects topics with no public factual basis ("my cat",
+ * "asdfgh", "my street") so they never reach the daily generator, where they
+ * would silently produce nothing.
+ *
+ * FAILS OPEN: when the categorizer is unavailable or returns malformed JSON we
+ * treat the topic as answerable, exactly like categorizeInterestDomain degrades
+ * to null. We never block a real user because the model is down; junk only slips
+ * through during an outage, and the daily queue already tolerates thin domains.
+ */
+export async function assessInterestAnswerability(topic: string): Promise<InterestAnswerability> {
+  const cleanInput = topic.trim().replace(/\s+/g, ' ').slice(0, 100);
+  if (!cleanInput) return { answerable: false, reason: 'Enter a topic name.' };
+
+  const client = getAnthropicClient();
+  if (!client) return { answerable: true, reason: null };
+
+  const systemPrompt = `Decide whether a daily trivia game could write real, factual, verifiable questions about a player's declared interest.
+Respond in JSON only: { "answerable": true | false, "reason": "..." }
+- Answerable: any public subject with a body of knowable facts — a person, place, work, era, field, sport, hobby, scene, or movement. When unsure, lean answerable.
+- NOT answerable: purely personal/private topics ("my cat", "my high school friends", "my street"), gibberish or nonsense ("asdfgh", "blah blah"), or topics with essentially no public factual basis to ask about.
+- "reason" is a short, friendly explanation shown to the player only when answerable is false. Suggest making it more specific or more widely known.${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+  try {
+    // ~200 tokens — below Haiku's 2048 cache threshold; plain string.
+    const response = await loggedMessagesCreate(client, 'interests-answerability', {
+      model: CANONICALIZE_MODEL,
+      max_tokens: 160,
+      temperature: 0.1,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: wrapUserInput('interest_topic', cleanInput) }],
+    });
+
+    const parsed = parseJsonObject(extractTextContent(response.content));
+    if (!parsed || typeof parsed.answerable !== 'boolean') {
+      return { answerable: true, reason: null };
+    }
+    if (parsed.answerable) return { answerable: true, reason: null };
+    return { answerable: false, reason: asTrimmedString(parsed.reason) ?? UNANSWERABLE_FALLBACK_REASON };
+  } catch {
+    return { answerable: true, reason: null };
+  }
+}
+
+// Thrown at the declared-interest write boundary when a typed topic has no
+// public factual basis. Callers (API routes) map this to a 422 so the client can
+// surface the reason inline, the same way TooBroadInterestError signals "expand".
+export class UnanswerableInterestError extends Error {
+  constructor(
+    public readonly attempted: string,
+    public readonly reason: string = UNANSWERABLE_FALLBACK_REASON,
+  ) {
+    super(reason);
+    this.name = 'UnanswerableInterestError';
+  }
+}
+
+/**
+ * Throw if a typed topic is not answerable. Use at the declared-interest write
+ * boundary (incremental adds) behind the client-side up-front check. Fails open
+ * with assessInterestAnswerability, so an LLM outage never blocks a save.
+ */
+export async function assertAnswerableInterest(topic: string): Promise<void> {
+  const result = await assessInterestAnswerability(topic);
+  if (!result.answerable) {
+    throw new UnanswerableInterestError(topic, result.reason ?? UNANSWERABLE_FALLBACK_REASON);
+  }
+}
+
 /**
  * True when a stored broad_category is the catch-all rather than a real
  * top-level bucket. normalizeBroadCategory() folds "Other"/"General"/


### PR DESCRIPTION
## What

Removes the 5-interest product cap for new players and adds an **answerability guard** so typed/seeded topics with no public factual basis ("your mom", gibberish) never reach the daily generator.

## Why

A new player could only ever declare 5 interests, and the only validation on a topic was the "too broad" (specificity) check — nothing stopped an unanswerable topic from being saved and then silently producing no questions. A friend's invite seeds were especially exposed: they auto-populated the invitee's selection with no check at all.

## Changes

**Uncap declared interests**
- Drop the hard 5-cap across onboarding, the write/save path, and the Knowledge page. Keep only a defensive **sanity bound (100)** on the LLM-heavy save (`MAX_ACTIVE_DECLARED_INTERESTS`) — no product cap, no real user reaches it.
- The onboarding counter now reads `Your interests · N` (no `/5`); the `≥3` minimum is unchanged.
- The separate "3 → 5" one-time top-up nudge (`area-top-up/rules.ts`) is intentionally left alone.

**Knowledge page: fixed 5-slot grid → dynamic list**
- Replace the hard-coded 5-slot grid with a dynamic add / swap / **remove** list (remove is blocked on the last interest; the route also rejects an empty list).
- Fix a latent bug: the swap/add save was `PATCH`ing `/api/onboarding/save-interests`, which has no `PATCH` handler (a silent 405). It now correctly hits `PATCH /api/declared-interests`.

**Answerability guard (Haiku, fails open)**
- New `assessInterestAnswerability` / `assertAnswerableInterest` / `UnanswerableInterestError` in `server/llm/interests.ts`, plus a `POST /api/interests/check` endpoint.
- Enforced up front on every entry path: typed "add your own" (onboarding + daily setup + Knowledge "use my wording"), and the incremental write boundary (`addDeclaredInterest` → 422).
- **Fails open** when the LLM is unavailable, mirroring how `categorizeInterestDomain` degrades — an outage never blocks a real save.

**Friend invite seeds checked at the invitee's first login**
- The inviter's free-text seeds are validated server-side in the onboarding page render, *before* the interests step paints. Only answerable, specific-enough seeds reach the invitee and pre-populate their selection — a rejected seed never appears (no flash, no spinner).
- Reads the stored invite without modifying it; fails open per seed. Seeds are capped at 3, so this is at most a few parallel Haiku checks on a one-time page load.

## Tests
- Updated `OnboardingFlow.test.tsx` (counter `N/5` → `N`) and `save-declared-interests.test.ts` (sanity bound 100, reject-before-categorize behavior unchanged).
- `tsc`, ESLint, and the onboarding/declared-interest suites pass.

## Not done / notes
- No save-time backstop on the final "Lock it in" (per discussion — entry paths are each gated, and warm-up suggestions come from our own constrained generator).
- The Knowledge grid→list rework was verified via typecheck/lint/tests but **not** visually QA'd in a running app.

https://claude.ai/code/session_01NQkST6A26Xjh67pH7YTASq

---
_Generated by [Claude Code](https://claude.ai/code/session_01NQkST6A26Xjh67pH7YTASq)_