### PR TITLE
fix(feed): serif territory-card masthead + per-bundle split capped at 5

### DIFF
--- a/src/components/feed/FriendTerritoryCard.tsx
+++ b/src/components/feed/FriendTerritoryCard.tsx
@@ -81,9 +81,11 @@ export function TerritoryTriangle({ played, color }: { played: boolean; color: s
 // MilestoneExpansion's "Answered" history can echo what the viewer typed.
 type Resolution = { submitted: string; isCorrect: boolean }
 
-// Every card shows the same number of topics (no hero variant); the rest fold
-// into the muted "+N more".
-const TOPIC_LIMIT = 4
+// A card carries at most CARD_QUESTION_CAP (5) questions, so it can surface at
+// most 5 distinct topics — the limit matches that cap, which means a full card
+// shows its whole territory and the "+N more" fold is a safety net that never
+// trips in practice (overflow continues on the next card, not behind a "+N").
+const TOPIC_LIMIT = 5
 
 // A friend's knowledge portrait in the "From Friends" zone: name, a warm
 // discovery-register status line, their recent territory (topic list with
@@ -133,13 +135,14 @@ export function FriendTerritoryCard({ card }: { card: FriendTerritoryCardModel }
 
   return (
     <FeedCardShell elevated className="p-4">
-      {/* Knowledge-portrait masthead: the friend's name large in the brand
-          sans (Montserrat via --font-sans), the discovery status line beneath
-          it in the LARGE editorial serif register (the same font-serif text-lg
-          treatment the feed's primary text actions use) on the brand orange,
-          and a warm yellow rule separating the masthead from the territory
-          list. */}
-      <h3 className="m-0 font-sans text-[22px] leading-[1.2] font-bold text-[var(--brand-ink)]">
+      {/* Knowledge-portrait masthead, read as one sentence ("Robyn keeps
+          finding new corners") in a single Editorial serif voice: the name is
+          the heavier Cormorant weight in full ink; the discovery status line is
+          the same serif a step down — regular weight, a softened ink (ink/700),
+          no italic and no terracotta (the orange is reserved for secondary
+          links). Name vs. descriptor is carried by weight + color, never slant,
+          per STYLE-GUIDE-TYPE. A warm yellow rule closes the masthead. */}
+      <h3 className="m-0 font-serif text-[26px] leading-[1.1] font-bold text-[var(--brand-ink)]">
         <Link
           href={`/users/${card.friendId}`}
           onClick={(e) => e.stopPropagation()}
@@ -148,7 +151,7 @@ export function FriendTerritoryCard({ card }: { card: FriendTerritoryCardModel }
           {card.friendName}
         </Link>
       </h3>
-      <p className="m-0 mt-1 font-serif text-lg leading-[1.35] font-semibold tracking-[0.05em] italic text-[var(--brand-orange)]">
+      <p className="m-0 mt-0.5 font-serif text-[18px] leading-[1.3] font-medium text-[var(--brand-ink-700)]">
         {card.statusLine}
       </p>
       <hr aria-hidden className="my-3 h-[2px] border-0 bg-[var(--tri-darkyellow)]" />

--- a/src/components/feed/__tests__/friend-territory.test.tsx
+++ b/src/components/feed/__tests__/friend-territory.test.tsx
@@ -56,8 +56,8 @@ function milestoneItem(
   }
 }
 
-describe('buildFriendTerritoryCards — one knowledge portrait per friend', () => {
-  it('merges a friend\'s deep + breadth bundles into one card, topics deduped in order, hero order = newest first', () => {
+describe('buildFriendTerritoryCards — knowledge portraits, capped at 5 per card', () => {
+  it('merges a friend\'s deep + breadth bundles (≤5 questions stay one card), topics deduped in order, lead = newest first', () => {
     const cards = buildFriendTerritoryCards([
       milestoneItem('m1', 'robyn', 'Robyn', [
         question({ questionId: 'q1', domain: 'Star Trek' }),
@@ -100,6 +100,26 @@ describe('buildFriendTerritoryCards — one knowledge portrait per friend', () =
     // one a correct answer produces — correctness never reaches this surface.
     expect(incorrect.topics).toEqual(correct.topics)
     expect(untried.topics[0]).toEqual({ name: 'Star Trek', played: false })
+  })
+
+  it('splits a friend with more than 5 questions onto consecutive cards (newest first), 5 max each', () => {
+    const qs = Array.from({ length: 7 }, (_, i) =>
+      question({ questionId: `q${i}`, domain: `Domain ${i}` }),
+    )
+    const cards = buildFriendTerritoryCards([milestoneItem('m1', 'robyn', 'Robyn', qs)])
+    expect(cards).toHaveLength(2)
+    // Both cards are the same friend, consecutive in the stack.
+    expect(cards.map((c) => c.friendId)).toEqual(['robyn', 'robyn'])
+    // The first card carries the 5 newest; the overflow continues on the next.
+    expect(cards[0]!.questions.map((q) => q.questionId)).toEqual([
+      'q0', 'q1', 'q2', 'q3', 'q4',
+    ])
+    expect(cards[1]!.questions.map((q) => q.questionId)).toEqual(['q5', 'q6'])
+    // Each card's territory is its own slice — no "+N more" spill.
+    expect(cards[0]!.topics).toHaveLength(5)
+    expect(cards[1]!.topics).toHaveLength(2)
+    // Stacked cards draw distinct ids so React keys (and the status seed) differ.
+    expect(cards[0]!.id).not.toBe(cards[1]!.id)
   })
 
   it('suppresses catch-all categories from the territory list but keeps their questions playable', () => {
@@ -170,17 +190,17 @@ describe('FriendTerritoryCard — render', () => {
     expect(html).not.toMatch(/Correct|Not this time/)
   })
 
-  it('every card shows 4 topics + a muted "+N more" — no hero variant', () => {
+  it('shows every topic on a full 5-question card — no "+N more" fold (overflow goes to the next card)', () => {
     const html = renderToStaticMarkup(<FriendTerritoryCard card={card()} />)
     expect(html).toContain('Jazz')
-    expect(html).not.toContain('Cubism')
-    expect(html).toContain('+1 more')
+    expect(html).toContain('Cubism')
+    expect(html).not.toMatch(/\+\d+ more/)
   })
 
   it('renders exactly two triangle states — played (filled) and untried (hollow bordered)', () => {
     const html = renderToStaticMarkup(<FriendTerritoryCard card={card()} />)
     const states = [...html.matchAll(/data-territory-state="(\w+)"/g)].map((m) => m[1])
-    expect(states).toEqual(['played', 'untried', 'untried', 'untried'])
+    expect(states).toEqual(['played', 'untried', 'untried', 'untried', 'untried'])
     expect(new Set(states).size).toBe(2)
   })
 

--- a/src/components/feed/__tests__/friend-territory.test.tsx
+++ b/src/components/feed/__tests__/friend-territory.test.tsx
@@ -56,8 +56,8 @@ function milestoneItem(
   }
 }
 
-describe('buildFriendTerritoryCards — knowledge portraits, capped at 5 per card', () => {
-  it('merges a friend\'s deep + breadth bundles (≤5 questions stay one card), topics deduped in order, lead = newest first', () => {
+describe('buildFriendTerritoryCards — one card per milestone bundle, capped at 5', () => {
+  it('emits one card per bundle (deep vs breadth stay distinct); a question across two of a friend\'s bundles plays once', () => {
     const cards = buildFriendTerritoryCards([
       milestoneItem('m1', 'robyn', 'Robyn', [
         question({ questionId: 'q1', domain: 'Star Trek' }),
@@ -72,11 +72,16 @@ describe('buildFriendTerritoryCards — knowledge portraits, capped at 5 per car
         question({ questionId: 'q1', domain: 'Star Trek' }),
       ]),
     ])
-    expect(cards.map((c) => c.friendId)).toEqual(['robyn', 'shanea'])
-    const robyn = cards[0]!
-    expect(robyn.friendName).toBe('Robyn')
-    expect(robyn.topics.map((t) => t.name)).toEqual(['Star Trek', 'French Herbs'])
-    expect(robyn.questions.map((q) => q.questionId)).toEqual(['q1', 'q2', 'q3'])
+    // Robyn's two bundles → two consecutive cards; Shanea's one bundle → one.
+    expect(cards.map((c) => c.friendId)).toEqual(['robyn', 'robyn', 'shanea'])
+    expect(cards[0]!.friendName).toBe('Robyn')
+    expect(cards[0]!.topics.map((t) => t.name)).toEqual(['Star Trek'])
+    expect(cards[0]!.questions.map((q) => q.questionId)).toEqual(['q1', 'q2'])
+    // q1 already claimed by the first card, so this bundle's card plays only q3.
+    expect(cards[1]!.topics.map((t) => t.name)).toEqual(['French Herbs'])
+    expect(cards[1]!.questions.map((q) => q.questionId)).toEqual(['q3'])
+    // Bundles map to distinct cards (and distinct status seeds).
+    expect(cards[0]!.id).not.toBe(cards[1]!.id)
   })
 
   it('fills on attempt: a wrong answer marks a topic played EXACTLY like a correct one (two states, no third)', () => {
@@ -102,15 +107,15 @@ describe('buildFriendTerritoryCards — knowledge portraits, capped at 5 per car
     expect(untried.topics[0]).toEqual({ name: 'Star Trek', played: false })
   })
 
-  it('splits a friend with more than 5 questions onto consecutive cards (newest first), 5 max each', () => {
+  it('defensively splits an over-cap bundle across consecutive cards (5 max each) rather than "+N more"', () => {
     const qs = Array.from({ length: 7 }, (_, i) =>
       question({ questionId: `q${i}`, domain: `Domain ${i}` }),
     )
+    // A single bundle carrying 7 questions (above the cap) — should not exist in
+    // practice, but the builder splits it instead of overflowing one card.
     const cards = buildFriendTerritoryCards([milestoneItem('m1', 'robyn', 'Robyn', qs)])
     expect(cards).toHaveLength(2)
-    // Both cards are the same friend, consecutive in the stack.
     expect(cards.map((c) => c.friendId)).toEqual(['robyn', 'robyn'])
-    // The first card carries the 5 newest; the overflow continues on the next.
     expect(cards[0]!.questions.map((q) => q.questionId)).toEqual([
       'q0', 'q1', 'q2', 'q3', 'q4',
     ])

--- a/src/components/feed/friend-territory.ts
+++ b/src/components/feed/friend-territory.ts
@@ -1,9 +1,11 @@
 // Friend-territory cards (B-FRIEND-TERRITORY-CARD-01): the "From Friends"
 // zone's milestone bundle rows, reframed per friend as a knowledge portrait —
 // name, a warm discovery-register status line, and the territory (topics) their
-// recent questions cover. One card per friend: a friend's deep + breadth
-// milestone rows in the zone merge here, so a single deep milestone (one
-// domain) still joins their other bundles into one breadth-of-curiosity list.
+// recent questions cover. Each card is a single playable unit capped at
+// CARD_QUESTION_CAP questions — the same per-bundle cap the milestone rows
+// carried. A friend's deep + breadth milestone rows merge and dedupe, then
+// split across consecutive cards (newest questions first) when they overflow
+// the cap, rather than collapsing into one card with a muted "+N more".
 //
 // Thesis constraint (load-bearing): the card celebrates breadth, never
 // performance. A topic's `played` is the VIEWER's "have I been here?" —
@@ -34,9 +36,41 @@ export type FriendTerritoryCardModel = {
   questions: StreamQuestion[]
 }
 
+// At most this many questions ride on a single card. A friend with more recent
+// questions than this splits across consecutive cards (newest first) — the cap
+// matches the milestone builder's MILESTONE_CARD_QUESTION_CAP so each card stays
+// a digestible, fully-playable bundle.
+export const CARD_QUESTION_CAP = 5
+
+// Distinct visible topics in question order (newest milestone first).
+// Suppressed catch-all categories ("Other", "General…") never make the
+// territory list, though their questions stay playable. `played` is the
+// VIEWER's "have I been here?" — attempted, right OR wrong, identically.
+function topicsForQuestions(
+  questions: readonly StreamQuestion[],
+): FriendTerritoryTopic[] {
+  const topics: FriendTerritoryTopic[] = []
+  const topicByName = new Map<string, FriendTerritoryTopic>()
+  for (const q of questions) {
+    const name = visibleFeedCategory(q.domain)
+    if (!name) continue
+    const played = q.priorResult !== null
+    const existing = topicByName.get(name)
+    if (existing) {
+      existing.played = existing.played || played
+    } else {
+      const topic: FriendTerritoryTopic = { name, played }
+      topicByName.set(name, topic)
+      topics.push(topic)
+    }
+  }
+  return topics
+}
+
 // Items must be the From Friends zone's milestone StreamItems, newest first;
-// card order follows first appearance, so the hero is the most recently
-// active friend.
+// card order follows first appearance, so the lead card is the most recently
+// active friend. Each friend's questions split into one or more cards of at
+// most CARD_QUESTION_CAP, consecutive in the stack.
 export function buildFriendTerritoryCards(
   items: readonly StreamItem[],
 ): FriendTerritoryCardModel[] {
@@ -72,33 +106,31 @@ export function buildFriendTerritoryCards(
     }
   }
 
-  return [...byFriend.entries()].map(([friendId, entry]) => {
-    // Distinct visible topics in question order (newest milestone first).
-    // Suppressed catch-all categories ("Other", "General…") never make the
-    // territory list, though their questions stay playable.
-    const topics: FriendTerritoryTopic[] = []
-    const topicByName = new Map<string, FriendTerritoryTopic>()
-    for (const q of entry.questions) {
-      const name = visibleFeedCategory(q.domain)
-      if (!name) continue
-      const played = q.priorResult !== null
-      const existing = topicByName.get(name)
-      if (existing) {
-        existing.played = existing.played || played
-      } else {
-        const topic: FriendTerritoryTopic = { name, played }
-        topicByName.set(name, topic)
-        topics.push(topic)
-      }
+  const cards: FriendTerritoryCardModel[] = []
+  for (const [friendId, entry] of byFriend.entries()) {
+    // Split the friend's deduped questions (newest milestone first) into cards
+    // of at most CARD_QUESTION_CAP; overflow lands on the next card. Each card
+    // derives its own topics and plays only its own slice, so the territory
+    // list never spills into a "+N more" — it continues on the card beneath.
+    const chunkCount = Math.ceil(entry.questions.length / CARD_QUESTION_CAP)
+    for (let chunk = 0; chunk < chunkCount; chunk++) {
+      const chunkQuestions = entry.questions.slice(
+        chunk * CARD_QUESTION_CAP,
+        (chunk + 1) * CARD_QUESTION_CAP,
+      )
+      if (chunkQuestions.length === 0) continue
+      // Seed includes the chunk index so a friend's stacked cards draw
+      // different status lines from the pool instead of repeating one line.
+      const seed = `${friendId}:${entry.newestItemId}:${chunk}`
+      cards.push({
+        id: `territory:${seed}`,
+        friendId,
+        friendName: entry.friendName,
+        statusLine: friendTerritoryStatusLine(seed),
+        topics: topicsForQuestions(chunkQuestions),
+        questions: chunkQuestions,
+      })
     }
-    const seed = `${friendId}:${entry.newestItemId}`
-    return {
-      id: `territory:${seed}`,
-      friendId,
-      friendName: entry.friendName,
-      statusLine: friendTerritoryStatusLine(seed),
-      topics,
-      questions: entry.questions,
-    }
-  })
+  }
+  return cards
 }

--- a/src/components/feed/friend-territory.ts
+++ b/src/components/feed/friend-territory.ts
@@ -1,11 +1,14 @@
 // Friend-territory cards (B-FRIEND-TERRITORY-CARD-01): the "From Friends"
-// zone's milestone bundle rows, reframed per friend as a knowledge portrait —
-// name, a warm discovery-register status line, and the territory (topics) their
-// recent questions cover. Each card is a single playable unit capped at
-// CARD_QUESTION_CAP questions — the same per-bundle cap the milestone rows
-// carried. A friend's deep + breadth milestone rows merge and dedupe, then
-// split across consecutive cards (newest questions first) when they overflow
-// the cap, rather than collapsing into one card with a muted "+N more".
+// zone's milestone bundle rows, reframed as knowledge portraits — name, a warm
+// discovery-register status line, and the territory (topics) their recent
+// questions cover. One card PER milestone bundle (not per friend): the
+// milestone builder already groups a friend's activity into semantic bundles —
+// a deep dive (one domain, ≤5 questions) and breadth bins (mixed domains, ≤5
+// each) — so each bundle becomes its own card and a deep dive reads distinctly
+// from a breadth sweep. A friend's bundles stack consecutively. A question
+// packed into two of a friend's bundles plays once (the newer card claims it),
+// and a bundle that somehow exceeds the cap splits rather than overflowing into
+// a muted "+N more".
 //
 // Thesis constraint (load-bearing): the card celebrates breadth, never
 // performance. A topic's `played` is the VIEWER's "have I been here?" —
@@ -31,15 +34,15 @@ export type FriendTerritoryCardModel = {
   friendName: string
   statusLine: string
   topics: FriendTerritoryTopic[]
-  // The deduped union of the friend's bundle questions, newest milestone
-  // first — what "Play these →" actually plays.
+  // This card's bundle questions (deduped against the friend's earlier cards),
+  // newest first — what "Play these →" actually plays.
   questions: StreamQuestion[]
 }
 
-// At most this many questions ride on a single card. A friend with more recent
-// questions than this splits across consecutive cards (newest first) — the cap
-// matches the milestone builder's MILESTONE_CARD_QUESTION_CAP so each card stays
-// a digestible, fully-playable bundle.
+// A card carries at most this many questions. Each milestone bundle is already
+// built ≤ MILESTONE_CARD_QUESTION_CAP upstream, so per-bundle cards are normally
+// under the cap on their own; this is the defensive ceiling — if a bundle ever
+// arrives over-cap it splits into extra cards rather than overflowing.
 export const CARD_QUESTION_CAP = 5
 
 // Distinct visible topics in question order (newest milestone first).
@@ -67,20 +70,20 @@ function topicsForQuestions(
   return topics
 }
 
-// Items must be the From Friends zone's milestone StreamItems, newest first;
-// card order follows first appearance, so the lead card is the most recently
-// active friend. Each friend's questions split into one or more cards of at
-// most CARD_QUESTION_CAP, consecutive in the stack.
+// Items must be the From Friends zone's milestone StreamItems, newest first.
+// Each qualifying bundle becomes its own card; a friend's bundles stack
+// consecutively (friend order = first appearance), so the lead cards belong to
+// the most recently active friend.
 export function buildFriendTerritoryCards(
   items: readonly StreamItem[],
 ): FriendTerritoryCardModel[] {
+  // Group bundles by friend, preserving first-appearance friend order and the
+  // newest-first bundle order within each friend.
   const byFriend = new Map<
     string,
     {
       friendName: string
-      newestItemId: string
-      questions: StreamQuestion[]
-      seen: Set<string>
+      bundles: Array<{ itemId: string; questions: readonly StreamQuestion[] }>
     }
   >()
 
@@ -89,47 +92,47 @@ export function buildFriendTerritoryCards(
     if (expand?.kind !== 'milestone' || expand.questions.length === 0) continue
     let entry = byFriend.get(expand.friendId)
     if (!entry) {
-      entry = {
-        friendName: expand.friendName,
-        newestItemId: item.id,
-        questions: [],
-        seen: new Set(),
-      }
+      entry = { friendName: expand.friendName, bundles: [] }
       byFriend.set(expand.friendId, entry)
     }
-    // A question can sit in two of the same friend's bundles (deep + breadth
-    // packing overlap); the card plays it once.
-    for (const q of expand.questions) {
-      if (entry.seen.has(q.questionId)) continue
-      entry.seen.add(q.questionId)
-      entry.questions.push(q)
-    }
+    entry.bundles.push({ itemId: item.id, questions: expand.questions })
   }
 
   const cards: FriendTerritoryCardModel[] = []
   for (const [friendId, entry] of byFriend.entries()) {
-    // Split the friend's deduped questions (newest milestone first) into cards
-    // of at most CARD_QUESTION_CAP; overflow lands on the next card. Each card
-    // derives its own topics and plays only its own slice, so the territory
-    // list never spills into a "+N more" — it continues on the card beneath.
-    const chunkCount = Math.ceil(entry.questions.length / CARD_QUESTION_CAP)
-    for (let chunk = 0; chunk < chunkCount; chunk++) {
-      const chunkQuestions = entry.questions.slice(
-        chunk * CARD_QUESTION_CAP,
-        (chunk + 1) * CARD_QUESTION_CAP,
-      )
-      if (chunkQuestions.length === 0) continue
-      // Seed includes the chunk index so a friend's stacked cards draw
-      // different status lines from the pool instead of repeating one line.
-      const seed = `${friendId}:${entry.newestItemId}:${chunk}`
-      cards.push({
-        id: `territory:${seed}`,
-        friendId,
-        friendName: entry.friendName,
-        statusLine: friendTerritoryStatusLine(seed),
-        topics: topicsForQuestions(chunkQuestions),
-        questions: chunkQuestions,
-      })
+    // `seen` spans the friend's bundles so a question packed into two of them
+    // (deep + breadth overlap) plays once — the newer bundle's card claims it.
+    const seen = new Set<string>()
+    for (const bundle of entry.bundles) {
+      const questions: StreamQuestion[] = []
+      for (const q of bundle.questions) {
+        if (seen.has(q.questionId)) continue
+        seen.add(q.questionId)
+        questions.push(q)
+      }
+      if (questions.length === 0) continue
+      // Normally one card per bundle (it arrives ≤ cap). The chunk loop is the
+      // defensive ceiling: an over-cap bundle splits into extra cards (seeded
+      // distinctly) rather than overflowing into a "+N more".
+      const chunkCount = Math.ceil(questions.length / CARD_QUESTION_CAP)
+      for (let chunk = 0; chunk < chunkCount; chunk++) {
+        const chunkQuestions = questions.slice(
+          chunk * CARD_QUESTION_CAP,
+          (chunk + 1) * CARD_QUESTION_CAP,
+        )
+        const seed =
+          chunkCount === 1
+            ? `${friendId}:${bundle.itemId}`
+            : `${friendId}:${bundle.itemId}:${chunk}`
+        cards.push({
+          id: `territory:${seed}`,
+          friendId,
+          friendName: entry.friendName,
+          statusLine: friendTerritoryStatusLine(seed),
+          topics: topicsForQuestions(chunkQuestions),
+          questions: chunkQuestions,
+        })
+      }
     }
   }
   return cards


### PR DESCRIPTION
## What & why

Two fixes to the "From Friends" friend-territory cards.

### 1. Masthead type (styling)
The name + descriptor now read as one Editorial serif sentence, per `STYLE-GUIDE-TYPE.md` (name = Editorial/Cormorant heavier weight, full ink; descriptor = same serif a step down, distinguished by **weight + color, never italic**).

- **Name** → heavier Cormorant serif (700) in full ink (`--brand-ink`). Was Montserrat sans bold.
- **Descriptor / status line** → same serif, regular weight (500), smaller (18px), softened ink (`--brand-ink-700`). **Dropped the italic and the terracotta** (`--brand-orange` is reserved for secondary links).

### 2. Five-question cap, restored as a per-bundle split (functionality)
`buildFriendTerritoryCards` was merging **every** one of a friend's questions into a single card per friend — so a friend with lots of recent activity collapsed into one card with a muted "+N more" (e.g. Robyn's "+18 more"). This regressed the prior behavior where each bundle capped at 5 and overflow continued on the next card.

Now there is **one card per milestone bundle**. The milestone builder already groups a friend's activity semantically — a deep dive (one domain, ≤5) and breadth bins (mixed domains, ≤5 each) — so each bundle becomes its own card and a deep dive reads distinctly from a breadth sweep. Details:

- Dedup spans a friend's bundles, so a question packed into two of them plays **once** (the newer card claims it).
- `CARD_QUESTION_CAP = 5` survives as a defensive ceiling: an over-cap bundle splits into extra cards rather than overflowing into "+N more".
- `TOPIC_LIMIT` bumped 4 → 5 so a full card shows its whole territory (the "+N more" fold is now a safety net that doesn't trip in practice).

## Files
- `src/components/feed/FriendTerritoryCard.tsx` — masthead classes + `TOPIC_LIMIT`
- `src/components/feed/friend-territory.ts` — per-bundle split + cross-bundle dedup
- `src/components/feed/__tests__/friend-territory.test.tsx` — updated/added coverage

## Testing
- `vitest run src/components/feed/` — **76 passed**; lint + typecheck clean on touched files.
- **Ran the real `next dev` server** and drove the rendered component over HTTP (a throwaway route, since reverted). Confirmed a friend with a deep + breadth bundle renders as **two stacked cards** (5 questions each), no "+N more"; name/status classes resolve through the compiled CSS to Cormorant + `--brand-ink` / `--brand-ink-700`, with **zero** `italic`/`brand-orange` in the mastheads; and an incorrect answer fills its triangle identically to a correct one.
  - Caveat: no glyph-level screenshot — the sandbox can't install a browser (Playwright CDN blocked, no system Chrome). The class→token→font-face chain was verified, but actual pixels weren't rasterized.

## Note for reviewer
The descriptor uses Cormorant `font-medium` (500), the lightest weight currently loaded via `next/font` (`500/600/700`). The style guide says "regular-weight"; if a visibly lighter descriptor is wanted, we'd add Cormorant 400 to the font config.

https://claude.ai/code/session_01WzQprzQ1q5oNdN89NN4EUn

---
_Generated by [Claude Code](https://claude.ai/code/session_01WzQprzQ1q5oNdN89NN4EUn)_