### PR TITLE
Fix Daily Five answer input visibility

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useState, type FormEvent } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
 import { GameplayChatThread } from '@/components/play/GameplayChat';
+import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import { ThreadCard } from '@/components/play/ThreadCard';
 import { useCatchupFlow, type CatchupBatchRecord } from '@/components/play/useCatchupFlow';
 import { CATCH_UP_EMPTY_COPY } from '@/server/play/catch-up-copy';
@@ -38,8 +39,7 @@ export default function DailyCatchupPage() {
   const showSummary = phase === 'summary';
   const roundComplete = phase === 'round_complete';
 
-  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
+  async function handleSubmit() {
     const submitted = answer.trim();
     if (!submitted) return;
     setAnswer('');
@@ -60,14 +60,16 @@ export default function DailyCatchupPage() {
           <Link
             href="/"
             aria-label="Close"
-            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2"
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             <X className="size-5" strokeWidth={1.9} />
           </Link>
         </div>
         <div className="mt-2 flex items-end justify-between gap-3">
           <div>
-            <p className="text-xs font-medium uppercase tracking-[0.12em] text-[var(--text-muted)]">Catch up</p>
+            <p className="text-xs font-medium tracking-[0.12em] text-[var(--text-muted)] uppercase">
+              Catch up
+            </p>
             <h1 className="font-serif text-xl font-semibold text-[var(--text)]">
               {loading
                 ? 'Missed questions'
@@ -75,7 +77,7 @@ export default function DailyCatchupPage() {
             </h1>
           </div>
           {!loading && hasItems && !showSummary ? (
-            <p className="shrink-0 text-right text-[0.65rem] font-medium uppercase tracking-[0.1em] text-[var(--text-muted)]">
+            <p className="shrink-0 text-right text-[0.65rem] font-medium tracking-[0.1em] text-[var(--text-muted)] uppercase">
               {remainingLabel}
             </p>
           ) : null}
@@ -85,9 +87,10 @@ export default function DailyCatchupPage() {
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
         style={{
-          paddingBottom: currentItem && phase === 'playing'
-            ? 'calc(130px + env(safe-area-inset-bottom))'
-            : 'calc(24px + env(safe-area-inset-bottom))',
+          paddingBottom:
+            currentItem && phase === 'playing'
+              ? 'calc(130px + env(safe-area-inset-bottom))'
+              : 'calc(24px + env(safe-area-inset-bottom))',
           // Cream backdrop on the recap so the near-white --brand-card recap cards
           // read against the page, matching the daily Session-recap surface.
           background: showSummary ? 'var(--brand-cream-page)' : undefined,
@@ -98,7 +101,10 @@ export default function DailyCatchupPage() {
         ) : error ? (
           <div
             className="rounded-[var(--radius-sm)] border px-3 py-2 text-sm text-[var(--danger)]"
-            style={{ borderColor: 'var(--danger)', background: 'color-mix(in srgb, var(--danger) 10%, var(--surface))' }}
+            style={{
+              borderColor: 'var(--danger)',
+              background: 'color-mix(in srgb, var(--danger) 10%, var(--surface))',
+            }}
           >
             <p>{error}</p>
             <button type="button" className="btn-ghost mt-3" onClick={() => void reload()}>
@@ -106,7 +112,10 @@ export default function DailyCatchupPage() {
             </button>
           </div>
         ) : !hasItems ? (
-          <div className="mt-10 rounded-[var(--radius-md)] border p-5 text-center" style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}>
+          <div
+            className="mt-10 rounded-[var(--radius-md)] border p-5 text-center"
+            style={{ borderColor: 'var(--border)', background: 'var(--surface-2)' }}
+          >
             <p className="font-serif text-lg text-[var(--text)]">{CATCH_UP_EMPTY_COPY}</p>
             <button type="button" className="btn-primary mt-4" onClick={() => router.push('/')}>
               Back home
@@ -143,30 +152,13 @@ export default function DailyCatchupPage() {
       </section>
 
       {currentItem && !loading && phase === 'playing' ? (
-        <form
-          className="fixed inset-x-0 bottom-0 z-30 mx-auto max-w-lg border-t px-4 py-3"
-          style={{
-            borderColor: 'var(--border)',
-            background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
-            backdropFilter: 'blur(8px)',
-            paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
-          }}
-          onSubmit={(event) => void handleSubmit(event)}
-        >
-          <div className="flex gap-2">
-            <input
-              value={answer}
-              onChange={(event) => setAnswer(event.target.value)}
-              disabled={submitting || isResolvingTurn}
-              placeholder="Your answer..."
-              className="min-h-11 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-4 text-base text-[var(--text)] outline-none"
-              style={{ borderColor: 'var(--border)' }}
-            />
-            <button type="submit" className="btn-primary shrink-0" disabled={submitting || isResolvingTurn || !answer.trim()}>
-              {submitting ? '...' : 'Answer'}
-            </button>
-          </div>
-        </form>
+        <AnswerInputBar
+          value={answer}
+          onChange={setAnswer}
+          onSubmit={handleSubmit}
+          submitting={submitting}
+          disabled={isResolvingTurn}
+        />
       ) : null}
     </main>
   );
@@ -252,7 +244,7 @@ function RoundSummary({
   return (
     <div className="mx-auto max-w-3xl text-[var(--brand-ink)]">
       <header className="pb-2">
-        <p className="text-[0.62rem] font-medium uppercase tracking-[0.12em] text-[var(--game-correct)]">
+        <p className="text-[0.62rem] font-medium tracking-[0.12em] text-[var(--game-correct)] uppercase">
           Round complete
         </p>
         <div className="mt-3 flex items-start justify-between gap-4">
@@ -304,7 +296,7 @@ function RoundSummary({
             type="button"
             className={
               hasMore
-                ? 'text-muted-foreground text-sm font-medium underline underline-offset-4 transition hover:text-foreground'
+                ? 'text-muted-foreground hover:text-foreground text-sm font-medium underline underline-offset-4 transition'
                 : 'btn-primary w-full rounded-full sm:w-auto sm:min-w-56'
             }
             onClick={onHome}
@@ -403,13 +395,13 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
 
       <div className="mt-5 grid gap-3 rounded-md border border-[var(--brand-border)] bg-[var(--brand-cream-page)] p-3 sm:grid-cols-2">
         <div>
-          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+          <p className="text-muted-foreground text-[0.68rem] font-semibold tracking-[0.08em] uppercase">
             You said
           </p>
           <p className="mt-1 text-sm leading-6 text-[var(--brand-ink)]">{yourAnswer}</p>
         </div>
         <div className="border-t border-[var(--brand-border)] pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-3">
-          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+          <p className="text-muted-foreground text-[0.68rem] font-semibold tracking-[0.08em] uppercase">
             Answer
           </p>
           <p
@@ -423,9 +415,7 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
 
       {record.explanation ? (
         <section className="mt-5 pl-1">
-          <h3 className="text-sm font-semibold text-[var(--brand-ink)]">
-            Why this is the answer
-          </h3>
+          <h3 className="text-sm font-semibold text-[var(--brand-ink)]">Why this is the answer</h3>
           <p
             className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]"
             style={

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/play/GameplayChat';
 import { pickOpenedTerritoryDomain } from '@/components/feed/territory';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
+import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import LoadingScreen from '@/components/LoadingScreen';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
@@ -173,8 +174,6 @@ export default function DailyPage() {
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
   const [showFirstRunIntro, setShowFirstRunIntro] = useState(false);
-  // Refs for keeping the answer bar above the on-screen keyboard on mobile.
-  const answerFormRef = useRef<HTMLFormElement>(null);
   const answerInputRef = useRef<HTMLInputElement>(null);
 
   // Show the first-run intro once, only for the server-flagged first untouched
@@ -668,31 +667,6 @@ export default function DailyPage() {
     }
   }, [queue, currentSlot, submitting]);
 
-  // Keep the "Answer" bar above the on-screen keyboard. On mobile the layout
-  // viewport doesn't shrink when the keyboard opens, so a `position: sticky`
-  // footer ends up hidden behind it (the original "scroll to find the button"
-  // bug). The VisualViewport API reports the genuinely-visible region, so we
-  // lift the bar by however much the keyboard overlaps it. Re-runs when the
-  // input bar mounts for a new pending slot. No-ops where VisualViewport is
-  // unsupported — the sticky positioning still applies as before.
-  useEffect(() => {
-    const form = answerFormRef.current;
-    const viewport = window.visualViewport;
-    if (!form || !viewport) return;
-    const update = () => {
-      const overlap = Math.max(0, window.innerHeight - viewport.height - viewport.offsetTop);
-      form.style.transform = overlap > 0 ? `translateY(-${overlap}px)` : '';
-    };
-    update();
-    viewport.addEventListener('resize', update);
-    viewport.addEventListener('scroll', update);
-    return () => {
-      viewport.removeEventListener('resize', update);
-      viewport.removeEventListener('scroll', update);
-      form.style.transform = '';
-    };
-  }, [currentSlot?.slot_index]);
-
   return (
     <main className="mx-auto flex min-h-dvh max-w-lg flex-col px-0">
       <header
@@ -731,7 +705,12 @@ export default function DailyPage() {
 
       <section
         className="flex-1 overflow-y-auto px-4 py-4"
-        style={{ paddingBottom: 'calc(24px + env(safe-area-inset-bottom))' }}
+        style={{
+          paddingBottom:
+            currentSlot && !loading
+              ? 'calc(120px + env(safe-area-inset-bottom))'
+              : 'calc(24px + env(safe-area-inset-bottom))',
+        }}
       >
         {loading ? (
           generatingAttempt != null ? (
@@ -768,62 +747,13 @@ export default function DailyPage() {
       </section>
 
       {currentSlot && !loading ? (
-        <form
-          ref={answerFormRef}
-          className="sticky bottom-0 z-30 mt-auto border-t px-4 py-3"
-          aria-label="Submit your answer"
-          style={{
-            borderColor: 'var(--border)',
-            background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
-            backdropFilter: 'blur(6px)',
-            paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
-            // Smooth the lift/settle as the keyboard opens and closes (the
-            // translateY is driven imperatively by the VisualViewport effect).
-            transition: 'transform 0.15s ease-out',
-          }}
-          onSubmit={(event) => {
-            // Native single-input form submit already fires on Enter/Return;
-            // handling it here keeps the click and keyboard paths identical
-            // across platforms.
-            event.preventDefault();
-            void submitAnswer();
-          }}
-        >
-          <div className="flex gap-2">
-            <input
-              ref={answerInputRef}
-              value={answer}
-              onChange={(event) => setAnswer(event.target.value)}
-              onFocus={() => {
-                // Belt-and-suspenders for browsers without VisualViewport: nudge
-                // the field into view once the keyboard has begun animating in.
-                window.setTimeout(() => {
-                  answerInputRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
-                }, 250);
-              }}
-              disabled={submitting}
-              placeholder="Your answer..."
-              aria-label="Your answer"
-              // Label the keyboard's return key as a send/submit action so it's
-              // the obvious way to answer on mobile.
-              enterKeyHint="send"
-              autoComplete="off"
-              autoCorrect="off"
-              autoCapitalize="off"
-              spellCheck={false}
-              className="min-h-11 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-4 text-base text-[var(--text)] outline-none"
-              style={{ borderColor: 'var(--border)' }}
-            />
-            <button
-              type="submit"
-              className="btn-primary shrink-0"
-              aria-label="Submit answer"
-              disabled={submitting || !answer.trim()}
-            >
-              {submitting ? '...' : 'Answer'}
-            </button>
-          </div>
-        </form>
+        <AnswerInputBar
+          value={answer}
+          onChange={setAnswer}
+          onSubmit={submitAnswer}
+          submitting={submitting}
+          inputRef={answerInputRef}
+        />
       ) : null}
 
       {showFirstRunIntro ? (

--- a/src/components/feed/AnswerSheet.tsx
+++ b/src/components/feed/AnswerSheet.tsx
@@ -1,17 +1,17 @@
-'use client'
+'use client';
 
-import { useEffect, useId, useRef, useState } from 'react'
-import { X } from 'lucide-react'
+import { useEffect, useId, useRef, useState } from 'react';
+import { X } from 'lucide-react';
 
-import { visibleFeedCategory } from './category'
+import { visibleFeedCategory } from './category';
 
 type AnswerSheetProps = {
-  question: string
-  category?: string | null
-  onSubmit: (answer: string) => void
-  onClose: () => void
-  loading?: boolean
-}
+  question: string;
+  category?: string | null;
+  onSubmit: (answer: string) => void;
+  onClose: () => void;
+  loading?: boolean;
+};
 
 export function AnswerSheet({
   question,
@@ -20,30 +20,30 @@ export function AnswerSheet({
   onClose,
   loading = false,
 }: AnswerSheetProps) {
-  const [value, setValue] = useState('')
-  const inputRef = useRef<HTMLInputElement>(null)
-  const inputId = useId()
-  const visibleCategory = visibleFeedCategory(category)
+  const [value, setValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+  const inputId = useId();
+  const visibleCategory = visibleFeedCategory(category);
 
   useEffect(() => {
-    const timer = setTimeout(() => inputRef.current?.focus(), 80)
-    return () => clearTimeout(timer)
-  }, [])
+    const timer = setTimeout(() => inputRef.current?.focus(), 80);
+    return () => clearTimeout(timer);
+  }, []);
 
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') onClose()
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [onClose])
+      if (e.key === 'Escape') onClose();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose]);
 
   const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault()
-    const trimmed = value.trim()
-    if (!trimmed || loading) return
-    onSubmit(trimmed)
-  }
+    e.preventDefault();
+    const trimmed = value.trim();
+    if (!trimmed || loading) return;
+    onSubmit(trimmed);
+  };
 
   return (
     <div className="fixed inset-0 z-[55] flex items-end justify-center">
@@ -56,7 +56,7 @@ export function AnswerSheet({
       <div className="relative w-full max-w-lg rounded-t-3xl bg-[var(--brand-card)] shadow-2xl">
         <div className="flex items-center justify-between px-5 pt-5 pb-2">
           {visibleCategory ? (
-            <p className="text-[0.68rem] font-semibold tracking-[0.18em] uppercase text-[var(--brand-ink-400)]">
+            <p className="text-[0.68rem] font-semibold tracking-[0.18em] text-[var(--brand-ink-400)] uppercase">
               {visibleCategory.toUpperCase()}
             </p>
           ) : (
@@ -66,15 +66,13 @@ export function AnswerSheet({
             type="button"
             onClick={onClose}
             aria-label="Close"
-            className="inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            className="hover:bg-muted hover:text-foreground focus-visible:ring-ring inline-flex size-11 items-center justify-center rounded-full text-[var(--brand-ink-400)] transition focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:outline-none"
           >
             <X className="size-4" />
           </button>
         </div>
 
-        <p className="px-5 pb-5 font-serif text-xl leading-8 text-[var(--brand-ink)]">
-          {question}
-        </p>
+        <p className="px-5 pb-5 font-serif text-xl leading-8 text-[var(--brand-ink)]">{question}</p>
 
         <form onSubmit={handleSubmit} className="px-5 pb-8">
           <label htmlFor={inputId} className="sr-only">
@@ -88,17 +86,17 @@ export function AnswerSheet({
             placeholder="Your answer…"
             disabled={loading}
             autoComplete="off"
-            className="w-full min-h-11 rounded-xl border bg-background px-4 text-base outline-none focus:border-primary focus-visible:ring-2 focus-visible:ring-ring disabled:opacity-60"
+            className="bg-background focus:border-primary focus-visible:ring-ring min-h-11 w-full rounded-xl border px-4 text-base outline-none focus-visible:ring-2 disabled:opacity-60"
           />
           <button
             type="submit"
             disabled={loading || !value.trim()}
             className="btn-primary mt-3 w-full"
           >
-            {loading ? 'Submitting…' : 'Submit answer'}
+            {loading ? 'Grading…' : 'Answer'}
           </button>
         </form>
       </div>
     </div>
-  )
+  );
 }

--- a/src/components/play/AnswerInputBar.tsx
+++ b/src/components/play/AnswerInputBar.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useRef, type FormEvent, type Ref } from 'react';
+
+type AnswerInputBarProps = {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void | Promise<void>;
+  submitting: boolean;
+  disabled?: boolean;
+  fixed?: boolean;
+  inputRef?: Ref<HTMLInputElement>;
+};
+
+const DRAG_CANCEL_THRESHOLD_PX = 8;
+
+export function AnswerInputBar({
+  value,
+  onChange,
+  onSubmit,
+  submitting,
+  disabled = false,
+  fixed = true,
+  inputRef,
+}: AnswerInputBarProps) {
+  const pointerStartRef = useRef<{ x: number; y: number; dragged: boolean } | null>(null);
+  const interactionDisabled = disabled || submitting;
+
+  function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (interactionDisabled || !value.trim()) return;
+    void onSubmit();
+  }
+
+  return (
+    <form
+      className={
+        fixed
+          ? 'fixed inset-x-0 bottom-0 z-40 mx-auto max-w-lg border-t px-4 py-3'
+          : 'border-t px-4 py-3'
+      }
+      aria-label="Submit your answer"
+      style={{
+        borderColor: 'var(--border)',
+        background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
+        backdropFilter: 'blur(8px)',
+        paddingBottom: 'calc(0.75rem + env(safe-area-inset-bottom))',
+      }}
+      onSubmit={handleSubmit}
+    >
+      <div className="flex gap-2">
+        <input
+          ref={inputRef}
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          disabled={interactionDisabled}
+          placeholder="Your answer..."
+          aria-label="Your answer"
+          enterKeyHint="send"
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck={false}
+          className="min-h-11 min-w-0 flex-1 rounded-[var(--radius-md)] border bg-[var(--bg)] px-4 text-base text-[var(--text)] outline-none disabled:cursor-not-allowed disabled:opacity-60"
+          style={{ borderColor: 'var(--border)' }}
+        />
+        <button
+          type="submit"
+          className="btn-primary shrink-0 disabled:cursor-not-allowed disabled:opacity-70"
+          aria-label="Submit answer"
+          disabled={interactionDisabled || !value.trim()}
+          onPointerDown={(event) => {
+            pointerStartRef.current = { x: event.clientX, y: event.clientY, dragged: false };
+          }}
+          onPointerMove={(event) => {
+            const start = pointerStartRef.current;
+            if (!start) return;
+            const distance = Math.hypot(event.clientX - start.x, event.clientY - start.y);
+            if (distance > DRAG_CANCEL_THRESHOLD_PX) {
+              start.dragged = true;
+            }
+          }}
+          onPointerUp={() => {
+            window.setTimeout(() => {
+              pointerStartRef.current = null;
+            }, 0);
+          }}
+          onClick={(event) => {
+            if (pointerStartRef.current?.dragged) {
+              event.preventDefault();
+              event.stopPropagation();
+            }
+          }}
+        >
+          {submitting ? 'Grading…' : 'Answer'}
+        </button>
+      </div>
+    </form>
+  );
+}


### PR DESCRIPTION
### Motivation
- The answer input and submission control could scroll off-screen in the Daily Five thread, and scrolling/drag interactions sometimes triggered unintended submits.  
- The input must remain visible and submission must only happen on the explicit tap or Enter, with a clear loading state while grading.  
- The design requires the primary button styling and copy to read `Answer` normally and `Grading…` while the grader runs.

### Description
- Add a new shared component `AnswerInputBar` (`src/components/play/AnswerInputBar.tsx`) that pins the input/button to the viewport bottom, uses the `btn-primary` style, shows `Grading…` while submitting, and disables input while inactive.  
- Integrate the new `AnswerInputBar` into the live Daily thread and the Daily catch-up screens by replacing the inline bottom forms in `src/app/daily/page.tsx` and `src/app/daily/catchup/page.tsx` and increasing bottom scroll padding so thread content never hides behind the bar.  
- Prevent accidental submission from drag/scroll gestures by cancelling pointer-clicks when a pointer moves more than a small threshold before release.  
- Update the feed modal answer sheet `src/components/feed/AnswerSheet.tsx` to use the requested copy and loading text (`Answer` / `Grading…`) and keep the input disabled while grading.

### Testing
- Ran `npm run format` to format the changed files and apply code styling, which completed successfully.  
- Ran `npm run lint`, which completed; existing design-token warnings remain but no new lint errors were introduced.  
- Ran TypeScript checks with `npx tsc --noEmit`, which passed without errors.  
- Started the dev server and attempted a Playwright screenshot to validate the visual behavior, but the headless Chromium binary could not be downloaded (`npx playwright install chromium` returned a 403 from the CDN), so automated visual capture was blocked in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0bc97ea0832e931eca4d2351f3c5)