### PR TITLE
Add flanking star to milestone announcement

### DIFF
--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -286,9 +286,9 @@ function StarMark({ seed }: { seed: string }) {
   );
 }
 
-// The same five-point star, used as a single flourish leading the centered
-// "played their first five" announcement (star — line) rather than a mark in the
-// left icon column. Decorative; the row copy carries the meaning.
+// The same five-point star, used as a flourish flanking the centered
+// "played their first five" announcement (star — line — star) rather than a mark
+// in the left icon column. Decorative; the row copy carries the meaning.
 export function MilestoneStar({ seed }: { seed: string }) {
   return (
     <span aria-hidden style={{ display: 'flex', flexShrink: 0 }}>

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -295,7 +295,8 @@ export function ActivityStreamItem({
         }}
       >
         {centeredStar ? (
-          // Celebratory announcement: a single star leading the centered line.
+          // Celebratory announcement: a star flourish on each side of the
+          // centered line (star — line — star).
           <>
             <MilestoneStar seed={item.id} />
             <p
@@ -310,6 +311,7 @@ export function ActivityStreamItem({
             >
               <Line parts={item.line} />
             </p>
+            <MilestoneStar seed={`${item.id}-end`} />
           </>
         ) : (
           <>


### PR DESCRIPTION
## Summary
Updates the milestone "played their first five" announcement to display a decorative star on both sides of the centered line, rather than just leading it.

## Changes
- **ActivityIcon.tsx**: Updated comment to reflect that `MilestoneStar` is now used as a flanking flourish (star — line — star) instead of a single leading mark
- **ActivityStreamItem.tsx**: 
  - Added a second `MilestoneStar` component after the centered line with a unique seed (`${item.id}-end`)
  - Updated comment to clarify the new symmetric star placement

## Implementation details
The second star uses a seeded variant of the item ID to ensure it renders differently from the leading star while maintaining deterministic styling based on the activity item.

https://claude.ai/code/session_01PKAqVGfUCtpHNcZ229rMyg