### PR TITLE
Replace hardcoded color literals with tokens in knowledge surface

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -538,7 +538,7 @@ function KnowledgePageContent() {
       <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-[0.9rem]">
         <section className="bg-white border border-[var(--border-warm)] p-4">
           <p className="m-0 text-[0.72rem] uppercase tracking-[0.08em] text-[var(--text-muted)]">Knowledge</p>
-          <h1 className="mt-[0.35rem] text-[clamp(1.1rem,2.5vw,1.55rem)] leading-[1.35] text-[#111111] font-[var(--font-neutral)] font-semibold">Could not load your map</h1>
+          <h1 className="mt-[0.35rem] text-[clamp(1.1rem,2.5vw,1.55rem)] leading-[1.35] text-[var(--warm-ink)] font-[var(--font-neutral)] font-semibold">Could not load your map</h1>
           <p className="m-0 text-[var(--text-muted-warm)]">{error ?? 'Something went sideways.'}</p>
         </section>
       </main>
@@ -632,7 +632,7 @@ function KnowledgePageContent() {
             ) : null}
             {!editMode ? (
               <div className="mt-5 flex justify-center">
-                <button type="button" className="px-8 py-[11px] border-[1.5px] border-[#0e0e0e] bg-[#0e0e0e] text-[var(--warm-paper)] font-mono text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
+                <button type="button" className="px-8 py-[11px] border-[1.5px] border-[var(--warm-ink)] bg-[var(--warm-ink)] text-[var(--warm-paper)] font-mono text-xs tracking-[0.12em] uppercase cursor-pointer shadow-[2px_2px_0_#3a3a3a]" onClick={() => setShareModalOpen(true)}>
                   Share portrait
                 </button>
               </div>

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -628,7 +628,7 @@ function KnowledgePageContent() {
               pendingDomain={hidePending}
             />
             {hideError ? (
-              <p className="mt-3 text-[0.78rem] text-[#8b1a0e] border border-[#c0392b]/40 p-2">{hideError}</p>
+              <p className="mt-3 text-[0.78rem] text-[var(--cat-literature-text)] border border-[var(--cat-literature)]/40 p-2">{hideError}</p>
             ) : null}
             {!editMode ? (
               <div className="mt-5 flex justify-center">
@@ -790,7 +790,7 @@ function KnowledgePageContent() {
               </div>
             </div>
 
-            {interestError ? <p className="mt-4 border border-[#c0392b]/40 text-[#8b1a0e] p-3 text-[0.88rem]">{interestError}</p> : null}
+            {interestError ? <p className="mt-4 border border-[var(--cat-literature)]/40 text-[var(--cat-literature-text)] p-3 text-[0.88rem]">{interestError}</p> : null}
 
             <div className="flex justify-end gap-2 mt-5">
               <button type="button" className="min-h-10 border border-[var(--border-warm)] bg-white text-[var(--text-muted-warm)] px-4 cursor-pointer" onClick={closeInterestModal} disabled={savingInterests}>Cancel</button>

--- a/src/components/knowledge/DomainCircle.tsx
+++ b/src/components/knowledge/DomainCircle.tsx
@@ -55,9 +55,9 @@ export function DomainCircle({
     ? domainBubbleGradient(domainColor.primary)
     : territoryType === 'declared'
       ? 'rgba(245, 240, 232, 0.3)'
-      : '#f5f0e8'
+      : 'var(--warm-cream)'
   const circleBorder = highlighted
-    ? '#0a1f3d'
+    ? 'var(--ink)'
     : (domainColor?.primary ?? '#d4cfc7')
   const resolvedCircleSlotSize = Math.max(circleSlotSize ?? diameter, diameter)
 
@@ -85,7 +85,7 @@ export function DomainCircle({
             border="1px dashed #c8c0b0"
             opacity={0.5}
           >
-            {Icon ? <Icon size={iconSize} color="#0a1f3d" /> : null}
+            {Icon ? <Icon size={iconSize} color="var(--ink)" /> : null}
           </KnowledgeBubble>
         </div>
         <p style={{ ...nameStyle, opacity: 0.3 }}>{canonicalSubcategory}</p>
@@ -120,7 +120,7 @@ export function DomainCircle({
             boxShadow: highlighted ? '0 0 8px var(--accent-gold)' : undefined,
           }}
         >
-          {Icon ? <Icon size={iconSize} color="#0a1f3d" /> : null}
+          {Icon ? <Icon size={iconSize} color="var(--ink)" /> : null}
         </KnowledgeBubble>
       </div>
       <p style={nameStyle}>{canonicalSubcategory}</p>
@@ -155,7 +155,7 @@ const circleSlotStyle: CSSProperties = {
 const nameStyle: CSSProperties = {
   marginTop: '8px',
   fontSize: '11px',
-  color: '#0a1f3d',
+  color: 'var(--ink)',
   lineHeight: 1.25,
   overflowWrap: 'anywhere',
 }
@@ -163,7 +163,7 @@ const nameStyle: CSSProperties = {
 const tierStyle: CSSProperties = {
   marginTop: '2px',
   fontSize: '10px',
-  color: '#8a8a8a',
+  color: 'var(--text-muted-warm)',
 }
 
 const dotsWrapStyle: CSSProperties = {
@@ -178,11 +178,11 @@ const dotStyle: CSSProperties = {
   width: '6px',
   height: '6px',
   borderRadius: '999px',
-  background: '#8a8a8a',
+  background: 'var(--text-muted-warm)',
 }
 
 const plusStyle: CSSProperties = {
   fontSize: '10px',
-  color: '#8a8a8a',
+  color: 'var(--text-muted-warm)',
   marginLeft: '2px',
 }


### PR DESCRIPTION
## What

Routes the re-literalized colors in the knowledge surface back through the token system, so they stay in lockstep with the canonical scale after the palette promotion.

`SharePortraitCard.tsx` and any canvas/OG surface are explicitly **untouched** — those literals are intentional mirrors that can't read CSS vars.

### Null-diff swaps (identical values, no visual change)
**`DomainCircle.tsx`** (inline styles/props)
- `#0a1f3d` → `var(--ink)` ×4 (highlighted border, two icon colors, name style)
- `#f5f0e8` → `var(--warm-cream)`
- `#8a8a8a` → `var(--text-muted-warm)` ×3 (tier, dot, plus)

**`knowledge/page.tsx`** (Tailwind arbitrary)
- `#8b1a0e` → `var(--cat-literature-text)` ×2
- `#c0392b]/40` → `[var(--cat-literature)]/40` ×2 (keeps Tailwind's own opacity so the `color-mix` output is byte-identical)

### Intentional value shift — near-black collapse
Per the documented intent in `globals.css` ("Near-duplicate blacks `#111111`, `#0e0e0e` collapse onto `--warm-ink`"), the share-button literals move to `var(--warm-ink)`:
- `text-[#111111]` → `text-[var(--warm-ink)]`
- `border-[#0e0e0e]` / `bg-[#0e0e0e]` → `[var(--warm-ink)]`

This nudges `#111111`/`#0e0e0e` → `#1a1208` (a slight warm darkening), the only non-null part of the diff.

## Left as-is — no matching token (flagged for a follow-up decision)
| Location | Literal | Reason |
|---|---|---|
| `DomainCircle.tsx:57` | `rgba(245, 240, 232, 0.3)` | warm-cream RGB but at 0.3 alpha — no translucent token |
| `DomainCircle.tsx:61` | `#d4cfc7` | no token at this value |
| `DomainCircle.tsx:85` / `page.tsx:868` | `#c8c0b0` | warm dashed-border grey — no token |
| `page.tsx:635` | `#3a3a3a` | offset *shadow* grey (not an ink) — no token |

## Verification
- `npm run lint` — 0 errors; **0 warnings on both touched files**.
- `npx tsc -p tsconfig.typecheck.json` — clean on both files.
- `npm run build` fails only on Google-Fonts fetches (Montserrat / Cormorant / Playfair) blocked by the sandbox network policy — unrelated to this change; the edited files compile.

https://claude.ai/code/session_01RL6t8maqwQtWordhv2MLqE

---
_Generated by [Claude Code](https://claude.ai/code/session_01RL6t8maqwQtWordhv2MLqE)_