### PR TITLE
Add playable milestone card with editorial headline styling

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -32,8 +32,19 @@ const ACTOR_BLUE = 'var(--brand-link)';
 // actor name / update copy begins, reading as a clear child of the update.
 const EXPANSION_INDENT = 32;
 
-export function ActorLink({ name, userId }: { name: string; userId: string | null }) {
-  if (!userId) return <b style={{ fontWeight: 600, color: ACTOR_BLUE }}>{name}</b>;
+export function ActorLink({
+  name,
+  userId,
+  style,
+}: {
+  name: string;
+  userId: string | null;
+  // Optional override for surfaces that render the actor in a different voice
+  // (e.g. the playable milestone headline, where the name reads in the large
+  // Editorial serif rather than the default activity-blue sans link).
+  style?: CSSProperties;
+}) {
+  if (!userId) return <b style={{ fontWeight: 600, color: ACTOR_BLUE, ...style }}>{name}</b>;
   return (
     <Link
       href={`/users/${userId}`}
@@ -44,12 +55,36 @@ export function ActorLink({ name, userId }: { name: string; userId: string | nul
         textDecoration: 'underline',
         textDecorationColor: RULE,
         textUnderlineOffset: 3,
+        ...style,
       }}
     >
       {name}
     </Link>
   );
 }
+
+// Strip the leading connective space from a milestone predicate so it reads
+// cleanly as its own second line under the name ("went deep on …", not
+// " went deep on …").
+function trimLeadingPredicate(parts: StreamLinePart[]): StreamLinePart[] {
+  const [first, ...rest] = parts;
+  if (first && first.t === 'text') {
+    return [{ t: 'text', v: first.v.replace(/^\s+/, '') }, ...rest];
+  }
+  return parts;
+}
+
+// The name reads in the large Editorial serif headline voice — still a profile
+// link, but dressed as the byline of the milestone sentence rather than the
+// default activity-blue sans actor.
+const HEADLINE_NAME_STYLE: CSSProperties = {
+  fontFamily: 'var(--font-serif)',
+  fontWeight: 500,
+  fontSize: 22,
+  letterSpacing: 0.2,
+  color: INK,
+  textDecoration: 'none',
+};
 
 export function Line({ parts }: { parts: StreamLinePart[] }) {
   return (
@@ -265,6 +300,21 @@ export function ActivityStreamItem({
   const playableCard =
     elevated && !nested && expandable && expand?.kind === 'milestone';
 
+  // On a playable milestone card the headline splits into two serif lines: the
+  // person's NAME (large) and the rest of the sentence (medium) below it. The
+  // milestone line is always built as [actor, ...predicate], so peel the leading
+  // actor part off here and render the remainder as the second line.
+  const headlineActor =
+    playableCard && item.line[0]?.t === 'actor' ? item.line[0] : null;
+  const headlinePredicate = headlineActor
+    ? trimLeadingPredicate(item.line.slice(1))
+    : null;
+  // The "Play {first}'s q's" affordance names the friend whose questions the
+  // bundle opens — their first name, from the headline actor (or the expand).
+  const playFirstName =
+    headlineActor?.name.split(/\s+/)[0] ??
+    (expand?.kind === 'milestone' ? expand.friendName.split(/\s+/)[0] : null);
+
   const containerStyle: CSSProperties = nested
     ? // Nested under a per-person heading: no border/fill, light padding.
       { padding: opened ? '6px 0' : '4px 0' }
@@ -326,6 +376,97 @@ export function ActivityStreamItem({
             </p>
             <MilestoneStar seed={`${item.id}-end`} />
           </>
+        ) : playableCard ? (
+          // Playable milestone card (home "What's Happening"): an editorial
+          // two-line headline — the person's NAME in the large serif, the rest
+          // of the sentence in a medium serif below it — with the play
+          // affordance in the lower-right corner (replacing the bare chevron).
+          <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+              <ActivityIcon spec={iconSpec} seed={item.id} />
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <p
+                  style={{
+                    margin: 0,
+                    fontFamily: 'var(--font-serif)',
+                    fontSize: 22,
+                    lineHeight: 1.15,
+                    letterSpacing: 0.2,
+                    color: INK,
+                  }}
+                >
+                  {headlineActor ? (
+                    <ActorLink
+                      name={headlineActor.name}
+                      userId={headlineActor.userId}
+                      style={HEADLINE_NAME_STYLE}
+                    />
+                  ) : (
+                    <Line parts={item.line} />
+                  )}
+                </p>
+                {headlinePredicate && headlinePredicate.length > 0 ? (
+                  <p
+                    style={{
+                      margin: '3px 0 0',
+                      fontFamily: 'var(--font-serif)',
+                      fontSize: 16,
+                      lineHeight: 1.4,
+                      color: INK2,
+                    }}
+                  >
+                    <Line parts={headlinePredicate} />
+                  </p>
+                ) : null}
+                {milestoneProgress ? (
+                  <p
+                    style={{
+                      margin: '8px 0 0',
+                      fontFamily: FM,
+                      fontSize: 10,
+                      letterSpacing: 1,
+                      color: INK3,
+                    }}
+                  >
+                    {milestoneProgress.answered} of {milestoneProgress.total} questions
+                  </p>
+                ) : null}
+              </div>
+            </div>
+            {/* Lower-right play affordance. The whole card is the button
+                (aria-expanded on the wrapper), so this is a styled label, not a
+                nested button; the disclosure arrow flips as the bundle opens. */}
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                marginTop: 12,
+              }}
+            >
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 5,
+                  fontSize: 12.5,
+                  fontWeight: 600,
+                  letterSpacing: 0.2,
+                  color: INK,
+                }}
+              >
+                {playFirstName ? `Play ${playFirstName}'s q's` : 'Play'}
+                <ChevronDown
+                  size={15}
+                  aria-hidden
+                  style={{
+                    transition: 'transform 150ms ease',
+                    transform: open ? 'rotate(180deg)' : 'none',
+                  }}
+                />
+              </span>
+            </div>
+          </div>
         ) : (
           <>
         {/* Nested rows carry no shape — the per-person heading holds the one

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -772,6 +772,33 @@ export function momentToStreamItem(moment: LatelyMoment): StreamItem {
 
 // --- Milestones --------------------------------------------------------------
 
+// Copy variation (D-4 §A soft-copy): the milestone headline reads in a few
+// interchangeable voices so a feed of milestones doesn't repeat one phrasing.
+// Hash-selected per milestone id (the same djb2 the relationship pools use) so a
+// given milestone always reads the same way while the feed as a whole varies.
+// Every lead is safe for ANY domain set and stays in the warm, non-competitive
+// register (no "mastered"/"beat"/"crushed"). DEEP precedes a single domain
+// ("{name} went deep on {domain}"); BREADTH precedes the rolled-up domain list
+// ("{name} has been on a roll — A, B and N others"). Both start with the leading
+// space that joins them to the name part before them.
+const DEEP_LEADS = [
+  ' went deep on ',
+  ' has been all over ',
+  " can't get enough of ",
+  ' has been living in ',
+  ' went down a rabbit hole on ',
+  ' has been on a tear through ',
+] as const;
+
+const BREADTH_LEADS = [
+  ' has been on a streak — ',
+  ' has been on a roll — ',
+  ' has been all over the map — ',
+  ' has been racking them up — ',
+  ' has been ranging wide — ',
+  ' has been keeping busy — ',
+] as const;
+
 // A milestone is a quiet roll-up of a friend showing skill. Collapsed: a few
 // domains + "and N others". Expanded: the friend's literal ≤5 questions, each
 // ANSWERABLE (someone else's questions -> answer).
@@ -782,7 +809,8 @@ export function milestoneToStreamItem(
   const friend = act(milestone.friendName, milestone.friendId);
   let tail: StreamLinePart[];
   if (milestone.kind === 'milestone_deep') {
-    tail = [txt(' went deep on '), cat(milestone.domain)];
+    const lead = DEEP_LEADS[djb2(milestone.id) % DEEP_LEADS.length];
+    tail = [txt(lead), cat(milestone.domain)];
   } else {
     // Name only the domains whose questions actually survived resolution — a
     // question can be deleted/hidden after the friend answered it, and the
@@ -793,7 +821,8 @@ export function milestoneToStreamItem(
       d.questionIds.some((id) => survivingIds.has(id)),
     );
     const named = (surviving.length > 0 ? surviving : milestone.domains).map((d) => d.domain);
-    tail = breadthTail(named);
+    const lead = BREADTH_LEADS[djb2(milestone.id) % BREADTH_LEADS.length];
+    tail = breadthTail(named, lead);
   }
   return {
     id: milestone.id,
@@ -819,9 +848,9 @@ export function milestoneToStreamItem(
 // rolls the rest into a count, instead of enumerating every domain. The named
 // domains are emitted as `category` parts so they pick up the serif treatment;
 // the connective copy and "N others" count stay plain text.
-function breadthTail(domains: string[]): StreamLinePart[] {
+function breadthTail(domains: string[], leadCopy: string): StreamLinePart[] {
   const [first, second, ...rest] = domains;
-  const lead = txt(' has been on a streak — ');
+  const lead = txt(leadCopy);
   if (!second) return [lead, cat(first)];
   if (rest.length === 0) return [lead, cat(first), txt(' and '), cat(second)];
   const others = rest.length === 1 ? '1 other' : `${rest.length} others`;


### PR DESCRIPTION
## Summary
Adds a new "playable milestone card" layout for the home feed's "What's Happening" section, featuring an editorial two-line headline design with the friend's name in large serif and the milestone predicate in medium serif below, plus a "Play {name}'s q's" affordance.

## Key Changes

- **ActorLink component enhancement**: Added optional `style` prop to allow custom styling (e.g., serif headline voice) while maintaining the profile link behavior
- **Milestone headline styling**: Introduced `HEADLINE_NAME_STYLE` constant with Editorial serif typography (22px, 500 weight, 0.2 letter-spacing)
- **Predicate trimming utility**: Added `trimLeadingPredicate()` function to strip leading whitespace from milestone predicates so they read cleanly as a second line
- **Playable card rendering**: New conditional branch in `ActivityStreamItem` that renders the two-line headline layout with:
  - Icon + name (large serif) on first line
  - Predicate (medium serif) on second line
  - Optional progress indicator ("X of Y questions")
  - Play affordance in lower-right corner with animated chevron
- **Milestone copy variation**: Added `DEEP_LEADS` and `BREADTH_LEADS` arrays with multiple phrasing options (6 variations each) to avoid repetitive milestone headlines in feeds
  - Uses djb2 hash of milestone ID for deterministic, consistent selection per milestone
  - Integrated into `milestoneToStreamItem()` and `breadthTail()` functions
  - All copy maintains warm, non-competitive register and is domain-agnostic

## Implementation Details

- The playable card only renders when `elevated && !nested && expandable && expand?.kind === 'milestone'`
- Headline splits the milestone line at the actor part: name becomes the first line, remaining predicate becomes the second line
- Play button text extracts first name from headline actor or fallback expand data
- Chevron rotates 180° on open with smooth 150ms transition
- All styling uses existing design tokens (INK, INK2, INK3, serif font family)

https://claude.ai/code/session_01GVNX7MYEaJdSpbYgJfjGsC