### PR TITLE
Limit home feed to one discovery graphic, off the top, no timestamp

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -120,6 +120,22 @@ async function CeremonyPinSection({ userId }: { userId: string }) {
   )
 }
 
+// At most one discovery graphic (common-ground OR world-expanding) per feed.
+// When both qualify, a coin flip drops one so neither dominates and the feed
+// isn't doubled up with two graphics. Kept at module scope (not in the server
+// component body) so the Math.random call isn't flagged as render-impure.
+function pickOneGraphicPromo<T>(
+  commonGround: T | null,
+  recentlyExpanding: T | null,
+): { commonGround: T | null; recentlyExpanding: T | null } {
+  if (commonGround && recentlyExpanding) {
+    return Math.random() < 0.5
+      ? { commonGround, recentlyExpanding: null }
+      : { commonGround: null, recentlyExpanding }
+  }
+  return { commonGround, recentlyExpanding }
+}
+
 async function FromYourFriendsSection({ userId }: { userId: string }) {
   // The unified "What's Happening" home feed: the question feed merged with the
   // full activity/Lately stream, interleaved chronologically inside FeedList.
@@ -136,20 +152,24 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
     getRecentlyExpandingPromo(userId),
     getAddFriendsPromo(userId),
   ])
+  // One discovery graphic per session: showing BOTH the common-ground circles
+  // and the world-expanding badges in a single feed is too much, and the two
+  // compete. When both are available, keep one at random so neither dominates;
+  // the survivor is pinned a few rows down by FeedList (never at the very top).
+  // The coin flip lives in pickOneGraphicPromo (module scope) so it isn't a
+  // render-impure Math.random call in this server component body.
+  const { commonGround, recentlyExpanding } = pickOneGraphicPromo(
+    commonGroundPromo,
+    recentlyExpandingPromo,
+  )
   // The weekly reflection lives in the dedicated CeremonyPin editorial marker
   // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
   // activity card here so the reflection doesn't double up / compete with social
   // activity in the home stream. It's the only activity that links to /ceremony/;
   // the card still appears in the full /activities log.
-  const homeActivityItems = [
-    // Home-only common-ground discovery promo at the head of the activity rows
-    // (see getCommonGroundPromo). Null when the viewer has no untested shared
-    // ground with any probed friend.
-    ...(commonGroundPromo ? [commonGroundPromo] : []),
-    ...activityItems.filter(
-      (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
-    ),
-  ]
+  const homeActivityItems = activityItems.filter(
+    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
+  )
   return (
     <>
       {/* Sit the header on the feed's left gutter — the same 2px the activity
@@ -166,7 +186,8 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         showContributeFooter
         unifiedHome
         activityItems={homeActivityItems}
-        expandingPromo={recentlyExpandingPromo}
+        commonGroundPromo={commonGround}
+        expandingPromo={recentlyExpanding}
         addFriendsPromo={addFriendsPromo}
       />
     </>

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -446,17 +446,26 @@ type FeedListProps = {
    */
   activityItems?: StreamItem[]
   /**
+   * Home-only "You share ground" common-ground promo. Like `expandingPromo`,
+   * this is pinned at a fixed offset a few rows down (NOT sorted into the
+   * chronological union) so it never lands at the very top. The page enforces
+   * that at most one of `commonGroundPromo` / `expandingPromo` is set per
+   * visit — the two discovery graphics never appear together. See
+   * getCommonGroundPromo / displayRows.
+   */
+  commonGroundPromo?: StreamItem | null
+  /**
    * Home-only "Your world is expanding" promo. Unlike `activityItems` (which
    * interleave chronologically), this is spliced in at a fixed offset a few rows
-   * down so it never lands at the very top or adjacent to the common-ground
-   * promo (which sorts to row 0). Null on most visits — it shows ~1 in 5. See
+   * down so it never lands at the very top. Mutually exclusive with
+   * `commonGroundPromo` (see above). Null on most visits — it shows ~1 in 5. See
    * getRecentlyExpandingPromo / displayRows.
    */
   expandingPromo?: StreamItem | null
   /**
    * Home-only "add friends" promo (contact-match suggestions, or an invite
-   * nudge). Spliced in at its own fixed offset, separated from `expandingPromo`
-   * so the two promos are never adjacent. See getAddFriendsPromo / displayRows.
+   * nudge). Spliced in at its own fixed offset, separated from the graphic promo
+   * so the two are never adjacent. See getAddFriendsPromo / displayRows.
    */
   addFriendsPromo?: StreamItem | null
 }
@@ -464,11 +473,12 @@ type FeedListProps = {
 type QuestionCardState = 'unanswered' | 'answered'
 
 // Where the home-only pinned promos land in the rendered row list: a few rows
-// down (so they're never the very first thing, and never adjacent to the common-
-// ground promo at row 0), and spaced apart from each other. Each offset is
-// measured against the original feed length; a promo only appears once the feed
-// has at least that many rows.
-const EXPANDING_PROMO_OFFSET = 3
+// down (so they're never the very first thing), and spaced apart from each
+// other. Each offset is measured against the original feed length; a promo only
+// appears once the feed has at least that many rows. The single discovery
+// graphic (common-ground OR world-expanding — the page guarantees at most one)
+// sits at GRAPHIC_PROMO_OFFSET; the add-friends promo sits further down.
+const GRAPHIC_PROMO_OFFSET = 3
 const ADD_FRIENDS_PROMO_OFFSET = 6
 
 // One row of the unified-home feed: either a paginated question card or an
@@ -704,6 +714,7 @@ function FeedListContent({
   showContributeFooter = false,
   unifiedHome = false,
   activityItems = [],
+  commonGroundPromo = null,
   expandingPromo = null,
   addFriendsPromo = null,
 }: FeedListProps) {
@@ -914,13 +925,15 @@ function FeedListContent({
 
   // Splice the home-only pinned promos in at fixed offsets a few rows down. They
   // are deliberately NOT part of the chronological union above: pinning them to
-  // indices keeps them off the very top and never adjacent to the common-ground
-  // promo (which sorts to row 0). Each is only inserted once the feed has enough
-  // rows above its offset; offsets are measured against the original feed so the
-  // two promos stay spaced apart even when both are present.
+  // indices keeps them off the very top. The single discovery graphic (common-
+  // ground OR world-expanding — at most one is non-null per the page's
+  // mutual-exclusivity guard) takes GRAPHIC_PROMO_OFFSET; the add-friends promo
+  // sits further down so the two stay spaced apart. Each is only inserted once
+  // the feed has enough rows above its offset.
   const displayRows = useMemo<UnifiedRow[]>(() => {
     const pinned = [
-      { offset: EXPANDING_PROMO_OFFSET, item: expandingPromo },
+      { offset: GRAPHIC_PROMO_OFFSET, item: commonGroundPromo },
+      { offset: GRAPHIC_PROMO_OFFSET, item: expandingPromo },
       { offset: ADD_FRIENDS_PROMO_OFFSET, item: addFriendsPromo },
     ]
       .filter((p): p is { offset: number; item: StreamItem } => p.item !== null)
@@ -946,7 +959,7 @@ function FeedListContent({
       inserted++
     }
     return next
-  }, [unifiedRows, expandingPromo, addFriendsPromo])
+  }, [unifiedRows, commonGroundPromo, expandingPromo, addFriendsPromo])
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -55,6 +55,12 @@ const EXPANDING_ROW_ACCENTS = [
   { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.20)' },
 ] as const;
 
+// Home discovery promos (common-ground circles, world-expanding badges, add-
+// friends) sit on a subtly warmer panel than the cream page so they read as a
+// distinct editorial moment without a loud card shadow — a faint parchment tint
+// + soft rounding + hairline, in the spirit of the "opened" milestone state.
+const PROMO_BG = '#f7f1e6';
+
 // An opened reveal indents to sit UNDER the row's header text, not flush to the
 // far-left edge below the icon. This is exactly the ActivityIcon column width —
 // MARK_W (24) + GAP (8) — so the expansion's left rule lines up with where the
@@ -206,21 +212,35 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
   // and header text don't shift sideways when the card opens.
   const opened = expandable && open;
 
+  // Discovery promos carry an embed (common-ground / world-expanding / add-
+  // friends); ordinary activity rows never do. Promos get the warm panel and
+  // drop the row timestamp (it's a borrowed/meaningless "just now" on a pinned
+  // card, not a real event time).
+  const isPromo = item.embed != null;
+
   return (
     <div
       id={item.anchorId ?? undefined}
       style={
-        opened
+        isPromo
           ? {
-              borderTop: `1px solid ${RULE}`,
-              borderBottom: `1px solid ${RULE}`,
-              padding: '18px 2px',
-              background: PAPER,
+              border: `1px solid ${RULE}`,
+              borderRadius: 12,
+              padding: '14px 12px',
+              margin: '8px 0',
+              background: PROMO_BG,
             }
-          : {
-              borderBottom: `1px solid ${RULE}`,
-              padding: '12px 2px',
-            }
+          : opened
+            ? {
+                borderTop: `1px solid ${RULE}`,
+                borderBottom: `1px solid ${RULE}`,
+                padding: '18px 2px',
+                background: PAPER,
+              }
+            : {
+                borderBottom: `1px solid ${RULE}`,
+                padding: '12px 2px',
+              }
       }
     >
       <div
@@ -269,17 +289,19 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
           ) : null}
         </div>
 
-        <div
-          style={{
-            flexShrink: 0,
-            display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-end',
-            gap: 4,
-          }}
-        >
-          <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap' }}>{timestamp}</span>
-        </div>
+        {isPromo ? null : (
+          <div
+            style={{
+              flexShrink: 0,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              gap: 4,
+            }}
+          >
+            <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap' }}>{timestamp}</span>
+          </div>
+        )}
       </div>
 
       {item.embed?.kind === 'common_ground' ? (

--- a/src/components/activity/__tests__/PromoStreamItem.test.tsx
+++ b/src/components/activity/__tests__/PromoStreamItem.test.tsx
@@ -1,0 +1,107 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  commonGroundPromoToStreamItem,
+  type StreamEmbed,
+  type StreamItem,
+} from '@/lib/activity-stream';
+
+vi.mock('next/link', () => ({
+  default: ({
+    href,
+    children,
+    ...props
+  }: {
+    href: string;
+    children: React.ReactNode;
+  }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+// The common-ground embed draws the overlapping-circle SVG motif; mock it so the
+// test stays focused on the row chrome (panel + timestamp), not the geometry.
+vi.mock('@/components/profile/common-ground-circles', () => ({
+  circleDatasetMax: () => 100,
+  DomainCircleSvg: () => <svg data-mock="domain-circle" />,
+}));
+
+// Heavy children of ActivityStreamItem a promo row never renders — mocked so the
+// module imports cleanly in the node test environment.
+vi.mock('@/components/activity/InlineAnswerFlow', () => ({
+  InlineAnswerFlow: () => <div data-mock="inline-answer" />,
+}));
+vi.mock('@/components/SendQuestionDrawer', () => ({
+  SendQuestionDrawer: () => <div data-mock="send-drawer" />,
+}));
+vi.mock('@/app/activities/FriendRequestActions', () => ({
+  FriendRequestActions: () => <div data-mock="friend-request" />,
+}));
+vi.mock('@/app/activities/ReactionGotItButton', () => ({
+  ReactionGotItButton: () => <div data-mock="reaction" />,
+}));
+
+// Imported AFTER the mocks are registered.
+import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem';
+
+const COMMON_GROUND_EMBED: Extract<StreamEmbed, { kind: 'common_ground' }> = {
+  kind: 'common_ground',
+  friendId: 'friend-1',
+  friendFirstName: 'Robyn',
+  friendHref: '/users/friend-1',
+  domains: [
+    {
+      label: 'Film & TV',
+      viewer: { points: 40, tier: 'familiar' },
+      friend: { points: 60, tier: 'solid' },
+    },
+  ],
+};
+
+// A plain (non-promo) activity one-liner: no embed, so it keeps the standard row
+// chrome (cream-on-cream, timestamp shown).
+const PLAIN_ITEM: StreamItem = {
+  id: 'plain-1',
+  sortAt: new Date('2026-05-20T12:00:00Z'),
+  tier: 0,
+  homeEligible: false,
+  line: [{ t: 'text', v: 'Robyn answered a question' }],
+  secondLine: null,
+  anchorId: null,
+  action: null,
+  expand: null,
+  icon: null,
+  embed: null,
+};
+
+describe('ActivityStreamItem — discovery promo rows (embed-bearing)', () => {
+  it('sets the common-ground promo apart on a warm panel and drops the timestamp', () => {
+    const promo = commonGroundPromoToStreamItem(
+      COMMON_GROUND_EMBED,
+      new Date('2026-05-20T12:00:00Z'),
+      'cg-promo:1',
+    );
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem item={promo} timestamp="just now" />,
+    );
+    // The one-liner still renders…
+    expect(html).toContain('share ground worth testing');
+    // …on the subtly warmer parchment panel (PROMO_BG)…
+    expect(html).toContain('f7f1e6');
+    // …with the borrowed/meaningless row timestamp suppressed.
+    expect(html).not.toContain('just now');
+  });
+
+  it('leaves ordinary activity rows unchanged — no panel, timestamp shown', () => {
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem item={PLAIN_ITEM} timestamp="just now" />,
+    );
+    expect(html).toContain('Robyn answered a question');
+    expect(html).toContain('just now');
+    expect(html).not.toContain('f7f1e6');
+  });
+});


### PR DESCRIPTION
The common-ground circles and world-expanding badges were both able to
appear in a single home feed, and the common-ground promo sorted to the
very top — together that read as too much.

- Show at most one discovery graphic per session: when both qualify, a
  coin flip drops one (pickOneGraphicPromo, module scope so the random
  call isn't render-impure).
- Pin the surviving graphic a few rows down via FeedList's existing promo
  splice instead of prepending common-ground into the chronological union,
  so it never lands at the top. Renames EXPANDING_PROMO_OFFSET to
  GRAPHIC_PROMO_OFFSET since either graphic now occupies that slot.
- Give promo rows (any embed-bearing row) a subtle warm parchment panel to
  set them apart, and drop the borrowed/meaningless row timestamp.
- Add ActivityStreamItem promo-row tests (panel + suppressed timestamp).