### PR TITLE
Add report actions to answered questions list (B-Report-2)

### DIFF
--- a/src/app/api/content-reports/route.ts
+++ b/src/app/api/content-reports/route.ts
@@ -30,7 +30,7 @@ const incorrectSchema = z.object({
   incorrectKind: z.enum(['answer_key', 'premise']),
   note: z.string().trim().min(1),
   suggestedAnswer: z.string().trim().min(1).optional(),
-  surface: z.enum(['round_recap', 'lately_result']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list']),
   ...target,
 });
 
@@ -42,7 +42,7 @@ const inappropriateSchema = z.object({
   incorrectKind: z.undefined().optional(),
   suggestedAnswer: z.undefined().optional(),
   note: z.string().trim().min(1),
-  surface: z.enum(['round_recap', 'lately_result']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list']),
   ...target,
 });
 

--- a/src/app/api/questions/answered/route.ts
+++ b/src/app/api/questions/answered/route.ts
@@ -27,6 +27,7 @@ export async function GET() {
     authorIsHouse: item.authorIsHouse,
     answeredAt: item.answeredAt,
     sourceLabel: item.sourceLabel,
+    reportTarget: item.reportTarget,
   }));
 
   return NextResponse.json({ items, nextCursor: archive.nextCursor });

--- a/src/components/questions/AnsweredQuestionsList.tsx
+++ b/src/components/questions/AnsweredQuestionsList.tsx
@@ -3,6 +3,7 @@
 import { answerHeadingStyle } from '@/components/answer-heading';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
+import { AnsweredRowActions } from '@/components/questions/AnsweredRowActions';
 
 export type AnsweredQuestionItem = {
   id: string;
@@ -16,6 +17,12 @@ export type AnsweredQuestionItem = {
   authorIsHouse: boolean;
   answeredAt: string | null;
   sourceLabel: string;
+  // B-Report-2: the content row to flag from the ⋯ menu. Null when there's no
+  // reportable row (a synthetic daily slot), in which case the menu is hidden.
+  reportTarget:
+    | { questionId: string; generatedQuestionId?: undefined }
+    | { generatedQuestionId: string; questionId?: undefined }
+    | null;
 };
 
 const DATE_FORMAT = new Intl.DateTimeFormat('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
@@ -107,7 +114,7 @@ export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[]
               <div className="hidden text-sm text-muted-foreground sm:block">
                 {formatDate(item.answeredAt)}
               </div>
-              <div className="hidden sm:flex sm:justify-end">
+              <div className="hidden sm:flex sm:justify-end sm:gap-2">
                 <SendQuestionAction
                   question={{
                     id: item.questionId,
@@ -117,8 +124,9 @@ export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[]
                   label=""
                   className="inline-flex size-9 items-center justify-center rounded-md border text-muted-foreground hover:bg-muted hover:text-foreground"
                 />
+                {item.reportTarget ? <AnsweredRowActions target={item.reportTarget} /> : null}
               </div>
-              <div className="sm:hidden">
+              <div className="flex items-center gap-2 sm:hidden">
                 <SendQuestionAction
                   question={{
                     id: item.questionId,
@@ -126,6 +134,7 @@ export function AnsweredQuestionsList({ items }: { items: AnsweredQuestionItem[]
                     domain: item.domainDisplayName,
                   }}
                 />
+                {item.reportTarget ? <AnsweredRowActions target={item.reportTarget} /> : null}
               </div>
             </li>
           );

--- a/src/components/questions/AnsweredRowActions.tsx
+++ b/src/components/questions/AnsweredRowActions.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { MoreHorizontal, X } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
+
+import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet';
+
+// B-Report-2: the per-row ⋯ menu on the Answered list. Mirrors the daily-summary
+// recap card — open the menu, pick "This is incorrect" / "This is inappropriate",
+// then land in the shared ReportReasonSheet (surface 'answered_list'). The target
+// is the row's reportTarget; rows with no reportable row (synthetic daily slots)
+// don't render this menu at all.
+export function AnsweredRowActions({ target }: { target: ReportReasonTarget }) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null);
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!isMenuOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsMenuOpen(false);
+    };
+    document.addEventListener('keydown', onKey);
+    return () => document.removeEventListener('keydown', onKey);
+  }, [isMenuOpen]);
+
+  return (
+    <div className="relative" ref={menuRef}>
+      <button
+        type="button"
+        aria-label="More actions"
+        aria-haspopup="menu"
+        aria-expanded={isMenuOpen}
+        onClick={() => setIsMenuOpen((current) => !current)}
+        className="inline-flex size-9 items-center justify-center rounded-md border text-muted-foreground transition hover:bg-muted hover:text-foreground"
+      >
+        <MoreHorizontal className="size-4" />
+      </button>
+
+      {isMenuOpen ? (
+        <div
+          className="fixed inset-0 z-[55] flex items-end justify-center px-3 pt-16 pb-3 sm:items-start sm:pt-24"
+          style={{ background: 'rgba(0,0,0,0.2)' }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close menu"
+            onClick={() => setIsMenuOpen(false)}
+          />
+          <div
+            role="menu"
+            aria-label="More actions"
+            className="bg-background relative w-full max-w-md rounded-3xl border p-2 shadow-2xl sm:w-64 sm:rounded-2xl sm:shadow-xl"
+          >
+            <div className="flex items-center justify-between px-3 py-2 sm:hidden">
+              <p className="text-foreground text-sm font-medium">More actions</p>
+              <button
+                type="button"
+                aria-label="Close menu"
+                onClick={() => setIsMenuOpen(false)}
+                className="text-muted-foreground hover:bg-muted hover:text-foreground inline-flex size-11 items-center justify-center rounded-full"
+              >
+                <X className="size-4" />
+              </button>
+            </div>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsMenuOpen(false);
+                setReportCategory('incorrect');
+              }}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is incorrect
+            </button>
+            <button
+              type="button"
+              role="menuitem"
+              onClick={() => {
+                setIsMenuOpen(false);
+                setReportCategory('inappropriate');
+              }}
+              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-11 w-full items-center rounded-xl px-3 text-left text-sm transition"
+            >
+              This is inappropriate
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {reportCategory ? (
+        <ReportReasonSheet
+          category={reportCategory}
+          target={target}
+          surface="answered_list"
+          onClose={() => setReportCategory(null)}
+          onSubmitted={() => setReportCategory(null)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/components/report/ReportReasonSheet.tsx
+++ b/src/components/report/ReportReasonSheet.tsx
@@ -28,7 +28,7 @@ export function ReportReasonSheet({
 }: {
   category: ReportCategory
   target: ReportReasonTarget
-  surface: 'round_recap' | 'lately_result'
+  surface: 'round_recap' | 'lately_result' | 'answered_list'
   onClose: () => void
   // Fires once on a successful submit (including an idempotent duplicate). For
   // 'inappropriate' the parent removes the card from view; for 'incorrect' the card

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -40,6 +40,16 @@ export type ArchiveItem = {
   verified: boolean;
   askerName: string;
   authorIsHouse: boolean;
+  /**
+   * B-Report-2: which content table this row points at, for a ContentReport.
+   * Exactly one id is set — curated questions carry `questionId`, LLM-origin
+   * questions carry `generatedQuestionId`. Null only for the synthetic-fallback
+   * daily slot (no real row to report), in which case the ⋯ report items hide.
+   */
+  reportTarget:
+    | { questionId: string; generatedQuestionId?: undefined }
+    | { generatedQuestionId: string; questionId?: undefined }
+    | null;
 };
 
 export type ArchiveKind = 'all' | 'answered';
@@ -225,6 +235,11 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
           verified: bankQuestion?.verified ?? true,
           askerName: authored.authorName ?? askerDisplay ?? (generated ? LLM_QUESTION_ATTRIBUTION : ''),
           authorIsHouse: authored.authorIsHouse,
+          reportTarget: slot.question_id
+            ? { questionId: slot.question_id }
+            : slot.generated_question_id
+              ? { generatedQuestionId: slot.generated_question_id }
+              : null,
         } satisfies ArchiveItem;
       }),
   );
@@ -302,6 +317,7 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       // resolve a real name via the creatorUser left join.
       askerName: creatorUser?.displayName ?? LLM_QUESTION_ATTRIBUTION,
       authorIsHouse: false,
+      reportTarget: { questionId: question.id },
     } satisfies ArchiveItem;
   });
 }
@@ -344,6 +360,7 @@ async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
       verified: question.verified,
       askerName: creatorUser?.displayName ?? '',
       authorIsHouse: false,
+      reportTarget: { questionId: question.id },
     } satisfies ArchiveItem;
   });
 }
@@ -399,6 +416,7 @@ async function readWrittenByMeItems(userId: string): Promise<ArchiveItem[]> {
       verified: question.verified,
       askerName: '',
       authorIsHouse: false,
+      reportTarget: { questionId: question.id },
     } satisfies ArchiveItem;
   });
 }


### PR DESCRIPTION
## Summary
Implements the per-row "more actions" menu on the Answered questions list, allowing users to report questions as incorrect or inappropriate. This mirrors the existing report flow from the daily-summary recap card and routes through the shared `ReportReasonSheet` component.

## Changes

- **New component:** `AnsweredRowActions` — a dropdown menu button that opens a modal with "This is incorrect" and "This is inappropriate" options. Keyboard-dismissible (Escape key) and responsive (full-width on mobile, compact on desktop).

- **Database query updates:** Extended `ArchiveItem` type with `reportTarget` field that tracks which content table a row points to:
  - `{ questionId }` for curated questions
  - `{ generatedQuestionId }` for LLM-origin questions  
  - `null` for synthetic daily slots (no reportable row)
  - Updated `readDailyItems`, `readFeedItems`, `readJoshingGameItems`, and `readWrittenByMeItems` to populate this field

- **API surface expansion:** Added `'answered_list'` to the `surface` enum in both `incorrectSchema` and `inappropriateSchema` in the content-reports endpoint, and updated `ReportReasonSheet` to accept this new surface value.

- **UI integration:** Updated `AnsweredQuestionsList` to:
  - Accept `reportTarget` in `AnsweredQuestionItem` type
  - Render `AnsweredRowActions` conditionally (only when `reportTarget` is not null)
  - Adjust layout spacing to accommodate the new action button alongside the existing "Send Question" action

## Implementation Details

- The menu uses a fixed overlay with semi-transparent backdrop for mobile, positioned at the bottom; on desktop it's positioned at the top with a smaller footprint.
- Rows with no reportable content (synthetic daily slots) hide the menu entirely by checking `reportTarget !== null`.
- The component follows existing accessibility patterns: proper ARIA attributes (`aria-haspopup`, `aria-expanded`, `role="menu"`), semantic button roles, and keyboard support.

https://claude.ai/code/session_01Q73UEk56kq6JUkJDVkuSjx