### PR TITLE
Replace hardcoded colors with design system variables

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,7 +27,7 @@ function TitleCard() {
         JOSHING
       </h1>
       <div className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--tri-amber)]" aria-hidden="true" />
-      <p className="mt-4 text-center font-inter text-lg font-normal uppercase leading-6 tracking-[3.6px] text-black">
+      <p className="mt-4 text-center font-inter text-lg font-normal uppercase leading-6 tracking-[3.6px] text-[var(--warm-ink)]">
         Trivia you wish you were asked
       </p>
     </section>

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -428,7 +428,7 @@ export default async function UserProfilePage({
           )}
           <Link
             href={`/users/${portrait.user.id}/knowledge`}
-            className="mt-3 inline-flex text-sm font-semibold text-stone-950 underline-offset-4 hover:underline"
+            className="mt-3 inline-flex text-sm font-semibold text-[var(--warm-ink)] underline-offset-4 hover:underline"
           >
             {isSelf
               ? 'View your full knowledge base →'

--- a/src/components/games/QuestionRatingButtons.tsx
+++ b/src/components/games/QuestionRatingButtons.tsx
@@ -91,7 +91,7 @@ export function QuestionRatingButtons({ questionId }: { questionId: string }) {
         className={cn(
           'inline-flex size-9 items-center justify-center rounded-md border text-muted-foreground transition',
           myRating === 'down'
-            ? 'border-stone-400 bg-stone-200 text-stone-800'
+            ? 'border-stone-400 bg-stone-200 text-[var(--warm-ink)]'
             : 'border-border bg-background hover:bg-muted hover:text-foreground',
         )}
         disabled={isPending}


### PR DESCRIPTION
## Summary
Replaces hardcoded color values with design system CSS variables to improve consistency and maintainability across the codebase.

## Changes
- **Login page**: Updated subtitle text color from `text-black` to `text-[var(--warm-ink)]` in the TitleCard component
- **User profile page**: Changed knowledge base link text color from `text-stone-950` to `text-[var(--warm-ink)]`
- **Question rating buttons**: Updated downvote button text color from `text-stone-800` to `text-[var(--warm-ink)]` when active

## Details
All three changes align text colors with the `--warm-ink` design system variable, which is part of the Ink-on-Cream palette defined in the design system. This ensures consistent color usage across the application and makes future design adjustments easier by centralizing color definitions.

https://claude.ai/code/session_01JuYuVYBepsoGE3oPGYJScj