### PR TITLE
Prevent unverified questions from being broadcast

### DIFF
--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -251,6 +251,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
     breadcrumb: null,
     masteryDelta,
     correctAnswer: question.answerText,
+    // Flags an author-written answer the LLM never confirmed, so the reveal can
+    // tag it. Only authored questions carry this; curated/house answers default
+    // to 'verified'. The legacy `verified` boolean mirrors `status`.
+    unverified: question.status === 'unverified',
     creatorNote: question.creatorNote ?? null,
     insideJoke: insideJoke?.text ?? null,
     insideJokeKind: insideJoke?.kind ?? null,

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -75,6 +75,16 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       );
     }
+    if (errors.includes('unverifiedBroadcast')) {
+      return NextResponse.json(
+        {
+          error: 'unverified_no_broadcast',
+          fields: errors,
+          message: "This question isn't verified, so it can only be sent directly to specific friends — not shared with all friends.",
+        },
+        { status: 400 },
+      );
+    }
     return NextResponse.json({ error: 'validation', fields: errors }, { status: 400 });
   }
 

--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -83,6 +83,18 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // An unverified question (its answer was never machine-confirmed) is a private
+  // ask between the author and the people they hand it to directly. The author
+  // may keep direct-sending it, but a recipient cannot forward it onward — an
+  // unconfirmed answer should not travel beyond the people its author chose. The
+  // author's own send is allowed (creatorId === sender); anyone else is forwarding.
+  if (question[0].status === 'unverified' && question[0].creatorId !== session.userId) {
+    return NextResponse.json(
+      { error: 'unverified_no_forward', message: "This question isn't verified, so it can't be forwarded. Only the person who wrote it can send it." },
+      { status: 400 },
+    );
+  }
+
   const [alreadyCorrect, alreadyInFeed] = await Promise.all([
     userAnsweredQuestionCorrectly(parsed.recipientUserId, sendableQuestionId!),
     userHasQuestionInBlockingFeed(parsed.recipientUserId, sendableQuestionId!),

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -122,6 +122,7 @@ type AnswerResponse = {
   insideJokeKind?: InsideJokeKind | null
   pointsAwarded?: number | null
   masteryDelta?: unknown | null
+  unverified?: boolean
 }
 
 type ResultState = {
@@ -134,6 +135,7 @@ type ResultState = {
   insideJokeKind: InsideJokeKind | null
   awardedPoints: number | null
   masteryDelta: unknown | null
+  unverified: boolean
 }
 
 function formatEventTime(value: string) {
@@ -1494,6 +1496,7 @@ function FeedListContent({
             insideJokeKind: body.insideJokeKind ?? null,
             awardedPoints: body.pointsAwarded ?? null,
             masteryDelta: body.masteryDelta ?? null,
+            unverified: Boolean(body.unverified),
           },
         }))
         setItems((current) =>
@@ -2042,6 +2045,7 @@ function FeedListContent({
             openedTerritoryDomain={pickOpenedTerritoryDomain(result.masteryDelta)}
             questionId={sheetItem.question_id}
             feedItemId={sheetItem.id}
+            unverified={result.unverified}
             onRecheck={result.correct ? null : () => submitRecheck(sheetItem)}
             onClose={() => setFeedbackSheetId(null)}
           />

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -460,7 +460,10 @@ export function QuestionForm({
         llmSuggestedAnswer: state.llmSuggestedAnswer,
         critiqueIterations: state.critiqueIterations,
         sendToFriendIds: state.specificMode ? state.sendToFriendIds : [],
-        shareToFeed: state.shareToFeed,
+        // An unverified question can never be broadcast — only direct-sent. Force
+        // the broadcast flag off regardless of stale checkbox state (the toggle is
+        // also disabled in the UI, and the server rejects unverified broadcasts).
+        shareToFeed: verified ? state.shareToFeed : false,
         visibility: state.visibility,
       });
       dispatch({ type: 'DONE' });
@@ -655,8 +658,13 @@ export function QuestionForm({
                 </div>
                 <p className="mt-2 text-xs text-foreground">{scopeSignpost(state.visibility)}</p>
               </div>
+              {!verified ? (
+                <p className="mb-3 rounded-md border border-[var(--warning-border)] bg-[var(--warning-surface)] px-3 py-2 text-xs leading-[1.5] text-[var(--warning)]">
+                  ⚠ This answer isn&apos;t verified. You can only send it directly to specific friends — it can&apos;t be shared with all friends, and the people you send it to won&apos;t be able to forward it. They&apos;ll see it tagged as unverified.
+                </p>
+              ) : null}
               <label className="mb-2 flex cursor-default items-center gap-2 text-sm"><input type="checkbox" checked readOnly disabled className="rounded" /><span className="text-foreground">Save to bank</span></label>
-              <label className="mb-2 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.shareToFeed} onChange={(event) => toggleShareToFeed(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING' || state.visibility === 'private'} /><span className="text-foreground">Share with all friends</span></label>
+              <label className={['mb-2 flex items-center gap-2 text-sm', !verified ? 'cursor-not-allowed opacity-50' : 'cursor-pointer'].join(' ')}><input type="checkbox" checked={verified && state.shareToFeed} onChange={(event) => toggleShareToFeed(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING' || state.visibility === 'private' || !verified} /><span className="text-foreground">Share with all friends{!verified ? ' (unavailable — answer not verified)' : ''}</span></label>
               <label className="mb-3 flex cursor-pointer items-center gap-2 text-sm"><input type="checkbox" checked={state.specificMode} onChange={(event) => toggleSpecificMode(event.target.checked)} className="rounded" disabled={state.stage === 'SUBMITTING' || state.visibility === 'private'} /><span className="text-foreground">Send to specific friends only</span></label>
               {state.specificMode ? (
                 <div className="mt-1 space-y-3">
@@ -750,7 +758,7 @@ export function QuestionForm({
                   )}
                 </div>
               ) : null}
-              <p className="mt-3 text-xs text-muted-foreground">{state.specificMode ? 'Sent directly to the friends you pick.' : state.shareToFeed ? "Your friends will see this in their feed (except friends who've marked this domain as Not my focus)." : 'Saved to your bank only.'}</p>
+              <p className="mt-3 text-xs text-muted-foreground">{state.specificMode ? 'Sent directly to the friends you pick.' : verified && state.shareToFeed ? "Your friends will see this in their feed (except friends who've marked this domain as Not my focus)." : 'Saved to your bank only.'}</p>
             </div>
           ) : null}
 

--- a/src/components/activity/DirectQuestionAnswer.tsx
+++ b/src/components/activity/DirectQuestionAnswer.tsx
@@ -19,6 +19,7 @@ type Feedback = {
   insideJokeKind: InsideJokeKind | null;
   openedNewTerritory: boolean;
   openedTerritoryDomain: string | null;
+  unverified: boolean;
 };
 
 // The "ANSWER →" action on a "{friend} sent you a question" stream row. A direct
@@ -48,8 +49,9 @@ export function DirectQuestionAnswer({
         body: JSON.stringify({ submitted_answer: answer }),
       });
       const body = (await res.json().catch(() => null)) as
-        | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
+        | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain' | 'unverified'> & {
             masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
+            unverified?: boolean;
           })
         | null;
       if (!res.ok || !body) throw new Error('Could not score that answer.');
@@ -66,6 +68,7 @@ export function DirectQuestionAnswer({
         openedTerritoryDomain: body.masteryDelta?.openedNewTerritory
           ? body.masteryDelta?.domain ?? null
           : null,
+        unverified: Boolean(body.unverified),
       });
       setPhase('result');
     } catch {
@@ -134,6 +137,7 @@ export function DirectQuestionAnswer({
           openedTerritoryDomain={feedback.openedTerritoryDomain}
           questionId={action.questionId}
           feedItemId={action.feedItemId}
+          unverified={feedback.unverified}
           onClose={finish}
         />
       ) : null}

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -31,6 +31,10 @@ type AnswerFeedbackSheetProps = {
   openedTerritoryDomain?: string | null
   questionId: string
   feedItemId: string
+  // The author's answer was never machine-confirmed (it differs from the LLM's
+  // suggestion). Surfaces an "Unverified answer" tag on the reveal so the
+  // recipient knows to take the answer with a grain of salt.
+  unverified?: boolean
   // Requests a second look at a wrong answer (typos, accepted synonyms, a
   // disputed canonical answer). Resolves with the verdict to surface inline.
   // Omit (or pass null) to hide the recheck affordance.
@@ -60,6 +64,7 @@ export function AnswerFeedbackSheet({
   openedTerritoryDomain = null,
   questionId,
   feedItemId,
+  unverified = false,
   onRecheck = null,
   report = null,
   onClose,
@@ -249,6 +254,17 @@ export function AnswerFeedbackSheet({
               >
                 {correctAnswer}
               </p>
+            ) : null}
+            {unverified ? (
+              <span
+                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.14em]"
+                style={{
+                  color: GOLD_INK,
+                  backgroundColor: 'color-mix(in srgb, var(--accent-gold) 16%, var(--brand-card))',
+                }}
+              >
+                Unverified answer
+              </span>
             ) : null}
             {!isCorrect ? (
               <p

--- a/src/server/questions/__tests__/create-payload.test.ts
+++ b/src/server/questions/__tests__/create-payload.test.ts
@@ -105,6 +105,41 @@ describe('create question payload categorization', () => {
     expect(result.value.sendToFriendIds).toEqual([]);
   });
 
+  describe('unverified question send constraints', () => {
+    it('rejects broadcasting an unverified question', () => {
+      const result = readCreateQuestionPayload({
+        ...basePayload,
+        verified: false,
+        shareToFeed: true,
+      });
+
+      expect(result.errors).toContain('unverifiedBroadcast');
+    });
+
+    it('allows direct-sending an unverified question to specific friends', () => {
+      const result = readCreateQuestionPayload({
+        ...basePayload,
+        verified: false,
+        shareToFeed: false,
+        sendToFriendIds: ['friend-1', 'friend-2'],
+      });
+
+      expect(result.errors).toEqual([]);
+      expect(result.value.verified).toBe(false);
+      expect(result.value.sendToFriendIds).toEqual(['friend-1', 'friend-2']);
+    });
+
+    it('does not constrain broadcasting a verified question', () => {
+      const result = readCreateQuestionPayload({
+        ...basePayload,
+        verified: true,
+        shareToFeed: true,
+      });
+
+      expect(result.errors).not.toContain('unverifiedBroadcast');
+    });
+  });
+
   describe('visibility (D-1 Stage 4)', () => {
     it('defaults to public when omitted', () => {
       const result = readCreateQuestionPayload({ ...basePayload });

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -76,6 +76,12 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   if (verified === null) errors.push('verified');
   if (!Number.isInteger(critiqueIterations) || critiqueIterations < 0) errors.push('critiqueIterations');
   if (shareToFeed && rawSendToFriendIds.length > 0) errors.push('shareToFeed');
+  // An unverified question (the author's answer differs from the LLM's, so it
+  // hasn't been machine-confirmed) can only be sent directly to specific people.
+  // It can never be broadcast to all friends — broadcast has no named recipient
+  // to take responsibility for an unconfirmed answer. The client disables the
+  // broadcast toggle when unverified; this is the server-side backstop.
+  if (verified === false && shareToFeed) errors.push('unverifiedBroadcast');
   if (text && correctAnswer && questionContainsAnswer(text, correctAnswer, alternateAnswers)) {
     errors.push('answerInQuestion');
   }


### PR DESCRIPTION
## Summary
Adds validation and UI constraints to prevent unverified questions (those whose answers differ from the LLM's suggestion) from being broadcast to all friends. Unverified questions can only be sent directly to specific friends, and recipients cannot forward them further.

## Key Changes

- **Server-side validation** (`create-payload.ts`): Added `unverifiedBroadcast` error when attempting to broadcast an unverified question; added comprehensive test coverage for unverified question constraints
- **API error handling** (`route.ts`): Returns `unverified_no_broadcast` error when validation fails; prevents non-authors from forwarding unverified questions via `send/route.ts`
- **UI constraints** (`QuestionForm.tsx`): 
  - Disables and visually de-emphasizes the "Share with all friends" checkbox when answer is unverified
  - Forces `shareToFeed` to `false` in the payload regardless of checkbox state
  - Displays warning message explaining unverified answer restrictions
  - Updates helper text to reflect broadcast unavailability
- **Answer reveal** (`AnswerFeedbackSheet.tsx`): Displays "Unverified answer" tag when showing feedback for unverified questions
- **Feedback propagation** (`DirectQuestionAnswer.tsx`, `FeedList.tsx`, `feed/[feedItemId]/answer/route.ts`): Threads `unverified` flag through answer scoring flow so the reveal can display the tag

## Implementation Details

- Unverified status is determined by `question.status === 'unverified'` (author's answer differs from LLM's)
- The `verified` boolean in payloads mirrors the `status` field for backward compatibility
- Client-side UI disabling is paired with server-side validation as a defense-in-depth measure
- Forwarding prevention uses `creatorId !== session.userId` check to allow authors to re-send but block recipients from forwarding
- Visual treatment uses warning colors (gold accent) consistent with the design system

https://claude.ai/code/session_018RFGg8LFEHS1sKVEuH9SVN