### PR TITLE
Remove inline hide-category link from FriendAddedCard

### DIFF
--- a/_docs/D-FEED-INVENTORY-01.md
+++ b/_docs/D-FEED-INVENTORY-01.md
@@ -95,7 +95,7 @@ literal. Quoted verbatim from the `line:` arrays.
 
 | `card_type` | Verbatim template | Meaning | Playable? | Plural | Fallback name |
 |---|---|---|---|---|---|
-| `direct_sent` (`DirectSentCard`+`SparkleEnvelope`) | `{senderName}` + `" thought you'd like this"` + ` about {category}` *(if category)* + `.` ; optional italic `"{personalMessage}"` | A friend sent you this question | **YES** ("Answer →") | — | `'A friend'` |
+| `direct_sent` (`DirectSentCard`+`SparkleEnvelope`) | eyebrow `'Sent directly to you'` + `{senderName}` + `" thought you'd like this"` + ` about {category}` *(if category)* + `.` ; optional italic `"{personalMessage}"` | A friend sent you this question | **YES** ("Answer →") | — | `'A friend'` |
 | `friend_added` (`FriendAddedCard`) | `{friendName}` + `' added a question'` + ` about {category}` *(if category)* | A friend authored/broadcast a question | **YES** ("Answer →") | — | `'A friend'` |
 | `friend_liked` (`FriendLikedCard`+`FeedCard`) | `{authorName}` + `' thought you would like this'` | A friend endorsed this question | **YES** ("Answer →") | endorsement collapse fields carried but **NOT rendered** (see §E) | `'Someone'` |
 | `answered_by_you` (`AnsweredByYouCard`) | eyebrow `'You answered'` + one of 6 comparison lines (§B) | Result of a question you already answered | No (Try again → / Recheck →) | single paired friend only | `'They'` |

--- a/_docs/D-FEED-INVENTORY-01.md
+++ b/_docs/D-FEED-INVENTORY-01.md
@@ -96,7 +96,7 @@ literal. Quoted verbatim from the `line:` arrays.
 | `card_type` | Verbatim template | Meaning | Playable? | Plural | Fallback name |
 |---|---|---|---|---|---|
 | `direct_sent` (`DirectSentCard`+`SparkleEnvelope`) | `{senderName}` + `" thought you'd like this"` + ` about {category}` *(if category)* + `.` ; optional italic `"{personalMessage}"` | A friend sent you this question | **YES** ("Answer →") | — | `'A friend'` |
-| `friend_added` (`FriendAddedCard`) | `{friendName}` + `' added a question'` + ` about {category}` *(if category)*; optional ` · Hide questions about {category}` | A friend authored/broadcast a question | **YES** ("Answer →") | — | `'A friend'` |
+| `friend_added` (`FriendAddedCard`) | `{friendName}` + `' added a question'` + ` about {category}` *(if category)* | A friend authored/broadcast a question | **YES** ("Answer →") | — | `'A friend'` |
 | `friend_liked` (`FriendLikedCard`+`FeedCard`) | `{authorName}` + `' thought you would like this'` | A friend endorsed this question | **YES** ("Answer →") | endorsement collapse fields carried but **NOT rendered** (see §E) | `'Someone'` |
 | `answered_by_you` (`AnsweredByYouCard`) | eyebrow `'You answered'` + one of 6 comparison lines (§B) | Result of a question you already answered | No (Try again → / Recheck →) | single paired friend only | `'They'` |
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1759,7 +1759,6 @@ function FeedListContent({
           overflow={overflow}
           onAnswer={onAnswer}
           onDismiss={onDismiss}
-          onHideCategory={() => void hideCategory(item)}
           elevated={homeZoneCards}
         />
       )

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -41,6 +41,10 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, elevated }
 
   return (
     <SparkleEnvelope
+      // Direct sends share the plain hairline-bordered tile with broadcasts
+      // (the triangle mat is retired); the eyebrow is what marks them out.
+      variant="bordered"
+      eyebrow="Sent directly to you"
       signal={signal}
       question={item.question}
       overflow={overflow}

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -10,7 +10,6 @@ type FriendAddedCardProps = {
   overflow?: ReactNode
   onAnswer?: () => void
   onDismiss?: () => void
-  onHideCategory?: () => void
   className?: string
   elevated?: boolean
 }
@@ -20,7 +19,6 @@ export function FriendAddedCard({
   overflow,
   onAnswer,
   onDismiss,
-  onHideCategory,
   className,
   elevated,
 }: FriendAddedCardProps) {
@@ -39,18 +37,6 @@ export function FriendAddedCard({
       )}{' '}
       added a question
       {visibleCategory ? <> about {visibleCategory}</> : null}
-      {visibleCategory && onHideCategory ? (
-        <>
-          <span className="mx-1.5 opacity-50">·</span>
-          <button
-            type="button"
-            onClick={onHideCategory}
-            className="font-medium text-[var(--brand-link)] hover:underline"
-          >
-            Hide questions about {visibleCategory}
-          </button>
-        </>
-      ) : null}
     </>
   )
 

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -42,8 +42,8 @@ export function FriendAddedCard({
 
   return (
     <SparkleEnvelope
-      // Broadcasts render on the plain hairline-bordered tile (Figma Frame 2),
-      // not the triangle mat — that motif is reserved for direct sends.
+      // Plain hairline-bordered tile (Figma Frame 2) — the same chrome as
+      // direct sends, which carry the "Sent directly to you" eyebrow instead.
       variant="bordered"
       signal={signal}
       question={item.question}

--- a/src/components/feed/SparkleEnvelope.tsx
+++ b/src/components/feed/SparkleEnvelope.tsx
@@ -7,6 +7,8 @@ import { FeedCardShell } from './FeedCardShell'
 import { FeedDismissButton } from './FeedDismissButton'
 
 type SparkleEnvelopeProps = {
+  /** Small-caps line above the attribution — e.g. "Sent directly to you". */
+  eyebrow?: ReactNode
   /** Attribution line — e.g. "<actor> thought you'd like this about <category>." */
   signal: ReactNode
   question: string
@@ -17,10 +19,12 @@ type SparkleEnvelopeProps = {
   answerLabel?: string
   className?: string
   /**
-   * Card chrome. 'triangle' (default) mats the question on the app triangle
-   * pattern — the "sent directly to you" treatment. 'bordered' is the plain
-   * hairline-border tile used for broadcasts ("shared a question about"). Both
-   * keep the identical inner layout (divider, dismiss, Answer link).
+   * Card chrome. 'bordered' is the plain hairline-border tile both feed cards
+   * (direct sends and broadcasts) now use; direct sends are distinguished by
+   * the "Sent directly to you" eyebrow instead of the chrome. 'triangle'
+   * (default for back-compat) mats the question on the app triangle pattern —
+   * retired from the feed but kept in FeedCardShell. Both keep the identical
+   * inner layout (divider, dismiss, Answer link).
    */
   variant?: 'triangle' | 'bordered'
   /** Tier 1 "playable" lift on the unified home feed. Forwarded to FeedCardShell. */
@@ -28,13 +32,15 @@ type SparkleEnvelopeProps = {
 }
 
 /**
- * The "shared with you" feed card (DirectSentCard, FriendAddedCard), built to
- * the Figma triangle-bordered design (frame 137:5911): the app triangle pattern
- * mats a cream card with a grey rule, a focal serif question, and an "Answer →"
- * link. The pattern is the same /images/Variant4.png used on the login/home
- * triangle banner, so the motif and scale stay consistent across surfaces.
+ * The "shared with you" feed card (DirectSentCard, FriendAddedCard): a cream
+ * card with a grey rule, a focal serif question, and an "Answer →" link, with
+ * an optional small-caps eyebrow ("Sent directly to you") above the
+ * attribution. Originally built to the Figma triangle-bordered design (frame
+ * 137:5911) — that mat survives as the 'triangle' variant but the feed now
+ * renders both card types on the plain bordered tile.
  */
 export function SparkleEnvelope({
+  eyebrow,
   signal,
   question,
   overflow,
@@ -49,9 +55,17 @@ export function SparkleEnvelope({
     <FeedCardShell variant={variant} className={className} elevated={elevated}>
       <div className="flex flex-col items-center gap-5 p-[14px]">
         <div className="flex w-full items-start justify-between gap-3">
-          <p className="font-sans text-[15px] leading-[23px] tracking-[0.05em] text-[var(--brand-ink)]">
-            {signal}
-          </p>
+          <div className="min-w-0 flex-1">
+            {eyebrow ? (
+              // Same small-caps eyebrow rhythm as the AnsweredByYouCard header.
+              <p className="mb-2 text-[11px] uppercase leading-none tracking-[0.08em] text-[var(--brand-ink)] opacity-70">
+                {eyebrow}
+              </p>
+            ) : null}
+            <p className="font-sans text-[15px] leading-[23px] tracking-[0.05em] text-[var(--brand-ink)]">
+              {signal}
+            </p>
+          </div>
           {overflow ? <div className="shrink-0">{overflow}</div> : null}
         </div>
 

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -91,6 +91,19 @@ describe('Feed card preview fixtures', () => {
     expect(answeredByYou).toContain('You both had it')
   })
 
+  it('marks direct sends with the eyebrow on the plain bordered tile (no triangle mat)', () => {
+    const directSent = html(
+      <DirectSentCard item={feedCardPreviewFixtures.directSentUnanswered} />
+    )
+    expect(directSent).toContain('Sent directly to you')
+    expect(directSent).not.toContain('/images/Variant4.png')
+
+    const friendAdded = html(
+      <FriendAddedCard item={feedCardPreviewFixtures.friendAddedWroteQuestion} />
+    )
+    expect(friendAdded).not.toContain('Sent directly to you')
+  })
+
   it('drops the "has knowledge to share" phrasing from the unanswered question card', () => {
     const variants = [
       html(<DirectSentCard item={feedCardPreviewFixtures.directSentUnanswered} />),
@@ -400,7 +413,7 @@ describe('Answer feedback sheet recheck affordance', () => {
 })
 
 describe('Authored-by-viewer card', () => {
-  it('renders the authored attribution and category (Figma triangle card has no eyebrow)', () => {
+  it('renders the authored attribution and category (broadcast card has no eyebrow)', () => {
     const rendered = html(
       <FriendAddedCard
         item={feedCardPreviewFixtures.authoredByViewerUnanswered}


### PR DESCRIPTION
The card header rendered 'Hide questions about {category}' as an inline
link next to the attribution line, duplicating the same action already
available in the ··· overflow menu. Drop the inline link and its
onHideCategory prop; the overflow menu path is unchanged.

https://claude.ai/code/session_014gRfBgeM7UCfRQrjSY6FWm