### PR TITLE
Redesign feed promos as full-bleed editorial sections

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -167,6 +167,14 @@
     --success-border:      color-mix(in srgb, var(--success) 30%, var(--border));
     --destructive-surface: color-mix(in srgb, var(--destructive) 8%, var(--card));
     --destructive-border:  color-mix(in srgb, var(--destructive) 28%, var(--border));
+    /* Editorial feature washes — full-bleed "featured moment" bands in the feed
+       (Shared Ground / Grow Your Circle / Your World Is Expanding). Subtle tints
+       derived from the page cream so they read as a calm change in surface, not a
+       card or banner. The per-tone eyebrow accent reuses an existing brand token
+       (orange / success-green / link-slate). */
+    --editorial-parchment: color-mix(in srgb, var(--brand-border) 22%, var(--brand-cream-page));
+    --editorial-sage:      color-mix(in srgb, var(--success) 8%, var(--brand-cream-page));
+    --editorial-slate:     color-mix(in srgb, var(--brand-link) 8%, var(--brand-cream-page));
     /* Legacy editorial aliases — re-pointed at the brand tokens so older
        surfaces (AnsweredByYouCard, FriendAddedCard/SparkleEnvelope, the
        Knowledge page, replay/catch-up) render with navy ink instead of warm
@@ -238,6 +246,11 @@
     --sidebar-accent-foreground: oklch(0.985 0 0);
     --sidebar-border: oklch(1 0 0 / 10%);
     --sidebar-ring: oklch(0.556 0 0);
+    /* Editorial feature washes — tinted off the dark card so the bands stay
+       legible as a featured surface in dark mode. */
+    --editorial-parchment: color-mix(in srgb, var(--brand-border) 10%, var(--card));
+    --editorial-sage:      color-mix(in srgb, var(--success) 12%, var(--card));
+    --editorial-slate:     color-mix(in srgb, var(--brand-link) 14%, var(--card));
 }
 
 @layer base {

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -25,6 +25,11 @@ import { SparkleDivider, SpeechBubbleIllustration } from '@/components/home/Feed
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
+import {
+  CommonGroundFeature,
+  GrowYourCircleFeature,
+  RecentlyExpandingFeature,
+} from '@/components/feed/EditorialPromos'
 import type { StreamItem } from '@/lib/activity-stream'
 import type { InsideJokeKind, QuestionSource } from '@/lib/questions-types'
 
@@ -620,78 +625,57 @@ function FeedContributeFooter() {
   return (
     <footer className="pt-6 pb-8">
       <SparkleDivider />
-      {/* Add-a-Question card — the brand triangle pattern (the same Variant4
-          asset as the home banner) clipped to the rounded card, with the
-          composer prompt overlaid. The box stays an input: the reader's typed
-          idea rides to the writer via ?text= (buildQuestionWriterHref). */}
-      <div className="mt-6">
-        <div className="relative overflow-hidden rounded-[8px] border border-[var(--brand-border)] shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/images/Variant4.png"
-            alt=""
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0 h-full w-full object-cover object-center"
-          />
-          {/* Cream scrim — softens the saturated triangle tiles to the muted
-              wash in the mock. */}
-          <div
-            aria-hidden="true"
-            className="pointer-events-none absolute inset-0"
-            style={{ background: 'color-mix(in srgb, var(--brand-cream-page) 40%, transparent)' }}
-          />
-          <div className="relative flex flex-col">
-            {/* Full-bleed cream band behind the headline (page cream
-                --brand-cream-page at 80%) so the serif prompt reads cleanly
-                over the triangles. */}
-            <div
-              className="mt-6 flex items-center justify-center px-10 py-6"
-              style={{ background: 'color-mix(in srgb, var(--brand-cream-page) 80%, transparent)' }}
-            >
-              <h2 className="w-[273px] max-w-full font-serif text-[32px] leading-[40px] font-medium tracking-[-0.1px] text-[var(--brand-ink)]">
-                Sometimes the best way to show you know someone is to ask them a
-                question.
-              </h2>
-            </div>
-            <form onSubmit={handleSubmit} className="flex flex-col gap-4 px-12 pt-6 pb-8">
-              {/* Wrapper lets the fading placeholder overlay sit exactly over
-                  the textarea. The overlay (not the native placeholder) is what
-                  cycles, so we can crossfade it; it shows only while empty and
-                  is hidden from AT (the textarea keeps the aria-label). */}
-              <div className="relative">
-                <textarea
-                  value={idea}
-                  onChange={(event) => setIdea(event.target.value)}
-                  aria-label="What question would you like to be asked?"
-                  rows={5}
-                  className="min-h-[200px] w-full resize-none rounded-[8px] border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-3 text-base text-[var(--brand-ink)] outline-none focus:border-[var(--brand-link)]"
-                />
-                {idea.trim() === '' ? (
-                  <span
-                    aria-hidden="true"
-                    className="pointer-events-none absolute inset-0 px-4 py-3 text-base text-[var(--brand-ink-400)]"
-                    style={{
-                      opacity: placeholderVisible ? 1 : 0,
-                      transition: `opacity ${
-                        placeholderVisible
-                          ? CONTRIBUTE_PLACEHOLDER_FADE_IN_MS
-                          : CONTRIBUTE_PLACEHOLDER_FADE_OUT_MS
-                      }ms ease-in-out`,
-                    }}
-                  >
-                    {CONTRIBUTE_PLACEHOLDER_EXAMPLES[placeholderIndex]}
-                  </span>
-                ) : null}
-              </div>
-              <button
-                type="submit"
-                className="text-primary-foreground flex min-h-11 w-full items-center justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] transition hover:opacity-90"
+      {/* Add-a-Question prompt — the same full-bleed editorial wash language as
+          the feed's other featured moments (no card, border, or triangle
+          mosaic): a parchment band that bleeds to the feed edges, with an
+          eyebrow, the serif prompt, and the composer. The box stays an input:
+          the reader's typed idea rides to the writer via ?text=
+          (buildQuestionWriterHref). */}
+      <div className="-mx-4 mt-6 bg-[var(--editorial-parchment)] px-4 py-12 md:py-14">
+        <p className="text-[11px] font-semibold tracking-[0.14em] text-[var(--brand-orange)] uppercase">
+          Your Turn
+        </p>
+        <h2 className="mt-4 max-w-[20ch] font-serif text-[26px] leading-[1.15] font-medium text-[var(--brand-ink)] md:text-[32px]">
+          Sometimes the best way to show you know someone is to ask them a
+          question.
+        </h2>
+        <form onSubmit={handleSubmit} className="mt-8 flex flex-col gap-4">
+          {/* Wrapper lets the fading placeholder overlay sit exactly over
+              the textarea. The overlay (not the native placeholder) is what
+              cycles, so we can crossfade it; it shows only while empty and
+              is hidden from AT (the textarea keeps the aria-label). */}
+          <div className="relative">
+            <textarea
+              value={idea}
+              onChange={(event) => setIdea(event.target.value)}
+              aria-label="What question would you like to be asked?"
+              rows={5}
+              className="min-h-[180px] w-full resize-none rounded-[8px] border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-3 text-base text-[var(--brand-ink)] outline-none focus:border-[var(--brand-link)]"
+            />
+            {idea.trim() === '' ? (
+              <span
+                aria-hidden="true"
+                className="pointer-events-none absolute inset-0 px-4 py-3 text-base text-[var(--brand-ink-400)]"
+                style={{
+                  opacity: placeholderVisible ? 1 : 0,
+                  transition: `opacity ${
+                    placeholderVisible
+                      ? CONTRIBUTE_PLACEHOLDER_FADE_IN_MS
+                      : CONTRIBUTE_PLACEHOLDER_FADE_OUT_MS
+                  }ms ease-in-out`,
+                }}
               >
-                Write a Question
-              </button>
-            </form>
+                {CONTRIBUTE_PLACEHOLDER_EXAMPLES[placeholderIndex]}
+              </span>
+            ) : null}
           </div>
-        </div>
+          <button
+            type="submit"
+            className="text-primary-foreground flex min-h-11 w-full items-center justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] transition hover:opacity-90"
+          >
+            Write a Question
+          </button>
+        </form>
       </div>
     </footer>
   )
@@ -1500,6 +1484,19 @@ function FeedListContent({
                 // Interleaved activity (Lately) one-liner: self-contained,
                 // renders its own row (no swipe/overflow/answer-sheet chrome).
                 if (row.kind === 'activity') {
+                  // Home-only promos render as full-bleed editorial feature
+                  // sections (a calm "featured moment" wash) rather than ordinary
+                  // activity rows; everything else is a normal one-liner.
+                  const embed = row.item.embed
+                  if (embed?.kind === 'common_ground') {
+                    return <CommonGroundFeature key={`e-${row.item.id}`} embed={embed} />
+                  }
+                  if (embed?.kind === 'add_friends') {
+                    return <GrowYourCircleFeature key={`e-${row.item.id}`} embed={embed} />
+                  }
+                  if (embed?.kind === 'recently_expanding') {
+                    return <RecentlyExpandingFeature key={`e-${row.item.id}`} embed={embed} />
+                  }
                   return (
                     <ActivityStreamItem
                       key={`a-${row.item.id}`}

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -2,25 +2,17 @@
 
 import { Send } from 'lucide-react';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 import { useState, type KeyboardEvent } from 'react';
 
 import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
-import { AddFriendButton } from '@/components/friends/AddFriendButton';
-import { colorForUser, initialsFor, isDarkColor } from '@/components/feed/visual';
 import { SendQuestionDrawer } from '@/components/SendQuestionDrawer';
 import type {
-  StreamEmbed,
   StreamExpand,
   StreamItem,
   StreamLinePart,
   StreamQuestion,
 } from '@/lib/activity-stream';
-import {
-  circleDatasetMax,
-  DomainCircleSvg,
-} from '@/components/profile/common-ground-circles';
 
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
@@ -32,28 +24,6 @@ import { assertNever } from '@/lib/assert-never';
 // linked or not, so the actor reads as the warm social anchor of the row.
 const ACTOR_BLUE = 'var(--brand-link)';
 
-// Promo embed CTA link ("See what you share" / "See your knowledge"): a plain
-// underlined text link in the body font, NOT the old monospace letterspaced caps
-// treatment, so it reads unmistakably as a link.
-const EMBED_LINK_STYLE = {
-  display: 'inline-block',
-  marginTop: 12,
-  fontFamily: FF,
-  fontSize: 13,
-  fontWeight: 600,
-  color: ACTOR_BLUE,
-  textDecoration: 'underline',
-  textUnderlineOffset: 3,
-} as const;
-
-// Badge accents for the recently-expanding embed rows — the reds / golds / blues
-// from the /knowledge "Recently Expanding" module (ROW_ACCENTS), trimmed to the
-// three we ever render.
-const EXPANDING_ROW_ACCENTS = [
-  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
-  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
-  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.20)' },
-] as const;
 
 // An opened reveal indents to sit UNDER the row's header text, not flush to the
 // far-left edge below the icon. This is exactly the ActivityIcon column width —
@@ -282,14 +252,6 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
         </div>
       </div>
 
-      {item.embed?.kind === 'common_ground' ? (
-        <CommonGroundEmbed embed={item.embed} />
-      ) : item.embed?.kind === 'recently_expanding' ? (
-        <RecentlyExpandingEmbed embed={item.embed} />
-      ) : item.embed?.kind === 'add_friends' ? (
-        <AddFriendsEmbed embed={item.embed} />
-      ) : null}
-
       {item.action ? <ItemAction action={item.action} /> : null}
 
       {expandable && open && expand ? (
@@ -308,218 +270,6 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
           )}
         </div>
       ) : null}
-    </div>
-  );
-}
-
-// The homepage common-ground promo embed: the friend's top shared-but-untested
-// domains as the overlapping-circle motif (same geometry as the profile page),
-// indented to sit under the row's one-liner, with a link through to the profile.
-// Read-only and non-expanding — it stops click propagation so taps on the
-// circles or link never toggle a (non-existent) expansion.
-function CommonGroundEmbed({
-  embed,
-}: {
-  embed: Extract<StreamEmbed, { kind: 'common_ground' }>;
-}) {
-  const datasetMax = circleDatasetMax(
-    embed.domains.flatMap((d) => [d.viewer.points, d.friend.points]),
-  );
-  return (
-    <div
-      onClick={(e) => e.stopPropagation()}
-      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
-    >
-      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
-        {embed.domains.map((d) => (
-          <div
-            key={d.label}
-            style={{
-              display: 'flex',
-              flexDirection: 'column',
-              alignItems: 'center',
-              gap: 6,
-              maxWidth: 120,
-            }}
-          >
-            <DomainCircleSvg
-              viewerPoints={d.viewer.points}
-              friendPoints={d.friend.points}
-              viewerTier={d.viewer.tier}
-              friendTier={d.friend.tier}
-              datasetMax={datasetMax}
-              ariaLabel={`${d.label}: shared with ${embed.friendFirstName}, still untested`}
-            />
-            <span
-              style={{
-                fontFamily: 'Georgia, serif',
-                fontSize: 12.5,
-                lineHeight: 1.3,
-                textAlign: 'center',
-                color: INK2,
-              }}
-            >
-              {d.label}
-            </span>
-          </div>
-        ))}
-      </div>
-      <Link href={embed.friendHref} style={EMBED_LINK_STYLE}>
-        See what you share →
-      </Link>
-    </div>
-  );
-}
-
-// The homepage recently-expanding promo embed: the viewer's fastest-growing
-// territories listed in the /knowledge "Recently Expanding" row style (colored
-// letter badge + serif title + supporting line), indented to sit under the row's
-// one-liner, with a link through to the knowledge page. Read-only and
-// non-expanding — it stops click propagation so taps never toggle a (non-
-// existent) expansion.
-function RecentlyExpandingEmbed({
-  embed,
-}: {
-  embed: Extract<StreamEmbed, { kind: 'recently_expanding' }>;
-}) {
-  return (
-    <div
-      onClick={(e) => e.stopPropagation()}
-      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
-    >
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-        {embed.domains.map((d, i) => {
-          const accent = EXPANDING_ROW_ACCENTS[i % EXPANDING_ROW_ACCENTS.length]!;
-          return (
-            <div key={d.label} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-              <div
-                aria-hidden="true"
-                style={{
-                  width: 30,
-                  height: 30,
-                  flexShrink: 0,
-                  borderRadius: 999,
-                  border: `1px solid ${accent.border}`,
-                  background: accent.fill,
-                  color: INK,
-                  display: 'grid',
-                  placeItems: 'center',
-                  fontSize: 13,
-                  fontWeight: 700,
-                  lineHeight: 1,
-                }}
-              >
-                {d.initial}
-              </div>
-              <div style={{ minWidth: 0 }}>
-                <p
-                  style={{
-                    margin: 0,
-                    fontFamily: 'Georgia, serif',
-                    fontSize: 14,
-                    fontWeight: 700,
-                    lineHeight: 1.2,
-                    color: INK,
-                  }}
-                >
-                  {d.label}
-                </p>
-                {d.caption ? (
-                  <p style={{ margin: '2px 0 0', fontSize: 12, lineHeight: 1.3, color: INK2 }}>
-                    {d.caption}
-                  </p>
-                ) : null}
-              </div>
-            </div>
-          );
-        })}
-      </div>
-      <Link href={embed.href} style={EMBED_LINK_STYLE}>
-        See your knowledge →
-      </Link>
-    </div>
-  );
-}
-
-// The homepage add-friends promo embed: either a few contact-match people the
-// viewer can follow (each row reuses the canonical AddFriendButton state machine
-// + a refresh on change) or, when there's no one to suggest, a copy-only nudge
-// toward /friends/find. Indented to sit under the row's one-liner; stops click
-// propagation so taps never toggle a (non-existent) expansion.
-function AddFriendsEmbed({
-  embed,
-}: {
-  embed: Extract<StreamEmbed, { kind: 'add_friends' }>;
-}) {
-  const router = useRouter();
-  return (
-    <div
-      onClick={(e) => e.stopPropagation()}
-      style={{ marginLeft: EXPANSION_INDENT, marginTop: 12 }}
-    >
-      {embed.variant === 'suggestions' ? (
-        <>
-          <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
-            {embed.people.map((p) => {
-              const bg = p.avatarColor ?? colorForUser(p.id);
-              return (
-                <div key={p.id} style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
-                  <Link
-                    href={`/users/${p.id}`}
-                    style={{
-                      width: 32,
-                      height: 32,
-                      flexShrink: 0,
-                      borderRadius: 999,
-                      background: bg,
-                      color: isDarkColor(bg) ? '#fff' : INK,
-                      display: 'grid',
-                      placeItems: 'center',
-                      fontSize: 12,
-                      fontWeight: 700,
-                      lineHeight: 1,
-                      textDecoration: 'none',
-                    }}
-                  >
-                    {initialsFor(p.displayName)}
-                  </Link>
-                  <div style={{ minWidth: 0, flex: 1 }}>
-                    <Link
-                      href={`/users/${p.id}`}
-                      style={{ color: INK, fontWeight: 600, fontSize: 14, textDecoration: 'none' }}
-                    >
-                      {p.displayName}
-                    </Link>
-                    {p.handle ? (
-                      <span style={{ display: 'block', fontSize: 12, lineHeight: 1.3, color: INK3 }}>
-                        @{p.handle}
-                      </span>
-                    ) : null}
-                  </div>
-                  <AddFriendButton
-                    targetUserId={p.id}
-                    targetDisplayName={p.displayName}
-                    relationship={p.relationship}
-                    onChange={() => router.refresh()}
-                  />
-                </div>
-              );
-            })}
-          </div>
-          <Link href={embed.href} style={EMBED_LINK_STYLE}>
-            Find more friends →
-          </Link>
-        </>
-      ) : (
-        <>
-          <p style={{ margin: 0, fontFamily: 'Georgia, serif', fontSize: 14, lineHeight: 1.45, color: INK2 }}>
-            Know someone who would enjoy the questions and discoveries happening here?
-          </p>
-          <Link href={embed.href} style={EMBED_LINK_STYLE}>
-            Find friends →
-          </Link>
-        </>
-      )}
     </div>
   );
 }

--- a/src/components/feed/EditorialFeature.tsx
+++ b/src/components/feed/EditorialFeature.tsx
@@ -1,0 +1,104 @@
+import Link from 'next/link'
+import type { ReactNode } from 'react'
+
+import { cn } from '@/lib/utils'
+
+// The three feed "featured moment" treatments. Each maps to a subtle full-bleed
+// background wash (--editorial-* in globals.css) plus an eyebrow accent color
+// borrowed from the brand palette. Add a tone here (and the matching CSS var +
+// accent) when a new editorial module joins the feed.
+export type EditorialTone = 'parchment' | 'sage' | 'slate'
+
+const TONE_BG: Record<EditorialTone, string> = {
+  parchment: 'bg-[var(--editorial-parchment)]',
+  sage: 'bg-[var(--editorial-sage)]',
+  slate: 'bg-[var(--editorial-slate)]',
+}
+
+const TONE_ACCENT: Record<EditorialTone, string> = {
+  parchment: 'text-[var(--brand-orange)]',
+  sage: 'text-[var(--success)]',
+  slate: 'text-[var(--brand-link)]',
+}
+
+interface EditorialFeatureProps {
+  tone: EditorialTone
+  // Small uppercase label (e.g. "Shared Ground"). Rendered uppercase; pass it in
+  // natural case.
+  eyebrow: string
+  // Optional mark beside the eyebrow (e.g. a filled bookmark), inheriting the
+  // tone accent color.
+  eyebrowIcon?: ReactNode
+  // Large editorial headline. A node, so callers can weave an inline link (e.g.
+  // the friend's name) into it.
+  headline: ReactNode
+  // The hero artwork slot (circles, avatar cluster, territory rows…).
+  artwork: ReactNode
+  // One short supporting line under the artwork (e.g. "2 shared interests").
+  supporting?: ReactNode
+  // A single text-link call to action. The arrow is part of `label`.
+  cta: { label: string; href: string }
+}
+
+/**
+ * A full-bleed editorial feature section for the home feed.
+ *
+ * Replaces the old promo "cards": no border, radius, or shadow — a subtle
+ * background wash bleeds edge to edge of the feed column (escaping the page
+ * gutter via `-mx-4`) and generous vertical space creates a calm "featured
+ * moment" that breaks the scrolling rhythm. This is the reusable editorial
+ * language for feed modules; new modules (milestones, ceremonies, summaries)
+ * should compose this rather than re-rolling their own chrome.
+ */
+export function EditorialFeature({
+  tone,
+  eyebrow,
+  eyebrowIcon,
+  headline,
+  artwork,
+  supporting,
+  cta,
+}: EditorialFeatureProps) {
+  return (
+    <section
+      // -mx-4 escapes the home <main>'s px-4 gutter so the wash reaches the feed
+      // column edges; -my-1.5 absorbs the feed's space-y-3 so the band meets its
+      // neighbors edge to edge. Inner content is re-padded with px-4.
+      className={cn('-mx-4 -my-1.5 px-4 py-12 md:py-14', TONE_BG[tone])}
+    >
+      <p
+        className={cn(
+          'flex items-center gap-1.5 text-[11px] font-semibold tracking-[0.14em] uppercase',
+          TONE_ACCENT[tone],
+        )}
+      >
+        {eyebrowIcon ? (
+          <span aria-hidden="true" className="inline-flex">
+            {eyebrowIcon}
+          </span>
+        ) : null}
+        {eyebrow}
+      </p>
+
+      <h2 className="mt-4 max-w-[20ch] font-serif text-[26px] leading-[1.15] font-medium text-[var(--brand-ink)] md:text-[32px]">
+        {headline}
+      </h2>
+
+      <div className="mt-8">{artwork}</div>
+
+      {supporting ? (
+        <p className="mt-6 text-[13px] text-[var(--brand-ink-400)]">{supporting}</p>
+      ) : null}
+
+      <Link
+        href={cta.href}
+        className={cn(
+          'mt-5 inline-flex min-h-11 items-center font-serif text-lg font-semibold tracking-[0.05em] underline underline-offset-4 transition hover:opacity-70 active:opacity-90',
+          TONE_ACCENT[tone],
+        )}
+      >
+        {cta.label}
+      </Link>
+    </section>
+  )
+}

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -1,0 +1,203 @@
+'use client'
+
+import { Bookmark } from 'lucide-react'
+import Link from 'next/link'
+import { useRouter } from 'next/navigation'
+
+import { EditorialFeature } from '@/components/feed/EditorialFeature'
+import { colorForUser, initialsFor, isDarkColor } from '@/components/feed/visual'
+import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import { circleDatasetMax, DomainCircleSvg } from '@/components/profile/common-ground-circles'
+import type { StreamEmbed } from '@/lib/activity-stream'
+
+// The "Shared Ground" circles render larger here than on the profile page — the
+// motif is the hero artwork, so it should catch the eye before the copy.
+const SHARED_GROUND_CIRCLE_SCALE = 1.35
+
+// Badge accents for the "Your World Is Expanding" territory rows — the
+// reds / golds / blues from the /knowledge "Recently Expanding" module, trimmed
+// to the three we ever render.
+const EXPANDING_ROW_ACCENTS = [
+  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
+  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
+  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.2)' },
+] as const
+
+// A faded decorative cluster of overlapping avatar circles for the
+// "Grow Your Circle" invite state — purely decorative (aria-hidden, no
+// initials, no buttons), softened into the sage wash.
+const INVITE_CLUSTER_SEEDS = ['circle-a', 'circle-b', 'circle-c', 'circle-d']
+
+/**
+ * "Shared Ground" — the overlapping-circle motif as a full-bleed editorial
+ * feature: the two strongest shared-but-untested domains the viewer holds with
+ * a friend, with a link through to that friend.
+ */
+export function CommonGroundFeature({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'common_ground' }>
+}) {
+  const datasetMax = circleDatasetMax(
+    embed.domains.flatMap((d) => [d.viewer.points, d.friend.points]),
+  )
+  const count = embed.domains.length
+  return (
+    <EditorialFeature
+      tone="parchment"
+      eyebrow="Shared Ground"
+      eyebrowIcon={<Bookmark size={13} strokeWidth={0} fill="currentColor" />}
+      headline={
+        <>
+          You and{' '}
+          <Link
+            href={embed.friendHref}
+            className="text-[var(--brand-ink)] underline-offset-4 hover:underline"
+          >
+            {embed.friendFirstName}
+          </Link>{' '}
+          keep finding one another here.
+        </>
+      }
+      artwork={
+        <div className="flex flex-wrap items-end gap-x-12 gap-y-8">
+          {embed.domains.map((d) => (
+            <div key={d.label} className="flex flex-col gap-4">
+              <DomainCircleSvg
+                viewerPoints={d.viewer.points}
+                friendPoints={d.friend.points}
+                viewerTier={d.viewer.tier}
+                friendTier={d.friend.tier}
+                datasetMax={datasetMax}
+                scale={SHARED_GROUND_CIRCLE_SCALE}
+                ariaLabel={`${d.label}: shared with ${embed.friendFirstName}, still untested`}
+              />
+              <span className="max-w-[150px] font-serif text-[14px] leading-snug text-[var(--brand-ink-700)]">
+                {d.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      }
+      supporting={`${count} shared interest${count === 1 ? '' : 's'}`}
+      cta={{ label: 'Explore your overlap →', href: embed.friendHref }}
+    />
+  )
+}
+
+/**
+ * "Grow Your Circle" — either a few contact-match people the viewer can follow
+ * inline (suggestions), or, when there's no one to suggest, a decorative invite
+ * nudge toward /friends/find.
+ */
+export function GrowYourCircleFeature({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'add_friends' }>
+}) {
+  const router = useRouter()
+  return (
+    <EditorialFeature
+      tone="sage"
+      eyebrow="Grow Your Circle"
+      headline="Know someone who belongs here?"
+      artwork={
+        embed.variant === 'suggestions' ? (
+          <div className="flex flex-col gap-3">
+            {embed.people.map((p) => {
+              const bg = p.avatarColor ?? colorForUser(p.id)
+              return (
+                <div key={p.id} className="flex items-center gap-3">
+                  <Link
+                    href={`/users/${p.id}`}
+                    className="grid size-8 shrink-0 place-items-center rounded-full text-xs font-bold no-underline"
+                    style={{ background: bg, color: isDarkColor(bg) ? '#fff' : '#0a1f3d' }}
+                  >
+                    {initialsFor(p.displayName)}
+                  </Link>
+                  <div className="min-w-0 flex-1">
+                    <Link
+                      href={`/users/${p.id}`}
+                      className="text-sm font-semibold text-[var(--brand-ink)] no-underline"
+                    >
+                      {p.displayName}
+                    </Link>
+                    {p.handle ? (
+                      <span className="block text-xs leading-tight text-[var(--brand-ink-400)]">
+                        @{p.handle}
+                      </span>
+                    ) : null}
+                  </div>
+                  <AddFriendButton
+                    targetUserId={p.id}
+                    targetDisplayName={p.displayName}
+                    relationship={p.relationship}
+                    onChange={() => router.refresh()}
+                  />
+                </div>
+              )
+            })}
+          </div>
+        ) : (
+          <div aria-hidden="true" className="flex items-center opacity-50">
+            {INVITE_CLUSTER_SEEDS.map((seed, i) => (
+              <span
+                key={seed}
+                className="size-12 rounded-full ring-4 ring-[var(--editorial-sage)]"
+                style={{ background: colorForUser(seed), marginLeft: i === 0 ? 0 : -16 }}
+              />
+            ))}
+          </div>
+        )
+      }
+      cta={{ label: 'Find friends →', href: embed.href }}
+    />
+  )
+}
+
+/**
+ * "Your World Is Expanding" — the viewer's fastest-growing territories as a
+ * full-bleed editorial feature, with a link through to /knowledge.
+ */
+export function RecentlyExpandingFeature({
+  embed,
+}: {
+  embed: Extract<StreamEmbed, { kind: 'recently_expanding' }>
+}) {
+  return (
+    <EditorialFeature
+      tone="slate"
+      eyebrow="Your World Is Expanding"
+      headline="The places you've been exploring lately."
+      artwork={
+        <div className="flex flex-col gap-3">
+          {embed.domains.map((d, i) => {
+            const accent = EXPANDING_ROW_ACCENTS[i % EXPANDING_ROW_ACCENTS.length]!
+            return (
+              <div key={d.label} className="flex items-center gap-3">
+                <span
+                  aria-hidden="true"
+                  className="grid size-8 shrink-0 place-items-center rounded-full text-sm font-bold text-[var(--brand-ink)]"
+                  style={{ border: `1px solid ${accent.border}`, background: accent.fill }}
+                >
+                  {d.initial}
+                </span>
+                <div className="min-w-0">
+                  <p className="font-serif text-sm font-bold leading-tight text-[var(--brand-ink)]">
+                    {d.label}
+                  </p>
+                  {d.caption ? (
+                    <p className="mt-0.5 text-xs leading-tight text-[var(--brand-ink-700)]">
+                      {d.caption}
+                    </p>
+                  ) : null}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      }
+      cta={{ label: 'See your knowledge →', href: embed.href }}
+    />
+  )
+}

--- a/src/components/feed/__tests__/EditorialFeature.test.tsx
+++ b/src/components/feed/__tests__/EditorialFeature.test.tsx
@@ -1,0 +1,64 @@
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+vi.mock('next/link', () => ({
+  default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}))
+
+import { EditorialFeature } from '@/components/feed/EditorialFeature'
+
+describe('EditorialFeature', () => {
+  function render(extra?: Partial<Parameters<typeof EditorialFeature>[0]>) {
+    return renderToStaticMarkup(
+      <EditorialFeature
+        tone="parchment"
+        eyebrow="Shared Ground"
+        headline={<>You and Robyn keep finding one another here.</>}
+        artwork={<div data-mock="art" />}
+        supporting="2 shared interests"
+        cta={{ label: 'Explore your overlap →', href: '/users/robyn' }}
+        {...extra}
+      />,
+    )
+  }
+
+  it('renders the eyebrow, headline, supporting line, and artwork', () => {
+    const html = render()
+    expect(html).toContain('Shared Ground')
+    expect(html).toContain('You and Robyn keep finding one another here.')
+    expect(html).toContain('2 shared interests')
+    expect(html).toContain('data-mock="art"')
+  })
+
+  it('renders the CTA as a single text link (no button) to the given href', () => {
+    const html = render()
+    expect(html).toContain('href="/users/robyn"')
+    expect(html).toContain('Explore your overlap →')
+    // Editorial language: the CTA is a text link, never a <button>.
+    expect(html).not.toContain('<button')
+  })
+
+  it('applies the tone background wash and accent', () => {
+    expect(render({ tone: 'parchment' })).toContain('bg-[var(--editorial-parchment)]')
+    expect(render({ tone: 'sage' })).toContain('bg-[var(--editorial-sage)]')
+    expect(render({ tone: 'slate' })).toContain('bg-[var(--editorial-slate)]')
+  })
+
+  it('is full-bleed with no border, radius, or shadow', () => {
+    const html = render()
+    expect(html).toContain('-mx-4')
+    expect(html).not.toMatch(/\bborder\b/)
+    expect(html).not.toMatch(/rounded/)
+    expect(html).not.toMatch(/shadow/)
+  })
+
+  it('omits the supporting line when not provided', () => {
+    const html = render({ supporting: undefined })
+    expect(html).not.toContain('2 shared interests')
+  })
+})

--- a/src/components/profile/common-ground-circles.tsx
+++ b/src/components/profile/common-ground-circles.tsx
@@ -73,6 +73,7 @@ export function DomainCircleSvg({
   friendTier,
   datasetMax,
   ariaLabel,
+  scale = 1,
 }: {
   viewerPoints: number
   friendPoints: number
@@ -80,6 +81,10 @@ export function DomainCircleSvg({
   friendTier: MasteryTier
   datasetMax: number
   ariaLabel: string
+  // Renders the motif larger (or smaller) without touching the geometry: the
+  // viewBox is unchanged, only the rendered width/height scale. The editorial
+  // "Shared Ground" feature uses this to make the circles the hero artwork.
+  scale?: number
 }) {
   const { svgWidth, svgHeight, cy, rA, rB, gap, offsetX } = circleGeometry(
     viewerPoints,
@@ -90,8 +95,8 @@ export function DomainCircleSvg({
   )
   return (
     <svg
-      width={svgWidth}
-      height={svgHeight}
+      width={svgWidth * scale}
+      height={svgHeight * scale}
       viewBox={`0 0 ${svgWidth} ${svgHeight}`}
       role="img"
       aria-label={ariaLabel}

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -19,7 +19,10 @@ import {
 import { getCommonGround } from '@/server/db/queries/common-ground';
 import { getFriends } from '@/server/db/queries/friends';
 
-const MAX_PROMO_DOMAINS = 3;
+// The editorial "Shared Ground" feature shows only the two strongest shared-but-
+// untested areas, so the circles stay the hero artwork (more than two crowds the
+// motif). See CommonGroundFeature.
+const MAX_PROMO_DOMAINS = 2;
 // Cap the per-render getCommonGround probes so the homepage stays cheap even for
 // users with many friends; the rotation still cycles through everyone over time.
 const MAX_CANDIDATES = 4;


### PR DESCRIPTION
The home feed's promo modules (Shared Ground, Grow Your Circle, Your
World Is Expanding) rendered as ordinary activity rows — a domain icon,
a one-liner, and a hairline — so they read as list items rather than
featured moments. Recast them as full-bleed editorial feature sections
that break the scrolling rhythm with a subtle background wash instead of
borders.

- Add a reusable EditorialFeature primitive (eyebrow, headline, hero
  artwork, supporting line, one text CTA) with three tinted washes
  (parchment / sage / slate) derived from existing palette tokens via
  color-mix. This is the editorial language future feed modules compose.
- Wrap each promo in EditorialPromos (CommonGroundFeature,
  GrowYourCircleFeature, RecentlyExpandingFeature) and intercept the
  three promo stream items in FeedList so they render as sections; the
  Grow Your Circle suggestions state keeps its interactive add-friend
  rows, the invite state shows a decorative avatar cluster.
- Make the overlapping-circle motif the hero artwork (new optional
  `scale` on DomainCircleSvg, +35%) and cap Shared Ground at the two
  strongest shared areas.
- Restyle the contribute footer composer to the same wash-band language
  (drops the rounded card, border, shadow, and triangle mosaic).
- Remove the now-dead inline embed renderers from ActivityStreamItem.

https://claude.ai/code/session_01DiPSkkVQhn8uMVneZUAznv