### PR TITLE
Simplify answer reveal popup: answer-first, de-boxed, one-sentence explainer

### DIFF
--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState, type CSSProperties } from 'react'
 import { Check, MoreHorizontal, Sparkles, X } from 'lucide-react'
 
 import { answerHeadingStyle } from '@/components/answer-heading'
+import { firstSentence } from '@/lib/first-sentence'
 import { FeedActionLink } from './FeedActionLink'
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
@@ -238,10 +239,6 @@ export function AnswerFeedbackSheet({
             />
           ) : null}
 
-          <p className="pb-2 font-serif text-lg leading-6 text-[var(--brand-ink)]">
-            {question}
-          </p>
-
           <div className="space-y-1 pb-2">
             {correctAnswer ? (
               <p
@@ -267,22 +264,22 @@ export function AnswerFeedbackSheet({
             ) : null}
           </div>
 
+          {/* The question reads as context for the answer, so it sits below the
+              answer headline (not above it). De-boxed: plain text, no panel. */}
+          <p className="pb-2 font-serif text-lg leading-6 text-[var(--brand-ink)]">
+            {question}
+          </p>
+
           {explanation ? (
-            <div className="rounded-2xl bg-muted p-3.5">
-              <p className="font-serif text-[15px] leading-6 text-[var(--brand-ink-700)]">
-                {explanation}
-              </p>
-            </div>
+            // Match the daily-5 game's reveal: a single-sentence explainer under
+            // the answer, not the full paragraph (which ran too long here).
+            <p className="pb-2 font-serif text-[15px] leading-6 text-[var(--brand-ink-700)]">
+              {firstSentence(explanation)}
+            </p>
           ) : null}
 
           {insideJoke ? (
-            <div
-              className="mt-2.5 rounded-2xl border p-3.5"
-              style={{
-                backgroundColor: 'color-mix(in srgb, var(--accent-gold) 12%, var(--brand-card))',
-                borderColor: 'color-mix(in srgb, var(--accent-gold) 40%, var(--brand-border))',
-              }}
-            >
+            <div className="pt-1">
               <p
                 className="text-[0.62rem] font-semibold tracking-[0.18em] uppercase"
                 style={{ color: GOLD_INK }}
@@ -296,7 +293,7 @@ export function AnswerFeedbackSheet({
           ) : null}
 
           {creatorNote ? (
-            <div className="mt-2.5 rounded-2xl border bg-muted p-3.5">
+            <div className="pt-3">
               <p className="text-[0.62rem] font-semibold tracking-[0.18em] uppercase text-muted-foreground">
                 Why they asked
               </p>

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -6,6 +6,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 
 import { answerHeadingStyle } from '@/components/answer-heading';
+import { firstSentence } from '@/lib/first-sentence';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { ThreadCard } from '@/components/play/ThreadCard';
 import { SessionCloseMessage } from '@/components/play/SessionCloseMessage';
@@ -190,12 +191,6 @@ const WRONG_NAMED_SUBLABEL: Array<(name: string) => string> = [
 // Trim an explainer to its first sentence for the live thread — the full text
 // still lives in the End of Session Review. Keeps the thread moving while giving
 // a one-line "why" directly under the answer.
-function firstSentence(text: string): string {
-  const trimmed = text.trim();
-  const match = trimmed.match(/^.*?[.!?](?=\s|$)/);
-  return match ? match[0] : trimmed;
-}
-
 function firstNameFrom(creatorName: string): string {
   const trimmed = creatorName.trim();
   const space = trimmed.indexOf(' ');

--- a/src/lib/first-sentence.ts
+++ b/src/lib/first-sentence.ts
@@ -1,0 +1,10 @@
+// The leading sentence of a longer explanation. Answer-reveal surfaces show
+// this one-line explainer directly under the answer; the full text lives in the
+// End of Session Review (see GameplayChat's ResultRow), so nothing is lost.
+// Shared so the in-game result card and the feed reveal sheet truncate
+// identically.
+export function firstSentence(text: string): string {
+  const trimmed = text.trim()
+  const match = trimmed.match(/^.*?[.!?](?=\s|$)/)
+  return match ? match[0] : trimmed
+}


### PR DESCRIPTION
- Lead with the answer as the headline; move the question text below it.
- Drop the boxes around the explanation, the Between us note, and the
  creator note — render them as plain text (keep the small eyebrow labels).
- Match the daily-5 game's reveal by showing only the first sentence of the
  explanation (extracted firstSentence into a shared @/lib/first-sentence
  helper, now used by both GameplayChat and the feed reveal sheet).

https://claude.ai/code/session_01MMmWyafHggNFTCeKrMbL4f