### PR TITLE
feat(feed): triangle = new questions only, convergence on Home (+ bui…

### DIFF
--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -63,7 +63,7 @@ function build() {
   return convergenceToStreamItem(CONVERGENCE, QUESTIONS, CAPTION);
 }
 
-describe('convergenceToStreamItem — person-first, Lately-only, read-only', () => {
+describe('convergenceToStreamItem — person-first, Home-eligible, read-only', () => {
   it('builds a person-first headline that names no domain', () => {
     const item = build();
     // The friend is an actor (link) part; the rest is plain copy. No domain
@@ -78,9 +78,9 @@ describe('convergenceToStreamItem — person-first, Lately-only, read-only', () 
     }
   });
 
-  it('is excluded from the homepage top-few (homeEligible false) and read-only', () => {
+  it('is Home-eligible (surfaces alongside the triangle rows) and read-only', () => {
     const item = build();
-    expect(item.homeEligible).toBe(false);
+    expect(item.homeEligible).toBe(true);
     expect(item.action).toBeNull();
     expect(item.expand?.kind).toBe('same_correct');
   });

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -18,7 +18,7 @@
  * action — friend-request approve, reaction ack, a link — but they don't expand).
  */
 
-import { HOME_TOP3_ELIGIBLE_TYPES } from '@/server/activity/write-activity';
+import { HOME_TOP3_ELIGIBLE_TYPES } from '@/lib/activity-types';
 import type { ActivityItemView } from '@/server/db/queries/activity';
 import type { MasteryTier } from '@/types/db';
 import type { LatelyMoment } from '@/server/db/queries/lately';
@@ -626,10 +626,12 @@ function breadthTail(domains: string[]): StreamLinePart[] {
 // independently got the same shared questions right. The headline is
 // PERSON-FIRST and names no domain — the caption template (assigned
 // deterministically by moment id) carries a `{Name}` token that becomes the
-// friend's first name as an actor link. It is Lately-ONLY (homeEligible: false,
-// the same slow-burn treatment as niche-match) and READ-ONLY: expanding reveals
-// the cluster's questions (domains may appear there as texture) with no answer,
-// send, or reaction affordance.
+// friend's first name as an actor link. It is the read-only counterpart to the
+// milestone triangle: the triangle row carries questions you have NOT answered
+// (answerable), while this row carries the ones you and the friend BOTH already
+// got right. Home-eligible so both rows surface together on Home, not just in
+// Lately. READ-ONLY: expanding reveals the cluster's questions (domains may
+// appear there as texture) with no answer, send, or reaction affordance.
 export function convergenceToStreamItem(
   convergence: Convergence,
   questions: StreamQuestion[],
@@ -646,7 +648,7 @@ export function convergenceToStreamItem(
     tier: LATELY_TIER.MILESTONE,
     // High-signal "same-correct overlap" — protected micro-tier.
     signal: 'micro',
-    homeEligible: false,
+    homeEligible: true,
     line,
     secondLine: null,
     anchorId: null,

--- a/src/lib/activity-types.ts
+++ b/src/lib/activity-types.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure activity-stream type + constant definitions — NO database or other
+ * server-only imports. This module exists so the client-shared, DB-free
+ * transform in `src/lib/activity-stream.ts` can read HOME_TOP3_ELIGIBLE_TYPES
+ * without dragging `src/server/activity/write-activity.ts` (and its `pg` DB
+ * import) into the browser bundle. The server writer re-exports these for
+ * existing server-side importers; client code imports straight from here.
+ */
+
+export type ActivityItemType =
+  | 'received_joshing_game'
+  | 'joshing_game_result'
+  | 'joshing_game_progress'
+  | 'friend_mastery'
+  | 'ceremony_ready'
+  // Legacy friend-request types — no longer written (the follow model below
+  // supersedes them) but retained so historical activity rows still type-check
+  // and render against the frozen Friendship table.
+  | 'friend_request'
+  | 'friend_request_accepted'
+  // D-1 Stage 3 follow model. `follow` = someone followed you (public account,
+  // auto-approved). `follow_request` = someone requested to follow you
+  // (approval_required). `follow_approved` = you approved their request.
+  | 'follow'
+  | 'follow_request'
+  | 'follow_approved'
+  // An invited friend both accepted the inviter's invitation and got far
+  // enough into the product to play their first five questions. Surfaced to
+  // the inviter as a "your invite stuck" milestone. Written from
+  // write-mastery-event.ts once the invitee crosses the fifth play.
+  | 'invited_friend_played_first_five'
+  | 'received_direct_question'
+  | 'reaction_received'
+  | 'question_curated'
+  | 'friend_answered_your_question'
+  | 'authored_question_shared'
+  | 'declared_promoted'
+  // §8.22 grade-dispute path: the question's author is notified when an
+  // answerer disputes their wrong-answer grade. The dispute is the
+  // answerer's explicit ask for a second look, which is the consent gate
+  // that exposes their submitted text to the author.
+  | 'grade_dispute_filed'
+  // D-2 niche-match discovery (slow-burn organic discovery between strangers
+  // through a shared authored question). Two asymmetric writes from
+  // notifyNicheMatch() in src/server/feed/create-feed-items-for-answer.ts,
+  // each gated by the *exposed* party's discoverableByNicheMatch flag.
+  // Deliberately NOT the same as friend_answered_your_question (which targets
+  // prior answerers, is friend-scoped, and carries a got-it/couldn't-get-it
+  // framing). Kept OUT of HOME_TOP3_ELIGIBLE_TYPES and the bell badge below —
+  // this is a slow-burn delight with no volume cues; it surfaces only in the
+  // full /activities list.
+  | 'niche_match_answered_your_question' // author-side: a stranger correctly answered a question you authored
+  | 'niche_match_you_answered'; // answerer-side: you correctly answered a stranger's authored question
+
+// Events surfaced in Home's top-3 RecentActivity and counted by the bell
+// badge. Light type filtering only — chronological within this set. Single
+// source of truth for "is this event home-worthy?" — see RecentActivitySection
+// and getBellBadgeCount.
+export const HOME_TOP3_ELIGIBLE_TYPES = [
+  'friend_answered_your_question',
+  'friend_mastery',
+  'declared_promoted',
+  'reaction_received',
+  'question_curated',
+  'authored_question_shared',
+  // A question a friend addressed directly to you is high-signal — surface it in
+  // Home's top-3 (and the bell badge), not just the full /activities list, so a
+  // sent question isn't easy to miss. Already-answered sends are dropped upstream
+  // by filterUtilityActivities, so this never shows a stale "sent you a question".
+  'received_direct_question',
+] as const satisfies readonly ActivityItemType[];
+
+export type HomeTop3EligibleType = (typeof HOME_TOP3_ELIGIBLE_TYPES)[number];

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -65,19 +65,30 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
     activityToStreamItem,
   );
   const momentItems = moments.map(momentToStreamItem);
-  const milestoneItems = milestones.map((m, i) => {
-    const questions: StreamQuestion[] = cappedIdsByMilestone[i].ids
-      .map((id) => textById.get(id))
-      .filter((q): q is NonNullable<typeof q> => Boolean(q))
-      .filter((q) => !hiddenIds.has(q.questionId))
-      .map((q) => ({
-        questionId: q.questionId,
-        text: q.text,
-        domain: q.domain,
-        priorResult: priorById.get(q.questionId) ?? null,
-      }));
-    return milestoneToStreamItem(m, questions);
-  });
+  const milestoneItems = milestones
+    .map((m, i) => {
+      const questions: StreamQuestion[] = cappedIdsByMilestone[i].ids
+        .map((id) => textById.get(id))
+        .filter((q): q is NonNullable<typeof q> => Boolean(q))
+        .filter((q) => !hiddenIds.has(q.questionId))
+        // The triangle row is for NEW questions only. Anything the viewer has
+        // already attempted on ANY surface (priorById carries every prior
+        // answer, right or wrong) is dropped here: questions you and the friend
+        // both got right surface in the convergence ("you both knew these")
+        // row, and your own misses live in Catch-Up. priorResult is therefore
+        // always null for what survives.
+        .filter((q) => !priorById.has(q.questionId))
+        .map((q) => ({
+          questionId: q.questionId,
+          text: q.text,
+          domain: q.domain,
+          priorResult: null,
+        }));
+      // A milestone whose questions all collapse out is a contentless streak
+      // card — suppress it rather than render an empty triangle.
+      return questions.length > 0 ? milestoneToStreamItem(m, questions) : null;
+    })
+    .filter((item): item is StreamItem => item !== null);
   const convergenceItems = convergences.map((c) => {
     const questions: StreamQuestion[] = c.questionIds
       .map((id) => textById.get(id))

--- a/src/server/activity/write-activity.ts
+++ b/src/server/activity/write-activity.ts
@@ -1,69 +1,13 @@
 import { activityItems, db } from '@/server/db';
+import { HOME_TOP3_ELIGIBLE_TYPES, type ActivityItemType } from '@/lib/activity-types';
 
-export type ActivityItemType =
-  | 'received_joshing_game'
-  | 'joshing_game_result'
-  | 'joshing_game_progress'
-  | 'friend_mastery'
-  | 'ceremony_ready'
-  // Legacy friend-request types — no longer written (the follow model below
-  // supersedes them) but retained so historical activity rows still type-check
-  // and render against the frozen Friendship table.
-  | 'friend_request'
-  | 'friend_request_accepted'
-  // D-1 Stage 3 follow model. `follow` = someone followed you (public account,
-  // auto-approved). `follow_request` = someone requested to follow you
-  // (approval_required). `follow_approved` = you approved their request.
-  | 'follow'
-  | 'follow_request'
-  | 'follow_approved'
-  // An invited friend both accepted the inviter's invitation and got far
-  // enough into the product to play their first five questions. Surfaced to
-  // the inviter as a "your invite stuck" milestone. Written from
-  // write-mastery-event.ts once the invitee crosses the fifth play.
-  | 'invited_friend_played_first_five'
-  | 'received_direct_question'
-  | 'reaction_received'
-  | 'question_curated'
-  | 'friend_answered_your_question'
-  | 'authored_question_shared'
-  | 'declared_promoted'
-  // §8.22 grade-dispute path: the question's author is notified when an
-  // answerer disputes their wrong-answer grade. The dispute is the
-  // answerer's explicit ask for a second look, which is the consent gate
-  // that exposes their submitted text to the author.
-  | 'grade_dispute_filed'
-  // D-2 niche-match discovery (slow-burn organic discovery between strangers
-  // through a shared authored question). Two asymmetric writes from
-  // notifyNicheMatch() in src/server/feed/create-feed-items-for-answer.ts,
-  // each gated by the *exposed* party's discoverableByNicheMatch flag.
-  // Deliberately NOT the same as friend_answered_your_question (which targets
-  // prior answerers, is friend-scoped, and carries a got-it/couldn't-get-it
-  // framing). Kept OUT of HOME_TOP3_ELIGIBLE_TYPES and the bell badge below —
-  // this is a slow-burn delight with no volume cues; it surfaces only in the
-  // full /activities list.
-  | 'niche_match_answered_your_question' // author-side: a stranger correctly answered a question you authored
-  | 'niche_match_you_answered'; // answerer-side: you correctly answered a stranger's authored question
-
-// Events surfaced in Home's top-3 RecentActivity and counted by the bell
-// badge. Light type filtering only — chronological within this set. Single
-// source of truth for "is this event home-worthy?" — see RecentActivitySection
-// and getBellBadgeCount.
-export const HOME_TOP3_ELIGIBLE_TYPES = [
-  'friend_answered_your_question',
-  'friend_mastery',
-  'declared_promoted',
-  'reaction_received',
-  'question_curated',
-  'authored_question_shared',
-  // A question a friend addressed directly to you is high-signal — surface it in
-  // Home's top-3 (and the bell badge), not just the full /activities list, so a
-  // sent question isn't easy to miss. Already-answered sends are dropped upstream
-  // by filterUtilityActivities, so this never shows a stale "sent you a question".
-  'received_direct_question',
-] as const satisfies readonly ActivityItemType[];
-
-export type HomeTop3EligibleType = (typeof HOME_TOP3_ELIGIBLE_TYPES)[number];
+// The activity-type vocabulary and the home-eligible set live in the DB-free
+// `@/lib/activity-types` module so the client-shared activity-stream transform
+// can read them without pulling this file's `pg` import into the browser
+// bundle. Re-exported here so existing server-side importers of
+// '@/server/activity/write-activity' keep working unchanged.
+export { HOME_TOP3_ELIGIBLE_TYPES };
+export type { ActivityItemType, HomeTop3EligibleType } from '@/lib/activity-types';
 
 export async function writeActivity(params: {
   userId: string;


### PR DESCRIPTION
…ld fix)

Completes the two-tier home stream and fixes the Vercel build it tripped.

Two-tier logic:
- build-stream: the milestone "triangle" row now drops any question the viewer has already attempted on ANY surface (priorById carries every prior answer, right or wrong), so it carries ONLY new/unanswered questions. A milestone that empties out is suppressed rather than shown as a contentless streak card. The both-correct overlap is told by the convergence row; the viewer's own misses live in Catch-Up.
- activity-stream: the convergence card ("you and X both knew these") is now homeEligible, so it surfaces on Home alongside the triangle rows instead of only in Lately.

Build fix (turbopack "Module not found: dns/fs/net/tls" on this branch): activity-stream is the client-shared, DB-free transform, but it imported HOME_TOP3_ELIGIBLE_TYPES (a value) from write-activity, which imports the pg DB layer — dragging pg into the browser bundle via FeedList. Extracted the activity-type vocabulary + home-eligible set into a pure @/lib/activity-types module; write-activity re-exports them for server callers, and activity-stream imports straight from the pure module.