### PR TITLE
Reorder stats and answerers in MyQuestionCard

### DIFF
--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -72,21 +72,21 @@ export function MyQuestionCard({
           </span>
         </p>
 
-        <p className="mt-2 text-[13px] leading-snug">
+        {answerersLine ? (
+          <p
+            className="mt-2 text-[13px] leading-snug"
+            style={{ color: 'var(--ink)', opacity: 0.65 }}
+          >
+            {answerersLine}
+          </p>
+        ) : null}
+        <p className={`${answerersLine ? 'mt-1' : 'mt-2'} text-[13px] leading-snug`}>
           <Stat value={`${question.timesAnswered}`} label="answers" />
           <StatSeparator />
           <Stat value={`${question.correctRate}%`} label="correct" />
           <StatSeparator />
           <Stat value={`${question.usedInGamesCount}`} label="games" />
         </p>
-        {answerersLine ? (
-          <p
-            className="mt-1 text-[13px] leading-snug"
-            style={{ color: 'var(--ink)', opacity: 0.65 }}
-          >
-            {answerersLine}
-          </p>
-        ) : null}
         {question.reportState ? <ReportStateNotice state={question.reportState} /> : null}
         {cardError ? (
           <p className="mt-2 text-[13px] text-destructive">{cardError}</p>


### PR DESCRIPTION
## Summary
Reordered the display of question statistics and answerers information in the MyQuestionCard component to improve visual hierarchy and readability.

## Changes
- Moved the stats section (answers, correct rate, games) below the answerers line instead of above it
- Adjusted margin classes to maintain consistent spacing:
  - Answerers line now uses `mt-2` (was `mt-1`)
  - Stats section uses conditional margin: `mt-2` when no answerers line, `mt-1` when answerers line is present
- This ensures proper visual separation between the question title and the detailed statistics

## Implementation Details
The reordering uses a conditional className on the stats paragraph to maintain appropriate spacing based on whether the answerers line is rendered. This prevents awkward gaps when the answerers information is absent while keeping the layout balanced when it's present.

https://claude.ai/code/session_014dc3fjwX4ojAgCKSikc31Q