### PR TITLE
Make reset time labels day-aware to fix "tomorrow" copy

### DIFF
--- a/src/app/daily/summary/FirstSessionRecap.tsx
+++ b/src/app/daily/summary/FirstSessionRecap.tsx
@@ -23,13 +23,15 @@ import {
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
-import { formatNextResetTimeLocal } from '@/lib/games/timezone';
+import { formatNextResetDayTimeLocal } from '@/lib/games/timezone';
 
 // useSyncExternalStore inputs for the client-only reset-time label, mirroring
 // the daily summary page: null during SSR keeps hydration stable, and the
-// snapshot is read on the client without a setState-in-effect.
+// snapshot is read on the client without a setState-in-effect. The label is
+// day-aware ("today at 1 PM" / "tomorrow at 1 PM") so the close copy stays
+// correct when the next reset falls later on the current local day.
 const subscribeNoop = () => () => {};
-const getResetTimeSnapshot = () => formatNextResetTimeLocal();
+const getResetTimeSnapshot = () => formatNextResetDayTimeLocal();
 const getResetTimeServerSnapshot = (): string | null => null;
 import type {
   FirstSessionRecapBeat2,
@@ -152,8 +154,8 @@ export function FirstSessionRecap({
 }) {
   const router = useRouter();
   const [currentIndex, setCurrentIndex] = useState(0);
-  // Client-only local wall-clock reset time for the close copy; null during SSR.
-  const resetLabel = useSyncExternalStore(
+  // Client-only day-aware reset label for the close copy; null during SSR.
+  const resetDayTime = useSyncExternalStore(
     subscribeNoop,
     getResetTimeSnapshot,
     getResetTimeServerSnapshot,
@@ -246,8 +248,7 @@ export function FirstSessionRecap({
         {isEnd ? (
           <div className="mx-auto max-w-2xl text-center">
             <h1 className="font-serif text-4xl font-semibold leading-tight tracking-normal sm:text-6xl">
-              Come back tomorrow
-              {resetLabel ? ` at ${resetLabel}` : ''} for five new questions.
+              Come back {resetDayTime ?? 'tomorrow'} for five new questions.
             </h1>
             <div className="mt-10 flex justify-center">
               <button

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -22,7 +22,7 @@ import MasteryMoment from '@/components/review/MasteryMoment'
 import { RefineYourGame } from '@/components/review/RefineYourGame'
 import { cn } from '@/lib/utils'
 import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types'
-import { formatNextResetTimeLocal } from '@/lib/games/timezone'
+import { formatNextResetTimeLocal, getNextResetDayLabelLocal } from '@/lib/games/timezone'
 import type {
   DailySummaryView,
   QuestionRecap,
@@ -37,6 +37,10 @@ import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/
 const subscribeNoop = () => () => {}
 const getResetTimeSnapshot = () => formatNextResetTimeLocal()
 const getResetTimeServerSnapshot = (): string | null => null
+// Day-aware label ("today"/"tomorrow"/weekday) for the next-round heading, so
+// it never hardcodes "Tomorrow" when the reset actually falls later today.
+const getResetDaySnapshot = () => getNextResetDayLabelLocal()
+const getResetDayServerSnapshot = (): string | null => null
 
 // The heart is the only feedback signal on the recap now; the negative surface is
 // the ⋯ report items (B-Report-2). The /api/daily/feedback route still accepts the
@@ -161,6 +165,11 @@ export default function DailySummaryPage() {
     subscribeNoop,
     getResetTimeSnapshot,
     getResetTimeServerSnapshot,
+  )
+  const resetDay = useSyncExternalStore(
+    subscribeNoop,
+    getResetDaySnapshot,
+    getResetDayServerSnapshot,
   )
 
   useEffect(() => {
@@ -324,7 +333,9 @@ export default function DailySummaryPage() {
       {summary.reminderPromptState === 'show' ? <RoundReminderCard /> : null}
 
       <section className="card mt-5 px-5 py-4">
-        <h2 style={titleStyle}>Tomorrow</h2>
+        <h2 style={titleStyle}>
+          {resetDay ? resetDay.charAt(0).toUpperCase() + resetDay.slice(1) : 'Tomorrow'}
+        </h2>
         <p className="text-foreground mt-2 text-sm leading-6">
           {resetTime ? `Five new at ${resetTime}.` : 'Five new tomorrow.'}
         </p>

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -4,12 +4,14 @@ import Link from 'next/link'
 import { Settings } from 'lucide-react'
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 
-import { formatNextResetTimeLocal } from '@/lib/games/timezone'
+import { formatNextResetDayTimeLocal } from '@/lib/games/timezone'
 
 // useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
-// the subscribe/snapshot functions are stable across renders.
+// the subscribe/snapshot functions are stable across renders. The label is
+// day-aware ("today at 1 PM" / "tomorrow at 1 PM"), so it stays correct when
+// the next reset falls later on the current local day.
 const subscribeNoop = () => () => {}
-const getResetTimeSnapshot = () => formatNextResetTimeLocal()
+const getResetTimeSnapshot = () => formatNextResetDayTimeLocal()
 const getResetTimeServerSnapshot = (): string | null => null
 
 export type SlotOutcome = 'correct' | 'incorrect' | 'skipped' | 'unanswered'
@@ -95,7 +97,7 @@ export default function TodaysFiveCard({
   const [status, setStatus] = useState<DailyStatus | null>(initialStatus)
   const [preferences, setPreferences] = useState<DailyPreferences | null>(initialPreferences)
   // Client-only reset-time label; null during SSR to keep hydration stable.
-  const resetTime = useSyncExternalStore(
+  const resetDayTime = useSyncExternalStore(
     subscribeNoop,
     getResetTimeSnapshot,
     getResetTimeServerSnapshot,
@@ -182,8 +184,8 @@ export default function TodaysFiveCard({
   const missedCount = Math.max(0, initialMissedCount)
   // The session-end forward beat — rendered as its own quiet line in both
   // completed branches so it survives even an all-skipped (answered === 0) round.
-  const forwardBeat = resetTime
-    ? `Five new at ${resetTime} tomorrow`
+  const forwardBeat = resetDayTime
+    ? `Five new ${resetDayTime}`
     : 'Five new tomorrow'
   const subtext = answered > 0 ? `${answered} of 5 answered` : 'Ready when you are'
   // Editorial serif headline (display/Body-Serif), contextual to round state.

--- a/src/lib/games/timezone.ts
+++ b/src/lib/games/timezone.ts
@@ -127,22 +127,22 @@ export function formatNextResetTimeLocal(
 }
 
 /**
- * Format the next daily reset boundary as a day-aware label in the viewer's
- * local timezone, e.g. "today at 1 PM", "tomorrow at 1 PM", or — when the
- * boundary is further out — the weekday name like "Wednesday at 1 PM".
+ * Return the day the next daily reset boundary falls on, relative to the
+ * viewer's local timezone: "today", "tomorrow", or — should the boundary ever
+ * be further out — the weekday name like "Wednesday" (a proper noun, so it
+ * stays capitalized; "today"/"tomorrow" are lowercase for mid-sentence use).
  *
  * The boundary is always within 24h, so in practice it resolves to "today" or
  * "tomorrow"; the weekday fallback exists so the label is never wrong if the
  * window math ever changes. This replaces hardcoded "tomorrow" copy, which was
  * incorrect whenever the next reset fell later on the current local day.
  */
-export function formatNextResetDayTimeLocal(
+export function getNextResetDayLabelLocal(
   timezone?: string,
   from: Date = new Date(),
-): string {
+): 'today' | 'tomorrow' | string {
   const next = getNextDailyResetBoundary(from);
   const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
-  const time = formatNextResetTimeLocal(timezone, from);
 
   // Compare local calendar days (YYYY-MM-DD) between now and the reset boundary.
   const dayFormatter = new Intl.DateTimeFormat('en-CA', {
@@ -151,17 +151,29 @@ export function formatNextResetDayTimeLocal(
     month: '2-digit',
     day: '2-digit',
   });
-  const todayKey = dayFormatter.format(from);
   const resetKey = dayFormatter.format(next);
 
-  if (resetKey === todayKey) return `today at ${time}`;
+  if (resetKey === dayFormatter.format(from)) return 'today';
 
   const tomorrow = new Date(from.getTime() + ONE_DAY_MS);
-  if (resetKey === dayFormatter.format(tomorrow)) return `tomorrow at ${time}`;
+  if (resetKey === dayFormatter.format(tomorrow)) return 'tomorrow';
 
-  const weekday = new Intl.DateTimeFormat('en-US', {
+  return new Intl.DateTimeFormat('en-US', {
     weekday: 'long',
     timeZone: tz,
   }).format(next);
-  return `${weekday} at ${time}`;
+}
+
+/**
+ * Format the next daily reset boundary as a day-aware label in the viewer's
+ * local timezone, e.g. "today at 1 PM", "tomorrow at 1 PM", or — when the
+ * boundary is further out — the weekday name like "wednesday at 1 PM".
+ */
+export function formatNextResetDayTimeLocal(
+  timezone?: string,
+  from: Date = new Date(),
+): string {
+  const day = getNextResetDayLabelLocal(timezone, from);
+  const time = formatNextResetTimeLocal(timezone, from);
+  return `${day} at ${time}`;
 }

--- a/src/lib/games/timezone.ts
+++ b/src/lib/games/timezone.ts
@@ -125,3 +125,43 @@ export function formatNextResetTimeLocal(
   const period = parts.find((p) => p.type === 'dayPeriod')?.value ?? '';
   return minute === '00' ? `${hour} ${period}` : `${hour}:${minute} ${period}`;
 }
+
+/**
+ * Format the next daily reset boundary as a day-aware label in the viewer's
+ * local timezone, e.g. "today at 1 PM", "tomorrow at 1 PM", or — when the
+ * boundary is further out — the weekday name like "Wednesday at 1 PM".
+ *
+ * The boundary is always within 24h, so in practice it resolves to "today" or
+ * "tomorrow"; the weekday fallback exists so the label is never wrong if the
+ * window math ever changes. This replaces hardcoded "tomorrow" copy, which was
+ * incorrect whenever the next reset fell later on the current local day.
+ */
+export function formatNextResetDayTimeLocal(
+  timezone?: string,
+  from: Date = new Date(),
+): string {
+  const next = getNextDailyResetBoundary(from);
+  const tz = timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone;
+  const time = formatNextResetTimeLocal(timezone, from);
+
+  // Compare local calendar days (YYYY-MM-DD) between now and the reset boundary.
+  const dayFormatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: tz,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const todayKey = dayFormatter.format(from);
+  const resetKey = dayFormatter.format(next);
+
+  if (resetKey === todayKey) return `today at ${time}`;
+
+  const tomorrow = new Date(from.getTime() + ONE_DAY_MS);
+  if (resetKey === dayFormatter.format(tomorrow)) return `tomorrow at ${time}`;
+
+  const weekday = new Intl.DateTimeFormat('en-US', {
+    weekday: 'long',
+    timeZone: tz,
+  }).format(next);
+  return `${weekday} at ${time}`;
+}


### PR DESCRIPTION
## Summary
Fixes incorrect "tomorrow" copy that appears when the next daily reset falls later on the current local day. Introduces day-aware reset time labels ("today at 1 PM", "tomorrow at 1 PM", or weekday names) to replace hardcoded "tomorrow" text.

## Key Changes
- **New timezone utilities** (`src/lib/games/timezone.ts`):
  - `getNextResetDayLabelLocal()`: Returns "today", "tomorrow", or a weekday name based on when the next reset boundary falls relative to the viewer's local timezone
  - `formatNextResetDayTimeLocal()`: Combines the day label with the reset time (e.g., "today at 1 PM")

- **Updated components** to use day-aware labels:
  - `FirstSessionRecap.tsx`: Changed "Come back tomorrow at X" to "Come back {day} at {time}" using `formatNextResetDayTimeLocal()`
  - `TodaysFiveCard.tsx`: Updated forward beat text from "Five new at X tomorrow" to "Five new {day} at {time}"
  - `daily/summary/page.tsx`: Made the "Tomorrow" section heading dynamic, showing "Today", "Tomorrow", or the actual weekday when the reset falls further out

## Implementation Details
- Uses `Intl.DateTimeFormat` with timezone support to compare calendar days (YYYY-MM-DD format) between now and the reset boundary
- Handles the common case (reset within 24h) with "today"/"tomorrow" fallback, with weekday names as a defensive fallback for edge cases
- Maintains SSR hydration stability by using `useSyncExternalStore` with null server snapshots (client-only computation)
- All labels respect the viewer's local timezone via optional `timezone` parameter

https://claude.ai/code/session_01PYehqwcu8tqGdzSyQMiYDq