### PR TITLE
fix(feed): restore "From Friends" pinned section for playable milestone bundles

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -26,7 +26,7 @@ import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visua
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
 import { PersonActivityCard } from '@/components/activity/PersonActivityCard'
-import { type GroupInputRow, type GroupedRow } from '@/components/feed/person-grouping'
+import { groupActivityByFriend, type GroupInputRow, type GroupedRow } from '@/components/feed/person-grouping'
 import {
   CommonGroundFeature,
   GrowYourCircleFeature,
@@ -679,9 +679,17 @@ function FeedContributeFooter() {
   )
 }
 
+// "From Friends" shows at most this many of the most-recent milestone cards
+// before collapsing the rest behind a "View more" control; each tap of "View
+// more" then reveals another FROM_FRIENDS_STEP cards (and keeps the control
+// while more remain).
+const FROM_FRIENDS_COLLAPSED_COUNT = 5
+const FROM_FRIENDS_STEP = 10
+
 // The uppercase eyebrow that labels a feed section — the recency day labels
-// ("Today", "This week") share this register. `first:pt-0` lets whichever
-// heading renders first sit flush to the top of the feed.
+// ("Today", "This week") and the home-only pinned "From Friends" section all
+// share this register. `first:pt-0` lets whichever heading renders first sit
+// flush to the top of the feed.
 function FeedSectionHeading({
   unifiedHome,
   children,
@@ -785,6 +793,11 @@ function FeedListContent({
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [hideToast, setHideToast] = useState<{ category: string } | null>(null)
+  // "From Friends" starts capped to its most recent few milestone cards; each
+  // "View more" reveals another batch. View-state only — never persisted.
+  const [fromFriendsVisibleCount, setFromFriendsVisibleCount] = useState(
+    FROM_FRIENDS_COLLAPSED_COUNT,
+  )
   // True for the very first render path when we already have server-rendered
   // data; the initial-fetch useEffect skips its work once.
   const skipInitialFetchRef = useRef(initialPageMatchesFilter)
@@ -954,12 +967,44 @@ function FeedListContent({
     return next
   }, [unifiedRows, commonGroundPromo, expandingPromo, addFriendsPromo])
 
-  // The home feed renders as a single flat chronological stream grouped by
-  // recency — no pinned "For You" / "From Friends" tiers. (Reverts the D-FEED
-  // pinned split; the calm full-sentence Group-3 styling below now applies to
-  // the whole feed.) The standalone Feed tab was always a single stream, so
-  // both surfaces now render through the same recency grouping.
-  const restRows = displayRows
+  // Home-only sectioning: the friends' milestone bundles (the up-to-5-triangle
+  // cards you can answer inline) are lifted out of the chronological stream
+  // into a single pinned "From Friends" section at the top. Everything else —
+  // question cards sent to you, ambient activity, per-person roll-ups, promos —
+  // falls through to `restRows` and keeps the existing recency grouping below.
+  // Off the unified home (the standalone Feed tab) the section is empty and
+  // restRows is the whole list, so that surface renders exactly as before.
+  const { fromFriendsRows, restRows } = useMemo(() => {
+    if (!unifiedHome) {
+      return {
+        fromFriendsRows: [] as UnifiedRow[],
+        restRows: displayRows,
+      }
+    }
+    const fromFriends: UnifiedRow[] = []
+    const rest: UnifiedRow[] = []
+    for (const row of displayRows) {
+      if (
+        row.kind === 'activity' &&
+        row.item.expand?.kind === 'milestone' &&
+        row.item.expand.questions.length > 0
+      ) {
+        fromFriends.push(row)
+      } else {
+        rest.push(row)
+      }
+    }
+    return { fromFriendsRows: fromFriends, restRows: rest }
+  }, [displayRows, unifiedHome])
+
+  // "From Friends" reveals its most recent cards in batches (fromFriendsRows is
+  // newest-first, so slicing the head keeps the latest). The "View more" control
+  // appears while cards remain hidden; each tap reveals up to FROM_FRIENDS_STEP
+  // more, and the label names how many that next tap will show.
+  const visibleFromFriendsRows = fromFriendsRows.slice(0, fromFriendsVisibleCount)
+  const fromFriendsHiddenCount =
+    fromFriendsRows.length - visibleFromFriendsRows.length
+  const fromFriendsNextBatch = Math.min(fromFriendsHiddenCount, FROM_FRIENDS_STEP)
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'
@@ -1689,13 +1734,36 @@ function FeedListContent({
         )
       ) : (
         <section className="space-y-3 pb-8">
-          {/* The whole feed is a single calm chronological stream grouped by
-              recency. Every row — question cards, friends' milestone bundles,
-              relationship events, promos — renders as a full-sentence LONE event
-              (D-FEED-GROUP3-01 §2 styling, applied feed-wide). Per-person
-              clustering (PersonActivityCard) stays dropped: the cluster form was
-              the source of the subject-stripped "wording is weird" copy, and
-              density now comes from visual quiet, not copy compression. */}
+          {/* Home-only: friends' milestone bundles (the up-to-5-triangle cards
+              you can answer inline) are pinned into a "From Friends" section at
+              the top, capped to the most recent few with a "View more" control.
+              groupActivityByFriend is a pass-through here (milestone rows never
+              group), keeping the render path uniform. */}
+          {fromFriendsRows.length > 0 ? (
+            <Fragment key="from-friends">
+              <FeedSectionHeading unifiedHome={unifiedHome}>From Friends</FeedSectionHeading>
+              {groupActivityByFriend(visibleFromFriendsRows).map(renderRow)}
+              {fromFriendsHiddenCount > 0 ? (
+                <button
+                  type="button"
+                  onClick={() =>
+                    setFromFriendsVisibleCount((count) => count + FROM_FRIENDS_STEP)
+                  }
+                  className={`flex min-h-11 items-center text-[13px] font-medium tracking-[0.04em] text-[var(--brand-link)] underline underline-offset-4 transition hover:opacity-70 ${
+                    unifiedHome ? 'pl-[2px]' : ''
+                  }`}
+                >
+                  View {fromFriendsNextBatch} more
+                </button>
+              ) : null}
+            </Fragment>
+          ) : null}
+          {/* Everything else — question cards sent to you, relationship events,
+              promos — stays in a single calm chronological stream grouped by
+              recency, rendered as full-sentence LONE events (D-FEED-GROUP3-01 §2
+              styling). Per-person clustering (PersonActivityCard) stays dropped
+              here: the cluster form was the source of the subject-stripped
+              "wording is weird" copy, and density now comes from visual quiet. */}
           {groupItemsByRecency(restRows).map((group) => (
             <Fragment key={group.key}>
               <FeedSectionHeading unifiedHome={unifiedHome}>{group.label}</FeedSectionHeading>


### PR DESCRIPTION
## Summary
Follow-up to #784 (already merged), which flattened the home feed by removing the "For You" / "From Friends" pinned sections. That went a touch too far — the playable milestone bundles read better pinned at the top. This restores **just** that one section.

## Changes
- **Pin a single "From Friends" section** at the top of the unified home feed, holding friends' playable triangle/milestone bundles (the up-to-5-triangle "match your friend's wins" cards).
- **Restore the section's rules:** capped at the 5 most-recent cards (`FROM_FRIENDS_COLLAPSED_COUNT`), with a **"View {n} more"** control revealing the rest in batches of 10 (`FROM_FRIENDS_STEP`).
- **Question cards are NOT pinned.** Unlike the original D-FEED split, the "For You" question-card tier does not come back — questions sent/broadcast to you stay in the flat recency stream alongside relationship events and promos.
- Re-introduces the `groupActivityByFriend` import (used as a pass-through for the pinned section, since milestone rows never group) and the `fromFriendsVisibleCount` view-state.

## Result
Net effect across #784 + this PR: the redundant "For You" tier is gone, but the "From Friends" playable section and its cap/pagination are back as before. Everything else renders as the calm full-sentence chronological stream.

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` (FeedList.tsx) — clean
- 65 feed/activity tests pass
- No `src/middleware.ts` (repo uses `src/proxy.ts`)

https://claude.ai/code/session_015xjpQpkGWfYAy9hav7nD6d

---
_Generated by [Claude Code](https://claude.ai/code/session_015xjpQpkGWfYAy9hav7nD6d)_