### PR TITLE
feat(home): overflow subpages for direct questions & pending playables (B-HOME-OVERFLOW-02)

### DIFF
--- a/src/app/for-you/page.tsx
+++ b/src/app/for-you/page.tsx
@@ -1,0 +1,42 @@
+import { redirect } from 'next/navigation'
+
+import FeedList from '@/components/FeedList'
+import { OverflowSubpageHeader } from '@/components/home/OverflowSubpageHeader'
+import { getSession } from '@/server/auth/session'
+import { buildPendingDirectQueue } from '@/server/home/build-edition'
+
+// B-HOME-OVERFLOW-02 — the direct-questions overflow subpage. Renders the FULL
+// pending "For You" queue (every question a friend sent or broadcast to you),
+// in the same sender-rotated order Home windows its served top-3 from, and
+// answerable in place via the same FeedList answer flow the home zone uses.
+// Reached only from Home's "N more from friends →" row; never a nav tab.
+export default async function ForYouPage() {
+  const session = await getSession()
+  if (!session) redirect('/login')
+
+  const { items, meta } = await buildPendingDirectQueue(session.userId)
+
+  const initialPage = {
+    viewer_user_id: session.userId,
+    meta,
+    items,
+    has_more: false,
+    next_cursor: null,
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-[18px] px-4 py-6 pb-32 md:py-10">
+      <OverflowSubpageHeader
+        eyebrow="For You"
+        title={
+          items.length > 0
+            ? `${items.length} waiting for you`
+            : 'Waiting for you'
+        }
+      />
+      <section>
+        <FeedList initialPage={initialPage} pendingQueue />
+      </section>
+    </main>
+  )
+}

--- a/src/app/from-friends/PendingPlayablesList.tsx
+++ b/src/app/from-friends/PendingPlayablesList.tsx
@@ -1,0 +1,31 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+
+import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
+import { formatRelativeTime } from '@/components/feed/visual'
+import type { StreamItem } from '@/lib/activity-stream'
+
+// The full pending-playables queue, answerable in place. Each bundle renders
+// through the exact home-zone treatment (elevated cream card, timestamp-free,
+// tap-to-open with the existing InlineAnswerFlow) — no new answer interaction.
+// Resolving a question refreshes the router cache so Home recomputes its
+// served top-4 and overflow count on return (D-HOME-PACING-01 §7); the card
+// itself stays open here as its in-session answered state.
+export function PendingPlayablesList({ items }: { items: StreamItem[] }) {
+  const router = useRouter()
+  return (
+    <section className="space-y-3">
+      {items.map((item) => (
+        <ActivityStreamItem
+          key={item.id}
+          item={item}
+          timestamp={formatRelativeTime(item.sortAt)}
+          showTimestamp={false}
+          elevated
+          onQuestionResolved={() => router.refresh()}
+        />
+      ))}
+    </section>
+  )
+}

--- a/src/app/from-friends/page.tsx
+++ b/src/app/from-friends/page.tsx
@@ -1,0 +1,36 @@
+import { redirect } from 'next/navigation'
+
+import { OverflowSubpageHeader } from '@/components/home/OverflowSubpageHeader'
+import { getSession } from '@/server/auth/session'
+import { buildPendingPlayablesQueue } from '@/server/home/build-edition'
+
+import { PendingPlayablesList } from './PendingPlayablesList'
+
+// B-HOME-OVERFLOW-02 — the pending-playables overflow subpage. Renders the
+// FULL pending playable queue (friends' answerable milestone bundles with at
+// least one question left to play), in the same actor-interleaved order Home
+// windows its served top-4 from. Lighter ambient register than /for-you — the
+// bundles keep the exact rendering the home zone already uses. Reached only
+// from Home's "N more →" row; never a nav tab.
+export default async function FromFriendsPage() {
+  const session = await getSession()
+  if (!session) redirect('/login')
+
+  const items = await buildPendingPlayablesQueue(session.userId)
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-[18px] px-4 py-6 pb-32 md:py-10">
+      <OverflowSubpageHeader
+        eyebrow="From Friends"
+        title={items.length > 0 ? `${items.length} more to play` : 'More to play'}
+      />
+      {items.length === 0 ? (
+        <p className="font-serif text-lg font-medium text-[var(--brand-ink)]">
+          You are all caught up!
+        </p>
+      ) : (
+        <PendingPlayablesList items={items} />
+      )}
+    </main>
+  )
+}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -478,6 +478,16 @@ type FeedListProps = {
    */
   addFriendsPromo?: StreamItem | null
   /**
+   * B-HOME-OVERFLOW-02: the /for-you overflow subpage. Renders the FULL pending
+   * direct queue (server-seeded via initialPage, in the same sender-rotated
+   * order Home windows) as a flat answerable list: filter pinned to 'all',
+   * surface tabs hidden, no recency buckets, no section headings, server order
+   * preserved. Cards keep the home-zone treatment (elevated, timestamp-free)
+   * and the full existing answer flow. After a successful answer the client
+   * router cache is refreshed so Home recomputes its top-N on return (§7).
+   */
+  pendingQueue?: boolean
+  /**
    * D-HOME-PACING-01: the server-computed budget for the unified home edition.
    * When supplied, FeedList renders a FIXED-BUDGET view rather than the unbounded
    * stream: the served direct/playable slices it was handed are shown with a
@@ -521,18 +531,26 @@ function panelRow(item: StreamItem): UnifiedRow {
 }
 
 // The quiet "N more →" overflow affordance under a budgeted question zone (§3).
-// Plain by design — card tiers are B-VISUAL-CARD-TIERS-01 and the destination
-// subpage is B-HOME-OVERFLOW-02; for now it states the abundance ("6 more
-// waiting for you," never "6 unanswered") without yet navigating.
-function OverflowRow({ unifiedHome, label }: { unifiedHome: boolean; label: string }) {
+// Plain by design — it states the abundance ("6 more waiting for you," never
+// "6 unanswered") and opens that zone's overflow subpage (B-HOME-OVERFLOW-02).
+function OverflowRow({
+  unifiedHome,
+  label,
+  href,
+}: {
+  unifiedHome: boolean
+  label: string
+  href: string
+}) {
   return (
-    <p
-      className={`min-h-11 pt-1 text-[13px] font-medium tracking-[0.04em] text-[var(--brand-link)] ${
+    <Link
+      href={href}
+      className={`flex min-h-11 items-center pt-1 text-[13px] font-medium tracking-[0.04em] text-[var(--brand-link)] ${
         unifiedHome ? 'pl-[2px]' : ''
       }`}
     >
       {label}
-    </p>
+    </Link>
   )
 }
 
@@ -776,25 +794,32 @@ function FeedListContent({
   expandingPromo = null,
   addFriendsPromo = null,
   budget = null,
+  pendingQueue = false,
 }: FeedListProps) {
+  const router = useRouter()
   const searchParams = useSearchParams()
   const initialFilterParam =
     searchParams.get('filter') ?? searchParams.get('feed_filter') ?? 'from-friends'
   // D-1 Stage 5: the feed is two surfaces — Broadcasts ('from-friends', default)
   // and Sent ('sent-to-me'). Legacy ?filter=all links land on Broadcasts.
   // unifiedHome overrides both: one merged surface pinned to 'all' so directly-
-  // sent questions thread in alongside the activity stream.
-  const initialFilter: FeedFilter = unifiedHome
-    ? 'all'
-    : initialFilterParam === 'sent-to-me'
-      ? 'sent-to-me'
-      : 'from-friends'
+  // sent questions thread in alongside the activity stream. The pendingQueue
+  // subpage windows the same 'all' source Home does, so it pins 'all' too.
+  const initialFilter: FeedFilter =
+    unifiedHome || pendingQueue
+      ? 'all'
+      : initialFilterParam === 'sent-to-me'
+        ? 'sent-to-me'
+        : 'from-friends'
   // initialPage is the server pre-fetch of the active surface, so it only seeds
   // state when that's the active filter; other surfaces fall back to a client
-  // fetch. On unifiedHome the prefetch is the 'all' page, so it seeds directly.
+  // fetch. On unifiedHome/pendingQueue the prefetch is the 'all' page, so it
+  // seeds directly.
   const initialPageMatchesFilter =
     initialPage !== null &&
-    (unifiedHome ? initialFilter === 'all' : initialFilter === 'from-friends')
+    (unifiedHome || pendingQueue
+      ? initialFilter === 'all'
+      : initialFilter === 'from-friends')
   const [feedFilter, setFeedFilter] = useState<FeedFilter>(initialFilter)
   const sentinelRef = useRef<HTMLDivElement | null>(null)
   const [items, setItems] = useState<FeedApiItem[]>(
@@ -1300,8 +1325,11 @@ function FeedListContent({
         const body = await response.json().catch(() => null)
         throw new Error(body?.message ?? 'Could not update that card.')
       }
+      // §7: a dismiss (or its undo) on the overflow subpage also changes the
+      // shared pending queue — invalidate the router cache like an answer does.
+      if (pendingQueue) router.refresh()
     },
-    [],
+    [pendingQueue, router],
   )
 
   // Shared by the left-swipe and the on-card Dismiss button — one handler, one
@@ -1484,6 +1512,12 @@ function FeedListContent({
         setCardStates((s) => ({ ...s, [item.id]: 'answered' }))
         setAnswerSheetId(null)
         setFeedbackSheetId(item.id)
+        // §7 hardening (B-HOME-OVERFLOW-02): an answer on the overflow subpage
+        // shrinks the shared pending queue, so invalidate the client router
+        // cache — a back-navigation to Home then refetches and recomputes its
+        // top-N window instead of restoring a stale edition. Local list state
+        // is untouched: the just-answered card stays visible as answered here.
+        if (pendingQueue) router.refresh()
       } catch (caught) {
         setError(
           caught instanceof Error
@@ -1494,7 +1528,7 @@ function FeedListContent({
         setBusyId(null)
       }
     },
-    []
+    [pendingQueue, router]
   )
 
   const submitRecheck = useCallback(
@@ -1537,6 +1571,11 @@ function FeedListContent({
     },
     []
   )
+
+  // The home zones and the overflow subpages share one card treatment: elevated
+  // Tier-1 cream cards with the relative timestamp hidden (the calmer register).
+  // The standalone Broadcasts/Sent surfaces keep flat, timestamped cards.
+  const homeZoneCards = unifiedHome || pendingQueue
 
   // One row of the rendered feed, shared by every section (the home-only "For
   // You" / "From Friends" splits and the recency groups all call this). Closes
@@ -1654,7 +1693,7 @@ function FeedListContent({
     )
 
     if (isAnswered) {
-      const answeredItem = toAnsweredByYouItem(item, result, unifiedHome)
+      const answeredItem = toAnsweredByYouItem(item, result, homeZoneCards)
       const isIncorrect = answeredItem.isCorrect === false
       const recheckAction: FeedRecheckAction | null = isIncorrect
         ? { onSubmit: () => submitRecheck(item) }
@@ -1677,7 +1716,7 @@ function FeedListContent({
       )
     }
 
-    const typedItem = toTypedFeedItem(item, unifiedHome)
+    const typedItem = toTypedFeedItem(item, homeZoneCards)
     const dismissible = !item.viewer_is_author
     const onAnswer = dismissible ? () => setAnswerSheetId(item.id) : undefined
     const onDismiss = dismissible ? () => requestDismiss(item) : undefined
@@ -1693,7 +1732,7 @@ function FeedListContent({
           overflow={overflow}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
-          elevated={unifiedHome}
+          elevated={homeZoneCards}
         />
       )
     } else if (typedItem.type === 'friend_liked') {
@@ -1703,7 +1742,7 @@ function FeedListContent({
           overflow={overflow}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
-          elevated={unifiedHome}
+          elevated={homeZoneCards}
         />
       )
     } else {
@@ -1714,7 +1753,7 @@ function FeedListContent({
           onAnswer={onAnswer}
           onDismiss={onDismiss}
           onHideCategory={() => void hideCategory(item)}
-          elevated={unifiedHome}
+          elevated={homeZoneCards}
         />
       )
     }
@@ -1749,7 +1788,7 @@ function FeedListContent({
           empty (otherwise a directly-sent question would be hidden behind a tab
           the recipient can't see). Fully empty feeds still fall back to the
           empty state's own "Questions from friends" eyebrow. */}
-      {!unifiedHome && hasAnySurfaceContent ? (
+      {!unifiedHome && !pendingQueue && hasAnySurfaceContent ? (
         <FeedSurfaceTabs active={feedFilter} meta={feedMeta} onSelect={handleSelectTab} />
       ) : null}
 
@@ -1783,7 +1822,7 @@ function FeedListContent({
               </p>
             ) : null}
           </section>
-        ) : unifiedHome ? (
+        ) : unifiedHome || pendingQueue ? (
           // D-HOME-PACING-01 §9 — the all-three-empty home edition. The hero
           // and composer always render around this; this is the inline empty
           // state between them (NOT a full-screen takeover), reviving the
@@ -1859,6 +1898,7 @@ function FeedListContent({
                 <OverflowRow
                   unifiedHome={unifiedHome}
                   label={`${budget.directOverflowCount} more from friends →`}
+                  href="/for-you"
                 />
               ) : null}
             </Fragment>
@@ -1879,6 +1919,7 @@ function FeedListContent({
                   <OverflowRow
                     unifiedHome={unifiedHome}
                     label={`${budget.playablesOverflowCount} more →`}
+                    href="/from-friends"
                   />
                 ) : null
               ) : fromFriendsHiddenCount > 0 ? (
@@ -1904,7 +1945,10 @@ function FeedListContent({
               removed (§4) — the set is already bounded to today-and-yesterday —
               so it renders as one calm flat stream; off the budget the standalone
               Feed keeps its recency grouping. */}
-          {budget ? (
+          {budget || pendingQueue ? (
+            // The overflow subpage renders the full pending queue flat, in the
+            // server's zone order (sender rotation) — no recency buckets, no
+            // section headings; the page header carries the one title.
             restRows.length > 0 ? (
               <Fragment key="texture">{restRows.map(renderRow)}</Fragment>
             ) : null

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -151,11 +151,14 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
       },
     })
 
-    // Both question zones render their headings and overflow affordances.
+    // Both question zones render their headings and overflow affordances,
+    // each linking to its zone's overflow subpage (B-HOME-OVERFLOW-02).
     expect(html).toContain('For You')
     expect(html).toContain('From Friends')
     expect(html).toContain('4 more from friends →')
     expect(html).toContain('3 more →')
+    expect(html).toContain('href="/for-you"')
+    expect(html).toContain('href="/from-friends"')
     // Served direct cards and playables both rendered.
     expect(html).toContain('direct:robyn')
     expect(html).toContain('activity:p0:josh')

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -1,0 +1,232 @@
+import type * as React from 'react'
+import { describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+// B-HOME-OVERFLOW-02 §7 round-trip test. Home, the "N more →" counts, and the
+// overflow subpages all window the SAME pending queue, so this asserts on
+// RENDERED HOME OUTPUT across a simulated subpage answer: the answered item
+// leaves the shared source, the next pending item is promoted into the freed
+// served slot, and the overflow count decrements — silently, with no clearing
+// step. It also covers the subpage render mode itself (flat full queue, no
+// tabs, no recency buckets, server order preserved).
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}))
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), prefetch: vi.fn(), refresh: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(''),
+}))
+
+vi.mock('@/components/feed/usePrefersReducedMotion', () => ({
+  usePrefersReducedMotion: () => false,
+}))
+
+vi.mock('@/components/feed', () => ({
+  DirectSentCard: ({ item }: { item: { avatarName?: string | null } }) => (
+    <div data-card="direct">direct:{item.avatarName}</div>
+  ),
+  FriendAddedCard: ({ item }: { item: { avatarName?: string | null } }) => (
+    <div data-card="added">added:{item.avatarName}</div>
+  ),
+  FriendLikedCard: () => <div data-card="liked" />,
+  AnsweredByYouCard: () => <div data-card="answered" />,
+  AnswerSheet: () => null,
+  AnswerFeedbackSheet: () => null,
+  DismissedFeedBar: () => null,
+  FeedOverflowMenu: () => null,
+  FeedCardSwipe: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  visibleFeedCategory: (c: string | null | undefined) => c ?? null,
+}))
+
+vi.mock('@/components/activity/ActivityStreamItem', () => ({
+  ActivityStreamItem: ({ item }: { item: { id: string; friendId?: string | null } }) => (
+    <div data-activity={item.id}>activity:{item.id}:{item.friendId ?? 'none'}</div>
+  ),
+}))
+
+vi.mock('@/components/activity/PersonActivityCard', () => ({
+  PersonActivityCard: () => <div data-person />,
+}))
+
+vi.mock('@/components/feed/EditorialPromos', () => ({
+  CommonGroundFeature: () => <div>PANEL:common_ground</div>,
+  GrowYourCircleFeature: () => <div>PANEL:add_friends</div>,
+  RecentlyExpandingFeature: () => <div>PANEL:recently_expanding</div>,
+}))
+
+import FeedList from '@/components/FeedList'
+import type { StreamItem } from '@/lib/activity-stream'
+import {
+  selectHomeEdition,
+  type FeedEditionItem,
+} from '@/server/home/select-edition'
+
+type AnyItem = Record<string, unknown>
+
+const NOW = Date.parse('2026-06-11T18:00:00Z')
+
+// One distinct sender per item, sent-at ascending with index, so the §5
+// sender rotation is deterministic: d0, d1, d2, …
+function directItem(i: number): AnyItem {
+  return {
+    id: `d${i}`,
+    kind: 'question',
+    card_type: 'direct_sent',
+    source_type: 'direct_sent',
+    source_user_id: `sender${i}`,
+    source_friend_display_name: `sender${i}`,
+    source_attribution: `sender${i} sent you a question`,
+    source_event_at: `2026-06-11T0${i}:00:00Z`,
+    state: 'active',
+    is_pinned: false,
+    question_id: `d${i}-q`,
+    question_text: `Question d${i}`,
+    domain_pill: 'Jazz',
+    is_in_bank: false,
+    viewer_is_author: false,
+  }
+}
+
+function bundle(i: number, results: Array<'correct' | 'incorrect' | null>): AnyItem {
+  return {
+    id: `p${i}`,
+    friendId: `friend${i}`,
+    sortAt: new Date('2026-06-11T12:00:00Z'),
+    expand: {
+      kind: 'milestone',
+      questions: results.map((priorResult, q) => ({ questionId: `p${i}-q${q}`, priorResult })),
+    },
+  }
+}
+
+const META = {
+  has_friends: true,
+  has_dismissed_domains: false,
+  total_item_count: 5,
+  active_item_count: 5,
+  pre_filter_active_count: 5,
+  broadcasts_item_count: 0,
+  sent_item_count: 5,
+  filter: 'all' as const,
+}
+
+// Render Home exactly the way page.tsx does: run the shared selection layer
+// over the pending sources, then seed FeedList with the served slices + counts.
+function renderHome(feedItems: AnyItem[], activityItems: AnyItem[]): string {
+  const edition = selectHomeEdition({
+    feedItems: feedItems as unknown as FeedEditionItem[],
+    activityItems: activityItems as unknown as StreamItem[],
+    promos: { sharedGround: null, expanding: null, growCircle: null },
+    now: NOW,
+  })
+  return renderToStaticMarkup(
+    <FeedList
+      unifiedHome
+      initialPage={{
+        viewer_user_id: 'me',
+        meta: META,
+        items: edition.direct.served,
+        has_more: false,
+        next_cursor: null,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      } as any}
+      activityItems={[...edition.playables.served, ...edition.texture]}
+      budget={{
+        directOverflowCount: edition.direct.overflowCount,
+        playablesOverflowCount: edition.playables.overflowCount,
+        panel: edition.panel,
+        isAllEmpty: edition.isAllEmpty,
+      }}
+    />,
+  )
+}
+
+describe('overflow subpages — §7 state sync (Home is a window onto the pending queue)', () => {
+  it('answering a direct question on the subpage promotes the next item and decrements the count on Home', () => {
+    const pending = [0, 1, 2, 3, 4].map(directItem)
+
+    const before = renderHome(pending, [])
+    expect(before).toContain('direct:sender0')
+    expect(before).toContain('direct:sender2')
+    expect(before).not.toContain('direct:sender3') // beyond the served window
+    expect(before).toContain('2 more from friends →')
+    expect(before).toContain('href="/for-you"')
+
+    // The subpage answer flips d0 to 'answered' server-side, so it simply
+    // leaves the pending feed query on Home's next read. No clearing step.
+    const afterAnswer = pending.filter((item) => item.id !== 'd0')
+
+    const after = renderHome(afterAnswer, [])
+    expect(after).not.toContain('direct:sender0')
+    expect(after).toContain('direct:sender3') // promoted into the freed slot
+    expect(after).toContain('1 more from friends →')
+  })
+
+  it('finishing a playable bundle on the subpage promotes the next bundle and decrements the count on Home', () => {
+    const pending = [0, 1, 2, 3, 4, 5].map((i) => bundle(i, [null]))
+
+    const before = renderHome([], pending)
+    expect(before).toContain('activity:p0:friend0')
+    expect(before).toContain('activity:p3:friend3')
+    expect(before).not.toContain('activity:p4:friend4') // beyond the served window
+    expect(before).toContain('2 more →')
+    expect(before).toContain('href="/from-friends"')
+
+    // The subpage answer records the viewer's result on p0's last open
+    // question, so the bundle is no longer pending on Home's next read.
+    const afterAnswer = [bundle(0, ['correct']), ...pending.slice(1)]
+
+    const after = renderHome([], afterAnswer)
+    expect(after).not.toContain('activity:p0:friend0')
+    expect(after).toContain('activity:p4:friend4') // promoted into the freed slot
+    expect(after).toContain('1 more →')
+  })
+})
+
+describe('FeedList — pendingQueue subpage mode (/for-you)', () => {
+  it('renders the FULL queue flat, in server order, with no tabs/buckets/headings', () => {
+    const html = renderToStaticMarkup(
+      <FeedList
+        pendingQueue
+        initialPage={{
+          viewer_user_id: 'me',
+          meta: META,
+          items: [0, 1, 2, 3, 4].map(directItem),
+          has_more: false,
+          next_cursor: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any}
+      />,
+    )
+
+    // Every pending item renders — the subpage is the un-windowed queue.
+    for (let i = 0; i < 5; i++) expect(html).toContain(`direct:sender${i}`)
+    // No surface tabs, no home section headings, no recency buckets.
+    expect(html).not.toContain('Broadcasts')
+    expect(html).not.toContain('For You')
+    expect(html).not.toContain('Today')
+    // No overflow affordance — nothing is windowed here.
+    expect(html).not.toContain('more from friends →')
+  })
+
+  it('renders the caught-up empty state when the queue is empty', () => {
+    const html = renderToStaticMarkup(
+      <FeedList
+        pendingQueue
+        initialPage={{
+          viewer_user_id: 'me',
+          meta: META,
+          items: [],
+          has_more: false,
+          next_cursor: null,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any}
+      />,
+    )
+    expect(html).toContain("You&#x27;ve answered every question your friends sent.")
+  })
+})

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -177,6 +177,7 @@ export function ActivityStreamItem({
   nested = false,
   showTimestamp = true,
   elevated = false,
+  onQuestionResolved,
 }: {
   item: StreamItem;
   timestamp: string;
@@ -193,6 +194,11 @@ export function ActivityStreamItem({
   // page as the thing you can play, while the ambient one-liners stay flat. Off
   // by default (the full /activities log keeps every row flat).
   elevated?: boolean;
+  // Fires after a milestone question is resolved in place (answered right or
+  // wrong). The pending-playables overflow subpage (B-HOME-OVERFLOW-02 §7)
+  // uses it to invalidate the client router cache so Home recomputes its
+  // served window on return; surfaces that don't care simply omit it.
+  onQuestionResolved?: () => void;
 }) {
   const [open, setOpen] = useState(false);
   const expandable = questionBacked(item.expand);
@@ -239,6 +245,7 @@ export function ActivityStreamItem({
       next.set(questionId, { submitted, isCorrect });
       return next;
     });
+    onQuestionResolved?.();
   }
 
   const answeredCount = (milestoneQuestions ?? []).filter((q) => isResolved(q.questionId)).length;

--- a/src/components/home/OverflowSubpageHeader.tsx
+++ b/src/components/home/OverflowSubpageHeader.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+import { ArrowLeft } from 'lucide-react'
+
+/**
+ * Header chrome shared by the two Home overflow subpages (B-HOME-OVERFLOW-02
+ * §6): a clear back affordance to Home over the zone's eyebrow + serif title.
+ * These pages are reached only from Home's "N more →" rows, so back is always
+ * a real Link to `/` — a fresh dynamic render there recomputes the served
+ * window from the shared pending queue (D-HOME-PACING-01 §7), which is why
+ * this is a Link and not history.back().
+ */
+export function OverflowSubpageHeader({
+  eyebrow,
+  title,
+}: {
+  eyebrow: string
+  title: string
+}) {
+  return (
+    <header>
+      <Link
+        href="/"
+        aria-label="Back to Home"
+        className="-ml-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--brand-ink-400)] transition hover:text-[var(--brand-ink)]"
+      >
+        <ArrowLeft className="size-5" strokeWidth={1.9} />
+      </Link>
+      <p className="text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+        {eyebrow}
+      </p>
+      <h1 className="mt-1 font-serif text-[26px] leading-[1.15] font-medium text-[var(--brand-ink)]">
+        {title}
+      </h1>
+    </header>
+  )
+}

--- a/src/server/home/__tests__/select-edition.test.ts
+++ b/src/server/home/__tests__/select-edition.test.ts
@@ -5,7 +5,9 @@ import {
   DIRECT_SERVE_CAP,
   PLAYABLE_SERVE_CAP,
   interleaveByActor,
+  isPendingPlayable,
   orderBySenderRotation,
+  orderPendingPlayables,
   selectHomeEdition,
   type FeedEditionItem,
 } from '@/server/home/select-edition'
@@ -29,6 +31,23 @@ function playable(id: string, friendId: string, type = 'milestone', sortAt = '20
     relationship: type === 'milestone' ? undefined : (type as StreamItem['relationship']),
     sortAt: new Date(sortAt),
     expand: { kind: 'milestone', questions: [{ questionId: `${id}-q` }] },
+  } as unknown as StreamItem
+}
+
+// A bundle whose questions carry the given viewer results (null = unanswered).
+function bundleWithResults(
+  id: string,
+  friendId: string,
+  results: Array<'correct' | 'incorrect' | null>,
+): StreamItem {
+  return {
+    id,
+    friendId,
+    sortAt: new Date('2026-06-11T12:00:00Z'),
+    expand: {
+      kind: 'milestone',
+      questions: results.map((priorResult, i) => ({ questionId: `${id}-q${i}`, priorResult })),
+    },
   } as unknown as StreamItem
 }
 
@@ -150,6 +169,51 @@ describe('selectHomeEdition — serve-and-overflow', () => {
     })
     expect(edition.direct.overflowCount).toBe(0)
     expect(edition.playables.overflowCount).toBe(0)
+  })
+})
+
+// --- pending-playable definition (B-HOME-OVERFLOW-02 §7) ----------------------
+
+describe('isPendingPlayable / orderPendingPlayables — §7 pending definition', () => {
+  it('a bundle is pending only while ≥1 question is unanswered', () => {
+    expect(isPendingPlayable(bundleWithResults('b-fresh', 'f0', [null, null]))).toBe(true)
+    expect(isPendingPlayable(bundleWithResults('b-partial', 'f0', ['correct', null]))).toBe(true)
+    expect(isPendingPlayable(bundleWithResults('b-spent', 'f0', ['correct', 'incorrect']))).toBe(false)
+  })
+
+  it('fully-answered bundles leave the playable queue, the count, and texture', () => {
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems: [
+        bundleWithResults('b-spent', 'f0', ['correct']),
+        ...Array.from({ length: 5 }, (_, i) => playable(`p${i}`, `f${i}`)),
+      ],
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    // 5 pending bundles: served 4 + 1 overflow — the spent one counts nowhere.
+    expect(edition.playables.served.map((p) => p.id)).not.toContain('b-spent')
+    expect(edition.playables.overflowCount).toBe(1)
+    // Consumed, not texture: it does not fall through as an ambient row.
+    expect(edition.texture.map((t) => t.id)).not.toContain('b-spent')
+  })
+
+  it('answering the last question of a served bundle promotes the next one (§7 round trip)', () => {
+    const queue = (items: StreamItem[]) => orderPendingPlayables(items).map((i) => i.id)
+    const before = [
+      bundleWithResults('p0', 'f0', [null]),
+      ...Array.from({ length: 5 }, (_, i) => playable(`p${i + 1}`, `f${i + 1}`)),
+    ]
+    expect(queue(before).slice(0, PLAYABLE_SERVE_CAP)).toContain('p0')
+    // The viewer answers p0's only question on the subpage → next read shows it spent.
+    const after = [
+      bundleWithResults('p0', 'f0', ['correct']),
+      ...before.slice(1),
+    ]
+    const served = queue(after).slice(0, PLAYABLE_SERVE_CAP)
+    expect(served).not.toContain('p0')
+    expect(served).toContain('p4') // promoted into the freed slot
+    expect(queue(after)).toHaveLength(5)
   })
 })
 

--- a/src/server/home/build-edition.ts
+++ b/src/server/home/build-edition.ts
@@ -12,17 +12,35 @@
  * and surface tabs read from.
  */
 
+import type { StreamItem } from '@/lib/activity-stream'
 import { buildActivityStream } from '@/server/activity/build-stream'
 import { getAddFriendsPromo } from '@/server/activity/add-friends-promo'
 import { getCommonGroundPromo } from '@/server/activity/common-ground-promo'
 import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-promo'
 import { getFeedPagePayload } from '@/server/feed/get-feed-page'
-import { selectHomeEdition, type HomeEdition } from '@/server/home/select-edition'
+import {
+  orderDirectPending,
+  orderPendingPlayables,
+  selectHomeEdition,
+  type HomeEdition,
+} from '@/server/home/select-edition'
 
 // The home feed leads with a deep first page; the budget then windows it down to
 // the served caps. Keep this generous so the pending pools (and therefore the
 // overflow counts) are accurate rather than truncated by the page size.
 const HOME_FEED_FETCH_LIMIT = 30
+
+// The overflow subpages render the FULL pending queue, so they fetch deeper
+// than the home edition does. Anything beyond this is pathological volume.
+const PENDING_QUEUE_FETCH_LIMIT = 100
+
+// The weekly reflection has its own editorial marker (CeremonyPin) above the
+// feed; drop the redundant 'ceremony_ready' activity so it doesn't double up
+// on the home surfaces. Shared by the home edition and the overflow subpages
+// so both read the same activity pool.
+function isHomeActivityItem(item: StreamItem): boolean {
+  return !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/'))
+}
 
 export type HomeEditionResult = {
   edition: HomeEdition
@@ -39,12 +57,7 @@ export async function buildHomeEdition(userId: string): Promise<HomeEditionResul
       getAddFriendsPromo(userId),
     ])
 
-  // The weekly reflection has its own editorial marker (CeremonyPin) above the
-  // feed; drop the redundant 'ceremony_ready' activity so it doesn't double up
-  // in the home stream. (Unchanged from the prior inline assembly.)
-  const homeActivityItems = activityItems.filter(
-    (item) => !(item.action?.kind === 'link' && item.action.href.startsWith('/ceremony/')),
-  )
+  const homeActivityItems = activityItems.filter(isHomeActivityItem)
 
   const edition = selectHomeEdition({
     feedItems: feedPage.items,
@@ -57,4 +70,35 @@ export async function buildHomeEdition(userId: string): Promise<HomeEditionResul
   })
 
   return { edition, feedMeta: feedPage.meta }
+}
+
+/**
+ * B-HOME-OVERFLOW-02 §7 — the full pending direct ("For You") queue, in the
+ * same sender-rotated order the home edition windows. Home shows the top 3 of
+ * exactly this list; the /for-you subpage renders all of it. Pending semantics
+ * live in the feed query itself (active/skipped only — answering anywhere
+ * flips the row to 'answered' and it leaves this list on the next read).
+ */
+export async function buildPendingDirectQueue(userId: string): Promise<{
+  items: ReturnType<typeof orderDirectPending>
+  meta: Awaited<ReturnType<typeof getFeedPagePayload>>['meta']
+}> {
+  const page = await getFeedPagePayload(userId, {
+    limit: PENDING_QUEUE_FETCH_LIMIT,
+    cursor: null,
+    filter: 'all',
+  })
+  return { items: orderDirectPending(page.items), meta: page.meta }
+}
+
+/**
+ * B-HOME-OVERFLOW-02 §7 — the full pending-playables queue, in the same
+ * actor-interleaved order the home edition windows. Home shows the top 4 of
+ * exactly this list; the /from-friends subpage renders all of it. A bundle
+ * leaves the queue once every question in it has been answered (see
+ * isPendingPlayable).
+ */
+export async function buildPendingPlayablesQueue(userId: string): Promise<StreamItem[]> {
+  const activityItems = await buildActivityStream(userId)
+  return orderPendingPlayables(activityItems.filter(isHomeActivityItem))
 }

--- a/src/server/home/select-edition.ts
+++ b/src/server/home/select-edition.ts
@@ -199,9 +199,54 @@ export function selectPanel(
   return sharedGround ?? expanding ?? growCircle ?? null
 }
 
-/** A playable is an answerable milestone bundle (≥1 question). */
-function isPlayable(item: StreamItem): boolean {
+/** A milestone bundle (≥1 question), pending or fully spent. */
+function isMilestoneBundle(item: StreamItem): boolean {
   return item.expand?.kind === 'milestone' && item.expand.questions.length > 0
+}
+
+/**
+ * §7 pending definition: a bundle is PENDING only while the viewer still has at
+ * least one unanswered question in it. build-stream keeps answered questions in
+ * the bundle (they render as spent triangles), so questions.length alone would
+ * keep a fully-played bundle in the queue forever — holding a served slot,
+ * inflating the "N more →" count, and never leaving the overflow subpage.
+ * Shared by Home, the overflow counts, and the pending-playables subpage so the
+ * three views can't disagree about what "pending" means.
+ */
+export function isPendingPlayable(item: StreamItem): boolean {
+  return (
+    item.expand?.kind === 'milestone' &&
+    item.expand.questions.some((q) => !q.priorResult)
+  )
+}
+
+/**
+ * §5 zone order for the direct ("For You") queue — the one ordering Home's
+ * served slice, the overflow count, and the /for-you subpage all window.
+ */
+export function orderDirectPending(
+  items: readonly FeedEditionItem[],
+): FeedEditionItem[] {
+  return orderBySenderRotation(
+    items,
+    (item) => item.source_user_id,
+    (item) => ms(item.source_event_at),
+  )
+}
+
+/**
+ * §5 zone order for the pending-playables queue — filters to pending bundles
+ * (see isPendingPlayable) and actor-interleaves. Home serves the top 4 of this;
+ * the /from-friends subpage renders all of it.
+ */
+export function orderPendingPlayables(
+  items: readonly StreamItem[],
+): StreamItem[] {
+  return interleaveByActor(
+    items.filter(isPendingPlayable),
+    (item) => item.friendId ?? null,
+    playableType,
+  )
 }
 
 /** Event-type key for the playable interleave's degenerate-case variety. */
@@ -235,31 +280,25 @@ export function selectHomeEdition(input: SelectHomeEditionInput): HomeEdition {
   const now = input.now ?? Date.now()
 
   // Direct ("For You") zone — broadcasts budgeted alongside direct sends (§5).
-  const directOrdered = orderBySenderRotation(
-    input.feedItems,
-    (item) => item.source_user_id,
-    (item) => ms(item.source_event_at),
-  )
+  const directOrdered = orderDirectPending(input.feedItems)
   const direct = serve(directOrdered, DIRECT_SERVE_CAP)
 
-  // Split the activity stream into playables (answerable milestone bundles) and
-  // texture (everything else non-feed). This mirrors the existing For You /
-  // From Friends / rest split exactly — selection only, no render change.
+  // Split the activity stream into pending playables (answerable milestone
+  // bundles with ≥1 unanswered question), texture (everything else non-feed),
+  // and consumed bundles. A fully-answered bundle is consumed: it is no longer
+  // pending (§7 — it left the queue) and it is not a texture moment either (the
+  // archive surfaces own anything cumulative), so it drops from the edition.
   const playablePool: StreamItem[] = []
   const texturePool: StreamItem[] = []
   for (const item of input.activityItems) {
-    if (isPlayable(item)) playablePool.push(item)
-    else texturePool.push(item)
+    if (isMilestoneBundle(item)) {
+      if (isPendingPlayable(item)) playablePool.push(item)
+    } else {
+      texturePool.push(item)
+    }
   }
 
-  const playables = serve(
-    interleaveByActor(
-      playablePool,
-      (item) => item.friendId ?? null,
-      playableType,
-    ),
-    PLAYABLE_SERVE_CAP,
-  )
+  const playables = serve(orderPendingPlayables(playablePool), PLAYABLE_SERVE_CAP)
 
   const texture = boundTexture(texturePool, now)
 


### PR DESCRIPTION
Two back-navigable subpages, each rendering the full pending queue its
Home zone windows (D-HOME-PACING-01 §3/§6/§7), answerable in place via
the existing answer interactions — no new flows, no modals, no nav tab,
bell untouched.

- /for-you: the full pending direct ("For You") queue, sender-rotated in
  the same order Home serves its top-3 from, rendered through FeedList's
  new pendingQueue mode (filter pinned to 'all', tabs/buckets/headings
  off, server order preserved, home-zone card treatment, existing
  AnswerSheet flow). Warmer register: sender + provenance come from the
  same DirectSentCard rendering the zone already uses.
- /from-friends: the full pending-playables queue, actor-interleaved in
  the same order Home serves its top-4 from, rendered through the
  existing ActivityStreamItem milestone cards + InlineAnswerFlow.
- Shared pending sources: buildPendingDirectQueue /
  buildPendingPlayablesQueue in build-edition.ts reuse the selection
  layer's orderDirectPending / orderPendingPlayables, so Home, the
  counts, and the subpages window one queue per zone (§7).
- §7 pending definition fix: a milestone bundle is pending only while
  ≥1 question is unanswered (isPendingPlayable). build-stream keeps
  answered questions in the bundle, so the old length>0 check kept a
  fully-played bundle in the queue forever — holding a served slot,
  inflating "N more →", and never leaving the subpage. Fully-spent
  bundles are consumed (not texture).
- State sync: back is a real Link to / (fresh dynamic render recomputes
  the served window); answering/dismissing on a subpage additionally
  invalidates the client router cache (router.refresh) so browser-back
  can't restore a stale edition. ActivityStreamItem grew an optional
  onQuestionResolved callback for this.
- Home's "N more →" rows now navigate (OverflowRow → Link).

Tests: §7 pending-definition unit tests; a round-trip render test
asserting on rendered Home output before/after a simulated subpage
answer (promotion into the freed slot + decremented count, both zones);
pendingQueue render-mode tests; overflow-row href assertions.

No proxy/middleware changes (new routes are covered by the existing
matcher), no schema changes, no new copy systems.

https://claude.ai/code/session_01XWqT3hQQ1LBjcv9t3cwao3