### PR TITLE
feat(play): merge Between-us wink into the result card + name the LLM author

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -143,7 +143,7 @@ type Resolution = { submitted: string; isCorrect: boolean };
 // question, a house/LLM-authored question MUST be marked — never rendered as if
 // a person wrote it. Returns the marker text, or null when no marker is needed:
 //   - authorIsHouse        → the house identity ("Joshing · Editorial")
-//   - authorName === null  → a non-person LLM-origin question ("Generated")
+//   - authorName === null  → a non-person LLM-origin question (LLM_QUESTION_ATTRIBUTION)
 //   - human name / undefined → null (the row frame already attributes it; a
 //                              human author needs no machine-honesty marker)
 function questionProvenance(q: StreamQuestion): string | null {

--- a/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
+++ b/src/components/activity/__tests__/ConvergenceStreamItem.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 
 import { convergenceToStreamItem, type StreamExpand } from '@/lib/activity-stream';
 import type { Convergence } from '@/lib/convergence';
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
 vi.mock('next/link', () => ({
   default: ({
@@ -153,7 +154,7 @@ describe('ConvergenceExpansion — the expanded reveal', () => {
       questions: [
         // House/editorial question — must be marked, never read as person-written.
         { questionId: 'h1', text: 'A house question', domain: 'History', priorResult: 'correct', authorName: 'Joshing', authorIsHouse: true },
-        // LLM-origin question — marked "Generated".
+        // LLM-origin question — marked with the LLM attribution label.
         { questionId: 'g1', text: 'A generated question', domain: 'Science', priorResult: 'correct', authorName: null, authorIsHouse: false },
         // Human-authored — no machine-honesty marker needed.
         { questionId: 'p1', text: 'A human question', domain: 'Music', priorResult: 'correct', authorName: 'Sadie', authorIsHouse: false },
@@ -161,7 +162,7 @@ describe('ConvergenceExpansion — the expanded reveal', () => {
     };
     const html = renderToStaticMarkup(<ConvergenceExpansion expand={expand} />);
     expect(html).toContain('JOSHING · EDITORIAL');
-    expect(html).toContain('GENERATED');
+    expect(html).toContain(LLM_QUESTION_ATTRIBUTION.toUpperCase());
     // The human author is not surfaced as a provenance marker.
     expect(html).not.toContain('SADIE');
   });

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -975,9 +975,10 @@ function ResultRow({
   // Correct keeps its explainer inline within the verdict block (before the
   // "common ground" beat); the other reveals render it after the discovery copy.
   const showDiscoveryExplainer = !correct && Boolean(explainerSentence);
-  // One reflection card beneath the result: the lighter "Between us!" wink is
+  // One reflection beneath the verdict: the lighter "Between us!" wink is
   // preferred over the creator note, which otherwise falls back in on correct
-  // answers. The fuller creator note lives in the review.
+  // answers. The wink renders as an inset panel INSIDE the result card (one
+  // item, not a second card); the fuller creator note lives in the review.
   const showJokeCard = Boolean(insideJoke);
   const showNoteCard = correct && !insideJoke && Boolean(authorNote);
   const requestRecheck = useCallback(async () => {
@@ -1224,6 +1225,41 @@ function ResultRow({
         {showDiscoveryExplainer && explainerSentence ? (
           <ExplainerLine text={explainerSentence} />
         ) : null}
+        {showJokeCard && insideJoke ? (
+          <div
+            style={{
+              marginTop: '12px',
+              borderRadius: 'var(--radius-md)',
+              border: '1px solid color-mix(in srgb, var(--brand-link) 22%, var(--border))',
+              background: 'var(--editorial-slate)',
+              padding: '10px 12px',
+            }}
+          >
+            <p
+              style={{
+                ...monoStyle,
+                fontSize: '0.55rem',
+                color: GOLD_INK,
+                letterSpacing: '0.18em',
+                textTransform: 'uppercase',
+              }}
+            >
+              {INSIDE_JOKE_LABELS[insideJokeKind ?? 'relational']}
+            </p>
+            <p
+              style={{
+                marginTop: '4px',
+                fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
+                // Reflection body bumped ~14% for readability (D-5); the small,
+                // letter-spaced label above stays secondary.
+                fontSize: '1.05rem',
+                lineHeight: 1.5,
+              }}
+            >
+              {insideJoke}
+            </p>
+          </div>
+        ) : null}
         {typeof pointsAwarded === 'number' ? (
           <p
             style={{
@@ -1238,37 +1274,6 @@ function ResultRow({
           </p>
         ) : null}
       </ThreadCard>
-      {showJokeCard && insideJoke ? (
-        <ThreadCard
-          border="color-mix(in srgb, var(--accent-gold) 40%, var(--border))"
-          fill="color-mix(in srgb, var(--accent-gold) 12%, var(--surface-2))"
-          style={{ marginTop: '8px' }}
-        >
-          <p
-            style={{
-              ...monoStyle,
-              fontSize: '0.55rem',
-              color: GOLD_INK,
-              letterSpacing: '0.18em',
-              textTransform: 'uppercase',
-            }}
-          >
-            {INSIDE_JOKE_LABELS[insideJokeKind ?? 'relational']}
-          </p>
-          <p
-            style={{
-              marginTop: '4px',
-              fontFamily: 'var(--font-serif), ui-serif, Georgia, serif',
-              // Reflection body bumped ~14% for readability (D-5); the small,
-              // letter-spaced label above stays secondary.
-              fontSize: '1.05rem',
-              lineHeight: 1.5,
-            }}
-          >
-            {insideJoke}
-          </p>
-        </ThreadCard>
-      ) : null}
       {showNoteCard && authorNote ? (
         <AuthorNoteCard
           text={authorNote}

--- a/src/components/play/__tests__/GameplayChat.house.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.house.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { GameplayChatThread, type ChatMessage } from '@/components/play/GameplayChat';
-import { HOUSE_AUTHOR } from '@/lib/questions-types';
+import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
 vi.mock('next/link', () => ({
   default: ({ href, children, ...props }: { href: string; children: React.ReactNode }) => (
@@ -63,11 +63,11 @@ describe('GameplayChat house author labeling (D-3 Stage 2)', () => {
     expect(rendered).not.toContain('Editorial');
   });
 
-  it('leaves the existing LLM "Generated" treatment unbadged and non-relational', () => {
+  it('leaves the LLM attribution treatment unbadged and non-relational', () => {
     const rendered = html([
-      questionMessage({ creatorName: 'Generated', creatorIsHouse: false }),
+      questionMessage({ creatorName: LLM_QUESTION_ATTRIBUTION, creatorIsHouse: false }),
     ]);
-    expect(rendered).toContain('Generated');
+    expect(rendered).toContain(LLM_QUESTION_ATTRIBUTION);
     expect(rendered).not.toContain('gave you this');
     expect(rendered).not.toContain('editorial-badge');
   });

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -56,7 +56,8 @@ export type StreamQuestion = {
   //   - undefined        — provenance not resolved for this source; show nothing
   //                        (the row frame already attributes it, e.g. moments are
   //                        human by construction).
-  //   - null             — a non-person LLM-origin question → render "Generated".
+  //   - null             — a non-person LLM-origin question → render the
+  //                        LLM_QUESTION_ATTRIBUTION label.
   //   - string (+isHouse) — a human name, or the house identity when authorIsHouse.
   // A house/LLM question must NEVER render as if a person wrote it.
   authorName?: string | null;

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -55,9 +55,10 @@ export function parseQuestionSource(value: string): QuestionSource {
 // Non-person, non-house attribution for LLM-origin questions
 // (source 'daily_generated' | 'curated_sent'; creatorId === null). A machine
 // question must never render a human name or imply a person wrote it.
-// PLACEHOLDER COPY — flagged for product sign-off. Must NOT be "Joshing"/"Editorial"
-// (those are the house identity below); this is for the non-house LLM origins.
-export const LLM_QUESTION_ATTRIBUTION = 'Generated' as const;
+// "Maid Acasa" is the named house-bot persona (product-approved, replacing the
+// placeholder "Generated"). Must NOT be "Joshing"/"Editorial" (those are the
+// house identity below); this is for the non-house LLM origins.
+export const LLM_QUESTION_ATTRIBUTION = 'Maid Acasa' as const;
 
 // D-3 — the single, fixed house/editorial author identity. House questions carry
 // creatorId === null + source 'house_authored'; this identity is resolved at
@@ -89,8 +90,8 @@ export function isHouseAttribution(name: string | null | undefined): boolean {
 //
 //   - creatorId set                      → human author (hydrate the users row)
 //   - (null, 'house_authored')           → the house identity constant
-//   - (null, 'daily_generated' | 'curated_sent') → the non-person 'Generated'
-//                                          treatment (B-5)
+//   - (null, 'daily_generated' | 'curated_sent') → the non-person
+//                                          LLM_QUESTION_ATTRIBUTION treatment (B-5)
 //
 // The switch ends in assertNever, so a future source value cannot compile until
 // it is routed here deliberately. No branch can resolve a house question to a
@@ -132,7 +133,7 @@ export function resolveQuestionAuthor<U>(input: {
 // into a view object: `{ ...resolveAuthorDisplay(creatorId, source, name) }`.
 //   - human author      → { authorName: displayName, authorIsHouse: false }
 //   - house             → { authorName: 'Joshing',   authorIsHouse: true  }
-//   - LLM-origin / null  → { authorName: null,        authorIsHouse: false } (client renders 'Generated')
+//   - LLM-origin / null  → { authorName: null,        authorIsHouse: false } (client renders LLM_QUESTION_ATTRIBUTION)
 export function resolveAuthorDisplay(
   creatorId: string | null,
   source: QuestionSource,

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -211,7 +211,7 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
         // Route the canonical question through resolveAuthorDisplay so a house
         // slot (creatorId null, source 'house_authored') positively resolves to
         // 'Joshing' + authorIsHouse, instead of falling through to ''. Pure-LLM
-        // slots carry no bankQuestion, so they keep the 'Generated'/'' fallback.
+        // slots carry no bankQuestion, so they keep the LLM-attribution/'' fallback.
         const authored = bankQuestion
           ? resolveAuthorDisplay(bankQuestion.creatorId, bankQuestion.source, askerDisplay)
           : { authorName: null, authorIsHouse: false };


### PR DESCRIPTION
- The "Between us" reflection now renders as an inset panel inside the
  result ThreadCard (one item in the thread) instead of a second card
  below it, on the system --editorial-slate wash.
- LLM_QUESTION_ATTRIBUTION: 'Generated' (placeholder) -> 'Maid Acasa',
  the product-approved house-bot persona; FROM lines, summary/replay/
  archive labels and the activity-stream provenance marker all follow
  via the constant. Tests now assert through the constant instead of
  the old literal.

https://claude.ai/code/session_01D1vskT8u4UhyD68RyDRbAQ