### PR TITLE
feat(home): texture "See all activity →" row + accurate direct overflow count

### DIFF
--- a/src/app/for-you/page.tsx
+++ b/src/app/for-you/page.tsx
@@ -15,6 +15,9 @@ export default async function ForYouPage() {
   if (!session) redirect('/login')
 
   const { items, meta } = await buildPendingDirectQueue(session.userId)
+  // The fetch is clamped (MAX_FEED_LIMIT), but active_item_count is the
+  // whole-table pending count — the title states the true abundance.
+  const pendingTotal = Math.max(items.length, meta.active_item_count)
 
   const initialPage = {
     viewer_user_id: session.userId,
@@ -29,9 +32,7 @@ export default async function ForYouPage() {
       <OverflowSubpageHeader
         eyebrow="For You"
         title={
-          items.length > 0
-            ? `${items.length} waiting for you`
-            : 'Waiting for you'
+          pendingTotal > 0 ? `${pendingTotal} waiting for you` : 'Waiting for you'
         }
       />
       <section>

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1951,7 +1951,22 @@ function FeedListContent({
             // server's zone order (sender rotation) — no recency buckets, no
             // section headings; the page header carries the one title.
             restRows.length > 0 ? (
-              <Fragment key="texture">{restRows.map(renderRow)}</Fragment>
+              <Fragment key="texture">
+                {restRows.map(renderRow)}
+                {/* §4: texture gets NO third subpage — older moments belong to
+                    Lately (/activities), the archive of this same stream. Revive
+                    the retired "See all activity →" affordance as the zone's
+                    quiet see-more row, in the same voice as the overflow rows.
+                    Texture-anchored: hidden with the zone (§9), and never on
+                    the pendingQueue subpages (no texture there). */}
+                {budget ? (
+                  <OverflowRow
+                    unifiedHome={unifiedHome}
+                    label="See all activity →"
+                    href="/activities"
+                  />
+                ) : null}
+              </Fragment>
             ) : null
           ) : (
             groupItemsByRecency(restRows).map((group) => (

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -166,6 +166,10 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('activity:t0:tex-friend')
     expect(html).not.toContain('Today')
     expect(html).not.toContain('Past two weeks')
+    // Texture's see-more goes to Lately (the archive of this stream) — no third
+    // subpage (§4); the revived "See all activity →" row closes the zone.
+    expect(html).toContain('See all activity →')
+    expect(html).toContain('href="/activities"')
     // Exactly one rotating panel.
     expect(html).toContain('PANEL:add_friends')
   })
@@ -210,6 +214,8 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     // The empty playable zone is omitted entirely — no heading, no placeholder.
     expect(html).not.toContain('From Friends')
     expect(html).not.toContain('Quiet today')
+    // Empty texture zone → its see-more row is hidden with it (§9).
+    expect(html).not.toContain('See all activity')
     // The populated page still gets its one panel.
     expect(html).toContain('PANEL:common_ground')
   })

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -209,8 +209,10 @@ describe('FeedList — pendingQueue subpage mode (/for-you)', () => {
     expect(html).not.toContain('Broadcasts')
     expect(html).not.toContain('For You')
     expect(html).not.toContain('Today')
-    // No overflow affordance — nothing is windowed here.
+    // No overflow affordance — nothing is windowed here — and no texture
+    // see-more row (the subpage has no texture zone).
     expect(html).not.toContain('more from friends →')
+    expect(html).not.toContain('See all activity')
   })
 
   it('renders the caught-up empty state when the queue is empty', () => {

--- a/src/server/home/__tests__/select-edition.test.ts
+++ b/src/server/home/__tests__/select-edition.test.ts
@@ -160,6 +160,32 @@ describe('selectHomeEdition — serve-and-overflow', () => {
     expect(edition.playables.overflowCount).toBe(9 - PLAYABLE_SERVE_CAP)
   })
 
+  it('uses the full pending total for the direct overflow when the fetched page is capped', () => {
+    // 7 items fetched (page cap), but the whole-table count says 40 pending:
+    // the overflow must reflect the real abundance, not "fetch limit minus cap".
+    const feedItems = Array.from({ length: 7 }, (_, i) =>
+      feedItem(`d${i}`, `sender${i}`, `2026-06-11T0${i}:00:00Z`),
+    )
+    const edition = selectHomeEdition({
+      feedItems,
+      directPendingTotal: 40,
+      activityItems: [],
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    expect(edition.direct.served).toHaveLength(DIRECT_SERVE_CAP)
+    expect(edition.direct.overflowCount).toBe(40 - DIRECT_SERVE_CAP)
+    // A stale/smaller total never shrinks the overflow below what was fetched.
+    const clamped = selectHomeEdition({
+      feedItems,
+      directPendingTotal: 2,
+      activityItems: [],
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    expect(clamped.direct.overflowCount).toBe(7 - DIRECT_SERVE_CAP)
+  })
+
   it('reports zero overflow when a zone is under budget', () => {
     const edition = selectHomeEdition({
       feedItems: [feedItem('d0', 's0', '2026-06-11T09:00:00Z')],

--- a/src/server/home/build-edition.ts
+++ b/src/server/home/build-edition.ts
@@ -31,8 +31,10 @@ import {
 const HOME_FEED_FETCH_LIMIT = 30
 
 // The overflow subpages render the FULL pending queue, so they fetch deeper
-// than the home edition does. Anything beyond this is pathological volume.
-const PENDING_QUEUE_FETCH_LIMIT = 100
+// than the home edition does. getFeedForUser clamps to MAX_FEED_LIMIT (50), so
+// this is the true ceiling — anything beyond it is pathological volume, and
+// the subpage title still reports the accurate total from meta.
+const PENDING_QUEUE_FETCH_LIMIT = 50
 
 // The weekly reflection has its own editorial marker (CeremonyPin) above the
 // feed; drop the redundant 'ceremony_ready' activity so it doesn't double up
@@ -61,6 +63,9 @@ export async function buildHomeEdition(userId: string): Promise<HomeEditionResul
 
   const edition = selectHomeEdition({
     feedItems: feedPage.items,
+    // Whole-table pending count for the direct zone, so the "N more →" count
+    // stays accurate even when the queue outgrows HOME_FEED_FETCH_LIMIT.
+    directPendingTotal: feedPage.meta.active_item_count,
     activityItems: homeActivityItems,
     promos: {
       sharedGround: commonGroundPromo,

--- a/src/server/home/select-edition.ts
+++ b/src/server/home/select-edition.ts
@@ -254,16 +254,27 @@ function playableType(item: StreamItem): string {
   return item.relationship ?? item.expand?.kind ?? 'milestone'
 }
 
-function serve<T>(ordered: readonly T[], cap: number): ServedZone<T> {
+function serve<T>(ordered: readonly T[], cap: number, totalPending?: number): ServedZone<T> {
+  // The fetched page may be capped upstream (HOME_FEED_FETCH_LIMIT); when the
+  // caller knows the full pending count, the overflow reflects it rather than
+  // silently understating at "fetch limit minus cap".
+  const total = Math.max(ordered.length, totalPending ?? 0)
   return {
     served: ordered.slice(0, cap),
-    overflowCount: Math.max(0, ordered.length - cap),
+    overflowCount: Math.max(0, total - cap),
   }
 }
 
 export type SelectHomeEditionInput = {
   /** The question feed (filter 'all'): direct-sent + broadcasts + legacy. */
   feedItems: readonly FeedEditionItem[]
+  /**
+   * Full pending count for the direct zone (meta.active_item_count from the
+   * filter:'all' first page — a whole-table count, not page-bounded). The
+   * fetched feedItems page is capped, so without this the "N more →" count
+   * would silently understate once the queue outgrows the fetch limit.
+   */
+  directPendingTotal?: number
   /** The full activity/Lately stream for the viewer. */
   activityItems: readonly StreamItem[]
   /** The three home discovery promos (each already null when data-absent). */
@@ -281,7 +292,7 @@ export function selectHomeEdition(input: SelectHomeEditionInput): HomeEdition {
 
   // Direct ("For You") zone — broadcasts budgeted alongside direct sends (§5).
   const directOrdered = orderDirectPending(input.feedItems)
-  const direct = serve(directOrdered, DIRECT_SERVE_CAP)
+  const direct = serve(directOrdered, DIRECT_SERVE_CAP, input.directPendingTotal)
 
   // Split the activity stream into pending playables (answerable milestone
   // bundles with ≥1 unanswered question), texture (everything else non-feed),


### PR DESCRIPTION
## Summary

Two follow-ups to the Home overflow work (#847/#848), per discussion:

### 1. Texture zone "see more" → Lately (`845ded86`)

The ambient social one-liners at the bottom of Home ("you and Robyn are on the same wavelength lately…") are the curated head of the Lately stream, bounded to today-and-yesterday and soft-capped (~5). Per D-HOME-PACING-01 §2/§4 texture gets **no third overflow subpage** — the full view of this exact stream already exists at `/activities` — so the zone now closes with a quiet **"See all activity →"** row (the retired `RecentActivitySection` copy, revived) linking there, rendered in the same voice as the two "N more →" overflow rows.

- Texture-anchored: hidden when the zone is empty (§9), never rendered on the `/for-you` / `/from-friends` subpages.
- Independent of the bell: the bell's link lives in `Nav.tsx` and is untouched, so repointing the bell at a friend-requests page later won't affect this row.

### 2. Accurate direct overflow count beyond the fetch limit (`1c467689`)

The "N more from friends →" count was derived from the fetched page (`HOME_FEED_FETCH_LIMIT` = 30), silently understating once the pending queue outgrew it. `meta.active_item_count` is already a whole-table pending count for the `filter:'all'` first page, so it now threads into `selectHomeEdition` as `directPendingTotal`; `serve()` takes the max of the fetched length and the total, so a stale/smaller total can never shrink the overflow below what was actually fetched.

Also:
- `PENDING_QUEUE_FETCH_LIMIT` drops 100 → 50 — `getFeedForUser` clamps to `MAX_FEED_LIMIT` (50), so 100 was a silent no-op.
- The `/for-you` title now states the true total from meta rather than the clamped page length.

## Test plan

- `select-edition.test.ts`: overflow uses the provided whole-table total when the page is capped (7 fetched / 40 total → 37 more); a stale smaller total never shrinks it below the fetched remainder.
- `FeedListBudget.test.tsx`: "See all activity →" + `href="/activities"` render with a populated texture zone; hidden when texture is empty (§9 hide-empty-zones).
- `OverflowSubpageSync.test.tsx`: the see-more row never renders in `pendingQueue` (subpage) mode.
- `npx tsc -p tsconfig.typecheck.json`, `npm run lint`, and all touched suites (38 tests) green.

https://claude.ai/code/session_01XWqT3hQQ1LBjcv9t3cwao3

---
_Generated by [Claude Code](https://claude.ai/code/session_01XWqT3hQQ1LBjcv9t3cwao3)_