### PR TITLE
Align unified-home feed day labels to activity row content

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,7 +140,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   )
   return (
     <>
-      <p className="mb-2 px-3 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+      <p className="mb-2 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
         What&rsquo;s happening
       </p>
       <FeedList

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1426,7 +1426,14 @@ function FeedListContent({
         <section className="space-y-3 pb-8">
           {groupItemsByRecency(unifiedRows).map((group) => (
             <Fragment key={group.key}>
-              <h2 className="text-muted-foreground/70 pt-4 text-[11px] font-medium tracking-[0.12em] uppercase first:pt-0">
+              <h2
+                className={`text-muted-foreground/70 pt-4 text-[11px] font-medium tracking-[0.12em] uppercase first:pt-0 ${
+                  // On the unified-home feed, the day label aligns to where the
+                  // activity-row copy starts — past the fixed icon column
+                  // (MARK_W 24 + GAP 8) plus the row's 2px horizontal padding.
+                  unifiedHome ? 'pl-[34px]' : ''
+                }`}
+              >
                 {group.label}
               </h2>
               {group.items.map((row) => {


### PR DESCRIPTION
## Summary
Adjusts the visual alignment of day/recency group labels in the unified-home feed to match the horizontal position where activity row content begins, accounting for the fixed icon column and row padding.

## Changes
- **FeedList.tsx**: Added conditional left padding (`pl-[34px]`) to day group labels when rendering the unified-home feed. The padding accounts for the fixed mark icon column (24px) plus gap (8px) plus the activity row's 2px horizontal padding, ensuring labels align with where the row's copy starts rather than the left edge.
- **page.tsx**: Removed unnecessary `px-3` padding from the "What's happening" section header in `FromYourFriendsSection`, simplifying the layout.

## Implementation Details
The alignment fix uses a template literal to conditionally apply the padding class only when `unifiedHome` is true, preserving the original behavior for other feed types. The specific pixel value (34px) is documented inline with a comment explaining the calculation.

https://claude.ai/code/session_01UU437mM6rCkm6zCNUieVky