### PR TITLE
fix(daily): guard the +2 bonus against re-worded versions of authored questions

### DIFF
--- a/src/server/daily/__tests__/bank-authored-exclusion.test.ts
+++ b/src/server/daily/__tests__/bank-authored-exclusion.test.ts
@@ -1,30 +1,55 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
 // queries/daily.ts imports @/server/db, which throws at module load without a
-// connection string. isBankRowServable / normalizeQuestionText are pure and
-// never touch the DB; a dummy URL plus dynamic import (the repo convention)
-// keeps the unit pure. Regression for the reported routing bug: a question the
-// viewer AUTHORED and sent a friend came back to the viewer in their own +2
-// bonus. The bonus picks from the bank via pickBankSource, which now skips any
-// row whose text matches a question the viewer authored.
+// connection string. isBankRowServable / normalizeQuestionText / authoredAnswerKey
+// are pure and never touch the DB; a dummy URL plus dynamic import (the repo
+// convention) keeps the unit pure. Regression for the reported routing bug: a
+// question the viewer AUTHORED and sent a friend came back to the viewer in
+// their own +2 bonus. The bonus picks from the bank via pickBankSource, which
+// skips any row whose verbatim text — OR whose domain+answer signature (the
+// "same fact, different wording" backstop) — matches a question the viewer
+// authored.
 let isBankRowServable: typeof import('@/server/db/queries/daily').isBankRowServable;
 let normalizeQuestionText: typeof import('@/server/db/queries/daily').normalizeQuestionText;
+let authoredAnswerKey: typeof import('@/server/db/queries/daily').authoredAnswerKey;
 
 beforeAll(async () => {
   process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
-  ({ isBankRowServable, normalizeQuestionText } = await import('@/server/db/queries/daily'));
+  ({ isBankRowServable, normalizeQuestionText, authoredAnswerKey } = await import(
+    '@/server/db/queries/daily'
+  ));
 });
 
+const DOMAIN = 'Musical Theatre';
 const RENT =
   "According to the song 'Seasons of Love' in Rent, how many minutes are there in a year?";
+const RENT_ANSWER = '525,600';
 
-function row(questionText: string, factKey: string | null = 'rent-seasons-of-love-minutes') {
-  return { factKey, questionText };
+function row(
+  questionText: string,
+  {
+    factKey = 'rent-seasons-of-love-minutes',
+    answer = RENT_ANSWER,
+    canonicalSubcategory = DOMAIN,
+  }: { factKey?: string | null; answer?: string; canonicalSubcategory?: string | null } = {},
+) {
+  return { factKey, questionText, answer, canonicalSubcategory };
 }
 
 describe('normalizeQuestionText', () => {
   it('trims and lowercases so cross-table text matching is stable', () => {
     expect(normalizeQuestionText(`  ${RENT}  `)).toBe(RENT.toLowerCase());
+  });
+});
+
+describe('authoredAnswerKey', () => {
+  it('is domain-scoped and normalized so an answer only collides within its subcategory', () => {
+    expect(authoredAnswerKey(DOMAIN, `  ${RENT_ANSWER}  `)).toBe(authoredAnswerKey(DOMAIN, RENT_ANSWER));
+    expect(authoredAnswerKey(DOMAIN, RENT_ANSWER)).not.toBe(authoredAnswerKey('Film', RENT_ANSWER));
+  });
+
+  it('treats a null domain as the "unknown" bucket', () => {
+    expect(authoredAnswerKey(null, RENT_ANSWER)).toBe(authoredAnswerKey('unknown', RENT_ANSWER));
   });
 });
 
@@ -41,10 +66,32 @@ describe('isBankRowServable', () => {
     expect(isBankRowServable(row(`  ${RENT.toUpperCase()}  `), noAvoid, authored)).toBe(false);
   });
 
-  it('serves a bank row in the same domain the viewer did NOT author', () => {
-    const authored = new Set([normalizeQuestionText(RENT)]);
+  it('drops a RE-WORDED version of an authored fact via the domain+answer guard', () => {
+    // Different wording (verbatim-text guard misses it) but the same answer in
+    // the same subcategory — the same fact, so it must not be served back.
+    const reworded = "In Rent's 'Seasons of Love', a year is measured in how many minutes?";
+    const answerKeys = new Set([authoredAnswerKey(DOMAIN, RENT_ANSWER)]);
+    expect(isBankRowServable(row(reworded), noAvoid, noAvoid, answerKeys)).toBe(false);
+  });
+
+  it('does NOT cross domains: same answer string in a different subcategory is served', () => {
+    const answerKeys = new Set([authoredAnswerKey('Film', RENT_ANSWER)]);
+    // Bank row is in Musical Theatre; the authored answer key was for Film.
+    expect(isBankRowServable(row(RENT), noAvoid, noAvoid, answerKeys)).toBe(true);
+  });
+
+  it('serves a same-domain bank row with a DIFFERENT answer the viewer did not author', () => {
     const other = "Who composed the musical 'Rent'?";
-    expect(isBankRowServable(row(other, 'rent-composer-larson'), noAvoid, authored)).toBe(true);
+    const authoredTexts = new Set([normalizeQuestionText(RENT)]);
+    const answerKeys = new Set([authoredAnswerKey(DOMAIN, RENT_ANSWER)]);
+    expect(
+      isBankRowServable(
+        row(other, { factKey: 'rent-composer-larson', answer: 'Jonathan Larson' }),
+        noAvoid,
+        authoredTexts,
+        answerKeys,
+      ),
+    ).toBe(true);
   });
 
   it('still excludes rows whose fact_key is in the recent avoid set', () => {
@@ -53,7 +100,7 @@ describe('isBankRowServable', () => {
   });
 
   it('drops rows lacking a fact_key (older bank rows)', () => {
-    expect(isBankRowServable(row(RENT, null), noAvoid, noAvoid)).toBe(false);
+    expect(isBankRowServable(row(RENT, { factKey: null }), noAvoid, noAvoid)).toBe(false);
   });
 
   it('serves a clean row when no avoid set matches', () => {

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -20,7 +20,8 @@ import {
   updateAdaptiveLevel,
 } from '@/server/adaptive-difficulty';
 import {
-  getAuthoredQuestionTexts,
+  authoredAnswerKey,
+  getAuthoredQuestionFacts,
   getKnowledgeBase,
   getRecentDailyQuestionTexts,
   getRecentDomainCounts,
@@ -1406,20 +1407,24 @@ export async function generateBonusQuestionsForDomains(
   const results: Array<{ domain: string; question: GeneratedQuestionRow }> = [];
   if (domains.length === 0) return results;
 
-  const [previousQuestionTexts, previousFactKeys, authoredTexts] = await Promise.all([
+  const [previousQuestionTexts, previousFactKeys, authoredFacts] = await Promise.all([
     getRecentDailyQuestionTexts(userId),
     getRecentFactKeys(userId),
-    getAuthoredQuestionTexts(userId),
+    getAuthoredQuestionFacts(userId),
   ]);
 
   // A +2 bonus must never hand the viewer a question they themselves authored.
   // Authored questions live in the canonical table, not the generated bank, so
   // the standard avoid lists miss them (D-4 §B invariant: "never a friend's
-  // literal answered question"). Fold them into BOTH paths: the Sonnet avoid
-  // list (the semantic Haiku dedupe gate then also catches re-wordings) and a
-  // normalized-text guard the bank pick honors verbatim.
-  const avoidAuthoredTexts = new Set(authoredTexts.map((entry) => normalizeQuestionText(entry.text)));
-  previousQuestionTexts.unshift(...authoredTexts.slice(0, AUTHORED_AVOID_TEXT_LIMIT));
+  // literal answered question"). Guard the bank pick on TWO signatures the
+  // viewer authored: the verbatim text, and the domain+answer key that catches
+  // the same fact re-worded (the embedding backstop covers this too, but only
+  // when VOYAGE embeddings are enabled — these guards hold regardless). Also
+  // seed the Sonnet avoid list with the authored texts (bounded; the semantic
+  // Haiku dedupe gate then also catches re-wordings on the generation path).
+  const avoidAuthoredTexts = new Set(authoredFacts.map((fact) => normalizeQuestionText(fact.text)));
+  const avoidAuthoredAnswerKeys = new Set(authoredFacts.map((fact) => authoredAnswerKey(fact.domain, fact.answer)));
+  previousQuestionTexts.unshift(...authoredFacts.slice(0, AUTHORED_AVOID_TEXT_LIMIT));
 
   for (const domain of domains) {
     // Bank-first. resolveDomainDifficulty maps 'normal' → accessible, so the
@@ -1433,6 +1438,7 @@ export async function generateBonusQuestionsForDomains(
       null,
       previousFactKeys,
       avoidAuthoredTexts,
+      avoidAuthoredAnswerKeys,
     ).catch(() => [] as GeneratedQuestionRow[]);
 
     let row: GeneratedQuestionRow | null = bankPicks[0] ?? null;
@@ -1509,6 +1515,9 @@ async function pickBankPicksForDomains(
   // bonus passes the viewer's authored question texts so the bank can't reuse a
   // fact the viewer themselves wrote (see generateBonusQuestionsForDomains).
   avoidQuestionTexts: ReadonlySet<string> = new Set(),
+  // Bank rows whose domain+answer signature (authoredAnswerKey) matches one of
+  // these are skipped too — the "same fact, different wording" backstop.
+  avoidAnswerKeys: ReadonlySet<string> = new Set(),
 ): Promise<GeneratedQuestionRow[]> {
   const avoidFactKeys = new Set(previousFactKeys.map((entry) => entry.factKey));
   const picks: GeneratedQuestionRow[] = [];
@@ -1522,7 +1531,7 @@ async function pickBankPicksForDomains(
       adaptiveLevel,
     );
     if (!difficulty) continue;
-    const source = await pickBankSource(userId, domain, difficulty, avoidFactKeys, avoidQuestionTexts).catch(() => null);
+    const source = await pickBankSource(userId, domain, difficulty, avoidFactKeys, avoidQuestionTexts, avoidAnswerKeys).catch(() => null);
     if (!source) continue;
     if (isGenericSubcategory(source.canonicalSubcategory)) continue;
 

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -1406,21 +1406,38 @@ export function normalizeQuestionText(text: string): string {
   return text.trim().toLowerCase();
 }
 
+// Domain-scoped answer signature for the "same fact, different wording" guard.
+// An authored question and a bank row that share a normalized answer WITHIN the
+// same canonical subcategory are almost certainly the same fact, even when the
+// phrasings differ enough to dodge the verbatim-text guard. Scoped to the
+// domain so a common answer string (e.g. a composer's name) only collides
+// inside one narrow subcategory, not across the whole pool.
+export function authoredAnswerKey(domain: string | null, answer: string): string {
+  return `${normalizeQuestionText(domain ?? 'unknown')}|${normalizeQuestionText(answer)}`;
+}
+
 // Pure servability check for a bank candidate (extracted for testing). A row is
 // servable only if it has a fact_key (older rows lack one), its fact_key isn't
-// in the viewer's recent avoid set, and its text isn't one the viewer authored
-// (`avoidQuestionTexts`). Keeping this pure lets the loop in pickBankSource stay
-// a thin DB shell while the routing rule itself is unit-tested.
+// in the viewer's recent avoid set, its text isn't one the viewer authored
+// (`avoidQuestionTexts`), and its domain+answer signature isn't one the viewer
+// authored (`avoidAnswerKeys` — the "same fact, different wording" backstop for
+// when embeddings are off/below-threshold). Keeping this pure lets the loop in
+// pickBankSource stay a thin DB shell while the routing rule itself is
+// unit-tested.
 export function isBankRowServable(
-  row: { factKey: string | null; questionText: string },
+  row: { factKey: string | null; questionText: string; answer: string; canonicalSubcategory: string | null },
   avoidFactKeys: ReadonlySet<string>,
   avoidQuestionTexts: ReadonlySet<string>,
+  avoidAnswerKeys: ReadonlySet<string> = new Set(),
 ): boolean {
   if (!row.factKey) return false;
   if (avoidFactKeys.has(row.factKey)) return false;
   // Never serve the viewer trivia they themselves authored — fact_key won't
-  // catch it (authored canonical questions have no fact_key), so match on text.
+  // catch it (authored canonical questions have no fact_key), so match on text…
   if (avoidQuestionTexts.has(normalizeQuestionText(row.questionText))) return false;
+  // …and on the domain+answer signature, which catches a re-worded version of
+  // the same authored fact that verbatim text alone misses.
+  if (avoidAnswerKeys.has(authoredAnswerKey(row.canonicalSubcategory, row.answer))) return false;
   return true;
 }
 
@@ -1430,6 +1447,7 @@ export async function pickBankSource(
   difficulty: BankDifficulty,
   avoidFactKeys: ReadonlySet<string>,
   avoidQuestionTexts: ReadonlySet<string> = new Set(),
+  avoidAnswerKeys: ReadonlySet<string> = new Set(),
 ): Promise<BankSource | null> {
   let candidates: Array<typeof generatedQuestions.$inferSelect>;
   try {
@@ -1471,7 +1489,7 @@ export async function pickBankSource(
   }
 
   for (const row of candidates) {
-    if (!isBankRowServable(row, avoidFactKeys, avoidQuestionTexts)) continue;
+    if (!isBankRowServable(row, avoidFactKeys, avoidQuestionTexts, avoidAnswerKeys)) continue;
     // isBankRowServable guarantees a non-null factKey; this narrows it for TS.
     if (!row.factKey) continue;
     return {
@@ -1611,23 +1629,30 @@ export async function getRecentFactKeys(
   return out;
 }
 
-// Question texts the viewer has AUTHORED (canonical `questions`, creator =
-// viewer). The +2 bonus (and any bank reuse) must never serve a fact the viewer
+// One authored question carried for the +2 bonus exclusion: the domain + text
+// (composes with the generation avoid list, RecentDailyQuestionEntry-shaped)
+// plus the answer (for the domain+answer "same fact, different wording" guard).
+export type AuthoredQuestionFact = RecentDailyQuestionEntry & { answer: string };
+
+// Questions the viewer has AUTHORED (canonical `questions`, creator = viewer).
+// The +2 bonus (and any bank reuse) must never serve a fact the viewer
 // personally wrote a question about — they obviously know it, and being handed
 // your own composed-and-sent question reads as a routing bug (reported 2026-06).
 // The other bonus avoid lists (getRecentDailyQuestionTexts / getRecentFactKeys)
 // read only generatedQuestions where userId = viewer, so authored questions —
 // which live in the canonical table and never in the generated bank — slip
-// through. Returned in the RecentDailyQuestionEntry shape so it composes
-// directly with the generation avoid list (the semantic Haiku dedupe gate then
-// also catches re-wordings); the bank pick matches the same texts verbatim.
-export async function getAuthoredQuestionTexts(
+// through. The `text` composes directly with the generation avoid list (the
+// semantic Haiku dedupe gate then also catches re-wordings) and the bank pick
+// matches it verbatim; the `answer` feeds the domain+answer signature guard
+// (authoredAnswerKey) that catches a re-worded version of the same fact.
+export async function getAuthoredQuestionFacts(
   userId: string,
   limit = 500,
-): Promise<RecentDailyQuestionEntry[]> {
+): Promise<AuthoredQuestionFact[]> {
   const rows = await db
     .select({
       questionText: canonicalQuestions.questionText,
+      answer: canonicalQuestions.answerText,
       domain: canonicalQuestions.canonicalSubcategory,
     })
     .from(canonicalQuestions)
@@ -1641,6 +1666,7 @@ export async function getAuthoredQuestionTexts(
   return rows.map((row) => ({
     domain: row.domain ?? 'unknown',
     text: row.questionText,
+    answer: row.answer,
   }));
 }
 


### PR DESCRIPTION
Follow-up to the authored-question +2 bonus fix (PR #673). Covers the *differently-worded same-fact* variant I flagged as a known limitation, and documents the embedding-path verification.

## The remaining gap

PR #673 added a **verbatim-text** guard so a question the viewer authored can't come back in their own +2 bonus. But a bank row about the **same fact with different wording** (different text → different `fact_key`) still slipped through whenever the semantic embedding backstop was unavailable:

- `VOYAGE_API_KEY` not set (`isEmbeddingEnabled()` false → `src/server/pool/dedup.ts` explicitly "falls back to deterministic guards"), or
- cosine similarity below the `0.92` threshold.

## Fix — deterministic domain+answer guard

Added a domain-scoped answer signature: `authoredAnswerKey(domain, answer) = normalize(domain)|normalize(answer)`. A bank row whose **canonical subcategory AND normalized answer** match a question the viewer authored is almost certainly the same fact, so it's skipped too.

- **Domain-scoped on purpose:** a common answer string (e.g. a composer's name) only collides inside one narrow subcategory, never across the whole pool — keeps over-exclusion tight, as discussed.
- `getAuthoredQuestionFacts` (renamed from `getAuthoredQuestionTexts`) now also selects the answer.
- The bonus threads **both** an authored-text set and an authored-answer-key set through `pickBankPicksForDomains` → `pickBankSource`; `isBankRowServable` applies both.
- The **core daily path is untouched** — both new bank params default to empty sets.

These guards hold **regardless of embedding availability**, so the fix is robust even with no `VOYAGE_API_KEY`.

## Embedding path — verification (the other half of "both")

No code change needed; the path is already wired correctly:

- Authored questions **are embedded at creation** — `createQuestion` → `embedAndResolveDuplicate({ origin: 'human' })` (`src/server/db/queries/questions.ts:554`).
- Human-beats-machine suppression marks the machine near-duplicate `is_duplicate = true` in **both** orderings (author-first or generate-first; `src/server/pool/dedup.ts` collision matrix).
- `pickBankSource` already filters `is_duplicate = false`, so suppressed rows never reach the bonus.

**Operational check (cannot be done from this session):** confirm `VOYAGE_API_KEY` is set in the prod/preview environment so the semantic backstop is actually active, and that `POOL_DEDUP_COSINE_THRESHOLD` (default `0.92`) is where you want it. With the new deterministic guard, the exact + same-domain-answer cases are covered even if embeddings are off; embeddings still add value for cross-wording matches with *different* answers.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — **0 errors**
- `eslint` on changed files — **clean**
- `vitest run src/server/daily/__tests__/` — **99/99 pass** (+4 new), including a re-worded same-fact case and a cross-domain non-collision case in `bank-authored-exclusion.test.ts`

## Residual

The domain+answer guard won't catch a same-fact question phrased with a *different answer string* (e.g. `525600` vs `525,600 minutes`) — that asymmetric case still relies on the embedding backstop. Normalization handles whitespace/case; it does not unify numeric/format variants.

https://claude.ai/code/session_01UBpJU6WzmoZZQ9yVEUVNSM

---
_Generated by [Claude Code](https://claude.ai/code/session_01UBpJU6WzmoZZQ9yVEUVNSM)_