### PR TITLE
Reduce max-width on questions page from 4xl to 2xl

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -103,7 +103,7 @@ function initialValues(question: QuestionView): QuestionFormValues {
 
 function LoadingSkeleton() {
   return (
-    <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24">
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24">
       <div className="mb-5 h-20 animate-pulse rounded-lg bg-muted" />
       <div className="mb-5 h-14 animate-pulse rounded-lg bg-muted" />
       <div className="space-y-3">
@@ -344,7 +344,7 @@ function QuestionsPageContent() {
   }
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24">
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-24">
       <div className="mb-5 flex border-b">
         <button
           type="button"


### PR DESCRIPTION
## Summary
Adjusts the layout constraints on the questions page to use a narrower maximum width, improving content density and visual hierarchy.

## Changes
- Updated `LoadingSkeleton` component's main container from `max-w-4xl` to `max-w-2xl`
- Updated `QuestionsPageContent` component's main container from `max-w-4xl` to `max-w-2xl`

Both changes maintain all other layout properties (flexbox, padding, min-height, etc.) and only modify the maximum width constraint.

## Details
This change narrows the content area on the questions page from 56rem (4xl) to 42rem (2xl), creating a more focused reading/interaction experience for the question form and related UI elements.

https://claude.ai/code/session_016tmBcD8jH3LbA7jK4U4qGp