### PR TITLE
Decouple optional enrichment from question save; render follow requests in Friends hub

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -130,6 +130,7 @@ vi.mock('@/server/knowledge/open-domain', () => ({
 
 vi.mock('@/server/questions/llm-difficulty', () => ({
   assessQuestionDifficulty: assessQuestionDifficultyMock,
+  fallbackQuestionDifficulty: () => ({ tier: 'solid', difficulty: 3 }),
 }))
 
 vi.mock('@/server/sms', () => ({
@@ -546,7 +547,7 @@ describe('POST /api/questions category leak handling', () => {
     expect(state.questionUpdateValues).toEqual([])
   })
 
-  it('returns 500 with a friendly message when an enrichment step throws', async () => {
+  it('still saves the question with a fallback difficulty when difficulty enrichment throws', async () => {
     categorizeQuestionMock.mockResolvedValue({
       broad_category: 'Arts & Literature',
       subcategory: 'Victorian Literature',
@@ -555,11 +556,28 @@ describe('POST /api/questions category leak handling', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
 
     const response = await POST(questionRequest({}))
-    const body = await response.json()
 
-    expect(response.status).toBe(500)
-    expect(body.error).toBe('server_error')
-    expect(body.message).toMatch(/something went wrong/i)
-    expect(createQuestionMock).not.toHaveBeenCalled()
+    // Enrichment is optional: an outage degrades the signal, it does not 500 the save.
+    expect(response.status).toBe(201)
+    expect(createQuestionMock).toHaveBeenCalledTimes(1)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { difficulty: number }
+    expect(createArgs.difficulty).toBe(3)
+  })
+
+  it('saves with needs_review status when the vet step throws, never auto-publishing', async () => {
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'Victorian Literature',
+    })
+    vetQuestionMock.mockRejectedValue(new Error('vet down'))
+    vi.spyOn(console, 'error').mockImplementation(() => undefined)
+
+    const response = await POST(questionRequest({}))
+
+    expect(response.status).toBe(201)
+    expect(createQuestionMock).toHaveBeenCalledTimes(1)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { publicStatus: string }
+    // verdictToPublicStatus maps needs_review → not_scored (never eligible/public).
+    expect(createArgs.publicStatus).toBe('not_scored')
   })
 })

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -25,7 +25,7 @@ import { sendSms } from '@/server/sms';
 import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 import { textContainsAnswer } from '@/server/questions/self-answering';
-import { assessQuestionDifficulty } from '@/server/questions/llm-difficulty';
+import { assessQuestionDifficulty, fallbackQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export const dynamic = 'force-dynamic';
@@ -151,44 +151,68 @@ export async function POST(request: NextRequest) {
   // inputs (question + answer + category) and don't depend on each other's
   // output — run them in parallel so the route's wall-clock is ~1× a single
   // LLM call instead of 3×. Categorization upstream is the only true
-  // sequencing dependency in this handler. Haiku-vet failure is meant to be
-  // non-fatal (the /api/cron/vet-questions sweep retries), but bundling it
-  // here is fine because Promise.all rejects fast and we treat the trio as
-  // a single enrichment stage.
-  try {
-    [difficultyAssessment, insideJoke, verdict] = await Promise.all([
-      assessQuestionDifficulty({
-        questionText: questionFields.text,
-        correctAnswer: questionFields.correctAnswer,
-        broadCategory: questionFields.broadCategory,
-        canonicalSubcategory: questionFields.canonicalSubcategory,
-        explanation: questionFields.explanation,
-      }),
-      generateInsideJoke({
-        questionText: questionFields.text,
-        correctAnswer: questionFields.correctAnswer,
-        broadCategory: questionFields.broadCategory,
-        canonicalSubcategory: questionFields.canonicalSubcategory,
-      }),
-      vetQuestion({
-        questionText: questionFields.text,
-        answer: questionFields.correctAnswer,
-        alternateAnswers: questionFields.alternateAnswers,
-        explanation: questionFields.explanation ?? null,
-        broadCategory: questionFields.broadCategory,
-        canonicalSubcategory: questionFields.canonicalSubcategory,
-      }),
-    ]);
-  } catch (error) {
-    console.error('[questions/create] unexpected_failure', {
-      stage: 'enrichment',
+  // sequencing dependency in this handler.
+  //
+  // Each of these is *optional* enrichment with its own degraded fallback
+  // (difficulty → fallbackQuestionDifficulty(); inside joke → null; vet →
+  // needs_review, which the /api/cron/vet-questions sweep retries). We use
+  // allSettled rather than Promise.all so a single enrichment outage degrades
+  // that one signal instead of rejecting the whole batch and 500ing the save.
+  // The structural guarantee lives here, not in each helper's internal
+  // try/catch discipline.
+  const [difficultyResult, insideJokeResult, verdictResult] = await Promise.allSettled([
+    assessQuestionDifficulty({
+      questionText: questionFields.text,
+      correctAnswer: questionFields.correctAnswer,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+      explanation: questionFields.explanation,
+    }),
+    generateInsideJoke({
+      questionText: questionFields.text,
+      correctAnswer: questionFields.correctAnswer,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+    }),
+    vetQuestion({
+      questionText: questionFields.text,
+      answer: questionFields.correctAnswer,
+      alternateAnswers: questionFields.alternateAnswers,
+      explanation: questionFields.explanation ?? null,
+      broadCategory: questionFields.broadCategory,
+      canonicalSubcategory: questionFields.canonicalSubcategory,
+    }),
+  ]);
+
+  const logEnrichmentFailure = (stage: string, reason: unknown) => {
+    console.error('[questions/create] enrichment_degraded', {
+      stage,
       userId: session.userId,
-      message: error instanceof Error ? error.message : String(error),
+      message: reason instanceof Error ? reason.message : String(reason),
     });
-    return NextResponse.json(
-      { error: 'server_error', message: 'Something went wrong saving that question. Try again.' },
-      { status: 500 },
-    );
+  };
+
+  if (difficultyResult.status === 'fulfilled') {
+    difficultyAssessment = difficultyResult.value;
+  } else {
+    logEnrichmentFailure('difficulty', difficultyResult.reason);
+    difficultyAssessment = fallbackQuestionDifficulty();
+  }
+
+  if (insideJokeResult.status === 'fulfilled') {
+    insideJoke = insideJokeResult.value;
+  } else {
+    logEnrichmentFailure('inside_joke', insideJokeResult.reason);
+    insideJoke = null;
+  }
+
+  if (verdictResult.status === 'fulfilled') {
+    verdict = verdictResult.value;
+  } else {
+    // Failed vet falls back to needs_review (never auto-publishes) — the cron
+    // sweep re-vets these. This mirrors vetQuestion's own internal llm_error path.
+    logEnrichmentFailure('vet', verdictResult.reason);
+    verdict = { status: 'needs_review' as const, score: null, reason: 'llm_error' };
   }
   let publicScoring = verdictToPublicStatus(verdict);
   // Safety-fail verdicts are hard-blocked from every surface: we override the

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -187,9 +187,124 @@ function PendingInviteCard({
   );
 }
 
+function requestTiming(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return 'Recently';
+  return formatRelativeTime(value);
+}
+
+function IncomingRequestCard({
+  request,
+  pendingRequestId,
+  onApprove,
+  onIgnore,
+}: {
+  request: IncomingRequest;
+  pendingRequestId: string | null;
+  onApprove: (request: IncomingRequest) => void;
+  onIgnore: (request: IncomingRequest) => void;
+}) {
+  const busy = pendingRequestId === request.id;
+
+  return (
+    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-foreground font-medium">{request.requesterName}</h3>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Wants to follow you · {requestTiming(request.createdAt)}
+          </p>
+        </div>
+      </div>
+
+      {request.personalNote ? (
+        <p className="text-muted-foreground mt-3 text-sm leading-6">“{request.personalNote}”</p>
+      ) : null}
+
+      {request.suggestedInterests.length > 0 ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          {request.suggestedInterests.map((interest) => (
+            <span
+              key={interest}
+              className="border-primary/10 bg-primary/5 text-foreground rounded-full border px-3 py-1 text-sm"
+            >
+              {interest}
+            </span>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="mt-4 flex items-center gap-3">
+        <button
+          type="button"
+          className="btn-primary flex min-h-11 flex-1 items-center justify-center rounded-full"
+          onClick={() => onApprove(request)}
+          disabled={busy}
+        >
+          {busy ? 'Working…' : 'Approve'}
+        </button>
+        <button
+          type="button"
+          className="text-muted-foreground min-h-11 px-4 text-sm"
+          onClick={() => onIgnore(request)}
+          disabled={busy}
+        >
+          Ignore
+        </button>
+      </div>
+    </article>
+  );
+}
+
+function OutboundRequestCard({
+  request,
+  pendingRequestId,
+  onCancel,
+}: {
+  request: OutboundRequest;
+  pendingRequestId: string | null;
+  onCancel: (request: OutboundRequest) => void;
+}) {
+  const busy = pendingRequestId === request.id;
+
+  return (
+    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <h3 className="text-foreground font-medium">{request.recipientName}</h3>
+          <p className="text-muted-foreground mt-1 text-sm">
+            Request sent · {requestTiming(request.createdAt)}
+          </p>
+        </div>
+        <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
+          Waiting
+        </span>
+      </div>
+
+      {request.personalNote ? (
+        <p className="text-muted-foreground mt-3 text-sm leading-6">“{request.personalNote}”</p>
+      ) : null}
+
+      <div className="mt-4 flex justify-center">
+        <button
+          type="button"
+          className="text-muted-foreground text-sm"
+          onClick={() => onCancel(request)}
+          disabled={busy}
+        >
+          {busy ? 'Cancelling…' : 'Cancel request'}
+        </button>
+      </div>
+    </article>
+  );
+}
+
 export default function FriendsList() {
   const [following, setFollowing] = useState<Person[]>([]);
   const [followers, setFollowers] = useState<Person[]>([]);
+  const [incomingRequests, setIncomingRequests] = useState<IncomingRequest[]>([]);
+  const [outboundRequests, setOutboundRequests] = useState<OutboundRequest[]>([]);
+  const [pendingRequestId, setPendingRequestId] = useState<string | null>(null);
   const [invites, setInvites] = useState<OutgoingInvite[]>([]);
   const [friendsLoading, setFriendsLoading] = useState(true);
   const [invitesLoading, setInvitesLoading] = useState(true);
@@ -218,12 +333,40 @@ export default function FriendsList() {
 
       setFollowing(body.following);
       setFollowers(body.followers);
+      setIncomingRequests(body.incomingRequests);
+      setOutboundRequests(body.outboundRequests);
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load friends.');
     } finally {
       setFriendsLoading(false);
     }
   }, []);
+
+  const actOnRequest = useCallback(
+    async (friendshipId: string, action: 'accept' | 'ignore' | 'cancel', failureMessage: string) => {
+      setPendingRequestId(friendshipId);
+      setError(null);
+
+      try {
+        const response = await fetch(`/api/friend-requests/${friendshipId}/${action}`, {
+          method: 'POST',
+          credentials: 'include',
+        });
+        const body = (await response.json().catch(() => null)) as { message?: string } | null;
+
+        if (!response.ok) {
+          throw new Error(body?.message ?? failureMessage);
+        }
+
+        await loadFriends();
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : failureMessage);
+      } finally {
+        setPendingRequestId(null);
+      }
+    },
+    [loadFriends],
+  );
 
   const loadInvites = useCallback(async () => {
     setError(null);
@@ -322,6 +465,18 @@ export default function FriendsList() {
     }
   }
 
+  function approveRequest(request: IncomingRequest) {
+    void actOnRequest(request.id, 'accept', 'Could not approve this request.');
+  }
+
+  function ignoreRequest(request: IncomingRequest) {
+    void actOnRequest(request.id, 'ignore', 'Could not ignore this request.');
+  }
+
+  function cancelRequest(request: OutboundRequest) {
+    void actOnRequest(request.id, 'cancel', 'Could not cancel this request.');
+  }
+
   const loading = friendsLoading || invitesLoading;
 
   return (
@@ -330,7 +485,29 @@ export default function FriendsList() {
 
       {loading ? <p className="text-muted-foreground text-sm">Loading friends…</p> : null}
 
-      {!loading && pendingInvites.length > 0 ? (
+      {!loading && incomingRequests.length > 0 ? (
+        <section aria-labelledby="follow-requests" className="space-y-3">
+          <h2
+            id="follow-requests"
+            className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase"
+          >
+            Follow Requests
+          </h2>
+          <div className="space-y-3">
+            {incomingRequests.map((request) => (
+              <IncomingRequestCard
+                key={request.id}
+                request={request}
+                pendingRequestId={pendingRequestId}
+                onApprove={approveRequest}
+                onIgnore={ignoreRequest}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {!loading && (pendingInvites.length > 0 || outboundRequests.length > 0) ? (
         <section aria-labelledby="waiting-for-response" className="space-y-3">
           <h2
             id="waiting-for-response"
@@ -347,6 +524,14 @@ export default function FriendsList() {
                 cancellingId={cancellingId}
                 onCopy={copyInvite}
                 onCancel={cancelInvite}
+              />
+            ))}
+            {outboundRequests.map((request) => (
+              <OutboundRequestCard
+                key={request.id}
+                request={request}
+                pendingRequestId={pendingRequestId}
+                onCancel={cancelRequest}
               />
             ))}
           </div>


### PR DESCRIPTION
Question creation bundled difficulty assessment, inside-joke generation, and
Haiku vetting into a single Promise.all, so any one enrichment outage rejected
the batch and 500'd the whole save — even though each step is individually
optional with its own degraded fallback. Switch to Promise.allSettled and
resolve each step independently: difficulty falls back to
fallbackQuestionDifficulty(), inside joke to null, and a failed vet to
needs_review (never auto-publishes; the cron sweep re-vets). Failures are logged
per-stage so outages stay observable. The save now proceeds with degraded
enrichment instead of failing.

The Friends hub fetched incomingRequests/outboundRequests from /api/friends but
dropped them on the floor — they were never stored in state or rendered. Wire
them up: a "Follow Requests" section with Approve/Ignore for incoming requests,
and outbound pending requests in the "Waiting for Response" section with Cancel.
Actions POST to the existing /api/friend-requests/[friendshipId]/{accept,ignore,
cancel} endpoints and refresh the hub.

https://claude.ai/code/session_013sQxxDF8pdHypnu5WnCTpa