### PR TITLE
Add recheck affordance to the answer feedback sheet

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1556,6 +1556,7 @@ function FeedListContent({
             openedTerritoryDomain={pickOpenedTerritoryDomain(result.masteryDelta)}
             questionId={sheetItem.question_id}
             feedItemId={sheetItem.id}
+            onRecheck={result.correct ? null : () => submitRecheck(sheetItem)}
             onClose={() => setFeedbackSheetId(null)}
           />
         )

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Check, Sparkles, X } from 'lucide-react'
 
+import { FeedActionLink } from './FeedActionLink'
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
 import { INSIDE_JOKE_LABELS, type InsideJokeKind } from '@/lib/questions-types'
@@ -27,10 +28,15 @@ type AnswerFeedbackSheetProps = {
   openedTerritoryDomain?: string | null
   questionId: string
   feedItemId: string
+  // Requests a second look at a wrong answer (typos, accepted synonyms, a
+  // disputed canonical answer). Resolves with the verdict to surface inline.
+  // Omit (or pass null) to hide the recheck affordance.
+  onRecheck?: (() => Promise<{ accepted: boolean; message: string }>) | null
   onClose: () => void
 }
 
 type BankState = 'idle' | 'saving' | 'saved' | 'undoing' | 'undone' | 'error'
+type RecheckState = 'idle' | 'submitting' | 'done' | 'error'
 
 export function AnswerFeedbackSheet({
   question,
@@ -47,6 +53,7 @@ export function AnswerFeedbackSheet({
   openedTerritoryDomain = null,
   questionId,
   feedItemId,
+  onRecheck = null,
   onClose,
 }: AnswerFeedbackSheetProps) {
   const visibleCategory = visibleFeedCategory(category)
@@ -54,6 +61,9 @@ export function AnswerFeedbackSheet({
   const showTerritoryUndo = Boolean(openedTerritoryDomain) && isCorrect
   const [bankState, setBankState] = useState<BankState>('idle')
   const hasAutoSavedRef = useRef(false)
+  const [recheckState, setRecheckState] = useState<RecheckState>('idle')
+  const [recheckMessage, setRecheckMessage] = useState<string | null>(null)
+  const [recheckAccepted, setRecheckAccepted] = useState(false)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -101,6 +111,23 @@ export function AnswerFeedbackSheet({
       setBankState('undone')
     } catch {
       setBankState('error')
+    }
+  }
+
+  const requestRecheck = async () => {
+    if (!onRecheck || recheckState === 'submitting') return
+    setRecheckState('submitting')
+    setRecheckMessage(null)
+    setRecheckAccepted(false)
+    try {
+      const outcome = await onRecheck()
+      setRecheckState('done')
+      setRecheckMessage(outcome.message)
+      setRecheckAccepted(outcome.accepted)
+    } catch {
+      setRecheckState('error')
+      setRecheckMessage('Could not recheck that answer.')
+      setRecheckAccepted(false)
     }
   }
 
@@ -252,6 +279,53 @@ export function AnswerFeedbackSheet({
               <p className="mt-1.5 font-serif text-[15px] leading-7 text-[var(--brand-ink)]">
                 {creatorNote}
               </p>
+            </div>
+          ) : null}
+
+          {onRecheck ? (
+            <div className="space-y-2 pt-3">
+              {!isCorrect && recheckState !== 'done' ? (
+                <div className="flex items-center justify-between gap-3">
+                  <p className="text-xs text-muted-foreground">
+                    Think we got this wrong?
+                  </p>
+                  <FeedActionLink
+                    onClick={() => void requestRecheck()}
+                    disabled={recheckState === 'submitting'}
+                  >
+                    {recheckState === 'submitting' ? 'Rechecking…' : 'Recheck →'}
+                  </FeedActionLink>
+                </div>
+              ) : null}
+              {recheckMessage ? (
+                recheckAccepted ? (
+                  <div
+                    role="status"
+                    aria-live="polite"
+                    className="flex items-center gap-2 rounded-md border px-3 py-2 text-[13px] font-medium"
+                    style={{
+                      backgroundColor: 'color-mix(in srgb, var(--game-correct) 12%, var(--cream))',
+                      borderColor: 'color-mix(in srgb, var(--game-correct) 35%, var(--border-warm))',
+                      color: 'var(--game-correct)',
+                    }}
+                  >
+                    <span aria-hidden className="text-[15px] leading-none">✓</span>
+                    <span>{recheckMessage}</span>
+                  </div>
+                ) : (
+                  <p
+                    role="status"
+                    aria-live="polite"
+                    className="text-[11px]"
+                    style={{
+                      color: recheckState === 'error' ? 'var(--game-wrong-strong)' : 'var(--ink)',
+                      opacity: recheckState === 'error' ? 1 : 0.6,
+                    }}
+                  >
+                    {recheckMessage}
+                  </p>
+                )
+              ) : null}
             </div>
           ) : null}
 

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { renderToStaticMarkup } from 'react-dom/server'
 
 import {
+  AnswerFeedbackSheet,
   AnsweredByYouCard,
   DirectSentCard,
   DismissedFeedBar,
@@ -31,8 +32,10 @@ vi.mock('next/link', () => ({
 }))
 
 vi.mock('lucide-react', () => ({
+  Check: () => <span aria-hidden="true" />,
   Flag: () => <span aria-hidden="true" />,
   MoreHorizontal: () => <span aria-hidden="true">⋯</span>,
+  Sparkles: () => <span aria-hidden="true" />,
   X: () => <span aria-hidden="true" />,
 }))
 
@@ -331,6 +334,51 @@ describe('Feed answered states', () => {
     // Brand action-link treatment (matches "Answer →"): serif, slate, underlined — no offset-shadow box.
     expect(rendered).toContain('text-[var(--brand-link)]')
     expect(rendered).not.toContain('3px 3px 0 var(--ink)')
+  })
+})
+
+describe('Answer feedback sheet recheck affordance', () => {
+  const baseProps = {
+    question: "Who is Achilles' secret lover?",
+    isCorrect: false,
+    pointsAwarded: null,
+    correctAnswer: 'Patroclus',
+    submittedAnswer: 'Petroclus',
+    explanation: null,
+    creatorNote: null,
+    questionId: 'q1',
+    feedItemId: 'f1',
+    onClose: () => {},
+  }
+
+  it('offers a Recheck → link on a wrong answer when onRecheck is provided', () => {
+    const rendered = html(
+      <AnswerFeedbackSheet
+        {...baseProps}
+        onRecheck={async () => ({ accepted: false, message: '' })}
+      />
+    )
+    expect(rendered).toContain('Recheck →')
+    // Reuses the shared serif slate action link, not a hand-rolled button.
+    expect(rendered).toContain('text-[var(--brand-link)]')
+  })
+
+  it('hides the recheck link when no onRecheck handler is supplied', () => {
+    const rendered = html(<AnswerFeedbackSheet {...baseProps} />)
+    expect(rendered).not.toContain('Recheck →')
+  })
+
+  it('does not offer a recheck on a correct answer', () => {
+    const rendered = html(
+      <AnswerFeedbackSheet
+        {...baseProps}
+        isCorrect
+        pointsAwarded={3}
+        submittedAnswer="Patroclus"
+        onRecheck={async () => ({ accepted: false, message: '' })}
+      />
+    )
+    expect(rendered).not.toContain('Recheck →')
   })
 })
 


### PR DESCRIPTION
The "Recheck →" appeal already existed on the answered feed card
(AnsweredByYouCard) but not on the feedback modal that pops up right
after a wrong answer — where players most want to dispute a typo or a
synonym. Wire the same submitRecheck flow into AnswerFeedbackSheet via
a new optional onRecheck prop, reusing FeedActionLink and mirroring the
accepted/rejected/error states. When a recheck is accepted the sheet
flips to its correct state since it re-renders from the shared result.

https://claude.ai/code/session_0127GL58Usk5o4Wyt21NmdZz