### PR TITLE
Fix clipped overlap circle when viewer's circle is the larger one

### DIFF
--- a/src/components/OverlapMap.tsx
+++ b/src/components/OverlapMap.tsx
@@ -84,7 +84,11 @@ function CategoryItem({
   const rB = dB / 2;
   const overlapRatio = overlapRatioOf(cell);
   const centerGap = (rA + rB) * (1 - overlapRatio * 0.85);
-  const svgWidth = rA + centerGap + rB;
+  // Circle B's right edge is at (rA + centerGap + rB), but circle A (centered
+  // at rA) reaches 2*rA. When A is the larger circle and the gap is small, A
+  // overruns that width and gets clipped by the SVG viewport. Size to the true
+  // bounding box so neither circle is cut off.
+  const svgWidth = Math.max(2 * rA, rA + centerGap + rB);
   const svgHeight = Math.max(dA, dB);
   const cxA = rA;
   const cxB = rA + centerGap;

--- a/src/components/profile/CommonGround.tsx
+++ b/src/components/profile/CommonGround.tsx
@@ -194,7 +194,12 @@ function DomainCircles({
     domain.friend.current_tier,
   )
   const gap = (rA + rB) * (1 - overlapRatio * 0.85)
-  const svgWidth = rA + gap + rB
+  // The friend circle's right edge sits at (rA + gap + rB), but the viewer
+  // circle (centered at rA) reaches 2*rA. When the viewer's circle is the
+  // larger of the two and the gap is small (high tier overlap), 2*rA exceeds
+  // rA + gap + rB and the viewer circle gets clipped by the SVG viewport.
+  // Size the viewport to the true bounding box so neither circle is cut off.
+  const svgWidth = Math.max(2 * rA, rA + gap + rB)
   const svgHeight = Math.max(dA, dB)
   const cy = svgHeight / 2
 


### PR DESCRIPTION
The SVG viewport width was computed as rA + gap + rB, assuming the friend
circle is always the rightmost element. But the viewer circle (centered at
rA) reaches 2*rA, so when it is larger than the friend circle and the gap is
small (high tier overlap), its right side overran the viewport and was
clipped into a half-moon — visible on John Milton's Paradise Lost in the
Common Ground section.

Size the viewport to the true bounding box: Math.max(2*rA, rA + gap + rB).
Apply the same fix to the OverlapMap component this geometry was ported from.

https://claude.ai/code/session_01G6SA3XcEFcigEncFwnBhy8