### PR TITLE
color: reconcile the lately TS neutrals against the CSS tokens (guide §2)

### DIFF
--- a/src/components/lately/tokens.ts
+++ b/src/components/lately/tokens.ts
@@ -1,13 +1,19 @@
-// Re-pointed to the JOSHING brand palette so the Lately surface matches the
-// rest of the app. The Playfair "Lately." flourish (FS) and warm highlighter
-// (HILITE) are kept as intentional editorial character.
-export const INK = '#0a1f3d'; // --brand-ink
-export const INK2 = '#3a4a5f'; // --brand-ink-700
-export const INK3 = '#8a8a8a'; // --brand-ink-400
-export const CREAM = '#fcf8f2'; // --brand-cream-page
-export const PAPER = '#fdfcfb'; // --brand-card
-export const RULE = '#e9e2d2'; // --brand-border
-export const HILITE = '#e9c97a'; // warm brand-aligned highlighter
+// Ergonomic aliases over the CSS brand tokens (globals.css :root) — references,
+// not copies, so the values can never drift from the app palette
+// (STYLE-GUIDE-COLOR §2: one source of truth per neutral).
+// NOTE: CREAM here is the PAGE cream (--brand-cream-page #fcf8f2) — the Lately
+// surface sits on the page surface. The app-wide CSS alias `--cream` is the
+// content-CARD cream (--brand-card, = PAPER below). Same word, two jobs; the
+// per-job brand tokens are the disambiguation.
+export const INK = 'var(--brand-ink)';
+export const INK2 = 'var(--brand-ink-700)';
+export const INK3 = 'var(--brand-ink-400)';
+export const CREAM = 'var(--brand-cream-page)';
+export const PAPER = 'var(--brand-card)';
+export const RULE = 'var(--brand-border)';
+// Warm highlighter — gold family; no CSS counterpart yet. Folding it into the
+// one --accent-gold is color fix-list step 4 (gold), not the neutrals pass.
+export const HILITE = '#e9c97a';
 
 // Body font intentionally uses the project default (Montserrat via next/font);
 // CSS var resolves to it. The mockup spec'd Inter — project decision to keep


### PR DESCRIPTION
Color fix-list **step 2** from `_docs/STYLE-GUIDE-COLOR.md` §2 — neutrals: one value per token, one source of truth. Follows the merged grading consolidation (#827).

## What changed
`INK` / `INK2` / `INK3` / `CREAM` / `PAPER` / `RULE` in `src/components/lately/tokens.ts` were **literal hex copies** of the brand tokens — the parallel TS token system the audit flagged, able to drift silently from `globals.css`. They are now `var(--brand-*)` **references**:

| Constant | Now |
|---|---|
| `INK` | `var(--brand-ink)` |
| `INK2` | `var(--brand-ink-700)` |
| `INK3` | `var(--brand-ink-400)` |
| `CREAM` | `var(--brand-cream-page)` |
| `PAPER` | `var(--brand-card)` |
| `RULE` | `var(--brand-border)` |

Verified no consumer does string math on them (hex-alpha suffixes, comparisons, concatenation) — all plain CSS-value usage across the activity/lately surfaces. **Zero visual change.**

## The CREAM name conflict
Resolved by single-sourcing + documentation rather than a rename: the audit's "two different creams" are genuinely two *jobs* — TS `CREAM` is the **page** cream (`--brand-cream-page` `#fcf8f2`, what the Lately surface sits on) while the CSS `--cream` alias is the **content-card** cream (`--brand-card` `#fdfcfb`, = `PAPER`). Each name now points at its per-job brand token, so the values can't drift apart, and the comment in `tokens.ts` spells out the distinction for the next reader. If you'd rather kill the name collision outright (e.g. rename TS `CREAM` → `PAGE`), that's a small mechanical follow-up — flagging rather than deciding.

## Deliberately left
`HILITE #e9c97a` stays literal: it's gold-family with no CSS counterpart, and folding it into the single `--accent-gold` is fix-list **step 4** (gold), not the neutrals pass.

## Verification
`npx tsc -p tsconfig.typecheck.json` clean; `npm run lint` 0 errors; `npm run check:fonts` 0/0; activity + lately suites 13/13, component sweep green.

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF

---
_Generated by [Claude Code](https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF)_