### PR TITLE
Normalize domain names to canonical keys for consistent counting

### DIFF
--- a/src/server/daily/__tests__/custom-domain-order.test.ts
+++ b/src/server/daily/__tests__/custom-domain-order.test.ts
@@ -1,5 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { domainKey } from '@/lib/knowledge/domain-key';
+
 // generate-questions.ts imports @/server/db, which throws at module load
 // without a connection string. The helper under test never touches the DB;
 // a dummy URL plus dynamic import (the repo convention) keeps the unit pure.
@@ -12,7 +14,9 @@ beforeAll(async () => {
 
 describe('orderCustomDomainsByLeastRecent', () => {
   it('puts the least-recently-generated domains first', () => {
-    // Mirrors the affected account: deep mined domains vs fresh picks.
+    // Mirrors the affected account: deep mined domains vs fresh picks. The count
+    // map is keyed by domainKey() (matching getRecentDomainCounts), so build the
+    // keys with the same fold the production code uses.
     const domains = [
       "Wagner's Ring Cycle",
       'Shakespearean Tragedy',
@@ -21,11 +25,11 @@ describe('orderCustomDomainsByLeastRecent', () => {
       'T.S. Eliot',
     ];
     const counts = new Map<string, number>([
-      ["Wagner's Ring Cycle", 12],
-      ['Shakespearean Tragedy', 15],
-      ['Classic Broadway Musicals (1940s-1960s)', 0],
-      ['Animated Television Series (1970s-1980s)', 0],
-      ['T.S. Eliot', 2],
+      [domainKey("Wagner's Ring Cycle"), 12],
+      [domainKey('Shakespearean Tragedy'), 15],
+      [domainKey('Classic Broadway Musicals (1940s-1960s)'), 0],
+      [domainKey('Animated Television Series (1970s-1980s)'), 0],
+      [domainKey('T.S. Eliot'), 2],
     ]);
 
     const ordered = orderCustomDomainsByLeastRecent(domains, counts);
@@ -42,10 +46,22 @@ describe('orderCustomDomainsByLeastRecent', () => {
     ]);
   });
 
+  it('collapses spelling variants onto one canonical count', () => {
+    // The generation history recorded a curly-apostrophe spelling, while the
+    // user's selected domain uses the straight apostrophe. Both fold to the same
+    // domainKey, so the mined count must apply to the selected variant and sink
+    // it below a genuinely fresh domain.
+    const ordered = orderCustomDomainsByLeastRecent(
+      ["90's Hip-Hop", 'Bebop'],
+      new Map([[domainKey('90’s Hip-Hop'), 9]]),
+    );
+    expect(ordered).toEqual(['Bebop', "90's Hip-Hop"]);
+  });
+
   it('treats a domain absent from the counts map as count 0 (fresh)', () => {
     const ordered = orderCustomDomainsByLeastRecent(
       ['Mined', 'NeverGenerated'],
-      new Map([['Mined', 7]]),
+      new Map([[domainKey('Mined'), 7]]),
     );
     expect(ordered).toEqual(['NeverGenerated', 'Mined']);
   });

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -37,6 +37,7 @@ import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
 import { planFirstRunDomains } from '@/server/daily/first-run-seeding';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
+import { domainKey } from '@/lib/knowledge/domain-key';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { normalizeFactKey } from '@/server/questions/fact-key';
@@ -1195,8 +1196,13 @@ export function orderCustomDomainsByLeastRecent(
   domains: string[],
   recentDomainCounts: ReadonlyMap<string, number>,
 ): string[] {
+  // recentDomainCounts is keyed by domainKey() (see getRecentDomainCounts), so
+  // fold each domain to the same canonical key before looking up its count —
+  // otherwise spelling variants miss the bucket and read as fresh (count 0).
   return [...domains].sort(
-    (a, b) => (recentDomainCounts.get(a) ?? 0) - (recentDomainCounts.get(b) ?? 0),
+    (a, b) =>
+      (recentDomainCounts.get(domainKey(a)) ?? 0) -
+      (recentDomainCounts.get(domainKey(b)) ?? 0),
   );
 }
 
@@ -1208,8 +1214,10 @@ function selectDiverseDomains(
   // Apply the soft cap: drop any domain that has already produced
   // DOMAIN_PER_WEEK_CAP questions in the last 7 days. If every domain is
   // over cap, fall back to the full set rather than starve the queue.
+  // recentCounts is keyed by domainKey() (see getRecentDomainCounts); fold the
+  // KB domain to the same key so spelling variants share one weekly tally.
   const overCap = (d: { domain: string }): boolean =>
-    (recentCounts.get(d.domain) ?? 0) >= DOMAIN_PER_WEEK_CAP;
+    (recentCounts.get(domainKey(d.domain)) ?? 0) >= DOMAIN_PER_WEEK_CAP;
   const eligibleKb = knowledgeBase.some((d) => !overCap(d))
     ? knowledgeBase.filter((d) => !overCap(d))
     : knowledgeBase;

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -39,6 +39,7 @@ import {
 } from '@/server/play/catch-up-turn-sequencing';
 import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import { domainKey } from '@/lib/knowledge/domain-key';
 
 function asQueueSlotDifficulty(
   value: string | null | undefined,
@@ -1516,6 +1517,14 @@ export async function pickBankSource(
 // to a lookback window. Used by `selectDiverseDomains` to deprioritise
 // over-saturated domains so a user with 10 active interests doesn't see
 // the same 2-3 domains every day.
+//
+// The map is keyed by domainKey() — the same apostrophe-folded, whitespace-
+// collapsed, lowercased key the knowledge/mastery code uses — so that spelling
+// variants of one subcategory ("90's Hip-Hop" / "90’s Hip-Hop", "T.S. Eliot" /
+// "T. S. Eliot", "Jazz" / "jazz") collapse into a single bucket. Without this
+// fold each variant counts separately, so the weekly cap and least-recent
+// ordering treat them as distinct domains and the cooldown silently leaks.
+// Callers must look up with domainKey(domain) to match.
 export async function getRecentDomainCounts(
   userId: string,
   lookbackDays = 7,
@@ -1533,9 +1542,13 @@ export async function getRecentDomainCounts(
     ))
     .groupBy(generatedQuestions.canonicalSubcategory);
 
+  // SQL groups by the raw column, so two spelling variants arrive as separate
+  // rows; sum them into the one canonical key here.
   const result = new Map<string, number>();
   for (const row of rows) {
-    if (row.domain) result.set(row.domain, Number(row.count) || 0);
+    if (!row.domain) continue;
+    const key = domainKey(row.domain);
+    result.set(key, (result.get(key) ?? 0) + (Number(row.count) || 0));
   }
   return result;
 }


### PR DESCRIPTION
## Summary
Fixes a bug where spelling variants of domain names (e.g., "90's Hip-Hop" vs "90's Hip-Hop" with curly apostrophe, "T.S. Eliot" vs "T. S. Eliot") were counted separately instead of being collapsed into a single bucket. This caused the weekly domain cap and least-recent ordering to silently leak across variants.

## Changes
- **`src/server/db/queries/daily.ts`**: Updated `getRecentDomainCounts()` to normalize domain names using `domainKey()` before storing in the result map. Added documentation explaining that the map is keyed by the canonical folded key (apostrophe-normalized, whitespace-collapsed, lowercased) to match the knowledge/mastery code's behavior. Now sums counts for spelling variants into a single canonical bucket.

- **`src/server/daily/generate-questions.ts`**: 
  - Updated `orderCustomDomainsByLeastRecent()` to look up domains using `domainKey()` before querying the counts map, ensuring spelling variants are matched against the correct bucket.
  - Updated `selectDiverseDomains()` to normalize domain names with `domainKey()` when checking the weekly cap, so variants share one tally.

- **`src/server/daily/__tests__/custom-domain-order.test.ts`**: 
  - Added import of `domainKey` from `@/lib/knowledge/domain-key`.
  - Updated existing test to build the counts map using `domainKey()` on all domain names, matching production behavior.
  - Added new test case `'collapses spelling variants onto one canonical count'` that verifies a curly-apostrophe variant in the history is correctly matched against a straight-apostrophe variant in the selected domains, causing the mined count to apply and sink it below a fresh domain.

## Implementation Details
- The `domainKey()` function (already used by knowledge/mastery code) provides the canonical normalization: apostrophe folding, whitespace collapsing, and lowercasing.
- `getRecentDomainCounts()` now aggregates multiple rows with the same canonical key (from SQL's raw column grouping) into a single map entry.
- All callers of `getRecentDomainCounts()` must now look up with `domainKey(domain)` to match the keying scheme.
- Documentation added to clarify the keying contract and why it matters for the cooldown mechanism.

https://claude.ai/code/session_0166b32LvWjvQCqvxvJKJ7Yp