### PR TITLE
Content reporting: suppression, author state, admin queue (B-Report-3…5)

### DIFF
--- a/PRD-D-6-CONTENT-REPORTING.md
+++ b/PRD-D-6-CONTENT-REPORTING.md
@@ -1,0 +1,252 @@
+# PRD-D-6 — Content Reporting ("This is incorrect / This is inappropriate")
+**Status:** DRAFT for sign-off. Synthesis stage — not yet a build prompt.
+**Line:** New section against the PRD-D (v12) line. Supersedes the stale v11.x
+"flag a public question" / thumbs-down references (see §Doc-drift cleanup).
+**Decisions locked in the 2026-06-08 align session.** Open items explicitly marked.
+---
+## 6.0 Why this exists
+Two failure modes are currently invisible to the system and to authors:
+1. **The answer key is wrong for the question as written** — the canonical
+   answer is incorrect, or the question has a false premise / is ambiguous /
+   is unanswerable. This is the direct cause of a *falsely-assigned wrong*,
+   which the product treats as a betrayal of its core promise. Catching it is
+   not generic moderation — it is defense of the north-star promise.
+2. **The content is offensive** — inappropriate regardless of correctness.
+Neither is the same as the two mechanisms that already exist and must remain
+distinct:
+- **Recheck / grade dispute** (`GradeDispute`) — "*my* answer was graded wrong."
+  The content is fine; one player's result is contested. Untouched by this spec.
+- **Reactions** (the heart, live in UI) — a *positive* signal. Untouched.
+Content reporting is the product's first **negative** signal surface. There is
+no live negative gesture today (thumbs-down is deprecated in the UI — see
+Doc-drift cleanup), so this does not replace or compete with anything on screen.
+---
+## 6.1 The player-facing model
+**One entry point: the existing `⋯` contextual menu.** The player never sees the
+words "flag," "report," or "thumbs-down." They name the *problem*; the system
+chooses the mechanism.
+Two new items in the `⋯` menu:
+- **"This is incorrect"**
+- **"This is inappropriate"**
+(Exact copy is a final-pass item; intent is locked.)
+### 6.1.1 Where the entry point appears (post-reveal only)
+The `⋯` items appear **only where a question is shown together with its answer,
+in a calm review state** — never during live play, never before the answer is
+revealed. Grounded against the real surfaces:
+| Surface | `⋯` items? | Rationale |
+|---|---|---|
+| **Round Recap card** (post-session review) | **Yes** | Canonical post-reveal surface; already has the `⋯`. |
+| **Lately answer-result modal** ("Correct! +N pts") | **Yes** | Post-reveal; these are the friend-authored / generated questions most likely to have a bad answer key. Needs the entry point added. |
+| In-play reveal ("Nice pull" / explainer mid-session) | No | Mid-session flow; wrong moment/register. Mirrors the existing "explainers out of the thread" instinct. |
+| Inline answer, pre-result (Lately expand) | No | Pre-reveal; you can't judge a false premise or bad key before seeing the answer. |
+Rule: **post-reveal review surfaces get the `⋯` items; live and pre-result
+surfaces do not.**
+### 6.1.2 The second step — the "why," shaped by the problem
+Selecting an item opens a light follow-up. It does **not** re-expose any
+mechanism choice; it captures the reason.
+**"This is incorrect" →**
+- Prompt: *what's wrong — the answer, or the question itself?* (answer key vs.
+  premise/ambiguity)
+- Free-text note (required; short).
+- **Optional "the answer should be ___" field.** A corrected answer key is the
+  single most actionable thing an author can receive; the card already has the
+  question + canonical answer + the player's answer in context, so the flow only
+  captures the delta.
+**"This is inappropriate" →**
+- Brief confirm + required free-text "why."
+- On confirm: the card is **removed from this player's view immediately** (see
+  6.2).
+### 6.1.3 What the player sees after submitting
+- **Incorrect:** quiet acknowledgment ("Thanks — we'll take a look"). Card
+  stays where it is; no dramatic state change.
+- **Inappropriate:** the card disappears from their recap/stream immediately.
+---
+## 6.2 Behavior & blast radius (the abuse-resistant core)
+The governing principle, which resolves the "bad actor flags everything to shut
+the game down" worry:
+> **Hiding from yourself is free and unlimited. Hiding from anyone else requires
+> a human (admin) review.** A malicious reporter can only ever affect their own
+> view; they can never silently remove a friend's question from the graph.
+| | Reporter's own view | Everyone else | Propagation to *new* surfaces | Admin queue |
+|---|---|---|---|---|
+| **Incorrect** | Unchanged (or optional self-hide) | Unchanged | **Suppressed** | Normal priority |
+| **Inappropriate** | **Hidden immediately** | Unchanged until admin review | **Suppressed** | **High priority** |
+Notes:
+- **"Suppress propagation"** = the question stops entering *new* feeds / daily
+  queues / sends. It is **reversible** and does **not** retroactively yank the
+  question from people who already have it. (Offensive content that an admin
+  upholds is then hard-removed — see 6.3.) This reuses existing
+  "flag-for-review, never auto-delete" machinery (see §Schema, 6.5).
+- A single report from one person is **high signal** in a small invite-only
+  graph — but it still cannot reach other players' views without admin action.
+- **No N-flag threshold.** Brigading is not the threat model (real identities,
+  small graphs); the threats are (a) one report being too powerful and (b)
+  offensive content lingering. This model defuses both.
+### 6.2.1 Flood-stop rate limit
+A soft per-user cap of **10 reports/day** (across both categories), purely as a
+queue-flood stop. Generous enough that honest use never hits it; one-line check;
+near-zero false-positive risk. Not framed to the user as friction — a user at
+the cap sees a gentle "you've reported a lot today" message.
+### 6.2.2 Abuse signal capture (no UI at launch)
+The report row stores `reporter_user_id` + the eventual admin `status`
+(`upheld` / `dismissed`). This makes **reporter uphold-rate** computable later —
+the basis for down-weighting or rate-limiting a bad-faith reporter — **without a
+future migration.** No launch UI; data capture only.
+---
+## 6.3 Author-facing behavior
+The unifying rule: **a correction reaches the author immediately because it
+helps them; an accusation reaches the author only after a human validates it.**
+| | Author learns of it… | When | What they see |
+|---|---|---|---|
+| **Incorrect** | Yes, quietly | Immediately, in their Questions bank | The reporter's **note**, **not** the reporter's identity; the question enters an editable "needs attention" state. |
+| **Inappropriate** | Only if **upheld** | After admin review | "This question was removed" + category. A **dismissed** inappropriate report is **never surfaced to the author** at all. |
+- **Incorrect, quiet, no name:** matches the no-notification ethos (no SMS — see
+  §8.11 deferral). The note carries the fix; the name would carry only a grudge
+  between friends. Fixing the answer key (editing
+  `answerText` / `acceptedAlternatives`) **clears the report and resumes
+  propagation.**
+- **Inappropriate, human-gated:** an unreviewed (possibly malicious) report must
+  never get to tell someone their content is offensive. Upheld → author told +
+  question hard-removed (authored: `visibility = 'blocked'`). Dismissed →
+  invisible to author; propagation restored.
+### 6.3.1 House / editorial content
+A report on `HOUSE_AUTHOR` content (per `house-editorial-copy-checklist.md`)
+routes **admin-only**. There is no author to notify, and — critically — the
+author-facing "needs attention" state **must never render for house content**,
+because surfacing a person-like author state on machine content is the exact
+live-honesty bug that doc warns against. House content has no human author;
+reports on it are purely an admin signal.
+---
+## 6.4 Review (admin)
+- **Sole reviewer: the admin (you).** A simple admin queue lists open reports,
+  newest/high-priority first, with: question text, both answers, category, the
+  note, the suggested-answer (if any), reporter (admin sees identity), and the
+  target table (authored vs. generated vs. house).
+- Per report, admin can: **uphold** or **dismiss**.
+  - Uphold **incorrect** → (typically) edit the answer key / mark the question
+    for correction; report resolves.
+  - Uphold **inappropriate** → hard-remove (authored: `visibility = 'blocked'`;
+    generated: equivalent review-flag terminal state); author told.
+  - Dismiss → propagation restored; nothing surfaced to author.
+- **Admin auth — RESOLVED (2026-06-08):** **`ADMIN_USER_IDS` env allowlist**,
+  checked in the admin route exactly as `CRON_SECRET` gates the cron routes. No
+  migration, no `isAdmin` column. The route resolves the session user id and
+  rejects (404, not 403 — don't reveal the route exists) anything not in the
+  allowlist. Add `ADMIN_USER_IDS` to `env-check.ts` as optional (the admin queue
+  is simply unreachable if unset, which is the correct safe default).
+---
+## 6.5 Schema delta (Drizzle)
+**New table only. No changes to existing tables required for the core.** Modeled
+on the `GradeDispute` review-lifecycle pattern already in `schema.ts`.
+```ts
+export const contentReportCategoryEnum = pgEnum('ContentReportCategory', [
+  'incorrect',
+  'inappropriate',
+]);
+// 'incorrect' sub-type: lets the author/admin see whether the answer key or the
+// premise is being challenged. Nullable (only meaningful for 'incorrect').
+export const contentReportIncorrectKindEnum = pgEnum('ContentReportIncorrectKind', [
+  'answer_key',   // canonical answer is wrong
+  'premise',      // false premise / ambiguous / unanswerable
+]);
+export const contentReportStatusEnum = pgEnum('ContentReportStatus', [
+  'open',
+  'upheld',
+  'dismissed',
+]);
+export const contentReports = pgTable(
+  'ContentReport',
+  {
+    id: id(),
+    reporterUserId: text('reporter_user_id').notNull().references(() => users.id),
+    // Dual-table target — mirrors QuestionFeedback. Exactly one is set.
+    questionId: text('question_id').references(() => questions.id),
+    generatedQuestionId: text('generated_question_id').references(() => generatedQuestions.id),
+    category: contentReportCategoryEnum('category').notNull(),
+    incorrectKind: contentReportIncorrectKindEnum('incorrect_kind'),
+    note: text('note').notNull(),
+    suggestedAnswer: text('suggested_answer'),       // optional corrected key
+    surface: text('surface'),                        // 'round_recap' | 'lately' (provenance)
+    status: contentReportStatusEnum('status').notNull().default('open'),
+    reviewDecision: text('review_decision'),
+    reviewReason: text('review_reason'),
+    reviewedAt: timestamp('reviewed_at', { withTimezone: true }),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    // One open report per user per question (either table). Prevents spam dupes;
+    // re-reporting after resolution is allowed (only 'open' is constrained — see
+    // note below; expressed as a partial unique index in the migration).
+    index('ContentReport_reporter_user_id_idx').on(table.reporterUserId),
+    index('ContentReport_question_id_idx').on(table.questionId),
+    index('ContentReport_generated_question_id_idx').on(table.generatedQuestionId),
+    index('ContentReport_status_idx').on(table.status),
+    // CHECK: exactly one target set (mirrors the QuestionFeedback dual-FK pattern)
+    check(
+      'ContentReport_one_target',
+      sql`(question_id IS NOT NULL)::int + (generated_question_id IS NOT NULL)::int = 1`,
+    ),
+    // CHECK: incorrect_kind only set when category = 'incorrect'
+    check(
+      'ContentReport_incorrect_kind_scope',
+      sql`incorrect_kind IS NULL OR category = 'incorrect'`,
+    ),
+  ],
+);
+```
+**Suppression — reuses existing fields, no new ones:**
+- **Authored question (`Question`):** offensive-upheld → `visibility = 'blocked'`
+  (the existing safety terminal state, already excluded by
+  `questionVisibilityPredicate` and all bank/send/game read paths).
+  Pre-review propagation suppression for either category is enforced by the
+  open-report check in the selection layer (see build note), not a new column.
+- **Generated question (`GeneratedQuestion`):** has existing review-flag
+  precedents (`nobodyCorrectFlag`, `isDuplicate`, both *"flag for review, never
+  auto-delete"*). Suppression follows the same pattern — an open/upheld report
+  flags the row out of selection without deletion.
+**Migration:** one additive migration (three enums + one table + partial unique
+index for one-open-report-per-user-per-question). No changes to existing tables.
+Auto-applies at boot per `instrumentation.ts` convention. Drizzle, not Prisma.
+---
+## 6.6 Doc-drift cleanup (do as part of this work)
+The stale specs describe thumbs-down as a **live** quality gate (UAT FEED-9,
+v11.2 §8.10, the `/api/feed/[feedItemId]/thumbsdown` endpoint). The reality
+discovered during the B-Report-2 trace (2026-06-08): the *positive* thumbs-down
+is gone, but a **live "Report content" `⋯` item** remains on the Round Recap
+card, wired to `thumbs_down` → `/api/daily/feedback` (coarse self-feed-removal +
+propagation suppression), using the forbidden word "Report."
+Canonical correction: **the negative-signal surface is the `⋯` content-reporting
+menu defined here.** The vestigial "Report content" item is **replaced** by the
+two problem-named items (not kept alongside — three overlapping negative entries
+is exactly the taxonomy confusion this model exists to prevent). Its coarse
+suppression behavior is superseded by §6.2 / B-Report-3 suppression, which is
+strictly more precise. B-Report-2 removes the item from the UI; if any non-UI
+reader depends on the `thumbs_down`/`daily/feedback` signal, B-Report-3 absorbs
+that behavior before the path is retired. The heart (`thumbs_up`) is untouched.
+---
+## 6.7 Locked decisions (for traceability)
+1. One entry: existing `⋯` menu, post-reveal review surfaces only (Round Recap +
+   Lately result modal). No mechanism words.
+2. Two problem-named items: "This is incorrect" / "This is inappropriate."
+   Heart (positive) untouched; no thumbs-down (deprecated).
+3. Second step = the "why," shaped by problem; incorrect optionally captures a
+   corrected answer.
+4. Blast radius: both suppress propagation; inappropriate adds instant
+   hide-from-flagger + high admin priority. Hide-from-self free; hide-from-others
+   needs admin. No N-flag threshold.
+5. Author learns of incorrect immediately + quietly (note, no name); learns of
+   inappropriate only if upheld. Dismissed inappropriate is invisible to author.
+6. Sole reviewer = admin (you). 10/day flood-stop. Reporter id + status captured
+   for future abuse-signalling, no launch UI.
+7. House content: admin-only; never renders an author-facing state.
+8. New `ContentReport` table (dual-FK, GradeDispute-style lifecycle); suppression
+   reuses `visibility='blocked'` (authored) and review-flag pattern (generated).
+## 6.8 Open decisions
+- **Admin auth — RESOLVED (2026-06-08):** `ADMIN_USER_IDS` env allowlist, 404 on
+  non-admin, optional in `env-check.ts`. See §6.4.
+- **Copy final pass (non-blocking)** — the two menu labels, the two
+  acknowledgments, the author-side "needs attention" + "removed" strings. Build
+  carries sensible defaults; adjust in PR review.
+- **Re-report policy (defaulted)** — "one *open* report per user per question; a
+  new report allowed after resolution." Drives the partial unique index. Flag now
+  if a different constraint is wanted.

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -1,0 +1,130 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+import type { AdminReviewReport } from '@/server/db/queries/content-reports';
+
+// Deliberately minimal — an internal ops tool, not a product surface. Two actions
+// (uphold / dismiss), the full review context including admin-only reporter identity.
+export function AdminReportsClient({ reports }: { reports: AdminReviewReport[] }) {
+  return (
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+      <header className="mb-5">
+        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Report queue</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          {reports.length === 0 ? 'Nothing open.' : `${reports.length} open`}
+        </p>
+      </header>
+
+      <div className="space-y-3">
+        {reports.map((report) => (
+          <ReportRow key={report.id} report={report} />
+        ))}
+      </div>
+    </main>
+  );
+}
+
+function ReportRow({ report }: { report: AdminReviewReport }) {
+  const router = useRouter();
+  const [reviewReason, setReviewReason] = useState('');
+  const [pending, setPending] = useState<'uphold' | 'dismiss' | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function act(action: 'uphold' | 'dismiss') {
+    if (pending) return;
+    setPending(action);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/content-reports', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ reportId: report.id, action, reviewReason: reviewReason.trim() || undefined }),
+      });
+      if (!res.ok) {
+        setError(`Action failed (${res.status}).`);
+        setPending(null);
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError('Action failed.');
+      setPending(null);
+    }
+  }
+
+  const kindLabel =
+    report.incorrectKind === 'answer_key'
+      ? 'answer key'
+      : report.incorrectKind === 'premise'
+        ? 'question premise'
+        : null;
+
+  return (
+    <article className="rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
+          style={
+            report.category === 'inappropriate'
+              ? { borderColor: 'var(--danger)', color: 'var(--danger)' }
+              : { borderColor: 'var(--border)', color: 'var(--text-muted)' }
+          }
+        >
+          {report.category}
+          {kindLabel ? ` · ${kindLabel}` : ''}
+        </span>
+        <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
+          {report.target.table} · {new Date(report.createdAt).toLocaleString()}
+        </span>
+      </div>
+
+      <p className="mt-2 font-medium text-[var(--brand-ink)]">{report.questionText ?? '(question unavailable)'}</p>
+      {report.correctAnswer ? (
+        <p className="text-muted-foreground mt-0.5">Answer: {report.correctAnswer}</p>
+      ) : null}
+
+      <p className="mt-2 italic text-[var(--brand-ink-700)]">&ldquo;{report.note}&rdquo;</p>
+      {report.suggestedAnswer ? (
+        <p className="text-muted-foreground mt-0.5">Suggested: {report.suggestedAnswer}</p>
+      ) : null}
+
+      {/* Admin-only — reporter identity is exposed nowhere else. */}
+      <p className="text-muted-foreground mt-2 text-[0.7rem]">
+        Reporter: {report.reporterName ?? report.reporterUserId}
+      </p>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <input
+          type="text"
+          value={reviewReason}
+          onChange={(e) => setReviewReason(e.target.value)}
+          placeholder="Reason (optional)"
+          className="min-w-0 flex-1 rounded-md border px-2 py-1 text-sm"
+          style={{ borderColor: 'var(--border)' }}
+        />
+        <button
+          type="button"
+          onClick={() => void act('uphold')}
+          disabled={pending !== null}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+        >
+          {pending === 'uphold' ? 'Upholding…' : 'Uphold'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void act('dismiss')}
+          disabled={pending !== null}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          {pending === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
+        </button>
+      </div>
+      {error ? <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>{error}</p> : null}
+    </article>
+  );
+}

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -1,0 +1,20 @@
+import { notFound } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { getOpenReportsForReview } from '@/server/db/queries/content-reports';
+
+import { AdminReportsClient } from './AdminReportsClient';
+
+export const dynamic = 'force-dynamic';
+
+// B-Report-5: the content-report review queue. Reachable ONLY to ADMIN_USER_IDS
+// members; everyone else (incl. authenticated non-admins) gets Next's 404 — the
+// route's existence is not revealed. Unset env ⇒ no admins ⇒ always 404.
+export default async function AdminReportsPage() {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+
+  const reports = await getOpenReportsForReview();
+  return <AdminReportsClient reports={reports} />;
+}

--- a/src/app/api/admin/content-reports/__tests__/route.test.ts
+++ b/src/app/api/admin/content-reports/__tests__/route.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+const { getSessionMock, isAdminUserMock, upholdMock, dismissMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'admin-1', id: 's-1' }) as { userId: string; id: string } | null),
+  isAdminUserMock: vi.fn(() => true),
+  upholdMock: vi.fn(async () => ({ ok: true, action: 'upheld', category: 'inappropriate', hardRemoved: true })),
+  dismissMock: vi.fn(async () => ({ ok: true, action: 'dismissed', category: 'incorrect', hardRemoved: false })),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/auth/admin', () => ({ isAdminUser: isAdminUserMock }));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  upholdReport: upholdMock,
+  dismissReport: dismissMock,
+}));
+
+import { POST } from '@/app/api/admin/content-reports/route';
+
+function post(body: unknown): Promise<Response> {
+  const request = new Request('http://localhost/api/admin/content-reports', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request as unknown as NextRequest);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'admin-1', id: 's-1' });
+  isAdminUserMock.mockReturnValue(true);
+});
+
+describe('POST /api/admin/content-reports', () => {
+  it('returns 404 (not 403) for an authenticated non-admin and takes no action', async () => {
+    isAdminUserMock.mockReturnValue(false);
+    const res = await post({ reportId: 'r1', action: 'uphold' });
+    expect(res.status).toBe(404);
+    expect(upholdMock).not.toHaveBeenCalled();
+    expect(dismissMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 for the unauthenticated', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    const res = await post({ reportId: 'r1', action: 'uphold' });
+    expect(res.status).toBe(404);
+  });
+
+  it('upholds for an admin', async () => {
+    const res = await post({ reportId: 'r1', action: 'uphold', reviewReason: 'bad' });
+    expect(res.status).toBe(200);
+    expect(upholdMock).toHaveBeenCalledWith('r1', 'bad');
+  });
+
+  it('dismisses for an admin', async () => {
+    const res = await post({ reportId: 'r2', action: 'dismiss' });
+    expect(res.status).toBe(200);
+    expect(dismissMock).toHaveBeenCalledWith('r2', undefined);
+  });
+
+  it('rejects an invalid action', async () => {
+    const res = await post({ reportId: 'r1', action: 'delete' });
+    expect(res.status).toBe(400);
+    expect(upholdMock).not.toHaveBeenCalled();
+  });
+
+  it('maps an already-resolved result to 409', async () => {
+    upholdMock.mockResolvedValueOnce({ ok: false, reason: 'already_resolved' });
+    const res = await post({ reportId: 'r1', action: 'uphold' });
+    expect(res.status).toBe(409);
+  });
+});

--- a/src/app/api/admin/content-reports/route.ts
+++ b/src/app/api/admin/content-reports/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { dismissReport, upholdReport } from '@/server/db/queries/content-reports';
+
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  reportId: z.string().trim().min(1),
+  action: z.enum(['uphold', 'dismiss']),
+  reviewReason: z.string().trim().max(500).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  // Non-admins (and the unauthenticated) get 404 — never reveal the route exists.
+  if (!session || !isAdminUser(session.userId)) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json({ error: 'validation' }, { status: 400 });
+  }
+
+  const { reportId, action, reviewReason } = parsed.data;
+  const result =
+    action === 'uphold'
+      ? await upholdReport(reportId, reviewReason)
+      : await dismissReport(reportId, reviewReason);
+
+  if (!result.ok) {
+    return NextResponse.json(
+      { error: result.reason },
+      { status: result.reason === 'not_found' ? 404 : 409 },
+    );
+  }
+
+  return NextResponse.json(result);
+}

--- a/src/app/api/questions/[id]/__tests__/edit-resolves-report.test.ts
+++ b/src/app/api/questions/[id]/__tests__/edit-resolves-report.test.ts
@@ -44,7 +44,7 @@ vi.mock('@/server/db/queries/questions', () => ({
   deleteQuestion: vi.fn(),
 }));
 vi.mock('@/server/db/queries/content-reports', () => ({
-  resolveOpenIncorrectReportsForQuestion: resolveMock,
+  resolveActiveIncorrectReportsForQuestion: resolveMock,
 }));
 vi.mock('@/lib/llm', () => ({ categorizeQuestion: categorizeMock }));
 vi.mock('@/server/questions/llm-difficulty', () => ({ assessQuestionDifficulty: assessDifficultyMock }));

--- a/src/app/api/questions/[id]/__tests__/edit-resolves-report.test.ts
+++ b/src/app/api/questions/[id]/__tests__/edit-resolves-report.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+// B-Report-4 Phase 3: an answer-key / alternatives edit resolves the open incorrect
+// report (which lifts B-Report-3 suppression); a pure explanation edit does not.
+const {
+  getSessionMock,
+  getQuestionMock,
+  updateQuestionMock,
+  resolveMock,
+  assessDifficultyMock,
+  categorizeMock,
+} = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'author-1', id: 's-1' }) as { userId: string; id: string } | null),
+  getQuestionMock: vi.fn(),
+  updateQuestionMock: vi.fn(async () => ({ ok: true })),
+  resolveMock: vi.fn(async () => 1),
+  assessDifficultyMock: vi.fn(async () => ({ difficulty: 2 })),
+  categorizeMock: vi.fn(async () => ({ broad_category: 'history', subcategory: 'World History' })),
+}));
+
+const EXISTING = {
+  id: 'q-1',
+  text: 'What is the capital of France?',
+  correctAnswer: 'Paris',
+  alternateAnswers: [] as string[],
+  explanation: 'Old explanation.',
+  broadCategory: 'History',
+  canonicalSubcategory: 'World History',
+  domain: 'World History',
+  usedInGamesCount: 0,
+};
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db', () => ({
+  // questionExistsForAnotherUser: same creator → not another user → proceeds.
+  db: { select: () => ({ from: () => ({ where: () => ({ limit: async () => [{ creatorId: 'author-1' }] }) }) }) },
+  questions: { id: 'q.id', creatorId: 'q.creatorId', deletedAt: 'q.deletedAt' },
+}));
+vi.mock('@/server/db/queries/questions', () => ({
+  getQuestion: getQuestionMock,
+  updateQuestion: updateQuestionMock,
+  deleteQuestion: vi.fn(),
+}));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  resolveOpenIncorrectReportsForQuestion: resolveMock,
+}));
+vi.mock('@/lib/llm', () => ({ categorizeQuestion: categorizeMock }));
+vi.mock('@/server/questions/llm-difficulty', () => ({ assessQuestionDifficulty: assessDifficultyMock }));
+
+import { PATCH } from '@/app/api/questions/[id]/route';
+
+function patch(body: unknown): Promise<Response> {
+  const request = new Request('http://localhost/api/questions/q-1', {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return PATCH(request as unknown as NextRequest, { params: Promise.resolve({ id: 'q-1' }) });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'author-1', id: 's-1' });
+  getQuestionMock.mockResolvedValue(EXISTING);
+  updateQuestionMock.mockResolvedValue({ ok: true });
+  resolveMock.mockResolvedValue(1);
+});
+
+describe('PATCH /api/questions/[id] — edit clears the incorrect report', () => {
+  it('resolves the open incorrect report when accepted alternatives change', async () => {
+    const res = await patch({ alternateAnswers: ['Lutetia'] });
+
+    expect(res.status).toBe(200);
+    expect(resolveMock).toHaveBeenCalledWith('q-1');
+  });
+
+  it('resolves the open incorrect report when the answer key changes', async () => {
+    const res = await patch({ correctAnswer: 'Paris (France)' });
+
+    expect(res.status).toBe(200);
+    expect(resolveMock).toHaveBeenCalledWith('q-1');
+  });
+
+  it('does NOT resolve the report on a pure explanation edit', async () => {
+    const res = await patch({ explanation: 'A clearer explanation.' });
+
+    expect(res.status).toBe(200);
+    expect(resolveMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -13,6 +13,7 @@ import {
   getQuestion,
   updateQuestion,
 } from '@/server/db/queries/questions';
+import { resolveOpenIncorrectReportsForQuestion } from '@/server/db/queries/content-reports';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -173,6 +174,13 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
     return NextResponse.json({ error: 'Question has been used in a game and cannot be edited.' }, { status: 409 });
   }
   if (!result.ok) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  // B-Report-4: fixing the answer key (or accepted alternatives) resolves any open
+  // incorrect report on this question, which lifts B-Report-3 suppression. Scoped to
+  // answer-key/alternatives edits — a pure text/explanation/category edit does not clear it.
+  if (values.correctAnswer !== undefined || values.alternateAnswers !== undefined) {
+    await resolveOpenIncorrectReportsForQuestion(id);
+  }
 
   return NextResponse.json({ ok: true, question: await getQuestion(id, session.userId) });
 }

--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -13,7 +13,7 @@ import {
   getQuestion,
   updateQuestion,
 } from '@/server/db/queries/questions';
-import { resolveOpenIncorrectReportsForQuestion } from '@/server/db/queries/content-reports';
+import { resolveActiveIncorrectReportsForQuestion } from '@/server/db/queries/content-reports';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -179,7 +179,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
   // incorrect report on this question, which lifts B-Report-3 suppression. Scoped to
   // answer-key/alternatives edits — a pure text/explanation/category edit does not clear it.
   if (values.correctAnswer !== undefined || values.alternateAnswers !== undefined) {
-    await resolveOpenIncorrectReportsForQuestion(id);
+    await resolveActiveIncorrectReportsForQuestion(id);
   }
 
   return NextResponse.json({ ok: true, question: await getQuestion(id, session.userId) });

--- a/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
+++ b/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
@@ -74,6 +74,11 @@ vi.mock('@/server/db/queries/feed', () => ({
 }));
 vi.mock('@/server/db/queries/friends', () => ({ getFriends: vi.fn() }));
 vi.mock('@/server/sms', () => ({ sendSms: vi.fn() }));
+// B-Report-3 added a suppression guard to POST; this suite is about resolution, so
+// stub the check off (the dedicated suppression.test.ts covers the gate itself).
+vi.mock('@/server/db/queries/content-reports', () => ({
+  isQuestionReportSuppressed: vi.fn(async () => false),
+}));
 
 import { POST, resolveQuestionIdForSend } from '@/app/api/questions/send/route';
 import { getSession } from '@/server/auth/session';

--- a/src/app/api/questions/send/__tests__/suppression.test.ts
+++ b/src/app/api/questions/send/__tests__/suppression.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { NextRequest } from 'next/server';
+
+// B-Report-3: a question under an open/upheld content report can't be direct-sent.
+// The guard runs on the RAW incoming id (before resolveQuestionIdForSend would mint
+// a GeneratedQuestion into a fresh curated Question), so we assert the 409 fires and
+// nothing downstream (resolution → feed write) runs.
+const { getSessionMock, getFriendsMock, isSuppressedMock, createFeedItemMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'sender-1', id: 's-1' }) as { userId: string; id: string } | null),
+  getFriendsMock: vi.fn(async () => [{ id: 'recipient-1' }] as Array<{ id: string }>),
+  isSuppressedMock: vi.fn(async () => false),
+  createFeedItemMock: vi.fn(async () => ({ id: 'feed-1' })),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/friends', () => ({ getFriends: getFriendsMock }));
+vi.mock('@/server/db/queries/content-reports', () => ({ isQuestionReportSuppressed: isSuppressedMock }));
+vi.mock('@/server/db', () => ({
+  db: { select: vi.fn(() => ({ from: () => ({ where: () => ({ limit: async () => [] }) }) })) },
+  feedItems: {},
+  generatedQuestions: {},
+  questions: {},
+  users: {},
+}));
+vi.mock('@/server/db/queries/feed', () => ({
+  createFeedItem: createFeedItemMock,
+  rollOffOldItems: vi.fn(async () => undefined),
+  userAnsweredQuestionCorrectly: vi.fn(async () => false),
+  userHasQuestionInBlockingFeed: vi.fn(async () => false),
+}));
+vi.mock('@/server/activity/write-activity', () => ({ writeActivity: vi.fn(async () => undefined) }));
+vi.mock('@/server/sms', () => ({ sendSms: vi.fn(async () => undefined) }));
+vi.mock('@/server/feed/visibility', () => ({ DIRECT_SENT_FEED_SOURCE_TYPE: 'direct_sent' }));
+
+import { POST } from '@/app/api/questions/send/route';
+
+function post(body: unknown): Promise<Response> {
+  const request = new Request('http://localhost/api/questions/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return POST(request as unknown as NextRequest);
+}
+
+const body = { question_id: 'q-1', recipient_user_id: 'recipient-1' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getSessionMock.mockResolvedValue({ userId: 'sender-1', id: 's-1' });
+  getFriendsMock.mockResolvedValue([{ id: 'recipient-1' }]);
+  isSuppressedMock.mockResolvedValue(false);
+});
+
+describe('POST /api/questions/send — content-report suppression', () => {
+  it('returns 409 under_review and writes no feed item when the question is suppressed', async () => {
+    isSuppressedMock.mockResolvedValue(true);
+
+    const res = await post(body);
+
+    expect(res.status).toBe(409);
+    expect((await res.json()).error).toBe('under_review');
+    expect(isSuppressedMock).toHaveBeenCalledWith('q-1');
+    expect(createFeedItemMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the suppression gate when the question is not suppressed', async () => {
+    isSuppressedMock.mockResolvedValue(false);
+
+    const res = await post(body);
+
+    // Not a 409: the request proceeds past the gate (it then 404s on the stubbed
+    // db, which is fine — the point is the suppression block did not fire).
+    expect(res.status).not.toBe(409);
+    expect(isSuppressedMock).toHaveBeenCalledWith('q-1');
+  });
+});

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -11,6 +11,7 @@ import {
   userHasQuestionInBlockingFeed,
 } from '@/server/db/queries/feed';
 import { getFriends } from '@/server/db/queries/friends';
+import { isQuestionReportSuppressed } from '@/server/db/queries/content-reports';
 import { sendSms } from '@/server/sms';
 import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
@@ -34,6 +35,17 @@ export async function POST(request: NextRequest) {
   const friends = await getFriends(session.userId);
   if (!friends.some((friend) => friend.id === parsed.recipientUserId)) {
     return NextResponse.json({ error: 'Recipient is not a friend.' }, { status: 403 });
+  }
+
+  // B-Report-3: a question under an open/upheld content report can't enter a new
+  // surface. Check the RAW incoming id (which may be a GeneratedQuestion) before
+  // resolveQuestionIdForSend mints it into a fresh curated Question — otherwise a
+  // report on the original would be laundered away by the new id.
+  if (await isQuestionReportSuppressed(parsed.questionId)) {
+    return NextResponse.json(
+      { error: 'under_review', message: 'This question is under review and can’t be sent right now.' },
+      { status: 409 },
+    );
   }
 
   const sendableQuestionId = await resolveQuestionIdForSend(parsed.questionId);

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -63,6 +63,8 @@ export function MyQuestionCard({
           </p>
         ) : null}
 
+        {question.reportState ? <ReportStateNotice state={question.reportState} /> : null}
+
         {cardError ? <p className="text-destructive mt-1.5 text-[13px]">{cardError}</p> : null}
 
         {confirming ? (
@@ -106,6 +108,61 @@ export function MyQuestionCard({
         )}
       </div>
     </article>
+  );
+}
+
+// B-Report-4: the quiet author-facing report state. Deliberately muted — no red,
+// no badge, no reporter identity. "needs attention" carries the correction so the
+// author can fix it; "removed" is the read-only upheld-inappropriate terminal state.
+function ReportStateNotice({ state }: { state: NonNullable<QuestionView['reportState']> }) {
+  if (state.kind === 'removed') {
+    return (
+      <div
+        className="mt-2 rounded-md border px-2.5 py-2 text-[13px] leading-snug"
+        style={{ borderColor: 'var(--border)', color: 'var(--ink)', opacity: 0.8 }}
+      >
+        <p className="font-medium">This question was removed.</p>
+        <p className="mt-0.5" style={{ opacity: 0.75 }}>
+          It was found inappropriate after review.
+        </p>
+      </div>
+    );
+  }
+
+  const concern =
+    state.incorrectKind === 'answer_key'
+      ? 'A reader thinks the answer key is wrong.'
+      : state.incorrectKind === 'premise'
+        ? 'A reader thinks the question itself is off.'
+        : 'A reader raised a concern about this one.';
+
+  return (
+    <div
+      className="mt-2 rounded-md border px-2.5 py-2 text-[13px] leading-snug"
+      style={{
+        borderColor: 'var(--border)',
+        background: 'color-mix(in srgb, var(--ink) 3%, transparent)',
+        color: 'var(--ink)',
+      }}
+    >
+      <p className="font-medium" style={{ opacity: 0.85 }}>
+        Needs a second look
+      </p>
+      <p className="mt-0.5" style={{ opacity: 0.7 }}>
+        {concern}
+      </p>
+      <p className="mt-0.5 italic" style={{ opacity: 0.7 }}>
+        &ldquo;{state.note}&rdquo;
+      </p>
+      {state.suggestedAnswer ? (
+        <p className="mt-0.5" style={{ opacity: 0.7 }}>
+          They suggested: {state.suggestedAnswer}
+        </p>
+      ) : null}
+      <p className="mt-1" style={{ opacity: 0.6 }}>
+        Update the answer key to clear this.
+      </p>
+    </div>
   );
 }
 

--- a/src/env-check.ts
+++ b/src/env-check.ts
@@ -7,7 +7,10 @@ const REQUIRED_ENV_VARS = [
   'TWILIO_MESSAGING_SERVICE_SID',
 ] as const;
 
-const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL'] as const;
+// ADMIN_USER_IDS (B-Report-5): comma-separated users.id allowlist for the content-
+// report review queue. Optional by design — unset ⇒ the queue is unreachable and the
+// app boots fine. Never promote to REQUIRED.
+const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL', 'ADMIN_USER_IDS'] as const;
 
 export default function checkEnv() {
   const jwtSecret = process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim();

--- a/src/server/activity/__tests__/build-stream-self-hide.test.ts
+++ b/src/server/activity/__tests__/build-stream-self-hide.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// B-Report-3 durable self-hide: a question the viewer reported as inappropriate
+// (open|upheld) must stay out of their Lately milestone stack across reloads. We
+// mock the upstream lately queries and the pure transforms (echoing the questions
+// they receive) so we can assert the hidden id is filtered before render.
+const { getViewerHiddenQuestionIdsMock } = vi.hoisted(() => ({
+  getViewerHiddenQuestionIdsMock: vi.fn(async () => new Set<string>()),
+}));
+
+vi.mock('@/app/activities/filter-utility-activities', () => ({
+  filterUtilityActivities: () => [],
+}));
+vi.mock('@/lib/activity-stream', () => ({
+  activityToStreamItem: (x: unknown) => x,
+  momentToStreamItem: (x: unknown) => x,
+  convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
+  milestoneToStreamItem: (m: { id: string }, questions: unknown) => ({ kind: 'milestone', id: m.id, questions }),
+}));
+vi.mock('@/lib/lately', () => ({
+  sortByProminence: (items: unknown[]) => items,
+  convergenceCaptionTemplate: () => '',
+}));
+vi.mock('@/lib/lately-milestones', () => ({ MILESTONE_CARD_QUESTION_CAP: 5 }));
+vi.mock('@/server/db/queries/activity', () => ({ getActivitiesForUser: vi.fn(async () => []) }));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  getViewerHiddenQuestionIds: getViewerHiddenQuestionIdsMock,
+}));
+vi.mock('@/server/db/queries/lately', () => ({
+  getLatelyMoments: vi.fn(async () => []),
+  getLatelyConvergences: vi.fn(async () => []),
+  getLatelyMilestones: vi.fn(async () => [{ id: 'm1', questionIds: ['q-keep', 'q-hidden'] }]),
+  getMilestoneQuestionText: vi.fn(async (ids: string[]) =>
+    new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
+  ),
+  getViewerPriorAnswerResults: vi.fn(async () => new Map()),
+}));
+
+import { buildActivityStream } from '@/server/activity/build-stream';
+
+type MilestoneItem = { kind: string; id: string; questions: Array<{ questionId: string }> };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getViewerHiddenQuestionIdsMock.mockResolvedValue(new Set<string>());
+});
+
+describe('buildActivityStream — durable inappropriate self-hide', () => {
+  it('drops a milestone question the viewer reported as inappropriate', async () => {
+    getViewerHiddenQuestionIdsMock.mockResolvedValue(new Set(['q-hidden']));
+
+    const stream = (await buildActivityStream('viewer-1')) as unknown as MilestoneItem[];
+    const milestone = stream.find((item) => item.kind === 'milestone');
+
+    const ids = milestone!.questions.map((q) => q.questionId);
+    expect(ids).toContain('q-keep');
+    expect(ids).not.toContain('q-hidden');
+  });
+
+  it('keeps every question when the viewer has hidden nothing', async () => {
+    const stream = (await buildActivityStream('viewer-1')) as unknown as MilestoneItem[];
+    const milestone = stream.find((item) => item.kind === 'milestone');
+
+    expect(milestone!.questions.map((q) => q.questionId)).toEqual(['q-keep', 'q-hidden']);
+  });
+});

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -22,6 +22,7 @@ import {
 import { convergenceCaptionTemplate, sortByProminence } from '@/lib/lately';
 import { MILESTONE_CARD_QUESTION_CAP } from '@/lib/lately-milestones';
 import { getActivitiesForUser } from '@/server/db/queries/activity';
+import { getViewerHiddenQuestionIds } from '@/server/db/queries/content-reports';
 import {
   getLatelyConvergences,
   getLatelyMilestones,
@@ -52,9 +53,12 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [textById, priorById] = await Promise.all([
+  const [textById, priorById, hiddenIds] = await Promise.all([
     getMilestoneQuestionText(allQuestionIds),
     getViewerPriorAnswerResults(userId, allQuestionIds),
+    // B-Report-3: durable self-hide — a question the viewer reported as
+    // inappropriate (open|upheld) stays out of their Lately stack across reloads.
+    getViewerHiddenQuestionIds(userId, allQuestionIds),
   ]);
 
   const utilityItems = filterUtilityActivities(items, moments).map(
@@ -65,6 +69,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
     const questions: StreamQuestion[] = cappedIdsByMilestone[i].ids
       .map((id) => textById.get(id))
       .filter((q): q is NonNullable<typeof q> => Boolean(q))
+      .filter((q) => !hiddenIds.has(q.questionId))
       .map((q) => ({
         questionId: q.questionId,
         text: q.text,
@@ -77,6 +82,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
     const questions: StreamQuestion[] = c.questionIds
       .map((id) => textById.get(id))
       .filter((q): q is NonNullable<typeof q> => Boolean(q))
+      .filter((q) => !hiddenIds.has(q.questionId))
       .map((q) => ({
         questionId: q.questionId,
         text: q.text,

--- a/src/server/auth/__tests__/admin.test.ts
+++ b/src/server/auth/__tests__/admin.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { isAdminUser } from '@/server/auth/admin';
+
+const ORIGINAL = process.env.ADMIN_USER_IDS;
+
+beforeEach(() => {
+  delete process.env.ADMIN_USER_IDS;
+});
+afterEach(() => {
+  if (ORIGINAL === undefined) delete process.env.ADMIN_USER_IDS;
+  else process.env.ADMIN_USER_IDS = ORIGINAL;
+});
+
+describe('isAdminUser', () => {
+  it('denies everyone when ADMIN_USER_IDS is unset (safe default)', () => {
+    expect(isAdminUser('user-1')).toBe(false);
+  });
+
+  it('denies a null/empty user id', () => {
+    process.env.ADMIN_USER_IDS = 'user-1';
+    expect(isAdminUser(null)).toBe(false);
+    expect(isAdminUser(undefined)).toBe(false);
+    expect(isAdminUser('')).toBe(false);
+  });
+
+  it('admits a listed id and denies an unlisted one (comma-separated, whitespace-tolerant)', () => {
+    process.env.ADMIN_USER_IDS = ' user-1 , user-2 ';
+    expect(isAdminUser('user-1')).toBe(true);
+    expect(isAdminUser('user-2')).toBe(true);
+    expect(isAdminUser('user-3')).toBe(false);
+  });
+
+  it('denies when the env is blank', () => {
+    process.env.ADMIN_USER_IDS = '   ';
+    expect(isAdminUser('user-1')).toBe(false);
+  });
+});

--- a/src/server/auth/admin.ts
+++ b/src/server/auth/admin.ts
@@ -1,0 +1,19 @@
+/**
+ * B-Report-5 admin gate. Mirrors the CRON_SECRET style in `src/server/auth/cron.ts`
+ * (fail closed): membership is an `ADMIN_USER_IDS` env allowlist, NOT a role column.
+ *
+ * `ADMIN_USER_IDS` is a comma-separated list of `users.id` values and is OPTIONAL
+ * (see src/env-check.ts). Unset ⇒ no admins ⇒ the admin queue is unreachable and
+ * every caller 404s — the correct safe default. Callers that fail this check must
+ * return 404 (never 403): the route's existence is not revealed to non-admins.
+ */
+export function isAdminUser(userId: string | null | undefined): boolean {
+  if (!userId) return false;
+  const raw = process.env.ADMIN_USER_IDS?.trim();
+  if (!raw) return false;
+  return raw
+    .split(',')
+    .map((id) => id.trim())
+    .filter(Boolean)
+    .includes(userId);
+}

--- a/src/server/db/queries/__tests__/content-reports-admin.test.ts
+++ b/src/server/db/queries/__tests__/content-reports-admin.test.ts
@@ -1,0 +1,161 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Structural drizzle mock so we can assert the exact admin outcome wiring: uphold
+// sets status='upheld' and, for inappropriate-authored ONLY, writes
+// questions.visibility='blocked'; generated-inappropriate writes no extra column;
+// dismiss sets status='dismissed' (which lifts B-Report-3 suppression). Sentinels +
+// mutable state live in vi.hoisted so the (hoisted) vi.mock factory can reference them.
+const { CONTENT_REPORTS, QUESTIONS, GENERATED, USERS, state } = vi.hoisted(() => ({
+  CONTENT_REPORTS: { __t: 'contentReports', id: 'cr.id', status: 'cr.status', category: 'cr.category', questionId: 'cr.questionId', generatedQuestionId: 'cr.generatedQuestionId', note: 'cr.note', suggestedAnswer: 'cr.suggestedAnswer', incorrectKind: 'cr.incorrectKind', surface: 'cr.surface', createdAt: 'cr.createdAt', reporterUserId: 'cr.reporterUserId', reviewDecision: 'cr.reviewDecision', reviewReason: 'cr.reviewReason', reviewedAt: 'cr.reviewedAt' },
+  QUESTIONS: { __t: 'questions', id: 'q.id', questionText: 'q.questionText', answerText: 'q.answerText', visibility: 'q.visibility', creatorId: 'q.creatorId', source: 'q.source' },
+  GENERATED: { __t: 'generatedQuestions', id: 'g.id', questionText: 'g.questionText', answer: 'g.answer' },
+  USERS: { __t: 'users', id: 'u.id', displayName: 'u.displayName' },
+  state: { selectRows: [] as unknown[], updates: [] as Array<{ table: unknown; set: Record<string, unknown>; where: unknown }> },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => {
+  const makeSelect = () => {
+    const chain: Record<string, unknown> = {
+      from: () => chain,
+      leftJoin: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      limit: () => Promise.resolve(state.selectRows),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(state.selectRows),
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: () => makeSelect(),
+      update: (table: unknown) => ({
+        set: (vals: Record<string, unknown>) => ({
+          where: (cond: unknown) => {
+            state.updates.push({ table, set: vals, where: cond });
+            return Promise.resolve();
+          },
+        }),
+      }),
+    },
+    contentReports: CONTENT_REPORTS,
+    questions: QUESTIONS,
+    generatedQuestions: GENERATED,
+    users: USERS,
+  };
+});
+
+import { dismissReport, getOpenReportsForReview, upholdReport } from '@/server/db/queries/content-reports';
+
+function questionVisibilityWrites() {
+  return state.updates.filter((u) => u.table === QUESTIONS && u.set.visibility === 'blocked');
+}
+function reportStatusWrites() {
+  return state.updates.filter((u) => u.table === CONTENT_REPORTS);
+}
+
+beforeEach(() => {
+  state.selectRows = [];
+  state.updates.length = 0;
+});
+
+describe('upholdReport', () => {
+  it('upholds an inappropriate AUTHORED report and sets visibility=blocked (the only place)', async () => {
+    state.selectRows = [{ category: 'inappropriate', questionId: 'q-1', generatedQuestionId: null, status: 'open' }];
+
+    const result = await upholdReport('report-1', 'looks bad');
+
+    expect(result).toEqual({ ok: true, action: 'upheld', category: 'inappropriate', hardRemoved: true });
+    expect(reportStatusWrites()[0]?.set).toMatchObject({ status: 'upheld', reviewDecision: 'admin_upheld', reviewReason: 'looks bad' });
+    expect(questionVisibilityWrites()).toHaveLength(1);
+  });
+
+  it('upholds an inappropriate GENERATED report without any visibility write (upheld report is terminal)', async () => {
+    state.selectRows = [{ category: 'inappropriate', questionId: null, generatedQuestionId: 'g-1', status: 'open' }];
+
+    const result = await upholdReport('report-2');
+
+    expect(result).toEqual({ ok: true, action: 'upheld', category: 'inappropriate', hardRemoved: true });
+    expect(questionVisibilityWrites()).toHaveLength(0); // no blocked column on generated; no migration
+  });
+
+  it('upholds an incorrect report without blocking the question', async () => {
+    state.selectRows = [{ category: 'incorrect', questionId: 'q-1', generatedQuestionId: null, status: 'open' }];
+
+    const result = await upholdReport('report-3');
+
+    expect(result).toEqual({ ok: true, action: 'upheld', category: 'incorrect', hardRemoved: false });
+    expect(questionVisibilityWrites()).toHaveLength(0);
+  });
+
+  it('is a no-op on a missing or already-resolved report', async () => {
+    state.selectRows = [];
+    expect(await upholdReport('missing')).toEqual({ ok: false, reason: 'not_found' });
+    expect(reportStatusWrites()).toHaveLength(0);
+
+    state.selectRows = [{ category: 'inappropriate', questionId: 'q-1', generatedQuestionId: null, status: 'upheld' }];
+    expect(await upholdReport('done')).toEqual({ ok: false, reason: 'already_resolved' });
+    expect(reportStatusWrites()).toHaveLength(0);
+  });
+});
+
+describe('dismissReport', () => {
+  it('dismisses an open report (lifting B-Report-3 suppression) and never blocks anything', async () => {
+    state.selectRows = [{ category: 'inappropriate', status: 'open' }];
+
+    const result = await dismissReport('report-4', 'not a problem');
+
+    expect(result).toEqual({ ok: true, action: 'dismissed', category: 'inappropriate', hardRemoved: false });
+    expect(reportStatusWrites()[0]?.set).toMatchObject({ status: 'dismissed', reviewDecision: 'admin_dismissed', reviewReason: 'not a problem' });
+    expect(questionVisibilityWrites()).toHaveLength(0);
+  });
+
+  it('is a no-op on an already-resolved report', async () => {
+    state.selectRows = [{ category: 'incorrect', status: 'dismissed' }];
+    expect(await dismissReport('done')).toEqual({ ok: false, reason: 'already_resolved' });
+    expect(reportStatusWrites()).toHaveLength(0);
+  });
+});
+
+describe('getOpenReportsForReview', () => {
+  it('resolves the target table + text/answer per row and exposes reporter identity', async () => {
+    state.selectRows = [
+      {
+        id: 'r1', category: 'inappropriate', incorrectKind: null, note: 'n1', suggestedAnswer: null, surface: 'round_recap',
+        createdAt: new Date('2026-06-01'), questionId: 'q-1', generatedQuestionId: null,
+        questionText: 'curated?', questionAnswer: 'A', generatedText: null, generatedAnswer: null,
+        reporterUserId: 'u-1', reporterName: 'Reporter One',
+      },
+      {
+        id: 'r2', category: 'incorrect', incorrectKind: 'answer_key', note: 'n2', suggestedAnswer: 'B', surface: 'lately_result',
+        createdAt: new Date('2026-06-02'), questionId: null, generatedQuestionId: 'g-9',
+        questionText: null, questionAnswer: null, generatedText: 'generated?', generatedAnswer: 'G',
+        reporterUserId: 'u-2', reporterName: null,
+      },
+    ];
+
+    const result = await getOpenReportsForReview();
+
+    expect(result[0]).toMatchObject({
+      id: 'r1', target: { table: 'question', id: 'q-1' }, questionText: 'curated?', correctAnswer: 'A',
+      reporterUserId: 'u-1', reporterName: 'Reporter One',
+    });
+    expect(result[1]).toMatchObject({
+      id: 'r2', target: { table: 'generated', id: 'g-9' }, questionText: 'generated?', correctAnswer: 'G',
+      reporterUserId: 'u-2',
+    });
+  });
+});

--- a/src/server/db/queries/__tests__/content-reports-author.test.ts
+++ b/src/server/db/queries/__tests__/content-reports-author.test.ts
@@ -72,9 +72,9 @@ vi.mock('@/server/db', () => {
 });
 
 import {
-  getOpenIncorrectReportsForAuthor,
+  getActiveIncorrectReportsForAuthor,
   getUpheldInappropriateForAuthor,
-  resolveOpenIncorrectReportsForQuestion,
+  resolveActiveIncorrectReportsForQuestion,
 } from '@/server/db/queries/content-reports';
 
 type Op = { op?: string; parts?: Op[]; column?: unknown; value?: unknown; values?: unknown[] };
@@ -87,15 +87,15 @@ beforeEach(() => {
   returningRows = [];
 });
 
-describe('getOpenIncorrectReportsForAuthor', () => {
-  it('maps the most recent open incorrect report per question and never selects reporter identity', async () => {
+describe('getActiveIncorrectReportsForAuthor', () => {
+  it('maps the most recent active incorrect report per question and never selects reporter identity', async () => {
     selectRows = [
       { questionId: 'q1', note: 'newest', incorrectKind: 'answer_key', suggestedAnswer: 'Paris' },
       { questionId: 'q1', note: 'older', incorrectKind: 'premise', suggestedAnswer: null },
       { questionId: 'q2', note: 'n2', incorrectKind: null, suggestedAnswer: null },
     ];
 
-    const result = await getOpenIncorrectReportsForAuthor('author-1', ['q1', 'q2']);
+    const result = await getActiveIncorrectReportsForAuthor('author-1', ['q1', 'q2']);
 
     expect(result.get('q1')).toEqual({
       questionId: 'q1',
@@ -109,13 +109,13 @@ describe('getOpenIncorrectReportsForAuthor', () => {
     expect(Object.keys(capturedProjection ?? {})).not.toContain('reporterUserId');
   });
 
-  it('scopes to open incorrect reports on the author own non-house questions (house guard)', async () => {
-    await getOpenIncorrectReportsForAuthor('author-1', ['q1']);
+  it('scopes to active (open|upheld) incorrect reports on the author own non-house questions (house guard)', async () => {
+    await getActiveIncorrectReportsForAuthor('author-1', ['q1']);
 
     expect((capturedWhere as Op).parts).toEqual(
       expect.arrayContaining([
         { op: 'eq', column: 'cr.category', value: 'incorrect' },
-        { op: 'eq', column: 'cr.status', value: 'open' },
+        { op: 'inArray', column: 'cr.status', values: ['open', 'upheld'] },
         { op: 'eq', column: 'q.creatorId', value: 'author-1' },
         { op: 'ne', column: 'q.source', value: 'house_authored' },
       ]),
@@ -123,7 +123,7 @@ describe('getOpenIncorrectReportsForAuthor', () => {
   });
 
   it('short-circuits with no query for an empty id list', async () => {
-    const result = await getOpenIncorrectReportsForAuthor('author-1', []);
+    const result = await getActiveIncorrectReportsForAuthor('author-1', []);
     expect(result.size).toBe(0);
     expect(capturedWhere).toBeNull();
   });
@@ -147,11 +147,11 @@ describe('getUpheldInappropriateForAuthor', () => {
   });
 });
 
-describe('resolveOpenIncorrectReportsForQuestion', () => {
-  it('dismisses open incorrect reports with an author_edited marker and returns the count', async () => {
+describe('resolveActiveIncorrectReportsForQuestion', () => {
+  it('dismisses active (open|upheld) incorrect reports with an author_edited marker and returns the count', async () => {
     returningRows = [{ id: 'r1' }, { id: 'r2' }];
 
-    const count = await resolveOpenIncorrectReportsForQuestion('q1');
+    const count = await resolveActiveIncorrectReportsForQuestion('q1');
 
     expect(count).toBe(2);
     expect(capturedSet).toMatchObject({
@@ -165,7 +165,7 @@ describe('resolveOpenIncorrectReportsForQuestion', () => {
       expect.arrayContaining([
         { op: 'eq', column: 'cr.questionId', value: 'q1' },
         { op: 'eq', column: 'cr.category', value: 'incorrect' },
-        { op: 'eq', column: 'cr.status', value: 'open' },
+        { op: 'inArray', column: 'cr.status', values: ['open', 'upheld'] },
       ]),
     );
   });

--- a/src/server/db/queries/__tests__/content-reports-author.test.ts
+++ b/src/server/db/queries/__tests__/content-reports-author.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Structural drizzle mock (mirrors content-reports-suppression.test.ts) so we can
+// assert the exact author-facing reads: the house guard (creator_id = author AND
+// source <> 'house_authored'), the open|upheld scoping, that reporter identity is
+// NEVER selected, and the author-edit resolution transition.
+let capturedWhere: unknown = null;
+let capturedSet: unknown = null;
+let capturedProjection: Record<string, unknown> | null = null;
+let selectRows: unknown[] = [];
+let returningRows: unknown[] = [];
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => {
+  const selectChain: Record<string, unknown> = {
+    from: () => selectChain,
+    innerJoin: () => selectChain,
+    where: (cond: unknown) => {
+      capturedWhere = cond;
+      return selectChain;
+    },
+    orderBy: () => selectChain,
+    then: (resolve: (r: unknown[]) => unknown) => resolve(selectRows),
+  };
+  const updateChain: Record<string, unknown> = {
+    set: (vals: unknown) => {
+      capturedSet = vals;
+      return updateChain;
+    },
+    where: (cond: unknown) => {
+      capturedWhere = cond;
+      return updateChain;
+    },
+    returning: () => Promise.resolve(returningRows),
+  };
+  return {
+    db: {
+      select: (proj: Record<string, unknown>) => {
+        capturedProjection = proj;
+        return selectChain;
+      },
+      update: () => updateChain,
+    },
+    contentReports: {
+      id: 'cr.id',
+      reporterUserId: 'cr.reporterUserId',
+      questionId: 'cr.questionId',
+      generatedQuestionId: 'cr.generatedQuestionId',
+      category: 'cr.category',
+      incorrectKind: 'cr.incorrectKind',
+      note: 'cr.note',
+      suggestedAnswer: 'cr.suggestedAnswer',
+      status: 'cr.status',
+      reviewDecision: 'cr.reviewDecision',
+      reviewReason: 'cr.reviewReason',
+      reviewedAt: 'cr.reviewedAt',
+      createdAt: 'cr.createdAt',
+    },
+    questions: { id: 'q.id', creatorId: 'q.creatorId', source: 'q.source' },
+  };
+});
+
+import {
+  getOpenIncorrectReportsForAuthor,
+  getUpheldInappropriateForAuthor,
+  resolveOpenIncorrectReportsForQuestion,
+} from '@/server/db/queries/content-reports';
+
+type Op = { op?: string; parts?: Op[]; column?: unknown; value?: unknown; values?: unknown[] };
+
+beforeEach(() => {
+  capturedWhere = null;
+  capturedSet = null;
+  capturedProjection = null;
+  selectRows = [];
+  returningRows = [];
+});
+
+describe('getOpenIncorrectReportsForAuthor', () => {
+  it('maps the most recent open incorrect report per question and never selects reporter identity', async () => {
+    selectRows = [
+      { questionId: 'q1', note: 'newest', incorrectKind: 'answer_key', suggestedAnswer: 'Paris' },
+      { questionId: 'q1', note: 'older', incorrectKind: 'premise', suggestedAnswer: null },
+      { questionId: 'q2', note: 'n2', incorrectKind: null, suggestedAnswer: null },
+    ];
+
+    const result = await getOpenIncorrectReportsForAuthor('author-1', ['q1', 'q2']);
+
+    expect(result.get('q1')).toEqual({
+      questionId: 'q1',
+      note: 'newest',
+      incorrectKind: 'answer_key',
+      suggestedAnswer: 'Paris',
+    });
+    expect(result.get('q2')?.note).toBe('n2');
+
+    // The author must never learn who reported — reporterUserId is not projected.
+    expect(Object.keys(capturedProjection ?? {})).not.toContain('reporterUserId');
+  });
+
+  it('scopes to open incorrect reports on the author own non-house questions (house guard)', async () => {
+    await getOpenIncorrectReportsForAuthor('author-1', ['q1']);
+
+    expect((capturedWhere as Op).parts).toEqual(
+      expect.arrayContaining([
+        { op: 'eq', column: 'cr.category', value: 'incorrect' },
+        { op: 'eq', column: 'cr.status', value: 'open' },
+        { op: 'eq', column: 'q.creatorId', value: 'author-1' },
+        { op: 'ne', column: 'q.source', value: 'house_authored' },
+      ]),
+    );
+  });
+
+  it('short-circuits with no query for an empty id list', async () => {
+    const result = await getOpenIncorrectReportsForAuthor('author-1', []);
+    expect(result.size).toBe(0);
+    expect(capturedWhere).toBeNull();
+  });
+});
+
+describe('getUpheldInappropriateForAuthor', () => {
+  it('returns only upheld inappropriate question ids, house-guarded', async () => {
+    selectRows = [{ questionId: 'q1' }, { questionId: 'q3' }];
+
+    const result = await getUpheldInappropriateForAuthor('author-1', ['q1', 'q3']);
+
+    expect([...result].sort()).toEqual(['q1', 'q3']);
+    expect((capturedWhere as Op).parts).toEqual(
+      expect.arrayContaining([
+        { op: 'eq', column: 'cr.category', value: 'inappropriate' },
+        { op: 'eq', column: 'cr.status', value: 'upheld' },
+        { op: 'eq', column: 'q.creatorId', value: 'author-1' },
+        { op: 'ne', column: 'q.source', value: 'house_authored' },
+      ]),
+    );
+  });
+});
+
+describe('resolveOpenIncorrectReportsForQuestion', () => {
+  it('dismisses open incorrect reports with an author_edited marker and returns the count', async () => {
+    returningRows = [{ id: 'r1' }, { id: 'r2' }];
+
+    const count = await resolveOpenIncorrectReportsForQuestion('q1');
+
+    expect(count).toBe(2);
+    expect(capturedSet).toMatchObject({
+      status: 'dismissed',
+      reviewDecision: 'author_edited',
+      reviewReason: 'Author edited the answer key',
+    });
+    expect((capturedSet as { reviewedAt: unknown }).reviewedAt).toBeInstanceOf(Date);
+
+    expect((capturedWhere as Op).parts).toEqual(
+      expect.arrayContaining([
+        { op: 'eq', column: 'cr.questionId', value: 'q1' },
+        { op: 'eq', column: 'cr.category', value: 'incorrect' },
+        { op: 'eq', column: 'cr.status', value: 'open' },
+      ]),
+    );
+  });
+});

--- a/src/server/db/queries/__tests__/content-reports-suppression.test.ts
+++ b/src/server/db/queries/__tests__/content-reports-suppression.test.ts
@@ -1,0 +1,161 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors question-visibility.test.ts: mock drizzle-orm operators as structural
+// constructors so we can assert the exact suppression predicate shape — the
+// open|upheld scope (and the absence of 'dismissed') is the correctness-critical
+// invariant (a dismissed report must NOT suppress), and is caught here.
+let capturedWhere: unknown = null;
+let chainRows: unknown[] = [];
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {
+      select: vi.fn(() => chain),
+      from: vi.fn(() => chain),
+      where: vi.fn((cond: unknown) => {
+        capturedWhere = cond;
+        return chain;
+      }),
+      limit: vi.fn(() => Promise.resolve(chainRows)),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(chainRows),
+    };
+    return chain;
+  };
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+    contentReports: {
+      id: 'contentReports.id',
+      reporterUserId: 'contentReports.reporterUserId',
+      questionId: 'contentReports.questionId',
+      generatedQuestionId: 'contentReports.generatedQuestionId',
+      category: 'contentReports.category',
+      status: 'contentReports.status',
+      createdAt: 'contentReports.createdAt',
+    },
+  };
+});
+
+import {
+  getViewerHiddenQuestionIds,
+  isQuestionReportSuppressed,
+  notSuppressedByContentReport,
+} from '@/server/db/queries/content-reports';
+
+type Op = { op: string; parts?: unknown[]; column?: unknown; values?: unknown[] };
+
+function findInArrayOnStatus(cond: unknown): Op | undefined {
+  const node = cond as Op;
+  if (!node || typeof node !== 'object') return undefined;
+  if (node.op === 'inArray' && node.column === 'contentReports.status') return node;
+  for (const part of node.parts ?? []) {
+    const found = findInArrayOnStatus(part);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  capturedWhere = null;
+  chainRows = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('notSuppressedByContentReport', () => {
+  it('builds a NOT EXISTS over open|upheld reports matching the curated question id', () => {
+    const predicate = notSuppressedByContentReport('questions.id' as never, 'question') as Op;
+    expect(predicate.op).toBe('notExists');
+
+    expect(capturedWhere).toMatchObject({
+      op: 'and',
+      parts: expect.arrayContaining([
+        { op: 'eq', column: 'contentReports.questionId', value: 'questions.id' },
+        { op: 'inArray', column: 'contentReports.status', values: ['open', 'upheld'] },
+      ]),
+    });
+  });
+
+  it('targets the generatedQuestionId column for generated rows', () => {
+    notSuppressedByContentReport('generatedQuestions.id' as never, 'generated');
+    expect(capturedWhere).toMatchObject({
+      parts: expect.arrayContaining([
+        { op: 'eq', column: 'contentReports.generatedQuestionId', value: 'generatedQuestions.id' },
+      ]),
+    });
+  });
+
+  it('never includes dismissed in the suppressing statuses', () => {
+    notSuppressedByContentReport('questions.id' as never, 'question');
+    const statusFilter = findInArrayOnStatus(capturedWhere);
+    expect(statusFilter?.values).toEqual(['open', 'upheld']);
+    expect(statusFilter?.values).not.toContain('dismissed');
+  });
+});
+
+describe('isQuestionReportSuppressed', () => {
+  it('is true when an open/upheld report row matches the id (either FK column)', async () => {
+    chainRows = [{ id: 'report-1' }];
+    expect(await isQuestionReportSuppressed('q-1')).toBe(true);
+
+    // The id is matched against BOTH columns so a report on a GeneratedQuestion
+    // still suppresses a send that would mint it into a curated Question.
+    expect(capturedWhere).toMatchObject({
+      op: 'and',
+      parts: expect.arrayContaining([
+        {
+          op: 'or',
+          parts: [
+            { op: 'eq', column: 'contentReports.questionId', value: 'q-1' },
+            { op: 'eq', column: 'contentReports.generatedQuestionId', value: 'q-1' },
+          ],
+        },
+      ]),
+    });
+    expect(findInArrayOnStatus(capturedWhere)?.values).toEqual(['open', 'upheld']);
+  });
+
+  it('is false when no open/upheld report exists (e.g. only a dismissed one)', async () => {
+    chainRows = [];
+    expect(await isQuestionReportSuppressed('q-1')).toBe(false);
+  });
+});
+
+describe('getViewerHiddenQuestionIds', () => {
+  it('returns only the viewer-reported candidate ids, mapped from either FK column', async () => {
+    chainRows = [
+      { questionId: 'q-1', generatedQuestionId: null },
+      { questionId: null, generatedQuestionId: 'g-2' },
+      { questionId: 'q-other', generatedQuestionId: null }, // not in candidate set
+    ];
+    const hidden = await getViewerHiddenQuestionIds('viewer-1', ['q-1', 'g-2']);
+    expect([...hidden].sort()).toEqual(['g-2', 'q-1']);
+
+    // Reporter-scoped, inappropriate-only, open|upheld.
+    expect(capturedWhere).toMatchObject({
+      op: 'and',
+      parts: expect.arrayContaining([
+        { op: 'eq', column: 'contentReports.reporterUserId', value: 'viewer-1' },
+        { op: 'eq', column: 'contentReports.category', value: 'inappropriate' },
+        { op: 'inArray', column: 'contentReports.status', values: ['open', 'upheld'] },
+      ]),
+    });
+  });
+
+  it('short-circuits with no query when there are no candidate ids', async () => {
+    const hidden = await getViewerHiddenQuestionIds('viewer-1', []);
+    expect(hidden.size).toBe(0);
+    expect(capturedWhere).toBeNull();
+  });
+});

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -1,7 +1,7 @@
-import { and, eq, gte, inArray, notExists, or, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, ne, notExists, or, sql } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
-import { contentReports, db } from '@/server/db';
+import { contentReports, db, questions } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 
 // B-Report-2: write + read helpers for ContentReport. Mirrors the house style in
@@ -178,4 +178,118 @@ export async function getViewerHiddenQuestionIds(
     }
   }
   return hidden;
+}
+
+// ─── B-Report-4: author-facing state ────────────────────────────────────────
+//
+// The author of a curated Question can see report state on their own bank rows,
+// per the rule "a correction reaches the author immediately; an accusation only
+// after a human validates it":
+//   * open incorrect       → quiet "needs attention" (the note, never the reporter)
+//   * upheld inappropriate → read-only "this was removed" + category
+//   * open/dismissed inappropriate → invisible to the author
+// HOUSE/machine content is NEVER author-facing: every read below joins Question
+// and filters `creator_id = author AND source <> 'house_authored'`, so a house
+// question can never surface an author-facing state (the load-bearing honesty
+// guard, enforced server-side).
+
+export type AuthorIncorrectReport = {
+  questionId: string;
+  note: string;
+  incorrectKind: ContentReportIncorrectKind | null;
+  suggestedAnswer: string | null;
+};
+
+// Reporter identity is intentionally NOT selected here — the author must never see
+// who reported. Returns the most recent open incorrect report per question.
+export async function getOpenIncorrectReportsForAuthor(
+  authorUserId: string,
+  questionIds: string[],
+): Promise<Map<string, AuthorIncorrectReport>> {
+  const byQuestion = new Map<string, AuthorIncorrectReport>();
+  if (questionIds.length === 0) return byQuestion;
+
+  const rows = await db
+    .select({
+      questionId: contentReports.questionId,
+      note: contentReports.note,
+      incorrectKind: contentReports.incorrectKind,
+      suggestedAnswer: contentReports.suggestedAnswer,
+    })
+    .from(contentReports)
+    .innerJoin(questions, eq(contentReports.questionId, questions.id))
+    .where(
+      and(
+        inArray(contentReports.questionId, questionIds),
+        eq(contentReports.category, 'incorrect'),
+        eq(contentReports.status, 'open'),
+        eq(questions.creatorId, authorUserId),
+        ne(questions.source, 'house_authored'),
+      ),
+    )
+    .orderBy(desc(contentReports.createdAt));
+
+  for (const row of rows) {
+    if (!row.questionId || byQuestion.has(row.questionId)) continue; // most recent wins
+    byQuestion.set(row.questionId, {
+      questionId: row.questionId,
+      note: row.note,
+      incorrectKind: row.incorrectKind,
+      suggestedAnswer: row.suggestedAnswer,
+    });
+  }
+  return byQuestion;
+}
+
+// Upheld inappropriate only — an accusation reaches the author solely after a human
+// validates it. open/dismissed inappropriate are never read, so they stay invisible.
+export async function getUpheldInappropriateForAuthor(
+  authorUserId: string,
+  questionIds: string[],
+): Promise<Set<string>> {
+  const removed = new Set<string>();
+  if (questionIds.length === 0) return removed;
+
+  const rows = await db
+    .select({ questionId: contentReports.questionId })
+    .from(contentReports)
+    .innerJoin(questions, eq(contentReports.questionId, questions.id))
+    .where(
+      and(
+        inArray(contentReports.questionId, questionIds),
+        eq(contentReports.category, 'inappropriate'),
+        eq(contentReports.status, 'upheld'),
+        eq(questions.creatorId, authorUserId),
+        ne(questions.source, 'house_authored'),
+      ),
+    );
+
+  for (const row of rows) {
+    if (row.questionId) removed.add(row.questionId);
+  }
+  return removed;
+}
+
+// B-Report-4 / B-Report-3 bridge: an author fixing the answer key resolves their
+// open incorrect reports. status → 'dismissed' lifts B-Report-3 suppression (which
+// reads open|upheld); reviewDecision='author_edited' distinguishes this from a
+// moderator dismissal. Returns the number of reports resolved.
+export async function resolveOpenIncorrectReportsForQuestion(questionId: string): Promise<number> {
+  const updated = await db
+    .update(contentReports)
+    .set({
+      status: 'dismissed',
+      reviewDecision: 'author_edited',
+      reviewReason: 'Author edited the answer key',
+      reviewedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(contentReports.questionId, questionId),
+        eq(contentReports.category, 'incorrect'),
+        eq(contentReports.status, 'open'),
+      ),
+    )
+    .returning({ id: contentReports.id });
+  return updated.length;
 }

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -1,4 +1,5 @@
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, notExists, or, sql } from 'drizzle-orm';
+import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 import { contentReports, db } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
@@ -81,4 +82,100 @@ export async function countContentReportsToday(reporterUserId: string): Promise<
       ),
     );
   return row?.count ?? 0;
+}
+
+// ─── B-Report-3: suppression ────────────────────────────────────────────────
+//
+// A question is "suppressed" while it has an open OR upheld report from anyone —
+// it stops entering NEW surfaces (daily queues, feed propagation, sends). This is
+// the reversible, pre-review layer: a `dismissed` report does NOT suppress, so a
+// resolution that clears the report automatically lifts suppression. (The terminal
+// hard-block — visibility='blocked' on upheld-offensive — is admin action in
+// B-Report-5 and is intentionally separate.) Existing copies on other players are
+// never touched; these helpers only gate entry into new surfaces.
+
+const SUPPRESSING_STATUSES = ['open', 'upheld'] as const;
+
+// A correlated NOT EXISTS predicate for SQL selection paths, mirroring the
+// `exists` style of questionVisibilityPredicate. Pass the candidate table's id
+// column and which ContentReport FK targets it. Add it to an existing `and(...)`
+// where-clause so suppressed rows are never drawn into a new queue.
+export function notSuppressedByContentReport(
+  targetIdColumn: AnyPgColumn,
+  kind: 'question' | 'generated',
+) {
+  const reportColumn =
+    kind === 'question' ? contentReports.questionId : contentReports.generatedQuestionId;
+  return notExists(
+    db
+      .select({ one: sql`1` })
+      .from(contentReports)
+      .where(
+        and(
+          eq(reportColumn, targetIdColumn),
+          inArray(contentReports.status, [...SUPPRESSING_STATUSES]),
+        ),
+      ),
+  );
+}
+
+// Runtime check for JS paths (feed propagation, direct send) where we hold a raw
+// id whose table may be either. Matches the id against both FK columns so a report
+// on a GeneratedQuestion still blocks a send that would mint it into a curated
+// Question.
+export async function isQuestionReportSuppressed(targetId: string): Promise<boolean> {
+  const [row] = await db
+    .select({ id: contentReports.id })
+    .from(contentReports)
+    .where(
+      and(
+        or(
+          eq(contentReports.questionId, targetId),
+          eq(contentReports.generatedQuestionId, targetId),
+        ),
+        inArray(contentReports.status, [...SUPPRESSING_STATUSES]),
+      ),
+    )
+    .limit(1);
+  return Boolean(row);
+}
+
+// Durable self-hide (inappropriate only). Of the given candidate ids, returns the
+// subset the viewer has personally reported as inappropriate and that is still
+// open|upheld — so their recap / Lately render can drop those cards on refresh by
+// reading the existing ContentReport row (no new state). Incorrect reports never
+// self-hide.
+export async function getViewerHiddenQuestionIds(
+  viewerUserId: string,
+  candidateIds: string[],
+): Promise<Set<string>> {
+  const hidden = new Set<string>();
+  if (candidateIds.length === 0) return hidden;
+
+  const rows = await db
+    .select({
+      questionId: contentReports.questionId,
+      generatedQuestionId: contentReports.generatedQuestionId,
+    })
+    .from(contentReports)
+    .where(
+      and(
+        eq(contentReports.reporterUserId, viewerUserId),
+        eq(contentReports.category, 'inappropriate'),
+        inArray(contentReports.status, [...SUPPRESSING_STATUSES]),
+        or(
+          inArray(contentReports.questionId, candidateIds),
+          inArray(contentReports.generatedQuestionId, candidateIds),
+        ),
+      ),
+    );
+
+  const candidateSet = new Set(candidateIds);
+  for (const row of rows) {
+    if (row.questionId && candidateSet.has(row.questionId)) hidden.add(row.questionId);
+    if (row.generatedQuestionId && candidateSet.has(row.generatedQuestionId)) {
+      hidden.add(row.generatedQuestionId);
+    }
+  }
+  return hidden;
 }

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -1,7 +1,7 @@
-import { and, desc, eq, gte, inArray, ne, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, ne, notExists, or, sql } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
-import { contentReports, db, questions } from '@/server/db';
+import { contentReports, db, generatedQuestions, questions, users } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 
 // B-Report-2: write + read helpers for ContentReport. Mirrors the house style in
@@ -201,8 +201,10 @@ export type AuthorIncorrectReport = {
 };
 
 // Reporter identity is intentionally NOT selected here — the author must never see
-// who reported. Returns the most recent open incorrect report per question.
-export async function getOpenIncorrectReportsForAuthor(
+// who reported. Returns the most recent active (open|upheld) incorrect report per
+// question. Upheld is included so an admin upholding "this answer is wrong" leaves
+// the author's "needs attention" in place until they fix it (B-Report-5 §6.4).
+export async function getActiveIncorrectReportsForAuthor(
   authorUserId: string,
   questionIds: string[],
 ): Promise<Map<string, AuthorIncorrectReport>> {
@@ -222,7 +224,7 @@ export async function getOpenIncorrectReportsForAuthor(
       and(
         inArray(contentReports.questionId, questionIds),
         eq(contentReports.category, 'incorrect'),
-        eq(contentReports.status, 'open'),
+        inArray(contentReports.status, ['open', 'upheld']),
         eq(questions.creatorId, authorUserId),
         ne(questions.source, 'house_authored'),
       ),
@@ -271,10 +273,11 @@ export async function getUpheldInappropriateForAuthor(
 }
 
 // B-Report-4 / B-Report-3 bridge: an author fixing the answer key resolves their
-// open incorrect reports. status → 'dismissed' lifts B-Report-3 suppression (which
-// reads open|upheld); reviewDecision='author_edited' distinguishes this from a
-// moderator dismissal. Returns the number of reports resolved.
-export async function resolveOpenIncorrectReportsForQuestion(questionId: string): Promise<number> {
+// active incorrect reports (open OR upheld — an admin-upheld "wrong answer" is also
+// cleared by the fix). status → 'dismissed' lifts B-Report-3 suppression (which reads
+// open|upheld); reviewDecision='author_edited' distinguishes this from a moderator
+// dismissal. Returns the number of reports resolved.
+export async function resolveActiveIncorrectReportsForQuestion(questionId: string): Promise<number> {
   const updated = await db
     .update(contentReports)
     .set({
@@ -287,9 +290,157 @@ export async function resolveOpenIncorrectReportsForQuestion(questionId: string)
       and(
         eq(contentReports.questionId, questionId),
         eq(contentReports.category, 'incorrect'),
-        eq(contentReports.status, 'open'),
+        inArray(contentReports.status, ['open', 'upheld']),
       ),
     )
     .returning({ id: contentReports.id });
   return updated.length;
+}
+
+// ─── B-Report-5: admin review queue ─────────────────────────────────────────
+//
+// Admin-only (ADMIN_USER_IDS allowlist, enforced at the route/page). The review list
+// is the ONLY place reporter identity is exposed. Uphold/dismiss are the only two
+// actions. Uphold-inappropriate on an authored question is the ONLY place
+// visibility='blocked' is set; for a generated question the upheld report itself is
+// the terminal suppression (B-Report-3 reads open|upheld), so no column is written.
+
+export type AdminReviewReport = {
+  id: string;
+  category: ContentReportCategory;
+  incorrectKind: ContentReportIncorrectKind | null;
+  note: string;
+  suggestedAnswer: string | null;
+  surface: string | null;
+  createdAt: Date;
+  target: { table: 'question' | 'generated'; id: string };
+  questionText: string | null;
+  correctAnswer: string | null;
+  // Admin-only — never exposed on any author/player surface.
+  reporterUserId: string;
+  reporterName: string | null;
+};
+
+// Open reports for review: inappropriate (high-priority) first, then oldest-first.
+export async function getOpenReportsForReview(): Promise<AdminReviewReport[]> {
+  const rows = await db
+    .select({
+      id: contentReports.id,
+      category: contentReports.category,
+      incorrectKind: contentReports.incorrectKind,
+      note: contentReports.note,
+      suggestedAnswer: contentReports.suggestedAnswer,
+      surface: contentReports.surface,
+      createdAt: contentReports.createdAt,
+      questionId: contentReports.questionId,
+      generatedQuestionId: contentReports.generatedQuestionId,
+      questionText: questions.questionText,
+      questionAnswer: questions.answerText,
+      generatedText: generatedQuestions.questionText,
+      generatedAnswer: generatedQuestions.answer,
+      reporterUserId: contentReports.reporterUserId,
+      reporterName: users.displayName,
+    })
+    .from(contentReports)
+    .leftJoin(questions, eq(contentReports.questionId, questions.id))
+    .leftJoin(generatedQuestions, eq(contentReports.generatedQuestionId, generatedQuestions.id))
+    .leftJoin(users, eq(contentReports.reporterUserId, users.id))
+    .where(eq(contentReports.status, 'open'))
+    .orderBy(
+      desc(sql`(${contentReports.category} = 'inappropriate')`),
+      asc(contentReports.createdAt),
+    );
+
+  return rows.map((row) => {
+    const isGenerated = row.generatedQuestionId != null;
+    return {
+      id: row.id,
+      category: row.category,
+      incorrectKind: row.incorrectKind,
+      note: row.note,
+      suggestedAnswer: row.suggestedAnswer,
+      surface: row.surface,
+      createdAt: row.createdAt,
+      target: isGenerated
+        ? { table: 'generated' as const, id: row.generatedQuestionId! }
+        : { table: 'question' as const, id: row.questionId! },
+      questionText: isGenerated ? row.generatedText : row.questionText,
+      correctAnswer: isGenerated ? row.generatedAnswer : row.questionAnswer,
+      reporterUserId: row.reporterUserId,
+      reporterName: row.reporterName,
+    };
+  });
+}
+
+export type AdminActionResult =
+  | { ok: true; action: 'upheld' | 'dismissed'; category: ContentReportCategory; hardRemoved: boolean }
+  | { ok: false; reason: 'not_found' | 'already_resolved' };
+
+// Uphold: status='upheld'. For inappropriate, hard-remove — authored →
+// visibility='blocked' (the ONLY place set); generated → the upheld report is itself
+// terminal (no column write). Incorrect uphold marks it actioned and leaves the
+// author's "needs attention" for them to clear by editing the key (B-Report-4).
+export async function upholdReport(reportId: string, reviewReason?: string): Promise<AdminActionResult> {
+  const [report] = await db
+    .select({
+      category: contentReports.category,
+      questionId: contentReports.questionId,
+      generatedQuestionId: contentReports.generatedQuestionId,
+      status: contentReports.status,
+    })
+    .from(contentReports)
+    .where(eq(contentReports.id, reportId))
+    .limit(1);
+
+  if (!report) return { ok: false, reason: 'not_found' };
+  if (report.status !== 'open') return { ok: false, reason: 'already_resolved' };
+
+  await db
+    .update(contentReports)
+    .set({
+      status: 'upheld',
+      reviewDecision: 'admin_upheld',
+      reviewReason: reviewReason?.trim() || null,
+      reviewedAt: new Date(),
+    })
+    .where(and(eq(contentReports.id, reportId), eq(contentReports.status, 'open')));
+
+  let hardRemoved = false;
+  if (report.category === 'inappropriate' && report.questionId) {
+    // The ONLY visibility='blocked' write in the codebase (excluded by
+    // questionVisibilityPredicate + every bank/send/game read path).
+    await db.update(questions).set({ visibility: 'blocked' }).where(eq(questions.id, report.questionId));
+    hardRemoved = true;
+  } else if (report.category === 'inappropriate' && report.generatedQuestionId) {
+    // Generated has no terminal column; the upheld report is the terminal state
+    // (B-Report-3 suppression reads open|upheld). Nothing else to write.
+    hardRemoved = true;
+  }
+
+  return { ok: true, action: 'upheld', category: report.category, hardRemoved };
+}
+
+// Dismiss: status='dismissed'. Lifts B-Report-3 suppression automatically (predicate
+// is open|upheld); for inappropriate, the author never learns it happened.
+export async function dismissReport(reportId: string, reviewReason?: string): Promise<AdminActionResult> {
+  const [report] = await db
+    .select({ category: contentReports.category, status: contentReports.status })
+    .from(contentReports)
+    .where(eq(contentReports.id, reportId))
+    .limit(1);
+
+  if (!report) return { ok: false, reason: 'not_found' };
+  if (report.status !== 'open') return { ok: false, reason: 'already_resolved' };
+
+  await db
+    .update(contentReports)
+    .set({
+      status: 'dismissed',
+      reviewDecision: 'admin_dismissed',
+      reviewReason: reviewReason?.trim() || null,
+      reviewedAt: new Date(),
+    })
+    .where(and(eq(contentReports.id, reportId), eq(contentReports.status, 'open')));
+
+  return { ok: true, action: 'dismissed', category: report.category, hardRemoved: false };
 }

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -11,6 +11,7 @@ import {
 } from '@/server/db';
 import { resolveTier } from '@/server/mastery/tiers';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
+import { getViewerHiddenQuestionIds } from '@/server/db/queries/content-reports';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { buildRefineSection } from '@/server/db/queries/refine';
 import { getFeedPagePayload } from '@/server/feed/get-feed-page';
@@ -259,6 +260,22 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     };
   });
 
+  // B-Report-3: durable self-hide. A recap card the viewer reported as
+  // inappropriate (open|upheld) stays gone across refreshes — read straight from
+  // the ContentReport row, no new state. Incorrect reports do not self-hide.
+  // Totals stay computed from slots (below), matching B-Report-2's card-only removal.
+  const reportTargetIds = recaps
+    .map((recap) => recap.reportTarget?.questionId ?? recap.reportTarget?.generatedQuestionId)
+    .filter((id): id is string => Boolean(id));
+  const hiddenIds = await getViewerHiddenQuestionIds(userId, reportTargetIds);
+  const visibleRecaps =
+    hiddenIds.size === 0
+      ? recaps
+      : recaps.filter((recap) => {
+          const targetId = recap.reportTarget?.questionId ?? recap.reportTarget?.generatedQuestionId;
+          return !(targetId && hiddenIds.has(targetId));
+        });
+
   const totalSkipped = slots.filter((slot) => slot.skipped).length;
   const totalAnswered = slots.filter((slot) => slot.answered).length;
   const totalCorrect = slots.filter((slot) => slot.answer_state === 'correct').length;
@@ -279,7 +296,7 @@ export async function getDailySummary(userId: string, date: Date): Promise<Daily
     totalSkipped,
     pointsEarned,
     difficultyMode: prefs.difficulty,
-    questions: recaps,
+    questions: visibleRecaps,
     domainGains: gainedDomains
       .map((domain) => ({
         domain,

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -15,6 +15,7 @@ import {
 } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { notSuppressedByContentReport } from '@/server/db/queries/content-reports';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATEGORIES, categoryLabel, HOUSE_AUTHOR, resolveAuthorDisplay } from '@/lib/questions-types';
 import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
@@ -1002,6 +1003,8 @@ export async function pickEligibleAuthoredQuestions(
       isNotNull(canonicalQuestions.canonicalSubcategory),
       inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
       isNull(canonicalQuestions.deletedAt),
+      // B-Report-3: never draw a reported question into a new daily queue.
+      notSuppressedByContentReport(canonicalQuestions.id, 'question'),
     ))
     .orderBy(
       desc(canonicalQuestions.publicEligibilityScore),
@@ -1244,6 +1247,8 @@ export async function pickHouseQuestions(
       isNotNull(canonicalQuestions.canonicalSubcategory),
       inArray(canonicalQuestions.canonicalSubcategory, [...allowedSubcategories]),
       isNull(canonicalQuestions.deletedAt),
+      // B-Report-3: a reported house question is suppressed from new queues too.
+      notSuppressedByContentReport(canonicalQuestions.id, 'question'),
     ))
     .orderBy(desc(canonicalQuestions.createdAt))
     .limit(Math.max(limit * 4, 20));
@@ -1458,6 +1463,8 @@ export async function pickBankSource(
         isNotNull(generatedQuestions.factKey),
         sql`${generatedQuestions.userId} <> ${userId}`,
         eq(generatedQuestions.isDuplicate, false),
+        // B-Report-3: skip generated questions under an open/upheld report.
+        notSuppressedByContentReport(generatedQuestions.id, 'generated'),
       ))
       .orderBy(desc(generatedQuestions.createdAt))
       .limit(BANK_RECENCY_WINDOW);

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -14,7 +14,7 @@ import { broadCategoryDisplayName } from '@/lib/question-categorization';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { embedAndResolveDuplicate } from '@/server/pool/dedup';
 import {
-  getOpenIncorrectReportsForAuthor,
+  getActiveIncorrectReportsForAuthor,
   getUpheldInappropriateForAuthor,
 } from '@/server/db/queries/content-reports';
 
@@ -303,7 +303,7 @@ async function attachAuthorReportState(
   if (ownIds.length === 0) return views;
 
   const [incorrectByQuestion, removed] = await Promise.all([
-    getOpenIncorrectReportsForAuthor(userId, ownIds),
+    getActiveIncorrectReportsForAuthor(userId, ownIds),
     getUpheldInappropriateForAuthor(userId, ownIds),
   ]);
   if (incorrectByQuestion.size === 0 && removed.size === 0) return views;

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -13,6 +13,10 @@ import {
 import { broadCategoryDisplayName } from '@/lib/question-categorization';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { embedAndResolveDuplicate } from '@/server/pool/dedup';
+import {
+  getOpenIncorrectReportsForAuthor,
+  getUpheldInappropriateForAuthor,
+} from '@/server/db/queries/content-reports';
 
 export type QuestionView = {
   id: string;
@@ -60,7 +64,22 @@ export type QuestionView = {
   llmSuggestedAnswer: string | null;
   critiqueIterations: number;
   answerers?: { names: string[]; total: number };
+  // B-Report-4: quiet author-facing content-report state on the author's own bank
+  // rows. Absent for everyone else and for house/machine content (never surfaced).
+  reportState?: QuestionReportState | null;
 };
+
+// "needs_attention" carries the correction (note + kind + suggested answer) but
+// never the reporter's identity; "removed" is the read-only upheld-inappropriate
+// terminal state.
+export type QuestionReportState =
+  | {
+      kind: 'needs_attention';
+      note: string;
+      incorrectKind: 'answer_key' | 'premise' | null;
+      suggestedAnswer: string | null;
+    }
+  | { kind: 'removed'; category: 'inappropriate' };
 
 export type QuestionMutationResult = { ok: boolean; reason?: 'not_found' | 'in_use' };
 
@@ -266,7 +285,47 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
 
 export async function getQuestionsForUser(userId: string): Promise<QuestionView[]> {
   const { getBankedQuestions } = await import('@/server/db/queries/bank');
-  return getBankedQuestions(userId, { onlyAuthored: true });
+  const views = await getBankedQuestions(userId, { onlyAuthored: true });
+  return attachAuthorReportState(userId, views);
+}
+
+// B-Report-4: attach the quiet author-facing report state to the author's own
+// authored rows. The read helpers already enforce the house guard server-side, so
+// house/machine content can never receive a state. "removed" (upheld inappropriate)
+// takes precedence over "needs attention" (open incorrect) on the same question.
+async function attachAuthorReportState(
+  userId: string,
+  views: QuestionView[],
+): Promise<QuestionView[]> {
+  const ownIds = views
+    .filter((view) => view.isOwnAuthored && view.creator_id === userId)
+    .map((view) => view.id);
+  if (ownIds.length === 0) return views;
+
+  const [incorrectByQuestion, removed] = await Promise.all([
+    getOpenIncorrectReportsForAuthor(userId, ownIds),
+    getUpheldInappropriateForAuthor(userId, ownIds),
+  ]);
+  if (incorrectByQuestion.size === 0 && removed.size === 0) return views;
+
+  return views.map((view) => {
+    if (removed.has(view.id)) {
+      return { ...view, reportState: { kind: 'removed', category: 'inappropriate' } };
+    }
+    const incorrect = incorrectByQuestion.get(view.id);
+    if (incorrect) {
+      return {
+        ...view,
+        reportState: {
+          kind: 'needs_attention',
+          note: incorrect.note,
+          incorrectKind: incorrect.incorrectKind,
+          suggestedAnswer: incorrect.suggestedAnswer,
+        },
+      };
+    }
+    return view;
+  });
 }
 
 export async function hasUserAuthoredAnyQuestion(userId: string): Promise<boolean> {

--- a/src/server/feed/__tests__/create-feed-items-suppression.test.ts
+++ b/src/server/feed/__tests__/create-feed-items-suppression.test.ts
@@ -1,0 +1,101 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// B-Report-3: a correct answer to a question under an open/upheld content report
+// must not propagate to NEW feeds, and must not touch existing copies. We mock the
+// collaborators and assert: suppressed → no insert/update/delete and the fan-out
+// (eligibility check, getFollowers) is never reached; not-suppressed → the gate is
+// passed (eligibility IS consulted).
+const {
+  isQuestionReportSuppressedMock,
+  isCorrectAnswerFeedEligibleMock,
+  getFollowersMock,
+  insertMock,
+  updateMock,
+  deleteMock,
+} = vi.hoisted(() => ({
+  isQuestionReportSuppressedMock: vi.fn(async () => false),
+  isCorrectAnswerFeedEligibleMock: vi.fn(() => false),
+  getFollowersMock: vi.fn(async () => [] as Array<{ id: string }>),
+  insertMock: vi.fn(() => ({ values: vi.fn(async () => undefined) })),
+  updateMock: vi.fn(() => ({ set: () => ({ where: vi.fn(async () => undefined) }) })),
+  deleteMock: vi.fn(() => ({ where: vi.fn(async () => undefined) })),
+}));
+
+// Every select resolves empty: the thumbs-down / rating-down probes find nothing,
+// so control reaches the suppression gate. The question fetch (also empty) only
+// matters on the not-suppressed path, where the eligibility mock short-circuits.
+const selectChain = {
+  from: () => selectChain,
+  where: () => selectChain,
+  limit: async () => [] as unknown[],
+};
+
+vi.mock('@/server/db', () => ({
+  db: {
+    select: () => selectChain,
+    insert: insertMock,
+    update: updateMock,
+    delete: deleteMock,
+  },
+  feedDismissedDomains: {},
+  feedItems: {},
+  masteryEvents: {},
+  questionFeedback: {},
+  questionRatings: {},
+  questions: {},
+}));
+
+vi.mock('@/server/db/queries/content-reports', () => ({
+  isQuestionReportSuppressed: isQuestionReportSuppressedMock,
+}));
+vi.mock('@/server/feed/visibility', () => ({
+  isCorrectAnswerFeedEligible: isCorrectAnswerFeedEligibleMock,
+  SOCIAL_FEED_SOURCE_TYPE: 'friend_answered',
+}));
+vi.mock('@/server/db/queries/friends', () => ({ getFollowers: getFollowersMock }));
+vi.mock('@/server/activity/write-activity', () => ({ writeActivity: vi.fn(async () => undefined) }));
+vi.mock('@/server/db/queries/account', () => ({ getNicheMatchDiscoverable: vi.fn(async () => new Set()) }));
+vi.mock('@/server/db/queries/friend-requests', () => ({ getRelationship: vi.fn(async () => ({ state: 'none' })) }));
+vi.mock('@/server/db/queries/feed', () => ({ rollOffOldItems: vi.fn(async () => undefined) }));
+
+import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  isQuestionReportSuppressedMock.mockResolvedValue(false);
+  isCorrectAnswerFeedEligibleMock.mockReturnValue(false);
+  getFollowersMock.mockResolvedValue([]);
+});
+
+describe('createFeedItemsForFriendsFromAnswer — content-report suppression', () => {
+  it('does not propagate a suppressed question and touches no existing rows', async () => {
+    isQuestionReportSuppressedMock.mockResolvedValue(true);
+
+    await createFeedItemsForFriendsFromAnswer('user-1', 'q-1', 'correct', 'ans-1');
+
+    expect(isQuestionReportSuppressedMock).toHaveBeenCalledWith('q-1');
+    // Blocked before the fan-out: eligibility never consulted, no followers fetched.
+    expect(isCorrectAnswerFeedEligibleMock).not.toHaveBeenCalled();
+    expect(getFollowersMock).not.toHaveBeenCalled();
+    // No new items, and crucially no mutation of existing copies on other players.
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(updateMock).not.toHaveBeenCalled();
+    expect(deleteMock).not.toHaveBeenCalled();
+  });
+
+  it('passes the suppression gate when the question is not suppressed', async () => {
+    isQuestionReportSuppressedMock.mockResolvedValue(false);
+
+    await createFeedItemsForFriendsFromAnswer('user-1', 'q-1', 'correct', 'ans-1');
+
+    expect(isQuestionReportSuppressedMock).toHaveBeenCalledWith('q-1');
+    // Got past the gate — the eligibility check (the next step) was reached.
+    expect(isCorrectAnswerFeedEligibleMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('never reaches the suppression gate for an incorrect answer', async () => {
+    await createFeedItemsForFriendsFromAnswer('user-1', 'q-1', 'incorrect', 'ans-1');
+    expect(isQuestionReportSuppressedMock).not.toHaveBeenCalled();
+    expect(insertMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -6,6 +6,7 @@ import { getNicheMatchDiscoverable } from '@/server/db/queries/account';
 import { getFollowers } from '@/server/db/queries/friends';
 import { getRelationship } from '@/server/db/queries/friend-requests';
 import { rollOffOldItems } from '@/server/db/queries/feed';
+import { isQuestionReportSuppressed } from '@/server/db/queries/content-reports';
 import { isCorrectAnswerFeedEligible, SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
 
 // Joshing-games funnel through this same after() entrypoint but stamp their
@@ -62,6 +63,12 @@ async function _createFeedItemsForFriendsFromAnswer(
     .limit(1);
 
   if (thumbsDown || ratingDown) return;
+
+  // B-Report-3: an open/upheld content report suppresses NEW propagation entirely —
+  // no friend fan-out, no niche-match discovery, no previous-answerer pings. This
+  // only blocks new feed items; existing copies on other players are untouched and
+  // lift automatically if the report is later dismissed.
+  if (await isQuestionReportSuppressed(questionId)) return;
 
   const [question] = await db
     .select({


### PR DESCRIPTION
Completes the content-reporting sequence (PRD-D-6). **B-Report-2 (write path + `⋯` items + "why" step) is already on `dev2`** — it's the merge-base of this branch — so this PR adds the remaining three prompts plus the canonical PRD doc.

## What's included
- **B-Report-3 — propagation suppression + durable self-hide.** One `open|upheld` suppression predicate, wired into every new-surface eligibility path (daily fill: authored/house/bank; feed propagation; direct send). Existing copies on other players are never touched. Reporter's inappropriate self-hide is durable (Round Recap + Lately) by reading the existing `ContentReport` row — no new state. `dismissed` suppresses nothing (reversible).
- **B-Report-4 — author-facing state.** Quiet "needs a second look" for open|upheld incorrect (note + kind + suggested answer, **never** reporter identity); read-only "removed" for upheld inappropriate; `open`/`dismissed` inappropriate invisible to the author. Server-side house guard so house/machine content never renders an author-facing state. Editing the answer key/alternatives resolves the report (→ `dismissed`, `author_edited`) and lifts suppression.
- **B-Report-5 — admin review queue.** `ADMIN_USER_IDS` env allowlist (fails closed; added to `env-check.ts` as **optional**), gated page + POST actions that **404** (not 403) for non-admins. Inappropriate-first, then oldest-first, with full review context incl. admin-only reporter identity. Uphold/dismiss are the only two actions; uphold-inappropriate-authored sets `visibility='blocked'` (the only place) — generated relies on the upheld report as terminal (no column, no migration).
- **PRD-D-6-CONTENT-REPORTING.md** — the canonical spec, committed at the repo root (was referenced everywhere but missing).

## Guardrails honored
No `schema.ts` change, no migration (B-Report-1 owns the schema), no `middleware.ts`, no `proxy.ts`/heart changes, no SMS/push. The only new `visibility='blocked'` write is uphold-inappropriate-authored.

## Test plan
- `npx tsc -p tsconfig.typecheck.json` → exits 0.
- `vitest run` → suite green **except** the pre-existing, unrelated `add-declared-interest.test.ts` failure (reproduces on a clean base — not introduced here).
- New coverage: suppression predicate (open|upheld scoping + dismissed-excluded), feed-propagation blocked-when-suppressed / existing-untouched, send 409, durable self-hide, author reads (house guard + no-identity projection + author_edited transition), edit-clears-report (answer-key vs explanation-only), admin gate allowlist, uphold/dismiss wiring (blocked only for authored-inappropriate), non-admin 404.

## Non-blocking follow-ups (from the PRD)
- Copy final pass on the menu labels / acknowledgments / author strings (§6.8).
- `surface` provenance label is `'lately_result'` vs the PRD's illustrative `'lately'` (free-text column; trivial to align if desired).
- Independent of this feature: rotate the Postgres credential noted in `_docs/pw.txt`.

https://claude.ai/code/session_013BX13hWHosjoUyrU76ZYxz

---
_Generated by [Claude Code](https://claude.ai/code/session_013BX13hWHosjoUyrU76ZYxz)_