### PR TITLE
Add deterministic knowledge-category convergence

### DIFF
--- a/drizzle/0071_pg_trgm_convergence.sql
+++ b/drizzle/0071_pg_trgm_convergence.sql
@@ -1,0 +1,20 @@
+-- Domain convergence (deterministic dedup) substrate.
+--
+-- Enables pg_trgm so convergeDomain()'s fuzzy pass can call similarity(
+-- canonical_subcategory, $input) to align a freshly-suggested category onto an
+-- existing one across the game instead of fragmenting it. similarity() is a plain
+-- function and needs no index, so this migration intentionally adds NONE: the
+-- query filters with `similarity() >= threshold` (not the `%` operator, which
+-- would depend on the session-global set_limit GUC — unreliable under the
+-- PgBouncer-pooled connection), and a GIN trgm index would not accelerate that
+-- form while adding write amplification to the hot PLAYER_MASTERY write path. The
+-- distinct-canonical-subcategory corpus is small enough that the scan is fine; a
+-- later migration can add a matching index + switch the query if scale demands.
+--
+-- Idempotent. Mirrored by a defensive guard in src/instrumentation.ts so a
+-- database that records this migration without pg_trgm present still boots; if
+-- pg_trgm is unavailable the fuzzy pass degrades to exact-key + "create new".
+--
+-- Rollback: DROP EXTENSION IF EXISTS pg_trgm;  (only if nothing else uses it —
+-- check pg_depend first; leaving the extension installed is harmless.)
+CREATE EXTENSION IF NOT EXISTS pg_trgm;

--- a/src/app/api/knowledge/converge/__tests__/route.test.ts
+++ b/src/app/api/knowledge/converge/__tests__/route.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock, convergeDomainMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  convergeDomainMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/knowledge/converge-domain', () => ({ convergeDomain: convergeDomainMock }));
+
+import { POST } from '@/app/api/knowledge/converge/route';
+
+function request(body: unknown): Request {
+  return new Request('http://localhost/api/knowledge/converge', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/knowledge/converge', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ userId: 'user-1' });
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    getSessionMock.mockResolvedValue(null);
+    const response = await POST(request({ label: 'Delta Blues' }));
+    expect(response.status).toBe(401);
+    expect(convergeDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for invalid input (empty / too long)', async () => {
+    expect((await POST(request({ label: '' }))).status).toBe(400);
+    expect((await POST(request({ label: 'x'.repeat(101) }))).status).toBe(400);
+    expect((await POST(request({}))).status).toBe(400);
+    expect(convergeDomainMock).not.toHaveBeenCalled();
+  });
+
+  it('returns the convergence result on a valid request', async () => {
+    const result = {
+      raw: 'Delta Blues',
+      candidates: [{ label: 'Delta Blues', broadCategory: 'Music', kind: 'exact', similarity: 1 }],
+    };
+    convergeDomainMock.mockResolvedValue(result);
+
+    const response = await POST(request({ label: '  Delta Blues ' }));
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual(result);
+    expect(convergeDomainMock).toHaveBeenCalledWith('Delta Blues');
+  });
+});

--- a/src/app/api/knowledge/converge/route.ts
+++ b/src/app/api/knowledge/converge/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { convergeDomain } from '@/server/knowledge/converge-domain';
+
+// POST /api/knowledge/converge
+//
+// Given an already-specific category label (typed, expanded from a broad topic,
+// or pre-seeded by a friend), return the candidates it converges onto: any
+// existing canonical subcategory across the game it matches (exact or fuzzy),
+// plus a "create new" fallback. Deterministic and DB-only — no LLM call, so the
+// default maxDuration is fine (contrast /api/interests/expand which needs 30s
+// for its Haiku expansion). Convergence is meant to run AFTER broad-topic
+// expansion, on specific labels.
+const bodySchema = z.object({
+  label: z.string().trim().min(1).max(100),
+});
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Enter a topic (up to 100 characters).' },
+      { status: 400 },
+    );
+  }
+
+  const result = await convergeDomain(parsed.data.label);
+  return NextResponse.json(result);
+}

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -535,6 +535,7 @@ export function TerritorySetupClient({
             heading="Explore something new"
             inputRef={newTopicInputRef}
             existingLabels={domains.map((domain) => domain.domain)}
+            convergeBeforeAdd
             disabled={addingTopic}
             limitReachedNode={
               <Link href="/knowledge" className="underline">

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -834,6 +834,7 @@ export default function OnboardingFlow({
                 heading="Add your own"
                 placeholder="e.g. Byzantine Coinage"
                 maxLength={100}
+                convergeBeforeAdd
                 disabled={selectedInterests.length >= MAX_INTERESTS}
                 existingLabels={selectedInterests.map((item) => item.domain)}
                 onAdd={addSelectedInterest}

--- a/src/app/onboarding/__tests__/page.test.ts
+++ b/src/app/onboarding/__tests__/page.test.ts
@@ -62,6 +62,12 @@ vi.mock('@/server/friends/user-invite-token', () => ({
   hasInviteLinkFriendship: hasInviteLinkFriendshipMock,
 }))
 
+// Seeds run through convergeDomain server-side; stub it to a passthrough (no
+// exact match) so this test stays off the real DB-backed corpus query.
+vi.mock('@/server/knowledge/converge-domain', () => ({
+  convergeDomain: vi.fn(async (label: string) => ({ raw: label, candidates: [] })),
+}))
+
 // Stub the client component import so this test stays server-side.
 vi.mock('@/app/onboarding/OnboardingFlow', () => ({
   default: () => null,

--- a/src/app/onboarding/page.tsx
+++ b/src/app/onboarding/page.tsx
@@ -6,6 +6,7 @@ import { db, friendInvitations } from '@/server/db';
 import { getPreSeededInterestsForUser, getUserOnboardingProfile } from '@/server/db/queries/users';
 import { hasInviteLinkFriendship } from '@/server/friends/user-invite-token';
 import { assessInterestAnswerability } from '@/server/llm/interests';
+import { convergeDomain } from '@/server/knowledge/converge-domain';
 import { isTooBroadInterest } from '@/lib/knowledge/interest-specificity';
 
 import OnboardingFlow, { type PreSeededInterest } from './OnboardingFlow';
@@ -58,11 +59,23 @@ export default async function OnboardingPage() {
   // stored invite without modifying it, and assessInterestAnswerability fails
   // open, so an LLM outage leaves the friend's picks intact. Seeds are capped at
   // 3, so this is at most a few parallel Haiku checks on a one-time page load.
+  // Run each surviving seed through the same convergence pass as user-typed
+  // adds: when a seed exactly matches a canonical domain that already exists
+  // across the game, swap to that spelling so the invitee joins the shared
+  // domain rather than minting a per-invite variant whose mastery never merges.
+  // Deterministic and DB-only; only the high-confidence exact case is applied
+  // silently — fuzzy seeds keep the inviter's wording (the invitee can still
+  // edit, and any topics they type converge in the review step).
   const checkedSeeds = await Promise.all(
     seeded.interests.map(async (interest) => {
       if (isTooBroadInterest(interest.label)) return null;
       const { answerable } = await assessInterestAnswerability(interest.label);
-      return answerable ? interest : null;
+      if (!answerable) return null;
+      const { candidates } = await convergeDomain(interest.label);
+      const exact = candidates.find((candidate) => candidate.kind === 'exact');
+      return exact
+        ? { ...interest, label: exact.label, broadCategory: exact.broadCategory ?? interest.broadCategory }
+        : interest;
     }),
   );
   const preSeededInterests: PreSeededInterest[] = checkedSeeds

--- a/src/components/daily/TopUpAreasModal.tsx
+++ b/src/components/daily/TopUpAreasModal.tsx
@@ -254,6 +254,7 @@ export function TopUpAreasModal({
         <AddTopicField
           className="mt-3"
           placeholder="Or write your own…"
+          convergeBeforeAdd
           disabled={busy || remaining <= 0}
           existingLabels={[
             ...existing.map((item) => item.label),

--- a/src/components/interests/AddTopicField.tsx
+++ b/src/components/interests/AddTopicField.tsx
@@ -17,6 +17,16 @@ export type AddTopicCandidate = { label: string; broadCategory?: string | null }
 // outcomes: re-expand on a too-broad backstop, or show the cap affordance.
 export type AddTopicError = Error & { code?: 'limit_reached' | 'too_broad' };
 
+// One convergence suggestion surfaced before a specific topic is added: an
+// existing canonical domain across the game the typed label is close to. Shape
+// mirrors POST /api/knowledge/converge.
+type ConvergeApiCandidate = {
+  label: string;
+  broadCategory: string | null;
+  kind: 'exact' | 'fuzzy' | 'new';
+  similarity: number;
+};
+
 // Cream / Ink-on-Cream defaults (the daily-setup surface). Overridable so the
 // same field matches differently-themed surfaces (e.g. the top-up modal).
 const DEFAULT_INPUT_CLASS =
@@ -40,6 +50,14 @@ type AddTopicFieldProps = {
   limitReachedNode?: ReactNode;
   /** Lets a parent focus the input (e.g. a "create your own" CTA). */
   inputRef?: RefObject<HTMLInputElement | null>;
+  /**
+   * Before adding a specific topic, run it through POST /api/knowledge/converge
+   * to align it onto an existing canonical domain across the game. An exact
+   * match is applied transparently (same domain); fuzzy matches surface as a
+   * dismissible "did you mean?" with the typed wording as the alternative.
+   * Off by default so surfaces opt in.
+   */
+  convergeBeforeAdd?: boolean;
   // Style overrides so the field can match each surface's palette.
   className?: string;
   inputClassName?: string;
@@ -64,6 +82,7 @@ export function AddTopicField({
   disabled = false,
   limitReachedNode,
   inputRef,
+  convergeBeforeAdd = false,
   className,
   inputClassName = DEFAULT_INPUT_CLASS,
   buttonClassName = DEFAULT_BUTTON_CLASS,
@@ -82,6 +101,9 @@ export function AddTopicField({
   const [candidates, setCandidates] = useState<AddTopicCandidate[] | null>(null);
   const [expandedFrom, setExpandedFrom] = useState<string | null>(null);
   const [pendingLabel, setPendingLabel] = useState<string | null>(null);
+  const [convergence, setConvergence] = useState<
+    { typed: AddTopicCandidate; suggestions: AddTopicCandidate[] } | null
+  >(null);
 
   const isDuplicate = useCallback(
     (label: string) =>
@@ -99,6 +121,7 @@ export function AddTopicField({
       setCandidates(null);
       setExpandedFrom(null);
       setPendingLabel(null);
+      setConvergence(null);
       try {
         const response = await fetch('/api/interests/expand', {
           method: 'POST',
@@ -132,7 +155,9 @@ export function AddTopicField({
     [isDuplicate],
   );
 
-  const commit = useCallback(
+  // The actual persistence step. Shared by every path; convergence (below)
+  // resolves WHICH label to persist before calling this.
+  const persistTopic = useCallback(
     async (candidate: AddTopicCandidate) => {
       const label = candidate.label.trim();
       if (!label || busy) return;
@@ -147,6 +172,7 @@ export function AddTopicField({
       try {
         await onAdd({ label, broadCategory: candidate.broadCategory ?? null });
         setValue('');
+        setConvergence(null);
         setCandidates((prev) => {
           if (!prev) return prev;
           const next = prev.filter(
@@ -168,6 +194,84 @@ export function AddTopicField({
       }
     },
     [busy, isDuplicate, onAdd, expand],
+  );
+
+  // Add a specific topic. When convergeBeforeAdd is on, first align it onto an
+  // existing canonical domain across the game: an exact match is applied
+  // transparently; fuzzy matches surface a "did you mean?" choice; otherwise we
+  // persist the typed label. Any converge failure falls through to a plain add.
+  const commit = useCallback(
+    async (candidate: AddTopicCandidate) => {
+      if (!convergeBeforeAdd) {
+        await persistTopic(candidate);
+        return;
+      }
+      const label = candidate.label.trim();
+      if (!label || busy) return;
+      if (isDuplicate(label)) {
+        setError('You already added that one.');
+        return;
+      }
+      setBusy(true);
+      setError(null);
+      setLimitReached(false);
+      setConvergence(null);
+      setPendingLabel(label);
+      let resolved: AddTopicCandidate | null = candidate;
+      let prompt: { typed: AddTopicCandidate; suggestions: AddTopicCandidate[] } | null = null;
+      try {
+        const response = await fetch('/api/knowledge/converge', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ label }),
+        });
+        const body = await response.json().catch(() => null);
+        if (response.ok) {
+          const list: ConvergeApiCandidate[] = Array.isArray(body?.candidates)
+            ? body.candidates
+            : [];
+          const exact = list.find(
+            (item) => item?.kind === 'exact' && typeof item.label === 'string',
+          );
+          const fuzzy = list.filter(
+            (item) => item?.kind === 'fuzzy' && typeof item.label === 'string',
+          );
+          if (exact) {
+            // Same domain — converge silently onto the canonical spelling.
+            resolved = {
+              label: exact.label,
+              broadCategory: exact.broadCategory ?? candidate.broadCategory ?? null,
+            };
+          } else if (fuzzy.length > 0) {
+            // Never auto-apply a fuzzy match — let the user pick or keep theirs.
+            resolved = null;
+            const own =
+              typeof body?.raw === 'string' && body.raw.trim() ? body.raw.trim() : label;
+            prompt = {
+              typed: { label: own, broadCategory: candidate.broadCategory ?? null },
+              suggestions: fuzzy.map((item) => ({
+                label: item.label,
+                broadCategory: item.broadCategory ?? null,
+              })),
+            };
+          }
+        }
+      } catch {
+        // Converge is best-effort — fall through and add the typed label.
+        resolved = candidate;
+      } finally {
+        setBusy(false);
+        setPendingLabel(null);
+      }
+
+      if (prompt) {
+        setConvergence(prompt);
+        return;
+      }
+      if (resolved) await persistTopic(resolved);
+    },
+    [convergeBeforeAdd, persistTopic, busy, isDuplicate],
   );
 
   const submit = useCallback(async () => {
@@ -244,6 +348,38 @@ export function AddTopicField({
                 {pendingLabel === candidate.label.trim() ? 'Adding…' : candidate.label}
               </button>
             ))}
+          </div>
+        </div>
+      ) : null}
+
+      {convergence ? (
+        <div className="mt-4">
+          <p className={mutedClassName}>
+            Did you mean one of these? Joining an area others already explore keeps your
+            questions sharper.
+          </p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {convergence.suggestions.map((suggestion) => (
+              <button
+                key={suggestion.label}
+                type="button"
+                onClick={() => void persistTopic(suggestion)}
+                disabled={busy}
+                className={chipClassName}
+              >
+                {pendingLabel === suggestion.label.trim() ? 'Adding…' : suggestion.label}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => void persistTopic(convergence.typed)}
+              disabled={busy}
+              className={chipClassName}
+            >
+              {pendingLabel === convergence.typed.label.trim()
+                ? 'Adding…'
+                : `Add “${convergence.typed.label}” instead`}
+            </button>
           </div>
         </div>
       ) : null}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -560,6 +560,18 @@ export async function register() {
       // database — migrate() handles creation; dedup is best-effort regardless.
     }
 
+    // Migration 0071 enables pg_trgm, which convergeDomain()'s fuzzy pass calls
+    // via similarity() (the /api/knowledge/converge route + the onboarding seed
+    // pipeline). similarity() needs no index, so none is created — see the
+    // migration header. A database that records the migration without the
+    // extension present must still boot; if pg_trgm is unavailable the whole
+    // block is skipped — convergence degrades to exact-key + "create new".
+    try {
+      await db.execute(sql`CREATE EXTENSION IF NOT EXISTS pg_trgm`);
+    } catch {
+      // pg_trgm may be unavailable on this database — convergence is best-effort.
+    }
+
     // Migration 0044 adds the nullable User.last_activity_bell_opened_at
     // timestamp used by getBellBadgeCount to compute "rolled-off + unseen"
     // counts. Apply it idempotently in case the migration is recorded

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -817,6 +817,102 @@ export async function getDomainDetail(userId: string, domain: string): Promise<D
   };
 }
 
+// ─── Domain convergence (deterministic dedup) ───────────────────────────────
+//
+// Powers convergeDomain() (src/server/knowledge/converge-domain.ts): align a
+// freshly-suggested category onto an existing canonical subcategory that already
+// exists ACROSS THE GAME, so the same hyper-specific domain isn't re-created per
+// user. The corpus is every player's PLAYER_MASTERY.canonical_subcategory — the
+// table the declared-interest write path already seeds — so converging onto it
+// directly merges mastery (PLAYER_MASTERY is keyed on canonical_subcategory).
+
+export type CanonicalCorpusMatch = {
+  /** The existing canonical-subcategory spelling to persist when chosen. */
+  label: string;
+  broadCategory: string | null;
+  /** How many PLAYER_MASTERY rows share this spelling (ranking + privacy floor). */
+  prevalence: number;
+  /** 1 for an exact-key match; the pg_trgm score for a fuzzy match. */
+  similarity: number;
+};
+
+// SQL mirror of domainKey() (src/lib/knowledge/domain-key.ts): fold curly
+// apostrophes to ASCII, collapse internal whitespace, trim, lowercase. Kept as a
+// single fragment so the JS and SQL key definitions can't drift — the
+// converge-domain test asserts parity. The fold-set chars and the regex pattern
+// are bound params (not inlined literals) so the apostrophe escaping stays sane.
+const CONVERGE_CURLY_APOSTROPHES = '‘’ʼ';
+const CONVERGE_ASCII_APOSTROPHES = "'''";
+const CONVERGE_WHITESPACE_PATTERN = '\\s+';
+function foldedCanonicalSubcategoryExpr() {
+  return sql`lower(btrim(regexp_replace(translate(${playerMastery.canonicalSubcategory}, ${CONVERGE_CURLY_APOSTROPHES}, ${CONVERGE_ASCII_APOSTROPHES}), ${CONVERGE_WHITESPACE_PATTERN}, ' ', 'g')))`;
+}
+
+const BROAD_CATEGORY_MODE = sql<string | null>`mode() within group (order by ${playerMastery.broadCategory})`;
+
+// Exact-key convergence: the most-prevalent corpus spelling whose domainKey()
+// equals the input's. Does NOT depend on pg_trgm, so it always works (the fuzzy
+// pass below degrades when the extension is absent). A folded-expression scan is
+// fine at the current distinct-canonical-subcategory corpus scale.
+export async function findExactCanonicalMatch(rawLabel: string): Promise<CanonicalCorpusMatch | null> {
+  const key = domainKey(rawLabel);
+  if (!key) return null;
+  const rows = await db
+    .select({
+      label: playerMastery.canonicalSubcategory,
+      broadCategory: BROAD_CATEGORY_MODE,
+      prevalence: sql<number>`count(*)::int`,
+    })
+    .from(playerMastery)
+    .where(sql`${foldedCanonicalSubcategoryExpr()} = ${key}`)
+    .groupBy(playerMastery.canonicalSubcategory)
+    .orderBy(sql`count(*) desc`)
+    .limit(1);
+  const row = rows[0];
+  if (!row) return null;
+  return {
+    label: row.label,
+    broadCategory: row.broadCategory ?? null,
+    prevalence: Number(row.prevalence),
+    similarity: 1,
+  };
+}
+
+// Fuzzy convergence via pg_trgm similarity(). Throws if pg_trgm is unavailable
+// (function does not exist) — convergeDomain() swallows that and degrades to
+// exact + "create new". The WHERE similarity() >= threshold filter is a
+// deliberate per-row scan: the index-using `%` operator depends on the
+// session-global set_limit GUC, which is unreliable under PgBouncer pooling. The
+// corpus (distinct canonical subcategories) is small enough that this is fine; a
+// later migration can add an index + switch the predicate if scale demands.
+export async function findFuzzyCanonicalMatches(
+  rawLabel: string,
+  threshold: number,
+  limit: number,
+): Promise<CanonicalCorpusMatch[]> {
+  const clean = rawLabel.trim().replace(/\s+/g, ' ');
+  if (!clean || limit <= 0) return [];
+  const score = sql<number>`max(similarity(${playerMastery.canonicalSubcategory}, ${clean}))`;
+  const rows = await db
+    .select({
+      label: playerMastery.canonicalSubcategory,
+      broadCategory: BROAD_CATEGORY_MODE,
+      prevalence: sql<number>`count(*)::int`,
+      similarity: score,
+    })
+    .from(playerMastery)
+    .where(sql`similarity(${playerMastery.canonicalSubcategory}, ${clean}) >= ${threshold}`)
+    .groupBy(playerMastery.canonicalSubcategory)
+    .orderBy(sql`max(similarity(${playerMastery.canonicalSubcategory}, ${clean})) desc`, sql`count(*) desc`)
+    .limit(limit);
+  return rows.map((row) => ({
+    label: row.label,
+    broadCategory: row.broadCategory ?? null,
+    prevalence: Number(row.prevalence),
+    similarity: Number(row.similarity),
+  }));
+}
+
 export async function getHiddenDomainKeys(userId: string): Promise<Set<string>> {
   const rows = await db
     .select({

--- a/src/server/knowledge/__tests__/converge-domain.test.ts
+++ b/src/server/knowledge/__tests__/converge-domain.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+const findExactCanonicalMatch = vi.fn();
+const findFuzzyCanonicalMatches = vi.fn();
+
+vi.mock('@/server/db/queries/knowledge', () => ({
+  findExactCanonicalMatch: (...args: unknown[]) => findExactCanonicalMatch(...args),
+  findFuzzyCanonicalMatches: (...args: unknown[]) => findFuzzyCanonicalMatches(...args),
+}));
+
+import {
+  convergeDomain,
+  DEFAULT_CONVERGE_FUZZY_MIN_PREVALENCE,
+} from '@/server/knowledge/converge-domain';
+
+describe('convergeDomain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findExactCanonicalMatch.mockResolvedValue(null);
+    findFuzzyCanonicalMatches.mockResolvedValue([]);
+  });
+
+  it('always appends a "create new" candidate when nothing matches', async () => {
+    const result = await convergeDomain('  Sondheim   Musicals ');
+    // input is trimmed + whitespace-collapsed
+    expect(result.raw).toBe('Sondheim Musicals');
+    expect(result.candidates).toEqual([
+      { label: 'Sondheim Musicals', broadCategory: null, kind: 'new', similarity: 0 },
+    ]);
+  });
+
+  it('ranks exact first, then fuzzy by similarity desc, then create-new', async () => {
+    findExactCanonicalMatch.mockResolvedValue(null);
+    findFuzzyCanonicalMatches.mockResolvedValue([
+      { label: 'Delta Blues', broadCategory: 'Music', prevalence: 9, similarity: 0.71 },
+      { label: 'Chicago Blues', broadCategory: 'Music', prevalence: 5, similarity: 0.63 },
+    ]);
+
+    const result = await convergeDomain('Blues');
+
+    expect(result.candidates.map((c) => [c.kind, c.label])).toEqual([
+      ['fuzzy', 'Delta Blues'],
+      ['fuzzy', 'Chicago Blues'],
+      ['new', 'Blues'],
+    ]);
+  });
+
+  it('puts the exact match first and suppresses the redundant create-new', async () => {
+    findExactCanonicalMatch.mockResolvedValue({
+      label: 'Late Tchaikovsky Symphonies',
+      broadCategory: 'Music',
+      prevalence: 12,
+      similarity: 1,
+    });
+    findFuzzyCanonicalMatches.mockResolvedValue([]);
+
+    // Input folds to the same domainKey as the exact match's label.
+    const result = await convergeDomain('late tchaikovsky symphonies');
+
+    expect(result.candidates).toEqual([
+      {
+        label: 'Late Tchaikovsky Symphonies',
+        broadCategory: 'Music',
+        kind: 'exact',
+        similarity: 1,
+      },
+    ]);
+    expect(result.candidates.some((c) => c.kind === 'new')).toBe(false);
+  });
+
+  it('keeps create-new when only fuzzy matches exist (escape hatch)', async () => {
+    findFuzzyCanonicalMatches.mockResolvedValue([
+      { label: 'Holy Roman Empire', broadCategory: 'History', prevalence: 8, similarity: 0.6 },
+    ]);
+
+    const result = await convergeDomain('Roman Empire');
+
+    expect(result.candidates.map((c) => c.kind)).toEqual(['fuzzy', 'new']);
+    expect(result.candidates.at(-1)?.label).toBe('Roman Empire');
+  });
+
+  it('drops fuzzy candidates below the privacy prevalence floor', async () => {
+    findFuzzyCanonicalMatches.mockResolvedValue([
+      {
+        label: 'Shared Domain',
+        broadCategory: 'Music',
+        prevalence: DEFAULT_CONVERGE_FUZZY_MIN_PREVALENCE,
+        similarity: 0.7,
+      },
+      { label: 'One Persons Private Phrase', broadCategory: null, prevalence: 1, similarity: 0.69 },
+    ]);
+
+    const result = await convergeDomain('Domain');
+
+    expect(result.candidates.map((c) => c.label)).toEqual(['Shared Domain', 'Domain']);
+    expect(result.candidates.some((c) => c.label === 'One Persons Private Phrase')).toBe(false);
+  });
+
+  it('does not duplicate a fuzzy match that equals the exact match key', async () => {
+    findExactCanonicalMatch.mockResolvedValue({
+      label: 'Jazz Fusion',
+      broadCategory: 'Music',
+      prevalence: 4,
+      similarity: 1,
+    });
+    findFuzzyCanonicalMatches.mockResolvedValue([
+      { label: 'jazz fusion', broadCategory: 'Music', prevalence: 4, similarity: 0.95 },
+      { label: 'Acid Jazz', broadCategory: 'Music', prevalence: 6, similarity: 0.55 },
+    ]);
+
+    const result = await convergeDomain('Jazz Fusion');
+
+    expect(result.candidates.map((c) => [c.kind, c.label])).toEqual([
+      ['exact', 'Jazz Fusion'],
+      ['fuzzy', 'Acid Jazz'],
+    ]);
+  });
+
+  it('degrades to exact + create-new when the fuzzy query throws (pg_trgm absent)', async () => {
+    findExactCanonicalMatch.mockResolvedValue(null);
+    findFuzzyCanonicalMatches.mockRejectedValue(
+      new Error('function similarity(text, text) does not exist'),
+    );
+
+    const result = await convergeDomain('Weimar Cinema');
+
+    expect(result.candidates).toEqual([
+      { label: 'Weimar Cinema', broadCategory: null, kind: 'new', similarity: 0 },
+    ]);
+  });
+
+  it('returns an empty candidate list for blank input', async () => {
+    const result = await convergeDomain('   ');
+    expect(result.raw).toBe('');
+    expect(result.candidates).toEqual([]);
+    expect(findExactCanonicalMatch).not.toHaveBeenCalled();
+  });
+
+  it('respects the configured fuzzy limit', async () => {
+    findFuzzyCanonicalMatches.mockResolvedValue([
+      { label: 'A', broadCategory: null, prevalence: 5, similarity: 0.9 },
+      { label: 'B', broadCategory: null, prevalence: 5, similarity: 0.8 },
+      { label: 'C', broadCategory: null, prevalence: 5, similarity: 0.7 },
+    ]);
+
+    const result = await convergeDomain('thing', { limit: 2 });
+    const fuzzy = result.candidates.filter((c) => c.kind === 'fuzzy');
+    expect(fuzzy).toHaveLength(2);
+  });
+
+  // Guards the JS domainKey() the service uses for dedup against the corpus.
+  it('uses domainKey folding so curly/straight apostrophes collapse', () => {
+    expect(domainKey('90’s Hip-Hop')).toBe(domainKey("90's Hip-Hop"));
+    expect(domainKey('  Mixed   CASE ')).toBe('mixed case');
+  });
+});

--- a/src/server/knowledge/converge-domain.ts
+++ b/src/server/knowledge/converge-domain.ts
@@ -1,0 +1,171 @@
+/**
+ * Domain convergence — deterministic dedup of a freshly-suggested knowledge
+ * category against the ones that already exist across the game.
+ *
+ * The goal (locked product decision) is CONVERGENCE ONLY: when a user types — or
+ * a friend pre-seeds — a category, align it onto an existing canonical
+ * subcategory if a close match exists, so the same hyper-specific domain doesn't
+ * fragment into per-user spelling variants ("90s Hip Hop" / "90's hip-hop" /
+ * "1990s Hip Hop") whose mastery points never merge.
+ *
+ * Deterministic, LLM-free. Two passes over the corpus (every player's
+ * PLAYER_MASTERY.canonical_subcategory):
+ *   1. exact-key  — domainKey() equality. Works without pg_trgm.
+ *   2. fuzzy      — pg_trgm similarity() >= threshold. Needs pg_trgm; degrades
+ *                   to nothing when the extension is absent (caught, non-fatal).
+ * A "create new" candidate (the user's own cleaned wording) is ALWAYS appended
+ * unless an exact match already covers it, so convergence is never forced — the
+ * escape hatch for false positives.
+ *
+ * Only exact matches are safe to auto-prefer; fuzzy matches must be surfaced as
+ * a dismissible "Did you mean X?" with "create new" as the alternative, because
+ * trigram similarity is purely lexical ("Roman Empire" ~ "Holy Roman Empire").
+ */
+
+import { domainKey } from '@/lib/knowledge/domain-key';
+import {
+  findExactCanonicalMatch,
+  findFuzzyCanonicalMatches,
+  type CanonicalCorpusMatch,
+} from '@/server/db/queries/knowledge';
+
+// pg_trgm similarity threshold (0..1). NOT cosine — trigram scores run lower
+// (pg_trgm's own default similarity_threshold is 0.3). Start conservative for
+// high precision (few wrong-domain false positives) and tune against the real
+// corpus; override per-environment without a deploy. Mirrors
+// DEFAULT_DEDUP_COSINE_THRESHOLD in src/server/pool/dedup.ts.
+export const DEFAULT_CONVERGE_TRGM_THRESHOLD = 0.55;
+
+// Privacy floor: only surface a FUZZY candidate shared by at least this many
+// players. Matching one user's input against every user's declared labels could
+// otherwise reveal that *someone* declared an idiosyncratic phrase. Exact
+// matches (the user typed essentially the same thing) are exempt. Prevalence
+// counts are used for ranking/this floor only and are NEVER shown in the UI.
+export const DEFAULT_CONVERGE_FUZZY_MIN_PREVALENCE = 3;
+
+// How many fuzzy suggestions to show at most.
+export const DEFAULT_CONVERGE_FUZZY_LIMIT = 3;
+
+function readPositiveIntEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+  return Math.floor(parsed);
+}
+
+export function getConvergeTrgmThreshold(): number {
+  const raw = process.env.KNOWLEDGE_CONVERGE_TRGM_THRESHOLD?.trim();
+  if (!raw) return DEFAULT_CONVERGE_TRGM_THRESHOLD;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return DEFAULT_CONVERGE_TRGM_THRESHOLD;
+  }
+  return parsed;
+}
+
+export function getConvergeFuzzyMinPrevalence(): number {
+  return readPositiveIntEnv(
+    'KNOWLEDGE_CONVERGE_FUZZY_MIN_PREVALENCE',
+    DEFAULT_CONVERGE_FUZZY_MIN_PREVALENCE,
+  );
+}
+
+export type ConvergeCandidateKind = 'exact' | 'fuzzy' | 'new';
+
+export type ConvergeCandidate = {
+  /** The label to actually persist when this candidate is chosen. */
+  label: string;
+  broadCategory: string | null;
+  kind: ConvergeCandidateKind;
+  /** 1 for exact, the trigram score for fuzzy, 0 for "create new". */
+  similarity: number;
+};
+
+export type ConvergeResult = {
+  /** The input after the same trim/whitespace cleanup the write path applies. */
+  raw: string;
+  /** Ranked: exact → fuzzy (desc) → "create new" fallback. */
+  candidates: ConvergeCandidate[];
+};
+
+export type ConvergeOptions = {
+  threshold?: number;
+  minPrevalence?: number;
+  limit?: number;
+};
+
+export async function convergeDomain(
+  rawLabel: string,
+  opts: ConvergeOptions = {},
+): Promise<ConvergeResult> {
+  const cleaned = rawLabel.trim().replace(/\s+/g, ' ');
+  const result: ConvergeResult = { raw: cleaned, candidates: [] };
+  if (!cleaned) return result;
+
+  const threshold = opts.threshold ?? getConvergeTrgmThreshold();
+  const minPrevalence = opts.minPrevalence ?? getConvergeFuzzyMinPrevalence();
+  const limit = opts.limit ?? DEFAULT_CONVERGE_FUZZY_LIMIT;
+
+  const inputKey = domainKey(cleaned);
+  const seen = new Set<string>();
+
+  // 1. Exact-key convergence (pg_trgm not required).
+  let exact: CanonicalCorpusMatch | null = null;
+  try {
+    exact = await findExactCanonicalMatch(cleaned);
+  } catch (error) {
+    console.warn('[converge-domain] exact match query failed (non-fatal)', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+  if (exact) {
+    result.candidates.push({
+      label: exact.label,
+      broadCategory: exact.broadCategory,
+      kind: 'exact',
+      similarity: 1,
+    });
+    seen.add(domainKey(exact.label));
+  }
+
+  // 2. Fuzzy convergence (pg_trgm). Privacy K-floor; never auto-applies.
+  try {
+    const fuzzy = await findFuzzyCanonicalMatches(cleaned, threshold, limit + 2);
+    let added = 0;
+    for (const match of fuzzy) {
+      if (added >= limit) break;
+      const matchKey = domainKey(match.label);
+      if (seen.has(matchKey)) continue;
+      if (match.prevalence < minPrevalence) continue;
+      result.candidates.push({
+        label: match.label,
+        broadCategory: match.broadCategory,
+        kind: 'fuzzy',
+        similarity: match.similarity,
+      });
+      seen.add(matchKey);
+      added += 1;
+    }
+  } catch (error) {
+    // pg_trgm likely unavailable (function similarity() does not exist) — the
+    // exact + "create new" candidates still stand. Best-effort, like the pool
+    // dedup backstop (src/server/pool/dedup.ts).
+    console.warn('[converge-domain] fuzzy match skipped (pg_trgm unavailable?)', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // 3. Always-present "create new" fallback (escape hatch). Skipped only when an
+  // exact match already covers the input key — converging onto it is identical.
+  if (!seen.has(inputKey)) {
+    result.candidates.push({
+      label: cleaned,
+      broadCategory: null,
+      kind: 'new',
+      similarity: 0,
+    });
+  }
+
+  return result;
+}


### PR DESCRIPTION
Aligns a newly-suggested knowledge category onto an existing canonical
domain that already exists across the game, so the same hyper-specific
domain ("90s Hip Hop" / "90's hip-hop") stops fragmenting into per-user
variants whose mastery never merges.

- convergeDomain() service (src/server/knowledge/converge-domain.ts):
  deterministic, LLM-free. domainKey() exact-key match + pg_trgm fuzzy
  match against every player's PLAYER_MASTERY.canonical_subcategory, plus
  an always-present "create new" fallback. Exact matches apply silently;
  fuzzy matches are a dismissible "did you mean?", gated by a privacy
  prevalence floor (>=3 players, counts never shown). Threshold + floor
  are env-overridable, mirroring the pool-dedup knob.
- Query helpers findExactCanonicalMatch / findFuzzyCanonicalMatches with
  a SQL fold that mirrors domainKey() (parity asserted in tests).
- POST /api/knowledge/converge (Zod-validated, no LLM call).
- AddTopicField gains opt-in convergeBeforeAdd, enabled on the three add
  surfaces it backs: onboarding review, daily setup, and the top-up modal.
- Onboarding seed pipeline converges friend pre-seeded interests (exact
  case applied transparently).
- Migration 0071 enables pg_trgm (no index: similarity() needs none, and
  the % operator's set_limit GUC is unreliable under PgBouncer); idempotent
  instrumentation guard mirrors the pgvector precedent.

The existing demonstrated path (answering a friend's question opens a
territory) is unchanged.

https://claude.ai/code/session_01UdSrGbyEP9DAn9RNKWurgF