### PR TITLE
Shared Ground: show up to two areas per friend, swipe stays per-friend

### DIFF
--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -62,9 +62,10 @@ function rotate<T>(pool: readonly T[], index: number | undefined): T {
 
 /**
  * "Shared Ground" — the overlapping-circle motif as a full-bleed editorial
- * feature. A carousel with a slide per friend (each their strongest shared-but-
- * untested domain), so the viewer can rotate through a few of the people they
- * share ground with, plus a closing nudge to widen their circle.
+ * feature. A carousel with a slide per friend (each showing their one or two
+ * strongest shared-but-untested areas), so swiping moves between PEOPLE the
+ * viewer shares ground with — never between areas — plus a closing nudge to
+ * widen their circle.
  */
 export function CommonGroundFeature({
   embed,
@@ -74,7 +75,9 @@ export function CommonGroundFeature({
   // One shared scale across every slide so circles are comparable friend to
   // friend, not re-normalized per slide.
   const datasetMax = circleDatasetMax(
-    embed.friends.flatMap((f) => [f.domain.viewer.points, f.domain.friend.points]),
+    embed.friends.flatMap((f) =>
+      f.domains.flatMap((d) => [d.viewer.points, d.friend.points]),
+    ),
   );
   const count = embed.friends.length;
   const headline = rotate(COMMON_GROUND_HEADLINES, embed.headlineIndex);
@@ -114,26 +117,33 @@ export function CommonGroundFeature({
           slides={[
             ...embed.friends.map((f) => (
               <div key={f.friendId} className="flex flex-col gap-4">
-                <DomainCircleSvg
-                  viewerPoints={f.domain.viewer.points}
-                  friendPoints={f.domain.friend.points}
-                  viewerTier={f.domain.viewer.tier}
-                  friendTier={f.domain.friend.tier}
-                  datasetMax={datasetMax}
-                  scale={SHARED_GROUND_CIRCLE_SCALE}
-                  ariaLabel={`${f.domain.label}: shared with ${f.friendFirstName}, still untested`}
-                />
-                <span className="flex max-w-[150px] flex-col gap-0.5">
-                  <Link
-                    href={f.friendHref}
-                    className="font-serif text-[15px] leading-snug font-semibold text-[var(--brand-ink)] no-underline hover:underline"
-                  >
-                    {f.friendFirstName}
-                  </Link>
-                  <span className="font-serif text-[13px] leading-snug text-[var(--brand-ink-400)]">
-                    {f.domain.label}
-                  </span>
-                </span>
+                {/* One or two shared areas side by side — each circle motif with
+                    its area label underneath, bottom-aligned so the labels share
+                    a baseline whatever the circle heights. */}
+                <div className="flex items-end gap-10">
+                  {f.domains.map((d) => (
+                    <span key={d.label} className="flex flex-col gap-2">
+                      <DomainCircleSvg
+                        viewerPoints={d.viewer.points}
+                        friendPoints={d.friend.points}
+                        viewerTier={d.viewer.tier}
+                        friendTier={d.friend.tier}
+                        datasetMax={datasetMax}
+                        scale={SHARED_GROUND_CIRCLE_SCALE}
+                        ariaLabel={`${d.label}: shared with ${f.friendFirstName}, still untested`}
+                      />
+                      <span className="max-w-[150px] font-serif text-[13px] leading-snug text-[var(--brand-ink-400)]">
+                        {d.label}
+                      </span>
+                    </span>
+                  ))}
+                </div>
+                <Link
+                  href={f.friendHref}
+                  className="max-w-[150px] font-serif text-[15px] leading-snug font-semibold text-[var(--brand-ink)] no-underline hover:underline"
+                >
+                  {f.friendFirstName}
+                </Link>
               </div>
             )),
             // Final slide: a gentle nudge to widen the circle. The personal-invite

--- a/src/components/feed/__tests__/EditorialCarousel.test.tsx
+++ b/src/components/feed/__tests__/EditorialCarousel.test.tsx
@@ -62,36 +62,48 @@ describe('CommonGroundFeature carousel', () => {
         friendId: 'sadie',
         friendFirstName: 'Sadie',
         friendHref: '/users/sadie',
-        domain: {
-          label: 'Simpsons Catchphrases',
-          viewer: { points: 40, tier: 'solid' },
-          friend: { points: 30, tier: 'familiar' },
-        },
+        domains: [
+          {
+            label: 'Simpsons Catchphrases',
+            viewer: { points: 40, tier: 'solid' },
+            friend: { points: 30, tier: 'familiar' },
+          },
+          {
+            label: 'Star Wars',
+            viewer: { points: 25, tier: 'familiar' },
+            friend: { points: 35, tier: 'solid' },
+          },
+        ],
       },
       {
         friendId: 'theo',
         friendFirstName: 'Theo',
         friendHref: '/users/theo',
-        domain: {
-          label: 'Bikini Bottom',
-          viewer: { points: 20, tier: 'familiar' },
-          friend: { points: 20, tier: 'familiar' },
-        },
+        domains: [
+          {
+            label: 'Bikini Bottom',
+            viewer: { points: 20, tier: 'familiar' },
+            friend: { points: 20, tier: 'familiar' },
+          },
+        ],
       },
     ],
   };
 
   it('renders a slide per friend plus a final "Invite someone" slide linking to /friends/find', () => {
     const html = renderToStaticMarkup(<CommonGroundFeature embed={embed} />);
-    // Each friend slide shows the friend's name and their shared domain.
+    // Each friend slide shows the friend's name and their shared areas — both of
+    // Sadie's, Theo's single one.
     expect(html).toContain('Sadie');
     expect(html).toContain('Simpsons Catchphrases');
+    expect(html).toContain('Star Wars');
     expect(html).toContain('Theo');
     expect(html).toContain('Bikini Bottom');
     expect(html).toContain('href="/users/theo"');
     expect(html).toContain('Invite someone');
     expect(html).toContain('href="/friends/find"');
-    // Two friends + invite = three pagination dots.
+    // Two friends + invite = three pagination dots: the carousel pages by
+    // FRIEND, so Sadie's two areas share one slide rather than adding a fourth.
     const dots = html.match(/aria-label="Go to item \d+ of 3"/g) ?? [];
     expect(dots).toHaveLength(3);
   });

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -145,16 +145,17 @@ export type CommonGroundPromoDomain = {
   friend: { points: number; tier: MasteryTier };
 };
 
-// One friend in the common-ground promo carousel: the friend, plus their single
-// strongest shared-but-untested domain (the circle hero). The promo carries a
-// few of these so the carousel is a quiet tour of the viewer's circle — a slide
-// per friend — rather than a single relationship. One domain per slide keeps the
-// overlapping-circle motif uncrowded (more than one circle crowds it).
+// One friend in the common-ground promo carousel: the friend, plus their
+// strongest shared-but-untested domains (at least one, at most two — see
+// MAX_DOMAINS_PER_FRIEND in common-ground-promo.ts). The promo carries a few of
+// these so the carousel is a quiet tour of the viewer's circle — a slide per
+// friend, with swipes moving between PEOPLE, not between areas.
 export type CommonGroundPromoFriend = {
   friendId: string;
   friendFirstName: string;
   friendHref: string;
-  domain: CommonGroundPromoDomain;
+  // Strongest first; never empty.
+  domains: CommonGroundPromoDomain[];
 };
 
 export type RecentlyExpandingPromoDomain = {

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -20,11 +20,14 @@ import {
 import { getCommonGround } from '@/server/db/queries/common-ground';
 import { getFriends } from '@/server/db/queries/friends';
 
-// The editorial "Shared Ground" carousel shows a slide per friend (each with
-// their single strongest shared-but-untested domain), so the viewer can rotate
-// through a few of the people they share ground with. One circle per slide keeps
-// the motif the hero (more than one crowds it). See CommonGroundFeature.
+// The editorial "Shared Ground" carousel shows a slide per friend, so swiping
+// rotates through PEOPLE the viewer shares ground with (not through areas). See
+// CommonGroundFeature.
 const MAX_PROMO_FRIENDS = 3;
+// Each friend's slide shows their strongest shared-but-untested domains — at
+// least one, and a second when they share more than one area. Two keeps the
+// circle motif the hero without crowding the slide.
+const MAX_DOMAINS_PER_FRIEND = 2;
 // Cap the per-render getCommonGround probes so the homepage stays cheap even for
 // users with many friends; the rotation still cycles through everyone over time.
 const MAX_CANDIDATES = 4;
@@ -69,17 +72,17 @@ export async function getCommonGroundPromo(
     const latent = grounds[i].latent;
     if (latent.length === 0) continue;
 
-    // The friend's single strongest shared-but-untested domain is the hero.
-    const top = latent[0];
+    // The friend's strongest shared-but-untested domains (up to two), strongest
+    // first — latent is already sorted by combined mastery points.
     promoFriends.push({
       friendId: friend.id,
       friendFirstName: firstName(friend.displayName),
       friendHref: `/users/${friend.id}`,
-      domain: {
-        label: top.canonical_subcategory,
-        viewer: { points: top.viewer.mastery_points, tier: top.viewer.current_tier },
-        friend: { points: top.friend.mastery_points, tier: top.friend.current_tier },
-      },
+      domains: latent.slice(0, MAX_DOMAINS_PER_FRIEND).map((d) => ({
+        label: d.canonical_subcategory,
+        viewer: { points: d.viewer.mastery_points, tier: d.viewer.current_tier },
+        friend: { points: d.friend.mastery_points, tier: d.friend.current_tier },
+      })),
     });
   }
 


### PR DESCRIPTION
Each carousel slide now carries the friend's one or two strongest
shared-but-untested areas (CommonGroundPromoFriend.domain ->
domains[]), rendered as side-by-side circle motifs with the area
labels underneath and the friend's name below. Swiping continues to
move between friends — never between areas — with the closing invite
slide unchanged.

https://claude.ai/code/session_013CG66SDEJPTifcFynsrr2r