### PR TITLE
Implement the Type Style Guide (token-first) + font ratchet

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - **Docs index + settled/open decisions:** `DECISIONS.md` (start here).
 - **Canonical product direction (the v12 line):** the `PRD-D-*.md` series (`PRD-D-0` through `PRD-D-5`). These supersede the 10.25/v11.x PRDs.
 - **Design system:** `_docs/DESIGN-SYSTEM.md` — tokens, fonts (Montserrat → `--font-sans`), the Ink-on-Cream palette.
-- **Type style guide:** `_docs/STYLE-GUIDE-TYPE.md` — the four type voices (Editorial/serif, System/mono, Interface/sans, Brand/script) and the token fix-list. Part 1 of 2; color is deferred to Part 2.
+- **Type style guide:** `_docs/STYLE-GUIDE-TYPE.md` — the four type voices (Editorial/serif, System/mono, Interface/sans, Brand/script) and the token fix-list. Part 1 of 2.
+- **Color style guide:** `_docs/STYLE-GUIDE-COLOR.md` — Part 2 of 2: the five color jobs (grading reserved, neutrals, category, gold accent, link/brand) and the color fix-list. Rules locked; some hex values still to set.
 - Architecture overview: `_docs/ARCHITECTURAL-DECISIONS.md` (may contain stale claims — treat as background, not gospel).
 - Superseded 10.25/v11.x PRDs and audits are archived under `_docs/archive/`.

--- a/_docs/STYLE-GUIDE-COLOR.md
+++ b/_docs/STYLE-GUIDE-COLOR.md
@@ -1,0 +1,121 @@
+# Joshing Style Guide — Color (Part 2 of 2)
+
+**Status:** frame and rules locked against live code via `D-STYLE-AUDIT-01` (2026-06-11) and the gold-density study. Specific hex values for the category scale and the new WRONG-red are marked _(set)_ where a value still needs to be chosen against the real domain list — the *rules* are build-ready now. Corrective calls vs. live code are flagged → FIX. Pairs with `STYLE-GUIDE-TYPE.md`; the friend card is the shared test surface across both halves.
+
+---
+
+## The core idea: color sorts by job, and the jobs don't share values
+
+Type had three voices. Color has **five jobs**, and the whole discipline is that a value does exactly one job. The live code drifted because one job's color leaked into another's (warm-red doing wrong *and* link *and* category-adjacent; gold doing six things). The guide fixes that by naming the jobs and reserving values to them.
+
+| Job | What it is | Reserved? |
+|---|---|---|
+| **Grading** | Correct / wrong on an answer | **Reserved** — used nowhere else, ever |
+| **Neutrals** | Ink, cream, surfaces, borders — the editorial ground | Shared, but one value per token |
+| **Category** | Which top-level domain a thing belongs to | A small fixed scale, designed off grading |
+| **Accent (gold)** | Highlight the single most notable thing in view | One value, scarcity-bound |
+| **Link / brand** | Interactive text + brand orange | One value (orange), freed by moving wrong off it |
+
+The thesis test for the whole system: **nothing that isn't a graded answer may render in a grading color.** If a category triangle, a link, or a decorative mark ever reads as "wrong," the color system has betrayed the product promise.
+
+---
+
+## 1. GRADING — reserved, and WRONG moves to a true red
+
+**The most important rule in the document.** Correct and wrong are sacred signals. They appear only on answer results — never on a category, a link, a marker, a surface, or decoration.
+
+**The change:** WRONG moves **out of the orange/terracotta family into a true red.** Live code has WRONG as `--game-wrong #c96b4a` / `--game-wrong-strong #c33d14` — both terracotta, sitting in the same family as the brand/link orange `#d15e36` and the territory accent `#c9564d`. That overload is why orange feels like it's doing too much. Pulling WRONG to a clear red:
+- removes every near-hex collision the audit found in one move,
+- frees orange to be cleanly **link + brand**,
+- makes the solid-orange "still to play" triangle stop reading as failure — *without* having to touch the triangle, because the failure color is simply no longer orange.
+
+| Token | Current | Target |
+|---|---|---|
+| `--game-wrong` | `#c96b4a` (terracotta) | a true red _(set)_ — clearly not orange, not the link color |
+| `--game-wrong-strong` | `#c33d14` | the strong variant of the new red _(set)_ |
+| `--game-correct` | `#366045` | keep — but **confirm it clears the knowledge greens** (`#5a7a2e`, `#4a7a5a`, `#2e8b57`); if any crowd it, the *category* green moves, not the grading green |
+
+**Per the existing WCAG note:** correct/wrong must never be carried by color alone — always paired with a label or mark. The new red doesn't change that; it just makes the color half unambiguous.
+
+→ FIX: retire `--destructive` (`oklch(...)`, a third red) and `--success #178245` (a second green) as grading signals — consolidate to `--game-wrong` / `--game-correct` so there is exactly one wrong and one correct value.
+
+---
+
+## 2. NEUTRALS — one value per token
+
+The editorial ground: ink, cream, card surfaces, borders. These are shared across everything (that's fine — they're the paper, not a signal), but each token must resolve to **one** value.
+
+→ FIX (from audit): `CREAM` has a name/value conflict — the TS constant `CREAM #fcf8f2` (matches `--brand-cream-page`) collides with the CSS `--cream #fdfcfb`. Pick one, point both names at it. Reconcile the parallel TS token system (`lately/tokens.ts`) against the CSS tokens generally — they should not be two sources of truth.
+
+Ink ramp (`--brand-ink` `#0a1f3d` and its 700/400 steps) and the cream/border ramp stay as-is once deduplicated. Descriptor text uses the softened ink step (ink-700 `#3a4a5f`), per the type guide.
+
+---
+
+## 3. CATEGORY — color = top-level domain
+
+**The rule:** color attaches to the **top-level domain**, not the leaf interest. Literature is one hue whether the question is T.S. Eliot or Cervantes. Plant Biology and Chemistry are both "Science" green. This is the architectural simplification that makes the category scale tractable: it needs one color per top-level domain (≈7–9 values), not one per hyper-specific interest.
+
+**Construction rules:**
+- The scale is a **small fixed set**, defined once, named `--cat-literature`, `--cat-science`, etc.
+- Every hue is **designed to clear the grading colors** — no category red near the new WRONG-red, no category green near CORRECT. (With WRONG moved to true red, the existing purple/teal/tan/orange category hues are mostly already clear; the greens are the ones to check.)
+- Leaf categories **inherit the parent domain's hue** — no per-leaf color, no hashing.
+
+→ FIX (big one): live code has **five separate category/domain color systems** (feed hash palette, knowledge `DOMAIN_COLORS`, the duplicated share-card copy, the position-based "expanding" accents, the ceremony gradient palette), none sharing values or logic. Collapse to **one** `--cat-*` scale keyed on top-level domain. This is the largest single source of the color sprawl.
+
+> **On the triangle hue:** the audit found triangle fill color is a *decorative* hash, not category-bearing. Two options once the `--cat-*` scale exists: (a) make the triangle actually use the category hue (color now means something), or (b) keep it decorative but draw from the muted category family so it can't collide with anything. Decide at build time; both are defensible. The one bit the triangle *does* encode — solid/hollow = unplayed/played — is safe the moment WRONG leaves orange.
+
+---
+
+## 4. ACCENT (gold) — one value, once per view
+
+Gold is the highlight. It behaves like emphasis, not decoration — the same discipline the type guide put on italics.
+
+**The rule (locked):** **gold marks the single most notable moment in view. At most one gold element per viewport/section. If two compete, the time-bound one (the ceremony countdown) wins.** "Once per page" is interpreted as once per logical section / viewport, not once per entire scrollable feed — so a long feed gets a gold standout per section, never a speck at the top and nothing after, and never one-per-row.
+
+**What gold is for:** the ceremony / "weekly reflection in N days" countdown; a single convergence or milestone standout card. **What gold is not:** a standing register for the descriptor line (the gold-density study ruled this out — gold serif under every name is too much), a per-row accent, a decorative tint.
+
+**One value.** → FIX (from audit): the "gold" is currently at least six values — `--tri-amber #d9a82e`, a thrice-duplicated `GOLD_INK` mix, the TS-only `HILITE #e9c97a`, `--tri-darkyellow #deae5c`, `--warning #b45309`/`--warning-border #e6c15a`, plus strays `#f0c060` / `#d9b56c`. Collapse the *accent* uses to one token (`--accent-gold`, value `#d9a82e` from `--tri-amber`). **Exception:** `--warning` is a distinct semantic (system warning state), not the editorial accent — keep it separate and named as such, don't fold it into the accent gold.
+
+---
+
+## 5. LINK / BRAND — orange, freed
+
+With WRONG off the orange family, **orange `#d15e36` is cleanly link + brand** (`--brand-orange` / `--tri-orange`, already one value). No further collision once §1 lands. Keep it; just stop sharing it with grading.
+
+---
+
+## 6. THE SHARED TEST SURFACE — the friend card, fully specified
+
+This card is specified across both guides. Type from Part 1, color here:
+
+| Element | Type voice | Color |
+|---|---|---|
+| **"Robyn"** (name) | Editorial / Cormorant | ink `#0a1f3d` |
+| descriptor sentence | Montserrat (per type guide) | ink-700 `#3a4a5f` |
+| category names | mono (→ FIX from Georgia) | ink-700 |
+| triangle marker | — (visual) | category hue (muted family); solid/hollow = unplayed/played; **never grading-red** |
+| "Play these" | mono | ink, underline ink |
+| **standout card only** (one per view) | — | gold accent: tint surface + rule + link, per §4 |
+
+The ordinary cards carry **zero gold and zero grading color.** Only the single most-notable card in view earns the gold treatment. That is the whole rule, visible in one surface.
+
+---
+
+## 7. The fix-list (color half of `B-VISUAL-STYLE-GUIDE-COLOR-01`)
+
+In dependency order, same define → route → de-collide shape as the type prompt:
+
+1. **Grading:** move WRONG to true red _(set value)_; consolidate `--destructive` and `--success` into the two grading tokens; confirm CORRECT clears knowledge greens.
+2. **Neutrals:** resolve the CREAM name/value conflict; reconcile the TS token system against CSS tokens (one source of truth).
+3. **Category:** define the one `--cat-*` scale keyed on top-level domain (off grading hues); collapse the five existing systems onto it; route all consumers.
+4. **Gold:** collapse the six golds to one `--accent-gold`; keep `--warning` separate; route consumers; enforce once-per-viewport in the standout components.
+5. **Triangle:** decide category-hued vs. muted-decorative; ensure solid fill is never grading-red.
+6. **Ratchet:** add a color ratchet (hardcoded hex + rgb/hsl count) alongside the type ratchet, baseline ≈312 color occurrences (235 hex + 77 rgb/hsl); propose the dev/debug exemption rather than deciding it.
+
+**Each step leaves the app working.** Grading first because it's thesis-critical and unblocks the triangle. Category third because it's the biggest sprawl. Gold's once-per-view rule is the one behavioral (not just token) change — it needs a component-level check, not just a value swap.
+
+---
+
+## What's settled vs. what still needs a value
+- **Settled (rules):** color-job taxonomy; WRONG→red; category = top-level domain with leaf inheritance; gold once-per-viewport, ceremony wins ties; orange = link/brand; one value per token.
+- **Still to set (values):** the specific WRONG-red hex; the per-domain category hues (needs the real top-level domain list from live code); the triangle category-vs-muted decision.

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -792,7 +792,7 @@ function DragPreview({ domain }: { domain: TerritoryDomain }) {
           <span
             style={{
               color: color.primary,
-              fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+              fontFamily: 'var(--font-serif)',
               fontSize: 18,
               fontWeight: 700,
               lineHeight: 1,
@@ -978,7 +978,7 @@ function TerritoryCircle({
             style={{
               fontSize: countFontSize,
               color: color.primary,
-              fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+              fontFamily: 'var(--font-serif)',
               fontWeight: 700,
               lineHeight: 1,
             }}

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -111,7 +111,9 @@ function FriendCard({ person }: { person: Person }) {
       href={`/users/${person.id}`}
       className="group focus-visible:ring-ring block py-4 transition focus-visible:rounded-md focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
     >
-      <h3 className="text-foreground font-medium group-hover:underline group-hover:underline-offset-4">
+      {/* Name-as-headline is the Editorial voice (STYLE-GUIDE-TYPE §5):
+          heavier serif, full ink. */}
+      <h3 className="text-foreground font-serif text-lg font-semibold leading-tight group-hover:underline group-hover:underline-offset-4">
         {person.displayName}
       </h3>
       <p className="text-muted-foreground mt-1 text-sm leading-6">{friendSecondary(person)}</p>
@@ -138,7 +140,7 @@ function PendingInviteCard({
     <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
-          <h3 className="text-foreground font-medium">{invitationName(invite)}</h3>
+          <h3 className="text-foreground font-serif text-lg font-semibold leading-tight">{invitationName(invite)}</h3>
           <p className="text-muted-foreground mt-1 text-sm">{invitationTiming(invite.sentAt)}</p>
         </div>
         <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -126,7 +126,7 @@ const CREAM = 'var(--brand-cream-card)';
 const PAPER = 'var(--brand-card)';
 const RULE = 'var(--brand-border)';
 const MONO = 'var(--font-mono)';
-const SERIF = "var(--font-cormorant), Georgia, 'Times New Roman', serif";
+const SERIF = 'var(--font-serif)';
 
 const cardStyle: CSSProperties = {
   background: `linear-gradient(180deg, ${PAPER} 0%, ${CREAM} 100%)`,

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -59,10 +59,21 @@ export function Line({ parts }: { parts: StreamLinePart[] }) {
           return <ActorLink key={i} name={part.name} userId={part.userId} />;
         }
         if (part.t === 'category') {
-          // Category names are structured metadata — System voice (mono), per
-          // STYLE-GUIDE-TYPE §5. The sentence around them stays in the sans.
+          // Category names are structured metadata — System voice (mono) with
+          // its caps + tracking signature (STYLE-GUIDE-TYPE §2, §5), set a step
+          // smaller than the sentence so it reads as a label, not typewriter
+          // prose. The sentence around it stays in the sans.
           return (
-            <span key={i} style={{ fontFamily: 'var(--font-mono)', color: INK2 }}>
+            <span
+              key={i}
+              style={{
+                fontFamily: 'var(--font-mono)',
+                fontSize: '0.8em',
+                textTransform: 'uppercase',
+                letterSpacing: 0.8,
+                color: INK2,
+              }}
+            >
               {part.v}
             </span>
           );
@@ -334,13 +345,19 @@ export function ActivityStreamItem({
               style={{
                 margin: '2px 0 0',
                 // Voice follows content (STYLE-GUIDE-TYPE §5): domain/label
-                // metadata is System mono; question text / sentences are
-                // Editorial serif.
-                fontFamily:
-                  item.secondLineVoice === 'system'
-                    ? 'var(--font-mono)'
-                    : 'var(--font-serif)',
-                fontSize: 14,
+                // metadata is System mono with the caps + tracking label
+                // signature (§2); question text / sentences are Editorial serif.
+                ...(item.secondLineVoice === 'system'
+                  ? {
+                      fontFamily: 'var(--font-mono)',
+                      fontSize: 11,
+                      textTransform: 'uppercase' as const,
+                      letterSpacing: 1,
+                    }
+                  : {
+                      fontFamily: 'var(--font-serif)',
+                      fontSize: 14,
+                    }),
                 lineHeight: 1.45,
                 color: INK2,
                 display: '-webkit-box',

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown, Share2 } from 'lucide-react';
+import { ChevronDown, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useState, type CSSProperties, type KeyboardEvent } from 'react';
 
@@ -686,8 +686,9 @@ function SendOnwardExpansion({
       <QuestionProvenance q={question} style={{ margin: '0 0 12px' }} />
 
       <div style={{ display: 'flex', flexWrap: 'wrap', alignItems: 'center', gap: 12 }}>
-        {/* Quiet, standard share icon (matches KnowledgeCard / RecentlyExpanding)
-            — no oversized labeled button. Opens the same SendQuestionDrawer. */}
+        {/* Quiet, icon-only share affordance — no oversized labeled button.
+            Send (paper plane) is the homepage's share glyph by request; the
+            knowledge surfaces still use Share2. Opens the same SendQuestionDrawer. */}
         <button
           type="button"
           onClick={() => setSendOpen(true)}
@@ -703,7 +704,7 @@ function SendOnwardExpansion({
             cursor: 'pointer',
           }}
         >
-          <Share2 size={15} strokeWidth={1.8} aria-hidden="true" />
+          <Send size={15} strokeWidth={1.8} aria-hidden="true" />
         </button>
 
         {expand.kind === 'niche_match' && expand.strangerId ? (

--- a/src/components/answer-heading.ts
+++ b/src/components/answer-heading.ts
@@ -9,7 +9,7 @@ import type { CSSProperties } from 'react'
 // Apply the result tone on top of this (green `--game-correct` when the player
 // nailed it, `--brand-ink` otherwise) so the headline still reads as a verdict.
 export const answerHeadingStyle: CSSProperties = {
-  fontFamily: 'var(--font-cormorant), Georgia, serif',
+  fontFamily: 'var(--font-serif)',
   fontSize: '1.65rem',
   fontWeight: 700,
   lineHeight: 1.14,

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -289,7 +289,7 @@ export function AnsweredByYouCard({ item, recheckAction, onRetry, overflow }: An
         <p
           className="mt-3 text-base leading-snug"
           style={{
-            fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+            fontFamily: 'var(--font-serif)',
             color: 'var(--ink)',
             opacity: 0.65,
           }}

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -194,7 +194,7 @@ const shareButtonStyle: CSSProperties = {
 
 const statementStyle: CSSProperties = {
   margin: 0,
-  fontFamily: 'var(--font-cormorant), Georgia, serif',
+  fontFamily: 'var(--font-serif)',
   fontSize: 21,
   color: 'var(--brand-ink)',
   lineHeight: 1.35,

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -285,7 +285,7 @@ export function PortraitDomainCircle({
                 style={{
                   fontSize: countFontSize,
                   color: dc.primary,
-                  fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+                  fontFamily: 'var(--font-serif)',
                   fontWeight: 'bold',
                   lineHeight: 1,
                 }}
@@ -337,7 +337,7 @@ export function PortraitDomainCircle({
                 placeItems: 'center',
                 fontSize: 12,
                 fontWeight: 700,
-                fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+                fontFamily: 'var(--font-serif)',
                 lineHeight: 1,
                 boxShadow: '0 1px 3px rgba(0,0,0,0.18)',
               }}
@@ -351,7 +351,7 @@ export function PortraitDomainCircle({
         style={{
           fontSize: 10.5,
           color: dc.text,
-          fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+          fontFamily: 'var(--font-serif)',
           textAlign: 'center',
           lineHeight: 1.3,
           maxWidth: Math.max(90, resolvedCircleSlotSize),
@@ -475,7 +475,7 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
               color: '#b0a090',
               fontStyle: 'italic',
               marginLeft: 'auto',
-              fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+              fontFamily: 'var(--font-serif)',
             }}
           >
             Size = depth
@@ -511,7 +511,7 @@ export function PortraitCircles({ entries, editMode = false, onToggleHidden, pen
                   marginBottom: 14,
                   paddingBottom: 6,
                   borderBottom: `1px solid ${color}33`,
-                  fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+                  fontFamily: 'var(--font-serif)',
                 }}
               >
                 {label}
@@ -616,7 +616,7 @@ const sparsePromptStyle: CSSProperties = {
   fontSize: 13,
   color: '#8a8070',
   fontStyle: 'italic',
-  fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+  fontFamily: 'var(--font-serif)',
   textAlign: 'center',
 }
 
@@ -625,5 +625,5 @@ const explainerStyle: CSSProperties = {
   fontSize: 9.5,
   color: '#b0a090',
   fontStyle: 'italic',
-  fontFamily: 'var(--font-cormorant, Georgia), "Times New Roman", serif',
+  fontFamily: 'var(--font-serif)',
 }

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -487,7 +487,7 @@ function QuestionRow({
               ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--tri-amber)'
               : '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
             padding: '14px 18px',
-            fontFamily: 'var(--font-cormorant), Georgia, serif',
+            fontFamily: 'var(--font-serif)',
             fontSize: '1.4875rem',
             fontWeight: 700,
             letterSpacing: 0,
@@ -600,7 +600,7 @@ function UserRow({ text }: { text: string }) {
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
           padding: '9px 15px',
           // Figma answer bubble — Cormorant serif, not the sans body font.
-          fontFamily: 'var(--font-cormorant), Georgia, serif',
+          fontFamily: 'var(--font-serif)',
           fontSize: '1.495rem',
           fontWeight: 700,
           letterSpacing: '-0.01em',

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -43,10 +43,10 @@ export function MyQuestionCard({
         <div className="flex min-w-0 flex-wrap items-center gap-2">
           {visibleCategory ? (
             <span
-              className="truncate text-[12px] leading-tight"
+              className="truncate text-[10px] uppercase tracking-[0.1em] leading-tight"
               style={{
-                // Category label is metadata — System voice (mono), per
-                // STYLE-GUIDE-TYPE §5. No italic: mono carries its own register.
+                // Category label is metadata — System voice (mono) with the
+                // caps + tracking label signature, per STYLE-GUIDE-TYPE §2/§5.
                 fontFamily: 'var(--font-mono)',
                 color: 'var(--ink)',
                 opacity: 0.7,

--- a/src/components/review/MasteryMoment.tsx
+++ b/src/components/review/MasteryMoment.tsx
@@ -77,7 +77,7 @@ export default function MasteryMoment({
       >
         <p
           style={{
-            fontFamily: 'var(--font-cormorant), ui-serif, Georgia, serif',
+            fontFamily: 'var(--font-serif)',
             fontSize: 'clamp(1.2rem, 4vw, 1.6rem)',
             color: 'var(--brand-ink-700)',
             marginBottom: '12px',
@@ -87,7 +87,7 @@ export default function MasteryMoment({
         </p>
         <p
           style={{
-            fontFamily: 'var(--font-cormorant), ui-serif, Georgia, serif',
+            fontFamily: 'var(--font-serif)',
             fontSize: 'clamp(2rem, 7vw, 3rem)',
             fontWeight: 700,
             color: 'var(--brand-ink)',


### PR DESCRIPTION
Implements `B-VISUAL-STYLE-GUIDE-TYPE-01` — the type half of the style guide (`_docs/STYLE-GUIDE-TYPE.md`), built token-first in four phases, one commit per phase, plus follow-ups from review.

## Phase 1 — Token foundation (`cb4b3bf`)
- Removed the Caveat load (zero consumers) and the unused `FH` constant.
- Folded `--font-literata` into `--font-serif`: 25 consumer sites across 11 files repointed, zero dangling references.
- `--font-mono` now resolves Courier New first (System voice, guide §2).
- Removed the self-referential `--font-sans` wart in the `@theme inline` block.

## Phase 2 — Route consumers onto voice tokens (`8927bce`)
- All hardcoded Georgia / Courier New / Inter font literals routed to `--font-serif` / `--font-mono` / `--font-sans`; `FM`/`G_FM`/`G_FF` constants now resolve through tokens, `FI` deleted, Inter load removed.
- `SharePortraitCard` literals kept — documented html2canvas raster path.

## Phase 3 — Voice reassignments (`28cf873`)
- Activity-line category names → System mono (covers per-person clusters too via the shared `Line`).
- `secondLine` carries both metadata and prose depending on row kind, so the stream model gained `secondLineVoice: 'system'` on the seven metadata builders; renderer picks mono vs serif.
- Questions-page category label → mono, italic dropped. Question text and headings untouched.

## Phase 4 — Font ratchet (`65101f7`)
- `scripts/check-font-ratchet.mjs` (+ `npm run check:fonts` + `.github/workflows/font-ratchet.yml`) counts raw font-family declarations, literal stacks, and `font-[...]` arbitraries in `src/`. **Ceiling: 0** — every shipped surface is on the voice tokens.
- Documented exemptions: `globals.css`, the raster card, email templates (CSS vars impossible in mail clients), and `src/app/dev/*` / `src/app/feed/debug/*` (internal tooling, per checkpoint decision).
- Font-only by design; color gets its own ratchet with the color prompt.

## Follow-ups from review
- `a25a340` — consolidated the remaining `var(--font-cormorant), Georgia…` spellings onto `--font-serif` (zero visual change).
- `247866e` — restored the `Send` paper-plane share icon on the homepage activity expansion (was swapped to `Share2` in `58a7be5`).
- `6009622` — committed `_docs/STYLE-GUIDE-COLOR.md` (Part 2; rules locked, implementation deferred) and indexed it in CLAUDE.md.
- `2e9b71a` — Friends-page names set in the Editorial serif (guide §5 name-as-headline).
- `73d2b62` — category metadata now carries the System label signature (smaller, UPPERCASE, tracked) instead of sentence-case typewriter text.

## Verification
- `npx tsc -p tsconfig.typecheck.json` clean; `npm run lint` 0 errors (16 pre-existing color warnings, out of scope); `npm run check:fonts` 0/0; vitest 1102 passed (1 pre-existing DB-test failure, confirmed failing on the unmodified baseline).
- `next build` could not run in the sandbox (Google Fonts fetch blocked by network policy; baseline fails identically) — worth one preview-deploy glance at the activity stream, Questions page, and Friends page.

## Intentional visual changes (everything else should render identically)
1. Mono surfaces now render Courier New (was system monospace).
2. Category metadata (activity lines, secondLine domains, Questions-page labels) renders as small-caps-style mono labels.
3. The two Inter uses (login subtitle, loading screen) now render Montserrat.
4. Homepage share icon back to the paper plane; Friends-page names in Cormorant semibold.

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF

---
_Generated by [Claude Code](https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF)_