### PR TITLE
fix(feed): flatten home feed, restore milestone progress, tidy modules

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -21,12 +21,11 @@ import {
   type FriendLikedFeedItem,
 } from '@/components/feed'
 import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion'
-import { SparkleDivider, SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
+import { SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
 import { PersonActivityCard } from '@/components/activity/PersonActivityCard'
-import { FeedCardShell } from '@/components/feed/FeedCardShell'
 import { groupActivityByFriend, type GroupInputRow } from '@/components/feed/person-grouping'
 import {
   CommonGroundFeature,
@@ -477,12 +476,6 @@ type FeedListProps = {
 
 type QuestionCardState = 'unanswered' | 'answered'
 
-// Where the common-ground module lands: a couple rows down so it's never the very
-// first thing when there's real activity (it falls to row 0 only on an empty
-// feed). The other two discovery modules render as first-class sections at the
-// feed tail (see displayRows), so they need no offset.
-const COMMON_GROUND_PROMO_OFFSET = 2
-
 // One row of the unified-home feed: either a paginated question card or an
 // interleaved activity (Lately) one-liner. Both carry `source_event_at` so the
 // existing recency grouping works over the merged list unchanged. The per-person
@@ -630,7 +623,6 @@ function FeedContributeFooter() {
 
   return (
     <footer className="pt-6 pb-8">
-      <SparkleDivider />
       {/* Add-a-Question prompt — the same full-bleed editorial wash language as
           the feed's other featured moments (no card, border, or triangle
           mosaic): a parchment band that bleeds to the feed edges, with an
@@ -904,11 +896,10 @@ function FeedListContent({
   }, [items, activityItems, unifiedHome])
 
   // Place the home-only discovery modules. They are NOT part of the chronological
-  // union above; each renders as a first-class section whenever its data exists.
-  // Common-ground sits a couple rows down (never first when there's activity);
-  // recently-expanding + add-friends anchor to the feed tail. Each borrows a
-  // neighbouring row's timestamp so recency grouping keeps it in that bucket
-  // rather than floating it into one of its own.
+  // union above; each renders whenever its data exists. Rather than clump them at
+  // the top or tail, SPREAD the present modules evenly through the feed so they
+  // read as occasional interludes, not a wall at the bottom. Each borrows a
+  // neighbouring row's timestamp so recency grouping keeps it in that bucket.
   const displayRows = useMemo<UnifiedRow[]>(() => {
     const next = [...unifiedRows]
 
@@ -922,17 +913,19 @@ function FeedListContent({
       }
     }
 
-    if (commonGroundPromo) {
-      const offset = next.length === 0 ? 0 : Math.min(COMMON_GROUND_PROMO_OFFSET, next.length)
-      const anchor = offset > 0 ? next[offset - 1]! : null
-      next.splice(offset, 0, toRow(commonGroundPromo, anchor))
-    }
-
-    for (const promo of [expandingPromo, addFriendsPromo]) {
-      if (!promo) continue
-      const anchor = next.length > 0 ? next[next.length - 1]! : null
-      next.push(toRow(promo, anchor))
-    }
+    const promos = [commonGroundPromo, expandingPromo, addFriendsPromo].filter(
+      (p): p is StreamItem => p !== null && p !== undefined,
+    )
+    const baseLen = unifiedRows.length
+    promos.forEach((promo, i) => {
+      // Even fractions through the ORIGINAL feed (1/(k+1), 2/(k+1), …), never the
+      // very first row; +i accounts for the promos already spliced in ahead.
+      const target =
+        baseLen === 0 ? 0 : Math.max(1, Math.round(((i + 1) * baseLen) / (promos.length + 1)))
+      const spliceAt = Math.min(target + i, next.length)
+      const anchor = spliceAt > 0 ? next[spliceAt - 1]! : null
+      next.splice(spliceAt, 0, toRow(promo, anchor))
+    })
 
     return next
   }, [unifiedRows, commonGroundPromo, expandingPromo, addFriendsPromo])
@@ -1517,23 +1510,9 @@ function FeedListContent({
                   if (embed?.kind === 'recently_expanding') {
                     return <RecentlyExpandingFeature key={`e-${row.item.id}`} embed={embed} />
                   }
-                  // The milestone "match your friend's wins" bundle is THE
-                  // standout playable card: wrap it in the elevated shell (cream
-                  // fill + hard ink offset) so it steps forward. The 5-triangle
-                  // mark + tap-to-answer expansion live inside ActivityStreamItem.
-                  if (row.item.expand?.kind === 'milestone') {
-                    return (
-                      <FeedCardShell key={`m-${row.item.id}`} elevated>
-                        <div className="px-3 py-1">
-                          <ActivityStreamItem
-                            item={row.item}
-                            timestamp={formatRelativeTime(row.item.sortAt)}
-                            inCard
-                          />
-                        </div>
-                      </FeedCardShell>
-                    )
-                  }
+                  // Everything else — including the milestone bundle — renders as a
+                  // plain flat row (its bundle triangle mark + tap-to-answer
+                  // expansion live inside ActivityStreamItem). No card treatment.
                   return (
                     <ActivityStreamItem
                       key={`a-${row.item.id}`}

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -194,6 +194,33 @@ function BundleMark({
   );
 }
 
+// A single milestone-question marker, sharing the bundle's vocabulary: a SOLID
+// palette triangle for a question still to play, a HOLLOW outline once it's been
+// answered. Used per-row in the milestone expansion so each question reads as
+// solid→hollow in lockstep with the bundle mark above it.
+export function QuestionTriangle({ solid, seed }: { solid: boolean; seed: string }) {
+  const S = 11; // base = height, matches one BundleMark triangle
+  return (
+    <svg
+      width={S}
+      height={S}
+      viewBox={`0 0 ${S} ${S}`}
+      fill="none"
+      aria-hidden="true"
+      style={{ display: 'block', flexShrink: 0 }}
+    >
+      <path
+        d={solid ? upTri(0, 0, S, S) : hollowTri(0, 0, S, S)}
+        fill={solid ? colorFor(seed, 0) : 'none'}
+        fillOpacity={solid ? FILL_OPACITY : undefined}
+        stroke={solid ? 'none' : HOLLOW}
+        strokeWidth={solid ? 0 : 1.4}
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
 // Rhombus: upward triangle over downward triangle, shared base. Each half a
 // random palette colour.
 function DiamondMark({ seed }: { seed: string }) {

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -16,7 +16,7 @@ import type {
 
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
-import { ActivityIcon, specForIcon } from './ActivityIcon';
+import { ActivityIcon, QuestionTriangle, specForIcon } from './ActivityIcon';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
 
@@ -97,13 +97,14 @@ type Resolution = { submitted: string; isCorrect: boolean };
 export function ActivityStreamItem({
   item,
   timestamp,
-  inCard = false,
+  nested = false,
 }: {
   item: StreamItem;
   timestamp: string;
-  // When the row is wrapped in a card (the milestone standout card), drop its own
-  // hairline border + paper fill so the card's surface shows through.
-  inCard?: boolean;
+  // When nested beneath a per-person heading, the row drops its own shape mark
+  // (the heading carries the only shape) and its hairline/padding chrome, so the
+  // sub-items read as a quiet indented list under the statement.
+  nested?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
@@ -154,6 +155,14 @@ export function ActivityStreamItem({
 
   const answeredCount = (milestoneQuestions ?? []).filter((q) => isResolved(q.questionId)).length;
 
+  // The plain "{answered} of {total} questions" progress label that rides under a
+  // milestone line, in lockstep with the bundle triangle mark — so the viewer can
+  // read their progress at a glance whether or not the card is open.
+  const milestoneProgress =
+    milestoneQuestions && milestoneQuestions.length > 0
+      ? { answered: answeredCount, total: milestoneQuestions.length }
+      : null;
+
   // The bundle mark (milestone) shares the row's live answered-state: as the
   // viewer answers questions inline, solid triangles flip to hollow. Caps at 5
   // triangles silently (the questions array is already ≤5); copy stays truthful.
@@ -190,9 +199,8 @@ export function ActivityStreamItem({
     <div
       id={item.anchorId ?? undefined}
       style={
-        inCard
-          ? // Inside the milestone standout card: the shell owns the surface, so
-            // the row drops its own border/fill and just keeps light padding.
+        nested
+          ? // Nested under a per-person heading: no border/fill, light padding.
             { padding: opened ? '6px 0' : '4px 0' }
           : opened
             ? {
@@ -220,7 +228,9 @@ export function ActivityStreamItem({
           WebkitTapHighlightColor: 'transparent',
         }}
       >
-        <ActivityIcon spec={iconSpec} seed={item.id} />
+        {/* Nested rows carry no shape — the per-person heading holds the one
+            diamond; everything beneath it is a plain indented line. */}
+        {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} />}
 
         <div style={{ minWidth: 0, flex: 1, paddingRight: 12 }}>
           <p
@@ -249,6 +259,19 @@ export function ActivityStreamItem({
               }}
             >
               {item.secondLine}
+            </p>
+          ) : null}
+          {milestoneProgress ? (
+            <p
+              style={{
+                margin: '4px 0 0',
+                fontFamily: FM,
+                fontSize: 10,
+                letterSpacing: 1,
+                color: INK3,
+              }}
+            >
+              {milestoneProgress.answered} of {milestoneProgress.total} questions
             </p>
           ) : null}
         </div>
@@ -363,11 +386,20 @@ export function MilestoneExpansion({
         marginTop: 14,
         display: 'flex',
         flexDirection: 'column',
-        gap: 20,
+        gap: 18,
       }}
     >
       {unanswered.map((q) => (
-        <InlineAnswerFlow key={q.questionId} question={q} onResolved={onResolved} />
+        // Solid triangle = still to play. It leads each answerable question so the
+        // per-question marks read solid→hollow in step with the bundle mark above.
+        <div key={q.questionId} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+          <span style={{ marginTop: 6 }}>
+            <QuestionTriangle solid seed={q.questionId} />
+          </span>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <InlineAnswerFlow question={q} onResolved={onResolved} />
+          </div>
+        </div>
       ))}
       {answered.length > 0 ? (
         <AnsweredHistory questions={answered} resolutions={resolutions} />
@@ -422,34 +454,41 @@ function AnsweredHistory({
           // red for "not this time" — same tokens the AnswerFeedbackSheet uses.
           const resultColor = isCorrect ? 'var(--game-correct)' : 'var(--game-wrong-strong)';
           return (
-            <div key={q.questionId}>
-              <p
-                style={{
-                  margin: 0,
-                  fontFamily: FF,
-                  fontSize: 12.5,
-                  lineHeight: 1.45,
-                  letterSpacing: 0.2,
-                  fontWeight: 600,
-                  color: resultColor,
-                }}
-              >
-                {isCorrect ? 'Correct' : 'Not this time'}
-                {r ? ` - ${r.submitted}` : null}
-              </p>
-              <p
-                style={{
-                  margin: '3px 0 0',
-                  paddingRight: 24,
-                  fontFamily: 'Georgia, serif',
-                  fontStyle: 'italic',
-                  fontSize: 13,
-                  lineHeight: 1.5,
-                  color: INK3,
-                }}
-              >
-                &ldquo;{q.text}&rdquo;
-              </p>
+            // Hollow triangle = already answered (spent), matching the bundle
+            // mark's hollow state, so the viewer sees which ones they've done.
+            <div key={q.questionId} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+              <span style={{ marginTop: 4 }}>
+                <QuestionTriangle solid={false} seed={q.questionId} />
+              </span>
+              <div style={{ flex: 1, minWidth: 0 }}>
+                <p
+                  style={{
+                    margin: 0,
+                    fontFamily: FF,
+                    fontSize: 12.5,
+                    lineHeight: 1.45,
+                    letterSpacing: 0.2,
+                    fontWeight: 600,
+                    color: resultColor,
+                  }}
+                >
+                  {isCorrect ? 'Correct' : 'Not this time'}
+                  {r ? ` - ${r.submitted}` : null}
+                </p>
+                <p
+                  style={{
+                    margin: '3px 0 0',
+                    paddingRight: 24,
+                    fontFamily: 'Georgia, serif',
+                    fontStyle: 'italic',
+                    fontSize: 13,
+                    lineHeight: 1.5,
+                    color: INK3,
+                  }}
+                >
+                  &ldquo;{q.text}&rdquo;
+                </p>
+              </div>
             </div>
           );
         })}

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -7,7 +7,7 @@ import { AnswerSheet } from '@/components/feed/AnswerSheet';
 import type { StreamQuestion } from '@/lib/activity-stream';
 import type { InsideJokeKind } from '@/lib/questions-types';
 
-import { FM, INK, INK2 } from '@/components/lately/tokens';
+import { FM, INK } from '@/components/lately/tokens';
 
 type Feedback = {
   isCorrect: boolean;
@@ -87,12 +87,7 @@ export function InlineAnswerFlow({
   }
 
   return (
-    <div
-      style={{
-        borderLeft: `2px solid ${INK2}`,
-        paddingLeft: 14,
-      }}
-    >
+    <div>
       <p
         style={{
           margin: 0,
@@ -124,7 +119,7 @@ export function InlineAnswerFlow({
           cursor: 'pointer',
         }}
       >
-        ANSWER THIS ONE →
+        ANSWER →
       </button>
 
       {phase === 'input' ? (

--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -4,6 +4,11 @@ import type { StreamItem } from '@/lib/activity-stream';
 import { FF, INK, RULE } from '@/components/lately/tokens';
 
 import { ActivityStreamItem, Line } from './ActivityStreamItem';
+import { ActivityIcon } from './ActivityIcon';
+
+// Width of the shape column (mark 24 + gap 8), so the nested events indent to sit
+// directly under the heading statement's text.
+const HEADING_INDENT = 32;
 
 // The friend's first name, pulled from the first actor part of any of their
 // rows (convergence uses the first name already; moments/activities carry the
@@ -20,12 +25,11 @@ function firstNameFromRows(rows: StreamItem[]): string {
   return 'They';
 }
 
-// Tier 2 + 3 of the home hierarchy: one card gathering everything a single friend
-// did. The heading (tier 2) is driven by the strongest relationship signal — a
-// convergence ("you and {friend} keep landing in the same place") leads when
-// present, otherwise a warm generic line — and the friend's events stack beneath
-// it (tier 3). Built only when a friend has ≥2 groupable events in a day bucket
-// (see groupActivityByFriend in FeedList); lone events stay ordinary one-liners.
+// Tier 2 + 3 of the home hierarchy: one quiet (no card) group of everything a
+// single friend did. The heading (tier 2) is the relationship statement — a
+// convergence ("You and Robyn are clearly on the same page") when present, else a
+// warm generic line — and it carries the ONE diamond shape. The friend's events
+// nest beneath it (tier 3) as a plain indented list with no shapes of their own.
 export function PersonActivityCard({
   rows,
   timestampFor,
@@ -34,38 +38,34 @@ export function PersonActivityCard({
   rows: StreamItem[];
   timestampFor: (item: StreamItem) => string;
 }) {
-  // A convergence, when present, becomes the headline and drops out of the
-  // sub-items below (it IS the heading, not a duplicate line).
   const convergence = rows.find((r) => r.expand?.kind === 'same_correct') ?? null;
   const subItems = convergence ? rows.filter((r) => r !== convergence) : rows;
   const firstName = firstNameFromRows(rows);
+  const seed = convergence?.id ?? rows[0]?.id ?? 'person';
 
   return (
-    <div
-      style={{
-        border: `1px solid ${RULE}`,
-        borderRadius: 4,
-        padding: '10px 12px',
-        background: 'var(--brand-card)',
-      }}
-    >
-      <p
-        style={{
-          margin: 0,
-          fontFamily: FF,
-          fontSize: 15,
-          fontWeight: 600,
-          lineHeight: 1.4,
-          color: INK,
-        }}
-      >
-        {convergence ? <Line parts={convergence.line} /> : `${firstName} gets you!`}
-      </p>
-      <div style={{ marginTop: 2 }}>
-        {subItems.map((item, idx) => (
-          <div key={item.id} style={idx > 0 ? { borderTop: `1px solid ${RULE}` } : undefined}>
-            <ActivityStreamItem item={item} timestamp={timestampFor(item)} inCard />
-          </div>
+    <div style={{ padding: '12px 2px', borderBottom: `1px solid ${RULE}` }}>
+      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+        <ActivityIcon spec={{ kind: 'diamond' }} seed={seed} />
+        <p
+          style={{
+            margin: 0,
+            flex: 1,
+            minWidth: 0,
+            fontFamily: FF,
+            fontSize: 15,
+            fontWeight: 600,
+            lineHeight: 1.4,
+            letterSpacing: 0.2,
+            color: INK,
+          }}
+        >
+          {convergence ? <Line parts={convergence.line} /> : `${firstName} gets you!`}
+        </p>
+      </div>
+      <div style={{ marginLeft: HEADING_INDENT, marginTop: 2 }}>
+        {subItems.map((item) => (
+          <ActivityStreamItem key={item.id} item={item} timestamp={timestampFor(item)} nested />
         ))}
       </div>
     </div>

--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -45,7 +45,10 @@ export function PersonActivityCard({
 
   return (
     <div style={{ padding: '12px 2px', borderBottom: `1px solid ${RULE}` }}>
-      <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+      {/* No flex `gap` here: ActivityIcon already reserves the 24px mark + 8px
+          marginRight, so the heading text lands at the same 32px x as the nested
+          events and every other feed row. */}
+      <div style={{ display: 'flex', alignItems: 'flex-start' }}>
         <ActivityIcon spec={{ kind: 'diamond' }} seed={seed} />
         <p
           style={{

--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -1,18 +1,18 @@
 'use client';
 
-import type { StreamItem } from '@/lib/activity-stream';
-import { FF, INK, RULE } from '@/components/lately/tokens';
+import type { ReactNode } from 'react';
 
-import { ActivityStreamItem, Line } from './ActivityStreamItem';
+import type { StreamItem } from '@/lib/activity-stream';
+import { FF, INK, INK2, INK3, RULE } from '@/components/lately/tokens';
+
+import { Line } from './ActivityStreamItem';
 import { ActivityIcon } from './ActivityIcon';
 
-// Width of the shape column (mark 24 + gap 8), so the nested events indent to sit
-// directly under the heading statement's text.
+// Width of the shape column (mark 24 + gap 8), so the rolled-up lines indent to
+// sit directly under the heading statement's text.
 const HEADING_INDENT = 32;
 
-// The friend's first name, pulled from the first actor part of any of their
-// rows (convergence uses the first name already; moments/activities carry the
-// display name). Falls back to a warm neutral if no actor part is present.
+// The friend's first name, pulled from the first actor part of any of their rows.
 function firstNameFromRows(rows: StreamItem[]): string {
   for (const row of rows) {
     for (const part of row.line) {
@@ -25,11 +25,51 @@ function firstNameFromRows(rows: StreamItem[]): string {
   return 'They';
 }
 
-// Tier 2 + 3 of the home hierarchy: one quiet (no card) group of everything a
-// single friend did. The heading (tier 2) is the relationship statement — a
-// convergence ("You and Robyn are clearly on the same page") when present, else a
-// warm generic line — and it carries the ONE diamond shape. The friend's events
-// nest beneath it (tier 3) as a plain indented list with no shapes of their own.
+// Distinct topics across a set of rows, first-seen order, nulls dropped.
+function topicsOf(rows: StreamItem[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const r of rows) {
+    const t = r.topic?.trim();
+    if (t && !seen.has(t)) {
+      seen.add(t);
+      out.push(t);
+    }
+  }
+  return out;
+}
+
+// The human predicate of a convergence caption ("keep landing in the same
+// place") with the "You and {Name}" lead stripped — the cluster header already
+// names the pair, so the echo is removed (v2 §3).
+function convergencePredicate(row: StreamItem): string {
+  const parts = row.line;
+  const actorIdx = parts.findIndex((p) => p.t === 'actor');
+  const after = parts.slice(actorIdx + 1).find((p) => p.t === 'text');
+  if (after && 'v' in after && after.v.trim()) return after.v.trim();
+  const before = [...parts.slice(0, actorIdx)].reverse().find((p) => p.t === 'text');
+  if (before && 'v' in before) {
+    const stripped = before.v.replace(/\b(you\s+and|and)\s*$/i, '').trim();
+    if (stripped) return stripped;
+  }
+  return 'both knew these';
+}
+
+// One quiet rolled-up line beneath the cluster header. No bold, no shape, no
+// timestamp — the texture layer (v2 §4).
+function SubLine({ children }: { children: ReactNode }) {
+  return (
+    <p style={{ margin: '4px 0 0', fontFamily: FF, fontSize: 14, lineHeight: 1.4, color: INK2 }}>
+      {children}
+    </p>
+  );
+}
+
+// Tier 2 + 3 of the home hierarchy (D-FEED-TIER v2 §3): one quiet per-person
+// cluster. The header is the relationship pair ("You & Robyn") with the single
+// diamond; the friend's events roll up beneath it by direction — "got {Name} —
+// topics", "{Name} got yours — topics", a folded convergence line — names said
+// once, topics on few lines, per-event timestamps/actions dropped.
 export function PersonActivityCard({
   rows,
   timestampFor,
@@ -38,16 +78,24 @@ export function PersonActivityCard({
   rows: StreamItem[];
   timestampFor: (item: StreamItem) => string;
 }) {
-  const convergence = rows.find((r) => r.expand?.kind === 'same_correct') ?? null;
-  const subItems = convergence ? rows.filter((r) => r !== convergence) : rows;
-  const firstName = firstNameFromRows(rows);
-  const seed = convergence?.id ?? rows[0]?.id ?? 'person';
+  const name = firstNameFromRows(rows);
+  const youGot = rows.filter((r) => r.relationship === 'you_got');
+  const gotYou = rows.filter((r) => r.relationship === 'got_you');
+  const saved = rows.filter((r) => r.relationship === 'saved');
+  const reacted = rows.filter((r) => r.relationship === 'reacted');
+  const convergence = rows.find((r) => r.relationship === 'convergence') ?? null;
+  // Anything without a relationship kind (mastery, opened a domain, follows…)
+  // keeps its own quiet one-liner as a fallback.
+  const others = rows.filter((r) => !r.relationship);
+
+  const youGotTopics = topicsOf(youGot);
+  const gotYouTopics = topicsOf(gotYou);
+  const seed = rows[0]?.id ?? 'person';
 
   return (
     <div style={{ padding: '12px 2px', borderBottom: `1px solid ${RULE}` }}>
-      {/* No flex `gap` here: ActivityIcon already reserves the 24px mark + 8px
-          marginRight, so the heading text lands at the same 32px x as the nested
-          events and every other feed row. */}
+      {/* No flex `gap`: ActivityIcon already reserves mark 24 + 8px marginRight,
+          so the heading lands at the same 32px x as the lines below it. */}
       <div style={{ display: 'flex', alignItems: 'flex-start' }}>
         <ActivityIcon spec={{ kind: 'diamond' }} seed={seed} />
         <p
@@ -63,12 +111,38 @@ export function PersonActivityCard({
             color: INK,
           }}
         >
-          {convergence ? <Line parts={convergence.line} /> : `${firstName} gets you!`}
+          You &amp; {name}
         </p>
+        {rows[0] ? (
+          <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap', marginLeft: 8 }}>
+            {timestampFor(rows[0])}
+          </span>
+        ) : null}
       </div>
       <div style={{ marginLeft: HEADING_INDENT, marginTop: 2 }}>
-        {subItems.map((item) => (
-          <ActivityStreamItem key={item.id} item={item} timestamp={timestampFor(item)} nested />
+        {youGot.length ? (
+          <SubLine>
+            got {name}
+            {youGotTopics.length ? ` — ${youGotTopics.join(', ')}` : ''}
+          </SubLine>
+        ) : null}
+        {gotYou.length ? (
+          <SubLine>
+            {name} got yours
+            {gotYouTopics.length ? ` — ${gotYouTopics.join(', ')}` : ''}
+          </SubLine>
+        ) : null}
+        {saved.length ? (
+          <SubLine>
+            {name} saved {saved.length > 1 ? `${saved.length} of your questions` : 'your question'}
+          </SubLine>
+        ) : null}
+        {reacted.length ? <SubLine>{name} reacted to your question</SubLine> : null}
+        {convergence ? <SubLine>{convergencePredicate(convergence)}</SubLine> : null}
+        {others.map((row) => (
+          <SubLine key={row.id}>
+            <Line parts={row.line} />
+          </SubLine>
         ))}
       </div>
     </div>

--- a/src/components/activity/__tests__/PersonActivityCard.test.tsx
+++ b/src/components/activity/__tests__/PersonActivityCard.test.tsx
@@ -1,0 +1,68 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { StreamItem, StreamLinePart } from '@/lib/activity-stream';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+vi.mock('@/components/SendQuestionDrawer', () => ({ SendQuestionDrawer: () => null }));
+vi.mock('@/app/activities/FriendRequestActions', () => ({ FriendRequestActions: () => null }));
+vi.mock('@/app/activities/ReactionGotItButton', () => ({ ReactionGotItButton: () => null }));
+
+import { PersonActivityCard } from '@/components/activity/PersonActivityCard';
+
+const txt = (v: string): StreamLinePart => ({ t: 'text', v });
+const act = (name: string): StreamLinePart => ({ t: 'actor', name, userId: 'robyn' });
+const cat = (v: string): StreamLinePart => ({ t: 'category', v });
+
+function row(over: Partial<StreamItem> & { id: string; line: StreamLinePart[] }): StreamItem {
+  return {
+    sortAt: new Date('2026-06-01T00:00:00Z'),
+    tier: 3,
+    friendId: 'robyn',
+    homeEligible: true,
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    expand: null,
+    icon: 'diamond',
+    ...over,
+  };
+}
+
+function render(rows: StreamItem[]) {
+  return renderToStaticMarkup(
+    <PersonActivityCard friendId="robyn" rows={rows} timestampFor={() => '1w ago'} />,
+  );
+}
+
+describe('PersonActivityCard — rolled-up cluster', () => {
+  it('rolls a friend up by direction with the name said once and topics listed', () => {
+    const html = render([
+      row({ id: 'g1', relationship: 'you_got', topic: 'Plant Taxonomy', line: [txt('You got '), act('Robyn'), txt(' on '), cat('Plant Taxonomy')] }),
+      row({ id: 'g2', relationship: 'you_got', topic: 'Color References', line: [txt('You got '), act('Robyn'), txt(' on '), cat('Color References')] }),
+      row({ id: 't1', relationship: 'got_you', topic: 'Rent', line: [act('Robyn'), txt(' got your question')] }),
+    ]);
+    expect(html).toContain('You &amp; Robyn');
+    expect(html).toContain('got Robyn — Plant Taxonomy, Color References');
+    expect(html).toContain('Robyn got yours — Rent');
+  });
+
+  it('folds a convergence to its predicate, dropping the "You and {Name}" echo', () => {
+    const html = render([
+      row({ id: 't1', relationship: 'got_you', topic: 'Rent', line: [act('Robyn'), txt(' got your question')] }),
+      row({
+        id: 'c1',
+        relationship: 'convergence',
+        line: [txt('You and '), act('Robyn'), txt(' keep landing in the same place')],
+      }),
+    ]);
+    expect(html).toContain('keep landing in the same place');
+    // The echoed "You and Robyn …" full caption is not repeated as its own line.
+    expect(html).not.toContain('You and Robyn keep landing');
+  });
+});

--- a/src/lib/__tests__/activity-stream-milestone.test.ts
+++ b/src/lib/__tests__/activity-stream-milestone.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { milestoneToStreamItem, type StreamQuestion } from '@/lib/activity-stream'
+import type { MilestoneBreadth } from '@/lib/lately-milestones'
+
+// The breadth milestone header must name only domains whose questions survived
+// resolution — a question can be deleted/hidden after the friend answered it, and
+// the header should never claim a domain the expansion can't show.
+
+function lineText(parts: { v?: string; name?: string }[]): string {
+  return parts.map((p) => p.v ?? p.name ?? '').join('')
+}
+
+function breadth(): MilestoneBreadth {
+  return {
+    kind: 'milestone_breadth',
+    id: 'breadth:f1:0',
+    friendId: 'f1',
+    friendName: 'Sadie',
+    friendFirstName: 'Sadie',
+    domains: [
+      { domain: 'Harry Potter', questionIds: ['q-hp'], correctCount: 1 },
+      { domain: 'Progressive Politics', questionIds: ['q-pol'], correctCount: 1 },
+    ],
+    questionIds: ['q-hp', 'q-pol'],
+    sortAt: new Date('2026-06-01T00:00:00Z'),
+  }
+}
+
+function question(id: string): StreamQuestion {
+  return { questionId: id, text: `Q ${id}`, domain: null, priorResult: null }
+}
+
+describe('milestoneToStreamItem breadth header', () => {
+  it('names both domains when both questions survive', () => {
+    const item = milestoneToStreamItem(breadth(), [question('q-hp'), question('q-pol')])
+    const text = lineText(item.line)
+    expect(text).toContain('Harry Potter')
+    expect(text).toContain('Progressive Politics')
+  })
+
+  it('drops a domain whose question did not survive resolution', () => {
+    // Only the Harry Potter question resolved; the politics question was deleted.
+    const item = milestoneToStreamItem(breadth(), [question('q-hp')])
+    const text = lineText(item.line)
+    expect(text).toContain('Harry Potter')
+    expect(text).not.toContain('Progressive Politics')
+  })
+})

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -184,6 +184,17 @@ export type StreamItem = {
   // viewer-only promos). Set at construction so the grouping never re-parses the
   // line parts.
   friendId?: string | null;
+  // How this row reads inside a per-person relationship cluster, so the cluster
+  // can roll events up by direction without re-parsing copy (D-FEED-TIER v2 §3):
+  //   you_got     — you answered THEIR question right ("got {Name} — topics")
+  //   got_you     — they answered YOUR question ("{Name} got yours — topics")
+  //   convergence — you both knew the same shared questions (folded, one line)
+  //   saved       — they saved your question
+  //   reacted     — they reacted to your question
+  // Undefined = not a per-person relationship event (renders as a plain line).
+  relationship?: 'you_got' | 'got_you' | 'convergence' | 'saved' | 'reacted';
+  // The topic/category this event is about, for the cluster's rolled-up lists.
+  topic?: string | null;
   // Whether this item is eligible for the homepage's curated head.
   homeEligible: boolean;
   line: StreamLinePart[];
@@ -249,6 +260,8 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         line: [a, txt(got ? ' got your question' : ' answered your question')],
         secondLine: domain,
         icon: 'diamond',
+        relationship: 'got_you',
+        topic: domain,
         action: null,
         expand:
           item.referenceId && faq?.questionText
@@ -356,6 +369,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(' reacted to your question')],
         secondLine: label,
+        relationship: 'reacted',
         action: {
           kind: 'reaction_got_it',
           reactionId: reaction?.id ?? item.referenceId ?? '',
@@ -370,6 +384,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(' saved your question')],
         secondLine: item.reference.curatedQuestion?.questionText ?? null,
+        relationship: 'saved',
         action: null,
         expand: null,
       };
@@ -554,6 +569,8 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
     // home-eligible. you_got_them is quieter; keep it to the full list.
     homeEligible: theyGotYou,
     friendId: moment.friendId,
+    relationship: theyGotYou ? 'got_you' : 'you_got',
+    topic: moment.category,
     line: theyGotYou
       ? [friend, txt(' got your question')]
       : [txt('You got '), friend, txt(' on '), cat(moment.category)],
@@ -658,6 +675,7 @@ export function convergenceToStreamItem(
     sortAt: convergence.sortAt,
     tier: LATELY_TIER.MILESTONE,
     friendId: convergence.friendId,
+    relationship: 'convergence',
     homeEligible: true,
     line,
     secondLine: null,

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -583,10 +583,21 @@ export function milestoneToStreamItem(
   questions: StreamQuestion[],
 ): StreamItem {
   const friend = act(milestone.friendName, milestone.friendId);
-  const tail =
-    milestone.kind === 'milestone_deep'
-      ? [txt(' went deep on '), cat(milestone.domain)]
-      : breadthTail(milestone.domains.map((d) => d.domain));
+  let tail: StreamLinePart[];
+  if (milestone.kind === 'milestone_deep') {
+    tail = [txt(' went deep on '), cat(milestone.domain)];
+  } else {
+    // Name only the domains whose questions actually survived resolution — a
+    // question can be deleted/hidden after the friend answered it, and the
+    // header must not claim a domain the expansion can't show. Fall back to all
+    // domains if nothing resolved (the line then isn't expandable anyway).
+    const survivingIds = new Set(questions.map((q) => q.questionId));
+    const surviving = milestone.domains.filter((d) =>
+      d.questionIds.some((id) => survivingIds.has(id)),
+    );
+    const named = (surviving.length > 0 ? surviving : milestone.domains).map((d) => d.domain);
+    tail = breadthTail(named);
+  }
   return {
     id: milestone.id,
     sortAt: milestone.sortAt,


### PR DESCRIPTION
Follow-up to the per-person home feed (#772, now merged) addressing feedback that it read too busy.

## Changes

- **Remove card treatments → neutral/flat.** The milestone bundle is no longer wrapped in an elevated card, and `PersonActivityCard` drops its white border/fill. Both render flat on the cream page.
- **One shape per group.** The per-person heading statement ("You and Robyn are clearly on the same page") carries the single **diamond**; the events nested beneath it render with **no shape** (`ActivityStreamItem` gains a `nested` prop that hides the icon + chrome).
- **Restore milestone progress.** Bring back the **"{answered} of {total} questions"** line under the bundle triangle mark (a recent commit had dropped it), and list every bundle question in the expansion with a per-question triangle — **solid = to play, hollow = answered** — so progress reads at a glance.
- **Breadth header matches contents.** Name only the domains whose questions survived resolution, so the header never claims a category the expansion can't show (the cause of "3 categories, 1 question").
- **"ANSWER →"** action text (was "ANSWER THIS ONE →").
- **Spread the discovery modules** (common-ground / expanding / add-friends) evenly through the feed instead of clumping them at the tail.
- **Remove the sparkle/star** above the "Your Turn" contribute footer.

## Verification

- ✅ `tsc -p tsconfig.typecheck.json` clean
- ✅ Tests pass (incl. new breadth-header unit test); lint 0 errors
- ⏳ Visual check is yours — the sandbox can't reach the dev server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)