### PR TITLE
Widen answer-grading fast-path to skip the LLM for trivial variants

### DIFF
--- a/src/server/__tests__/grading-fail-toward-player.test.ts
+++ b/src/server/__tests__/grading-fail-toward-player.test.ts
@@ -32,6 +32,34 @@ describe('gradeAnswer — acceptable variants (B4 Phase 4)', () => {
     if (result.status !== 'scored') throw new Error('expected scored');
     expect(result.result).toBe('correct');
   });
+
+  // The deterministic fast-path normalizes away trivial differences so the
+  // common "right answer, slightly off spelling" case skips the blocking LLM
+  // round-trip entirely. Each of these must score WITHOUT calling the LLM.
+  it.each([
+    ['punctuation', 'Spider Man', 'Spider-Man!'],
+    ['diacritics', 'Beyonce', 'Beyoncé'],
+    ['leading article', 'Eroica', 'The Eroica'],
+    ['hyphenation', 'Wall E', 'Wall-E'],
+    ['extra whitespace', '  the   police ', 'The Police'],
+  ])('marks a %s variant correct without the LLM', async (_label, submitted, canonical) => {
+    const result = await gradeAnswer(submitted, canonical, [], 'q');
+    expect(result.status).toBe('scored');
+    if (result.status !== 'scored') throw new Error('expected scored');
+    expect(result.result).toBe('correct');
+    expect(result.gradedVia).toBe('exact');
+    expect(llmMock.gradeAnswerWithLLM).not.toHaveBeenCalled();
+  });
+
+  // Guard against over-eager normalization: dropping an *interior* article would
+  // collapse "Vitamin A" onto "Vitamin". It must not — that defers to the LLM.
+  it('does not collapse an interior article (Vitamin A ≠ Vitamin)', async () => {
+    llmMock.gradeAnswerWithLLM.mockResolvedValue({
+      status: 'scored', result: 'wrong', confidence: 0.9, reason: 'different', consolation: null,
+    });
+    await gradeAnswer('Vitamin', 'Vitamin A', [], 'q');
+    expect(llmMock.gradeAnswerWithLLM).toHaveBeenCalledOnce();
+  });
 });
 
 describe('gradeAnswer — fail toward the player on outage (Drift Risk 2)', () => {

--- a/src/server/grading.ts
+++ b/src/server/grading.ts
@@ -38,18 +38,42 @@ export type UnscoredGrade = {
 export type GradeOutcome = ScoredGrade | UnscoredGrade;
 
 /**
- * Fast-path exact match before calling the LLM.
- * Returns true if the submission is an obvious exact/alternative match.
+ * Normalize an answer for the deterministic fast-path: lower-case, strip
+ * diacritics, drop punctuation, collapse whitespace, and remove a single
+ * leading article. This is deliberately conservative — it only ever causes the
+ * fast-path to fire (returning `correct`) when two answers are character-for-
+ * character the same once trivial differences are removed, so it cannot
+ * manufacture a false `correct` for a genuinely different answer. A leading
+ * article is dropped (e.g. "The Eroica" ≡ "Eroica") but interior articles are
+ * kept so distinct answers like "Vitamin A" don't collapse onto "Vitamin".
+ */
+function normalizeForMatch(value: string): string {
+  return value
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // strip diacritics: "Beyoncé" → "Beyonce"
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, ' ') // punctuation → space: "J.S. Bach" → "j s bach"
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/^(the|a|an) /, ''); // drop a single leading article
+}
+
+/**
+ * Fast-path exact match before calling the LLM. Returns true if the submission
+ * is the same answer as the canonical (or an accepted alternative) once trivial
+ * differences — case, diacritics, punctuation, whitespace, a leading article —
+ * are normalized away. Catching these here skips the blocking LLM round-trip for
+ * the common "right answer, slightly different spelling" case.
  */
 function exactMatch(
   submitted: string,
   canonicalAnswer: string,
   acceptedAlternatives: string[]
 ): boolean {
-  const normalized = submitted.trim().toLowerCase();
+  const normalized = normalizeForMatch(submitted);
   if (!normalized) return false;
-  if (normalized === canonicalAnswer.trim().toLowerCase()) return true;
-  return acceptedAlternatives.some((alt) => alt.trim().toLowerCase() === normalized);
+  if (normalized === normalizeForMatch(canonicalAnswer)) return true;
+  return acceptedAlternatives.some((alt) => normalizeForMatch(alt) === normalized);
 }
 
 /**


### PR DESCRIPTION
The blocking, non-streaming Haiku grade call is what users feel as the
answer-check delay. The deterministic fast-path that bypasses it only
matched on trim + lowercase, so common same-answer variants (diacritics,
punctuation, hyphenation, a leading article, extra whitespace) all paid
for a full LLM round-trip.

Normalize both sides before comparing so these cases resolve instantly.
The normalization is conservative: it only ever fires the fast-path
(returning correct) when the strings are identical once trivial
differences are removed, and it keeps interior articles so distinct
answers like "Vitamin A" don't collapse onto "Vitamin".