### PR TITLE
Intra-day diversity cap per canonical subcategory (frequency-aware)

### DIFF
--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -219,6 +219,65 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     expect(totalSlots).toBe(DAILY_QUEUE_SIZE);
   });
 
+  it('exempts an "often"-marked subcategory from the cap (Game settings honored)', async () => {
+    // The player explicitly asked to see lots of Botany. The diversity cap must NOT
+    // throttle a topic the player deliberately requested — "often" is exempt, so a
+    // botany-heavy day the player asked for is delivered in full.
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: { Botany: 'often' },
+    });
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('b1', 'Botany'),
+      genq('b2', 'Botany'),
+      genq('b3', 'Botany'),
+      genq('b4', 'Botany'),
+      genq('b5', 'Botany'),
+    ]);
+
+    await fillDailyQueueForUser(USER);
+
+    // All five botany slots persisted — not capped at DAILY_QUEUE_MAX_PER_SUBCATEGORY.
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+  });
+
+  it('still caps OTHER subcategories while an "often" one runs free', async () => {
+    // Botany is "often" (exempt); Jazz is unset (base cap). A mixed batch should let
+    // botany exceed the base cap while jazz is still spaced out — the cap and the
+    // frequency preference coexist.
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: { Botany: 'often' },
+    });
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('b1', 'Botany'),
+      genq('b2', 'Botany'),
+      genq('b3', 'Botany'),
+      genq('j1', 'Jazz'),
+      genq('j2', 'Jazz'),
+      genq('j3', 'Jazz'),
+    ]);
+
+    await fillDailyQueueForUser(USER);
+
+    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    const domains = mocks.createDailyQueueItem.mock.calls.map((call) => {
+      const id = call[1] as string;
+      return id.startsWith('b') ? 'Botany' : 'Jazz';
+    });
+    // Botany (often) exceeds the base cap; Jazz (unset) is held at it.
+    expect(domains.filter((d) => d === 'Botany').length).toBeGreaterThan(
+      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
+    );
+    expect(domains.filter((d) => d === 'Jazz').length).toBeLessThanOrEqual(
+      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
+    );
+  });
+
   it('does not shorten a queue when only one subcategory is available (soft cap)', async () => {
     // Single-domain knowledge base: the cap can never diversify, so it must NOT
     // turn a previously-full queue into a short one or a 503. The effective cap

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -59,15 +59,20 @@ type SubcategoryDiversityGate = {
 };
 
 // Shared across all three core sources (authored → house → generated) so the cap is
-// enforced over the WHOLE queue, not per-source. See DAILY_QUEUE_MAX_PER_SUBCATEGORY.
-function makeSubcategoryDiversityGate(maxPerSubcategory: number): SubcategoryDiversityGate {
+// enforced over the WHOLE queue, not per-source. The cap is resolved PER subcategory
+// (capForSubcategory receives the normalized key) so an explicit "often" preference
+// from the Game settings page can lift the default cap for that subcategory — see
+// DAILY_QUEUE_MAX_PER_SUBCATEGORY and the capForSubcategory builder in the caller.
+function makeSubcategoryDiversityGate(
+  capForSubcategory: (normalizedSubcategory: string) => number,
+): SubcategoryDiversityGate {
   const counts = new Map<string, number>();
   return {
     admit(subcategory) {
       const key = (subcategory ?? '').trim().toLowerCase();
       if (!key) return true;
       const current = counts.get(key) ?? 0;
-      if (current >= maxPerSubcategory) return false;
+      if (current >= capForSubcategory(key)) return false;
       counts.set(key, current + 1);
       return true;
     },
@@ -208,19 +213,35 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
 
   // Intra-day diversity cap (D: "5-question botany run" / "3-Hamlet day"). One
   // shared gate enforces DAILY_QUEUE_MAX_PER_SUBCATEGORY across all three core
-  // sources. Scale the cap up when too few distinct subcategories are available to
-  // field five under it, so a narrow knowledge base doesn't trigger pointless
+  // sources. Scale the BASE cap up when too few distinct subcategories are available
+  // to field five under it, so a narrow knowledge base doesn't trigger pointless
   // top-up generation that can only ever come back over-cap; the reserve backfill
   // further down is the final safety net regardless of this estimate.
   const distinctAllowed = allowedSubcategories.size;
-  const diversityCap =
+  const baseDiversityCap =
     distinctAllowed > 0
       ? Math.max(
           DAILY_QUEUE_MAX_PER_SUBCATEGORY,
           Math.ceil(DAILY_QUEUE_SIZE / distinctAllowed),
         )
       : DAILY_QUEUE_SIZE;
-  const diversityGate = makeSubcategoryDiversityGate(diversityCap);
+
+  // In concert with the Game settings page: a subcategory the player explicitly
+  // marked "often" is EXEMPT from the diversity cap (bounded only by the queue
+  // size), so the cap never throttles a topic the player deliberately asked to see
+  // a lot of. The cap exists to break up runs the player did NOT request — and an
+  // explicit "often" IS that request, so it wins. ("resting" is already removed from
+  // allowedSubcategories upstream; "sometimes"/"blue_moon"/unset keep the base cap.)
+  // Keys are lowercased to match how restingDomains is built above and how the gate
+  // normalizes each subcategory.
+  const oftenDomains = new Set(
+    Object.entries(preferences.domainPreferenceFrequency ?? {})
+      .filter(([, frequency]) => frequency === 'often')
+      .map(([domain]) => domain.toLowerCase()),
+  );
+  const capForSubcategory = (normalizedSubcategory: string): number =>
+    oftenDomains.has(normalizedSubcategory) ? DAILY_QUEUE_SIZE : baseDiversityCap;
+  const diversityGate = makeSubcategoryDiversityGate(capForSubcategory);
 
   const socialGraph = await getFriendAndFoFUserIds(userId);
   const authoredAll = await pickEligibleAuthoredQuestions(
@@ -458,7 +479,8 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
-      diversityCap,
+      baseDiversityCap,
+      oftenDomains: oftenDomains.size,
       deflectedForDiversity,
       diversityBackfilled,
       domainMode: preferences.domainMode,
@@ -486,7 +508,8 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
       topUpRounds,
       droppedDuplicates,
       droppedGeneric,
-      diversityCap,
+      baseDiversityCap,
+      oftenDomains: oftenDomains.size,
       deflectedForDiversity,
       diversityBackfilled,
       knowledgeBaseDomains: knowledgeBase.length,


### PR DESCRIPTION
## What & why

Adds an **intra-day diversity cap** to the Daily Five builder: within a single daily queue, one canonical subcategory may fill at most `DAILY_QUEUE_MAX_PER_SUBCATEGORY` (2) of the core slots before further same-subcategory picks are deflected. This breaks up runs like a 5-question botany day or a 3-Hamlet day where one niche crowds out the rest of the five.

## How it works

- A **single shared gate** enforces the cap across all three core sources (authored → house → generated), so spacing holds over the whole queue rather than per-source, and across the initial generation pass *and* every top-up round.
- **Soft cap, regression-safe.** Cap-deflected picks are held in a reserve (not discarded) and backfill the queue if the cap would otherwise leave it short — so a narrow, single-subcategory knowledge base degrades to exactly the queue it would have built without the cap. Never shorter, never a spurious `generation_failed` below the floor.
- **Adaptive base cap.** When too few distinct subcategories exist to fill five under the cap, the effective cap scales up (`DAILY_QUEUE_SIZE / distinct-subcategory-count`), so thin knowledge bases don't burn LLM top-up rounds chasing diversity they can't supply.

## In concert with the Game settings page

The frequency preferences (`often`/`sometimes`/`blue_moon`/`resting`) are keyed at the **same canonical-subcategory granularity** as the cap. A flat cap would throttle the domains a player explicitly marked **"often"** — the opposite of intent. So the cap is **frequency-aware**:

| Setting | Behavior |
|---|---|
| **Often** | Exempt — bounded only by queue size (the player asked for it) |
| **Sometimes** / unset | Base/adaptive cap (2/day) |
| **Blue Moon** | Base/adaptive cap (2/day) |
| **Resting** | Already excluded upstream — cap never touches it |

The two coexist: in a mixed day an "often" topic runs free while everything else stays spaced out.

## Tests

New `src/server/daily/__tests__/diversity-cap.test.ts`:
- Cap holds across the initial pass and top-up rounds
- Botany capped when other subcategories can fill the rest
- A 3-Hamlet authored run capped, remainder from generation
- Single-domain KB degrades gracefully (no short queue / no 503)
- `"often"` subcategory fully exempt
- `"often"` runs free while other subcategories stay capped

Full daily suite green (119 tests), 0 type errors, lint clean. Diagnostics log base cap, often-domain count, deflected count, and backfill count.

## Notes / open judgment calls

- `"often"` is **fully exempt** (can fill all 5). Could instead be a higher-but-finite cap if some enforced variety is preferred — one-line change.
- The **+2 bonus slots** are intentionally untouched (already domain-diverse by construction).
- Possible follow-up: cap **Blue Moon** at 1/day to mirror "surfaces only occasionally" intra-day.

https://claude.ai/code/session_01VcCdKTPWraL4XeA69Tj4Ym

---
_Generated by [Claude Code](https://claude.ai/code/session_01VcCdKTPWraL4XeA69Tj4Ym)_