### PR TITLE
Give New Territory card a 4-way frequency selector

### DIFF
--- a/src/__tests__/refine-derive.test.ts
+++ b/src/__tests__/refine-derive.test.ts
@@ -45,14 +45,16 @@ describe('deriveFriendExpansion', () => {
   });
 
   it('does not fire when the player already owns the subdomain', () => {
-    const slots = [
-      slot({ presence_source_id: 'f1', domain: 'Jazz', answer_state: 'correct' }),
-    ];
+    const slots = [slot({ presence_source_id: 'f1', domain: 'Jazz', answer_state: 'correct' })];
     expect(deriveFriendExpansion(slots, new Set(['jazz']))).toHaveLength(0);
   });
 
   it('does not fire on an incorrect answer or a non-bonus slot', () => {
-    const incorrectBonus = slot({ presence_source_id: 'f1', domain: 'Jazz', answer_state: 'incorrect' });
+    const incorrectBonus = slot({
+      presence_source_id: 'f1',
+      domain: 'Jazz',
+      answer_state: 'incorrect',
+    });
     const nonBonusCorrect = slot({ domain: 'Jazz', answer_state: 'correct' });
     expect(deriveFriendExpansion([incorrectBonus, nonBonusCorrect], new Set())).toHaveLength(0);
   });
@@ -106,9 +108,22 @@ describe('pruningThreshold + deriveStrugglePruning', () => {
 });
 
 describe('selectRefineCandidates', () => {
-  const friend: RefineCandidate = { type: 'friend_expansion', subdomainId: 'a', subdomainLabel: 'a', friendId: 'f1' };
-  const escalation: RefineCandidate = { type: 'difficulty_escalation', subdomainId: 'b', subdomainLabel: 'b' };
-  const pruning: RefineCandidate = { type: 'struggle_pruning', subdomainId: 'c', subdomainLabel: 'c' };
+  const friend: RefineCandidate = {
+    type: 'friend_expansion',
+    subdomainId: 'a',
+    subdomainLabel: 'a',
+    friendId: 'f1',
+  };
+  const escalation: RefineCandidate = {
+    type: 'difficulty_escalation',
+    subdomainId: 'b',
+    subdomainLabel: 'b',
+  };
+  const pruning: RefineCandidate = {
+    type: 'struggle_pruning',
+    subdomainId: 'c',
+    subdomainLabel: 'c',
+  };
 
   it('orders by priority friend → escalation → pruning', () => {
     const out = selectRefineCandidates([pruning, escalation, friend], new Set());
@@ -142,8 +157,16 @@ describe('selectRefineCandidates', () => {
   });
 
   it('keeps both candidates when one subdomain qualifies for two types', () => {
-    const dualEscalation: RefineCandidate = { type: 'difficulty_escalation', subdomainId: 'dual', subdomainLabel: 'dual' };
-    const dualPruning: RefineCandidate = { type: 'struggle_pruning', subdomainId: 'dual', subdomainLabel: 'dual' };
+    const dualEscalation: RefineCandidate = {
+      type: 'difficulty_escalation',
+      subdomainId: 'dual',
+      subdomainLabel: 'dual',
+    };
+    const dualPruning: RefineCandidate = {
+      type: 'struggle_pruning',
+      subdomainId: 'dual',
+      subdomainLabel: 'dual',
+    };
     const out = selectRefineCandidates([dualPruning, dualEscalation], new Set());
     expect(out.map((c) => c.type)).toEqual(['difficulty_escalation', 'struggle_pruning']);
   });
@@ -165,7 +188,9 @@ describe('copy', () => {
     expect(openText(pruning)).toBe(
       "You've missed the last 4 subprime mortgage questions. Rest them for now?",
     );
-    expect(resolvedText(pruning)).toBe("Resting subprime mortgage for now — it won't be asked.");
+    expect(resolvedText(pruning)).toBe(
+      "Moving subprime mortgage to Never for now — it won't be asked.",
+    );
 
     const escalation: RefineCandidate = {
       type: 'difficulty_escalation',

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -41,16 +41,16 @@ type ActiveTerritory = {
 } | null;
 
 const ZONES: Array<{ value: TerritoryFrequency; title: string; copy: string }> = [
-  { value: 'often', title: 'Asked Often', copy: 'These show up most in your rounds.' },
-  { value: 'sometimes', title: 'Asked Sometimes', copy: 'These stay in rotation, but less often.' },
+  { value: 'often', title: 'Often', copy: 'These show up most in your rounds.' },
+  { value: 'sometimes', title: 'Sometimes', copy: 'These stay in rotation, but less often.' },
   {
     value: 'blue_moon',
-    title: 'Once in a Blue Moon',
+    title: 'Blue Moon',
     copy: 'Still on your map, but only surface every so often.',
   },
   {
     value: 'resting',
-    title: 'Resting',
+    title: 'Never',
     copy: 'These are part of your map, but won’t be asked for now.',
   },
 ];
@@ -252,9 +252,9 @@ export function TerritorySetupClient({
       });
       const body = await response.json().catch(() => null);
       if (!response.ok) {
-        const error = new Error(
-          body?.message ?? 'Could not add that topic.',
-        ) as Error & { code?: 'limit_reached' | 'too_broad' };
+        const error = new Error(body?.message ?? 'Could not add that topic.') as Error & {
+          code?: 'limit_reached' | 'too_broad';
+        };
         if (body?.error === 'interest_limit_reached') error.code = 'limit_reached';
         else if (body?.error === 'too_broad') error.code = 'too_broad';
         throw error;

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -1,79 +1,70 @@
-'use client'
+'use client';
 
-import { useState } from 'react'
-import { Moon, Sparkles } from 'lucide-react'
+import { useState } from 'react';
+import { Sparkles } from 'lucide-react';
 
-import type { TerritoryFrequency } from '@/lib/daily/territory-model'
+import {
+  TERRITORY_FREQUENCIES,
+  TERRITORY_FREQUENCY_LABEL,
+  type TerritoryFrequency,
+} from '@/lib/daily/territory-model';
 
 // Darkened triangle-gold so the "New territory" copy clears AA on the cream
 // card (raw --tri-amber #d9a82e is too light for small text).
-const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))'
+const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))';
 
-// Default-add with a soft demote (B-1): a correct answer in an unfamiliar domain
+// Default-add with player control (B-1): a correct answer in an unfamiliar domain
 // opens it in the player's Knowledge base automatically (server-side, via
-// writeMasteryEvent). This card surfaces that the domain was added, and the
-// primary control doesn't delete it — it moves the freshly-opened domain to
-// "Once in a Blue Moon" so it stays on the map but only surfaces every so often.
-// After moving, an "Undo" steps back to the just-added stage by restoring the
-// domain's prior frequency. The player stays in control without losing the
-// territory. Used on both reveal surfaces.
+// writeMasteryEvent), starting in the default "Sometimes" rotation. This card
+// surfaces that the domain was added and lets the player dial how often it should
+// come up — Often / Sometimes / Blue Moon / Never — via a segmented control that
+// saves on tap. No Undo is needed: the control is self-reversible (re-tap another
+// tier). Used on both reveal surfaces.
+const FREQUENCY_HINT: Record<TerritoryFrequency, string> = {
+  often: 'Shows up most in your rounds.',
+  sometimes: 'Stays in normal rotation.',
+  blue_moon: 'Only surfaces every so often.',
+  resting: "Stays on your map, but won't be asked.",
+};
+
 export function NewTerritoryUndo({
   domain,
   category,
 }: {
-  domain: string
-  category?: string | null
+  domain: string;
+  category?: string | null;
 }) {
-  // 'open' = freshly added (default rotation); 'blue_moon' = demoted to rare.
-  const [stage, setStage] = useState<'open' | 'blue_moon'>('open')
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState(false)
-  // The frequency the domain had before we moved it to blue_moon, so Undo can
-  // restore exactly that (usually unset → null, i.e. default rotation).
-  const [previousFrequency, setPreviousFrequency] = useState<TerritoryFrequency | null>(null)
-  const label = category || domain
+  // Freshly-added domains start in the default rotation ('sometimes').
+  const [selected, setSelected] = useState<TerritoryFrequency>('sometimes');
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState(false);
+  const label = category || domain;
 
-  const setFrequency = async (frequency: TerritoryFrequency | null) => {
+  const setFrequency = async (frequency: TerritoryFrequency) => {
     const response = await fetch('/api/daily/preferences/domain-frequency', {
       method: 'POST',
       credentials: 'include',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ domain, frequency }),
-    })
-    if (!response.ok) throw new Error('frequency update failed')
-    return (await response.json().catch(() => null)) as {
-      previousFrequency?: TerritoryFrequency | null
-    } | null
-  }
+    });
+    if (!response.ok) throw new Error('frequency update failed');
+  };
 
-  const handleBlueMoon = async () => {
-    if (busy) return
-    setBusy(true)
-    setError(false)
+  const handleSelect = async (frequency: TerritoryFrequency) => {
+    if (busy || frequency === selected) return;
+    const previous = selected;
+    setSelected(frequency);
+    setBusy(true);
+    setError(false);
     try {
-      const result = await setFrequency('blue_moon')
-      setPreviousFrequency(result?.previousFrequency ?? null)
-      setStage('blue_moon')
+      await setFrequency(frequency);
     } catch {
-      setError(true)
+      setSelected(previous);
+      setError(true);
     } finally {
-      setBusy(false)
+      setBusy(false);
     }
-  }
-
-  const handleUndo = async () => {
-    if (busy) return
-    setBusy(true)
-    setError(false)
-    try {
-      await setFrequency(previousFrequency)
-      setStage('open')
-    } catch {
-      setError(true)
-    } finally {
-      setBusy(false)
-    }
-  }
+  };
 
   return (
     <div
@@ -92,56 +83,47 @@ export function NewTerritoryUndo({
           }}
           aria-hidden
         >
-          {stage === 'blue_moon' ? <Moon className="size-3.5" /> : <Sparkles className="size-3.5" />}
+          <Sparkles className="size-3.5" />
         </span>
         <div className="min-w-0 flex-1">
-          {stage === 'blue_moon' ? (
-            <>
-              <p className="font-serif text-sm leading-snug font-semibold" style={{ color: GOLD_INK }}>
-                {label} is now once in a blue moon.
-              </p>
-              <p className="mt-1 text-[13px] text-[var(--brand-ink)]">
-                It stays on your map but will only surface every so often.
-              </p>
-              <p className="mt-1.5 text-[13px] text-[var(--brand-ink)]">
-                {busy ? (
-                  <span className="text-[var(--brand-ink-400)]">Undoing…</span>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => void handleUndo()}
-                    className="font-semibold underline underline-offset-2 hover:opacity-70"
-                    style={{ color: GOLD_INK }}
-                  >
-                    Undo
-                  </button>
-                )}
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="font-serif text-sm leading-snug font-semibold" style={{ color: GOLD_INK }}>
-                Added {label} to your knowledge base.
-              </p>
-              <p className="mt-1 text-[13px] text-[var(--brand-ink)]">
-                Want it only every so often?
-              </p>
-              <p className="mt-1.5 text-[13px] text-[var(--brand-ink)]">
-                {busy ? (
-                  <span className="text-[var(--brand-ink-400)]">Moving…</span>
-                ) : (
-                  <button
-                    type="button"
-                    onClick={() => void handleBlueMoon()}
-                    className="font-semibold underline underline-offset-2 hover:opacity-70"
-                    style={{ color: GOLD_INK }}
-                  >
-                    Move to Once in a Blue Moon
-                  </button>
-                )}
-              </p>
-            </>
-          )}
+          <p className="font-serif text-sm leading-snug font-semibold" style={{ color: GOLD_INK }}>
+            Added {label} to your knowledge base.
+          </p>
+          <p className="mt-1 text-[13px] text-[var(--brand-ink)]">How often should it come up?</p>
+
+          <div
+            className="mt-2 flex flex-wrap gap-1.5"
+            role="group"
+            aria-label={`How often to ask about ${label}`}
+          >
+            {TERRITORY_FREQUENCIES.map((frequency) => {
+              const isSelected = frequency === selected;
+              return (
+                <button
+                  key={frequency}
+                  type="button"
+                  onClick={() => void handleSelect(frequency)}
+                  disabled={busy}
+                  aria-pressed={isSelected}
+                  className="rounded-full border px-3 py-1 text-[13px] font-semibold transition-opacity disabled:opacity-60"
+                  style={{
+                    color: isSelected ? 'var(--brand-card)' : GOLD_INK,
+                    backgroundColor: isSelected
+                      ? GOLD_INK
+                      : 'color-mix(in srgb, var(--tri-amber) 12%, var(--brand-card))',
+                    borderColor: 'color-mix(in srgb, var(--tri-amber) 40%, var(--brand-border))',
+                  }}
+                >
+                  {TERRITORY_FREQUENCY_LABEL[frequency]}
+                </button>
+              );
+            })}
+          </div>
+
+          <p className="mt-1.5 text-[13px] text-[var(--brand-ink-400)]">
+            {busy ? 'Saving…' : FREQUENCY_HINT[selected]}
+          </p>
+
           {error ? (
             <p className="mt-1.5 text-xs" style={{ color: 'var(--game-wrong-strong)' }}>
               Could not update it. Try again.
@@ -150,5 +132,5 @@ export function NewTerritoryUndo({
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/lib/daily/territory-model.ts
+++ b/src/lib/daily/territory-model.ts
@@ -12,10 +12,18 @@ export type DomainPreferenceFrequency = Record<string, TerritoryFrequency>;
 
 export const TERRITORY_FREQUENCIES = ['often', 'sometimes', 'blue_moon', 'resting'] as const;
 
+// Player-facing labels for each frequency tier. Single source of truth shared by
+// the Territory Setup zones and the "New territory" reveal card so the wording
+// stays consistent. The enum values are internal; only these strings are shown.
+export const TERRITORY_FREQUENCY_LABEL: Record<TerritoryFrequency, string> = {
+  often: 'Often',
+  sometimes: 'Sometimes',
+  blue_moon: 'Blue Moon',
+  resting: 'Never',
+};
+
 export function isTerritoryFrequency(value: unknown): value is TerritoryFrequency {
-  return (
-    value === 'often' || value === 'sometimes' || value === 'blue_moon' || value === 'resting'
-  );
+  return value === 'often' || value === 'sometimes' || value === 'blue_moon' || value === 'resting';
 }
 
 function normalizeDomainKey(domain: string): string {

--- a/src/server/refine/copy.ts
+++ b/src/server/refine/copy.ts
@@ -41,6 +41,6 @@ export function resolvedText(candidate: RefineCandidate): string {
     case 'difficulty_escalation':
       return `We'll keep ${label} at this level for the next month.`;
     case 'struggle_pruning':
-      return `Resting ${label} for now — it won't be asked.`;
+      return `Moving ${label} to Never for now — it won't be asked.`;
   }
 }


### PR DESCRIPTION
Replace the single 'Move to Once in a Blue Moon' action on the New
Territory reveal card with a segmented Often / Sometimes / Blue Moon /
Never selector that saves on tap (Sometimes is the freshly-added
default). The backend already models these four tiers, so this is a
UI + labeling change only — no schema or selection-logic changes.

Centralize the tier labels in territory-model.ts and rename the
Territory Setup zones and Refine copy to match.

https://claude.ai/code/session_01KuseUHxkoR7jnPbYxXma1A