### PR TITLE
Allow clearing feedback by sending null signal

### DIFF
--- a/src/app/api/daily/feedback/route.ts
+++ b/src/app/api/daily/feedback/route.ts
@@ -1,4 +1,4 @@
-import { and, eq } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
@@ -10,7 +10,9 @@ export const dynamic = 'force-dynamic';
 const bodySchema = z.object({
   question_id: z.string().optional().catch(undefined),
   generated_question_id: z.string().optional().catch(undefined),
-  signal: z.enum(['thumbs_up', 'thumbs_down']).optional().catch(undefined),
+  // null clears a previously recorded signal (un-react); omit/garbage is treated
+  // the same as an explicit clear via the .catch below.
+  signal: z.enum(['thumbs_up', 'thumbs_down']).nullable().optional().catch(null),
 });
 
 export async function POST(request: NextRequest) {
@@ -24,14 +26,10 @@ export async function POST(request: NextRequest) {
   const generatedQuestionId = typeof body?.generated_question_id === 'string' && body.generated_question_id
     ? body.generated_question_id
     : null;
+  // A null signal is a valid request: it clears any feedback the user
+  // previously recorded for this question (the heart un-react path).
   const signal = body?.signal ?? null;
 
-  if (!signal) {
-    return NextResponse.json(
-      { error: 'validation', message: 'signal must be thumbs_up or thumbs_down' },
-      { status: 400 },
-    );
-  }
   if ((questionId && generatedQuestionId) || (!questionId && !generatedQuestionId)) {
     return NextResponse.json(
       { error: 'validation', message: 'exactly one of question_id or generated_question_id is required' },
@@ -47,13 +45,23 @@ export async function POST(request: NextRequest) {
       .limit(1);
     if (!question) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
-    await db
-      .insert(questionFeedback)
-      .values({ userId: session.userId, questionId, generatedQuestionId: null, signal })
-      .onConflictDoUpdate({
-        target: [questionFeedback.userId, questionFeedback.questionId],
-        set: { signal, createdAt: new Date() },
-      });
+    if (signal) {
+      await db
+        .insert(questionFeedback)
+        .values({ userId: session.userId, questionId, generatedQuestionId: null, signal })
+        .onConflictDoUpdate({
+          target: [questionFeedback.userId, questionFeedback.questionId],
+          set: { signal, createdAt: new Date() },
+        });
+    } else {
+      await db
+        .delete(questionFeedback)
+        .where(and(
+          eq(questionFeedback.userId, session.userId),
+          eq(questionFeedback.questionId, questionId),
+          isNull(questionFeedback.generatedQuestionId),
+        ));
+    }
   }
 
   if (generatedQuestionId) {
@@ -67,13 +75,23 @@ export async function POST(request: NextRequest) {
       .limit(1);
     if (!generated) return NextResponse.json({ error: 'not_found' }, { status: 404 });
 
-    await db
-      .insert(questionFeedback)
-      .values({ userId: session.userId, questionId: null, generatedQuestionId, signal })
-      .onConflictDoUpdate({
-        target: [questionFeedback.userId, questionFeedback.generatedQuestionId],
-        set: { signal, createdAt: new Date() },
-      });
+    if (signal) {
+      await db
+        .insert(questionFeedback)
+        .values({ userId: session.userId, questionId: null, generatedQuestionId, signal })
+        .onConflictDoUpdate({
+          target: [questionFeedback.userId, questionFeedback.generatedQuestionId],
+          set: { signal, createdAt: new Date() },
+        });
+    } else {
+      await db
+        .delete(questionFeedback)
+        .where(and(
+          eq(questionFeedback.userId, session.userId),
+          eq(questionFeedback.generatedQuestionId, generatedQuestionId),
+          isNull(questionFeedback.questionId),
+        ));
+    }
   }
 
   return NextResponse.json({ ok: true });

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -601,8 +601,9 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
         <button
           type="button"
           aria-label="More actions"
+          aria-haspopup="menu"
           aria-expanded={isOverflowOpen}
-          onClick={() => setIsOverflowOpen(true)}
+          onClick={() => setIsOverflowOpen((open) => !open)}
           className="text-muted-foreground hover:bg-muted/60 hover:text-foreground focus-visible:ring-ring -mr-2 -mt-2 inline-flex size-10 shrink-0 items-center justify-center rounded-full transition focus-visible:ring-2 focus-visible:outline-none"
         >
           <MoreHorizontal className="size-5" />

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -481,7 +481,6 @@ function QuestionCard({ question, onHide }: { question: QuestionRecap; onHide: (
       const signal = previous === next ? null : next
       setRating(signal)
 
-      if (!signal) return
       startFeedbackTransition(async () => {
         const response = await fetch('/api/daily/feedback', {
           method: 'POST',


### PR DESCRIPTION
## Summary
Enable users to "un-react" to questions by sending a `null` signal to the feedback API, which deletes any previously recorded feedback instead of requiring a thumbs_up or thumbs_down.

## Changes
- **API route (`src/app/api/daily/feedback/route.ts`)**:
  - Updated `signal` schema to accept `null` as a valid value (`.nullable().optional().catch(null)`)
  - Removed validation that rejected falsy signals
  - Added conditional logic: when `signal` is truthy, insert/upsert feedback; when falsy (null), delete existing feedback
  - Applied deletion logic to both question and generated question paths with appropriate WHERE clauses
  - Added `isNull` import from drizzle-orm for null checks in deletion queries

- **Client component (`src/app/daily/summary/page.tsx`)**:
  - Removed early return when signal is null, allowing the feedback request to proceed even when clearing a reaction
  - Fixed overflow menu button to toggle state instead of only opening (`setIsOverflowOpen((open) => !open)`)
  - Added `aria-haspopup="menu"` attribute for better accessibility

## Implementation Details
- Null signals are treated as explicit feedback clears (the "un-react" path), distinct from omitted/garbage values which also default to null via `.catch(null)`
- Deletion uses `isNull()` checks to ensure we only delete feedback for the correct question type (regular or generated)
- The API now accepts three states: `thumbs_up`, `thumbs_down`, or `null` (clear), with any invalid input coerced to `null`

https://claude.ai/code/session_011X3YUNSThHBURSvukyohd4