### PR TITLE
Let recipients answer a directly-sent question inline in What's Happening

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -13,6 +13,7 @@ import type {
   StreamQuestion,
 } from '@/lib/activity-stream';
 
+import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
 import { ActivityIcon, specForIcon } from './ActivityIcon';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
@@ -301,6 +302,8 @@ function ItemAction({ action }: { action: NonNullable<StreamItem['action']> }) {
         </Link>
       ) : action.kind === 'friend_request' ? (
         <FriendRequestActions friendshipId={action.friendshipId} />
+      ) : action.kind === 'answer_direct' ? (
+        <DirectQuestionAnswer action={action} />
       ) : (
         <ReactionGotItButton reactionId={action.reactionId} replied={action.replied} />
       )}

--- a/src/components/activity/DirectQuestionAnswer.tsx
+++ b/src/components/activity/DirectQuestionAnswer.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import { useState } from 'react';
+
+import { AnswerFeedbackSheet } from '@/components/feed/AnswerFeedbackSheet';
+import { AnswerSheet } from '@/components/feed/AnswerSheet';
+import type { StreamAction } from '@/lib/activity-stream';
+import type { InsideJokeKind } from '@/lib/questions-types';
+
+import { FM, INK, INK3 } from '@/components/lately/tokens';
+
+type Feedback = {
+  isCorrect: boolean;
+  pointsAwarded: number | null;
+  correctAnswer: string;
+  explanation: string | null;
+  creatorNote: string | null;
+  insideJoke: string | null;
+  insideJokeKind: InsideJokeKind | null;
+  openedNewTerritory: boolean;
+  openedTerritoryDomain: string | null;
+};
+
+// The "ANSWER →" action on a "{friend} sent you a question" stream row. A direct
+// send is backed by a feed item, so this answers in place against
+// /api/feed/{feedItemId}/answer — the same endpoint the home feed uses — and
+// then shows the standard result sheet. A wrong answer keeps the button live so
+// the recipient can take another swing (the route allows retry on direct sends);
+// a correct one retires the button to a quiet "Answered" note for the session.
+export function DirectQuestionAnswer({
+  action,
+}: {
+  action: Extract<StreamAction, { kind: 'answer_direct' }>;
+}) {
+  const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState('');
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const [answeredCorrectly, setAnsweredCorrectly] = useState(false);
+
+  async function submit(answer: string) {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/feed/${action.feedItemId}/answer`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ submitted_answer: answer }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
+            masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
+          })
+        | null;
+      if (!res.ok || !body) throw new Error('Could not score that answer.');
+      setSubmitted(answer);
+      setFeedback({
+        isCorrect: body.isCorrect,
+        pointsAwarded: body.pointsAwarded,
+        correctAnswer: body.correctAnswer,
+        explanation: body.explanation,
+        creatorNote: body.creatorNote,
+        insideJoke: body.insideJoke,
+        insideJokeKind: body.insideJokeKind,
+        openedNewTerritory: Boolean(body.masteryDelta?.openedNewTerritory),
+        openedTerritoryDomain: body.masteryDelta?.openedNewTerritory
+          ? body.masteryDelta?.domain ?? null
+          : null,
+      });
+      setPhase('result');
+    } catch {
+      // Leave the input sheet open so the viewer can retry.
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Once the result sheet is dismissed, a correct answer retires the button; a
+  // wrong one returns the row to its idle "ANSWER →" state so they can try again.
+  function finish() {
+    setPhase('closed');
+    if (feedback?.isCorrect) setAnsweredCorrectly(true);
+  }
+
+  if (answeredCorrectly) {
+    return (
+      <span style={{ fontFamily: FM, fontSize: 10, letterSpacing: 2, color: INK3 }}>ANSWERED</span>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setPhase('input')}
+        style={{
+          display: 'inline-block',
+          background: INK,
+          color: '#fcf8f2',
+          border: 'none',
+          fontFamily: FM,
+          fontSize: 10,
+          letterSpacing: 2,
+          padding: '8px 12px',
+          cursor: 'pointer',
+        }}
+      >
+        ANSWER →
+      </button>
+
+      {phase === 'input' ? (
+        <AnswerSheet
+          question={action.questionText}
+          category={action.domain}
+          loading={loading}
+          onSubmit={(answer) => void submit(answer)}
+          onClose={() => setPhase('closed')}
+        />
+      ) : null}
+
+      {phase === 'result' && feedback ? (
+        <AnswerFeedbackSheet
+          question={action.questionText}
+          category={action.domain}
+          isCorrect={feedback.isCorrect}
+          pointsAwarded={feedback.pointsAwarded}
+          correctAnswer={feedback.correctAnswer}
+          submittedAnswer={submitted}
+          explanation={feedback.explanation}
+          creatorNote={feedback.creatorNote}
+          insideJoke={feedback.insideJoke}
+          insideJokeKind={feedback.insideJokeKind}
+          openedNewTerritory={feedback.openedNewTerritory}
+          openedTerritoryDomain={feedback.openedTerritoryDomain}
+          questionId={action.questionId}
+          feedItemId={action.feedItemId}
+          onClose={finish}
+        />
+      ) : null}
+    </>
+  );
+}

--- a/src/lib/__tests__/activity-stream-direct-question.test.ts
+++ b/src/lib/__tests__/activity-stream-direct-question.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+
+import { activityToStreamItem } from '@/lib/activity-stream';
+import type { ActivityItemView } from '@/server/db/queries/activity';
+
+function directQuestionActivity(
+  overrides?: Partial<NonNullable<ActivityItemView['reference']['directQuestion']>>,
+): ActivityItemView {
+  return {
+    id: 'a-1',
+    userId: 'viewer-1',
+    type: 'received_direct_question',
+    actorUserId: 'sender-1',
+    referenceId: 'fi-1',
+    referenceType: 'feed_item',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'Sadie' },
+    reference: {
+      directQuestion: {
+        feedItemId: 'fi-1',
+        questionId: 'q-catch22',
+        questionText: 'Why was Major Major promoted in Catch-22?',
+        personalMessage: null,
+        category: 'Catch-22',
+        ...overrides,
+      },
+    },
+  };
+}
+
+describe('activityToStreamItem — received_direct_question', () => {
+  it('offers an inline answer_direct action (not a link back to home)', () => {
+    const item = activityToStreamItem(directQuestionActivity());
+
+    expect(item.action).toEqual({
+      kind: 'answer_direct',
+      feedItemId: 'fi-1',
+      questionId: 'q-catch22',
+      questionText: 'Why was Major Major promoted in Catch-22?',
+      domain: 'Catch-22',
+    });
+    expect(item.secondLine).toBe('Why was Major Major promoted in Catch-22?');
+    expect(item.icon).toBe('hourglass');
+  });
+
+  it('falls back to the home link only when the feed-item reference is missing', () => {
+    const item = activityToStreamItem({
+      ...directQuestionActivity(),
+      reference: {},
+    });
+
+    expect(item.action).toEqual({ kind: 'link', href: '/', label: 'Answer' });
+  });
+});

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -82,7 +82,19 @@ export type StreamExpand =
 export type StreamAction =
   | { kind: 'link'; href: string; label: string }
   | { kind: 'friend_request'; friendshipId: string }
-  | { kind: 'reaction_got_it'; reactionId: string; replied: boolean };
+  | { kind: 'reaction_got_it'; reactionId: string; replied: boolean }
+  // A question a friend addressed directly to you (received_direct_question) ->
+  // ANSWER it inline, right here in the stream. The card is backed by a feed
+  // item, so the answer posts to /api/feed/{feedItemId}/answer (NOT the
+  // milestone endpoint). Everything the inline answer flow needs travels on the
+  // action so the row never has to round-trip to the home feed to be answered.
+  | {
+      kind: 'answer_direct';
+      feedItemId: string;
+      questionId: string;
+      questionText: string;
+      domain: string | null;
+    };
 
 // The triangle event-indicator family (Figma "From Your Friends" marks). One
 // 24px-wide mark per event class, rendered in the activity row's icon column
@@ -300,15 +312,28 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
       };
     }
 
-    case 'received_direct_question':
+    case 'received_direct_question': {
+      const dq = item.reference.directQuestion;
       return {
         ...base,
         line: [a, txt(' sent you a question')],
-        secondLine: item.reference.directQuestion?.questionText ?? null,
+        secondLine: dq?.questionText ?? null,
         icon: 'hourglass',
-        action: { kind: 'link', href: '/', label: 'Answer' },
+        // Answer it right here rather than linking to '/' (which only reloaded
+        // home and left the recipient with no way to actually answer). Falls
+        // back to a deep link only if the feed-item reference didn't hydrate.
+        action: dq
+          ? {
+              kind: 'answer_direct',
+              feedItemId: dq.feedItemId,
+              questionId: dq.questionId,
+              questionText: dq.questionText,
+              domain: dq.category,
+            }
+          : { kind: 'link', href: '/', label: 'Answer' },
         expand: null,
       };
+    }
 
     case 'received_joshing_game': {
       const complete = item.reference.game?.viewerStatus === 'complete';


### PR DESCRIPTION
A 'X sent you a question' row in the What's Happening / activity stream
carried an 'ANSWER →' action that linked to '/', which only reloaded home
and left the recipient with no way to actually answer the question.

The directly-sent question is backed by a feed item, and the activity's
directQuestion reference already carries feedItemId, questionId, text and
category — everything needed to answer in place. Replace the dead home link
with a new answer_direct stream action that opens the standard answer +
feedback sheets and posts to /api/feed/{feedItemId}/answer (the same endpoint
the home feed uses). A wrong answer keeps the button live for another swing
(the route allows retry on direct sends); a correct one settles to a quiet
'Answered'. Falls back to the old home link only if the feed-item reference
fails to hydrate.

https://claude.ai/code/session_0189tULxExy8XvSAA4y5rLxQ