### PR TITLE
Lock attempted milestone questions across sessions; route misses to catch up

### DIFF
--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -5,7 +5,7 @@ import { z } from 'zod';
 import { computeAnswerState } from '@/server/answer-state';
 import { readPriorAnswersForQuestion } from '@/server/answer-history';
 import { getSession } from '@/server/auth/session';
-import { db, playerMastery, questions } from '@/server/db';
+import { db, feedItems, playerMastery, questions } from '@/server/db';
 import { getSeededPlayQuestions } from '@/server/db/queries/lately';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { gradeAnswer } from '@/server/grading';
@@ -183,6 +183,43 @@ export async function POST(request: NextRequest) {
       'correct',
       `milestone:${question.id}:${session.userId}`,
     ));
+  } else {
+    // A milestone is a read-derived roll-up, not a feed card, so a wrong answer
+    // here leaves no FeedItem — and catch up only surfaces incorrect, unresolved
+    // FeedItem rows (getFeedCatchupItems). Write a synthetic answered/incorrect
+    // row so the existing feed catch-up pipeline gives the viewer a second swing.
+    // state='answered' keeps it OUT of the actionable feed (which only shows
+    // active/skipped), and the deterministic sourceAnswerId + onConflictDoNothing
+    // guarantees one row per (viewer, question): re-missing never resets the
+    // catch-up clock or resurrects an already-resolved miss. A failure here must
+    // never fail the answer itself.
+    try {
+      await db
+        .insert(feedItems)
+        .values({
+          recipientUserId: session.userId,
+          questionId: question.id,
+          sourceType: 'milestone_missed',
+          // sourceUserId is NOT NULL + FK; the friend whose milestone surfaced
+          // this isn't reliably in scope here, so attribute to the question
+          // author (the natural "source"), falling back to the viewer for
+          // author-less LLM questions. Catch up does not read this field.
+          sourceUserId: question.creatorId ?? session.userId,
+          sourceResult: 'incorrect',
+          sourceEventAt: new Date(),
+          submittedAnswer,
+          answerResult: 'incorrect',
+          sourceAnswerId: `milestone-miss:${question.id}`,
+          state: 'answered',
+        })
+        .onConflictDoNothing({
+          target: [feedItems.recipientUserId, feedItems.sourceAnswerId],
+        });
+    } catch (error) {
+      console.warn('[lately/milestone/answer] failed to write catch-up feed item', {
+        error: error instanceof Error ? error.message : 'unknown',
+      });
+    }
   }
 
   const explanation = isCorrect

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -106,11 +106,18 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
   // read it back. Milestone lines only.
   const expand = item.expand;
   const milestoneQuestions = expand && expand.kind === 'milestone' ? expand.questions : null;
-  // Questions the server already records as answered (correctly) on load. We
-  // don't have the original submitted text for these, so the history shows a
-  // calm "Correct" without the "You answered:" clause for them.
+  // Questions the server already records as attempted on load — right OR wrong.
+  // A single attempt is the viewer's only swing in the feed, so any prior
+  // result locks the question here. We don't have the original submitted text
+  // for these, so the history shows a calm "Correct" / "Not this time" (per the
+  // server-recorded result) without the "You answered:" clause for them.
   const [serverAnswered] = useState<Set<string>>(
-    () => new Set((milestoneQuestions ?? []).filter((q) => q.answered).map((q) => q.questionId)),
+    () =>
+      new Set(
+        (milestoneQuestions ?? [])
+          .filter((q) => q.priorResult !== null)
+          .map((q) => q.questionId),
+      ),
   );
   // Resolutions captured this session — both correct and "not this time" — keyed
   // by questionId, carrying what the viewer typed so the history can echo it. A
@@ -303,7 +310,7 @@ function ItemAction({ action }: { action: NonNullable<StreamItem['action']> }) {
 // the quiet "Answered" history below, so what remains above is always exactly
 // the work left to do. The answered-state is owned by the parent so the bundle
 // triangle mark ticks from solid to hollow in lockstep as questions settle.
-function MilestoneExpansion({
+export function MilestoneExpansion({
   expand,
   isResolved,
   resolutions,
@@ -373,10 +380,12 @@ function AnsweredHistory({
       >
         {questions.map((q) => {
           const r = resolutions.get(q.questionId);
-          // No in-session resolution means the server already had it on load as
-          // a correct answer; we lack the original text, so we show a calm
-          // "Correct" without the answer clause rather than invent one.
-          const isCorrect = r ? r.isCorrect : true;
+          // No in-session resolution means the server already had this attempt on
+          // load; we lack the original text, so we show a calm "Correct" / "Not
+          // this time" from the server-recorded result without inventing an
+          // answer clause. priorResult is non-null here (it's why the question
+          // sits in this answered list); treat anything but 'incorrect' as right.
+          const isCorrect = r ? r.isCorrect : q.priorResult !== 'incorrect';
           // Result reads in the app's semantic answer colors: green for correct,
           // red for "not this time" — same tokens the AnswerFeedbackSheet uses.
           const resultColor = isCorrect ? 'var(--game-correct)' : 'var(--game-wrong-strong)';

--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -52,9 +52,9 @@ const CONVERGENCE: Convergence = {
 };
 
 const QUESTIONS = [
-  { questionId: 'q1', text: 'Who painted Guernica?', domain: 'Cubism', answered: true },
-  { questionId: 'q2', text: 'What is the capital of Mongolia?', domain: 'Geography', answered: true },
-  { questionId: 'q3', text: 'Who composed The Rite of Spring?', domain: 'Composers', answered: true },
+  { questionId: 'q1', text: 'Who painted Guernica?', domain: 'Cubism', priorResult: 'correct' as const },
+  { questionId: 'q2', text: 'What is the capital of Mongolia?', domain: 'Geography', priorResult: 'correct' as const },
+  { questionId: 'q3', text: 'Who composed The Rite of Spring?', domain: 'Composers', priorResult: 'correct' as const },
 ];
 
 const CAPTION = 'You and {Name} keep landing in the same place.';

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -1,0 +1,87 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { StreamExpand, StreamQuestion } from '@/lib/activity-stream';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// InlineAnswerFlow is the answerable affordance; mock it to echo "ANSWER THIS
+// ONE" with the question text so the test can assert exactly which questions
+// remain answerable in the expansion.
+vi.mock('@/components/activity/InlineAnswerFlow', () => ({
+  InlineAnswerFlow: ({ question }: { question: StreamQuestion }) => (
+    <div data-mock="inline-answer">ANSWER THIS ONE → {question.text}</div>
+  ),
+}));
+vi.mock('@/components/SendQuestionDrawer', () => ({
+  SendQuestionDrawer: () => <div data-mock="send-drawer" />,
+}));
+vi.mock('@/app/activities/FriendRequestActions', () => ({
+  FriendRequestActions: () => <div data-mock="friend-request" />,
+}));
+vi.mock('@/app/activities/ReactionGotItButton', () => ({
+  ReactionGotItButton: () => <div data-mock="reaction" />,
+}));
+
+import { MilestoneExpansion } from '@/components/activity/ActivityStreamItem';
+
+// q-correct: answered right in a prior session. q-wrong: answered WRONG in a
+// prior session (the bug — must NOT be answerable here, and the ANSWERED
+// history must read "Not this time", not "Correct"). q-fresh: never attempted.
+const QUESTIONS: StreamQuestion[] = [
+  { questionId: 'q-correct', text: 'Who captains the Enterprise-D?', domain: 'Star Trek', priorResult: 'correct' },
+  { questionId: 'q-wrong', text: 'What is a prior inconsistent statement?', domain: 'Mock Trial', priorResult: 'incorrect' },
+  { questionId: 'q-fresh', text: 'Name the Enterprise-D android.', domain: 'Star Trek', priorResult: null },
+];
+
+const EXPAND: Extract<StreamExpand, { kind: 'milestone' }> = {
+  kind: 'milestone',
+  friendId: 'friend-1',
+  friendName: 'Sadie Brooks',
+  questions: QUESTIONS,
+};
+
+// Mirrors the seed ActivityStreamItem applies at mount: a question with any
+// prior result (right OR wrong) is resolved/locked across reloads.
+function renderExpansion() {
+  const serverAnswered = new Set(
+    QUESTIONS.filter((q) => q.priorResult !== null).map((q) => q.questionId),
+  );
+  return renderToStaticMarkup(
+    <MilestoneExpansion
+      expand={EXPAND}
+      isResolved={(id) => serverAnswered.has(id)}
+      resolutions={new Map()}
+      onResolved={() => {}}
+    />,
+  );
+}
+
+describe('MilestoneExpansion — cross-session answer lock', () => {
+  it('keeps only never-attempted questions answerable', () => {
+    const html = renderExpansion();
+    // The fresh question is the only one offered to answer.
+    expect(html).toContain('ANSWER THIS ONE → Name the Enterprise-D android.');
+    // A prior WRONG answer is NOT answerable again here (the reported bug).
+    expect(html).not.toContain('ANSWER THIS ONE → What is a prior inconsistent statement?');
+    // A prior CORRECT answer is likewise locked.
+    expect(html).not.toContain('ANSWER THIS ONE → Who captains the Enterprise-D?');
+  });
+
+  it('reads a prior wrong answer back as "Not this time", not "Correct"', () => {
+    const html = renderExpansion();
+    expect(html).toContain('ANSWERED');
+    expect(html).toContain('Not this time');
+    // The wrong question sits in the answered history...
+    expect(html).toContain('What is a prior inconsistent statement?');
+    // ...and the correct one reads as Correct.
+    expect(html).toContain('Correct');
+  });
+});

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -43,9 +43,12 @@ export type StreamQuestion = {
   questionId: string;
   text: string;
   domain: string | null;
-  // True when the viewer has already answered this question correctly. Drives
-  // the milestone "{k} of {n} answered" progress and the no-double-credit story.
-  answered: boolean;
+  // The viewer's own prior result on this question, if any. `null` = never
+  // attempted. ANY non-null value (correct OR incorrect) locks the question in
+  // the milestone expansion — a single attempt is the viewer's only swing in
+  // the feed — and drives the ANSWERED history's "Correct" / "Not this time"
+  // copy plus the bundle progress mark.
+  priorResult: 'correct' | 'incorrect' | null;
 };
 
 // The action an expanded, question-backed item offers — determined by the
@@ -182,7 +185,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: faq.questionText,
                   domain,
-                  answered: false,
+                  priorResult: null,
                 },
               }
             : null,
@@ -206,7 +209,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: false,
+                  priorResult: null,
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -232,7 +235,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   questionId: item.referenceId,
                   text: nm.questionText,
                   domain,
-                  answered: true,
+                  priorResult: 'correct',
                 },
                 strangerId: item.actorUserId,
                 strangerName: actorName(item),
@@ -482,7 +485,7 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
         questionId: moment.questionId,
         text: moment.questionText,
         domain: moment.category,
-        answered: true,
+        priorResult: 'correct',
       },
     },
   };

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -27,7 +27,7 @@ import {
   getLatelyMilestones,
   getLatelyMoments,
   getMilestoneQuestionText,
-  getViewerCorrectlyAnsweredIds,
+  getViewerPriorAnswerResults,
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
@@ -40,7 +40,8 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
 
   // Resolve every milestone's first ≤5 literal questions and every
   // convergence's 3 cluster questions in one batch (text + display domain), and
-  // which of them the viewer already answered correctly.
+  // the viewer's prior result on each (right OR wrong) — so a question the
+  // viewer already attempted stays locked in the expansion across reloads.
   const cappedIdsByMilestone = milestones.map((m) => ({
     id: m.id,
     ids: m.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
@@ -51,9 +52,9 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [textById, answeredIds] = await Promise.all([
+  const [textById, priorById] = await Promise.all([
     getMilestoneQuestionText(allQuestionIds),
-    getViewerCorrectlyAnsweredIds(userId, allQuestionIds),
+    getViewerPriorAnswerResults(userId, allQuestionIds),
   ]);
 
   const utilityItems = filterUtilityActivities(items, moments).map(
@@ -68,7 +69,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: answeredIds.has(q.questionId),
+        priorResult: priorById.get(q.questionId) ?? null,
       }));
     return milestoneToStreamItem(m, questions);
   });
@@ -80,7 +81,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         questionId: q.questionId,
         text: q.text,
         domain: q.domain,
-        answered: true, // read-only reveal: both already answered correctly
+        priorResult: 'correct' as const, // read-only reveal: both already answered correctly
       }));
     return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id));
   });

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -354,28 +354,39 @@ export async function getMilestoneQuestionText(
   return out;
 }
 
-// Which of the given questions the viewer has ALREADY answered correctly. Drives
-// the milestone expansion's "{k} of {n} answered" progress on first render and
-// makes the no-double-credit reality visible (a question already in the viewer's
-// mastery history won't earn new credit on re-answer — it becomes repeat_correct).
-export async function getViewerCorrectlyAnsweredIds(
+// The viewer's own prior result on each of the given questions, if any. Drives
+// the milestone expansion's progress on first render AND the cross-session lock:
+// a single attempt (right OR wrong) settles the question, so it must report
+// incorrect attempts too — reporting only correct ones is what let a
+// wrong-answered question re-open as answerable on reload. Correct wins over
+// incorrect (mirrors getViewerAnswerStatusForQuestions in feed.ts); a question
+// the viewer never attempted is simply absent from the map. Scoped to
+// answeredByUserId so author/curator-credit events (a non-answerer's row) never
+// count as the viewer's own attempt.
+export async function getViewerPriorAnswerResults(
   userId: string,
   ids: string[],
-): Promise<Set<string>> {
-  const out = new Set<string>();
+): Promise<Map<string, 'correct' | 'incorrect'>> {
+  const out = new Map<string, 'correct' | 'incorrect'>();
   if (ids.length === 0) return out;
   const rows = await db
-    .select({ questionId: masteryEvents.questionId })
+    .select({ questionId: masteryEvents.questionId, answerState: masteryEvents.answerState })
     .from(masteryEvents)
     .where(
       and(
         eq(masteryEvents.userId, userId),
+        eq(masteryEvents.answeredByUserId, userId),
         inArray(masteryEvents.questionId, ids),
-        inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
       ),
     );
   for (const row of rows) {
-    if (row.questionId) out.add(row.questionId);
+    if (!row.questionId) continue;
+    const isCorrect = row.answerState !== null && row.answerState !== 'incorrect';
+    if (isCorrect) {
+      out.set(row.questionId, 'correct');
+    } else if (!out.has(row.questionId)) {
+      out.set(row.questionId, 'incorrect');
+    }
   }
   return out;
 }


### PR DESCRIPTION
Milestone/streak cards in the activity stream seeded each question's
answered-state from correct answers only (getViewerCorrectlyAnsweredIds),
so a question answered WRONG re-opened as answerable after a reload — the
in-session lock didn't survive. Wrong milestone answers also never reached
catch up, because the route writes no FeedItem and catch up reads incorrect
FeedItem rows.

- Replace StreamQuestion.answered:boolean with priorResult:'correct'|
  'incorrect'|null, carrying prior correctness so the ANSWERED history can
  render "Not this time" for a previously-wrong question on reload.
- Replace getViewerCorrectlyAnsweredIds with getViewerPriorAnswerResults
  (any attempt; correct wins), scoped to answeredByUserId.
- Seed the cross-session lock from any prior attempt, not just correct ones.
- On a wrong milestone answer, write a synthetic answered/incorrect FeedItem
  (deduped via sourceAnswerId + onConflictDoNothing) so the existing feed
  catch-up pipeline gives a second chance; state='answered' keeps it out of
  the actionable feed.

Adds MilestoneStreamItem regression test for the lock + history copy.

https://claude.ai/code/session_011vaYs24gWD6fQ4mx5nnFBV