### PR TITLE
Document VOYAGE_API_KEY + add embedding-backfill npm aliases

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,6 +16,19 @@ DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
 # ── Anthropic ─────────────────────────────────────────────────
 ANTHROPIC_API_KEY=""
 
+# ── Voyage AI (embeddings) ────────────────────────────────────
+# Powers the semantic near-duplicate suppression for the question pool
+# (GeneratedQuestion/Question.embedding, voyage-3.5-lite, 1024-dim).
+# WITHOUT this key the whole embedding-dedup path is a no-op: embeddings are
+# never written and near-duplicates are never flagged (the cheap fact_key/text
+# guards still run). After provisioning, backfill existing rows with:
+#   npm run pool:embed-backfill        # dry-run (counts + Voyage cost estimate)
+#   npm run pool:embed-backfill:apply  # embed + run the collision pass
+VOYAGE_API_KEY=""
+# Optional: cosine-similarity threshold for suppression (default 0.92, range 0-1).
+# Lower = more aggressive. Catches near-identical rephrasings, not topic overlap.
+# POOL_DEDUP_COSINE_THRESHOLD="0.92"
+
 # ── Auth ──────────────────────────────────────────────────────
 # 32+ random bytes, base64-encoded.
 # Generate: node -e "console.log(require('crypto').randomBytes(32).toString('base64'))"

--- a/package.json
+++ b/package.json
@@ -21,6 +21,8 @@
     "smoke:niche-match-dedup": "tsx scripts/niche-match-dedup.smoke.ts",
     "smoke:gameplay": "tsx scripts/playtest/playtest.ts",
     "pool:health": "tsx scripts/pool-health.ts",
+    "pool:embed-backfill": "tsx scripts/backfill-pool-embeddings.ts",
+    "pool:embed-backfill:apply": "tsx scripts/backfill-pool-embeddings.ts --apply",
     "format": "node scripts/format-changed.mjs",
     "format:all": "prettier --write ."
   },


### PR DESCRIPTION
## Scope (narrowed)
Originally this PR also added an intra-day per-subcategory diversity cap — but `dev2` landed an independent, **more complete** implementation in parallel (`6baa6a0`: enforces the cap across top-up rounds and adaptively scales it). That superseded my version, so I dropped my redundant cap + its test and rebased. **This PR is now just the embedding turn-on docs/tooling**, which is still unique to `dev2`.

## Why
The semantic near-duplicate pipeline (Voyage embeddings client, collision matrix, generation-time wiring, served-set exclusion of `is_duplicate`, idempotent backfill script) is fully built but **dormant**: every `GeneratedQuestion`/`Question.embedding` row is NULL because `VOYAGE_API_KEY` was never provisioned. The whole path is hard-gated on that one key.

## What this changes (15 lines, no behavior change)
- `.env.example`: document `VOYAGE_API_KEY` + optional `POOL_DEDUP_COSINE_THRESHOLD`, with the turn-on runbook.
- `package.json`: add `pool:embed-backfill` / `pool:embed-backfill:apply` aliases for the existing `scripts/backfill-pool-embeddings.ts` (sits alongside the existing `pool:health`).

## Activation (operational, not in this PR)
1. Provision `VOYAGE_API_KEY` (`.env.local` + Vercel env).
2. `npm run pool:embed-backfill` — dry-run; reports ~1,174 rows needing embedding, ~\$0.001 Voyage cost.
3. `npm run pool:embed-backfill:apply` — embeds + runs the collision pass.

After that, every new generation self-embeds and self-suppresses via the wiring already in the tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)