### PR TITLE
feat(home): overflow subpages for direct questions & pending playables (B-HOME-OVERFLOW-02)

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1620,10 +1620,11 @@ function FeedListContent({
           key={`a-${row.item.id}`}
           item={row.item}
           timestamp={formatRelativeTime(row.item.sortAt)}
-          // The home "What's Happening" feed reads calmer without the per-row
-          // "1d ago" ledger; the full /activities log keeps its timestamps.
-          showTimestamp={!unifiedHome}
-          elevated={unifiedHome}
+          // The home "What's Happening" feed (and the overflow subpages, which
+          // share its register) reads calmer without the per-row "1d ago"
+          // ledger; the full /activities log keeps its timestamps.
+          showTimestamp={!homeZoneCards}
+          elevated={homeZoneCards}
         />
       )
     }


### PR DESCRIPTION
## Summary

Implements **B-HOME-OVERFLOW-02** (D-HOME-PACING-01 §3/§6/§7): two back-navigable subpages, each rendering the full pending queue its Home zone windows, answerable in place via the existing answer interactions. Builds on the selection layer from B-HOME-BUDGET-01 (#846).

- **`/for-you`** — the full pending direct ("For You") queue, sender-rotated in exactly the order Home serves its top-3 from. Rendered through a new `pendingQueue` mode on `FeedList` (filter pinned to `'all'`, tabs/recency buckets/section headings off, server order preserved, home-zone card treatment) so the existing `DirectSentCard` → `AnswerSheet` → feedback flow, sender links, and provenance verbs carry over unchanged.
- **`/from-friends`** — the full pending-playables queue, actor-interleaved in the order Home serves its top-4 from, rendered through the existing `ActivityStreamItem` milestone cards + `InlineAnswerFlow`. Lighter ambient register via the rendering the zone already uses.
- **Shared pending sources (§7):** `buildPendingDirectQueue` / `buildPendingPlayablesQueue` reuse the selection layer's `orderDirectPending` / `orderPendingPlayables`, so Home, the overflow counts, and the subpages all window one queue per zone.
- **§7 pending-definition fix:** a milestone bundle now counts as pending only while ≥1 question is unanswered (`isPendingPlayable`). `build-stream` keeps answered questions in the bundle, so the old `length > 0` check kept a fully-played bundle in the queue forever — holding a served slot, inflating "N more →", and never leaving the subpage. Fully-spent bundles are consumed (dropped from the edition, not demoted to texture).
- **State sync:** back is a real `Link` to `/` (fresh dynamic render recomputes the served window); answering/dismissing on a subpage also calls `router.refresh()` so browser-back can't restore a stale edition. `ActivityStreamItem` gained an optional `onQuestionResolved` callback for this.
- Home's "N more →" rows now navigate (`OverflowRow` → `Link`): direct → `/for-you`, playables → `/from-friends`.

**Guardrails honored:** bell untouched, no nav tab, no modals, no combined inbox, no new answer flow, no schema changes, no proxy/middleware changes (the existing matcher covers the new routes), no new copy systems.

**Documented divergence:** the spec names the direct page "direct questions sent to you," but the For You zone includes broadcasts by the locked budget-layer decision, and §7 requires the subpage to window the *same* source — so `/for-you` shows both (approved in the Phase 1 audit).

## Test plan

- §7 pending-definition unit tests (`select-edition.test.ts`): partial vs. fully-answered bundles, spent-bundle exclusion from queue/count/texture, promotion after answering a served bundle's last question.
- Round-trip render test (`OverflowSubpageSync.test.tsx`): asserts on **rendered Home output** before/after a simulated subpage answer — answered item leaves, next item promoted into the freed slot, "N more →" count decremented, both zones.
- `pendingQueue` mode render tests: full queue flat in server order, no tabs/buckets/headings, caught-up empty state; overflow-row `href` assertions in `FeedListBudget.test.tsx`.
- `npx tsc -p tsconfig.typecheck.json`, `npm run lint`, font/color ratchets, proxy/middleware tests: all green. Full suite: 1122 passed; the one failure (`add-declared-interest.test.ts`) is pre-existing on the base commit.
- Production build verified locally (route manifest includes `ƒ /for-you`, `ƒ /from-friends`, proxy intact); the sandbox can't fetch Google Fonts or reach a DB, so CI should confirm the unstubbed build.
- Feed-card surface validation (`feed-card-changes`) run: all checks pass; its one advisory (activity-row treatment keyed off `unifiedHome`) fixed in the follow-up commit.

https://claude.ai/code/session_01XWqT3hQQ1LBjcv9t3cwao3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWqT3hQQ1LBjcv9t3cwao3)_