### PR TITLE
Add production email config validation at boot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,10 +47,14 @@ NEXT_PUBLIC_APP_URL="http://localhost:3000"
 # ── Email (Resend) ────────────────────────────────────────────
 # Used by src/server/email/client.ts to send the email-verification
 # confirm-link. Missing in dev is fine — the client falls back to
-# console.log so local development isn't blocked.
-# EMAIL_FROM must be a sender verified in your Resend domain.
+# console.log so local development isn't blocked. BOTH must be set in
+# production or nothing sends (the client silently logs + returns).
+# EMAIL_FROM's domain (the part after @) MUST exactly match a domain shown
+# as Verified in your Resend dashboard. Resend treats a root domain and its
+# subdomain as separate domains, so notifications@joshuapalay.com only works
+# if joshuapalay.com (not send.joshuapalay.com) is the verified one.
 RESEND_API_KEY=""
-EMAIL_FROM="Joshing <notifications@send.joshuapalay.com>"
+EMAIL_FROM="Joshing <notifications@joshuapalay.com>"
 
 # ── Playtest harness (scripts/playtest) ──────────────────────
 # Used only by `npm run smoke:gameplay`. The harness drives the local dev

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -14,6 +14,25 @@ export async function register() {
       );
     }
 
+    // RESEND_API_KEY + EMAIL_FROM back the email-verification confirm-link
+    // (src/server/email/client.ts). The client never throws — if either is
+    // missing it silently logs to stdout and returns missing_config, so a
+    // misconfigured production deploy drops every verification email with no
+    // user-visible error. Warn loudly at boot so the gap surfaces here rather
+    // than as silently-undelivered mail. (Warning only, like PHONE_HASH_SALT
+    // above — throwing would 500 every request via the instrumentation hook.)
+    if (process.env.NODE_ENV === 'production') {
+      const missingEmailVars = [
+        !process.env.RESEND_API_KEY && 'RESEND_API_KEY',
+        !process.env.EMAIL_FROM && 'EMAIL_FROM',
+      ].filter(Boolean);
+      if (missingEmailVars.length > 0) {
+        console.error(
+          `[instrumentation] ${missingEmailVars.join(' and ')} not set in production; email verification will silently no-op. Set both, and ensure EMAIL_FROM's domain matches a Verified domain in Resend.`,
+        );
+      }
+    }
+
     const { migrate } = await import('drizzle-orm/node-postgres/migrator');
     const { drizzle } = await import('drizzle-orm/node-postgres');
     const { Pool } = await import('pg');


### PR DESCRIPTION
## Summary
Add explicit validation and warnings for email configuration (`RESEND_API_KEY` and `EMAIL_FROM`) at application boot in production environments. This surfaces misconfiguration early rather than silently failing to deliver verification emails.

## Changes
- **`src/instrumentation.ts`**: Added production-only validation that warns loudly if either `RESEND_API_KEY` or `EMAIL_FROM` is missing. The warning explains that the email client silently no-ops on missing config, so this boot-time check prevents the gap from surfacing as undelivered mail with no user-visible error.
- **`.env.example`**: 
  - Clarified that both email variables must be set in production (previously only mentioned `EMAIL_FROM` needing verification)
  - Expanded documentation on Resend domain verification requirements, specifically that `EMAIL_FROM`'s domain must exactly match a Verified domain in the Resend dashboard
  - Updated example `EMAIL_FROM` from `notifications@send.joshuapalay.com` to `notifications@joshuapalay.com` to reflect correct domain matching (root domain, not subdomain)

## Implementation Details
- Validation runs only in production (`NODE_ENV === 'production'`) to avoid noise in development where the email client gracefully falls back to `console.log`
- Uses `console.error()` rather than throwing, consistent with the existing `PHONE_HASH_SALT` validation pattern — warnings surface the issue without causing 500 errors on every request
- Follows the existing instrumentation hook pattern for boot-time configuration checks

https://claude.ai/code/session_011vm1w94U4v2Lok1QuLLq1U