### PR TITLE
Add homepage promo embeds for expanding knowledge and friend suggestions

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,6 +11,7 @@ import { MissedQuestionsCard } from '@/components/home/MissedQuestionsCard'
 import { getSession } from '@/server/auth/session'
 import { buildActivityStream } from '@/server/activity/build-stream'
 import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
+import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
@@ -123,7 +124,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // full activity/Lately stream, interleaved chronologically inside FeedList.
   // Filter 'all' (not 'from-friends') so directly-sent questions thread in; the
   // prefetch matches FeedList's unifiedHome seeding for a no-round-trip paint.
-  const [feedPage, activityItems, commonGroundPromo] = await Promise.all([
+  const [feedPage, activityItems, commonGroundPromo, recentlyExpandingPromo] = await Promise.all([
     getFeedPagePayload(userId, {
       limit: FEED_PAGE_SIZE,
       cursor: null,
@@ -131,6 +132,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
     }),
     buildActivityStream(userId),
     getCommonGroundPromo(userId),
+    getRecentlyExpandingPromo(userId),
   ])
   // The weekly reflection lives in the dedicated CeremonyPin editorial marker
   // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
@@ -162,6 +164,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         showContributeFooter
         unifiedHome
         activityItems={homeActivityItems}
+        expandingPromo={recentlyExpandingPromo}
       />
     </>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,6 +12,7 @@ import { getSession } from '@/server/auth/session'
 import { buildActivityStream } from '@/server/activity/build-stream'
 import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
 import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo'
+import { getAddFriendsPromo } from '@/server/activity/add-friends-promo'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
@@ -124,7 +125,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // full activity/Lately stream, interleaved chronologically inside FeedList.
   // Filter 'all' (not 'from-friends') so directly-sent questions thread in; the
   // prefetch matches FeedList's unifiedHome seeding for a no-round-trip paint.
-  const [feedPage, activityItems, commonGroundPromo, recentlyExpandingPromo] = await Promise.all([
+  const [feedPage, activityItems, commonGroundPromo, recentlyExpandingPromo, addFriendsPromo] = await Promise.all([
     getFeedPagePayload(userId, {
       limit: FEED_PAGE_SIZE,
       cursor: null,
@@ -133,6 +134,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
     buildActivityStream(userId),
     getCommonGroundPromo(userId),
     getRecentlyExpandingPromo(userId),
+    getAddFriendsPromo(userId),
   ])
   // The weekly reflection lives in the dedicated CeremonyPin editorial marker
   // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
@@ -165,6 +167,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         unifiedHome
         activityItems={homeActivityItems}
         expandingPromo={recentlyExpandingPromo}
+        addFriendsPromo={addFriendsPromo}
       />
     </>
   )

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -445,9 +445,23 @@ type FeedListProps = {
    * row is de-duped against its richer direct_sent feed card (see unifiedRows).
    */
   activityItems?: StreamItem[]
+  /**
+   * Home-only "Your world is expanding" promo. Unlike `activityItems` (which
+   * interleave chronologically), this is spliced in at a fixed offset a few rows
+   * down so it never lands at the very top or adjacent to the common-ground
+   * promo (which sorts to row 0). Null on most visits — it shows ~1 in 5. See
+   * getRecentlyExpandingPromo / displayRows.
+   */
+  expandingPromo?: StreamItem | null
 }
 
 type QuestionCardState = 'unanswered' | 'answered'
+
+// Where the home-only "Your world is expanding" promo lands in the rendered row
+// list: a few rows down (so it's never the very first thing, and never adjacent
+// to the common-ground promo at row 0). The feed must have at least this many
+// rows for it to appear at all.
+const EXPANDING_PROMO_OFFSET = 3
 
 // One row of the unified-home feed: either a paginated question card or an
 // interleaved activity (Lately) one-liner. Both carry `source_event_at` so the
@@ -682,6 +696,7 @@ function FeedListContent({
   showContributeFooter = false,
   unifiedHome = false,
   activityItems = [],
+  expandingPromo = null,
 }: FeedListProps) {
   const searchParams = useSearchParams()
   const initialFilterParam =
@@ -887,6 +902,29 @@ function FeedListContent({
     }
     return [...feedRows, ...activityRows].sort((a, b) => b.sortMs - a.sortMs)
   }, [items, activityItems, unifiedHome])
+
+  // Splice the "Your world is expanding" promo in at a fixed offset a few rows
+  // down. It is deliberately NOT part of the chronological union above: pinning
+  // it to an index keeps it off the very top and never adjacent to the common-
+  // ground promo (which sorts to row 0). Only inserted once the feed has enough
+  // rows above it; otherwise it's dropped so it can't float up next to row 0.
+  const displayRows = useMemo<UnifiedRow[]>(() => {
+    if (!expandingPromo || unifiedRows.length < EXPANDING_PROMO_OFFSET) {
+      return unifiedRows
+    }
+    const anchor = unifiedRows[EXPANDING_PROMO_OFFSET - 1]!
+    const promoRow: UnifiedRow = {
+      kind: 'activity',
+      item: expandingPromo,
+      // Borrow the preceding row's timestamp so recency grouping keeps the promo
+      // in place rather than floating it into its own day bucket.
+      source_event_at: anchor.source_event_at,
+      sortMs: anchor.sortMs,
+    }
+    const next = [...unifiedRows]
+    next.splice(EXPANDING_PROMO_OFFSET, 0, promoRow)
+    return next
+  }, [unifiedRows, expandingPromo])
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'
@@ -1424,7 +1462,7 @@ function FeedListContent({
         )
       ) : (
         <section className="space-y-3 pb-8">
-          {groupItemsByRecency(unifiedRows).map((group) => (
+          {groupItemsByRecency(displayRows).map((group) => (
             <Fragment key={group.key}>
               <h2
                 className={`text-muted-foreground/70 pt-4 text-[11px] font-medium tracking-[0.12em] uppercase first:pt-0 ${

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -453,15 +453,23 @@ type FeedListProps = {
    * getRecentlyExpandingPromo / displayRows.
    */
   expandingPromo?: StreamItem | null
+  /**
+   * Home-only "add friends" promo (contact-match suggestions, or an invite
+   * nudge). Spliced in at its own fixed offset, separated from `expandingPromo`
+   * so the two promos are never adjacent. See getAddFriendsPromo / displayRows.
+   */
+  addFriendsPromo?: StreamItem | null
 }
 
 type QuestionCardState = 'unanswered' | 'answered'
 
-// Where the home-only "Your world is expanding" promo lands in the rendered row
-// list: a few rows down (so it's never the very first thing, and never adjacent
-// to the common-ground promo at row 0). The feed must have at least this many
-// rows for it to appear at all.
+// Where the home-only pinned promos land in the rendered row list: a few rows
+// down (so they're never the very first thing, and never adjacent to the common-
+// ground promo at row 0), and spaced apart from each other. Each offset is
+// measured against the original feed length; a promo only appears once the feed
+// has at least that many rows.
 const EXPANDING_PROMO_OFFSET = 3
+const ADD_FRIENDS_PROMO_OFFSET = 6
 
 // One row of the unified-home feed: either a paginated question card or an
 // interleaved activity (Lately) one-liner. Both carry `source_event_at` so the
@@ -697,6 +705,7 @@ function FeedListContent({
   unifiedHome = false,
   activityItems = [],
   expandingPromo = null,
+  addFriendsPromo = null,
 }: FeedListProps) {
   const searchParams = useSearchParams()
   const initialFilterParam =
@@ -903,28 +912,41 @@ function FeedListContent({
     return [...feedRows, ...activityRows].sort((a, b) => b.sortMs - a.sortMs)
   }, [items, activityItems, unifiedHome])
 
-  // Splice the "Your world is expanding" promo in at a fixed offset a few rows
-  // down. It is deliberately NOT part of the chronological union above: pinning
-  // it to an index keeps it off the very top and never adjacent to the common-
-  // ground promo (which sorts to row 0). Only inserted once the feed has enough
-  // rows above it; otherwise it's dropped so it can't float up next to row 0.
+  // Splice the home-only pinned promos in at fixed offsets a few rows down. They
+  // are deliberately NOT part of the chronological union above: pinning them to
+  // indices keeps them off the very top and never adjacent to the common-ground
+  // promo (which sorts to row 0). Each is only inserted once the feed has enough
+  // rows above its offset; offsets are measured against the original feed so the
+  // two promos stay spaced apart even when both are present.
   const displayRows = useMemo<UnifiedRow[]>(() => {
-    if (!expandingPromo || unifiedRows.length < EXPANDING_PROMO_OFFSET) {
-      return unifiedRows
-    }
-    const anchor = unifiedRows[EXPANDING_PROMO_OFFSET - 1]!
-    const promoRow: UnifiedRow = {
-      kind: 'activity',
-      item: expandingPromo,
-      // Borrow the preceding row's timestamp so recency grouping keeps the promo
-      // in place rather than floating it into its own day bucket.
-      source_event_at: anchor.source_event_at,
-      sortMs: anchor.sortMs,
-    }
+    const pinned = [
+      { offset: EXPANDING_PROMO_OFFSET, item: expandingPromo },
+      { offset: ADD_FRIENDS_PROMO_OFFSET, item: addFriendsPromo },
+    ]
+      .filter((p): p is { offset: number; item: StreamItem } => p.item !== null)
+      .sort((a, b) => a.offset - b.offset)
+    if (pinned.length === 0) return unifiedRows
+
     const next = [...unifiedRows]
-    next.splice(EXPANDING_PROMO_OFFSET, 0, promoRow)
+    let inserted = 0
+    for (const { offset, item } of pinned) {
+      if (offset > unifiedRows.length) continue
+      // Account for promos already spliced in ahead of this one so each keeps its
+      // intended distance from the others.
+      const spliceAt = offset + inserted
+      const anchor = next[spliceAt - 1]!
+      next.splice(spliceAt, 0, {
+        kind: 'activity',
+        item,
+        // Borrow the preceding row's timestamp so recency grouping keeps the
+        // promo in place rather than floating it into its own day bucket.
+        source_event_at: anchor.source_event_at,
+        sortMs: anchor.sortMs,
+      })
+      inserted++
+    }
     return next
-  }, [unifiedRows, expandingPromo])
+  }, [unifiedRows, expandingPromo, addFriendsPromo])
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -2,10 +2,13 @@
 
 import { Send } from 'lucide-react';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { useState, type KeyboardEvent } from 'react';
 
 import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
+import { AddFriendButton } from '@/components/friends/AddFriendButton';
+import { colorForUser, initialsFor, isDarkColor } from '@/components/feed/visual';
 import { SendQuestionDrawer } from '@/components/SendQuestionDrawer';
 import type {
   StreamEmbed,
@@ -283,6 +286,8 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
         <CommonGroundEmbed embed={item.embed} />
       ) : item.embed?.kind === 'recently_expanding' ? (
         <RecentlyExpandingEmbed embed={item.embed} />
+      ) : item.embed?.kind === 'add_friends' ? (
+        <AddFriendsEmbed embed={item.embed} />
       ) : null}
 
       {item.action ? <ItemAction action={item.action} /> : null}
@@ -432,6 +437,89 @@ function RecentlyExpandingEmbed({
       <Link href={embed.href} style={EMBED_LINK_STYLE}>
         See your knowledge →
       </Link>
+    </div>
+  );
+}
+
+// The homepage add-friends promo embed: either a few contact-match people the
+// viewer can follow (each row reuses the canonical AddFriendButton state machine
+// + a refresh on change) or, when there's no one to suggest, a copy-only nudge
+// toward /friends/find. Indented to sit under the row's one-liner; stops click
+// propagation so taps never toggle a (non-existent) expansion.
+function AddFriendsEmbed({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'add_friends' }>;
+}) {
+  const router = useRouter();
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
+    >
+      {embed.variant === 'suggestions' ? (
+        <>
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
+            {embed.people.map((p) => {
+              const bg = p.avatarColor ?? colorForUser(p.id);
+              return (
+                <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+                  <Link
+                    href={`/users/${p.id}`}
+                    style={{
+                      width: 32,
+                      height: 32,
+                      flexShrink: 0,
+                      borderRadius: 999,
+                      background: bg,
+                      color: isDarkColor(bg) ? '#fff' : INK,
+                      display: 'grid',
+                      placeItems: 'center',
+                      fontSize: 12,
+                      fontWeight: 700,
+                      lineHeight: 1,
+                      textDecoration: 'none',
+                    }}
+                  >
+                    {initialsFor(p.displayName)}
+                  </Link>
+                  <div style={{ minWidth: 0, flex: 1 }}>
+                    <Link
+                      href={`/users/${p.id}`}
+                      style={{ color: INK, fontWeight: 600, fontSize: 14, textDecoration: 'none' }}
+                    >
+                      {p.displayName}
+                    </Link>
+                    {p.handle ? (
+                      <span style={{ display: 'block', fontSize: 12, lineHeight: 1.3, color: INK3 }}>
+                        @{p.handle}
+                      </span>
+                    ) : null}
+                  </div>
+                  <AddFriendButton
+                    targetUserId={p.id}
+                    targetDisplayName={p.displayName}
+                    relationship={p.relationship}
+                    onChange={() => router.refresh()}
+                  />
+                </div>
+              );
+            })}
+          </div>
+          <Link href={embed.href} style={EMBED_LINK_STYLE}>
+            Find more friends →
+          </Link>
+        </>
+      ) : (
+        <>
+          <p style={{ margin: 0, fontFamily: 'Georgia, serif', fontSize: 14, lineHeight: 1.45, color: INK2 }}>
+            Know someone who would enjoy the questions and discoveries happening here?
+          </p>
+          <Link href={embed.href} style={EMBED_LINK_STYLE}>
+            Find friends →
+          </Link>
+        </>
+      )}
     </div>
   );
 }

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -29,6 +29,29 @@ import { assertNever } from '@/lib/assert-never';
 // linked or not, so the actor reads as the warm social anchor of the row.
 const ACTOR_BLUE = 'var(--brand-link)';
 
+// Promo embed CTA link ("See what you share" / "See your knowledge"): a plain
+// underlined text link in the body font, NOT the old monospace letterspaced caps
+// treatment, so it reads unmistakably as a link.
+const EMBED_LINK_STYLE = {
+  display: 'inline-block',
+  marginTop: 12,
+  fontFamily: FF,
+  fontSize: 13,
+  fontWeight: 600,
+  color: ACTOR_BLUE,
+  textDecoration: 'underline',
+  textUnderlineOffset: 3,
+} as const;
+
+// Badge accents for the recently-expanding embed rows — the reds / golds / blues
+// from the /knowledge "Recently Expanding" module (ROW_ACCENTS), trimmed to the
+// three we ever render.
+const EXPANDING_ROW_ACCENTS = [
+  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
+  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
+  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.20)' },
+] as const;
+
 // An opened reveal indents to sit UNDER the row's header text, not flush to the
 // far-left edge below the icon. This is exactly the ActivityIcon column width —
 // MARK_W (24) + GAP (8) — so the expansion's left rule lines up with where the
@@ -258,6 +281,8 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
 
       {item.embed?.kind === 'common_ground' ? (
         <CommonGroundEmbed embed={item.embed} />
+      ) : item.embed?.kind === 'recently_expanding' ? (
+        <RecentlyExpandingEmbed embed={item.embed} />
       ) : null}
 
       {item.action ? <ItemAction action={item.action} /> : null}
@@ -334,19 +359,78 @@ function CommonGroundEmbed({
           </div>
         ))}
       </div>
-      <Link
-        href={embed.friendHref}
-        style={{
-          display: 'inline-block',
-          marginTop: 12,
-          fontFamily: FM,
-          fontSize: 10,
-          letterSpacing: 2,
-          color: ACTOR_BLUE,
-          textDecoration: 'none',
-        }}
-      >
-        SEE WHAT YOU SHARE →
+      <Link href={embed.friendHref} style={EMBED_LINK_STYLE}>
+        See what you share →
+      </Link>
+    </div>
+  );
+}
+
+// The homepage recently-expanding promo embed: the viewer's fastest-growing
+// territories listed in the /knowledge "Recently Expanding" row style (colored
+// letter badge + serif title + supporting line), indented to sit under the row's
+// one-liner, with a link through to the knowledge page. Read-only and
+// non-expanding — it stops click propagation so taps never toggle a (non-
+// existent) expansion.
+function RecentlyExpandingEmbed({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'recently_expanding' }>;
+}) {
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+        {embed.domains.map((d, i) => {
+          const accent = EXPANDING_ROW_ACCENTS[i % EXPANDING_ROW_ACCENTS.length]!;
+          return (
+            <div key={d.label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <div
+                aria-hidden="true"
+                style={{
+                  width: 30,
+                  height: 30,
+                  flexShrink: 0,
+                  borderRadius: 999,
+                  border: `1px solid ${accent.border}`,
+                  background: accent.fill,
+                  color: INK,
+                  display: 'grid',
+                  placeItems: 'center',
+                  fontSize: 13,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                }}
+              >
+                {d.initial}
+              </div>
+              <div style={{ minWidth: 0 }}>
+                <p
+                  style={{
+                    margin: 0,
+                    fontFamily: 'Georgia, serif',
+                    fontSize: 14,
+                    fontWeight: 700,
+                    lineHeight: 1.2,
+                    color: INK,
+                  }}
+                >
+                  {d.label}
+                </p>
+                {d.caption ? (
+                  <p style={{ margin: '2px 0 0', fontSize: 12, lineHeight: 1.3, color: INK2 }}>
+                    {d.caption}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      <Link href={embed.href} style={EMBED_LINK_STYLE}>
+        See your knowledge →
       </Link>
     </div>
   );

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -123,13 +123,33 @@ export type CommonGroundPromoDomain = {
   friend: { points: number; tier: MasteryTier };
 };
 
-export type StreamEmbed = {
-  kind: 'common_ground';
-  friendId: string;
-  friendFirstName: string;
-  friendHref: string;
-  domains: CommonGroundPromoDomain[];
+export type RecentlyExpandingPromoDomain = {
+  // The domain display name, its short supporting line, and the letter shown in
+  // the row's colored badge — all precomputed server-side so the embed stays a
+  // pure render (mirrors the /knowledge "Recently Expanding" module rows).
+  label: string;
+  caption: string;
+  initial: string;
 };
+
+// Inline embeds rendered under a stream row's one-liner. A discriminated union
+// so each promo carries only its own payload; ActivityStreamItem switches on
+// `kind`. `common_ground` draws the overlapping-circle motif with a link to a
+// friend; `recently_expanding` lists the viewer's fastest-growing territories
+// with a link to /knowledge.
+export type StreamEmbed =
+  | {
+      kind: 'common_ground';
+      friendId: string;
+      friendFirstName: string;
+      friendHref: string;
+      domains: CommonGroundPromoDomain[];
+    }
+  | {
+      kind: 'recently_expanding';
+      href: string;
+      domains: RecentlyExpandingPromoDomain[];
+    };
 
 export type StreamItem = {
   id: string;
@@ -605,7 +625,7 @@ export function convergenceToStreamItem(
 // expands; the embed carries everything ActivityStreamItem needs to render the
 // circles plus a link through to the friend's profile.
 export function commonGroundPromoToStreamItem(
-  embed: StreamEmbed,
+  embed: Extract<StreamEmbed, { kind: 'common_ground' }>,
   sortAt: Date,
   id: string,
 ): StreamItem {
@@ -615,6 +635,30 @@ export function commonGroundPromoToStreamItem(
     tier: LATELY_TIER.OTHER,
     homeEligible: true,
     line: [txt('You and '), act(embed.friendFirstName, embed.friendId), txt(' share ground worth testing')],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'domain',
+    expand: null,
+    embed,
+  };
+}
+
+// A homepage-only knowledge nudge: "Your world is expanding", with the viewer's
+// fastest-growing territories listed in the same row style as the /knowledge
+// "Recently Expanding" module. Question-free, so it never expands; the embed
+// carries the (capped) domain rows plus a link through to the knowledge page.
+export function recentlyExpandingPromoToStreamItem(
+  embed: Extract<StreamEmbed, { kind: 'recently_expanding' }>,
+  sortAt: Date,
+  id: string,
+): StreamItem {
+  return {
+    id,
+    sortAt,
+    tier: LATELY_TIER.OTHER,
+    homeEligible: true,
+    line: [txt('Your world is expanding')],
     secondLine: null,
     anchorId: null,
     action: null,

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -25,6 +25,7 @@ import type { LatelyMoment } from '@/server/db/queries/lately';
 import { LATELY_TIER, latelyTierForMomentDir } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
 import type { Convergence } from '@/lib/convergence';
+import type { RelationshipResult } from '@/server/db/queries/friend-requests';
 
 // --- Serializable model ------------------------------------------------------
 
@@ -132,11 +133,22 @@ export type RecentlyExpandingPromoDomain = {
   initial: string;
 };
 
+export type AddFriendsPromoPerson = {
+  // A contact-match suggestion. avatarColor / handle may be null; relationship
+  // drives the AddFriendButton state machine (so the embed stays a pure render).
+  id: string;
+  displayName: string;
+  handle: string | null;
+  avatarColor: string | null;
+  relationship: RelationshipResult;
+};
+
 // Inline embeds rendered under a stream row's one-liner. A discriminated union
 // so each promo carries only its own payload; ActivityStreamItem switches on
 // `kind`. `common_ground` draws the overlapping-circle motif with a link to a
 // friend; `recently_expanding` lists the viewer's fastest-growing territories
-// with a link to /knowledge.
+// with a link to /knowledge; `add_friends` either suggests people to follow or
+// (when there are none) nudges toward inviting someone.
 export type StreamEmbed =
   | {
       kind: 'common_ground';
@@ -149,6 +161,17 @@ export type StreamEmbed =
       kind: 'recently_expanding';
       href: string;
       domains: RecentlyExpandingPromoDomain[];
+    }
+  | {
+      kind: 'add_friends';
+      variant: 'suggestions';
+      href: string;
+      people: AddFriendsPromoPerson[];
+    }
+  | {
+      kind: 'add_friends';
+      variant: 'invite';
+      href: string;
     };
 
 export type StreamItem = {
@@ -659,6 +682,30 @@ export function recentlyExpandingPromoToStreamItem(
     tier: LATELY_TIER.OTHER,
     homeEligible: true,
     line: [txt('Your world is expanding')],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'domain',
+    expand: null,
+    embed,
+  };
+}
+
+// A homepage-only "grow your circle" nudge. With `suggestions` it lists a few
+// contact-match people to follow (each row carries its relationship so the
+// embed's AddFriendButton can act); with `invite` it's a copy-only prompt toward
+// /friends/find. Question-free, so it never expands.
+export function addFriendsPromoToStreamItem(
+  embed: Extract<StreamEmbed, { kind: 'add_friends' }>,
+  sortAt: Date,
+  id: string,
+): StreamItem {
+  return {
+    id,
+    sortAt,
+    tier: LATELY_TIER.OTHER,
+    homeEligible: true,
+    line: [txt(embed.variant === 'suggestions' ? 'People you may know' : 'Grow your circle')],
     secondLine: null,
     anchorId: null,
     action: null,

--- a/src/server/activity/__tests__/add-friends-promo.test.ts
+++ b/src/server/activity/__tests__/add-friends-promo.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The home-only add-friends promo: suggestions (addable contact matches) take
+// priority and are always shown; otherwise an invite nudge is gated ~1 in 5. We
+// mock the one query it reads so we can assert the filter, the cap, the variant
+// selection, and the gate without a DB.
+const { listContactMatchesMock } = vi.hoisted(() => ({
+  listContactMatchesMock: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/contact-hashes', () => ({
+  listContactMatches: listContactMatchesMock,
+}));
+
+import { getAddFriendsPromo } from '@/server/activity/add-friends-promo';
+import type { RelationshipState } from '@/server/db/queries/friend-requests';
+
+function match(id: string, state: RelationshipState, displayName = id, handle: string | null = id) {
+  return {
+    id,
+    handle,
+    displayName,
+    avatarColor: null,
+    createdAt: new Date(),
+    relationship: { state, friendshipId: null, formedAt: null, isBlocked: false },
+  };
+}
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+describe('getAddFriendsPromo', () => {
+  beforeEach(() => {
+    listContactMatchesMock.mockReset();
+  });
+
+  it('suggests up to three addable matches and shows them regardless of the gate', async () => {
+    listContactMatchesMock.mockResolvedValue([
+      match('a', 'none'),
+      match('b', 'follows_you'),
+      match('c', 'following'), // already following — not addable
+      match('d', 'none'),
+      match('e', 'none'),
+    ]);
+
+    // random() that would gate OUT the invite path; suggestions ignore it.
+    const item = await getAddFriendsPromo('user-1', NOW, () => 0.99);
+    expect(item).not.toBeNull();
+    const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'add_friends' }>;
+    expect(embed.kind).toBe('add_friends');
+    expect(embed.variant).toBe('suggestions');
+    if (embed.variant !== 'suggestions') throw new Error('expected suggestions variant');
+    expect(embed.people.map((p) => p.id)).toEqual(['a', 'b', 'd']);
+    expect(embed.href).toBe('/friends/find');
+  });
+
+  it('falls back to the invite nudge when no match is addable and the gate passes', async () => {
+    listContactMatchesMock.mockResolvedValue([match('c', 'following'), match('f', 'friends')]);
+    const item = await getAddFriendsPromo('user-1', NOW, () => 0.0);
+    expect(item).not.toBeNull();
+    const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'add_friends' }>;
+    expect(embed.variant).toBe('invite');
+  });
+
+  it('returns null when there is nothing to suggest and the invite gate fails', async () => {
+    listContactMatchesMock.mockResolvedValue([]);
+    const item = await getAddFriendsPromo('user-1', NOW, () => 0.9);
+    expect(item).toBeNull();
+  });
+});

--- a/src/server/activity/__tests__/add-friends-promo.test.ts
+++ b/src/server/activity/__tests__/add-friends-promo.test.ts
@@ -1,9 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-// The home-only add-friends promo: suggestions (addable contact matches) take
-// priority and are always shown; otherwise an invite nudge is gated ~1 in 5. We
-// mock the one query it reads so we can assert the filter, the cap, the variant
-// selection, and the gate without a DB.
+// The home-only add-friends promo: gated ~1 in 5 first, then either suggestions
+// (addable contact matches) or an invite nudge — never both. We mock the one
+// query it reads so we can assert the gate, the filter, the cap, and the variant
+// selection without a DB.
 const { listContactMatchesMock } = vi.hoisted(() => ({
   listContactMatchesMock: vi.fn(),
 }));
@@ -33,7 +33,13 @@ describe('getAddFriendsPromo', () => {
     listContactMatchesMock.mockReset();
   });
 
-  it('suggests up to three addable matches and shows them regardless of the gate', async () => {
+  it('returns null without reading contacts when the visit is gated out', async () => {
+    const item = await getAddFriendsPromo('user-1', NOW, () => 0.9);
+    expect(item).toBeNull();
+    expect(listContactMatchesMock).not.toHaveBeenCalled();
+  });
+
+  it('suggests up to three addable matches when shown', async () => {
     listContactMatchesMock.mockResolvedValue([
       match('a', 'none'),
       match('b', 'follows_you'),
@@ -42,8 +48,7 @@ describe('getAddFriendsPromo', () => {
       match('e', 'none'),
     ]);
 
-    // random() that would gate OUT the invite path; suggestions ignore it.
-    const item = await getAddFriendsPromo('user-1', NOW, () => 0.99);
+    const item = await getAddFriendsPromo('user-1', NOW, () => 0.1);
     expect(item).not.toBeNull();
     const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'add_friends' }>;
     expect(embed.kind).toBe('add_friends');
@@ -53,17 +58,11 @@ describe('getAddFriendsPromo', () => {
     expect(embed.href).toBe('/friends/find');
   });
 
-  it('falls back to the invite nudge when no match is addable and the gate passes', async () => {
+  it('falls back to the invite nudge when shown but no match is addable', async () => {
     listContactMatchesMock.mockResolvedValue([match('c', 'following'), match('f', 'friends')]);
     const item = await getAddFriendsPromo('user-1', NOW, () => 0.0);
     expect(item).not.toBeNull();
     const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'add_friends' }>;
     expect(embed.variant).toBe('invite');
-  });
-
-  it('returns null when there is nothing to suggest and the invite gate fails', async () => {
-    listContactMatchesMock.mockResolvedValue([]);
-    const item = await getAddFriendsPromo('user-1', NOW, () => 0.9);
-    expect(item).toBeNull();
   });
 });

--- a/src/server/activity/__tests__/recently-expanding-promo.test.ts
+++ b/src/server/activity/__tests__/recently-expanding-promo.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The home-only "Your world is expanding" promo: gated ~1 in 5 visits, mirrors
+// the /knowledge Recently Expanding module (capped at 3 rows) with a link to
+// /knowledge. We mock the one query it reads so we can assert the gate, the cap,
+// and the empty-state short-circuit without a DB.
+const { getExpandingDomainsMock } = vi.hoisted(() => ({
+  getExpandingDomainsMock: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/knowledge', () => ({
+  getExpandingDomains: getExpandingDomainsMock,
+}));
+
+import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo';
+
+type Reason = 'new-discovery' | 'mastery-shift' | 'social-overlap' | 'saved-questions' | 'active-play';
+
+function domain(name: string, reason: Reason = 'new-discovery', supportingText?: string) {
+  return { domain: name, momentumScore: 50, reason, supportingText };
+}
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+describe('getRecentlyExpandingPromo', () => {
+  beforeEach(() => {
+    getExpandingDomainsMock.mockReset();
+  });
+
+  it('returns null without reading the DB when the visit is gated out', async () => {
+    // random() >= 0.2 means "skip"; nothing should be read.
+    const result = await getRecentlyExpandingPromo('user-1', NOW, () => 0.9);
+    expect(result).toBeNull();
+    expect(getExpandingDomainsMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when the viewer has no expanding territories', async () => {
+    getExpandingDomainsMock.mockResolvedValue([]);
+    const result = await getRecentlyExpandingPromo('user-1', NOW, () => 0.0);
+    expect(result).toBeNull();
+  });
+
+  it('builds a recently_expanding embed capped at three rows', async () => {
+    getExpandingDomainsMock.mockResolvedValue([
+      domain('Star Trek', 'social-overlap', 'Shared overlap grew here.'),
+      domain('Classic Broadway Musicals', 'new-discovery', 'New territory opened this week.'),
+      domain('Wagner Ring Cycle', 'mastery-shift', 'This territory moved recently.'),
+      domain('John Milton Paradise Lost', 'active-play'),
+    ]);
+
+    const item = await getRecentlyExpandingPromo('user-1', NOW, () => 0.1);
+    expect(item).not.toBeNull();
+    expect(item!.embed?.kind).toBe('recently_expanding');
+    const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'recently_expanding' }>;
+    expect(embed.href).toBe('/knowledge');
+    expect(embed.domains).toHaveLength(3);
+    expect(embed.domains.map((d) => d.label)).toEqual([
+      'Star Trek',
+      'Classic Broadway Musicals',
+      'Wagner Ring Cycle',
+    ]);
+    // Badge initials are the first meaningful letter of the domain name.
+    expect(embed.domains.map((d) => d.initial)).toEqual(['S', 'C', 'W']);
+  });
+
+  it('swaps the "territory moved recently" placeholder for a qualitative label', async () => {
+    getExpandingDomainsMock.mockResolvedValue([
+      domain('Wagner Ring Cycle', 'mastery-shift', 'This territory moved recently.'),
+    ]);
+    const item = await getRecentlyExpandingPromo('user-1', NOW, () => 0.1);
+    const embed = item!.embed as Extract<NonNullable<typeof item.embed>, { kind: 'recently_expanding' }>;
+    expect(embed.domains[0]!.caption).toBe('Leveling up');
+  });
+});

--- a/src/server/activity/add-friends-promo.ts
+++ b/src/server/activity/add-friends-promo.ts
@@ -1,0 +1,71 @@
+/**
+ * Homepage "add friends" promo.
+ *
+ * Produces a single, optional `StreamItem` (the inline add-friends embed) that
+ * the home feed splices a few rows down. Two shapes, in priority order:
+ *   1. `suggestions` — contact-match people the viewer can follow, each with an
+ *      Add affordance. Shown whenever there's at least one addable match (it's
+ *      genuinely actionable), so it isn't probabilistically gated.
+ *   2. `invite` — when there are no addable matches, an occasional (~1 in 5)
+ *      copy-only nudge toward /friends/find.
+ *
+ * HOME-ONLY: assembled here, not in buildActivityStream, so /activities and
+ * Lately stay free of the promo. Stateless — no per-user counter.
+ */
+
+import {
+  addFriendsPromoToStreamItem,
+  type StreamEmbed,
+  type StreamItem,
+} from '@/lib/activity-stream';
+import { listContactMatches } from '@/server/db/queries/contact-hashes';
+
+const MAX_SUGGESTIONS = 3;
+// The invite fallback reads as an occasional nudge, not a fixture.
+const INVITE_SHOW_PROBABILITY = 0.2;
+const FRIENDS_FIND_HREF = '/friends/find';
+
+export async function getAddFriendsPromo(
+  userId: string,
+  now: Date = new Date(),
+  // Injectable for tests; defaults to Math.random in [0, 1).
+  random: () => number = Math.random,
+): Promise<StreamItem | null> {
+  const matches = await listContactMatches(userId);
+  // Addable = a NEW follow is the action: 'none' (no edge) or 'follows_you'
+  // (they follow me; I can follow back). Anyone already requested / following /
+  // friends is dropped — there's nothing to add.
+  const addable = matches.filter(
+    (m) => m.relationship.state === 'none' || m.relationship.state === 'follows_you',
+  );
+
+  // Stable id within a UTC day so the row's React key doesn't churn across
+  // re-renders, but advances day to day.
+  const daySeed = Math.floor(now.getTime() / 86_400_000);
+
+  if (addable.length > 0) {
+    const people = addable.slice(0, MAX_SUGGESTIONS).map((m) => ({
+      id: m.id,
+      displayName: m.displayName ?? m.handle ?? 'Someone you know',
+      handle: m.handle,
+      avatarColor: m.avatarColor,
+      relationship: m.relationship,
+    }));
+    const embed: Extract<StreamEmbed, { kind: 'add_friends'; variant: 'suggestions' }> = {
+      kind: 'add_friends',
+      variant: 'suggestions',
+      href: FRIENDS_FIND_HREF,
+      people,
+    };
+    return addFriendsPromoToStreamItem(embed, now, `add-friends-suggestions-${daySeed}`);
+  }
+
+  // No one to suggest — fall back to the occasional invite nudge.
+  if (random() >= INVITE_SHOW_PROBABILITY) return null;
+  const embed: Extract<StreamEmbed, { kind: 'add_friends'; variant: 'invite' }> = {
+    kind: 'add_friends',
+    variant: 'invite',
+    href: FRIENDS_FIND_HREF,
+  };
+  return addFriendsPromoToStreamItem(embed, now, `add-friends-invite-${daySeed}`);
+}

--- a/src/server/activity/add-friends-promo.ts
+++ b/src/server/activity/add-friends-promo.ts
@@ -2,12 +2,13 @@
  * Homepage "add friends" promo.
  *
  * Produces a single, optional `StreamItem` (the inline add-friends embed) that
- * the home feed splices a few rows down. Two shapes, in priority order:
+ * the home feed splices a few rows down. Shown on ~1 in 5 visits (gated first,
+ * like the common-ground promo, so the visits we skip do no reads); when shown
+ * it takes one of two shapes — never both:
  *   1. `suggestions` — contact-match people the viewer can follow, each with an
- *      Add affordance. Shown whenever there's at least one addable match (it's
- *      genuinely actionable), so it isn't probabilistically gated.
- *   2. `invite` — when there are no addable matches, an occasional (~1 in 5)
- *      copy-only nudge toward /friends/find.
+ *      Add affordance.
+ *   2. `invite` — when there are no addable matches, a copy-only nudge toward
+ *      /friends/find.
  *
  * HOME-ONLY: assembled here, not in buildActivityStream, so /activities and
  * Lately stay free of the promo. Stateless — no per-user counter.
@@ -21,8 +22,9 @@ import {
 import { listContactMatches } from '@/server/db/queries/contact-hashes';
 
 const MAX_SUGGESTIONS = 3;
-// The invite fallback reads as an occasional nudge, not a fixture.
-const INVITE_SHOW_PROBABILITY = 0.2;
+// Show on ~1 in 5 home visits so the promo reads as an occasional nudge, not a
+// fixture — the same stateless gating as the common-ground promo.
+const PROMO_SHOW_PROBABILITY = 0.2;
 const FRIENDS_FIND_HREF = '/friends/find';
 
 export async function getAddFriendsPromo(
@@ -31,6 +33,9 @@ export async function getAddFriendsPromo(
   // Injectable for tests; defaults to Math.random in [0, 1).
   random: () => number = Math.random,
 ): Promise<StreamItem | null> {
+  // Gate first so the visits we won't show the promo skip the contact read.
+  if (random() >= PROMO_SHOW_PROBABILITY) return null;
+
   const matches = await listContactMatches(userId);
   // Addable = a NEW follow is the action: 'none' (no edge) or 'follows_you'
   // (they follow me; I can follow back). Anyone already requested / following /
@@ -60,8 +65,7 @@ export async function getAddFriendsPromo(
     return addFriendsPromoToStreamItem(embed, now, `add-friends-suggestions-${daySeed}`);
   }
 
-  // No one to suggest — fall back to the occasional invite nudge.
-  if (random() >= INVITE_SHOW_PROBABILITY) return null;
+  // No one to suggest — fall back to the invite nudge.
   const embed: Extract<StreamEmbed, { kind: 'add_friends'; variant: 'invite' }> = {
     kind: 'add_friends',
     variant: 'invite',

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -75,7 +75,7 @@ export async function getCommonGroundPromo(
       friend: { points: d.friend.mastery_points, tier: d.friend.current_tier },
     }));
 
-    const embed: StreamEmbed = {
+    const embed: Extract<StreamEmbed, { kind: 'common_ground' }> = {
       kind: 'common_ground',
       friendId: friend.id,
       friendFirstName: firstName(friend.displayName),

--- a/src/server/activity/recently-expanding-promo.ts
+++ b/src/server/activity/recently-expanding-promo.ts
@@ -1,0 +1,86 @@
+/**
+ * Homepage "Your world is expanding" promo.
+ *
+ * Produces a single, optional `StreamItem` (the inline recently-expanding embed)
+ * that the home feed splices a few rows down — a condensed mirror of the
+ * /knowledge "Recently Expanding" module (the viewer's fastest-growing
+ * territories), capped at three rows with a link through to /knowledge. This is a
+ * HOME-ONLY surface — assembled here, NOT inside buildActivityStream, so
+ * /activities and Lately stay free of the promo.
+ *
+ * Gating is stateless/probabilistic (~1 in 5 visits) so it needs no per-user
+ * counter cookie or DB row — the same approach as the common-ground promo.
+ */
+
+import {
+  recentlyExpandingPromoToStreamItem,
+  type StreamEmbed,
+  type StreamItem,
+} from '@/lib/activity-stream';
+import { getExpandingDomains, type ExpandingDomain } from '@/server/db/queries/knowledge';
+
+const MAX_PROMO_DOMAINS = 3;
+// Show on ~1 in 5 home visits so it reads as an occasional nudge, not a fixture.
+const PROMO_SHOW_PROBABILITY = 0.2;
+
+// The letter shown in the row's colored badge: the first meaningful character of
+// the domain name (mirrors getDomainInitial in the RecentlyExpanding module).
+function initialFor(domain: string): string {
+  const firstMeaningfulWord = domain
+    .replace(/&/g, ' ')
+    .split(/\s+/)
+    .find((word) => /^[a-z0-9]/i.test(word));
+  return (firstMeaningfulWord?.[0] ?? domain[0] ?? '?').toUpperCase();
+}
+
+// The row's supporting line. Mirrors getRowActivity in the RecentlyExpanding
+// module: prefer the server's real supportingText, but swap the "territory moved
+// recently" placeholder for a qualitative label so the promo never shows it.
+function captionFor(domain: ExpandingDomain): string {
+  if (domain.supportingText && !/territory moved recently/i.test(domain.supportingText)) {
+    return domain.supportingText;
+  }
+  switch (domain.reason) {
+    case 'new-discovery':
+      return 'New territory';
+    case 'social-overlap':
+      return 'People answered yours';
+    case 'saved-questions':
+      return 'New questions explored';
+    case 'mastery-shift':
+      return 'Leveling up';
+    case 'active-play':
+    default:
+      return 'Revisited and growing';
+  }
+}
+
+export async function getRecentlyExpandingPromo(
+  userId: string,
+  now: Date = new Date(),
+  // Injectable for tests; defaults to Math.random in [0, 1).
+  random: () => number = Math.random,
+): Promise<StreamItem | null> {
+  // Gate first so the visits we won't show the promo skip the read entirely.
+  if (random() >= PROMO_SHOW_PROBABILITY) return null;
+
+  const expanding = await getExpandingDomains(userId);
+  if (expanding.length === 0) return null;
+
+  const domains = expanding.slice(0, MAX_PROMO_DOMAINS).map((domain) => ({
+    label: domain.domain,
+    caption: captionFor(domain),
+    initial: initialFor(domain.domain),
+  }));
+
+  const embed: Extract<StreamEmbed, { kind: 'recently_expanding' }> = {
+    kind: 'recently_expanding',
+    href: '/knowledge',
+    domains,
+  };
+
+  // Stable id within a UTC day so the row's React key doesn't churn across
+  // re-renders, but advances day to day.
+  const daySeed = Math.floor(now.getTime() / 86_400_000);
+  return recentlyExpandingPromoToStreamItem(embed, now, `recently-expanding-promo-${daySeed}`);
+}

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -629,6 +629,24 @@ export async function getKnowledgePageData(userId: string): Promise<KnowledgePag
   };
 }
 
+// The "Recently Expanding" territories in isolation — the same derivation the
+// knowledge page uses, but without the mastery / declared / hidden joins, so the
+// home-feed promo (getRecentlyExpandingPromo) can read it cheaply.
+export async function getExpandingDomains(userId: string): Promise<ExpandingDomain[]> {
+  const eventRows = await db
+    .select({
+      canonicalSubcategory: masteryEvents.canonicalSubcategory,
+      sourceType: masteryEvents.sourceType,
+      answerState: masteryEvents.answerState,
+      sessionContext: masteryEvents.sessionContext,
+      awardedPoints: masteryEvents.awardedPoints,
+      createdAt: masteryEvents.createdAt,
+    })
+    .from(masteryEvents)
+    .where(eq(masteryEvents.userId, userId));
+  return deriveExpandingDomains(eventRows);
+}
+
 export async function getProgressionLandscape(userId: string): Promise<ProgressionView[]> {
   const pageData = await getKnowledgePageData(userId);
 


### PR DESCRIPTION
## Summary
Adds two new home-only promotional embeds to the activity stream: a "Your world is expanding" promo showing the viewer's fastest-growing territories, and an "add friends" promo suggesting contact-match people to follow or inviting the user to find friends. Both are stateless, probabilistically gated (~1 in 5 visits), and pinned to fixed offsets in the feed to avoid landing at the top or adjacent to the common-ground promo.

## Key Changes

**New embed types and infrastructure:**
- Extended `StreamEmbed` discriminated union in `src/lib/activity-stream.ts` with `recently_expanding` and `add_friends` variants, each carrying their own payload
- Added `recentlyExpandingPromoToStreamItem()` and `addFriendsPromoToStreamItem()` factory functions to construct stream items from embeds

**Recently expanding promo (`src/server/activity/recently-expanding-promo.ts`):**
- Reads the viewer's fastest-growing territories via `getExpandingDomains()` (new query in `src/server/db/queries/knowledge.ts`)
- Caps at 3 rows with colored letter badges, serif titles, and supporting captions
- Mirrors the `/knowledge` "Recently Expanding" module styling
- Swaps placeholder "territory moved recently" text for qualitative labels based on the expansion reason
- Includes comprehensive test coverage in `src/server/activity/__tests__/recently-expanding-promo.test.ts`

**Add friends promo (`src/server/activity/add-friends-promo.ts`):**
- Reads contact-match suggestions via `listContactMatches()` and filters to addable matches (state `none` or `follows_you`)
- Two variants: `suggestions` (up to 3 people with Add buttons) or `invite` (copy-only nudge when no matches are addable)
- Each suggestion carries relationship state so the embed's `AddFriendButton` can act and refresh on change
- Includes comprehensive test coverage in `src/server/activity/__tests__/add-friends-promo.test.ts`

**UI rendering (`src/components/activity/ActivityStreamItem.tsx`):**
- New `RecentlyExpandingEmbed` component rendering domain rows with colored badges and serif typography
- New `AddFriendsEmbed` component rendering either contact suggestions with Add buttons or an invite prompt
- Extracted shared embed link styling (`EMBED_LINK_STYLE`) and accent colors (`EXPANDING_ROW_ACCENTS`) as constants
- Both embeds stop click propagation to prevent toggling non-existent expansions

**Feed integration (`src/components/FeedList.tsx`):**
- Added `expandingPromo` and `addFriendsPromo` props to `FeedListProps`
- New `displayRows` memo that splices promos into the unified feed at fixed offsets (`EXPANDING_PROMO_OFFSET = 3`, `ADD_FRIENDS_PROMO_OFFSET = 6`)
- Promos inherit the preceding row's timestamp for recency grouping so they stay in place rather than floating into their own day bucket
- Offsets measured against the original feed length so promos only appear once the feed has enough rows

**Home page integration (`src/app/page.tsx`):**
- Calls `getRecentlyExpandingPromo()` and `getAddFriendsPromo()` on the home route
- Passes results to `FeedList` as `expandingPromo` and `addFriendsPromo` props

## Implementation Details

- **Stateless gating:** Both promos use `Math.random()` with a 0.2 probability threshold, gated *before* any DB reads so skipped visits incur no query cost
- **Stable daily IDs:** Promo IDs include a day seed (`Math.floor(now.getTime() / 86_400_000)`) so React keys don't churn across re-renders within a day but advance daily
- **Discriminated unions:** `StreamEmbed` is now a tagged union with separate type guards for each variant, enabling type-safe rendering in `ActivityStreamItem`
- **Reusable styling:** Embed link styling

https://claude.ai/code/session_01VRfH7SLKurEcCBG3HmqvCq