### PR TITLE
feed: restore the two flanking stars on the first-five announcement

### DIFF
--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -286,9 +286,9 @@ function StarMark({ seed }: { seed: string }) {
   );
 }
 
-// The same five-point star, used as a single flourish leading the centered
-// "played their first five" announcement (star — line) rather than a mark in the
-// left icon column. Decorative; the row copy carries the meaning.
+// The same five-point star, used as a flanking flourish on each side of the
+// centered "played their first five" announcement (star — line — star) rather
+// than in the left icon column. Decorative; the row copy carries the meaning.
 export function MilestoneStar({ seed }: { seed: string }) {
   return (
     <span aria-hidden style={{ display: 'flex', flexShrink: 0 }}>

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -274,7 +274,7 @@ export function ActivityStreamItem({
         }}
       >
         {centeredStar ? (
-          // Celebratory announcement: a single star leading the centered line.
+          // Celebratory announcement: star — centered line — star.
           <>
             <MilestoneStar seed={item.id} />
             <p
@@ -289,6 +289,7 @@ export function ActivityStreamItem({
             >
               <Line parts={item.line} />
             </p>
+            <MilestoneStar seed={item.id} />
           </>
         ) : (
           <>


### PR DESCRIPTION
## What

`dev2` currently has the **single-star** version of the "invited friend played their first five questions" announcement (merged via #812 at commit `1d6609c`). You asked for **two** stars — that revert (`c1a5381`) was pushed to the branch after #812 had already merged, so it never reached `dev2`.

This PR lands it: restores the flanking pair so the row reads **★ — *Shanea played their first five questions* — ★**, keeping the legibility recolor (saturated tokens at full opacity) from #812.

## Changes

- `src/components/activity/ActivityStreamItem.tsx` — render two `MilestoneStar`s (one on each side) instead of one.
- `src/components/activity/ActivityIcon.tsx` — `MilestoneStar` doc restored to the two-star description.

https://claude.ai/code/session_013x3TyHyVKXsgxdpQWUH4aq

---
_Generated by [Claude Code](https://claude.ai/code/session_013x3TyHyVKXsgxdpQWUH4aq)_