### PR TITLE
fix(feed): calmer baseline + restore milestone hollow-triangle bundle

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -203,16 +203,14 @@ export function ActivityStreamItem({
           ? // Nested under a per-person heading: no border/fill, light padding.
             { padding: opened ? '6px 0' : '4px 0' }
           : opened
-            ? {
-                borderTop: `1px solid ${RULE}`,
-                borderBottom: `1px solid ${RULE}`,
-                padding: '18px 2px',
+            ? // Opened reveal: a soft paper wash defines the expanded cluster —
+              // no hard hairlines (v2 §4 prefers whitespace over dividers).
+              {
+                padding: '16px 2px',
                 background: PAPER,
               }
-            : {
-                borderBottom: `1px solid ${RULE}`,
-                padding: '12px 2px',
-              }
+            : // Calm default: no row hairline; whitespace separates the rows.
+              { padding: '14px 2px' }
       }
     >
       <div
@@ -287,17 +285,19 @@ export function ActivityStreamItem({
             gap: 4,
           }}
         >
-          <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap' }}>{timestamp}</span>
-          {/* Cards backed by answerable questions get a chevron in the bottom-
-              right corner that signals (and reflects) the expand/collapse state.
-              The row itself is the button (aria-expanded above), so this stays
-              decorative. */}
+          {/* Metadata recedes to near-invisible (v2 §4): quiet, small timestamp. */}
+          <span style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap' }}>
+            {timestamp}
+          </span>
+          {/* Decorative disclosure chevron — demoted; the row itself is the
+              button (aria-expanded above). */}
           {expandable ? (
             <ChevronDown
-              size={18}
+              size={16}
               aria-hidden
               style={{
                 color: INK3,
+                opacity: 0.5,
                 transition: 'transform 150ms ease',
                 transform: open ? 'rotate(180deg)' : 'none',
               }}

--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -3,7 +3,7 @@
 import type { ReactNode } from 'react';
 
 import type { StreamItem } from '@/lib/activity-stream';
-import { FF, INK, INK2, INK3, RULE } from '@/components/lately/tokens';
+import { FF, INK, INK2, INK3 } from '@/components/lately/tokens';
 
 import { Line } from './ActivityStreamItem';
 import { ActivityIcon } from './ActivityIcon';
@@ -93,7 +93,7 @@ export function PersonActivityCard({
   const seed = rows[0]?.id ?? 'person';
 
   return (
-    <div style={{ padding: '12px 2px', borderBottom: `1px solid ${RULE}` }}>
+    <div style={{ padding: '14px 2px' }}>
       {/* No flex `gap`: ActivityIcon already reserves mark 24 + 8px marginRight,
           so the heading lands at the same 32px x as the lines below it. */}
       <div style={{ display: 'flex', alignItems: 'flex-start' }}>
@@ -114,7 +114,9 @@ export function PersonActivityCard({
           You &amp; {name}
         </p>
         {rows[0] ? (
-          <span style={{ fontSize: 13, color: INK3, whiteSpace: 'nowrap', marginLeft: 8 }}>
+          <span
+            style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap', marginLeft: 8 }}
+          >
             {timestampFor(rows[0])}
           </span>
         ) : null}

--- a/src/server/activity/__tests__/build-stream-self-hide.test.ts
+++ b/src/server/activity/__tests__/build-stream-self-hide.test.ts
@@ -4,8 +4,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // (open|upheld) must stay out of their Lately milestone stack across reloads. We
 // mock the upstream lately queries and the pure transforms (echoing the questions
 // they receive) so we can assert the hidden id is filtered before render.
-const { getViewerHiddenQuestionIdsMock } = vi.hoisted(() => ({
+const { getViewerHiddenQuestionIdsMock, getViewerPriorAnswerResultsMock } = vi.hoisted(() => ({
   getViewerHiddenQuestionIdsMock: vi.fn(async () => new Set<string>()),
+  getViewerPriorAnswerResultsMock: vi.fn(
+    async () => new Map<string, 'correct' | 'incorrect'>(),
+  ),
 }));
 
 vi.mock('@/app/activities/filter-utility-activities', () => ({
@@ -33,16 +36,21 @@ vi.mock('@/server/db/queries/lately', () => ({
   getMilestoneQuestionText: vi.fn(async (ids: string[]) =>
     new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
   ),
-  getViewerPriorAnswerResults: vi.fn(async () => new Map()),
+  getViewerPriorAnswerResults: getViewerPriorAnswerResultsMock,
 }));
 
 import { buildActivityStream } from '@/server/activity/build-stream';
 
-type MilestoneItem = { kind: string; id: string; questions: Array<{ questionId: string }> };
+type MilestoneItem = {
+  kind: string;
+  id: string;
+  questions: Array<{ questionId: string; priorResult: 'correct' | 'incorrect' | null }>;
+};
 
 beforeEach(() => {
   vi.clearAllMocks();
   getViewerHiddenQuestionIdsMock.mockResolvedValue(new Set<string>());
+  getViewerPriorAnswerResultsMock.mockResolvedValue(new Map());
 });
 
 describe('buildActivityStream — durable inappropriate self-hide', () => {
@@ -62,5 +70,19 @@ describe('buildActivityStream — durable inappropriate self-hide', () => {
     const milestone = stream.find((item) => item.kind === 'milestone');
 
     expect(milestone!.questions.map((q) => q.questionId)).toEqual(['q-keep', 'q-hidden']);
+  });
+
+  it('keeps an already-answered question in the bundle, carrying its prior result', async () => {
+    // The viewer answered q-keep correctly on some earlier surface. It must stay
+    // in the bundle (as a spent/hollow triangle), not vanish — and the title
+    // stays stable because the question count doesn't shrink.
+    getViewerPriorAnswerResultsMock.mockResolvedValue(new Map([['q-keep', 'correct']]));
+
+    const stream = (await buildActivityStream('viewer-1')) as unknown as MilestoneItem[];
+    const milestone = stream.find((item) => item.kind === 'milestone');
+
+    expect(milestone!.questions.map((q) => q.questionId)).toEqual(['q-keep', 'q-hidden']);
+    expect(milestone!.questions.find((q) => q.questionId === 'q-keep')!.priorResult).toBe('correct');
+    expect(milestone!.questions.find((q) => q.questionId === 'q-hidden')!.priorResult).toBeNull();
   });
 });

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -71,18 +71,16 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         .map((id) => textById.get(id))
         .filter((q): q is NonNullable<typeof q> => Boolean(q))
         .filter((q) => !hiddenIds.has(q.questionId))
-        // The triangle row is for NEW questions only. Anything the viewer has
-        // already attempted on ANY surface (priorById carries every prior
-        // answer, right or wrong) is dropped here: questions you and the friend
-        // both got right surface in the convergence ("you both knew these")
-        // row, and your own misses live in Catch-Up. priorResult is therefore
-        // always null for what survives.
-        .filter((q) => !priorById.has(q.questionId))
+        // Keep EVERY one of the friend's questions in the bundle — including the
+        // ones the viewer already answered. Each carries its prior result, so the
+        // answered ones render as spent (hollow) triangles in the expansion and
+        // the title stays stable across reloads (answered questions don't vanish,
+        // and the triangle count doesn't shrink as you play).
         .map((q) => ({
           questionId: q.questionId,
           text: q.text,
           domain: q.domain,
-          priorResult: null,
+          priorResult: priorById.get(q.questionId) ?? null,
         }));
       // A milestone whose questions all collapse out is a contentless streak
       // card — suppress it rather than render an empty triangle.


### PR DESCRIPTION
Two changes on top of the merged per-person feed work (#773).

## 1. Calmer baseline (v2 §4)
- Remove the per-row hairline dividers on activity rows and the person cluster; whitespace separates rows now. The opened milestone reveal keeps a soft paper wash instead of hard rules.
- Demote metadata toward near-invisible: timestamps to 12px / 0.6 opacity, the disclosure chevron to 16px / 0.5 opacity.

## 2. Restore the milestone hollow-triangle bundle
Commit `84a776e` ("triangle = new questions only") had dropped every question the viewer already attempted from the milestone bundle, so answered questions vanished and the title shrank to only the remaining categories as you played.

Restored: keep all of the friend's questions in the bundle, each carrying its prior result — so answered ones render as spent (hollow) triangles in the expansion, the "{answered} of {total}" count holds, and the title stays stable across reloads. Locked in with a test asserting an already-answered question stays in the bundle with its result.

(With answered-correct questions back in the bundle, a both-correct question can appear as a hollow triangle here *and* in the convergence line, but on Home the convergence is just the folded "keep landing in the same place" text — no question list — so there's no visible duplication.)

## Verification
- ✅ `tsc -p tsconfig.typecheck.json` clean (against current dev2)
- ✅ 90 tests pass; lint 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)