### PR TITLE
Remove breadcrumb generation and fetching infrastructure

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -16,7 +16,6 @@ import { awardAuthorCredit, isAuthorCreditEligible } from '@/server/mastery/auth
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
-import { generateBreadcrumb } from '@/server/daily/generate-breadcrumb';
 import { type QueueSlot } from '@/server/daily/types';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
@@ -406,54 +405,6 @@ export async function POST(request: NextRequest) {
     ).catch((err) => {
       console.warn('[daily/answer] updateDomainDifficultyOnAnswer failed', err);
     });
-
-    // Precompute the reveal breadcrumb in the background so the client's
-    // follow-up POST /api/breadcrumb hits the slot-cache short-circuit
-    // (handleDaily at src/app/api/breadcrumb/route.ts:52) instead of waiting
-    // on Haiku. Skipped for give-ups to match the breadcrumb route's own
-    // gaveUp gate. Race window: if the client POST lands before this finishes,
-    // both paths generate independently; the second persist wins (same input
-    // → same output, so functionally identical), at the cost of one extra
-    // Haiku call per occurrence.
-    if (!parsed.gaveUp) {
-      void (async () => {
-        try {
-          const breadcrumb = await generateBreadcrumb({
-            questionId: question.generatedId ?? question.canonicalId ?? undefined,
-            questionText: question.questionText,
-            correctAnswer: canonicalAnswer,
-            submittedAnswer: parsed.submittedAnswer,
-            isCorrect,
-            domain: question.canonicalSubcategory,
-          });
-          if (!breadcrumb) return;
-
-          const [freshQueue] = await db
-            .select()
-            .from(dailyQueues)
-            .where(eq(dailyQueues.id, queue.id))
-            .limit(1);
-          if (!freshQueue) return;
-
-          const freshSlots = asQueueSlots(freshQueue.slots);
-          const updatedSlots = freshSlots.map((s) =>
-            s.slot_index === parsed.slotIndex
-              ? ({ ...s, reveal_breadcrumb: breadcrumb } satisfies QueueSlot)
-              : s,
-          );
-          await db
-            .update(dailyQueues)
-            .set({ slots: updatedSlots })
-            .where(eq(dailyQueues.id, queue.id));
-        } catch (error) {
-          console.warn('[daily/answer] precompute breadcrumb failed', {
-            queueId: queue.id,
-            slotIndex: parsed.slotIndex,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        }
-      })();
-    }
 
     if (canonicalQuestionId && !parsed.gaveUp) {
       const propagationKey = question.generatedId ?? question.canonicalId ?? canonicalQuestionId;

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -510,35 +510,6 @@ export default function DailyPage() {
     return map;
   }, [queue?.slots]);
 
-  const fetchBreadcrumb = useCallback(async (queueId: string, slotIndex: number) => {
-    try {
-      const response = await fetch('/api/breadcrumb', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ source: 'daily', queueId, slotIndex }),
-      });
-      if (!response.ok) return;
-      const body = (await response.json().catch(() => null)) as {
-        breadcrumb?: string | null;
-      } | null;
-      const breadcrumb = body?.breadcrumb ?? null;
-      if (!breadcrumb) return;
-      setQueue((existing) =>
-        existing && existing.queue_id === queueId
-          ? {
-              ...existing,
-              slots: existing.slots.map((slot) =>
-                slot.slot_index === slotIndex ? { ...slot, reveal_breadcrumb: breadcrumb } : slot,
-              ),
-            }
-          : existing,
-      );
-    } catch {
-      // Breadcrumb is purely additive context; failure is silently ignored.
-    }
-  }, []);
-
   const postAnswer = useCallback(
     async (opts: { submittedAnswer: string; gaveUp: boolean }) => {
       if (!queue || !currentSlot || submitting) return;
@@ -608,17 +579,13 @@ export default function DailyPage() {
         setPausedAfterSlotIndex(currentSlot.slot_index);
         window.setTimeout(() => setPausedAfterSlotIndex(null), 850);
         setAnswer('');
-
-        if (!opts.gaveUp) {
-          void fetchBreadcrumb(queue.queue_id, currentSlot.slot_index);
-        }
       } catch (caught) {
         setError(caught instanceof Error ? caught.message : 'Could not record that answer.');
       } finally {
         setSubmitting(false);
       }
     },
-    [currentSlot, fetchBreadcrumb, queue, submitting],
+    [currentSlot, queue, submitting],
   );
 
   const submitAnswer = useCallback(async () => {

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -1,38 +1,11 @@
 'use client';
 
-import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { X } from 'lucide-react';
 
 import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
-
-async function fetchJoshingGameBreadcrumb(
-  gameId: string,
-  questionId: string,
-  messageId: string,
-  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
-): Promise<void> {
-  try {
-    const response = await fetch('/api/breadcrumb', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ source: 'joshing_game', gameId, questionId }),
-    });
-    if (!response.ok) return;
-    const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
-    const breadcrumb = body?.breadcrumb ?? null;
-    if (!breadcrumb) return;
-    setMessages((existing) => existing.map((message) =>
-      message.id === messageId && message.kind === 'result'
-        ? { ...message, breadcrumb }
-        : message,
-    ));
-  } catch {
-    // Breadcrumb is purely additive context; failure is silently ignored.
-  }
-}
 import { difficultyCopyFromEstimate } from '@/lib/questions/difficulty-copy';
 import type { InsideJokeKind } from '@/lib/questions-types';
 import type { JoshingGameView, QuestionRow } from '@/server/db/queries/joshing-game';
@@ -228,8 +201,6 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
             : null,
         },
       ]);
-
-      void fetchJoshingGameBreadcrumb(game.game.id, currentQuestion.questionId, resultMessageId, setMessages);
 
       nextQuestionTimerRef.current = window.setTimeout(() => {
         setPausingAfterAnswer(false);

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -591,57 +591,23 @@ function UserRow({ text }: { text: string }) {
   );
 }
 
-function BreadcrumbLine({
-  text,
-  creatorName,
-  creatorIsHouse = false,
-}: {
-  text: string;
-  creatorName: string | null;
-  creatorIsHouse?: boolean;
-}) {
-  const author = creatorName?.trim() ?? null;
-  // House is non-relational like the LLM origin: no "From {firstName}." line.
-  const isBot = creatorIsHouse || isLlmAttribution(author);
-  const showAuthor = author && !isBot;
-  return (
-    <div
-      style={{
-        marginTop: '9px',
-        borderLeft: '2px solid color-mix(in srgb, var(--text) 20%, transparent)',
-        paddingLeft: '8px',
-      }}
-    >
-      {showAuthor ? (
-        <p
-          style={{
-            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
-            fontSize: '0.7rem',
-            fontStyle: 'italic',
-            color: 'var(--text-muted)',
-          }}
-        >
-          From {firstNameFrom(author!)}.
-        </p>
-      ) : null}
-      <p
-        style={{
-          marginTop: showAuthor ? '2px' : '0',
-          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
-          fontSize: '0.782rem',
-          fontStyle: 'italic',
-          color: 'color-mix(in srgb, var(--text-muted) 50%, var(--text))',
-          opacity: 0.78,
-          lineHeight: 1.46,
-        }}
-      >
-        &ldquo;{text}&rdquo;
-      </p>
-    </div>
-  );
+// The reveal carries one short explanatory line. It must read as a single,
+// consistent sentence (two at the most) — stored explainers can run several
+// sentences or paragraphs, so clamp to the first two and never let the card
+// swap in longer content after the fact.
+function clampToSentences(text: string, max = 2): string {
+  const trimmed = text.trim();
+  if (!trimmed) return trimmed;
+  // Split on sentence terminators that are followed by whitespace, keeping the
+  // terminator with its sentence. Abbreviations may over-split, but the result
+  // is still a tidy one-to-two-sentence blurb, which is the goal.
+  const sentences = trimmed.match(/[^.!?]+[.!?]+(?=\s|$)|[^.!?]+$/g);
+  if (!sentences || sentences.length <= max) return trimmed;
+  return sentences.slice(0, max).join(' ').trim();
 }
 
 function ExplanationLine({ text }: { text: string }) {
+  const clamped = clampToSentences(text);
   return (
     <div
       style={{
@@ -659,7 +625,7 @@ function ExplanationLine({ text }: { text: string }) {
           lineHeight: 1.51,
         }}
       >
-        {text}
+        {clamped}
       </p>
     </div>
   );
@@ -987,7 +953,6 @@ function ResultRow({
   consolation,
   insideJoke,
   insideJokeKind,
-  breadcrumb,
   authorNote,
   explanation,
   copyVariant,
@@ -1272,15 +1237,7 @@ function ResultRow({
             ) : null}
           </>
         )}
-        {breadcrumb ? (
-          <BreadcrumbLine
-            text={breadcrumb}
-            creatorName={creatorName}
-            creatorIsHouse={creatorIsHouse}
-          />
-        ) : explanation ? (
-          <ExplanationLine text={explanation} />
-        ) : null}
+        {explanation ? <ExplanationLine text={explanation} /> : null}
         {typeof pointsAwarded === 'number' ? (
           <p
             style={{

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { newMessageId, type ChatMessage } from '@/components/play/GameplayChat';
 import { CATCH_UP_BATCH_SIZE } from '@/lib/game-constants';
@@ -94,33 +94,6 @@ function formatQuestionSubhead(item: CatchupQueueItem): string {
   const date = new Date(`${item.queueDate}T12:00:00.000Z`);
   if (Number.isNaN(date.getTime())) return 'FROM EARLIER';
   return `FROM ${new Intl.DateTimeFormat('en-US', { weekday: 'long' }).format(date).toUpperCase()}`;
-}
-
-async function fetchBreadcrumbForCatchupMessage(
-  queueId: string,
-  slotIndex: number,
-  messageId: string,
-  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
-): Promise<void> {
-  try {
-    const response = await fetch('/api/breadcrumb', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ source: 'daily', queueId, slotIndex }),
-    });
-    if (!response.ok) return;
-    const body = await response.json().catch(() => null) as { breadcrumb?: string | null } | null;
-    const breadcrumb = body?.breadcrumb ?? null;
-    if (!breadcrumb) return;
-    setMessages((existing) => existing.map((message) =>
-      message.id === messageId && message.kind === 'result'
-        ? { ...message, breadcrumb }
-        : message,
-    ));
-  } catch {
-    // Breadcrumb is purely additive context; failure is silently ignored.
-  }
 }
 
 // Builds the result-turn message a catch-up answer produces, mapping the
@@ -484,16 +457,6 @@ export function useCatchupFlow() {
           pointsAwarded,
         }),
       ]);
-
-      // Breadcrumbs are computed from daily-queue slots only; feed-sourced
-      // catch-up items use a `feed:<feedItemId>` ID and have no slot to look up.
-      if (!item.dailyQueueItemId.startsWith('feed:')) {
-        const [queueId, slotIndexValue] = item.dailyQueueItemId.split(':');
-        const slotIndex = Number(slotIndexValue);
-        if (queueId && Number.isInteger(slotIndex)) {
-          void fetchBreadcrumbForCatchupMessage(queueId, slotIndex, resultMessageId, setMessages);
-        }
-      }
 
       const revealedAnswer = data.correctAnswer ?? data.answer ?? item.correctAnswer;
       window.setTimeout(() => {


### PR DESCRIPTION
## Summary
This PR removes the breadcrumb feature entirely—the short explanatory lines that appeared on reveal cards. The feature involved precomputing breadcrumbs via LLM calls and fetching them asynchronously, which added complexity without sufficient value. In its place, we now rely solely on the `explanation` field for contextual information on reveals.

## Key Changes

- **Removed `BreadcrumbLine` component** from `GameplayChat.tsx` — this rendered the breadcrumb text with author attribution
- **Removed breadcrumb precomputation** from the daily answer route (`/api/daily/answer/route.ts`) — eliminated the background LLM call that generated and cached breadcrumbs in queue slots
- **Removed breadcrumb fetching** from client-side code:
  - Deleted `fetchBreadcrumbForCatchupMessage()` from `useCatchupFlow.ts`
  - Deleted `fetchBreadcrumb()` callback from `DailyPage` 
  - Deleted `fetchJoshingGameBreadcrumb()` from `play-client.tsx`
- **Simplified result rendering** in `ResultRow` — now only renders `ExplanationLine` if explanation exists; removed the conditional breadcrumb rendering path
- **Added `clampToSentences()` utility** in `GameplayChat.tsx` — ensures explanation text is clamped to 1–2 sentences for consistency on reveal cards (prevents longer stored explanations from breaking the card layout)
- **Removed breadcrumb parameter** from `ResultRow` props and related type signatures

## Implementation Details

The `clampToSentences()` function uses a regex to split on sentence terminators (`.`, `!`, `?`) followed by whitespace, keeping the terminator with its sentence. This ensures reveal cards display concise, single-sentence-to-two-sentence blurbs without swapping in longer content after initial render.

All breadcrumb-related API endpoints and database slot fields remain in place but are no longer populated or fetched, allowing for a clean removal without schema changes.

https://claude.ai/code/session_018imNnwFBEchSxYeWNjx8cW