### PR TITLE
Fix stacked activity icon marks to use isosceles triangles

### DIFF
--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -44,17 +44,16 @@ const MARK_W = 24;
 const GAP = 8;
 const LINE_H = 22.5; // first text line: 15px × 1.5
 // The stacked single-shape marks (diamond / hourglass / domain) are a vertical
-// pair of triangles. Full base=height triangles would make the pair 24×48 — too
-// tall, and the two halves end up far apart vertically (they read as two
-// disconnected shapes). We draw each half intentionally shorter than base=height
-// so the pair is 24×STACK_H and the halves sit close together. The cluster
-// (BundleMark, made of small triangles) keeps full base=height. Rendered at 70%,
-// centered horizontally in the 24px column.
+// pair of triangles. Each half is base=height (24×24) so the triangles stay
+// isosceles and un-smushed — matching the BundleMark invariant below. The pair
+// is therefore 24×48; we render it at 70% so it isn't too tall next to the text,
+// centered horizontally in the 24px column. (Drawing the halves shorter than
+// base=height squishes the rhombus/hourglass/domain and was reverted.)
 const LARGE_SCALE = 0.7;
 // Height of each half of a stacked mark, and the total viewBox height of the
-// pair. Shorter than the 24px base on purpose — see LARGE_SCALE note above.
-const STACK_HALF = 18;
-const STACK_H = STACK_HALF * 2; // 36
+// pair. base=height (= MARK_W) keeps the triangles un-smushed.
+const STACK_HALF = 24;
+const STACK_H = STACK_HALF * 2; // 48
 
 export type ActivityIconSpec =
   | { kind: 'bundle'; total: number; unanswered: number }


### PR DESCRIPTION
## Summary
Reverts a previous optimization that shortened the stacked mark halves (diamond/hourglass/domain icons), restoring them to proper isosceles triangles with base=height proportions. This ensures the marks render correctly without visual distortion.

## Changes
- Updated `STACK_HALF` from 18 to 24 (matching `MARK_W`)
- Updated `STACK_H` from 36 to 48 (reflecting the full pair height)
- Clarified that the 70% scale (`LARGE_SCALE`) handles height management next to text, not shape distortion
- Updated comments to document the invariant: each triangle half is 24×24 (base=height), keeping them isosceles and un-smushed, matching the BundleMark design

## Implementation Details
The stacked marks are rendered at 70% scale to prevent them from appearing too tall next to text. Previously, the halves were intentionally drawn shorter than base=height to reduce the pair's visual height, but this squished the rhombus/hourglass/domain shapes. This change restores proper triangle geometry while maintaining the 70% scale for appropriate sizing in the UI.

https://claude.ai/code/session_01GhgJ2knvkRrhSVV9jmQJ4M