### PR TITLE
feat(daily): one-time first-session recap after first completed Daily Five

### DIFF
--- a/drizzle/0072_first_session_recap_seen.sql
+++ b/drizzle/0072_first_session_recap_seen.sql
@@ -1,0 +1,13 @@
+-- B-FirstRecap-1 — First-Session Recap "seen" signal.
+--
+-- The one-time cinematic recap (recap.type = 'first_session') fires after the
+-- user's first ever completed Daily Five. This nullable timestamp records when
+-- it was shown so re-entering the app, refreshing, or replaying catch-up never
+-- re-trigger it. NULL = not yet seen; a non-NULL value permanently suppresses it.
+--
+-- Additive nullable column with no default — the safe case. Mirrored by a
+-- defensive guard in src/instrumentation.ts so a preview/production database
+-- that records this migration without the column present still boots.
+--
+-- Rollback: ALTER TABLE "User" DROP COLUMN IF EXISTS "first_session_recap_seen_at";
+ALTER TABLE "User" ADD COLUMN IF NOT EXISTS "first_session_recap_seen_at" timestamp with time zone;

--- a/src/app/api/daily/first-session-recap/route.ts
+++ b/src/app/api/daily/first-session-recap/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getFirstSessionRecap } from '@/server/daily/get-first-session-recap';
+
+export const dynamic = 'force-dynamic';
+
+// B-FirstRecap-1: returns the one-time first-session recap after the user's
+// first completed Daily Five, or { recap: null } when it must not fire.
+export async function GET() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const recap = await getFirstSessionRecap(session.userId);
+  return NextResponse.json({ recap });
+}

--- a/src/app/api/daily/first-session-recap/seen/route.ts
+++ b/src/app/api/daily/first-session-recap/seen/route.ts
@@ -1,0 +1,18 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { markFirstSessionRecapSeen } from '@/server/daily/get-first-session-recap';
+
+export const dynamic = 'force-dynamic';
+
+// B-FirstRecap-1: persist the seen-signal so the recap never fires again. Called
+// when the recap is first shown; idempotent on the server.
+export async function POST() {
+  const session = await getSession();
+  if (!session) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  await markFirstSessionRecapSeen(session.userId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/app/daily/summary/FirstSessionRecap.tsx
+++ b/src/app/daily/summary/FirstSessionRecap.tsx
@@ -1,0 +1,300 @@
+'use client';
+
+/**
+ * First-Session Recap (B-FirstRecap-1) — cinematic overlay.
+ *
+ * Reuses the biweekly ceremony's cinematic SHELL register (full-screen beats,
+ * tap-to-advance with a left-third "back" zone, fade transitions, progress
+ * dots) — but NONE of its beat-computation code. Beats are assembled from the
+ * server-computed FirstSessionRecapView with the same null-omit discipline the
+ * ceremony uses: a beat with no content is simply not pushed.
+ *
+ * Fires once: the seen-signal is persisted as soon as the overlay mounts, so
+ * re-entry/refresh/catch-up never re-trigger it.
+ */
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import { useRouter } from 'next/navigation';
+import { X } from 'lucide-react';
+
+import { formatNextResetTimeLocal } from '@/lib/games/timezone';
+
+// useSyncExternalStore inputs for the client-only reset-time label, mirroring
+// the daily summary page: null during SSR keeps hydration stable, and the
+// snapshot is read on the client without a setState-in-effect.
+const subscribeNoop = () => () => {};
+const getResetTimeSnapshot = () => formatNextResetTimeLocal();
+const getResetTimeServerSnapshot = (): string | null => null;
+import type {
+  FirstSessionRecapBeat2,
+  FirstSessionRecapBeat3,
+  FirstSessionRecapView,
+} from '@/server/daily/first-session-recap';
+
+type BeatNode = { key: string; content: ReactNode };
+
+function Beat1({ firstName }: { firstName: string }) {
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
+        Nice start{firstName ? `, ${firstName}` : ''}.
+      </h1>
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+        You answered your first five.
+      </p>
+    </div>
+  );
+}
+
+function Beat2({
+  beat,
+  onOpenMap,
+}: {
+  beat: FirstSessionRecapBeat2;
+  onOpenMap: () => void;
+}) {
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <p className="text-sm uppercase tracking-[0.16em] text-stone-400">
+        Today&rsquo;s five touched
+      </p>
+      <h1 className="mt-4 font-serif text-4xl font-semibold leading-tight tracking-normal sm:text-6xl">
+        {beat.touchedDomains.join(' · ')}
+      </h1>
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+        Your knowledge map has its first marks.
+      </p>
+      {beat.offTheGroundDomain ? (
+        <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+          {beat.offTheGroundDomain} is already off the ground.
+        </p>
+      ) : null}
+      {beat.newTerritoryDomain ? (
+        <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-300 sm:text-xl">
+          {beat.newTerritoryDomain} is new territory &mdash; that&rsquo;s where the map grows.
+        </p>
+      ) : null}
+      <button
+        type="button"
+        className="mt-10 inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-6 text-sm font-medium text-stone-950 transition hover:bg-white"
+        onClick={(event) => {
+          event.stopPropagation();
+          onOpenMap();
+        }}
+      >
+        Open your knowledge map →
+      </button>
+    </div>
+  );
+}
+
+function Beat3({
+  beat,
+  onInvite,
+}: {
+  beat: FirstSessionRecapBeat3;
+  onInvite: () => void;
+}) {
+  if (beat.kind === 'no_inviter') {
+    return (
+      <div className="mx-auto max-w-2xl text-center">
+        <h1 className="font-serif text-4xl font-semibold leading-tight tracking-normal sm:text-6xl">
+          Invite someone whose questions you&rsquo;d want to see.
+        </h1>
+        <button
+          type="button"
+          className="mt-10 inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-6 text-sm font-medium text-stone-950 transition hover:bg-white"
+          onClick={(event) => {
+            event.stopPropagation();
+            onInvite();
+          }}
+        >
+          Invite a friend →
+        </button>
+      </div>
+    );
+  }
+
+  const { inviterName } = beat;
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <h1 className="font-serif text-4xl font-semibold leading-tight tracking-normal sm:text-6xl">
+        {inviterName} invited you here.
+      </h1>
+      {beat.kind === 'inviter_present' ? (
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+          {inviterName}&rsquo;s been playing &mdash; their last few questions are
+          already waiting for you on your home screen. You&rsquo;ll start to see
+          where your maps overlap.
+        </p>
+      ) : (
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+          As {inviterName} plays, their questions show up on your home screen, and
+          you&rsquo;ll see where your maps overlap.
+        </p>
+      )}
+    </div>
+  );
+}
+
+export function FirstSessionRecap({
+  recap,
+  onDismiss,
+}: {
+  recap: FirstSessionRecapView;
+  onDismiss: () => void;
+}) {
+  const router = useRouter();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  // Client-only local wall-clock reset time for the close copy; null during SSR.
+  const resetLabel = useSyncExternalStore(
+    subscribeNoop,
+    getResetTimeSnapshot,
+    getResetTimeServerSnapshot,
+  );
+
+  // Persist the seen-signal the moment the recap is shown — re-entry, refresh,
+  // and replaying catch-up must never re-trigger it. Fire-and-forget.
+  useEffect(() => {
+    fetch('/api/daily/first-session-recap/seen', {
+      method: 'POST',
+      credentials: 'include',
+    }).catch(() => undefined);
+  }, []);
+
+  const openMap = () => {
+    onDismiss();
+    router.push('/knowledge');
+  };
+  const invite = () => {
+    onDismiss();
+    router.push('/friends');
+  };
+
+  const beats = useMemo<BeatNode[]>(() => {
+    const nodes: BeatNode[] = [];
+    // Beat 1 always renders.
+    nodes.push({ key: 'beat1', content: <Beat1 firstName={recap.firstName} /> });
+    // Beat 2 omitted only in the defensive empty-session case.
+    if (recap.beat2) {
+      nodes.push({
+        key: 'beat2',
+        content: <Beat2 beat={recap.beat2} onOpenMap={openMap} />,
+      });
+    }
+    // Beat 3 always renders (no-inviter variant when there is no inviter).
+    nodes.push({
+      key: 'beat3',
+      content: <Beat3 beat={recap.beat3} onInvite={invite} />,
+    });
+    return nodes;
+    // openMap/invite are stable enough for this short-lived overlay.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [recap]);
+
+  const isEnd = currentIndex >= beats.length;
+
+  function advance() {
+    setCurrentIndex((value) => Math.min(value + 1, beats.length));
+  }
+  function goBack() {
+    setCurrentIndex((value) => Math.max(value - 1, 0));
+  }
+  function done() {
+    onDismiss();
+    router.push('/');
+  }
+
+  // Story-style tap navigation: a tap on the left third steps back, anywhere
+  // else advances. Buttons inside beats stopPropagation, so this only fires on
+  // the backdrop.
+  function handleTap(event: React.MouseEvent<HTMLElement>) {
+    const width = event.currentTarget.clientWidth;
+    if (width > 0 && event.clientX < width * 0.3) {
+      goBack();
+    } else {
+      advance();
+    }
+  }
+
+  return (
+    <main
+      className="fixed inset-0 z-50 grid cursor-pointer place-items-center overflow-hidden bg-stone-950 px-6 py-16 text-stone-50"
+      onClick={handleTap}
+    >
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(245,240,232,0.12),transparent_36%),linear-gradient(180deg,#1c1917_0%,#0c0a09_100%)]" />
+
+      <button
+        type="button"
+        aria-label="Close"
+        className="absolute right-5 top-[max(1.25rem,env(safe-area-inset-top))] z-20 grid size-11 place-items-center rounded-full text-stone-300 transition hover:bg-white/10 hover:text-stone-50"
+        onClick={(event) => {
+          event.stopPropagation();
+          done();
+        }}
+      >
+        <X className="size-7" />
+      </button>
+
+      <div key={currentIndex} className="relative z-10 w-full animate-[fadeIn_0.4s_ease]">
+        {isEnd ? (
+          <div className="mx-auto max-w-2xl text-center">
+            <h1 className="font-serif text-4xl font-semibold leading-tight tracking-normal sm:text-6xl">
+              Come back tomorrow
+              {resetLabel ? ` at ${resetLabel}` : ''} for five new questions.
+            </h1>
+            <div className="mt-10 flex justify-center">
+              <button
+                type="button"
+                className="inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-8 text-sm font-medium text-stone-950 transition hover:bg-white"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  done();
+                }}
+              >
+                Done
+              </button>
+            </div>
+          </div>
+        ) : (
+          beats[currentIndex]!.content
+        )}
+      </div>
+
+      {!isEnd && beats.length > 0 ? (
+        <div
+          className="absolute left-0 right-0 z-10 flex justify-center gap-2"
+          style={{ bottom: 'max(1.75rem, env(safe-area-inset-bottom))' }}
+        >
+          {beats.map((beat, index) => (
+            <span
+              key={beat.key}
+              className={
+                index === currentIndex
+                  ? 'h-2 w-8 rounded-full bg-stone-50'
+                  : 'h-2 w-2 rounded-full bg-stone-500'
+              }
+            />
+          ))}
+        </div>
+      ) : null}
+
+      <style jsx global>{`
+        @keyframes fadeIn {
+          from {
+            opacity: 0;
+          }
+          to {
+            opacity: 1;
+          }
+        }
+      `}</style>
+    </main>
+  );
+}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -28,6 +28,8 @@ import type {
   QuestionRecap,
 } from '@/server/db/queries/daily-summary'
 import { RoundReminderCard } from './RoundReminderCard'
+import { FirstSessionRecap } from './FirstSessionRecap'
+import type { FirstSessionRecapView } from '@/server/daily/first-session-recap'
 
 // useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
 // the subscribe/snapshot functions are stable across renders.
@@ -141,6 +143,10 @@ export default function DailySummaryPage() {
   const [summary, setSummary] = useState<DailySummaryView | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
+  // B-FirstRecap-1: the one-time cinematic recap that fires AFTER this summary on
+  // the user's first completed Daily Five. Null unless eligible + not yet seen.
+  const [firstSessionRecap, setFirstSessionRecap] =
+    useState<FirstSessionRecapView | null>(null)
   // Client-only reset-time label; null during SSR to keep hydration stable.
   const resetTime = useSyncExternalStore(
     subscribeNoop,
@@ -172,6 +178,28 @@ export default function DailySummaryPage() {
       }
     }
     void load()
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // B-FirstRecap-1: fetch the first-session recap. The endpoint returns
+  // { recap: null } unless this is the user's first completed round and the
+  // recap has not been seen, so this is a no-op for everyone else.
+  useEffect(() => {
+    let cancelled = false
+    fetch('/api/daily/first-session-recap', {
+      credentials: 'include',
+      cache: 'no-store',
+    })
+      .then(async (response) => {
+        if (!response.ok) return
+        const body = await response.json().catch(() => null)
+        if (!cancelled && body?.recap) {
+          setFirstSessionRecap(body.recap as FirstSessionRecapView)
+        }
+      })
+      .catch(() => undefined)
     return () => {
       cancelled = true
     }
@@ -301,6 +329,13 @@ export default function DailySummaryPage() {
           See your knowledge map
         </Link>
       </div>
+
+      {firstSessionRecap ? (
+        <FirstSessionRecap
+          recap={firstSessionRecap}
+          onDismiss={() => setFirstSessionRecap(null)}
+        />
+      ) : null}
     </main>
   )
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1176,6 +1176,23 @@ export async function register() {
       // creates it before this migration runs.
     }
 
+    // Migration 0072 (B-FirstRecap-1) adds the nullable
+    // User.first_session_recap_seen_at timestamp. The first-session recap
+    // orchestrator (GET /api/daily/first-session-recap) and the seen-marker
+    // (POST .../seen) both read/write it on the post-summary path, so a
+    // preview/production database with the migration recorded but the column
+    // missing would 42703 before migrate() could repair it. Additive nullable
+    // column with no default — pre-apply it idempotently.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "first_session_recap_seen_at" timestamp with time zone
+      `);
+    } catch {
+      // User may not exist yet on a fresh database — migrate() creates it
+      // before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/daily/__tests__/first-session-recap.test.ts
+++ b/src/server/daily/__tests__/first-session-recap.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeFirstSessionRecapBeats,
+  isFirstSessionRecapEligible,
+  pickFirstName,
+  type FirstSessionRecapQuestion,
+} from '@/server/daily/first-session-recap';
+
+function q(
+  domainDisplayName: string,
+  isCorrect: boolean,
+  isSkipped = false,
+): FirstSessionRecapQuestion {
+  return { domainDisplayName, isCorrect, isSkipped };
+}
+
+describe('isFirstSessionRecapEligible (first-session detection)', () => {
+  it('is TRUE on the first completed round when never seen', () => {
+    expect(
+      isFirstSessionRecapEligible({ seenAt: null, isFirstCompletedRound: true }),
+    ).toBe(true);
+  });
+
+  it('is FALSE once the recap has been seen', () => {
+    expect(
+      isFirstSessionRecapEligible({
+        seenAt: new Date('2026-06-08T12:00:00.000Z'),
+        isFirstCompletedRound: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('is FALSE when this is not the first completed round', () => {
+    expect(
+      isFirstSessionRecapEligible({ seenAt: null, isFirstCompletedRound: false }),
+    ).toBe(false);
+  });
+});
+
+describe('pickFirstName', () => {
+  it('takes the first token', () => {
+    expect(pickFirstName('Ada Lovelace')).toBe('Ada');
+  });
+  it('returns empty string when there is no usable name', () => {
+    expect(pickFirstName('   ')).toBe('');
+    expect(pickFirstName(null)).toBe('');
+  });
+});
+
+describe('computeFirstSessionRecapBeats — Beat 1', () => {
+  it('always carries the first name', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'Grace Hopper',
+      questions: [q('History', true)],
+      inviter: null,
+      inviterBackfillItemCount: 0,
+    });
+    expect(view.type).toBe('first_session');
+    expect(view.firstName).toBe('Grace');
+  });
+});
+
+describe('computeFirstSessionRecapBeats — Beat 2 (discovery framing)', () => {
+  const inviterless = { inviter: null, inviterBackfillItemCount: 0 } as const;
+
+  it('lists distinct touched domains in first-seen order', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [
+        q('History', true),
+        q('History', false),
+        q('Science', true),
+        q('Film Tv', false),
+      ],
+      ...inviterless,
+    });
+    expect(view.beat2?.touchedDomains).toEqual(['History', 'Science', 'Film Tv']);
+  });
+
+  it('omits the new-territory line when every answer is correct', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [q('History', true), q('Science', true)],
+      ...inviterless,
+    });
+    expect(view.beat2?.offTheGroundDomain).toBe('History');
+    expect(view.beat2?.newTerritoryDomain).toBeNull();
+  });
+
+  it('omits the off-the-ground line when none are correct', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [q('History', false), q('Science', false)],
+      ...inviterless,
+    });
+    expect(view.beat2?.offTheGroundDomain).toBeNull();
+    expect(view.beat2?.newTerritoryDomain).toBe('History');
+  });
+
+  it('picks a distinct domain for new territory so the two lines never collide', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      // History: one correct + one wrong; Science: one wrong.
+      questions: [q('History', true), q('History', false), q('Science', false)],
+      ...inviterless,
+    });
+    expect(view.beat2?.offTheGroundDomain).toBe('History');
+    expect(view.beat2?.newTerritoryDomain).toBe('Science');
+  });
+
+  it('chooses the domain with the most correct answers as off-the-ground', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [q('History', true), q('Science', true), q('Science', true)],
+      ...inviterless,
+    });
+    expect(view.beat2?.offTheGroundDomain).toBe('Science');
+  });
+
+  it('treats a skipped question as touched but not correct/wrong', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [q('History', false, true), q('Science', true)],
+      ...inviterless,
+    });
+    expect(view.beat2?.touchedDomains).toEqual(['History', 'Science']);
+    expect(view.beat2?.offTheGroundDomain).toBe('Science');
+    // The skipped History question must not become "new territory".
+    expect(view.beat2?.newTerritoryDomain).toBeNull();
+  });
+
+  it('returns a null beat2 for an empty session', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions: [],
+      ...inviterless,
+    });
+    expect(view.beat2).toBeNull();
+  });
+});
+
+describe('computeFirstSessionRecapBeats — Beat 3 branch selection', () => {
+  const questions = [q('History', true)];
+
+  it('PRESENT tense when the inviter backfill seeded the home feed', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions,
+      inviter: { name: 'Lin' },
+      inviterBackfillItemCount: 3,
+    });
+    expect(view.beat3).toEqual({ kind: 'inviter_present', inviterName: 'Lin' });
+  });
+
+  it('FUTURE tense when an inviter exists but nothing was backfilled', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions,
+      inviter: { name: 'Lin' },
+      inviterBackfillItemCount: 0,
+    });
+    expect(view.beat3).toEqual({ kind: 'inviter_future', inviterName: 'Lin' });
+  });
+
+  it('NO-INVITER variant when there is no inviter on record', () => {
+    const view = computeFirstSessionRecapBeats({
+      displayName: 'X',
+      questions,
+      inviter: null,
+      inviterBackfillItemCount: 0,
+    });
+    expect(view.beat3).toEqual({ kind: 'no_inviter' });
+  });
+});

--- a/src/server/daily/first-session-recap.ts
+++ b/src/server/daily/first-session-recap.ts
@@ -1,0 +1,154 @@
+/**
+ * First-Session Recap (B-FirstRecap-1) — pure beat computation.
+ *
+ * A one-time cinematic recap (`type = 'first_session'`) that fires immediately
+ * after the end-of-session summary on the user's FIRST ever completed Daily
+ * Five. It is NOT the biweekly ceremony: its own (shorter) three-beat set, no
+ * shareable card, and its own beat logic — none of the ceremony's
+ * beat-computation code is reused here.
+ *
+ * CORE PRINCIPLE — grading fails toward the player. After five questions there
+ * is not enough signal to characterize a domain as weakness. Beat 2 uses
+ * DISCOVERY framing only for wrong answers ("new territory"), never judgment.
+ * There is deliberately no "resistance"/"struggled"/"missed"/"weak" path.
+ *
+ * The pure decision functions (eligibility + beat shaping) live here, split from
+ * the DB I/O in get-first-session-recap.ts, so first-session detection and the
+ * Beat 3 branch selection are unit-testable without a database — mirroring the
+ * pick/dedupe/build split in backfill-inviter-feed.ts.
+ */
+
+export type FirstSessionRecapQuestion = {
+  /** Human-readable domain label for this question (e.g. "Film Tv"). */
+  domainDisplayName: string;
+  isCorrect: boolean;
+  isSkipped: boolean;
+};
+
+export type FirstSessionRecapBeat2 = {
+  /** Distinct domains the five questions touched, in first-seen order. */
+  touchedDomains: string[];
+  /** One domain answered correctly ("off the ground"); null when none correct. */
+  offTheGroundDomain: string | null;
+  /** One wrong domain framed as discovery; null when all correct. */
+  newTerritoryDomain: string | null;
+};
+
+export type FirstSessionRecapBeat3 =
+  // Inviter has played in window — their backfilled questions are already on the
+  // home feed (present tense).
+  | { kind: 'inviter_present'; inviterName: string }
+  // Inviter on record but no backfilled items yet (future tense).
+  | { kind: 'inviter_future'; inviterName: string }
+  // Organic/admin signup with no inviter on record — invite-flow CTA instead.
+  | { kind: 'no_inviter' };
+
+export type FirstSessionRecapView = {
+  type: 'first_session';
+  /** First name for Beat 1; '' when the user has no display name. */
+  firstName: string;
+  /** Null only in the defensive empty-session case; Beat 1 always renders. */
+  beat2: FirstSessionRecapBeat2 | null;
+  beat3: FirstSessionRecapBeat3;
+};
+
+export type FirstSessionRecapInput = {
+  displayName: string | null;
+  questions: FirstSessionRecapQuestion[];
+  /** Resolved inviter (name already normalized); null when none on record. */
+  inviter: { name: string } | null;
+  /**
+   * Count of the inviter's backfilled `friend_answered` feed items currently
+   * present for this user. > 0 ⇒ present tense; 0 ⇒ future tense.
+   */
+  inviterBackfillItemCount: number;
+};
+
+/**
+ * First-session detection. Eligible only when the recap has never been shown
+ * AND this is the user's first completed Daily Five round. Pure so both
+ * branches are testable without a DB.
+ */
+export function isFirstSessionRecapEligible(input: {
+  seenAt: Date | null;
+  isFirstCompletedRound: boolean;
+}): boolean {
+  return input.seenAt == null && input.isFirstCompletedRound === true;
+}
+
+/** First token of the display name; '' when there is no usable name. */
+export function pickFirstName(displayName: string | null): string {
+  const trimmed = displayName?.trim().replace(/\s+/g, ' ') ?? '';
+  if (!trimmed) return '';
+  return trimmed.split(' ')[0] ?? '';
+}
+
+function computeBeat2(
+  questions: FirstSessionRecapQuestion[],
+): FirstSessionRecapBeat2 | null {
+  // "Touched" = distinct domains across the five served questions, first-seen
+  // order. A skipped question still touched its domain (it was shown).
+  const touchedDomains: string[] = [];
+  const seen = new Set<string>();
+  for (const question of questions) {
+    const domain = question.domainDisplayName?.trim();
+    if (!domain || seen.has(domain)) continue;
+    seen.add(domain);
+    touchedDomains.push(domain);
+  }
+  if (touchedDomains.length === 0) return null;
+
+  // "Off the ground" = the domain with the most correct answers; ties broken by
+  // first-seen order. Null when nothing was answered correctly.
+  const correctCounts = new Map<string, number>();
+  const wrongDomains: string[] = [];
+  for (const question of questions) {
+    const domain = question.domainDisplayName?.trim();
+    if (!domain || question.isSkipped) continue;
+    if (question.isCorrect) {
+      correctCounts.set(domain, (correctCounts.get(domain) ?? 0) + 1);
+    } else {
+      wrongDomains.push(domain);
+    }
+  }
+
+  let offTheGroundDomain: string | null = null;
+  let bestCount = 0;
+  for (const domain of touchedDomains) {
+    const count = correctCounts.get(domain) ?? 0;
+    if (count > bestCount) {
+      bestCount = count;
+      offTheGroundDomain = domain;
+    }
+  }
+
+  // One wrong domain, discovery framing only. Prefer a domain other than the
+  // off-the-ground one so the two lines never contradict each other. Null when
+  // every answer was correct.
+  const newTerritoryDomain =
+    wrongDomains.find((domain) => domain !== offTheGroundDomain) ?? null;
+
+  return { touchedDomains, offTheGroundDomain, newTerritoryDomain };
+}
+
+function computeBeat3(
+  inviter: { name: string } | null,
+  inviterBackfillItemCount: number,
+): FirstSessionRecapBeat3 {
+  if (!inviter) return { kind: 'no_inviter' };
+  if (inviterBackfillItemCount > 0) {
+    return { kind: 'inviter_present', inviterName: inviter.name };
+  }
+  return { kind: 'inviter_future', inviterName: inviter.name };
+}
+
+export function computeFirstSessionRecapBeats(
+  input: FirstSessionRecapInput,
+): FirstSessionRecapView {
+  return {
+    type: 'first_session',
+    firstName: pickFirstName(input.displayName),
+    beat2: computeBeat2(input.questions),
+    beat3: computeBeat3(input.inviter, input.inviterBackfillItemCount),
+  };
+}

--- a/src/server/daily/get-first-session-recap.ts
+++ b/src/server/daily/get-first-session-recap.ts
@@ -1,0 +1,125 @@
+/**
+ * First-Session Recap (B-FirstRecap-1) — DB orchestration.
+ *
+ * Loads the signals the pure beat logic needs and assembles the recap view:
+ *   • seen-signal + display name from User
+ *   • first-completed-round signal from the existing daily summary
+ *   • inviter resolution (FriendInvitation → User), and whether the inviter's
+ *     B-HomeSeed-1 backfill placed any `friend_answered` items on the home feed
+ *
+ * Returns null whenever the recap must NOT fire (already seen, or not the first
+ * completed round). The seen-marker is set separately when the recap is shown.
+ */
+
+import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
+
+import { getDailyAssignmentBounds } from '@/lib/games/timezone';
+import { db, feedItems, friendInvitations, users } from '@/server/db';
+import { getDailySummary } from '@/server/db/queries/daily-summary';
+import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import {
+  computeFirstSessionRecapBeats,
+  isFirstSessionRecapEligible,
+  type FirstSessionRecapView,
+} from '@/server/daily/first-session-recap';
+
+function todayAssignmentDate(): Date {
+  return new Date(`${getDailyAssignmentBounds().assignmentDateStr}T00:00:00.000Z`);
+}
+
+/**
+ * Assemble the first-session recap for `userId`, or null when it must not fire.
+ */
+export async function getFirstSessionRecap(
+  userId: string,
+): Promise<FirstSessionRecapView | null> {
+  const [user] = await db
+    .select({
+      displayName: users.displayName,
+      seenAt: users.firstSessionRecapSeenAt,
+    })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  // Fast exit: missing user, or the recap has already been shown.
+  if (!user || user.seenAt != null) return null;
+
+  const summary = await getDailySummary(userId, todayAssignmentDate());
+
+  if (
+    !isFirstSessionRecapEligible({
+      seenAt: user.seenAt,
+      isFirstCompletedRound: summary.isFirstCompletedRound,
+    })
+  ) {
+    return null;
+  }
+
+  // Resolve the inviter (most recently accepted invitation), if any.
+  const [invitation] = await db
+    .select({
+      inviterUserId: friendInvitations.inviterUserId,
+      inviterName: users.displayName,
+    })
+    .from(friendInvitations)
+    .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
+    .where(
+      and(
+        eq(friendInvitations.inviteeUserId, userId),
+        isNotNull(friendInvitations.acceptedAt),
+      ),
+    )
+    .orderBy(desc(friendInvitations.acceptedAt))
+    .limit(1);
+
+  let inviter: { name: string } | null = null;
+  let inviterBackfillItemCount = 0;
+  if (invitation?.inviterUserId) {
+    // An inviter exists even if their display name is unset; fall back to a
+    // non-fabricated generic rather than dropping Beat 3 to the no-inviter copy.
+    inviter = { name: invitation.inviterName?.trim() || 'Your friend' };
+
+    // Present vs future tense keys on whether the B-HomeSeed-1 backfill actually
+    // seeded the inviter's recent answers onto this user's home feed. Presence
+    // (limit 1) is all we need.
+    const seeded = await db
+      .select({ id: feedItems.id })
+      .from(feedItems)
+      .where(
+        and(
+          eq(feedItems.recipientUserId, userId),
+          eq(feedItems.sourceUserId, invitation.inviterUserId),
+          eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+          eq(feedItems.state, 'active'),
+        ),
+      )
+      .limit(1);
+    inviterBackfillItemCount = seeded.length;
+  }
+
+  return computeFirstSessionRecapBeats({
+    displayName: user.displayName,
+    questions: summary.questions.map((question) => ({
+      domainDisplayName: question.domainDisplayName,
+      isCorrect: question.isCorrect,
+      isSkipped: question.isSkipped,
+    })),
+    inviter,
+    inviterBackfillItemCount,
+  });
+}
+
+/**
+ * Mark the first-session recap as seen. Idempotent: only stamps the timestamp
+ * when it is still NULL, so the recap can never be re-triggered by re-entry,
+ * refresh, or replaying catch-up.
+ */
+export async function markFirstSessionRecapSeen(userId: string): Promise<void> {
+  await db
+    .update(users)
+    .set({ firstSessionRecapSeenAt: new Date() })
+    .where(
+      and(eq(users.id, userId), isNull(users.firstSessionRecapSeenAt)),
+    );
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -225,6 +225,10 @@ export const users = pgTable(
     phoneHash: text('phone_hash'),
     lastFriendDiscoveryCheckAt: timestamp('last_friend_discovery_check_at', { withTimezone: true }),
     onboardingComplete: boolean('onboardingComplete').notNull().default(false),
+    // B-FirstRecap-1: timestamp the one-time first-session recap was shown. NULL
+    // until the user sees the cinematic recap that fires after their first ever
+    // completed Daily Five; set once so re-entry/refresh/catch-up never re-fire it.
+    firstSessionRecapSeenAt: timestamp('first_session_recap_seen_at', { withTimezone: true }),
     birthYear: integer('birth_year'),
     grewUpCountry: text('grew_up_country'),
     grewUpRegion: text('grew_up_region'),


### PR DESCRIPTION
Add B-FirstRecap-1: a one-time cinematic recap (type 'first_session') that
fires immediately after the end-of-session summary on a user's first ever
completed Daily Five, and never again.

- Fire condition reuses the existing real signal DailySummaryView
  .isFirstCompletedRound (no new completion flag).
- Seen-signal persisted as User.first_session_recap_seen_at (migration 0072 +
  idempotent instrumentation guard) so re-entry/refresh/catch-up never re-fire.
- Three beats with the ceremony's null-omit discipline: Beat 1 (arrival, always
  renders), Beat 2 (touched domains → taps through to the knowledge map; omits
  the off-the-ground line when none correct and the new-territory line when all
  correct — discovery framing only, never judgment), Beat 3 (inviter present /
  future / no-inviter, keyed on whether the B-HomeSeed-1 backfill seeded the
  home feed). Reuses the biweekly ceremony's cinematic SHELL only, not its
  beat-computation code; no shareable card.
- Hosted as an overlay on the existing /daily/summary page (no new route); the
  summary's behavior is unchanged. New GET/POST endpoints under
  /api/daily/first-session-recap.
- Pure beat logic split from DB I/O; hook-level test covers first-session
  detection true/false and Beat 3 branch selection (present/future/no-inviter).

https://claude.ai/code/session_01XWt8aJ4QXgupbh5zo5Fowx