### PR TITLE
Sync Common Ground headline with active carousel slide

### DIFF
--- a/src/components/feed/EditorialCarousel.tsx
+++ b/src/components/feed/EditorialCarousel.tsx
@@ -12,6 +12,9 @@ type EditorialCarouselProps = {
   slides: ReactNode[];
   // Describes the set for assistive tech (e.g. "Shared interests").
   ariaLabel?: string;
+  // Fired when the visible slide changes (scroll or dot tap), so a parent can
+  // mirror copy outside the artwork (e.g. a headline) to the active slide.
+  onActiveIndexChange?: (index: number) => void;
 };
 
 /**
@@ -23,7 +26,11 @@ type EditorialCarouselProps = {
  * prefers-reduced-motion by jumping dot taps instantly. SSR-safe: with no
  * client scroll yet, the first dot reads active.
  */
-export function EditorialCarousel({ slides, ariaLabel }: EditorialCarouselProps) {
+export function EditorialCarousel({
+  slides,
+  ariaLabel,
+  onActiveIndexChange,
+}: EditorialCarouselProps) {
   const reducedMotion = usePrefersReducedMotion();
   const trackRef = useRef<HTMLDivElement | null>(null);
   const [activeIndex, setActiveIndex] = useState(0);
@@ -31,7 +38,9 @@ export function EditorialCarousel({ slides, ariaLabel }: EditorialCarouselProps)
   function handleScroll(event: UIEvent<HTMLDivElement>) {
     const track = event.currentTarget;
     const next = Math.round(track.scrollLeft / track.clientWidth);
-    setActiveIndex((prev) => (prev === next ? prev : next));
+    if (next === activeIndex) return;
+    setActiveIndex(next);
+    onActiveIndexChange?.(next);
   }
 
   function goTo(index: number) {

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -3,6 +3,7 @@
 import { Bookmark } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
+import { useState } from 'react';
 
 import { EditorialCarousel } from '@/components/feed/EditorialCarousel';
 import { EditorialFeature } from '@/components/feed/EditorialFeature';
@@ -76,6 +77,13 @@ export function CommonGroundFeature({
   );
   const count = embed.friends.length;
   const headline = rotate(COMMON_GROUND_HEADLINES, embed.headlineIndex);
+  // The headline names the friend in the active carousel slide, so rotating the
+  // carousel updates the copy with it. The trailing "invite" slide has no friend
+  // (index === count), so clamp back to the last friend rather than flicker.
+  const [activeIndex, setActiveIndex] = useState(0);
+  const activeFriend = embed.friends[Math.min(activeIndex, count - 1)];
+  const friendFirstName = activeFriend?.friendFirstName ?? embed.friendFirstName;
+  const friendHref = activeFriend?.friendHref ?? embed.friendHref;
   return (
     <EditorialFeature
       tone="parchment"
@@ -85,10 +93,10 @@ export function CommonGroundFeature({
         <>
           {headline.before}
           <Link
-            href={embed.friendHref}
+            href={friendHref}
             className="text-[var(--brand-ink)] underline-offset-4 hover:underline"
           >
-            {embed.friendFirstName}
+            {friendFirstName}
           </Link>
           {headline.after}
         </>
@@ -96,6 +104,7 @@ export function CommonGroundFeature({
       artwork={
         <EditorialCarousel
           ariaLabel="Friends you share ground with"
+          onActiveIndexChange={setActiveIndex}
           slides={[
             ...embed.friends.map((f) => (
               <div key={f.friendId} className="flex flex-col gap-4">
@@ -142,7 +151,7 @@ export function CommonGroundFeature({
         />
       }
       supporting={`Shared ground with ${count} ${count === 1 ? 'friend' : 'friends'}`}
-      cta={{ label: 'Explore your overlap →', href: embed.friendHref }}
+      cta={{ label: 'Explore your overlap →', href: friendHref }}
     />
   );
 }


### PR DESCRIPTION
## Summary
Updates the Common Ground feature to dynamically sync the headline copy with the currently active carousel slide, ensuring the friend name in the headline matches the visible slide rather than remaining static.

## Key Changes
- **EditorialCarousel**: Added `onActiveIndexChange` callback prop to notify parent components when the visible slide changes (via scroll or dot navigation)
- **CommonGroundFeature**: 
  - Introduced `activeIndex` state to track the currently visible carousel slide
  - Dynamically select the active friend's data based on `activeIndex`, with fallback to the primary friend when on the trailing "invite" slide
  - Pass `onActiveIndexChange` to EditorialCarousel to keep headline copy in sync with carousel position
  - Updated headline link and CTA to use the active friend's `friendHref` instead of the static embed value

## Implementation Details
- The carousel's trailing "invite" slide has no associated friend (index === count), so the active friend selection clamps to `Math.min(activeIndex, count - 1)` to prevent flickering back to the last real friend
- The headline copy now updates reactively as users navigate the carousel, improving UX coherence
- Scroll and dot-tap navigation both trigger the callback, ensuring consistent behavior across interaction methods

https://claude.ai/code/session_01AnS2L3v5QjEfC41gE19Z3R