### PR TITLE
Extract common-ground circle geometry; add homepage promo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { CeremonyPin } from '@/components/home/CeremonyPin'
 import { MissedQuestionsCard } from '@/components/home/MissedQuestionsCard'
 import { getSession } from '@/server/auth/session'
 import { buildActivityStream } from '@/server/activity/build-stream'
+import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
@@ -122,22 +123,29 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // full activity/Lately stream, interleaved chronologically inside FeedList.
   // Filter 'all' (not 'from-friends') so directly-sent questions thread in; the
   // prefetch matches FeedList's unifiedHome seeding for a no-round-trip paint.
-  const [feedPage, activityItems] = await Promise.all([
+  const [feedPage, activityItems, commonGroundPromo] = await Promise.all([
     getFeedPagePayload(userId, {
       limit: FEED_PAGE_SIZE,
       cursor: null,
       filter: 'all',
     }),
     buildActivityStream(userId),
+    getCommonGroundPromo(userId),
   ])
   // The weekly reflection lives in the dedicated CeremonyPin editorial marker
   // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
   // activity card here so the reflection doesn't double up / compete with social
   // activity in the home stream. It's the only activity that links to /ceremony/;
   // the card still appears in the full /activities log.
-  const homeActivityItems = activityItems.filter(
-    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
-  )
+  const homeActivityItems = [
+    // Home-only common-ground discovery promo at the head of the activity rows
+    // (see getCommonGroundPromo). Null when the viewer has no untested shared
+    // ground with any probed friend.
+    ...(commonGroundPromo ? [commonGroundPromo] : []),
+    ...activityItems.filter(
+      (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
+    ),
+  ]
   return (
     <>
       <p className="mb-2 px-3 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -8,11 +8,16 @@ import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
 import { SendQuestionDrawer } from '@/components/SendQuestionDrawer';
 import type {
+  StreamEmbed,
   StreamExpand,
   StreamItem,
   StreamLinePart,
   StreamQuestion,
 } from '@/lib/activity-stream';
+import {
+  circleDatasetMax,
+  DomainCircleSvg,
+} from '@/components/profile/common-ground-circles';
 
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
@@ -251,6 +256,10 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
         </div>
       </div>
 
+      {item.embed?.kind === 'common_ground' ? (
+        <CommonGroundEmbed embed={item.embed} />
+      ) : null}
+
       {item.action ? <ItemAction action={item.action} /> : null}
 
       {expandable && open && expand ? (
@@ -269,6 +278,76 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
           )}
         </div>
       ) : null}
+    </div>
+  );
+}
+
+// The homepage common-ground promo embed: the friend's top shared-but-untested
+// domains as the overlapping-circle motif (same geometry as the profile page),
+// indented to sit under the row's one-liner, with a link through to the profile.
+// Read-only and non-expanding — it stops click propagation so taps on the
+// circles or link never toggle a (non-existent) expansion.
+function CommonGroundEmbed({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'common_ground' }>;
+}) {
+  const datasetMax = circleDatasetMax(
+    embed.domains.flatMap((d) => [d.viewer.points, d.friend.points]),
+  );
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
+    >
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
+        {embed.domains.map((d) => (
+          <div
+            key={d.label}
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              gap: 6,
+              maxWidth: 120,
+            }}
+          >
+            <DomainCircleSvg
+              viewerPoints={d.viewer.points}
+              friendPoints={d.friend.points}
+              viewerTier={d.viewer.tier}
+              friendTier={d.friend.tier}
+              datasetMax={datasetMax}
+              ariaLabel={`${d.label}: shared with ${embed.friendFirstName}, still untested`}
+            />
+            <span
+              style={{
+                fontFamily: 'Georgia, serif',
+                fontSize: 12.5,
+                lineHeight: 1.3,
+                textAlign: 'center',
+                color: INK2,
+              }}
+            >
+              {d.label}
+            </span>
+          </div>
+        ))}
+      </div>
+      <Link
+        href={embed.friendHref}
+        style={{
+          display: 'inline-block',
+          marginTop: 12,
+          fontFamily: FM,
+          fontSize: 10,
+          letterSpacing: 2,
+          color: ACTOR_BLUE,
+          textDecoration: 'none',
+        }}
+      >
+        SEE WHAT YOU SHARE →
+      </Link>
     </div>
   );
 }

--- a/src/components/profile/CommonGround.tsx
+++ b/src/components/profile/CommonGround.tsx
@@ -4,38 +4,18 @@ import type {
   CommonGround as CommonGroundData,
   CommonGroundDomain,
 } from '@/server/db/queries/common-ground'
-import type { MasteryTier } from '@/types/db'
+
+import {
+  circleDatasetMax,
+  DomainCircleSvg,
+  FRIEND_FILL,
+  VIEWER_FILL,
+} from './common-ground-circles'
 
 type CommonGroundProps = {
   // Null when the section isn't applicable (e.g. owner self-view); renders nothing.
   data: CommonGroundData | null
   friendFirstName: string
-}
-
-// Circle geometry is ported from src/components/OverlapMap.tsx (CategoryItem).
-// Diameter scales with a user's mastery points in the domain; the gap between
-// the two circles encodes overlap strength. Unlike OverlapMap (whose overlap
-// ratio comes from shared correct answers), here overlap is derived from tier
-// closeness, per the profile-page spec.
-const MIN_DIAMETER = 20
-const MAX_DIAMETER = 56
-
-// Viewer = brand navy, friend = brand orange — the app's two signature accents
-// (--brand-navy / --brand-orange) form a calm, on-brand two-tone split so each
-// circle reads as "you" vs the friend at a glance against the cream surface.
-const VIEWER_FILL = '#1f3a5a' // --brand-navy
-const FRIEND_FILL = '#d15e36' // --brand-orange
-const CIRCLE_OPACITY = 0.72
-
-const TIER_INDEX: Record<MasteryTier, number> = {
-  establishing: 0,
-  familiar: 1,
-  solid: 2,
-  mastery: 3,
-}
-
-function overlapRatioFromTiers(a: MasteryTier, b: MasteryTier): number {
-  return 1 - Math.abs(TIER_INDEX[a] - TIER_INDEX[b]) / 3
 }
 
 export function CommonGround({ data, friendFirstName }: CommonGroundProps) {
@@ -54,12 +34,8 @@ export function CommonGround({ data, friendFirstName }: CommonGroundProps) {
     headline = `No overlap with ${friendFirstName} yet.`
   }
 
-  // Scale circle diameters against the largest mastery score across everything
-  // we render, so the biggest circle is always MAX_DIAMETER. Floored at 1 to
-  // avoid divide-by-zero when every domain is latent at zero points.
-  const datasetMax = Math.max(
-    1,
-    ...[...proven, ...latent].flatMap((d) => [
+  const datasetMax = circleDatasetMax(
+    [...proven, ...latent].flatMap((d) => [
       d.viewer.mastery_points,
       d.friend.mastery_points,
     ]),
@@ -181,28 +157,6 @@ function DomainCircles({
   datasetMax: number
   friendFirstName: string
 }) {
-  const dA =
-    MIN_DIAMETER +
-    (domain.viewer.mastery_points / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
-  const dB =
-    MIN_DIAMETER +
-    (domain.friend.mastery_points / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
-  const rA = dA / 2
-  const rB = dB / 2
-  const overlapRatio = overlapRatioFromTiers(
-    domain.viewer.current_tier,
-    domain.friend.current_tier,
-  )
-  const gap = (rA + rB) * (1 - overlapRatio * 0.85)
-  // The friend circle's right edge sits at (rA + gap + rB), but the viewer
-  // circle (centered at rA) reaches 2*rA. When the viewer's circle is the
-  // larger of the two and the gap is small (high tier overlap), 2*rA exceeds
-  // rA + gap + rB and the viewer circle gets clipped by the SVG viewport.
-  // Size the viewport to the true bounding box so neither circle is cut off.
-  const svgWidth = Math.max(2 * rA, rA + gap + rB)
-  const svgHeight = Math.max(dA, dB)
-  const cy = svgHeight / 2
-
   const label =
     domain.kind === 'proven'
       ? `You and ${friendFirstName} both know ${domain.canonical_subcategory}`
@@ -210,29 +164,14 @@ function DomainCircles({
 
   return (
     <div className="flex max-w-[160px] min-w-[110px] flex-col items-center gap-1.5 px-1">
-      <svg
-        width={svgWidth}
-        height={svgHeight}
-        viewBox={`0 0 ${svgWidth} ${svgHeight}`}
-        role="img"
-        aria-label={label}
-      >
-        {/* fill via style (not the SVG attribute) to keep parity with OverlapMap */}
-        <circle
-          cx={rA}
-          cy={cy}
-          r={rA}
-          style={{ fill: VIEWER_FILL }}
-          opacity={CIRCLE_OPACITY}
-        />
-        <circle
-          cx={rA + gap}
-          cy={cy}
-          r={rB}
-          style={{ fill: FRIEND_FILL }}
-          opacity={CIRCLE_OPACITY}
-        />
-      </svg>
+      <DomainCircleSvg
+        viewerPoints={domain.viewer.mastery_points}
+        friendPoints={domain.friend.mastery_points}
+        viewerTier={domain.viewer.current_tier}
+        friendTier={domain.friend.current_tier}
+        datasetMax={datasetMax}
+        ariaLabel={label}
+      />
       <p
         className="text-center font-serif text-sm leading-tight"
         style={{ color: 'var(--brand-ink)' }}

--- a/src/components/profile/common-ground-circles.tsx
+++ b/src/components/profile/common-ground-circles.tsx
@@ -1,0 +1,116 @@
+import type { MasteryTier } from '@/types/db'
+
+// Shared geometry + rendering for the "Common ground" overlapping-circles motif.
+// Ported from OverlapMap (CategoryItem): diameter scales with a user's mastery
+// points in the domain; the gap between the two circles encodes overlap strength
+// (derived here from tier closeness). Used both by the profile-page CommonGround
+// section and by the homepage "What's happening" common-ground promo, so the
+// (clip-safe) bounding-box math lives in ONE place — see circleGeometry.
+export const MIN_DIAMETER = 20
+export const MAX_DIAMETER = 56
+
+// Viewer = brand navy, friend = brand orange — the app's two signature accents
+// (--brand-navy / --brand-orange) form a calm, on-brand two-tone split so each
+// circle reads as "you" vs the friend at a glance against the cream surface.
+export const VIEWER_FILL = '#1f3a5a' // --brand-navy
+export const FRIEND_FILL = '#d15e36' // --brand-orange
+export const CIRCLE_OPACITY = 0.72
+
+const TIER_INDEX: Record<MasteryTier, number> = {
+  establishing: 0,
+  familiar: 1,
+  solid: 2,
+  mastery: 3,
+}
+
+function overlapRatioFromTiers(a: MasteryTier, b: MasteryTier): number {
+  return 1 - Math.abs(TIER_INDEX[a] - TIER_INDEX[b]) / 3
+}
+
+// Scale circle diameters against the largest mastery score across everything we
+// render, so the biggest circle is always MAX_DIAMETER. Floored at 1 to avoid
+// divide-by-zero when every point value is zero.
+export function circleDatasetMax(points: number[]): number {
+  return Math.max(1, ...points)
+}
+
+// The pure geometry, shared so the clip fix lives in one place. The viewer
+// circle (centered at rA) spans [0, 2*rA]; the friend circle (centered at
+// rA + gap) spans [rA + gap - rB, rA + gap + rB]. Either edge can fall outside
+// the naive [0, 2*rA] box: when the viewer is larger with a small gap its RIGHT
+// edge overflows, and when the friend is larger (e.g. Wagner's Ring Cycle) with
+// a small gap its LEFT edge goes negative. We size the viewport to the union of
+// both circles and shift everything right by -minX so neither circle is clipped
+// by the viewBox origin.
+function circleGeometry(
+  viewerPoints: number,
+  friendPoints: number,
+  viewerTier: MasteryTier,
+  friendTier: MasteryTier,
+  datasetMax: number,
+) {
+  const dA = MIN_DIAMETER + (viewerPoints / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
+  const dB = MIN_DIAMETER + (friendPoints / datasetMax) * (MAX_DIAMETER - MIN_DIAMETER)
+  const rA = dA / 2
+  const rB = dB / 2
+  const overlapRatio = overlapRatioFromTiers(viewerTier, friendTier)
+  const gap = (rA + rB) * (1 - overlapRatio * 0.85)
+  const minX = Math.min(0, rA + gap - rB)
+  const maxX = Math.max(2 * rA, rA + gap + rB)
+  const offsetX = -minX
+  const svgWidth = maxX - minX
+  const svgHeight = Math.max(dA, dB)
+  const cy = svgHeight / 2
+  return { svgWidth, svgHeight, cy, rA, rB, gap, offsetX }
+}
+
+// The two overlapping circles alone (no label, no wrapper) so callers can frame
+// them however the surface needs.
+export function DomainCircleSvg({
+  viewerPoints,
+  friendPoints,
+  viewerTier,
+  friendTier,
+  datasetMax,
+  ariaLabel,
+}: {
+  viewerPoints: number
+  friendPoints: number
+  viewerTier: MasteryTier
+  friendTier: MasteryTier
+  datasetMax: number
+  ariaLabel: string
+}) {
+  const { svgWidth, svgHeight, cy, rA, rB, gap, offsetX } = circleGeometry(
+    viewerPoints,
+    friendPoints,
+    viewerTier,
+    friendTier,
+    datasetMax,
+  )
+  return (
+    <svg
+      width={svgWidth}
+      height={svgHeight}
+      viewBox={`0 0 ${svgWidth} ${svgHeight}`}
+      role="img"
+      aria-label={ariaLabel}
+    >
+      {/* fill via style (not the SVG attribute) to keep parity with OverlapMap */}
+      <circle
+        cx={rA + offsetX}
+        cy={cy}
+        r={rA}
+        style={{ fill: VIEWER_FILL }}
+        opacity={CIRCLE_OPACITY}
+      />
+      <circle
+        cx={rA + gap + offsetX}
+        cy={cy}
+        r={rB}
+        style={{ fill: FRIEND_FILL }}
+        opacity={CIRCLE_OPACITY}
+      />
+    </svg>
+  )
+}

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -20,6 +20,7 @@
 
 import { HOME_TOP3_ELIGIBLE_TYPES } from '@/server/activity/write-activity';
 import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { MasteryTier } from '@/types/db';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 import { LATELY_TIER, latelyTierForMomentDir } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
@@ -112,6 +113,24 @@ export type StreamAction =
 //                   domain opened (expansion).
 export type StreamIconKind = 'bundle' | 'diamond' | 'hourglass' | 'domain' | null;
 
+// An optional rich embed rendered inline beneath a row's one-liner. Almost no
+// rows carry one. The common-ground promo (homepage "What's happening" ONLY)
+// uses it to surface a few domains the viewer shares with a friend as the
+// overlapping-circle motif from the profile page — a quiet discovery nudge.
+export type CommonGroundPromoDomain = {
+  label: string;
+  viewer: { points: number; tier: MasteryTier };
+  friend: { points: number; tier: MasteryTier };
+};
+
+export type StreamEmbed = {
+  kind: 'common_ground';
+  friendId: string;
+  friendFirstName: string;
+  friendHref: string;
+  domains: CommonGroundPromoDomain[];
+};
+
 export type StreamItem = {
   id: string;
   sortAt: Date;
@@ -126,6 +145,8 @@ export type StreamItem = {
   expand: StreamExpand | null;
   // Which triangle mark (if any) precedes this row. See StreamIconKind.
   icon: StreamIconKind;
+  // Optional inline embed rendered under the one-liner (see StreamEmbed).
+  embed?: StreamEmbed | null;
 };
 
 // --- Small builders ----------------------------------------------------------
@@ -573,5 +594,32 @@ export function convergenceToStreamItem(
       friendName: convergence.friendName,
       questions,
     },
+  };
+}
+
+// --- Common-ground promo -----------------------------------------------------
+
+// A homepage-only discovery nudge: "You and {friend} share ground worth
+// testing", with the friend's top few shared-but-untested domains drawn as the
+// overlapping-circle motif from their profile. Question-free, so it never
+// expands; the embed carries everything ActivityStreamItem needs to render the
+// circles plus a link through to the friend's profile.
+export function commonGroundPromoToStreamItem(
+  embed: StreamEmbed,
+  sortAt: Date,
+  id: string,
+): StreamItem {
+  return {
+    id,
+    sortAt,
+    tier: LATELY_TIER.OTHER,
+    homeEligible: true,
+    line: [txt('You and '), act(embed.friendFirstName, embed.friendId), txt(' share ground worth testing')],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'domain',
+    expand: null,
+    embed,
   };
 }

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -1,0 +1,84 @@
+/**
+ * Homepage "What's happening" common-ground promo.
+ *
+ * Produces a single, optional `StreamItem` (the inline common-ground embed) that
+ * the home feed prepends to its activity rows. This is a HOME-ONLY surface — it
+ * is assembled here, NOT inside buildActivityStream, so /activities and Lately
+ * stay free of the promo.
+ *
+ * "Rotating discovery": we rotate the viewer's friends by a day seed and probe
+ * the first few for LATENT common ground (domains both hold but at least one
+ * hasn't proven — shared, still untested), surfacing the first that has any.
+ */
+
+import {
+  commonGroundPromoToStreamItem,
+  type StreamEmbed,
+  type StreamItem,
+} from '@/lib/activity-stream';
+import { getCommonGround } from '@/server/db/queries/common-ground';
+import { getFriends } from '@/server/db/queries/friends';
+
+const MAX_PROMO_DOMAINS = 3;
+// Cap the per-render getCommonGround probes so the homepage stays cheap even for
+// users with many friends; the rotation still cycles through everyone over time.
+const MAX_CANDIDATES = 4;
+
+function firstName(displayName: string | null): string {
+  const trimmed = (displayName ?? '').trim();
+  if (!trimmed) return 'They';
+  const [first] = trimmed.split(/\s+/);
+  return first ?? trimmed;
+}
+
+// Stable within a UTC day so the rotating pick (and the row's React key) don't
+// churn across re-renders, but advances day to day.
+function daySeed(now: Date): number {
+  return Math.floor(now.getTime() / 86_400_000);
+}
+
+export async function getCommonGroundPromo(
+  userId: string,
+  now: Date = new Date(),
+): Promise<StreamItem | null> {
+  const friends = await getFriends(userId);
+  if (friends.length === 0) return null;
+
+  const seed = daySeed(now);
+  const candidates = Array.from(
+    { length: Math.min(friends.length, MAX_CANDIDATES) },
+    (_, i) => friends[(i + seed) % friends.length],
+  );
+
+  const grounds = await Promise.all(
+    candidates.map((friend) => getCommonGround(userId, friend.id)),
+  );
+
+  for (let i = 0; i < candidates.length; i++) {
+    const friend = candidates[i];
+    const latent = grounds[i].latent;
+    if (latent.length === 0) continue;
+
+    const domains = latent.slice(0, MAX_PROMO_DOMAINS).map((d) => ({
+      label: d.canonical_subcategory,
+      viewer: { points: d.viewer.mastery_points, tier: d.viewer.current_tier },
+      friend: { points: d.friend.mastery_points, tier: d.friend.current_tier },
+    }));
+
+    const embed: StreamEmbed = {
+      kind: 'common_ground',
+      friendId: friend.id,
+      friendFirstName: firstName(friend.displayName),
+      friendHref: `/users/${friend.id}`,
+      domains,
+    };
+
+    return commonGroundPromoToStreamItem(
+      embed,
+      now,
+      `common-ground-promo-${friend.id}-${seed}`,
+    );
+  }
+
+  return null;
+}

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -23,6 +23,10 @@ const MAX_PROMO_DOMAINS = 3;
 // Cap the per-render getCommonGround probes so the homepage stays cheap even for
 // users with many friends; the rotation still cycles through everyone over time.
 const MAX_CANDIDATES = 4;
+// The promo should read as an occasional nudge, not a fixture — show it on only
+// ~2 in 5 visits (roughly once every two to three times on the site). Gating is
+// probabilistic (stateless) so it needs no per-user counter cookie or DB row.
+const PROMO_SHOW_PROBABILITY = 0.4;
 
 function firstName(displayName: string | null): string {
   const trimmed = (displayName ?? '').trim();
@@ -40,7 +44,13 @@ function daySeed(now: Date): number {
 export async function getCommonGroundPromo(
   userId: string,
   now: Date = new Date(),
+  // Injectable for tests; defaults to Math.random in [0, 1).
+  random: () => number = Math.random,
 ): Promise<StreamItem | null> {
+  // Gate first so the visits we won't show the promo skip the friend and
+  // common-ground reads entirely.
+  if (random() >= PROMO_SHOW_PROBABILITY) return null;
+
   const friends = await getFriends(userId);
   if (friends.length === 0) return null;
 


### PR DESCRIPTION
## Summary
Refactors the overlapping-circle "common ground" visualization into a reusable component and adds a homepage discovery feature that surfaces shared-but-untested domains between friends.

## Key Changes

- **New `common-ground-circles.tsx`**: Extracted shared geometry and rendering logic for the overlapping-circles motif (diameter scaling, gap calculation, SVG viewport math) into a single source of truth. Exports `DomainCircleSvg` component and constants (`MIN_DIAMETER`, `MAX_DIAMETER`, color fills, `circleDatasetMax` helper).

- **Profile CommonGround refactor**: Updated to use the new `DomainCircleSvg` component and `circleDatasetMax` helper, removing ~60 lines of duplicated geometry code. The visual output and behavior remain identical.

- **New `common-ground-promo.ts`**: Implements a homepage-only discovery feature that:
  - Rotates through the viewer's friends using a day-stable seed (so the pick doesn't churn across re-renders)
  - Probes up to 4 candidates for latent common ground (domains both hold but at least one hasn't proven)
  - Returns the first friend with any latent overlap, capped at 3 domains
  - Gated by ~40% probability so the promo appears as an occasional nudge (~2 in 5 visits)

- **Activity stream integration**: 
  - Added `StreamEmbed` type to `activity-stream.ts` with `common_ground` kind, carrying friend metadata and domain data
  - Added `commonGroundPromoToStreamItem` builder to convert the promo into a `StreamItem`
  - New `CommonGroundEmbed` component in `ActivityStreamItem.tsx` renders the circles and link inline beneath the row's one-liner
  - Updated homepage (`page.tsx`) to fetch and prepend the promo to the activity feed

## Implementation Details

- **Clip-safe viewport math**: The extracted `circleGeometry` function handles the case where either circle's edge can fall outside the naive bounding box (e.g., when the viewer's circle is larger with a small gap, or the friend's circle extends left of zero). The SVG viewport is sized to the union and everything is offset right by `-minX`.

- **Overlap encoding**: Overlap ratio is derived from tier closeness (0–3 scale), not shared correct answers like the original OverlapMap. Gap = `(rA + rB) * (1 - overlapRatio * 0.85)`.

- **Stateless gating**: The promo's probability gate is stateless (no cookie or DB counter), so it needs no per-user tracking.

- **Read-only embed**: The promo embed is non-expanding and stops click propagation so taps on circles or the "SEE WHAT YOU SHARE" link never toggle a (non-existent) expansion.

https://claude.ai/code/session_01R9G9w8sgYdtknvhcCaGXpt