### PR TITLE
Match loading screen typography to login page and drop attempt counter

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -104,8 +104,8 @@ const QUEUE_CREATE_BACKOFF_MS = [2000, 4000, 8000];
 const QUEUE_GENERATION_FAILED_MESSAGE =
   "We're still crafting today's bespoke questions and it's taking longer than usual. Give it a moment and try again.";
 
-function generatingLabel(attempt: number): string {
-  return `Crafting your bespoke questions (attempt ${attempt}/${MAX_QUEUE_CREATE_ATTEMPTS})`;
+function generatingLabel(): string {
+  return 'Crafting your bespoke questions';
 }
 
 // Returns the slot the player should be on, or null when the round is over.
@@ -618,7 +618,7 @@ export default function DailyPage() {
         {loading ? (
           <LoadingScreen
             fullScreen
-            label={generatingAttempt != null ? generatingLabel(generatingAttempt) : 'Loading today'}
+            label={generatingAttempt != null ? generatingLabel() : 'Loading today'}
           />
         ) : error ? (
           // Generation hiccups are warm and retryable, not alarming — keep this

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -148,14 +148,11 @@ export default function LoadingScreen({
       />
 
       <div className="relative z-10 mx-6 flex w-full max-w-xs flex-col items-center rounded-2xl bg-[#F5EBD3] px-8 py-10 shadow-[0_8px_24px_rgba(20,18,8,0.18)] ring-1 ring-black/5">
-        <p
-          className="text-3xl font-black tracking-[0.18em] text-[var(--warm-ink)]"
-          style={{ fontFamily: "var(--font-sans-body), system-ui, sans-serif" }}
-        >
+        <p className="font-sans text-3xl font-bold tracking-[0.1em] text-[var(--brand-ink-950)]">
           JOSHING
         </p>
         <div className="mt-6 h-px w-12 bg-[#1a1208]/20" aria-hidden="true" />
-        <p className="mt-5 flex items-baseline gap-1 text-sm font-medium tracking-wider uppercase text-[#1a1208]/70">
+        <p className="mt-5 flex items-baseline gap-1 font-inter text-sm font-normal tracking-wider uppercase text-[#1a1208]/70">
           <span>{label}</span>
           <span className="ml-0.5 inline-flex gap-0.5" aria-hidden="true">
             <span


### PR DESCRIPTION
The daily generation loading screen rendered the JOSHING wordmark in
font-black with warm-ink color and an inline font-family override, which
read as a different typeface from the login page's wordmark. Align it with
the login TitleCard: font-sans bold, brand-ink-950 ink, and the login's
0.1em tracking ratio; render the loading label in the Inter register the
login subtitle uses.

Also remove the "(attempt N/4)" suffix from the generating label so the
retry counter is no longer surfaced to players.