### PR TITLE
Add post-OTP profile completion step (display name + handle)

### DIFF
--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -62,6 +62,7 @@ vi.mock('@/server/db', () => ({
     id: 'users.id',
     phoneNumber: 'users.phoneNumber',
     displayName: 'users.displayName',
+    handle: 'users.handle',
     timezone: 'users.timezone',
   },
 }))
@@ -84,6 +85,7 @@ const EXISTING_USER = {
   id: 'user-1',
   phoneNumber: '+15551234567',
   displayName: null,
+  handle: null,
   timezone: 'America/New_York',
 }
 
@@ -91,6 +93,7 @@ const NEW_USER = {
   id: 'user-2',
   phoneNumber: '+15559876543',
   displayName: null,
+  handle: null,
   timezone: 'America/New_York',
 }
 
@@ -145,6 +148,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
 
       expect(response.status).toBe(200)
       expect(body.user.id).toBe('user-1')
+      expect(body.user.handle).toBeNull()
       expect(body.invitation).toEqual({ accepted: false })
       expect(createSessionMock).toHaveBeenCalledWith('user-1', {
         invitationAccepted: true,
@@ -332,6 +336,7 @@ describe('/api/auth/verify-otp invitation gate', () => {
 
       expect(response.status).toBe(200)
       expect(body.user.id).toBe('user-2')
+      expect(body.user.handle).toBeNull()
       expect(body.invitation).toEqual({ accepted: true })
       expect(provisionUserInsertMock).toHaveBeenCalled()
       expect(acceptFriendInvitationMock).toHaveBeenCalledWith({

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -39,6 +39,7 @@ type AuthUser = {
   id: string
   phoneNumber: string
   displayName: string | null
+  handle: string | null
   timezone: string
 }
 
@@ -46,6 +47,7 @@ const USER_SELECTION = {
   id: users.id,
   phoneNumber: users.phoneNumber,
   displayName: users.displayName,
+  handle: users.handle,
   timezone: users.timezone,
 }
 
@@ -206,6 +208,7 @@ export async function POST(request: Request) {
           id: existingUser.id,
           phone_number: existingUser.phoneNumber,
           display_name: existingUser.displayName,
+          handle: existingUser.handle,
           timezone: existingUser.timezone,
           onboardingComplete: false,
         },
@@ -273,6 +276,7 @@ export async function POST(request: Request) {
         id: user.id,
         phone_number: user.phoneNumber,
         display_name: user.displayName,
+        handle: user.handle,
         timezone: user.timezone,
         onboardingComplete: false,
       },

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -95,7 +95,40 @@ type LoginPanelProps = {
   inviteContext?: InviteContext | null;
 };
 
-type Step = 'invite' | 'phone' | 'code';
+type Step = 'invite' | 'phone' | 'code' | 'profile';
+
+type VerifiedIdentity = {
+  displayName: string;
+  handle: string;
+};
+
+type VerifyOtpUserPayload = {
+  display_name?: unknown;
+  displayName?: unknown;
+  handle?: unknown;
+};
+
+function identityValue(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export function readVerifiedIdentity(data: unknown): VerifiedIdentity {
+  const user =
+    data && typeof data === 'object' && 'user' in data
+      ? (data as { user?: VerifyOtpUserPayload }).user
+      : null;
+
+  if (!user || typeof user !== 'object') return { displayName: '', handle: '' };
+
+  return {
+    displayName: identityValue(user.display_name ?? user.displayName),
+    handle: identityValue(user.handle),
+  };
+}
+
+export function shouldCollectProfileIdentity(identity: VerifiedIdentity): boolean {
+  return !identity.displayName || !identity.handle;
+}
 
 function InviteContextCard({ invite }: { invite: InviteContext }) {
   return (
@@ -128,6 +161,12 @@ export default function LoginPanel({
 
   const [phone, setPhone] = useState('');
   const [code, setCode] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [handle, setHandle] = useState('');
+  const [verifiedIdentity, setVerifiedIdentity] = useState<VerifiedIdentity>({
+    displayName: '',
+    handle: '',
+  });
   // Start on the invite confirmation step only when the link resolved to a
   // recipient phone; otherwise fall straight through to manual entry.
   const [step, setStep] = useState<Step>(invitePrefill?.maskedPhone ? 'invite' : 'phone');
@@ -263,9 +302,78 @@ export default function LoginPanel({
         return;
       }
 
+      const identity = readVerifiedIdentity(data);
+      setVerifiedIdentity(identity);
+      setDisplayName(identity.displayName);
+      setHandle(identity.handle);
+
+      if (shouldCollectProfileIdentity(identity)) {
+        setLoading(false);
+        swapStep('profile');
+        return;
+      }
+
       // Success: navigation is async and doesn't block, so keep the button in
       // its "Verifying…" state. Resetting loading here would flash "Continue"
       // before the redirect lands.
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      router.replace('/');
+      router.refresh();
+    } catch {
+      setError('Something went wrong. Please try again.');
+      setLoading(false);
+    }
+  }
+
+  async function completeProfile(event: FormEvent) {
+    event.preventDefault();
+    setError(null);
+
+    const trimmedDisplayName = displayName.trim();
+    const trimmedHandle = handle.trim().replace(/^@+/, '');
+
+    if (!trimmedDisplayName) {
+      setError('Enter your display name.');
+      return;
+    }
+
+    if (!trimmedHandle) {
+      setError('Enter your call sign.');
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const profileResponse = await fetch('/api/account/profile', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ displayName: trimmedDisplayName }),
+      });
+      const profileData = await profileResponse.json().catch(() => ({}));
+
+      if (!profileResponse.ok) {
+        setError(profileData?.message ?? 'Unable to save your display name.');
+        setLoading(false);
+        return;
+      }
+
+      if (trimmedHandle !== verifiedIdentity.handle) {
+        const handleResponse = await fetch('/api/account/handle', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ handle: trimmedHandle }),
+        });
+        const handleData = await handleResponse.json().catch(() => ({}));
+
+        if (!handleResponse.ok) {
+          setError(handleData?.message ?? 'Unable to save your call sign.');
+          setLoading(false);
+          return;
+        }
+      }
+
       window.scrollTo({ top: 0, behavior: 'smooth' });
       router.replace('/');
       router.refresh();
@@ -374,7 +482,7 @@ export default function LoginPanel({
             {loading ? 'Continuing…' : 'Continue'}
           </button>
         </form>
-      ) : (
+      ) : step === 'code' ? (
         <form className="space-y-[14px]" onSubmit={verifyCode}>
           {/* Two overlapping oval speech bubbles — navy behind, orange in front
               — recreating the Figma two-tone mark. The front bubble is drawn
@@ -447,6 +555,54 @@ export default function LoginPanel({
               Change number
             </button>
           </div>
+        </form>
+      ) : (
+        <form className="space-y-[14px]" onSubmit={completeProfile}>
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-[var(--brand-navy)] text-2xl font-bold text-white">
+            @
+          </div>
+          <p className="block text-center text-[17px] leading-[26px] font-medium tracking-[1.7px] text-black">
+            Finish your profile
+          </p>
+          <p className="text-center text-[15px] leading-6 text-black/70">
+            Pick the name friends will see and the call sign they can use to find you.
+          </p>
+          <div className="space-y-2">
+            <label
+              className="block text-center text-sm font-medium text-black"
+              htmlFor="display-name"
+            >
+              Display name
+            </label>
+            <input
+              id="display-name"
+              type="text"
+              autoComplete="name"
+              className={INPUT_CLASS}
+              placeholder="Jane Palay"
+              value={displayName}
+              onChange={(event) => setDisplayName(event.target.value)}
+              disabled={loading}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="block text-center text-sm font-medium text-black" htmlFor="handle">
+              Call sign / handle
+            </label>
+            <input
+              id="handle"
+              type="text"
+              autoComplete="username"
+              className={INPUT_CLASS}
+              placeholder="jpalay"
+              value={handle}
+              onChange={(event) => setHandle(event.target.value.replace(/^@+/, ''))}
+              disabled={loading}
+            />
+          </div>
+          <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
+            {loading ? 'Saving…' : 'Enter Joshing'}
+          </button>
         </form>
       )}
 

--- a/src/app/login/__tests__/LoginPanel.test.ts
+++ b/src/app/login/__tests__/LoginPanel.test.ts
@@ -4,6 +4,8 @@ import {
   buildInviteVerifyOtpRequestBody,
   buildVerifyOtpRequestBody,
   readInvitationToken,
+  readVerifiedIdentity,
+  shouldCollectProfileIdentity,
 } from '@/app/login/LoginPanel'
 
 describe('LoginPanel invitation token query aliases', () => {
@@ -83,5 +85,23 @@ describe('LoginPanel invite-phone verify payload', () => {
       useInvitePhone: true,
       userInvite: { handle: 'jpalay', token: 'user-token' },
     })
+  })
+})
+
+describe('LoginPanel profile identity detection', () => {
+  it('collects both identity fields from verify-otp user payloads', () => {
+    expect(
+      readVerifiedIdentity({
+        user: { display_name: '  Jane Palay  ', handle: '  jpalay  ' },
+      })
+    ).toEqual({ displayName: 'Jane Palay', handle: 'jpalay' })
+  })
+
+  it('requires the profile step when either display name or handle is missing', () => {
+    expect(shouldCollectProfileIdentity({ displayName: '', handle: 'jpalay' })).toBe(true)
+    expect(shouldCollectProfileIdentity({ displayName: 'Jane Palay', handle: '' })).toBe(true)
+    expect(shouldCollectProfileIdentity({ displayName: 'Jane Palay', handle: 'jpalay' })).toBe(
+      false
+    )
   })
 })


### PR DESCRIPTION
### Motivation

- Ensure new users (or users missing identity fields) can provide both a display name and a call sign/handle immediately after OTP verification before entering the app.
- Let the client detect missing identity fields from the `verify-otp` response so it can branch to a profile completion step instead of redirecting straight to `/`.
- Reuse the existing visual rhythm and styling constants so the new UI remains consistent with the login flow.

### Description

- Extend the login flow state by adding a `profile` step to `type Step` and wire the UI to render a single card with two inputs for display name and call sign, reusing `INPUT_CLASS`, `SUBMIT_CLASS`, and `CARD_CLASS` in `src/app/login/LoginPanel.tsx`.
- Add parsing helpers `readVerifiedIdentity` and `shouldCollectProfileIdentity` so the client inspects the `verify-otp` response for `display_name` / `handle` and decides whether to show the profile step.
- After a successful `verify-otp`, populate the profile fields from the response and transition to the `profile` step when either identity field is missing; otherwise keep the existing redirect flow.
- Implement `completeProfile` which saves the display name via `PATCH /api/account/profile` and the handle via `PATCH /api/account/handle` (only if needed), and only redirects to `/` after both saves succeed.
- Include minimal server/client adjustments and test updates so the `verify-otp` response includes `handle` and unit tests cover identity detection and payload expectations.

### Testing

- Ran the targeted unit tests with `npm test -- --run src/app/login/__tests__/LoginPanel.test.ts src/app/api/auth/verify-otp/__tests__/route.test.ts` and the test suite passed for those files.
- Ran `npm run lint` which completed successfully; it reported the existing off-system color warnings in unrelated files but produced no new errors.
- Updated/added tests in `src/app/login/__tests__/LoginPanel.test.ts` and made corresponding adjustments to `src/app/api/auth/verify-otp/__tests__/route.test.ts` to assert `handle` presence and profile-detection behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c1c009fac832ea7309b3c58352ef1)