### PR TITLE
Render playable milestone bundles as cards on the home feed

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1513,9 +1513,11 @@ function FeedListContent({
       if (embed?.kind === 'recently_expanding') {
         return <RecentlyExpandingFeature key={`e-${row.item.id}`} embed={embed} />
       }
-      // Everything else — including the milestone bundle — renders as a
-      // plain flat row (its bundle triangle mark + tap-to-answer
-      // expansion live inside ActivityStreamItem). No card treatment.
+      // Everything else renders as a one-liner row, with its bundle triangle
+      // mark + tap-to-answer expansion living inside ActivityStreamItem. On the
+      // home feed the playable milestone bundles take the cream card treatment
+      // (elevated) so they step forward from the flat ambient rows; the full
+      // /activities log keeps every row flat.
       return (
         <ActivityStreamItem
           key={`a-${row.item.id}`}
@@ -1524,6 +1526,7 @@ function FeedListContent({
           // The home "What's Happening" feed reads calmer without the per-row
           // "1d ago" ledger; the full /activities log keeps its timestamps.
           showTimestamp={!unifiedHome}
+          elevated={unifiedHome}
         />
       )
     }

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -132,6 +132,7 @@ export function ActivityStreamItem({
   timestamp,
   nested = false,
   showTimestamp = true,
+  elevated = false,
 }: {
   item: StreamItem;
   timestamp: string;
@@ -142,6 +143,12 @@ export function ActivityStreamItem({
   // The home "What's Happening" feed hides the relative timestamp for a calmer,
   // less ledger-like read; the full /activities log keeps it. Defaults on.
   showTimestamp?: boolean;
+  // On the home "What's Happening" feed, the playable milestone bundles (the
+  // "X of 5 questions" rows you can answer inline) read as cream cards — a warm
+  // fill, a light stroke, and a soft drop shadow — so they step forward off the
+  // page as the thing you can play, while the ambient one-liners stay flat. Off
+  // by default (the full /activities log keeps every row flat).
+  elevated?: boolean;
 }) {
   const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
@@ -240,24 +247,38 @@ export function ActivityStreamItem({
   // and header text don't shift sideways when the card opens.
   const opened = expandable && open;
 
+  // The playable card treatment (home feed only): a milestone bundle is the
+  // answer-inline row, so on the home feed it reads as a cream card that steps
+  // forward — a warm fill, a light warm-ink stroke, and a soft drop shadow.
+  // Matches the FeedCardShell elevated question cards so the two playable
+  // surfaces share one "liftable" look. Other activity rows (relationship
+  // events, reactions, read-only reveals) stay flat one-liners.
+  const playableCard =
+    elevated && !nested && expandable && expand?.kind === 'milestone';
+
+  const containerStyle: CSSProperties = nested
+    ? // Nested under a per-person heading: no border/fill, light padding.
+      { padding: opened ? '6px 0' : '4px 0' }
+    : playableCard
+      ? {
+          padding: opened ? '16px 14px' : '14px',
+          background: 'var(--game-card-question)',
+          border: '1px solid rgba(40, 32, 30, 0.22)',
+          borderRadius: 4,
+          boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
+        }
+      : opened
+        ? // Opened reveal: a soft paper wash defines the expanded cluster —
+          // no hard hairlines (v2 §4 prefers whitespace over dividers).
+          {
+            padding: '16px 2px',
+            background: PAPER,
+          }
+        : // Calm default: no row hairline; whitespace separates the rows.
+          { padding: '14px 2px' };
+
   return (
-    <div
-      id={item.anchorId ?? undefined}
-      style={
-        nested
-          ? // Nested under a per-person heading: no border/fill, light padding.
-            { padding: opened ? '6px 0' : '4px 0' }
-          : opened
-            ? // Opened reveal: a soft paper wash defines the expanded cluster —
-              // no hard hairlines (v2 §4 prefers whitespace over dividers).
-              {
-                padding: '16px 2px',
-                background: PAPER,
-              }
-            : // Calm default: no row hairline; whitespace separates the rows.
-              { padding: '14px 2px' }
-      }
-    >
+    <div id={item.anchorId ?? undefined} style={containerStyle}>
       <div
         role={expandable ? 'button' : undefined}
         tabIndex={expandable ? 0 : undefined}

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -2,7 +2,7 @@ import type * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import type { StreamExpand, StreamQuestion } from '@/lib/activity-stream';
+import type { StreamExpand, StreamItem, StreamQuestion } from '@/lib/activity-stream';
 
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
@@ -30,7 +30,7 @@ vi.mock('@/app/activities/ReactionGotItButton', () => ({
   ReactionGotItButton: () => <div data-mock="reaction" />,
 }));
 
-import { MilestoneExpansion } from '@/components/activity/ActivityStreamItem';
+import { ActivityStreamItem, MilestoneExpansion } from '@/components/activity/ActivityStreamItem';
 
 // q-correct: answered right in a prior session. q-wrong: answered WRONG in a
 // prior session (the bug — must NOT be answerable here, and the ANSWERED
@@ -63,6 +63,45 @@ function renderExpansion() {
     />,
   );
 }
+
+// A whole milestone-bundle row (the "went deep on X — N of 5 questions" line you
+// can answer inline), used to assert the home-feed card treatment.
+const MILESTONE_ITEM: StreamItem = {
+  id: 'm-1',
+  sortAt: new Date('2026-05-20T12:00:00Z'),
+  tier: 0,
+  friendId: 'friend-1',
+  homeEligible: true,
+  line: [
+    { t: 'actor', name: 'Sadie Brooks', userId: 'friend-1' },
+    { t: 'text', v: ' went deep on ' },
+    { t: 'category', v: 'Star Trek' },
+  ],
+  secondLine: null,
+  anchorId: null,
+  action: null,
+  icon: 'bundle',
+  expand: EXPAND,
+};
+
+describe('ActivityStreamItem — playable milestone card on the home feed', () => {
+  it('gives an elevated milestone bundle the cream card chrome (fill + stroke + drop shadow)', () => {
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem item={MILESTONE_ITEM} timestamp="2:00 PM" elevated showTimestamp={false} />,
+    );
+    expect(html).toContain('var(--game-card-question)');
+    expect(html).toContain('rgba(40, 32, 30, 0.22)'); // the light warm-ink stroke
+    expect(html).toContain('rgba(40, 32, 30, 0.1)'); // the soft drop shadow
+  });
+
+  it('keeps the row flat when not elevated (the full /activities log)', () => {
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem item={MILESTONE_ITEM} timestamp="2:00 PM" />,
+    );
+    expect(html).not.toContain('var(--game-card-question)');
+    expect(html).not.toContain('rgba(40, 32, 30, 0.22)');
+  });
+});
 
 describe('MilestoneExpansion — cross-session answer lock', () => {
   it('keeps only never-attempted questions answerable', () => {


### PR DESCRIPTION
## Why

On the home "What's Happening" feed, the rows you can actually play — the **milestone bundles** ("went deep on X", "N of 5 questions" with the triangle marks) — render as flat `ActivityStreamItem` one-liners (the D-FEED design historically gave them "No card treatment"). The earlier `FeedCardShell` elevation (#810) only touched the "For You" question cards, so these playable rows still read as flat and didn't stand out.

## What

Give the playable milestone bundles the same cream **card** treatment on the home feed (`elevated`), matching the elevated question cards so the two playable surfaces share one "liftable" look:

- **Fill:** `--game-card-question` (warm cream)
- **Stroke:** light warm-ink `rgba(40, 32, 30, 0.22)`
- **Shadow:** `0 4px 12px rgba(40, 32, 30, 0.1)` (soft drop shadow)
- **Radius:** 4px

Scope is deliberately narrow:
- Only **playable milestone bundles** become cards. Other activity rows (relationship events, reactions, read-only convergence/send-onward reveals) stay flat one-liners, so the playable rows clearly step forward.
- Only on the **home feed** (`elevated` is threaded from `FeedList`'s `unifiedHome`). The full `/activities` log keeps every row flat.
- Nested per-person rows are unaffected.

## Tests

Added two cases in `MilestoneStreamItem.test.tsx`: an elevated milestone bundle emits the cream fill + stroke + drop shadow; the default (non-elevated) row stays flat. All activity + feed-card tests pass; typecheck and lint clean.

https://claude.ai/code/session_01JqxpmVcfTR9su2KzttMxQV

---
_Generated by [Claude Code](https://claude.ai/code/session_01JqxpmVcfTR9su2KzttMxQV)_