### PR TITLE
feed: centered star — announcement — star for the "invited friend played first five" row

### DIFF
--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -269,6 +269,17 @@ function StarMark({ seed }: { seed: string }) {
   );
 }
 
+// The same five-point star, used as a flanking flourish on each side of the
+// centered "played their first five" announcement (star — line — star) rather
+// than in the left icon column. Decorative; the row copy carries the meaning.
+export function MilestoneStar({ seed }: { seed: string }) {
+  return (
+    <span aria-hidden style={{ display: 'flex', flexShrink: 0 }}>
+      <StarMark seed={seed} />
+    </span>
+  );
+}
+
 // Rhombus: upward triangle over downward triangle, shared base. Each half a
 // random palette colour.
 function DiamondMark({ seed }: { seed: string }) {

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -16,7 +16,7 @@ import type {
 
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
-import { ActivityIcon, QuestionTriangle, specForIcon } from './ActivityIcon';
+import { ActivityIcon, MilestoneStar, QuestionTriangle, specForIcon } from './ActivityIcon';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
 import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
@@ -213,6 +213,14 @@ export function ActivityStreamItem({
       : null;
   const iconSpec = specForIcon(item.icon, bundleCounts);
 
+  // The "invited friend played their first five" star is a celebratory
+  // announcement, not a normal left-aligned event row: it renders centered with
+  // a star flourish on each side (star — line — star) instead of a single mark
+  // in the left icon column. It carries no action/expansion/second line, so the
+  // centered branch is a self-contained one-liner. Nested rows keep the plain
+  // indented form.
+  const centeredStar = !nested && item.icon === 'star';
+
   function toggle() {
     if (expandable) setOpen((v) => !v);
   }
@@ -258,11 +266,33 @@ export function ActivityStreamItem({
         onKeyDown={handleKeyDown}
         style={{
           display: 'flex',
-          alignItems: 'flex-start',
+          alignItems: centeredStar ? 'center' : 'flex-start',
+          justifyContent: centeredStar ? 'center' : undefined,
+          gap: centeredStar ? 10 : undefined,
           cursor: expandable ? 'pointer' : 'default',
           WebkitTapHighlightColor: 'transparent',
         }}
       >
+        {centeredStar ? (
+          // Celebratory announcement: star — centered line — star.
+          <>
+            <MilestoneStar seed={item.id} />
+            <p
+              style={{
+                margin: 0,
+                fontSize: 15,
+                lineHeight: 1.5,
+                letterSpacing: 0.2,
+                color: INK,
+                textAlign: 'center',
+              }}
+            >
+              <Line parts={item.line} />
+            </p>
+            <MilestoneStar seed={item.id} />
+          </>
+        ) : (
+          <>
         {/* Nested rows carry no shape — the per-person heading holds the one
             diamond; everything beneath it is a plain indented line. */}
         {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} />}
@@ -344,6 +374,8 @@ export function ActivityStreamItem({
             />
           ) : null}
         </div>
+          </>
+        )}
       </div>
 
       {item.action ? <ItemAction action={item.action} /> : null}


### PR DESCRIPTION
## What

The **"someone you invited played their first five questions"** row (`invited_friend_played_first_five`) now reads as a centered, celebratory announcement instead of a normal left-aligned event row.

1. **Icon** — a five-point star built from five palette triangles (one point per question), replacing the old bundle-cluster shape that blurred into the rest of the triangle-mark family. Single layer, five points — not a hexagram.
2. **Layout** — the row is centered with a star flourish on **each** side: ★ — *Shanea played their first five questions* — ★.

## Changes

- `src/lib/activity-stream.ts` — renames the `StreamIconKind` `cluster → star` (this row was its only consumer); copy unchanged (gender-neutral "their").
- `src/components/activity/ActivityIcon.tsx` — new `StarMark` plus an exported `MilestoneStar` flourish for the flanking stars.
- `src/components/activity/ActivityStreamItem.tsx` — special-cases the `star` icon: centered flex, star / centered line / star. The row carries no action, second line, or expansion, so the centered branch is a self-contained one-liner. All other rows and nested rows are untouched.

## Notes

- Supersedes the earlier PRs for this work (#803, #807), which carried interim states of the same change.
- Tunable in `ActivityIcon.tsx`: `STAR_SCALE` (size), `STAR_INNER_RATIO` (point sharpness), and the `gap` between star and text in `ActivityStreamItem.tsx`.

https://claude.ai/code/session_013x3TyHyVKXsgxdpQWUH4aq

---
_Generated by [Claude Code](https://claude.ai/code/session_013x3TyHyVKXsgxdpQWUH4aq)_