### PR TITLE
Add divider hairlines to activity stream rows for visual rhythm

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -279,14 +279,18 @@ export function ActivityStreamItem({
           boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
         }
       : opened
-        ? // Opened reveal: a soft paper wash defines the expanded cluster —
-          // no hard hairlines (v2 §4 prefers whitespace over dividers).
+        ? // Opened reveal: a soft paper wash defines the expanded cluster, with
+          // the same very-light hairline below as the flat rows so the stream
+          // keeps an even rhythm of dividers whether a row is open or closed.
           {
             padding: '16px 2px',
             background: PAPER,
+            borderBottom: `1px solid ${RULE}`,
           }
-        : // Calm default: no row hairline; whitespace separates the rows.
-          { padding: '14px 2px' };
+        : // Calm default: a very-light hairline separates consecutive rows so the
+          // one-liners read as a divided list rather than relying on whitespace
+          // alone.
+          { padding: '14px 2px', borderBottom: `1px solid ${RULE}` };
 
   return (
     <div id={item.anchorId ?? undefined} style={containerStyle}>


### PR DESCRIPTION
## Summary
Updates the ActivityStreamItem component to add consistent bottom-border hairlines to all rows in the activity stream, creating a more defined visual rhythm whether rows are expanded or collapsed.

## Changes
- **Opened state:** Added `borderBottom: 1px solid ${RULE}` to the expanded cluster style to match the divider treatment of flat rows
- **Closed state:** Added `borderBottom: 1px solid ${RULE}` to the default row style, replacing reliance on whitespace alone for visual separation
- **Comments:** Updated inline documentation to explain the rationale—maintaining an even rhythm of dividers across the stream regardless of row state, and reading one-liners as a divided list rather than relying solely on whitespace

## Implementation Details
Both states now use the same `RULE` color token for the hairline, ensuring visual consistency. The padding values remain unchanged (16px for opened, 14px for closed), so the hairlines integrate seamlessly with the existing layout.

https://claude.ai/code/session_01STJFTe1ijkzZVdX63WRWdn