### PR TITLE
feat(feed): D-FEED-GROUP3-01 — "everything else" social stream (cut 1)

### DIFF
--- a/_docs/D-FEED-GROUP3-01.md
+++ b/_docs/D-FEED-GROUP3-01.md
@@ -1,0 +1,68 @@
+# D-FEED-GROUP3-01 — "Everything Else" Social Stream (cut 1, build notes)
+
+**Status:** Cut 1 built against latest `dev2`. Straight-stream-first; per-person
+clustering deliberately gated (NOT shipped). Grounded in `D-FEED-INVENTORY-01.md`.
+
+## What shipped (cut 1)
+
+**Structure (§2).** Group 3 — the "everything else" zone (relationship events +
+promos, i.e. the recency-bucketed `restRows`) — now renders as a **straight
+chronological stream of full-sentence LONE events**. `PersonActivityCard`
+clustering is dropped for this zone (`FeedList.tsx`, rest-zone render). Recency
+buckets are kept. For You / From Friends are untouched (they never clustered).
+The component is left in place; re-enabling clustering here is a one-line change
+(restore `groupActivityByFriend(group.items)`).
+
+**Copy (§3, Appendix A).** Full-sentence relationship copy, hash-selected per
+event id so a feed of the same type still varies (`activity-stream.ts`):
+- Pool 1 `got_you` and Pool 2 `you_got` — topic folded into the line, second
+  line cleared (no echo). Topic-less fallback when an event carries no domain.
+- Pool 3 convergence — replaced the old 6-line pool with **3a single-topic**
+  (when all 3 cluster questions share one domain, detected in `build-stream.ts`)
+  and **3b topic-less** (`lately.ts`). Never lists all three topics.
+- Pool 4 promos — headline rotates by a day-seeded `headlineIndex` on the embed
+  (`EditorialPromos.tsx`); eyebrow / CTA / supporting copy stay fixed.
+- Register is connection-only; the banned competition words are kept out by
+  construction (and asserted in tests).
+
+**Expand-to-send-onward + honest authorship (§4).** A row gets a chevron only
+when it references a sendable question. Newly expandable: `saved`
+(`question_curated`) and `reacted` (`reaction_received`) now carry a
+`your_question` expand and reveal the question with a Send affordance. Pure
+status events stay flat. The reveal marks provenance honestly: **house →
+"Joshing · Editorial", LLM-origin → "Generated", human → unmarked** — a machine
+question can never read as if a person wrote it. This required server work:
+`hydrateCuratedQuestions` / `hydrateReactions` / `hydrateFriendAnsweredQuestions`
+and `getMilestoneQuestionText` (covers convergence) now thread domain +
+`creatorId`/`source` → `resolveAuthorDisplay`.
+
+**Calm baseline (§5).** Already largely in place from the prior calm-baseline
+work (no row hairlines, demoted timestamps/chevrons, no blue-for-emphasis). No
+new design tokens; no changes to groups 1 & 2.
+
+**Dead copy (§E).** Confirmed unused and NOT designed around: the "killing it"
+breadth phrasing and the all-caps `THEY_GOT_YOU_CAPTIONS` / `YOU_GOT_THEM_CAPTIONS`
+pools (Home renders `momentToStreamItem`, not those).
+
+## Evaluation note — does the straight stream read calm, or is clustering needed?
+
+**Checkpoint, pending real-content review.** Cut 1 is the deliberate experiment:
+get density from visual quiet, not copy compression. The reasoning that the
+*wording* problem is now fixed independent of clustering holds — the broken form
+was the cluster's subject-stripped fragments ("got Robyn — French Herbs"), and
+those are gone; every row is a full lone sentence. The *busyness* question can
+only be judged against a real, dense feed.
+
+**Re-introduce clustering ONLY if** the straight stream, viewed with a busy real
+account (many same-friend events in one bucket), still reads as a wall. Signals
+to watch: the same friend's name repeating many times in a single recency
+bucket; the eye unable to find a resting point. If that happens, the gated path
+is a one-line restore in `FeedList.tsx` — but clustering must then use the
+full-sentence lone copy, not regress to fragments.
+
+**Open threads for Josh:**
+- Convergence 3a depends on detecting "all 3 questions share one topic" from
+  data — implemented in `build-stream.ts` (all domains non-null and equal),
+  defaulting to 3b otherwise. Confirm the topic-detection feels right on real
+  clusters.
+- Promo eyebrows stay fixed (headline-only rotation). Confirm.

--- a/_docs/D-FEED-INVENTORY-01.md
+++ b/_docs/D-FEED-INVENTORY-01.md
@@ -1,0 +1,271 @@
+# D-FEED-INVENTORY-01 — Home Activity Feed Content Inventory (READ-ONLY findings)
+
+**Scope:** Everything that can render in the Home "What's Happening" scrolling feed
+(`src/app/page.tsx` → `FromYourFriendsSection` → `src/components/FeedList.tsx` with `unifiedHome`).
+**Method:** Live code only. Templates quoted verbatim. No code changed.
+
+---
+
+## 0. How the feed is assembled (orientation)
+
+The Home feed is **three row families merged into one scroll**, then rendered in three layout zones.
+
+**Row families (data sources):**
+1. **Feed question cards** — paginated `FeedApiItem`s from `src/server/feed/get-feed-page.ts`, keyed by
+   `card_type` ∈ `direct_sent | friend_added | friend_liked | answered_by_you`. Rendered by the
+   `feed/*Card` components.
+2. **Activity-stream one-liners** — `StreamItem[]` from `buildActivityStream()`
+   (`src/server/activity/build-stream.ts`), built by the pure transforms in `src/lib/activity-stream.ts`.
+   Three sub-sources: **activity rows** (`activityToStreamItem`), **Lately moments**
+   (`momentToStreamItem`), **milestones** (`milestoneToStreamItem`), **convergences**
+   (`convergenceToStreamItem`).
+3. **Editorial promos** — three home-only `StreamItem`s carrying an `embed`: `common_ground`,
+   `recently_expanding`, `add_friends`. Rendered full-bleed via `EditorialPromos.tsx`.
+
+**Layout zones (FeedList render, `FeedList.tsx:1745-1779`):**
+- **"For You"** (pinned top) — `kind:'feed'` question cards (sent/broadcast/liked/answered).
+- **"From Friends"** (pinned, capped to most-recent few, reveal-in-batches) — milestone bundle cards
+  (`expand.kind==='milestone'`).
+- **Recency groups** (everything else) — bucketed by `groupItemsByRecency`
+  (`src/components/feed/visual.ts`): *Past few hours / Today / Past few days / This week / Past two
+  weeks / Past few weeks / Older*. This zone holds ambient activity one-liners, **per-person clusters**
+  (`PersonActivityCard`), and the promos (spread evenly).
+
+**Per-person clustering layer:** within a recency bucket, a friend's ≥2 *relationship* events collapse
+into one `PersonActivityCard` (`src/components/feed/person-grouping.ts` + `PersonActivityCard.tsx`).
+A lone event renders as its raw `ActivityStreamItem`. **This means the same event has TWO rendered
+forms — clustered vs. lone — catalogued in §A5.**
+
+---
+
+## A. Event-type catalog
+
+### A1 — Activity-stream rows (`activityToStreamItem`, `src/lib/activity-stream.ts:232-537`)
+
+Line templates are assembled from parts; `{friend}` = actor display name (an actor link), `txt(...)` =
+literal. Quoted verbatim from the `line:` arrays.
+
+| Event type | Verbatim line template | `secondLine` | Meaning | Playable? | Class | Fields | Volume |
+|---|---|---|---|---|---|---|---|
+| `friend_answered_your_question` | `{friend}` + `' got your question'` *(correct)* / `' answered your question'` *(wrong)* | `{domain}` | A friend answered YOUR authored question | No (chevron→"send onward" if `your_question` expand) | relationship (`got_you`) | friend, domain, questionText | **HIGH** (every friend correct-answer fan-out) |
+| `niche_match_answered_your_question` | `{friend}` + `' answered your question — someone shares this corner'` | `{domain}` | A stranger answered a question you authored | No | relationship (untagged) | stranger, domain, questionText | Low (opt-in gated; /activities-only, not home-eligible) |
+| `niche_match_you_answered` | `'You answered '` + `{friend}` + `"'s question — you found someone"` | `{domain}` | You answered a stranger's authored question | No | relationship (untagged) | stranger, domain, questionText | Low (opt-in gated; /activities-only) |
+| `declared_promoted` | `{friend}` + `' opened ' + domain` / `' opened a new domain'` | `{domain}` | A friend opened a new knowledge domain | No (trailing link "See your map") | relationship (untagged) | friend, domain | Low |
+| `friend_mastery` | `{friend}` + `` ` reached ${tier} ` `` (or `'a new tier'`) | `{domain}` | A friend reached a mastery tier | No | relationship (untagged) | friend, tier, domain | **DEAD — never written** (see §E) |
+| `reaction_received` | `{friend}` + `' reacted to your question'` | `{emoji label}` | A friend reacted to your question | No (trailing "got it" button) | relationship (`reacted`) | friend, reactionEmoji, reactionLabel | Medium |
+| `question_curated` | `{friend}` + `' saved your question'` | `{questionText}` | A friend saved/banked your question | No | relationship (`saved`) | friend, questionText | Low |
+| `authored_question_shared` | `` `You shared a question with ${count} ${count===1?'friend':'friends'}` `` | `{domain}` | You broadcast a question | No | friend-less (`friendId:null`) | count, domain | **DEAD via writeActivity** (hydrated from feedItems) |
+| `received_direct_question` | `{friend}` + `' sent you a question'` | `{questionText}` | A friend sent you a question directly | **Answerable inline** (`answer_direct` action) | relationship (untagged) | friend, questionText, feedItemId | Medium (5/day send cap). *Deduped against the `direct_sent` feed card.* |
+| `received_joshing_game` | `{friend}` + `` ` sent you ${title}` `` | — | A friend sent you a Joshing game | No (link Play/See results) | (untagged) | friend, gameTitle | Medium. *Not home-eligible.* |
+| `joshing_game_progress` | `{friend}` + `` ` played ${title}` `` | — | A friend played a shared game | No (link "See so far") | friend-less (`friendId:null`) | friend, gameTitle | Medium. *Not home-eligible.* |
+| `joshing_game_result` | `` `Everyone played ${title}` `` | — | A shared game completed | No (link "See results") | friend-less (`friendId:null`) | gameTitle | Low. *Not home-eligible.* |
+| `ceremony_ready` | `'Your weekly reflection is ready'` | `'A look at the questions, friends, and territories that defined your week.'` | Weekly reflection ready | No (link "See it now") | friend-less (`friendId:null`) | ceremonyId | Weekly (1/user/cycle). *Not home-eligible; also de-duped — see §C.* |
+| `friend_request` / `follow_request` | `{friend}` + `' wants to follow you'` | — | Someone requested to follow you | No (Approve action if pending) | (untagged) | friend, friendshipId | `friend_request` **LEGACY-dead**; `follow_request` Medium |
+| `follow` | `{friend}` + `' started following you'` | — | Someone followed you | No | (untagged) | friend | Medium |
+| `follow_approved` | `{friend}` + `' accepted your follow'` | — | Your follow request was approved | No | (untagged) | friend | Medium |
+| `invited_friend_played_first_five` | `{friend}` + `' played their first five questions'` | — | An invitee hit the 5-play milestone | No | (untagged) | friend | Low |
+| `grade_dispute_filed` | `{friend}` + `' asked for a re-look at your question'` | `{questionText}` | An answerer disputed your grade | No | (untagged) | friend, questionText | Low. *Not home-eligible.* |
+| `default` (unknown type) | `'Something happened on Joshing'` | — | Fallback for an unmapped type | No | friend-less | — | Should never fire |
+
+> **Home-eligibility filter:** only `HOME_TOP3_ELIGIBLE_TYPES`
+> (`friend_answered_your_question`, `friend_mastery`, `declared_promoted`, `reaction_received`,
+> `question_curated`, `authored_question_shared`, `received_direct_question`) set `homeEligible:true`
+> (`activity-types.ts:59-71`). The other activity rows surface only in the full `/activities` list, not
+> the Home head — but the Home feed renders the **full** `buildActivityStream` result, so eligibility
+> currently gates other surfaces (bell badge / RecentActivity), not this scroll. Verify intended.
+
+### A2 — Lately-derived stream rows (verbatim)
+
+| Source / fn | Verbatim line template | Meaning | Playable? | Class | Fields |
+|---|---|---|---|---|---|
+| **moment, `they_got_you`** (`momentToStreamItem`) | `{friend}` + `' got your question'`; `secondLine={category}` | A friend answered your authored question (correct) | No (chevron→send onward) | relationship (`got_you`) | friend, category, questionText |
+| **moment, `you_got_them`** | `'You got '` + `{friend}` + `' on '` + `{category}` | You answered a friend's question (correct) | No | relationship (`you_got`) | friend, category, questionText |
+| **milestone, deep** (`milestoneToStreamItem`) | `{friend}` + `' went deep on '` + `{domain}` | A friend got ≥3 right in one domain | **YES — triangle bundle** | playable | friend, domain, ≤5 questionIds |
+| **milestone, breadth** (`breadthTail`, `activity-stream.ts:642-649`) | `{friend}` + `' has been on a streak — '` + …domains | A friend got right across ≥2 light domains | **YES — triangle bundle** | playable | friend, domains[], ≤5 questionIds |
+| **milestone progress sub-label** (`ActivityStreamItem`) | `` `${answered} of ${total} questions` `` | Bundle progress; ticks as you answer | (label) | — | answered/total |
+| **milestone answer button** (`InlineAnswerFlow`) | `'ANSWER →'` | Per-question answer affordance in the bundle | (control) | — | — |
+| **convergence** (`convergenceToStreamItem`) | one of 6 caption templates (see §B) with `{Name}` → friend first name | You + a friend both got the same shared questions right | No (read-only) | relationship (`convergence`) | friend, 3 questionIds |
+
+**Breadth pluralization (verbatim, `breadthTail`):**
+- 1 domain → `' has been on a streak — ' {d1}`
+- 2 domains → `' has been on a streak — ' {d1} ' and ' {d2}`
+- 3+ → `' has been on a streak — ' {d1} ', ' {d2} ' and ${rest} other(s)'` (`'1 other'` vs `'N others'`)
+
+### A3 — Feed question cards ("For You" zone; verbatim)
+
+| `card_type` | Verbatim template | Meaning | Playable? | Plural | Fallback name |
+|---|---|---|---|---|---|
+| `direct_sent` (`DirectSentCard`+`SparkleEnvelope`) | `{senderName}` + `" thought you'd like this"` + ` about {category}` *(if category)* + `.` ; optional italic `"{personalMessage}"` | A friend sent you this question | **YES** ("Answer →") | — | `'A friend'` |
+| `friend_added` (`FriendAddedCard`) | `{friendName}` + `' added a question'` + ` about {category}` *(if category)*; optional ` · Hide questions about {category}` | A friend authored/broadcast a question | **YES** ("Answer →") | — | `'A friend'` |
+| `friend_liked` (`FriendLikedCard`+`FeedCard`) | `{authorName}` + `' thought you would like this'` | A friend endorsed this question | **YES** ("Answer →") | endorsement collapse fields carried but **NOT rendered** (see §E) | `'Someone'` |
+| `answered_by_you` (`AnsweredByYouCard`) | eyebrow `'You answered'` + one of 6 comparison lines (§B) | Result of a question you already answered | No (Try again → / Recheck →) | single paired friend only | `'They'` |
+
+### A4 — Editorial promos (verbatim, `EditorialPromos.tsx`)
+
+| `embed.kind` | Eyebrow | Headline | Supporting / CTA | Plural |
+|---|---|---|---|---|
+| `common_ground` | `'Shared Ground'` | `'You and {friendFirstName} keep finding one another here.'` | supporting `` `${count} shared interest${count===1?'':'s'}` ``; CTA `'Explore your overlap →'` | `1 shared interest` / `N shared interests` |
+| `add_friends` (`suggestions` & `invite`) | `'Grow Your Circle'` | `'Know someone who belongs here?'` | CTA `'Find friends →'` | none |
+| `recently_expanding` | `'Your World Is Expanding'` | `"The places you've been exploring lately."` | CTA `'See your knowledge →'` | none |
+
+### A5 — Per-person CLUSTER rollup (`PersonActivityCard.tsx`) — the alternate rendered form
+
+When a friend has **≥2** relationship events in a bucket, their raw lines are replaced by:
+
+```
+◆ You & {Name}                                  {one cluster timestamp}
+    got {Name} — {topic, topic, …}              ← all `you_got` events, topics deduped
+    {Name} got yours — {topic, topic, …}        ← all `got_you` events
+    {Name} saved your question                  ← `saved` (or "saved N of your questions")
+    {Name} reacted to your question             ← `reacted`
+    {convergence predicate}                      ← e.g. "keep landing in the same place"
+    {raw line}                                   ← any untagged event (mastery/opened/follow…) as fallback
+```
+
+So e.g. a `you_got_them` moment renders **"You got Robyn on Star Trek"** when lone, but folds into
+**"got Robyn — Star Trek, …"** when clustered. **Both forms must be considered for any copy redesign.**
+
+---
+
+## B. Edge cases & variants
+
+**Convergence — all 6 phrasings (verbatim, `src/lib/lately.ts:81-92`):** selected deterministically by
+`djb2(momentId) % 6` — stable per convergence, no semantic selection.
+1. `'You and {Name} keep landing in the same place.'`
+2. `'Turns out you and {Name} think alike.'`
+3. `'You and {Name} are on the same wavelength lately.'`
+4. `'You and {Name} both knew these.'`
+5. `'You and {Name} just get each other.'`
+6. `'You and {Name} are clearly on the same page.'`
+In a cluster the leading "You and {Name}" is stripped and only the predicate shows
+(`PersonActivityCard.convergencePredicate`), e.g. "keep landing in the same place"; fallback predicate
+`'both knew these'`.
+
+**Legacy moment caption pools (verbatim, `lately.ts:39-53`) — NOT used by the Home stream** (see §E):
+`THEY_GOT_YOU_CAPTIONS = ['THEY KNEW YOU','{NAME} GOT IT','THEY SAW IT','A MATCH','ON YOUR FREQUENCY']`,
+`YOU_GOT_THEM_CAPTIONS = ['YOU KNEW THEM','YOU SAW IT','YOU NAILED IT','A MATCH','ON THEIR FREQUENCY']`.
+
+**`answered_by_you` — 6 comparison lines (`FeedList.comparisonCopy`):**
+1. both correct → `'You and {friend} share this knowledge.'`
+2. you right, friend wrong → `'You found a connection {friend} missed.'`
+3. you wrong, friend right → `'{friend} has knowledge to share. You might next time.'`
+4. both wrong → `'This one is still waiting for common ground.'`
+5. no prior result → `'You have already answered this question.'`
+6. authored source (direct/broadcast) → correct `'You and {friend} have that in common.'` / wrong
+   `'{friend} knows this one. You might next time.'`
+
+**Singular/plural & self/friend:**
+- moment direction: `they_got_you` ("{Friend} got your question") vs `you_got_them` ("You got {Friend} on {topic}").
+- friend_answered correct vs wrong: " got your question" vs " answered your question".
+- breadth domains: 1 / 2 / 3+ forms (§A2).
+- saved cluster line: "your question" vs "N of your questions".
+- shared count: "1 friend" vs "N friends".
+- common_ground supporting: "1 shared interest" vs "N shared interests".
+
+**Fallbacks (missing data):** actor name → `'Someone'` (activity rows), `'A friend'` (direct/added cards),
+`'Someone'` (friend_liked), `'They'` (answered/cluster); tier → `'a new tier'`; domain on `declared_promoted`
+→ `'opened a new domain'`; game title → `'a Joshing Game'`. Missing category/topic ⇒ the ` about {category}`
+/ ` — {topics}` fragment is omitted (no empty dangling " on ").
+
+**Machine/LLM honesty risk:**
+- `direct_sent` attribution is source-aware: `feedSourceVerb` distinguishes `'wrote you this'` (authored)
+  vs `'sent you this'` (forwarded/curated), so an LLM/curated question is never copy-attributed as the
+  sender's own writing. **Good.**
+- `'A friend' / 'Someone' / 'They'` fallbacks can attribute a real social event to an unnamed actor — low
+  risk but worth noting for honesty (an event implies a real person who couldn't be named).
+- `question_curated` shows the **question text** as `secondLine`; if that question is house/LLM-authored,
+  it renders without authorship marker (the card frames it as "{friend} saved your question").
+
+---
+
+## C. Grouping & ordering
+
+- **Server sort:** `buildActivityStream` ends with `sortByProminence` (`lately.ts:25-32`) — tier ascending
+  (`ANSWERED_YOU 0 < NICHE_MATCH 1 < MILESTONE 2 < OTHER 3`) then recency.
+- **Client re-sort:** `FeedList.unifiedRows` re-sorts the merged feed+activity union **strictly by
+  `sortMs` (recency)**, discarding the prominence tier on Home. (Prominence still governs `/activities`.)
+- **Zones:** pinned **"For You"** (question cards) and **"From Friends"** (milestone cards, capped + batch
+  reveal) render first; the remainder is bucketed by `groupItemsByRecency`
+  (RECENCY_BUCKETS: past-few-hours → older, `MIN_GROUP_SIZE=5`).
+- **Per-person clustering** runs **within each recency bucket** (`groupActivityByFriend`) so a cluster never
+  spans a day label; cluster takes its newest member's slot.
+- **Promo distribution:** the 3 promos splice at even fractions through the feed
+  (`round((i+1)*len/(k+1))`), never first.
+- **Server-side dedup/grouping already happening:** (a) milestones are derived & rolled up server-side
+  (deep vs breadth, ≤5-question cap, multi-line split — `lately-milestones.ts`); (b) moments aggregate
+  from `masteryEvents`; (c) `filter-utility-activities` drops the *correct* `friend_answered_your_question`
+  activity row in favor of the `they_got_you` moment, and drops already-answered `received_direct_question`;
+  (d) `ceremony_ready` is dropped from this scroll in `page.tsx` (it lives in the `CeremonyPin` marker
+  above the feed). Everything else is flat per-event until the client cluster pass.
+
+---
+
+## D. Data availability for redesign (the two feasibility questions)
+
+**Q1 — Can events be grouped by person at render time?** **YES.** Every relationship `StreamItem` carries
+`friendId` (`activity-stream.ts` StreamItem field), set at construction: activity rows = `actorUserId`
+(nulled for the friend-less `authored_question_shared` / `joshing_game_*` / `ceremony_ready`), moments =
+`moment.friendId`, milestones = `milestone.friendId`, convergence = `convergence.friendId`. It is stable
+and already used by `person-grouping.ts`.
+
+**Q2 — Can relationship vs. playable be determined from a data flag (not copy)?** **YES, two flags:**
+- **Playable (the triangle + chevron answerable bundle)** = `item.expand?.kind === 'milestone'`
+  (equivalently `item.icon === 'bundle'`). The chevron itself is `questionBacked(item.expand)` in
+  `ActivityStreamItem`, but only the milestone carries the **triangle bundle** mark. *(The "For You" feed
+  question cards are also answerable, but via the `card_type` + "Answer →" link, a separate mechanism.)*
+- **Relationship/texture class** = the `item.relationship` discriminator
+  (`'you_got' | 'got_you' | 'convergence' | 'saved' | 'reacted'`). NOTE: it is **only set on the five
+  rolled-up kinds today**; other relationship events (mastery, declared_promoted, follows, niche-match)
+  are currently `relationship: undefined` and fall through as the cluster's "untagged fallback". For a
+  redesign that wants a clean playable-vs-relationship split with **no copy parsing**, either (a) treat
+  "not a promo and not `expand.kind==='milestone'`" as relationship, or (b) extend `relationship` to cover
+  the untagged kinds. Both are field-based, not copy-based.
+
+---
+
+## E. Open questions / drift
+
+**Dead / legacy event types (never written — render only for historical or other-path rows):**
+- `friend_request`, `friend_request_accepted` — explicitly legacy (`activity-types.ts:16-20`), superseded
+  by the follow model; no `writeActivity` call sites.
+- `friend_mastery` — **deferred**: `write-mastery-event.ts` carries a `TODO Phase 8: write friend_mastery`.
+  The `' reached {tier}'` template renders nothing because nothing writes it.
+- `authored_question_shared` — defined + rendered, but **not written via `writeActivity`**; only hydrated
+  from a `feedItems` join. Write-path debt.
+- `declared_promoted` — written as a `masteryEvents` row (`sourceType='declared_promoted'`), not via
+  `writeActivity`; hydrated back into an activity view. Second writer path outside the canonical writer.
+
+**Duplicate / dead COPY (two implementations, only one renders — verify before any copy edit):**
+- **Milestones:** Home renders `milestoneToStreamItem` → `breadthTail` → **"… has been on a streak — …"**
+  and **"… went deep on …"**. But `lately-milestones.ts` also defines `deepMilestoneCopy`
+  (`"{first} went deep on {domain}"`) and `breadthMilestoneCopy` (`"{first}'s been killing it — {a}, {b},
+  and {N} more"`). The "killing it" phrasing appears **unused by Home** — confirm it's dead before treating
+  it as live copy.
+- **Moments:** Home renders `momentToStreamItem` ("{Friend} got your question" / "You got {Friend} on
+  {topic}"). The all-caps caption pools `THEY_GOT_YOU_CAPTIONS` / `YOU_GOT_THEM_CAPTIONS` + `assignCaption`
+  (`lately.ts:39-72`) are a **separate, older** caption system — confirm whether any surface still renders
+  them (they are NOT in the Home stream path).
+
+**Recently-changed milestone surfacing (history note):** commit `84a776e` had dropped already-answered
+questions from the milestone bundle ("triangle = new questions only"); current code (PR #777) restores
+keeping them as spent/hollow triangles. Any redesign should assume **answered questions stay in the bundle
+with `priorResult`**, the title is stable, and `{answered} of {total}` ticks.
+
+**Retired-vocabulary scan:** No retired-vocabulary leakage in the feed copy. "Ceremony" survives **only**
+as `ceremony_ready` → user-facing **"Your weekly reflection is ready"** (the word "ceremony" is in the
+route `/ceremony/{id}` and SMS copy, not the feed line). No "season/off-season/daily five/off-season"
+strings in the feed render path.
+
+**PRD drift:** event types broadly track the D-series (D-1 follow model, D-2 niche-match, D-4 Lately
+milestones/moments, B-Convergence-1). The notable code-vs-doc gaps are the **two write-path exceptions**
+(`authored_question_shared`, `declared_promoted`) and the **deferred `friend_mastery`** — all present in
+the type union but not produced by the canonical writer.
+
+---
+
+## Done-when checklist
+- [x] Every feed event type catalogued with verbatim templates (§A1–A5).
+- [x] All 6 convergence phrasings + selection logic enumerated (§B); legacy caption pools flagged (§B/§E).
+- [x] Playable-detection field named: `expand.kind === 'milestone'` / `icon === 'bundle'` (§A2/§D).
+- [x] Person-grouping feasibility answered: `friendId`, stable, already used (§D).
+- [x] No code changed (this is the only file written; it is documentation, under `_docs/`).

--- a/scripts/niche-match-dedup.smoke.ts
+++ b/scripts/niche-match-dedup.smoke.ts
@@ -61,12 +61,12 @@ const items: ActivityItemView[] = [
   mk('nm-collide', 'niche_match_you_answered', { directQuestion: { feedItemId: 'fi', questionId: 'q-shared', questionText: 'Q?', personalMessage: null, category: null } }),
 
   // Utility types that the Lately moments already narrate — should be dropped.
-  mk('drop-friend-correct', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'correct' } }),
+  mk('drop-friend-correct', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'correct', authorName: null, authorIsHouse: false } }),
   mk('drop-declared', 'declared_promoted'),
   mk('drop-direct-covered', 'received_direct_question', { directQuestion: { feedItemId: 'fi', questionId: 'q-shared', questionText: 'Q?', personalMessage: null, category: null } }),
 
   // Same families, but NOT covered by a moment — should survive.
-  mk('keep-friend-incorrect', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'incorrect' } }),
+  mk('keep-friend-incorrect', 'friend_answered_your_question', { friendAnsweredQuestion: { domain: 'Music', questionText: 'Q?', result: 'incorrect', authorName: null, authorIsHouse: false } }),
   mk('keep-direct-uncovered', 'received_direct_question', { directQuestion: { feedItemId: 'fi', questionId: 'q-other', questionText: 'Q?', personalMessage: null, category: null } }),
 ];
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1774,7 +1774,17 @@ function FeedListContent({
           {groupItemsByRecency(restRows).map((group) => (
             <Fragment key={group.key}>
               <FeedSectionHeading unifiedHome={unifiedHome}>{group.label}</FeedSectionHeading>
-              {groupActivityByFriend(group.items).map(renderRow)}
+              {/* D-FEED-GROUP3-01 §2 — "everything else" renders as a calm straight
+                  chronological stream of full-sentence LONE events. Per-person
+                  clustering (PersonActivityCard) is deliberately DROPPED for this
+                  zone in cut 1: the cluster form was the source of the
+                  subject-stripped "wording is weird" copy, and density now comes
+                  from visual quiet, not copy compression. Clustering is a gated
+                  follow-up (re-introduce groupActivityByFriend here only if the
+                  straight stream still reads busy with real content). On the
+                  standalone Feed tab restRows is just question cards, which never
+                  grouped anyway, so this is a pure pass-through there. */}
+              {group.items.map(renderRow)}
             </Fragment>
           ))}
         </section>

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDown, Share2 } from 'lucide-react';
 import Link from 'next/link';
-import { useState, type KeyboardEvent } from 'react';
+import { useState, type CSSProperties, type KeyboardEvent } from 'react';
 
 import { FriendRequestActions } from '@/app/activities/FriendRequestActions';
 import { ReactionGotItButton } from '@/app/activities/ReactionGotItButton';
@@ -19,6 +19,7 @@ import { InlineAnswerFlow } from './InlineAnswerFlow';
 import { ActivityIcon, QuestionTriangle, specForIcon } from './ActivityIcon';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
+import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
 // Friend names render in the activity-blue from Figma (--brand-link #4a5d75),
 // linked or not, so the actor reads as the warm social anchor of the row.
@@ -93,6 +94,38 @@ function questionBacked(expand: StreamExpand | null): boolean {
 // One in-session answer to a milestone question: what the viewer typed and
 // whether it was scored correct. Drives the calm "Answered" history copy.
 type Resolution = { submitted: string; isCorrect: boolean };
+
+// D-FEED-GROUP3-01 §4 (honesty, load-bearing): when a row expands to reveal its
+// question, a house/LLM-authored question MUST be marked — never rendered as if
+// a person wrote it. Returns the marker text, or null when no marker is needed:
+//   - authorIsHouse        → the house identity ("Joshing · Editorial")
+//   - authorName === null  → a non-person LLM-origin question ("Generated")
+//   - human name / undefined → null (the row frame already attributes it; a
+//                              human author needs no machine-honesty marker)
+function questionProvenance(q: StreamQuestion): string | null {
+  if (q.authorIsHouse) return `${HOUSE_AUTHOR.displayName} · ${HOUSE_AUTHOR.label}`;
+  if (q.authorName === null) return LLM_QUESTION_ATTRIBUTION;
+  return null;
+}
+
+function QuestionProvenance({ q, style }: { q: StreamQuestion; style?: CSSProperties }) {
+  const label = questionProvenance(q);
+  if (!label) return null;
+  return (
+    <p
+      style={{
+        margin: '4px 0 0',
+        fontFamily: FM,
+        fontSize: 10,
+        letterSpacing: 1,
+        color: INK3,
+        ...style,
+      }}
+    >
+      {label.toUpperCase()}
+    </p>
+  );
+}
 
 export function ActivityStreamItem({
   item,
@@ -545,6 +578,9 @@ export function ConvergenceExpansion({
               {q.domain.toUpperCase()}
             </p>
           ) : null}
+          {/* Honest authorship (§4): mark a house/LLM question even in the
+              read-only convergence reveal. */}
+          <QuestionProvenance q={q} />
         </div>
       ))}
     </div>
@@ -570,7 +606,7 @@ function SendOnwardExpansion({
     >
       <p
         style={{
-          margin: '0 0 12px',
+          margin: '0 0 4px',
           fontFamily: 'Georgia, serif',
           fontStyle: 'italic',
           fontSize: 14,
@@ -580,6 +616,9 @@ function SendOnwardExpansion({
       >
         &ldquo;{question.text}&rdquo;
       </p>
+      {/* Honest authorship (§4): house/LLM questions are marked so the reveal
+          never implies a person wrote machine content. */}
+      <QuestionProvenance q={question} style={{ margin: '0 0 12px' }} />
 
       <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
         {/* Quiet, standard share icon (matches KnowledgeCard / RecentlyExpanding)

--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -130,4 +130,25 @@ describe('ConvergenceExpansion — the expanded reveal', () => {
     expect(html).not.toContain('DISCOVER');
     expect(html.toLowerCase()).not.toContain('<button');
   });
+
+  it('marks house/LLM questions honestly and leaves human questions unmarked (§4)', () => {
+    const expand: Extract<StreamExpand, { kind: 'same_correct' }> = {
+      kind: 'same_correct',
+      friendId: 'friend-1',
+      friendName: 'Robyn Fielding',
+      questions: [
+        // House/editorial question — must be marked, never read as person-written.
+        { questionId: 'h1', text: 'A house question', domain: 'History', priorResult: 'correct', authorName: 'Joshing', authorIsHouse: true },
+        // LLM-origin question — marked "Generated".
+        { questionId: 'g1', text: 'A generated question', domain: 'Science', priorResult: 'correct', authorName: null, authorIsHouse: false },
+        // Human-authored — no machine-honesty marker needed.
+        { questionId: 'p1', text: 'A human question', domain: 'Music', priorResult: 'correct', authorName: 'Sadie', authorIsHouse: false },
+      ],
+    };
+    const html = renderToStaticMarkup(<ConvergenceExpansion expand={expand} />);
+    expect(html).toContain('JOSHING · EDITORIAL');
+    expect(html).toContain('GENERATED');
+    // The human author is not surfaced as a provenance marker.
+    expect(html).not.toContain('SADIE');
+  });
 });

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -29,6 +29,35 @@ const EXPANDING_ROW_ACCENTS = [
 // initials, no buttons), softened into the sage wash.
 const INVITE_CLUSTER_SEEDS = ['circle-a', 'circle-b', 'circle-c', 'circle-d'];
 
+// Promo HEADLINE pools (D-FEED-GROUP3-01 Pool 4). Only the headline rotates —
+// eyebrow, CTA, and supporting copy stay fixed (functional wayfinding). The
+// rotation is by the embed's day-seeded `headlineIndex`, not an event hash, so
+// a promo that recurs as the same type still varies day to day. `{friend}` in
+// the common-ground pool is rendered as a link (see CommonGroundFeature).
+const RECENTLY_EXPANDING_HEADLINES = [
+  "The places you've been exploring lately.",
+  "New ground you've been covering.",
+  "Where your curiosity's been wandering.",
+] as const;
+
+const ADD_FRIENDS_HEADLINES = [
+  'Know someone who belongs here?',
+  'Who else should be in your circle?',
+  'There’s room for the people who get you.',
+] as const;
+
+// Common-ground headlines split into the copy AROUND the friend link so the
+// friend's name stays a link wherever it falls in the line.
+const COMMON_GROUND_HEADLINES = [
+  { before: 'You and ', after: ' keep finding one another here.' },
+  { before: 'You and ', after: ' keep meeting in the same places.' },
+  { before: 'The ground you and ', after: ' share.' },
+] as const;
+
+function rotate<T>(pool: readonly T[], index: number | undefined): T {
+  return pool[(index ?? 0) % pool.length]!;
+}
+
 /**
  * "Shared Ground" — the overlapping-circle motif as a full-bleed editorial
  * feature: the two strongest shared-but-untested domains the viewer holds with
@@ -43,6 +72,7 @@ export function CommonGroundFeature({
     embed.domains.flatMap((d) => [d.viewer.points, d.friend.points]),
   );
   const count = embed.domains.length;
+  const headline = rotate(COMMON_GROUND_HEADLINES, embed.headlineIndex);
   return (
     <EditorialFeature
       tone="parchment"
@@ -50,14 +80,14 @@ export function CommonGroundFeature({
       eyebrowIcon={<Bookmark size={13} strokeWidth={0} fill="currentColor" />}
       headline={
         <>
-          You and{' '}
+          {headline.before}
           <Link
             href={embed.friendHref}
             className="text-[var(--brand-ink)] underline-offset-4 hover:underline"
           >
             {embed.friendFirstName}
-          </Link>{' '}
-          keep finding one another here.
+          </Link>
+          {headline.after}
         </>
       }
       artwork={
@@ -121,7 +151,7 @@ export function GrowYourCircleFeature({
     <EditorialFeature
       tone="sage"
       eyebrow="Grow Your Circle"
-      headline="Know someone who belongs here?"
+      headline={rotate(ADD_FRIENDS_HEADLINES, embed.headlineIndex)}
       artwork={
         embed.variant === 'suggestions' ? (
           <div className="flex flex-col gap-3">
@@ -189,7 +219,7 @@ export function RecentlyExpandingFeature({
     <EditorialFeature
       tone="slate"
       eyebrow="Your World Is Expanding"
-      headline="The places you've been exploring lately."
+      headline={rotate(RECENTLY_EXPANDING_HEADLINES, embed.headlineIndex)}
       artwork={
         <div className="flex flex-col gap-3">
           {embed.domains.map((d, i) => {

--- a/src/lib/__tests__/activity-stream-group3.test.ts
+++ b/src/lib/__tests__/activity-stream-group3.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest';
+
+import { activityToStreamItem, momentToStreamItem } from '@/lib/activity-stream';
+import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { LatelyMoment } from '@/server/db/queries/lately';
+
+// D-FEED-GROUP3-01 — the "everything else" social stream. These pin the new
+// expand-to-send-onward affordance (§4), the honest-authorship fields the
+// reveal needs, and the full-sentence relationship copy (Appendix A pools).
+
+function activity(
+  type: ActivityItemView['type'],
+  over: Partial<ActivityItemView> = {},
+): ActivityItemView {
+  return {
+    id: 'act-1',
+    userId: 'viewer-1',
+    type,
+    actorUserId: 'friend-1',
+    referenceId: 'q-1',
+    referenceType: 'question',
+    read: false,
+    createdAt: new Date('2026-06-01T12:00:00.000Z'),
+    actor: { displayName: 'Robyn' },
+    reference: {},
+    ...over,
+  } as unknown as ActivityItemView;
+}
+
+function moment(over: Partial<LatelyMoment> = {}): LatelyMoment {
+  return {
+    momentId: 'm-1',
+    dir: 'they_got_you',
+    friendId: 'friend-9',
+    friendName: 'Sadie',
+    friendFirstName: 'Sadie',
+    questionId: 'q-1',
+    questionText: 'Who is Bird?',
+    category: 'Jazz',
+    answeredAt: new Date('2026-06-01T12:00:00.000Z'),
+    ...over,
+  } as LatelyMoment;
+}
+
+const lineText = (item: { line: { t: string; v?: string; name?: string }[] }) =>
+  item.line.map((p) => ('v' in p ? p.v : p.name)).join('');
+
+describe('question_curated (saved) — expands to send the question onward (§4)', () => {
+  it('carries a your_question expand with domain + honest authorship', () => {
+    const item = activityToStreamItem(
+      activity('question_curated', {
+        type: 'question_curated',
+        reference: {
+          curatedQuestion: {
+            questionText: 'What key is Giant Steps in?',
+            domain: 'Jazz',
+            authorName: null, // LLM-origin
+            authorIsHouse: false,
+          },
+        },
+      } as unknown as Partial<ActivityItemView>),
+    );
+    expect(item.relationship).toBe('saved');
+    expect(item.expand?.kind).toBe('your_question');
+    if (item.expand?.kind !== 'your_question') throw new Error('expected your_question');
+    expect(item.expand.question.questionId).toBe('q-1');
+    expect(item.expand.question.domain).toBe('Jazz');
+    // null authorName is preserved (not coerced) so the reveal can mark it Generated.
+    expect(item.expand.question.authorName).toBeNull();
+    expect(item.expand.question.authorIsHouse).toBe(false);
+  });
+
+  it('does not expand when the saved question did not hydrate', () => {
+    const item = activityToStreamItem(
+      activity('question_curated', { type: 'question_curated', reference: {} } as unknown as Partial<ActivityItemView>),
+    );
+    expect(item.expand).toBeNull();
+  });
+});
+
+describe('reaction_received (reacted) — keeps "got it" AND expands (§4)', () => {
+  it('carries both the got-it action and a your_question expand with authorship', () => {
+    const item = activityToStreamItem(
+      activity('reaction_received', {
+        type: 'reaction_received',
+        referenceType: 'question_reaction',
+        referenceId: 'rx-1',
+        reference: {
+          reaction: {
+            id: 'rx-1',
+            reactionLabel: 'Loved it',
+            reactionEmoji: '❤️',
+            customMessage: null,
+            repliedAt: null,
+            questionId: 'q-7',
+            questionText: 'Who painted Guernica?',
+            domain: 'Cubism',
+            authorName: 'Joshing',
+            authorIsHouse: true, // house/editorial
+            submittedAnswer: null,
+          },
+        },
+      } as unknown as Partial<ActivityItemView>),
+    );
+    expect(item.relationship).toBe('reacted');
+    expect(item.action?.kind).toBe('reaction_got_it');
+    expect(item.expand?.kind).toBe('your_question');
+    if (item.expand?.kind !== 'your_question') throw new Error('expected your_question');
+    expect(item.expand.question.questionId).toBe('q-7');
+    expect(item.expand.question.authorIsHouse).toBe(true);
+  });
+});
+
+describe('relationship copy pools (Appendix A) — full sentences, topic folded in', () => {
+  it('got_you (they answered your question) reads as a full sentence, no echoed second line', () => {
+    const item = momentToStreamItem(moment({ dir: 'they_got_you', category: 'Jazz' }));
+    expect(item.relationship).toBe('got_you');
+    // The friend is the social anchor; the topic is in the line, so secondLine clears.
+    expect(item.line.some((p) => p.t === 'actor')).toBe(true);
+    expect(item.secondLine).toBeNull();
+    // Connection register only — never competition language.
+    expect(lineText(item).toLowerCase()).not.toMatch(/beat|nailed|crushed|schooled|called/);
+  });
+
+  it('you_got (you answered their question) reads as a full sentence about the topic', () => {
+    const item = momentToStreamItem(moment({ dir: 'you_got_them', category: 'Geography' }));
+    expect(item.relationship).toBe('you_got');
+    expect(item.line.some((p) => p.t === 'category')).toBe(true);
+    expect(item.secondLine).toBeNull();
+  });
+
+  it('is stable: the same moment id always selects the same line', () => {
+    const a = lineText(momentToStreamItem(moment({ momentId: 'm-stable', category: 'Jazz' })));
+    const b = lineText(momentToStreamItem(moment({ momentId: 'm-stable', category: 'Jazz' })));
+    expect(a).toBe(b);
+  });
+});

--- a/src/lib/__tests__/convergence.test.ts
+++ b/src/lib/__tests__/convergence.test.ts
@@ -6,7 +6,8 @@ import {
   type ConvergenceCoCorrectRow,
 } from '@/lib/convergence';
 import {
-  CONVERGENCE_CAPTIONS,
+  CONVERGENCE_SINGLE_TOPIC,
+  CONVERGENCE_NO_TOPIC,
   convergenceCaptionTemplate,
 } from '@/lib/lately';
 
@@ -124,17 +125,28 @@ describe('deriveConvergences — single owner', () => {
   });
 });
 
-describe('convergenceCaptionTemplate — deterministic, person-first', () => {
-  it('is stable for a given moment id and drawn from the pool', () => {
+describe('convergenceCaptionTemplate — deterministic, person-first, topic-aware', () => {
+  it('is stable for a given moment id and drawn from the matching pool', () => {
     const id = 'converge:F:q1_q2_q3';
-    const first = convergenceCaptionTemplate(id);
-    expect(convergenceCaptionTemplate(id)).toBe(first);
-    expect(CONVERGENCE_CAPTIONS).toContain(first);
+    // No shared topic → the topic-less pool (3b), stably.
+    const noTopic = convergenceCaptionTemplate(id, null);
+    expect(convergenceCaptionTemplate(id, null)).toBe(noTopic);
+    expect(CONVERGENCE_NO_TOPIC).toContain(noTopic);
+    // A shared topic → the single-topic pool (3a), stably, and carries {topic}.
+    const single = convergenceCaptionTemplate(id, 'Jazz');
+    expect(convergenceCaptionTemplate(id, 'Jazz')).toBe(single);
+    expect(CONVERGENCE_SINGLE_TOPIC).toContain(single);
+    expect(single).toContain('{topic}');
   });
 
-  it('every caption is person-first via the {Name} token and names no domain', () => {
-    for (const caption of CONVERGENCE_CAPTIONS) {
+  it('every caption is person-first via the {Name} token', () => {
+    for (const caption of [...CONVERGENCE_SINGLE_TOPIC, ...CONVERGENCE_NO_TOPIC]) {
       expect(caption).toContain('{Name}');
     }
+  });
+
+  it('only the single-topic pool names a topic; the topic-less pool never does', () => {
+    for (const caption of CONVERGENCE_SINGLE_TOPIC) expect(caption).toContain('{topic}');
+    for (const caption of CONVERGENCE_NO_TOPIC) expect(caption).not.toContain('{topic}');
   });
 });

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -22,7 +22,7 @@ import { HOME_TOP3_ELIGIBLE_TYPES } from '@/lib/activity-types';
 import type { ActivityItemView } from '@/server/db/queries/activity';
 import type { MasteryTier } from '@/types/db';
 import type { LatelyMoment } from '@/server/db/queries/lately';
-import { LATELY_TIER, latelyTierForMomentDir } from '@/lib/lately';
+import { LATELY_TIER, latelyTierForMomentDir, djb2 } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
 import type { Convergence } from '@/lib/convergence';
 import type { RelationshipResult } from '@/server/db/queries/friend-requests';
@@ -51,6 +51,16 @@ export type StreamQuestion = {
   // the feed — and drives the ANSWERED history's "Correct" / "Not this time"
   // copy plus the bundle progress mark.
   priorResult: 'correct' | 'incorrect' | null;
+  // Honest authorship for the expanded reveal (D-FEED-GROUP3-01 §4). Tri-state,
+  // and the distinction is load-bearing for the provenance marker:
+  //   - undefined        — provenance not resolved for this source; show nothing
+  //                        (the row frame already attributes it, e.g. moments are
+  //                        human by construction).
+  //   - null             — a non-person LLM-origin question → render "Generated".
+  //   - string (+isHouse) — a human name, or the house identity when authorIsHouse.
+  // A house/LLM question must NEVER render as if a person wrote it.
+  authorName?: string | null;
+  authorIsHouse?: boolean;
 };
 
 // The action an expanded, question-backed item offers — determined by the
@@ -149,6 +159,12 @@ export type AddFriendsPromoPerson = {
 // friend; `recently_expanding` lists the viewer's fastest-growing territories
 // with a link to /knowledge; `add_friends` either suggests people to follow or
 // (when there are none) nudges toward inviting someone.
+// Promos recur as the same promo TYPE over time, so the hash-by-event-id trick
+// the relationship lines use won't vary them. Each embed instead carries a
+// `headlineIndex` (D-FEED-GROUP3-01 Pool 4) — a day-seeded number the feature
+// component takes `% pool.length` to rotate the HEADLINE only (eyebrow, CTA, and
+// supporting copy stay fixed for wayfinding). Optional so older callers/tests
+// default to the first headline.
 export type StreamEmbed =
   | {
       kind: 'common_ground';
@@ -156,22 +172,26 @@ export type StreamEmbed =
       friendFirstName: string;
       friendHref: string;
       domains: CommonGroundPromoDomain[];
+      headlineIndex?: number;
     }
   | {
       kind: 'recently_expanding';
       href: string;
       domains: RecentlyExpandingPromoDomain[];
+      headlineIndex?: number;
     }
   | {
       kind: 'add_friends';
       variant: 'suggestions';
       href: string;
       people: AddFriendsPromoPerson[];
+      headlineIndex?: number;
     }
   | {
       kind: 'add_friends';
       variant: 'invite';
       href: string;
+      headlineIndex?: number;
     };
 
 export type StreamItem = {
@@ -225,6 +245,70 @@ function actorName(item: ActivityItemView): string {
 
 const HOME_ELIGIBLE = new Set<string>(HOME_TOP3_ELIGIBLE_TYPES);
 
+// --- Relationship copy pools (D-FEED-GROUP3-01 Appendix A) --------------------
+//
+// Full-sentence lone-event copy. Each line is hash-selected per event id (the
+// same djb2 the convergence pool uses) so a feed of the same event type still
+// varies, while a given event always reads the same way. The `{friend}` token
+// becomes the actor link; `{topic}` the serif category. Every line is safe for
+// ANY instance of its type, and the register is connection-only — the banned
+// competition words (beat/called/nailed/crushed/schooled/"had your number") are
+// kept out by construction.
+//
+// Pool 1 — got_you: a friend answered a question YOU wrote (one-way; no "you both").
+const GOT_YOU_LINES = [
+  '{friend} knew your {topic} question',
+  '{friend} knows {topic} down',
+  '{friend} was right there with you on {topic}',
+  '{friend} came through on your {topic} question',
+  '{friend} understood your {topic} question',
+  '{friend} has {topic} down cold',
+] as const;
+// When the event carries no topic, fall back to the calm topic-less baseline
+// rather than dangling an empty category.
+const GOT_YOU_NO_TOPIC = '{friend} got your question';
+
+// Pool 2 — you_got: YOU answered a friend's question (one-way; no "you both").
+const YOU_GOT_LINES = [
+  "You knew {friend}'s {topic} question",
+  'You know {topic} down',
+  'You were right there with {friend} on {topic}',
+  "You came through on {friend}'s {topic} question",
+  "You understood {friend}'s {topic} question",
+  "You've got {topic} down cold",
+] as const;
+const YOU_GOT_NO_TOPIC = "You knew {friend}'s question";
+
+function pickLine(
+  pool: readonly string[],
+  noTopic: string,
+  eventId: string,
+  topic: string | null,
+): string {
+  if (!topic) return noTopic;
+  return pool[djb2(eventId) % pool.length];
+}
+
+// Render a copy template into stream line parts: `{friend}` → actor link,
+// `{topic}` → serif category, everything else plain text.
+function renderTemplate(
+  template: string,
+  friend: { name: string; userId: string | null },
+  topic: string | null,
+): StreamLinePart[] {
+  const parts: StreamLinePart[] = [];
+  const re = /\{(friend|topic)\}/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(template)) !== null) {
+    if (m.index > last) parts.push(txt(template.slice(last, m.index)));
+    parts.push(m[1] === 'friend' ? act(friend.name, friend.userId) : cat(topic ?? ''));
+    last = re.lastIndex;
+  }
+  if (last < template.length) parts.push(txt(template.slice(last)));
+  return parts;
+}
+
 // --- Activity rows -----------------------------------------------------------
 
 // Port of the per-type copy (formerly split across NewsRow.buildCopy and the
@@ -255,10 +339,20 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
       const faq = item.reference.friendAnsweredQuestion;
       const got = faq?.result === 'correct';
       const domain = faq?.domain?.trim() || null;
+      // Correct = the warm "got_you" event: full-sentence Pool 1 copy with the
+      // topic folded into the line (so no echoed second line). A miss keeps the
+      // calm factual "answered your question" with the domain as the second line.
+      const line = got
+        ? renderTemplate(
+            pickLine(GOT_YOU_LINES, GOT_YOU_NO_TOPIC, item.id, domain),
+            { name: actorName(item), userId: item.actorUserId },
+            domain,
+          )
+        : [a, txt(' answered your question')];
       return {
         ...base,
-        line: [a, txt(got ? ' got your question' : ' answered your question')],
-        secondLine: domain,
+        line,
+        secondLine: got ? null : domain,
         icon: 'diamond',
         relationship: 'got_you',
         topic: domain,
@@ -272,6 +366,8 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
                   text: faq.questionText,
                   domain,
                   priorResult: null,
+                  authorName: faq.authorName,
+                  authorIsHouse: faq.authorIsHouse,
                 },
               }
             : null,
@@ -365,29 +461,66 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
       const label = reaction?.reactionLabel
         ? `${reaction.reactionEmoji ? `${reaction.reactionEmoji} ` : ''}${reaction.reactionLabel}`
         : null;
+      const domain = reaction?.domain?.trim() || null;
       return {
         ...base,
         line: [a, txt(' reacted to your question')],
         secondLine: label,
         relationship: 'reacted',
+        topic: domain,
+        // Keep the lightweight "got it" acknowledgement AND let the row expand to
+        // reveal the reacted-to question with honest authorship + send-onward
+        // (D-FEED-GROUP3-01 §4).
         action: {
           kind: 'reaction_got_it',
           reactionId: reaction?.id ?? item.referenceId ?? '',
           replied: Boolean(reaction?.repliedAt),
         },
-        expand: null,
+        expand:
+          reaction?.questionId && reaction.questionText
+            ? {
+                kind: 'your_question',
+                question: {
+                  questionId: reaction.questionId,
+                  text: reaction.questionText,
+                  domain,
+                  priorResult: null,
+                  authorName: reaction.authorName,
+                  authorIsHouse: reaction.authorIsHouse,
+                },
+              }
+            : null,
       };
     }
 
-    case 'question_curated':
+    case 'question_curated': {
+      const cq = item.reference.curatedQuestion;
+      const domain = cq?.domain?.trim() || null;
       return {
         ...base,
         line: [a, txt(' saved your question')],
-        secondLine: item.reference.curatedQuestion?.questionText ?? null,
+        secondLine: cq?.questionText ?? null,
         relationship: 'saved',
+        topic: domain,
         action: null,
-        expand: null,
+        // Expand to reveal the saved question (honest authorship) and send it
+        // onward (D-FEED-GROUP3-01 §4). The question id is the activity referenceId.
+        expand:
+          item.referenceId && cq?.questionText
+            ? {
+                kind: 'your_question',
+                question: {
+                  questionId: item.referenceId,
+                  text: cq.questionText,
+                  domain,
+                  priorResult: null,
+                  authorName: cq.authorName,
+                  authorIsHouse: cq.authorIsHouse,
+                },
+              }
+            : null,
       };
+    }
 
     case 'authored_question_shared': {
       const shared = item.reference.authoredSharedQuestion;
@@ -559,22 +692,28 @@ function nicheTier(type: ActivityItemView['type']): number {
 // it's their question, but you already answered it, so the only forward action
 // is still to send it onward to someone new.
 export function momentToStreamItem(moment: LatelyMoment): StreamItem {
-  const friend = act(moment.friendName, moment.friendId);
   const theyGotYou = moment.dir === 'they_got_you';
+  const topic = moment.category;
+  const friend = { name: moment.friendName, userId: moment.friendId };
+  // Full-sentence lone copy from the relationship pools (Appendix A), with the
+  // topic folded into the line so there's no echoed second line. Moments are
+  // human-authored by query construction (house/LLM questions are excluded), so
+  // the reveal needs no provenance marker — author fields stay undefined.
+  const line = theyGotYou
+    ? renderTemplate(pickLine(GOT_YOU_LINES, GOT_YOU_NO_TOPIC, moment.momentId, topic), friend, topic)
+    : renderTemplate(pickLine(YOU_GOT_LINES, YOU_GOT_NO_TOPIC, moment.momentId, topic), friend, topic);
   return {
     id: moment.momentId,
     sortAt: moment.answeredAt,
     tier: latelyTierForMomentDir(moment.dir),
-    // they_got_you ("Robyn got your question") is the headline social signal —
-    // home-eligible. you_got_them is quieter; keep it to the full list.
+    // they_got_you is the headline social signal — home-eligible. you_got_them is
+    // quieter; keep it to the full list.
     homeEligible: theyGotYou,
     friendId: moment.friendId,
     relationship: theyGotYou ? 'got_you' : 'you_got',
-    topic: moment.category,
-    line: theyGotYou
-      ? [friend, txt(' got your question')]
-      : [txt('You got '), friend, txt(' on '), cat(moment.category)],
-    secondLine: theyGotYou ? moment.category : null,
+    topic,
+    line,
+    secondLine: null,
     anchorId: null,
     action: null,
     icon: 'diamond',
@@ -664,12 +803,28 @@ export function convergenceToStreamItem(
   convergence: Convergence,
   questions: StreamQuestion[],
   captionTemplate: string,
+  // Non-null only when all 3 cluster questions share ONE topic (Pool 3a); drives
+  // the `{topic}` token. Null → the template is from the topic-less set (3b) and
+  // carries no `{topic}` token, so nothing is interpolated.
+  sharedTopic: string | null = null,
 ): StreamItem {
-  const [before, after] = captionTemplate.split('{Name}');
+  // Person-first headline: `{Name}` → the friend actor link, `{topic}` → the
+  // serif category (only present in the single-topic pool). No domain ever
+  // reaches the line unless it's the one shared topic.
   const line: StreamLinePart[] = [];
-  if (before) line.push(txt(before));
-  line.push(act(convergence.friendFirstName, convergence.friendId));
-  if (after) line.push(txt(after));
+  const re = /\{(Name|topic)\}/g;
+  let last = 0;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(captionTemplate)) !== null) {
+    if (m.index > last) line.push(txt(captionTemplate.slice(last, m.index)));
+    line.push(
+      m[1] === 'Name'
+        ? act(convergence.friendFirstName, convergence.friendId)
+        : cat(sharedTopic ?? ''),
+    );
+    last = re.lastIndex;
+  }
+  if (last < captionTemplate.length) line.push(txt(captionTemplate.slice(last)));
   return {
     id: convergence.id,
     sortAt: convergence.sortAt,

--- a/src/lib/lately.ts
+++ b/src/lib/lately.ts
@@ -52,7 +52,11 @@ export const YOU_GOT_THEM_CAPTIONS = [
   'ON THEIR FREQUENCY',
 ] as const;
 
-function djb2(input: string): number {
+// Stable, dependency-free string hash used to spread copy-pool selection across
+// events (the same event always draws the same line; a feed of the same event
+// type still varies). Exported so the relationship copy pools in
+// `activity-stream.ts` (D-FEED-GROUP3-01 Appendix A) select the same way.
+export function djb2(input: string): number {
   let hash = 5381;
   for (let i = 0; i < input.length; i++) {
     hash = ((hash << 5) + hash + input.charCodeAt(i)) | 0;
@@ -71,24 +75,40 @@ export function assignCaption(
   return template.replace('{NAME}', friendFirstName.toUpperCase());
 }
 
-// Convergence (B-Convergence-1) headlines are PERSON-FIRST and never name a
-// domain — naming one of a mixed-domain cluster misrepresents the rest, and
-// naming all reads as a stats list (a brand violation). Unlike the moment
-// CAPTIONS above (all-caps chips), these are sentence-case one-liners: the
-// `{Name}` token is replaced with the friend's first name AT RENDER (as an
-// actor link), so the template is returned verbatim here. Assigned
-// deterministically by moment id, the same djb2 mechanism the moments use.
-export const CONVERGENCE_CAPTIONS = [
-  'You and {Name} keep landing in the same place.',
-  'Turns out you and {Name} think alike.',
-  'You and {Name} are on the same wavelength lately.',
-  'You and {Name} both knew these.',
-  'You and {Name} just get each other.',
-  'You and {Name} are clearly on the same page.',
+// Convergence (B-Convergence-1) headlines are PERSON-FIRST. They come in two
+// pools (D-FEED-GROUP3-01 Pool 3): when the cluster's 3 questions share ONE
+// topic, name it via the `{topic}` token (rendered in the serif category
+// register); when the topics differ, fall back to the topic-less set rather
+// than listing all three (listing reintroduces the wordiness we removed). Both
+// carry the `{Name}` token, replaced with the friend's first name AT RENDER (as
+// an actor link). Selection is deterministic by moment id (the same djb2
+// mechanism the moments use). "you both" is accurate here only — convergence is
+// the one mutual event.
+export const CONVERGENCE_SINGLE_TOPIC = [
+  'You and {Name} both know {topic} down',
+  'You and {Name} have {topic} down cold',
+  'You and {Name} both know {topic} inside out',
+  'You and {Name} are right there together on {topic}',
+  'You and {Name} both came through on {topic}',
+  'Turns out you and {Name} both know {topic}',
 ] as const;
 
-export function convergenceCaptionTemplate(momentId: string): string {
-  return CONVERGENCE_CAPTIONS[djb2(momentId) % CONVERGENCE_CAPTIONS.length];
+export const CONVERGENCE_NO_TOPIC = [
+  'You and {Name} keep landing in the same place',
+  'You and {Name} keep meeting in the same corners',
+  'You and {Name} are on the same wavelength lately',
+  'Turns out you and {Name} just get each other',
+] as const;
+
+// Pick a convergence headline template. `sharedTopic` non-null means all three
+// cluster questions resolved to the SAME topic (detected at build time, where
+// the domains are known); null means they differ (or weren't all resolvable),
+// in which case we never name a topic.
+export function convergenceCaptionTemplate(momentId: string, sharedTopic: string | null): string {
+  if (sharedTopic) {
+    return CONVERGENCE_SINGLE_TOPIC[djb2(momentId) % CONVERGENCE_SINGLE_TOPIC.length];
+  }
+  return CONVERGENCE_NO_TOPIC[djb2(momentId) % CONVERGENCE_NO_TOPIC.length];
 }
 
 function ymdInZone(date: Date, tz: string): string {

--- a/src/server/activity/add-friends-promo.ts
+++ b/src/server/activity/add-friends-promo.ts
@@ -55,6 +55,8 @@ export async function getAddFriendsPromo(
       variant: 'suggestions',
       href: FRIENDS_FIND_HREF,
       people,
+      // Rotate the headline by the day seed (Pool 4); eyebrow / CTA stay fixed.
+      headlineIndex: daySeed,
     };
     return addFriendsPromoToStreamItem(embed, now, `add-friends-suggestions-${daySeed}`);
   }
@@ -64,6 +66,7 @@ export async function getAddFriendsPromo(
     kind: 'add_friends',
     variant: 'invite',
     href: FRIENDS_FIND_HREF,
+    headlineIndex: daySeed,
   };
   return addFriendsPromoToStreamItem(embed, now, `add-friends-invite-${daySeed}`);
 }

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -81,6 +81,8 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
           text: q.text,
           domain: q.domain,
           priorResult: priorById.get(q.questionId) ?? null,
+          authorName: q.authorName,
+          authorIsHouse: q.authorIsHouse,
         }));
       // A milestone whose questions all collapse out is a contentless streak
       // card — suppress it rather than render an empty triangle.
@@ -97,8 +99,17 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
         text: q.text,
         domain: q.domain,
         priorResult: 'correct' as const, // read-only reveal: both already answered correctly
+        authorName: q.authorName,
+        authorIsHouse: q.authorIsHouse,
       }));
-    return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id));
+    // Single-topic headline (Pool 3a) only when EVERY surviving cluster question
+    // resolved to the same non-null domain; otherwise the topic-less set (3b).
+    const domains = questions.map((q) => q.domain);
+    const sharedTopic =
+      questions.length > 0 && domains.every((d): d is string => Boolean(d)) && new Set(domains).size === 1
+        ? domains[0]
+        : null;
+    return convergenceToStreamItem(c, questions, convergenceCaptionTemplate(c.id, sharedTopic), sharedTopic);
   });
 
   return sortByProminence([

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -76,6 +76,9 @@ export async function getCommonGroundPromo(
       friendFirstName: firstName(friend.displayName),
       friendHref: `/users/${friend.id}`,
       domains,
+      // Rotate the headline by the day seed (Pool 4) so it doesn't always show
+      // line 1; eyebrow / CTA stay fixed.
+      headlineIndex: seed,
     };
 
     return commonGroundPromoToStreamItem(

--- a/src/server/activity/recently-expanding-promo.ts
+++ b/src/server/activity/recently-expanding-promo.ts
@@ -68,14 +68,16 @@ export async function getRecentlyExpandingPromo(
     initial: initialFor(domain.domain),
   }));
 
+  // Stable id within a UTC day so the row's React key doesn't churn across
+  // re-renders, but advances day to day. Also seeds the headline rotation (Pool
+  // 4) so the headline cycles day to day instead of always showing line 1.
+  const daySeed = Math.floor(now.getTime() / 86_400_000);
   const embed: Extract<StreamEmbed, { kind: 'recently_expanding' }> = {
     kind: 'recently_expanding',
     href: '/knowledge',
     domains,
+    headlineIndex: daySeed,
   };
 
-  // Stable id within a UTC day so the row's React key doesn't churn across
-  // re-renders, but advances day to day.
-  const daySeed = Math.floor(now.getTime() / 86_400_000);
   return recentlyExpandingPromoToStreamItem(embed, now, `recently-expanding-promo-${daySeed}`);
 }

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -18,6 +18,7 @@ import {
   users,
 } from '@/server/db';
 import { getCannedReaction } from '@/lib/reactions';
+import { resolveAuthorDisplay } from '@/lib/questions-types';
 import { HOME_TOP3_ELIGIBLE_TYPES, type ActivityItemType } from '@/server/activity/write-activity';
 import { pgErrorCode, pgErrorMessage } from '@/server/db/pg-error';
 import type { MasteryTier } from '@/types/db';
@@ -50,7 +51,15 @@ export type ActivityItemView = Pick<
       reactionEmoji: string;
       customMessage: string | null;
       repliedAt: Date | null;
+      // The reacted-to question, surfaced so the row can expand to reveal it and
+      // offer "send onward" (D-FEED-GROUP3-01 §4). domain + author resolve the
+      // honest-authorship reveal: a house/LLM question must never read as if a
+      // person wrote it.
+      questionId: string;
       questionText: string;
+      domain: string | null;
+      authorName: string | null;
+      authorIsHouse: boolean;
       // §8.22 wrong-answer text visibility: populated only when the answerer
       // explicitly opted in (includeSubmittedAnswer=true on a wrong-answer
       // reaction). Null in every other case.
@@ -65,11 +74,20 @@ export type ActivityItemView = Pick<
     };
     curatedQuestion?: {
       questionText: string;
+      // domain + author for the expand-to-send-onward reveal (D-FEED-GROUP3-01
+      // §4). The question id is the activity's referenceId.
+      domain: string | null;
+      authorName: string | null;
+      authorIsHouse: boolean;
     };
     friendAnsweredQuestion?: {
       domain: string | null;
       questionText: string | null;
       result: 'correct' | 'incorrect';
+      // Honest authorship for the expanded "your question" reveal — a forwarded
+      // house/LLM question must not render as if the viewer wrote it.
+      authorName: string | null;
+      authorIsHouse: boolean;
     };
     // D-2 niche-match discovery. Hydrated for both new types
     // (niche_match_answered_your_question / niche_match_you_answered). Reuses
@@ -388,9 +406,18 @@ async function hydrateReactions(items: ActivityItemRow[]) {
       contextType: questionReactions.contextType,
       contextId: questionReactions.contextId,
       includeSubmittedAnswer: questionReactions.includeSubmittedAnswer,
+      // Domain + provenance for the expand-to-send-onward reveal.
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+      category: questions.category,
+      creatorId: questions.creatorId,
+      source: questions.source,
+      authorDisplayName: users.displayName,
     })
     .from(questionReactions)
     .innerJoin(questions, eq(questionReactions.questionId, questions.id))
+    // creator may be null (house/LLM), so the author join is a left join.
+    .leftJoin(users, eq(users.id, questions.creatorId))
     .where(inArray(questionReactions.id, reactionIds));
 
   // §8.22 opt-in resolution: for any reaction the answerer flagged with
@@ -447,6 +474,7 @@ async function hydrateReactions(items: ActivityItemRow[]) {
         submittedAnswer = gameAnswerByKey.get(`${row.contextId}:${row.questionId}:${row.senderUserId}`) ?? null;
       }
     }
+    const author = resolveAuthorDisplay(row.creatorId, row.source, row.authorDisplayName);
     return [
       row.id,
       {
@@ -455,7 +483,11 @@ async function hydrateReactions(items: ActivityItemRow[]) {
         reactionEmoji: reaction?.emoji ?? '',
         customMessage: row.customMessage,
         repliedAt: row.repliedAt,
+        questionId: row.questionId,
         questionText: row.questionText,
+        domain: row.canonicalSubcategory?.trim() || row.broadCategory || row.category || null,
+        authorName: author.authorName,
+        authorIsHouse: author.authorIsHouse,
         submittedAnswer,
       },
     ] as const;
@@ -517,11 +549,27 @@ async function hydrateCuratedQuestions(items: ActivityItemRow[]) {
     .select({
       id: questions.id,
       questionText: questions.questionText,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      broadCategory: questions.broadCategory,
+      category: questions.category,
+      creatorId: questions.creatorId,
+      source: questions.source,
+      authorDisplayName: users.displayName,
     })
     .from(questions)
+    // creator may be null (house/LLM), so the author join is a left join.
+    .leftJoin(users, eq(users.id, questions.creatorId))
     .where(inArray(questions.id, questionIds));
 
-  return new Map(rows.map((row) => [row.id, { questionText: row.questionText }] as const));
+  return new Map(rows.map((row) => {
+    const author = resolveAuthorDisplay(row.creatorId, row.source, row.authorDisplayName);
+    return [row.id, {
+      questionText: row.questionText,
+      domain: row.canonicalSubcategory?.trim() || row.broadCategory || row.category || null,
+      authorName: author.authorName,
+      authorIsHouse: author.authorIsHouse,
+    }] as const;
+  }));
 }
 
 async function hydrateGradeDisputes(items: ActivityItemRow[]) {
@@ -582,8 +630,18 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
 
   const [questionRows, masteryRows] = await Promise.all([
     db
-      .select({ id: questions.id, questionText: questions.questionText, canonicalSubcategory: questions.canonicalSubcategory, broadCategory: questions.broadCategory })
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        canonicalSubcategory: questions.canonicalSubcategory,
+        broadCategory: questions.broadCategory,
+        creatorId: questions.creatorId,
+        source: questions.source,
+        authorDisplayName: users.displayName,
+      })
       .from(questions)
+      // creator may be null (house/LLM), so the author join is a left join.
+      .leftJoin(users, eq(users.id, questions.creatorId))
       .where(inArray(questions.id, questionIds)),
     db
       .select({ userId: masteryEvents.userId, questionId: masteryEvents.questionId })
@@ -602,12 +660,17 @@ async function hydrateFriendAnsweredQuestions(items: ActivityItemRow[]) {
   return new Map(
     relevant.map((item) => {
       const q = questionById.get(item.referenceId!);
+      const author = q
+        ? resolveAuthorDisplay(q.creatorId, q.source, q.authorDisplayName)
+        : { authorName: null, authorIsHouse: false };
       return [
         item.id,
         {
           domain: q ? (q.canonicalSubcategory ?? q.broadCategory ?? null) : null,
           questionText: q?.questionText ?? null,
           result: correctSet.has(`${item.actorUserId}:${item.referenceId}`) ? 'correct' : 'incorrect',
+          authorName: author.authorName,
+          authorIsHouse: author.authorIsHouse,
         } satisfies NonNullable<ActivityItemView['reference']['friendAnsweredQuestion']>,
       ];
     }),

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -325,6 +325,11 @@ export type MilestoneCardQuestion = {
   questionId: string;
   text: string;
   domain: string | null;
+  // Honest authorship for the expanded reveal (D-FEED-GROUP3-01 §4). Shared by
+  // milestone bundles and convergence clusters — a house/LLM question in either
+  // reveal must be marked, never rendered as if a person wrote it.
+  authorName: string | null;
+  authorIsHouse: boolean;
 };
 
 export async function getMilestoneQuestionText(
@@ -339,16 +344,24 @@ export async function getMilestoneQuestionText(
       canonicalSubcategory: questions.canonicalSubcategory,
       broadCategory: questions.broadCategory,
       category: questions.category,
+      creatorId: questions.creatorId,
+      source: questions.source,
+      authorDisplayName: users.displayName,
       deletedAt: questions.deletedAt,
     })
     .from(questions)
+    // creator may be null (house/LLM), so the author join is a left join.
+    .leftJoin(users, eq(users.id, questions.creatorId))
     .where(inArray(questions.id, ids));
   for (const row of rows) {
     if (row.deletedAt) continue;
+    const author = resolveAuthorDisplay(row.creatorId, row.source, row.authorDisplayName);
     out.set(row.id, {
       questionId: row.id,
       text: row.questionText,
       domain: resolveMilestoneDomain(row.canonicalSubcategory, row.broadCategory, row.category),
+      authorName: author.authorName,
+      authorIsHouse: author.authorIsHouse,
     });
   }
   return out;


### PR DESCRIPTION
Cut 1 of the Group 3 ("everything else") social-stream redesign, grounded in `D-FEED-INVENTORY-01`. Group 3 only — groups 1 & 2 untouched. Built on latest `dev2`.

## What's in it

**§2 Structure** — Group 3 (relationship events + promos) renders as a **calm straight chronological stream of full-sentence lone events**. `PersonActivityCard` clustering is dropped for this zone and **gated** for later (one-line restore); recency buckets kept. For You / From Friends unchanged.

**§3 + Appendix A Copy** — Full-sentence relationship pools, hash-selected per event so a feed of the same type still varies:
- Pool 1 `got_you` / Pool 2 `you_got` — topic folded into the line, second line cleared (no echo); topic-less fallback when no domain.
- Pool 3 convergence — replaced with **3a single-topic** (when all 3 cluster questions share one domain) + **3b topic-less**; never lists all three.
- Pool 4 promos — headline rotates by a day-seeded index; eyebrow / CTA / supporting copy fixed.
- Connection-only register; banned competition words kept out by construction + asserted.

**§4 Expand-to-send-onward + honest authorship** (the load-bearing server work) — `saved` and `reacted` are now expandable and reveal the question with a Send affordance. The reveal marks provenance honestly: **house → "Joshing · Editorial", LLM → "Generated", human → unmarked** — a machine question can never read as if a person wrote it. Threaded `domain` + `creatorId`/`source` → `resolveAuthorDisplay` through `hydrateCuratedQuestions`, `hydrateReactions`, `hydrateFriendAnsweredQuestions`, and `getMilestoneQuestionText` (covers convergence).

**§5 / §E** — Calm baseline already in place (no new tokens); confirmed the "killing it" + all-caps caption pools are dead and not designed around.

**§8 Evaluation note** — `_docs/D-FEED-GROUP3-01.md`: the wording fix holds independent of clustering; the clustering decision is the explicit checkpoint pending a real dense-feed review.

## Open threads
- Convergence 3a topic detection = "all 3 domains non-null and equal → name it, else 3b" — sanity-check on real clusters.
- Promo eyebrows stay fixed (headline-only rotation) — confirm.

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean
- ESLint on all touched files — clean
- 163 feed/activity/promo tests pass (156 existing + 7 new, 0 regressions)

## Note
Includes the `D-FEED-INVENTORY-01` audit doc commit (from PR #779, not yet merged), since it grounds this build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)