### PR TITLE
Keep Daily Five "Answer" button visible above the mobile keyboard

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
@@ -150,6 +150,9 @@ export default function DailyPage() {
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
   const [showFirstRunIntro, setShowFirstRunIntro] = useState(false);
+  // Refs for keeping the answer bar above the on-screen keyboard on mobile.
+  const answerFormRef = useRef<HTMLFormElement>(null);
+  const answerInputRef = useRef<HTMLInputElement>(null);
 
   // Show the first-run intro once, only for the server-flagged first untouched
   // queue and only if this device hasn't already dismissed it.
@@ -551,6 +554,31 @@ export default function DailyPage() {
     }
   }, [postAnswer]);
 
+  // Keep the "Answer" bar above the on-screen keyboard. On mobile the layout
+  // viewport doesn't shrink when the keyboard opens, so a `position: sticky`
+  // footer ends up hidden behind it (the original "scroll to find the button"
+  // bug). The VisualViewport API reports the genuinely-visible region, so we
+  // lift the bar by however much the keyboard overlaps it. Re-runs when the
+  // input bar mounts for a new pending slot. No-ops where VisualViewport is
+  // unsupported — the sticky positioning still applies as before.
+  useEffect(() => {
+    const form = answerFormRef.current;
+    const viewport = window.visualViewport;
+    if (!form || !viewport) return;
+    const update = () => {
+      const overlap = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
+      form.style.transform = overlap > 0 ? `translateY(-${overlap}px)` : '';
+    };
+    update();
+    viewport.addEventListener('resize', update);
+    viewport.addEventListener('scroll', update);
+    return () => {
+      viewport.removeEventListener('resize', update);
+      viewport.removeEventListener('scroll', update);
+      form.style.transform = '';
+    };
+  }, [currentSlot?.slot_index]);
+
   return (
     <main className="mx-auto flex min-h-dvh max-w-lg flex-col px-0">
       <header
@@ -620,28 +648,57 @@ export default function DailyPage() {
 
       {currentSlot && !loading ? (
         <form
+          ref={answerFormRef}
           className="sticky bottom-0 z-30 mt-auto border-t px-4 py-3"
+          aria-label="Submit your answer"
           style={{
             borderColor: 'var(--border)',
             background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
             backdropFilter: 'blur(6px)',
             paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
+            // Smooth the lift/settle as the keyboard opens and closes (the
+            // translateY is driven imperatively by the VisualViewport effect).
+            transition: 'transform 0.15s ease-out',
           }}
           onSubmit={(event) => {
+            // Native single-input form submit already fires on Enter/Return;
+            // handling it here keeps the click and keyboard paths identical
+            // across platforms.
             event.preventDefault();
             void submitAnswer();
           }}
         >
           <div className="flex gap-2">
             <input
+              ref={answerInputRef}
               value={answer}
               onChange={(event) => setAnswer(event.target.value)}
+              onFocus={() => {
+                // Belt-and-suspenders for browsers without VisualViewport: nudge
+                // the field into view once the keyboard has begun animating in.
+                window.setTimeout(() => {
+                  answerInputRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+                }, 250);
+              }}
               disabled={submitting}
               placeholder="Your answer..."
+              aria-label="Your answer"
+              // Label the keyboard's return key as a send/submit action so it's
+              // the obvious way to answer on mobile.
+              enterKeyHint="send"
+              autoComplete="off"
+              autoCorrect="off"
+              autoCapitalize="off"
+              spellCheck={false}
               className="min-h-11 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-4 text-base text-[var(--text)] outline-none"
               style={{ borderColor: 'var(--border)' }}
             />
-            <button type="submit" className="btn-primary shrink-0" disabled={submitting || !answer.trim()}>
+            <button
+              type="submit"
+              className="btn-primary shrink-0"
+              aria-label="Submit answer"
+              disabled={submitting || !answer.trim()}
+            >
               {submitting ? '...' : 'Answer'}
             </button>
           </div>


### PR DESCRIPTION
The answer CTA could fall below the fold when the on-screen keyboard
opened: the layout viewport doesn't shrink for the keyboard, so the
position: sticky footer was hidden behind it and users had to scroll to
submit. Lift the bar by the keyboard overlap using the VisualViewport
API, with a scrollIntoView fallback on focus for browsers without it.

Also clarify the submit affordance and accessibility:
- enterKeyHint="send" labels the mobile return key, and the form's
  native single-input Enter submit is wired through submitAnswer so the
  click and keyboard paths are identical on all platforms.
- aria-label="Submit answer" on the CTA and aria-label="Your answer" on
  the input so screen readers announce each control's purpose.

Note: the Daily Five answer area has no grey arrow/audio icon, so there
was no adjacent control to differentiate or remove.