### PR TITLE
Pin common-ground promo separately; adjust day-label alignment

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -141,15 +141,13 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // activity card here so the reflection doesn't double up / compete with social
   // activity in the home stream. It's the only activity that links to /ceremony/;
   // the card still appears in the full /activities log.
-  const homeActivityItems = [
-    // Home-only common-ground discovery promo at the head of the activity rows
-    // (see getCommonGroundPromo). Null when the viewer has no untested shared
-    // ground with any probed friend.
-    ...(commonGroundPromo ? [commonGroundPromo] : []),
-    ...activityItems.filter(
-      (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
-    ),
-  ]
+  // The common-ground discovery promo is no longer prepended into the activity
+  // rows (which would float it to row 0 on its `now` timestamp). It's passed
+  // separately as a pinned promo so it never leads the feed when there's other
+  // activity to show — see FeedList's displayRows.
+  const homeActivityItems = activityItems.filter(
+    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
+  )
   return (
     <>
       {/* Sit the header on the feed's left gutter — the same 2px the activity
@@ -166,6 +164,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         showContributeFooter
         unifiedHome
         activityItems={homeActivityItems}
+        commonGroundPromo={commonGroundPromo}
         expandingPromo={recentlyExpandingPromo}
         addFriendsPromo={addFriendsPromo}
       />

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -451,10 +451,18 @@ type FeedListProps = {
    */
   activityItems?: StreamItem[]
   /**
+   * Home-only "Shared Ground" common-ground promo (the overlapping-circle
+   * editorial feature). Like the other promos it is pinned at a fixed offset
+   * rather than interleaved chronologically, so it is never the very first feed
+   * item when there is other activity to lead with — it only falls to row 0 when
+   * the feed is otherwise empty. Null on most visits. See displayRows.
+   */
+  commonGroundPromo?: StreamItem | null
+  /**
    * Home-only "Your world is expanding" promo. Unlike `activityItems` (which
    * interleave chronologically), this is spliced in at a fixed offset a few rows
    * down so it never lands at the very top or adjacent to the common-ground
-   * promo (which sorts to row 0). Null on most visits — it shows ~1 in 5. See
+   * promo. Null on most visits — it shows ~1 in 5. See
    * getRecentlyExpandingPromo / displayRows.
    */
   expandingPromo?: StreamItem | null
@@ -469,10 +477,12 @@ type FeedListProps = {
 type QuestionCardState = 'unanswered' | 'answered'
 
 // Where the home-only pinned promos land in the rendered row list: a few rows
-// down (so they're never the very first thing, and never adjacent to the common-
-// ground promo at row 0), and spaced apart from each other. Each offset is
-// measured against the original feed length; a promo only appears once the feed
-// has at least that many rows.
+// down (so they're never the very first thing) and spaced apart from each other.
+// Each offset is measured against the original feed length; the `expanding` /
+// `add_friends` promos only appear once the feed has at least that many rows,
+// while the common-ground promo always renders (clamping to the feed's end on a
+// short feed, and falling to row 0 only when the feed is otherwise empty).
+const COMMON_GROUND_PROMO_OFFSET = 2
 const EXPANDING_PROMO_OFFSET = 3
 const ADD_FRIENDS_PROMO_OFFSET = 6
 
@@ -688,6 +698,7 @@ function FeedListContent({
   showContributeFooter = false,
   unifiedHome = false,
   activityItems = [],
+  commonGroundPromo = null,
   expandingPromo = null,
   addFriendsPromo = null,
 }: FeedListProps) {
@@ -898,39 +909,56 @@ function FeedListContent({
 
   // Splice the home-only pinned promos in at fixed offsets a few rows down. They
   // are deliberately NOT part of the chronological union above: pinning them to
-  // indices keeps them off the very top and never adjacent to the common-ground
-  // promo (which sorts to row 0). Each is only inserted once the feed has enough
-  // rows above its offset; offsets are measured against the original feed so the
-  // two promos stay spaced apart even when both are present.
+  // indices keeps them off the very top so a promo never leads the feed when
+  // there's real activity to show. The common-ground promo `alwaysShow`s — it
+  // clamps to the feed's end on a short feed and only falls to row 0 when the
+  // feed is otherwise empty — while the others are skipped until the feed has
+  // enough rows. Offsets are measured against the original feed so the promos
+  // stay spaced apart even when several are present.
   const displayRows = useMemo<UnifiedRow[]>(() => {
+    // Common-ground must always render but must never be FIRST when other rows
+    // exist: clamp its offset to the feed length (so a 1-row feed puts it at
+    // index 1, not 0), and let it sit at row 0 only when the feed is empty.
+    const commonGroundOffset =
+      unifiedRows.length === 0
+        ? 0
+        : Math.min(COMMON_GROUND_PROMO_OFFSET, unifiedRows.length)
     const pinned = [
-      { offset: EXPANDING_PROMO_OFFSET, item: expandingPromo },
-      { offset: ADD_FRIENDS_PROMO_OFFSET, item: addFriendsPromo },
+      { offset: commonGroundOffset, item: commonGroundPromo, alwaysShow: true },
+      { offset: EXPANDING_PROMO_OFFSET, item: expandingPromo, alwaysShow: false },
+      { offset: ADD_FRIENDS_PROMO_OFFSET, item: addFriendsPromo, alwaysShow: false },
     ]
-      .filter((p): p is { offset: number; item: StreamItem } => p.item !== null)
+      .filter(
+        (p): p is { offset: number; item: StreamItem; alwaysShow: boolean } =>
+          p.item !== null,
+      )
       .sort((a, b) => a.offset - b.offset)
     if (pinned.length === 0) return unifiedRows
 
     const next = [...unifiedRows]
     let inserted = 0
-    for (const { offset, item } of pinned) {
-      if (offset > unifiedRows.length) continue
+    for (const { offset, item, alwaysShow } of pinned) {
+      if (!alwaysShow && offset > unifiedRows.length) continue
       // Account for promos already spliced in ahead of this one so each keeps its
       // intended distance from the others.
       const spliceAt = offset + inserted
-      const anchor = next[spliceAt - 1]!
+      // Borrow the preceding row's timestamp so recency grouping keeps the promo
+      // in place rather than floating it into its own day bucket. At index 0 (an
+      // otherwise-empty feed) there's nothing ahead, so fall back to the promo's
+      // own sortAt.
+      const anchor = spliceAt > 0 ? next[spliceAt - 1]! : null
+      const sortAt =
+        item.sortAt instanceof Date ? item.sortAt : new Date(item.sortAt)
       next.splice(spliceAt, 0, {
         kind: 'activity',
         item,
-        // Borrow the preceding row's timestamp so recency grouping keeps the
-        // promo in place rather than floating it into its own day bucket.
-        source_event_at: anchor.source_event_at,
-        sortMs: anchor.sortMs,
+        source_event_at: anchor ? anchor.source_event_at : sortAt.toISOString(),
+        sortMs: anchor ? anchor.sortMs : sortAt.getTime(),
       })
       inserted++
     }
     return next
-  }, [unifiedRows, expandingPromo, addFriendsPromo])
+  }, [unifiedRows, commonGroundPromo, expandingPromo, addFriendsPromo])
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'
@@ -1472,10 +1500,12 @@ function FeedListContent({
             <Fragment key={group.key}>
               <h2
                 className={`text-muted-foreground/70 pt-4 text-[11px] font-medium tracking-[0.12em] uppercase first:pt-0 ${
-                  // On the unified-home feed, the day label aligns to where the
-                  // activity-row copy starts — past the fixed icon column
-                  // (MARK_W 24 + GAP 8) plus the row's 2px horizontal padding.
-                  unifiedHome ? 'pl-[34px]' : ''
+                  // On the unified-home feed, the day label sits flush left on
+                  // the feed's left gutter — the same 2px the activity rows pad
+                  // in (where the shape column begins) and where the
+                  // "What's happening" header aligns — rather than indenting past
+                  // the icon column to meet the row copy.
+                  unifiedHome ? 'pl-[2px]' : ''
                 }`}
               >
                 {group.label}

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -59,12 +59,13 @@ const LARGE_SCALE = 0.5;
 // pair. base=height (= MARK_W) keeps the triangles un-smushed.
 const STACK_HALF = 24;
 const STACK_H = STACK_HALF * 2; // 48
-// Every mark TOP-ANCHORS its top to the first line's cap height (the top of
+// Every mark TOP-ANCHORS its top near the first line's cap height (the top of
 // "R"), not the line-box top above it — so the top of the shape lines up with
-// the top of the letter beside it. Equal to the line's half-leading
-// ((22.5 − 15) / 2 ≈ 3.75) plus the gap from the em-box top down to the cap;
-// tuned to 7 against Montserrat at 15px.
-const CAP_NUDGE = 7;
+// the top of the letter beside it. The line's half-leading is ((22.5 − 15) / 2
+// ≈ 3.75); we keep the nudge just under that so the single marks sit a hair
+// higher and stop drooping below a one-line row, which re-centers the row's
+// content between its hairline borders.
+const CAP_NUDGE = 3;
 
 export type ActivityIconSpec =
   | { kind: 'bundle'; total: number; unanswered: number }

--- a/src/components/profile/common-ground-circles.tsx
+++ b/src/components/profile/common-ground-circles.tsx
@@ -100,6 +100,12 @@ export function DomainCircleSvg({
       viewBox={`0 0 ${svgWidth} ${svgHeight}`}
       role="img"
       aria-label={ariaLabel}
+      // The viewBox hugs both circles exactly (see circleGeometry), so each
+      // circle's outer edge lands ON the viewBox boundary. An outer <svg>
+      // defaults to overflow:hidden, which shaves those edge pixels and reads as
+      // a flat "cut off" side — most visible on the large editorial scale. Let
+      // the boundary pixels paint.
+      style={{ overflow: 'visible' }}
     >
       {/* fill via style (not the SVG attribute) to keep parity with OverlapMap */}
       <circle


### PR DESCRIPTION
## Summary
Refactors the common-ground discovery promo from being prepended into the activity feed (where it would float to row 0 on its timestamp) to being passed as a separate pinned promo. This ensures it never leads the feed when other activity exists, while still appearing at row 0 on otherwise-empty feeds. Also adjusts day-label alignment and icon positioning for better visual consistency on the unified home feed.

## Key changes

- **Common-ground promo pinning:** Moved `commonGroundPromo` from being spliced into `homeActivityItems` to a separate `FeedListProps` parameter, allowing it to be pinned at a fixed offset via the `displayRows` logic rather than floating chronologically.

- **Promo offset logic:** Introduced `COMMON_GROUND_PROMO_OFFSET = 2` and refactored the pinned-promo insertion to support an `alwaysShow` flag. The common-ground promo always renders (clamping to feed length on short feeds, falling to row 0 only when empty), while `expandingPromo` and `addFriendsPromo` remain conditional on feed length.

- **Timestamp handling:** Updated promo row creation to handle the case where a promo lands at index 0 (no preceding row to borrow timestamp from), falling back to the promo's own `sortAt` value.

- **Day-label alignment:** Changed unified-home day-label padding from `pl-[34px]` (indenting past the icon column) to `pl-[2px]` (flush with the feed's left gutter, matching activity-row padding and the "What's happening" header).

- **Icon vertical positioning:** Reduced `CAP_NUDGE` from 7 to 3 in `ActivityIcon.tsx` to prevent single marks from drooping below one-line rows, re-centering row content between hairline borders.

- **SVG overflow fix:** Added `style={{ overflow: 'visible' }}` to `DomainCircleSvg` to prevent viewBox boundary pixels from being clipped on the large editorial scale.

## Implementation details

- The common-ground promo's offset is dynamically clamped: `Math.min(COMMON_GROUND_PROMO_OFFSET, unifiedRows.length)` ensures it never lands before the feed's actual content.
- Promo rows borrow the preceding row's `source_event_at` and `sortMs` for recency grouping, keeping them in place rather than floating into separate day buckets.
- The filter and sort logic for pinned promos now preserves the `alwaysShow` flag through the type guard, enabling conditional insertion based on feed length.

https://claude.ai/code/session_01HbXrkYuQJiNuWmbkRfjPbq