### PR TITLE
B-VISUAL-CARD-TIERS-01: tokenize Home card tiers + bucket-C primitives

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -35,11 +35,11 @@ const TOKEN_LINT_RULE = {
 // (and any cleaned file removed from this list) are held at error. Shrink this
 // list; don't add to it. These warnings are the *only* ones `npm run lint`
 // tolerates: the script pins `--max-warnings` to their current count (16), so the
-// warning lane can't silently grow. When you clean a file off this list, drop the
-// `--max-warnings` ceiling in package.json by the number of warnings it removed.
+// warning lane can't silently grow (ceiling currently 13). When you clean a file
+// off this list, drop the `--max-warnings` ceiling in package.json by the number
+// of warnings it removed.
 const TOKEN_LINT_GRANDFATHERED = [
   "src/components/CreateChooser.tsx",
-  "src/components/LoadingScreen.tsx",
   "src/components/SendQuestionDrawer.tsx",
   "src/components/TodaysFiveCard.tsx",
   "src/components/feed/AnswerFeedbackSheet.tsx",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "start": "next start",
     "test": "vitest run",
     "test:evals": "RUN_LLM_EVALS=1 vitest run eval.test",
-    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 16",
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx --max-warnings 13",
     "check:fonts": "node scripts/check-font-ratchet.mjs",
     "check:colors": "node scripts/check-color-ratchet.mjs",
     "smoke:daily-catchup": "tsx scripts/daily-catchup.smoke.ts",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -268,6 +268,25 @@
     --radius-md: 0.5rem;
     --radius-lg: 0.625rem;
     --shadow-paper-rest: 0 1px 2px rgb(0 0 0 / 0.05);
+    /* Card tier shadows/strokes (B-VISUAL-CARD-TIERS-01). The Home feed reads
+       loud→quiet→loud via a named tier set: a Playable tier (direct-question /
+       friend-activity question cards) that steps forward off the cream, and a
+       flat Ambient tier (activity one-liners). These tokenize what used to be
+       arbitrary inline rgba(40,32,30,…) values duplicated in FeedCardShell and
+       ActivityStreamItem — rgb(40,32,30)=#28201E, the same warm-ink shadow color
+       the resting cards already use. --rest is the quiet/answered card shadow;
+       --playable is a deeper soft drop + a visible warm-ink border (rendered at
+       1.5px) so playable is unmistakable next to the flat ambient rows. */
+    --shadow-card-rest:     0 4px 12px rgba(40, 32, 30, 0.04);
+    --shadow-card-playable: 0 6px 16px rgba(40, 32, 30, 0.14);
+    --stroke-card-playable: rgba(40, 32, 30, 0.35);
+    /* LoadingScreen bespoke primitives (B-VISUAL-CARD-TIERS-01, bucket-C). The
+       triangle-field mat is a warm sand darker than every cream token so the
+       --tri-* triangles read against it; the JOSHING card keeps its layered
+       drop shadow. Tokenized here so no bespoke hex/shadow lives in the
+       component. */
+    --loading-backdrop:     #e8dcc0;
+    --shadow-loading-card:  0 4px 4px 0 rgba(0, 0, 0, 0.25), 0 4px 12px 0 rgba(40, 32, 30, 0.04);
 }
 
 /* ───────────────────────────────────────────────────────────────────────────

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -33,13 +33,17 @@ const VIEWBOX_H = 900;
 const SIZE = 56;
 const TRI_H = SIZE * 0.8660254;
 
+// The triangle field draws from the decorative --tri-* palette (globals.css).
+// Each entry is a token reference, not a raw hex: it feeds the per-triangle
+// `--tri-color-a/-b` custom properties, and `fill: var(--tri-color-a)` resolves
+// the nested var() so the animation cross-fades between two token colors.
 const PALETTE = [
-  "#D15E36", // orange
-  "#6D837F", // darkteal
-  "#ADB19E", // lightteal
-  "#F8E6C7", // cream
-  "#DEAE5C", // darkyellow
-  "#EDD2A3", // lighttan
+  "var(--tri-orange)",
+  "var(--tri-darkteal)",
+  "var(--tri-lightteal)",
+  "var(--tri-cream)",
+  "var(--tri-darkyellow)",
+  "var(--tri-lighttan)",
 ];
 
 function rand(seed: number) {
@@ -139,7 +143,7 @@ export default function LoadingScreen({
   const current = rotation[Math.min(index, rotation.length - 1)] ?? rotation[0];
 
   const wrapperClass = [
-    "isolate flex items-center justify-center overflow-hidden bg-[#E8DCC0]",
+    "isolate flex items-center justify-center overflow-hidden bg-[var(--loading-backdrop)]",
     fullScreen
       ? "fixed inset-0 z-[60]"
       : "relative h-full w-full min-h-[480px]",
@@ -188,7 +192,7 @@ export default function LoadingScreen({
         aria-hidden="true"
       />
 
-      <div className="relative z-10 mx-6 w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-[46px] py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
+      <div className="relative z-10 mx-6 w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-[46px] py-7 text-center shadow-[var(--shadow-loading-card)] ring-1 ring-black/5">
         <p className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
           JOSHING
         </p>

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -320,11 +320,15 @@ export function ActivityStreamItem({
       { padding: opened ? '6px 0' : '4px 0' }
     : playableCard
       ? {
+          // Playable tier (B-VISUAL-CARD-TIERS-01) — same tokens as the
+          // FeedCardShell elevated question cards so the two playable surfaces
+          // read identically: cream fill, a visible 1.5px warm-ink stroke, and
+          // the deeper soft drop shadow that lifts them off the flat ambient rows.
           padding: opened ? '16px 14px' : '14px',
           background: 'var(--game-card-question)',
-          border: '1px solid rgba(40, 32, 30, 0.22)',
+          border: '1.5px solid var(--stroke-card-playable)',
           borderRadius: 4,
-          boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
+          boxShadow: 'var(--shadow-card-playable)',
         }
       : opened
         ? // Opened reveal: a soft paper wash defines the expanded cluster, with

--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -14,19 +14,20 @@ import { cn } from '@/lib/utils'
 // 'triangle' variant for the envelope motif.
 
 const FEED_CARD_RADIUS = 'rounded-[4px]'
-const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
+const FEED_CARD_SHADOW = 'shadow-[var(--shadow-card-rest)]'
 
-// Elevated ("playable" / Tier 1) treatment for the unified home feed
-// (D-FEED-TIER): the warm light-cream question fill, a visible — but still
-// light — warm-ink stroke, and a deeper soft drop shadow than the ambient
-// cards carry. On the home feed the activity rows render as flat one-liners
-// (no card), so a playable question card needs more than a 4% lift to read as
-// the thing you can play; the stronger stroke + shadow make it step forward
-// off the cream while the chatter stays quiet text. Shares the shadow color
-// (#28201E warm ink) with the resting cards, just at a higher opacity.
+// Elevated ("Playable" tier) treatment for the unified home feed
+// (B-VISUAL-CARD-TIERS-01): the warm light-cream question fill, a visible
+// warm-ink stroke (rendered at 1.5px), and a deeper soft drop shadow than the
+// ambient cards carry. On the home feed the activity rows render as flat
+// one-liners (no card), so a playable question card needs more than a 4% lift
+// to read as the thing you can play; the stronger stroke + shadow make it step
+// forward off the cream while the chatter stays quiet text. Shares the shadow
+// color (#28201E warm ink) with the resting cards via the tier tokens, just at
+// a higher opacity.
 const FEED_CARD_ELEVATED_FILL = 'bg-[var(--game-card-question)]'
-const FEED_CARD_ELEVATED_STROKE = 'border-[rgba(40,32,30,0.22)]'
-const FEED_CARD_ELEVATED_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.10)]'
+const FEED_CARD_ELEVATED_STROKE = 'border-[1.5px] border-[var(--stroke-card-playable)]'
+const FEED_CARD_ELEVATED_SHADOW = 'shadow-[var(--shadow-card-playable)]'
 
 export type FeedCardShellProps = {
   children: ReactNode
@@ -100,8 +101,8 @@ export function FeedCardShell({
   return (
     <article
       className={cn(
-        'relative overflow-hidden border',
-        elevated ? FEED_CARD_ELEVATED_STROKE : 'border-[var(--brand-rule)]',
+        'relative overflow-hidden',
+        elevated ? FEED_CARD_ELEVATED_STROKE : 'border border-[var(--brand-rule)]',
         elevated ? FEED_CARD_ELEVATED_FILL : 'bg-[var(--brand-card)]',
         FEED_CARD_RADIUS,
         elevated ? FEED_CARD_ELEVATED_SHADOW : FEED_CARD_SHADOW,


### PR DESCRIPTION
Give Home a named tier set (Hero / Playable / Ambient / Panel) expressed
through tokens. The Playable tier (direct-question + friend-activity cards
and milestone bundles) now steps forward off the ambient one-liners with a
deeper soft drop shadow + a visible 1.5px warm-ink border, so playable vs.
ambient is unmistakable at a glance.

- Add tier tokens to globals.css: --shadow-card-rest, --shadow-card-playable,
  --stroke-card-playable. These replace the arbitrary rgba(40,32,30,...)
  values that were duplicated inline in FeedCardShell and ActivityStreamItem.
- Resolve the bucket-C bespoke primitives: add --loading-backdrop (#e8dcc0)
  and --shadow-loading-card; remap LoadingScreen's backdrop, JOSHING-card
  shadow, and triangle PALETTE onto tokens (PALETTE -> existing --tri-*).
  OverlapMap was already on color tokens; left as-is.
- Ratchet follow-through: LoadingScreen is now clean, removed from the
  token-lint grandfather list; lower --max-warnings 16 -> 13.

No structural/selection/copy changes; visual register only.