### PR TITLE
Add intra-day diversity cap to daily queue orchestrator

### DIFF
--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -1,0 +1,240 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DAILY_QUEUE_MAX_PER_SUBCATEGORY, DAILY_QUEUE_SIZE } from '@/server/daily/types';
+
+// Same wholesale-mock strategy as queue-floor.test.ts: fillDailyQueueForUser
+// orchestrates DB pickers + LLM generation, all of which touch @/server/db (which
+// throws at module load without a connection string). Mock the entire dependency
+// surface so these tests exercise ONLY the orchestrator's intra-day diversity cap
+// (the "5-question botany run" / "3-Hamlet day" lever).
+const mocks = vi.hoisted(() => ({
+  getTodaysDailyQueue: vi.fn(),
+  carryForwardUntouchedDailyQueue: vi.fn(),
+  clearStaleShortTodayQueue: vi.fn(),
+  countDailyQueues: vi.fn(),
+  getKnowledgeBase: vi.fn(),
+  pickEligibleAuthoredQuestions: vi.fn(),
+  pickHouseQuestions: vi.fn(),
+  createDailyQueueItem: vi.fn(),
+  createDailyQueueItemFromAuthored: vi.fn(),
+  createDailyQueueItemFromHouse: vi.fn(),
+  createDailyQueueItemFromPresence: vi.fn(),
+  getDailyPreferences: vi.fn(),
+  getFriendAndFoFUserIds: vi.fn(),
+  getFriendDomainsForBonus: vi.fn(),
+  generateDailyQuestionsFromKnowledgeBase: vi.fn(),
+  generateBonusQuestionsForDomains: vi.fn(),
+  isGenericSubcategory: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/daily', () => ({
+  getTodaysDailyQueue: mocks.getTodaysDailyQueue,
+  carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
+  clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
+  countDailyQueues: mocks.countDailyQueues,
+  getKnowledgeBase: mocks.getKnowledgeBase,
+  pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
+  pickHouseQuestions: mocks.pickHouseQuestions,
+  createDailyQueueItem: mocks.createDailyQueueItem,
+  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
+  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
+  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+}));
+
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: mocks.getDailyPreferences,
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendAndFoFUserIds: mocks.getFriendAndFoFUserIds,
+}));
+
+vi.mock('@/server/db/queries/friend-presence-domains', () => ({
+  getFriendDomainsForBonus: mocks.getFriendDomainsForBonus,
+}));
+
+vi.mock('@/server/daily/generate-questions', () => ({
+  generateDailyQuestionsFromKnowledgeBase: mocks.generateDailyQuestionsFromKnowledgeBase,
+  generateBonusQuestionsForDomains: mocks.generateBonusQuestionsForDomains,
+}));
+
+vi.mock('@/server/questions/canonical-subcategory', () => ({
+  isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+
+const USER = 'user-1';
+
+// Minimal stand-in for a generated question row — the orchestrator only reads
+// id, questionText, and canonicalSubcategory.
+function genq(id: string, subcategory: string) {
+  return { id, questionText: `Question ${id}`, canonicalSubcategory: subcategory } as never;
+}
+
+// Minimal stand-in for an authored/house pick — the orchestrator reads
+// canonicalSubcategory for the cap and questionText for cross-source dedup.
+function authoredPick(id: string, subcategory: string) {
+  return {
+    id,
+    creatorId: `creator-${id}`,
+    questionText: `Authored ${id}`,
+    canonicalSubcategory: subcategory,
+    broadCategory: null,
+    category: '',
+    authorName: null,
+    authorNote: null,
+  } as never;
+}
+
+/** The canonicalSubcategory each generated slot was persisted under, in slot order. */
+function persistedGeneratedDomains(generatedRows: ReturnType<typeof genq>[]): string[] {
+  const byId = new Map(
+    generatedRows.map((row) => {
+      const q = row as unknown as { id: string; canonicalSubcategory: string };
+      return [q.id, q.canonicalSubcategory] as const;
+    }),
+  );
+  return mocks.createDailyQueueItem.mock.calls.map((call) => byId.get(call[1] as string) ?? '?');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Fresh build path: no existing queue, nothing to carry forward.
+  mocks.getTodaysDailyQueue.mockResolvedValue(null);
+  mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
+  mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
+  mocks.countDailyQueues.mockResolvedValue(3);
+
+  // A broad knowledge base (≥3 domains) so the effective cap stays at the base
+  // DAILY_QUEUE_MAX_PER_SUBCATEGORY rather than scaling up for a thin KB.
+  mocks.getKnowledgeBase.mockResolvedValue([
+    { domain: 'Botany' },
+    { domain: 'Hamlet' },
+    { domain: 'Jazz' },
+    { domain: 'Astronomy' },
+    { domain: 'Cartography' },
+  ]);
+  mocks.getDailyPreferences.mockResolvedValue({
+    difficulty: 'adaptive',
+    domainMode: 'random',
+    selectedDomains: [],
+    domainPreferenceFrequency: {},
+  });
+  mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
+  mocks.pickHouseQuestions.mockResolvedValue([]);
+  mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+
+  mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+  mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+
+  mocks.isGenericSubcategory.mockReturnValue(false);
+
+  mocks.createDailyQueueItem.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
+  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+});
+
+describe('fillDailyQueueForUser — intra-day diversity cap', () => {
+  it('holds the cap across the initial pass AND top-up rounds', async () => {
+    // The cap state is shared across the first generation pass and every top-up
+    // round, so a botany cluster spread over rounds is still spaced out. First pass:
+    // three botany (two admitted, one reserved) + one jazz; top-up round brings two
+    // fresh domains that finish the diverse five.
+    const rows = [
+      genq('b1', 'Botany'),
+      genq('b2', 'Botany'),
+      genq('b3', 'Botany'),
+      genq('j1', 'Jazz'),
+      genq('a1', 'Astronomy'),
+      genq('c1', 'Cartography'),
+    ];
+    mocks.generateDailyQuestionsFromKnowledgeBase
+      .mockResolvedValueOnce([rows[0], rows[1], rows[2], rows[3]])
+      .mockResolvedValueOnce([rows[4], rows[5]]);
+
+    await fillDailyQueueForUser(USER);
+
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    const domains = persistedGeneratedDomains(rows);
+    // Exactly the cap of botany; b3 was deflected and never needed (the round
+    // brought diverse material), so it does not appear.
+    expect(domains.filter((d) => d === 'Botany').length).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
+    expect(domains).not.toContain('?');
+    expect(new Set(domains)).toEqual(new Set(['Botany', 'Jazz', 'Astronomy', 'Cartography']));
+  });
+
+  it('caps botany at the limit when other subcategories can fill the rest', async () => {
+    // A mixed batch with a botany cluster plus enough distinct domains to fill five.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('b1', 'Botany'),
+      genq('b2', 'Botany'),
+      genq('b3', 'Botany'),
+      genq('b4', 'Botany'),
+      genq('b5', 'Botany'),
+      genq('j1', 'Jazz'),
+      genq('a1', 'Astronomy'),
+      genq('c1', 'Cartography'),
+    ]);
+
+    await fillDailyQueueForUser(USER);
+
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    const domains = mocks.createDailyQueueItem.mock.calls.map((call) => {
+      const id = call[1] as string;
+      return id.startsWith('b') ? 'Botany' : id;
+    });
+    const botanyCount = domains.filter((d) => d === 'Botany').length;
+    // No more than the cap, and the freed slots are filled by other subcategories.
+    expect(botanyCount).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
+    expect(new Set(domains).size).toBeGreaterThan(1);
+  });
+
+  it('caps a 3-Hamlet authored run, sourcing the rest from generation', async () => {
+    // Three authored Hamlet questions; the cap admits only two into the core.
+    mocks.pickEligibleAuthoredQuestions.mockResolvedValue([
+      authoredPick('h1', 'Hamlet'),
+      authoredPick('h2', 'Hamlet'),
+      authoredPick('h3', 'Hamlet'),
+    ]);
+    // Generation fills the remaining slots with distinct domains.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('j1', 'Jazz'),
+      genq('a1', 'Astronomy'),
+      genq('c1', 'Cartography'),
+    ]);
+
+    await fillDailyQueueForUser(USER);
+
+    // Only two Hamlet authored slots persisted (cap), not three.
+    expect(mocks.createDailyQueueItemFromAuthored).toHaveBeenCalledTimes(
+      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
+    );
+    // Generation backfilled the slot the cap freed, so the queue is still full.
+    const totalSlots =
+      mocks.createDailyQueueItemFromAuthored.mock.calls.length +
+      mocks.createDailyQueueItem.mock.calls.length;
+    expect(totalSlots).toBe(DAILY_QUEUE_SIZE);
+  });
+
+  it('does not shorten a queue when only one subcategory is available (soft cap)', async () => {
+    // Single-domain knowledge base: the cap can never diversify, so it must NOT
+    // turn a previously-full queue into a short one or a 503. The effective cap
+    // scales up (DAILY_QUEUE_SIZE / 1) and the reserve backfill is the safety net.
+    mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Botany' }]);
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('b1', 'Botany'),
+      genq('b2', 'Botany'),
+      genq('b3', 'Botany'),
+      genq('b4', 'Botany'),
+      genq('b5', 'Botany'),
+    ]);
+
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+
+    // A full five-question queue still builds — the cap degraded gracefully.
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+  });
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -24,6 +24,7 @@ import {
 } from '@/server/daily/generate-questions';
 import {
   DAILY_BONUS_SLOT_MAX,
+  DAILY_QUEUE_MAX_PER_SUBCATEGORY,
   DAILY_QUEUE_MIN_SIZE,
   DAILY_QUEUE_SIZE,
   type QueueSlot,
@@ -45,6 +46,32 @@ export class DailyQueueFillError extends Error {
 
 function asQueueSlots(value: unknown): QueueSlot[] {
   return Array.isArray(value) ? (value as QueueSlot[]) : [];
+}
+
+type SubcategoryDiversityGate = {
+  /**
+   * Records and admits a pick while its canonical subcategory is still under the
+   * cap; returns false (without recording) once the subcategory is full. A blank or
+   * absent label is never blocked — the generic-subcategory gate owns those — and is
+   * not counted toward any cap. Matching is case- and whitespace-insensitive.
+   */
+  admit: (subcategory: string | null | undefined) => boolean;
+};
+
+// Shared across all three core sources (authored → house → generated) so the cap is
+// enforced over the WHOLE queue, not per-source. See DAILY_QUEUE_MAX_PER_SUBCATEGORY.
+function makeSubcategoryDiversityGate(maxPerSubcategory: number): SubcategoryDiversityGate {
+  const counts = new Map<string, number>();
+  return {
+    admit(subcategory) {
+      const key = (subcategory ?? '').trim().toLowerCase();
+      if (!key) return true;
+      const current = counts.get(key) ?? 0;
+      if (current >= maxPerSubcategory) return false;
+      counts.set(key, current + 1);
+      return true;
+    },
+  };
 }
 
 // Quality-first completeness loop. Rather than a single recovery pass, we keep
@@ -179,23 +206,56 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
           .filter((domain) => !restingDomains.has(domain.toLowerCase())),
   );
 
+  // Intra-day diversity cap (D: "5-question botany run" / "3-Hamlet day"). One
+  // shared gate enforces DAILY_QUEUE_MAX_PER_SUBCATEGORY across all three core
+  // sources. Scale the cap up when too few distinct subcategories are available to
+  // field five under it, so a narrow knowledge base doesn't trigger pointless
+  // top-up generation that can only ever come back over-cap; the reserve backfill
+  // further down is the final safety net regardless of this estimate.
+  const distinctAllowed = allowedSubcategories.size;
+  const diversityCap =
+    distinctAllowed > 0
+      ? Math.max(
+          DAILY_QUEUE_MAX_PER_SUBCATEGORY,
+          Math.ceil(DAILY_QUEUE_SIZE / distinctAllowed),
+        )
+      : DAILY_QUEUE_SIZE;
+  const diversityGate = makeSubcategoryDiversityGate(diversityCap);
+
   const socialGraph = await getFriendAndFoFUserIds(userId);
-  const authored = await pickEligibleAuthoredQuestions(
+  const authoredAll = await pickEligibleAuthoredQuestions(
     userId,
     socialGraph,
     DAILY_QUEUE_SIZE,
     allowedSubcategories,
   );
+  // Cap authored picks first (highest trust → first claim on each subcategory's
+  // slots); deflected picks go to a reserve the backfill can draw on if the cap
+  // would otherwise leave the queue short.
+  const authoredReserve: typeof authoredAll = [];
+  const authored = authoredAll.filter((pick) => {
+    if (diversityGate.admit(pick.canonicalSubcategory)) return true;
+    authoredReserve.push(pick);
+    return false;
+  });
 
   // D-3: seed curated house/editorial questions into the core for the niches
   // friend content didn't cover, before falling back to LLM generation. Matched
   // by domain (the viewer's knowledge base), never the +2 friend-answer ranking.
   // House content does not enter the Feed and never occupies a +2 bonus slot.
-  const housePicks = await pickHouseQuestions(
+  // Request against the CAPPED authored count so house can fill any slot the cap
+  // freed, then run house through the same shared diversity gate.
+  const housePicksAll = await pickHouseQuestions(
     userId,
     DAILY_QUEUE_SIZE - authored.length,
     allowedSubcategories,
   );
+  const houseReserve: typeof housePicksAll = [];
+  const housePicks = housePicksAll.filter((pick) => {
+    if (diversityGate.admit(pick.canonicalSubcategory)) return true;
+    houseReserve.push(pick);
+    return false;
+  });
 
   const remaining = DAILY_QUEUE_SIZE - authored.length - housePicks.length;
   const generated =
@@ -219,8 +279,14 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     seenTexts.add(normalize(pick.questionText));
   }
   const dedupedGenerated: typeof generated = [];
+  // Generated questions deflected ONLY by the intra-day diversity cap (not generic,
+  // not duplicate). Held — not discarded — so the top-up loop can try to replace
+  // them with a different subcategory, and the soft-cap backfill can restore them if
+  // nothing diverse materializes rather than serving a short queue.
+  const generatedReserve: typeof generated = [];
   let droppedDuplicates = 0;
   let droppedGeneric = 0;
+  let deflectedForDiversity = 0;
   for (const question of generated) {
     // Drop bucket-level domains ("general"/"trivia"/short labels) BEFORE the
     // shortfall count below, so a generic pick is treated as a missing slot the
@@ -236,6 +302,14 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       continue;
     }
     seenTexts.add(key);
+    // Intra-day diversity cap, applied AFTER the generic + dedup gates so a deflected
+    // pick is a genuine, distinct question we're merely spacing out — see the reserve
+    // backfill below.
+    if (!diversityGate.admit(question.canonicalSubcategory)) {
+      deflectedForDiversity += 1;
+      generatedReserve.push(question);
+      continue;
+    }
     dedupedGenerated.push(question);
   }
   if (droppedDuplicates > 0) {
@@ -288,6 +362,11 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       const key = normalize(question.questionText);
       if (seenTexts.has(key)) continue;
       seenTexts.add(key);
+      if (!diversityGate.admit(question.canonicalSubcategory)) {
+        deflectedForDiversity += 1;
+        generatedReserve.push(question);
+        continue;
+      }
       topUpGenerated.push(question);
       recoveredThisRound += 1;
     }
@@ -313,7 +392,43 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
 
   const generatedForQueue = [...dedupedGenerated, ...topUpGenerated];
-  const achieved = authored.length + housePicks.length + generatedForQueue.length;
+
+  // Soft-cap relaxation. If the diversity cap (on top of any honest under-yield)
+  // left the core short of DAILY_QUEUE_SIZE, backfill from the reserve of
+  // cap-deflected picks — authored first (vetted, highest trust), then house, then
+  // generated — until we're full or the reserve runs dry. This is what makes the cap
+  // SOFT: it only ever DIVERSIFIES a queue that had the material to stay full. A
+  // knowledge base too narrow to field five distinct subcategories degrades to
+  // exactly the queue it would have built without the cap — never shorter, and never
+  // a spurious generation_failed below the floor.
+  const authoredBackfill: typeof authored = [];
+  const houseBackfill: typeof housePicks = [];
+  const generatedBackfill: typeof generatedForQueue = [];
+  let backfillShortfall =
+    DAILY_QUEUE_SIZE - (authored.length + housePicks.length + generatedForQueue.length);
+  for (const pick of authoredReserve) {
+    if (backfillShortfall <= 0) break;
+    authoredBackfill.push(pick);
+    backfillShortfall -= 1;
+  }
+  for (const pick of houseReserve) {
+    if (backfillShortfall <= 0) break;
+    houseBackfill.push(pick);
+    backfillShortfall -= 1;
+  }
+  for (const question of generatedReserve) {
+    if (backfillShortfall <= 0) break;
+    generatedBackfill.push(question);
+    backfillShortfall -= 1;
+  }
+  const diversityBackfilled =
+    authoredBackfill.length + houseBackfill.length + generatedBackfill.length;
+
+  const coreAuthored = [...authored, ...authoredBackfill];
+  const coreHouse = [...housePicks, ...houseBackfill];
+  const coreGenerated = [...generatedForQueue, ...generatedBackfill];
+
+  const achieved = coreAuthored.length + coreHouse.length + coreGenerated.length;
 
   // Graceful degrade WITH A FLOOR. Some niche domains have very low generation
   // yield — the quality/factual/dedup gates correctly reject most of each batch —
@@ -343,6 +458,9 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
+      diversityCap,
+      deflectedForDiversity,
+      diversityBackfilled,
       domainMode: preferences.domainMode,
       selectedDomains: preferences.selectedDomains.length,
       elapsedMs: Date.now() - startedAt,
@@ -368,6 +486,9 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
+      diversityCap,
+      deflectedForDiversity,
+      diversityBackfilled,
       knowledgeBaseDomains: knowledgeBase.length,
       domainMode: preferences.domainMode,
       selectedDomains: preferences.selectedDomains.length,
@@ -375,16 +496,19 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     });
   }
 
+  // Persist in source order (authored → house → generated), each group already
+  // diversity-capped and reserve-backfilled above. Slice defensively so the core
+  // never exceeds DAILY_QUEUE_SIZE even if a source over-supplied.
   let position = 0;
-  for (const pick of authored) {
+  for (const pick of coreAuthored.slice(0, DAILY_QUEUE_SIZE - position)) {
     await createDailyQueueItemFromAuthored(userId, pick, position);
     position += 1;
   }
-  for (const pick of housePicks.slice(0, DAILY_QUEUE_SIZE - position)) {
+  for (const pick of coreHouse.slice(0, DAILY_QUEUE_SIZE - position)) {
     await createDailyQueueItemFromHouse(userId, pick, position);
     position += 1;
   }
-  for (const question of generatedForQueue.slice(0, DAILY_QUEUE_SIZE - position)) {
+  for (const question of coreGenerated.slice(0, DAILY_QUEUE_SIZE - position)) {
     await createDailyQueueItem(userId, question.id, position);
     position += 1;
   }

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -126,6 +126,22 @@ export const DAILY_QUEUE_SIZE = 5;
 export const DAILY_QUEUE_MIN_SIZE = 3;
 
 /**
+ * Intra-day diversity cap. Within a SINGLE daily queue, one canonical subcategory
+ * may fill at most this many of the DAILY_QUEUE_SIZE core slots before further
+ * same-subcategory picks are deflected. This is the lever that breaks up a
+ * "5-question botany run" or a "3-Hamlet day" — where one niche crowds the rest of
+ * the five out — without changing how individual questions are chosen.
+ *
+ * It is deliberately SOFT. The orchestrator holds cap-deflected picks in a reserve
+ * and uses them to backfill only if the cap would otherwise leave the queue short,
+ * and it scales the effective cap up when too few distinct subcategories are
+ * available to field five under it (DAILY_QUEUE_SIZE / distinct-domain-count). So a
+ * thin, single-subcategory knowledge base degrades to exactly the queue it would
+ * have built without the cap — never shorter, never a spurious generation_failed.
+ */
+export const DAILY_QUEUE_MAX_PER_SUBCATEGORY = 2;
+
+/**
  * Daily Five +2 — up to this many bonus slots are appended after the core
  * DAILY_QUEUE_SIZE, each a freshly generated accessible question in a domain
  * drawn from the territory ∪ activity of people the viewer follows (D-4 §B; see


### PR DESCRIPTION
## Summary
Implements an intra-day diversity cap that prevents any single canonical subcategory from dominating a user's daily queue. This addresses the "5-question botany run" / "3-Hamlet day" problem where one niche crowds out variety in the five-question core.

## Key Changes

- **New `DAILY_QUEUE_MAX_PER_SUBCATEGORY` constant** (`types.ts`): Set to 2, limiting how many slots any one subcategory can occupy in the core queue. The cap is deliberately soft — it scales up when too few distinct subcategories are available, ensuring narrow knowledge bases don't produce short queues.

- **Subcategory diversity gate** (`queue-orchestrator.ts`): Added `SubcategoryDiversityGate` that tracks and enforces the per-subcategory cap across all three core sources (authored → house → generated). The gate is shared across the initial generation pass and all top-up rounds, so diversity constraints persist throughout queue building.

- **Reserve backfill mechanism** (`queue-orchestrator.ts`): Cap-deflected picks (authored, house, and generated) are held in reserves rather than discarded. If the cap would leave the queue short of `DAILY_QUEUE_SIZE`, the orchestrator backfills from these reserves in source order (highest trust first), making the cap truly soft — it only diversifies when material exists to stay full.

- **Adaptive cap scaling** (`queue-orchestrator.ts`): When the knowledge base has fewer distinct subcategories than needed to field five under the base cap, the effective cap scales up to `ceil(DAILY_QUEUE_SIZE / distinct-count)`, preventing artificial shortfalls.

- **Comprehensive test suite** (`diversity-cap.test.ts`): Four test cases covering:
  - Cap persistence across initial pass and top-up rounds
  - Capping a single subcategory cluster while other domains fill remaining slots
  - Capping authored picks and backfilling from generation
  - Graceful degradation when only one subcategory is available (soft cap behavior)

## Implementation Details

- The diversity gate normalizes subcategory labels (case- and whitespace-insensitive) and treats blank/null labels as generic (never blocked, not counted).
- Deflected picks are tracked separately from duplicates and generic drops for observability (new `deflectedForDiversity` and `diversityBackfilled` metrics in logging).
- The cap is applied after generic and deduplication gates, so a deflected pick is a genuine, distinct question being merely spaced out.
- Defensive slicing ensures the core never exceeds `DAILY_QUEUE_SIZE` even if a source over-supplies after backfill.

https://claude.ai/code/session_01VcCdKTPWraL4XeA69Tj4Ym