### PR TITLE
Simplify elevated feed card styling: remove hard ink shadow

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1621,6 +1621,9 @@ function FeedListContent({
     const onAnswer = dismissible ? () => setAnswerSheetId(item.id) : undefined
     const onDismiss = dismissible ? () => requestDismiss(item) : undefined
 
+    // On the home "What's Happening" feed these answerable question cards are
+    // the playable rows, interleaved with flat activity one-liners — give them
+    // the Tier 1 lift (cream fill + stroke + drop shadow) so they step forward.
     let card: ReactNode
     if (typedItem.type === 'direct_sent') {
       card = (
@@ -1629,6 +1632,7 @@ function FeedListContent({
           overflow={overflow}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
+          elevated={unifiedHome}
         />
       )
     } else if (typedItem.type === 'friend_liked') {
@@ -1638,6 +1642,7 @@ function FeedListContent({
           overflow={overflow}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
+          elevated={unifiedHome}
         />
       )
     } else {
@@ -1648,6 +1653,7 @@ function FeedListContent({
           onAnswer={onAnswer}
           onDismiss={onDismiss}
           onHideCategory={() => void hideCategory(item)}
+          elevated={unifiedHome}
         />
       )
     }

--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -17,13 +17,12 @@ const FEED_CARD_RADIUS = 'rounded-[4px]'
 const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
 
 // Elevated ("playable" / Tier 1) treatment for the unified home feed
-// (D-FEED-TIER): the warm pale-cream fill of the real answer card, plus a hard
-// INK offset shadow — the app's native "liftable object" vocabulary (see
-// ShareCard / OverlapMap) — so a playable row visibly steps forward off the
-// cream while the ambient one-liners stay flat. Zero new tokens. The hairline
-// border stays, defining the edge so the offset reads as a deliberate lift.
+// (D-FEED-TIER): the warm light-cream question fill, kept on the same hairline
+// stroke and soft drop shadow as every other card. On the home feed the
+// ambient activity rows render as flat one-liners (no card), so a cream card
+// with a stroke + lift visibly steps forward as the thing you can play, while
+// the chatter stays quiet text. Zero new tokens.
 const FEED_CARD_ELEVATED_FILL = 'bg-[var(--game-card-question)]'
-const FEED_CARD_ELEVATED_SHADOW = 'shadow-[2px_2px_0_var(--brand-ink)]'
 
 export type FeedCardShellProps = {
   children: ReactNode
@@ -39,9 +38,11 @@ export type FeedCardShellProps = {
    */
   variant?: 'bordered' | 'triangle'
   /**
-   * Tier 1 "playable" lift for the unified home feed: pale-cream fill + hard INK
-   * offset shadow so the card steps forward. Defaults to false (the standalone
-   * Feed tab and answered/result cards keep the soft resting chrome).
+   * Tier 1 "playable" lift for the unified home feed: the warm light-cream
+   * question fill (on the same hairline stroke + soft drop shadow as every
+   * card) so a playable card steps forward off the cream while the ambient
+   * activity one-liners stay flat. Defaults to false (the standalone Feed tab
+   * and answered/result cards keep the near-white resting fill).
    */
   elevated?: boolean
 }
@@ -71,9 +72,9 @@ export function FeedCardShell({
         className={cn(
           "overflow-hidden bg-[url('/images/Variant4.png')] bg-[length:300px_auto] bg-center p-3",
           FEED_CARD_RADIUS,
-          // The whole matted card lifts on the offset shadow (mat image intact);
-          // the inset panel below carries the warm cream fill.
-          elevated ? FEED_CARD_ELEVATED_SHADOW : FEED_CARD_SHADOW,
+          // The whole matted card carries the soft drop shadow (mat image
+          // intact); the inset panel below carries the warm cream fill.
+          FEED_CARD_SHADOW,
           className,
         )}
       >
@@ -97,7 +98,7 @@ export function FeedCardShell({
         'relative overflow-hidden border border-[var(--brand-rule)]',
         elevated ? FEED_CARD_ELEVATED_FILL : 'bg-[var(--brand-card)]',
         FEED_CARD_RADIUS,
-        elevated ? FEED_CARD_ELEVATED_SHADOW : FEED_CARD_SHADOW,
+        FEED_CARD_SHADOW,
         className,
       )}
     >

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -489,28 +489,32 @@ describe('FeedCardShell (shared C7 shell)', () => {
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
   })
 
-  it('lifts the bordered card with cream fill + hard ink offset when elevated', () => {
+  it('lifts the bordered card with cream fill on the soft drop shadow + hairline stroke when elevated', () => {
     const rendered = html(
       <FeedCardShell elevated accentColor="#abc123">
         <p>body</p>
       </FeedCardShell>
     )
     expect(rendered).toContain('bg-[var(--game-card-question)]')
-    expect(rendered).toContain('shadow-[2px_2px_0_var(--brand-ink)]')
+    // Same soft drop shadow as every card — the cream fill + stroke do the lift.
+    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
     // The hairline border stays, defining the lifted card's edge.
     expect(rendered).toContain('border-[var(--brand-rule)]')
+    // No hard ink offset shadow.
+    expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     expect(rendered).not.toContain('bg-[var(--brand-card)]')
   })
 
-  it('lifts the triangle variant via the mat offset + cream inner panel when elevated', () => {
+  it('lifts the triangle variant with the soft drop shadow + cream inner panel when elevated', () => {
     const rendered = html(
       <FeedCardShell variant="triangle" elevated>
         <p>body</p>
       </FeedCardShell>
     )
-    // Mat image intact; the whole matted card lifts on the offset shadow.
+    // Mat image intact; the matted card carries the soft drop shadow.
     expect(rendered).toContain('/images/Variant4.png')
-    expect(rendered).toContain('shadow-[2px_2px_0_var(--brand-ink)]')
+    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     // Inner panel carries the warm cream fill instead of brand-card.
     expect(rendered).toContain('bg-[var(--game-card-question)]')
     expect(rendered).not.toContain('bg-[var(--brand-card)]')


### PR DESCRIPTION
## Summary
Refactors the elevated feed card treatment to use a simpler visual hierarchy. Instead of the previous "hard ink offset shadow" approach, elevated cards now rely on the warm light-cream fill combined with the hairline stroke and standard soft drop shadow to visually step forward from the ambient activity one-liners.

## Changes
- **Remove hard ink offset shadow constant** (`FEED_CARD_ELEVATED_SHADOW`) and its usage in `FeedCardShell.tsx`
- **Unify shadow treatment**: all cards (elevated and default) now use the same soft drop shadow (`FEED_CARD_SHADOW`), eliminating the conditional shadow logic
- **Apply elevated styling to home feed**: pass `elevated={unifiedHome}` prop to answerable question cards (`DirectSentCard`, `FriendLikedCard`, `AnswerableCard`) in the unified home feed, so they visually distinguish themselves from flat activity one-liners
- **Update documentation**: clarify in comments and JSDoc that the lift comes from the cream fill + hairline stroke + soft shadow combination, not from an offset shadow
- **Update tests**: verify that elevated cards use the standard soft drop shadow (not the hard ink shadow) and contain the cream fill + hairline border

## Implementation Details
The visual hierarchy on the home "What's Happening" feed now works by:
1. Ambient activity rows render as flat one-liners (no card container)
2. Answerable question cards get the cream fill + hairline stroke + soft drop shadow, making them step forward as the playable interactive elements
3. No new design tokens required — reuses existing `--game-card-question` fill and standard shadow

This simplifies the component API and reduces visual complexity while maintaining clear affordance that question cards are the interactive focal points.

https://claude.ai/code/session_01JqxpmVcfTR9su2KzttMxQV