### PR TITLE
Refine typography and layout spacing across UI components

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -53,14 +53,7 @@ export default function DailyCatchupPage() {
           backdropFilter: 'blur(8px)',
         }}
       >
-        <div className="flex items-center justify-between gap-3">
-          <nav className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">
-            <button type="button" onClick={() => router.push('/')} className="underline-offset-4 hover:underline">
-              Home
-            </button>
-            <span className="px-1.5">/</span>
-            <span>Catch up</span>
-          </nav>
+        <div className="flex items-center justify-end gap-3">
           <Link
             href="/"
             aria-label="Close"

--- a/src/components/answer-heading.ts
+++ b/src/components/answer-heading.ts
@@ -12,5 +12,5 @@ export const answerHeadingStyle: CSSProperties = {
   fontFamily: 'var(--font-serif)',
   fontSize: '1.65rem',
   fontWeight: 700,
-  lineHeight: 1.14,
+  lineHeight: 1.24,
 }

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -486,13 +486,13 @@ function QuestionRow({
             boxShadow: isBonus
               ? '0 8px 22px rgba(13, 31, 58, 0.14), 0 1px 3px rgba(40, 32, 30, 0.08), inset 4px 0 0 var(--accent-gold)'
               : '0 4px 16px rgba(40, 32, 30, 0.08), 0 1px 3px rgba(40, 32, 30, 0.06)',
-            padding: '14px 18px',
+            padding: '20px 22px',
             fontFamily: 'var(--font-serif)',
             fontSize: '1.4875rem',
             fontWeight: 700,
             letterSpacing: 0,
             color: 'var(--brand-ink)',
-            lineHeight: 1.14,
+            lineHeight: 1.3,
           }}
         >
           <p style={{ margin: 0 }}>{questionText}</p>
@@ -598,13 +598,13 @@ function UserRow({ text }: { text: string }) {
           maxWidth: '88%',
           background: 'var(--brand-navy)',
           borderRadius: 'var(--radius-md) var(--radius-md) 0 var(--radius-md)',
-          padding: '9px 15px',
+          padding: '12px 18px',
           // Figma answer bubble — Cormorant serif, not the sans body font.
           fontFamily: 'var(--font-serif)',
           fontSize: '1.495rem',
           fontWeight: 700,
           letterSpacing: '-0.01em',
-          lineHeight: 1.2,
+          lineHeight: 1.32,
           color: 'var(--primary-foreground)',
         }}
       >


### PR DESCRIPTION
## Summary
Adjusts typography line-height values and component padding across the daily catchup page, gameplay chat, and answer heading styles to improve visual hierarchy and readability. Also simplifies the daily catchup header by removing the breadcrumb navigation.

## Key changes
- **Daily catchup page header:** Removed breadcrumb navigation (`Home / Catch up`) and changed flex alignment from `justify-between` to `justify-end`, leaving only the close button
- **GameplayChat question row:** Increased padding from `14px 18px` to `20px 22px` and adjusted line-height from `1.14` to `1.3` for better breathing room
- **GameplayChat user answer row:** Increased padding from `9px 15px` to `12px 18px` and adjusted line-height from `1.2` to `1.32` for improved readability
- **Answer heading style:** Increased line-height from `1.14` to `1.24` for better text spacing

## Implementation details
These changes maintain the serif font family and font sizes while improving vertical spacing and line-height ratios across chat and answer components. The adjustments appear to follow design refinements for better visual hierarchy and readability in the gameplay interface.

https://claude.ai/code/session_01LTFaJqqCbdhjgXCHKNNCBH