### PR TITLE
fix(daily): send reminder email even when the queue already exists

### DIFF
--- a/drizzle/0075_daily_queue_email_reminder.sql
+++ b/drizzle/0075_daily_queue_email_reminder.sql
@@ -1,0 +1,24 @@
+-- Daily reminder email idempotency — per-queue (per user/day) sent marker.
+--
+-- The daily-assignments cron used to gate the reminder email on
+-- `freshlyGenerated` (the queue was built by THIS invocation). That doubled as
+-- crude idempotency: the workflow curls the route with `--retry 2` and a
+-- timeout equal to maxDuration, so a client-side timeout replays the whole run,
+-- and the gate stopped a replay from re-emailing. But it also meant any user
+-- who built their own queue before this drift-prone cron (the common case, the
+-- GitHub scheduler runs ~1-2.5h late) never got a reminder.
+--
+-- Decoupling the email from `freshlyGenerated` (so it nudges eligible users
+-- whose queue already exists, as long as an unanswered slot remains) removes
+-- that crude guard. email_reminder_sent_at restores correctness: the cron
+-- claims it atomically (UPDATE ... SET = now() WHERE id = ? AND it IS NULL
+-- RETURNING) before sending, so a retry-replay loses the claim and skips. A
+-- send failure resets it to null so a later run can retry.
+--
+-- Additive nullable column with no default — the safe case. Mirrored by a
+-- defensive guard in src/instrumentation.ts (precedent: 0074's domain_key
+-- guard) so a preview/production database that records this migration without
+-- the column present still boots.
+--
+-- Rollback: ALTER TABLE "DailyQueue" DROP COLUMN IF EXISTS "email_reminder_sent_at";
+ALTER TABLE "DailyQueue" ADD COLUMN IF NOT EXISTS "email_reminder_sent_at" timestamptz;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -526,6 +526,13 @@
       "when": 1782950400000,
       "tag": "0074_generated_question_domain_key",
       "breakpoints": true
+    },
+    {
+      "idx": 75,
+      "version": "7",
+      "when": 1783036800000,
+      "tag": "0075_daily_queue_email_reminder",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -1,7 +1,11 @@
 import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
-import { getTodaysDailyQueue } from '@/server/db/queries/daily';
+import {
+  claimDailyEmailReminder,
+  getTodaysDailyQueue,
+  releaseDailyEmailReminder,
+} from '@/server/db/queries/daily';
 import { db, users } from '@/server/db';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { type QueueSlot } from '@/server/daily/types';
@@ -110,34 +114,42 @@ export async function GET(request: NextRequest) {
         results.smsSent += 1;
       }
 
-      // Email reminder — mirrors the SMS nudge for opted-in + verified users,
-      // but previews today's first question as a no-spoiler teaser. sendEmail
-      // never throws (returns a discriminated union), so a provider failure
-      // counts as a skipped email, not a failed user. Same freshly-generated
-      // gate as SMS (there is no email-send log to dedupe against).
-      if (freshlyGenerated && queue && user.emailOptIn === 'opted_in' && user.emailVerified && user.email) {
+      // Email reminder — previews today's first question as a no-spoiler teaser.
+      // Unlike SMS, this is NOT gated on freshlyGenerated: a user whose queue
+      // already existed (self-generated before this drift-prone cron, or built
+      // by an earlier run) should still get one nudge. The idempotency that the
+      // freshly-generated gate used to provide is now an atomic per-queue claim
+      // (claimDailyEmailReminder), so the workflow's retry-replay can't
+      // double-send. Only fires when an unanswered slot remains, so a user who
+      // already finished today is skipped. sendEmail never throws (returns a
+      // discriminated union), so a provider failure counts as a skipped email.
+      if (queue && user.emailOptIn === 'opted_in' && user.emailVerified && user.email) {
         const teaserSlot = asQueueSlots(queue.slots).find(
           (slot) => !slot.answered && !slot.skipped && slot.question_text,
         );
-        const template = buildDailyReminderTemplate({
-          dailyUrl: `${baseUrl}/daily`,
-          teaser: teaserSlot
-            ? { questionText: teaserSlot.question_text, domain: teaserSlot.domain }
-            : null,
-        });
-        const emailResult = await sendEmail({
-          to: user.email,
-          subject: template.subject,
-          html: template.html,
-          text: template.text,
-        });
-        if (emailResult.ok) {
-          results.emailSent += 1;
-        } else {
-          console.warn('[cron/daily-assignments] reminder email failed', {
-            userId: user.id,
-            reason: emailResult.reason,
+        // Claim before send so concurrent retries race on the DB, not the
+        // provider; a losing claim (already sent today) skips silently.
+        if (teaserSlot && (await claimDailyEmailReminder(queue.id))) {
+          const template = buildDailyReminderTemplate({
+            dailyUrl: `${baseUrl}/daily`,
+            teaser: { questionText: teaserSlot.question_text, domain: teaserSlot.domain },
           });
+          const emailResult = await sendEmail({
+            to: user.email,
+            subject: template.subject,
+            html: template.html,
+            text: template.text,
+          });
+          if (emailResult.ok) {
+            results.emailSent += 1;
+          } else {
+            // Send failed after we claimed — release so a later run can retry.
+            await releaseDailyEmailReminder(queue.id);
+            console.warn('[cron/daily-assignments] reminder email failed', {
+              userId: user.id,
+              reason: emailResult.reason,
+            });
+          }
         }
       }
     } catch (error) {

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -252,6 +252,20 @@ export async function register() {
       // FeedItem table may not exist yet — migrate() handles initial creation.
     }
 
+    // Migration 0075 adds DailyQueue.email_reminder_sent_at, the per-queue
+    // idempotency marker the daily-assignments cron claims before sending a
+    // reminder email. A preview/production DB that records 0075 without the
+    // column present would make the cron's claim UPDATE fail; pre-apply it
+    // idempotently (precedent: 0074's domain_key guard above).
+    try {
+      await db.execute(sql`
+        ALTER TABLE "DailyQueue"
+          ADD COLUMN IF NOT EXISTS "email_reminder_sent_at" timestamptz
+      `);
+    } catch {
+      // DailyQueue table may not exist yet — migrate() handles initial creation.
+    }
+
     // Migration 0028 adds the Category.general_knowledge enum value and migration
     // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
     // migrations in one transaction, but Postgres requires a newly-added enum value

--- a/src/server/db/queries/__tests__/daily-email-reminder.test.ts
+++ b/src/server/db/queries/__tests__/daily-email-reminder.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// What the claim's `UPDATE ... RETURNING` resolves to. One row = this call won
+// the claim (the marker was null); empty = another run already claimed it.
+let returningRows: Array<{ id: string }> = [];
+const updates: Array<{ set: Record<string, unknown>; usedReturning: boolean }> = [];
+
+vi.mock('@/server/db', () => ({
+  db: {
+    update: () => ({
+      set: (vals: Record<string, unknown>) => ({
+        where: () => {
+          const capture = { set: vals, usedReturning: false };
+          updates.push(capture);
+          // Drizzle's query builder is thenable (release awaits it directly)
+          // AND exposes `.returning()` (claim chains it). Model both.
+          const thenable = Promise.resolve(returningRows) as Promise<unknown> & {
+            returning?: () => Promise<unknown>;
+          };
+          thenable.returning = () => {
+            capture.usedReturning = true;
+            return Promise.resolve(returningRows);
+          };
+          return thenable;
+        },
+      }),
+    }),
+  },
+  dailyQueues: { id: 'id', emailReminderSentAt: 'email_reminder_sent_at' },
+  // The remaining named exports daily.ts pulls in at import time — unused here.
+  generatedQuestions: {},
+  dailyPreferences: {},
+  declaredInterests: {},
+  feedItems: {},
+  masteryEvents: {},
+  playerMastery: {},
+  questions: {},
+  userDomainExclusions: {},
+  users: {},
+}));
+
+import {
+  claimDailyEmailReminder,
+  releaseDailyEmailReminder,
+} from '@/server/db/queries/daily';
+
+beforeEach(() => {
+  returningRows = [];
+  updates.length = 0;
+});
+
+describe('claimDailyEmailReminder', () => {
+  it('returns true and stamps the marker when the row was unclaimed', async () => {
+    returningRows = [{ id: 'q1' }];
+
+    const won = await claimDailyEmailReminder('q1');
+
+    expect(won).toBe(true);
+    // Claim must use the conditional RETURNING update, not a blind write.
+    expect(updates.at(-1)?.usedReturning).toBe(true);
+    expect(updates.at(-1)?.set).toMatchObject({ emailReminderSentAt: expect.any(Date) });
+  });
+
+  it('returns false when another run already claimed it (no row returned)', async () => {
+    returningRows = [];
+
+    const won = await claimDailyEmailReminder('q1');
+
+    expect(won).toBe(false);
+  });
+});
+
+describe('releaseDailyEmailReminder', () => {
+  it('resets the marker to null so a later run can retry', async () => {
+    await releaseDailyEmailReminder('q1');
+
+    expect(updates.at(-1)?.set).toEqual({ emailReminderSentAt: null });
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -294,6 +294,34 @@ export async function getTodaysDailyQueue(userId: string): Promise<DailyQueueRow
 }
 
 /**
+ * Atomically claim the daily reminder email for a queue so concurrent cron
+ * retries can't double-send. The single UPDATE flips email_reminder_sent_at
+ * from null to now() only if it is still null, and RETURNs the row iff this
+ * call won the race. Returns true iff THIS call should send; a losing or
+ * duplicate call returns false and must not send.
+ */
+export async function claimDailyEmailReminder(queueId: string): Promise<boolean> {
+  const claimed = await db
+    .update(dailyQueues)
+    .set({ emailReminderSentAt: new Date() })
+    .where(and(eq(dailyQueues.id, queueId), isNull(dailyQueues.emailReminderSentAt)))
+    .returning({ id: dailyQueues.id });
+
+  return claimed.length > 0;
+}
+
+/**
+ * Release a claim (reset email_reminder_sent_at to null) after a send failure,
+ * so a later cron run can retry the reminder for this queue. Idempotent.
+ */
+export async function releaseDailyEmailReminder(queueId: string): Promise<void> {
+  await db
+    .update(dailyQueues)
+    .set({ emailReminderSentAt: null })
+    .where(eq(dailyQueues.id, queueId));
+}
+
+/**
  * Total number of daily queues ever built for this user, across all dates.
  *
  * Used to detect a user's FIRST Daily Five: the orchestrator treats a zero count

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -745,6 +745,11 @@ export const dailyQueues = pgTable(
     queueDate: date('queue_date').notNull(),
     slots: jsonb('slots').notNull(),
     createdAt: createdAt(),
+    // Set when the daily reminder email has been sent for this queue (one row
+    // per user/day). Claimed atomically before send so the cron's retry-replay
+    // can't double-send; null = not yet sent, or released back to null after a
+    // send failure so a later run can retry.
+    emailReminderSentAt: timestamp('email_reminder_sent_at', { withTimezone: true }),
   },
   (table) => [
     unique('DailyQueue_user_id_queue_date_key').on(table.userId, table.queueDate),


### PR DESCRIPTION
## Problem

The daily-assignments cron gated the reminder **email** on `freshlyGenerated` (the queue was built by *this* invocation). That doubled as crude idempotency against the workflow's retry-replay (`curl --retry 2`, `--max-time` = `maxDuration`). But the GitHub Actions scheduler fires this cron **~1–2.5h late**, so eligible users routinely open the app and self-generate their queue first → they land in the `existing` branch and **never get a reminder**. With effectively one eligible recipient today, that's a ~100% miss rate.

(Surfaced while diagnosing "daily reminder email not reaching users": the only eligible recipient had already built today's queue at 17:24 UTC before the cron fired at 19:40 UTC, so `freshlyGenerated` was false and the email was skipped. Recipient set wasn't empty; the gate was the cause.)

## Change

Decouple the **email** from `freshlyGenerated`: send to an eligible user whenever their queue still has an **unanswered slot** (so users who already finished today stay skipped), regardless of who built the queue or when the cron fires.

Restore idempotency with an atomic **per-queue claim** instead of the gate:
- New nullable column `DailyQueue.email_reminder_sent_at` (migration `0075`, + instrumentation guard mirroring `0074`'s `domain_key` precedent).
- `claimDailyEmailReminder(queueId)` — single `UPDATE … SET = now() WHERE id = ? AND email_reminder_sent_at IS NULL RETURNING id`. Postgres row-lock means exactly one concurrent retry wins; losers skip. Claim happens **before** `sendEmail`, so contention resolves at the DB, not the provider.
- `releaseDailyEmailReminder(queueId)` resets to null on a send failure so a later run retries.

**SMS is unchanged** — it keeps its `freshlyGenerated` gate (there's no per-send log to dedupe against and double-texting is the riskier failure mode).

## Delivery semantics (note for reviewers)

This is **at-most-once**: the claim commits before the send returns, so if the process is killed (e.g. `maxDuration`) between claim-commit and send-completion, that user gets no reminder that day. This matches the old `freshlyGenerated` gate's at-most-once property and is the right default for a reminder email — calling it out so no one expects at-least-once.

## Tests

- `daily-email-reminder.test.ts` — claim returns true/false on won/lost, uses the conditional `RETURNING` path, release resets to null.
- Existing `daily.test.ts` still green (8/8); full `tsc -p tsconfig.typecheck.json` clean (0 errors).
- No route-level behavior test (no existing `__tests__` for this route; the route pulls heavy deps). Primitive-level coverage + the manual trace cover the idempotency.

## Rollback

`ALTER TABLE "DailyQueue" DROP COLUMN IF EXISTS "email_reminder_sent_at";`

🤖 Generated with [Claude Code](https://claude.com/claude-code)