### PR TITLE
Personalize invite login context

### DIFF
--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
+import { AvatarChip } from '@/components/AvatarChip'
 import { getFriendInvitationLandingByToken } from '@/server/friends/invitations'
 
 type InvitePageProps = {
@@ -9,6 +10,25 @@ type InvitePageProps = {
 
 function inviteLoginHref(token: string) {
   return `/login?invitationToken=${encodeURIComponent(token)}`
+}
+
+function InviterIdentity({
+  name,
+  userId,
+  avatarColor,
+}: {
+  name: string
+  userId: string | null
+  avatarColor: string | null
+}) {
+  if (!userId) return null
+
+  return (
+    <div className="mb-4 flex items-center gap-3">
+      <AvatarChip displayName={name} userId={userId} color={avatarColor} size="lg" />
+      <span className="text-sm font-semibold">{name}</span>
+    </div>
+  )
 }
 
 function InviteShell({ children }: { children: ReactNode }) {
@@ -30,6 +50,11 @@ export default async function InvitePage({ params }: InvitePageProps) {
       <InviteShell>
         <div className="space-y-5">
           <div>
+            <InviterIdentity
+              name={invitation.inviterName}
+              userId={invitation.inviterUserId}
+              avatarColor={invitation.inviterAvatarColor}
+            />
             <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
               A note from a friend
             </p>

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -4,6 +4,8 @@ import { useCallback, useState } from 'react';
 import type { FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { AvatarChip } from '@/components/AvatarChip';
+
 const US_E164_REGEX = /^\+1\d{10}$/;
 
 /** Format a stored E.164 US number as (734)-277-6819 for display. */
@@ -38,7 +40,9 @@ function normalizePhone(phone: string): string {
 }
 
 export function readInvitationToken(searchParams: URLSearchParams) {
-  return searchParams.get('invitationToken') ?? searchParams.get('invite') ?? searchParams.get('token');
+  return (
+    searchParams.get('invitationToken') ?? searchParams.get('invite') ?? searchParams.get('token')
+  );
 }
 
 export function readUserInvite(searchParams: URLSearchParams) {
@@ -50,7 +54,7 @@ export function readUserInvite(searchParams: URLSearchParams) {
 export function buildVerifyOtpRequestBody(
   phone: string,
   code: string,
-  searchParams: URLSearchParams
+  searchParams: URLSearchParams,
 ) {
   return {
     phone,
@@ -68,7 +72,7 @@ export function buildVerifyOtpRequestBody(
 export function buildInviteVerifyOtpRequestBody(
   code: string,
   invitationToken: string,
-  searchParams: URLSearchParams
+  searchParams: URLSearchParams,
 ) {
   return {
     code,
@@ -78,15 +82,45 @@ export function buildInviteVerifyOtpRequestBody(
   };
 }
 
-type InvitePrefill = { inviterName: string; maskedPhone: string };
+type InviteContext = {
+  inviterName: string;
+  inviterUserId: string;
+  inviterAvatarColor: string | null;
+};
+
+type InvitePrefill = InviteContext & { maskedPhone: string };
 
 type LoginPanelProps = {
   invitePrefill?: InvitePrefill | null;
+  inviteContext?: InviteContext | null;
 };
 
 type Step = 'invite' | 'phone' | 'code';
 
-export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
+function InviteContextCard({ invite }: { invite: InviteContext }) {
+  return (
+    <div className="space-y-3 rounded-[8px] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
+      <div className="flex items-center justify-center gap-3">
+        <AvatarChip
+          displayName={invite.inviterName}
+          userId={invite.inviterUserId}
+          color={invite.inviterAvatarColor}
+          size="lg"
+        />
+        <span className="text-[17px] leading-6 font-semibold text-black">{invite.inviterName}</span>
+      </div>
+      <p className="text-[15px] leading-6 text-black/75">
+        {invite.inviterName} invited you to Joshing. Enter your phone number to join and start
+        answering their questions.
+      </p>
+    </div>
+  );
+}
+
+export default function LoginPanel({
+  invitePrefill = null,
+  inviteContext = null,
+}: LoginPanelProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = readInvitationToken(searchParams);
@@ -96,9 +130,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
   const [code, setCode] = useState('');
   // Start on the invite confirmation step only when the link resolved to a
   // recipient phone; otherwise fall straight through to manual entry.
-  const [step, setStep] = useState<Step>(
-    invitePrefill?.maskedPhone ? 'invite' : 'phone'
-  );
+  const [step, setStep] = useState<Step>(invitePrefill?.maskedPhone ? 'invite' : 'phone');
   // True once the OTP was sent to the invite's phone (so the code step and
   // verify call use the masked phone + token instead of a typed number).
   const [invitePhoneMode, setInvitePhoneMode] = useState(false);
@@ -256,11 +288,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
         <form className="space-y-[14px]" onSubmit={sendCodeToInvitePhone}>
           {/* Texting glyph (the two-tone speech bubble) — this step is about us
               sending a code by text, so it mirrors the OTP step's mark. */}
-          <svg
-            className="mx-auto h-14 w-auto"
-            viewBox="-3 -3 54 44"
-            aria-hidden="true"
-          >
+          <svg className="mx-auto h-14 w-auto" viewBox="-3 -3 54 44" aria-hidden="true">
             <g fill="var(--brand-navy)">
               <ellipse cx="15" cy="15" rx="15" ry="12" />
               <path d="M3 22 L11 26.5 L1 31 Z" />
@@ -277,12 +305,16 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
               <path d="M44 30 L36 34.5 L46.5 39 Z" />
             </g>
           </svg>
-          <p className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black">
-            {invitePrefill?.inviterName ?? 'A friend'} invited you to Joshing.
-          </p>
+          {inviteContext ? (
+            <InviteContextCard invite={inviteContext} />
+          ) : (
+            <p className="block text-center text-[17px] leading-[26px] font-medium tracking-[1.7px] text-black">
+              {invitePrefill?.inviterName ?? 'A friend'} invited you to Joshing.
+            </p>
+          )}
           <p className="text-center text-[15px] leading-6 text-black/70">
             We&rsquo;ll text a code to{' '}
-            <span className="whitespace-nowrap font-medium text-black">{maskedPhone}</span>.
+            <span className="font-medium whitespace-nowrap text-black">{maskedPhone}</span>.
           </p>
 
           {/* Button + divider + secondary action form a tight 6px cluster,
@@ -300,7 +332,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
 
             <button
               type="button"
-              className="mx-auto block text-sm font-medium uppercase leading-5 tracking-[0.56px] text-[var(--brand-orange)] underline underline-offset-4 disabled:opacity-60"
+              className="mx-auto block text-sm leading-5 font-medium tracking-[0.56px] text-[var(--brand-orange)] uppercase underline underline-offset-4 disabled:opacity-60"
               onClick={() => {
                 setInvitePhoneMode(false);
                 swapStep('phone');
@@ -317,15 +349,12 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
               (and the filled treatment of the OTP step's bubble icon).
               Hand-drawn as a fill-only glyph rather than a force-filled
               lucide outline, which rendered with a muddy stroked edge. */}
-          <svg
-            className="mx-auto h-12 w-12 fill-black"
-            viewBox="0 0 24 24"
-            aria-hidden="true"
-          >
+          <svg className="mx-auto h-12 w-12 fill-black" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M6.62 10.79c1.44 2.83 3.76 5.14 6.59 6.59l2.2-2.2c.27-.27.67-.36 1.02-.24 1.12.37 2.33.57 3.57.57.55 0 1 .45 1 1V20c0 .55-.45 1-1 1-9.39 0-17-7.61-17-17 0-.55.45-1 1-1h3.5c.55 0 1 .45 1 1 0 1.25.2 2.45.57 3.57.11.35.03.74-.25 1.02l-2.2 2.2z" />
           </svg>
+          {inviteContext ? <InviteContextCard invite={inviteContext} /> : null}
           <label
-            className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"
+            className="block text-center text-[17px] leading-[26px] font-medium tracking-[1.7px] text-black"
             htmlFor="phone"
           >
             What is your phone number?
@@ -352,11 +381,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
               twice: first as a slightly larger cream copy (the page background
               color) so a crescent of background shows where it overlaps the
               navy, then as the orange bubble on top. */}
-          <svg
-            className="mx-auto h-14 w-auto"
-            viewBox="-3 -3 54 44"
-            aria-hidden="true"
-          >
+          <svg className="mx-auto h-14 w-auto" viewBox="-3 -3 54 44" aria-hidden="true">
             <g fill="var(--brand-navy)">
               <ellipse cx="15" cy="15" rx="15" ry="12" />
               <path d="M3 22 L11 26.5 L1 31 Z" />
@@ -375,7 +400,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
             </g>
           </svg>
           <label
-            className="block text-center text-[17px] font-medium leading-[26px] tracking-[1.7px] text-black"
+            className="block text-center text-[17px] leading-[26px] font-medium tracking-[1.7px] text-black"
             htmlFor="code"
           >
             Enter your code for{' '}
@@ -410,7 +435,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
 
             <button
               type="button"
-              className="mx-auto block text-sm font-medium uppercase leading-5 tracking-[0.56px] text-[var(--brand-orange)] underline underline-offset-4 disabled:opacity-60"
+              className="mx-auto block text-sm leading-5 font-medium tracking-[0.56px] text-[var(--brand-orange)] uppercase underline underline-offset-4 disabled:opacity-60"
               onClick={() => {
                 setCode('');
                 // Leaving the invite phone behind — collect a number manually.
@@ -426,7 +451,7 @@ export default function LoginPanel({ invitePrefill = null }: LoginPanelProps) {
       )}
 
       {error ? (
-        <p className="mt-4 rounded-md border border-destructive/30 bg-destructive/10 px-3 py-2 text-center text-sm text-destructive">
+        <p className="border-destructive/30 bg-destructive/10 text-destructive mt-4 rounded-md border px-3 py-2 text-center text-sm">
           {error}
         </p>
       ) : null}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,32 +2,44 @@ import { Suspense } from 'react';
 
 import TriangleBackground from '@/components/TriangleBackground';
 import { getInvitePrefillByToken } from '@/server/friends/invitations';
+import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
 import LoginPanel from './LoginPanel';
 
 // Mirror LoginPanel.readInvitationToken: accept any of the aliases an invite
 // link may use so the prefill resolves regardless of which one routed here.
-function readInvitationToken(
-  params: Record<string, string | string[] | undefined>
-): string | null {
-  const first = (value: string | string[] | undefined) =>
-    Array.isArray(value) ? value[0] : value;
+function firstParam(value: string | string[] | undefined) {
+  return Array.isArray(value) ? value[0] : value;
+}
+
+function readInvitationToken(params: Record<string, string | string[] | undefined>): string | null {
   return (
-    first(params.invitationToken) ??
-    first(params.invite) ??
-    first(params.token) ??
+    firstParam(params.invitationToken) ??
+    firstParam(params.invite) ??
+    firstParam(params.token) ??
     null
   );
+}
+
+function readUserInvite(
+  params: Record<string, string | string[] | undefined>,
+): { handle: string; token: string } | null {
+  const handle = firstParam(params.inviteHandle);
+  const token = firstParam(params.inviteUserToken);
+  return handle && token ? { handle, token } : null;
 }
 
 function TitleCard() {
   return (
     <section className="w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-[46px] py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
-      <h1 className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
+      <h1 className="font-sans text-5xl leading-[52px] font-bold tracking-[4.8px] text-[var(--brand-ink-950)]">
         JOSHING
       </h1>
-      <div className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--accent-gold)]" aria-hidden="true" />
-      <p className="mt-4 text-center font-sans text-lg font-normal uppercase leading-6 tracking-[3.6px] text-[var(--warm-ink)]">
+      <div
+        className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--accent-gold)]"
+        aria-hidden="true"
+      />
+      <p className="mt-4 text-center font-sans text-lg leading-6 font-normal tracking-[3.6px] text-[var(--warm-ink)] uppercase">
         Trivia you wish you were asked
       </p>
     </section>
@@ -41,15 +53,37 @@ type LoginPageProps = {
 export default async function LoginPage({ searchParams }: LoginPageProps) {
   const params = await searchParams;
   const invitationToken = readInvitationToken(params);
+  const userInvite = readUserInvite(params);
   // Resolve the invite's recipient phone server-side so the login panel can
   // skip manual phone entry. Only the masked form crosses to the client — the
   // raw phone never leaves the server.
-  const prefill = invitationToken
-    ? await getInvitePrefillByToken(invitationToken)
+  const prefill = invitationToken ? await getInvitePrefillByToken(invitationToken) : null;
+  const userInviteResolution = userInvite
+    ? await resolveInviteLink(userInvite.handle, userInvite.token)
     : null;
   const invitePrefill = prefill
-    ? { inviterName: prefill.inviterName, maskedPhone: prefill.maskedPhone }
+    ? {
+        inviterName: prefill.inviterName,
+        inviterUserId: prefill.inviterUserId,
+        inviterAvatarColor: prefill.inviterAvatarColor,
+        maskedPhone: prefill.maskedPhone,
+      }
     : null;
+  const inviteContext = prefill
+    ? {
+        inviterName: prefill.inviterName,
+        inviterUserId: prefill.inviterUserId,
+        inviterAvatarColor: prefill.inviterAvatarColor,
+      }
+    : userInviteResolution
+      ? {
+          inviterName:
+            userInviteResolution.inviterDisplayName?.trim() ||
+            `@${userInviteResolution.inviterHandle}`,
+          inviterUserId: userInviteResolution.inviterUserId,
+          inviterAvatarColor: userInviteResolution.inviterAvatarColor,
+        }
+      : null;
 
   return (
     <TriangleBackground>
@@ -60,7 +94,7 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
             <div className="h-72 w-full max-w-sm rounded-2xl bg-[var(--brand-cream-card)] shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5" />
           }
         >
-          <LoginPanel invitePrefill={invitePrefill} />
+          <LoginPanel invitePrefill={invitePrefill} inviteContext={inviteContext} />
         </Suspense>
       </main>
     </TriangleBackground>

--- a/src/app/u/[handle]/[token]/page.tsx
+++ b/src/app/u/[handle]/[token]/page.tsx
@@ -16,6 +16,7 @@ import type { ReactNode } from 'react'
 import { redirect } from 'next/navigation'
 import Link from 'next/link'
 
+import { AvatarChip } from '@/components/AvatarChip'
 import { AddFriendButton } from '@/components/friends/AddFriendButton'
 import { getSession } from '@/server/auth/session'
 import { getRelationship } from '@/server/db/queries/friend-requests'
@@ -23,6 +24,23 @@ import { resolveInviteLink } from '@/server/friends/user-invite-token'
 
 type InvitePageProps = {
   params: Promise<{ handle: string; token: string }>
+}
+
+function InviterIdentity({
+  name,
+  userId,
+  avatarColor,
+}: {
+  name: string
+  userId: string
+  avatarColor: string | null
+}) {
+  return (
+    <div className="mb-4 flex items-center gap-3">
+      <AvatarChip displayName={name} userId={userId} color={avatarColor} size="lg" />
+      <span className="text-sm font-semibold">{name}</span>
+    </div>
+  )
 }
 
 function InviteShell({ children }: { children: ReactNode }) {
@@ -114,6 +132,11 @@ export default async function UserInvitePage({ params }: InvitePageProps) {
     <InviteShell>
       <div className="space-y-5">
         <div>
+          <InviterIdentity
+            name={displayName}
+            userId={inviter.inviterUserId}
+            avatarColor={inviter.inviterAvatarColor}
+          />
           <p className="text-muted-foreground text-xs font-medium uppercase tracking-wide">
             A note from a friend
           </p>

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -32,10 +32,14 @@ export type OutgoingFriendInvitation = FriendInvitation & {
 export type FriendInvitationLanding = {
   status: 'valid' | 'expired' | 'accepted' | 'invalid'
   inviterName: string
+  inviterUserId: string | null
+  inviterAvatarColor: string | null
 }
 
 export type InvitePrefill = {
   inviterName: string
+  inviterUserId: string
+  inviterAvatarColor: string | null
   // Server-only: the recipient's E.164 phone resolved from the invite token.
   // Never expose this to the client — surface `maskedPhone` instead.
   inviteePhone: string
@@ -105,7 +109,7 @@ export async function getFriendInvitationLandingByToken(
 ): Promise<FriendInvitationLanding> {
   const normalizedToken = token.trim()
   if (!normalizedToken) {
-    return { status: 'invalid', inviterName: 'Someone' }
+    return { status: 'invalid', inviterName: 'Someone', inviterUserId: null, inviterAvatarColor: null }
   }
 
   const [row] = await db
@@ -115,6 +119,8 @@ export async function getFriendInvitationLandingByToken(
       expiresAt: friendInvitations.expiresAt,
       preSeededInterests: friendInvitations.preSeededInterests,
       inviterName: users.displayName,
+      inviterUserId: users.id,
+      inviterAvatarColor: users.avatarColor,
     })
     .from(friendInvitations)
     .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
@@ -126,7 +132,7 @@ export async function getFriendInvitationLandingByToken(
       status: 'invalid',
       invite_hash: hashTelemetryValue(normalizedToken),
     })
-    return { status: 'invalid', inviterName: 'Someone' }
+    return { status: 'invalid', inviterName: 'Someone', inviterUserId: null, inviterAvatarColor: null }
   }
 
   const inviterName = displayInviterName(row.inviterName)
@@ -143,7 +149,12 @@ export async function getFriendInvitationLandingByToken(
       invite_hash: hashTelemetryValue(normalizedToken),
       suggested_interest_count: 0,
     })
-    return { status: 'accepted', inviterName }
+    return {
+      status: 'accepted',
+      inviterName,
+      inviterUserId: row.inviterUserId,
+      inviterAvatarColor: row.inviterAvatarColor,
+    }
   }
 
   if (row.expiresAt <= now) {
@@ -152,7 +163,12 @@ export async function getFriendInvitationLandingByToken(
       invite_hash: hashTelemetryValue(normalizedToken),
       suggested_interest_count: 0,
     })
-    return { status: 'expired', inviterName }
+    return {
+      status: 'expired',
+      inviterName,
+      inviterUserId: row.inviterUserId,
+      inviterAvatarColor: row.inviterAvatarColor,
+    }
   }
 
   logTelemetry('friend_invite_link_opened', {
@@ -161,7 +177,12 @@ export async function getFriendInvitationLandingByToken(
     suggested_interest_count: interestCount,
   })
 
-  return { status: 'valid', inviterName }
+  return {
+    status: 'valid',
+    inviterName,
+    inviterUserId: row.inviterUserId,
+    inviterAvatarColor: row.inviterAvatarColor,
+  }
 }
 
 /**
@@ -186,6 +207,8 @@ export async function getInvitePrefillByToken(
       expiresAt: friendInvitations.expiresAt,
       inviteePhone: friendInvitations.inviteePhone,
       inviterName: users.displayName,
+      inviterUserId: users.id,
+      inviterAvatarColor: users.avatarColor,
     })
     .from(friendInvitations)
     .leftJoin(users, eq(friendInvitations.inviterUserId, users.id))
@@ -201,6 +224,8 @@ export async function getInvitePrefillByToken(
 
   return {
     inviterName: displayInviterName(row.inviterName),
+    inviterUserId: row.inviterUserId ?? 'friend-invite',
+    inviterAvatarColor: row.inviterAvatarColor,
     inviteePhone,
     maskedPhone: maskPhoneE164(inviteePhone),
   }


### PR DESCRIPTION
### Motivation
- When a user arrives via an invite link the login page lacked context about who invited them; the goal is to show the inviter’s avatar and name and a short message above the phone input while leaving the generic login unchanged.

### Description
- Resolve inviter identity server-side for both friend-invitation tokens (`/invite/[token]`) and per-user evergreen links (`/u/[handle]/[token]`) and return inviter id + avatar color in `getFriendInvitationLandingByToken` and `getInvitePrefillByToken` in `src/server/friends/invitations.ts`.
- Wire inviter context into the login flow: `src/app/login/page.tsx` now resolves both invite token and per-user invite links and passes an `inviteContext` prop into the client `LoginPanel`.
- Add an `InviteContextCard` to `src/app/login/LoginPanel.tsx` that renders the inviter avatar (`AvatarChip`), inviter name, and the required copy: “[Inviter] invited you to Joshing. Enter your phone number to join and start answering their questions.”; the card appears above phone input and in the invite confirmation step.
- Surface inviter avatar/name on invite landing pages (`src/app/invite/[token]/page.tsx` and `src/app/u/[handle]/[token]/page.tsx`) by rendering an identity chip when available.

### Testing
- Ran unit tests with `npm test -- src/app/login/__tests__/LoginPanel.test.ts src/app/invite/[token]/__tests__/page.test.tsx`, all tests passed (`14 passed`).
- Type-checked with `npx tsc --noEmit`, which completed successfully.
- Ran `npm run lint`; lint completed with existing design-token warnings (13 warnings) but no new errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c0bd65094832eaea9977d376367dd)