### PR TITLE
Email reminders: daily reminder email, change-email flow, prod-safe confirm links

### DIFF
--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -8,6 +8,8 @@ import { type QueueSlot } from '@/server/daily/types';
 import { runWithConcurrency } from '@/server/lib/concurrency';
 import { isCronAuthorized } from '@/server/auth/cron';
 import { sendSms } from '@/server/sms';
+import { sendEmail } from '@/server/email/client';
+import { buildDailyReminderTemplate } from '@/server/email/templates/daily-reminder';
 
 export const dynamic = 'force-dynamic';
 // Scheduled at 17:05 UTC (vercel.json) to fire just after the 17:00 UTC daily
@@ -49,6 +51,9 @@ export async function GET(request: NextRequest) {
       id: users.id,
       phoneNumber: users.phoneNumber,
       smsOptIn: users.smsOptIn,
+      email: users.email,
+      emailOptIn: users.emailOptIn,
+      emailVerified: users.emailVerified,
     })
     .from(users)
     .where(eq(users.onboardingComplete, true));
@@ -67,6 +72,7 @@ export async function GET(request: NextRequest) {
     failedGeneration: 0,
     failedOther: 0,
     smsSent: 0,
+    emailSent: 0,
   };
 
   await runWithConcurrency(onboardedUsers, USER_CONCURRENCY, async (user) => {
@@ -90,6 +96,36 @@ export async function GET(request: NextRequest) {
           user.id,
         );
         results.smsSent += 1;
+      }
+
+      // Email reminder — mirrors the SMS nudge for opted-in + verified users,
+      // but previews today's first question as a no-spoiler teaser. sendEmail
+      // never throws (returns a discriminated union), so a provider failure
+      // counts as a skipped email, not a failed user.
+      if (queue && user.emailOptIn === 'opted_in' && user.emailVerified && user.email) {
+        const teaserSlot = asQueueSlots(queue.slots).find(
+          (slot) => !slot.answered && !slot.skipped && slot.question_text,
+        );
+        const template = buildDailyReminderTemplate({
+          dailyUrl: `${baseUrl}/daily`,
+          teaser: teaserSlot
+            ? { questionText: teaserSlot.question_text, domain: teaserSlot.domain }
+            : null,
+        });
+        const emailResult = await sendEmail({
+          to: user.email,
+          subject: template.subject,
+          html: template.html,
+          text: template.text,
+        });
+        if (emailResult.ok) {
+          results.emailSent += 1;
+        } else {
+          console.warn('[cron/daily-assignments] reminder email failed', {
+            userId: user.id,
+            reason: emailResult.reason,
+          });
+        }
       }
     } catch (error) {
       results.failed += 1;

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -77,11 +77,17 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
   const [resending, setResending] = useState(false);
   const [resendNotice, setResendNotice] = useState<string | null>(null);
   const [resendCooldown, setResendCooldown] = useState(0);
+  const [editingEmail, setEditingEmail] = useState(false);
 
   const smsOn = state.smsOptIn === 'opted_in';
   const emailOn = state.emailOptIn === 'opted_in';
   const hasPendingEmail = Boolean(state.pendingEmail);
   const hasVerifiedEmail = state.emailVerified && Boolean(state.email);
+  // Show the address input for a brand-new email, or when a verified user has
+  // tapped "Change email". A pending change to an already-verified address
+  // leaves the old one in force until the new link is confirmed.
+  const showEmailInput = !hasVerifiedEmail || editingEmail;
+  const pendingIsChange = hasPendingEmail && hasVerifiedEmail;
 
   useEffect(() => {
     if (resendCooldown <= 0) return;
@@ -95,6 +101,10 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
       setEmailError('Please enter an email address.');
       return;
     }
+    if (trimmed.toLowerCase() === (state.email ?? '').toLowerCase()) {
+      setEmailError('That’s already your confirmed email.');
+      return;
+    }
     setSavingEmail(true);
     setEmailError(null);
     setResendNotice(null);
@@ -105,10 +115,24 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
       return;
     }
     setState(result.state);
+    setEditingEmail(false);
     if (result.verificationEmailSent) {
       setResendCooldown(RESEND_COOLDOWN_SECONDS);
       setResendNotice('Confirmation email sent.');
     }
+  }
+
+  function startEditingEmail() {
+    setEmailDraft('');
+    setEmailError(null);
+    setResendNotice(null);
+    setEditingEmail(true);
+  }
+
+  function cancelEditingEmail() {
+    setEditingEmail(false);
+    setEmailDraft(state.pendingEmail ?? '');
+    setEmailError(null);
   }
 
   async function toggleEmail() {
@@ -177,6 +201,15 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
                 ? `Email ${state.email} when a new round opens.`
                 : 'Add an email address to enable email reminders.'}
             </p>
+            {hasVerifiedEmail && !editingEmail ? (
+              <button
+                type="button"
+                className="mt-2 self-start text-xs font-medium underline-offset-2 hover:underline"
+                onClick={startEditingEmail}
+              >
+                Change email
+              </button>
+            ) : null}
           </div>
           {hasVerifiedEmail ? (
             <Switch
@@ -188,13 +221,13 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
           ) : null}
         </div>
 
-        {!hasVerifiedEmail ? (
+        {showEmailInput ? (
           <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center">
             <input
               type="email"
               inputMode="email"
               autoComplete="email"
-              placeholder="you@example.com"
+              placeholder={hasVerifiedEmail ? 'new@example.com' : 'you@example.com'}
               value={emailDraft}
               disabled={savingEmail}
               onChange={(event) => {
@@ -209,15 +242,33 @@ export function NotificationsForm({ initialState, maskedPhone }: Props) {
               onClick={() => void saveEmail()}
               disabled={savingEmail}
             >
-              {savingEmail ? 'Saving…' : hasPendingEmail ? 'Update' : 'Save'}
+              {savingEmail
+                ? 'Saving…'
+                : hasVerifiedEmail
+                  ? 'Send confirmation'
+                  : hasPendingEmail
+                    ? 'Update'
+                    : 'Save'}
             </button>
+            {editingEmail ? (
+              <button
+                type="button"
+                className="text-sm text-muted-foreground underline-offset-2 hover:underline disabled:opacity-50"
+                onClick={cancelEditingEmail}
+                disabled={savingEmail}
+              >
+                Cancel
+              </button>
+            ) : null}
           </div>
         ) : null}
 
-        {hasPendingEmail && !hasVerifiedEmail ? (
+        {hasPendingEmail ? (
           <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
             <p className="text-xs text-muted-foreground">
-              Check {state.pendingEmail} for a confirmation link. It expires in 24 hours.
+              {pendingIsChange
+                ? `Confirm ${state.pendingEmail} to switch your reminder address. Until then, we’ll keep emailing ${state.email}.`
+                : `Check ${state.pendingEmail} for a confirmation link. It expires in 24 hours.`}
             </p>
             <button
               type="button"

--- a/src/server/email/send-verification.ts
+++ b/src/server/email/send-verification.ts
@@ -10,9 +10,19 @@ export type SendVerificationEmailResult =
   | { ok: true }
   | { ok: false; reason: 'no_pending_email' | 'rate_limited' | 'send_failed'; retryAfterMs?: number };
 
+// Mirrors the fallback chain in getBaseUrl() (src/app/api/friend-invitations/
+// route.ts) so a forgotten NEXT_PUBLIC_APP_URL can't silently emit localhost
+// confirm-links in production. VERCEL_PROJECT_PRODUCTION_URL is auto-injected
+// on every Vercel deployment (hostname only, no scheme) and points at the
+// stable production host. localhost remains the last-resort dev default.
 function appBaseUrl(): string {
-  const fromEnv = process.env.NEXT_PUBLIC_APP_URL?.trim();
+  const fromEnv =
+    process.env.NEXT_PUBLIC_APP_URL?.trim() || process.env.APP_URL?.trim();
   if (fromEnv) return fromEnv.replace(/\/+$/, '');
+
+  const vercelProd = process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim();
+  if (vercelProd) return `https://${vercelProd.replace(/\/+$/, '')}`;
+
   return 'http://localhost:3000';
 }
 

--- a/src/server/email/templates/daily-reminder.ts
+++ b/src/server/email/templates/daily-reminder.ts
@@ -1,0 +1,117 @@
+export type DailyReminderTemplateParams = {
+  dailyUrl: string;
+  /**
+   * A no-spoiler teaser drawn from the user's freshly built queue: the first
+   * slot's question_text (+ optional domain label). Safe to show because a
+   * newly built slot carries no reveal_canonical_answer yet. When absent (empty
+   * or short queue), the email gracefully falls back to the generic nudge.
+   */
+  teaser?: { questionText: string; domain?: string | null } | null;
+};
+
+// The daily "your five for today" nudge, sent from the daily-assignments cron
+// to opted-in + verified users right after the 17:00 UTC reset. Mirrors the SMS
+// copy ("Your five for today") and the Ink-on-Cream styling of verify-email.ts,
+// and previews today's first question to make the open worth it.
+export function buildDailyReminderTemplate(params: DailyReminderTemplateParams): {
+  subject: string;
+  html: string;
+  text: string;
+} {
+  const { dailyUrl, teaser } = params;
+
+  const teaserText = teaser?.questionText?.trim() || null;
+  const teaserDomain = teaser?.domain?.trim() || null;
+
+  const subject = teaserText
+    ? `Today’s five: ${truncate(teaserText, 60)}`
+    : 'Your five for today';
+
+  const text = [
+    'Your five for today are ready.',
+    '',
+    teaserText
+      ? `First up${teaserDomain ? ` (${teaserDomain})` : ''}: ${teaserText}`
+      : 'Five fresh questions, picked for what you know and what you’re curious about.',
+    '',
+    `Play today’s five: ${dailyUrl}`,
+    '',
+    'You can turn these reminders off any time from your profile settings.',
+  ].join('\n');
+
+  const teaserBlock = teaserText
+    ? `<tr>
+              <td style="padding-bottom:24px;">
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f7f5f0;border:1px solid #e5e1d8;border-radius:10px;padding:18px 20px;">
+                  ${
+                    teaserDomain
+                      ? `<tr><td style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:#8a857b;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">First up · ${escapeHtml(teaserDomain)}</td></tr>`
+                      : `<tr><td style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:#8a857b;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">First up</td></tr>`
+                  }
+                  <tr><td style="font-size:17px;line-height:1.5;color:#1f1d1a;">${escapeHtml(teaserText)}</td></tr>
+                </table>
+              </td>
+            </tr>`
+    : `<tr>
+              <td style="font-size:15px;line-height:1.55;padding-bottom:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+                Five fresh questions are waiting — picked for what you know and what you’re curious about.
+              </td>
+            </tr>`;
+
+  const html = `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:#f7f5f0;font-family:Georgia,'Times New Roman',serif;color:#1f1d1a;">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f7f5f0;padding:32px 16px;">
+      <tr>
+        <td align="center">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:520px;background:#ffffff;border:1px solid #e5e1d8;border-radius:12px;padding:32px;">
+            <tr>
+              <td style="font-size:24px;font-weight:700;padding-bottom:16px;">Your five for today</td>
+            </tr>
+            ${teaserBlock}
+            <tr>
+              <td align="left" style="padding-bottom:24px;">
+                <a href="${dailyUrl}" style="display:inline-block;background:#111111;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;font-weight:600;">
+                  Play today’s five
+                </a>
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:13px;color:#6b6760;line-height:1.55;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+                Or paste this link into your browser:
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:12px;color:#6b6760;word-break:break-all;font-family:ui-monospace,Menlo,Consolas,monospace;padding-bottom:24px;">
+                ${dailyUrl}
+              </td>
+            </tr>
+            <tr>
+              <td style="font-size:12px;color:#8a857b;line-height:1.55;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
+                You can turn these reminders off any time from your profile settings.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, html, text };
+}
+
+function truncate(value: string, max: number): string {
+  const trimmed = value.trim();
+  if (trimmed.length <= max) return trimmed;
+  return `${trimmed.slice(0, max - 1).trimEnd()}…`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}


### PR DESCRIPTION
## Summary

Follow-up work to the email-verification fixes in #765 (which merged only the first commit, `b0ed2fe`). This PR carries the three commits pushed to the branch after #765 was merged, plus the new change-email UI.

## Changes

### 1. Daily reminder email with a no-spoiler question teaser (`d7e86cc`)
- Piggybacks on the existing `/api/cron/daily-assignments` cron (the SMS "your five for today" sender) — no new cron, `vercel.json`, or workflow changes; rides the same 17:05 UTC schedule already driven by `external-crons.yml`.
- After each user's queue is built, opted-in + verified users (`emailOptIn === 'opted_in' && emailVerified && email`) get a reminder that previews today's **first question** as a teaser. Safe because a freshly built slot carries `question_text` but no revealed answer yet.
- New template `src/server/email/templates/daily-reminder.ts` (Ink-on-Cream styling matching the verification email; graceful fallback when no teaser is available).
- `sendEmail` never throws, so a provider failure counts as a skipped email (`results.emailSent`), never a failed user.

### 2. Change a verified email from profile settings (`beec88d`)
- Once an email was verified, `NotificationsForm` hid the address input, leaving no way to change it. Adds a **"Change email"** affordance (with Cancel) for verified users.
- Submitting sets a new `pendingEmail`, which the reminders route confirms by emailing the new address. The old verified address stays in force — and keeps receiving reminders — until the new link is confirmed, then `consumeVerificationToken` promotes it (`emailOptIn` preserved).
- Guards against re-entering the already-confirmed address.

### 3. Prod-safe confirm-link base URL (`a7130d0`)
- `appBaseUrl()` only read `NEXT_PUBLIC_APP_URL` before falling back to `localhost`, so a deploy without that var emitted localhost confirm-links. Now mirrors the friend-invitation fallback chain: `NEXT_PUBLIC_APP_URL` → `APP_URL` → `VERCEL_PROJECT_PRODUCTION_URL` (auto-injected on Vercel) → localhost.

## Validation
- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- `npm run lint` (changed files) — clean
- No `src/middleware.ts` (repo uses `src/proxy.ts`)

## Notes
- The "reminders aren't sending yet / coming soon" copy in `NotificationsForm` is left untouched — flagging it since the daily reminder now actually sends, in case you want to update that messaging at launch.

https://claude.ai/code/session_011vm1w94U4v2Lok1QuLLq1U

---
_Generated by [Claude Code](https://claude.ai/code/session_011vm1w94U4v2Lok1QuLLq1U)_