### PR TITLE
Refine daily summary knowledge link

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -326,11 +326,14 @@ export default function DailySummaryPage() {
         </section>
       ) : null}
 
-      <div className="mt-6 flex flex-col gap-3 sm:flex-row">
-        <Link className="btn-primary sm:flex-1" href="/">
+      <div className="mt-6 flex flex-col items-center gap-3">
+        <Link className="btn-primary w-full" href="/">
           Back home
         </Link>
-        <Link className="btn-ghost sm:flex-1" href="/knowledge">
+        <Link
+          className="text-muted-foreground text-sm font-medium underline underline-offset-4 transition hover:text-foreground"
+          href="/knowledge"
+        >
           See your knowledge map
         </Link>
       </div>


### PR DESCRIPTION
### Motivation
- Keep "Back home" as the single primary CTA on the daily summary page and present "See your knowledge map" as a quiet secondary text link that matches the page's typographic affordances while preserving its `/knowledge` destination.

### Description
- Replace the action row so `Back home` is full-width (`btn-primary w-full`) and convert the knowledge map CTA from `btn-ghost` to a muted text link using `text-muted-foreground text-sm font-medium underline underline-offset-4 transition hover:text-foreground` while keeping `href="/knowledge"`.
- Update the container spacing to `flex flex-col items-center gap-3` for consistent layout and apply automatic code formatting changes across the file.

### Testing
- Ran `npm run lint`, which completed successfully but reported existing unrelated warnings; no new lint errors were introduced.
- Ran `npm run format`, which formatted the modified file.
- Ran `git diff --check`, which reported no issues.
- Attempted a Playwright screenshot end-to-end check, which failed because Playwright's browser download returned `403 Forbidden` from the CDN.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2983223844832e97060d2e3e716aaa)