### PR TITLE
Move catch-up link into TodaysFiveCard play state

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -90,11 +90,10 @@ async function TodaysFiveSection({ userId }: { userId: string }) {
 
   const missedCount = catchupItems.length
   const expiringCount = catchupItems.filter((item) => item.expiresSoon).length
-  // Suppress the standalone Catch up card in the missed>0 completed state — the
-  // completed hero's Branch A already owns that entry point, so showing both
-  // would be a duplicate. When the round is still in progress (hero is in its
-  // play state, not Branch A), the standalone card stays.
-  const showStandaloneCatchup = missedCount > 0 && !status.isComplete
+  // The standalone Catch up card is suppressed entirely — when the round is in
+  // progress the TodaysFiveCard now shows a small catch-up link under the play
+  // button; when the round is complete, Branch A on the card owns that entry point.
+  const showStandaloneCatchup = false
 
   return (
     <>

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -332,12 +332,22 @@ export default function TodaysFiveCard({
           </Link>
         </div>
       ) : (
-        <Link
-          href={playHref}
-          className="btn-primary mt-4 min-h-12 w-full justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"
-        >
-          {actionLabel}
-        </Link>
+        <>
+          <Link
+            href={playHref}
+            className="btn-primary mt-4 min-h-12 w-full justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"
+          >
+            {actionLabel}
+          </Link>
+          {missedCount > 0 ? (
+            <Link
+              href="/daily/catchup"
+              className="mt-3 block text-sm font-medium text-[var(--brand-ink-400)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
+            >
+              Catch up &middot; {missedCount} missed {missedCount === 1 ? 'question' : 'questions'} &rarr;
+            </Link>
+          ) : null}
+        </>
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
Consolidates the catch-up entry point by moving the "Catch up" link into the `TodaysFiveCard` component when in play state, and removes the standalone catch-up card entirely. This reduces UI duplication and provides a more integrated experience.

## Changes
- **TodaysFiveCard.tsx**: Added a conditional catch-up link below the play button when `missedCount > 0`. The link displays the count of missed questions and routes to `/daily/catchup`.
- **page.tsx**: Disabled the standalone catch-up card by setting `showStandaloneCatchup = false` unconditionally. Updated the comment to reflect that the card is now suppressed entirely—the play-state link handles in-progress rounds, and Branch A on the card handles completed rounds.

## Implementation details
- The catch-up link uses the same styling pattern as other secondary actions (small text, underline, hover state) and sits below the primary play button with `mt-3` spacing.
- Pluralization of "question/questions" is handled based on `missedCount`.
- The link is wrapped in a Fragment to maintain the existing conditional structure and only renders when `missedCount > 0`.

https://claude.ai/code/session_013e7jvqpVpnyEHK3gcnPzsM