### PR TITLE
fix(daily): dedup re-worded copies of the same fact across sources

### DIFF
--- a/src/server/daily/__tests__/cross-source-dedup.test.ts
+++ b/src/server/daily/__tests__/cross-source-dedup.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DAILY_QUEUE_SIZE } from '@/server/daily/types';
+
+// Regression: a daily once served two adjacent "The Inner Light" Picard
+// questions — one authored, one LLM-generated — both answered "a Ressikan
+// flute". They have DIFFERENT question text and DIFFERENT canonical_subcategory
+// labels ("Star Trek" vs "Star Trek: The Next Generation"), so the
+// orchestrator's exact-text cross-source dedup let both through. The fix adds a
+// fact signature (normalized answer scoped to a coarse domain key) so re-worded
+// copies of the same trivia collapse. This test pins that behaviour without a DB
+// by mocking the picker/generator surface, exactly like queue-floor.test.ts.
+const mocks = vi.hoisted(() => ({
+  getTodaysDailyQueue: vi.fn(),
+  carryForwardUntouchedDailyQueue: vi.fn(),
+  clearStaleShortTodayQueue: vi.fn(),
+  getKnowledgeBase: vi.fn(),
+  pickEligibleAuthoredQuestions: vi.fn(),
+  pickHouseQuestions: vi.fn(),
+  createDailyQueueItem: vi.fn(),
+  createDailyQueueItemFromAuthored: vi.fn(),
+  createDailyQueueItemFromHouse: vi.fn(),
+  createDailyQueueItemFromPresence: vi.fn(),
+  getDailyPreferences: vi.fn(),
+  getFriendAndFoFUserIds: vi.fn(),
+  getFriendDomainsForBonus: vi.fn(),
+  generateDailyQuestionsFromKnowledgeBase: vi.fn(),
+  generateBonusQuestionsForDomains: vi.fn(),
+  isGenericSubcategory: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/daily', () => ({
+  getTodaysDailyQueue: mocks.getTodaysDailyQueue,
+  carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
+  clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
+  getKnowledgeBase: mocks.getKnowledgeBase,
+  pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
+  pickHouseQuestions: mocks.pickHouseQuestions,
+  createDailyQueueItem: mocks.createDailyQueueItem,
+  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
+  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
+  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+}));
+
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: mocks.getDailyPreferences,
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendAndFoFUserIds: mocks.getFriendAndFoFUserIds,
+}));
+
+vi.mock('@/server/db/queries/friend-presence-domains', () => ({
+  getFriendDomainsForBonus: mocks.getFriendDomainsForBonus,
+}));
+
+vi.mock('@/server/daily/generate-questions', () => ({
+  generateDailyQuestionsFromKnowledgeBase: mocks.generateDailyQuestionsFromKnowledgeBase,
+  generateBonusQuestionsForDomains: mocks.generateBonusQuestionsForDomains,
+}));
+
+vi.mock('@/server/questions/canonical-subcategory', () => ({
+  isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+
+const USER = 'user-1';
+
+// The orchestrator reads questionText/answerText/canonicalSubcategory off
+// authored picks; the rest of the row is passed opaquely to the (mocked)
+// persistence helper.
+function authoredPick(
+  id: string,
+  questionText: string,
+  answerText: string,
+  canonicalSubcategory: string,
+) {
+  return { id, questionId: id, questionText, answerText, canonicalSubcategory, broadCategory: null } as never;
+}
+
+// Generated rows expose answer + canonicalSubcategory + questionText + id.
+function genq(id: string, answer: string, canonicalSubcategory: string, questionText = `Question ${id}`) {
+  return { id, questionText, answer, canonicalSubcategory } as never;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.getTodaysDailyQueue.mockResolvedValue(null);
+  mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
+  mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
+
+  mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Star Trek: The Next Generation' }]);
+  mocks.getDailyPreferences.mockResolvedValue({
+    difficulty: 'adaptive',
+    domainMode: 'random',
+    selectedDomains: [],
+  });
+  mocks.pickHouseQuestions.mockResolvedValue([]);
+  mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+  mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+  mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+  mocks.isGenericSubcategory.mockReturnValue(false);
+
+  mocks.createDailyQueueItem.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+});
+
+describe('fillDailyQueueForUser — cross-source fact dedup', () => {
+  it('drops an LLM question that re-words an authored fact (the Ressikan-flute regression)', async () => {
+    mocks.pickEligibleAuthoredQuestions.mockResolvedValue([
+      authoredPick(
+        'authored-flute',
+        "In the TNG episode 'The Inner Light,' Picard lives an entire lifetime as a man named Katan on a dying alien world, all while comatose for 25 minutes. What instrument does he keep when he wakes?",
+        'A Ressikan flute (a small flute)',
+        'Star Trek',
+      ),
+    ]);
+    // The generated batch leads with a re-worded copy of the same fact, then
+    // distinct fillers. Only the duplicate should be dropped.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq(
+        'gen-flute-dup',
+        'a Ressikan flute (a penny whistle / Katan’s flute)',
+        'Star Trek: The Next Generation',
+        "In 'Star Trek: The Next Generation,' the episode 'The Inner Light' features Picard living an entire lifetime as a man named Katan. What does he learn to play?",
+      ),
+      genq('g1', 'William Riker', 'Star Trek: The Next Generation'),
+      genq('g2', 'Locutus of Borg', 'Star Trek: The Next Generation'),
+      genq('g3', 'Gul Madred', 'Star Trek: The Next Generation'),
+      genq('g4', 'Darmok and Jalad at Tanagra', 'Star Trek: The Next Generation'),
+    ]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // The authored copy is kept and persisted...
+    expect(mocks.createDailyQueueItemFromAuthored).toHaveBeenCalledWith(
+      USER,
+      expect.objectContaining({ id: 'authored-flute' }),
+      0,
+    );
+    // ...and the re-worded LLM copy is never written to the queue.
+    expect(mocks.createDailyQueueItem).not.toHaveBeenCalledWith(USER, 'gen-flute-dup', expect.anything());
+    // The queue still fills (authored flute + 4 distinct generated = 5).
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE - 1);
+  });
+
+  it('keeps a same-answer question in a different domain (signature is domain-scoped)', async () => {
+    // Guard against over-dedup: an identical answer about a different subject is
+    // a different fact, so the coarse domain key must keep them apart.
+    mocks.pickEligibleAuthoredQuestions.mockResolvedValue([
+      authoredPick(
+        'authored-flute',
+        "Which instrument does Picard keep from 'The Inner Light'?",
+        'A Ressikan flute (a small flute)',
+        'Star Trek',
+      ),
+    ]);
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      // Same normalized answer ("ressikan flute") but a different domain.
+      genq('gen-other-domain', 'A Ressikan flute', 'Baroque Woodwind Instruments'),
+      genq('g1', 'William Riker', 'Star Trek: The Next Generation'),
+      genq('g2', 'Locutus of Borg', 'Star Trek: The Next Generation'),
+      genq('g3', 'Gul Madred', 'Star Trek: The Next Generation'),
+    ]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // The different-domain question survives and is persisted.
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledWith(USER, 'gen-other-domain', expect.anything());
+  });
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -165,18 +165,60 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     ? await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(remaining))
     : [];
 
-  // Cross-source dedup by normalized question text. The authored picker
-  // dedupes by question_id against past queues, and the generator has its
-  // own batch/history dedup — but neither knows about the other, so the
-  // same prompt can land in two slots of the same queue (e.g. an authored
-  // "Apples are in what plant family?" alongside an LLM-generated one).
+  // Cross-source dedup. The authored picker dedupes by question_id against
+  // past queues, and the generator has its own batch/history dedup — but
+  // neither knows about the other, so the same trivia can land in two slots
+  // of the same queue (e.g. an authored "Apples are in what plant family?"
+  // alongside an LLM-generated one).
+  //
+  // Exact-text matching is necessary but not sufficient: it misses the
+  // cross-phrasing case, where an authored question and an LLM one encode the
+  // SAME fact in different words. That is exactly how a daily once served two
+  // adjacent "The Inner Light" Picard questions — one authored ("In the TNG
+  // episode 'The Inner Light,' Picard lives an entire lifetime…") and one
+  // generated ("In 'Star Trek: The Next Generation,' the episode 'The Inner
+  // Light' features Picard…") — both answered "a Ressikan flute". Different
+  // text, different canonical_subcategory label ("Star Trek" vs "Star Trek:
+  // The Next Generation"), identical trivia. So we also dedup on a fact
+  // signature: the normalized answer scoped to a coarse domain key. Two
+  // questions with the same answer about the same subject are the same fact
+  // regardless of wording. (The pool's embedding-based dedup would also catch
+  // this, but it is inert wherever VOYAGE_API_KEY is unset.)
   const seenTexts = new Set<string>();
+  const seenFacts = new Set<string>();
   const normalize = (text: string) => text.trim().toLowerCase();
+  const factSignature = (answer: string | null, domain: string | null): string | null => {
+    const normAnswer = (answer ?? '')
+      .normalize('NFKC')
+      .toLowerCase()
+      .replace(/\([^)]*\)/g, ' ') // drop parenthetical glosses, e.g. "(a small flute)"
+      .replace(/^(a|an|the)\s+/, '') // leading article
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim();
+    // Too short/generic to dedup on safely (e.g. a bare year or single common
+    // word could collide across genuinely different questions).
+    if (normAnswer.length < 4) return null;
+    const coarseDomain = (domain ?? '')
+      .normalize('NFKC')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, ' ')
+      .trim()
+      .split(' ')
+      .slice(0, 2) // "star trek" collapses "Star Trek" and "Star Trek: The Next Generation"
+      .join(' ');
+    return `${coarseDomain}|${normAnswer}`;
+  };
+  const rememberFact = (answer: string | null, domain: string | null) => {
+    const sig = factSignature(answer, domain);
+    if (sig) seenFacts.add(sig);
+  };
   for (const pick of authored) {
     seenTexts.add(normalize(pick.questionText));
+    rememberFact(pick.answerText, pick.canonicalSubcategory);
   }
   for (const pick of housePicks) {
     seenTexts.add(normalize(pick.questionText));
+    rememberFact(pick.answerText, pick.canonicalSubcategory);
   }
   const dedupedGenerated: typeof generated = [];
   let droppedDuplicates = 0;
@@ -191,11 +233,13 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       continue;
     }
     const key = normalize(question.questionText);
-    if (seenTexts.has(key)) {
+    const sig = factSignature(question.answer, question.canonicalSubcategory);
+    if (seenTexts.has(key) || (sig !== null && seenFacts.has(sig))) {
       droppedDuplicates += 1;
       continue;
     }
     seenTexts.add(key);
+    if (sig) seenFacts.add(sig);
     dedupedGenerated.push(question);
   }
   if (droppedDuplicates > 0) {
@@ -239,8 +283,10 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
         continue;
       }
       const key = normalize(question.questionText);
-      if (seenTexts.has(key)) continue;
+      const sig = factSignature(question.answer, question.canonicalSubcategory);
+      if (seenTexts.has(key) || (sig !== null && seenFacts.has(sig))) continue;
       seenTexts.add(key);
+      if (sig) seenFacts.add(sig);
       topUpGenerated.push(question);
       recoveredThisRound += 1;
     }


### PR DESCRIPTION
## What

The daily queue assembler's cross-source dedup only compared **exact question text**, so an authored question and an LLM-generated one that encode the **same fact in different words** could both land in one daily.

## The incident

A real daily session served two adjacent "The Inner Light" Picard questions:

| Slot | Source | Subcategory | Answer |
|---|---|---|---|
| 1 | `authored` | `Star Trek` | A Ressikan flute (a small flute) |
| 2 | `daily_generated` | `Star Trek: The Next Generation` | a Ressikan flute (a penny whistle / Katan's flute) |

Different text, different subcategory label, identical trivia — and the player's domain mastery got credited twice for it. Exact-text matching never fired; the semantic backstop (pgvector embeddings) is inert wherever `VOYAGE_API_KEY` is unset (currently 0/355 pool questions are embedded).

## The fix

`src/server/daily/queue-orchestrator.ts` — the cross-source dedup now also keys on a **fact signature**: the normalized answer (parenthetical glosses, leading articles, and punctuation stripped → `ressikan flute`) scoped to a **coarse domain key** (first two tokens → `star trek`, which collapses both subcategory variants). Applied in both the initial pass and the top-up loop. A length guard skips signatures on very short answers so bare years / single common words can't over-dedup.

## Tests

`src/server/daily/__tests__/cross-source-dedup.test.ts`:
- pins the Ressikan-flute regression (the re-worded LLM copy is dropped, queue still fills)
- control: a same-answer question in a **different** domain is kept (proves the signature stays domain-scoped)

Verified: new + existing `queue-floor` tests pass; typecheck and ESLint clean on the changed files.

## Follow-ups (not in this PR)

- Backfill/collapse the stale duplicate rows already in the pool (this fix only prevents new same-daily collisions).
- Extend persist-time fact-key dedup beyond `daily_generated ↔ daily_generated` to compare authored copies.
- Turn on `VOYAGE_API_KEY` + backfill embeddings so the semantic dedup layer is actually live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)