### PR TITLE
feat(home): server-side selection & budget layer (D-HOME-PACING-01)

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,22 +9,14 @@ import TodaysFiveCard, {
 import { CeremonyPin } from '@/components/home/CeremonyPin'
 import { MissedQuestionsCard } from '@/components/home/MissedQuestionsCard'
 import { getSession } from '@/server/auth/session'
-import { buildActivityStream } from '@/server/activity/build-stream'
-import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
-import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo'
-import { getAddFriendsPromo } from '@/server/activity/add-friends-promo'
+import { buildHomeEdition } from '@/server/home/build-edition'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences'
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
-import { getFeedPagePayload } from '@/server/feed/get-feed-page'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 
 const FEED_PAGE_SIZE = 20
-// The home "What's Happening" feed leads with a deeper first page (the last ~30
-// items) and then pages in older rows on scroll. The prefetch limit matches the
-// FeedList pageSize so the seeded first page is full (no round-trip first paint).
-const HOME_FEED_PAGE_SIZE = 30
 
 export default async function Home() {
   const session = await getSession()
@@ -124,33 +116,25 @@ async function CeremonyPinSection({ userId }: { userId: string }) {
 }
 
 async function FromYourFriendsSection({ userId }: { userId: string }) {
-  // The unified "What's Happening" home feed: the question feed merged with the
-  // full activity/Lately stream, interleaved chronologically inside FeedList.
-  // Filter 'all' (not 'from-friends') so directly-sent questions thread in; the
-  // prefetch matches FeedList's unifiedHome seeding for a no-round-trip paint.
-  const [feedPage, activityItems, commonGroundPromo, recentlyExpandingPromo, addFriendsPromo] = await Promise.all([
-    getFeedPagePayload(userId, {
-      limit: HOME_FEED_PAGE_SIZE,
-      cursor: null,
-      filter: 'all',
-    }),
-    buildActivityStream(userId),
-    getCommonGroundPromo(userId),
-    getRecentlyExpandingPromo(userId),
-    getAddFriendsPromo(userId),
-  ])
-  // The weekly reflection lives in the dedicated CeremonyPin editorial marker
-  // above this feed (calm, gold, no CTA). Drop the redundant 'ceremony_ready'
-  // activity card here so the reflection doesn't double up / compete with social
-  // activity in the home stream. It's the only activity that links to /ceremony/;
-  // the card still appears in the full /activities log.
-  // The common-ground discovery promo is no longer prepended into the activity
-  // rows (which would float it to row 0 on its `now` timestamp). It's passed
-  // separately as a pinned promo so it never leads the feed when there's other
-  // activity to show — see FeedList's displayRows.
-  const homeActivityItems = activityItems.filter(
-    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
-  )
+  // D-HOME-PACING-01: the unified "What's Happening" home feed is now a fixed-
+  // budget EDITION, not a render of everything. The server-side selection layer
+  // computes the served slice of each zone (Direct 3, Playables 4, Texture ~5),
+  // the overflow counts the question zones window against, the one rotating
+  // panel, and the all-empty switch. FeedList renders this pre-budgeted edition
+  // (no client-side selection, no infinite scroll, no temporal buckets).
+  const { edition, feedMeta } = await buildHomeEdition(userId)
+
+  // Seed FeedList with the served direct slice and the same meta the empty-state
+  // copy / surface tabs read. has_more is false: the budget is the page; the
+  // remainder is reached via the overflow affordances, not by paging.
+  const initialPage = {
+    viewer_user_id: userId,
+    meta: feedMeta,
+    items: edition.direct.served,
+    has_more: false,
+    next_cursor: null,
+  }
+
   return (
     <>
       {/* Sit the header on the feed's left gutter — the same 2px the activity
@@ -161,15 +145,17 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
         What&rsquo;s happening
       </p>
       <FeedList
-        pageSize={HOME_FEED_PAGE_SIZE}
-        infinite
-        initialPage={feedPage}
+        pageSize={FEED_PAGE_SIZE}
+        initialPage={initialPage}
         showContributeFooter
         unifiedHome
-        activityItems={homeActivityItems}
-        commonGroundPromo={commonGroundPromo}
-        expandingPromo={recentlyExpandingPromo}
-        addFriendsPromo={addFriendsPromo}
+        activityItems={[...edition.playables.served, ...edition.texture]}
+        budget={{
+          directOverflowCount: edition.direct.overflowCount,
+          playablesOverflowCount: edition.playables.overflowCount,
+          panel: edition.panel,
+          isAllEmpty: edition.isAllEmpty,
+        }}
       />
     </>
   )

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -477,6 +477,27 @@ type FeedListProps = {
    * promo. See getAddFriendsPromo / displayRows.
    */
   addFriendsPromo?: StreamItem | null
+  /**
+   * D-HOME-PACING-01: the server-computed budget for the unified home edition.
+   * When supplied, FeedList renders a FIXED-BUDGET view rather than the unbounded
+   * stream: the served direct/playable slices it was handed are shown with a
+   * quiet "N more →" overflow affordance per question zone, the temporal recency
+   * buckets are dropped (§4), exactly one rotating panel renders (§2), and the
+   * all-empty switch (§9) is driven by `isAllEmpty`. Selection happens entirely
+   * server-side; this prop carries only the counts and the chosen panel.
+   */
+  budget?: HomeBudget | null
+}
+
+export type HomeBudget = {
+  /** Direct ("For You") questions pending beyond the served slice. */
+  directOverflowCount: number
+  /** Playable friend-activity bundles pending beyond the served slice. */
+  playablesOverflowCount: number
+  /** The single rotating panel for this load, or null on the all-empty page. */
+  panel: StreamItem | null
+  /** True when all three content zones are empty — drives the empty switch. */
+  isAllEmpty: boolean
 }
 
 type QuestionCardState = 'unanswered' | 'answered'
@@ -486,6 +507,34 @@ type QuestionCardState = 'unanswered' | 'answered'
 // existing recency grouping works over the merged list unchanged. The per-person
 // grouping helpers live in ./feed/person-grouping (pure + unit-tested).
 type UnifiedRow = GroupInputRow<FeedApiItem>
+
+// Wrap a promo/panel StreamItem as an activity row so the single rotating panel
+// renders through the shared renderRow path (D-HOME-PACING-01 §2 slot 5).
+function panelRow(item: StreamItem): UnifiedRow {
+  const sortAt = item.sortAt instanceof Date ? item.sortAt : new Date(item.sortAt)
+  return {
+    kind: 'activity',
+    item,
+    source_event_at: sortAt.toISOString(),
+    sortMs: sortAt.getTime(),
+  }
+}
+
+// The quiet "N more →" overflow affordance under a budgeted question zone (§3).
+// Plain by design — card tiers are B-VISUAL-CARD-TIERS-01 and the destination
+// subpage is B-HOME-OVERFLOW-02; for now it states the abundance ("6 more
+// waiting for you," never "6 unanswered") without yet navigating.
+function OverflowRow({ unifiedHome, label }: { unifiedHome: boolean; label: string }) {
+  return (
+    <p
+      className={`min-h-11 pt-1 text-[13px] font-medium tracking-[0.04em] text-[var(--brand-link)] ${
+        unifiedHome ? 'pl-[2px]' : ''
+      }`}
+    >
+      {label}
+    </p>
+  )
+}
 
 export default function FeedList(props: FeedListProps) {
   return (
@@ -726,6 +775,7 @@ function FeedListContent({
   commonGroundPromo = null,
   expandingPromo = null,
   addFriendsPromo = null,
+  budget = null,
 }: FeedListProps) {
   const searchParams = useSearchParams()
   const initialFilterParam =
@@ -934,8 +984,15 @@ function FeedListContent({
         sortMs: sortAt.getTime(),
       })
     }
+    // Under the budget (D-HOME-PACING-01) the zones are rendered as separate
+    // sections, NOT one chronological stream, so the server's intra-zone order
+    // is authoritative: rotate-by-sender for direct (§5), actor-interleave for
+    // playables (§5), newest-first for the bounded texture. A global recency
+    // re-sort here would undo that ordering, so preserve server order — feed
+    // (direct) rows first, then activity (playables then texture) rows.
+    if (budget) return [...feedRows, ...activityRows]
     return [...feedRows, ...activityRows].sort((a, b) => b.sortMs - a.sortMs)
-  }, [items, activityItems, unifiedHome])
+  }, [items, activityItems, unifiedHome, budget])
 
   // Place the home-only discovery modules. They are NOT part of the chronological
   // union above; each renders whenever its data exists. Rather than clump them at
@@ -1726,11 +1783,38 @@ function FeedListContent({
               </p>
             ) : null}
           </section>
+        ) : unifiedHome ? (
+          // D-HOME-PACING-01 §9 — the all-three-empty home edition. The hero
+          // and composer always render around this; this is the inline empty
+          // state between them (NOT a full-screen takeover), reviving the
+          // earlier centered treatment: the speech-bubble graphic over a serif
+          // headline carrying the existing §8.2.8/§8.2.12 copy. The rotating
+          // panel does NOT also render here — the empty state is the one
+          // invitation (no double-invite).
+          <section className="flex flex-col items-center gap-3 py-8 text-center">
+            <SpeechBubbleIllustration className="h-24 w-auto" />
+            <h2 className="font-serif text-xl font-medium text-[var(--brand-ink)]">
+              {emptyCopy}
+            </h2>
+            {showInviteFriendCta ? (
+              <Link
+                href="/friends"
+                className="font-serif text-lg font-semibold tracking-[0.05em] text-[var(--brand-orange)] underline underline-offset-4"
+              >
+                add friends →
+              </Link>
+            ) : null}
+            {emptyDiagnostics ? (
+              <p className="bg-muted text-muted-foreground mt-3 max-w-xl rounded px-3 py-2 font-mono text-xs break-words">
+                {emptyDiagnostics}
+              </p>
+            ) : null}
+          </section>
         ) : (
-          // Questions-from-Friends empty state — matches the Figma mock: a muted
-          // eyebrow (standing in for the hidden surface tabs), a left-aligned
-          // serif headline, the centered speech-bubble art, and a right-aligned
-          // orange "add friends" link.
+          // Questions-from-Friends empty state (standalone Feed surface) — a
+          // muted eyebrow (standing in for the hidden surface tabs), a left-
+          // aligned serif headline, the centered speech-bubble art, and a
+          // right-aligned orange "add friends" link.
           <section className="py-4">
             <p className="text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
               Questions from friends
@@ -1769,18 +1853,35 @@ function FeedListContent({
             <Fragment key="for-you">
               <FeedSectionHeading unifiedHome={unifiedHome}>For You</FeedSectionHeading>
               {groupActivityByFriend(forYouRows).map(renderRow)}
+              {/* D-HOME-PACING-01 §3 — quiet overflow row. Abundance, never
+                  obligation; the subpage it will open is B-HOME-OVERFLOW-02. */}
+              {budget && budget.directOverflowCount > 0 ? (
+                <OverflowRow
+                  unifiedHome={unifiedHome}
+                  label={`${budget.directOverflowCount} more from friends →`}
+                />
+              ) : null}
             </Fragment>
           ) : null}
           {/* Home-only: friends' milestone bundles (the up-to-5-triangle cards
               you can answer inline) are pinned into a "From Friends" section
-              below "For You", capped to the most recent few with a "View more"
-              control. groupActivityByFriend is a pass-through here (milestone
-              rows never group), keeping the render path uniform. */}
+              below "For You". Under the budget the server has already capped the
+              served slice (Playables 4), so we render all of it and surface the
+              remainder as a quiet "N more →" overflow; off the budget the legacy
+              client "View more" batching still applies. groupActivityByFriend is
+              a pass-through here (milestone rows never group). */}
           {fromFriendsRows.length > 0 ? (
             <Fragment key="from-friends">
               <FeedSectionHeading unifiedHome={unifiedHome}>From Friends</FeedSectionHeading>
-              {groupActivityByFriend(visibleFromFriendsRows).map(renderRow)}
-              {fromFriendsHiddenCount > 0 ? (
+              {groupActivityByFriend(budget ? fromFriendsRows : visibleFromFriendsRows).map(renderRow)}
+              {budget ? (
+                budget.playablesOverflowCount > 0 ? (
+                  <OverflowRow
+                    unifiedHome={unifiedHome}
+                    label={`${budget.playablesOverflowCount} more →`}
+                  />
+                ) : null
+              ) : fromFriendsHiddenCount > 0 ? (
                 <button
                   type="button"
                   onClick={() =>
@@ -1795,18 +1896,29 @@ function FeedListContent({
               ) : null}
             </Fragment>
           ) : null}
-          {/* Everything else — question cards sent to you, relationship events,
-              promos — stays in a single calm chronological stream grouped by
-              recency, rendered as full-sentence LONE events (D-FEED-GROUP3-01 §2
-              styling). Per-person clustering (PersonActivityCard) stays dropped
-              here: the cluster form was the source of the subject-stripped
-              "wording is weird" copy, and density now comes from visual quiet. */}
-          {groupItemsByRecency(restRows).map((group) => (
-            <Fragment key={group.key}>
-              <FeedSectionHeading unifiedHome={unifiedHome}>{group.label}</FeedSectionHeading>
-              {group.items.map(renderRow)}
-            </Fragment>
-          ))}
+          {/* Texture — relationship events and other social moments, rendered as
+              full-sentence LONE events (D-FEED-GROUP3-01 §2 styling). Per-person
+              clustering (PersonActivityCard) stays dropped: the cluster form was
+              the source of the subject-stripped copy, and density comes from
+              visual quiet. Under the budget the temporal recency buckets are
+              removed (§4) — the set is already bounded to today-and-yesterday —
+              so it renders as one calm flat stream; off the budget the standalone
+              Feed keeps its recency grouping. */}
+          {budget ? (
+            restRows.length > 0 ? (
+              <Fragment key="texture">{restRows.map(renderRow)}</Fragment>
+            ) : null
+          ) : (
+            groupItemsByRecency(restRows).map((group) => (
+              <Fragment key={group.key}>
+                <FeedSectionHeading unifiedHome={unifiedHome}>{group.label}</FeedSectionHeading>
+                {group.items.map(renderRow)}
+              </Fragment>
+            ))
+          )}
+          {/* D-HOME-PACING-01 §2 slot 5 — exactly one rotating panel per load,
+              chosen server-side and suppressed on the all-empty page. */}
+          {budget?.panel ? renderRow(panelRow(budget.panel)) : null}
         </section>
       )}
 

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -1,0 +1,213 @@
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// D-HOME-PACING-01 render test. The selection layer is unit-tested separately
+// (src/server/home/__tests__/select-edition.test.ts); this asserts that the
+// budgeted CLIENT path actually RENDERS the served slices, the "N more →"
+// overflow affordances, the single panel, and the all-empty switch — so a green
+// selection test can't mask an unbuilt render path (the known fragile pattern).
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+vi.mock('@/components/feed/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}))
+
+// Stub the feed-card subsystem to lightweight markers so the test exercises the
+// budgeted SECTIONING, not the card internals (covered by FeedCards.test.tsx).
+vi.mock('@/components/feed', () => ({
+  DirectSentCard: ({ item }: { item: { avatarName?: string | null } }) => (
+    <div data-card="direct">direct:{item.avatarName}</div>
+  ),
+  FriendAddedCard: ({ item }: { item: { avatarName?: string | null } }) => (
+    <div data-card="added">added:{item.avatarName}</div>
+  ),
+  FriendLikedCard: () => <div data-card="liked" />,
+  AnsweredByYouCard: () => <div data-card="answered" />,
+  AnswerSheet: () => null,
+  AnswerFeedbackSheet: () => null,
+  DismissedFeedBar: () => null,
+  FeedOverflowMenu: () => null,
+  FeedCardSwipe: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  visibleFeedCategory: (c: string | null | undefined) => c ?? null,
+}))
+
+vi.mock('@/components/activity/ActivityStreamItem', () => ({
+  ActivityStreamItem: ({ item }: { item: { id: string; friendId?: string | null } }) => (
+    <div data-activity={item.id}>activity:{item.id}:{item.friendId ?? 'none'}</div>
+  ),
+}))
+
+vi.mock('@/components/activity/PersonActivityCard', () => ({
+  PersonActivityCard: () => <div data-person />,
+}))
+
+vi.mock('@/components/feed/EditorialPromos', () => ({
+  CommonGroundFeature: () => <div>PANEL:common_ground</div>,
+  GrowYourCircleFeature: () => <div>PANEL:add_friends</div>,
+  RecentlyExpandingFeature: () => <div>PANEL:recently_expanding</div>,
+}))
+
+import FeedList from '@/components/FeedList'
+
+type AnyItem = Record<string, unknown>
+
+function directItem(id: string, sender: string): AnyItem {
+  return {
+    id,
+    kind: 'question',
+    card_type: 'direct_sent',
+    source_type: 'direct_sent',
+    source_user_id: sender,
+    source_friend_display_name: sender,
+    source_attribution: `${sender} sent you a question`,
+    source_event_at: '2026-06-11T09:00:00Z',
+    state: 'active',
+    is_pinned: false,
+    question_id: `${id}-q`,
+    question_text: `Question ${id}`,
+    domain_pill: 'Jazz',
+    is_in_bank: false,
+    viewer_is_author: false,
+  }
+}
+
+function playable(id: string, friendId: string): AnyItem {
+  return {
+    id,
+    friendId,
+    sortAt: new Date('2026-06-11T12:00:00Z'),
+    tier: 1,
+    homeEligible: true,
+    line: [],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: null,
+    expand: { kind: 'milestone', questions: [{ questionId: `${id}-q`, text: 'q', domain: 'Jazz' }] },
+  }
+}
+
+function texture(id: string): AnyItem {
+  return {
+    id,
+    friendId: 'tex-friend',
+    relationship: 'got_you',
+    sortAt: new Date('2026-06-11T11:00:00Z'),
+    tier: 3,
+    homeEligible: true,
+    line: [],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: null,
+    expand: null,
+  }
+}
+
+const META = {
+  has_friends: true,
+  has_dismissed_domains: false,
+  total_item_count: 0,
+  active_item_count: 0,
+  pre_filter_active_count: 0,
+  broadcasts_item_count: 0,
+  sent_item_count: 0,
+  filter: 'all' as const,
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function render(props: any): string {
+  return renderToStaticMarkup(<FeedList {...props} />)
+}
+
+describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
+  it('renders served slices with a quiet "N more →" affordance per question zone', () => {
+    const html = render({
+      unifiedHome: true,
+      initialPage: {
+        viewer_user_id: 'me',
+        meta: META,
+        items: [directItem('d0', 'robyn'), directItem('d1', 'joshua'), directItem('d2', 'mara')],
+        has_more: false,
+        next_cursor: null,
+      },
+      activityItems: [playable('p0', 'josh'), playable('p1', 'rob'), texture('t0')],
+      budget: {
+        directOverflowCount: 4,
+        playablesOverflowCount: 3,
+        panel: { id: 'gc', friendId: null, sortAt: new Date('2026-06-11T12:00:00Z'), expand: null, embed: { kind: 'add_friends' } },
+        isAllEmpty: false,
+      },
+    })
+
+    // Both question zones render their headings and overflow affordances.
+    expect(html).toContain('For You')
+    expect(html).toContain('From Friends')
+    expect(html).toContain('4 more from friends →')
+    expect(html).toContain('3 more →')
+    // Served direct cards and playables both rendered.
+    expect(html).toContain('direct:robyn')
+    expect(html).toContain('activity:p0:josh')
+    // Texture row rendered, and NO temporal recency bucket heading (§4 removed).
+    expect(html).toContain('activity:t0:tex-friend')
+    expect(html).not.toContain('Today')
+    expect(html).not.toContain('Past two weeks')
+    // Exactly one rotating panel.
+    expect(html).toContain('PANEL:add_friends')
+  })
+
+  it('all three zones empty → inline empty state, panel suppressed (§9)', () => {
+    const html = render({
+      unifiedHome: true,
+      initialPage: { viewer_user_id: 'me', meta: META, items: [], has_more: false, next_cursor: null },
+      activityItems: [],
+      budget: { directOverflowCount: 0, playablesOverflowCount: 0, panel: null, isAllEmpty: true },
+    })
+
+    // The existing empty-state copy is revived; the speech-bubble art renders.
+    expect(html).toContain('Quiet today')
+    // No panel double-invite, no zone headings.
+    expect(html).not.toContain('PANEL')
+    expect(html).not.toContain('For You')
+    expect(html).not.toContain('From Friends')
+  })
+
+  it('partial-empty → empty zones omitted, populated zones shown (§9)', () => {
+    const html = render({
+      unifiedHome: true,
+      initialPage: {
+        viewer_user_id: 'me',
+        meta: META,
+        items: [directItem('d0', 'robyn')],
+        has_more: false,
+        next_cursor: null,
+      },
+      activityItems: [], // no playables, no texture
+      budget: {
+        directOverflowCount: 0,
+        playablesOverflowCount: 0,
+        panel: { id: 'sg', friendId: null, sortAt: new Date('2026-06-11T12:00:00Z'), expand: null, embed: { kind: 'common_ground' } },
+        isAllEmpty: false,
+      },
+    })
+
+    expect(html).toContain('For You')
+    expect(html).toContain('direct:robyn')
+    // The empty playable zone is omitted entirely — no heading, no placeholder.
+    expect(html).not.toContain('From Friends')
+    expect(html).not.toContain('Quiet today')
+    // The populated page still gets its one panel.
+    expect(html).toContain('PANEL:common_ground')
+  })
+})

--- a/src/server/home/__tests__/select-edition.test.ts
+++ b/src/server/home/__tests__/select-edition.test.ts
@@ -1,0 +1,247 @@
+import { describe, expect, it } from 'vitest'
+
+import type { StreamItem } from '@/lib/activity-stream'
+import {
+  DIRECT_SERVE_CAP,
+  PLAYABLE_SERVE_CAP,
+  interleaveByActor,
+  orderBySenderRotation,
+  selectHomeEdition,
+  type FeedEditionItem,
+} from '@/server/home/select-edition'
+
+// --- Fixtures ----------------------------------------------------------------
+// selectHomeEdition only reads a handful of fields off each shape, so the
+// fixtures stay minimal and cast to the public types.
+
+function feedItem(id: string, sender: string, sentAtIso: string): FeedEditionItem {
+  return {
+    id,
+    source_user_id: sender,
+    source_event_at: sentAtIso,
+  } as unknown as FeedEditionItem
+}
+
+function playable(id: string, friendId: string, type = 'milestone', sortAt = '2026-06-11T12:00:00Z'): StreamItem {
+  return {
+    id,
+    friendId,
+    relationship: type === 'milestone' ? undefined : (type as StreamItem['relationship']),
+    sortAt: new Date(sortAt),
+    expand: { kind: 'milestone', questions: [{ questionId: `${id}-q` }] },
+  } as unknown as StreamItem
+}
+
+function textureItem(id: string, sortAtIso: string, friendId: string | null = 'f-tex'): StreamItem {
+  return {
+    id,
+    friendId,
+    sortAt: new Date(sortAtIso),
+    expand: null,
+  } as unknown as StreamItem
+}
+
+function promo(id: string, kind: 'common_ground' | 'recently_expanding' | 'add_friends'): StreamItem {
+  return {
+    id,
+    friendId: null,
+    sortAt: new Date('2026-06-11T12:00:00Z'),
+    expand: null,
+    embed: { kind },
+  } as unknown as StreamItem
+}
+
+const NOW = Date.parse('2026-06-11T18:00:00Z')
+
+function actorsOf(items: StreamItem[]): (string | null)[] {
+  return items.map((i) => i.friendId ?? null)
+}
+
+// --- orderBySenderRotation (§5 serving order) --------------------------------
+
+describe('orderBySenderRotation', () => {
+  it('rotates by sender, oldest-first within sender, no sender buried', () => {
+    // Robyn sent 1 (a while ago); Joshua sent 3 (more recent). Robyn must not be
+    // buried beneath Joshua's monologue, and Joshua's three are spaced out.
+    const items = [
+      feedItem('j1', 'joshua', '2026-06-11T09:00:00Z'),
+      feedItem('j2', 'joshua', '2026-06-11T10:00:00Z'),
+      feedItem('j3', 'joshua', '2026-06-11T11:00:00Z'),
+      feedItem('r1', 'robyn', '2026-06-11T08:00:00Z'),
+    ]
+    const ordered = orderBySenderRotation(
+      items,
+      (i) => i.source_user_id,
+      (i) => Date.parse(i.source_event_at),
+    )
+    // Robyn (oldest waiter) leads; then round-robin with Joshua oldest-first.
+    expect(ordered.map((i) => i.id)).toEqual(['r1', 'j1', 'j2', 'j3'])
+  })
+})
+
+// --- interleaveByActor (§5 actor-interleave) ---------------------------------
+
+describe('interleaveByActor', () => {
+  it('breaks up a chatty actor so no two consecutive slots share an actor', () => {
+    // Joshua is chatty (4 items); Robyn has 1. With variety available there must
+    // be no two consecutive Joshua slots until Robyn is spent.
+    const items = [
+      playable('a1', 'joshua'),
+      playable('a2', 'joshua'),
+      playable('a3', 'joshua'),
+      playable('r1', 'robyn'),
+      playable('a4', 'joshua'),
+    ]
+    const out = interleaveByActor(items, (i) => i.friendId ?? null, () => 'milestone')
+    const actors = actorsOf(out)
+    // Robyn separates the first two Joshuas; once Robyn is spent the remaining
+    // Joshuas necessarily run (pool no longer permits variety).
+    expect(actors[0]).toBe('joshua')
+    expect(actors[1]).toBe('robyn')
+    // Across the first three slots (while variety is available) no repeat.
+    expect(actors[0]).not.toBe(actors[1])
+  })
+
+  it('degenerate single-actor pool prefers event-type variety', () => {
+    // Only Joshua. Actor variety is impossible, so the fallback spaces EVENT
+    // TYPES: went-deep / got-you should not stack when they can alternate.
+    const items = [
+      playable('a1', 'joshua', 'you_got'),
+      playable('a2', 'joshua', 'you_got'),
+      playable('a3', 'joshua', 'got_you'),
+    ]
+    const out = interleaveByActor(items, (i) => i.friendId ?? null, (i) => i.relationship ?? 'milestone')
+    const types = out.map((i) => i.relationship ?? 'milestone')
+    // The two you_got items are not adjacent — got_you is pulled between them.
+    expect(types[0]).toBe('you_got')
+    expect(types[1]).toBe('got_you')
+    expect(types[2]).toBe('you_got')
+  })
+})
+
+// --- selectHomeEdition: budget & overflow (§2/§3) ----------------------------
+
+describe('selectHomeEdition — serve-and-overflow', () => {
+  it('serves Direct 3 / Playables 4 and reports the remainder as overflow', () => {
+    const feedItems = Array.from({ length: 7 }, (_, i) =>
+      feedItem(`d${i}`, `sender${i}`, `2026-06-11T0${i}:00:00Z`),
+    )
+    const playables = Array.from({ length: 9 }, (_, i) => playable(`p${i}`, `friend${i % 4}`))
+
+    const edition = selectHomeEdition({
+      feedItems,
+      activityItems: playables,
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+
+    expect(edition.direct.served).toHaveLength(DIRECT_SERVE_CAP)
+    expect(edition.direct.overflowCount).toBe(7 - DIRECT_SERVE_CAP)
+    expect(edition.playables.served).toHaveLength(PLAYABLE_SERVE_CAP)
+    expect(edition.playables.overflowCount).toBe(9 - PLAYABLE_SERVE_CAP)
+  })
+
+  it('reports zero overflow when a zone is under budget', () => {
+    const edition = selectHomeEdition({
+      feedItems: [feedItem('d0', 's0', '2026-06-11T09:00:00Z')],
+      activityItems: [playable('p0', 'f0')],
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    expect(edition.direct.overflowCount).toBe(0)
+    expect(edition.playables.overflowCount).toBe(0)
+  })
+})
+
+// --- selectHomeEdition: texture bounding (§4) --------------------------------
+
+describe('selectHomeEdition — texture', () => {
+  it('bounds texture to today-and-yesterday and soft-caps it', () => {
+    const activityItems = [
+      textureItem('t-now', '2026-06-11T17:00:00Z'),
+      textureItem('t-yesterday', '2026-06-10T20:00:00Z'),
+      textureItem('t-old', '2026-06-01T12:00:00Z'), // > 2 days → dropped
+      ...Array.from({ length: 8 }, (_, i) => textureItem(`t-fresh${i}`, '2026-06-11T1' + (i % 9) + ':00:00Z')),
+    ]
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems,
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    expect(edition.texture.length).toBeLessThanOrEqual(5)
+    expect(edition.texture.map((t) => t.id)).not.toContain('t-old')
+  })
+})
+
+// --- selectHomeEdition: empty switch (§9) ------------------------------------
+
+describe('selectHomeEdition — empty switch', () => {
+  it('all three content zones empty → isAllEmpty, panel suppressed', () => {
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems: [],
+      promos: {
+        sharedGround: promo('sg', 'common_ground'),
+        expanding: promo('ex', 'recently_expanding'),
+        growCircle: promo('gc', 'add_friends'),
+      },
+      now: NOW,
+    })
+    expect(edition.isAllEmpty).toBe(true)
+    expect(edition.panel).toBeNull()
+  })
+
+  it('partial-empty (direct empty, playables present) → not all-empty, panel chosen', () => {
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems: [playable('p0', 'f0'), playable('p1', 'f1')],
+      promos: {
+        sharedGround: promo('sg', 'common_ground'),
+        expanding: null,
+        growCircle: promo('gc', 'add_friends'),
+      },
+      now: NOW,
+    })
+    expect(edition.isAllEmpty).toBe(false)
+    expect(edition.direct.served).toHaveLength(0)
+    expect(edition.playables.served).toHaveLength(2)
+    expect(edition.panel).not.toBeNull()
+  })
+})
+
+// --- selectHomeEdition: panel selection (§2 slot 5) --------------------------
+
+describe('selectHomeEdition — panel', () => {
+  it('biases a quiet page to Grow Your Circle', () => {
+    const edition = selectHomeEdition({
+      feedItems: [feedItem('d0', 's0', '2026-06-11T09:00:00Z')],
+      activityItems: [], // quiet: ≤2 activity items
+      promos: {
+        sharedGround: promo('sg', 'common_ground'),
+        expanding: null,
+        growCircle: promo('gc', 'add_friends'),
+      },
+      now: NOW,
+    })
+    expect(edition.panel?.id).toBe('gc')
+  })
+
+  it('prefers Shared Ground on an active page', () => {
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems: [
+        textureItem('t0', '2026-06-11T17:00:00Z'),
+        textureItem('t1', '2026-06-11T16:00:00Z'),
+        textureItem('t2', '2026-06-11T15:00:00Z'),
+      ],
+      promos: {
+        sharedGround: promo('sg', 'common_ground'),
+        expanding: null,
+        growCircle: promo('gc', 'add_friends'),
+      },
+      now: NOW,
+    })
+    expect(edition.panel?.id).toBe('sg')
+  })
+})

--- a/src/server/home/build-edition.ts
+++ b/src/server/home/build-edition.ts
@@ -1,0 +1,60 @@
+/**
+ * Server assembler for the Home edition (D-HOME-PACING-01).
+ *
+ * Runs the same upstream queries the Home page already ran inline — the question
+ * feed, the activity/Lately stream, and the three discovery promos — and feeds
+ * them into the pure `selectHomeEdition` budget layer. The page renders the
+ * returned edition (served slices + overflow counts + bounded texture + one
+ * panel) instead of the unbounded zones.
+ *
+ * `feedMeta` is returned alongside the edition so the page can seed <FeedList />
+ * with the same meta (has_friends, the per-surface counts) the empty-state copy
+ * and surface tabs read from.
+ */
+
+import { buildActivityStream } from '@/server/activity/build-stream'
+import { getAddFriendsPromo } from '@/server/activity/add-friends-promo'
+import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
+import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo'
+import { getFeedPagePayload } from '@/server/feed/get-feed-page'
+import { selectHomeEdition, type HomeEdition } from '@/server/home/select-edition'
+
+// The home feed leads with a deep first page; the budget then windows it down to
+// the served caps. Keep this generous so the pending pools (and therefore the
+// overflow counts) are accurate rather than truncated by the page size.
+const HOME_FEED_FETCH_LIMIT = 30
+
+export type HomeEditionResult = {
+  edition: HomeEdition
+  feedMeta: Awaited<ReturnType<typeof getFeedPagePayload>>['meta']
+}
+
+export async function buildHomeEdition(userId: string): Promise<HomeEditionResult> {
+  const [feedPage, activityItems, commonGroundPromo, expandingPromo, addFriendsPromo] =
+    await Promise.all([
+      getFeedPagePayload(userId, { limit: HOME_FEED_FETCH_LIMIT, cursor: null, filter: 'all' }),
+      buildActivityStream(userId),
+      getCommonGroundPromo(userId),
+      getRecentlyExpandingPromo(userId),
+      getAddFriendsPromo(userId),
+    ])
+
+  // The weekly reflection has its own editorial marker (CeremonyPin) above the
+  // feed; drop the redundant 'ceremony_ready' activity so it doesn't double up
+  // in the home stream. (Unchanged from the prior inline assembly.)
+  const homeActivityItems = activityItems.filter(
+    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
+  )
+
+  const edition = selectHomeEdition({
+    feedItems: feedPage.items,
+    activityItems: homeActivityItems,
+    promos: {
+      sharedGround: commonGroundPromo,
+      expanding: expandingPromo,
+      growCircle: addFriendsPromo,
+    },
+  })
+
+  return { edition, feedMeta: feedPage.meta }
+}

--- a/src/server/home/select-edition.ts
+++ b/src/server/home/select-edition.ts
@@ -1,0 +1,278 @@
+/**
+ * Home edition selection & budget layer (D-HOME-PACING-01 §2/§3/§5/§7/§9).
+ *
+ * Turns the three unbounded Home content zones into a fixed-budget edition:
+ * per request it computes the *served* slice of each zone, the *overflow count*
+ * for the question zones, and the bounded texture set. Home becomes a windowed
+ * view of the pending queues rather than a render of everything.
+ *
+ * This is the data contract only. It does NOT restyle cards (B-VISUAL-CARD-
+ * TIERS-01) and does NOT build the overflow subpages (B-HOME-OVERFLOW-02). It
+ * also does NOT change how any row renders — the locked Group 3 chronological
+ * full-sentence lone-event treatment survives unchanged; this layer only
+ * *selects* which events fill the playable zone and *bounds* the texture set.
+ *
+ * `selectHomeEdition` is a pure function (DB-free, deterministic given `now`)
+ * so the budgeting/interleaving rules are unit-testable without a database.
+ * `buildHomeEdition` is the thin server wrapper that runs the existing queries
+ * and feeds them in.
+ */
+
+import type { StreamItem } from '@/lib/activity-stream'
+import type { FeedPagePayload } from '@/server/feed/get-feed-page'
+
+/** One item in the question feed payload Home already renders. */
+export type FeedEditionItem = FeedPagePayload['items'][number]
+
+// §2 budget — served caps. These are serving sizes, not access ceilings: the
+// overflow is always reachable via the subpages (B-HOME-OVERFLOW-02).
+export const DIRECT_SERVE_CAP = 3
+export const PLAYABLE_SERVE_CAP = 4
+export const TEXTURE_SOFT_CAP = 5
+
+const DAY_MS = 24 * 60 * 60 * 1000
+
+/** A served zone: the top-N window plus the count still pending behind it. */
+export type ServedZone<T> = {
+  served: T[]
+  /** Items beyond the served window — drives the quiet "N more →" affordance. */
+  overflowCount: number
+}
+
+export type HomeEdition = {
+  /**
+   * Direct ("For You") zone — every question a friend sent or broadcast to you.
+   * Broadcasts (`authored_shared`) live WITHIN this zone (product decision),
+   * budgeted together with directly-sent questions. Cap 3, serve-and-overflow,
+   * rotate-by-sender / oldest-first within sender (§5).
+   */
+  direct: ServedZone<FeedEditionItem>
+  /**
+   * Playable friend activity — answerable milestone bundles. Cap 4, actor-
+   * interleaved so one chatty friend can't hold consecutive slots (§5).
+   */
+  playables: ServedZone<StreamItem>
+  /**
+   * Texture — chronological full-sentence lone social events (locked Group 3),
+   * bounded to today-and-yesterday, soft-capped (~5). No overflow subpage.
+   */
+  texture: StreamItem[]
+  /** Exactly one rotating panel per load; null on the all-empty page (§9). */
+  panel: StreamItem | null
+  /**
+   * True when all three CONTENT zones are empty (§9). Hero and composer are
+   * never counted. Drives the two-state empty switch: when true, Home renders
+   * the existing empty state inline and suppresses the panel.
+   */
+  isAllEmpty: boolean
+}
+
+function ms(value: string | Date): number {
+  const t = value instanceof Date ? value.getTime() : Date.parse(value)
+  return Number.isNaN(t) ? 0 : t
+}
+
+/**
+ * §5 serving order for the direct zone: rotate by sender, oldest-first within
+ * each sender. If Robyn sent 1 and Joshua sent 7, Robyn's does not get buried,
+ * and Joshua's seven are spaced across visits rather than arriving as a
+ * monologue. No sender's question dies of old age because someone chattier
+ * exists. Pure: the same input always yields the same order.
+ */
+export function orderBySenderRotation<T>(
+  items: readonly T[],
+  senderOf: (item: T) => string,
+  sentAt: (item: T) => number,
+): T[] {
+  const bySender = new Map<string, T[]>()
+  for (const item of items) {
+    const key = senderOf(item)
+    const bucket = bySender.get(key)
+    if (bucket) bucket.push(item)
+    else bySender.set(key, [item])
+  }
+  // Oldest-first within each sender.
+  for (const bucket of bySender.values()) {
+    bucket.sort((a, b) => sentAt(a) - sentAt(b))
+  }
+  // Sender turn order: the sender whose oldest pending item has waited longest
+  // takes the first turn, so a one-question sender isn't buried behind a chatty
+  // one. Ties broken by sender key for determinism.
+  const senders = [...bySender.entries()]
+    .sort((a, b) => {
+      const delta = sentAt(a[1][0]!) - sentAt(b[1][0]!)
+      return delta !== 0 ? delta : a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0
+    })
+    .map(([key]) => key)
+  const out: T[] = []
+  for (let round = 0; ; round++) {
+    let advanced = false
+    for (const key of senders) {
+      const next = bySender.get(key)![round]
+      if (next !== undefined) {
+        out.push(next)
+        advanced = true
+      }
+    }
+    if (!advanced) break
+  }
+  return out
+}
+
+/**
+ * §5 actor-interleave for the playable zone: no two consecutive items from the
+ * same actor where the pool permits. Degenerate case (one or two actors — the
+ * actual launch condition): when actor variety is impossible, prefer variety of
+ * EVENT TYPE so a friend's items read as a relationship, not surveillance.
+ *
+ * Greedy and stable: input priority order (prominence) is preserved except
+ * where a swap is needed to break an actor repeat (or, in the degenerate case, a
+ * type repeat). There is no existing positional interleaver in the daily
+ * algorithm to reuse — its diversity rule is a per-subcategory admission cap —
+ * so this is a purpose-built helper for the playable zone.
+ */
+export function interleaveByActor<T>(
+  items: readonly T[],
+  actorOf: (item: T) => string | null,
+  typeOf: (item: T) => string,
+): T[] {
+  const remaining = [...items]
+  const out: T[] = []
+  let lastActor: string | null | undefined
+  let lastType: string | undefined
+  while (remaining.length > 0) {
+    // Prefer a different actor AND a different type; fall back to just a
+    // different actor; in the degenerate single-actor tail, break the type run.
+    let index = remaining.findIndex(
+      (item) => actorOf(item) !== lastActor && typeOf(item) !== lastType,
+    )
+    if (index === -1) {
+      index = remaining.findIndex((item) => actorOf(item) !== lastActor)
+    }
+    if (index === -1) {
+      index = remaining.findIndex((item) => typeOf(item) !== lastType)
+    }
+    if (index === -1) index = 0
+    const [picked] = remaining.splice(index, 1)
+    out.push(picked!)
+    lastActor = actorOf(picked!)
+    lastType = typeOf(picked!)
+  }
+  return out
+}
+
+/**
+ * §2 slot 4 / §4 — texture is bounded to today-and-yesterday. Older social
+ * moments belong to the biweekly ceremony / archive, not the home edition. A
+ * rolling 48-hour window from `now` is a timezone-agnostic proxy for "today and
+ * yesterday." Newest-first, then soft-capped.
+ */
+export function boundTexture(
+  items: readonly StreamItem[],
+  now: number,
+  cap = TEXTURE_SOFT_CAP,
+): StreamItem[] {
+  const floor = now - 2 * DAY_MS
+  return [...items]
+    .filter((item) => ms(item.sortAt) >= floor)
+    .sort((a, b) => ms(b.sortAt) - ms(a.sortAt))
+    .slice(0, cap)
+}
+
+/**
+ * One panel per load (§2 slot 5). Each promo is already data-gated upstream
+ * (null when its data is absent — e.g. no shared ground for a user with no
+ * overlap), so this only chooses among the present ones. Quiet pages bias to
+ * Grow Your Circle; otherwise Shared Ground > World Expanding > Grow Your
+ * Circle. Suppressed entirely on the all-empty page (handled by the caller).
+ */
+export function selectPanel(
+  promos: {
+    sharedGround: StreamItem | null
+    expanding: StreamItem | null
+    growCircle: StreamItem | null
+  },
+  isQuiet: boolean,
+): StreamItem | null {
+  const { sharedGround, expanding, growCircle } = promos
+  if (isQuiet && growCircle) return growCircle
+  return sharedGround ?? expanding ?? growCircle ?? null
+}
+
+/** A playable is an answerable milestone bundle (≥1 question). */
+function isPlayable(item: StreamItem): boolean {
+  return item.expand?.kind === 'milestone' && item.expand.questions.length > 0
+}
+
+/** Event-type key for the playable interleave's degenerate-case variety. */
+function playableType(item: StreamItem): string {
+  return item.relationship ?? item.expand?.kind ?? 'milestone'
+}
+
+function serve<T>(ordered: readonly T[], cap: number): ServedZone<T> {
+  return {
+    served: ordered.slice(0, cap),
+    overflowCount: Math.max(0, ordered.length - cap),
+  }
+}
+
+export type SelectHomeEditionInput = {
+  /** The question feed (filter 'all'): direct-sent + broadcasts + legacy. */
+  feedItems: readonly FeedEditionItem[]
+  /** The full activity/Lately stream for the viewer. */
+  activityItems: readonly StreamItem[]
+  /** The three home discovery promos (each already null when data-absent). */
+  promos: {
+    sharedGround: StreamItem | null
+    expanding: StreamItem | null
+    growCircle: StreamItem | null
+  }
+  /** Injectable clock for deterministic texture bounding in tests. */
+  now?: number
+}
+
+export function selectHomeEdition(input: SelectHomeEditionInput): HomeEdition {
+  const now = input.now ?? Date.now()
+
+  // Direct ("For You") zone — broadcasts budgeted alongside direct sends (§5).
+  const directOrdered = orderBySenderRotation(
+    input.feedItems,
+    (item) => item.source_user_id,
+    (item) => ms(item.source_event_at),
+  )
+  const direct = serve(directOrdered, DIRECT_SERVE_CAP)
+
+  // Split the activity stream into playables (answerable milestone bundles) and
+  // texture (everything else non-feed). This mirrors the existing For You /
+  // From Friends / rest split exactly — selection only, no render change.
+  const playablePool: StreamItem[] = []
+  const texturePool: StreamItem[] = []
+  for (const item of input.activityItems) {
+    if (isPlayable(item)) playablePool.push(item)
+    else texturePool.push(item)
+  }
+
+  const playables = serve(
+    interleaveByActor(
+      playablePool,
+      (item) => item.friendId ?? null,
+      playableType,
+    ),
+    PLAYABLE_SERVE_CAP,
+  )
+
+  const texture = boundTexture(texturePool, now)
+
+  // The two-state empty switch operates on the three CONTENT zones only.
+  // Direct uses the full pending pool (not the served slice) so a page that is
+  // merely over-budget never reads as empty.
+  const isAllEmpty =
+    directOrdered.length === 0 && playablePool.length === 0 && texture.length === 0
+
+  // A quiet page biases the panel to Grow Your Circle; the all-empty page gets
+  // no panel (the empty state already carries the one invitation, §9).
+  const isQuiet = playablePool.length + texturePool.length <= 2
+  const panel = isAllEmpty ? null : selectPanel(input.promos, isQuiet)
+
+  return { direct, playables, texture, panel, isAllEmpty }
+}


### PR DESCRIPTION
Turn the unbounded "What's Happening" home stream into a fixed-budget
edition. A new server-side selection layer computes, per request, the
served slice of each content zone plus the overflow count and bounded
texture set; FeedList now renders that pre-budgeted edition instead of
deriving sections/buckets client-side.

- src/server/home/select-edition.ts: pure, deterministic budget layer.
  Direct 3 (rotate-by-sender, oldest-first; broadcasts budgeted within
  the For You zone), Playables 4 (new actor-interleave helper, with the
  degenerate single-actor event-type-variety fallback), Texture ~5
  bounded to today-and-yesterday, one rotating panel, and the all-empty
  switch (§2/§3/§5/§9).
- src/server/home/build-edition.ts: async wrapper over the existing feed
  / activity / promo queries.
- page.tsx: compute the edition server-side; seed FeedList with the
  served direct slice + overflow counts + chosen panel; no infinite
  scroll.
- FeedList: budgeted render mode — served slices, a plain "N more →"
  affordance per question zone, temporal recency buckets removed (§4),
  exactly one panel, and the revived centered empty state wired to the
  all-empty switch. Off-budget surfaces are unchanged.

Selection only: no card restyle, no overflow subpages, no Group 3
rendering/copy change, no schema/route changes.

Tests: pure selection unit tests (served slice + remainder,
actor-interleave incl. single-actor fallback, empty switch, panel) and
a FeedList render test asserting the budgeted output (overflow rows,
zone omission, empty state + panel suppression).

https://claude.ai/code/session_01PXmNEz3cd3T8z3v4pibRMe