### PR TITLE
Home feed: deeper first page, no per-row timestamps, mark the first-five milestone

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,6 +21,10 @@ import { getFeedPagePayload } from '@/server/feed/get-feed-page'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 
 const FEED_PAGE_SIZE = 20
+// The home "What's Happening" feed leads with a deeper first page (the last ~30
+// items) and then pages in older rows on scroll. The prefetch limit matches the
+// FeedList pageSize so the seeded first page is full (no round-trip first paint).
+const HOME_FEED_PAGE_SIZE = 30
 
 export default async function Home() {
   const session = await getSession()
@@ -127,7 +131,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // prefetch matches FeedList's unifiedHome seeding for a no-round-trip paint.
   const [feedPage, activityItems, commonGroundPromo, recentlyExpandingPromo, addFriendsPromo] = await Promise.all([
     getFeedPagePayload(userId, {
-      limit: FEED_PAGE_SIZE,
+      limit: HOME_FEED_PAGE_SIZE,
       cursor: null,
       filter: 'all',
     }),
@@ -158,7 +162,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         What&rsquo;s happening
       </p>
       <FeedList
-        pageSize={FEED_PAGE_SIZE}
+        pageSize={HOME_FEED_PAGE_SIZE}
         infinite
         initialPage={feedPage}
         showContributeFooter

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -285,7 +285,10 @@ function feedMetadata(item: FeedApiItem, answered = false) {
   )
 }
 
-function baseTypedFields(item: FeedApiItem, answered = false) {
+// `hideTimestamp` blanks the relative "1d ago" on the home "What's Happening"
+// feed (unifiedHome), so its question cards match the timestamp-free activity
+// rows; the Broadcasts/Sent surfaces leave it on.
+function baseTypedFields(item: FeedApiItem, answered = false, hideTimestamp = false) {
   return {
     id: item.id,
     metadata: feedMetadata(item, answered),
@@ -296,13 +299,13 @@ function baseTypedFields(item: FeedApiItem, answered = false) {
     avatarName: item.source_friend_display_name,
     avatarUserId: item.source_user_id,
     authorHref: item.source_profile_href ?? profileHref(item.source_user_id),
-    timestamp: formatRelativeTime(item.source_event_at),
+    timestamp: hideTimestamp ? '' : formatRelativeTime(item.source_event_at),
     viewerIsAuthor: item.viewer_is_author === true,
   }
 }
 
-function toTypedFeedItem(item: FeedApiItem) {
-  const base = baseTypedFields(item)
+function toTypedFeedItem(item: FeedApiItem, hideTimestamp = false) {
+  const base = baseTypedFields(item, false, hideTimestamp)
 
   if (item.card_type === 'direct_sent') {
     return {
@@ -384,11 +387,12 @@ function pickPairedFriend(
 
 function toAnsweredByYouItem(
   item: FeedApiItem,
-  result?: ResultState
+  result?: ResultState,
+  hideTimestamp = false
 ): AnsweredByYouFeedItem {
   const masteryDeltaRaw = result?.masteryDelta ?? item.mastery_delta
   return {
-    ...baseTypedFields(item, true),
+    ...baseTypedFields(item, true, hideTimestamp),
     avatarName: null,
     avatarUserId: null,
     type: 'answered_by_you',
@@ -1508,6 +1512,9 @@ function FeedListContent({
           key={`a-${row.item.id}`}
           item={row.item}
           timestamp={formatRelativeTime(row.item.sortAt)}
+          // The home "What's Happening" feed reads calmer without the per-row
+          // "1d ago" ledger; the full /activities log keeps its timestamps.
+          showTimestamp={!unifiedHome}
         />
       )
     }
@@ -1577,7 +1584,7 @@ function FeedListContent({
     )
 
     if (isAnswered) {
-      const answeredItem = toAnsweredByYouItem(item, result)
+      const answeredItem = toAnsweredByYouItem(item, result, unifiedHome)
       const isIncorrect = answeredItem.isCorrect === false
       const recheckAction: FeedRecheckAction | null = isIncorrect
         ? { onSubmit: () => submitRecheck(item) }
@@ -1600,7 +1607,7 @@ function FeedListContent({
       )
     }
 
-    const typedItem = toTypedFeedItem(item)
+    const typedItem = toTypedFeedItem(item, unifiedHome)
     const dismissible = !item.viewer_is_author
     const onAnswer = dismissible ? () => setAnswerSheetId(item.id) : undefined
     const onDismiss = dismissible ? () => requestDismiss(item) : undefined

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -10,6 +10,8 @@
 // Shape vocabulary (Figma JOSHING-DESIGN-SYSTEM2 is the source for shape):
 //   bundle   → 2–2–1 cluster      a friend's questions for you (milestone).
 //                                 Unanswered = filled, answered = hollow outline.
+//   cluster  → 2–2–1 cluster, static + all-solid, scaled to line height: a
+//                                 friend played their first five (a settled set).
 //   diamond  → rhombus             someone answered ("got") a question.
 //   hourglass→ two triangles apex-to-apex   someone sends you a question.
 //   domain   → half-triangles split on a diagonal   a new domain opened.
@@ -55,6 +57,11 @@ const LINE_H = 22.5; // first text line: 15px × 1.5
 // was reverted; the fix for "too tall" is the scale + centering here, not the
 // geometry.)
 const LARGE_SCALE = 0.5;
+// The static 'cluster' mark (a friend's settled first five) reuses the tall
+// BundleMark (viewBox height 33) but shrinks it to ~the text line height
+// (33 × 0.7 ≈ 23 ≈ LINE_H) so it sits on a single-line row like the diamond,
+// instead of drooping the way the full milestone bundle does into its 2nd line.
+const CLUSTER_SCALE = 0.7;
 // Height of each half of a stacked mark, and the total viewBox height of the
 // pair. base=height (= MARK_W) keeps the triangles un-smushed.
 const STACK_HALF = 24;
@@ -69,6 +76,7 @@ const CAP_NUDGE = 3;
 
 export type ActivityIconSpec =
   | { kind: 'bundle'; total: number; unanswered: number }
+  | { kind: 'cluster' }
   | { kind: 'diamond' }
   | { kind: 'hourglass' }
   | { kind: 'domain' };
@@ -83,6 +91,8 @@ export function specForIcon(
   switch (icon) {
     case 'bundle':
       return bundle && bundle.total > 0 ? { kind: 'bundle', ...bundle } : null;
+    case 'cluster':
+      return { kind: 'cluster' };
     case 'diamond':
       return { kind: 'diamond' };
     case 'hourglass':
@@ -159,10 +169,15 @@ function BundleMark({
   total,
   unanswered,
   seed,
+  scale = 1,
 }: {
   total: number;
   unanswered: number;
   seed: string;
+  // The full milestone bundle renders at scale 1 (tall, growing down through the
+  // row's second line). The static 'cluster' mark passes a sub-1 scale so the
+  // same shape shrinks to roughly the single text line, matching the diamond.
+  scale?: number;
 }) {
   const B = 11; // triangle base
   const TH = 11; // triangle height — isosceles, base = height (not smushed)
@@ -175,7 +190,7 @@ function BundleMark({
     [13, 22],
   ];
   return (
-    <MarkSvg h={33}>
+    <MarkSvg h={33} scale={scale}>
       {pos.slice(0, total).map(([x, y], i) => {
         const solid = i < unanswered;
         return (
@@ -285,6 +300,11 @@ function Mark({ spec, seed }: { spec: ActivityIconSpec; seed: string }) {
   switch (spec.kind) {
     case 'bundle':
       return <BundleMark total={spec.total} unanswered={spec.unanswered} seed={seed} />;
+    case 'cluster':
+      // A friend's first five, settled: the bundle shape, all five solid, scaled
+      // down to line height so it reads as a quiet sibling of the diamond rather
+      // than the tall interactive milestone bundle.
+      return <BundleMark total={5} unanswered={5} seed={seed} scale={CLUSTER_SCALE} />;
     case 'diamond':
       return <DiamondMark seed={seed} />;
     case 'hourglass':

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -131,6 +131,7 @@ export function ActivityStreamItem({
   item,
   timestamp,
   nested = false,
+  showTimestamp = true,
 }: {
   item: StreamItem;
   timestamp: string;
@@ -138,6 +139,9 @@ export function ActivityStreamItem({
   // (the heading carries the only shape) and its hairline/padding chrome, so the
   // sub-items read as a quiet indented list under the statement.
   nested?: boolean;
+  // The home "What's Happening" feed hides the relative timestamp for a calmer,
+  // less ledger-like read; the full /activities log keeps it. Defaults on.
+  showTimestamp?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
@@ -318,10 +322,13 @@ export function ActivityStreamItem({
             gap: 4,
           }}
         >
-          {/* Metadata recedes to near-invisible (v2 §4): quiet, small timestamp. */}
-          <span style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap' }}>
-            {timestamp}
-          </span>
+          {/* Metadata recedes to near-invisible (v2 §4): quiet, small timestamp.
+              Hidden entirely on the home feed (showTimestamp=false). */}
+          {showTimestamp ? (
+            <span style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap' }}>
+              {timestamp}
+            </span>
+          ) : null}
           {/* Decorative disclosure chevron — demoted; the row itself is the
               button (aria-expanded above). */}
           {expandable ? (

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -118,11 +118,19 @@ export type StreamAction =
 //   - 'bundle'    → 2–2–1 cluster: a friend's questions for you (milestone).
 //                   Solid = unanswered, hollow = already played. Live count
 //                   comes from the row's answered-state; caps at 5 silently.
+//   - 'cluster'   → the bundle shape rendered static + all-solid at line size: a
+//                   friend played their first five (a settled set, not playable).
 //   - 'diamond'   → tan/darkyellow rhombus: someone answered ("got") a question.
 //   - 'hourglass' → orange/teal triangles apex-to-apex: someone sends you a Q.
 //   - 'domain'    → orange/teal half-triangles split on a diagonal: a new
 //                   domain opened (expansion).
-export type StreamIconKind = 'bundle' | 'diamond' | 'hourglass' | 'domain' | null;
+export type StreamIconKind =
+  | 'bundle'
+  | 'cluster'
+  | 'diamond'
+  | 'hourglass'
+  | 'domain'
+  | null;
 
 // An optional rich embed rendered inline beneath a row's one-liner. Almost no
 // rows carry one. The common-ground promo (homepage "What's happening" ONLY)
@@ -655,6 +663,10 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(' played their first five questions')],
         secondLine: null,
+        // A settled milestone: the static all-solid cluster mark (the bundle
+        // shape, not playable) so this row sits in the triangle family without
+        // borrowing the diamond the relationship rows use.
+        icon: 'cluster',
         action: null,
         expand: null,
       };


### PR DESCRIPTION
## Summary
Three home "What's Happening" feed refinements, riding on top of the merged #793 "From Friends" pinned section (this branch was rebased onto `dev2` so #793 is untouched in the base).

- **Deeper first page** — the home feed leads with the last ~30 items (`HOME_FEED_PAGE_SIZE`), then pages older rows in on scroll. The prefetch limit matches so the first paint stays round-trip-free. Independent of #793's "View 10 more" (that paginates only the pinned milestone section).
- **No per-row timestamps on the home feed** — hidden for both activity rows (new `showTimestamp` prop on `ActivityStreamItem`) and question cards (a `hideTimestamp` thread through the typed-item builders). The full `/activities` log keeps its timestamps.
- **Mark the "played their first five" milestone** — it rendered with no triangle. Added a distinct static `'cluster'` icon (the bundle shape, all-solid, scaled to line height) so it joins the triangle family without borrowing the relationship rows' diamond.

## Not included
- The "Between Friends" eyebrow from an earlier draft was dropped — redundant now that #793 adds a "From Friends" heading.

## Files
- `src/app/page.tsx` — `HOME_FEED_PAGE_SIZE = 30` for the home feed + its prefetch.
- `src/components/FeedList.tsx` — `hideTimestamp` threading; `showTimestamp={!unifiedHome}` on the activity row.
- `src/components/activity/ActivityStreamItem.tsx` — `showTimestamp` prop gating the timestamp.
- `src/components/activity/ActivityIcon.tsx` — new `'cluster'` spec/mark; `BundleMark` gains an optional `scale`.
- `src/lib/activity-stream.ts` — `'cluster'` added to `StreamIconKind`; the first-five milestone now carries it.

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` (touched files) — clean
- 88 activity/feed tests pass
- No `src/middleware.ts` (repo uses `src/proxy.ts`)

## Note vs reference screenshots
The reference images (the #793 result) still show per-row timestamps and an unmarked first-five row; with this branch the home feed differs in exactly those two ways — which is the intended change.

https://claude.ai/code/session_01FWcaFk65P1TDNgxd5Pn5Qd

---
_Generated by [Claude Code](https://claude.ai/code/session_01FWcaFk65P1TDNgxd5Pn5Qd)_