### PR TITLE
Auto-retry Daily Five generation with a warm "still working" state

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -84,6 +84,24 @@ function answerFailureMessage(body: FailedAnswerResponse | null): string {
   return body?.message ?? (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined) ?? 'Could not record that answer.';
 }
 
+// Daily Five generation can come up short transiently: the queue endpoint
+// returns 503 `generation_failed` even for users with a valid knowledge base
+// when a round falls below the minimum size. Rather than dumping a bare error,
+// auto-retry a few times with backoff and surface a friendly "still working"
+// state with the attempt counter (the server has already burned its own
+// internal top-up rounds by the time we see this, so these are fresh attempts).
+const MAX_QUEUE_CREATE_ATTEMPTS = 4;
+const QUEUE_CREATE_BACKOFF_MS = [2000, 4000, 8000];
+
+// Shown after the auto-retries are exhausted — kept warm and retryable rather
+// than alarming, since the most common cause is slow generation, not a fault.
+const QUEUE_GENERATION_FAILED_MESSAGE =
+  "We're still crafting today's bespoke questions and it's taking longer than usual. Give it a moment and try again.";
+
+function generatingLabel(attempt: number): string {
+  return `Crafting your bespoke questions (attempt ${attempt}/${MAX_QUEUE_CREATE_ATTEMPTS})`;
+}
+
 // Returns the slot the player should be on, or null when the round is over.
 // The `!answered && !skipped` predicate is the canonical "pending" definition
 // shared with the status API via isRoundComplete (see @/server/daily/types) —
@@ -119,6 +137,9 @@ export default function DailyPage() {
   const [loading, setLoading] = useState(true);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Non-null while we're auto-retrying queue generation; drives the friendly
+  // "still working (attempt N/4)" loading label instead of a bare error.
+  const [generatingAttempt, setGeneratingAttempt] = useState<number | null>(null);
   const [pausedAfterSlotIndex, setPausedAfterSlotIndex] = useState<number | null>(null);
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
@@ -132,23 +153,44 @@ export default function DailyPage() {
       const body = await response.json().catch(() => null);
 
       if (response.ok && body?.queue === null) {
-        const createResponse = await fetch('/api/daily/queue', {
-          method: 'POST',
-          credentials: 'include',
-          cache: 'no-store',
-        });
-        if (!createResponse.ok) {
+        // The queue doesn't exist yet — generate it. Generation can fall below
+        // the minimum and return 503 (generation_failed) even with a valid
+        // knowledge base, so auto-retry with backoff while showing the friendly
+        // "still working" state. 409 (no_knowledge_base) means the user
+        // genuinely has nothing to generate from — that's terminal; send them
+        // to setup rather than retrying.
+        for (let attempt = 1; attempt <= MAX_QUEUE_CREATE_ATTEMPTS; attempt += 1) {
+          setGeneratingAttempt(attempt);
+          const createResponse = await fetch('/api/daily/queue', {
+            method: 'POST',
+            credentials: 'include',
+            cache: 'no-store',
+          });
+          if (createResponse.ok) break;
+
           const createBody = await createResponse.json().catch(() => null);
-          // 409 (no_knowledge_base) means the user genuinely has nothing to
-          // generate from — send them to setup. A 503 (generation_failed) is a
-          // transient/slow-generation hiccup; surface the retryable message
-          // instead of bouncing a user with a valid knowledge base to setup.
           if (createResponse.status === 409) {
             router.replace('/daily/setup');
             return;
           }
-          throw new Error(createBody?.message ?? 'Could not load today.');
+          // Only the transient generation_failed (503) is worth retrying; a
+          // different status is a real fault, so surface its message and stop.
+          if (createResponse.status !== 503) {
+            throw new Error(createBody?.message ?? 'Could not load today.');
+          }
+          // Out of retries: fall back to the warm, retryable message.
+          if (attempt === MAX_QUEUE_CREATE_ATTEMPTS) {
+            throw new Error(QUEUE_GENERATION_FAILED_MESSAGE);
+          }
+          await new Promise((resolve) =>
+            setTimeout(
+              resolve,
+              QUEUE_CREATE_BACKOFF_MS[attempt - 1] ??
+                QUEUE_CREATE_BACKOFF_MS[QUEUE_CREATE_BACKOFF_MS.length - 1],
+            ),
+          );
         }
+        setGeneratingAttempt(null);
         const refetchResponse = await fetch('/api/daily/queue', { cache: 'no-store', credentials: 'include' });
         const refetchBody = await refetchResponse.json().catch(() => null);
         if (!refetchResponse.ok) {
@@ -188,6 +230,7 @@ export default function DailyPage() {
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load today.');
     } finally {
+      setGeneratingAttempt(null);
       setLoading(false);
     }
   }, [router]);
@@ -545,10 +588,26 @@ export default function DailyPage() {
         style={{ paddingBottom: "calc(24px + env(safe-area-inset-bottom))" }}
       >
         {loading ? (
-          <LoadingScreen fullScreen label="Loading today" />
+          <LoadingScreen
+            fullScreen
+            label={generatingAttempt != null ? generatingLabel(generatingAttempt) : 'Loading today'}
+          />
         ) : error ? (
-          <div className="rounded-[var(--radius-sm)] border px-3 py-2 text-sm text-[var(--danger)]" style={{ borderColor: 'var(--danger)' }}>
-            {error}
+          // Generation hiccups are warm and retryable, not alarming — keep this
+          // neutral (not --danger) and give the player a one-tap way to retry.
+          <div
+            className="flex flex-col items-start gap-3 rounded-[var(--radius-sm)] border px-3 py-3 text-sm text-[var(--text)]"
+            style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}
+          >
+            <p className="text-[var(--text-muted)]">{error}</p>
+            <button
+              type="button"
+              onClick={() => void loadQueue()}
+              className="inline-flex min-h-11 items-center rounded-md border px-3 py-1.5 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              Try again
+            </button>
           </div>
         ) : (
           <GameplayChatThread


### PR DESCRIPTION
When the queue endpoint returns 503 generation_failed (a transient
slow-generation hiccup, not a real fault), the daily page now auto-retries
up to 4 times with backoff instead of dropping a bare red error. While
retrying it shows a friendly "Crafting your bespoke questions (attempt
N/4)" loading state, and only after the retries are exhausted does it
surface a warm, retryable message with a one-tap "Try again" button
(neutral styling, not --danger).

https://claude.ai/code/session_01157KK64W67LhA6VouPz1GA