### PR TITLE
Refactor stacked activity marks and improve login input styling

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -16,7 +16,7 @@ function formatPhoneForDisplay(e164: string): string {
 const CARD_CLASS =
   'w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-[46px] py-8 shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5';
 const INPUT_CLASS =
-  'h-11 w-full rounded-[4px] border border-[var(--tri-amber)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none ring-offset-2 ring-offset-[var(--brand-cream-card)] focus:ring-2 focus:ring-[var(--brand-navy)]';
+  'h-11 w-full rounded-[4px] border border-[var(--tri-amber)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none transition-colors focus:border-[var(--brand-navy)]';
 const SUBMIT_CLASS =
   'h-11 w-full rounded-[4px] bg-[var(--brand-navy)] px-4 text-base font-bold tracking-[0.04em] text-white transition hover:opacity-90 disabled:opacity-60';
 

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -44,10 +44,17 @@ const MARK_W = 24;
 const GAP = 8;
 const LINE_H = 22.5; // first text line: 15px × 1.5
 // The stacked single-shape marks (diamond / hourglass / domain) are a vertical
-// pair of base=height triangles, so at full width they're 24×48 — too tall next
-// to the text. Render them at 70% (the cluster, made of small triangles, stays
-// full size). They center horizontally in the 24px column.
+// pair of triangles. Full base=height triangles would make the pair 24×48 — too
+// tall, and the two halves end up far apart vertically (they read as two
+// disconnected shapes). We draw each half intentionally shorter than base=height
+// so the pair is 24×STACK_H and the halves sit close together. The cluster
+// (BundleMark, made of small triangles) keeps full base=height. Rendered at 70%,
+// centered horizontally in the 24px column.
 const LARGE_SCALE = 0.7;
+// Height of each half of a stacked mark, and the total viewBox height of the
+// pair. Shorter than the 24px base on purpose — see LARGE_SCALE note above.
+const STACK_HALF = 18;
+const STACK_H = STACK_HALF * 2; // 36
 
 export type ActivityIconSpec =
   | { kind: 'bundle'; total: number; unanswered: number }
@@ -180,9 +187,17 @@ function BundleMark({
 // random palette colour.
 function DiamondMark({ seed }: { seed: string }) {
   return (
-    <MarkSvg h={48} scale={LARGE_SCALE}>
-      <path d="M12,0 L0,24 L24,24 Z" fill={colorFor(seed, 0)} fillOpacity={FILL_OPACITY} />
-      <path d="M0,24 L24,24 L12,48 Z" fill={colorFor(seed, 1)} fillOpacity={FILL_OPACITY} />
+    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
+      <path
+        d={`M12,0 L0,${STACK_HALF} L24,${STACK_HALF} Z`}
+        fill={colorFor(seed, 0)}
+        fillOpacity={FILL_OPACITY}
+      />
+      <path
+        d={`M0,${STACK_HALF} L24,${STACK_HALF} L12,${STACK_H} Z`}
+        fill={colorFor(seed, 1)}
+        fillOpacity={FILL_OPACITY}
+      />
     </MarkSvg>
   );
 }
@@ -191,9 +206,17 @@ function DiamondMark({ seed }: { seed: string }) {
 // sent your way.
 function HourglassMark({ seed }: { seed: string }) {
   return (
-    <MarkSvg h={48} scale={LARGE_SCALE}>
-      <path d="M0,0 L24,0 L12,24 Z" fill={colorFor(seed, 0)} fillOpacity={FILL_OPACITY} />
-      <path d="M12,24 L0,48 L24,48 Z" fill={colorFor(seed, 1)} fillOpacity={FILL_OPACITY} />
+    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
+      <path
+        d={`M0,0 L24,0 L12,${STACK_HALF} Z`}
+        fill={colorFor(seed, 0)}
+        fillOpacity={FILL_OPACITY}
+      />
+      <path
+        d={`M12,${STACK_HALF} L0,${STACK_H} L24,${STACK_H} Z`}
+        fill={colorFor(seed, 1)}
+        fillOpacity={FILL_OPACITY}
+      />
     </MarkSvg>
   );
 }
@@ -205,9 +228,17 @@ function HourglassMark({ seed }: { seed: string }) {
 // they still split on the same diagonal and stay rotationally symmetric.
 function DomainMark({ seed }: { seed: string }) {
   return (
-    <MarkSvg h={48} scale={LARGE_SCALE}>
-      <path d="M18,0 L6,0 L18,24 Z" fill={colorFor(seed, 0)} fillOpacity={FILL_OPACITY} />
-      <path d="M6,24 L18,48 L6,48 Z" fill={colorFor(seed, 1)} fillOpacity={FILL_OPACITY} />
+    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
+      <path
+        d={`M18,0 L6,0 L18,${STACK_HALF} Z`}
+        fill={colorFor(seed, 0)}
+        fillOpacity={FILL_OPACITY}
+      />
+      <path
+        d={`M6,${STACK_HALF} L18,${STACK_H} L6,${STACK_H} Z`}
+        fill={colorFor(seed, 1)}
+        fillOpacity={FILL_OPACITY}
+      />
     </MarkSvg>
   );
 }

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -83,7 +83,8 @@ export const CONVERGENCE_CAPTIONS = [
   'Turns out you and {Name} think alike.',
   'You and {Name} are on the same wavelength lately.',
   'You and {Name} both knew these.',
-  'The people who get you, getting you — you and {Name}.',
+  'You and {Name} just get each other.',
+  'You and {Name} are clearly on the same page.',
 ] as const;
 
 export function convergenceCaptionTemplate(momentId: string): string {


### PR DESCRIPTION
## Summary
This PR makes three focused improvements: refactors stacked activity mark rendering to use configurable dimensions for better visual balance, updates convergence captions for clarity, and simplifies login input focus styling.

## Key Changes

**ActivityIcon.tsx:**
- Introduced `STACK_HALF` and `STACK_H` constants to replace hardcoded `48` viewBox heights in stacked marks (Diamond, Hourglass, Domain)
- Updated comment to clarify the design rationale: stacked marks are intentionally rendered shorter than full base=height triangles (36px instead of 48px) so the two halves sit visually close together rather than appearing as disconnected shapes
- Refactored all three mark functions to use template literals with the new constants, making the geometry more maintainable and the intent clearer

**lately.ts:**
- Replaced awkward convergence caption "The people who get you, getting you — you and {Name}." with two clearer alternatives:
  - "You and {Name} just get each other."
  - "You and {Name} are clearly on the same page."

**LoginPanel.tsx:**
- Simplified `INPUT_CLASS` focus styling: removed `ring-offset-2 ring-offset-[var(--brand-cream-card)] focus:ring-2 focus:ring-[var(--brand-navy)]` and replaced with `transition-colors focus:border-[var(--brand-navy)]`
- This provides a cleaner, more subtle focus indicator via border color change rather than an offset ring

## Implementation Details
The stacked mark refactor maintains visual consistency while improving code clarity. The new constants make it explicit that these marks are intentionally undersized (36px total height at 70% scale = ~25px rendered) to keep the two triangular halves visually cohesive, unlike the cluster mark which maintains full base=height proportions.

https://claude.ai/code/session_01618SbCWBDTcxktJVzW5H7e