### PR TITLE
feat(catchup): close the round in-thread with recap/next-five options

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
 import { GameplayChatThread } from '@/components/play/GameplayChat';
+import { ThreadCard } from '@/components/play/ThreadCard';
 import { useCatchupFlow, type CatchupBatchRecord } from '@/components/play/useCatchupFlow';
 import { CATCH_UP_EMPTY_COPY } from '@/server/play/catch-up-copy';
 
@@ -25,6 +26,7 @@ export default function DailyCatchupPage() {
     remainingCount,
     nextBatchSize,
     startNextBatch,
+    openSummary,
     reload,
     submitCurrent,
     skipCurrent,
@@ -34,6 +36,7 @@ export default function DailyCatchupPage() {
 
   const hasItems = initialTotal > 0;
   const showSummary = phase === 'summary';
+  const roundComplete = phase === 'round_complete';
 
   async function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
@@ -82,7 +85,7 @@ export default function DailyCatchupPage() {
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
         style={{
-          paddingBottom: currentItem && !showSummary
+          paddingBottom: currentItem && phase === 'playing'
             ? 'calc(130px + env(safe-area-inset-bottom))'
             : 'calc(24px + env(safe-area-inset-bottom))',
           // Cream backdrop on the recap so the near-white --brand-card recap cards
@@ -126,11 +129,20 @@ export default function DailyCatchupPage() {
               onDismiss={() => void dismissCurrent()}
               dismissDisabled={submitting || isResolvingTurn}
             />
+            {roundComplete ? (
+              <RoundCloseCard
+                records={batchRecords}
+                remainingCount={remainingCount}
+                nextBatchSize={nextBatchSize}
+                onSeeProgress={openSummary}
+                onPlayNext={startNextBatch}
+              />
+            ) : null}
           </>
         )}
       </section>
 
-      {currentItem && !loading && !showSummary ? (
+      {currentItem && !loading && phase === 'playing' ? (
         <form
           className="fixed inset-x-0 bottom-0 z-30 mx-auto max-w-lg border-t px-4 py-3"
           style={{
@@ -157,6 +169,60 @@ export default function DailyCatchupPage() {
         </form>
       ) : null}
     </main>
+  );
+}
+
+// Mirrors the Daily Five session-close turn (SessionCloseRow in GameplayChat):
+// when the round of five resolves, the thread stays up and closes with this
+// card — see the recap, or roll straight into another round — instead of
+// cutting directly to the recap.
+function RoundCloseCard({
+  records,
+  remainingCount,
+  nextBatchSize,
+  onSeeProgress,
+  onPlayNext,
+}: {
+  records: CatchupBatchRecord[];
+  remainingCount: number;
+  nextBatchSize: number;
+  onSeeProgress: () => void;
+  onPlayNext: () => void;
+}) {
+  const total = records.length;
+  const correct = records.filter((record) => record.outcome === 'correct').length;
+  const hasMore = remainingCount > 0;
+
+  return (
+    <ThreadCard
+      className="mt-4"
+      border="var(--border)"
+      fill="var(--surface-2)"
+      style={{ maxWidth: 'var(--play-thread-card-width)' }}
+    >
+      <p className="text-[1.22rem] leading-relaxed text-[var(--text)]">
+        {total > 0 ? `That’s the round — ${correct} of ${total}.` : 'That’s the round.'}
+      </p>
+      <p className="mt-1 text-[1.05rem] leading-relaxed text-[var(--text-muted)]">
+        {hasMore
+          ? `${remainingCount} missed ${remainingCount === 1 ? 'question' : 'questions'} still waiting.`
+          : 'You’re all caught up.'}
+      </p>
+      <div className="flex flex-wrap items-center gap-x-5 gap-y-3 pt-3">
+        <button type="button" className="btn-primary" onClick={onSeeProgress}>
+          See all this progress
+        </button>
+        {hasMore ? (
+          <button
+            type="button"
+            className="text-sm font-medium text-[var(--text-muted)] underline underline-offset-4 transition hover:text-[var(--text)]"
+            onClick={onPlayNext}
+          >
+            Start another {nextBatchSize}
+          </button>
+        ) : null}
+      </div>
+    </ThreadCard>
   );
 }
 

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -108,9 +108,12 @@ export type CatchupBatchRecord = {
 
 /**
  * 'playing' — the round's chat thread + answer input is live.
- * 'summary' — the round is done; show the recap with "play next" / "return home".
+ * 'round_complete' — the round is done; the thread stays up and closes with a
+ *   card offering the recap or another round (mirroring the Daily Five
+ *   session-close turn) instead of cutting straight to the recap.
+ * 'summary' — show the recap with "play next" / "return home".
  */
-export type CatchupPhase = 'playing' | 'summary';
+export type CatchupPhase = 'playing' | 'round_complete' | 'summary';
 
 function formatQuestionSubhead(item: CatchupQueueItem): string {
   if (item.queueAge <= 1) return 'FROM YESTERDAY';
@@ -316,8 +319,9 @@ export function useCatchupFlow() {
   useEffect(() => {
     const id = currentItem?.dailyQueueItemId ?? null;
     if (!currentItem) return;
-    // Don't introduce the next round's first question while the summary is up;
-    // it gets introduced when startNextBatch flips the phase back to 'playing'.
+    // Don't introduce the next round's first question while the round-close
+    // card or the summary is up; it gets introduced when startNextBatch flips
+    // the phase back to 'playing'.
     if (phase !== 'playing') return;
     if (!shouldIntroduceCatchUpQuestion({
       currentCatchUpItemId: id,
@@ -335,8 +339,10 @@ export function useCatchupFlow() {
     setItems((existing) => existing.filter((item) => item.dailyQueueItemId !== dailyQueueItemId));
   }, []);
 
-  // Records the resolved turn and, once the round is full, flips to the summary.
-  // Called from inside the post-result timeout in both submit and give-up.
+  // Records the resolved turn and, once the round is full, closes the round
+  // (the thread stays up with the round-close options; the recap is opened
+  // explicitly via openSummary). Called from inside the post-result timeout in
+  // both submit and give-up.
   const finishTurn = useCallback((dailyQueueItemId: string, record: CatchupBatchRecord) => {
     answeredInBatchRef.current += 1;
     setBatchRecords((existing) => [...existing, record]);
@@ -344,9 +350,14 @@ export function useCatchupFlow() {
     setIsResolvingTurn(false);
     const roundSize = Math.min(CATCH_UP_BATCH_SIZE, batchStartRemainingRef.current);
     if (answeredInBatchRef.current >= roundSize) {
-      setPhase('summary');
+      setPhase('round_complete');
     }
   }, [advancePast]);
+
+  // Moves from the round-close card to the full recap.
+  const openSummary = useCallback(() => {
+    setPhase('summary');
+  }, []);
 
   // Begins the next round: clears the thread + recap and re-enters 'playing',
   // which re-introduces the next current question via the effect above.
@@ -378,7 +389,7 @@ export function useCatchupFlow() {
     // End the round if the queue is now empty (otherwise the thread dead-ends
     // with no current question and no input) or the shrunken target is met.
     if (emptiesQueue || answeredInBatchRef.current >= roundSize) {
-      setPhase('summary');
+      setPhase('round_complete');
     }
   }, [advancePast, items.length]);
 
@@ -678,6 +689,7 @@ export function useCatchupFlow() {
     remainingCount,
     nextBatchSize,
     startNextBatch,
+    openSummary,
     reload: load,
     submitCurrent,
     skipCurrent,


### PR DESCRIPTION
The catch-up round used to cut straight to the inline recap after the
fifth question resolved. Mirror the Daily Five session-close turn
instead: the thread stays up and ends with a close card (score line +
remaining count) offering "See all this progress" (opens the recap) or
"Start another five" (rolls straight into the next batch).

Adds a 'round_complete' phase to useCatchupFlow between 'playing' and
'summary', plus an openSummary action; the recap's own play-next /
return-home options are unchanged.

https://claude.ai/code/session_01TNJFyyVM8irPDWL3pQ6x9Y