### PR TITLE
Use gold accent for bordered home-feed cards

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -329,7 +329,7 @@ export function ActivityStreamItem({
       ? {
           padding: opened ? '16px 14px' : '14px',
           background: 'var(--game-card-question)',
-          border: '1px solid rgba(40, 32, 30, 0.22)',
+          border: '1px solid var(--accent-gold)',
           borderRadius: 4,
           boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
         }

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -90,7 +90,7 @@ describe('ActivityStreamItem — playable milestone card on the home feed', () =
       <ActivityStreamItem item={MILESTONE_ITEM} timestamp="2:00 PM" elevated showTimestamp={false} />,
     );
     expect(html).toContain('var(--game-card-question)');
-    expect(html).toContain('rgba(40, 32, 30, 0.22)'); // the light warm-ink stroke
+    expect(html).toContain('var(--accent-gold)'); // the gold accent stroke
     expect(html).toContain('rgba(40, 32, 30, 0.1)'); // the soft drop shadow
   });
 

--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -17,15 +17,15 @@ const FEED_CARD_RADIUS = 'rounded-[4px]'
 const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
 
 // Elevated ("playable" / Tier 1) treatment for the unified home feed
-// (D-FEED-TIER): the warm light-cream question fill, a visible — but still
-// light — warm-ink stroke, and a deeper soft drop shadow than the ambient
-// cards carry. On the home feed the activity rows render as flat one-liners
-// (no card), so a playable question card needs more than a 4% lift to read as
-// the thing you can play; the stronger stroke + shadow make it step forward
-// off the cream while the chatter stays quiet text. Shares the shadow color
-// (#28201E warm ink) with the resting cards, just at a higher opacity.
+// (D-FEED-TIER): the warm light-cream question fill, a gold accent stroke, and
+// a deeper soft drop shadow than the ambient cards carry. On the home feed the
+// activity rows render as flat one-liners (no card), so a playable question card
+// needs more than a 4% lift to read as the thing you can play; the gold stroke +
+// shadow make it step forward off the cream while the chatter stays quiet text.
+// Shares the shadow color (#28201E warm ink) with the resting cards, just at a
+// higher opacity. The stroke uses the editorial accent gold (--accent-gold).
 const FEED_CARD_ELEVATED_FILL = 'bg-[var(--game-card-question)]'
-const FEED_CARD_ELEVATED_STROKE = 'border-[rgba(40,32,30,0.22)]'
+const FEED_CARD_ELEVATED_STROKE = 'border-[var(--accent-gold)]'
 const FEED_CARD_ELEVATED_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.10)]'
 
 export type FeedCardShellProps = {

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -503,8 +503,8 @@ describe('FeedCardShell (shared C7 shell)', () => {
     // Deeper drop shadow (10% ink) than the ambient cards' 4%.
     expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
     expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
-    // Visible warm-ink stroke replaces the faint hairline rule.
-    expect(rendered).toContain('border-[rgba(40,32,30,0.22)]')
+    // Gold accent stroke replaces the faint hairline rule.
+    expect(rendered).toContain('border-[var(--accent-gold)]')
     expect(rendered).not.toContain('border-[var(--brand-rule)]')
     // No hard ink offset shadow, no near-white resting fill.
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')


### PR DESCRIPTION
The elevated 'playable' home-zone cards (feed question cards via
FeedCardShell and the milestone activity cards via ActivityStreamItem)
now carry the editorial accent-gold stroke instead of the faint warm-ink
hairline. The main Play Today's 5 card is untouched.

https://claude.ai/code/session_01D1UMcFbCFwfsERzfYTMwRH