### PR TITLE
Restructure home texture zone: 3 rows, panel interlude, up to 5 more, see-all

### DIFF
--- a/D-HOME-PACING-01.md
+++ b/D-HOME-PACING-01.md
@@ -26,8 +26,8 @@ This division is load-bearing for the rest of the spec: it is *why* the temporal
 | 1 | **Today's Five (hero)** | 1 | Full-width, display-scale, the one loud thing. Everything below is subordinate. |
 | 2 | **Direct questions** | 3 served | Serve-and-overflow (see §3). Overflow → "N more →" → direct-questions subpage. |
 | 3 | **Playable friend activity** | 4 served | Serve-and-overflow. Actor-interleaved (see §5). Overflow → "N more →" → pending-playables subpage. |
-| 4 | **Texture (social connection)** | ~5 | Chronological full-sentence lone events per locked Group 3 spec. Today-and-yesterday only. Reaction affordance lives here. |
-| 5 | **One panel** | 1 | Shared Ground / World Expanding / Grow Your Circle rotate; exactly one per page load. |
+| 4 | **Texture (social connection)** | ~8 | Chronological full-sentence lone events per locked Group 3 spec. Today-and-yesterday preferred, older items backfill to the cap. Reaction affordance lives here. *(Tuned 2026-06-12 from ~5/hard window.)* |
+| 5 | **One panel** | 1 | Shared Ground / World Expanding / Grow Your Circle rotate; exactly one per page load. Runs mid-texture, after the third texture row *(tuned 2026-06-12; falls to the page foot when texture is empty)*. |
 | 6 | **Composer** | 1 | "Write a Question." Closes the page, as today. |
 
 Caps are serving sizes, not access ceilings. Nothing is hidden; everything overflows to a findable place.
@@ -127,6 +127,6 @@ A budgeted page of same-sized rows is still flat. The tier system (**B-VISUAL-CA
 3. **Tier rendering** — B-VISUAL-CARD-TIERS-01, already scoped; carries the rhythm (§9).
 
 Decisions locked (2026-06-11):
-- **Served caps:** Direct 3, Playables 4. Texture ~5 (still a soft cap, tune in build).
+- **Served caps:** Direct 3, Playables 4. Texture ~5 (still a soft cap, tune in build). *Tuned 2026-06-12: texture soft cap 8, rendered as 3 rows → panel → up to 5 more rows → "See all activity →"; the 48h window backfills with older items rather than starving the zone.*
 - **Panel:** rotates one per load, activity-aware (quiet pages bias to Grow Your Circle; never Shared Ground for a user with no overlap data). Suppressed entirely on the all-empty page per §9.
 - **Both overflows are subpages** (back-navigable routes), not modals.

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -518,6 +518,12 @@ type QuestionCardState = 'unanswered' | 'answered'
 // grouping helpers live in ./feed/person-grouping (pure + unit-tested).
 type UnifiedRow = GroupInputRow<FeedApiItem>
 
+// D-HOME-PACING-01 §2 (tuned 2026-06-12): on the budgeted home, the texture
+// zone runs this many rows, then the rotating panel as a mid-zone interlude,
+// then the remaining rows (the server caps the set at TEXTURE_SOFT_CAP = 8),
+// closed by the "See all activity →" row.
+const TEXTURE_LEAD_COUNT = 3
+
 // Wrap a promo/panel StreamItem as an activity row so the single rotating panel
 // renders through the shared renderRow path (D-HOME-PACING-01 §2 slot 5).
 function panelRow(item: StreamItem): UnifiedRow {
@@ -1952,7 +1958,13 @@ function FeedListContent({
             // section headings; the page header carries the one title.
             restRows.length > 0 ? (
               <Fragment key="texture">
-                {restRows.map(renderRow)}
+                {restRows.slice(0, TEXTURE_LEAD_COUNT).map(renderRow)}
+                {/* §2 slot 5 (tuned 2026-06-12) — the one rotating panel per
+                    load now runs as a mid-zone interlude after the lead texture
+                    rows, with the remaining rows continuing below it. Budget-
+                    only: the pendingQueue subpages carry no panel. */}
+                {budget?.panel ? renderRow(panelRow(budget.panel)) : null}
+                {restRows.slice(TEXTURE_LEAD_COUNT).map(renderRow)}
                 {/* §4: texture gets NO third subpage — older moments belong to
                     Lately (/activities), the archive of this same stream. Revive
                     the retired "See all activity →" affordance as the zone's
@@ -1976,9 +1988,12 @@ function FeedListContent({
               </Fragment>
             ))
           )}
-          {/* D-HOME-PACING-01 §2 slot 5 — exactly one rotating panel per load,
-              chosen server-side and suppressed on the all-empty page. */}
-          {budget?.panel ? renderRow(panelRow(budget.panel)) : null}
+          {/* D-HOME-PACING-01 §2 slot 5 fallback — when the texture zone is
+              empty the single rotating panel still renders once, here at the
+              foot of the page (suppressed on the all-empty page, where the
+              server sends panel: null). With texture present it renders mid-
+              zone above instead. */}
+          {budget?.panel && restRows.length === 0 ? renderRow(panelRow(budget.panel)) : null}
         </section>
       )}
 

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -142,7 +142,15 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
         has_more: false,
         next_cursor: null,
       },
-      activityItems: [playable('p0', 'josh'), playable('p1', 'rob'), texture('t0')],
+      activityItems: [
+        playable('p0', 'josh'),
+        playable('p1', 'rob'),
+        texture('t0'),
+        texture('t1'),
+        texture('t2'),
+        texture('t3'),
+        texture('t4'),
+      ],
       budget: {
         directOverflowCount: 4,
         playablesOverflowCount: 3,
@@ -170,8 +178,13 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     // subpage (§4); the revived "See all activity →" row closes the zone.
     expect(html).toContain('See all activity →')
     expect(html).toContain('href="/activities"')
-    // Exactly one rotating panel.
-    expect(html).toContain('PANEL:add_friends')
+    // Exactly one rotating panel, interleaved after the third texture row
+    // (§2 slot 5, tuned 2026-06-12): t0 t1 t2, panel, t3 t4, see-all.
+    const panelAt = html.indexOf('PANEL:add_friends')
+    expect(panelAt).toBeGreaterThan(html.indexOf('activity:t2:'))
+    expect(panelAt).toBeLessThan(html.indexOf('activity:t3:'))
+    expect(html.indexOf('See all activity →')).toBeGreaterThan(html.indexOf('activity:t4:'))
+    expect(html.lastIndexOf('PANEL:')).toBe(panelAt) // one panel, not two
   })
 
   it('all three zones empty → inline empty state, panel suppressed (§9)', () => {

--- a/src/server/home/__tests__/select-edition.test.ts
+++ b/src/server/home/__tests__/select-edition.test.ts
@@ -4,6 +4,7 @@ import type { StreamItem } from '@/lib/activity-stream'
 import {
   DIRECT_SERVE_CAP,
   PLAYABLE_SERVE_CAP,
+  TEXTURE_SOFT_CAP,
   interleaveByActor,
   isPendingPlayable,
   orderBySenderRotation,
@@ -246,11 +247,11 @@ describe('isPendingPlayable / orderPendingPlayables — §7 pending definition',
 // --- selectHomeEdition: texture bounding (§4) --------------------------------
 
 describe('selectHomeEdition — texture', () => {
-  it('bounds texture to today-and-yesterday and soft-caps it', () => {
+  it('soft-caps texture at 8 and prefers today-and-yesterday over older items', () => {
     const activityItems = [
       textureItem('t-now', '2026-06-11T17:00:00Z'),
       textureItem('t-yesterday', '2026-06-10T20:00:00Z'),
-      textureItem('t-old', '2026-06-01T12:00:00Z'), // > 2 days → dropped
+      textureItem('t-old', '2026-06-01T12:00:00Z'), // fresh items fill the cap → dropped
       ...Array.from({ length: 8 }, (_, i) => textureItem(`t-fresh${i}`, '2026-06-11T1' + (i % 9) + ':00:00Z')),
     ]
     const edition = selectHomeEdition({
@@ -259,8 +260,24 @@ describe('selectHomeEdition — texture', () => {
       promos: { sharedGround: null, expanding: null, growCircle: null },
       now: NOW,
     })
-    expect(edition.texture.length).toBeLessThanOrEqual(5)
+    expect(edition.texture).toHaveLength(TEXTURE_SOFT_CAP)
     expect(edition.texture.map((t) => t.id)).not.toContain('t-old')
+  })
+
+  it('backfills older moments (newest-first) when the fresh window is under the cap', () => {
+    const activityItems = [
+      textureItem('t-old-newer', '2026-06-05T12:00:00Z'),
+      textureItem('t-fresh', '2026-06-11T17:00:00Z'),
+      textureItem('t-old-older', '2026-06-02T12:00:00Z'),
+    ]
+    const edition = selectHomeEdition({
+      feedItems: [],
+      activityItems,
+      promos: { sharedGround: null, expanding: null, growCircle: null },
+      now: NOW,
+    })
+    // Fresh leads; the quiet window no longer starves the zone at one row.
+    expect(edition.texture.map((t) => t.id)).toEqual(['t-fresh', 't-old-newer', 't-old-older'])
   })
 })
 

--- a/src/server/home/select-edition.ts
+++ b/src/server/home/select-edition.ts
@@ -28,7 +28,10 @@ export type FeedEditionItem = FeedPagePayload['items'][number]
 // overflow is always reachable via the subpages (B-HOME-OVERFLOW-02).
 export const DIRECT_SERVE_CAP = 3
 export const PLAYABLE_SERVE_CAP = 4
-export const TEXTURE_SOFT_CAP = 5
+// Tuned 2026-06-12: the texture zone runs three rows, then the rotating panel
+// as a mid-zone interlude, then up to five more rows (FeedList owns the panel
+// placement; this layer just bounds the set).
+export const TEXTURE_SOFT_CAP = 8
 
 const DAY_MS = 24 * 60 * 60 * 1000
 
@@ -54,7 +57,8 @@ export type HomeEdition = {
   playables: ServedZone<StreamItem>
   /**
    * Texture — chronological full-sentence lone social events (locked Group 3),
-   * bounded to today-and-yesterday, soft-capped (~5). No overflow subpage.
+   * newest-first, today-and-yesterday preferred with older backfill, soft-
+   * capped (~8). No overflow subpage.
    */
   texture: StreamItem[]
   /** Exactly one rotating panel per load; null on the all-empty page (§9). */
@@ -162,10 +166,11 @@ export function interleaveByActor<T>(
 }
 
 /**
- * §2 slot 4 / §4 — texture is bounded to today-and-yesterday. Older social
- * moments belong to the biweekly ceremony / archive, not the home edition. A
- * rolling 48-hour window from `now` is a timezone-agnostic proxy for "today and
- * yesterday." Newest-first, then soft-capped.
+ * §2 slot 4 / §4 — texture prefers today-and-yesterday (a rolling 48-hour
+ * window from `now` is the timezone-agnostic proxy). Tuned 2026-06-12: when
+ * the fresh window can't fill the soft cap, older moments backfill —
+ * newest-first — so a quiet stretch doesn't leave the zone threadbare. The
+ * cap, not the window, bounds the page.
  */
 export function boundTexture(
   items: readonly StreamItem[],
@@ -173,10 +178,10 @@ export function boundTexture(
   cap = TEXTURE_SOFT_CAP,
 ): StreamItem[] {
   const floor = now - 2 * DAY_MS
-  return [...items]
-    .filter((item) => ms(item.sortAt) >= floor)
-    .sort((a, b) => ms(b.sortAt) - ms(a.sortAt))
-    .slice(0, cap)
+  const sorted = [...items].sort((a, b) => ms(b.sortAt) - ms(a.sortAt))
+  const fresh = sorted.filter((item) => ms(item.sortAt) >= floor)
+  if (fresh.length >= cap) return fresh.slice(0, cap)
+  return [...fresh, ...sorted.filter((item) => ms(item.sortAt) < floor)].slice(0, cap)
 }
 
 /**


### PR DESCRIPTION
- Raise TEXTURE_SOFT_CAP 5 -> 8; boundTexture now backfills older moments
  (newest-first) when the 48h window is under the cap, so a quiet stretch
  no longer starves the zone at three rows
- Render the single rotating panel after the third texture row as a
  mid-zone interlude (falls back to the page foot when texture is empty)
- Keep "See all activity ->" closing the zone
- Update FeedListBudget + select-edition tests; note the tuning in
  D-HOME-PACING-01.md

https://claude.ai/code/session_01KngVa5Lbkw6P9QuViZvqwd