### PR TITLE
Disable auto-broadcast for new questions and add question activity metrics

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -200,10 +200,9 @@ function QuestionsPageContent() {
   }, []);
 
   useEffect(() => {
-    if (tab !== 'answered') return;
-    if (answered !== null || answeredLoading) return;
+    if (answered !== null || answeredLoading || answeredError) return;
     void Promise.resolve().then(loadAnswered);
-  }, [tab, answered, answeredLoading, loadAnswered]);
+  }, [answered, answeredLoading, answeredError, loadAnswered]);
 
   useEffect(() => {
     if (!toast) return;
@@ -235,6 +234,13 @@ function QuestionsPageContent() {
     setEditingQuestion(null);
     clearComposerParams();
   }, [clearComposerParams]);
+
+  const totalAnswersReceived = useMemo(
+    () => questions.reduce((total, question) => total + question.timesAnswered, 0),
+    [questions],
+  );
+
+  const answeredCountLabel = answered === null ? (answeredLoading ? '…' : '—') : String(answered.length);
 
   const filteredQuestions = useMemo(() => {
     const query = search.trim().toLowerCase();
@@ -345,6 +351,17 @@ function QuestionsPageContent() {
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-4xl flex-col px-4 py-6 pb-24">
+      <section className="mb-5 grid grid-cols-2 gap-3" aria-label="Question activity metrics">
+        <div className="rounded-md border bg-muted/30 px-4 py-3">
+          <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Answers gotten</p>
+          <p className="mt-1 font-serif text-3xl font-semibold">{totalAnswersReceived}</p>
+        </div>
+        <div className="rounded-md border bg-muted/30 px-4 py-3">
+          <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">Questions answered</p>
+          <p className="mt-1 font-serif text-3xl font-semibold">{answeredCountLabel}</p>
+        </div>
+      </section>
+
       <div className="mb-5 flex border-b">
         <button
           type="button"

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -114,7 +114,7 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     suggestionError: null,
     suggesting: false,
     specificMode: initialSpecificMode,
-    shareToFeed: initialValues?.shareToFeed ?? !initialSpecificMode,
+    shareToFeed: initialValues?.shareToFeed ?? false,
     visibility: initialValues?.visibility ?? 'public',
     friends: [],
     friendsLoading: false,


### PR DESCRIPTION
### Motivation
- Authors requested that new questions should not broadcast to all friends by default to avoid unexpected sharing. 
- There's a desire for quick visibility into authored-question activity, specifically totals for answers received and questions answered, without switching tabs. 

### Description
- Defaulted the question composer `shareToFeed` to off by changing the initial state in `QuestionForm` so new questions do not share to friends unless explicitly chosen or provided by an explicit create intent (`src/components/QuestionForm.tsx`).
- Preloaded the answered-question count outside the Answered tab by adjusting the answered-loading `useEffect` so it no longer depends on the active tab and includes `answeredError` in its guard (`src/app/questions/page.tsx`).
- Added `totalAnswersReceived` (sum of authored questions' `timesAnswered`) and `answeredCountLabel` computed values and rendered a top-of-page metrics strip showing “Answers gotten” and “Questions answered” (`src/app/questions/page.tsx`).
- Small tweak to the answered-loading logic to avoid double-loading when errors or loading are already present (`src/app/questions/page.tsx`).

### Testing
- Ran unit tests with `npm test -- src/components/__tests__/QuestionForm.test.tsx` and all tests passed. 
- Ran type checking with `npx tsc --noEmit --project tsconfig.typecheck.json` and it passed without errors. 
- Ran lint with `npm run lint -- --max-warnings 16` and the run completed within the repo's allowed warnings (16 warnings). 
- Attempted browser-driven screenshot via Playwright, but `npx playwright install chromium` failed due to a Chromium download `403 Forbidden`, so the end-to-end screenshot step did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac66dc810832e89cc7bce774d590d)