### PR TITLE
Redesign daily catchup recap to match Session-recap visual treatment

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -92,6 +92,9 @@ export default function DailyCatchupPage() {
           paddingBottom: currentItem && !showSummary
             ? 'calc(130px + env(safe-area-inset-bottom))'
             : 'calc(24px + env(safe-area-inset-bottom))',
+          // Cream backdrop on the recap so the near-white --brand-card recap cards
+          // read against the page, matching the daily Session-recap surface.
+          background: showSummary ? 'var(--brand-cream-page)' : undefined,
         }}
       >
         {loading ? (
@@ -164,6 +167,12 @@ export default function DailyCatchupPage() {
   );
 }
 
+// The Play Missed recap mirrors the daily Session-recap visual treatment
+// (src/app/daily/summary/page.tsx): the editorial Ink-on-Cream card, a colored
+// left accent bar, a status pill, the "You said / Answer" grid, the explainer,
+// and the creator's-note block. Both surfaces share the same palette already
+// (--surface → --brand-card, --text → --brand-ink); the recap just adopts the
+// brand tokens directly so the styling reads as one family.
 function RoundSummary({
   records,
   remainingCount,
@@ -182,109 +191,216 @@ function RoundSummary({
   const hasMore = remainingCount > 0;
 
   return (
-    <div className="mt-1">
-      <header className="mb-4">
-        <p className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--success)]">Round complete</p>
-        <h2 className="mt-2 font-serif text-2xl font-semibold text-[var(--text)]">How you did</h2>
-        <p className="mt-1 text-sm text-[var(--text-muted)]">
-          {correct}/{total} correct
-          {hasMore ? ` - ${remainingCount} still to catch up` : ''}
+    <div className="mx-auto max-w-3xl text-[var(--brand-ink)]">
+      <header className="pb-2">
+        <p className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--game-correct)]">
+          Round complete
         </p>
+        <div className="mt-3 flex items-start justify-between gap-4">
+          <div>
+            <h2 className="font-serif text-[2.25rem] leading-[0.95] tracking-[-0.03em] text-[var(--brand-ink)]">
+              How you did
+            </h2>
+            <p className="mt-3 max-w-xl text-[1.02rem] leading-7 text-[var(--brand-ink-700)]">
+              {hasMore
+                ? `You worked through ${total}. ${remainingCount} still waiting to be cleared.`
+                : 'You cleared the questions you had missed.'}
+            </p>
+          </div>
+          <p
+            className="shrink-0 pt-2 text-sm font-medium text-[var(--brand-ink-400)]"
+            aria-label={`${correct} out of ${total} correct`}
+          >
+            {correct} / {total}
+          </p>
+        </div>
+        <div className="mt-5">
+          <CatchupResultDots records={records} />
+        </div>
       </header>
 
-      <div className="space-y-3">
+      <div className="mt-8 space-y-4">
         {records.map((record, index) => (
           <RoundRecapCard key={`${record.questionId}-${index}`} record={record} />
         ))}
       </div>
 
-      <div className="mt-6 flex flex-col gap-3">
-        {hasMore ? (
-          <button type="button" className="btn-primary" onClick={onPlayNext}>
-            Play the next {nextBatchSize}
+      <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-6 text-center">
+        <p className="text-[1.05rem] leading-7 text-[var(--brand-ink-700)]">
+          {hasMore
+            ? `${remainingCount} still waiting whenever you’re ready.`
+            : 'You’re all caught up.'}
+        </p>
+        <div className="mt-5 flex flex-col items-center gap-3">
+          {hasMore ? (
+            <button
+              type="button"
+              className="btn-primary w-full rounded-full sm:w-auto sm:min-w-56"
+              onClick={onPlayNext}
+            >
+              Play the next {nextBatchSize}
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className={
+              hasMore
+                ? 'text-muted-foreground text-sm font-medium underline underline-offset-4 transition hover:text-foreground'
+                : 'btn-primary w-full rounded-full sm:w-auto sm:min-w-56'
+            }
+            onClick={onHome}
+          >
+            Return home
           </button>
-        ) : null}
-        <button type="button" className={hasMore ? 'btn-ghost' : 'btn-primary'} onClick={onHome}>
-          Return home
-        </button>
-      </div>
+        </div>
+      </section>
     </div>
   );
 }
 
-const RECAP_TONE = {
-  correct: {
-    label: 'CORRECT',
-    border: 'color-mix(in srgb, var(--success) 30%, var(--border))',
-    background: 'color-mix(in srgb, var(--success) 8%, var(--surface-2))',
-    accent: 'var(--success)',
-  },
-  wrong: {
-    label: 'Not this time',
-    border: 'var(--border)',
-    background: 'color-mix(in srgb, var(--muted) 42%, var(--surface-2))',
-    accent: 'var(--text-muted)',
-  },
-  revealed: {
-    label: 'REVEALED',
-    border: 'var(--border)',
-    background: 'var(--surface-2)',
-    accent: 'var(--text-muted)',
-  },
-} as const;
+function CatchupResultDots({ records }: { records: CatchupBatchRecord[] }) {
+  return (
+    <div className="flex items-center gap-2" aria-label="Question results">
+      {records.map((record, index) => (
+        <span
+          key={`${record.questionId}-${index}`}
+          className="size-2.5 rounded-full border"
+          style={{
+            backgroundColor:
+              record.outcome === 'revealed'
+                ? 'color-mix(in srgb, var(--brand-ink) 24%, transparent)'
+                : record.outcome === 'correct'
+                  ? 'color-mix(in srgb, var(--game-correct) 88%, var(--brand-card))'
+                  : 'color-mix(in srgb, var(--game-wrong) 78%, var(--brand-card))',
+            borderColor: 'color-mix(in srgb, var(--brand-border) 72%, transparent)',
+            boxShadow: '0 0 0 2px var(--brand-card)',
+          }}
+          aria-label={`Question ${index + 1}: ${
+            record.outcome === 'revealed'
+              ? 'revealed'
+              : record.outcome === 'correct'
+                ? 'correct'
+                : 'not this time'
+          }`}
+        />
+      ))}
+    </div>
+  );
+}
 
 function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
-  const tone = RECAP_TONE[record.outcome];
-  const yourAnswer = record.outcome === 'revealed'
+  const [isExplainerOpen, setIsExplainerOpen] = useState(false);
+
+  const isCorrect = record.outcome === 'correct';
+  const isRevealed = record.outcome === 'revealed';
+  const statusLabel = isCorrect ? 'Correct' : isRevealed ? 'Revealed' : 'Not this time';
+  const accentColor = isRevealed
+    ? 'color-mix(in srgb, var(--brand-ink) 26%, var(--brand-card))'
+    : isCorrect
+      ? 'var(--game-correct)'
+      : 'color-mix(in srgb, var(--game-wrong) 76%, var(--brand-card))';
+  const yourAnswer = isRevealed
     ? 'You asked to see the answer'
     : record.submittedAnswer?.trim() || 'No answer submitted';
+  const creatorNoteLabel = record.authorName
+    ? `${record.authorName.split(/\s+/)[0]}’s note`
+    : record.authorIsHouse
+      ? 'Editor’s note'
+      : 'Creator’s note';
 
   return (
-    <article
-      className="rounded-[var(--radius-md)] border p-4"
-      style={{ borderColor: tone.border, background: tone.background, borderLeft: `3px solid ${tone.accent}` }}
-    >
-      <div className="flex flex-wrap items-center gap-2">
+    <article className="relative overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] p-5 shadow-none">
+      <div className="absolute inset-y-0 left-0 w-1" style={{ backgroundColor: accentColor }} />
+
+      <div className="flex flex-wrap items-center gap-2 pl-1">
         <span
-          className="rounded-sm border px-2 py-1 text-[0.6rem] font-semibold tracking-[0.08em]"
-          style={{ borderColor: tone.border, color: tone.accent }}
+          className="rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold tracking-[0.05em]"
+          style={{
+            borderColor: isCorrect
+              ? 'color-mix(in srgb, var(--game-correct) 28%, var(--brand-border))'
+              : 'var(--brand-border)',
+            backgroundColor: isCorrect
+              ? 'color-mix(in srgb, var(--game-correct) 8%, var(--brand-card))'
+              : 'color-mix(in srgb, var(--brand-cream-page) 62%, var(--brand-card))',
+            color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink-700)',
+          }}
         >
-          {tone.label}
+          {statusLabel}
         </span>
-        <span className="text-[0.6rem] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">
-          {record.authorName ? `From ${record.authorName}` : record.domainDisplayName}
-        </span>
+        <p className="text-xs leading-5 text-[var(--brand-ink-400)]">
+          <span>{record.domainDisplayName}</span>
+          {record.authorName ? (
+            <>
+              <span aria-hidden="true"> · </span>
+              <span>by {record.authorName}</span>
+            </>
+          ) : null}
+        </p>
       </div>
 
-      <p className="mt-3 font-medium leading-snug text-[var(--text)]">{record.questionText}</p>
+      <p className="mt-4 pl-1 text-[1.12rem] leading-7 font-medium tracking-[-0.01em] text-[var(--brand-ink)]">
+        {record.questionText}
+      </p>
 
-      <div className="mt-3 space-y-1 text-sm text-[var(--text-muted)]">
-        <p>
-          <span className="font-medium text-[var(--text)]">You:</span> {yourAnswer}
-        </p>
-        <p>
-          <span className="font-medium text-[var(--text)]">Answer:</span> {record.correctAnswer || 'No answer available'}
-        </p>
+      <div className="mt-5 grid gap-3 rounded-md border border-[var(--brand-border)] bg-[var(--brand-cream-page)] p-3 sm:grid-cols-2">
+        <div>
+          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            You said
+          </p>
+          <p className="mt-1 text-sm leading-6 text-[var(--brand-ink)]">{yourAnswer}</p>
+        </div>
+        <div className="border-t border-[var(--brand-border)] pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-3">
+          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            Answer
+          </p>
+          <p
+            className="mt-1 text-sm leading-6 font-medium"
+            style={{ color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink)' }}
+          >
+            {record.correctAnswer || 'No answer available'}
+          </p>
+        </div>
       </div>
 
       {record.explanation ? (
-        <p className="mt-3 rounded-[var(--radius-sm)] px-3 py-2 text-sm leading-6 text-[var(--text-muted)]" style={{ background: 'color-mix(in srgb, var(--border) 18%, var(--surface))' }}>
-          {record.explanation}
-        </p>
+        <section className="mt-5 pl-1">
+          <h3 className="text-sm font-semibold text-[var(--brand-ink)]">
+            Why this is the answer
+          </h3>
+          <p
+            className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]"
+            style={
+              isExplainerOpen
+                ? undefined
+                : {
+                    display: '-webkit-box',
+                    WebkitLineClamp: 3,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }
+            }
+          >
+            {record.explanation}
+          </p>
+          {!isExplainerOpen ? (
+            <button
+              type="button"
+              onClick={() => setIsExplainerOpen(true)}
+              className="mt-2 text-sm font-medium text-[var(--brand-link)] underline underline-offset-4"
+            >
+              More context →
+            </button>
+          ) : null}
+        </section>
       ) : null}
+
       {/* The fuller creator note the live thread defers to keep its momentum —
           surfaced here in the recap so it is never lost. */}
       {record.authorNote ? (
-        <p className="mt-3 rounded-[var(--radius-sm)] border p-3 text-sm leading-6 text-[var(--text)]" style={{ borderColor: 'var(--border)', background: 'color-mix(in srgb, var(--border) 12%, var(--surface))' }}>
-          <span className="font-medium">
-            {record.authorIsHouse
-              ? 'Editor’s note:'
-              : record.authorName
-                ? `${record.authorName}’s note`
-                : 'Their note'}
-          </span>{' '}
-          {record.authorNote}
-        </p>
+        <section className="mt-5 rounded-md border border-[var(--brand-border)] bg-[var(--brand-cream-page)] px-4 py-3">
+          <h3 className="text-sm font-semibold text-[var(--brand-ink)]">{creatorNoteLabel}</h3>
+          <p className="mt-1 text-sm leading-6 text-[var(--brand-ink-700)]">{record.authorNote}</p>
+        </section>
       ) : null}
     </article>
   );


### PR DESCRIPTION
Refactors the "Play Missed" recap summary to adopt the Ink-on-Cream design system and visual language of the daily Session-recap surface, creating a cohesive editorial experience across both surfaces.

## Summary
The catchup recap now mirrors the Session-recap's design treatment: cream backdrop, brand color tokens, left accent bars, status pills, structured "You said / Answer" grids, expandable explainers, and creator's-note blocks. Both surfaces now share the same palette (`--surface` → `--brand-card`, `--text` → `--brand-ink`) and read as one design family.

## Key changes
- **Page background:** Added cream backdrop (`--brand-cream-page`) when summary is shown, matching the Session-recap surface
- **RoundSummary header redesign:**
  - Larger, serif headline (2.25rem) with tighter leading and tracking
  - Restructured layout with flex row: headline/description on left, score pill on right
  - Added `CatchupResultDots` component showing visual indicator dots for each question outcome
  - Updated copy to be more conversational ("You worked through X. Y still waiting…")
- **RoundRecapCard refactor:**
  - Replaced `RECAP_TONE` object with inline color logic using brand tokens
  - Left accent bar (absolute positioned) instead of left border
  - Rounded status pill with conditional styling (green for correct, neutral for others)
  - Restructured metadata: domain + author on single line with separator
  - "You said / Answer" grid with cream background, responsive (stacked on mobile, 2-col on desktop)
  - New "Why this is the answer" section with expandable explainer (3-line clamp, "More context →" button)
  - Creator's note in branded card with semantic heading
- **CatchupResultDots component:** New visual indicator showing outcome for each question (correct/wrong/revealed) with appropriate colors and accessibility labels
- **Call-to-action section:** Moved buttons into a branded card container with centered layout and responsive button sizing

## Implementation details
- Uses brand color tokens throughout (`--brand-ink`, `--brand-card`, `--brand-cream-page`, `--game-correct`, `--game-wrong`)
- Maintains accessibility with proper ARIA labels and semantic HTML
- Responsive design: mobile-first with `sm:` breakpoints for desktop layout
- Explainer text uses `-webkit-line-clamp` for graceful truncation with expand affordance

https://claude.ai/code/session_01QQpuU8BDi988JprPzc9vUY