### PR TITLE
Enforce a 12-interest maximum on onboarding

### DIFF
--- a/src/app/api/onboarding/save-interests/__tests__/route.test.ts
+++ b/src/app/api/onboarding/save-interests/__tests__/route.test.ts
@@ -23,6 +23,10 @@ vi.mock('@/server/db/queries/users', () => ({
   getUserOnboardingProfile: getUserOnboardingProfileMock,
   markOnboardingComplete: markOnboardingCompleteMock,
   saveDeclaredInterests: saveDeclaredInterestsMock,
+  // Account-wide sanity bound used by the route's parse step. Kept well above
+  // the onboarding-specific cap so the 12-cap test below exercises the right
+  // guard.
+  MAX_ACTIVE_DECLARED_INTERESTS: 100,
 }))
 
 import { POST } from '@/app/api/onboarding/save-interests/route'
@@ -179,17 +183,23 @@ describe('POST /api/onboarding/save-interests', () => {
     }
   })
 
-  it('enforces the max interest cap', async () => {
-    const response = await POST(
-      jsonRequest([
-        { domain: 'One', broadCategory: 'Other' },
-        { domain: 'Two', broadCategory: 'Other' },
-        { domain: 'Three', broadCategory: 'Other' },
-        { domain: 'Four', broadCategory: 'Other' },
-        { domain: 'Five', broadCategory: 'Other' },
-        { domain: 'Six', broadCategory: 'Other' },
-      ])
-    )
+  function manyInterests(count: number) {
+    return Array.from({ length: count }, (_, index) => ({
+      domain: `Topic ${index + 1}`,
+      broadCategory: 'Other',
+    }))
+  }
+
+  it('accepts exactly the onboarding max of 12 interests', async () => {
+    const response = await POST(jsonRequest(manyInterests(12)))
+
+    expect(response.status).toBe(200)
+    expect(saveDeclaredInterestsMock).toHaveBeenCalledTimes(1)
+    expect(markOnboardingCompleteMock).toHaveBeenCalledWith('user-invitee')
+  })
+
+  it('enforces the onboarding max interest cap of 12', async () => {
+    const response = await POST(jsonRequest(manyInterests(13)))
 
     expect(response.status).toBe(400)
     expect(saveDeclaredInterestsMock).not.toHaveBeenCalled()

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -19,6 +19,13 @@ type SaveInterestsBody = {
   telemetry?: unknown;
 };
 
+// Onboarding's build-your-world screen caps the selection at 12 (per product
+// spec); the client mirrors this with MAX_INTERESTS in OnboardingFlow. This is
+// the onboarding-specific ceiling and is intentionally lower than the
+// account-wide MAX_ACTIVE_DECLARED_INTERESTS used on daily setup / the
+// knowledge page.
+const MAX_ONBOARDING_INTERESTS = 12;
+
 function parseInterest(value: unknown): DeclaredInterestInput | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
 
@@ -84,6 +91,13 @@ export async function POST(request: Request) {
   if (!interests || (interests.length === 0 && !isInviteSkip)) {
     return NextResponse.json(
       { error: 'invalid_request', message: 'Save at least 1 interest, or skip invite suggestions. Domains must be 2 to 100 characters.' },
+      { status: 400 },
+    );
+  }
+
+  if (interests.length > MAX_ONBOARDING_INTERESTS) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: `Pick ${MAX_ONBOARDING_INTERESTS} interests or fewer.` },
       { status: 400 },
     );
   }

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -89,10 +89,10 @@ const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
 ]
 
 const MIN_INTERESTS = 3
-// No upper product cap — players pick as many interests as they like. This is a
-// defensive sanity bound only (the save path fans out into per-interest LLM
-// work); no real user reaches it, and the UI never shows it as a ceiling.
-const MAX_INTERESTS = 100
+// Onboarding caps the build-your-world selection at 12 (per product spec). The
+// cap also bounds the save path's per-interest LLM fan-out. Inviter-suggested
+// topics live in selectedInterests too, so they count toward this ceiling.
+const MAX_INTERESTS = 12
 
 function normalizeDomain(domain: string) {
   return domain.trim().replace(/\s+/g, ' ')
@@ -999,7 +999,9 @@ export default function OnboardingFlow({
                 <p className="text-muted-foreground mb-3 text-sm">
                   {selectedInterests.length < MIN_INTERESTS
                     ? `Pick at least ${MIN_INTERESTS} to continue (${selectedInterests.length}/${MIN_INTERESTS}).`
-                    : `${selectedInterests.length} selected.`}
+                    : selectedInterests.length >= MAX_INTERESTS
+                      ? `${MAX_INTERESTS}/${MAX_INTERESTS} — that's the max.`
+                      : `${selectedInterests.length} selected.`}
                 </p>
                 <button
                   type="button"


### PR DESCRIPTION
The build-your-world onboarding screen previously had no upper cap on
selected interests (MAX_INTERESTS=100). Per product spec, selected
topics — including inviter-suggested ones, which already live in the same
selection list — should count toward a 12-interest maximum.

- OnboardingFlow: cap MAX_INTERESTS at 12; the existing cap machinery
  (disabled add-field, dimmed suggestion cards, toggle/add guards, save
  slice) engages automatically. Surface "12/12 — that's the max." in the
  footer when at the ceiling.
- save-interests route: add an onboarding-scoped 12 guard (kept distinct
  from the account-wide MAX_ACTIVE_DECLARED_INTERESTS used by daily setup
  and the knowledge page) as defense-in-depth.
- Repair the route's test suite, which was red since interests were
  uncapped: the users mock was missing MAX_ACTIVE_DECLARED_INTERESTS, and
  the cap test asserted a stale 6-interest limit. It now verifies 12 is
  accepted and 13 is rejected.

The inviter-suggested-topics feature itself is already implemented
end-to-end and is unchanged.

https://claude.ai/code/session_01KLvRTB1DFwVTFFVRkBEmen