### PR TITLE
Add expand/collapse chevron indicator to expandable activity items

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Send } from 'lucide-react';
+import { ChevronDown, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useState, type KeyboardEvent } from 'react';
 
@@ -242,13 +242,30 @@ export function ActivityStreamItem({ item, timestamp }: { item: StreamItem; time
         <div
           style={{
             flexShrink: 0,
+            alignSelf: 'stretch',
             display: 'flex',
             flexDirection: 'column',
             alignItems: 'flex-end',
+            justifyContent: 'space-between',
             gap: 4,
           }}
         >
           <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap' }}>{timestamp}</span>
+          {/* Cards backed by answerable questions get a chevron in the bottom-
+              right corner that signals (and reflects) the expand/collapse state.
+              The row itself is the button (aria-expanded above), so this stays
+              decorative. */}
+          {expandable ? (
+            <ChevronDown
+              size={18}
+              aria-hidden
+              style={{
+                color: INK3,
+                transition: 'transform 150ms ease',
+                transform: open ? 'rotate(180deg)' : 'none',
+              }}
+            />
+          ) : null}
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
Adds a visual chevron icon to activity stream items that are backed by answerable questions, providing a clear visual indicator of the expand/collapse state.

## Changes
- Import `ChevronDown` icon from lucide-react
- Add a decorative chevron icon to the bottom-right corner of expandable activity items
- Chevron rotates 180° when the item is expanded, providing visual feedback of the current state
- Update flex layout to use `justifyContent: 'space-between'` and `alignSelf: 'stretch'` to properly position the timestamp and chevron
- Chevron is marked as `aria-hidden` since the expand/collapse functionality is already exposed via the row's `aria-expanded` attribute

## Implementation Details
- The chevron only renders when `expandable` is true
- Uses a smooth 150ms ease transition for the rotation animation
- Styled with the same `INK3` color as the timestamp for visual consistency
- The row itself remains the interactive button element; the chevron is purely decorative

https://claude.ai/code/session_01T8s34ew3YMsyanvoqQZtzv