### PR TITLE
B-Report-2: content reporting write path, ⋯ menu items, and "why" step

### DIFF
--- a/src/app/api/content-reports/__tests__/route.test.ts
+++ b/src/app/api/content-reports/__tests__/route.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+const { getSessionMock, insertContentReportMock, countContentReportsTodayMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' }) as { userId: string; id: string } | null),
+  insertContentReportMock: vi.fn(async () => 'inserted' as 'inserted' | 'duplicate'),
+  countContentReportsTodayMock: vi.fn(async () => 0),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  insertContentReport: insertContentReportMock,
+  countContentReportsToday: countContentReportsTodayMock,
+}));
+
+import { POST } from '@/app/api/content-reports/route';
+
+function post(body: unknown): Promise<Response> {
+  const request = new Request('http://localhost/api/content-reports', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request as unknown as NextRequest);
+}
+
+const validIncorrect = {
+  category: 'incorrect',
+  incorrectKind: 'answer_key',
+  note: 'the answer key is wrong',
+  suggestedAnswer: 'Paris',
+  surface: 'round_recap',
+  questionId: 'q-1',
+};
+
+const validInappropriate = {
+  category: 'inappropriate',
+  note: 'this is offensive',
+  surface: 'lately_result',
+  questionId: 'q-7',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'user-1', id: 's-1' });
+  insertContentReportMock.mockResolvedValue('inserted');
+  countContentReportsTodayMock.mockResolvedValue(0);
+});
+
+describe('POST /api/content-reports', () => {
+  it('rejects unauthenticated requests', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    const res = await post(validIncorrect);
+    expect(res.status).toBe(401);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('lands an incorrect report with the curated-question target', async () => {
+    const res = await post(validIncorrect);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, duplicate: false });
+    expect(insertContentReportMock).toHaveBeenCalledTimes(1);
+    expect(insertContentReportMock).toHaveBeenCalledWith({
+      reporterUserId: 'user-1',
+      questionId: 'q-1',
+      generatedQuestionId: null,
+      category: 'incorrect',
+      incorrectKind: 'answer_key',
+      suggestedAnswer: 'Paris',
+      note: 'the answer key is wrong',
+      surface: 'round_recap',
+    });
+  });
+
+  it('lands an inappropriate report and nulls incorrect-only fields', async () => {
+    const res = await post({ ...validInappropriate, generatedQuestionId: undefined });
+    expect(res.status).toBe(200);
+    expect(insertContentReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'inappropriate',
+        incorrectKind: null,
+        suggestedAnswer: null,
+        questionId: 'q-7',
+        generatedQuestionId: null,
+      }),
+    );
+  });
+
+  it('accepts a generated-question target', async () => {
+    const res = await post({
+      category: 'inappropriate',
+      note: 'nope',
+      surface: 'round_recap',
+      generatedQuestionId: 'gq-3',
+    });
+    expect(res.status).toBe(200);
+    expect(insertContentReportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ questionId: null, generatedQuestionId: 'gq-3' }),
+    );
+  });
+
+  it('rejects a missing note', async () => {
+    const res = await post({ ...validIncorrect, note: '   ' });
+    expect(res.status).toBe(400);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when both targets are present', async () => {
+    const res = await post({ ...validIncorrect, generatedQuestionId: 'gq-1' });
+    expect(res.status).toBe(400);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects when neither target is present', async () => {
+    const { questionId: _omit, ...noTarget } = validIncorrect;
+    const res = await post(noTarget);
+    expect(res.status).toBe(400);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects incorrectKind on an inappropriate report', async () => {
+    const res = await post({ ...validInappropriate, incorrectKind: 'premise' });
+    expect(res.status).toBe(400);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects an unknown surface', async () => {
+    const res = await post({ ...validIncorrect, surface: 'in_play' });
+    expect(res.status).toBe(400);
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('soft-429s at the daily cap without writing', async () => {
+    countContentReportsTodayMock.mockResolvedValueOnce(10);
+    const res = await post(validIncorrect);
+    expect(res.status).toBe(429);
+    const json = await res.json();
+    expect(json.error).toBe('rate_limited');
+    expect(json.message).toBeTruthy();
+    expect(insertContentReportMock).not.toHaveBeenCalled();
+  });
+
+  it('still writes at one below the cap', async () => {
+    countContentReportsTodayMock.mockResolvedValueOnce(9);
+    const res = await post(validIncorrect);
+    expect(res.status).toBe(200);
+    expect(insertContentReportMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats an idempotent duplicate as success', async () => {
+    insertContentReportMock.mockResolvedValueOnce('duplicate');
+    const res = await post(validIncorrect);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true, duplicate: true });
+  });
+});

--- a/src/app/api/content-reports/route.ts
+++ b/src/app/api/content-reports/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  countContentReportsToday,
+  insertContentReport,
+} from '@/server/db/queries/content-reports';
+
+export const dynamic = 'force-dynamic';
+
+// B-Report-2: the player's negative surface. A reporter opens the existing ⋯ on a
+// post-reveal review surface, picks "This is incorrect" / "This is inappropriate",
+// answers a short shaped "why", and lands a ContentReport row. No suppression /
+// author surfacing / admin queue yet — this only captures the report.
+
+// §6.2.1 flood-stop. At or over the cap we soft-429 (the report is not written) so a
+// single frustrated session can't bury the queue. The client shows a gentle nudge.
+const DAILY_REPORT_CAP = 10;
+
+const target = {
+  questionId: z.string().trim().min(1).optional(),
+  generatedQuestionId: z.string().trim().min(1).optional(),
+};
+
+// "incorrect": which part is wrong (incorrectKind), a required note, and an optional
+// "the answer should be ___" (suggestedAnswer).
+const incorrectSchema = z.object({
+  category: z.literal('incorrect'),
+  incorrectKind: z.enum(['answer_key', 'premise']),
+  note: z.string().trim().min(1),
+  suggestedAnswer: z.string().trim().min(1).optional(),
+  surface: z.enum(['round_recap', 'lately_result']),
+  ...target,
+});
+
+// "inappropriate": a required note only. incorrectKind / suggestedAnswer are not
+// meaningful here and are rejected so the ContentReport_incorrect_kind_scope CHECK
+// (incorrect_kind only when category='incorrect') can never be violated.
+const inappropriateSchema = z.object({
+  category: z.literal('inappropriate'),
+  incorrectKind: z.undefined().optional(),
+  suggestedAnswer: z.undefined().optional(),
+  note: z.string().trim().min(1),
+  surface: z.enum(['round_recap', 'lately_result']),
+  ...target,
+});
+
+const bodySchema = z
+  .discriminatedUnion('category', [incorrectSchema, inappropriateSchema])
+  // Exactly one target — the dual-FK invariant the ContentReport_one_target CHECK
+  // also enforces. Reject a generated id smuggled in alongside a curated one.
+  .refine(
+    (data) => (data.questionId ? 1 : 0) + (data.generatedQuestionId ? 1 : 0) === 1,
+    { message: 'exactly one of questionId or generatedQuestionId is required' },
+  );
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', message: parsed.error.issues[0]?.message ?? 'invalid report' },
+      { status: 400 },
+    );
+  }
+  const data = parsed.data;
+
+  // Flood-stop runs before the insert so an over-cap report never lands.
+  const todayCount = await countContentReportsToday(session.userId);
+  if (todayCount >= DAILY_REPORT_CAP) {
+    return NextResponse.json(
+      {
+        error: 'rate_limited',
+        message: "You've sent us a lot today. Take a break — you can pick this back up tomorrow.",
+      },
+      { status: 429 },
+    );
+  }
+
+  const result = await insertContentReport({
+    reporterUserId: session.userId,
+    questionId: data.questionId ?? null,
+    generatedQuestionId: data.generatedQuestionId ?? null,
+    category: data.category,
+    incorrectKind: data.category === 'incorrect' ? data.incorrectKind : null,
+    suggestedAnswer: data.category === 'incorrect' ? data.suggestedAnswer ?? null : null,
+    note: data.note,
+    surface: data.surface,
+  });
+
+  // 'duplicate' = an open report for this target already exists (one-open-report
+  // partial unique index). Idempotent: the player gets the same quiet success.
+  return NextResponse.json({ ok: true, duplicate: result === 'duplicate' });
+}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Flag, Heart, MoreHorizontal, X } from 'lucide-react'
+import { Heart, MoreHorizontal, X } from 'lucide-react'
 import LoadingScreen from '@/components/LoadingScreen'
 import {
   type CSSProperties,
@@ -30,6 +30,7 @@ import type {
 import { RoundReminderCard } from './RoundReminderCard'
 import { FirstSessionRecap } from './FirstSessionRecap'
 import type { FirstSessionRecapView } from '@/server/daily/first-session-recap'
+import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet'
 
 // useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
 // the subscribe/snapshot functions are stable across renders.
@@ -37,7 +38,10 @@ const subscribeNoop = () => () => {}
 const getResetTimeSnapshot = () => formatNextResetTimeLocal()
 const getResetTimeServerSnapshot = (): string | null => null
 
-type FeedbackSignal = 'thumbs_up' | 'thumbs_down'
+// The heart is the only feedback signal on the recap now; the negative surface is
+// the ⋯ report items (B-Report-2). The /api/daily/feedback route still accepts the
+// other signal for the separate feed thumbs-down, which this page no longer sends.
+type FeedbackSignal = 'thumbs_up'
 
 
 const DAILY_DIFFICULTY_LABELS: Record<string, string> = {
@@ -147,6 +151,11 @@ export default function DailySummaryPage() {
   // the user's first completed Daily Five. Null unless eligible + not yet seen.
   const [firstSessionRecap, setFirstSessionRecap] =
     useState<FirstSessionRecapView | null>(null)
+  // B-Report-2: recap rows the player removed by reporting them as inappropriate.
+  // View-state only this prompt — durable self-hide is B-Report-3.
+  const [hiddenQuestionIds, setHiddenQuestionIds] = useState<Set<string>>(
+    () => new Set(),
+  )
   // Client-only reset-time label; null during SSR to keep hydration stable.
   const resetTime = useSyncExternalStore(
     subscribeNoop,
@@ -294,9 +303,21 @@ export default function DailySummaryPage() {
       <section className="mt-6">
         <h2 style={titleStyle}>Round Recap</h2>
         <div className="mt-3 space-y-3">
-          {summary.questions.map((question) => (
-            <QuestionCard key={question.questionId} question={question} />
-          ))}
+          {summary.questions
+            .filter((question) => !hiddenQuestionIds.has(question.questionId))
+            .map((question) => (
+              <QuestionCard
+                key={question.questionId}
+                question={question}
+                onHide={() =>
+                  setHiddenQuestionIds((prev) => {
+                    const next = new Set(prev)
+                    next.add(question.questionId)
+                    return next
+                  })
+                }
+              />
+            ))}
         </div>
       </section>
 
@@ -401,13 +422,15 @@ function InterpretiveLine({ text }: { text: string }) {
   )
 }
 
-function QuestionCard({ question }: { question: QuestionRecap }) {
+function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: () => void }) {
   const [isOverflowOpen, setIsOverflowOpen] = useState(false)
   const [rating, setRating] = useState<FeedbackSignal | null>(null)
   const [isFeedbackPending, startFeedbackTransition] = useTransition()
   const [exclusionState, setExclusionState] = useState<ExclusionState>({
     kind: 'idle',
   })
+  // B-Report-2: which "why" sheet is open, if any. Null = no sheet.
+  const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null)
   const undoTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   const updateFeedback = useCallback(
@@ -469,11 +492,6 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
       // Fire-and-forget; the affordance returns on reload if persistence failed.
     }
   }, [question.domain])
-
-  const handleReportContent = useCallback(() => {
-    updateFeedback('thumbs_down')
-    setIsOverflowOpen(false)
-  }, [updateFeedback])
 
   useEffect(() => {
     return () => {
@@ -663,9 +681,27 @@ function QuestionCard({ question }: { question: QuestionRecap }) {
           onClose={() => setIsOverflowOpen(false)}
           onHideQuestionsLikeThis={handleExcludeDomain}
           onMuteCategory={handleExcludeDomain}
-          onReportContent={handleReportContent}
-          reportSelected={rating === 'thumbs_down'}
-          reportDisabled={isFeedbackPending}
+          canReport={question.reportTarget !== null}
+          onReportIncorrect={() => {
+            setIsOverflowOpen(false)
+            setReportCategory('incorrect')
+          }}
+          onReportInappropriate={() => {
+            setIsOverflowOpen(false)
+            setReportCategory('inappropriate')
+          }}
+        />
+      ) : null}
+
+      {reportCategory && question.reportTarget ? (
+        <ReportReasonSheet
+          category={reportCategory}
+          target={question.reportTarget as ReportReasonTarget}
+          surface="round_recap"
+          onClose={() => setReportCategory(null)}
+          onSubmitted={(category) => {
+            if (category === 'inappropriate') onHide()
+          }}
         />
       ) : null}
     </article>
@@ -677,17 +713,17 @@ function QuestionCardOverflowMenu({
   onClose,
   onHideQuestionsLikeThis,
   onMuteCategory,
-  onReportContent,
-  reportSelected,
-  reportDisabled,
+  canReport,
+  onReportIncorrect,
+  onReportInappropriate,
 }: {
   question: QuestionRecap
   onClose: () => void
   onHideQuestionsLikeThis: () => void
   onMuteCategory: () => void
-  onReportContent: () => void
-  reportSelected: boolean
-  reportDisabled: boolean
+  canReport: boolean
+  onReportIncorrect: () => void
+  onReportInappropriate: () => void
 }) {
   return (
     <div className="fixed inset-0 z-50 flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:top-14 sm:right-3 sm:block sm:bg-transparent sm:p-0">
@@ -739,19 +775,24 @@ function QuestionCardOverflowMenu({
             className="hover:bg-muted flex min-h-11 w-full justify-start rounded-xl border-0 px-3 text-left text-sm"
           />
         ) : null}
-        <button
-          type="button"
-          onClick={onReportContent}
-          disabled={reportDisabled}
-          aria-pressed={reportSelected}
-          className={cn(
-            'text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center gap-2 rounded-xl px-3 text-left text-sm transition disabled:opacity-60',
-            reportSelected ? 'bg-muted text-foreground' : ''
-          )}
-        >
-          <Flag className="size-4" />
-          Report content
-        </button>
+        {canReport ? (
+          <>
+            <button
+              type="button"
+              onClick={onReportIncorrect}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is incorrect
+            </button>
+            <button
+              type="button"
+              onClick={onReportInappropriate}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is inappropriate
+            </button>
+          </>
+        ) : null}
       </div>
     </div>
   )

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -153,6 +153,7 @@ export function InlineAnswerFlow({
           openedTerritoryDomain={feedback.openedTerritoryDomain}
           questionId={question.questionId}
           feedItemId={`milestone:${question.questionId}`}
+          report={{ target: { questionId: question.questionId }, surface: 'lately_result' }}
           onClose={finish}
         />
       ) : null}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -1,12 +1,13 @@
 'use client'
 
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
-import { Check, Sparkles, X } from 'lucide-react'
+import { Check, MoreHorizontal, Sparkles, X } from 'lucide-react'
 
 import { FeedActionLink } from './FeedActionLink'
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
 import { INSIDE_JOKE_LABELS, type InsideJokeKind } from '@/lib/questions-types'
+import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet'
 
 // Darkened triangle-gold for text/eyebrows that need to clear AA on the cream
 // card (raw --tri-amber #d9a82e is too light for small text). Used by the
@@ -32,6 +33,10 @@ type AnswerFeedbackSheetProps = {
   // disputed canonical answer). Resolves with the verdict to surface inline.
   // Omit (or pass null) to hide the recheck affordance.
   onRecheck?: (() => Promise<{ accepted: boolean; message: string }>) | null
+  // B-Report-2: opt-in content-reporting ⋯ menu. This sheet is shared across several
+  // post-result surfaces; only the milestone inline flow enables it (the prompt scopes
+  // the entry point to that surface). Omit on the feed/direct-answer result modals.
+  report?: { target: ReportReasonTarget; surface: 'round_recap' | 'lately_result' } | null
   onClose: () => void
 }
 
@@ -54,6 +59,7 @@ export function AnswerFeedbackSheet({
   questionId,
   feedItemId,
   onRecheck = null,
+  report = null,
   onClose,
 }: AnswerFeedbackSheetProps) {
   const visibleCategory = visibleFeedCategory(category)
@@ -64,6 +70,10 @@ export function AnswerFeedbackSheet({
   const [recheckState, setRecheckState] = useState<RecheckState>('idle')
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null)
   const [recheckAccepted, setRecheckAccepted] = useState(false)
+  // B-Report-2: the ⋯ menu (none existed on this surface before) and the "why" sheet.
+  // A Lately milestone question is always a curated Question, so the target is questionId.
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null)
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
@@ -167,14 +177,27 @@ export function AnswerFeedbackSheet({
           ) : (
             <div />
           )}
-          <button
-            type="button"
-            onClick={onClose}
-            aria-label="Close"
-            className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-          >
-            <X className="size-4" />
-          </button>
+          <div className="flex items-center gap-1">
+            {report ? (
+              <button
+                type="button"
+                onClick={() => setIsMenuOpen(true)}
+                aria-label="More actions"
+                aria-expanded={isMenuOpen}
+                className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              >
+                <MoreHorizontal className="size-5" />
+              </button>
+            ) : null}
+            <button
+              type="button"
+              onClick={onClose}
+              aria-label="Close"
+              className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              <X className="size-4" />
+            </button>
+          </div>
         </div>
 
         <div className="flex-1 overflow-y-auto px-5 pb-2">
@@ -363,6 +386,67 @@ export function AnswerFeedbackSheet({
           </button>
         </div>
       </div>
+
+      {report && isMenuOpen ? (
+        <div
+          className="fixed inset-0 z-[58] flex items-end justify-center px-3 pt-16 pb-3 sm:items-start sm:pt-24"
+          style={{ background: 'rgba(0,0,0,0.2)' }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close menu"
+            onClick={() => setIsMenuOpen(false)}
+          />
+          <div className="bg-background relative w-full max-w-md rounded-3xl border p-2 shadow-2xl sm:w-72 sm:rounded-2xl">
+            <div className="flex items-center justify-between px-3 py-2 sm:hidden">
+              <p className="text-foreground text-sm font-medium">More actions</p>
+              <button
+                type="button"
+                aria-label="Close menu"
+                onClick={() => setIsMenuOpen(false)}
+                className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-11 items-center justify-center rounded-full"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                setIsMenuOpen(false)
+                setReportCategory('incorrect')
+              }}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is incorrect
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setIsMenuOpen(false)
+                setReportCategory('inappropriate')
+              }}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is inappropriate
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {report && reportCategory ? (
+        <ReportReasonSheet
+          category={reportCategory}
+          target={report.target}
+          surface={report.surface}
+          onClose={() => setReportCategory(null)}
+          onSubmitted={(category) => {
+            // Inappropriate → the result card disappears from view (close the modal).
+            // Durable self-hide / propagation suppression is B-Report-3.
+            if (category === 'inappropriate') onClose()
+          }}
+        />
+      ) : null}
     </div>
   )
 }

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -380,6 +380,23 @@ describe('Answer feedback sheet recheck affordance', () => {
     )
     expect(rendered).not.toContain('Recheck →')
   })
+
+  // B-Report-2: the content-reporting ⋯ is opt-in so the shared result sheet does not
+  // surface it on the feed / direct-answer result modals — only where a surface passes `report`.
+  it('hides the content-report ⋯ menu when no report context is supplied', () => {
+    const rendered = html(<AnswerFeedbackSheet {...baseProps} />)
+    expect(rendered).not.toContain('More actions')
+  })
+
+  it('shows the content-report ⋯ when a report context is supplied', () => {
+    const rendered = html(
+      <AnswerFeedbackSheet
+        {...baseProps}
+        report={{ target: { questionId: 'q1' }, surface: 'lately_result' }}
+      />
+    )
+    expect(rendered).toContain('More actions')
+  })
 })
 
 describe('Authored-by-viewer card', () => {

--- a/src/components/report/ReportReasonSheet.tsx
+++ b/src/components/report/ReportReasonSheet.tsx
@@ -1,0 +1,266 @@
+'use client'
+
+import { useEffect, useState, type CSSProperties } from 'react'
+import { X } from 'lucide-react'
+
+import { cn } from '@/lib/utils'
+
+// B-Report-2: the shaped "why" step (PRD §6.1.2 / §6.1.3). Shared form only — each
+// surface keeps its own ⋯ menu (no menu refactor in this prompt). The two problem-
+// named entry points open this sheet with the matching `category`; it collects the
+// shaped reason and POSTs a ContentReport. No mechanism words ("flag/report/thumbs")
+// appear in any copy here.
+
+export type ReportReasonTarget =
+  | { questionId: string; generatedQuestionId?: undefined }
+  | { generatedQuestionId: string; questionId?: undefined }
+
+type ReportCategory = 'incorrect' | 'inappropriate'
+type IncorrectKind = 'answer_key' | 'premise'
+type Status = 'form' | 'submitting' | 'done' | 'rate_limited' | 'error'
+
+export function ReportReasonSheet({
+  category,
+  target,
+  surface,
+  onClose,
+  onSubmitted,
+}: {
+  category: ReportCategory
+  target: ReportReasonTarget
+  surface: 'round_recap' | 'lately_result'
+  onClose: () => void
+  // Fires once on a successful submit (including an idempotent duplicate). For
+  // 'inappropriate' the parent removes the card from view; for 'incorrect' the card
+  // is left unchanged and this sheet shows the quiet acknowledgement itself.
+  onSubmitted: (category: ReportCategory) => void
+}) {
+  const [incorrectKind, setIncorrectKind] = useState<IncorrectKind | null>(null)
+  const [note, setNote] = useState('')
+  const [suggestedAnswer, setSuggestedAnswer] = useState('')
+  const [status, setStatus] = useState<Status>('form')
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const noteTrimmed = note.trim()
+  const canSubmit =
+    status !== 'submitting' &&
+    noteTrimmed.length > 0 &&
+    (category === 'inappropriate' || incorrectKind !== null)
+
+  async function submit() {
+    if (!canSubmit) return
+    setStatus('submitting')
+    try {
+      const payload: Record<string, unknown> = {
+        category,
+        note: noteTrimmed,
+        surface,
+        ...(target.questionId
+          ? { questionId: target.questionId }
+          : { generatedQuestionId: target.generatedQuestionId }),
+      }
+      if (category === 'incorrect') {
+        payload.incorrectKind = incorrectKind
+        if (suggestedAnswer.trim()) payload.suggestedAnswer = suggestedAnswer.trim()
+      }
+      const res = await fetch('/api/content-reports', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify(payload),
+      })
+      if (res.status === 429) {
+        setStatus('rate_limited')
+        return
+      }
+      if (!res.ok) {
+        setStatus('error')
+        return
+      }
+      // Success (incl. idempotent re-submit of an already-open item).
+      if (category === 'inappropriate') {
+        // The card vanishing is the feedback (§6.1.3); hand removal to the parent.
+        onSubmitted('inappropriate')
+        onClose()
+        return
+      }
+      setStatus('done')
+      onSubmitted('incorrect')
+    } catch {
+      setStatus('error')
+    }
+  }
+
+  const heading =
+    category === 'incorrect' ? 'What looks off?' : 'What feels wrong here?'
+
+  return (
+    <div className="fixed inset-0 z-[60] flex items-end justify-center">
+      <button
+        type="button"
+        className="absolute inset-0"
+        style={{ background: 'rgba(0,0,0,0.4)' }}
+        onClick={onClose}
+        aria-label="Dismiss"
+      />
+      <div className="relative flex max-h-[90dvh] w-full max-w-lg flex-col rounded-t-3xl bg-[var(--brand-card)] shadow-2xl">
+        <div className="flex items-center justify-between px-5 pt-4 pb-1">
+          <p className="text-[0.68rem] font-semibold tracking-[0.18em] uppercase text-[var(--brand-ink-400)]">
+            {category === 'incorrect' ? 'A second look' : 'Between us'}
+          </p>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close"
+            className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          >
+            <X className="size-4" />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 pb-2">
+          {status === 'done' ? (
+            <div className="py-6">
+              <p className="font-serif text-lg leading-6 text-[var(--brand-ink)]">
+                Thanks — we&apos;ll take a look.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                It stays in your recap for now.
+              </p>
+            </div>
+          ) : status === 'rate_limited' ? (
+            <div className="py-6">
+              <p className="font-serif text-lg leading-6 text-[var(--brand-ink)]">
+                You&apos;ve sent us a lot today.
+              </p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Take a break — you can pick this back up tomorrow.
+              </p>
+            </div>
+          ) : (
+            <>
+              <p className="pb-3 font-serif text-lg leading-6 text-[var(--brand-ink)]">
+                {heading}
+              </p>
+
+              {category === 'incorrect' ? (
+                <div className="pb-3">
+                  <div className="flex gap-2">
+                    <SegmentButton
+                      selected={incorrectKind === 'answer_key'}
+                      onClick={() => setIncorrectKind('answer_key')}
+                    >
+                      The answer
+                    </SegmentButton>
+                    <SegmentButton
+                      selected={incorrectKind === 'premise'}
+                      onClick={() => setIncorrectKind('premise')}
+                    >
+                      The question
+                    </SegmentButton>
+                  </div>
+                </div>
+              ) : (
+                <p className="pb-3 text-sm leading-6 text-[var(--brand-ink-700)]">
+                  Tell us what makes this a problem and we&apos;ll review it.
+                </p>
+              )}
+
+              <label className="block">
+                <span className="text-[0.62rem] font-semibold tracking-[0.14em] uppercase text-muted-foreground">
+                  In your words
+                </span>
+                <textarea
+                  value={note}
+                  onChange={(e) => setNote(e.target.value)}
+                  rows={3}
+                  placeholder={
+                    category === 'incorrect'
+                      ? 'What did we get wrong?'
+                      : 'What feels off about this?'
+                  }
+                  className="mt-1 w-full resize-none rounded-2xl border bg-[var(--brand-card)] p-3 font-serif text-[15px] leading-6 text-[var(--brand-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                />
+              </label>
+
+              {category === 'incorrect' ? (
+                <label className="mt-3 block">
+                  <span className="text-[0.62rem] font-semibold tracking-[0.14em] uppercase text-muted-foreground">
+                    The answer should be (optional)
+                  </span>
+                  <input
+                    value={suggestedAnswer}
+                    onChange={(e) => setSuggestedAnswer(e.target.value)}
+                    placeholder="If you know it"
+                    className="mt-1 w-full rounded-2xl border bg-[var(--brand-card)] p-3 font-serif text-[15px] leading-6 text-[var(--brand-ink)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  />
+                </label>
+              ) : null}
+
+              {status === 'error' ? (
+                <p
+                  role="status"
+                  aria-live="polite"
+                  className="mt-3 text-[13px]"
+                  style={{ color: 'var(--game-wrong-strong)' } as CSSProperties}
+                >
+                  That didn&apos;t go through. Give it another go in a moment.
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        <div className="px-5 pt-2 pb-[max(1.25rem,env(safe-area-inset-bottom))]">
+          {status === 'done' || status === 'rate_limited' ? (
+            <button type="button" onClick={onClose} className="btn-primary w-full">
+              Done
+            </button>
+          ) : (
+            <button
+              type="button"
+              onClick={() => void submit()}
+              disabled={!canSubmit}
+              className="btn-primary w-full disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {status === 'submitting' ? 'Sending…' : 'Send'}
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SegmentButton({
+  selected,
+  onClick,
+  children,
+}: {
+  selected: boolean
+  onClick: () => void
+  children: React.ReactNode
+}) {
+  return (
+    <button
+      type="button"
+      aria-pressed={selected}
+      onClick={onClick}
+      className={cn(
+        'flex-1 rounded-2xl border px-3 py-2 text-sm font-medium transition',
+        selected
+          ? 'border-[var(--brand-ink)] bg-muted text-foreground'
+          : 'text-muted-foreground hover:bg-muted hover:text-foreground',
+      )}
+    >
+      {children}
+    </button>
+  )
+}

--- a/src/server/db/queries/__tests__/content-reports.test.ts
+++ b/src/server/db/queries/__tests__/content-reports.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+// Capture what the insert helper writes and control how the db responds, mirroring
+// the chainable-mock style in daily.test.ts.
+let insertedValues: Record<string, unknown> | null = null;
+let insertImpl: () => Promise<unknown> = async () => undefined;
+let selectRows: unknown[] = [];
+
+vi.mock('@/server/db', () => ({
+  db: {
+    insert: () => ({
+      values: (vals: Record<string, unknown>) => {
+        insertedValues = vals;
+        return insertImpl();
+      },
+    }),
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(selectRows),
+      }),
+    }),
+  },
+  contentReports: {
+    reporterUserId: 'reporter_user_id',
+    createdAt: 'created_at',
+  },
+}));
+
+vi.mock('@/lib/games/timezone', () => ({
+  getDailyAssignmentBounds: () => ({
+    assignmentDate: new Date('2026-06-08T00:00:00.000Z'),
+    assignmentDateStr: '2026-06-08',
+    expiresAt: new Date('2026-06-09T00:00:00.000Z'),
+  }),
+}));
+
+import {
+  countContentReportsToday,
+  insertContentReport,
+} from '@/server/db/queries/content-reports';
+
+afterEach(() => {
+  insertedValues = null;
+  insertImpl = async () => undefined;
+  selectRows = [];
+});
+
+describe('insertContentReport', () => {
+  it('writes an open report with the curated-question target and returns inserted', async () => {
+    const result = await insertContentReport({
+      reporterUserId: 'user-1',
+      questionId: 'q-1',
+      generatedQuestionId: null,
+      category: 'incorrect',
+      incorrectKind: 'answer_key',
+      note: 'the key is wrong',
+      suggestedAnswer: '42',
+      surface: 'lately_result',
+    });
+
+    expect(result).toBe('inserted');
+    expect(insertedValues).toMatchObject({
+      reporterUserId: 'user-1',
+      questionId: 'q-1',
+      generatedQuestionId: null,
+      category: 'incorrect',
+      incorrectKind: 'answer_key',
+      note: 'the key is wrong',
+      suggestedAnswer: '42',
+      surface: 'lately_result',
+      status: 'open',
+    });
+  });
+
+  it('writes the generated-question target without coercing it into questionId', async () => {
+    await insertContentReport({
+      reporterUserId: 'user-1',
+      questionId: null,
+      generatedQuestionId: 'gq-9',
+      category: 'inappropriate',
+      incorrectKind: null,
+      note: 'not okay',
+      suggestedAnswer: null,
+      surface: 'round_recap',
+    });
+
+    expect(insertedValues).toMatchObject({
+      questionId: null,
+      generatedQuestionId: 'gq-9',
+      category: 'inappropriate',
+      incorrectKind: null,
+    });
+  });
+
+  it('treats the one-open-report unique violation (23505) as an idempotent duplicate', async () => {
+    insertImpl = async () => {
+      throw Object.assign(new Error('duplicate key value'), { code: '23505' });
+    };
+
+    const result = await insertContentReport({
+      reporterUserId: 'user-1',
+      questionId: 'q-1',
+      generatedQuestionId: null,
+      category: 'inappropriate',
+      incorrectKind: null,
+      note: 'again',
+      suggestedAnswer: null,
+      surface: 'round_recap',
+    });
+
+    expect(result).toBe('duplicate');
+  });
+
+  it('rethrows non-unique-violation database errors', async () => {
+    insertImpl = async () => {
+      throw Object.assign(new Error('connection reset'), { code: '08006' });
+    };
+
+    await expect(
+      insertContentReport({
+        reporterUserId: 'user-1',
+        questionId: 'q-1',
+        generatedQuestionId: null,
+        category: 'inappropriate',
+        incorrectKind: null,
+        note: 'x',
+        suggestedAnswer: null,
+        surface: 'round_recap',
+      }),
+    ).rejects.toThrow('connection reset');
+  });
+});
+
+describe('countContentReportsToday', () => {
+  it('returns the counted rows for the reporter in the current daily window', async () => {
+    selectRows = [{ count: 7 }];
+    expect(await countContentReportsToday('user-1')).toBe(7);
+  });
+
+  it('returns 0 when no rows are present', async () => {
+    selectRows = [];
+    expect(await countContentReportsToday('user-1')).toBe(0);
+  });
+});

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -1,0 +1,84 @@
+import { and, eq, gte, sql } from 'drizzle-orm';
+
+import { contentReports, db } from '@/server/db';
+import { getDailyAssignmentBounds } from '@/lib/games/timezone';
+
+// B-Report-2: write + read helpers for ContentReport. Mirrors the house style in
+// ratings.ts — db + schema imports from '@/server/db', explicit field assignment,
+// count(*)::int for aggregates. Suppression/author-surfacing/admin-queue are out
+// of scope here (B-Report-3..5); this module only captures the report row and the
+// per-day volume the flood-stop reads.
+
+export type ContentReportCategory = 'incorrect' | 'inappropriate';
+export type ContentReportIncorrectKind = 'answer_key' | 'premise';
+
+export type InsertContentReportInput = {
+  reporterUserId: string;
+  // Exactly one of these is non-null (enforced by the caller's Zod schema and the
+  // ContentReport_one_target CHECK). Do not coerce a generated id into questionId.
+  questionId: string | null;
+  generatedQuestionId: string | null;
+  category: ContentReportCategory;
+  // Only set when category === 'incorrect' (ContentReport_incorrect_kind_scope CHECK).
+  incorrectKind: ContentReportIncorrectKind | null;
+  note: string;
+  suggestedAnswer: string | null;
+  surface: string | null;
+};
+
+// 'duplicate' means the one-open-report partial unique index (B-Report-1) already
+// has an open report from this reporter for this target. The re-report is a no-op
+// the caller treats as success (idempotent), not an error.
+export type InsertContentReportResult = 'inserted' | 'duplicate';
+
+// Postgres unique_violation. The ContentReport_one_open_per_{question,generated_question}
+// partial unique indexes raise this when an open report already exists.
+const PG_UNIQUE_VIOLATION = '23505';
+
+function isUniqueViolation(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === PG_UNIQUE_VIOLATION
+  );
+}
+
+export async function insertContentReport(
+  input: InsertContentReportInput,
+): Promise<InsertContentReportResult> {
+  try {
+    await db.insert(contentReports).values({
+      reporterUserId: input.reporterUserId,
+      questionId: input.questionId,
+      generatedQuestionId: input.generatedQuestionId,
+      category: input.category,
+      incorrectKind: input.incorrectKind,
+      note: input.note,
+      suggestedAnswer: input.suggestedAnswer,
+      surface: input.surface,
+      status: 'open',
+    });
+    return 'inserted';
+  } catch (err) {
+    if (isUniqueViolation(err)) return 'duplicate';
+    throw err;
+  }
+}
+
+// Reports created in the current daily window for this reporter — the input to the
+// 10/day flood-stop. Reuses getDailyAssignmentBounds() so "today" matches the rest
+// of the app's daily reset rather than inventing a separate calendar boundary.
+export async function countContentReportsToday(reporterUserId: string): Promise<number> {
+  const { assignmentDate } = getDailyAssignmentBounds();
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(contentReports)
+    .where(
+      and(
+        eq(contentReports.reporterUserId, reporterUserId),
+        gte(contentReports.createdAt, assignmentDate),
+      ),
+    );
+  return row?.count ?? 0;
+}

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -68,6 +68,16 @@ export type QuestionRecap = {
   authorNote: string | null;
   /** D-3: the author is the non-human house/editorial author (Editorial badge, non-relational copy). */
   authorIsHouse: boolean;
+  /**
+   * B-Report-2: which content table this recap row points at, for a ContentReport.
+   * Exactly one id is set — curated questions carry `questionId`, LLM-origin questions
+   * carry `generatedQuestionId`. Null only for the synthetic-fallback slot (no real row
+   * to report), in which case the ⋯ report items are hidden.
+   */
+  reportTarget:
+    | { questionId: string; generatedQuestionId?: undefined }
+    | { generatedQuestionId: string; questionId?: undefined }
+    | null;
 };
 
 export type DomainGain = {
@@ -241,6 +251,11 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
       authorId: slot.source === 'friend' ? (slot.author_id ?? null) : null,
       authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
       authorIsHouse: slot.source === 'house',
+      reportTarget: slot.question_id
+        ? { questionId: slot.question_id }
+        : slot.generated_question_id
+          ? { generatedQuestionId: slot.generated_question_id }
+          : null,
     };
   });
 


### PR DESCRIPTION
Capture player content reports from the two post-reveal review surfaces.
No suppression / author surfacing / admin queue yet — this only writes the
ContentReport row and gives immediate feedback.

Server
- src/server/db/queries/content-reports.ts: insertContentReport (status
  'open'; unique-violation on the one-open-report index → idempotent
  'duplicate') and countContentReportsToday (per-day window via
  getDailyAssignmentBounds).
- src/app/api/content-reports/route.ts: POST validated with Zod
  (discriminated union on category, conditional incorrectKind, required
  note, optional suggestedAnswer, exactly-one-of question/generated target,
  surface enum). 10/day flood-stop returns a soft 429 before insert.

UI
- Shared "why" sheet (src/components/report/ReportReasonSheet.tsx): incorrect
  (answer/question → incorrectKind, required note, optional suggestedAnswer)
  and inappropriate (confirm + required note). Incorrect → quiet "we'll take
  a look"; inappropriate → card removed from view client-side.
- Round Recap (daily/summary): replaces the vestigial live "Report content"
  thumbs_down item with "This is incorrect" / "This is inappropriate". The
  recap thumbs_down wrote generatedQuestionId-keyed questionFeedback rows
  that nothing read (propagation suppression reads questionId-keyed rows
  only), so it is cleanly removed. Heart (thumbs_up) untouched. Adds a
  reportTarget discriminator to QuestionRecap for the dual-table target.
- Lately milestone result modal (AnswerFeedbackSheet via InlineAnswerFlow):
  adds an opt-in ⋯ hosting the two items. Opt-in so the shared result sheet
  does not surface reporting on the feed / direct-answer result modals.

No player-facing flag/report/thumbs wording. Route + query tests prove the
row lands, the 429 fires at the cap, and duplicates are idempotent.

https://claude.ai/code/session_013BX13hWHosjoUyrU76ZYxz