### PR TITLE
Move new-territory removal to "Once in a Blue Moon" with undo

### DIFF
--- a/src/app/api/daily/preferences/domain-frequency/__tests__/route.test.ts
+++ b/src/app/api/daily/preferences/domain-frequency/__tests__/route.test.ts
@@ -1,0 +1,111 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  getSessionMock,
+  getDailyPreferencesMock,
+  getKnowledgeBaseMock,
+  updateDailyPreferencesMock,
+  invalidateUntouchedDailyQueuesMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  getDailyPreferencesMock: vi.fn(),
+  getKnowledgeBaseMock: vi.fn(),
+  updateDailyPreferencesMock: vi.fn(),
+  invalidateUntouchedDailyQueuesMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/daily', () => ({
+  getKnowledgeBase: getKnowledgeBaseMock,
+  invalidateUntouchedDailyQueues: invalidateUntouchedDailyQueuesMock,
+}));
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: getDailyPreferencesMock,
+  updateDailyPreferences: updateDailyPreferencesMock,
+}));
+
+import { POST } from '@/app/api/daily/preferences/domain-frequency/route';
+
+function request(body: unknown): Request {
+  return new Request('http://localhost/api/daily/preferences/domain-frequency', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+}
+
+describe('POST /api/daily/preferences/domain-frequency', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockResolvedValue({ userId: 'user-1' });
+    getKnowledgeBaseMock.mockResolvedValue([
+      { domain: 'Harry Potter Book 3' },
+      { domain: 'Dune' },
+    ]);
+    getDailyPreferencesMock.mockResolvedValue({
+      userId: 'user-1',
+      difficulty: 'adaptive',
+      domainMode: 'custom',
+      selectedDomains: ['Dune'],
+      domainPreferenceFrequency: { Dune: 'often' },
+      updatedAt: null,
+    });
+    updateDailyPreferencesMock.mockImplementation(async (_userId, data) => ({
+      userId: 'user-1',
+      difficulty: 'adaptive',
+      domainMode: 'custom',
+      selectedDomains: ['Dune'],
+      domainPreferenceFrequency: data.domainPreferenceFrequency,
+      updatedAt: new Date(),
+    }));
+  });
+
+  it('returns 401 when unauthenticated', async () => {
+    getSessionMock.mockResolvedValue(null);
+    const response = await POST(request({ domain: 'Dune', frequency: 'blue_moon' }));
+    expect(response.status).toBe(401);
+    expect(updateDailyPreferencesMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown frequency', async () => {
+    const response = await POST(request({ domain: 'Dune', frequency: 'never' }));
+    expect(response.status).toBe(400);
+    expect(updateDailyPreferencesMock).not.toHaveBeenCalled();
+  });
+
+  it('merges blue_moon in without clobbering other domains and reports no prior value', async () => {
+    const response = await POST(request({ domain: 'Harry Potter Book 3', frequency: 'blue_moon' }));
+
+    expect(response.status).toBe(200);
+    // Canonical KB casing is used for the new entry; existing entries survive.
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: { Dune: 'often', 'Harry Potter Book 3': 'blue_moon' },
+    });
+    const body = await response.json();
+    expect(body.previousFrequency).toBeNull();
+    expect(invalidateUntouchedDailyQueuesMock).toHaveBeenCalledWith('user-1');
+  });
+
+  it('captures the prior frequency case-insensitively', async () => {
+    const response = await POST(request({ domain: 'dune', frequency: 'blue_moon' }));
+
+    expect(response.status).toBe(200);
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: { Dune: 'blue_moon' },
+    });
+    const body = await response.json();
+    expect(body.previousFrequency).toBe('often');
+  });
+
+  it('clears the entry when frequency is null (undo to default)', async () => {
+    const response = await POST(request({ domain: 'Dune', frequency: null }));
+
+    expect(response.status).toBe(200);
+    // The Dune entry is dropped entirely, restoring default rotation.
+    expect(updateDailyPreferencesMock).toHaveBeenCalledWith('user-1', {
+      domainPreferenceFrequency: {},
+    });
+    const body = await response.json();
+    expect(body.previousFrequency).toBe('often');
+  });
+});

--- a/src/app/api/daily/preferences/domain-frequency/route.ts
+++ b/src/app/api/daily/preferences/domain-frequency/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { TERRITORY_FREQUENCIES, type TerritoryFrequency } from '@/lib/daily/territory-model';
+import { getKnowledgeBase, invalidateUntouchedDailyQueues } from '@/server/db/queries/daily';
+import { getDailyPreferences, updateDailyPreferences } from '@/server/db/queries/daily-preferences';
+
+export const dynamic = 'force-dynamic';
+
+// `frequency: null` clears any explicit preference, restoring the domain to its
+// default rotation — that's how the reveal-card "Undo" steps back to the stage
+// before it was moved to "Once in a Blue Moon".
+const bodySchema = z.object({
+  domain: z.string().trim().min(1),
+  frequency: z.enum(TERRITORY_FREQUENCIES).nullable(),
+});
+
+// Set a single domain's Daily Five frequency without the caller needing the full
+// preference map. Used by the new-territory reveal card to nudge a freshly-opened
+// domain into "Once in a Blue Moon" (and to undo it). Merges server-side so a
+// targeted change can't clobber the rest of the user's frequency choices.
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', message: 'domain and frequency are required' },
+      { status: 400 },
+    );
+  }
+  const { domain, frequency } = parsed.data;
+
+  const [preferences, knowledgeBase] = await Promise.all([
+    getDailyPreferences(session.userId),
+    getKnowledgeBase(session.userId),
+  ]);
+
+  const domainKey = domain.toLowerCase();
+  const matched =
+    knowledgeBase.map((entry) => entry.domain).find((d) => d.toLowerCase() === domainKey) ?? domain;
+
+  // Capture the prior value (case-insensitively) so the client can offer a true
+  // revert, then rebuild the map dropping any case variants of this domain.
+  let previousFrequency: TerritoryFrequency | null = null;
+  const nextFrequencyByDomain: Record<string, TerritoryFrequency> = {};
+  for (const [existingDomain, existingFrequency] of Object.entries(
+    preferences.domainPreferenceFrequency,
+  )) {
+    if (existingDomain.toLowerCase() === domainKey) {
+      previousFrequency = existingFrequency;
+      continue;
+    }
+    nextFrequencyByDomain[existingDomain] = existingFrequency;
+  }
+  if (frequency) nextFrequencyByDomain[matched] = frequency;
+
+  const updated = await updateDailyPreferences(session.userId, {
+    domainPreferenceFrequency: nextFrequencyByDomain,
+  });
+
+  // Frequency is a question-defining input, so drop untouched pre-built queues;
+  // the next /api/daily/queue POST regenerates from the new preference. Mirrors
+  // the PATCH handler in ../route.ts. In-progress rounds are left intact.
+  await invalidateUntouchedDailyQueues(session.userId);
+
+  return NextResponse.json({
+    ok: true,
+    domain: matched,
+    frequency,
+    previousFrequency,
+    domainPreferenceFrequency: updated.domainPreferenceFrequency,
+  });
+}

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -1,20 +1,22 @@
 'use client'
 
 import { useState } from 'react'
-import { Sparkles } from 'lucide-react'
+import { Moon, Sparkles } from 'lucide-react'
+
+import type { TerritoryFrequency } from '@/lib/daily/territory-model'
 
 // Darkened triangle-gold so the "New territory" copy clears AA on the cream
 // card (raw --tri-amber #d9a82e is too light for small text).
 const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))'
 
-type RemoveState = 'idle' | 'removing' | 'removed' | 'error'
-
-// Default-add with undo (B-1): a correct answer in an unfamiliar domain opens
-// it in the player's Knowledge base automatically (server-side, via
-// writeMasteryEvent). This card surfaces that the domain was added and offers
-// a single "remove" that deletes the freshly-opened domain — reversing the KB
-// open and pulling it from any custom Daily Five selection. The player stays in
-// control via removal, not an opt-in gate. Used on both reveal surfaces.
+// Default-add with a soft demote (B-1): a correct answer in an unfamiliar domain
+// opens it in the player's Knowledge base automatically (server-side, via
+// writeMasteryEvent). This card surfaces that the domain was added, and the
+// primary control doesn't delete it — it moves the freshly-opened domain to
+// "Once in a Blue Moon" so it stays on the map but only surfaces every so often.
+// After moving, an "Undo" steps back to the just-added stage by restoring the
+// domain's prior frequency. The player stays in control without losing the
+// territory. Used on both reveal surfaces.
 export function NewTerritoryUndo({
   domain,
   category,
@@ -22,21 +24,54 @@ export function NewTerritoryUndo({
   domain: string
   category?: string | null
 }) {
-  const [state, setState] = useState<RemoveState>('idle')
+  // 'open' = freshly added (default rotation); 'blue_moon' = demoted to rare.
+  const [stage, setStage] = useState<'open' | 'blue_moon'>('open')
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState(false)
+  // The frequency the domain had before we moved it to blue_moon, so Undo can
+  // restore exactly that (usually unset → null, i.e. default rotation).
+  const [previousFrequency, setPreviousFrequency] = useState<TerritoryFrequency | null>(null)
   const label = category || domain
 
-  const handleRemove = async () => {
-    if (state === 'removing' || state === 'removed') return
-    setState('removing')
+  const setFrequency = async (frequency: TerritoryFrequency | null) => {
+    const response = await fetch('/api/daily/preferences/domain-frequency', {
+      method: 'POST',
+      credentials: 'include',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ domain, frequency }),
+    })
+    if (!response.ok) throw new Error('frequency update failed')
+    return (await response.json().catch(() => null)) as {
+      previousFrequency?: TerritoryFrequency | null
+    } | null
+  }
+
+  const handleBlueMoon = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(false)
     try {
-      const response = await fetch(`/api/knowledge/${encodeURIComponent(domain)}`, {
-        method: 'DELETE',
-        credentials: 'include',
-      })
-      if (!response.ok) throw new Error('remove failed')
-      setState('removed')
+      const result = await setFrequency('blue_moon')
+      setPreviousFrequency(result?.previousFrequency ?? null)
+      setStage('blue_moon')
     } catch {
-      setState('error')
+      setError(true)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleUndo = async () => {
+    if (busy) return
+    setBusy(true)
+    setError(false)
+    try {
+      await setFrequency(previousFrequency)
+      setStage('open')
+    } catch {
+      setError(true)
+    } finally {
+      setBusy(false)
     }
   }
 
@@ -57,39 +92,67 @@ export function NewTerritoryUndo({
           }}
           aria-hidden
         >
-          <Sparkles className="size-3.5" />
+          {stage === 'blue_moon' ? <Moon className="size-3.5" /> : <Sparkles className="size-3.5" />}
         </span>
         <div className="min-w-0 flex-1">
-          {state === 'removed' ? (
-            <p className="font-serif text-[14px] leading-snug" style={{ color: 'var(--brand-ink)' }}>
-              Removed {label} from your knowledge base.
-            </p>
-          ) : (
+          {stage === 'blue_moon' ? (
             <>
-              <p className="font-serif text-[14px] leading-snug font-semibold" style={{ color: GOLD_INK }}>
-                Added {label} to your knowledge base.
+              <p
+                className="font-serif text-[14px] leading-snug font-semibold"
+                style={{ color: GOLD_INK }}
+              >
+                {label} is now once in a blue moon.
+              </p>
+              <p className="mt-1 text-[13px] text-[var(--brand-ink)]">
+                It stays on your map but will only surface every so often.
               </p>
               <p className="mt-1.5 text-[13px] text-[var(--brand-ink)]">
-                {state === 'removing' ? (
-                  <span className="text-[var(--brand-ink-400)]">Removing…</span>
+                {busy ? (
+                  <span className="text-[var(--brand-ink-400)]">Undoing…</span>
                 ) : (
                   <button
                     type="button"
-                    onClick={() => void handleRemove()}
+                    onClick={() => void handleUndo()}
                     className="font-semibold underline underline-offset-2 hover:opacity-70"
                     style={{ color: GOLD_INK }}
                   >
-                    Remove
+                    Undo
                   </button>
                 )}
               </p>
-              {state === 'error' ? (
-                <p className="mt-1.5 text-[12px]" style={{ color: 'var(--game-wrong-strong)' }}>
-                  Could not remove it. Try again.
-                </p>
-              ) : null}
+            </>
+          ) : (
+            <>
+              <p
+                className="font-serif text-[14px] leading-snug font-semibold"
+                style={{ color: GOLD_INK }}
+              >
+                Added {label} to your knowledge base.
+              </p>
+              <p className="mt-1 text-[13px] text-[var(--brand-ink)]">
+                Want it only every so often?
+              </p>
+              <p className="mt-1.5 text-[13px] text-[var(--brand-ink)]">
+                {busy ? (
+                  <span className="text-[var(--brand-ink-400)]">Moving…</span>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => void handleBlueMoon()}
+                    className="font-semibold underline underline-offset-2 hover:opacity-70"
+                    style={{ color: GOLD_INK }}
+                  >
+                    Move to Once in a Blue Moon
+                  </button>
+                )}
+              </p>
             </>
           )}
+          {error ? (
+            <p className="mt-1.5 text-[12px]" style={{ color: 'var(--game-wrong-strong)' }}>
+              Could not update it. Try again.
+            </p>
+          ) : null}
         </div>
       </div>
     </div>


### PR DESCRIPTION
The new-territory reveal card auto-opened a domain on a correct answer and
offered a single "Remove" that hard-deleted it from the knowledge base, with
no way back. Replace that destructive action with a softer, reversible one:
the primary control now moves the freshly-added territory to the "Once in a
Blue Moon" daily frequency (it stays on the map but only surfaces every so
often), and the card's copy says so up front. After moving, an "Undo" restores
the territory's prior frequency, stepping back to the just-added stage.

- Add POST /api/daily/preferences/domain-frequency to set a single domain's
  frequency, merging server-side so a targeted change can't clobber the rest
  of the user's frequency map. Returns previousFrequency so the client can
  offer a true revert; frequency: null clears the entry (undo to default).
- Rework NewTerritoryUndo to drive the move/undo flow with optimistic state.
- Cover the route's merge, case-insensitive prior-value capture, and
  null-clears-on-undo behavior with tests.