### PR TITLE
Add mute-presence action for bonus slots (D-4 §B)

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -5,13 +5,21 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
-import { GameplayChatThread, newMessageId, type ChatMessage, type RecheckActionResult } from '@/components/play/GameplayChat';
+import {
+  GameplayChatThread,
+  newMessageId,
+  type ChatMessage,
+  type RecheckActionResult,
+} from '@/components/play/GameplayChat';
 import { pickOpenedTerritoryDomain } from '@/components/feed/territory';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import LoadingScreen from '@/components/LoadingScreen';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
-import { buildSessionCloseLines, type SessionSlotSummary } from '@/server/mastery/session-close-copy';
+import {
+  buildSessionCloseLines,
+  type SessionSlotSummary,
+} from '@/server/mastery/session-close-copy';
 
 function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' | 'warning' }> {
   // Figma shows the topic/category as the question chip (not the difficulty tier).
@@ -19,7 +27,9 @@ function questionBadges(slot: QueueSlot): Array<{ label: string; tone?: 'muted' 
     (slot.broad_category && slot.broad_category.trim()) ||
     (slot.category ? categoryLabel(slot.category) : '') ||
     slot.domain;
-  const badges: Array<{ label: string; tone?: 'muted' | 'warning' }> = category ? [{ label: category }] : [];
+  const badges: Array<{ label: string; tone?: 'muted' | 'warning' }> = category
+    ? [{ label: category }]
+    : [];
   // Daily Five +2 bonus slots (D-4 §B) carry presence attribution and are always
   // "accessible" — surface the accessibility badge so the lighter pick reads as
   // a deliberate, easier add rather than a generation miss. The "bonus from a
@@ -87,7 +97,11 @@ const ANSWER_ERROR_MESSAGES: Record<string, string> = {
 };
 
 function answerFailureMessage(body: FailedAnswerResponse | null): string {
-  return body?.message ?? (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined) ?? 'Could not record that answer.';
+  return (
+    body?.message ??
+    (body?.error ? ANSWER_ERROR_MESSAGES[body.error] : undefined) ??
+    'Could not record that answer.'
+  );
 }
 
 // Daily Five generation can come up short transiently: the queue endpoint
@@ -118,7 +132,10 @@ function currentPendingSlot(slots: QueueSlot[]): QueueSlot | null {
   return slots.find((slot) => !slot.answered && !slot.skipped) ?? null;
 }
 
-function sessionCloseLines(slots: QueueSlot[]): { scoreLine: string; interpretiveLine: string | null } {
+function sessionCloseLines(slots: QueueSlot[]): {
+  scoreLine: string;
+  interpretiveLine: string | null;
+} {
   if (slots.length > 0 && slots.every((slot) => slot.skipped)) {
     return { scoreLine: "We'll come back to these.", interpretiveLine: null };
   }
@@ -180,7 +197,10 @@ export default function DailyPage() {
     setLoading(true);
     setError(null);
     try {
-      const response = await fetch('/api/daily/queue', { cache: 'no-store', credentials: 'include' });
+      const response = await fetch('/api/daily/queue', {
+        cache: 'no-store',
+        credentials: 'include',
+      });
       const body = await response.json().catch(() => null);
 
       if (response.ok && body?.queue === null) {
@@ -222,7 +242,10 @@ export default function DailyPage() {
           );
         }
         setGeneratingAttempt(null);
-        const refetchResponse = await fetch('/api/daily/queue', { cache: 'no-store', credentials: 'include' });
+        const refetchResponse = await fetch('/api/daily/queue', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
         const refetchBody = await refetchResponse.json().catch(() => null);
         if (!refetchResponse.ok) {
           throw new Error(refetchBody?.message ?? 'Could not load today.');
@@ -233,7 +256,11 @@ export default function DailyPage() {
           return;
         }
         const refetchSlots = Array.isArray(refetchBody.slots) ? refetchBody.slots : [];
-        setQueue({ queue_id: refetchBody.queue_id, queue_date: refetchBody.queue_date, slots: refetchSlots });
+        setQueue({
+          queue_id: refetchBody.queue_id,
+          queue_date: refetchBody.queue_date,
+          slots: refetchSlots,
+        });
         maybeShowFirstRunIntro(refetchBody.is_first_daily);
         setLoading(false);
         return;
@@ -285,54 +312,72 @@ export default function DailyPage() {
   const queueLength = queue && queue.slots.length > 0 ? queue.slots.length : DAILY_QUEUE_SIZE;
   const allDone = Boolean(queue && queue.slots.length > 0 && !actualCurrentSlot);
 
+  const requestRecheck = useCallback(
+    async (slotIndex: number): Promise<RecheckActionResult> => {
+      if (!queue) throw new Error('No active queue');
 
-  const requestRecheck = useCallback(async (slotIndex: number): Promise<RecheckActionResult> => {
-    if (!queue) throw new Error('No active queue');
+      const response = await fetch('/api/daily/recheck', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slotIndex }),
+      });
+      const body = (await response.json().catch(() => null)) as
+        | RecheckResponse
+        | FailedAnswerResponse
+        | null;
 
-    const response = await fetch('/api/daily/recheck', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slotIndex }),
-    });
-    const body = await response.json().catch(() => null) as RecheckResponse | FailedAnswerResponse | null;
+      if (!response.ok) {
+        throw new Error(
+          body && 'message' in body && body.message
+            ? body.message
+            : 'Could not recheck that answer.',
+        );
+      }
 
-    if (!response.ok) {
-      throw new Error(body && 'message' in body && body.message ? body.message : 'Could not recheck that answer.');
-    }
+      const accepted = Boolean(body && 'accepted' in body && body.accepted);
+      const status = body && 'status' in body ? body.status : accepted ? 'accepted' : 'rejected';
+      const reason = body && 'reason' in body && body.reason ? body.reason : null;
+      const pointsAwarded =
+        body && 'pointsAwarded' in body && typeof body.pointsAwarded === 'number'
+          ? body.pointsAwarded
+          : 0;
+      const correctAnswer =
+        body && 'correctAnswer' in body && body.correctAnswer ? body.correctAnswer : undefined;
 
-    const accepted = Boolean(body && 'accepted' in body && body.accepted);
-    const status = body && 'status' in body ? body.status : accepted ? 'accepted' : 'rejected';
-    const reason = body && 'reason' in body && body.reason ? body.reason : null;
-    const pointsAwarded = body && 'pointsAwarded' in body && typeof body.pointsAwarded === 'number' ? body.pointsAwarded : 0;
-    const correctAnswer = body && 'correctAnswer' in body && body.correctAnswer ? body.correctAnswer : undefined;
+      setQueue((existing) =>
+        existing
+          ? {
+              ...existing,
+              slots: existing.slots.map((slot) =>
+                slot.slot_index === slotIndex
+                  ? {
+                      ...slot,
+                      answer_state: accepted ? 'correct' : 'incorrect',
+                      awarded_points: accepted ? pointsAwarded : slot.awarded_points,
+                      reveal_canonical_answer: correctAnswer ?? slot.reveal_canonical_answer,
+                      recheck_status: status,
+                      recheck_reason: reason,
+                    }
+                  : slot,
+              ),
+            }
+          : existing,
+      );
 
-    setQueue((existing) => existing
-      ? {
-          ...existing,
-          slots: existing.slots.map((slot) =>
-            slot.slot_index === slotIndex
-              ? {
-                  ...slot,
-                  answer_state: accepted ? 'correct' : 'incorrect',
-                  awarded_points: accepted ? pointsAwarded : slot.awarded_points,
-                  reveal_canonical_answer: correctAnswer ?? slot.reveal_canonical_answer,
-                  recheck_status: status,
-                  recheck_reason: reason,
-                }
-              : slot
-          ),
-        }
-      : existing);
-
-    if (accepted) {
-      return { accepted: true, message: `Recheck accepted — +${pointsAwarded} ${pointsAwarded === 1 ? 'point' : 'points'}.` };
-    }
-    if (status === 'needs_human') {
-      return { accepted: false, message: reason ?? 'Flagged for a human look.' };
-    }
-    return { accepted: false, message: reason ?? 'Rechecked and still marked wrong.' };
-  }, [queue]);
+      if (accepted) {
+        return {
+          accepted: true,
+          message: `Recheck accepted — +${pointsAwarded} ${pointsAwarded === 1 ? 'point' : 'points'}.`,
+        };
+      }
+      if (status === 'needs_human') {
+        return { accepted: false, message: reason ?? 'Flagged for a human look.' };
+      }
+      return { accepted: false, message: reason ?? 'Rechecked and still marked wrong.' };
+    },
+    [queue],
+  );
 
   const messages = useMemo<ChatMessage[]>(() => {
     if (!queue) return [];
@@ -368,27 +413,39 @@ export default function DailyPage() {
           consolation: slot.reveal_quip ?? null,
           insideJoke: slot.reveal_inside_joke ?? null,
           insideJokeKind: slot.reveal_inside_joke_kind ?? null,
-          authorNote: slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
+          authorNote:
+            slot.source === 'friend' || slot.source === 'house' ? (slot.author_note ?? null) : null,
           breadcrumb: slot.reveal_breadcrumb ?? null,
           explanation: slot.reveal_explainer ?? null,
           copyVariant: slot.slot_index,
           // D-3: house core slots surface the 'Joshing' name + Editorial badge
           // (creatorIsHouse), rendered non-relationally by GameplayChat.
-          creatorName: slot.source === 'friend' || slot.source === 'house' ? (slot.author_name ?? null) : null,
+          creatorName:
+            slot.source === 'friend' || slot.source === 'house' ? (slot.author_name ?? null) : null,
           creatorIsHouse: slot.source === 'house',
           canonicalSubcategory: slot.domain,
           openedTerritoryDomain: openedTerritoryBySlot[slot.slot_index] ?? null,
-          recheckAction: slot.answer_state === 'incorrect' && !gaveUp && !slot.recheck_status
-            ? { onSubmit: () => requestRecheck(slot.slot_index) }
-            : null,
+          recheckAction:
+            slot.answer_state === 'incorrect' && !gaveUp && !slot.recheck_status
+              ? { onSubmit: () => requestRecheck(slot.slot_index) }
+              : null,
         });
         continue;
       }
       if (slot.skipped) {
+        // A rested bonus slot ("This is {Name}'s bag but not mine") is closed via
+        // the same skip path, but it's an opt-out, not a "bring it back later" —
+        // so it gets its own copy naming the category we've stopped surfacing.
+        const restedLabel =
+          (slot.broad_category && slot.broad_category.trim()) ||
+          (slot.category ? categoryLabel(slot.category) : '') ||
+          slot.domain;
         rows.push({
           id: `s-${slot.slot_index}`,
           kind: 'system',
-          text: "Skipped. We'll bring it back later.",
+          text: slot.presence_source_name
+            ? `Resting ${restedLabel}. You won't see these in your five.`
+            : "Skipped. We'll bring it back later.",
         });
         continue;
       }
@@ -408,8 +465,10 @@ export default function DailyPage() {
           rows.push({ id: 'u-pending', kind: 'user', text: answer.trim() });
           rows.push({ id: 'grading', kind: 'typing' });
         } else if (pendingGiveUp) {
+          // "Show me the answer" is not a graded submission — there's nothing to
+          // check, so skip the "Grading..." indicator and go straight to the
+          // reveal (the answered slot rebuilds with the gave_up result row).
           rows.push({ id: 'u-pending-giveup', kind: 'user', text: 'show me the answer' });
-          rows.push({ id: 'grading', kind: 'typing' });
         }
         break;
       }
@@ -429,7 +488,16 @@ export default function DailyPage() {
     return rows.length > 0
       ? rows
       : [{ id: newMessageId(), kind: 'system', text: "Today's five is not ready yet." }];
-  }, [allDone, currentSlot?.slot_index, queue, requestRecheck, submitting, answer, pendingGiveUp, openedTerritoryBySlot]);
+  }, [
+    allDone,
+    currentSlot?.slot_index,
+    queue,
+    requestRecheck,
+    submitting,
+    answer,
+    pendingGiveUp,
+    openedTerritoryBySlot,
+  ]);
 
   const results = useMemo(() => {
     const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
@@ -451,95 +519,107 @@ export default function DailyPage() {
         body: JSON.stringify({ source: 'daily', queueId, slotIndex }),
       });
       if (!response.ok) return;
-      const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
+      const body = (await response.json().catch(() => null)) as {
+        breadcrumb?: string | null;
+      } | null;
       const breadcrumb = body?.breadcrumb ?? null;
       if (!breadcrumb) return;
-      setQueue((existing) => existing && existing.queue_id === queueId
-        ? {
-            ...existing,
-            slots: existing.slots.map((slot) =>
-              slot.slot_index === slotIndex
-                ? { ...slot, reveal_breadcrumb: breadcrumb }
-                : slot,
-            ),
-          }
-        : existing);
+      setQueue((existing) =>
+        existing && existing.queue_id === queueId
+          ? {
+              ...existing,
+              slots: existing.slots.map((slot) =>
+                slot.slot_index === slotIndex ? { ...slot, reveal_breadcrumb: breadcrumb } : slot,
+              ),
+            }
+          : existing,
+      );
     } catch {
       // Breadcrumb is purely additive context; failure is silently ignored.
     }
   }, []);
 
-  const postAnswer = useCallback(async (opts: { submittedAnswer: string; gaveUp: boolean }) => {
-    if (!queue || !currentSlot || submitting) return;
-    setSubmitting(true);
-    setError(null);
-    try {
-      const response = await fetch('/api/daily/answer', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          queue_id: queue.queue_id,
-          slot_index: currentSlot.slot_index,
-          submitted_answer: opts.submittedAnswer,
-          gave_up: opts.gaveUp,
-        }),
-      });
-      if (!response.ok) {
-        const failedBody = await response.json().catch(() => null) as FailedAnswerResponse | null;
-        throw new Error(answerFailureMessage(failedBody));
-      }
+  const postAnswer = useCallback(
+    async (opts: { submittedAnswer: string; gaveUp: boolean }) => {
+      if (!queue || !currentSlot || submitting) return;
+      setSubmitting(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/daily/answer', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            queue_id: queue.queue_id,
+            slot_index: currentSlot.slot_index,
+            submitted_answer: opts.submittedAnswer,
+            gave_up: opts.gaveUp,
+          }),
+        });
+        if (!response.ok) {
+          const failedBody = (await response
+            .json()
+            .catch(() => null)) as FailedAnswerResponse | null;
+          throw new Error(answerFailureMessage(failedBody));
+        }
 
-      const body = await response.json().catch(() => null) as AnswerResponse | null;
-      if (!body) {
-        throw new Error('Could not record that answer.');
-      }
+        const body = (await response.json().catch(() => null)) as AnswerResponse | null;
+        if (!body) {
+          throw new Error('Could not record that answer.');
+        }
 
-      const isCorrect = Boolean(body.isCorrect ?? body.correct);
-      // A correct answer in an unfamiliar domain default-adds it to the KB
-      // (B-1). The server reports the freshly-opened domain on masteryDelta;
-      // stash it per-slot so the reveal can surface the "Added — remove?" undo.
-      // Client-only — deliberately not persisted into the QueueSlot schema.
-      const masteryDelta = body.masteryDelta ?? body.mastery_delta;
-      const openedDomain = isCorrect ? pickOpenedTerritoryDomain(masteryDelta) : null;
-      if (openedDomain) {
-        setOpenedTerritoryBySlot((existing) => ({ ...existing, [currentSlot.slot_index]: openedDomain }));
-      }
-      setQueue((existing) => existing
-        ? {
+        const isCorrect = Boolean(body.isCorrect ?? body.correct);
+        // A correct answer in an unfamiliar domain default-adds it to the KB
+        // (B-1). The server reports the freshly-opened domain on masteryDelta;
+        // stash it per-slot so the reveal can surface the "Added — remove?" undo.
+        // Client-only — deliberately not persisted into the QueueSlot schema.
+        const masteryDelta = body.masteryDelta ?? body.mastery_delta;
+        const openedDomain = isCorrect ? pickOpenedTerritoryDomain(masteryDelta) : null;
+        if (openedDomain) {
+          setOpenedTerritoryBySlot((existing) => ({
             ...existing,
-            slots: existing.slots.map((slot) =>
-              slot.slot_index === currentSlot.slot_index
-                ? {
-                    ...slot,
-                    answered: true,
-                    answer_state: isCorrect ? 'correct' : 'incorrect',
-                    submitted_answer: opts.gaveUp ? '' : opts.submittedAnswer,
-                    awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
-                    reveal_canonical_answer: body.correctAnswer ?? body.answer,
-                    reveal_explainer: body.explanation ?? body.explainer,
-                    reveal_breadcrumb: null,
-                    reveal_quip: opts.gaveUp ? null : body.consolation ?? null,
-                    reveal_inside_joke: body.insideJoke ?? null,
-                    reveal_inside_joke_kind: body.insideJokeKind ?? null,
-                  }
-                : slot
-            ),
-          }
-        : existing);
-      setPausedAfterSlotIndex(currentSlot.slot_index);
-      window.setTimeout(() => setPausedAfterSlotIndex(null), 850);
-      setAnswer('');
+            [currentSlot.slot_index]: openedDomain,
+          }));
+        }
+        setQueue((existing) =>
+          existing
+            ? {
+                ...existing,
+                slots: existing.slots.map((slot) =>
+                  slot.slot_index === currentSlot.slot_index
+                    ? {
+                        ...slot,
+                        answered: true,
+                        answer_state: isCorrect ? 'correct' : 'incorrect',
+                        submitted_answer: opts.gaveUp ? '' : opts.submittedAnswer,
+                        awarded_points: body.pointsAwarded ?? body.awarded_points ?? 0,
+                        reveal_canonical_answer: body.correctAnswer ?? body.answer,
+                        reveal_explainer: body.explanation ?? body.explainer,
+                        reveal_breadcrumb: null,
+                        reveal_quip: opts.gaveUp ? null : (body.consolation ?? null),
+                        reveal_inside_joke: body.insideJoke ?? null,
+                        reveal_inside_joke_kind: body.insideJokeKind ?? null,
+                      }
+                    : slot,
+                ),
+              }
+            : existing,
+        );
+        setPausedAfterSlotIndex(currentSlot.slot_index);
+        window.setTimeout(() => setPausedAfterSlotIndex(null), 850);
+        setAnswer('');
 
-      if (!opts.gaveUp) {
-        void fetchBreadcrumb(queue.queue_id, currentSlot.slot_index);
+        if (!opts.gaveUp) {
+          void fetchBreadcrumb(queue.queue_id, currentSlot.slot_index);
+        }
+      } catch (caught) {
+        setError(caught instanceof Error ? caught.message : 'Could not record that answer.');
+      } finally {
+        setSubmitting(false);
       }
-    } catch (caught) {
-      setError(caught instanceof Error ? caught.message : 'Could not record that answer.');
-    } finally {
-      setSubmitting(false);
-    }
-  }, [currentSlot, fetchBreadcrumb, queue, submitting]);
+    },
+    [currentSlot, fetchBreadcrumb, queue, submitting],
+  );
 
   const submitAnswer = useCallback(async () => {
     const trimmed = answer.trim();
@@ -555,6 +635,65 @@ export default function DailyPage() {
       setPendingGiveUp(false);
     }
   }, [postAnswer]);
+
+  // Bonus slots only (D-4 §B): "This is {Name}'s bag but not mine". Rests the
+  // slot's domain so the category stops surfacing in future rounds, and closes
+  // this bonus question (a skip — bonus slots are additive, so closing one never
+  // drops the round below the core five). Optimistic: the slot is marked skipped
+  // immediately, then reverted if either request fails.
+  const muteBonusDomain = useCallback(async () => {
+    if (!queue || !currentSlot || submitting) return;
+    const slotIndex = currentSlot.slot_index;
+    const { domain } = currentSlot;
+    setError(null);
+    setQueue((existing) =>
+      existing
+        ? {
+            ...existing,
+            slots: existing.slots.map((slot) =>
+              slot.slot_index === slotIndex ? { ...slot, skipped: true } : slot,
+            ),
+          }
+        : existing,
+    );
+    try {
+      // Rest the category (durable preference). Best-effort, but the skip below
+      // is what actually closes this question, so a failure here still throws.
+      const restResponse = await fetch('/api/daily/preferences/domain-frequency', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain, frequency: 'resting' }),
+      });
+      if (!restResponse.ok) throw new Error('Could not update that category.');
+
+      const skipResponse = await fetch('/api/daily/skip', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ queue_id: queue.queue_id, slot_index: slotIndex }),
+      });
+      if (!skipResponse.ok) throw new Error('Could not close that question.');
+      const body = (await skipResponse.json().catch(() => null)) as { slots?: QueueSlot[] } | null;
+      if (Array.isArray(body?.slots)) {
+        const nextSlots = body.slots;
+        setQueue((existing) => (existing ? { ...existing, slots: nextSlots } : existing));
+      }
+    } catch (caught) {
+      // Revert the optimistic skip so the question stays answerable.
+      setQueue((existing) =>
+        existing
+          ? {
+              ...existing,
+              slots: existing.slots.map((slot) =>
+                slot.slot_index === slotIndex ? { ...slot, skipped: false } : slot,
+              ),
+            }
+          : existing,
+      );
+      setError(caught instanceof Error ? caught.message : 'Could not update that category.');
+    }
+  }, [queue, currentSlot, submitting]);
 
   // Keep the "Answer" bar above the on-screen keyboard. On mobile the layout
   // viewport doesn't shrink when the keyboard opens, so a `position: sticky`
@@ -593,8 +732,12 @@ export default function DailyPage() {
       >
         <div className="flex items-center gap-3">
           <div>
-            <p className="text-xs uppercase tracking-[0.1em] text-[var(--text-muted)]">Daily Five</p>
-            <h1 className="font-serif text-xl font-semibold text-[var(--text)]">Today&apos;s five</h1>
+            <p className="text-xs tracking-[0.1em] text-[var(--text-muted)] uppercase">
+              Daily Five
+            </p>
+            <h1 className="font-serif text-xl font-semibold text-[var(--text)]">
+              Today&apos;s five
+            </h1>
           </div>
         </div>
         <div className="flex items-center gap-2">
@@ -606,7 +749,7 @@ export default function DailyPage() {
           <Link
             href="/"
             aria-label="Close"
-            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             <X className="size-5" strokeWidth={1.9} />
           </Link>
@@ -615,7 +758,7 @@ export default function DailyPage() {
 
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
-        style={{ paddingBottom: "calc(24px + env(safe-area-inset-bottom))" }}
+        style={{ paddingBottom: 'calc(24px + env(safe-area-inset-bottom))' }}
       >
         {loading ? (
           <LoadingScreen
@@ -633,7 +776,7 @@ export default function DailyPage() {
             <button
               type="button"
               onClick={() => void loadQueue()}
-              className="inline-flex min-h-11 items-center rounded-md border px-3 py-1.5 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--surface)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+              className="inline-flex min-h-11 items-center rounded-md border px-3 py-1.5 text-sm font-medium text-[var(--text)] transition hover:bg-[var(--surface)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
               style={{ borderColor: 'var(--border)' }}
             >
               Try again
@@ -644,6 +787,8 @@ export default function DailyPage() {
             messages={messages}
             onGiveUp={() => void giveUpCurrent()}
             giveUpDisabled={submitting}
+            onMutePresence={() => void muteBonusDomain()}
+            muteDisabled={submitting}
           />
         )}
       </section>

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -115,7 +115,13 @@ export type ChatMessage =
       roundsRemaining: number;
       nextRoundOpensAt: string | null;
     }
-  | { id: string; kind: 'session_close'; scoreLine: string; interpretiveLine: string | null; summaryHref?: string }
+  | {
+      id: string;
+      kind: 'session_close';
+      scoreLine: string;
+      interpretiveLine: string | null;
+      summaryHref?: string;
+    }
   | {
       id: string;
       kind: 'bonus_offer';
@@ -133,10 +139,14 @@ const CORRECT_COPY: Array<{ headline: string }> = [
 
 function wrongHeadline(variant: number): string {
   switch (variant % 3) {
-    case 0: return 'Not this time — here\u2019s the answer.';
-    case 1: return 'You\u2019ll know this one next time.';
-    case 2: return 'Close, but not quite.';
-    default: return 'Not this time — here\u2019s the answer.';
+    case 0:
+      return 'Not this time — here\u2019s the answer.';
+    case 1:
+      return 'You\u2019ll know this one next time.';
+    case 2:
+      return 'Close, but not quite.';
+    default:
+      return 'Not this time — here\u2019s the answer.';
   }
 }
 
@@ -169,7 +179,11 @@ function firstNameFrom(creatorName: string): string {
   return space === -1 ? trimmed : trimmed.slice(0, space);
 }
 
-function wrongNamedSubLabel(creatorName: string | null, variant: number, isHouse = false): string | null {
+function wrongNamedSubLabel(
+  creatorName: string | null,
+  variant: number,
+  isHouse = false,
+): string | null {
   if (!creatorName) return null;
   // House and LLM origins are non-relational: no "{name} carries this one".
   if (isHouse || isLlmAttribution(creatorName)) return null;
@@ -223,7 +237,14 @@ function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
 
   return (
     <div className="flex flex-col items-center gap-0.5 py-0.5">
-      <p style={{ ...monoStyle, fontSize: '0.58rem', color: 'var(--text-muted)', textAlign: 'center' }}>
+      <p
+        style={{
+          ...monoStyle,
+          fontSize: '0.58rem',
+          color: 'var(--text-muted)',
+          textAlign: 'center',
+        }}
+      >
         <span>Dismissed</span>
         <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
         {state === 'undoing' ? (
@@ -249,7 +270,9 @@ function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
         )}
       </p>
       {state === 'error' ? (
-        <p style={{ ...monoStyle, fontSize: '0.54rem', color: 'var(--danger)', textAlign: 'center' }}>
+        <p
+          style={{ ...monoStyle, fontSize: '0.54rem', color: 'var(--danger)', textAlign: 'center' }}
+        >
           Could not undo. Try again.
         </p>
       ) : null}
@@ -271,6 +294,8 @@ function QuestionRow({
   giveUpDisabled = false,
   onDismiss,
   dismissDisabled = false,
+  onMutePresence,
+  muteDisabled = false,
 }: {
   subhead?: string | null;
   badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
@@ -285,6 +310,10 @@ function QuestionRow({
   giveUpDisabled?: boolean;
   onDismiss?: () => void;
   dismissDisabled?: boolean;
+  // Bonus slots only (D-4 §B): "This is {Name}'s bag but not mine" — rests the
+  // slot's domain so the category stops surfacing, and closes this question.
+  onMutePresence?: () => void;
+  muteDisabled?: boolean;
 }) {
   const [visible, setVisible] = useState(!isNew);
   // A bonus slot is one drawn from a followed friend's knowledge (D-4 §B). It
@@ -295,7 +324,7 @@ function QuestionRow({
     if (!isNew) return;
     const t = window.setTimeout(() => setVisible(true), 30);
     return () => window.clearTimeout(t);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
@@ -334,13 +363,22 @@ function QuestionRow({
             lineHeight: 1.3,
           }}
         >
-          <span style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginRight: '6px' }}>
+          <span
+            style={{
+              ...monoStyle,
+              fontSize: '0.55rem',
+              color: 'var(--text-muted)',
+              marginRight: '6px',
+            }}
+          >
             FROM
           </span>
           <span style={{ fontWeight: 600 }}>{creatorName}</span>
           {creatorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
           {creatorIsHouse || isLlmAttribution(creatorName) ? null : (
-            <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>gave you this</span>
+            <span style={{ marginLeft: '6px', opacity: 0.55, fontStyle: 'italic' }}>
+              gave you this
+            </span>
           )}
         </p>
       ) : null}
@@ -357,7 +395,8 @@ function QuestionRow({
               borderRadius: 'var(--radius-md) var(--radius-md) 0 0',
               border: '1px solid var(--brand-navy)',
               borderBottom: 'none',
-              background: 'linear-gradient(135deg, var(--brand-navy), color-mix(in srgb, var(--brand-navy) 82%, var(--accent)))',
+              background:
+                'linear-gradient(135deg, var(--brand-navy), color-mix(in srgb, var(--brand-navy) 82%, var(--accent)))',
               boxShadow: '0 8px 20px rgba(13, 31, 58, 0.18)',
               color: 'var(--primary-foreground)',
               padding: '9px 13px 8px',
@@ -385,7 +424,10 @@ function QuestionRow({
                   lineHeight: 1.25,
                 }}
               >
-                <span aria-hidden style={{ color: 'var(--tri-amber)', fontSize: '0.8rem', lineHeight: 1 }}>
+                <span
+                  aria-hidden
+                  style={{ color: 'var(--tri-amber)', fontSize: '0.8rem', lineHeight: 1 }}
+                >
                   ✦
                 </span>
                 Bonus item
@@ -434,41 +476,70 @@ function QuestionRow({
           {badges.length > 0 ? (
             <div style={{ display: 'flex', flexWrap: 'wrap', gap: '6px', marginTop: '12px' }}>
               {badges.map((badge) => (
-              <span
-                key={badge.label}
-                style={{
-                  // Figma display/pill/sans — Georgia, 12px, title-case (not the
-                  // mono uppercase used elsewhere).
-                  fontFamily: 'Georgia, "Times New Roman", serif',
-                  fontSize: '0.675rem',
-                  lineHeight: 1.1,
-                  letterSpacing: '0.01em',
-                  borderRadius: '999px',
-                  border: '1px solid var(--border)',
-                  background: badge.tone === 'warning'
-                    ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
-                    : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
-                  color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
-                  opacity: 0.9,
-                  padding: '3px 9px',
-                }}
-              >
-                {badge.label}
-              </span>
+                <span
+                  key={badge.label}
+                  style={{
+                    // Figma display/pill/sans — Georgia, 12px, title-case (not the
+                    // mono uppercase used elsewhere).
+                    fontFamily: 'Georgia, "Times New Roman", serif',
+                    fontSize: '0.675rem',
+                    lineHeight: 1.1,
+                    letterSpacing: '0.01em',
+                    borderRadius: '999px',
+                    border: '1px solid var(--border)',
+                    background:
+                      badge.tone === 'warning'
+                        ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
+                        : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
+                    color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
+                    opacity: 0.9,
+                    padding: '3px 9px',
+                  }}
+                >
+                  {badge.label}
+                </span>
               ))}
             </div>
           ) : null}
         </div>
       </div>
-      {!faded && (onGiveUp || onDismiss) ? (
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: '14px', marginTop: '4px', paddingLeft: '2px' }}>
+      {!faded && (onGiveUp || onDismiss || onMutePresence) ? (
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: '14px',
+            marginTop: '4px',
+            paddingLeft: '2px',
+          }}
+        >
           {onGiveUp ? (
-            <button type="button" onClick={onGiveUp} disabled={giveUpDisabled} style={questionActionLinkStyle}>
+            <button
+              type="button"
+              onClick={onGiveUp}
+              disabled={giveUpDisabled}
+              style={questionActionLinkStyle}
+            >
               Show me the answer
             </button>
           ) : null}
+          {onMutePresence && presenceSourceName ? (
+            <button
+              type="button"
+              onClick={onMutePresence}
+              disabled={muteDisabled}
+              style={questionActionLinkStyle}
+            >
+              This is {firstNameFrom(presenceSourceName)}&rsquo;s bag but not mine
+            </button>
+          ) : null}
           {onDismiss ? (
-            <button type="button" onClick={onDismiss} disabled={dismissDisabled} style={questionActionLinkStyle}>
+            <button
+              type="button"
+              onClick={onDismiss}
+              disabled={dismissDisabled}
+              style={questionActionLinkStyle}
+            >
               Dismiss
             </button>
           ) : null}
@@ -520,7 +591,15 @@ function UserRow({ text }: { text: string }) {
   );
 }
 
-function BreadcrumbLine({ text, creatorName, creatorIsHouse = false }: { text: string; creatorName: string | null; creatorIsHouse?: boolean }) {
+function BreadcrumbLine({
+  text,
+  creatorName,
+  creatorIsHouse = false,
+}: {
+  text: string;
+  creatorName: string | null;
+  creatorIsHouse?: boolean;
+}) {
   const author = creatorName?.trim() ?? null;
   // House is non-relational like the LLM origin: no "From {firstName}." line.
   const isBot = creatorIsHouse || isLlmAttribution(author);
@@ -610,17 +689,28 @@ function RelationalFeedbackFade({ text }: { text: string }) {
 
 function reactionEmoji(value: string): string {
   switch (value) {
-    case ':exploding_head:': return '🤯';
-    case ':ok_hand:': return '👌';
-    case ':smirk:': return '😏';
-    case ':face_palm:': return '🤦';
-    case ':sunny:': return '☀️';
-    case ':thought_balloon:': return '💭';
-    case ':thinking_face:': return '🤔';
-    case ':open_book:': return '📖';
-    case ':memo:': return '📝';
-    case ':sweat_smile:': return '😅';
-    default: return value;
+    case ':exploding_head:':
+      return '🤯';
+    case ':ok_hand:':
+      return '👌';
+    case ':smirk:':
+      return '😏';
+    case ':face_palm:':
+      return '🤦';
+    case ':sunny:':
+      return '☀️';
+    case ':thought_balloon:':
+      return '💭';
+    case ':thinking_face:':
+      return '🤔';
+    case ':open_book:':
+      return '📖';
+    case ':memo:':
+      return '📝';
+    case ':sweat_smile:':
+      return '😅';
+    default:
+      return value;
   }
 }
 
@@ -647,29 +737,38 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
     return () => window.clearTimeout(timer);
   }, [status]);
 
-  const sendReaction = useCallback(async (reactionType: ReactionKey) => {
-    setStatus('sending');
-    try {
-      const response = await fetch('/api/reactions', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          questionId: prompt.questionId,
-          contextType: prompt.contextType,
-          contextId: prompt.contextId,
-          reactionType,
-          customMessage: customMessage.trim() || null,
-          includeSubmittedAnswer:
-            includeSubmittedAnswer && isWrongAnswerReactionKey(reactionType),
-        }),
-      });
-      if (!response.ok) throw new Error('Could not send reaction');
-      setStatus('sent');
-    } catch {
-      setStatus('error');
-    }
-  }, [customMessage, includeSubmittedAnswer, prompt.contextId, prompt.contextType, prompt.questionId]);
+  const sendReaction = useCallback(
+    async (reactionType: ReactionKey) => {
+      setStatus('sending');
+      try {
+        const response = await fetch('/api/reactions', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({
+            questionId: prompt.questionId,
+            contextType: prompt.contextType,
+            contextId: prompt.contextId,
+            reactionType,
+            customMessage: customMessage.trim() || null,
+            includeSubmittedAnswer:
+              includeSubmittedAnswer && isWrongAnswerReactionKey(reactionType),
+          }),
+        });
+        if (!response.ok) throw new Error('Could not send reaction');
+        setStatus('sent');
+      } catch {
+        setStatus('error');
+      }
+    },
+    [
+      customMessage,
+      includeSubmittedAnswer,
+      prompt.contextId,
+      prompt.contextType,
+      prompt.questionId,
+    ],
+  );
 
   if (status === 'hidden') return null;
 
@@ -683,7 +782,14 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
 
   return (
     <div style={{ marginTop: '10px', maxWidth: '100%' }}>
-      <p style={{ ...monoStyle, marginBottom: '6px', fontSize: '0.6rem', color: 'var(--text-muted)' }}>
+      <p
+        style={{
+          ...monoStyle,
+          marginBottom: '6px',
+          fontSize: '0.6rem',
+          color: 'var(--text-muted)',
+        }}
+      >
         React to {prompt.senderName}?
       </p>
       {customOpen ? (
@@ -725,7 +831,15 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
           Include what I wrote
         </label>
       ) : null}
-      <div style={{ display: 'flex', gap: '6px', maxWidth: '100%', overflowX: 'auto', paddingBottom: '3px' }}>
+      <div
+        style={{
+          display: 'flex',
+          gap: '6px',
+          maxWidth: '100%',
+          overflowX: 'auto',
+          paddingBottom: '3px',
+        }}
+      >
         {cannedSet.map((reaction) => (
           <button
             key={reaction.key}
@@ -746,7 +860,9 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
               cursor: status === 'sending' ? 'default' : 'pointer',
             }}
           >
-            <span aria-hidden style={{ marginRight: '5px' }}>{reactionEmoji(reaction.emoji)}</span>
+            <span aria-hidden style={{ marginRight: '5px' }}>
+              {reactionEmoji(reaction.emoji)}
+            </span>
             {reaction.label}
           </button>
         ))}
@@ -781,7 +897,15 @@ export function QuestionReactionPrompt({ prompt }: { prompt: ReactionPromptData 
   );
 }
 
-function AuthorNoteCard({ text, creatorName, creatorIsHouse = false }: { text: string; creatorName: string | null; creatorIsHouse?: boolean }) {
+function AuthorNoteCard({
+  text,
+  creatorName,
+  creatorIsHouse = false,
+}: {
+  text: string;
+  creatorName: string | null;
+  creatorIsHouse?: boolean;
+}) {
   return (
     <div
       style={{
@@ -898,7 +1022,9 @@ function ResultRow({
   recheckAction?: RecheckAction | null;
   openedTerritoryDomain?: string | null;
 }) {
-  const [recheckState, setRecheckState] = useState<'idle' | 'submitting' | 'done' | 'error'>('idle');
+  const [recheckState, setRecheckState] = useState<'idle' | 'submitting' | 'done' | 'error'>(
+    'idle',
+  );
   const [recheckMessage, setRecheckMessage] = useState<string | null>(null);
   const [recheckAccepted, setRecheckAccepted] = useState(false);
   const expired = result === 'expired';
@@ -926,33 +1052,36 @@ function ResultRow({
   // red "not quite"); neutral for expired/gave-up.
   const resultToneStyle: CSSProperties = expired
     ? {
-      background: 'var(--surface-2)',
-      border: '1px solid var(--border)',
-      borderLeft: '3px solid var(--border)',
-    }
+        background: 'var(--surface-2)',
+        border: '1px solid var(--border)',
+        borderLeft: '3px solid var(--border)',
+      }
     : correct
       ? {
-        // Figma Correct (#366045) — forest green, lighter card body than the
-        // vivid --success used elsewhere.
-        background: 'color-mix(in srgb, var(--game-correct) 6%, var(--surface))',
-        border: '1px solid color-mix(in srgb, var(--game-correct) 26%, var(--border))',
-        borderLeft: '3px solid var(--game-correct)',
-      }
+          // Figma Correct (#366045) — forest green, lighter card body than the
+          // vivid --success used elsewhere.
+          background: 'color-mix(in srgb, var(--game-correct) 6%, var(--surface))',
+          border: '1px solid color-mix(in srgb, var(--game-correct) 26%, var(--border))',
+          borderLeft: '3px solid var(--game-correct)',
+        }
       : gaveUp
         ? {
-          background: 'var(--surface-2)',
-          border: '1px solid var(--border)',
-          borderLeft: '3px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)',
-        }
+            background: 'var(--surface-2)',
+            border: '1px solid var(--border)',
+            borderLeft: '3px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)',
+          }
         : {
-          // Figma text/wrong (#c96b4a) body + game/wrong/in-question (#c33d14) bar.
-          background: 'color-mix(in srgb, var(--game-wrong) 12%, var(--surface))',
-          border: '1px solid color-mix(in srgb, var(--game-wrong) 30%, var(--border))',
-          borderLeft: '3px solid var(--game-wrong-strong)',
-        };
+            // Figma text/wrong (#c96b4a) body + game/wrong/in-question (#c33d14) bar.
+            background: 'color-mix(in srgb, var(--game-wrong) 12%, var(--surface))',
+            border: '1px solid color-mix(in srgb, var(--game-wrong) 30%, var(--border))',
+            borderLeft: '3px solid var(--game-wrong-strong)',
+          };
 
   return (
-    <div className="flex flex-col gap-0 pt-0.5" style={{ alignItems: 'flex-start', maxWidth: '88%' }}>
+    <div
+      className="flex flex-col gap-0 pt-0.5"
+      style={{ alignItems: 'flex-start', maxWidth: '88%' }}
+    >
       <div
         style={{
           ...resultToneStyle,
@@ -969,7 +1098,13 @@ function ResultRow({
           <span style={{ color: 'var(--text-muted)' }}>This one wasn&apos;t recorded in time.</span>
         ) : correct ? (
           <>
-            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--game-correct)', fontWeight: 600 }}>
+            <p
+              style={{
+                fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+                color: 'var(--game-correct)',
+                fontWeight: 600,
+              }}
+            >
               <span style={{ color: 'var(--game-correct)', marginRight: '6px' }}>✓</span>
               {copy.headline}
             </p>
@@ -978,7 +1113,9 @@ function ResultRow({
                 {correctAnswer}
               </p>
             ) : null}
-            {relationalFeedbackLine ? <RelationalFeedbackFade text={relationalFeedbackLine} /> : null}
+            {relationalFeedbackLine ? (
+              <RelationalFeedbackFade text={relationalFeedbackLine} />
+            ) : null}
           </>
         ) : gaveUp ? (
           <>
@@ -1007,7 +1144,13 @@ function ResultRow({
           </>
         ) : (
           <>
-            <p style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', color: 'var(--game-wrong-strong)', fontWeight: 600 }}>
+            <p
+              style={{
+                fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+                color: 'var(--game-wrong-strong)',
+                fontWeight: 600,
+              }}
+            >
               <span style={{ color: 'var(--game-wrong-strong)', marginRight: '6px' }}>✕</span>
               {wrongHeadline(copyVariant)}
             </p>
@@ -1023,19 +1166,40 @@ function ResultRow({
                 {correctAnswer}
               </p>
             ) : null}
-            <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '4px' }}>
+            <p
+              style={{
+                ...monoStyle,
+                fontSize: '0.55rem',
+                color: 'var(--text-muted)',
+                marginTop: '4px',
+              }}
+            >
               Now it&rsquo;s in yours too
             </p>
             {(() => {
               const namedSubLabel = wrongNamedSubLabel(creatorName, copyVariant, creatorIsHouse);
               return namedSubLabel ? (
-                <p style={{ ...monoStyle, fontSize: '0.6rem', color: 'var(--text-muted)', marginTop: '4px' }}>
+                <p
+                  style={{
+                    ...monoStyle,
+                    fontSize: '0.6rem',
+                    color: 'var(--text-muted)',
+                    marginTop: '4px',
+                  }}
+                >
                   {namedSubLabel}
                 </p>
               ) : null;
             })()}
             {consolation ? (
-              <p style={{ marginTop: '8px', fontSize: '0.88rem', color: 'var(--text-muted)', fontStyle: 'italic' }}>
+              <p
+                style={{
+                  marginTop: '8px',
+                  fontSize: '0.88rem',
+                  color: 'var(--text-muted)',
+                  fontStyle: 'italic',
+                }}
+              >
                 {consolation}
               </p>
             ) : null}
@@ -1050,7 +1214,10 @@ function ResultRow({
                     border: '1px solid var(--border)',
                     background: 'var(--surface)',
                     color: 'var(--text)',
-                    cursor: recheckState === 'submitting' || recheckState === 'done' ? 'default' : 'pointer',
+                    cursor:
+                      recheckState === 'submitting' || recheckState === 'done'
+                        ? 'default'
+                        : 'pointer',
                     fontFamily: 'var(--font-mono)',
                     fontSize: '0.58rem',
                     letterSpacing: '0.06em',
@@ -1071,7 +1238,8 @@ function ResultRow({
                         alignItems: 'center',
                         gap: '8px',
                         borderRadius: 'var(--radius-md)',
-                        border: '1px solid color-mix(in srgb, var(--game-correct) 35%, var(--border))',
+                        border:
+                          '1px solid color-mix(in srgb, var(--game-correct) 35%, var(--border))',
                         background: 'color-mix(in srgb, var(--game-correct) 12%, var(--surface))',
                         color: 'var(--game-correct)',
                         padding: '8px 12px',
@@ -1080,11 +1248,22 @@ function ResultRow({
                         lineHeight: 1.35,
                       }}
                     >
-                      <span aria-hidden style={{ fontSize: '1rem', lineHeight: 1 }}>✓</span>
+                      <span aria-hidden style={{ fontSize: '1rem', lineHeight: 1 }}>
+                        ✓
+                      </span>
                       <span>{recheckMessage}</span>
                     </div>
                   ) : (
-                    <p role="status" aria-live="polite" style={{ marginTop: '6px', fontSize: '0.78rem', color: recheckState === 'error' ? 'var(--danger)' : 'var(--text-muted)', lineHeight: 1.35 }}>
+                    <p
+                      role="status"
+                      aria-live="polite"
+                      style={{
+                        marginTop: '6px',
+                        fontSize: '0.78rem',
+                        color: recheckState === 'error' ? 'var(--danger)' : 'var(--text-muted)',
+                        lineHeight: 1.35,
+                      }}
+                    >
                       {recheckMessage}
                     </p>
                   )
@@ -1093,11 +1272,24 @@ function ResultRow({
             ) : null}
           </>
         )}
-        {breadcrumb
-          ? <BreadcrumbLine text={breadcrumb} creatorName={creatorName} creatorIsHouse={creatorIsHouse} />
-          : explanation ? <ExplanationLine text={explanation} /> : null}
+        {breadcrumb ? (
+          <BreadcrumbLine
+            text={breadcrumb}
+            creatorName={creatorName}
+            creatorIsHouse={creatorIsHouse}
+          />
+        ) : explanation ? (
+          <ExplanationLine text={explanation} />
+        ) : null}
         {typeof pointsAwarded === 'number' ? (
-          <p style={{ ...monoStyle, fontSize: '0.55rem', color: 'var(--text-muted)', marginTop: '10px' }}>
+          <p
+            style={{
+              ...monoStyle,
+              fontSize: '0.55rem',
+              color: 'var(--text-muted)',
+              marginTop: '10px',
+            }}
+          >
             +{pointsAwarded} {pointsAwarded === 1 ? 'point' : 'points'}
             {pointsLabel ? ` - ${pointsLabel}` : ''}
           </p>
@@ -1138,7 +1330,13 @@ function ResultRow({
           </p>
         </div>
       ) : null}
-      {authorNote ? <AuthorNoteCard text={authorNote} creatorName={creatorName} creatorIsHouse={creatorIsHouse} /> : null}
+      {authorNote ? (
+        <AuthorNoteCard
+          text={authorNote}
+          creatorName={creatorName}
+          creatorIsHouse={creatorIsHouse}
+        />
+      ) : null}
       {correct && openedTerritoryDomain ? (
         <NewTerritoryUndo domain={openedTerritoryDomain} category={canonicalSubcategory} />
       ) : null}
@@ -1245,7 +1443,11 @@ function SessionCompleteRow({
         <Link
           href={detailsHref}
           className="mt-2 inline-flex text-sm"
-          style={{ color: 'var(--text-muted)', textDecoration: 'underline', textUnderlineOffset: '2px' }}
+          style={{
+            color: 'var(--text-muted)',
+            textDecoration: 'underline',
+            textUnderlineOffset: '2px',
+          }}
         >
           Game details
         </Link>
@@ -1296,7 +1498,9 @@ function BonusOfferRow({
       >
         {available} more {available === 1 ? 'question' : 'questions'} in the pool.
       </p>
-      <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>Untimed. Counts toward your score.</p>
+      <p className="mt-1 text-sm" style={{ color: 'var(--text-muted)' }}>
+        Untimed. Counts toward your score.
+      </p>
       <div style={{ display: 'flex', gap: '0.6rem', marginTop: '1rem', flexWrap: 'wrap' }}>
         <button type="button" className="btn-primary" onClick={onAccept}>
           Keep going
@@ -1315,12 +1519,17 @@ export function GameplayChatThread({
   giveUpDisabled,
   onDismiss,
   dismissDisabled,
+  onMutePresence,
+  muteDisabled,
 }: {
   messages: ChatMessage[];
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
   onDismiss?: () => void;
   dismissDisabled?: boolean;
+  // Bonus-slot opt-out (D-4 §B). Wired only to the active bonus question.
+  onMutePresence?: () => void;
+  muteDisabled?: boolean;
 }) {
   // "Show me the answer" and "Dismiss" belong only under the active (still-
   // unanswered) question — the last question message with no result after it.
@@ -1362,6 +1571,12 @@ export function GameplayChatThread({
                 giveUpDisabled={giveUpDisabled}
                 onDismiss={onDismiss && m.id === activeQuestionId ? onDismiss : undefined}
                 dismissDisabled={dismissDisabled}
+                onMutePresence={
+                  onMutePresence && m.id === activeQuestionId && m.presenceSourceName
+                    ? onMutePresence
+                    : undefined
+                }
+                muteDisabled={muteDisabled}
               />
             );
           case 'user':

--- a/src/server/daily/__tests__/friend-presence-domains.visibility.test.ts
+++ b/src/server/daily/__tests__/friend-presence-domains.visibility.test.ts
@@ -7,24 +7,29 @@ import type { SectionVisibility } from '@/server/profile/visibility';
 // the profile enforces. These tests exercise the DB-backed
 // `getFriendDomainsForBonus` with the REAL `canViewSection` predicate, mocking
 // only the data-fetching helpers it composes.
-const { getFollowingMock, getMutualFollowsMock, getKnowledgePageDataMock, getSectionVisibilitiesMock, state } =
-  vi.hoisted(() => {
-    const state = {
-      // friendId -> that friend's knowledge_base section visibility.
-      sectionByFriend: new Map<string, SectionVisibility>(),
-    };
-    return {
-      getFollowingMock: vi.fn(),
-      getMutualFollowsMock: vi.fn(async () => [] as Array<{ id: string }>),
-      getKnowledgePageDataMock: vi.fn(),
-      getSectionVisibilitiesMock: vi.fn(async (userId: string) => ({
-        knowledge_base: state.sectionByFriend.get(userId) ?? 'public',
-        friends_list: 'friends' as SectionVisibility,
-        authored_questions: 'public' as SectionVisibility,
-      })),
-      state,
-    };
-  });
+const {
+  getFollowingMock,
+  getMutualFollowsMock,
+  getKnowledgePageDataMock,
+  getSectionVisibilitiesMock,
+  state,
+} = vi.hoisted(() => {
+  const state = {
+    // friendId -> that friend's knowledge_base section visibility.
+    sectionByFriend: new Map<string, SectionVisibility>(),
+  };
+  return {
+    getFollowingMock: vi.fn(),
+    getMutualFollowsMock: vi.fn(async () => [] as Array<{ id: string }>),
+    getKnowledgePageDataMock: vi.fn(),
+    getSectionVisibilitiesMock: vi.fn(async (userId: string) => ({
+      knowledge_base: state.sectionByFriend.get(userId) ?? 'public',
+      friends_list: 'friends' as SectionVisibility,
+      authored_questions: 'public' as SectionVisibility,
+    })),
+    state,
+  };
+});
 
 vi.mock('@/server/db/queries/friends', () => ({
   getFollowing: getFollowingMock,
@@ -126,5 +131,28 @@ describe('getFriendDomainsForBonus — knowledge_base section visibility gate', 
 
     const result = await getFriendDomainsForBonus('viewer', 2);
     expect(result.map((c) => c.domain)).toEqual(['pub-domain']);
+  });
+});
+
+describe('getFriendDomainsForBonus — resting-domain opt-out', () => {
+  it('drops a rested domain from the +2 pool ("This is {Name}’s bag but not mine")', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'pub', displayName: 'Pub' }]);
+    state.sectionByFriend.set('pub', 'public');
+    // The viewer parked this exact friend-presence domain in "Resting".
+    const result = await getFriendDomainsForBonus('viewer', 2, new Set(['pub-domain']));
+    expect(result).toEqual([]);
+  });
+
+  it('matches rested domains case-insensitively and keeps the non-rested ones', async () => {
+    getFollowingMock.mockResolvedValue([{ id: 'pub', displayName: 'Pub' }]);
+    state.sectionByFriend.set('pub', 'public');
+    getKnowledgePageDataMock.mockImplementation(async () => ({
+      allDomains: [territoryDomain('Jazz'), territoryDomain('Opera')],
+      declaredInterests: [],
+      expandingDomains: [],
+    }));
+    // 'JAZZ' rested (different case) should still be excluded; 'Opera' remains.
+    const result = await getFriendDomainsForBonus('viewer', 2, new Set(['jazz']));
+    expect(result.map((c) => c.domain)).toEqual(['Opera']);
   });
 });

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -22,14 +22,22 @@ import {
   generateBonusQuestionsForDomains,
   generateDailyQuestionsFromKnowledgeBase,
 } from '@/server/daily/generate-questions';
-import { DAILY_BONUS_SLOT_MAX, DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import {
+  DAILY_BONUS_SLOT_MAX,
+  DAILY_QUEUE_MIN_SIZE,
+  DAILY_QUEUE_SIZE,
+  type QueueSlot,
+} from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { commitPendingRefineDecisions } from '@/server/refine/commit';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
 
 export class DailyQueueFillError extends Error {
-  constructor(readonly code: DailyQueueFillErrorCode, message: string) {
+  constructor(
+    readonly code: DailyQueueFillErrorCode,
+    message: string,
+  ) {
     super(message);
     this.name = 'DailyQueueFillError';
   }
@@ -190,9 +198,12 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   );
 
   const remaining = DAILY_QUEUE_SIZE - authored.length - housePicks.length;
-  const generated = remaining > 0
-    ? await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(remaining), { firstRun: isFirstRun })
-    : [];
+  const generated =
+    remaining > 0
+      ? await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(remaining), {
+          firstRun: isFirstRun,
+        })
+      : [];
 
   // Cross-source dedup by normalized question text. The authored picker
   // dedupes by question_id against past queues, and the generator has its
@@ -253,14 +264,21 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   const topUpGenerated: typeof dedupedGenerated = [];
   let topUpRounds = 0;
   while (
-    DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length) > 0 &&
+    DAILY_QUEUE_SIZE -
+      (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length) >
+      0 &&
     topUpRounds < MAX_TOP_UP_ROUNDS &&
     Date.now() - startedAt < TOP_UP_TIME_BUDGET_MS
   ) {
     topUpRounds += 1;
     const roundShortfall =
-      DAILY_QUEUE_SIZE - (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length);
-    const extra = await generateDailyQuestionsFromKnowledgeBase(userId, overRequest(roundShortfall), { firstRun: isFirstRun });
+      DAILY_QUEUE_SIZE -
+      (authored.length + housePicks.length + dedupedGenerated.length + topUpGenerated.length);
+    const extra = await generateDailyQuestionsFromKnowledgeBase(
+      userId,
+      overRequest(roundShortfall),
+      { firstRun: isFirstRun },
+    );
     let recoveredThisRound = 0;
     for (const question of extra) {
       if (isGenericSubcategory(question.canonicalSubcategory)) {
@@ -381,7 +399,10 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   // fewer slots (graceful shrink), yielding a 5–7 slot queue. The +2 serves only
   // fresh questions — never a friend's literal answered question (those live
   // behind the Lately milestone click-through, D-4 §A).
-  const bonusDomains = await getFriendDomainsForBonus(userId, DAILY_BONUS_SLOT_MAX);
+  // Resting domains are excluded from the +2 pool too, so "This is {Name}'s bag
+  // but not mine" (which parks the domain in Resting) stops it surfacing as a
+  // bonus, not just in the core five.
+  const bonusDomains = await getFriendDomainsForBonus(userId, DAILY_BONUS_SLOT_MAX, restingDomains);
   if (bonusDomains.length > 0) {
     const presenceByDomain = new Map(
       bonusDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
@@ -392,7 +413,12 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     );
     for (const { domain, question } of generatedBonus) {
       const candidate = presenceByDomain.get(domain.toLowerCase());
-      await createDailyQueueItemFromPresence(userId, question.id, toBonusPresence(candidate), position);
+      await createDailyQueueItemFromPresence(
+        userId,
+        question.id,
+        toBonusPresence(candidate),
+        position,
+      );
       position += 1;
     }
   }

--- a/src/server/db/queries/friend-presence-domains.ts
+++ b/src/server/db/queries/friend-presence-domains.ts
@@ -116,7 +116,10 @@ export function rankFriendDomainsForBonus(
     acc.anyTerritory ||= c.inTerritory;
     acc.anyActivity ||= c.inActivity;
     if (c.broadCategory && !acc.broadCategory) acc.broadCategory = c.broadCategory;
-    if (c.lastActivityAt != null && (acc.lastActivityAt == null || c.lastActivityAt > acc.lastActivityAt)) {
+    if (
+      c.lastActivityAt != null &&
+      (acc.lastActivityAt == null || c.lastActivityAt > acc.lastActivityAt)
+    ) {
       acc.lastActivityAt = c.lastActivityAt;
     }
     if (c.strength > acc.strength) acc.strength = c.strength;
@@ -205,6 +208,12 @@ function activityMs(lastActivityAt: string | null): number | null {
 export async function getFriendDomainsForBonus(
   viewerUserId: string,
   limit: number,
+  // Lowercased domains the viewer parked in "Resting" ("won't be asked"). A
+  // rested domain is dropped from the bonus pool BEFORE ranking/limiting, so the
+  // opt-out ("This is {Name}'s bag but not mine") holds for the +2 the same way
+  // it already does for the core five — and we still surface up to `limit`
+  // non-rested friend domains rather than letting a rested one consume a slot.
+  excludeDomains: ReadonlySet<string> = new Set(),
 ): Promise<FriendDomainCandidate[]> {
   if (limit <= 0) return [];
 
@@ -218,9 +227,7 @@ export async function getFriendDomainsForBonus(
 
   const perFriend = await Promise.all(
     following.map(async (friend) => {
-      const effectiveViewer: EffectiveViewer = mutualIds.has(friend.id)
-        ? 'friend'
-        : 'stranger';
+      const effectiveViewer: EffectiveViewer = mutualIds.has(friend.id) ? 'friend' : 'stranger';
       const sectionSettings = await getSectionVisibilities(friend.id);
       if (!canViewSection(sectionSettings, 'knowledge_base', effectiveViewer)) {
         return [] as FriendDomainContribution[];
@@ -235,6 +242,7 @@ export async function getFriendDomainsForBonus(
 
       const contributions: FriendDomainContribution[] = [];
       for (const domain of allDomains) {
+        if (excludeDomains.has(domain.domain.toLowerCase())) continue;
         const inTerritory = isTerritoryDomain(domain);
         const inActivity = !domain.isHidden && activityDomains.has(domain.domain.toLowerCase());
         if (!inTerritory && !inActivity) continue;


### PR DESCRIPTION
## Summary
Implements the "This is {Name}'s bag but not mine" action for bonus slots, allowing users to rest a friend's domain and close the bonus question. This is part of the Daily Five +2 bonus feature (D-4 §B).

## Key Changes

**GameplayChat component (`src/components/play/GameplayChat.tsx`)**
- Added `onMutePresence` and `muteDisabled` parameters to `QuestionRow` component
- Renders a new action button "This is {firstName}'s bag but not mine" for bonus slots with presence attribution
- Button uses `firstNameFrom()` helper to extract first name from creator name
- Integrated into the action button row alongside "Show me the answer" and "Dismiss"
- Extensive code formatting improvements (multi-line object/function signatures, switch statement formatting)

**Daily page (`src/app/daily/page.tsx`)**
- Added `mutePresenceSlot` callback to handle resting a domain via the mute-presence action
- Marks the slot as skipped with a domain-specific message: "Resting {category}. You won't see these in your five."
- Passes `onMutePresence` and `muteDisabled` to `QuestionRow` for bonus slots only
- Updated skip message logic to distinguish between regular skips ("We'll bring it back later") and rested bonus slots
- Removed "Grading..." indicator for "show me the answer" (give-up) since it's not a graded submission
- Improved code formatting throughout

**Friend presence domains (`src/server/db/queries/friend-presence-domains.ts`)**
- Added `restingDomains` parameter to `getFriendDomainsForBonus()` to filter out rested domains
- Implements case-insensitive domain matching for rested domains
- Excludes rested domains from the +2 bonus pool

**Queue orchestrator (`src/server/daily/queue-orchestrator.ts`)**
- Passes rested domains from user preferences to `getFriendDomainsForBonus()`
- Ensures rested domains don't resurface in future bonus slot generation

**Tests (`src/server/daily/__tests__/friend-presence-domains.visibility.test.ts`)**
- Added test suite for resting-domain opt-out behavior
- Verifies rested domains are dropped from the bonus pool
- Tests case-insensitive domain matching

## Implementation Details

- The mute-presence action is bonus-slot-only (presence_source_name must be set)
- Resting a domain is permanent per user (stored in user preferences)
- The action closes the bonus question immediately (marks as skipped)
- Domain matching is case-insensitive to handle variations in how domains are stored/displayed
- Code formatting changes align with project style conventions (multi-line function signatures, switch statement formatting)

https://claude.ai/code/session_01LASEPcZ9YE4ChiXkmrrEWw