### PR TITLE
Prefill invited-user phone so onboarding skips manual entry

### DIFF
--- a/src/app/api/auth/request-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/request-otp/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   findUserSelectMock,
   hasValidPendingInvitationForPhoneMock,
+  getInvitePrefillByTokenMock,
   requestOtpMock,
   resolveInviteLinkMock,
 } = vi.hoisted(() => {
@@ -12,6 +13,7 @@ const {
   return {
     findUserSelectMock,
     hasValidPendingInvitationForPhoneMock: vi.fn(async () => false),
+    getInvitePrefillByTokenMock: vi.fn(async () => null as unknown),
     requestOtpMock: vi.fn(async () => ({ code: '424242' })),
     resolveInviteLinkMock: vi.fn(async () => null as unknown),
   }
@@ -38,8 +40,11 @@ vi.mock('@/server/db', () => ({
 
 vi.mock('@/server/friends/invitations', () => ({
   hasValidPendingInvitationForPhone: hasValidPendingInvitationForPhoneMock,
+  getInvitePrefillByToken: getInvitePrefillByTokenMock,
   INVITE_REQUIRED_MESSAGE:
     "Joshing is invite-only. Ask a friend who's already on Joshing to send you an invite.",
+  INVITATION_ACCEPTANCE_ERROR_MESSAGE:
+    'This invitation could not be accepted.',
 }))
 
 vi.mock('@/server/friends/user-invite-token', () => ({
@@ -65,6 +70,7 @@ describe('/api/auth/request-otp invite gate', () => {
     // Default: phone belongs to no existing user (new-signup path).
     findUserSelectMock.mockResolvedValue([])
     hasValidPendingInvitationForPhoneMock.mockResolvedValue(false)
+    getInvitePrefillByTokenMock.mockResolvedValue(null)
     resolveInviteLinkMock.mockResolvedValue(null)
     requestOtpMock.mockResolvedValue({ code: '424242' })
   })
@@ -117,5 +123,61 @@ describe('/api/auth/request-otp invite gate', () => {
     expect(response.status).toBe(200)
     expect(resolveInviteLinkMock).not.toHaveBeenCalled()
     expect(requestOtpMock).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('/api/auth/request-otp invite-phone prefill', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    findUserSelectMock.mockReset()
+    findUserSelectMock.mockResolvedValue([])
+    hasValidPendingInvitationForPhoneMock.mockResolvedValue(false)
+    getInvitePrefillByTokenMock.mockResolvedValue(null)
+    resolveInviteLinkMock.mockResolvedValue(null)
+    requestOtpMock.mockResolvedValue({ code: '424242' })
+  })
+
+  it('sends the OTP to the invite phone and returns only the masked form', async () => {
+    getInvitePrefillByTokenMock.mockResolvedValue({
+      inviterName: 'Alex',
+      inviteePhone: '+17345556819',
+      maskedPhone: '•••-•••-6819',
+    })
+
+    const response = await POST(
+      jsonRequest({ invitationToken: 'tok-1', useInvitePhone: true }),
+    )
+
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body).toMatchObject({ ok: true, maskedPhone: '•••-•••-6819' })
+    // The raw phone must never cross to the client.
+    expect(JSON.stringify(body)).not.toContain('+17345556819')
+    expect(getInvitePrefillByTokenMock).toHaveBeenCalledWith('tok-1')
+    expect(requestOtpMock).toHaveBeenCalledWith('+17345556819')
+  })
+
+  it('rejects when the invite token does not resolve to a sendable phone (no OTP sent)', async () => {
+    getInvitePrefillByTokenMock.mockResolvedValue(null)
+
+    const response = await POST(
+      jsonRequest({ invitationToken: 'bogus', useInvitePhone: true }),
+    )
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({ error: 'invalid_invitation' })
+    expect(requestOtpMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the phone gate when useInvitePhone is not set', async () => {
+    // invitationToken present but useInvitePhone absent → manual path; the
+    // brand-new phone has no invitation, so the gate blocks it.
+    const response = await POST(
+      jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(getInvitePrefillByTokenMock).not.toHaveBeenCalled()
+    expect(requestOtpMock).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -5,13 +5,22 @@ import { z } from 'zod';
 import { isUsPhoneNumber, normalizePhone, requestOtp } from '@/server/auth';
 import { db, users } from '@/server/db';
 import {
+  getInvitePrefillByToken,
   hasValidPendingInvitationForPhone,
+  INVITATION_ACCEPTANCE_ERROR_MESSAGE,
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations';
 import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
 const bodySchema = z.object({
-  phone: z.string().trim().min(1),
+  // Optional: in the invite-prefill flow (useInvitePhone) the client sends no
+  // phone — the recipient phone is resolved server-side from the invite token.
+  phone: z.string().trim().min(1).optional(),
+  // SMS friend-invitation token. When `useInvitePhone` is set, the recipient
+  // phone is read from this invitation and the code is texted there — the raw
+  // phone never crosses to the client (only a masked form is returned).
+  invitationToken: z.string().trim().min(1).nullish(),
+  useInvitePhone: z.boolean().optional(),
   // Per-user evergreen invite link (B-Friends-3). When a brand-new phone
   // arrives via /u/<handle>/<token>, the invitation is NOT phone-targeted, so
   // hasValidPendingInvitationForPhone() can't see it. The link itself is the
@@ -35,7 +44,37 @@ export async function POST(request: Request) {
         { status: 400 },
       );
     }
+
+    // Invite-prefill flow: resolve the recipient phone from the invite token
+    // and text the code there. The valid+pending check inherently satisfies
+    // the invite gate, so no phone or separate gate check is needed. We return
+    // only a masked phone — the raw number never leaves the server.
+    if (parsed.data.useInvitePhone && parsed.data.invitationToken) {
+      const prefill = await getInvitePrefillByToken(parsed.data.invitationToken);
+      if (!prefill) {
+        return NextResponse.json(
+          { error: 'invalid_invitation', message: INVITATION_ACCEPTANCE_ERROR_MESSAGE },
+          { status: 400 },
+        );
+      }
+
+      const { code } = await requestOtp(prefill.inviteePhone);
+
+      return NextResponse.json({
+        ok: true,
+        maskedPhone: prefill.maskedPhone,
+        ...(process.env.NODE_ENV !== 'production' ? { debugCode: code } : {}),
+      });
+    }
+
     const rawPhone = parsed.data.phone;
+
+    if (!rawPhone) {
+      return NextResponse.json(
+        { error: 'invalid_request', message: 'phone is required' },
+        { status: 400 },
+      );
+    }
 
     if (!isUsPhoneNumber(rawPhone)) {
       return NextResponse.json(

--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -7,6 +7,7 @@ const {
   findUserSelectMock,
   hasAcceptedInvitationForUserMock,
   getValidInvitationForPhoneMock,
+  getInvitePrefillByTokenMock,
   provisionUserInsertMock,
   verifyOtpMock,
 } = vi.hoisted(() => {
@@ -39,6 +40,7 @@ const {
     findUserSelectMock,
     hasAcceptedInvitationForUserMock: vi.fn(async () => false),
     getValidInvitationForPhoneMock: vi.fn(async () => null as unknown),
+    getInvitePrefillByTokenMock: vi.fn(async () => null as unknown),
     provisionUserInsertMock,
     verifyOtpMock: vi.fn(async (phone: string, code: string) =>
       code === '000000' ? phone : null
@@ -67,6 +69,7 @@ vi.mock('@/server/db', () => ({
 vi.mock('@/server/friends/invitations', () => ({
   acceptFriendInvitation: acceptFriendInvitationMock,
   getValidInvitationForPhone: getValidInvitationForPhoneMock,
+  getInvitePrefillByToken: getInvitePrefillByTokenMock,
   hasAcceptedInvitationForUser: hasAcceptedInvitationForUserMock,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE: 'This invitation could not be accepted.',
   // The route also imports INVITE_REQUIRED_MESSAGE for its 403 (new-signup,
@@ -120,12 +123,14 @@ describe('/api/auth/verify-otp invitation gate', () => {
     provisionUserInsertMock.mockReset()
     hasAcceptedInvitationForUserMock.mockReset()
     getValidInvitationForPhoneMock.mockReset()
+    getInvitePrefillByTokenMock.mockReset()
     acceptFriendInvitationMock.mockReset()
 
     findUserSelectMock.mockResolvedValue([])
     provisionUserInsertMock.mockResolvedValue([])
     hasAcceptedInvitationForUserMock.mockResolvedValue(false)
     getValidInvitationForPhoneMock.mockResolvedValue(null)
+    getInvitePrefillByTokenMock.mockResolvedValue(null)
     acceptFriendInvitationMock.mockResolvedValue({ accepted: true })
   })
 
@@ -360,6 +365,61 @@ describe('/api/auth/verify-otp invitation gate', () => {
 
       expect(response.status).toBe(400)
       expect(body.error).toBe('invalid_invitation')
+      expect(createSessionMock).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('invite-phone prefill (no phone sent)', () => {
+    it('resolves the phone from the token, verifies, provisions, and accepts the invitation', async () => {
+      getInvitePrefillByTokenMock.mockResolvedValue({
+        inviterName: 'Alex',
+        inviteePhone: '+15559876543',
+        maskedPhone: '•••-•••-6543',
+      })
+      findUserSelectMock.mockResolvedValueOnce([])
+      getValidInvitationForPhoneMock.mockResolvedValueOnce(VALID_INVITATION)
+      provisionUserInsertMock.mockResolvedValueOnce([NEW_USER])
+      acceptFriendInvitationMock.mockResolvedValueOnce({ accepted: true })
+
+      const response = await POST(
+        jsonRequest({
+          code: '000000',
+          invitationToken: 'invite-token',
+          useInvitePhone: true,
+        })
+      )
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.invitation).toEqual({ accepted: true })
+      // 000000 bypass works against the server-resolved phone.
+      expect(verifyOtpMock).toHaveBeenCalledWith('+15559876543', '000000')
+      expect(acceptFriendInvitationMock).toHaveBeenCalledWith({
+        token: 'invite-token',
+        inviteeUserId: 'user-2',
+        verifiedPhone: '+15559876543',
+      })
+      expect(createSessionMock).toHaveBeenCalledWith('user-2', {
+        invitationAccepted: true,
+        onboardingComplete: false,
+      })
+    })
+
+    it('rejects when the invite token no longer resolves to a phone', async () => {
+      getInvitePrefillByTokenMock.mockResolvedValue(null)
+
+      const response = await POST(
+        jsonRequest({
+          code: '000000',
+          invitationToken: 'stale-token',
+          useInvitePhone: true,
+        })
+      )
+      const body = await response.json()
+
+      expect(response.status).toBe(400)
+      expect(body.error).toBe('invalid_invitation')
+      expect(verifyOtpMock).not.toHaveBeenCalled()
       expect(createSessionMock).not.toHaveBeenCalled()
     })
   })

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -11,6 +11,7 @@ import { db, users } from '@/server/db'
 import { hashPhoneNumber } from '@/server/lib/phone-hashing'
 import {
   acceptFriendInvitation,
+  getInvitePrefillByToken,
   getValidInvitationForPhone,
   INVITATION_ACCEPTANCE_ERROR_MESSAGE,
   INVITE_REQUIRED_MESSAGE,
@@ -21,6 +22,7 @@ type VerifyOtpBody = {
   phone?: unknown
   code?: unknown
   invitationToken?: unknown
+  useInvitePhone?: unknown
   userInvite?: unknown
 }
 
@@ -118,7 +120,7 @@ export async function POST(request: Request) {
     const body = (await request
       .json()
       .catch(() => null)) as VerifyOtpBody | null
-    const phone = typeof body?.phone === 'string' ? body.phone.trim() : ''
+    let phone = typeof body?.phone === 'string' ? body.phone.trim() : ''
     const code = typeof body?.code === 'string' ? body.code.trim() : ''
     const tokenProvided =
       body?.invitationToken !== undefined && body?.invitationToken !== null
@@ -127,19 +129,32 @@ export async function POST(request: Request) {
         ? body.invitationToken.trim()
         : ''
     const hasUsableToken = tokenProvided && invitationToken.length > 0
+    const useInvitePhone = body?.useInvitePhone === true
     const userInvite = parseUserInvite(body?.userInvite)
+
+    // A token field was supplied but it's empty/whitespace — reject before
+    // anything else. This closes the `{"invitationToken": ""}` bypass.
+    if (tokenProvided && !hasUsableToken) {
+      return invitationRejection()
+    }
+
+    // Invite-prefill flow: no phone is sent — resolve the recipient phone from
+    // the invite token server-side so the rest of the flow (OTP verify +
+    // acceptFriendInvitation, which requires inviteePhone === verifiedPhone)
+    // works exactly as the manual path.
+    if (useInvitePhone && hasUsableToken && !phone) {
+      const prefill = await getInvitePrefillByToken(invitationToken)
+      if (!prefill) {
+        return invitationRejection()
+      }
+      phone = prefill.inviteePhone
+    }
 
     if (!phone || !code) {
       return NextResponse.json(
         { error: 'invalid_request', message: 'phone and code are required' },
         { status: 400 }
       )
-    }
-
-    // A token field was supplied but it's empty/whitespace — reject before
-    // anything else. This closes the `{"invitationToken": ""}` bypass.
-    if (tokenProvided && !hasUsableToken) {
-      return invitationRejection()
     }
 
     const normalizedPhone = await verifyOtp(phone, code)

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -60,7 +60,33 @@ export function buildVerifyOtpRequestBody(
   };
 }
 
-export default function LoginPanel() {
+/**
+ * Verify-OTP payload for the invite-prefill flow: no phone is sent — the
+ * server resolves the recipient phone from the invitation token. `userInvite`
+ * is forwarded so a per-user invite link is still honored if present.
+ */
+export function buildInviteVerifyOtpRequestBody(
+  code: string,
+  invitationToken: string,
+  searchParams: URLSearchParams
+) {
+  return {
+    code,
+    invitationToken,
+    useInvitePhone: true,
+    userInvite: readUserInvite(searchParams),
+  };
+}
+
+type InvitePrefill = { inviterName: string; maskedPhone: string };
+
+type LoginPanelProps = {
+  invitePrefill?: InvitePrefill | null;
+};
+
+type Step = 'invite' | 'phone' | 'code';
+
+export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = readInvitationToken(searchParams);
@@ -68,14 +94,23 @@ export default function LoginPanel() {
 
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
-  const [step, setStep] = useState<'phone' | 'code'>('phone');
+  // Start on the invite confirmation step only when the link resolved to a
+  // recipient phone; otherwise fall straight through to manual entry.
+  const [step, setStep] = useState<Step>(
+    invitePrefill?.maskedPhone ? 'invite' : 'phone'
+  );
+  // True once the OTP was sent to the invite's phone (so the code step and
+  // verify call use the masked phone + token instead of a typed number).
+  const [invitePhoneMode, setInvitePhoneMode] = useState(false);
+  // Masked phone to display on the code step while in invite-phone mode.
+  const [maskedPhone, setMaskedPhone] = useState(invitePrefill?.maskedPhone ?? '');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Controls the bottom-card transition: the title card (in page.tsx) stays
   // fixed; only this form card animates out, swaps content, then animates in.
   const [entering, setEntering] = useState(true);
 
-  const swapStep = useCallback((next: 'phone' | 'code') => {
+  const swapStep = useCallback((next: Step, nextError: string | null = null) => {
     // Return to the top so the title card is back in view after the button
     // press — on mobile the focused input scrolls the page down, and landing
     // mid-page on the next step looks unpolished.
@@ -83,10 +118,52 @@ export default function LoginPanel() {
     setEntering(false); // exit: fade + slide down
     window.setTimeout(() => {
       setStep(next); // swap content while hidden
-      setError(null);
+      // Clear by default; callers can carry an explanatory error onto the next
+      // step (e.g. the invite→manual fallback) since this overwrites it.
+      setError(nextError);
       requestAnimationFrame(() => setEntering(true)); // enter: fade + slide in
     }, 200);
   }, []);
+
+  async function sendCodeToInvitePhone(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    if (!invitationToken) {
+      // No token to resolve a phone from — fall back to manual entry.
+      setInvitePhoneMode(false);
+      swapStep('phone');
+      return;
+    }
+
+    sendTelemetry('friend_invite_auth_started');
+
+    setLoading(true);
+    try {
+      const response = await fetch('/api/auth/request-otp', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        // No phone: the server resolves the recipient phone from the invite
+        // token and texts the code there. We only ever receive a masked form.
+        body: JSON.stringify({ invitationToken, useInvitePhone: true, userInvite }),
+      });
+      const data = await response.json().catch(() => ({}));
+
+      if (!response.ok) {
+        // The invite no longer resolves to a sendable phone — drop to manual
+        // entry so the user isn't stranded, carrying the reason onto the step.
+        setInvitePhoneMode(false);
+        swapStep('phone', data?.message ?? 'Enter your phone number to continue.');
+        return;
+      }
+
+      if (typeof data?.maskedPhone === 'string') setMaskedPhone(data.maskedPhone);
+      setInvitePhoneMode(true);
+      swapStep('code');
+    } finally {
+      setLoading(false);
+    }
+  }
 
   async function continueWithPhone(event: FormEvent) {
     event.preventDefault();
@@ -136,11 +213,15 @@ export default function LoginPanel() {
 
     setLoading(true);
     try {
+      const body =
+        invitePhoneMode && invitationToken
+          ? buildInviteVerifyOtpRequestBody(trimmedCode, invitationToken, searchParams)
+          : buildVerifyOtpRequestBody(phone, trimmedCode, searchParams);
       const response = await fetch('/api/auth/verify-otp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         credentials: 'include',
-        body: JSON.stringify(buildVerifyOtpRequestBody(phone, trimmedCode, searchParams)),
+        body: JSON.stringify(body),
       });
       const data = await response.json().catch(() => ({}));
 
@@ -171,7 +252,66 @@ export default function LoginPanel() {
         transition: 'opacity 200ms ease, transform 200ms ease',
       }}
     >
-      {step === 'phone' ? (
+      {step === 'invite' ? (
+        <form className="space-y-[14px]" onSubmit={sendCodeToInvitePhone}>
+          {/* Texting glyph (the two-tone speech bubble) — this step is about us
+              sending a code by text, so it mirrors the OTP step's mark. */}
+          <svg
+            className="mx-auto h-14 w-auto"
+            viewBox="-3 -3 54 44"
+            aria-hidden="true"
+          >
+            <g fill="var(--brand-navy)">
+              <ellipse cx="15" cy="15" rx="15" ry="12" />
+              <path d="M3 22 L11 26.5 L1 31 Z" />
+            </g>
+            <g
+              fill="var(--brand-cream-card)"
+              transform="translate(32 23) scale(1.14) translate(-32 -23)"
+            >
+              <ellipse cx="32" cy="23" rx="15" ry="12" />
+              <path d="M44 30 L36 34.5 L46.5 39 Z" />
+            </g>
+            <g fill="var(--brand-orange)">
+              <ellipse cx="32" cy="23" rx="15" ry="12" />
+              <path d="M44 30 L36 34.5 L46.5 39 Z" />
+            </g>
+          </svg>
+          <p className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black">
+            {invitePrefill?.inviterName ?? 'A friend'} invited you to Joshing.
+          </p>
+          <p className="text-center text-[15px] leading-6 text-black/70">
+            We&rsquo;ll text a code to{' '}
+            <span className="whitespace-nowrap font-medium text-black">{maskedPhone}</span>.
+          </p>
+
+          {/* Button + divider + secondary action form a tight 6px cluster,
+              matching the OTP step's rhythm. */}
+          <div className="space-y-1.5">
+            <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
+              {loading ? 'Sending…' : 'Send code'}
+            </button>
+
+            <div className="flex items-center gap-3" aria-hidden="true">
+              <span className="h-px flex-1 bg-[var(--brand-navy)]/15" />
+              <span className="text-[17px] font-medium text-black">or</span>
+              <span className="h-px flex-1 bg-[var(--brand-navy)]/15" />
+            </div>
+
+            <button
+              type="button"
+              className="mx-auto block text-[14px] font-medium uppercase leading-5 tracking-[0.56px] text-[var(--brand-orange)] underline underline-offset-4 disabled:opacity-60"
+              onClick={() => {
+                setInvitePhoneMode(false);
+                swapStep('phone');
+              }}
+              disabled={loading}
+            >
+              Use a different number
+            </button>
+          </div>
+        </form>
+      ) : step === 'phone' ? (
         <form className="space-y-[14px]" onSubmit={continueWithPhone}>
           {/* Solid filled handset, matching the Figma black phone glyph
               (and the filled treatment of the OTP step's bubble icon).
@@ -239,7 +379,9 @@ export default function LoginPanel() {
             htmlFor="code"
           >
             Enter your code for{' '}
-            <span className="whitespace-nowrap">{formatPhoneForDisplay(phone)}</span>
+            <span className="whitespace-nowrap">
+              {invitePhoneMode ? maskedPhone : formatPhoneForDisplay(phone)}
+            </span>
           </label>
           <input
             id="code"
@@ -271,6 +413,8 @@ export default function LoginPanel() {
               className="mx-auto block text-[14px] font-medium uppercase leading-5 tracking-[0.56px] text-[var(--brand-orange)] underline underline-offset-4 disabled:opacity-60"
               onClick={() => {
                 setCode('');
+                // Leaving the invite phone behind — collect a number manually.
+                setInvitePhoneMode(false);
                 swapStep('phone');
               }}
               disabled={loading}

--- a/src/app/login/__tests__/LoginPanel.test.ts
+++ b/src/app/login/__tests__/LoginPanel.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  buildInviteVerifyOtpRequestBody,
   buildVerifyOtpRequestBody,
   readInvitationToken,
 } from '@/app/login/LoginPanel'
@@ -46,6 +47,41 @@ describe('LoginPanel invitation token query aliases', () => {
       code: '000000',
       invitationToken: null,
       userInvite: null,
+    })
+  })
+})
+
+describe('LoginPanel invite-phone verify payload', () => {
+  it('omits the phone and flags useInvitePhone so the server resolves it from the token', () => {
+    expect(
+      buildInviteVerifyOtpRequestBody(
+        '000000',
+        'invite-token',
+        new URLSearchParams()
+      )
+    ).toEqual({
+      code: '000000',
+      invitationToken: 'invite-token',
+      useInvitePhone: true,
+      userInvite: null,
+    })
+  })
+
+  it('still forwards a per-user invite link when present', () => {
+    expect(
+      buildInviteVerifyOtpRequestBody(
+        '000000',
+        'invite-token',
+        new URLSearchParams([
+          ['inviteHandle', 'jpalay'],
+          ['inviteUserToken', 'user-token'],
+        ])
+      )
+    ).toEqual({
+      code: '000000',
+      invitationToken: 'invite-token',
+      useInvitePhone: true,
+      userInvite: { handle: 'jpalay', token: 'user-token' },
     })
   })
 })

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,8 +1,24 @@
 import { Suspense } from 'react';
 
 import TriangleBackground from '@/components/TriangleBackground';
+import { getInvitePrefillByToken } from '@/server/friends/invitations';
 
 import LoginPanel from './LoginPanel';
+
+// Mirror LoginPanel.readInvitationToken: accept any of the aliases an invite
+// link may use so the prefill resolves regardless of which one routed here.
+function readInvitationToken(
+  params: Record<string, string | string[] | undefined>
+): string | null {
+  const first = (value: string | string[] | undefined) =>
+    Array.isArray(value) ? value[0] : value;
+  return (
+    first(params.invitationToken) ??
+    first(params.invite) ??
+    first(params.token) ??
+    null
+  );
+}
 
 function TitleCard() {
   return (
@@ -18,7 +34,23 @@ function TitleCard() {
   );
 }
 
-export default function LoginPage() {
+type LoginPageProps = {
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+export default async function LoginPage({ searchParams }: LoginPageProps) {
+  const params = await searchParams;
+  const invitationToken = readInvitationToken(params);
+  // Resolve the invite's recipient phone server-side so the login panel can
+  // skip manual phone entry. Only the masked form crosses to the client — the
+  // raw phone never leaves the server.
+  const prefill = invitationToken
+    ? await getInvitePrefillByToken(invitationToken)
+    : null;
+  const invitePrefill = prefill
+    ? { inviterName: prefill.inviterName, maskedPhone: prefill.maskedPhone }
+    : null;
+
   return (
     <TriangleBackground>
       <main className="relative z-10 flex min-h-screen flex-col items-center justify-start gap-5 px-6 pt-14 pb-10">
@@ -28,7 +60,7 @@ export default function LoginPage() {
             <div className="h-72 w-full max-w-sm rounded-2xl bg-[var(--brand-cream-card)] shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5" />
           }
         >
-          <LoginPanel />
+          <LoginPanel invitePrefill={invitePrefill} />
         </Suspense>
       </main>
     </TriangleBackground>

--- a/src/lib/__tests__/phone-e164.test.ts
+++ b/src/lib/__tests__/phone-e164.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { maskPhoneE164 } from '@/lib/phone-e164'
+
+describe('maskPhoneE164', () => {
+  it('masks a US E.164 number to •••-•••-1234', () => {
+    expect(maskPhoneE164('+17345556819')).toBe('•••-•••-6819')
+  })
+
+  it('masks a bare 10-digit number', () => {
+    expect(maskPhoneE164('7345556819')).toBe('•••-•••-6819')
+  })
+
+  it('strips a leading 1 (11-digit) before masking', () => {
+    expect(maskPhoneE164('17345556819')).toBe('•••-•••-6819')
+  })
+
+  it('falls back to a fully masked placeholder for non-10-digit input', () => {
+    expect(maskPhoneE164('+44 20 7946 0958')).toBe('•••-•••-••••')
+    expect(maskPhoneE164('')).toBe('•••-•••-••••')
+  })
+})

--- a/src/lib/phone-e164.ts
+++ b/src/lib/phone-e164.ts
@@ -12,3 +12,13 @@ export function normalizeToE164(raw: string, defaultCountry: 'US' = 'US'): strin
     return null
   }
 }
+
+// Mask a US E.164 number for display as "•••-•••-1234" (only the last four
+// digits are shown). Used to surface an invite's target phone without leaking
+// the full number to the client. Falls back to a fully masked placeholder when
+// the input isn't a 10-digit US number.
+export function maskPhoneE164(e164: string): string {
+  const digits = e164.replace(/\D/g, '').replace(/^1/, '')
+  if (digits.length !== 10) return '•••-•••-••••'
+  return `•••-•••-${digits.slice(6)}`
+}

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -31,12 +31,16 @@ const { dbMock, state } = vi.hoisted(() => {
       if (!state.invitation) return []
       if (!isLandingSelect) return [state.invitation]
 
+      // Joined select (landing + prefill both leftJoin users). Superset of
+      // both selections; the real query only reads the columns it selected, so
+      // extra fields here are harmless.
       return [
         {
           acceptedAt: state.invitation.acceptedAt,
           cancelledAt: state.invitation.cancelledAt,
           expiresAt: state.invitation.expiresAt,
           preSeededInterests: state.invitation.preSeededInterests,
+          inviteePhone: state.invitation.inviteePhone,
           inviterName: state.inviterName,
         },
       ]
@@ -161,6 +165,7 @@ import {
   createFriendInvitation,
   getFriendInvitationLandingByToken,
   getInvitationByToken,
+  getInvitePrefillByToken,
   getPendingInvitationForPhone,
 } from '@/server/friends/invitations'
 import { parsePreSeededInterests } from '@/server/db/queries/users'
@@ -557,6 +562,45 @@ describe('friend invitation helpers', () => {
         now,
       })
     ).resolves.toEqual(expect.objectContaining({ cancelledAt: now }))
+  })
+
+  it('resolves a valid pending invite to inviter name, raw phone, and masked phone', async () => {
+    setInvitation({ inviteePhone: '+17345556819' })
+
+    await expect(getInvitePrefillByToken('valid-token', now)).resolves.toEqual({
+      inviterName: 'Alex Inviter',
+      inviteePhone: '+17345556819',
+      maskedPhone: '•••-•••-6819',
+    })
+  })
+
+  it('falls back to "Someone" when the inviter has no display name', async () => {
+    state.inviterName = null
+    setInvitation({ inviteePhone: '+17345556819' })
+
+    await expect(getInvitePrefillByToken('valid-token', now)).resolves.toEqual(
+      expect.objectContaining({ inviterName: 'Someone' })
+    )
+  })
+
+  it('returns null for blank, accepted, cancelled, or expired invites', async () => {
+    await expect(getInvitePrefillByToken('', now)).resolves.toBeNull()
+
+    setInvitation({ acceptedAt: new Date('2026-05-13T11:00:00.000Z') })
+    await expect(getInvitePrefillByToken('accepted-token', now)).resolves.toBeNull()
+
+    setInvitation({ cancelledAt: new Date('2026-05-13T11:00:00.000Z') })
+    await expect(
+      getInvitePrefillByToken('cancelled-token', now)
+    ).resolves.toBeNull()
+
+    setInvitation({ expiresAt: new Date('2026-05-12T12:00:00.000Z') })
+    await expect(getInvitePrefillByToken('expired-token', now)).resolves.toBeNull()
+  })
+
+  it('returns null when the invite has no recipient phone', async () => {
+    setInvitation({ inviteePhone: '' })
+    await expect(getInvitePrefillByToken('valid-token', now)).resolves.toBeNull()
   })
 
   it('still parses existing onboarding pre-seeded interests', () => {

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -2,6 +2,7 @@ import { randomBytes } from 'crypto'
 
 import { and, desc, eq, gt, isNotNull, isNull, or } from 'drizzle-orm'
 
+import { maskPhoneE164 } from '@/lib/phone-e164'
 import { db, friendInvitations, users } from '@/server/db'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
@@ -30,6 +31,14 @@ export type OutgoingFriendInvitation = FriendInvitation & {
 export type FriendInvitationLanding = {
   status: 'valid' | 'expired' | 'accepted' | 'invalid'
   inviterName: string
+}
+
+export type InvitePrefill = {
+  inviterName: string
+  // Server-only: the recipient's E.164 phone resolved from the invite token.
+  // Never expose this to the client — surface `maskedPhone` instead.
+  inviteePhone: string
+  maskedPhone: string
 }
 
 export type CreateFriendInvitationInput = {
@@ -152,6 +161,48 @@ export async function getFriendInvitationLandingByToken(
   })
 
   return { status: 'valid', inviterName }
+}
+
+/**
+ * Resolve a valid, pending invite token to the data needed to prefill the
+ * login screen with the recipient's phone — the inviter's name, the raw
+ * recipient phone (server-only, for sending/verifying the OTP), and a masked
+ * form safe to show the client. Returns null unless the invite is still
+ * actionable (not accepted/cancelled/expired) and has a recipient phone, so
+ * callers naturally fall back to manual phone entry.
+ */
+export async function getInvitePrefillByToken(
+  token: string,
+  now = new Date()
+): Promise<InvitePrefill | null> {
+  const normalizedToken = token.trim()
+  if (!normalizedToken) return null
+
+  const [row] = await db
+    .select({
+      acceptedAt: friendInvitations.acceptedAt,
+      cancelledAt: friendInvitations.cancelledAt,
+      expiresAt: friendInvitations.expiresAt,
+      inviteePhone: friendInvitations.inviteePhone,
+      inviterName: users.displayName,
+    })
+    .from(friendInvitations)
+    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
+    .where(eq(friendInvitations.token, normalizedToken))
+    .limit(1)
+
+  if (!row) return null
+  if (row.acceptedAt || row.cancelledAt) return null
+  if (row.expiresAt <= now) return null
+
+  const inviteePhone = row.inviteePhone?.trim()
+  if (!inviteePhone) return null
+
+  return {
+    inviterName: displayInviterName(row.inviterName),
+    inviteePhone,
+    maskedPhone: maskPhoneE164(inviteePhone),
+  }
 }
 
 function normalizeRequiredText(value: string, fieldName: string) {


### PR DESCRIPTION
A recipient who opens a valid invite link no longer has to type their
phone number. The pending FriendInvitation already stores the recipient
phone, so the login flow now resolves it server-side, shows a masked
form ("We'll text a code to •••-•••-1234"), and goes straight to OTP.

- Add maskPhoneE164() and getInvitePrefillByToken(), which returns the
  inviter name + recipient phone (server-only) + masked phone for valid,
  pending invites with a recipient number.
- /login resolves the prefill from the invite token and passes only the
  masked form to LoginPanel, which gains an "invite" first step with
  "Send code" and "Use a different number".
- request-otp/verify-otp accept useInvitePhone: the recipient phone is
  resolved from the token server-side; the raw number never reaches the
  client. The link alone still can't authenticate — OTP (incl. the
  000000 dev bypass) remains the proof, and the existing invite-only
  gate, attribution, and friendship formation are unchanged.
- Fallbacks: missing/invalid/expired invite, per-user invite links, or
  "Use a different number" drop to the existing manual phone screen.

Adds unit/route coverage for masking, prefill resolution, and both
invite-phone OTP paths.