### PR TITLE
Redesign weekly reflection feed treatment as a ceremonial marker

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,7 +50,6 @@ const TOKEN_LINT_GRANDFATHERED = [
   "src/components/friends/ContactMatchBlock.tsx",
   "src/components/friends/FindFriendsSearch.tsx",
   "src/components/games/QuestionRatingButtons.tsx",
-  "src/components/home/CeremonyPin.tsx",
   "src/components/knowledge/AskFriendForDomain.tsx",
   "src/components/profile/AuthoredQuestionsFeed.tsx",
   "src/components/profile/InlineHandleField.tsx",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run src/lib/llm.grading.eval.test.ts",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 33",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 31",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -130,6 +130,14 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
     }),
     buildActivityStream(userId),
   ])
+  // The weekly reflection lives in the dedicated CeremonyPin editorial marker
+  // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
+  // activity card here so the reflection doesn't double up / compete with social
+  // activity in the home stream. It's the only activity that links to /ceremony/;
+  // the card still appears in the full /activities log.
+  const homeActivityItems = activityItems.filter(
+    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
+  )
   return (
     <>
       <p className="mb-2 px-3 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
@@ -141,7 +149,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         initialPage={feedPage}
         showContributeFooter
         unifiedHome
-        activityItems={activityItems}
+        activityItems={homeActivityItems}
       />
     </>
   )

--- a/src/components/home/CeremonyPin.tsx
+++ b/src/components/home/CeremonyPin.tsx
@@ -5,36 +5,33 @@ export type CeremonyPinStatus = {
   latestUnviewed: { id: string; firedAt: string } | null
 }
 
+// One ceremonial editorial marker, in the same visual family as the existing
+// weekly-summary countdown: centered, gold, uppercase, calm. No card, no border,
+// no box, no CTA button — the line itself is the moment. A subtle opacity-only
+// fade-in on first paint (no movement, no pulse), gated to motion-safe. When a
+// reflection is ready the whole row is the tap target; the future-state
+// countdown is the same treatment with only the text changed.
+const MARKER_CLASS =
+  'flex items-center justify-center gap-2 py-3 text-center text-xs font-medium tracking-[0.08em] text-[var(--tri-amber)] uppercase motion-safe:animate-in motion-safe:fade-in motion-safe:duration-700'
+
 /**
  * Top-of-home ceremony slot. Lifted out of FeedList so Home can render it
- * directly (above RecentActivity) and FeedList stays focused on the playable
- * stream.
+ * directly (above the feed) and FeedList stays focused on the playable stream.
  *
- * Three states:
- *   1. Unviewed ceremony → amber link card "Your weekly reflection is ready"
- *   2. Today is Sunday (UTC) → hidden (cron is firing; nothing to nag about)
- *   3. Otherwise → countdown "Weekly Summary in N days"
+ * Three states, ONE treatment (always the calm gold marker, never a dashboard
+ * card):
+ *   1. Unviewed ceremony → tappable "Your weekly reflection is ready"
+ *   2. Today is Sunday (UTC) → hidden (cron is firing; nothing to anticipate)
+ *   3. Otherwise → countdown "Weekly Reflection in N days"
  */
 export function CeremonyPin({ status }: { status: CeremonyPinStatus | null }) {
   if (!status) return null
 
   if (status.latestUnviewed) {
     return (
-      <Link
-        href={`/ceremony/${status.latestUnviewed.id}`}
-        className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-4 text-stone-950 shadow-sm"
-      >
-        <div className="flex items-start gap-3">
-          <span className="mt-0.5 text-lg" aria-hidden>
-            ✦
-          </span>
-          <div>
-            <p className="font-medium">Your weekly reflection is ready</p>
-            <p className="mt-1 text-sm text-stone-700">
-              See what you&rsquo;ve been up to {'->'}
-            </p>
-          </div>
-        </div>
+      <Link href={`/ceremony/${status.latestUnviewed.id}`} className={MARKER_CLASS}>
+        <span aria-hidden>✦</span>
+        <span>Your weekly reflection is ready</span>
       </Link>
     )
   }
@@ -59,11 +56,11 @@ export function CeremonyPin({ status }: { status: CeremonyPinStatus | null }) {
   )
   const label =
     daysUntil === 1
-      ? 'Weekly Summary tomorrow'
-      : `Weekly Summary in ${daysUntil} days`
+      ? 'Weekly Reflection tomorrow'
+      : `Weekly Reflection in ${daysUntil} days`
 
   return (
-    <div className="-my-2 flex items-center justify-center gap-2 text-xs font-medium tracking-[0.08em] text-[var(--tri-amber)] uppercase">
+    <div className={MARKER_CLASS}>
       <span aria-hidden>✦</span>
       <span>{label}</span>
     </div>


### PR DESCRIPTION
Replace the dashboard-style "Your weekly reflection is ready" amber card
with a single calm, gold, centered editorial marker in the same visual
family as the existing weekly-summary countdown — no card, border, box,
or CTA button. The whole row is the tap target when a reflection is
ready; the future-state countdown is the same treatment with only the
text changed ("Weekly Reflection in N days"). Adds a subtle motion-safe,
opacity-only fade-in (no movement, no pulse).

Also drop the redundant 'ceremony_ready' activity card from the home
"What's Happening" stream so the reflection no longer doubles up with the
marker or competes with social activity; it still appears in the full
/activities log.

The redesign removes all of CeremonyPin's off-system color classes, so
it comes off the eslint token grandfather list and the --max-warnings
ceiling drops 33 -> 31.