### PR TITLE
Move daily-game reset onto profile "Create test game" action

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -94,8 +94,6 @@ export default function TodaysFiveCard({
 }: TodaysFiveCardProps = {}) {
   const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
   const [preferences, setPreferences] = useState<DailyPreferences | null>(initialPreferences)
-  const [resetting, setResetting] = useState(false)
-  const [resetError, setResetError] = useState<string | null>(null)
   // Client-only reset-time label; null during SSR to keep hydration stable.
   const resetTime = useSyncExternalStore(
     subscribeNoop,
@@ -199,29 +197,6 @@ export default function TodaysFiveCard({
     : hasStartedRound
       ? 'Pick up where you left off'
       : 'Ready when you are!'
-
-  const resetForToday = async () => {
-    if (resetting) return
-    setResetError(null)
-    setResetting(true)
-    try {
-      const response = await fetch('/api/daily/reset', {
-        method: 'POST',
-        credentials: 'include',
-      })
-      const body = await response.json().catch(() => null)
-      if (!response.ok)
-        throw new Error(body?.message ?? 'Could not reset daily round.')
-      window.location.assign('/daily')
-    } catch (caught) {
-      setResetError(
-        caught instanceof Error
-          ? caught.message
-          : 'Could not reset daily round.'
-      )
-      setResetting(false)
-    }
-  }
 
   return (
     <div className="bg-card text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
@@ -353,21 +328,6 @@ export default function TodaysFiveCard({
           >
             See today&apos;s recap
           </Link>
-
-          {/* Quiet tertiary reset link in both branches. */}
-          <button
-            type="button"
-            onClick={() => {
-              void resetForToday()
-            }}
-            disabled={resetting}
-            className="block text-xs font-medium tracking-[0.08em] text-[var(--brand-ink-400)] uppercase underline underline-offset-4 disabled:opacity-60"
-          >
-            {resetting ? 'Resetting…' : 'Reset game for today and play again'}
-          </button>
-          {resetError ? (
-            <p className="text-destructive text-xs">{resetError}</p>
-          ) : null}
         </div>
       ) : (
         <Link

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -23,8 +23,33 @@ export function AccountActions() {
   const [deleteConfirmation, setDeleteConfirmation] = useState('');
   const [deletingAccount, setDeletingAccount] = useState(false);
   const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [resettingGame, setResettingGame] = useState(false);
+  const [resetGameError, setResetGameError] = useState<string | null>(null);
 
   const canDeleteAccount = deleteConfirmation === 'DELETE';
+
+  async function createTestGame() {
+    if (resettingGame) return;
+    setResetGameError(null);
+    setResettingGame(true);
+
+    try {
+      const response = await fetch('/api/daily/reset', {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const body = (await response.json().catch(() => null)) as { message?: string } | null;
+
+      if (!response.ok) {
+        throw new Error(body?.message ?? 'Could not reset daily round.');
+      }
+
+      router.push('/daily');
+    } catch (caught) {
+      setResetGameError(caught instanceof Error ? caught.message : 'Could not reset daily round.');
+      setResettingGame(false);
+    }
+  }
 
   async function confirmLogout() {
     setLoggingOut(true);
@@ -78,9 +103,10 @@ export function AccountActions() {
         <SettingsGroup>
           <SettingsRow
             icon={<FlaskConical className="size-5" />}
-            title="Create test game"
-            subtitle="Spin up a test game instantly"
-            href="/dev/test-game"
+            title={resettingGame ? 'Resetting…' : 'Create test game'}
+            subtitle="Reset today's game and play again"
+            onClick={() => void createTestGame()}
+            disabled={resettingGame}
           />
           <SettingsRow
             icon={<RefreshCw className="size-5" />}
@@ -107,6 +133,7 @@ export function AccountActions() {
             href="/dev/points-diagnostic"
           />
         </SettingsGroup>
+        {resetGameError ? <p className="mt-2 text-sm text-destructive">{resetGameError}</p> : null}
       </section>
 
       <section className="mb-8">


### PR DESCRIPTION
Wire the profile page's "Create test game" developer tool to reset
today's daily round (POST /api/daily/reset) and navigate to /daily,
mirroring the homepage reset link. Remove the now-redundant reset
link from TodaysFiveCard.

https://claude.ai/code/session_01GUHwM6yRpztTvtbBNNwcLh