### PR TITLE
color: complete the fix-list — gold, category routing, triangle, ratchet (+ muted WRONG wash)

### DIFF
--- a/.github/workflows/color-ratchet.yml
+++ b/.github/workflows/color-ratchet.yml
@@ -1,0 +1,21 @@
+# Color ratchet (B-VISUAL-STYLE-GUIDE-COLOR-01, fix-list step 6): fail the PR
+# if off-system color usage (hardcoded hex / rgb / hsl / raw Tailwind color
+# arbitraries) in src/ rises above the recorded ceiling. The ceiling and the
+# exemption list live in scripts/check-color-ratchet.mjs. Independent of the
+# font ratchet by design — the two halves of the style guide enforce separately.
+name: Color ratchet
+
+on:
+  pull_request:
+  push:
+    branches: [main, dev2]
+
+jobs:
+  color-ratchet:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node scripts/check-color-ratchet.mjs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - `npm run build` — production build
 - `npm run lint` — ESLint over `src/`
 - `npm run check:fonts` — font ratchet (off-system font-family count must stay ≤ the ceiling in `scripts/check-font-ratchet.mjs`; runs in CI)
+- `npm run check:colors` — color ratchet (off-system hex/rgb/hsl count must stay ≤ the ceiling in `scripts/check-color-ratchet.mjs`; runs in CI)
 - `npm run format` — Prettier write
 - `npm run db:migrate` — Drizzle migrations
 - `npm run smoke:daily-catchup` — daily catchup smoke test

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test:evals": "RUN_LLM_EVALS=1 vitest run eval.test",
     "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 16",
     "check:fonts": "node scripts/check-font-ratchet.mjs",
+    "check:colors": "node scripts/check-color-ratchet.mjs",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",
     "smoke:question-vetting": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/question-vetting.smoke.mjs",
     "smoke:invite-first-five": "node --experimental-strip-types --disable-warning=MODULE_TYPELESS_PACKAGE_JSON scripts/invite-first-five.smoke.mjs",

--- a/scripts/check-color-ratchet.mjs
+++ b/scripts/check-color-ratchet.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+// Color ratchet (B-VISUAL-STYLE-GUIDE-COLOR-01, fix-list step 6) — fails if
+// off-system color usage in src/ rises above the recorded ceiling. The
+// font-only twin is scripts/check-font-ratchet.mjs; the two are deliberately
+// independent (STYLE-GUIDE-COLOR pairs with STYLE-GUIDE-TYPE).
+//
+// "Off-system" means a color declared outside the tokens in
+// src/app/globals.css. Three patterns count:
+//   A. hardcoded hex colors (#abc / #aabbcc / #aabbccdd) in code
+//   B. raw rgb()/rgba()/hsl()/hsla() calls
+//   C. Tailwind arbitrary raw-color values (e.g. bg-[#fff], text-[#1a1208]/70)
+// Heuristic: line comments (// …) and block-comment continuation lines (* …)
+// are stripped first, so hexes in prose don't count. var(--…) consumers never
+// match any pattern — they're the point.
+//
+// To LOWER the ceiling after a cleanup: run the script, take the count, update
+// CEILING. To raise it: don't — route the color through a token instead
+// (see _docs/STYLE-GUIDE-COLOR.md; brand/category/gold tokens in globals.css).
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+
+// ── The ceiling ──────────────────────────────────────────────────────────────
+// Baseline recorded 2026-06-11 after the color fix-list steps 1–5 (grading
+// consolidation, neutrals reconciliation, category --cat-* scale + feed/
+// expanding routing, gold collapse, triangle decision) — down from the
+// audit's ~312. The remainder is dominated by: the ceremony gradient palette
+// (open PRs touch it), the LoadingScreen/visual.ts mirrors of brand values,
+// warm shadow/scrim rgba() tuples, and SVG art fills.
+const CEILING = 180;
+
+// ── Exemptions (mirrors the font ratchet; keep this list short) ─────────────
+const EXEMPT = [
+  // Token definitions live here — the one place raw colors are correct.
+  'src/app/globals.css',
+  // html2canvas raster path: literal values are load-bearing (documented
+  // "intentionally literal — do NOT tokenize" at the top of the file).
+  'src/components/knowledge/SharePortraitCard.tsx',
+  // Email HTML cannot use CSS custom properties (no :root in mail clients).
+  'src/server/email/templates/',
+  // Internal tooling, never shipped to users (same decision as the font
+  // ratchet's checkpoint).
+  'src/app/dev/',
+  'src/app/feed/debug/',
+];
+
+const isTest = (p) => /(\.test\.|__tests__\/)/.test(p);
+const isExempt = (p) => EXEMPT.some((e) => p === e || p.startsWith(e)) || isTest(p);
+
+const HEX = /#[0-9a-fA-F]{3,8}\b/g;
+const RGB_HSL = /\b(?:rgba?|hsla?)\(/g;
+const TW_RAW_COLOR =
+  /(?:bg|text|border|ring|shadow|fill|stroke|from|via|to|decoration|outline|accent|caret)-\[#[0-9a-fA-F]{3,8}/g;
+
+function stripComments(line) {
+  const t = line.trimStart();
+  if (t.startsWith('//') || t.startsWith('*') || t.startsWith('/*')) return '';
+  return line.replace(/\/\/.*$/, '');
+}
+
+function* walk(dir) {
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    if (statSync(full).isDirectory()) yield* walk(full);
+    else if (/\.(tsx?|jsx?|css)$/.test(name)) yield full;
+  }
+}
+
+const root = process.cwd();
+const offenders = [];
+
+for (const file of walk(join(root, 'src'))) {
+  const rel = relative(root, file).replaceAll('\\', '/');
+  if (isExempt(rel)) continue;
+  const lines = readFileSync(file, 'utf8').split('\n');
+  lines.forEach((raw, i) => {
+    const line = stripComments(raw);
+    if (!line) return;
+    let n = 0;
+    for (const re of [HEX, RGB_HSL, TW_RAW_COLOR]) {
+      re.lastIndex = 0;
+      // TW arbitraries also match the bare-hex pattern; count the max of the
+      // pattern hits on the line rather than summing overlaps.
+      const hits = line.match(re)?.length ?? 0;
+      if (re === TW_RAW_COLOR) n = Math.max(n - hits, 0) + hits;
+      else n += hits;
+    }
+    if (n > 0) offenders.push({ loc: `${rel}:${i + 1}`, n, text: raw.trim().slice(0, 100) });
+  });
+}
+
+const count = offenders.reduce((sum, o) => sum + o.n, 0);
+if (count > CEILING) {
+  console.error(`✖ color ratchet: ${count} off-system color occurrence(s) in src/ (ceiling: ${CEILING})\n`);
+  for (const o of offenders.slice(0, 60)) console.error(`  ${o.loc} (${o.n}): ${o.text}`);
+  if (offenders.length > 60) console.error(`  … and ${offenders.length - 60} more lines`);
+  console.error(
+    '\nRoute colors through the tokens in globals.css (--brand-* / --cat-* / --accent-gold / --game-*);' +
+      ' see _docs/STYLE-GUIDE-COLOR.md. Do not raise the ceiling.',
+  );
+  process.exit(1);
+}
+console.log(`✓ color ratchet: ${count} off-system color occurrence(s) (ceiling: ${CEILING})`);

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -263,9 +263,15 @@
 :root[data-palette="proposed"] {
     /* §1 GRADING — WRONG leaves the terracotta family for a true red. This is the
        thesis change: it de-collides wrong from the brand/link orange (#d15e36)
-       and from the solid "still to play" triangle, in one move. */
-    --game-wrong:        #c1121f;  /* was #c96b4a terracotta */
-    --game-wrong-strong: #8c0d17;  /* was #c33d14            */
+       and from the solid "still to play" triangle, in one move.
+       Two registers, mirroring how the tokens are consumed:
+       • --game-wrong is the WASH/FILL base (result-card backgrounds at 8–12%
+         mixes) — a MUTED brick red, per feedback that the vivid red made the
+         incorrect-answer background too harsh. Still clearly red, not orange.
+       • --game-wrong-strong is the SIGNAL (rail + label text) — the clear,
+         saturated red that says "wrong" at a glance. */
+    --game-wrong:        #a93b3b;  /* was #c96b4a terracotta; muted brick red */
+    --game-wrong-strong: #c1121f;  /* was #c33d14; clear true red             */
     /* CORRECT stays forest green; kept here as the single tuning point and to
        confirm by eye that it clears the knowledge greens. */
     --game-correct:      #366045;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -78,6 +78,15 @@
     --tri-darkyellow:    #deae5c;
     --tri-lighttan:      #edd2a3;
     --tri-amber:         #d9a82e;
+    /* Accent gold (STYLE-GUIDE-COLOR §4) — THE editorial highlight. One value,
+       scarcity-bound: gold marks the single most notable moment in view (the
+       ceremony countdown wins ties). Shares the amber value, but this token is
+       the accent JOB — triangle fills keep --tri-amber (decorative palette
+       job), and --warning stays separate (system caution, not the accent). */
+    --accent-gold:       #d9a82e;
+    /* AA-darkened gold for small text on cream (eyebrows, "BETWEEN US!",
+       "NEW TERRITORY") — was the GOLD_INK formula copy-pasted in three files. */
+    --accent-gold-ink:   color-mix(in srgb, var(--accent-gold) 50%, var(--brand-ink));
     /* Gameplay surface — sourced from the Figma "Game" frame variables.
        game/card/question fill, plus the forest-green/terracotta result accents
        (Correct, text/wrong, Color/game/wrong/in-question). These intentionally

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -71,6 +71,12 @@
     --brand-rule:        rgba(60, 50, 40, 0.14); /* border/rule — divider      */
     --domain-language:   #7a9eaa;
     --domain-science:    #8aa68a;
+    /* Triangle palette — DECORATIVE by decision (STYLE-GUIDE-COLOR §3 note +
+       §5 fix-list step 5, option b): triangle fill hue is a deterministic hash
+       over these six muted fills and carries NO category meaning. The one bit a
+       triangle encodes is solid/hollow = unplayed/played — safe from grading
+       confusion once WRONG leaves the orange family (§1). Revisit to option (a)
+       (hue = --cat-* category) only as a deliberate product change. */
     --tri-orange:        #d15e36;
     --tri-cream:         #f8e6c7;
     --tri-darkteal:      #6d837f;

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -642,7 +642,7 @@ function KnowledgePageContent() {
       )}
 
       {emptyQuestionDomain ? (
-        <section className="bg-[#fff7e8] border border-[#d9b56c] px-[0.95rem] py-5" aria-label={`No ${emptyQuestionDomain} questions yet`}>
+        <section className="bg-[color-mix(in_srgb,var(--accent-gold)_8%,var(--brand-card))] border border-[color-mix(in_srgb,var(--accent-gold)_55%,var(--brand-border))] px-[0.95rem] py-5" aria-label={`No ${emptyQuestionDomain} questions yet`}>
           <p className="m-0 text-[13px] [font-variant:small-caps] text-[var(--ink)] font-[var(--font-neutral)] tracking-[0.06em]">No matching public questions</p>
           <h2 className="mt-[0.4rem] text-xl leading-[1.35] text-[var(--ink)] font-[var(--font-serif)] font-semibold">We don&apos;t have {emptyQuestionDomain} questions yet. Want to ask someone who might?</h2>
           <p className="mt-3 text-[0.88rem] leading-[1.6] text-[var(--text-muted-warm)]">Josh is going deep on {emptyQuestionDomain} — and thinks someone in your world might be the one to stump them.</p>

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -16,7 +16,7 @@ function formatPhoneForDisplay(e164: string): string {
 const CARD_CLASS =
   'w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-[46px] py-8 shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5';
 const INPUT_CLASS =
-  'h-11 w-full rounded-[4px] border border-[var(--tri-amber)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none transition-colors focus:border-[var(--brand-navy)]';
+  'h-11 w-full rounded-[4px] border border-[var(--accent-gold)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none transition-colors focus:border-[var(--brand-navy)]';
 const SUBMIT_CLASS =
   'h-11 w-full rounded-[4px] bg-[var(--brand-navy)] px-4 text-base font-bold tracking-[0.04em] text-white transition hover:opacity-90 disabled:opacity-60';
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -26,7 +26,7 @@ function TitleCard() {
       <h1 className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
         JOSHING
       </h1>
-      <div className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--tri-amber)]" aria-hidden="true" />
+      <div className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--accent-gold)]" aria-hidden="true" />
       <p className="mt-4 text-center font-sans text-lg font-normal uppercase leading-6 tracking-[3.6px] text-[var(--warm-ink)]">
         Trivia you wish you were asked
       </p>

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -293,6 +293,7 @@ function baseTypedFields(item: FeedApiItem, answered = false, hideTimestamp = fa
     id: item.id,
     metadata: feedMetadata(item, answered),
     category: item.domain_pill,
+    broadCategory: item.broad_category ?? null,
     question: item.question_text ?? 'Untitled question',
     personalMessage: item.personal_message,
     isInBank: item.is_in_bank,

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -25,7 +25,8 @@ const STORAGE_KEY = 'joshing-palette';
 // What the toggle visibly changes, so a tester knows where to look. Extend this
 // as more color jobs (category, gold) get routed onto tokens.
 const CHANGES: Array<{ label: string; from: string; to: string }> = [
-  { label: 'WRONG', from: '#c96b4a', to: '#c1121f' },
+  { label: 'WRONG WASH', from: '#c96b4a', to: '#a93b3b' },
+  { label: 'WRONG TEXT', from: '#c33d14', to: '#c1121f' },
   { label: 'LITERATURE', from: '#c0392b', to: '#7d2c3f' },
   { label: 'LANGUAGE', from: '#4a7a5a', to: '#2e6e7e' },
 ];

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -11,9 +11,9 @@ import { INSIDE_JOKE_LABELS, type InsideJokeKind } from '@/lib/questions-types'
 import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet'
 
 // Darkened triangle-gold for text/eyebrows that need to clear AA on the cream
-// card (raw --tri-amber #d9a82e is too light for small text). Used by the
+// card (raw --accent-gold #d9a82e is too light for small text). Used by the
 // "New territory" celebration and the "Between us friends" inside-joke card.
-const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))'
+const GOLD_INK = 'var(--accent-gold-ink)'
 
 type AnswerFeedbackSheetProps = {
   question: string
@@ -158,7 +158,7 @@ export function AnswerFeedbackSheet({
             ? 'relative flex max-h-[90dvh] w-full max-w-lg flex-col overflow-hidden rounded-t-3xl bg-[var(--brand-card)] shadow-2xl ring-2'
             : 'relative flex max-h-[90dvh] w-full max-w-lg flex-col rounded-t-3xl bg-[var(--brand-card)] shadow-2xl'
         }
-        style={showNewTerritory ? { '--tw-ring-color': 'color-mix(in srgb, var(--tri-amber) 55%, transparent)' } as CSSProperties : undefined}
+        style={showNewTerritory ? { '--tw-ring-color': 'color-mix(in srgb, var(--accent-gold) 55%, transparent)' } as CSSProperties : undefined}
       >
         <div className="flex items-center justify-between px-5 pt-4 pb-1">
           {showNewTerritory ? (
@@ -279,8 +279,8 @@ export function AnswerFeedbackSheet({
             <div
               className="mt-2.5 rounded-2xl border p-3.5"
               style={{
-                backgroundColor: 'color-mix(in srgb, var(--tri-amber) 12%, var(--brand-card))',
-                borderColor: 'color-mix(in srgb, var(--tri-amber) 40%, var(--brand-border))',
+                backgroundColor: 'color-mix(in srgb, var(--accent-gold) 12%, var(--brand-card))',
+                borderColor: 'color-mix(in srgb, var(--accent-gold) 40%, var(--brand-border))',
               }}
             >
               <p

--- a/src/components/feed/AnsweredByYouCard.tsx
+++ b/src/components/feed/AnsweredByYouCard.tsx
@@ -236,7 +236,7 @@ function AnsweredResult({
 
 export function AnsweredByYouCard({ item, recheckAction, onRetry, overflow }: AnsweredByYouCardProps) {
   const category = visibleFeedCategory(item.category)
-  const categoryColor = colorForCategory(item.category)
+  const categoryColor = colorForCategory(item.category, item.broadCategory)
 
   return (
     <FeedCardShell accentColor={categoryColor} accentPlacement="left">

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -8,6 +8,7 @@ import { EditorialCarousel } from '@/components/feed/EditorialCarousel';
 import { EditorialFeature } from '@/components/feed/EditorialFeature';
 import { colorForUser, initialsFor, isDarkColor } from '@/components/feed/visual';
 import { AddFriendButton } from '@/components/friends/AddFriendButton';
+import { expandingTerritoryAccent } from '@/components/knowledge/PortraitCircles';
 import { circleDatasetMax, DomainCircleSvg } from '@/components/profile/common-ground-circles';
 import type { StreamEmbed } from '@/lib/activity-stream';
 
@@ -15,14 +16,9 @@ import type { StreamEmbed } from '@/lib/activity-stream';
 // motif is the hero artwork, so it should catch the eye before the copy.
 const SHARED_GROUND_CIRCLE_SCALE = 1.35;
 
-// Badge accents for the "Your World Is Expanding" territory rows — the
-// reds / golds / blues from the /knowledge "Recently Expanding" module, trimmed
-// to the three we ever render.
-const EXPANDING_ROW_ACCENTS = [
-  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)' },
-  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)' },
-  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.2)' },
-] as const;
+// Badge accents for the "Your World Is Expanding" territory rows are keyed by
+// the row's domain via expandingTerritoryAccent — shared with the /knowledge
+// "Recently Expanding" module, so a territory carries one hue on both surfaces.
 
 // A faded decorative cluster of overlapping avatar circles for the
 // "Grow Your Circle" invite state — purely decorative (aria-hidden, no
@@ -233,8 +229,8 @@ export function RecentlyExpandingFeature({
       headline={rotate(RECENTLY_EXPANDING_HEADLINES, embed.headlineIndex)}
       artwork={
         <div className="flex flex-col gap-3">
-          {embed.domains.map((d, i) => {
-            const accent = EXPANDING_ROW_ACCENTS[i % EXPANDING_ROW_ACCENTS.length]!;
+          {embed.domains.map((d) => {
+            const accent = expandingTerritoryAccent(d.label);
             return (
               <div key={d.label} className="flex items-center gap-3">
                 <span

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -67,7 +67,7 @@ export function FeedCard({
   dimQuestion,
   elevated,
 }: FeedCardProps) {
-  const categoryColor = colorForCategory(item.category)
+  const categoryColor = colorForCategory(item.category, item.broadCategory)
   const visibleCategory = visibleFeedCategory(item.category)
   const authorName = item.avatarName ?? 'Someone'
   // Figma colors the actor name in the user's avatar color (e.g. Allan blue,

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -11,8 +11,8 @@ import {
 } from '@/lib/daily/territory-model';
 
 // Darkened triangle-gold so the "New territory" copy clears AA on the cream
-// card (raw --tri-amber #d9a82e is too light for small text).
-const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))';
+// card (raw --accent-gold #d9a82e is too light for small text).
+const GOLD_INK = 'var(--accent-gold-ink)';
 
 // Default-add with player control (B-1): a correct answer in an unfamiliar domain
 // opens it in the player's Knowledge base automatically (server-side, via
@@ -69,9 +69,9 @@ export function NewTerritoryUndo({
 
   return (
     <ThreadCard
-      rail="var(--tri-amber)"
-      border="color-mix(in srgb, var(--tri-amber) 32%, var(--brand-rule))"
-      fill="color-mix(in srgb, var(--tri-amber) 7%, var(--brand-card))"
+      rail="var(--accent-gold)"
+      border="color-mix(in srgb, var(--accent-gold) 32%, var(--brand-rule))"
+      fill="color-mix(in srgb, var(--accent-gold) 7%, var(--brand-card))"
       style={{ marginTop: '8px' }}
     >
       {/* Quiet label — same eyebrow rhythm as the result cards. */}
@@ -122,10 +122,10 @@ export function NewTerritoryUndo({
                 fontWeight: isSelected ? 700 : 500,
                 color: isSelected ? GOLD_INK : 'var(--text-muted)',
                 backgroundColor: isSelected
-                  ? 'color-mix(in srgb, var(--tri-amber) 20%, var(--brand-card))'
+                  ? 'color-mix(in srgb, var(--accent-gold) 20%, var(--brand-card))'
                   : 'transparent',
                 borderColor: isSelected
-                  ? 'color-mix(in srgb, var(--tri-amber) 55%, var(--brand-border))'
+                  ? 'color-mix(in srgb, var(--accent-gold) 55%, var(--brand-border))'
                   : 'var(--brand-rule)',
               }}
             >

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -5,6 +5,8 @@ export type FeedCardBaseItem = {
   metadata: ReactNode
   question: string
   category?: string | null
+  /** Top-level domain — keys the accent-bar hue on the --cat-* scale (§3). */
+  broadCategory?: string | null
   personalMessage?: string | null
   isInBank?: boolean
   avatarName?: string | null
@@ -56,7 +58,6 @@ export type AnsweredByYouFeedItem = FeedCardBaseItem & {
   explanation?: string | null
   creatorNote?: string | null
   unverifiedAnswer?: boolean
-  broadCategory?: string | null
   masteryDelta?: AnsweredByYouMasteryDelta | null
   pairedFriend?: AnsweredByYouPairedFriend | null
 }

--- a/src/components/feed/visual.ts
+++ b/src/components/feed/visual.ts
@@ -1,6 +1,9 @@
-// Brand-muted palette (triangle + domain colors from the Figma design system)
-// so category accents (feed top bars) and avatars stay on-brand instead of the
-// old vibrant Tailwind-600 set.
+import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles'
+import { normalizeBroadCategory } from '@/lib/knowledge/broad-category'
+
+// Legacy brand-muted hash palette — now only the FALLBACK for items whose
+// broad category didn't resolve (so nothing renders the off-brand gray).
+// Category-bearing accents use the --cat-* domain scale via colorForCategory.
 const CATEGORY_COLORS = [
   '#1f3a5a', // navy
   '#d15e36', // triangle orange
@@ -27,7 +30,16 @@ function hashString(str: string): number {
   return Array.from(str).reduce((sum, char) => sum + char.charCodeAt(0), 0)
 }
 
-export function colorForCategory(category?: string | null): string {
+// Category accent = the top-level domain's hue from the --cat-* scale
+// (STYLE-GUIDE-COLOR §3: color attaches to the domain, leaf categories inherit
+// the parent hue, no hashing). The leaf-name hash survives only as the
+// fallback for items without a resolved broad category.
+export function colorForCategory(
+  category?: string | null,
+  broadCategory?: string | null,
+): string {
+  const broad = normalizeBroadCategory(broadCategory) ?? broadCategory?.trim()
+  if (broad) return getPortraitDomainColor(broad).primary
   if (!category) return '#9ca3af'
   return CATEGORY_COLORS[
     hashString(category.toLowerCase()) % CATEGORY_COLORS.length

--- a/src/components/home/CeremonyPin.tsx
+++ b/src/components/home/CeremonyPin.tsx
@@ -12,7 +12,7 @@ export type CeremonyPinStatus = {
 // reflection is ready the whole row is the tap target; the future-state
 // countdown is the same treatment with only the text changed.
 const MARKER_CLASS =
-  'flex items-center justify-center gap-2 py-3 text-center text-xs font-medium tracking-[0.08em] text-[var(--tri-amber)] uppercase motion-safe:animate-in motion-safe:fade-in motion-safe:duration-700'
+  'flex items-center justify-center gap-2 py-3 text-center text-xs font-medium tracking-[0.08em] text-[var(--accent-gold)] uppercase motion-safe:animate-in motion-safe:fade-in motion-safe:duration-700'
 
 /**
  * Top-of-home ceremony slot. Lifted out of FeedList so Home can render it

--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -117,7 +117,7 @@ export function DomainCircle({
           border={`1px solid ${circleBorder}`}
           style={{
             transition: 'border-color 300ms ease, box-shadow 300ms ease',
-            boxShadow: highlighted ? '0 0 8px #f0c060' : undefined,
+            boxShadow: highlighted ? '0 0 8px var(--accent-gold)' : undefined,
           }}
         >
           {Icon ? <Icon size={iconSize} color="#0a1f3d" /> : null}

--- a/src/components/knowledge/PortraitCircles.tsx
+++ b/src/components/knowledge/PortraitCircles.tsx
@@ -90,6 +90,18 @@ export function getPortraitDomainColor(domain: string): DomainColor {
   return DOMAIN_COLORS[domain] ?? hashColor(domain)
 }
 
+// Accent pair for an "expanding territory" row — keyed by the row's domain
+// (STYLE-GUIDE-COLOR §3: color = category) instead of the old row-position
+// red/gold/blue. Known domains ride the --cat-* scale; unknown ones get the
+// deterministic hash hue — either way a territory keeps ONE color everywhere.
+export function expandingTerritoryAccent(domain: string): { border: string; fill: string } {
+  const c = getPortraitDomainColor(domain)
+  return {
+    border: c.primary,
+    fill: `color-mix(in srgb, ${c.primary} 15%, transparent)`,
+  }
+}
+
 const SPARSE_THRESHOLD = 5
 const MIN_OPACITY = 0.22
 

--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -3,6 +3,8 @@
 import { useMemo, type CSSProperties } from 'react';
 import { Share2 } from 'lucide-react';
 
+import { expandingTerritoryAccent } from '@/components/knowledge/PortraitCircles';
+
 export type ExpandingDomain = {
   domain: string;
   momentumScore: number;
@@ -22,13 +24,6 @@ type RecentlyExpandingProps = {
 };
 
 const MAX_EXPANDING_DOMAINS = 5;
-const ROW_ACCENTS = [
-  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)', text: '#9b3f37' },
-  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)', text: '#7c6332' },
-  { border: '#c9564d', fill: 'rgba(201, 86, 77, 0.16)', text: '#9b3f37' },
-  { border: '#65a8bb', fill: 'rgba(101, 168, 187, 0.20)', text: '#2f7487' },
-  { border: '#a98a4c', fill: 'rgba(169, 138, 76, 0.14)', text: '#7c6332' },
-];
 
 export function RecentlyExpanding({ domains, playerDisplayName = 'Josh', onNotice }: RecentlyExpandingProps) {
   const visibleDomains = domains.slice(0, MAX_EXPANDING_DOMAINS);
@@ -93,7 +88,7 @@ type RowProps = {
 };
 
 function ExpandingDomainRow({ domain, index }: RowProps) {
-  const accent = ROW_ACCENTS[index % ROW_ACCENTS.length];
+  const accent = expandingTerritoryAccent(domain.domain);
   const activity = getRowActivity(domain);
   const initial = getDomainInitial(domain.domain);
 

--- a/src/components/lately/tokens.ts
+++ b/src/components/lately/tokens.ts
@@ -11,9 +11,10 @@ export const INK3 = 'var(--brand-ink-400)';
 export const CREAM = 'var(--brand-cream-page)';
 export const PAPER = 'var(--brand-card)';
 export const RULE = 'var(--brand-border)';
-// Warm highlighter — gold family; no CSS counterpart yet. Folding it into the
-// one --accent-gold is color fix-list step 4 (gold), not the neutrals pass.
-export const HILITE = '#e9c97a';
+// Warm highlighter swipe (the "Lately." headline) — derived from the one
+// accent gold (STYLE-GUIDE-COLOR §4) lightened over the page cream, replacing
+// the orphan literal #e9c97a (≈ visually identical mix).
+export const HILITE = 'color-mix(in srgb, var(--accent-gold) 55%, var(--brand-cream-page))';
 
 // Body font intentionally uses the project default (Montserrat via next/font);
 // CSS var resolves to it. The mockup spec'd Inter — project decision to keep

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -177,9 +177,9 @@ const verdictLabelStyle: CSSProperties = {
 // (this card, the feed sheet, the summary recap, the history list) stays in sync.
 
 // Darkened triangle-gold so warning/inside-joke labels clear AA on the cream
-// surface (raw --tri-amber #d9a82e is too light for small text). Mirrors the
+// surface (raw --accent-gold #d9a82e is too light for small text). Mirrors the
 // GOLD_INK used on the feed answer sheets.
-const GOLD_INK = 'color-mix(in srgb, var(--tri-amber) 50%, var(--brand-ink))';
+const GOLD_INK = 'var(--accent-gold-ink)';
 
 const WRONG_NAMED_SUBLABEL: Array<(name: string) => string> = [
   (name) => `${name}’s world includes this`,
@@ -449,7 +449,7 @@ function QuestionRow({
               >
                 <span
                   aria-hidden
-                  style={{ color: 'var(--tri-amber)', fontSize: '0.8rem', lineHeight: 1 }}
+                  style={{ color: 'var(--accent-gold)', fontSize: '0.8rem', lineHeight: 1 }}
                 >
                   ✦
                 </span>
@@ -463,7 +463,7 @@ function QuestionRow({
                   textTransform: 'uppercase',
                   letterSpacing: '0.12em',
                   lineHeight: 1.25,
-                  color: 'color-mix(in srgb, var(--tri-amber) 35%, white)',
+                  color: 'color-mix(in srgb, var(--accent-gold) 35%, white)',
                 }}
               >
                 {bonusSourceLabel(presenceSourceName, presenceSourceExtraCount)}
@@ -476,15 +476,15 @@ function QuestionRow({
             // Bonus questions get a navy banner plus warm card tint so the
             // gifted-from-a-friend item reads as an extra, not an ordinary prompt.
             background: isBonus
-              ? 'color-mix(in srgb, var(--tri-amber) 10%, var(--game-card-question))'
+              ? 'color-mix(in srgb, var(--accent-gold) 10%, var(--game-card-question))'
               : 'var(--game-card-question)',
             border: isBonus
-              ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--tri-amber))'
+              ? '1px solid color-mix(in srgb, var(--brand-navy) 72%, var(--accent-gold))'
               : '1px solid var(--brand-rule)',
             borderRadius: isBonus ? '0 0 var(--radius-md) var(--radius-md)' : 'var(--radius-md)',
             // effect/card/question — soft layered drop shadow (bonus adds a gold inset rail).
             boxShadow: isBonus
-              ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--tri-amber)'
+              ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
               : '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
             padding: '14px 18px',
             fontFamily: 'var(--font-serif)',
@@ -512,7 +512,7 @@ function QuestionRow({
                     border: '1px solid var(--border)',
                     background:
                       badge.tone === 'warning'
-                        ? 'color-mix(in srgb, var(--tri-amber) 14%, var(--surface))'
+                        ? 'color-mix(in srgb, var(--accent-gold) 14%, var(--surface))'
                         : 'color-mix(in srgb, var(--border) 18%, var(--surface))',
                     color: badge.tone === 'warning' ? GOLD_INK : 'var(--text-muted)',
                     opacity: 0.9,
@@ -1240,8 +1240,8 @@ function ResultRow({
       </ThreadCard>
       {showJokeCard && insideJoke ? (
         <ThreadCard
-          border="color-mix(in srgb, var(--tri-amber) 40%, var(--border))"
-          fill="color-mix(in srgb, var(--tri-amber) 12%, var(--surface-2))"
+          border="color-mix(in srgb, var(--accent-gold) 40%, var(--border))"
+          fill="color-mix(in srgb, var(--accent-gold) 12%, var(--surface-2))"
           style={{ marginTop: '8px' }}
         >
           <p


### PR DESCRIPTION
Completes the color fix-list from `_docs/STYLE-GUIDE-COLOR.md` — steps 4, 5, 6 and the rest of step 3 — plus the WRONG-wash tuning from review feedback. Four commits, reviewable independently. (Steps 1–2 and the first slice of 3 landed in #827/#829/#825.)

## 1. `800f6d0` — mute the proposed WRONG wash (review feedback)
The two WRONG tokens map to two registers, so the proposal now respects the split: `--game-wrong` (the **wash/fill base**, result-card backgrounds at 8–12% mixes) goes to a **muted brick red `#a93b3b`** — keeping the soft character of the current terracotta, just out of the orange family — while `--game-wrong-strong` (the **rail/label signal**) carries the clear true red `#c1121f`. Toggle legend shows WRONG WASH / WRONG TEXT pairs.

## 2. `44dc7dd` — gold (step 4): six golds → one `--accent-gold`
- New tokens: `--accent-gold` (#d9a82e — the accent **job**; triangle fills keep `--tri-amber`) and `--accent-gold-ink` (the AA-dark text mix that was copy-pasted as `GOLD_INK` in three files).
- Routed: feed answer sheet + NewTerritoryUndo chrome, GameplayChat bonus/inside-joke chrome, CeremonyPin countdown, login underline/input border, the DomainCircle glow (`#f0c060` stray), the knowledge empty-state chip (`#fff7e8`/`#d9b56c` strays), and `HILITE` (`#e9c97a` orphan → accent-gold lightened over page cream).
- Kept separate per the guide: `--warning` (system caution) and the games-summary difficulty pills (documented triangle-palette use). The **once-per-viewport rule is behavioral** — flagged for a design pass, not enforced blindly.

## 3. `27156b2` — category (rest of step 3): feed accents + expanding rows keyed by domain
- **Feed card accent bars**: `colorForCategory` now prefers the item's `broadCategory` and returns the domain's `--cat-*` hue — color attaches to the top-level domain, leaves inherit, **no hashing**. `broadCategory` moved to `FeedCardBaseItem`, populated from the API row for every card type; the old hash palette survives only as fallback.
- **"Recently Expanding" + "Your World Is Expanding"**: the duplicated position-keyed red/gold/blue accents are replaced by one shared `expandingTerritoryAccent(domain)` — a territory carries one hue on both surfaces. This retires `#c9564d`, the near-collision with `--game-wrong` the audit flagged.
- **Avatars deliberately untouched**: they key on user identity (persisted in the DB), not category.
- **Ceremony gradients deliberately untouched**: open PRs #707–#711 are mid-flight on those exact colors — collapsing them now would conflict; left as a follow-up.

## 4. `ac802c5` — triangle (step 5) + color ratchet (step 6)
- **Triangle: option (b)** — fills stay decorative (hash over the six muted `--tri-*` values, no category meaning); solid/hollow = unplayed/played is the one encoded bit, safe once WRONG leaves orange. Documented at the palette definition.
- **Color ratchet**: `scripts/check-color-ratchet.mjs` counts hardcoded hex, raw `rgb()`/`hsl()`, and Tailwind raw-color arbitraries in `src/` (comments stripped). **Ceiling 180** — down from the audit's ~312. Exemptions mirror the font ratchet (globals.css, raster card, email templates, dev/debug). Wired as `npm run check:colors` + its own workflow, independent of the font ratchet. Known accepted noise: `href="/#feed"` parses as a hex color 🙂. The testing-only PaletteToggle's own chrome accounts for ~16 of the 180 — deleting it later buys ceiling headroom.

## Visible changes to expect (intentional)
1. Feed accent bars now stable per domain (e.g. every Literature card shares one hue) instead of hash-shuffled per category name.
2. Expanding-territory badges colored by their domain on both surfaces, not by row position.
3. Knowledge empty-state chip and the highlighted-circle glow shift slightly onto the accent gold.
4. With the toggle on Proposed: incorrect-answer backgrounds are muted brick instead of vivid red.

## Verification
`npx tsc -p tsconfig.typecheck.json` clean · `npm run lint` 0 errors · `check:fonts` 0/0 · `check:colors` 180/180 (fails correctly on an injected hex) · vitest 1102 passed, 1 pre-existing DB-test failure (confirmed on baseline).

https://claude.ai/code/session_018JfsL2Hx9E98jEqVMy2bZF