### PR TITLE
TESTING: proposed-palette preview toggle (color style guide)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -212,6 +212,27 @@
     --shadow-paper-rest: 0 1px 2px rgb(0 0 0 / 0.05);
 }
 
+/* ───────────────────────────────────────────────────────────────────────────
+   TESTING ONLY — proposed color palette preview (see _docs/STYLE-GUIDE-COLOR.md).
+   Toggled by <PaletteToggle> via the `data-palette` attribute on <html>. This
+   block repoints color *tokens* to their proposed values, so flipping the
+   attribute re-colors every surface that reads a token — no per-page edits. Any
+   surface still on hardcoded hex (the five category systems, some golds) will
+   NOT flip here; routing those onto tokens is the actual color build (color
+   fix-list steps 3–4). First-pass values — tune them in place.
+   Remove this block and the component before merging to a shipping branch.
+   ─────────────────────────────────────────────────────────────────────────── */
+:root[data-palette="proposed"] {
+    /* §1 GRADING — WRONG leaves the terracotta family for a true red. This is the
+       thesis change: it de-collides wrong from the brand/link orange (#d15e36)
+       and from the solid "still to play" triangle, in one move. */
+    --game-wrong:        #c1121f;  /* was #c96b4a terracotta */
+    --game-wrong-strong: #8c0d17;  /* was #c33d14            */
+    /* CORRECT stays forest green; kept here as the single tuning point and to
+       confirm by eye that it clears the knowledge greens. */
+    --game-correct:      #366045;
+}
+
 .dark {
     --background: oklch(0.145 0 0);
     --foreground: oklch(0.985 0 0);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,9 @@ import type { Metadata } from 'next'
 import { Cormorant_Garamond, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
+// TESTING ONLY — proposed-palette preview bar (see _docs/STYLE-GUIDE-COLOR.md).
+// Remove this import + the <PaletteToggle/> + boot script before shipping.
+import { PaletteToggle } from "@/components/dev/PaletteToggle";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
 import { getBellBadgeCount } from '@/server/db/queries/activity';
@@ -64,6 +67,14 @@ export default async function RootLayout({
       className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable}`}
     >
       <body className={montserrat.className}>
+        {/* TESTING ONLY — apply the saved palette choice before paint so there's
+            no flash on navigation. Remove with <PaletteToggle/> before shipping. */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `try{if(localStorage.getItem('joshing-palette')==='proposed')document.documentElement.setAttribute('data-palette','proposed')}catch(e){}`,
+          }}
+        />
+        <PaletteToggle />
         <Nav
           initialUserId={claims?.userId ?? null}
           initialDisplayName={profile?.displayName ?? null}

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useSyncExternalStore, type CSSProperties } from 'react';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TESTING ONLY — proposed-palette preview switch (see _docs/STYLE-GUIDE-COLOR.md).
+//
+// Flips the `data-palette` attribute on <html>. The `:root[data-palette="proposed"]`
+// override block in globals.css repoints the color *tokens*, so every surface
+// that reads a token recolors automatically — no per-page edits. Surfaces still
+// on hardcoded hex (the category systems, some golds) won't flip until they're
+// routed onto tokens; that routing is the actual color build.
+//
+// Colors here are inline (not Tailwind classes) on purpose: this is chrome, not
+// app surface, so it deliberately sits outside the brand-token lint.
+//
+// Remove this component (and the globals.css block) before merging to a shipping
+// branch. The boot script in layout.tsx applies the saved choice pre-paint.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type Palette = 'current' | 'proposed';
+
+const STORAGE_KEY = 'joshing-palette';
+
+// What the toggle visibly changes, so a tester knows where to look. Extend this
+// as more color jobs (category, gold) get routed onto tokens.
+const CHANGES: Array<{ label: string; from: string; to: string }> = [
+  { label: 'WRONG', from: '#c96b4a', to: '#c1121f' },
+];
+
+const PALETTE_EVENT = 'joshing-palette-change';
+
+// Read the live palette straight off the <html> attribute (the source of truth,
+// also set by the boot script before paint). useSyncExternalStore keeps the
+// control in sync without an effect-setState and without a hydration mismatch —
+// the server snapshot is always 'current'.
+function subscribe(onChange: () => void) {
+  window.addEventListener(PALETTE_EVENT, onChange);
+  return () => window.removeEventListener(PALETTE_EVENT, onChange);
+}
+function readSnapshot(): Palette {
+  return document.documentElement.getAttribute('data-palette') === 'proposed' ? 'proposed' : 'current';
+}
+function serverSnapshot(): Palette {
+  return 'current';
+}
+
+export function PaletteToggle() {
+  const palette = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
+
+  function apply(next: Palette) {
+    if (next === 'proposed') {
+      document.documentElement.setAttribute('data-palette', 'proposed');
+    } else {
+      document.documentElement.removeAttribute('data-palette');
+    }
+    try {
+      localStorage.setItem(STORAGE_KEY, next);
+    } catch {
+      /* private mode / disabled storage — non-fatal */
+    }
+    window.dispatchEvent(new Event(PALETTE_EVENT));
+  }
+
+  const proposed = palette === 'proposed';
+
+  return (
+    <div
+      style={{
+        position: 'sticky',
+        top: 0,
+        zIndex: 60,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 12,
+        padding: '6px 16px',
+        fontSize: 12,
+        lineHeight: 1.2,
+        background: '#11161c',
+        color: '#e7e1d4',
+        borderBottom: '1px solid rgba(255,255,255,0.12)',
+      }}
+    >
+      <span style={{ fontWeight: 700, letterSpacing: '0.08em', whiteSpace: 'nowrap' }}>
+        ⚠ PALETTE TEST
+      </span>
+
+      <div
+        role="group"
+        aria-label="Color palette preview"
+        style={{
+          display: 'inline-flex',
+          padding: 2,
+          gap: 2,
+          borderRadius: 999,
+          background: 'rgba(255,255,255,0.08)',
+        }}
+      >
+        <button type="button" onClick={() => apply('current')} style={segStyle(!proposed)}>
+          Current
+        </button>
+        <button type="button" onClick={() => apply('proposed')} style={segStyle(proposed)}>
+          Proposed
+        </button>
+      </div>
+
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
+        {CHANGES.map((c) => (
+          <span key={c.label} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap' }}>
+            <span style={{ opacity: 0.8, letterSpacing: '0.04em' }}>{c.label}</span>
+            <Swatch color={c.from} dim={proposed} />
+            <span style={{ opacity: 0.5 }}>→</span>
+            <Swatch color={c.to} dim={!proposed} />
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function segStyle(active: boolean): CSSProperties {
+  return {
+    appearance: 'none',
+    border: 'none',
+    cursor: 'pointer',
+    borderRadius: 999,
+    padding: '3px 12px',
+    fontSize: 12,
+    fontWeight: 600,
+    background: active ? '#e7e1d4' : 'transparent',
+    color: active ? '#11161c' : '#e7e1d4',
+    transition: 'background 120ms ease, color 120ms ease',
+  };
+}
+
+function Swatch({ color, dim }: { color: string; dim: boolean }) {
+  return (
+    <span
+      aria-hidden="true"
+      title={color}
+      style={{
+        display: 'inline-block',
+        width: 14,
+        height: 14,
+        borderRadius: 3,
+        background: color,
+        boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.25)',
+        opacity: dim ? 0.35 : 1,
+        transition: 'opacity 120ms ease',
+      }}
+    />
+  );
+}


### PR DESCRIPTION
> ⚠️ **TESTING ONLY — not for production.** This adds a visible dev bar and a palette-override block so you can eyeball the proposed colors on a preview deploy. It must be reverted before any production release. Merge to `dev2` only if you want it on a preview; otherwise review and close.

Follows the merged type-guide PR (#822). Adds a way to **see** the color changes from `_docs/STYLE-GUIDE-COLOR.md` without rewiring each surface.

## What it does
A sticky bar at the top of every page with a **Current / Proposed** switch and a `WRONG → ` swatch legend. Flipping it sets `data-palette="proposed"` on `<html>`; the `:root[data-palette="proposed"]` override block in `globals.css` repoints the color **tokens**, so every token-driven surface recolors at once — no per-page edits. The choice persists in `localStorage` and is applied pre-paint by a small boot script, so it holds as you navigate page to page.

## Files
- `src/components/dev/PaletteToggle.tsx` — the bar (client component; reads the live `<html>` attribute via `useSyncExternalStore`, colors inline so it sits outside the brand-token lint).
- `src/app/globals.css` — `:root[data-palette="proposed"]` override block.
- `src/app/layout.tsx` — the boot script + `<PaletteToggle/>`, both clearly marked for removal.

## Scope of the preview (important)
First-pass scope is the thesis change from §1: **WRONG moves from terracotta `#c96b4a` to a true red `#c1121f`** (strong variant `#c33d14 → #8c0d17`). That flips on every surface reading `--game-wrong` / `--game-wrong-strong`: gameplay result cards, the feed answer sheet, activity-history "Not this time," daily-summary tiles.

It will **not** flip yet (these need consumer routing — the actual color build):
- **Category colors** — five separate hardcoded systems; need collapsing onto a `--cat-*` scale first.
- **Most golds** — largely hardcoded.
- **Today's Five result dots** — on `--destructive`/`--success`, which is itself the drift §1 flags. Toggling actually *demonstrates* this: the reveal surfaces go true-red while the dots stay vivid-red.

The `#c1121f` is a starting value — tune it in the `globals.css` override block (and the matching swatch in `PaletteToggle.tsx`).

## To remove later
Delete `PaletteToggle.tsx`, the `<PaletteToggle/>` + boot script in `layout.tsx`, and the `:root[data-palette="proposed"]` block in `globals.css`.

## Verification
`npx tsc -p tsconfig.typecheck.json` clean; `npm run lint` 0 errors (16 pre-existing warnings); `npm run check:fonts` 0/0; component tests 119/119.

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF

---
_Generated by [Claude Code](https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF)_