### PR TITLE
Fix answer-it-twice loop: reuse canonical Question when sending a generated question

### DIFF
--- a/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
+++ b/src/app/api/questions/send/__tests__/resolve-question-id-for-send.test.ts
@@ -79,6 +79,12 @@ vi.mock('@/server/sms', () => ({ sendSms: vi.fn() }));
 vi.mock('@/server/db/queries/content-reports', () => ({
   isQuestionReportSuppressed: vi.fn(async () => false),
 }));
+// The reuse lookup that prevents a sent GeneratedQuestion from forking into a
+// second canonical Question. Stubbed to "no existing row" by default so the mint
+// path is exercised; individual tests override it to assert reuse.
+vi.mock('@/server/questions/persist-generated-question', () => ({
+  findCanonicalQuestionIdForGenerated: vi.fn(async () => null),
+}));
 
 import { POST, resolveQuestionIdForSend } from '@/app/api/questions/send/route';
 import { getSession } from '@/server/auth/session';
@@ -88,6 +94,7 @@ import {
   userAnsweredQuestionCorrectly,
   userHasQuestionInBlockingFeed,
 } from '@/server/db/queries/feed';
+import { findCanonicalQuestionIdForGenerated } from '@/server/questions/persist-generated-question';
 
 describe('resolveQuestionIdForSend', () => {
   beforeEach(() => {
@@ -95,6 +102,29 @@ describe('resolveQuestionIdForSend', () => {
     state.generated = null;
     state.insertedValues = null;
     dbMock.insert.mockClear();
+    vi.mocked(findCanonicalQuestionIdForGenerated).mockResolvedValue(null);
+  });
+
+  it('reuses an existing canonical Question for a generated id without minting a duplicate', async () => {
+    // The loop fix: the sender passes a GeneratedQuestion id they already answered
+    // in their daily, which persisted a canonical Question. Reuse that row instead
+    // of forking a second curated_sent row (which broke question_id-keyed dedup).
+    state.generated = {
+      id: 'gen-1',
+      questionText: 'What is the capital of France?',
+      answer: 'Paris',
+      explainer: null,
+      broadCategory: 'Geography',
+      canonicalSubcategory: 'European Capitals',
+      difficultyEstimate: 'accessible',
+    };
+    vi.mocked(findCanonicalQuestionIdForGenerated).mockResolvedValue('existing-canonical-q');
+
+    const result = await resolveQuestionIdForSend('gen-1');
+
+    expect(result).toBe('existing-canonical-q');
+    expect(findCanonicalQuestionIdForGenerated).toHaveBeenCalledWith('gen-1');
+    expect(dbMock.insert).not.toHaveBeenCalled();
   });
 
   it('returns a real Question id unchanged without inserting', async () => {
@@ -158,6 +188,7 @@ describe('POST /api/questions/send — house guard (D-3)', () => {
     vi.mocked(userAnsweredQuestionCorrectly).mockResolvedValue(false as never);
     vi.mocked(userHasQuestionInBlockingFeed).mockResolvedValue(false as never);
     vi.mocked(createFeedItem).mockResolvedValue({ id: 'feed-1' } as never);
+    vi.mocked(findCanonicalQuestionIdForGenerated).mockResolvedValue(null);
     dbMock.insert.mockClear();
   });
 

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -14,6 +14,7 @@ import { getFriends } from '@/server/db/queries/friends';
 import { isQuestionReportSuppressed } from '@/server/db/queries/content-reports';
 import { sendSms } from '@/server/sms';
 import { DIRECT_SENT_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import { findCanonicalQuestionIdForGenerated } from '@/server/questions/persist-generated-question';
 
 export const dynamic = 'force-dynamic';
 
@@ -192,6 +193,16 @@ export async function resolveQuestionIdForSend(questionId: string): Promise<stri
     .limit(1);
 
   if (!generated) return null;
+
+  // Reuse a canonical Question that already represents this generated row rather
+  // than minting a second one. The daily-answer path persists it as
+  // generated_question_id and a prior send persists it as source_question_id;
+  // either is the same fact. Minting a fresh row here forks the question into two
+  // ids, which defeats every question_id-keyed dedup downstream (feed "already
+  // answered" suppression, the already-in-feed guard above) — the cause of the
+  // observed loop where a question you'd answered came back via a friend's feed.
+  const existingId = await findCanonicalQuestionIdForGenerated(generated.id);
+  if (existingId) return existingId;
 
   // A sent LLM question keeps its LLM/curated provenance: no author is recorded
   // (creatorId stays null so author/curator credit never accrues to the

--- a/src/server/questions/__tests__/find-canonical-question-for-generated.test.ts
+++ b/src/server/questions/__tests__/find-canonical-question-for-generated.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Minimal db mock: the helper issues one select…from…where…orderBy…limit chain
+// and reads the first row. We only need to control the rows it returns.
+const { dbMock, state } = vi.hoisted(() => {
+  const state = { rows: [] as Array<{ id: string }> };
+  const chain = {
+    from: vi.fn(() => chain),
+    where: vi.fn(() => chain),
+    orderBy: vi.fn(() => chain),
+    limit: vi.fn(async () => state.rows),
+  };
+  const dbMock = { select: vi.fn(() => chain) };
+  return { dbMock, state };
+});
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  questions: { source: 'questions.source' },
+  generatedQuestions: {},
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...p) => ({ op: 'and', p })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  or: vi.fn((...p) => ({ op: 'or', p })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
+  sql: Object.assign(vi.fn(() => ({ op: 'sql' })), { raw: vi.fn() }),
+}));
+
+import { findCanonicalQuestionIdForGenerated } from '@/server/questions/persist-generated-question';
+
+describe('findCanonicalQuestionIdForGenerated', () => {
+  beforeEach(() => {
+    state.rows = [];
+  });
+
+  it('returns the canonical Question id when a row links to the generated id', async () => {
+    state.rows = [{ id: 'canonical-q' }];
+    await expect(findCanonicalQuestionIdForGenerated('gen-1')).resolves.toBe('canonical-q');
+  });
+
+  it('returns null when no Question links to the generated id', async () => {
+    state.rows = [];
+    await expect(findCanonicalQuestionIdForGenerated('gen-unknown')).resolves.toBeNull();
+  });
+});

--- a/src/server/questions/persist-generated-question.ts
+++ b/src/server/questions/persist-generated-question.ts
@@ -1,10 +1,41 @@
-import { and, eq, isNull, sql } from 'drizzle-orm';
+import { and, eq, isNull, or, sql } from 'drizzle-orm';
 
 import { db, generatedQuestions, questions } from '@/server/db';
 import {
   GenericCanonicalSubcategoryError,
   isGenericSubcategory,
 } from '@/server/questions/canonical-subcategory';
+
+/**
+ * The single canonical `Question` id for a generated question, if one already
+ * exists — across BOTH provenance columns:
+ *   - `generated_question_id`: the row the daily-answer path persists.
+ *   - `source_question_id`:    the row the send-to-friend path mints (curated_sent).
+ *
+ * Both link back to the same `GeneratedQuestion`, i.e. the same fact. Resolving
+ * to one shared id is what stops a question from forking into two `Question`
+ * rows — which otherwise defeats every question_id-keyed dedup downstream (feed
+ * "already answered" suppression, the send already-in-feed guard) and produces
+ * the answer-it-twice loop. Prefers the daily_generated row so repeated calls
+ * converge on one stable id regardless of which path created which first.
+ */
+export async function findCanonicalQuestionIdForGenerated(
+  generatedId: string,
+): Promise<string | null> {
+  const [existing] = await db
+    .select({ id: questions.id })
+    .from(questions)
+    .where(and(
+      isNull(questions.deletedAt),
+      or(
+        eq(questions.generatedQuestionId, generatedId),
+        eq(questions.sourceQuestionId, generatedId),
+      ),
+    ))
+    .orderBy(sql`case when ${questions.source} = 'daily_generated' then 0 else 1 end`)
+    .limit(1);
+  return existing?.id ?? null;
+}
 
 function normalizeQuestionTextForDedup(value: string): string {
   return value
@@ -28,14 +59,14 @@ function asDifficulty(value: string): 'accessible' | 'moderate' | 'specialist' |
 
 export async function persistGeneratedQuestion(generatedQuestionId: string, slotDomain?: string): Promise<PersistGeneratedQuestionResult> {
   try {
-    const [existing] = await db
-      .select({ id: questions.id })
-      .from(questions)
-      .where(eq(questions.generatedQuestionId, generatedQuestionId))
-      .limit(1);
-
-    if (existing) {
-      return { questionId: existing.id, alreadyExisted: true };
+    // Reuse any canonical Question already linked to this generated row — by
+    // generated_question_id (the usual daily path) OR source_question_id (a
+    // curated_sent row a prior send-to-friend minted). The latter is what closes
+    // the send-then-answer ordering: without it, persisting after a send would
+    // create a SECOND row for the same fact and re-open the answer-it-twice loop.
+    const existingId = await findCanonicalQuestionIdForGenerated(generatedQuestionId);
+    if (existingId) {
+      return { questionId: existingId, alreadyExisted: true };
     }
 
     const [generated] = await db


### PR DESCRIPTION
## The bug (traced in the DB)
You answered the Aster/Asteraceae question in your Daily Five, sent it to Robyn, she answered it — and her answer fanned a *"Robyn answered — your turn"* card **back to you**, for a question you'd already answered. You then answered it again.

Root cause: **one question, two `Question` rows.**
- Your daily answer persisted **Question A** (`1f684e1a`, `source=daily_generated`, `generated_question_id=f0e45d4a`).
- Sending it to Robyn minted a **second** **Question B** (`9f6a1578`, `source=curated_sent`, `source_question_id=f0e45d4a`).

`resolveQuestionIdForSend` mints a fresh `curated_sent` row whenever you send a question by its **GeneratedQuestion** id (which is exactly what a daily slot carries) — without checking for an existing canonical row. The feed's "already answered" suppression (`createFeedItemsForFriendsFromAnswer`) is correct, but keys on `question_id`: Robyn answered **B**, your mastery event is on **A**, B ≠ A → you weren't suppressed.

## The fix
New `findCanonicalQuestionIdForGenerated(generatedId)` — resolves the single canonical `Question` for a generated row, matching **both** provenance columns (`generated_question_id` and `source_question_id`), preferring the `daily_generated` row so repeated calls converge.

- **`resolveQuestionIdForSend`** reuses it instead of minting a duplicate → closes the **answer-then-send** order (the reported loop): the send now references Question A, so Robyn's answer hits the existing A-keyed suppression.
- **`persistGeneratedQuestion`**'s first lookup uses it too → closes the **send-then-answer** order: persisting after a send reuses the `curated_sent` row rather than forking a second one.

## Why this closes the loop (not just the dupe)
With one shared `question_id`, the *existing* feed suppression at `create-feed-items-for-answer.ts:147-154` finally matches — it already had the right intent, it was only defeated by the forked id. The send-side guards (`userAnsweredQuestionCorrectly` / `userHasQuestionInBlockingFeed`) also start working, since they now run against the real shared row instead of a brand-new one.

## Tests
- `resolve-question-id-for-send`: new "reuses an existing canonical Question without minting" case + existing mint/guard cases.
- New focused contract test for the helper.
- Re-ran send suppression, feed-suppression, and daily/catchup answer suites (which exercise `persistGeneratedQuestion`). **All green; `tsc` clean; lint clean.**

## Not included (follow-ups)
- **Data cleanup**: the already-forked pair (B → A) still exists. A one-off to repoint B's FeedItems/mastery to A and soft-delete B would stop *this* question from looping again — I'd first count how many other texts are forked. Happy to do this as a separate, reviewable script.
- **Lineage-keyed suppression backstop** (suppress on `fact_key`/embedding, not just `question_id`) for any dupes that predate this fix — ties into the dormant embedding work (PR #752).

🤖 Generated with [Claude Code](https://claude.com/claude-code)