### PR TITLE
Honor Resting categories from Game settings in Daily Five picks

### DIFF
--- a/src/server/daily/__tests__/resting-domains.test.ts
+++ b/src/server/daily/__tests__/resting-domains.test.ts
@@ -1,0 +1,144 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DAILY_QUEUE_SIZE } from '@/server/daily/types';
+
+// Same dependency-surface mock as queue-floor.test.ts: fillDailyQueueForUser
+// touches @/server/db (which throws without a connection string), so the whole
+// picker/generator surface is stubbed. This suite exercises ONLY how the
+// orchestrator builds the allow-set it hands to the authored + house pickers —
+// specifically that a "Resting" domain set on the Game settings page is excluded
+// from Daily Five selection in random mode (custom mode drops rested domains
+// from selectedDomains upstream, so it's already covered).
+const mocks = vi.hoisted(() => ({
+  getTodaysDailyQueue: vi.fn(),
+  carryForwardUntouchedDailyQueue: vi.fn(),
+  clearStaleShortTodayQueue: vi.fn(),
+  getKnowledgeBase: vi.fn(),
+  pickEligibleAuthoredQuestions: vi.fn(),
+  pickHouseQuestions: vi.fn(),
+  createDailyQueueItem: vi.fn(),
+  createDailyQueueItemFromAuthored: vi.fn(),
+  createDailyQueueItemFromHouse: vi.fn(),
+  createDailyQueueItemFromPresence: vi.fn(),
+  getDailyPreferences: vi.fn(),
+  getFriendAndFoFUserIds: vi.fn(),
+  getFriendDomainsForBonus: vi.fn(),
+  generateDailyQuestionsFromKnowledgeBase: vi.fn(),
+  generateBonusQuestionsForDomains: vi.fn(),
+  isGenericSubcategory: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/daily', () => ({
+  getTodaysDailyQueue: mocks.getTodaysDailyQueue,
+  carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
+  clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
+  getKnowledgeBase: mocks.getKnowledgeBase,
+  pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
+  pickHouseQuestions: mocks.pickHouseQuestions,
+  createDailyQueueItem: mocks.createDailyQueueItem,
+  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
+  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
+  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+}));
+
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: mocks.getDailyPreferences,
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendAndFoFUserIds: mocks.getFriendAndFoFUserIds,
+}));
+
+vi.mock('@/server/db/queries/friend-presence-domains', () => ({
+  getFriendDomainsForBonus: mocks.getFriendDomainsForBonus,
+}));
+
+vi.mock('@/server/daily/generate-questions', () => ({
+  generateDailyQuestionsFromKnowledgeBase: mocks.generateDailyQuestionsFromKnowledgeBase,
+  generateBonusQuestionsForDomains: mocks.generateBonusQuestionsForDomains,
+}));
+
+vi.mock('@/server/questions/canonical-subcategory', () => ({
+  isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+vi.mock('@/server/refine/commit', () => ({
+  commitPendingRefineDecisions: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+
+const USER = 'user-1';
+
+function genq(id: string, subcategory = 'Opera') {
+  return { id, questionText: `Question ${id}`, canonicalSubcategory: subcategory } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.getTodaysDailyQueue.mockResolvedValue(null);
+  mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
+  mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
+
+  mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
+  mocks.pickHouseQuestions.mockResolvedValue([]);
+  mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+  mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+  mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+  mocks.isGenericSubcategory.mockReturnValue(false);
+
+  // Enough generated questions to reach the full five so the build succeeds and
+  // we can inspect the allow-set the pickers were called with.
+  mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue(
+    Array.from({ length: DAILY_QUEUE_SIZE }, (_, i) => genq(`q${i}`)),
+  );
+
+  mocks.createDailyQueueItem.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+});
+
+describe('fillDailyQueueForUser — Game settings categories drive selection', () => {
+  it('excludes Resting domains from authored + house picks in random mode', async () => {
+    mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }, { domain: 'Opera' }]);
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      // "Jazz" parked in the Resting zone on the Game settings page.
+      domainPreferenceFrequency: { Jazz: 'resting', Opera: 'often' },
+    });
+
+    await fillDailyQueueForUser(USER);
+
+    for (const picker of [mocks.pickEligibleAuthoredQuestions, mocks.pickHouseQuestions]) {
+      expect(picker).toHaveBeenCalled();
+      const allowed = picker.mock.calls[0].find(
+        (arg): arg is ReadonlySet<string> => arg instanceof Set,
+      );
+      expect(allowed).toBeDefined();
+      expect(allowed!.has('Jazz')).toBe(false);
+      expect(allowed!.has('Opera')).toBe(true);
+    }
+  });
+
+  it('passes the full knowledge base when nothing is Resting (random mode)', async () => {
+    mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }, { domain: 'Opera' }]);
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: { Opera: 'often' },
+    });
+
+    await fillDailyQueueForUser(USER);
+
+    const allowed = mocks.pickEligibleAuthoredQuestions.mock.calls[0].find(
+      (arg): arg is ReadonlySet<string> => arg instanceof Set,
+    );
+    expect(allowed!.has('Jazz')).toBe(true);
+    expect(allowed!.has('Opera')).toBe(true);
+  });
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -130,16 +130,31 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   // (src/server/daily/types.ts), so this is a picker change — no slot-shape
   // migration required.
   //
-  // Constrain authored picks to the viewer's effective knowledge base — in
-  // custom mode that's the explicit selectedDomains list, in random mode
-  // it's the full knowledge base (which getKnowledgeBase already filters
-  // against userDomainExclusions). Without this, the authored picker
-  // surfaced any vetted public question regardless of the viewer's declared
-  // or demonstrated interests.
+  // Constrain authored AND house picks to the viewer's effective knowledge
+  // base — in custom mode that's the explicit selectedDomains list, in random
+  // mode it's the full knowledge base (which getKnowledgeBase already filters
+  // against userDomainExclusions). Without this, the authored picker surfaced
+  // any vetted public question regardless of the viewer's declared or
+  // demonstrated interests.
+  //
+  // In random mode, also drop domains the player parked in "Resting" on the
+  // Game settings page. "Resting" means "won't be asked for now" (see the
+  // territory setup zones), and the LLM generator already honors it in both
+  // modes — but the authored/house pickers only filtered by this allow-set, so
+  // a rested category could still leak into the Daily Five via a vetted friend
+  // or house question. Custom mode needs no extra handling here: buildSavePayload
+  // excludes rested domains from selectedDomains upstream, so they're already out.
+  const restingDomains = new Set(
+    Object.entries(preferences.domainPreferenceFrequency ?? {})
+      .filter(([, frequency]) => frequency === 'resting')
+      .map(([domain]) => domain.toLowerCase()),
+  );
   const allowedSubcategories: ReadonlySet<string> = new Set(
     preferences.domainMode === 'custom'
       ? preferences.selectedDomains
-      : knowledgeBase.map((domain) => domain.domain),
+      : knowledgeBase
+          .map((domain) => domain.domain)
+          .filter((domain) => !restingDomains.has(domain.toLowerCase())),
   );
 
   const socialGraph = await getFriendAndFoFUserIds(userId);


### PR DESCRIPTION
## Summary

Makes sure the categories configured on the **Game settings** page (`/daily/setup`) are reflected in **Daily Five** question selection — specifically the **Resting** zone ("won't be asked for now").

The Daily Five is built from three sources: authored (friend) questions, house/editorial questions, then LLM-generated questions. Tracing each:

- The **LLM generator** already honored the Resting setting in both random and custom modes.
- The **authored + house pickers** are constrained only by an `allowedSubcategories` allow-set. In **custom mode** that set is `selectedDomains`, which already excludes rested categories. But in **random mode** (the default) the allow-set was the *entire* knowledge base — so a category parked in Resting could still leak into the Daily Five via a vetted friend or house question.

## Fix

In `src/server/daily/queue-orchestrator.ts`, build the random-mode allow-set with the same Resting filter the generator uses, so authored + house picks match. Custom mode needs no change — `buildSavePayload` drops rested domains from `selectedDomains` upstream.

## Edge case

If *every* category is Resting, generation falls back to the full knowledge base rather than producing an empty Daily Five (matching existing generator behavior); authored/house simply contribute nothing in that degenerate case.

## Tests

- New `src/server/daily/__tests__/resting-domains.test.ts` covering both the rested-exclusion and the nothing-rested cases.
- Existing + new orchestrator tests pass (6/6), typecheck clean on changed files, lint clean, no `middleware.ts` regression.

https://claude.ai/code/session_01ToJGRR7HnwQNPkTQxEx9HF

---
_Generated by [Claude Code](https://claude.ai/code/session_01ToJGRR7HnwQNPkTQxEx9HF)_