### PR TITLE
Update invite landing copy

### DIFF
--- a/src/app/invite/[token]/__tests__/page.test.tsx
+++ b/src/app/invite/[token]/__tests__/page.test.tsx
@@ -1,42 +1,44 @@
-import { renderToStaticMarkup } from 'react-dom/server'
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { getFriendInvitationLandingByTokenMock } = vi.hoisted(() => ({
   getFriendInvitationLandingByTokenMock: vi.fn(),
-}))
+}));
 
 vi.mock('@/server/friends/invitations', () => ({
   getFriendInvitationLandingByToken: getFriendInvitationLandingByTokenMock,
-}))
+}));
 
-import InvitePage from '@/app/invite/[token]/page'
+import InvitePage from '@/app/invite/[token]/page';
 
 async function renderInvite(token = 'safe-token') {
-  const element = await InvitePage({ params: Promise.resolve({ token }) })
-  return renderToStaticMarkup(element)
+  const element = await InvitePage({ params: Promise.resolve({ token }) });
+  return renderToStaticMarkup(element);
 }
 
 describe('/invite/[token] landing QA states', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   it('opens a valid invite landing with inviter name and auth continuation, but does NOT leak pre-seeded interests (F1.5)', async () => {
     getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
       status: 'valid',
       inviterName: 'Alex Inviter',
-    })
+    });
 
-    const html = await renderInvite('valid-token')
+    const html = await renderInvite('valid-token');
 
-    expect(getFriendInvitationLandingByTokenMock).toHaveBeenCalledWith(
-      'valid-token'
-    )
-    expect(html).toContain('Alex Inviter thought of you for Joshing.')
-    expect(html).toContain('href="/login?invitationToken=valid-token"')
-    expect(html).not.toContain('href="/login"')
-    expect(html).not.toMatch(/leaderboard|ranking|score|points?|percent|%/i)
-  })
+    expect(getFriendInvitationLandingByTokenMock).toHaveBeenCalledWith('valid-token');
+    expect(html).toContain('A friend thought of you');
+    expect(html).toContain('Alex Inviter thought of you for Joshing.');
+    expect(html).toContain('Continue to Joshing');
+    expect(html).not.toContain('A note from a friend');
+    expect(html).not.toContain('See the note');
+    expect(html).toContain('href="/login?invitationToken=valid-token"');
+    expect(html).not.toContain('href="/login"');
+    expect(html).not.toMatch(/leaderboard|ranking|score|points?|percent|%/i);
+  });
 
   it('never renders pre-seeded interest labels even if a stale payload includes them (defensive)', async () => {
     // Defends against a regression where the type is reverted: even if the
@@ -46,12 +48,12 @@ describe('/invite/[token] landing QA states', () => {
       inviterName: 'Alex Inviter',
       // @ts-expect-error - field is intentionally not on the type
       suggestedInterests: [{ label: 'Jazz' }, { label: 'Poetry' }],
-    })
+    });
 
-    const html = await renderInvite('valid-token')
-    expect(html).not.toContain('Jazz')
-    expect(html).not.toContain('Poetry')
-  })
+    const html = await renderInvite('valid-token');
+    expect(html).not.toContain('Jazz');
+    expect(html).not.toContain('Poetry');
+  });
 
   it.each([
     {
@@ -75,14 +77,14 @@ describe('/invite/[token] landing QA states', () => {
       getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
         status,
         inviterName: 'Alex Inviter',
-      })
+      });
 
-      const html = await renderInvite(`${status}-token`)
+      const html = await renderInvite(`${status}-token`);
 
-      expect(html).toContain(expectedEyebrow)
-      expect(html).toContain(expectedHeading)
-      expect(html).toContain('href="/login"')
-      expect(html).not.toContain(`${status}-token`)
-    }
-  )
-})
+      expect(html).toContain(expectedEyebrow);
+      expect(html).toContain(expectedHeading);
+      expect(html).toContain('href="/login"');
+      expect(html).not.toContain(`${status}-token`);
+    },
+  );
+});

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,15 +1,15 @@
-import type { ReactNode } from 'react'
-import Link from 'next/link'
+import type { ReactNode } from 'react';
+import Link from 'next/link';
 
-import { AvatarChip } from '@/components/AvatarChip'
-import { getFriendInvitationLandingByToken } from '@/server/friends/invitations'
+import { AvatarChip } from '@/components/AvatarChip';
+import { getFriendInvitationLandingByToken } from '@/server/friends/invitations';
 
 type InvitePageProps = {
-  params: Promise<{ token: string }>
-}
+  params: Promise<{ token: string }>;
+};
 
 function inviteLoginHref(token: string) {
-  return `/login?invitationToken=${encodeURIComponent(token)}`
+  return `/login?invitationToken=${encodeURIComponent(token)}`;
 }
 
 function InviterIdentity({
@@ -17,18 +17,18 @@ function InviterIdentity({
   userId,
   avatarColor,
 }: {
-  name: string
-  userId: string | null
-  avatarColor: string | null
+  name: string;
+  userId: string | null;
+  avatarColor: string | null;
 }) {
-  if (!userId) return null
+  if (!userId) return null;
 
   return (
     <div className="mb-4 flex items-center gap-3">
       <AvatarChip displayName={name} userId={userId} color={avatarColor} size="lg" />
       <span className="text-sm font-semibold">{name}</span>
     </div>
-  )
+  );
 }
 
 function InviteShell({ children }: { children: ReactNode }) {
@@ -38,12 +38,12 @@ function InviteShell({ children }: { children: ReactNode }) {
         {children}
       </section>
     </main>
-  )
+  );
 }
 
 export default async function InvitePage({ params }: InvitePageProps) {
-  const { token } = await params
-  const invitation = await getFriendInvitationLandingByToken(token)
+  const { token } = await params;
+  const invitation = await getFriendInvitationLandingByToken(token);
 
   if (invitation.status === 'valid') {
     return (
@@ -56,9 +56,9 @@ export default async function InvitePage({ params }: InvitePageProps) {
               avatarColor={invitation.inviterAvatarColor}
             />
             <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-              A note from a friend
+              A friend thought of you
             </p>
-            <h1 className="mt-2 font-serif text-3xl font-semibold leading-tight">
+            <h1 className="mt-2 font-serif text-3xl leading-tight font-semibold">
               {invitation.inviterName} thought of you for Joshing.
             </h1>
           </div>
@@ -67,11 +67,11 @@ export default async function InvitePage({ params }: InvitePageProps) {
             href={inviteLoginHref(token)}
             className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
           >
-            See the note
+            Continue to Joshing
           </Link>
         </div>
       </InviteShell>
-    )
+    );
   }
 
   if (invitation.status === 'expired') {
@@ -81,9 +81,8 @@ export default async function InvitePage({ params }: InvitePageProps) {
           <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
             Invitation expired
           </p>
-          <h1 className="font-serif text-2xl font-semibold leading-tight">
-            This invitation has expired. Ask {invitation.inviterName} to send
-            you a new one.
+          <h1 className="font-serif text-2xl leading-tight font-semibold">
+            This invitation has expired. Ask {invitation.inviterName} to send you a new one.
           </h1>
           <Link
             href="/login"
@@ -93,7 +92,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
           </Link>
         </div>
       </InviteShell>
-    )
+    );
   }
 
   if (invitation.status === 'accepted') {
@@ -103,7 +102,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
           <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
             Invitation already used
           </p>
-          <h1 className="font-serif text-2xl font-semibold leading-tight">
+          <h1 className="font-serif text-2xl leading-tight font-semibold">
             This invitation has already been used.
           </h1>
           <p className="text-muted-foreground text-sm leading-6">
@@ -117,7 +116,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
           </Link>
         </div>
       </InviteShell>
-    )
+    );
   }
 
   return (
@@ -140,5 +139,5 @@ export default async function InvitePage({ params }: InvitePageProps) {
         </Link>
       </div>
     </InviteShell>
-  )
+  );
 }


### PR DESCRIPTION
### Motivation
- Change invite landing copy to be invitation-focused instead of referencing a “note”, clarifying the CTA for invite recipients.
- Ensure regression coverage prevents the old note-focused wording from reappearing.

### Description
- Update `src/app/invite/[token]/page.tsx` to replace the eyebrow text `A note from a friend` with `A friend thought of you` and the CTA from `See the note` to `Continue to Joshing`.
- Update `src/app/invite/[token]/__tests__/page.test.tsx` to assert the new copy and to assert the old strings (`A note from a friend`, `See the note`) are not rendered.
- Run project formatting which normalized some punctuation/semicolons in the edited files.

### Testing
- Ran `npm test -- src/app/invite/[token]/__tests__/page.test.tsx` and all tests passed (`5` tests).
- Ran `npm run format` which reformatted the modified files successfully.
- Ran `npm run lint` which completed; linter reported warnings but no errors and remained within the configured warning limit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c184880dc832e967215fa401387d6)