### PR TITLE
fix(feed): route FriendTerritoryCard topic name through serif voice token

### DIFF
--- a/src/components/feed/FriendTerritoryCard.tsx
+++ b/src/components/feed/FriendTerritoryCard.tsx
@@ -161,7 +161,7 @@ export function FriendTerritoryCard({ card }: { card: FriendTerritoryCardModel }
                 played={topicPlayed(topic)}
                 color={territoryTopicColor(topic.name)}
               />
-              <span className="text-[14px] leading-[1.45] text-[var(--brand-ink-700)] [font-family:var(--font-serif),Georgia,serif]">
+              <span className="font-serif text-[14px] leading-[1.45] text-[var(--brand-ink-700)]">
                 {topic.name}
               </span>
             </li>


### PR DESCRIPTION
## Why

The Phase 4 font ratchet (`scripts/check-font-ratchet.mjs`, ceiling 0) is failing on `dev2` and every branch based on it. The single offender:

```
src/components/feed/FriendTerritoryCard.tsx:164
  <span className="… [font-family:var(--font-serif),Georgia,serif]">
```

The ratchet's `STACK_CONST` rule flags the className because it contains a literal face-name + generic (`Georgia,serif`). That inline fallback is also **redundant** — `--font-serif` is defined in `globals.css` as `var(--font-cormorant, Georgia, "Times New Roman", serif)`, so Georgia/serif are already in the stack.

## Fix

Swap the inline arbitrary property for the canonical **`font-serif` utility class** — the same pattern every other serif usage in `src/` uses post Phase 1–3 migration. Same resolved font stack, **no visual change**, ceiling stays at 0 (not raised).

## Verification
- `node scripts/check-font-ratchet.mjs` → `✓ 0 off-system font declaration(s) (ceiling: 0)`
- `tsc -p tsconfig.typecheck.json` → 0 errors
- 1-line diff

Introduced by `ce21385` (inline font-family) meeting `65101f7` (ratchet added with ceiling 0). Unblocks `dev2` and dependent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)