### PR TITLE
Token conformance: burn down off-system color lint + add warning/status tokens

### DIFF
--- a/B-VISUAL-TOKEN-BUDGET-01-bucket-B.html
+++ b/B-VISUAL-TOKEN-BUDGET-01-bucket-B.html
@@ -1,0 +1,797 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>B-VISUAL-TOKEN-BUDGET-01 — Bucket B color comparison</title>
+<style>
+:root {
+  --bg: #f7f7f8;
+  --text: #111827;
+  --muted: #6b7280;
+  --card: #ffffff;
+  --header: #f3f4f6;
+  --border: #e5e7eb;
+  --radius: 12px;
+  --shadow: 0 1px 2px rgba(0,0,0,.05);
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+  font: 14px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+.page {
+  max-width: 1400px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+h1 {
+  margin: 0 0 8px;
+  font-size: 28px;
+  line-height: 1.2;
+}
+
+.intro {
+  margin: 0 0 18px;
+  color: var(--muted);
+  max-width: 1100px;
+}
+
+.section {
+  margin-top: 28px;
+}
+
+.section h2 {
+  margin: 0 0 12px;
+  font-size: 20px;
+  line-height: 1.2;
+}
+
+.section p.note {
+  margin: 8px 0 0;
+  color: var(--muted);
+}
+
+.matrix {
+  display: grid;
+  grid-template-columns: 120px minmax(320px, 1fr) minmax(320px, 1fr);
+  gap: 12px 16px;
+  align-items: stretch;
+}
+
+.cell {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: 12px;
+  min-height: 120px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.header {
+  background: var(--header);
+  font-weight: 700;
+  min-height: auto;
+}
+
+.want {
+  gap: 10px;
+  align-items: flex-start;
+  justify-content: center;
+}
+
+.want label {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  user-select: none;
+}
+
+.swatch {
+  width: 100%;
+  height: 72px;
+  border: 1px solid rgba(0,0,0,.12);
+  border-radius: 10px;
+  margin-bottom: 10px;
+}
+
+.meta {
+  font-size: 13px;
+  line-height: 1.35;
+}
+
+.meta code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  background: #f3f4f6;
+  padding: 2px 4px;
+  border-radius: 4px;
+}
+
+.row-label {
+  font-weight: 700;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  font-size: 13px;
+}
+
+.divider {
+  grid-column: 1 / -1;
+  height: 8px;
+}
+
+.no-token {
+  color: #9ca3af;
+  font-style: italic;
+}
+
+.small {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+/* ── Added: per-row code example ─────────────────────────────────────────── */
+.example-label {
+  margin-top: 10px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.example {
+  margin: 4px 0 0;
+  background: #f8fafc;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 11px;
+  line-height: 1.45;
+  color: #0f172a;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+/* ── Added: "where each color appears" overview ──────────────────────────── */
+.overview {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 4px;
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+  box-shadow: var(--shadow);
+}
+
+.overview th,
+.overview td {
+  text-align: left;
+  vertical-align: top;
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+
+.overview tr:last-child td { border-bottom: none; }
+
+.overview th {
+  background: var(--header);
+  font-weight: 700;
+}
+
+.overview td code,
+.overview th code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 12px;
+  background: #f3f4f6;
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
+.overview .file { white-space: nowrap; font-weight: 600; }
+
+.legend-dot {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 3px;
+  border: 1px solid rgba(0,0,0,.12);
+  margin-right: 6px;
+  vertical-align: -1px;
+}
+</style>
+</head>
+<body>
+<div class="page">
+
+  <h1>B-VISUAL-TOKEN-BUDGET-01 — Bucket B color comparison</h1>
+  <p class="intro">
+    Side-by-side of every <strong>bucket B</strong> off-system color flagged by the
+    <code>no-restricted-syntax</code> token-lint rule, with the resolved hex of the flagged
+    Tailwind utility next to the resolved hex of the <strong>nearest existing token</strong> in
+    <code>src/app/globals.css</code>. Bucket B is, by definition, the set where the remap is
+    <em>not</em> 1:1 — every row shifts the rendered color by some amount. Tailwind palette hex
+    are the standard reference values; this project renders them via <code>oklch</code> in v4, so
+    on-screen sRGB can differ by a sub-perceptual amount. <code>--destructive</code> is stored as
+    <code>oklch(0.577 0.245 27.325)</code> (exactly v4 <code>red-600</code>), shown as
+    <code>≈#dc2626</code>.
+  </p>
+
+  <!-- ── OVERVIEW: where each color appears ───────────────────────────────── -->
+  <div class="section">
+    <h2>Overview — where each color appears</h2>
+    <p class="note">
+      Every component surface that carries a bucket-B off-system color, the utilities it uses, and
+      what the color is doing there. The <strong>Example</strong> column under each swatch below
+      shows the exact flagged source line.
+    </p>
+    <table class="overview">
+      <thead>
+        <tr>
+          <th style="width:230px">Component &amp; lines</th>
+          <th style="width:160px">Bucket</th>
+          <th>Off-system colors → what they render</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="file">AddToBankAction.tsx:78</td>
+          <td>Warning (amber)</td>
+          <td><code>border-amber-300 bg-amber-50 text-amber-700</code> — the “in bank” state chip</td>
+        </tr>
+        <tr>
+          <td class="file">QuestionForm.tsx:528, 611, 617, 620, 625</td>
+          <td>Warning + Success</td>
+          <td><code>amber-200/50/500/700/950</code> + <code>emerald-700</code> — LLM-verify / unverified validation banners and the “Verified” line</td>
+        </tr>
+        <tr>
+          <td class="file">TodaysFiveCard.tsx:334, 374</td>
+          <td>White</td>
+          <td><code>text-white</code> — primary CTA button label (on <code>bg-[var(--brand-link)]</code>)</td>
+        </tr>
+        <tr>
+          <td class="file">AnswerFeedbackSheet.tsx:202</td>
+          <td>White</td>
+          <td><code>text-white</code> — result pill label</td>
+        </tr>
+        <tr>
+          <td class="file">ContactMatchBlock.tsx:228</td>
+          <td>White</td>
+          <td><code>text-white</code> — contact avatar initials</td>
+        </tr>
+        <tr>
+          <td class="file">FindFriendsSearch.tsx:135</td>
+          <td>White</td>
+          <td><code>text-white</code> — search-result avatar initials</td>
+        </tr>
+        <tr>
+          <td class="file">FeedCard.tsx:30, 117</td>
+          <td>Black</td>
+          <td><code>text-black</code> — category line + body text <span class="small">(remapped to <code>var(--brand-ink)</code>)</span></td>
+        </tr>
+        <tr>
+          <td class="file">SparkleEnvelope.tsx:49</td>
+          <td>Black</td>
+          <td><code>text-black</code> — signal headline <span class="small">(remapped to <code>var(--brand-ink)</code>)</span></td>
+        </tr>
+        <tr>
+          <td class="file">QuestionRatingButtons.tsx:78, 94</td>
+          <td>Warning + Neutral</td>
+          <td><code>amber-300/100/700</code> (selected) and <code>stone-400/200/800</code> (alt-selected) rating button states</td>
+        </tr>
+        <tr>
+          <td class="file">CeremonyPin.tsx:25, 33</td>
+          <td>Warning + Neutral</td>
+          <td><code>amber-300/50</code> card + <code>stone-950/700</code> text on the ceremony pin</td>
+        </tr>
+        <tr>
+          <td class="file">AuthoredQuestionsFeed.tsx:205</td>
+          <td>Error (red)</td>
+          <td><code>border-red-200 bg-red-50 text-red-700</code> — error banner</td>
+        </tr>
+        <tr>
+          <td class="file">InlineEditableField.tsx:257</td>
+          <td>Success</td>
+          <td><code>text-emerald-600</code> — the “Saved” indicator <span class="small">(remapped to <code>var(--success)</code>)</span></td>
+        </tr>
+        <tr>
+          <td class="file">InlineHandleField.tsx:119, 124, 132, 224</td>
+          <td>Warning + White + Success</td>
+          <td><code>amber-300/50/600/700/900</code> + <code>text-white</code> handle-change warning; <code>emerald-600</code> “Saved” <span class="small">(remapped to <code>var(--success)</code>)</span></td>
+        </tr>
+        <tr>
+          <td class="file">PreviewBanner.tsx:23, 32</td>
+          <td>Warning + White</td>
+          <td><code>amber-300/50/900/100</code> banner + <code>bg-white</code> button</td>
+        </tr>
+        <tr>
+          <td class="file">NotificationsForm.tsx:151, 242, 245</td>
+          <td>Warning + Success + Error</td>
+          <td><code>amber-300/50/800</code> verify badge; <code>emerald-700</code> + <code>rose-700</code> status messages <span class="small">(both remapped)</span></td>
+        </tr>
+        <tr>
+          <td class="file">ReplaySummary.tsx:70, 89, 90</td>
+          <td>Special + Success + Error</td>
+          <td><code>text-[#111111]</code> score number <span class="small">(remapped to <code>var(--warm-ink)</code>)</span>; <code>emerald-200/50/700</code> + <code>rose-200/50/700</code> correct/wrong rows</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <!-- ── FREQUENCY: how often each color appears ──────────────────────────── -->
+  <div class="section">
+    <h2>Frequency — how often each color appears</h2>
+    <p class="note">
+      Two numbers per remap target: <strong>Flagged uses</strong> = how many of the off-system
+      sites in this audit would land on that token; <strong>Already in codebase</strong> = how many
+      times that token is <em>already</em> referenced across <code>src/</code> today. A target with
+      a big “already” number is a well-trodden token — remapping onto it is low-risk and consistent.
+      <br><br>
+      <strong>Direct answer on <code>≈#dc2626</code> (<code>--destructive</code>):</strong> only
+      <strong>3</strong> flagged sites map to it (<code>text-red-700</code> ×1,
+      <code>text-rose-700</code> ×2), but it is the app’s <strong>canonical error color</strong> —
+      already referenced <strong>~57×</strong> across the codebase (<code>text-destructive</code> ×50,
+      <code>var(--destructive)</code> ×4, plus variants). So those 3 stragglers just join a token
+      that already shows up a lot.
+    </p>
+    <table class="overview">
+      <thead>
+        <tr>
+          <th style="width:280px">Off-system color(s) → target token</th>
+          <th style="width:160px">Flagged uses</th>
+          <th style="width:170px">Already in codebase</th>
+          <th>Read</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><span class="legend-dot" style="background:#fbf4e3"></span><code>text-white</code> → <code>--primary-foreground</code></td>
+          <td>6 <span style="display:inline-block;height:9px;width:60px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>~12×</td>
+          <td>Button / avatar / chip labels — small Δ, safe.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#178245"></span><code>text-emerald-600/700</code> → <code>--success</code></td>
+          <td>5 <span style="display:inline-block;height:9px;width:50px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>23×</td>
+          <td>Already the success color elsewhere — clean.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#dc2626"></span><code>text-red-700 / text-rose-700</code> → <code>--destructive</code> <code>≈#dc2626</code></td>
+          <td>3 <span style="display:inline-block;height:9px;width:30px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td><strong>~57×</strong></td>
+          <td>Few flagged, but the token itself is everywhere.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#1a1208"></span><code>text-[#111111] / text-stone-950/800</code> → <code>--warm-ink</code></td>
+          <td>3 <span style="display:inline-block;height:9px;width:30px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>17×</td>
+          <td>Near-black warm ink; documented collapse for <code>#111111</code>.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#0a1f3d"></span><code>text-black</code> → <code>--brand-ink</code> <span class="small">(or <code>--warm-ink</code>)</span></td>
+          <td>3 <span style="display:inline-block;height:9px;width:30px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>53× <span class="small">(--brand-ink)</span></td>
+          <td>Two candidate tokens — the judgment call of bucket B.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#fdfcfb"></span><code>bg-white</code> → <code>--brand-card</code></td>
+          <td>1 <span style="display:inline-block;height:9px;width:10px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>23×</td>
+          <td>≈match; one straggler onto a common surface token.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#696257"></span><code>text-stone-700</code> → <code>--warm-ink-700</code></td>
+          <td>1 <span style="display:inline-block;height:9px;width:10px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>—</td>
+          <td>One-off neutral text.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#8a8070"></span><code>border-stone-400</code> → <code>--warm-ink-400</code></td>
+          <td>1 <span style="display:inline-block;height:9px;width:10px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>—</td>
+          <td>One-off neutral border.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#e8e2d6"></span><code>bg-stone-200</code> → <code>--warm-border</code></td>
+          <td>1 <span style="display:inline-block;height:9px;width:10px;background:#cbd5e1;border-radius:2px;vertical-align:1px"></span></td>
+          <td>—</td>
+          <td>≈match; one-off.</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#fcd34d"></span><strong>Amber / warning family</strong> → <span class="no-token">no semantic token</span></td>
+          <td><strong>31</strong> <span style="display:inline-block;height:9px;width:140px;background:#f59e0b;border-radius:2px;vertical-align:1px"></span></td>
+          <td>n/a</td>
+          <td><strong>By far the largest cluster</strong> — 31 utility uses across 13 className literals. Strongly argues for inventing a <code>--warning*</code> token (bucket C).</td>
+        </tr>
+        <tr>
+          <td><span class="legend-dot" style="background:#a7f3d0"></span><strong>Pale tint backgrounds/borders</strong> (emerald/red/rose 50–200) → <span class="no-token">no semantic token</span></td>
+          <td>6 <span style="display:inline-block;height:9px;width:60px;background:#86efac;border-radius:2px;vertical-align:1px"></span></td>
+          <td>n/a</td>
+          <td>6 uses across 3 banner literals; need pale success/error tokens (bucket C).</td>
+        </tr>
+      </tbody>
+    </table>
+    <p class="note">
+      Most-used single utility overall is <code>border-amber-300</code> (8 sites), then
+      <code>bg-amber-50</code> (7) and <code>text-white</code> (6). The whole amber family (31 uses)
+      dwarfs every clean-mappable color combined — the warning role is the real gap in the token set.
+    </p>
+  </div>
+
+  <div class="section">
+    <h2>Success / green</h2>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want">
+        <label><input type="checkbox"> utility</label>
+        <label><input type="checkbox"> nearest</label>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#047857"></div>
+        <div class="meta"><code>text-emerald-700</code><br><code>#047857</code><br><span class="small">QuestionForm:617, NotificationsForm:242, ReplaySummary:89</span></div>
+        <div class="example-label">Example · QuestionForm.tsx:617</div>
+        <pre class="example">&lt;p className="text-sm text-emerald-700"&gt;✓ Verified — matches LLM suggestion&lt;/p&gt;</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#178245"></div>
+        <div class="meta"><code>--success</code><br><code>#178245</code><br><span class="small">Δ: small</span></div>
+      </div>
+
+      <div class="cell want">
+        <label><input type="checkbox"> utility</label>
+        <label><input type="checkbox"> nearest</label>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#059669"></div>
+        <div class="meta"><code>text-emerald-600</code><br><code>#059669</code><br><span class="small">InlineEditableField:257, InlineHandleField:224</span></div>
+        <div class="example-label">Example · InlineEditableField.tsx:257</div>
+        <pre class="example">&lt;span className="inline-flex items-center gap-1 text-xs text-emerald-600"&gt;</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#178245"></div>
+        <div class="meta"><code>--success</code><br><code>#178245</code><br><span class="small">Δ: moderate</span></div>
+      </div>
+
+      <div class="cell want">
+        <label><input type="checkbox"> utility</label>
+        <label><input type="checkbox"> nearest</label>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#ecfdf5"></div>
+        <div class="meta"><code>bg-emerald-50</code><br><code>#ecfdf5</code><br><span class="small">ReplaySummary:89</span></div>
+        <div class="example-label">Example · ReplaySummary.tsx:89</div>
+        <pre class="example">? 'border-emerald-200 bg-emerald-50 text-emerald-700'</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#ffffff"></div>
+        <div class="meta no-token">no pale-green token</div>
+      </div>
+
+      <div class="cell want">
+        <label><input type="checkbox"> utility</label>
+        <label><input type="checkbox"> nearest</label>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#a7f3d0"></div>
+        <div class="meta"><code>border-emerald-200</code><br><code>#a7f3d0</code><br><span class="small">ReplaySummary:89</span></div>
+        <div class="example-label">Example · ReplaySummary.tsx:89</div>
+        <pre class="example">? 'border-emerald-200 bg-emerald-50 text-emerald-700'</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#ffffff"></div>
+        <div class="meta no-token">no pale-green token</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Error / red / rose</h2>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#b91c1c"></div>
+        <div class="meta"><code>text-red-700</code><br><code>#b91c1c</code><br><span class="small">AuthoredQuestionsFeed:205</span></div>
+        <div class="example-label">Example · AuthoredQuestionsFeed.tsx:205</div>
+        <pre class="example">&lt;p className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"&gt;</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#dc2626"></div>
+        <div class="meta"><code>--destructive</code><br><code>≈#dc2626</code><br><span class="small">Δ: small</span></div>
+      </div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#be123c"></div>
+        <div class="meta"><code>text-rose-700</code><br><code>#be123c</code><br><span class="small">NotificationsForm:245, ReplaySummary:90</span></div>
+        <div class="example-label">Example · NotificationsForm.tsx:245</div>
+        <pre class="example">&lt;p className="mt-2 text-xs text-rose-700"&gt;{emailError}&lt;/p&gt;</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#dc2626"></div>
+        <div class="meta"><code>--destructive</code><br><code>≈#dc2626</code><br><span class="small">Δ: moderate</span></div>
+      </div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fef2f2"></div>
+        <div class="meta"><code>bg-red-50</code><br><code>#fef2f2</code><br><span class="small">AuthoredQuestionsFeed:205</span></div>
+        <div class="example-label">Example · AuthoredQuestionsFeed.tsx:205</div>
+        <pre class="example">&lt;p className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#ffffff"></div><div class="meta no-token">no pale-red token</div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fecaca"></div>
+        <div class="meta"><code>border-red-200</code><br><code>#fecaca</code><br><span class="small">AuthoredQuestionsFeed:205</span></div>
+        <div class="example-label">Example · AuthoredQuestionsFeed.tsx:205</div>
+        <pre class="example">&lt;p className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#ffffff"></div><div class="meta no-token">no pale-red token</div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fff1f2"></div>
+        <div class="meta"><code>bg-rose-50</code><br><code>#fff1f2</code><br><span class="small">ReplaySummary:90</span></div>
+        <div class="example-label">Example · ReplaySummary.tsx:90</div>
+        <pre class="example">: 'border-rose-200 bg-rose-50 text-rose-700'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#ffffff"></div><div class="meta no-token">no pale-red token</div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fecdd3"></div>
+        <div class="meta"><code>border-rose-200</code><br><code>#fecdd3</code><br><span class="small">ReplaySummary:90</span></div>
+        <div class="example-label">Example · ReplaySummary.tsx:90</div>
+        <pre class="example">: 'border-rose-200 bg-rose-50 text-rose-700'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#ffffff"></div><div class="meta no-token">no pale-red token</div></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Warning / amber</h2>
+    <p class="note">No semantic warning token exists; these are approximate decorative matches.</p>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fcd34d"></div>
+        <div class="meta"><code>border-amber-300</code><br><code>#fcd34d</code><br><span class="small">AddToBankAction:78, CeremonyPin:25, InlineHandleField:119/132, PreviewBanner:23/32, NotificationsForm:151, QuestionRatingButtons:78</span></div>
+        <div class="example-label">Example · AddToBankAction.tsx:78</div>
+        <pre class="example">inBank ? 'border-amber-300 bg-amber-50 text-amber-700' : '',</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#deae5c"></div><div class="meta"><code>--tri-darkyellow</code><br><code>#deae5c</code><br><span class="small">Δ: moderate</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fde68a"></div>
+        <div class="meta"><code>border-amber-200</code><br><code>#fde68a</code><br><span class="small">QuestionForm:528</span></div>
+        <div class="example-label">Example · QuestionForm.tsx:528</div>
+        <pre class="example">&lt;div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#edd2a3"></div><div class="meta"><code>--tri-lighttan</code><br><code>#edd2a3</code><br><span class="small">Δ: moderate</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fffbeb"></div>
+        <div class="meta"><code>bg-amber-50</code><br><code>#fffbeb</code><br><span class="small">AddToBankAction:78, CeremonyPin:25, InlineHandleField:119, PreviewBanner:23/32, NotificationsForm:151, QuestionForm:528/625</span></div>
+        <div class="example-label">Example · InlineHandleField.tsx:119</div>
+        <pre class="example">&lt;div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#fbf5e9"></div><div class="meta"><code>--brand-cream-card</code><br><code>#fbf5e9</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#fef3c7"></div>
+        <div class="meta"><code>bg-amber-100</code><br><code>#fef3c7</code><br><span class="small">QuestionRatingButtons:78, PreviewBanner:32</span></div>
+        <div class="example-label">Example · QuestionRatingButtons.tsx:78</div>
+        <pre class="example">? 'border-amber-300 bg-amber-100 text-amber-700'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#f8e6c7"></div><div class="meta"><code>--brand-cream</code><br><code>#f8e6c7</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#b45309"></div>
+        <div class="meta"><code>text-amber-700</code><br><code>#b45309</code><br><span class="small">AddToBankAction:78, QuestionForm:620/625, QuestionRatingButtons:78</span></div>
+        <div class="example-label">Example · QuestionForm.tsx:620</div>
+        <pre class="example">&lt;p className="text-sm text-amber-700"&gt;⚠ Unverified — your answer differs from the LLM&apos;s suggestion. Recipients will see this.&lt;/p&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#d15e36"></div><div class="meta"><code>--brand-orange</code><br><code>#d15e36</code><br><span class="small">Δ: large</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#92400e"></div>
+        <div class="meta"><code>text-amber-800</code><br><code>#92400e</code><br><span class="small">NotificationsForm:151</span></div>
+        <div class="example-label">Example · NotificationsForm.tsx:151</div>
+        <pre class="example">&lt;span className="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#d15e36"></div><div class="meta"><code>--brand-orange</code><br><code>#d15e36</code><br><span class="small">Δ: large</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#78350f"></div>
+        <div class="meta"><code>text-amber-900</code><br><code>#78350f</code><br><span class="small">InlineHandleField:119, PreviewBanner:23/32</span></div>
+        <div class="example-label">Example · PreviewBanner.tsx:23</div>
+        <pre class="example">&lt;div className="mb-5 flex items-center justify-between gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#1a1208"></div><div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: large</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#451a03"></div>
+        <div class="meta"><code>text-amber-950</code><br><code>#451a03</code><br><span class="small">QuestionForm:528</span></div>
+        <div class="example-label">Example · QuestionForm.tsx:528</div>
+        <pre class="example">&lt;div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#1a1208"></div><div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: large</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#f59e0b"></div>
+        <div class="meta"><code>decoration-amber-500</code><br><code>#f59e0b</code><br><span class="small">QuestionForm:611</span></div>
+        <div class="example-label">Example · QuestionForm.tsx:611</div>
+        <pre class="example">&lt;p className="mt-1 line-through decoration-amber-500"&gt;{state.llmSuggestedAnswer}&lt;/p&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#d9a82e"></div><div class="meta"><code>--tri-amber</code><br><code>#d9a82e</code><br><span class="small">Δ: moderate</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#d97706"></div>
+        <div class="meta"><code>bg-amber-600</code> / <code>hover:bg-amber-700</code><br><code>#d97706</code> / <code>#b45309</code><br><span class="small">InlineHandleField:124</span></div>
+        <div class="example-label">Example · InlineHandleField.tsx:124</div>
+        <pre class="example">className="rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-60"</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#d15e36"></div><div class="meta"><code>--brand-orange</code><br><code>#d15e36</code><br><span class="small">Δ: moderate–large</span></div></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Neutral / stone</h2>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#0c0a09"></div>
+        <div class="meta"><code>text-stone-950</code><br><code>#0c0a09</code><br><span class="small">CeremonyPin:25</span></div>
+        <div class="example-label">Example · CeremonyPin.tsx:25</div>
+        <pre class="example">className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-4 text-stone-950 shadow-sm"</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#1a1208"></div><div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#292524"></div>
+        <div class="meta"><code>text-stone-800</code><br><code>#292524</code><br><span class="small">QuestionRatingButtons:94</span></div>
+        <div class="example-label">Example · QuestionRatingButtons.tsx:94</div>
+        <pre class="example">? 'border-stone-400 bg-stone-200 text-stone-800'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#1a1208"></div><div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#44403c"></div>
+        <div class="meta"><code>text-stone-700</code><br><code>#44403c</code><br><span class="small">CeremonyPin:33</span></div>
+        <div class="example-label">Example · CeremonyPin.tsx:33</div>
+        <pre class="example">&lt;p className="mt-1 text-sm text-stone-700"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#696257"></div><div class="meta"><code>--warm-ink-700</code><br><code>#696257</code><br><span class="small">Δ: moderate</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#a8a29e"></div>
+        <div class="meta"><code>border-stone-400</code><br><code>#a8a29e</code><br><span class="small">QuestionRatingButtons:94</span></div>
+        <div class="example-label">Example · QuestionRatingButtons.tsx:94</div>
+        <pre class="example">? 'border-stone-400 bg-stone-200 text-stone-800'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#8a8070"></div><div class="meta"><code>--warm-ink-400</code><br><code>#8a8070</code><br><span class="small">Δ: moderate</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#e7e5e4"></div>
+        <div class="meta"><code>bg-stone-200</code><br><code>#e7e5e4</code><br><span class="small">QuestionRatingButtons:94</span></div>
+        <div class="example-label">Example · QuestionRatingButtons.tsx:94</div>
+        <pre class="example">? 'border-stone-400 bg-stone-200 text-stone-800'</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#e8e2d6"></div><div class="meta"><code>--warm-border</code><br><code>#e8e2d6</code><br><span class="small">Δ: ≈match</span></div></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>White / black</h2>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#ffffff"></div>
+        <div class="meta"><code>bg-white</code><br><code>#ffffff</code><br><span class="small">PreviewBanner:32</span></div>
+        <div class="example-label">Example · PreviewBanner.tsx:32</div>
+        <pre class="example">className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 text-xs font-medium text-amber-900 transition hover:bg-amber-100"</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#fdfcfb"></div><div class="meta"><code>--brand-card</code><br><code>#fdfcfb</code><br><span class="small">Δ: ≈match</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#ffffff"></div>
+        <div class="meta"><code>text-white</code><br><code>#ffffff</code><br><span class="small">TodaysFiveCard:334/374, AnswerFeedbackSheet:202, ContactMatchBlock:228, FindFriendsSearch:135, InlineHandleField:124</span></div>
+        <div class="example-label">Example · TodaysFiveCard.tsx:334</div>
+        <pre class="example">className="btn-primary flex min-h-12 w-full items-center justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#fbf4e3"></div><div class="meta"><code>--primary-foreground</code><br><code>#fbf4e3</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#000000"></div>
+        <div class="meta"><code>text-black</code><br><code>#000000</code><br><span class="small">FeedCard:30/117, SparkleEnvelope:49</span></div>
+        <div class="example-label">Example · FeedCard.tsx:30</div>
+        <pre class="example">&lt;p className="font-serif text-base font-semibold leading-[24px] tracking-[0.04em] text-black"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#1a1208"></div><div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: small</span></div></div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#000000"></div>
+        <div class="meta"><code>text-black</code><br><code>#000000</code><br><span class="small">FeedCard:30/117, SparkleEnvelope:49</span></div>
+        <div class="example-label">Example · SparkleEnvelope.tsx:49</div>
+        <pre class="example">&lt;p className="font-sans text-[15px] leading-[23px] tracking-[0.05em] text-black"&gt;</pre>
+      </div>
+      <div class="cell"><div class="swatch" style="background:#0a1f3d"></div><div class="meta"><code>--brand-ink</code><br><code>#0a1f3d</code><br><span class="small">Δ: moderate</span></div></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <h2>Special case — documented near-duplicate black</h2>
+    <div class="matrix">
+      <div class="cell header">I want</div>
+      <div class="cell header">Utility color</div>
+      <div class="cell header">Nearest token color</div>
+
+      <div class="cell want"><label><input type="checkbox"> utility</label><label><input type="checkbox"> nearest</label></div>
+      <div class="cell">
+        <div class="swatch" style="background:#111111"></div>
+        <div class="meta"><code>text-[#111111]</code><br><code>#111111</code><br><span class="small">ReplaySummary:70</span></div>
+        <div class="example-label">Example · ReplaySummary.tsx:70</div>
+        <pre class="example">&lt;p className="mt-2 font-mono text-5xl font-bold leading-none text-[#111111]"&gt;</pre>
+      </div>
+      <div class="cell">
+        <div class="swatch" style="background:#1a1208"></div>
+        <div class="meta"><code>--warm-ink</code><br><code>#1a1208</code><br><span class="small">Δ: small · globals.css documents #111111 collapsing onto --warm-ink</span></div>
+      </div>
+    </div>
+  </div>
+
+</div>
+</body>
+</html>

--- a/_docs/DESIGN-SYSTEM.md
+++ b/_docs/DESIGN-SYSTEM.md
@@ -115,11 +115,19 @@ Defined in `globals.css` lines 96-103. Hex approximations are authored as commen
 
 Worth holding as named Figma swatches because they appear directly in component classes:
 
-`amber-50, amber-100, amber-700, amber-800, amber-900, amber-950`  
-`emerald-50, emerald-100, emerald-600, emerald-700`  
 `stone-50, stone-100, stone-200, stone-800, stone-950`  
-`rose-50, rose-200`  
 `sky-200`
+
+**Now tokenized** (no longer reach for the raw utility): the amber/warning and the
+success/error status colors below resolved into semantic tokens in `globals.css :root`.
+
+| Was (raw utility) | Now (token) |
+|---|---|
+| `amber-50/100` fills, `amber-300` borders, `amber-700/800/900/950` text | `--warning-surface` / `--warning-border` / `--warning` |
+| `emerald-600/700` text | `--success` |
+| `emerald-50` fill, `emerald-200` border | `--success-surface` / `--success-border` |
+| `red-700 / rose-700` text | `--destructive` |
+| `red-50 / rose-50` fill, `red-200 / rose-200` border | `--destructive-surface` / `--destructive-border` |
 
 ---
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,14 +34,12 @@ const TOKEN_LINT_RULE = {
 // a warning so the build stays green while the backlog is worked down — new files
 // (and any cleaned file removed from this list) are held at error. Shrink this
 // list; don't add to it. These warnings are the *only* ones `npm run lint`
-// tolerates: the script pins `--max-warnings` to their current count (33), so the
+// tolerates: the script pins `--max-warnings` to their current count (17), so the
 // warning lane can't silently grow. When you clean a file off this list, drop the
 // `--max-warnings` ceiling in package.json by the number of warnings it removed.
 const TOKEN_LINT_GRANDFATHERED = [
-  "src/components/AddToBankAction.tsx",
   "src/components/CreateChooser.tsx",
   "src/components/LoadingScreen.tsx",
-  "src/components/QuestionForm.tsx",
   "src/components/SendQuestionDrawer.tsx",
   "src/components/TodaysFiveCard.tsx",
   "src/components/feed/AnswerFeedbackSheet.tsx",
@@ -52,12 +50,7 @@ const TOKEN_LINT_GRANDFATHERED = [
   "src/components/games/QuestionRatingButtons.tsx",
   "src/components/home/CeremonyPin.tsx",
   "src/components/knowledge/AskFriendForDomain.tsx",
-  "src/components/profile/AuthoredQuestionsFeed.tsx",
-  "src/components/profile/InlineHandleField.tsx",
-  "src/components/profile/PreviewBanner.tsx",
   "src/components/profile/SharedInterestsOverlap.tsx",
-  "src/components/profile/settings/NotificationsForm.tsx",
-  "src/components/replay/ReplaySummary.tsx",
 ];
 
 const eslintConfig = defineConfig([

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run src/lib/llm.grading.eval.test.ts",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 33",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 17",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,6 +145,20 @@
     --success: #178245;
     --danger: var(--destructive);
     --wrong: var(--destructive);
+    /* Status surfaces — banner/chip fills + hairlines for the success / warning /
+       error roles. Formalizes the raw amber-50/300/700/900 + emerald/red/rose
+       50–200 utilities the 2026-05-30 audit flagged (DESIGN-SYSTEM.md §1.7).
+       Warning is a new hue (no prior accent), so its three values are explicit;
+       success/error tints derive from their existing accent via color-mix — the
+       same proportions already used inline in GameplayChat/ReplaySummary, so the
+       tints track the accent if it ever moves. */
+    --warning:             #b45309;  /* amber/700 — caution text / accent      */
+    --warning-surface:     #fdf6e6;  /* pale caution banner fill               */
+    --warning-border:      #e6c15a;  /* caution hairline                       */
+    --success-surface:     color-mix(in srgb, var(--success) 10%, var(--card));
+    --success-border:      color-mix(in srgb, var(--success) 30%, var(--border));
+    --destructive-surface: color-mix(in srgb, var(--destructive) 8%, var(--card));
+    --destructive-border:  color-mix(in srgb, var(--destructive) 28%, var(--border));
     /* Legacy editorial aliases — re-pointed at the brand tokens so older
        surfaces (AnsweredByYouCard, FriendAddedCard/SparkleEnvelope, the
        Knowledge page, replay/catch-up) render with navy ink instead of warm

--- a/src/components/AddToBankAction.tsx
+++ b/src/components/AddToBankAction.tsx
@@ -75,7 +75,7 @@ export function AddToBankAction({
         onClick={toggle}
         className={cn(
           'inline-flex min-h-9 items-center justify-center gap-2 rounded-md border px-3 text-sm text-muted-foreground transition hover:bg-muted hover:text-foreground disabled:opacity-60',
-          inBank ? 'border-amber-300 bg-amber-50 text-amber-700' : '',
+          inBank ? 'border-[var(--warning-border)] bg-[var(--warning-surface)] text-[var(--warning)]' : '',
           className,
         )}
       >

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -525,7 +525,7 @@ export function QuestionForm({
       </div>
 
       {state.stage === 'CRITIQUED' && critique && !critique.ok ? (
-        <div className="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-950">
+        <div className="rounded-md border border-[var(--warning-border)] bg-[var(--warning-surface)] p-3 text-sm text-[var(--warning)]">
           <p className="font-medium">⚠ This question might be unclear:</p>
           <ul className="mt-2 list-disc space-y-1 pl-5">
             {critique.issues.map((issue) => <li key={issue}>{issue}</li>)}
@@ -608,7 +608,7 @@ export function QuestionForm({
           {state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (
             <div className="rounded-md border bg-muted/40 p-3 text-sm">
               <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">LLM suggestion</p>
-              <p className="mt-1 line-through decoration-amber-500">{state.llmSuggestedAnswer}</p>
+              <p className="mt-1 line-through decoration-[var(--warning)]">{state.llmSuggestedAnswer}</p>
             </div>
           ) : null}
 
@@ -617,12 +617,12 @@ export function QuestionForm({
               <p className="text-sm text-[var(--success)]">✓ Verified — matches LLM suggestion</p>
             ) : (
               <div className="flex flex-wrap items-center gap-3">
-                <p className="text-sm text-amber-700">⚠ Unverified — your answer differs from the LLM&apos;s suggestion. Recipients will see this.</p>
+                <p className="text-sm text-[var(--warning)]">⚠ Unverified — your answer differs from the LLM&apos;s suggestion. Recipients will see this.</p>
                 <button
                   type="button"
                   onClick={() => dispatch({ type: 'FIELD', field: 'userAnswer', value: state.llmSuggestedAnswer ?? '' })}
                   disabled={state.stage === 'SUBMITTING'}
-                  className="rounded-md border border-amber-700 px-3 py-1 text-xs font-medium text-amber-700 hover:bg-amber-50 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="rounded-md border border-[var(--warning)] px-3 py-1 text-xs font-medium text-[var(--warning)] hover:bg-[var(--warning-surface)] disabled:cursor-not-allowed disabled:opacity-60"
                 >
                   Use LLM answer
                 </button>

--- a/src/components/games/QuestionRatingButtons.tsx
+++ b/src/components/games/QuestionRatingButtons.tsx
@@ -75,7 +75,7 @@ export function QuestionRatingButtons({ questionId }: { questionId: string }) {
         className={cn(
           'inline-flex size-9 items-center justify-center rounded-md border text-muted-foreground transition',
           myRating === 'up'
-            ? 'border-amber-300 bg-amber-100 text-amber-700'
+            ? 'border-[var(--warning-border)] bg-[var(--warning-surface)] text-[var(--warning)]'
             : 'border-border bg-background hover:bg-muted hover:text-foreground',
         )}
         disabled={isPending}

--- a/src/components/home/CeremonyPin.tsx
+++ b/src/components/home/CeremonyPin.tsx
@@ -22,7 +22,7 @@ export function CeremonyPin({ status }: { status: CeremonyPinStatus | null }) {
     return (
       <Link
         href={`/ceremony/${status.latestUnviewed.id}`}
-        className="block rounded-lg border border-amber-300 bg-amber-50 px-4 py-4 text-stone-950 shadow-sm"
+        className="block rounded-lg border border-[var(--warning-border)] bg-[var(--warning-surface)] px-4 py-4 text-[var(--warm-ink)] shadow-sm"
       >
         <div className="flex items-start gap-3">
           <span className="mt-0.5 text-lg" aria-hidden>

--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -202,7 +202,7 @@ export function AuthoredQuestionsFeed({
       </div>
 
       {error ? (
-        <p className="mb-3 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+        <p className="mb-3 rounded-md border border-[var(--destructive-border)] bg-[var(--destructive-surface)] px-3 py-2 text-sm text-destructive">
           {error}
         </p>
       ) : null}

--- a/src/components/profile/InlineHandleField.tsx
+++ b/src/components/profile/InlineHandleField.tsx
@@ -116,12 +116,12 @@ export function InlineHandleField({
         />
       </div>
       {confirming ? (
-        <div className="mt-3 rounded-md border border-amber-300 bg-amber-50 p-3 text-sm text-amber-900">
+        <div className="mt-3 rounded-md border border-[var(--warning-border)] bg-[var(--warning-surface)] p-3 text-sm text-[var(--warning)]">
           <p>You can change your handle once every {cooldownDays} days. Continue?</p>
           <div className="mt-2 flex gap-2">
             <button
               type="button"
-              className="rounded-md bg-amber-600 px-3 py-1 text-xs font-medium text-white hover:bg-amber-700 disabled:opacity-60"
+              className="rounded-md bg-[var(--warning)] px-3 py-1 text-xs font-medium text-[var(--primary-foreground)] transition hover:opacity-90 disabled:opacity-60"
               onClick={() => void confirmSave()}
               disabled={status === 'saving'}
             >
@@ -129,7 +129,7 @@ export function InlineHandleField({
             </button>
             <button
               type="button"
-              className="rounded-md border border-amber-300 px-3 py-1 text-xs"
+              className="rounded-md border border-[var(--warning-border)] px-3 py-1 text-xs"
               onClick={cancel}
               disabled={status === 'saving'}
             >

--- a/src/components/profile/PreviewBanner.tsx
+++ b/src/components/profile/PreviewBanner.tsx
@@ -20,7 +20,7 @@ type Props = {
 // you exit, not a permanent setting.
 export function PreviewBanner({ label, exitHref }: Props) {
   return (
-    <div className="mb-5 flex items-center justify-between gap-3 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+    <div className="mb-5 flex items-center justify-between gap-3 rounded-xl border border-[var(--warning-border)] bg-[var(--warning-surface)] px-4 py-3 text-sm text-[var(--warning)]">
       <div className="flex min-w-0 items-center gap-2">
         <Eye className="size-4 flex-none" />
         <span className="truncate">
@@ -29,7 +29,7 @@ export function PreviewBanner({ label, exitHref }: Props) {
       </div>
       <Link
         href={exitHref}
-        className="inline-flex items-center gap-1 rounded-md border border-amber-300 bg-white px-2 py-1 text-xs font-medium text-amber-900 transition hover:bg-amber-100"
+        className="inline-flex items-center gap-1 rounded-md border border-[var(--warning-border)] bg-[var(--brand-card)] px-2 py-1 text-xs font-medium text-[var(--warning)] transition hover:bg-[var(--warning-surface)]"
       >
         <X className="size-3" />
         Exit preview

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -148,7 +148,7 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
           <div className="flex min-w-0 flex-1 flex-col">
             <div className="flex flex-wrap items-center gap-2">
               <h3 className="font-serif text-lg font-semibold">SMS reminders</h3>
-              <span className="inline-flex items-center rounded-full border border-amber-300 bg-amber-50 px-2 py-0.5 text-xs font-medium text-amber-800">
+              <span className="inline-flex items-center rounded-full border border-[var(--warning-border)] bg-[var(--warning-surface)] px-2 py-0.5 text-xs font-medium text-[var(--warning)]">
                 Coming soon
               </span>
             </div>

--- a/src/components/replay/ReplaySummary.tsx
+++ b/src/components/replay/ReplaySummary.tsx
@@ -86,8 +86,8 @@ export function ReplaySummary({ results, hasMore, onPlayNext, loadingNext }: Pro
               <span
                 className={`rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] ${
                   isCorrect
-                    ? 'border-emerald-200 bg-emerald-50 text-emerald-700'
-                    : 'border-rose-200 bg-rose-50 text-rose-700'
+                    ? 'border-[var(--success-border)] bg-[var(--success-surface)] text-[var(--success)]'
+                    : 'border-[var(--destructive-border)] bg-[var(--destructive-surface)] text-destructive'
                 }`}
               >
                 {isCorrect ? 'CORRECT' : 'WRONG'}


### PR DESCRIPTION
## Summary

Drives the off-system-color lint warning lane from **44 → 17** and ratchets `--max-warnings` down in lockstep so future drift fails the build. Started as a mechanical token-conformance pass (B-VISUAL-TOKEN-BUDGET-01), then closed the biggest gap by adding the missing **warning** semantic role plus pale success/error surfaces.

All component edits are **className/style-value only** — no JSX structure or behavior changes (one exception noted below).

## What changed, in order

1. **Remap exact + close colors → existing tokens** (ceiling 44 → 33)
   - `text-[#D9A82E]` → `--tri-amber` (exact 1:1)
   - `text-emerald-600/700` → `var(--success)`, `text-rose-700` → `text-destructive`
   - `text-[#111111]` → `var(--warm-ink)` (documented collapse in globals.css)
   - `text-black` → `var(--brand-ink)` (feed editorial idiom + the lint message's own pick)

2. **Add warning + status-surface tokens** (`globals.css`) and sweep the rest of bucket C (ceiling 33 → 17)
   - `--warning #b45309` / `--warning-surface #fdf6e6` / `--warning-border #e6c15a` — explicit (new hue, no prior accent). This was the largest off-system cluster: 31 amber uses across 13 literals, previously **no token at all**.
   - `--success-surface/-border`, `--destructive-surface/-border` — derived via `color-mix` off the existing accents, matching the proportions already used inline in `GameplayChat`/`ReplaySummary`.
   - Remapped 13 amber banners/chips/button + 3 pale-tint result banners onto these tokens.

3. **Ratchet + de-grandfather** — 10 files went fully clean and were removed from the `TOKEN_LINT_GRANDFATHERED` list (now held at *error*); `--max-warnings` lowered 44 → 17.

4. **Docs** — `DESIGN-SYSTEM.md §1.7` updated (amber/emerald/rose moved from "not yet tokenized" to a "now tokenized" mapping table). Two analysis artifacts added at repo root: `B-VISUAL-TOKEN-BUDGET-01-bucket-B.md` and `.html` (swatch matrix, per-site examples, frequency analysis).

## Behavior note

`InlineHandleField` confirm button: `hover:bg-amber-700` → `hover:opacity-90` (the repo's `btn-*` hover convention) since the warning token is a single accent. The only intentional non-color tweak.

## Verification

- `npm run lint` → **0 errors / 17 warnings** (exit 0 at the new ceiling)
- `npx tsc --noEmit -p tsconfig.typecheck.json` → clean
- No token *definitions* removed, no rules suppressed/`eslint-ignore`d.

## Remaining 17 (intentionally untouched)

Modal scrims `bg-black/20–40` (7, no scrim token) · LoadingScreen bespoke palette (3, scoped to B-VISUAL-CARD-TIERS-01) · `text-white` on solid buttons/avatars (5) · neutral `stone` (2). A `--scrim` token and mapping `text-white` → `--primary-foreground` would clear most of these in a follow-up.

https://claude.ai/code/session_018YMTek5UCfcRySpSC1ZGMs

---
_Generated by [Claude Code](https://claude.ai/code/session_018YMTek5UCfcRySpSC1ZGMs)_