### PR TITLE
fix(daily): never serve the viewer their own authored question in the +2 bonus

### DIFF
--- a/src/server/daily/__tests__/bank-authored-exclusion.test.ts
+++ b/src/server/daily/__tests__/bank-authored-exclusion.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// queries/daily.ts imports @/server/db, which throws at module load without a
+// connection string. isBankRowServable / normalizeQuestionText are pure and
+// never touch the DB; a dummy URL plus dynamic import (the repo convention)
+// keeps the unit pure. Regression for the reported routing bug: a question the
+// viewer AUTHORED and sent a friend came back to the viewer in their own +2
+// bonus. The bonus picks from the bank via pickBankSource, which now skips any
+// row whose text matches a question the viewer authored.
+let isBankRowServable: typeof import('@/server/db/queries/daily').isBankRowServable;
+let normalizeQuestionText: typeof import('@/server/db/queries/daily').normalizeQuestionText;
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  ({ isBankRowServable, normalizeQuestionText } = await import('@/server/db/queries/daily'));
+});
+
+const RENT =
+  "According to the song 'Seasons of Love' in Rent, how many minutes are there in a year?";
+
+function row(questionText: string, factKey: string | null = 'rent-seasons-of-love-minutes') {
+  return { factKey, questionText };
+}
+
+describe('normalizeQuestionText', () => {
+  it('trims and lowercases so cross-table text matching is stable', () => {
+    expect(normalizeQuestionText(`  ${RENT}  `)).toBe(RENT.toLowerCase());
+  });
+});
+
+describe('isBankRowServable', () => {
+  const noAvoid = new Set<string>();
+
+  it('drops the reported case: a bank row the viewer themselves authored', () => {
+    const authored = new Set([normalizeQuestionText(RENT)]);
+    expect(isBankRowServable(row(RENT), noAvoid, authored)).toBe(false);
+  });
+
+  it('matches authored text regardless of surrounding whitespace/case', () => {
+    const authored = new Set([normalizeQuestionText(RENT)]);
+    expect(isBankRowServable(row(`  ${RENT.toUpperCase()}  `), noAvoid, authored)).toBe(false);
+  });
+
+  it('serves a bank row in the same domain the viewer did NOT author', () => {
+    const authored = new Set([normalizeQuestionText(RENT)]);
+    const other = "Who composed the musical 'Rent'?";
+    expect(isBankRowServable(row(other, 'rent-composer-larson'), noAvoid, authored)).toBe(true);
+  });
+
+  it('still excludes rows whose fact_key is in the recent avoid set', () => {
+    const avoidFactKeys = new Set(['rent-seasons-of-love-minutes']);
+    expect(isBankRowServable(row(RENT), avoidFactKeys, noAvoid)).toBe(false);
+  });
+
+  it('drops rows lacking a fact_key (older bank rows)', () => {
+    expect(isBankRowServable(row(RENT, null), noAvoid, noAvoid)).toBe(false);
+  });
+
+  it('serves a clean row when no avoid set matches', () => {
+    expect(isBankRowServable(row(RENT), noAvoid, noAvoid)).toBe(true);
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -20,11 +20,13 @@ import {
   updateAdaptiveLevel,
 } from '@/server/adaptive-difficulty';
 import {
+  getAuthoredQuestionTexts,
   getKnowledgeBase,
   getRecentDailyQuestionTexts,
   getRecentDomainCounts,
   getRecentFactKeys,
   getRecentSubAnglesByDomain,
+  normalizeQuestionText,
   pickBankSource,
   type BankDifficulty,
   type RecentDailyQuestionEntry,
@@ -47,6 +49,12 @@ import { askToAnswerBatch, resolveMachineTrustTier } from './ask-to-answer';
 const RECENT_QUESTION_TEXT_LIMIT = 80;
 // Cap the recent fact-key block at this many entries inside the prompt.
 const RECENT_FACT_KEY_LIMIT = 200;
+// How many of the viewer's most-recent AUTHORED questions to seed into the +2
+// bonus Sonnet avoid list. Bounded so a prolific author doesn't flush the
+// recent-GENERATED dedup signal out of the RECENT_QUESTION_TEXT_LIMIT /
+// history-gate windows. The bank pick guards against the FULL authored set
+// separately (avoidAuthoredTexts), so the literal-reuse path stays fully covered.
+const AUTHORED_AVOID_TEXT_LIMIT = 40;
 
 export type GeneratedQuestionRow = typeof generatedQuestions.$inferSelect;
 
@@ -1398,10 +1406,20 @@ export async function generateBonusQuestionsForDomains(
   const results: Array<{ domain: string; question: GeneratedQuestionRow }> = [];
   if (domains.length === 0) return results;
 
-  const [previousQuestionTexts, previousFactKeys] = await Promise.all([
+  const [previousQuestionTexts, previousFactKeys, authoredTexts] = await Promise.all([
     getRecentDailyQuestionTexts(userId),
     getRecentFactKeys(userId),
+    getAuthoredQuestionTexts(userId),
   ]);
+
+  // A +2 bonus must never hand the viewer a question they themselves authored.
+  // Authored questions live in the canonical table, not the generated bank, so
+  // the standard avoid lists miss them (D-4 §B invariant: "never a friend's
+  // literal answered question"). Fold them into BOTH paths: the Sonnet avoid
+  // list (the semantic Haiku dedupe gate then also catches re-wordings) and a
+  // normalized-text guard the bank pick honors verbatim.
+  const avoidAuthoredTexts = new Set(authoredTexts.map((entry) => normalizeQuestionText(entry.text)));
+  previousQuestionTexts.unshift(...authoredTexts.slice(0, AUTHORED_AVOID_TEXT_LIMIT));
 
   for (const domain of domains) {
     // Bank-first. resolveDomainDifficulty maps 'normal' → accessible, so the
@@ -1414,6 +1432,7 @@ export async function generateBonusQuestionsForDomains(
       undefined,
       null,
       previousFactKeys,
+      avoidAuthoredTexts,
     ).catch(() => [] as GeneratedQuestionRow[]);
 
     let row: GeneratedQuestionRow | null = bankPicks[0] ?? null;
@@ -1486,6 +1505,10 @@ async function pickBankPicksForDomains(
   domainDifficultyOverrides: ReadonlyMap<string, string> | undefined,
   adaptiveLevel: number | null,
   previousFactKeys: AvoidFactKeyEntry[],
+  // Bank rows whose (normalized) text matches one of these are skipped. The +2
+  // bonus passes the viewer's authored question texts so the bank can't reuse a
+  // fact the viewer themselves wrote (see generateBonusQuestionsForDomains).
+  avoidQuestionTexts: ReadonlySet<string> = new Set(),
 ): Promise<GeneratedQuestionRow[]> {
   const avoidFactKeys = new Set(previousFactKeys.map((entry) => entry.factKey));
   const picks: GeneratedQuestionRow[] = [];
@@ -1499,7 +1522,7 @@ async function pickBankPicksForDomains(
       adaptiveLevel,
     );
     if (!difficulty) continue;
-    const source = await pickBankSource(userId, domain, difficulty, avoidFactKeys).catch(() => null);
+    const source = await pickBankSource(userId, domain, difficulty, avoidFactKeys, avoidQuestionTexts).catch(() => null);
     if (!source) continue;
     if (isGenericSubcategory(source.canonicalSubcategory)) continue;
 

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1377,7 +1377,15 @@ export type BankDifficulty = 'accessible' | 'moderate' | 'specialist';
 //
 // Restrictions:
 // - fact_key must be present (predates 2026-05-24; older rows lack it)
-// - not authored by the viewer
+// - not GENERATED for the viewer (userId <> viewer)
+// - not the same trivia the viewer themselves AUTHORED. The `userId <> viewer`
+//   guard only covers questions GENERATED for the viewer; a question the viewer
+//   *wrote* lives in the canonical `questions` table (creatorId = viewer), never
+//   in the generated bank, so an independently-generated bank row about the same
+//   fact would otherwise be served straight back to its author — e.g. the +2
+//   bonus handing you a question you composed and sent a friend (reported
+//   2026-06). `avoidQuestionTexts` lets the caller pass the viewer's authored
+//   question texts so those rows are skipped here.
 // - not suppressed as an embedding near-duplicate (is_duplicate; B3)
 // - fact_key not already in the viewer's recent avoid set
 //
@@ -1390,11 +1398,38 @@ export type BankDifficulty = 'accessible' | 'moderate' | 'specialist';
 // Returns null when the bank is empty for this domain+difficulty — caller
 // falls back to fresh LLM generation, which incidentally grows the bank.
 const BANK_RECENCY_WINDOW = 50;
+
+// Canonical form for cross-table question-text matching (bank row text vs. a
+// viewer-authored canonical question). Mirrors the queue-orchestrator's own
+// dedup normalization (trim + lowercase) so the two stay consistent.
+export function normalizeQuestionText(text: string): string {
+  return text.trim().toLowerCase();
+}
+
+// Pure servability check for a bank candidate (extracted for testing). A row is
+// servable only if it has a fact_key (older rows lack one), its fact_key isn't
+// in the viewer's recent avoid set, and its text isn't one the viewer authored
+// (`avoidQuestionTexts`). Keeping this pure lets the loop in pickBankSource stay
+// a thin DB shell while the routing rule itself is unit-tested.
+export function isBankRowServable(
+  row: { factKey: string | null; questionText: string },
+  avoidFactKeys: ReadonlySet<string>,
+  avoidQuestionTexts: ReadonlySet<string>,
+): boolean {
+  if (!row.factKey) return false;
+  if (avoidFactKeys.has(row.factKey)) return false;
+  // Never serve the viewer trivia they themselves authored — fact_key won't
+  // catch it (authored canonical questions have no fact_key), so match on text.
+  if (avoidQuestionTexts.has(normalizeQuestionText(row.questionText))) return false;
+  return true;
+}
+
 export async function pickBankSource(
   userId: string,
   domain: string,
   difficulty: BankDifficulty,
   avoidFactKeys: ReadonlySet<string>,
+  avoidQuestionTexts: ReadonlySet<string> = new Set(),
 ): Promise<BankSource | null> {
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
@@ -1436,8 +1471,9 @@ export async function pickBankSource(
   }
 
   for (const row of candidates) {
+    if (!isBankRowServable(row, avoidFactKeys, avoidQuestionTexts)) continue;
+    // isBankRowServable guarantees a non-null factKey; this narrows it for TS.
     if (!row.factKey) continue;
-    if (avoidFactKeys.has(row.factKey)) continue;
     return {
       questionText: row.questionText,
       answer: row.answer,
@@ -1573,6 +1609,39 @@ export async function getRecentFactKeys(
     }
   }
   return out;
+}
+
+// Question texts the viewer has AUTHORED (canonical `questions`, creator =
+// viewer). The +2 bonus (and any bank reuse) must never serve a fact the viewer
+// personally wrote a question about — they obviously know it, and being handed
+// your own composed-and-sent question reads as a routing bug (reported 2026-06).
+// The other bonus avoid lists (getRecentDailyQuestionTexts / getRecentFactKeys)
+// read only generatedQuestions where userId = viewer, so authored questions —
+// which live in the canonical table and never in the generated bank — slip
+// through. Returned in the RecentDailyQuestionEntry shape so it composes
+// directly with the generation avoid list (the semantic Haiku dedupe gate then
+// also catches re-wordings); the bank pick matches the same texts verbatim.
+export async function getAuthoredQuestionTexts(
+  userId: string,
+  limit = 500,
+): Promise<RecentDailyQuestionEntry[]> {
+  const rows = await db
+    .select({
+      questionText: canonicalQuestions.questionText,
+      domain: canonicalQuestions.canonicalSubcategory,
+    })
+    .from(canonicalQuestions)
+    .where(and(
+      eq(canonicalQuestions.creatorId, userId),
+      isNull(canonicalQuestions.deletedAt),
+    ))
+    .orderBy(desc(canonicalQuestions.createdAt))
+    .limit(limit);
+
+  return rows.map((row) => ({
+    domain: row.domain ?? 'unknown',
+    text: row.questionText,
+  }));
 }
 
 export async function getAnsweredDailyCount(queue: DailyQueueRow): Promise<number> {


### PR DESCRIPTION
A question the viewer wrote and sent a friend could come back to the viewer
in their own Daily Five +2 bonus slot. The bonus is bank-first
(pickBankSource over generatedQuestions) and its exclusion lists
(getRecentDailyQuestionTexts / getRecentFactKeys) only cover the viewer's
*generated* questions — never the questions the viewer *authored*, which live
in the canonical `questions` table (creatorId = viewer) and never enter the
generated bank. So the documented "not authored by the viewer" / "never a
friend's literal answered question" invariant (D-4 §B) wasn't actually
enforced for human-authored questions: an independently-generated bank row
about the same fact was served straight back to its author.

Fix: add getAuthoredQuestionTexts (the viewer's authored canonical question
texts) and exclude them from the +2 bonus on both paths — a normalized-text
guard the bank pick honors verbatim (full authored set), and the Sonnet avoid
list (bounded slice, so a prolific author doesn't crowd out the
recent-generated dedup window; the semantic Haiku gate then also catches
re-wordings). The bank servability check is extracted to a pure
isBankRowServable + normalizeQuestionText and unit-tested against the reported
Rent / "Seasons of Love" case.