### PR TITLE
Order friend territory cards chronologically across friends

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -690,8 +690,8 @@ function FeedContributeFooter() {
 // cards (one card per friend) before collapsing the rest behind a "View more"
 // control; each tap of "View more" then reveals another FROM_FRIENDS_STEP
 // cards (and keeps the control while more remain).
-const FROM_FRIENDS_COLLAPSED_COUNT = 5
-const FROM_FRIENDS_STEP = 10
+const FROM_FRIENDS_COLLAPSED_COUNT = 8
+const FROM_FRIENDS_STEP = 8
 
 // The uppercase eyebrow that labels a feed section — the recency day labels
 // ("Today", "This week") and the home-only pinned "For You" / "From Friends"
@@ -1017,8 +1017,9 @@ function FeedListContent({
   // each friend's milestone bundle rows merge into ONE knowledge-portrait card
   // — name, a discovery-register status line, their recent topics with
   // two-state territory triangles, and the same inline answer flow the old
-  // event rows carried. fromFriendsRows is newest-first, so the stack leads
-  // with the most recently active friend.
+  // event rows carried. buildFriendTerritoryCards orders the cards
+  // chronologically by each bundle's recency, so the stack interleaves friends
+  // newest-first rather than dumping one active friend's whole backlog on top.
   const fromFriendsCards = useMemo(
     () =>
       buildFriendTerritoryCards(

--- a/src/components/feed/__tests__/friend-territory.test.tsx
+++ b/src/components/feed/__tests__/friend-territory.test.tsx
@@ -40,10 +40,11 @@ function milestoneItem(
   friendId: string,
   friendName: string,
   questions: StreamQuestion[],
+  sortAt: Date = new Date('2026-06-01T00:00:00Z'),
 ): StreamItem {
   return {
     id,
-    sortAt: new Date('2026-06-01T00:00:00Z'),
+    sortAt,
     tier: 2,
     friendId,
     homeEligible: true,
@@ -82,6 +83,21 @@ describe('buildFriendTerritoryCards — one card per milestone bundle, capped at
     expect(cards[1]!.questions.map((q) => q.questionId)).toEqual(['q3'])
     // Bundles map to distinct cards (and distinct status seeds).
     expect(cards[0]!.id).not.toBe(cards[1]!.id)
+  })
+
+  it('orders cards chronologically across friends — an active friend\'s older bundle drops below another friend\'s newer one (no friend-major stacking)', () => {
+    const cards = buildFriendTerritoryCards([
+      milestoneItem('m1', 'robyn', 'Robyn', [question({ questionId: 'q1' })],
+        new Date('2026-06-03T00:00:00Z')),
+      milestoneItem('m2', 'shanea', 'Shanea', [question({ questionId: 'q5', domain: 'Jazz' })],
+        new Date('2026-06-02T00:00:00Z')),
+      milestoneItem('m3', 'robyn', 'Robyn', [question({ questionId: 'q3', domain: 'French Herbs' })],
+        new Date('2026-06-01T00:00:00Z')),
+    ])
+    // Friend-major would give ['robyn','robyn','shanea']; chronological
+    // interleaves so Shanea's newer bundle sits above Robyn's stale one.
+    expect(cards.map((c) => c.friendId)).toEqual(['robyn', 'shanea', 'robyn'])
+    expect(cards.map((c) => c.questions[0]!.questionId)).toEqual(['q1', 'q5', 'q3'])
   })
 
   it('fills on attempt: a wrong answer marks a topic played EXACTLY like a correct one (two states, no third)', () => {

--- a/src/components/feed/friend-territory.ts
+++ b/src/components/feed/friend-territory.ts
@@ -5,7 +5,9 @@
 // milestone builder already groups a friend's activity into semantic bundles —
 // a deep dive (one domain, ≤5 questions) and breadth bins (mixed domains, ≤5
 // each) — so each bundle becomes its own card and a deep dive reads distinctly
-// from a breadth sweep. A friend's bundles stack consecutively. A question
+// from a breadth sweep. Cards are ordered CHRONOLOGICALLY by each bundle's
+// recency (newest first), across friends — so a very active friend's older
+// bundles no longer leapfrog another friend's newer activity. A question
 // packed into two of a friend's bundles plays once (the newer card claims it),
 // and a bundle that somehow exceeds the cap splits rather than overflowing into
 // a muted "+N more".
@@ -71,19 +73,21 @@ function topicsForQuestions(
 }
 
 // Items must be the From Friends zone's milestone StreamItems, newest first.
-// Each qualifying bundle becomes its own card; a friend's bundles stack
-// consecutively (friend order = first appearance), so the lead cards belong to
-// the most recently active friend.
+// Each qualifying bundle becomes its own card; cards are then ordered
+// chronologically by their bundle's recency (newest first) across friends, so
+// the lead cards are the most recent activity from ANYONE — not a single active
+// friend's whole backlog stacked ahead of everybody else.
 export function buildFriendTerritoryCards(
   items: readonly StreamItem[],
 ): FriendTerritoryCardModel[] {
   // Group bundles by friend, preserving first-appearance friend order and the
-  // newest-first bundle order within each friend.
+  // newest-first bundle order within each friend — the per-friend `seen` dedup
+  // below relies on that order so the newer bundle claims a shared question.
   const byFriend = new Map<
     string,
     {
       friendName: string
-      bundles: Array<{ itemId: string; questions: readonly StreamQuestion[] }>
+      bundles: Array<{ itemId: string; sortMs: number; questions: readonly StreamQuestion[] }>
     }
   >()
 
@@ -95,10 +99,17 @@ export function buildFriendTerritoryCards(
       entry = { friendName: expand.friendName, bundles: [] }
       byFriend.set(expand.friendId, entry)
     }
-    entry.bundles.push({ itemId: item.id, questions: expand.questions })
+    entry.bundles.push({
+      itemId: item.id,
+      sortMs: item.sortAt.getTime(),
+      questions: expand.questions,
+    })
   }
 
-  const cards: FriendTerritoryCardModel[] = []
+  // Build cards per friend (so dedup runs over a friend's bundles in order),
+  // tagging each with its bundle's timestamp; the final sort then interleaves
+  // friends by recency.
+  const built: Array<{ sortMs: number; card: FriendTerritoryCardModel }> = []
   for (const [friendId, entry] of byFriend.entries()) {
     // `seen` spans the friend's bundles so a question packed into two of them
     // (deep + breadth overlap) plays once — the newer bundle's card claims it.
@@ -124,16 +135,24 @@ export function buildFriendTerritoryCards(
           chunkCount === 1
             ? `${friendId}:${bundle.itemId}`
             : `${friendId}:${bundle.itemId}:${chunk}`
-        cards.push({
-          id: `territory:${seed}`,
-          friendId,
-          friendName: entry.friendName,
-          statusLine: friendTerritoryStatusLine(seed),
-          topics: topicsForQuestions(chunkQuestions),
-          questions: chunkQuestions,
+        built.push({
+          sortMs: bundle.sortMs,
+          card: {
+            id: `territory:${seed}`,
+            friendId,
+            friendName: entry.friendName,
+            statusLine: friendTerritoryStatusLine(seed),
+            topics: topicsForQuestions(chunkQuestions),
+            questions: chunkQuestions,
+          },
         })
       }
     }
   }
-  return cards
+
+  // Newest bundle first, across friends. The sort is stable (ES2019+), so a
+  // friend's same-instant bundles (and the split chunks of one bundle) keep
+  // their build order and stay adjacent.
+  built.sort((a, b) => b.sortMs - a.sortMs)
+  return built.map((b) => b.card)
 }


### PR DESCRIPTION
## Summary
Changes the ordering of friend territory cards from friend-major stacking (all bundles from one friend grouped together) to chronological interleaving (newest bundles first across all friends). This prevents active friends' older activity from appearing above other friends' newer activity.

## Key Changes
- **Card ordering logic:** Modified `buildFriendTerritoryCards()` to sort cards by bundle timestamp (`sortMs`) in descending order (newest first) after building per-friend cards, rather than relying on friend-major grouping
- **Data structure:** Added `sortMs: number` field to bundle objects to track each bundle's recency for sorting
- **Test coverage:** Added test case verifying chronological interleaving — an active friend's older bundle now correctly appears below another friend's newer one
- **UI constants:** Updated `FROM_FRIENDS_COLLAPSED_COUNT` and `FROM_FRIENDS_STEP` from 5/10 to 8/8 to accommodate the new interleaved layout
- **Documentation:** Updated comments throughout to clarify the new chronological ordering behavior and explain that deduplication still runs per-friend to ensure newer bundles claim shared questions

## Implementation Details
- The stable sort (ES2019+) preserves build order for same-timestamp bundles and split chunks, keeping a friend's related cards adjacent
- Per-friend deduplication still runs during card building (before the final sort) so the newer bundle within a friend's bundles correctly claims shared questions
- The sort is applied after all per-friend processing, enabling clean separation of concerns: build cards per friend, then interleave by recency

https://claude.ai/code/session_017AXj7gkG4thoKgyeSvqnBb