### PR TITLE
Add ContentReport table and enums (B-Report-1 substrate)

### DIFF
--- a/drizzle/0073_content_report.sql
+++ b/drizzle/0073_content_report.sql
@@ -1,0 +1,132 @@
+-- B-Report-1 — Content Reporting substrate.
+--
+-- Adds the ContentReport table plus its three enums. Purely additive: no
+-- existing table is altered and nothing here is wired to a surface yet
+-- (B-Report-2 onward does the wiring). The table mirrors two existing
+-- patterns in schema.ts:
+--   * GradeDispute lifecycle — status enum + review_decision / review_reason
+--     / reviewed_at columns that a reviewer stamps when resolving a report.
+--   * QuestionFeedback dual-FK — a report targets exactly one of a curated
+--     Question or a generated GeneratedQuestion via two nullable FK columns.
+--
+-- Two CHECK constraints encode the invariants:
+--   * ContentReport_one_target           — exactly one of the two target FKs is set.
+--   * ContentReport_incorrect_kind_scope — incorrect_kind only when category = 'incorrect'.
+--
+-- "One open report per user per target" is enforced with two partial UNIQUE
+-- indexes (the target is split across two nullable columns, so a single
+-- COALESCE index isn't expressible). Each is scoped to status = 'open', so a
+-- fresh report is permitted once a prior one resolves (re-report policy).
+--
+-- Every statement is idempotent (DO $$ … duplicate_object for enums,
+-- IF NOT EXISTS for the table / constraints / indexes) and is mirrored by a
+-- defensive guard in src/instrumentation.ts so a preview/production database
+-- that records this migration without the objects present still boots.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "ContentReport";
+--   DROP TYPE  IF EXISTS "ContentReportStatus";
+--   DROP TYPE  IF EXISTS "ContentReportIncorrectKind";
+--   DROP TYPE  IF EXISTS "ContentReportCategory";
+DO $$ BEGIN
+  CREATE TYPE "public"."ContentReportCategory" AS ENUM('incorrect', 'inappropriate');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."ContentReportIncorrectKind" AS ENUM('answer_key', 'premise');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+  CREATE TYPE "public"."ContentReportStatus" AS ENUM('open', 'upheld', 'dismissed');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "ContentReport" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "reporter_user_id" text NOT NULL,
+  "question_id" text,
+  "generated_question_id" text,
+  "category" "public"."ContentReportCategory" NOT NULL,
+  "incorrect_kind" "public"."ContentReportIncorrectKind",
+  "note" text NOT NULL,
+  "suggested_answer" text,
+  "surface" text,
+  "status" "public"."ContentReportStatus" NOT NULL DEFAULT 'open',
+  "review_decision" text,
+  "review_reason" text,
+  "reviewed_at" timestamp with time zone,
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  CONSTRAINT "ContentReport_one_target"
+    CHECK ((question_id IS NOT NULL)::int + (generated_question_id IS NOT NULL)::int = 1),
+  CONSTRAINT "ContentReport_incorrect_kind_scope"
+    CHECK (incorrect_kind IS NULL OR category = 'incorrect')
+);
+--> statement-breakpoint
+DO $$
+DECLARE
+  report_table regclass := to_regclass('public."ContentReport"');
+  user_table regclass := to_regclass('public."User"');
+  question_table regclass := to_regclass('public."Question"');
+  generated_question_table regclass := to_regclass('public."GeneratedQuestion"');
+BEGIN
+  IF report_table IS NOT NULL
+    AND user_table IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'ContentReport_reporter_user_id_User_id_fk'
+        AND conrelid = report_table
+    )
+  THEN
+    ALTER TABLE "ContentReport"
+      ADD CONSTRAINT "ContentReport_reporter_user_id_User_id_fk"
+      FOREIGN KEY ("reporter_user_id") REFERENCES "User"("id");
+  END IF;
+
+  IF report_table IS NOT NULL
+    AND question_table IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'ContentReport_question_id_Question_id_fk'
+        AND conrelid = report_table
+    )
+  THEN
+    ALTER TABLE "ContentReport"
+      ADD CONSTRAINT "ContentReport_question_id_Question_id_fk"
+      FOREIGN KEY ("question_id") REFERENCES "Question"("id");
+  END IF;
+
+  IF report_table IS NOT NULL
+    AND generated_question_table IS NOT NULL
+    AND NOT EXISTS (
+      SELECT 1 FROM pg_constraint
+      WHERE conname = 'ContentReport_generated_question_id_GeneratedQuestion_id_fk'
+        AND conrelid = report_table
+    )
+  THEN
+    ALTER TABLE "ContentReport"
+      ADD CONSTRAINT "ContentReport_generated_question_id_GeneratedQuestion_id_fk"
+      FOREIGN KEY ("generated_question_id") REFERENCES "GeneratedQuestion"("id");
+  END IF;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ContentReport_reporter_user_id_idx"
+  ON "ContentReport" ("reporter_user_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ContentReport_question_id_idx"
+  ON "ContentReport" ("question_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ContentReport_generated_question_id_idx"
+  ON "ContentReport" ("generated_question_id");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "ContentReport_status_idx"
+  ON "ContentReport" ("status");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_question"
+  ON "ContentReport" ("reporter_user_id", "question_id")
+  WHERE status = 'open' AND question_id IS NOT NULL;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_generated_question"
+  ON "ContentReport" ("reporter_user_id", "generated_question_id")
+  WHERE status = 'open' AND generated_question_id IS NOT NULL;

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1193,6 +1193,122 @@ export async function register() {
       // before this migration runs.
     }
 
+    // Migration 0073 (B-Report-1) adds the ContentReport table + its three
+    // enums (ContentReportCategory / ContentReportIncorrectKind /
+    // ContentReportStatus). Purely additive substrate — nothing reads it yet
+    // (B-Report-2 onward wires it up) — but a preview/production database that
+    // records the migration without the objects present must still boot, and a
+    // newly-added enum value/type referenced inside the migrator transaction
+    // can 22P02/42704, so create the enums, table, FKs, CHECKs, and indexes
+    // idempotently outside that transaction. Re-running is a no-op.
+    try {
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."ContentReportCategory" AS ENUM('incorrect', 'inappropriate');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."ContentReportIncorrectKind" AS ENUM('answer_key', 'premise');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        DO $$ BEGIN
+          CREATE TYPE "public"."ContentReportStatus" AS ENUM('open', 'upheld', 'dismissed');
+        EXCEPTION WHEN duplicate_object THEN NULL;
+        END $$
+      `);
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "ContentReport" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "reporter_user_id" text NOT NULL,
+          "question_id" text,
+          "generated_question_id" text,
+          "category" "public"."ContentReportCategory" NOT NULL,
+          "incorrect_kind" "public"."ContentReportIncorrectKind",
+          "note" text NOT NULL,
+          "suggested_answer" text,
+          "surface" text,
+          "status" "public"."ContentReportStatus" NOT NULL DEFAULT 'open',
+          "review_decision" text,
+          "review_reason" text,
+          "reviewed_at" timestamp with time zone,
+          "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+          CONSTRAINT "ContentReport_one_target"
+            CHECK ((question_id IS NOT NULL)::int + (generated_question_id IS NOT NULL)::int = 1),
+          CONSTRAINT "ContentReport_incorrect_kind_scope"
+            CHECK (incorrect_kind IS NULL OR category = 'incorrect')
+        )
+      `);
+      await db.execute(sql`
+        DO $$
+        DECLARE
+          report_table regclass := to_regclass('public."ContentReport"');
+          user_table regclass := to_regclass('public."User"');
+          question_table regclass := to_regclass('public."Question"');
+          generated_question_table regclass := to_regclass('public."GeneratedQuestion"');
+        BEGIN
+          IF report_table IS NOT NULL
+            AND user_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'ContentReport_reporter_user_id_User_id_fk'
+                AND conrelid = report_table
+            )
+          THEN
+            ALTER TABLE "ContentReport"
+              ADD CONSTRAINT "ContentReport_reporter_user_id_User_id_fk"
+              FOREIGN KEY ("reporter_user_id") REFERENCES "User"("id");
+          END IF;
+
+          IF report_table IS NOT NULL
+            AND question_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'ContentReport_question_id_Question_id_fk'
+                AND conrelid = report_table
+            )
+          THEN
+            ALTER TABLE "ContentReport"
+              ADD CONSTRAINT "ContentReport_question_id_Question_id_fk"
+              FOREIGN KEY ("question_id") REFERENCES "Question"("id");
+          END IF;
+
+          IF report_table IS NOT NULL
+            AND generated_question_table IS NOT NULL
+            AND NOT EXISTS (
+              SELECT 1 FROM pg_constraint
+              WHERE conname = 'ContentReport_generated_question_id_GeneratedQuestion_id_fk'
+                AND conrelid = report_table
+            )
+          THEN
+            ALTER TABLE "ContentReport"
+              ADD CONSTRAINT "ContentReport_generated_question_id_GeneratedQuestion_id_fk"
+              FOREIGN KEY ("generated_question_id") REFERENCES "GeneratedQuestion"("id");
+          END IF;
+        END $$
+      `);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_reporter_user_id_idx" ON "ContentReport" ("reporter_user_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_question_id_idx" ON "ContentReport" ("question_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_generated_question_id_idx" ON "ContentReport" ("generated_question_id")`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "ContentReport_status_idx" ON "ContentReport" ("status")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_question"
+          ON "ContentReport" ("reporter_user_id", "question_id")
+          WHERE status = 'open' AND question_id IS NOT NULL
+      `);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "ContentReport_one_open_per_generated_question"
+          ON "ContentReport" ("reporter_user_id", "generated_question_id")
+          WHERE status = 'open' AND generated_question_id IS NOT NULL
+      `);
+    } catch {
+      // User, Question, or GeneratedQuestion may not exist yet on a fresh
+      // database — migrate() creates them before this migration runs.
+    }
+
     try {
       await migrate(db, {
         migrationsFolder: path.join(process.cwd(), 'drizzle'),

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -89,6 +89,19 @@ export const gradeDisputeStatusEnum = pgEnum('GradeDisputeStatus', [
   'alternative_added',
   'dismissed',
 ]);
+export const contentReportCategoryEnum = pgEnum('ContentReportCategory', [
+  'incorrect',
+  'inappropriate',
+]);
+export const contentReportIncorrectKindEnum = pgEnum('ContentReportIncorrectKind', [
+  'answer_key',
+  'premise',
+]);
+export const contentReportStatusEnum = pgEnum('ContentReportStatus', [
+  'open',
+  'upheld',
+  'dismissed',
+]);
 export const difficultyEstimateEnum = pgEnum('DifficultyEstimate', [
   'accessible',
   'moderate',
@@ -667,6 +680,51 @@ export const questionRatings = pgTable(
     unique('QuestionRating_user_id_question_id_key').on(table.userId, table.questionId),
     index('QuestionRating_user_id_idx').on(table.userId),
     index('QuestionRating_question_id_idx').on(table.questionId),
+  ],
+);
+
+export const contentReports = pgTable(
+  'ContentReport',
+  {
+    id: id(),
+    reporterUserId: text('reporter_user_id').notNull().references(() => users.id),
+    questionId: text('question_id').references(() => questions.id),
+    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
+    category: contentReportCategoryEnum('category').notNull(),
+    incorrectKind: contentReportIncorrectKindEnum('incorrect_kind'),
+    note: text('note').notNull(),
+    suggestedAnswer: text('suggested_answer'),
+    surface: text('surface'),
+    status: contentReportStatusEnum('status').notNull().default('open'),
+    reviewDecision: text('review_decision'),
+    reviewReason: text('review_reason'),
+    reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    index('ContentReport_reporter_user_id_idx').on(table.reporterUserId),
+    index('ContentReport_question_id_idx').on(table.questionId),
+    index('ContentReport_generated_question_id_idx').on(table.generatedQuestionId),
+    index('ContentReport_status_idx').on(table.status),
+    check(
+      'ContentReport_one_target',
+      sql`(question_id IS NOT NULL)::int + (generated_question_id IS NOT NULL)::int = 1`,
+    ),
+    check(
+      'ContentReport_incorrect_kind_scope',
+      sql`incorrect_kind IS NULL OR category = 'incorrect'`,
+    ),
+    // One open report per user per target. The target is split across two
+    // nullable columns, so the single-COALESCE form Drizzle can't express
+    // becomes two partial unique indexes — each scoped to its own column and
+    // to status = 'open', mirroring feed_dismissed_domains_active_unique. A
+    // fresh report is allowed once a prior one leaves 'open' (re-report policy).
+    uniqueIndex('ContentReport_one_open_per_question')
+      .on(table.reporterUserId, table.questionId)
+      .where(sql`status = 'open' AND question_id IS NOT NULL`),
+    uniqueIndex('ContentReport_one_open_per_generated_question')
+      .on(table.reporterUserId, table.generatedQuestionId)
+      .where(sql`status = 'open' AND generated_question_id IS NOT NULL`),
   ],
 );
 


### PR DESCRIPTION
## Summary
Adds the foundational database schema for content reporting (B-Report-1). This is purely additive substrate — no existing tables are modified and the feature is not yet wired to any user-facing surface (B-Report-2 onward handles integration).

## Changes
- **New migration** (`drizzle/0073_content_report.sql`): Creates three enums (`ContentReportCategory`, `ContentReportIncorrectKind`, `ContentReportStatus`) and the `ContentReport` table with:
  - Dual-FK pattern targeting either a curated `Question` or `GeneratedQuestion` (mirrors `QuestionFeedback` design)
  - Review workflow columns (`review_decision`, `review_reason`, `reviewed_at`) mirroring `GradeDispute` lifecycle
  - Two CHECK constraints enforcing exactly one target and scoping `incorrect_kind` to the 'incorrect' category
  - Two partial UNIQUE indexes preventing multiple open reports per user per target (re-report allowed after resolution)
  - Idempotent statements with `DO $$ … EXCEPTION WHEN duplicate_object` for enums and `IF NOT EXISTS` for table/constraints/indexes

- **Schema definition** (`src/server/db/schema.ts`): Adds enum exports and `contentReports` table definition with matching constraints and indexes

- **Boot-time guard** (`src/instrumentation.ts`): Mirrors all migration DDL idempotently outside the Drizzle transaction to handle preview/production databases that record the migration without the objects present (prevents 22P02/42704 errors on enum references)

## Implementation notes
- All statements are idempotent and can be safely re-run
- The dual-FK + two partial UNIQUE indexes pattern avoids the single-COALESCE form that Drizzle cannot express
- Rollback instructions included in migration comments

https://claude.ai/code/session_01YBkMYQUcZfuH7o6n8Q2onh