### PR TITLE
Align "What's happening" header with feed activity rows

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -148,7 +148,11 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   ]
   return (
     <>
-      <p className="mb-2 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+      {/* Sit the header on the feed's left gutter — the same 2px the activity
+          rows pad in (where the fixed icon column / shape marks begin), so the
+          header and the shapes share one left edge. The day labels indent
+          further (pl-[34px], past the icon column) to meet the row copy. */}
+      <p className="mb-2 pl-[2px] text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
         What&rsquo;s happening
       </p>
       <FeedList


### PR DESCRIPTION
## Summary
Adjusts the left padding of the "What's happening" section header to align with the feed's activity rows, ensuring consistent visual alignment across the feed layout.

## Changes
- Added `pl-[2px]` class to the section header paragraph to match the left gutter padding of activity rows
- Added clarifying comment explaining the alignment strategy: the header sits on the feed's 2px left gutter (same as activity row padding), while day labels indent further (`pl-[34px]`) past the icon column to align with row content

## Implementation Details
This change ensures visual consistency by aligning the header's left edge with the activity rows' left edge, where the fixed icon column and shape marks begin. The comment documents the intentional padding hierarchy: header at 2px, day labels at 34px (past the icon column).

https://claude.ai/code/session_01H66wH9V2DBY6DzrhNPuCev