### PR TITLE
color: tokenize the category scale (--cat-*) + wire to the palette preview

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -784,8 +784,8 @@ function DragPreview({ domain }: { domain: TerritoryDomain }) {
     <div className="flex max-w-24 flex-col items-center gap-1 text-center drop-shadow-lg">
       <KnowledgeBubble
         diameter={58}
-        light={color.light}
-        border={`1px solid ${color.primary}55`}
+        tint={color.primary}
+        border={`1px solid color-mix(in srgb, ${color.primary} 33%, transparent)`}
         style={{ boxShadow: '0 12px 28px rgba(26,18,8,0.16)' }}
       >
         {domain.correctAnswerCount > 0 ? (
@@ -969,8 +969,8 @@ function TerritoryCircle({
     >
       <KnowledgeBubble
         diameter={size}
-        light={color.light}
-        border={`1px solid ${color.primary}44`}
+        tint={color.primary}
+        border={`1px solid color-mix(in srgb, ${color.primary} 27%, transparent)`}
         style={{ boxShadow: '0 8px 22px rgba(26,18,8,0.08)' }}
       >
         {correctCount > 0 ? (
@@ -1085,7 +1085,7 @@ function GhostTerritoryCircle({
 }) {
   const color = getPortraitDomainColor(territory.broadCategory ?? 'General Knowledge');
   const style = {
-    '--territory-border': `${color.primary}66`,
+    '--territory-border': `color-mix(in srgb, ${color.primary} 40%, transparent)`,
     '--territory-text': color.text,
   } as CSSProperties;
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -87,6 +87,39 @@
     --game-correct-soft:  #5d6f5b;  /* text/right — muted correct label          */
     --game-wrong:         #c96b4a;  /* text/wrong — terracotta result accent     */
     --game-wrong-strong:  #c33d14;  /* game/wrong/in-question — strong terracotta */
+    /* ── Category scale (STYLE-GUIDE-COLOR §3) ──────────────────────────────
+       One color per top-level domain; leaf categories inherit the parent hue.
+       Values = the knowledge map's DOMAIN_COLORS (the only true per-category
+       map in live code), now tokenized so consumers route through one scale
+       and the palette preview can flip them. `-text` is the hand-tuned darker
+       label variant; the soft circle fill derives from the primary at render
+       (domainBubbleGradient). The other category systems (feed hash palette,
+       expanding accents, ceremony gradients) are still hardcoded — collapsing
+       them onto this scale is color fix-list step 3, in progress. */
+    --cat-literature:       #c0392b;
+    --cat-literature-text:  #8b1a0e;
+    --cat-music:            #1a6b8a;
+    --cat-music-text:       #0e4060;
+    --cat-film-tv:          #6b3fa0;
+    --cat-film-tv-text:     #3d1f6b;
+    --cat-architecture:     #b07d2e;
+    --cat-architecture-text:#7a5010;
+    --cat-food:             #2e8b57;
+    --cat-food-text:        #0e5c30;
+    --cat-technology:       #3a6b8a;
+    --cat-technology-text:  #1a3f5c;
+    --cat-sports:           #c06b1a;
+    --cat-sports-text:      #8b3e0e;
+    --cat-history:          #5a6b7a;
+    --cat-history-text:     #2a3f50;
+    --cat-science:          #5a7a2e;
+    --cat-science-text:     #2a4a0e;
+    --cat-philosophy:       #7a5a8a;
+    --cat-philosophy-text:  #4a2a5c;
+    --cat-pop-culture:      #8a2a4a;
+    --cat-pop-culture-text: #5c0e2a;
+    --cat-language:         #4a7a5a;
+    --cat-language-text:    #1e4e30;
     /* Shared width for every left-aligned card in the play thread (question,
        bonus, result, reflection, session-close) so the column reads as one
        coherent conversation with a consistent left + right edge. A percentage of
@@ -231,6 +264,17 @@
     /* CORRECT stays forest green; kept here as the single tuning point and to
        confirm by eye that it clears the knowledge greens. */
     --game-correct:      #366045;
+
+    /* §3 CATEGORY — shift the two hues the guide flags as grading collisions.
+       Literature's strong red sat next to the NEW WRONG-red; it moves to a
+       darker bordeaux. Language was the green closest to CORRECT (#366045); it
+       moves to a teal, leaving the green family to Science/Food (judge those
+       by eye with the toggle — the guide says category greens move if they
+       crowd CORRECT, never the grading green). First-pass values — tune here. */
+    --cat-literature:      #7d2c3f;  /* was #c0392b */
+    --cat-literature-text: #571f2c;
+    --cat-language:        #2e6e7e;  /* was #4a7a5a */
+    --cat-language-text:   #173f4a;
 }
 
 .dark {

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -26,6 +26,8 @@ const STORAGE_KEY = 'joshing-palette';
 // as more color jobs (category, gold) get routed onto tokens.
 const CHANGES: Array<{ label: string; from: string; to: string }> = [
   { label: 'WRONG', from: '#c96b4a', to: '#c1121f' },
+  { label: 'LITERATURE', from: '#c0392b', to: '#7d2c3f' },
+  { label: 'LANGUAGE', from: '#4a7a5a', to: '#2e6e7e' },
 ];
 
 const PALETTE_EVENT = 'joshing-palette-change';

--- a/src/components/knowledge/CategoryCircles.tsx
+++ b/src/components/knowledge/CategoryCircles.tsx
@@ -161,7 +161,7 @@ export function KnowledgeCircle({
     >
       <KnowledgeBubble
         diameter={displaySize}
-        light={dc.light}
+        tint={dc.primary}
         opacity={opacity}
         style={{ transition: animate ? undefined : 'none' }}
       />

--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -52,7 +52,7 @@ export function DomainCircle({
     ? getPortraitDomainColor(normalizedCategory)
     : null
   const circleBackground = domainColor
-    ? domainBubbleGradient(domainColor.light)
+    ? domainBubbleGradient(domainColor.primary)
     : territoryType === 'declared'
       ? 'rgba(245, 240, 232, 0.3)'
       : '#f5f0e8'

--- a/src/components/knowledge/KnowledgeBubble.tsx
+++ b/src/components/knowledge/KnowledgeBubble.tsx
@@ -1,22 +1,23 @@
 import type { CSSProperties, ReactNode } from 'react'
 
 /**
- * Single source for the domain "bubble" gradient — a soft radial fill that
- * brightens the inner stop of a domain's `light` color. Three knowledge circle
- * renderers (KnowledgeCircle, DomainCircle, PortraitDomainCircle) previously
- * inlined this exact string, each repeating the fragile `.replace('0.12','0.22')`
- * that bumps the light token's 0.12 alpha to 0.22 for the highlight. (Design
- * audit C8 — consolidate the circle renderers behind one primitive.)
+ * Single source for the domain "bubble" gradient — a soft radial fill derived
+ * from the domain's primary color: a 22% inner stop brightening to a 12% outer
+ * stop. Built with color-mix so it works for hex, hsl(), and var(--cat-*) token
+ * values alike (the old version string-replaced an rgba alpha, which silently
+ * flattened the gradient for any non-rgba color). Three knowledge circle
+ * renderers (KnowledgeCircle, DomainCircle, PortraitDomainCircle) share it.
+ * (Design audit C8 — consolidate the circle renderers behind one primitive.)
  */
-export function domainBubbleGradient(light: string): string {
-  return `radial-gradient(circle at 38% 38%, ${light.replace('0.12', '0.22')}, ${light})`
+export function domainBubbleGradient(base: string): string {
+  return `radial-gradient(circle at 38% 38%, color-mix(in srgb, ${base} 22%, transparent), color-mix(in srgb, ${base} 12%, transparent))`
 }
 
 export type KnowledgeBubbleProps = {
   /** Circle diameter in px. */
   diameter: number
-  /** Domain `light` color; builds the radial gradient unless `background` is set. */
-  light?: string
+  /** Domain primary color; builds the radial gradient unless `background` is set. */
+  tint?: string
   /** Explicit background override (ghost/declared fills that aren't a domain gradient). */
   background?: string
   opacity?: number
@@ -34,7 +35,7 @@ export type KnowledgeBubbleProps = {
  */
 export function KnowledgeBubble({
   diameter,
-  light,
+  tint,
   background,
   opacity,
   border,
@@ -47,7 +48,7 @@ export function KnowledgeBubble({
         width: diameter,
         height: diameter,
         borderRadius: '50%',
-        background: background ?? (light ? domainBubbleGradient(light) : undefined),
+        background: background ?? (tint ? domainBubbleGradient(tint) : undefined),
         opacity,
         border,
         display: 'grid',

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -38,7 +38,6 @@ const TIER_ORDER: PortraitTier[] = [
 
 type DomainColor = {
   primary: string
-  light: string
   text: string
 }
 
@@ -55,67 +54,24 @@ function displaySectionLabel(broadCategory: string): string {
   return SECTION_LABEL_OVERRIDES[broadCategory] ?? broadCategory
 }
 
+// The per-domain hues live in the --cat-* token scale (globals.css,
+// STYLE-GUIDE-COLOR §3) so they have one definition and the palette preview can
+// flip them; this map only routes domain display names onto that scale. The
+// soft circle fill derives from the primary at render (domainBubbleGradient),
+// so no `light` variant exists anymore.
 const DOMAIN_COLORS: Record<string, DomainColor> = {
-  Literature: {
-    primary: '#c0392b',
-    light: 'rgba(192,57,43,0.12)',
-    text: '#8b1a0e',
-  },
-  Music: {
-    primary: '#1a6b8a',
-    light: 'rgba(26,107,138,0.12)',
-    text: '#0e4060',
-  },
-  'Film & Television': {
-    primary: '#6b3fa0',
-    light: 'rgba(107,63,160,0.12)',
-    text: '#3d1f6b',
-  },
-  'Architecture & Design': {
-    primary: '#b07d2e',
-    light: 'rgba(176,125,46,0.12)',
-    text: '#7a5010',
-  },
-  'Food & Cuisine': {
-    primary: '#2e8b57',
-    light: 'rgba(46,139,87,0.12)',
-    text: '#0e5c30',
-  },
-  Technology: {
-    primary: '#3a6b8a',
-    light: 'rgba(58,107,138,0.12)',
-    text: '#1a3f5c',
-  },
-  Sports: {
-    primary: '#c06b1a',
-    light: 'rgba(192,107,26,0.12)',
-    text: '#8b3e0e',
-  },
-  History: {
-    primary: '#5a6b7a',
-    light: 'rgba(90,107,122,0.12)',
-    text: '#2a3f50',
-  },
-  Science: {
-    primary: '#5a7a2e',
-    light: 'rgba(90,122,46,0.12)',
-    text: '#2a4a0e',
-  },
-  Philosophy: {
-    primary: '#7a5a8a',
-    light: 'rgba(122,90,138,0.12)',
-    text: '#4a2a5c',
-  },
-  'Pop Culture': {
-    primary: '#8a2a4a',
-    light: 'rgba(138,42,74,0.12)',
-    text: '#5c0e2a',
-  },
-  Language: {
-    primary: '#4a7a5a',
-    light: 'rgba(74,122,90,0.12)',
-    text: '#1e4e30',
-  },
+  Literature: { primary: 'var(--cat-literature)', text: 'var(--cat-literature-text)' },
+  Music: { primary: 'var(--cat-music)', text: 'var(--cat-music-text)' },
+  'Film & Television': { primary: 'var(--cat-film-tv)', text: 'var(--cat-film-tv-text)' },
+  'Architecture & Design': { primary: 'var(--cat-architecture)', text: 'var(--cat-architecture-text)' },
+  'Food & Cuisine': { primary: 'var(--cat-food)', text: 'var(--cat-food-text)' },
+  Technology: { primary: 'var(--cat-technology)', text: 'var(--cat-technology-text)' },
+  Sports: { primary: 'var(--cat-sports)', text: 'var(--cat-sports-text)' },
+  History: { primary: 'var(--cat-history)', text: 'var(--cat-history-text)' },
+  Science: { primary: 'var(--cat-science)', text: 'var(--cat-science-text)' },
+  Philosophy: { primary: 'var(--cat-philosophy)', text: 'var(--cat-philosophy-text)' },
+  'Pop Culture': { primary: 'var(--cat-pop-culture)', text: 'var(--cat-pop-culture-text)' },
+  Language: { primary: 'var(--cat-language)', text: 'var(--cat-language-text)' },
 }
 
 function hashColor(str: string): DomainColor {
@@ -126,7 +82,6 @@ function hashColor(str: string): DomainColor {
   const hue = Math.abs(h) % 360
   return {
     primary: `hsl(${hue},45%,35%)`,
-    light: `hsla(${hue},45%,35%,0.12)`,
     text: `hsl(${hue},45%,25%)`,
   }
 }
@@ -276,7 +231,7 @@ export function PortraitDomainCircle({
         <div style={{ position: 'relative', width: size, height: size }}>
           <KnowledgeBubble
             diameter={size}
-            light={dc.light}
+            tint={dc.primary}
             opacity={opacity}
             style={{ filter: dimForHidden ? 'grayscale(0.6)' : undefined }}
           >


### PR DESCRIPTION
Follows the merged palette-toggle PR (#824). First slice of color fix-list **step 3** from `_docs/STYLE-GUIDE-COLOR.md` §3: give the per-domain category hues one definition so consumers route through a single scale and the palette preview can flip them.

## What changed
- **`--cat-*` token scale** in `globals.css`: the knowledge map's 12 `DOMAIN_COLORS` hues (the only true per-category map in live code) are now `--cat-<domain>` / `--cat-<domain>-text` tokens. The TS map in `PortraitCircles.tsx` just routes display names onto them. **Values unchanged — "Current" mode is pixel-identical.**
- **`domainBubbleGradient`** now derives both stops from the primary via `color-mix` (22% → 12%), replacing a `light.replace('0.12','0.22')` rgba-alpha string hack that silently flattened the gradient for any non-rgba color. The `KnowledgeBubble` prop `light` → `tint`; the per-domain `light` variant is gone from the map.
- **`TerritorySetupClient`** hex-alpha suffixes (`${primary}55/44/66`) → `color-mix` equivalents, so `var(--cat-*)` primaries work where raw hex used to.

## What this unlocks in the preview
The proposed palette now also previews the two category collisions §3 flags:
- **Literature** `#c0392b` → `#7d2c3f` (bordeaux) — clears the new WRONG-red.
- **Language** `#4a7a5a` → `#2e6e7e` (teal) — clears the CORRECT green.

The toggle bar's legend shows all three swatch pairs (WRONG, LITERATURE, LANGUAGE). Flip to Proposed on the **Knowledge page** (domain circles, game summaries, territory setup) to see it. First-pass values — tune in the `:root[data-palette="proposed"]` block.

## Still hardcoded (later slices of step 3)
Feed accent-bar/avatar hash palette (`feed/visual.ts`), the "expanding territory" accents, ceremony gradients, and the share-card raster copy. Collapsing the feed hash palette is the next slice and is **not** pixel-preserving in current mode (hash-by-name assignment goes away).

## Verification
`npx tsc -p tsconfig.typecheck.json` clean (it caught two `light` consumers in `TerritorySetupClient` my grep missed — both fixed); `npm run lint` 0 errors; `npm run check:fonts` 0/0; component tests 119/119.

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF

---
_Generated by [Claude Code](https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF)_