### PR TITLE
Append cluster categories to topic-less convergence headlines

### DIFF
--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -39,14 +39,22 @@ function topicsOf(rows: StreamItem[]): string[] {
   return out;
 }
 
-// The human predicate of a convergence caption ("keep landing in the same
-// place") with the "You and {Name}" lead stripped — the cluster header already
-// names the pair, so the echo is removed (v2 §3).
+// The human predicate of a convergence caption ("keep landing in the same place
+// — Cubism, Geography") with the "You and {Name}" lead stripped — the cluster
+// header already names the pair, so the echo is removed (v2 §3). Everything
+// after the actor is kept, including the serif category tail, so the folded
+// line carries the same WHAT the ungrouped headline does.
 function convergencePredicate(row: StreamItem): string {
   const parts = row.line;
   const actorIdx = parts.findIndex((p) => p.t === 'actor');
-  const after = parts.slice(actorIdx + 1).find((p) => p.t === 'text');
-  if (after && 'v' in after && after.v.trim()) return after.v.trim();
+  if (actorIdx !== -1) {
+    const tail = parts
+      .slice(actorIdx + 1)
+      .map((p) => ('v' in p ? p.v : ''))
+      .join('')
+      .trim();
+    if (tail) return tail;
+  }
   const before = [...parts.slice(0, actorIdx)].reverse().find((p) => p.t === 'text');
   if (before && 'v' in before) {
     const stripped = before.v.replace(/\b(you\s+and|and)\s*$/i, '').trim();

--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -64,18 +64,32 @@ function build() {
 }
 
 describe('convergenceToStreamItem — person-first, Home-eligible, read-only', () => {
-  it('builds a person-first headline that names no domain', () => {
+  it('builds a person-first headline with the cluster categories appended', () => {
     const item = build();
-    // The friend is an actor (link) part; the rest is plain copy. No domain
-    // ever reaches the headline (no `category` part, no domain string).
+    // The friend is an actor (link) part; the rest is plain copy. With a
+    // topic-less caption the distinct cluster categories are appended as serif
+    // `category` parts so the line says WHAT you converged on.
     const actorPart = item.line.find((p) => p.t === 'actor');
     expect(actorPart).toMatchObject({ name: 'Robyn', userId: 'friend-1' });
-    expect(item.line.some((p) => p.t === 'category')).toBe(false);
+    const categories = item.line.filter((p) => p.t === 'category').map((p) => ('v' in p ? p.v : ''));
+    expect(categories).toEqual(['Cubism', 'Geography', 'Composers']);
     const headlineText = item.line.map((p) => ('v' in p ? p.v : p.name)).join('');
-    expect(headlineText).toBe('You and Robyn keep landing in the same place.');
-    for (const q of QUESTIONS) {
-      expect(headlineText).not.toContain(q.domain);
-    }
+    expect(headlineText).toBe(
+      'You and Robyn keep landing in the same place — Cubism, Geography, Composers',
+    );
+  });
+
+  it('does not re-list categories when the cluster shares one topic (single-topic pool)', () => {
+    // Single-topic pool already names its one topic inline via `{topic}`, so the
+    // tail must not duplicate it.
+    const item = convergenceToStreamItem(
+      CONVERGENCE,
+      QUESTIONS,
+      'You and {Name} both know {topic} down',
+      'Cubism',
+    );
+    const categories = item.line.filter((p) => p.t === 'category').map((p) => ('v' in p ? p.v : ''));
+    expect(categories).toEqual(['Cubism']);
   });
 
   it('is Home-eligible (surfaces alongside the triangle rows) and read-only', () => {
@@ -94,7 +108,7 @@ describe('convergenceToStreamItem — person-first, Home-eligible, read-only', (
 });
 
 describe('ActivityStreamItem — collapsed convergence one-liner', () => {
-  it('renders the person-first line, no expand label, questions hidden', () => {
+  it('renders the person-first line with categories, no expand label, questions hidden', () => {
     const html = renderToStaticMarkup(
       <ActivityStreamItem item={build()} timestamp="2:00 PM" />,
     );
@@ -106,8 +120,8 @@ describe('ActivityStreamItem — collapsed convergence one-liner', () => {
     expect(html).not.toContain('+ QUESTIONS');
     // Collapsed: the cluster questions are NOT shown yet.
     expect(html).not.toContain('Who painted Guernica');
-    // No domain leaks into the collapsed headline.
-    expect(html).not.toContain('Cubism');
+    // The categories DO surface in the collapsed headline so it means something.
+    expect(html).toContain('Cubism');
   });
 });
 

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -821,8 +821,9 @@ export function convergenceToStreamItem(
   sharedTopic: string | null = null,
 ): StreamItem {
   // Person-first headline: `{Name}` → the friend actor link, `{topic}` → the
-  // serif category (only present in the single-topic pool). No domain ever
-  // reaches the line unless it's the one shared topic.
+  // serif category (only present in the single-topic pool). When the cluster's
+  // topics differ (topic-less pool), the distinct categories are appended as a
+  // serif tail below so the line still says what you converged on.
   const line: StreamLinePart[] = [];
   const re = /\{(Name|topic)\}/g;
   let last = 0;
@@ -837,6 +838,38 @@ export function convergenceToStreamItem(
     last = re.lastIndex;
   }
   if (last < captionTemplate.length) line.push(txt(captionTemplate.slice(last)));
+
+  // Topic-less pool (3b): the headline names no single domain, so on its own the
+  // line ("…keep landing in the same place") says nothing about WHAT you and the
+  // friend converged on. Append the cluster's distinct categories as a quiet
+  // serif tail so the overlap is legible. (The single-topic pool already names
+  // its one topic inline, so when `sharedTopic` is set we add nothing here.)
+  if (!sharedTopic) {
+    const seen = new Set<string>();
+    const categories: string[] = [];
+    for (const q of questions) {
+      const d = q.domain?.trim();
+      if (d && !seen.has(d)) {
+        seen.add(d);
+        categories.push(d);
+      }
+    }
+    if (categories.length) {
+      // Drop a trailing period on the predicate so the tail reads
+      // "…same place — A, B, C" rather than "…same place. — A, B, C".
+      const tailIdx = line.length - 1;
+      const tailPart = line[tailIdx];
+      if (tailPart && tailPart.t === 'text') {
+        line[tailIdx] = txt(tailPart.v.replace(/\.\s*$/, ''));
+      }
+      line.push(txt(' — '));
+      categories.forEach((c, i) => {
+        if (i > 0) line.push(txt(', '));
+        line.push(cat(c));
+      });
+    }
+  }
+
   return {
     id: convergence.id,
     sortAt: convergence.sortAt,


### PR DESCRIPTION
## Summary
When a convergence cluster has no single shared topic (topic-less pool), the headline "You and {Name} keep landing in the same place" is ambiguous about *what* was converged on. This change appends the cluster's distinct categories as a serif tail so the line reads "…same place — Cubism, Geography, Composers" and the overlap becomes legible.

## Key Changes
- **activity-stream.ts**: Added logic to append distinct cluster categories as a quiet serif tail when `sharedTopic` is null. The tail is only added for topic-less pools; single-topic pools already name their topic inline via `{topic}` and skip the tail to avoid duplication. Trailing periods are stripped from the predicate so the tail reads naturally with an em-dash separator.

- **ConvergenceStreamItem.test.tsx**: Updated test expectations to verify categories surface in the collapsed headline. The test now confirms that topic-less pools show "You and Robyn keep landing in the same place — Cubism, Geography, Composers" and that single-topic pools do not duplicate their shared topic in the tail.

- **PersonActivityCard.tsx**: Modified `convergencePredicate()` to preserve the entire tail after the actor (including category parts), not just the first text part. This ensures the folded line in grouped views carries the same semantic weight as the ungrouped headline.

## Implementation Details
- Categories are deduplicated via a `Set` and collected in order of first appearance in the questions array.
- The em-dash separator (`—`) is added as a text part between the predicate and categories for proper styling.
- Category parts are rendered as `cat()` parts (matching the existing `category` part type) so they inherit serif styling from the design system.

https://claude.ai/code/session_01NPHsNmjxud3GA8K19msRCp