### PR TITLE
Use neutral label & styling for wrong-answer results

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -220,10 +220,10 @@ const RECAP_TONE = {
     accent: 'var(--success)',
   },
   wrong: {
-    label: 'WRONG',
-    border: 'color-mix(in srgb, var(--danger) 28%, var(--border))',
-    background: 'color-mix(in srgb, var(--danger) 7%, var(--surface-2))',
-    accent: 'var(--danger)',
+    label: 'Not this time',
+    border: 'var(--border)',
+    background: 'color-mix(in srgb, var(--muted) 42%, var(--surface-2))',
+    accent: 'var(--text-muted)',
   },
   revealed: {
     label: 'REVEALED',
@@ -246,7 +246,7 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
     >
       <div className="flex flex-wrap items-center gap-2">
         <span
-          className="rounded-sm border px-2 py-1 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
+          className="rounded-sm border px-2 py-1 text-[0.6rem] font-semibold tracking-[0.08em]"
           style={{ borderColor: tone.border, color: tone.accent }}
         >
           {tone.label}

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -523,15 +523,15 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
                 borderLeft: '3px solid var(--success)',
               }
             : {
-                background: 'color-mix(in srgb, #b42318 7%, var(--brand-card))',
-                borderColor: 'color-mix(in srgb, #b42318 24%, var(--brand-border))',
-                borderLeft: '3px solid #b42318',
+                background: 'color-mix(in srgb, var(--muted) 36%, var(--brand-card))',
+                borderColor: 'var(--brand-border)',
+                borderLeft: '3px solid var(--brand-border)',
               }
       }
     >
       <div className="flex flex-wrap items-start gap-2 pr-11">
         <span
-          className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold tracking-[0.08em] uppercase"
+          className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold tracking-[0.08em]"
           style={
             question.isSkipped
               ? { borderColor: 'var(--brand-border)', background: 'var(--secondary)', color: 'var(--brand-ink-400)' }
@@ -542,9 +542,9 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
                     color: '#0f5c30',
                   }
                 : {
-                    borderColor: 'color-mix(in srgb, #b42318 35%, var(--brand-border))',
-                    background: 'color-mix(in srgb, #b42318 12%, var(--brand-card))',
-                    color: '#8b1f16',
+                    borderColor: 'var(--brand-border)',
+                    background: 'color-mix(in srgb, var(--muted) 44%, var(--brand-card))',
+                    color: 'var(--text-muted)',
                   }
           }
         >
@@ -552,7 +552,7 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
             ? 'SKIPPED'
             : question.isCorrect
               ? 'CORRECT'
-              : 'WRONG'}
+              : 'Not this time'}
         </span>
         <p className="pt-1" style={{ ...monoStyle, color: 'var(--text-muted)' }}>
           {question.authorName ? null : `${LLM_QUESTION_ATTRIBUTION.toUpperCase()} · ${question.domainDisplayName.toUpperCase()}`}

--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -49,8 +49,8 @@ function resolvedDifficulty(question: JoshingGameView['questions'][number]['ques
 }
 
 // Difficulty pills use the triangle palette (amber/dark-yellow/dark-teal) so the
-// 3-level metadata scale reads as distinct from the green/terracotta CORRECT/WRONG
-// pill beside it. Text is mixed toward --brand-ink so the lighter tones clear AA.
+// 3-level metadata scale reads as distinct from the result pill beside it.
+// Text is mixed toward --brand-ink so the lighter tones clear AA.
 function difficultyPillStyle(level: string): CSSProperties {
   const tone =
     level === 'specialist'
@@ -105,7 +105,7 @@ function responseKey(userId: string, questionId: string) {
 }
 
 function resultLabel(isCorrect: boolean | null | undefined) {
-  return isCorrect ? 'CORRECT' : 'WRONG';
+  return isCorrect ? 'CORRECT' : 'Not this time';
 }
 
 function formatGameDate(value: Date) {
@@ -311,7 +311,7 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
                         ) : null;
                       })()}
                       <span
-                        className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em]"
+                        className="rounded-sm border px-2 py-1 text-[0.65rem] font-semibold tracking-[0.08em]"
                         style={
                           correct
                             ? {
@@ -320,9 +320,9 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
                                 color: 'var(--game-correct)',
                               }
                             : {
-                                borderColor: 'color-mix(in srgb, var(--game-wrong-strong) 30%, var(--border))',
-                                backgroundColor: 'color-mix(in srgb, var(--game-wrong-strong) 10%, var(--surface))',
-                                color: 'var(--game-wrong-strong)',
+                                borderColor: 'var(--border)',
+                                backgroundColor: 'color-mix(in srgb, var(--muted) 45%, var(--surface))',
+                                color: 'var(--text-muted)',
                               }
                         }
                       >


### PR DESCRIPTION
### Motivation
- Replace punitive "WRONG" copy and hard-coded red visuals with a gentler user-facing label and neutral system/Tailwind treatments to avoid negative framing. 
- Keep success (`CORRECT`) and skipped/revealed states visually distinct while making the wrong state muted and consistent with design tokens. 

### Description
- Replaced user-facing `WRONG` strings with `Not this time` in `src/app/daily/summary/page.tsx`, `src/app/daily/catchup/page.tsx`, and `src/app/games/[id]/summary/page.tsx`. 
- Switched wrong-answer card/pill styles away from hard-coded punitive red (`#b42318`, `var(--danger)`, `var(--game-wrong-strong)`) to neutral/border/muted tokens such as `var(--border)`, `var(--text-muted)`, and `var(--muted)` color-mix treatments. 
- Updated related small UI class usage (removed forced uppercase on some result pills) and adjusted nearby comment that referenced `CORRECT/WRONG` to avoid reintroducing punitive terminology. 

### Testing
- Ran formatting with `npm run format` to apply code style changes and write the modified files. 
- Ran `npm run lint` which completed (the repository still reports the preexisting 16 warnings unrelated to these changes). 
- Verified the targeted labels and hard-coded red tokens were removed using a project-wide search (`rg`) of the modified files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297db1cbb4832e8fb847bc74ca5ac3)