### PR TITLE
Unify answer reveal styling across all surfaces

### DIFF
--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -3,6 +3,7 @@ import { notFound, redirect } from 'next/navigation';
 import type { CSSProperties } from 'react';
 import { and, eq, inArray, sql } from 'drizzle-orm';
 
+import { answerHeadingStyle } from '@/components/answer-heading';
 import { QuestionRatingButtons } from '@/components/games/QuestionRatingButtons';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
@@ -335,8 +336,13 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
                       <span className="font-medium text-foreground">You:</span>{' '}
                       {response?.submittedAnswer?.trim() || 'No answer submitted'}
                     </p>
-                    <p className="text-muted-foreground">
-                      <span className="font-medium text-foreground">Answer:</span> {gameQuestion.question.answerText}
+                    <p
+                      style={{
+                        ...answerHeadingStyle,
+                        color: correct ? 'var(--game-correct)' : 'var(--brand-ink)',
+                      }}
+                    >
+                      {gameQuestion.question.answerText}
                     </p>
                   </div>
                   {briefForDisplay ? (

--- a/src/components/answer-heading.ts
+++ b/src/components/answer-heading.ts
@@ -1,0 +1,16 @@
+import type { CSSProperties } from 'react'
+
+// The canonical answer rendered as a prominent serif headline — the "answer as
+// headline" reveal treatment from the in-game result card (GameplayChat's
+// ResultRow). Shared so every surface that reveals an answer — the in-game
+// result card, the feed reveal sheet, the "answered by you" card, the game
+// summary recap, and the answered-history list — sizes the answer identically.
+//
+// Apply the result tone on top of this (green `--game-correct` when the player
+// nailed it, `--brand-ink` otherwise) so the headline still reads as a verdict.
+export const answerHeadingStyle: CSSProperties = {
+  fontFamily: 'var(--font-cormorant), Georgia, serif',
+  fontSize: '1.65rem',
+  fontWeight: 700,
+  lineHeight: 1.14,
+}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Check, MoreHorizontal, Sparkles, X } from 'lucide-react'
 
+import { answerHeadingStyle } from '@/components/answer-heading'
 import { FeedActionLink } from './FeedActionLink'
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
@@ -242,26 +243,26 @@ export function AnswerFeedbackSheet({
           </p>
 
           <div className="space-y-1 pb-2">
-            <p
-              className="text-[13px] italic"
-              style={{
-                fontFamily: 'var(--font-literata)',
-                color: 'var(--ink)',
-                opacity: 0.7,
-              }}
-            >
-              Your answer: {submittedAnswer}
-            </p>
-            {!isCorrect && correctAnswer ? (
+            {correctAnswer ? (
+              <p
+                style={{
+                  ...answerHeadingStyle,
+                  color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink)',
+                }}
+              >
+                {correctAnswer}
+              </p>
+            ) : null}
+            {!isCorrect ? (
               <p
                 className="text-[13px] italic"
                 style={{
                   fontFamily: 'var(--font-literata)',
                   color: 'var(--ink)',
-                  opacity: 0.85,
+                  opacity: 0.7,
                 }}
               >
-                Correct answer: {correctAnswer}
+                Your answer: {submittedAnswer}
               </p>
             ) : null}
           </div>

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useState, type ReactNode } from 'react'
 
+import { answerHeadingStyle } from '@/components/answer-heading'
 import { KnowledgeCircle } from '@/components/knowledge/CategoryCircles'
 import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
 import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy'
@@ -162,13 +163,11 @@ function AnsweredResult({
         </p>
         {item.isCorrect ? <KnowledgeGainIndicator item={item} /> : null}
       </div>
-      {!item.isCorrect && item.correctAnswer ? (
+      {item.correctAnswer ? (
         <p
-          className="text-[13px] italic"
           style={{
-            fontFamily: 'var(--font-literata)',
-            color: 'var(--ink)',
-            opacity: 0.7,
+            ...answerHeadingStyle,
+            color: item.isCorrect ? 'var(--game-correct)' : 'var(--brand-ink)',
           }}
         >
           {item.correctAnswer}

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -5,6 +5,7 @@
 import Link from 'next/link';
 import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
+import { answerHeadingStyle } from '@/components/answer-heading';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { SessionCloseMessage } from '@/components/play/SessionCloseMessage';
 import { NewTerritoryUndo } from '@/components/feed/NewTerritoryUndo';
@@ -148,14 +149,8 @@ const monoStyle: CSSProperties = {
 
 // The answer, repeated as a prominent serif headline on the result card —
 // mirrors the feed reveal treatment ("eyebrow → answer as headline →
-// explanation"). Shared by the correct and wrong cards so the two stay in
-// sync; bumped up from the previous 1.4875rem so the answer reads clearly.
-const answerHeadingStyle: CSSProperties = {
-  fontFamily: 'var(--font-cormorant), Georgia, serif',
-  fontSize: '1.65rem',
-  fontWeight: 700,
-  lineHeight: 1.14,
-};
+// explanation"). Shared via `answer-heading.ts` so every answer-reveal surface
+// (this card, the feed sheet, the summary recap, the history list) stays in sync.
 
 // Darkened triangle-gold so warning/inside-joke labels clear AA on the cream
 // surface (raw --tri-amber #d9a82e is too light for small text). Mirrors the

--- a/src/components/questions/AnsweredQuestionsList.tsx
+++ b/src/components/questions/AnsweredQuestionsList.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { answerHeadingStyle } from '@/components/answer-heading';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 
@@ -71,24 +72,28 @@ export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[]
                 <p className="line-clamp-3 text-foreground">{item.questionText}</p>
               </div>
               <div className="text-sm">
-                <span
-                  className={
-                    answer.muted
-                      ? 'italic text-muted-foreground'
-                      : correct
-                        ? 'text-foreground'
-                        : skipped
+                {correct ? (
+                  <p style={{ ...answerHeadingStyle, color: 'var(--game-correct)' }}>
+                    {answer.text}
+                  </p>
+                ) : (
+                  <>
+                    <span
+                      className={
+                        answer.muted || skipped
                           ? 'italic text-muted-foreground'
                           : 'text-foreground line-through decoration-muted-foreground/60'
-                  }
-                >
-                  {answer.text}
-                </span>
-                {!answer.muted && !correct && !skipped ? (
-                  <span className="ml-2 text-xs text-muted-foreground">
-                    correct: {item.correctAnswer}
-                  </span>
-                ) : null}
+                      }
+                    >
+                      {answer.text}
+                    </span>
+                    {item.correctAnswer ? (
+                      <p style={{ ...answerHeadingStyle, color: 'var(--brand-ink)' }}>
+                        {item.correctAnswer}
+                      </p>
+                    ) : null}
+                  </>
+                )}
                 <p className="mt-0.5 text-xs text-muted-foreground sm:hidden">
                   Asked by {askerDisplay(item)}
                   {item.authorIsHouse ? <EditorialBadge style={{ marginLeft: 4 }} /> : null}


### PR DESCRIPTION
Extracts the answer-heading style into a shared constant and applies it consistently across all answer-reveal surfaces in the app.

## Summary
Creates a canonical `answerHeadingStyle` in a new `src/components/answer-heading.ts` module and uses it to standardize how answers are displayed when revealed to the player — whether in the in-game result card, feed reveal sheet, game summary, answered-history list, or "answered by you" card. This ensures the answer reads identically as a prominent serif headline across every surface.

## Key changes
- **New module:** `src/components/answer-heading.ts` exports `answerHeadingStyle` with serif font (Cormorant), 1.65rem size, 700 weight, and 1.14 line-height
- **GameplayChat.tsx:** Removes the local `answerHeadingStyle` definition and imports from the shared module; updates the comment to reflect the new shared approach
- **AnswerFeedbackSheet.tsx:** Refactors answer display to use the shared style; reorders to show the correct answer first (styled with result tone), then the submitted answer below
- **AnsweredQuestionsList.tsx:** Restructures answer rendering to use the shared style for correct answers and the correct-answer reveal, with conditional styling based on correctness/skip status
- **GameSummaryPage.tsx:** Applies the shared style to the answer display in the summary recap
- **AnsweredByYouCard.tsx:** Uses the shared style for the correct-answer display with appropriate result tone coloring

## Implementation details
The style is applied with result-tone coloring on top: `var(--game-correct)` when the player answered correctly, `var(--brand-ink)` otherwise. This maintains the visual verdict while keeping the headline sizing and typography consistent across all reveal surfaces.

https://claude.ai/code/session_017SNNw89BmzzWWCSFVLdfnb