### PR TITLE
fix(security): fail closed in cron/admin auth when CRON_SECRET is unset

### DIFF
--- a/src/app/api/admin/backfill-domains/route.ts
+++ b/src/app/api/admin/backfill-domains/route.ts
@@ -3,18 +3,9 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { db, users } from '@/server/db';
 import { runAggressiveDomainBackfillForUser } from '@/server/mastery/ceremony';
+import { isCronAuthorized } from '@/server/auth/cron';
 
 export const dynamic = 'force-dynamic';
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
-  if (!secret) return true;
-  return (
-    request.headers.get('cron_secret') === secret ||
-    request.headers.get('x-cron-secret') === secret ||
-    request.headers.get('authorization') === `Bearer ${secret}`
-  );
-}
 
 type PerUserResult = {
   userId: string;
@@ -24,7 +15,7 @@ type PerUserResult = {
 };
 
 export async function POST(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -6,6 +6,7 @@ import { db, users } from '@/server/db';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { type QueueSlot } from '@/server/daily/types';
 import { runWithConcurrency } from '@/server/lib/concurrency';
+import { isCronAuthorized } from '@/server/auth/cron';
 import { sendSms } from '@/server/sms';
 
 export const dynamic = 'force-dynamic';
@@ -37,15 +38,8 @@ function getBaseUrl(request: NextRequest): string {
   return host ? `${protocol}://${host}` : 'http://localhost:3000';
 }
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
-  if (!secret) return true;
-  const authHeader = request.headers.get('authorization');
-  return authHeader === `Bearer ${secret}`;
-}
-
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/expire-friend-requests/route.ts
+++ b/src/app/api/cron/expire-friend-requests/route.ts
@@ -2,15 +2,9 @@ import { NextRequest, NextResponse } from 'next/server'
 import { sql } from 'drizzle-orm'
 
 import { db } from '@/server/db'
+import { isCronAuthorized } from '@/server/auth/cron'
 
 export const dynamic = 'force-dynamic'
-
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET
-  if (!secret) return true
-  const authHeader = request.headers.get('authorization')
-  return authHeader === `Bearer ${secret}`
-}
 
 // Two-step cleanup on the Friendship table:
 //   1. Expire stale pending requests whose expiresAt has passed.
@@ -19,7 +13,7 @@ function isAuthorized(request: NextRequest): boolean {
 // Both operations are idempotent; running twice in a single window is harmless.
 // No ActivityItems are written — expiration and GC are passive.
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
   }
 

--- a/src/app/api/cron/pool-refill/route.ts
+++ b/src/app/api/cron/pool-refill/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { runPoolRefill } from '@/server/daily/retrieval-grounded';
+import { isCronAuthorized } from '@/server/auth/cron';
 
 export const dynamic = 'force-dynamic';
 // B3 retrieval-grounded pool refill (PRD-D-5 §5.3). Heavy, off the user's
@@ -11,15 +12,8 @@ export const dynamic = 'force-dynamic';
 // retrieval calls.
 export const maxDuration = 300;
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
-  if (!secret) return true;
-  const authHeader = request.headers.get('authorization');
-  return authHeader === `Bearer ${secret}`;
-}
-
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/vet-questions/route.ts
+++ b/src/app/api/cron/vet-questions/route.ts
@@ -5,6 +5,7 @@ import { db, questions } from '@/server/db';
 import { runWithConcurrency } from '@/server/lib/concurrency';
 import { verdictToPublicStatus, vetQuestion } from '@/server/llm/vet-question';
 import { verdictToBlockedVisibility } from '@/server/llm/vet-verdict';
+import { isCronAuthorized } from '@/server/auth/cron';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 300;
@@ -15,13 +16,6 @@ const BATCH_SIZE = 25;
 // become binding before DB does.
 const VET_CONCURRENCY = 4;
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
-  if (!secret) return true;
-  const authHeader = request.headers.get('authorization');
-  return authHeader === `Bearer ${secret}`;
-}
-
 /**
  * Sweeps `Question` rows that are still at `publicStatus = 'not_scored'`
  * (the default) and re-runs the Haiku vetter. The submit route also vets
@@ -29,7 +23,7 @@ function isAuthorized(request: NextRequest): boolean {
  * error or returned `factual: 'unknown'`.
  */
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/app/api/cron/weekly-ceremony/__tests__/route.test.ts
+++ b/src/app/api/cron/weekly-ceremony/__tests__/route.test.ts
@@ -47,8 +47,13 @@ const SUNDAY = new Date('2026-06-07T08:00:00.000Z')
 // Account old enough to clear MIN_ACCOUNT_AGE_DAYS.
 const OLD_ACCOUNT = new Date('2026-01-01T00:00:00.000Z')
 
+const CRON_SECRET = 'test-cron-secret'
+
 function buildRequest() {
-  return new Request('https://joshing.example/api/cron/weekly-ceremony', { method: 'GET' })
+  return new Request('https://joshing.example/api/cron/weekly-ceremony', {
+    method: 'GET',
+    headers: { authorization: `Bearer ${CRON_SECRET}` },
+  })
 }
 
 describe('GET /api/cron/weekly-ceremony — per-user resilience', () => {
@@ -56,12 +61,14 @@ describe('GET /api/cron/weekly-ceremony — per-user resilience', () => {
     vi.clearAllMocks()
     vi.useFakeTimers()
     vi.setSystemTime(SUNDAY)
+    process.env.CRON_SECRET = CRON_SECRET
     recentCeremonyMock.mockResolvedValue([])
     fireCeremonyMock.mockResolvedValue('cer-1')
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    delete process.env.CRON_SECRET
   })
 
   it('does not 500 when one user fails — it skips them and fires the rest', async () => {

--- a/src/app/api/cron/weekly-ceremony/route.ts
+++ b/src/app/api/cron/weekly-ceremony/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 
 import { fireCeremony } from '@/server/ceremony/fire-ceremony';
 import { biweeklyCeremonies, db, users } from '@/server/db';
+import { isCronAuthorized } from '@/server/auth/cron';
 
 export const dynamic = 'force-dynamic';
 
@@ -14,14 +15,6 @@ const CEREMONY_WEEKDAY_UTC = 0; // 0 = Sunday
 const MIN_ACCOUNT_AGE_DAYS = 3; // brand-new accounts wait for their first real Sunday
 const RECENT_FIRE_LOOKBACK_DAYS = 6; // dedupe: a user can't fire twice within 6 days
 
-function isAuthorized(request: NextRequest): boolean {
-  const secret = process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET;
-  if (!secret) return true;
-  return request.headers.get('cron_secret') === secret
-    || request.headers.get('x-cron-secret') === secret
-    || request.headers.get('authorization') === `Bearer ${secret}`;
-}
-
 function daysSinceUtc(start: Date, end: Date): number {
   const startUtc = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), start.getUTCDate());
   const endUtc = Date.UTC(end.getUTCFullYear(), end.getUTCMonth(), end.getUTCDate());
@@ -29,7 +22,7 @@ function daysSinceUtc(start: Date, end: Date): number {
 }
 
 export async function GET(request: NextRequest) {
-  if (!isAuthorized(request)) {
+  if (!isCronAuthorized(request)) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
 

--- a/src/server/auth/__tests__/cron.test.ts
+++ b/src/server/auth/__tests__/cron.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+import { isCronAuthorized } from '@/server/auth/cron';
+
+function requestWithHeaders(headers: Record<string, string>): NextRequest {
+  return { headers: new Headers(headers) } as unknown as NextRequest;
+}
+
+describe('isCronAuthorized', () => {
+  const ORIGINAL_ENV = { ...process.env };
+
+  beforeEach(() => {
+    delete process.env.CRON_SECRET;
+    delete process.env.VERCEL_CRON_SECRET;
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    vi.restoreAllMocks();
+  });
+
+  it('fails CLOSED when no secret is configured (the bug fix)', () => {
+    // No CRON_SECRET / VERCEL_CRON_SECRET set. Previously this returned true,
+    // making the route publicly triggerable. It must now deny.
+    expect(isCronAuthorized(requestWithHeaders({}))).toBe(false);
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer anything' }))).toBe(false);
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('treats a whitespace-only secret as unset and fails closed', () => {
+    process.env.CRON_SECRET = '   ';
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer    ' }))).toBe(false);
+  });
+
+  it('accepts the matching Authorization: Bearer header', () => {
+    process.env.CRON_SECRET = 's3cr3t';
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer s3cr3t' }))).toBe(true);
+  });
+
+  it('accepts the cron_secret and x-cron-secret header forms', () => {
+    process.env.CRON_SECRET = 's3cr3t';
+    expect(isCronAuthorized(requestWithHeaders({ cron_secret: 's3cr3t' }))).toBe(true);
+    expect(isCronAuthorized(requestWithHeaders({ 'x-cron-secret': 's3cr3t' }))).toBe(true);
+  });
+
+  it('rejects a wrong or missing secret when one is configured', () => {
+    process.env.CRON_SECRET = 's3cr3t';
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer nope' }))).toBe(false);
+    expect(isCronAuthorized(requestWithHeaders({}))).toBe(false);
+  });
+
+  it('falls back to VERCEL_CRON_SECRET when CRON_SECRET is unset', () => {
+    process.env.VERCEL_CRON_SECRET = 'vercel-secret';
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer vercel-secret' }))).toBe(true);
+    expect(isCronAuthorized(requestWithHeaders({ authorization: 'Bearer nope' }))).toBe(false);
+  });
+});

--- a/src/server/auth/cron.ts
+++ b/src/server/auth/cron.ts
@@ -1,0 +1,37 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Shared authorization gate for cron- and admin-triggered routes
+ * (queue generation, ceremony firing, question vetting, backfills, …).
+ *
+ * SECURITY — fails CLOSED. Every caller previously inlined its own
+ * `isAuthorized()` that returned `true` when no secret was configured, so a
+ * single missing env var silently made these privileged, side-effecting
+ * endpoints publicly triggerable. This helper instead DENIES when the secret
+ * is absent. `CRON_SECRET` is a required boot env var (see `src/env-check.ts`),
+ * so a missing secret is a misconfiguration, not a valid "open" state.
+ *
+ * Accepted credential forms (any one matching the configured secret passes):
+ *   - `Authorization: Bearer <secret>`  (Vercel Cron + external-crons.yml)
+ *   - `cron_secret: <secret>`
+ *   - `x-cron-secret: <secret>`
+ */
+export function isCronAuthorized(request: NextRequest): boolean {
+  const secret = (process.env.CRON_SECRET ?? process.env.VERCEL_CRON_SECRET)?.trim();
+
+  if (!secret) {
+    // Fail closed: without a configured secret there is no way to authenticate
+    // the caller, so deny rather than wave everyone through.
+    console.error(
+      '[auth/cron] Denying request: neither CRON_SECRET nor VERCEL_CRON_SECRET is set. ' +
+        'Set CRON_SECRET so cron/admin routes can authenticate.',
+    );
+    return false;
+  }
+
+  return (
+    request.headers.get('authorization') === `Bearer ${secret}` ||
+    request.headers.get('cron_secret') === secret ||
+    request.headers.get('x-cron-secret') === secret
+  );
+}


### PR DESCRIPTION
isAuthorized() was duplicated across five cron routes and the admin
backfill route, and every copy returned true when neither CRON_SECRET
nor VERCEL_CRON_SECRET was set. A single missing env var therefore made
queue generation, ceremony firing, question vetting, friend-request
expiry, pool refill, and domain backfills publicly triggerable.

Replace the six inlined helpers with a single isCronAuthorized() in
src/server/auth/cron.ts that fails CLOSED: when no secret is configured
it logs an error and denies. CRON_SECRET is already a required boot env
var (src/env-check.ts), so a missing secret is a misconfiguration, not a
valid open state. The helper accepts the union of credential forms the
old copies used (Authorization: Bearer, cron_secret, x-cron-secret) so
no legitimate caller regresses.

Adds unit tests for the helper and updates the weekly-ceremony route
test to authenticate (it previously relied on the fail-open path).