### PR TITLE
fix(cron): isolate per-user failures in weekly-ceremony so one bad user can't 500 the whole run

### DIFF
--- a/src/app/api/cron/weekly-ceremony/__tests__/route.test.ts
+++ b/src/app/api/cron/weekly-ceremony/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fireCeremonyMock, onboardedUsersMock, recentCeremonyMock, dbMock } = vi.hoisted(() => {
+  const onboardedUsersMock = vi.fn(async () => [] as Array<{ id: string; createdAt: Date }>)
+  const recentCeremonyMock = vi.fn(async () => [] as unknown[])
+  // The route issues two distinct select() shapes:
+  //   1) onboarded users: select({id, createdAt}).from(users).where(eq(...))  — no .limit
+  //   2) recent ceremony: select({id}).from(biweeklyCeremonies).where(and(...)).orderBy(...).limit(1)
+  const dbMock = {
+    select: vi.fn(() => ({
+      from: () => ({
+        where: (...args: unknown[]) => {
+          // The recent-ceremony query chains .orderBy().limit(); the onboarded
+          // query awaits the where() result directly. Return a thenable that
+          // also exposes orderBy/limit so both shapes resolve correctly.
+          void args
+          const recent = {
+            orderBy: () => ({ limit: () => recentCeremonyMock() }),
+          }
+          return Object.assign(Promise.resolve(onboardedUsersMock()), recent)
+        },
+      }),
+    })),
+  }
+  return {
+    fireCeremonyMock: vi.fn(async () => 'cer-1' as string | null),
+    onboardedUsersMock,
+    recentCeremonyMock,
+    dbMock,
+  }
+})
+
+vi.mock('@/server/ceremony/fire-ceremony', () => ({
+  fireCeremony: fireCeremonyMock,
+}))
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  biweeklyCeremonies: { id: 'b.id', userId: 'b.uid', firedAt: 'b.fired' },
+  users: { id: 'u.id', createdAt: 'u.created', onboardingComplete: 'u.onboard' },
+}))
+
+import { GET } from '@/app/api/cron/weekly-ceremony/route'
+
+// A Sunday in UTC so the ceremony-day gate passes and the loop actually runs.
+const SUNDAY = new Date('2026-06-07T08:00:00.000Z')
+// Account old enough to clear MIN_ACCOUNT_AGE_DAYS.
+const OLD_ACCOUNT = new Date('2026-01-01T00:00:00.000Z')
+
+function buildRequest() {
+  return new Request('https://joshing.example/api/cron/weekly-ceremony', { method: 'GET' })
+}
+
+describe('GET /api/cron/weekly-ceremony — per-user resilience', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    vi.setSystemTime(SUNDAY)
+    recentCeremonyMock.mockResolvedValue([])
+    fireCeremonyMock.mockResolvedValue('cer-1')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not 500 when one user fails — it skips them and fires the rest', async () => {
+    onboardedUsersMock.mockResolvedValue([
+      { id: 'user-ok-1', createdAt: OLD_ACCOUNT },
+      { id: 'user-boom', createdAt: OLD_ACCOUNT },
+      { id: 'user-ok-2', createdAt: OLD_ACCOUNT },
+    ])
+    fireCeremonyMock
+      .mockResolvedValueOnce('cer-1')
+      .mockRejectedValueOnce(new Error('LLM merge suggestion failed: 429'))
+      .mockResolvedValueOnce('cer-2')
+
+    const response = await GET(buildRequest() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ fired: 2, failed: 1, skippedNoActivity: 0 })
+    expect(fireCeremonyMock).toHaveBeenCalledTimes(3)
+  })
+
+  it('counts a no-activity null return separately from a failure', async () => {
+    onboardedUsersMock.mockResolvedValue([{ id: 'user-quiet', createdAt: OLD_ACCOUNT }])
+    fireCeremonyMock.mockResolvedValueOnce(null)
+
+    const response = await GET(buildRequest() as never)
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(body).toMatchObject({ fired: 0, failed: 0, skippedNoActivity: 1 })
+  })
+})

--- a/src/app/api/cron/weekly-ceremony/route.ts
+++ b/src/app/api/cron/weekly-ceremony/route.ts
@@ -49,6 +49,7 @@ export async function GET(request: NextRequest) {
   let fired = 0;
   let skipped = 0;
   let skippedNoActivity = 0;
+  let failed = 0;
 
   for (const user of onboardedUsers) {
     const accountAgeDays = daysSinceUtc(user.createdAt, today);
@@ -69,13 +70,26 @@ export async function GET(request: NextRequest) {
       continue;
     }
 
-    const ceremonyId = await fireCeremony(user.id);
-    if (ceremonyId) {
-      fired += 1;
-    } else {
-      skippedNoActivity += 1;
+    // Isolate each user: fireCeremony can throw on a transient per-user failure
+    // (e.g. the LLM domain-merge call in runDomainMergesForUser, or beats
+    // validation). Without this guard a single user's exception 500s the whole
+    // cron — every other user goes unfired and the external cron job exits 1.
+    // This is the behavior fire-ceremony.ts promises ("the cron handler will
+    // see the exception and skip this user"). Idempotency (the unique
+    // (userId, cycleStart, cycleEnd) index) means a retried run picks up any
+    // user we skip here.
+    try {
+      const ceremonyId = await fireCeremony(user.id);
+      if (ceremonyId) {
+        fired += 1;
+      } else {
+        skippedNoActivity += 1;
+      }
+    } catch (error) {
+      failed += 1;
+      console.error(`[weekly-ceremony] fireCeremony failed for user ${user.id}`, error);
     }
   }
 
-  return NextResponse.json({ fired, skipped, skippedNoActivity });
+  return NextResponse.json({ fired, skipped, skippedNoActivity, failed });
 }


### PR DESCRIPTION
The external cron hitting /api/cron/weekly-ceremony was returning HTTP 500
(GitHub Action exits 1). Root cause: the route's loop called fireCeremony(user)
with no per-user error handling. fireCeremony -> runDomainMergesForUser ->
suggestAggressiveDomainMerges throws on a transient Anthropic failure (rate
limit / network), and computeBeats / beatsPayloadSchema.parse can throw too.
A single user's exception propagated up uncaught and 500'd the entire cron,
so every other user went unfired.

fire-ceremony.ts already promised this behavior ("the cron handler will see
the exception and skip this user rather than shipping a broken ceremony") but
the handler never implemented it. Wrap the per-user call in try/catch: log,
count failures, continue. Idempotency (the unique (userId, cycleStart,
cycleEnd) index) means a retried run picks up any skipped user.

Adds a `failed` count to the JSON response and a route test covering the
mixed success/failure path and the no-activity null path.