### PR TITLE
Update creator note labels

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -280,8 +280,8 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
             {record.authorIsHouse
               ? 'Editor’s note:'
               : record.authorName
-                ? `Why ${record.authorName} asked:`
-                : 'Why they asked:'}
+                ? `${record.authorName}’s note`
+                : 'Their note'}
           </span>{' '}
           {record.authorNote}
         </p>

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -630,12 +630,10 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
               'Editor’s note:'
             ) : question.authorName ? (
               <>
-                Why{' '}
-                <AuthorName name={question.authorName} authorId={question.authorId} />{' '}
-                asked:
+                <AuthorName name={question.authorName} authorId={question.authorId} />’s note
               </>
             ) : (
-              'Why they asked:'
+              'Their note'
             )}
           </span>{' '}
           {question.authorNote}

--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -362,7 +362,7 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
                   ) : null}
                   {authorNote ? (
                     <p className="mt-3 rounded-md border bg-muted/50 p-3 text-sm leading-6 text-foreground">
-                      <span className="font-medium">{authorName ? `Why ${authorName} asked:` : 'Why they asked:'}</span>{' '}
+                      <span className="font-medium">{authorName ? `${authorName}’s note` : 'Their note'}</span>{' '}
                       {authorNote}
                     </p>
                   ) : null}


### PR DESCRIPTION
### Motivation
- Simplify and soften the creator-note copy by replacing “Why [name] asked” / “Why they asked” with a concise possessive label and a quiet unnamed fallback while preserving house/editorial treatment.

### Description
- Replace creator-note text in `src/app/daily/summary/page.tsx`, `src/app/daily/catchup/page.tsx`, and `src/app/games/[id]/summary/page.tsx` so named human creators render as `[Creator Name]’s note`, unnamed creators render as `Their note`, and existing `Editor’s note:` handling for house/editorial authors is preserved.

### Testing
- Ran `npm run format` (auto-formatted the changed files) and `npm run lint`, and `eslint` completed with the repository's existing design-token warnings (no errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a297f655bd8832e8f37504905a67b49)