### PR TITLE
Make playable home-feed cards stand out with a stronger lift

### DIFF
--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -17,12 +17,16 @@ const FEED_CARD_RADIUS = 'rounded-[4px]'
 const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
 
 // Elevated ("playable" / Tier 1) treatment for the unified home feed
-// (D-FEED-TIER): the warm light-cream question fill, kept on the same hairline
-// stroke and soft drop shadow as every other card. On the home feed the
-// ambient activity rows render as flat one-liners (no card), so a cream card
-// with a stroke + lift visibly steps forward as the thing you can play, while
-// the chatter stays quiet text. Zero new tokens.
+// (D-FEED-TIER): the warm light-cream question fill, a visible — but still
+// light — warm-ink stroke, and a deeper soft drop shadow than the ambient
+// cards carry. On the home feed the activity rows render as flat one-liners
+// (no card), so a playable question card needs more than a 4% lift to read as
+// the thing you can play; the stronger stroke + shadow make it step forward
+// off the cream while the chatter stays quiet text. Shares the shadow color
+// (#28201E warm ink) with the resting cards, just at a higher opacity.
 const FEED_CARD_ELEVATED_FILL = 'bg-[var(--game-card-question)]'
+const FEED_CARD_ELEVATED_STROKE = 'border-[rgba(40,32,30,0.22)]'
+const FEED_CARD_ELEVATED_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.10)]'
 
 export type FeedCardShellProps = {
   children: ReactNode
@@ -39,10 +43,10 @@ export type FeedCardShellProps = {
   variant?: 'bordered' | 'triangle'
   /**
    * Tier 1 "playable" lift for the unified home feed: the warm light-cream
-   * question fill (on the same hairline stroke + soft drop shadow as every
-   * card) so a playable card steps forward off the cream while the ambient
-   * activity one-liners stay flat. Defaults to false (the standalone Feed tab
-   * and answered/result cards keep the near-white resting fill).
+   * question fill + a visible warm-ink stroke + a deeper drop shadow than the
+   * ambient cards, so a playable card clearly steps forward off the cream while
+   * the activity one-liners stay flat. Defaults to false (the standalone Feed
+   * tab and answered/result cards keep the near-white resting fill + hairline).
    */
   elevated?: boolean
 }
@@ -72,9 +76,10 @@ export function FeedCardShell({
         className={cn(
           "overflow-hidden bg-[url('/images/Variant4.png')] bg-[length:300px_auto] bg-center p-3",
           FEED_CARD_RADIUS,
-          // The whole matted card carries the soft drop shadow (mat image
-          // intact); the inset panel below carries the warm cream fill.
-          FEED_CARD_SHADOW,
+          // The whole matted card carries the drop shadow (mat image intact);
+          // elevated cards lift on the deeper shadow. The inset panel below
+          // carries the warm cream fill.
+          elevated ? FEED_CARD_ELEVATED_SHADOW : FEED_CARD_SHADOW,
           className,
         )}
       >
@@ -95,10 +100,11 @@ export function FeedCardShell({
   return (
     <article
       className={cn(
-        'relative overflow-hidden border border-[var(--brand-rule)]',
+        'relative overflow-hidden border',
+        elevated ? FEED_CARD_ELEVATED_STROKE : 'border-[var(--brand-rule)]',
         elevated ? FEED_CARD_ELEVATED_FILL : 'bg-[var(--brand-card)]',
         FEED_CARD_RADIUS,
-        FEED_CARD_SHADOW,
+        elevated ? FEED_CARD_ELEVATED_SHADOW : FEED_CARD_SHADOW,
         className,
       )}
     >

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -485,35 +485,42 @@ describe('FeedCardShell (shared C7 shell)', () => {
     )
     expect(rendered).toContain('bg-[var(--brand-card)]')
     expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).toContain('border-[var(--brand-rule)]')
     expect(rendered).not.toContain('bg-[var(--game-card-question)]')
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
+    // No elevated lift on the resting card.
+    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
+    expect(rendered).not.toContain('border-[rgba(40,32,30,0.22)]')
   })
 
-  it('lifts the bordered card with cream fill on the soft drop shadow + hairline stroke when elevated', () => {
+  it('lifts the bordered card with cream fill + visible stroke + deeper drop shadow when elevated', () => {
     const rendered = html(
       <FeedCardShell elevated accentColor="#abc123">
         <p>body</p>
       </FeedCardShell>
     )
     expect(rendered).toContain('bg-[var(--game-card-question)]')
-    // Same soft drop shadow as every card — the cream fill + stroke do the lift.
-    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
-    // The hairline border stays, defining the lifted card's edge.
-    expect(rendered).toContain('border-[var(--brand-rule)]')
-    // No hard ink offset shadow.
+    // Deeper drop shadow (10% ink) than the ambient cards' 4%.
+    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
+    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    // Visible warm-ink stroke replaces the faint hairline rule.
+    expect(rendered).toContain('border-[rgba(40,32,30,0.22)]')
+    expect(rendered).not.toContain('border-[var(--brand-rule)]')
+    // No hard ink offset shadow, no near-white resting fill.
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     expect(rendered).not.toContain('bg-[var(--brand-card)]')
   })
 
-  it('lifts the triangle variant with the soft drop shadow + cream inner panel when elevated', () => {
+  it('lifts the triangle variant with the deeper drop shadow + cream inner panel when elevated', () => {
     const rendered = html(
       <FeedCardShell variant="triangle" elevated>
         <p>body</p>
       </FeedCardShell>
     )
-    // Mat image intact; the matted card carries the soft drop shadow.
+    // Mat image intact; the matted card carries the deeper drop shadow.
     expect(rendered).toContain('/images/Variant4.png')
-    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
+    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     // Inner panel carries the warm cream fill instead of brand-card.
     expect(rendered).toContain('bg-[var(--game-card-question)]')


### PR DESCRIPTION
## Why

Follow-up to #805. That pass only swapped the elevated card fill to cream — but the hairline stroke and the 4% drop shadow already existed on **every** feed card, so the playable "What's Happening" cards read as essentially unchanged.

## What

Give the `elevated` (Tier 1 "playable") treatment a clearly visible — but still light — lift, so playable question cards step forward off the cream page while the ambient activity one-liners stay flat:

- **Visible stroke:** elevated cards use `border-[rgba(40,32,30,0.22)]` (warm ink @ 22%) instead of the faint `--brand-rule` hairline (14%).
- **Deeper shadow:** elevated cards use `shadow-[0_4px_12px_rgba(40,32,30,0.10)]` (same `#28201E` warm-ink color, 10% vs the ambient 4%).
- **Cream fill:** unchanged — keeps `--game-card-question` (`#faf4e9`).

Resting (non-elevated) cards on the standalone Feed tab and answered/result cards are untouched — they keep the near-white fill, hairline rule, and 4% shadow.

## Tests

Updated `FeedCards.test.tsx` to assert the elevated bordered + triangle variants now carry the deeper shadow and visible stroke (and that the resting card does not). All 41 tests pass; typecheck and lint clean.

https://claude.ai/code/session_01JqxpmVcfTR9su2KzttMxQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqxpmVcfTR9su2KzttMxQV)_