### PR TITLE
Update daily summary closing copy

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -10,7 +10,6 @@ import {
   useMemo,
   useRef,
   useState,
-  useSyncExternalStore,
   useTransition,
 } from 'react'
 
@@ -22,7 +21,6 @@ import MasteryMoment from '@/components/review/MasteryMoment'
 import { RefineYourGame } from '@/components/review/RefineYourGame'
 import { cn } from '@/lib/utils'
 import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types'
-import { formatNextResetTimeLocal, getNextResetDayLabelLocal } from '@/lib/games/timezone'
 import type {
   DailySummaryView,
   QuestionRecap,
@@ -31,16 +29,6 @@ import { RoundReminderCard } from './RoundReminderCard'
 import { FirstSessionRecap } from './FirstSessionRecap'
 import type { FirstSessionRecapView } from '@/server/daily/first-session-recap'
 import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet'
-
-// useSyncExternalStore inputs for the client-only reset-time label. Hoisted so
-// the subscribe/snapshot functions are stable across renders.
-const subscribeNoop = () => () => {}
-const getResetTimeSnapshot = () => formatNextResetTimeLocal()
-const getResetTimeServerSnapshot = (): string | null => null
-// Day-aware label ("today"/"tomorrow"/weekday) for the next-round heading, so
-// it never hardcodes "Tomorrow" when the reset actually falls later today.
-const getResetDaySnapshot = () => getNextResetDayLabelLocal()
-const getResetDayServerSnapshot = (): string | null => null
 
 // The heart is the only feedback signal on the recap now; the negative surface is
 // the ⋯ report items (B-Report-2). The /api/daily/feedback route still accepts the
@@ -160,18 +148,6 @@ export default function DailySummaryPage() {
   const [hiddenQuestionIds, setHiddenQuestionIds] = useState<Set<string>>(
     () => new Set(),
   )
-  // Client-only reset-time label; null during SSR to keep hydration stable.
-  const resetTime = useSyncExternalStore(
-    subscribeNoop,
-    getResetTimeSnapshot,
-    getResetTimeServerSnapshot,
-  )
-  const resetDay = useSyncExternalStore(
-    subscribeNoop,
-    getResetDaySnapshot,
-    getResetDayServerSnapshot,
-  )
-
   useEffect(() => {
     let cancelled = false
     async function load() {
@@ -333,11 +309,8 @@ export default function DailySummaryPage() {
       {summary.reminderPromptState === 'show' ? <RoundReminderCard /> : null}
 
       <section className="card mt-5 px-5 py-4">
-        <h2 style={titleStyle}>
-          {resetDay ? resetDay.charAt(0).toUpperCase() + resetDay.slice(1) : 'Tomorrow'}
-        </h2>
-        <p className="text-foreground mt-2 text-sm leading-6">
-          {resetTime ? `Five new at ${resetTime}.` : 'Five new tomorrow.'}
+        <p className="text-muted-foreground text-sm leading-6">
+          Tomorrow’s five arrive at noon.
         </p>
       </section>
 


### PR DESCRIPTION
### Motivation
- Make the bottom close-message of the Daily Summary quieter and fixed to the requested copy so it doesn’t present celebratory or completion-heavy language.  
- Simplify the client-side logic for rendering reset labels since the footer should now be a simple, static line.

### Description
- Replaced the dynamic reset heading and `Five new…` variants with the static line `Tomorrow’s five arrive at noon.` in `src/app/daily/summary/page.tsx`.  
- Removed the now-unused `useSyncExternalStore` imports and helper snapshots/variables (`resetTime`, `resetDay`, and associated helper functions) from the same file.  
- Kept the area visually quiet by using existing `card` and `text-muted-foreground` styles and avoided adding any celebratory language.

### Testing
- Ran `npm run format`, which formatted and wrote the changed file.  
- Ran `npm run lint`, which completed with no errors (the repository still shows 16 existing design-token warnings in unrelated files).  
- Changes committed to the repository (`Update daily summary closing copy`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29809f3c6c832ea3a599dceb84ebf0)