### PR TITLE
Backfill inviter's recent answers at signup (B-HomeSeed-1 Part A)

### DIFF
--- a/src/server/feed/__tests__/backfill-inviter-feed.test.ts
+++ b/src/server/feed/__tests__/backfill-inviter-feed.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Chainable db mock: each db.select() resolves to the next queued row set (in
+// call order — 1st = inviter mastery rows, 2nd = existing feed rows), and
+// db.insert(...).values(rows) records the inserted rows.
+const { dbMock, state } = vi.hoisted(() => {
+  const state = {
+    selectResults: [] as unknown[][],
+    inserted: [] as Array<Record<string, unknown>>,
+  };
+
+  function makeChain(rows: unknown[]) {
+    const chain: Record<string, unknown> = {};
+    for (const method of ['from', 'innerJoin', 'leftJoin', 'where', 'orderBy', 'limit', 'groupBy']) {
+      chain[method] = vi.fn(() => chain);
+    }
+    chain.then = (resolve: (rows: unknown[]) => unknown) => resolve(rows);
+    return chain;
+  }
+
+  const dbMock = {
+    select: vi.fn(() => makeChain(state.selectResults.shift() ?? [])),
+    insert: vi.fn(() => ({
+      values: vi.fn(async (rows: Array<Record<string, unknown>>) => {
+        state.inserted.push(...rows);
+        return undefined;
+      }),
+    })),
+  };
+
+  return { dbMock, state };
+});
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  feedItems: {
+    recipientUserId: 'feedItems.recipientUserId',
+    questionId: 'feedItems.questionId',
+    sourceUserId: 'feedItems.sourceUserId',
+    sourceType: 'feedItems.sourceType',
+    sourceAnswerId: 'feedItems.sourceAnswerId',
+  },
+  masteryEvents: {
+    id: 'masteryEvents.id',
+    userId: 'masteryEvents.userId',
+    questionId: 'masteryEvents.questionId',
+    sourceType: 'masteryEvents.sourceType',
+    answerState: 'masteryEvents.answerState',
+    createdAt: 'masteryEvents.createdAt',
+  },
+  questions: {
+    id: 'questions.id',
+    visibility: 'questions.visibility',
+    deletedAt: 'questions.deletedAt',
+    creatorId: 'questions.creatorId',
+  },
+}));
+
+vi.mock('@/server/feed/visibility', () => ({ SOCIAL_FEED_SOURCE_TYPE: 'friend_answered' }));
+
+import {
+  backfillInviterFeedItems,
+  backfillSourceAnswerId,
+  dropAlreadyPresent,
+  INVITER_BACKFILL_MAX_ITEMS,
+  pickInviterBackfillAnswers,
+  toBackfillFeedItemRows,
+  type InviterAnswerRow,
+} from '@/server/feed/backfill-inviter-feed';
+
+const INVITER = 'inviter-1';
+const INVITEE = 'invitee-1';
+
+function answerRow(n: number, opts: { questionId?: string; at?: string } = {}): InviterAnswerRow {
+  return {
+    masteryEventId: `me-${n}`,
+    questionId: opts.questionId ?? `q-${n}`,
+    answeredAt: new Date(opts.at ?? `2026-06-0${(n % 9) + 1}T12:00:00.000Z`),
+  };
+}
+
+function masteryDbRows(rows: InviterAnswerRow[]) {
+  return rows.map((r) => ({
+    masteryEventId: r.masteryEventId,
+    questionId: r.questionId,
+    answeredAt: r.answeredAt,
+  }));
+}
+
+beforeEach(() => {
+  state.selectResults = [];
+  state.inserted = [];
+  dbMock.select.mockClear();
+  dbMock.insert.mockClear();
+});
+
+describe('pure decision helpers', () => {
+  it('dedupes by questionId keeping the first (most-recent) occurrence', () => {
+    const rows = [
+      answerRow(1, { questionId: 'q-a', at: '2026-06-08T12:00:00.000Z' }),
+      answerRow(2, { questionId: 'q-a', at: '2026-06-01T12:00:00.000Z' }),
+      answerRow(3, { questionId: 'q-b', at: '2026-06-07T12:00:00.000Z' }),
+    ];
+    const picked = pickInviterBackfillAnswers(rows);
+    expect(picked.map((p) => p.questionId)).toEqual(['q-a', 'q-b']);
+    expect(picked[0].masteryEventId).toBe('me-1'); // kept the most-recent answer
+  });
+
+  it('enforces the cap (8 most recent distinct questions)', () => {
+    const rows = Array.from({ length: 12 }, (_, i) => answerRow(i, { questionId: `q-${i}` }));
+    const picked = pickInviterBackfillAnswers(rows);
+    expect(INVITER_BACKFILL_MAX_ITEMS).toBe(8);
+    expect(picked).toHaveLength(8);
+    expect(picked.map((p) => p.questionId)).toEqual(rows.slice(0, 8).map((r) => r.questionId));
+  });
+
+  it('returns nothing for an empty input', () => {
+    expect(pickInviterBackfillAnswers([])).toEqual([]);
+  });
+
+  it('drops questions that already have a row (idempotent re-fire)', () => {
+    const picked = [answerRow(1, { questionId: 'q-a' }), answerRow(2, { questionId: 'q-b' })];
+    expect(dropAlreadyPresent(picked, ['q-a', 'q-b'])).toEqual([]);
+    expect(dropAlreadyPresent(picked, ['q-a']).map((p) => p.questionId)).toEqual(['q-b']);
+  });
+
+  it('builds feed rows with friend_answered shape, true answer time, and a deterministic id', () => {
+    const at = new Date('2026-06-05T09:30:00.000Z');
+    const rows = toBackfillFeedItemRows(INVITER, INVITEE, [
+      { masteryEventId: 'me-x', questionId: 'q-x', answeredAt: at },
+    ]);
+    expect(rows).toEqual([
+      {
+        recipientUserId: INVITEE,
+        questionId: 'q-x',
+        sourceType: 'friend_answered',
+        sourceUserId: INVITER,
+        sourceResult: 'correct',
+        sourceEventAt: at,
+        sourceAnswerId: backfillSourceAnswerId('me-x'),
+        state: 'active',
+        isPinned: false,
+      },
+    ]);
+    expect(rows[0].sourceAnswerId).toBe('inviter-backfill:me-x');
+  });
+});
+
+describe('backfillInviterFeedItems (hook)', () => {
+  it('creates feed items for the inviter, capped at 8, with truthful ordering', async () => {
+    const rows = Array.from({ length: 11 }, (_, i) =>
+      answerRow(i, { questionId: `q-${i}`, at: `2026-06-08T12:00:0${i}.000Z` }),
+    );
+    state.selectResults = [masteryDbRows(rows), /* existing */ []];
+
+    const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITEE });
+
+    expect(result).toEqual({ created: 8 });
+    expect(state.inserted).toHaveLength(8);
+    expect(state.inserted.every((r) => r.sourceType === 'friend_answered')).toBe(true);
+    expect(state.inserted.every((r) => r.sourceUserId === INVITER)).toBe(true);
+    expect(state.inserted.every((r) => r.recipientUserId === INVITEE)).toBe(true);
+    // sourceEventAt preserves the inviter's original answer time (not now).
+    expect(state.inserted[0].sourceEventAt).toEqual(rows[0].answeredAt);
+  });
+
+  it('creates nothing when the inviter has no qualifying answers', async () => {
+    state.selectResults = [[]]; // no mastery rows; existing select never runs
+
+    const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITEE });
+
+    expect(result).toEqual({ created: 0 });
+    expect(dbMock.insert).not.toHaveBeenCalled();
+    expect(state.inserted).toHaveLength(0);
+  });
+
+  it('is idempotent on re-fire — inserts no duplicates when rows already exist', async () => {
+    const rows = [answerRow(1, { questionId: 'q-a' }), answerRow(2, { questionId: 'q-b' })];
+    // 2nd select reports both questions already have a friend_answered row.
+    state.selectResults = [masteryDbRows(rows), [{ questionId: 'q-a' }, { questionId: 'q-b' }]];
+
+    const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITEE });
+
+    expect(result).toEqual({ created: 0 });
+    expect(dbMock.insert).not.toHaveBeenCalled();
+  });
+
+  it('only inserts the not-yet-backfilled subset', async () => {
+    const rows = [answerRow(1, { questionId: 'q-a' }), answerRow(2, { questionId: 'q-b' })];
+    state.selectResults = [masteryDbRows(rows), [{ questionId: 'q-a' }]];
+
+    const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITEE });
+
+    expect(result).toEqual({ created: 1 });
+    expect(state.inserted.map((r) => r.questionId)).toEqual(['q-b']);
+  });
+
+  it('no-ops when inviter and invitee are the same user', async () => {
+    const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITER });
+    expect(result).toEqual({ created: 0 });
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/feed/backfill-inviter-feed.ts
+++ b/src/server/feed/backfill-inviter-feed.ts
@@ -1,0 +1,212 @@
+/**
+ * One-time inviter feed backfill (B-HomeSeed-1, Part A).
+ *
+ * When the auto-friendship between an inviter and a brand-new user is formed at
+ * signup completion (acceptFriendInvitation / acceptUserInviteLink, both via
+ * upsertInvitationFriendship), seed the new user with the inviter's most recent
+ * correctly-answered daily questions as real `friend_answered` feed items.
+ *
+ * Why this is honest under the current model: forward propagation only fires for
+ * answers the inviter gives AFTER the follow edge exists. These rows reconstruct
+ * exactly what WOULD have propagated had the two been friends when the inviter
+ * answered — same source_type, same attribution, same true answer time. The D-1
+ * "feed flip" means `friend_answered` rows no longer render as feed cards; they
+ * are now the source signal for Lately milestones (getLatelyMilestones), so a
+ * backfilled inviter surfaces in the unified "What's Happening" home feed as a
+ * milestone line that expands to their literal answerable questions.
+ *
+ * NOT a reuse of createFeedItemsForFriendsFromAnswer: that helper fans out to ALL
+ * of the answerer's followers and stamps sourceEventAt = now. Here we target the
+ * one invitee and preserve the inviter's ORIGINAL answer time so Lately ordering
+ * stays truthful. The row SHAPE (columns + source_type constant) is shared.
+ *
+ * The pure decision functions (pick / dedupe / build) are split from the DB I/O
+ * so the cap, the empty case, and idempotency are unit-testable without a DB —
+ * mirroring the deriveLatelyMilestones / getLatelyMilestones split.
+ */
+
+import { and, desc, eq, inArray, isNull, ne, or } from 'drizzle-orm';
+
+import { db, feedItems, masteryEvents, questions } from '@/server/db';
+import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+
+// The inviter's daily/catchup CORRECT answers are the seed. Both surfaces
+// originate from the Daily Five queue (live = answered in the round, catchup =
+// a previously-missed daily answered later), matching the LIVE_SOURCE_TYPES the
+// Lately surfaces already key on.
+const DAILY_SURFACE_SOURCE_TYPES = ['live_correct', 'catchup_correct'] as const;
+const CORRECT_ANSWER_STATES = [
+  'first_correct',
+  'first_correct_after_wrong',
+  'repeat_correct',
+] as const;
+
+// Most recent N of the inviter's correct daily answers, regardless of date.
+export const INVITER_BACKFILL_MAX_ITEMS = 8;
+
+// Over-read the inviter's mastery rows before per-question dedupe so a few
+// repeat-correct rows can't starve us below the cap.
+const MASTERY_SCAN_LIMIT = 200;
+
+export type InviterAnswerRow = {
+  masteryEventId: string;
+  questionId: string;
+  answeredAt: Date;
+};
+
+export type BackfillFeedItemRow = {
+  recipientUserId: string;
+  questionId: string;
+  sourceType: typeof SOCIAL_FEED_SOURCE_TYPE;
+  sourceUserId: string;
+  sourceResult: 'correct';
+  sourceEventAt: Date;
+  sourceAnswerId: string;
+  state: 'active';
+  isPinned: false;
+};
+
+// Deterministic so a re-fire produces the SAME sourceAnswerId, colliding on the
+// partial unique index FeedItem_recipientUserId_sourceAnswerId_key. Prefixed so
+// it can never collide with a real answer id used by forward propagation.
+export function backfillSourceAnswerId(masteryEventId: string): string {
+  return `inviter-backfill:${masteryEventId}`;
+}
+
+// Dedupe by questionId (rows arrive newest-first, so the first occurrence is the
+// most recent answer of that question), then keep the most recent `limit`
+// distinct questions. Pure.
+export function pickInviterBackfillAnswers(
+  rows: InviterAnswerRow[],
+  limit = INVITER_BACKFILL_MAX_ITEMS,
+): InviterAnswerRow[] {
+  const seen = new Set<string>();
+  const picked: InviterAnswerRow[] = [];
+  for (const row of rows) {
+    if (!row.questionId || !row.answeredAt) continue;
+    if (seen.has(row.questionId)) continue;
+    seen.add(row.questionId);
+    picked.push(row);
+    if (picked.length >= limit) break;
+  }
+  return picked;
+}
+
+// Drop questions that already have a friend_answered row from this inviter for
+// this invitee, so a re-fire (or a race with forward propagation) is a no-op.
+// Pure.
+export function dropAlreadyPresent(
+  picked: InviterAnswerRow[],
+  existingQuestionIds: Iterable<string>,
+): InviterAnswerRow[] {
+  const existing = new Set(existingQuestionIds);
+  return picked.filter((row) => !existing.has(row.questionId));
+}
+
+// Build the feed-item insert rows. Same source_type + shape as the organic
+// friend_answered path; sourceEventAt is the inviter's TRUE answer time. Pure.
+export function toBackfillFeedItemRows(
+  inviterUserId: string,
+  inviteeUserId: string,
+  picked: InviterAnswerRow[],
+): BackfillFeedItemRow[] {
+  return picked.map((row) => ({
+    recipientUserId: inviteeUserId,
+    questionId: row.questionId,
+    sourceType: SOCIAL_FEED_SOURCE_TYPE,
+    sourceUserId: inviterUserId,
+    sourceResult: 'correct',
+    sourceEventAt: row.answeredAt,
+    sourceAnswerId: backfillSourceAnswerId(row.masteryEventId),
+    state: 'active',
+    isPinned: false,
+  }));
+}
+
+/**
+ * Inviter-only, one-time backfill. Best-effort: any failure is swallowed so a
+ * backfill hiccup can never break invitation acceptance / signup. Returns the
+ * number of feed items created (0 when the inviter has no qualifying answers, or
+ * when everything was already backfilled).
+ */
+export async function backfillInviterFeedItems({
+  inviterUserId,
+  inviteeUserId,
+  limit = INVITER_BACKFILL_MAX_ITEMS,
+}: {
+  inviterUserId: string;
+  inviteeUserId: string;
+  limit?: number;
+}): Promise<{ created: number }> {
+  try {
+    if (!inviterUserId || !inviteeUserId || inviterUserId === inviteeUserId) {
+      return { created: 0 };
+    }
+
+    // The inviter's correct daily/catchup answers, newest first, joined to a
+    // feed-eligible question (public, not deleted, not authored by the invitee —
+    // the milestone surface 403s "answer your own question", so don't seed it).
+    const rows = await db
+      .select({
+        masteryEventId: masteryEvents.id,
+        questionId: masteryEvents.questionId,
+        answeredAt: masteryEvents.createdAt,
+      })
+      .from(masteryEvents)
+      .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+      .where(
+        and(
+          eq(masteryEvents.userId, inviterUserId),
+          inArray(masteryEvents.sourceType, DAILY_SURFACE_SOURCE_TYPES),
+          inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
+          eq(questions.visibility, 'public'),
+          isNull(questions.deletedAt),
+          or(isNull(questions.creatorId), ne(questions.creatorId, inviteeUserId)),
+        ),
+      )
+      .orderBy(desc(masteryEvents.createdAt))
+      .limit(MASTERY_SCAN_LIMIT);
+
+    const answerRows: InviterAnswerRow[] = [];
+    for (const row of rows) {
+      if (!row.questionId || !row.answeredAt) continue;
+      answerRows.push({
+        masteryEventId: row.masteryEventId,
+        questionId: row.questionId,
+        answeredAt: row.answeredAt,
+      });
+    }
+
+    const candidates = pickInviterBackfillAnswers(answerRows, limit);
+    if (candidates.length === 0) return { created: 0 };
+
+    const candidateQuestionIds = candidates.map((c) => c.questionId);
+    const existing = await db
+      .select({ questionId: feedItems.questionId })
+      .from(feedItems)
+      .where(
+        and(
+          eq(feedItems.recipientUserId, inviteeUserId),
+          eq(feedItems.sourceUserId, inviterUserId),
+          inArray(feedItems.questionId, candidateQuestionIds),
+        ),
+      );
+
+    const toInsert = dropAlreadyPresent(
+      candidates,
+      existing.map((e) => e.questionId).filter((id): id is string => Boolean(id)),
+    );
+    if (toInsert.length === 0) return { created: 0 };
+
+    await db.insert(feedItems).values(toBackfillFeedItemRows(inviterUserId, inviteeUserId, toInsert));
+
+    return { created: toInsert.length };
+  } catch (error) {
+    console.error('[backfillInviterFeedItems] suppressed error:', {
+      inviterUserId,
+      inviteeUserId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return { created: 0 };
+  }
+}

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -159,6 +159,13 @@ vi.mock('@/server/db', () => ({
   },
 }))
 
+// The one-time inviter feed backfill (B-HomeSeed-1) fires inside
+// acceptFriendInvitation; it has its own dedicated test, so stub it here to keep
+// these tests focused on the acceptance logic.
+vi.mock('@/server/feed/backfill-inviter-feed', () => ({
+  backfillInviterFeedItems: vi.fn(async () => ({ created: 0 })),
+}))
+
 import {
   acceptFriendInvitation,
   cancelFriendInvitation,

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -4,6 +4,7 @@ import { and, desc, eq, gt, isNotNull, isNull, or } from 'drizzle-orm'
 
 import { maskPhoneE164 } from '@/lib/phone-e164'
 import { db, friendInvitations, users } from '@/server/db'
+import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 import { hashTelemetryValue, logTelemetry } from '@/server/telemetry'
 
@@ -585,6 +586,15 @@ export async function acceptFriendInvitation({
     inviter_user_id: invitation.inviterUserId,
     invitee_user_id: inviteeUserId,
     suggested_interest_count: parseInvitationInterests(invitation.preSeededInterests).length,
+  })
+
+  // One-time inviter feed backfill (B-HomeSeed-1). Runs AFTER the acceptance tx
+  // commits and only on a successful claim, so it fires exactly once per
+  // invitation and never on subsequent logins. Best-effort internally — it
+  // cannot throw, so it can't affect the accepted result.
+  await backfillInviterFeedItems({
+    inviterUserId: invitation.inviterUserId,
+    inviteeUserId,
   })
 
   return { accepted: true }

--- a/src/server/friends/user-invite-token.ts
+++ b/src/server/friends/user-invite-token.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'node:crypto'
 import { and, eq, sql } from 'drizzle-orm'
 
 import { db, follows, users } from '@/server/db'
+import { backfillInviterFeedItems } from '@/server/feed/backfill-inviter-feed'
 import { upsertInvitationFriendship } from '@/server/friends/friendships'
 
 // Match the prior-art token primitive used for FriendInvitation tokens at
@@ -165,6 +166,12 @@ export async function acceptUserInviteLink({
       inviterUserId: inviter.inviterUserId,
       inviteeUserId,
       formedAt: now,
+    })
+    // One-time inviter feed backfill (B-HomeSeed-1). Best-effort internally so
+    // it can't throw — a backfill hiccup must never fail the link acceptance.
+    await backfillInviterFeedItems({
+      inviterUserId: inviter.inviterUserId,
+      inviteeUserId,
     })
     return { accepted: true }
   } catch {


### PR DESCRIPTION
When the auto-friendship between an inviter and a brand-new user is formed
at signup completion, seed the new user with the inviter's most recent
correctly-answered daily questions as real `friend_answered` feed items.

Under the current "What's Happening" home model, `friend_answered` rows no
longer render as standalone feed cards (D-1 feed flip) but are the source
signal for Lately milestones (getLatelyMilestones). Backfilling them surfaces
the inviter in the new user's unified home feed as a milestone line that
expands to their literal answerable questions — honest attribution, real
questions, true answer time, no curation/authoring path.

- New src/server/feed/backfill-inviter-feed.ts: 8 most recent distinct correct
  daily/catchup answers, joined to feed-eligible (public, non-deleted,
  not-invitee-authored) questions, written with the same source_type and shape
  as organic friend_answered propagation but targeted at the one invitee and
  preserving the inviter's original answer time.
- Hooked into both inviter paths: acceptFriendInvitation (FriendInvitation)
  and acceptUserInviteLink (per-user link), firing once on successful
  acceptance, after the friendship commits. Best-effort — it cannot throw, so
  it never affects signup.
- Idempotent: pre-checks existing friend_answered rows for this
  (invitee, inviter, question) and skips them; deterministic sourceAnswerId
  backs the existing partial unique index as a DB-level backstop. No migration.
- Pure decision helpers (pick/cap, dedupe, row-build) split from DB I/O,
  mirroring deriveLatelyMilestones/getLatelyMilestones, with hook-level tests
  covering cap enforcement, zero-qualifying-answers, and idempotent re-fire.

Part B (day-one "From your friends" header) intentionally not built: that
section and its tabs were removed in the "What's Happening" redesign.

https://claude.ai/code/session_0168LiTSKV2vzmBYC15kdjJe