### PR TITLE
color: consolidate grading onto --game-correct / --game-wrong (guide §1)

### DIFF
--- a/src/app/games/[id]/summary/page.tsx
+++ b/src/app/games/[id]/summary/page.tsx
@@ -248,8 +248,8 @@ export default async function JoshingGameSummaryPage({ params }: PageProps) {
       <section
         className="mt-5 rounded-md border px-5 py-5"
         style={{
-          background: 'color-mix(in srgb, var(--success) 10%, var(--surface))',
-          borderColor: 'color-mix(in srgb, var(--success) 22%, var(--border))',
+          background: 'color-mix(in srgb, var(--game-correct) 10%, var(--surface))',
+          borderColor: 'color-mix(in srgb, var(--game-correct) 22%, var(--border))',
         }}
       >
         <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>Total</p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -136,8 +136,11 @@
          surfaces (login, knowledge portrait, sparkle envelope).
        • Card radius — content cards use `rounded-md`; the login cards use
          `rounded-[8px]` (Figma) and the envelope uses `rounded-[1.5rem]`.
-       • Correct/wrong — use `--success` (#178245) and #b42318 (destructive ink)
-         with a 3px colored left border (see GameplayChat ResultRow + summary).
+       • Correct/wrong (grading) — use `--game-correct` / `--game-wrong` /
+         `--game-wrong-strong` ONLY (STYLE-GUIDE-COLOR §1: grading is reserved;
+         exactly one correct and one wrong value). `--success`/`--danger`/
+         `--destructive` are system states — saves, errors, destructive
+         actions — never answer grading.
        ──────────────────────────────────────────────────────────────────── */
 
     --background: var(--brand-cream-page);
@@ -183,7 +186,9 @@
     --user-bubble-foreground: oklch(0.99 0 0);
     --success: #178245;
     --danger: var(--destructive);
-    --wrong: var(--destructive);
+    /* (--wrong, an alias of --destructive, was retired: a grading-named token
+       pointing at the system-error red was exactly the §1 confusion. Grading is
+       --game-wrong/--game-wrong-strong; errors are --danger.) */
     /* Status surfaces — banner/chip fills + hairlines for the success / warning /
        error roles. Formalizes the raw amber-50/300/700/900 + emerald/red/rose
        50–200 utilities the 2026-05-30 audit flagged (DESIGN-SYSTEM.md §1.7).

--- a/src/components/QuestionBankPicker.tsx
+++ b/src/components/QuestionBankPicker.tsx
@@ -73,7 +73,7 @@ export function QuestionBankPicker({ onSelect, onQuestionsLoaded, maxSelect = 5,
   }
 
   if (error) {
-    return <p className="text-sm text-[var(--wrong)]">{error}</p>;
+    return <p className="text-sm text-[var(--danger)]">{error}</p>;
   }
 
   return (

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -234,9 +234,9 @@ export default function TodaysFiveCard({
           const isFilled = outcome !== 'unanswered'
           const background =
             outcome === 'correct'
-              ? 'var(--success)'
+              ? 'var(--game-correct)'
               : outcome === 'incorrect'
-                ? 'var(--destructive)'
+                ? 'var(--game-wrong-strong)'
                 : outcome === 'skipped'
                   ? 'color-mix(in srgb, var(--brand-ink) 35%, transparent)'
                   : 'transparent'

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1331,8 +1331,8 @@ function SessionCompleteRow({
       className="mt-6"
       style={{
         borderRadius: 'var(--radius-lg)',
-        border: '1px solid color-mix(in srgb, var(--success) 40%, var(--border))',
-        background: 'color-mix(in srgb, var(--success) 8%, var(--surface))',
+        border: '1px solid color-mix(in srgb, var(--game-correct) 40%, var(--border))',
+        background: 'color-mix(in srgb, var(--game-correct) 8%, var(--surface))',
         padding: '1.25rem 1.25rem 1.25rem',
       }}
     >
@@ -1342,7 +1342,7 @@ function SessionCompleteRow({
           fontSize: '0.6rem',
           textTransform: 'uppercase',
           letterSpacing: '0.1em',
-          color: 'var(--success)',
+          color: 'var(--game-correct)',
           marginBottom: '0.5rem',
         }}
       >
@@ -1353,7 +1353,7 @@ function SessionCompleteRow({
           fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
           fontSize: '2rem',
           fontWeight: 600,
-          color: 'var(--success)',
+          color: 'var(--game-correct)',
           lineHeight: 1,
         }}
       >

--- a/src/components/play/GeometricProgress.tsx
+++ b/src/components/play/GeometricProgress.tsx
@@ -20,9 +20,9 @@ export function GeometricProgress({
         const done = !!res;
 
         const dotColor = res === 'correct'
-          ? 'var(--success)'
+          ? 'var(--game-correct)'
           : res === 'wrong'
-            ? 'var(--wrong)'
+            ? 'var(--game-wrong-strong)'
             : res === 'expired'
               ? 'color-mix(in srgb, var(--text-muted) 60%, transparent)'
               : 'color-mix(in srgb, var(--text) 22%, transparent)';

--- a/src/components/replay/ReplaySummary.tsx
+++ b/src/components/replay/ReplaySummary.tsx
@@ -62,8 +62,8 @@ export function ReplaySummary({ results, hasMore, onPlayNext, loadingNext }: Pro
       <div
         className="mt-4 rounded-md border px-5 py-5"
         style={{
-          background: 'color-mix(in srgb, var(--success) 10%, var(--surface))',
-          borderColor: 'color-mix(in srgb, var(--success) 22%, var(--border))',
+          background: 'color-mix(in srgb, var(--game-correct) 10%, var(--surface))',
+          borderColor: 'color-mix(in srgb, var(--game-correct) 22%, var(--border))',
         }}
       >
         <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>This round</p>
@@ -86,8 +86,8 @@ export function ReplaySummary({ results, hasMore, onPlayNext, loadingNext }: Pro
               <span
                 className={`rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] ${
                   isCorrect
-                    ? 'border-[var(--success-border)] bg-[var(--success-surface)] text-[var(--success)]'
-                    : 'border-[var(--destructive-border)] bg-[var(--destructive-surface)] text-destructive'
+                    ? 'border-[color-mix(in_srgb,var(--game-correct)_30%,var(--border))] bg-[color-mix(in_srgb,var(--game-correct)_10%,var(--card))] text-[var(--game-correct)]'
+                    : 'border-[color-mix(in_srgb,var(--game-wrong)_28%,var(--border))] bg-[color-mix(in_srgb,var(--game-wrong)_8%,var(--card))] text-[var(--game-wrong-strong)]'
                 }`}
               >
                 {isCorrect ? 'CORRECT' : 'WRONG'}


### PR DESCRIPTION
Color fix-list **step 1** from `_docs/STYLE-GUIDE-COLOR.md` §1 — the guide's "most important rule": grading is reserved, with exactly **one** correct and **one** wrong value. Live code had a second grading system: the vivid `--success` green / `--destructive` red rendered the Today's Five dots and play-screen progress marks while every reveal surface used the forest/terracotta `--game-*` pair — so the same day's results showed in two different color systems.

## Visible changes (intentional)
- **Today's Five result dots** (home card): vivid green/red → `--game-correct` forest / `--game-wrong-strong` terracotta, matching the reveals they summarize.
- **Play-screen progress marks** (`GeometricProgress`): same switch.
- **ReplaySummary** CORRECT/WRONG chips + "How You Did" wash, **game-summary** total wash, and the **round-complete** card in the play thread: `--success` mixes → `--game-correct` mixes. These all sat next to `--game-correct` surfaces in the same files — the exact inconsistency the audit flagged.

A side benefit: these surfaces now follow the palette preview — flip the toggle to Proposed and the dots/chips track the new true-red WRONG along with the reveal surfaces, instead of demonstrating the drift.

## Cleanup
- Retired the **`--wrong` alias** (a grading-named token that pointed at the system-error red — exactly the §1 confusion). Its one non-grading consumer (a load-error message) now uses `--danger`. Zero `var(--wrong)` references remain.
- Updated the stale `globals.css` conventions comment that still prescribed `--success` + `#b42318` for correct/wrong (a convention the audit found nothing actually followed).

`--success` / `--danger` / `--destructive` are untouched for their real jobs — save confirmations, error text, destructive actions, the Nav badge — just never answer grading.

## Verification
`npx tsc -p tsconfig.typecheck.json` clean; `npm run lint` 0 errors (16 pre-existing warnings); `npm run check:fonts` 0/0; component tests 119/119.

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF

---
_Generated by [Claude Code](https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF)_