### PR TITLE
type guide phase 1: token foundation

### DIFF
--- a/.github/workflows/font-ratchet.yml
+++ b/.github/workflows/font-ratchet.yml
@@ -1,0 +1,20 @@
+# Font ratchet (B-VISUAL-STYLE-GUIDE-TYPE-01, Phase 4): fail the PR if raw
+# (non-token) font-family usage in src/ rises above the recorded ceiling.
+# The ceiling and the exemption list live in scripts/check-font-ratchet.mjs.
+# Font-only by design — the color half of the style guide gets its own ratchet.
+name: Font ratchet
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev2]
+
+jobs:
+  font-ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/check-font-ratchet.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - `npm run dev` — Next dev server
 - `npm run build` — production build
 - `npm run lint` — ESLint over `src/`
+- `npm run check:fonts` — font ratchet (off-system font-family count must stay ≤ the ceiling in `scripts/check-font-ratchet.mjs`; runs in CI)
 - `npm run format` — Prettier write
 - `npm run db:migrate` — Drizzle migrations
 - `npm run smoke:daily-catchup` — daily catchup smoke test

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run eval.test",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 16",
+    "check:fonts": "node scripts/check-font-ratchet.mjs",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/scripts/check-font-ratchet.mjs
+++ b/scripts/check-font-ratchet.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+// Font ratchet (B-VISUAL-STYLE-GUIDE-TYPE-01, Phase 4) — fails if off-system
+// font usage in src/ rises above the recorded ceiling.
+//
+// "Off-system" means a font declared outside the voice tokens defined in
+// src/app/globals.css (--font-serif / --font-mono / --font-sans / --font-neutral
+// / --font-display / the next-font load vars). Three patterns count:
+//   A. font-family / fontFamily declarations whose value is not var(--font-…)
+//      (or `inherit`)
+//   B. Tailwind arbitrary font values: font-[…] not wrapping var(--font-…)
+//      (or inherit)
+//   C. string constants that define a literal font stack by face name
+//      (e.g. const FM = '"Courier New", monospace')
+//
+// Color is deliberately NOT counted here — the color half of the style guide
+// gets its own ratchet (see _docs/STYLE-GUIDE-TYPE.md, "Part 2"), and the two
+// must stay independently enforceable.
+//
+// To LOWER the ceiling after a cleanup: run the script, take the reported
+// count, update CEILING. To raise it: don't — route the new use through a
+// voice token instead (see _docs/STYLE-GUIDE-TYPE.md §6).
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// ── The ceiling ──────────────────────────────────────────────────────────────
+// Set 2026-06-11, after the Phase 1–3 token routing. Product code is fully on
+// the voice tokens, so the ceiling is 0: any new raw font-family literal in a
+// shipped surface fails this check.
+const CEILING = 0;
+
+// ── Exemptions (each documented; keep this list short) ──────────────────────
+const EXEMPT = [
+  // Token definitions live here — the one place raw stacks are correct.
+  'src/app/globals.css',
+  // html2canvas raster path: literal font names are load-bearing (the hashed
+  // next-font vars aren't reliably available to the detached canvas render).
+  // Documented at the top of the file: "intentionally literal — do NOT tokenize".
+  'src/components/knowledge/SharePortraitCard.tsx',
+  // Email HTML cannot use CSS custom properties (no :root in mail clients);
+  // inline literal stacks are the only option there.
+  'src/server/email/templates/',
+  // Internal tooling, never shipped to users: deliberately unstyled
+  // monospace/system-ui diagnostics. Exempt so the product ceiling stays at 0.
+  'src/app/dev/',
+  'src/app/feed/debug/',
+];
+
+const isTest = (p) => /(\.test\.|__tests__\/)/.test(p);
+const isExempt = (p) => EXEMPT.some((e) => p === e || p.startsWith(e)) || isTest(p);
+
+// A. raw font-family / fontFamily declarations (TS/TSX inline styles, CSS)
+const DECL_TS = /fontFamily\s*[:=]\s*\{?\s*['"`](?!var\(--font-|inherit\b)/g;
+const DECL_CSS = /font-family\s*:\s*(?!var\(--font-|inherit\b)/g;
+// B. Tailwind arbitrary font value
+const TW_ARBITRARY = /font-\[(?!var\(--font-|inherit\])/g;
+// C. literal font-stack string constants, recognized by face name + generic
+//    family. Strings that LEAD with a token (e.g. 'var(--font-serif), Georgia,
+//    serif') are on-system — the face names there are only fallbacks.
+const STACK_CONST =
+  /(['"`])(?!var\(--font-)(?:(?!\1)[^\n])*?(?:Courier New|Georgia|Times New Roman|Caveat|Playfair Display|Helvetica|Arial|Inter)(?:(?!\1)[^\n])*?(?:serif|monospace|cursive|sans)(?:(?!\1)[^\n])*?\1/g;
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (/\.(tsx?|jsx?|css)$/.test(name)) yield full;
+  }
+}
+
+const root = process.cwd();
+// One offense per offending line (a line matching several patterns is still
+// one declaration to fix), keyed file:line.
+const offenders = new Set();
+
+for (const file of walk(join(root, 'src'))) {
+  const rel = relative(root, file).replaceAll('\\', '/');
+  if (isExempt(rel)) continue;
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((line, i) => {
+    const patterns = rel.endsWith('.css') ? [DECL_CSS, TW_ARBITRARY] : [DECL_TS, TW_ARBITRARY, STACK_CONST];
+    for (const re of patterns) {
+      re.lastIndex = 0;
+      if (re.test(line)) {
+        offenders.add(`${rel}:${i + 1}: ${line.trim().slice(0, 120)}`);
+      }
+    }
+  });
+}
+
+const count = offenders.size;
+if (count > CEILING) {
+  console.error(`✖ font ratchet: ${count} off-system font declaration(s) in src/ (ceiling: ${CEILING})\n`);
+  for (const o of offenders) console.error(`  ${o}`);
+  console.error(
+    '\nRoute fonts through the voice tokens (--font-serif / --font-mono / --font-sans);' +
+      ' see _docs/STYLE-GUIDE-TYPE.md §6. Do not raise the ceiling.',
+  );
+  process.exit(1);
+}
+console.log(`✓ font ratchet: ${count} off-system font declaration(s) (ceiling: ${CEILING})`);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,6 @@
 
 @theme inline {
     --font-heading: var(--font-sans);
-    --font-sans: var(--font-sans);
     --font-serif: var(--font-cormorant, Georgia, "Times New Roman", serif);
     --font-inter: var(--font-inter, ui-sans-serif, system-ui, sans-serif);
     --color-sidebar-ring: var(--sidebar-ring);
@@ -201,11 +200,13 @@
     --warm-paper:       #faf8f2;  /* warm off-white surface (share chrome)*/
     --warm-cream:       #f5f0e8;  /* warm cream panel                     */
     --font-neutral: var(--font-sans-body, ui-sans-serif, system-ui, -apple-system, sans-serif);
-    --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-    /* Editorial serif — Cormorant Garamond (the brand serif). Playfair Display
-       italic remains available via --font-display for the few editorial labels
-       that intentionally use it (PortraitCircles, Hero subtitle). */
-    --font-literata: var(--font-cormorant, Georgia), "Times New Roman", serif;
+    /* System voice (STYLE-GUIDE-TYPE §2) — Courier New first, by design. */
+    --font-mono: "Courier New", ui-monospace, monospace;
+    /* Editorial serif — Cormorant Garamond (the brand serif). Mirrors the
+       @theme --font-serif above so inline `var(--font-serif)` styles resolve.
+       Playfair Display italic remains available via --font-display for the few
+       editorial labels that intentionally use it (PortraitCircles, Hero). */
+    --font-serif: var(--font-cormorant, Georgia, "Times New Roman", serif);
     --radius-sm: 0.375rem;
     --radius-md: 0.5rem;
     --radius-lg: 0.625rem;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,7 +7,6 @@
 @theme inline {
     --font-heading: var(--font-sans);
     --font-serif: var(--font-cormorant, Georgia, "Times New Roman", serif);
-    --font-inter: var(--font-inter, ui-sans-serif, system-ui, sans-serif);
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -632,7 +632,7 @@ function KnowledgePageContent() {
             ) : null}
             {!editMode ? (
               <div className="mt-5 flex justify-center">
-                <button type="button" className="px-8 py-[11px] border-[1.5px] border-[#0e0e0e] bg-[#0e0e0e] text-[var(--warm-paper)] font-['Courier_New',monospace] text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
+                <button type="button" className="px-8 py-[11px] border-[1.5px] border-[#0e0e0e] bg-[#0e0e0e] text-[var(--warm-paper)] font-mono text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
                   Share portrait
                 </button>
               </div>

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -644,7 +644,7 @@ function KnowledgePageContent() {
       {emptyQuestionDomain ? (
         <section className="bg-[#fff7e8] border border-[#d9b56c] px-[0.95rem] py-5" aria-label={`No ${emptyQuestionDomain} questions yet`}>
           <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">No matching public questions</p>
-          <h2 className="mt-[0.4rem] text-xl leading-[1.35] text-[var(--ink)] font-[var(--font-literata)] font-semibold">We don&apos;t have {emptyQuestionDomain} questions yet. Want to ask someone who might?</h2>
+          <h2 className="mt-[0.4rem] text-xl leading-[1.35] text-[var(--ink)] font-[var(--font-serif)] font-semibold">We don&apos;t have {emptyQuestionDomain} questions yet. Want to ask someone who might?</h2>
           <p className="mt-3 text-[0.88rem] leading-[1.6] text-[var(--text-muted-warm)]">Josh is going deep on {emptyQuestionDomain} — and thinks someone in your world might be the one to stump them.</p>
           <div className="flex flex-wrap gap-[10px] mt-5">
             <button type="button" className="min-h-10 border border-[var(--ink)] bg-[var(--ink)] text-[var(--cream-warm)] px-4 cursor-pointer text-[0.82rem] font-[inherit]" onClick={() => setAskFriendDomain(emptyQuestionDomain)}>
@@ -658,7 +658,7 @@ function KnowledgePageContent() {
       ) : null}
 
       <section className="bg-[var(--cream)] border border-[var(--border-warm)] px-[0.95rem] py-5">
-        <h2 className="m-0 text-[1.1rem] font-[var(--font-literata)] text-[var(--ink)]">Grow your map</h2>
+        <h2 className="m-0 text-[1.1rem] font-[var(--font-serif)] text-[var(--ink)]">Grow your map</h2>
         <p className="mt-3 text-[0.88rem] leading-[1.6] text-[var(--text-muted-warm)]">
           Answer a friend&apos;s question correctly, or write your own — writing opens new territory; a friend&apos;s correct answer proves it.
         </p>
@@ -713,7 +713,7 @@ function KnowledgePageContent() {
           <div className="w-[min(540px,100%)] max-h-[90vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <div>
-                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">{activeModal.currentDomain ? `Swap ${activeModal.currentDomain}` : 'Add to your declared interests'}</h2>
+                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-serif)]">{activeModal.currentDomain ? `Swap ${activeModal.currentDomain}` : 'Add to your declared interests'}</h2>
                 {activeModal.currentDomain ? (
                   <p className="mt-[0.45rem] text-[var(--text-muted-warm)] text-[0.88rem] leading-[1.5]">Your progress in {activeModal.currentDomain} is preserved. It moves to your demonstrated knowledge.</p>
                 ) : null}
@@ -807,7 +807,7 @@ function KnowledgePageContent() {
           <div className="w-[min(430px,100%)] max-h-[90vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <div>
-                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Tidy up your map?</h2>
+                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-serif)]">Tidy up your map?</h2>
                 <p className="mt-[0.45rem] text-[var(--text-muted-warm)] text-[0.88rem] leading-[1.5]">We&apos;ll look for domains in your map that could be combined. This is automatic and based on what you&apos;ve answered.</p>
               </div>
               <button type="button" className="w-[34px] h-[34px] border-none bg-transparent text-[var(--text-muted-warm)] grid place-items-center cursor-pointer" onClick={() => setActiveModal(null)} aria-label="Close" disabled={tidying}>
@@ -839,7 +839,7 @@ function KnowledgePageContent() {
           <div className="w-[min(540px,100%)] max-h-[90vh] overflow-y-auto bg-white border border-[var(--border-warm)] p-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
               <div>
-                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Manage interests</h2>
+                <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-serif)]">Manage interests</h2>
                 <p className="mt-[0.45rem] text-[var(--text-muted-warm)] text-[0.88rem] leading-[1.5]">Your declared interests seed your Daily Five questions. Add as many as you like.</p>
               </div>
               <button type="button" className="w-[34px] h-[34px] border-none bg-transparent text-[var(--text-muted-warm)] grid place-items-center cursor-pointer" onClick={() => setActiveModal(null)} aria-label="Close">
@@ -882,7 +882,7 @@ function KnowledgePageContent() {
         <div className="fixed inset-0 z-[55] flex items-center justify-center bg-black/30 p-4">
           <div className="w-[min(540px,100%)] max-h-[92vh] overflow-y-auto bg-white border border-[var(--border-warm)] px-5 pt-5 shadow-[0_18px_48px_rgba(0,0,0,0.18)]">
             <div className="flex justify-between gap-4">
-              <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-literata)]">Write a question</h2>
+              <h2 className="m-0 text-[var(--ink)] text-[1.45rem] font-[var(--font-serif)]">Write a question</h2>
               <button type="button" className="w-[34px] h-[34px] border-none bg-transparent text-[var(--text-muted-warm)] grid place-items-center cursor-pointer" onClick={() => setActiveModal(null)} aria-label="Close">
                 <X className="size-4" />
               </button>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Caveat, Cormorant_Garamond, Inter, Montserrat, Playfair_Display } from 'next/font/google'
+import { Cormorant_Garamond, Inter, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
@@ -39,13 +39,6 @@ const cormorant = Cormorant_Garamond({
   display: 'swap',
 })
 
-// Handwritten register for the Lately flourish on /activities. Used sparingly.
-const caveat = Caveat({
-  subsets: ['latin'],
-  variable: '--font-caveat',
-  display: 'swap',
-})
-
 // Inter — loaded for opt-in use (e.g. the login subtitle's display/heading/section
 // spec). Exposed via --font-inter and surfaced to Tailwind as `font-inter` in
 // globals.css. Montserrat remains the app-wide body font.
@@ -77,7 +70,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${montserrat.variable} ${playfair.variable} ${caveat.variable} ${cormorant.variable} ${inter.variable}`}
+      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable} ${inter.variable}`}
     >
       <body className={montserrat.className}>
         <Nav

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Cormorant_Garamond, Inter, Montserrat, Playfair_Display } from 'next/font/google'
+import { Cormorant_Garamond, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
@@ -39,15 +39,6 @@ const cormorant = Cormorant_Garamond({
   display: 'swap',
 })
 
-// Inter — loaded for opt-in use (e.g. the login subtitle's display/heading/section
-// spec). Exposed via --font-inter and surfaced to Tailwind as `font-inter` in
-// globals.css. Montserrat remains the app-wide body font.
-const inter = Inter({
-  subsets: ['latin'],
-  variable: '--font-inter',
-  display: 'swap',
-})
-
 export const metadata: Metadata = {
   title: 'Joshing',
   description: 'A daily knowledge game',
@@ -70,7 +61,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable} ${inter.variable}`}
+      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable}`}
     >
       <body className={montserrat.className}>
         <Nav

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -27,7 +27,7 @@ function TitleCard() {
         JOSHING
       </h1>
       <div className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--tri-amber)]" aria-hidden="true" />
-      <p className="mt-4 text-center font-inter text-lg font-normal uppercase leading-6 tracking-[3.6px] text-[var(--warm-ink)]">
+      <p className="mt-4 text-center font-sans text-lg font-normal uppercase leading-6 tracking-[3.6px] text-[var(--warm-ink)]">
         Trivia you wish you were asked
       </p>
     </section>

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -152,7 +152,7 @@ export default function LoadingScreen({
           JOSHING
         </p>
         <div className="mt-6 h-px w-12 bg-[#1a1208]/20" aria-hidden="true" />
-        <p className="mt-5 flex items-baseline gap-1 font-inter text-sm font-normal tracking-wider uppercase text-[#1a1208]/70">
+        <p className="mt-5 flex items-baseline gap-1 font-sans text-sm font-normal tracking-wider uppercase text-[#1a1208]/70">
           <span>{label}</span>
           <span className="ml-0.5 inline-flex gap-0.5" aria-hidden="true">
             <span

--- a/src/components/QuickAddQuestionModal.tsx
+++ b/src/components/QuickAddQuestionModal.tsx
@@ -135,7 +135,7 @@ export function QuickAddQuestionModal({ onClose, onAdded }: Props) {
         <div style={{ display: 'flex', alignItems: 'baseline', justifyContent: 'space-between', marginBottom: '20px' }}>
           <h2
             id="quick-add-title"
-            style={{ fontFamily: 'var(--font-literata), ui-serif, Georgia, serif', fontSize: '1.35rem', fontWeight: 600, color: 'var(--text)' }}
+            style={{ fontFamily: 'var(--font-serif), ui-serif, Georgia, serif', fontSize: '1.35rem', fontWeight: 600, color: 'var(--text)' }}
           >
             Quick add question
           </h2>

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -59,10 +59,10 @@ export function Line({ parts }: { parts: StreamLinePart[] }) {
           return <ActorLink key={i} name={part.name} userId={part.userId} />;
         }
         if (part.t === 'category') {
-          // Same editorial serif register categories get as the homepage
-          // "What's Happening" second line, applied inline here.
+          // Category names are structured metadata — System voice (mono), per
+          // STYLE-GUIDE-TYPE §5. The sentence around them stays in the sans.
           return (
-            <span key={i} style={{ fontFamily: 'Georgia, serif', color: INK2 }}>
+            <span key={i} style={{ fontFamily: 'var(--font-mono)', color: INK2 }}>
               {part.v}
             </span>
           );
@@ -333,7 +333,13 @@ export function ActivityStreamItem({
             <p
               style={{
                 margin: '2px 0 0',
-                fontFamily: 'Georgia, serif',
+                // Voice follows content (STYLE-GUIDE-TYPE §5): domain/label
+                // metadata is System mono; question text / sentences are
+                // Editorial serif.
+                fontFamily:
+                  item.secondLineVoice === 'system'
+                    ? 'var(--font-mono)'
+                    : 'var(--font-serif)',
                 fontSize: 14,
                 lineHeight: 1.45,
                 color: INK2,

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -571,7 +571,7 @@ function AnsweredHistory({
                   style={{
                     margin: '3px 0 0',
                     paddingRight: 24,
-                    fontFamily: 'Georgia, serif',
+                    fontFamily: 'var(--font-serif)',
                     fontStyle: 'italic',
                     fontSize: 13,
                     lineHeight: 1.5,
@@ -615,7 +615,7 @@ export function ConvergenceExpansion({
           <p
             style={{
               margin: 0,
-              fontFamily: 'Georgia, serif',
+              fontFamily: 'var(--font-serif)',
               fontStyle: 'italic',
               fontSize: 14,
               lineHeight: 1.55,
@@ -666,7 +666,7 @@ function SendOnwardExpansion({
       <p
         style={{
           margin: '0 0 4px',
-          fontFamily: 'Georgia, serif',
+          fontFamily: 'var(--font-serif)',
           fontStyle: 'italic',
           fontSize: 14,
           lineHeight: 1.55,

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -92,7 +92,7 @@ export function InlineAnswerFlow({
         style={{
           margin: 0,
           paddingRight: 24,
-          fontFamily: 'Georgia, serif',
+          fontFamily: 'var(--font-serif)',
           fontSize: 17,
           lineHeight: 1.5,
           color: INK,

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -257,7 +257,7 @@ export function AnswerFeedbackSheet({
               <p
                 className="text-[13px] italic"
                 style={{
-                  fontFamily: 'var(--font-literata)',
+                  fontFamily: 'var(--font-serif)',
                   color: 'var(--ink)',
                   opacity: 0.7,
                 }}

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -180,7 +180,7 @@ function AnsweredResult({
           </p>
           <p
             className="mt-1 text-[13px] leading-6"
-            style={{ fontFamily: 'var(--font-literata)', color: 'var(--ink)' }}
+            style={{ fontFamily: 'var(--font-serif)', color: 'var(--ink)' }}
           >
             {item.creatorNote}
           </p>
@@ -263,7 +263,7 @@ export function AnsweredByYouCard({ item, recheckAction, onRetry, overflow }: An
               <p
                 className="mt-1 truncate text-xs italic leading-tight"
                 style={{
-                  fontFamily: 'var(--font-literata)',
+                  fontFamily: 'var(--font-serif)',
                   color: 'var(--ink)',
                   opacity: 0.7,
                 }}
@@ -301,7 +301,7 @@ export function AnsweredByYouCard({ item, recheckAction, onRetry, overflow }: An
           <p
             className="mt-2 text-[13px] italic leading-snug"
             style={{
-              fontFamily: 'var(--font-literata)',
+              fontFamily: 'var(--font-serif)',
               color: 'var(--ink)',
               opacity: 0.65,
             }}

--- a/src/components/feed/DismissedFeedBar.tsx
+++ b/src/components/feed/DismissedFeedBar.tsx
@@ -72,7 +72,7 @@ export function DismissedFeedBar({
           <p
             className="text-[13px] italic"
             style={{
-              fontFamily: 'var(--font-literata)',
+              fontFamily: 'var(--font-serif)',
               color: 'var(--ink)',
               opacity: 0.7,
             }}

--- a/src/components/games/interpretive-sections.tsx
+++ b/src/components/games/interpretive-sections.tsx
@@ -30,8 +30,8 @@ export type GrowthRow = {
 
 const G_INK = 'var(--warm-ink)';
 const G_INK3 = 'var(--brand-ink-400)';
-const G_FM = "'Courier New', monospace";
-const G_FF = "'Georgia', serif";
+const G_FM = 'var(--font-mono)';
+const G_FF = 'var(--font-serif)';
 const G_RULE = 'var(--warm-border)';
 
 function GrowthCircleRow({

--- a/src/components/knowledge/CategoryCircles.tsx
+++ b/src/components/knowledge/CategoryCircles.tsx
@@ -229,7 +229,7 @@ function GameCircleRow({
         <div
           style={{
             fontSize: 14,
-            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+            fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
             fontWeight: 600,
             color: 'var(--text)',
             lineHeight: 1.25,
@@ -325,7 +325,7 @@ function RoundCircleRow({
         <div
           style={{
             fontSize: 13,
-            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+            fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
             fontWeight: 600,
             color: 'var(--text)',
             lineHeight: 1.25,

--- a/src/components/knowledge/KnowledgeOverviewClient.tsx
+++ b/src/components/knowledge/KnowledgeOverviewClient.tsx
@@ -302,7 +302,7 @@ const sharePortraitBtnStyle: CSSProperties = {
   border: '1.5px solid #0e0e0e',
   backgroundColor: '#0e0e0e',
   color: 'var(--warm-paper)',
-  fontFamily: "'Courier New', monospace",
+  fontFamily: 'var(--font-mono)',
   fontSize: 12,
   letterSpacing: '0.12em',
   textTransform: 'uppercase',

--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -286,7 +286,7 @@ const rowTextStyle: CSSProperties = {
 const domainNameStyle: CSSProperties = {
   margin: 0,
   color: 'var(--warm-ink)',
-  fontFamily: 'var(--font-literata), Georgia, serif',
+  fontFamily: 'var(--font-serif), Georgia, serif',
   fontSize: '0.92rem',
   fontWeight: 700,
   lineHeight: 1.18,

--- a/src/components/lately/tokens.ts
+++ b/src/components/lately/tokens.ts
@@ -1,6 +1,6 @@
 // Re-pointed to the JOSHING brand palette so the Lately surface matches the
-// rest of the app. The Playfair "Lately." flourish (FS), Caveat accent (FH),
-// and warm highlighter (HILITE) are kept as intentional editorial character.
+// rest of the app. The Playfair "Lately." flourish (FS) and warm highlighter
+// (HILITE) are kept as intentional editorial character.
 export const INK = '#0a1f3d'; // --brand-ink
 export const INK2 = '#3a4a5f'; // --brand-ink-700
 export const INK3 = '#8a8a8a'; // --brand-ink-400
@@ -16,4 +16,3 @@ export const FF = 'var(--font-sans-body), -apple-system, system-ui, sans-serif';
 export const FM = '"Courier New", ui-monospace, monospace';
 export const FS = 'var(--font-display), Georgia, serif';
 export const FI = 'Georgia, var(--font-display), serif';
-export const FH = 'var(--font-caveat), "Caveat", cursive';

--- a/src/components/lately/tokens.ts
+++ b/src/components/lately/tokens.ts
@@ -13,6 +13,6 @@ export const HILITE = '#e9c97a'; // warm brand-aligned highlighter
 // CSS var resolves to it. The mockup spec'd Inter — project decision to keep
 // Montserrat (see CLAUDE.md + intentional comment in src/app/layout.tsx).
 export const FF = 'var(--font-sans-body), -apple-system, system-ui, sans-serif';
-export const FM = '"Courier New", ui-monospace, monospace';
+// System voice — routed through the app-wide mono token (Courier New first).
+export const FM = 'var(--font-mono)';
 export const FS = 'var(--font-display), Georgia, serif';
-export const FI = 'Georgia, var(--font-display), serif';

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -377,7 +377,7 @@ function QuestionRow({
       {creatorName ? (
         <p
           style={{
-            fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+            fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
             fontSize: '0.86rem',
             color: 'var(--text)',
             paddingLeft: '2px',
@@ -623,7 +623,7 @@ function ExplainerLine({ text }: { text: string }) {
     <p
       style={{
         marginTop: '8px',
-        fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+        fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
         fontSize: '0.92rem',
         color: 'color-mix(in srgb, var(--text-muted) 35%, var(--text))',
         lineHeight: 1.5,
@@ -880,7 +880,7 @@ function AuthorNoteCard({
       <p
         style={{
           marginTop: '4px',
-          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+          fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
           // Reflection/creator-note body bumped ~14% for readability (D-5);
           // the eyebrow label above stays small and secondary.
           fontSize: '1.05rem',
@@ -1091,7 +1091,7 @@ function ResultRow({
           <>
             <p
               style={{
-                fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+                fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
                 color: 'var(--game-wrong-strong)',
                 fontWeight: 600,
               }}
@@ -1258,7 +1258,7 @@ function ResultRow({
           <p
             style={{
               marginTop: '4px',
-              fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+              fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
               // Reflection body bumped ~14% for readability (D-5); the small,
               // letter-spaced label above stays secondary.
               fontSize: '1.05rem',
@@ -1350,7 +1350,7 @@ function SessionCompleteRow({
       </p>
       <p
         style={{
-          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+          fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
           fontSize: '2rem',
           fontWeight: 600,
           color: 'var(--success)',
@@ -1423,7 +1423,7 @@ function BonusOfferRow({
       </p>
       <p
         style={{
-          fontFamily: 'var(--font-literata), ui-serif, Georgia, serif',
+          fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
           fontSize: '1.3rem',
           fontWeight: 600,
           color: 'var(--text)',

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -502,9 +502,9 @@ function QuestionRow({
                 <span
                   key={badge.label}
                   style={{
-                    // Figma display/pill/sans — Georgia, 12px, title-case (not the
+                    // Figma display/pill/sans — serif, 12px, title-case (not the
                     // mono uppercase used elsewhere).
-                    fontFamily: 'Georgia, "Times New Roman", serif',
+                    fontFamily: 'var(--font-serif)',
                     fontSize: '0.675rem',
                     lineHeight: 1.1,
                     letterSpacing: '0.01em',

--- a/src/components/profile/RecentlyExploringSection.tsx
+++ b/src/components/profile/RecentlyExploringSection.tsx
@@ -131,7 +131,7 @@ const rowTextStyle: CSSProperties = {
 const domainNameStyle: CSSProperties = {
   margin: 0,
   color: 'var(--warm-ink)',
-  fontFamily: 'var(--font-literata), Georgia, serif',
+  fontFamily: 'var(--font-serif), Georgia, serif',
   fontSize: '0.92rem',
   fontWeight: 700,
   lineHeight: 1.18,

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -45,7 +45,7 @@ export function MyQuestionCard({
             <span
               className="truncate text-[12px] italic leading-tight"
               style={{
-                fontFamily: 'var(--font-literata)',
+                fontFamily: 'var(--font-serif)',
                 color: 'var(--ink)',
                 opacity: 0.7,
               }}

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -43,9 +43,11 @@ export function MyQuestionCard({
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           {visibleCategory ? (
             <span
-              className="truncate text-[12px] italic leading-tight"
+              className="truncate text-[12px] leading-tight"
               style={{
-                fontFamily: 'var(--font-serif)',
+                // Category label is metadata — System voice (mono), per
+                // STYLE-GUIDE-TYPE §5. No italic: mono carries its own register.
+                fontFamily: 'var(--font-mono)',
                 color: 'var(--ink)',
                 opacity: 0.7,
               }}

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -36,9 +36,9 @@ import type { RelationshipResult } from '@/server/db/queries/friend-requests';
 export type StreamLinePart =
   | { t: 'text'; v: string }
   | { t: 'actor'; name: string; userId: string | null }
-  // A category/topic name embedded in a one-liner. Rendered in the editorial
-  // serif register — the SAME font treatment categories get as the `secondLine`
-  // on the homepage "What's Happening" head (see ActivityStreamItem).
+  // A category/topic name embedded in a one-liner. Structured metadata, so it
+  // renders in the System mono register (STYLE-GUIDE-TYPE §5) — the same
+  // treatment metadata `secondLine`s get (see ActivityStreamItem).
   | { t: 'category'; v: string };
 
 export type StreamQuestion = {
@@ -243,6 +243,11 @@ export type StreamItem = {
   homeEligible: boolean;
   line: StreamLinePart[];
   secondLine: string | null;
+  // Which type voice renders `secondLine` (STYLE-GUIDE-TYPE §5): 'system' for
+  // structured metadata (domain names, reaction labels) → mono; omitted for
+  // Editorial content (question text, sentences) → serif. secondLine carries
+  // both kinds depending on the row, so the builder declares which it is.
+  secondLineVoice?: 'system';
   // Optional DOM id (friend-invitation deep link: /activities#friendship-{id}).
   anchorId: string | null;
   action: StreamAction | null;
@@ -377,6 +382,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line,
         secondLine: got ? null : domain,
+        secondLineVoice: 'system',
         icon: 'diamond',
         relationship: 'got_you',
         topic: domain,
@@ -405,6 +411,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(' answered your question — someone shares this corner')],
         secondLine: domain,
+        secondLineVoice: 'system',
         icon: 'diamond',
         action: null,
         expand:
@@ -431,6 +438,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [txt('You answered '), a, txt("'s question — you found someone")],
         secondLine: domain,
+        secondLineVoice: 'system',
         icon: 'diamond',
         action: null,
         expand:
@@ -457,6 +465,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(domain ? ' opened ' + domain : ' opened a new domain')],
         secondLine: domain,
+        secondLineVoice: 'system',
         icon: 'domain',
         action: domain
           ? {
@@ -475,6 +484,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(` reached ${m?.tier ?? 'a new tier'}`)],
         secondLine: m?.domain ?? null,
+        secondLineVoice: 'system',
         action: null,
         expand: null,
       };
@@ -490,6 +500,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [a, txt(' reacted to your question')],
         secondLine: label,
+        secondLineVoice: 'system',
         relationship: 'reacted',
         topic: domain,
         // Keep the lightweight "got it" acknowledgement AND let the row expand to
@@ -554,6 +565,7 @@ export function activityToStreamItem(item: ActivityItemView): StreamItem {
         ...base,
         line: [txt(`You shared a question with ${count} ${friendWord}`)],
         secondLine: shared?.domain ?? null,
+        secondLineVoice: 'system',
         icon: 'hourglass',
         // Friend-less: this is the viewer's own broadcast, not one friend acting.
         friendId: null,


### PR DESCRIPTION
- Remove the Caveat font load (zero consumers) and the unused FH constant
- Fold --font-literata into --font-serif: repointed all 25 consumer sites
  across 11 files, zero dangling references remain
- Point --font-mono at Courier New first (System voice, STYLE-GUIDE-TYPE §2)
- Remove the self-referential --font-sans wart in the @theme inline block

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF