### PR TITLE
fix(daily): grade answers against the displayed question, not a stale slot

### DIFF
--- a/src/app/api/daily/answer/__tests__/route.test.ts
+++ b/src/app/api/daily/answer/__tests__/route.test.ts
@@ -362,6 +362,51 @@ describe('POST /api/daily/answer mastery scoring (F2.1)', () => {
   })
 })
 
+describe('POST /api/daily/answer — slot identity guard (stale snapshot)', () => {
+  // Regression: the client displays slot.question_text but only submits
+  // slot_index; if the queue is re-indexed after load (a +2 bonus insert
+  // re-sorts slots) the slot_index now holds a different question, and grading
+  // would score the typed answer against the wrong question (answered Austerlitz,
+  // marked wrong against Omaha Beach). expected_question_id pins the displayed
+  // question so the server refuses to grade a mismatched slot.
+  beforeEach(() => {
+    vi.clearAllMocks()
+    readPriorAnswersForQuestionMock.mockResolvedValue([])
+  })
+
+  it('grades normally when expected_question_id matches the slot FK', async () => {
+    setupDbChain()
+    gradeAnswerMock.mockResolvedValueOnce({ result: 'correct', consolation: null })
+
+    const res = await POST(
+      jsonRequest({ ...VALID_BODY, expected_question_id: 'gen-q-1' }) as never,
+    )
+
+    expect(res.status).toBe(200)
+    expect(gradeAnswerMock).toHaveBeenCalled()
+  })
+
+  it('refuses to grade (409 slot_changed) and returns fresh slots when the FK no longer matches', async () => {
+    // Only the queue select is reached — the guard returns before the question
+    // lookup, so no grading / persistence / mastery side effects fire.
+    selectCallChain.length = 0
+    selectCallChain.push(async () => [dbState.queue])
+
+    const res = await POST(
+      jsonRequest({ ...VALID_BODY, expected_question_id: 'gen-q-STALE' }) as never,
+    )
+
+    expect(res.status).toBe(409)
+    const body = await res.json()
+    expect(body.error).toBe('slot_changed')
+    expect(body.slots).toEqual(dbState.queue.slots)
+
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
+    expect(dbMock.update).not.toHaveBeenCalled()
+    expect(writeMasteryEventMock).not.toHaveBeenCalled()
+  })
+})
+
 describe('POST /api/daily/answer grader outage (#6 — never score wrong on LLM failure)', () => {
   beforeEach(() => {
     vi.clearAllMocks()

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -37,10 +37,29 @@ type DailyAnswerErrorCode =
   | 'question_not_found'
   | 'forbidden'
   | 'grader_unavailable'
+  | 'slot_changed'
   | 'unexpected';
 
 function dailyAnswerErrorResponse(status: number, error: DailyAnswerErrorCode, message: string) {
   return NextResponse.json({ error, message }, { status });
+}
+
+// The slot the client is answering no longer holds the question it displayed —
+// the stored queue was mutated (e.g. a +2 bonus inserted, slots re-indexed)
+// after the client snapshotted it, so this slot_index now resolves to a
+// different question. Grading would score the typed answer against the wrong
+// question (the "answered Austerlitz, marked wrong against Omaha Beach" bug).
+// Refuse to grade and hand back the fresh slots so the client can reconcile and
+// re-display the real current question without recording a bogus miss.
+function slotChangedResponse(slots: QueueSlot[]) {
+  return NextResponse.json(
+    {
+      error: 'slot_changed' satisfies DailyAnswerErrorCode,
+      message: 'This question just refreshed — give it another look and answer again.',
+      slots,
+    },
+    { status: 409 },
+  );
 }
 
 async function resolveCanonicalAnswer(question: typeof generatedQuestions.$inferSelect): Promise<string> {
@@ -79,6 +98,12 @@ async function resolveCanonicalAnswer(question: typeof generatedQuestions.$infer
 const bodySchema = z.object({
   queue_id: z.string().min(1),
   slot_index: z.number().int(),
+  // The question id (generated_question_id ?? question_id) the client believes
+  // occupies this slot. Optional for backward compatibility, but when present
+  // the server verifies the slot still resolves to it before grading, so a
+  // client answering a stale slot_index can't be scored against a different
+  // question. See slotChangedResponse.
+  expected_question_id: z.string().optional().catch(undefined),
   // gave_up / submitted_answer / answer are permissive: a malformed type is
   // coerced away (matching the prior hand-rolled parser) rather than 400-ing.
   gave_up: z.boolean().optional().catch(undefined),
@@ -86,10 +111,16 @@ const bodySchema = z.object({
   answer: z.string().optional().catch(undefined),
 });
 
-function parseBody(value: unknown): { queueId: string; slotIndex: number; submittedAnswer: string; gaveUp: boolean } | null {
+function parseBody(value: unknown): {
+  queueId: string;
+  slotIndex: number;
+  submittedAnswer: string;
+  gaveUp: boolean;
+  expectedQuestionId: string | null;
+} | null {
   const parsed = bodySchema.safeParse(value);
   if (!parsed.success) return null;
-  const { queue_id, slot_index, gave_up, submitted_answer, answer } = parsed.data;
+  const { queue_id, slot_index, expected_question_id, gave_up, submitted_answer, answer } = parsed.data;
   const gaveUp = gave_up === true;
   const submittedAnswer = (
     typeof submitted_answer === 'string'
@@ -99,7 +130,13 @@ function parseBody(value: unknown): { queueId: string; slotIndex: number; submit
         : ''
   ).trim();
   if (!gaveUp && !submittedAnswer) return null;
-  return { queueId: queue_id, slotIndex: slot_index, submittedAnswer, gaveUp };
+  return {
+    queueId: queue_id,
+    slotIndex: slot_index,
+    submittedAnswer,
+    gaveUp,
+    expectedQuestionId: expected_question_id ?? null,
+  };
 }
 
 export async function POST(request: NextRequest) {
@@ -134,6 +171,19 @@ export async function POST(request: NextRequest) {
     }
     if (!slot.generated_question_id && !slot.question_id) {
       return dailyAnswerErrorResponse(400, 'invalid_state', 'That Daily Five slot is not ready yet.');
+    }
+
+    // Identity guard: the client displays slot.question_text but only submits
+    // slot_index, and grading below resolves the question from the slot's FK. If
+    // the queue was re-indexed after the client snapshotted it (a +2 bonus
+    // insert re-sorts slots by slot_index), this slot_index can now hold a
+    // different question than the one the player saw. Verify the slot still
+    // resolves to the question id the client expected; on mismatch, refuse to
+    // grade and return the fresh slots so the client re-displays the real
+    // question rather than scoring the answer against the wrong one.
+    const slotQuestionId = slot.generated_question_id ?? slot.question_id ?? null;
+    if (parsed.expectedQuestionId && slotQuestionId && parsed.expectedQuestionId !== slotQuestionId) {
+      return slotChangedResponse(slots);
     }
 
     // The Daily 5 mixes two slot shapes — bot-generated questions live in

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -75,6 +75,9 @@ type AnswerResponse = {
 type FailedAnswerResponse = {
   message?: string;
   error?: string;
+  // Present on a 409 'slot_changed': the server's fresh slots, so the client can
+  // reconcile a stale snapshot instead of grading against the wrong question.
+  slots?: QueueSlot[];
 };
 
 type RecheckResponse = {
@@ -523,6 +526,12 @@ export default function DailyPage() {
           body: JSON.stringify({
             queue_id: queue.queue_id,
             slot_index: currentSlot.slot_index,
+            // Pin the question this slot is displaying so the server won't grade
+            // a stale slot_index against a different question (see the answer
+            // route's identity guard). Bot slots carry generated_question_id,
+            // friend/house slots carry question_id.
+            expected_question_id:
+              currentSlot.generated_question_id ?? currentSlot.question_id,
             submitted_answer: opts.submittedAnswer,
             gave_up: opts.gaveUp,
           }),
@@ -531,6 +540,18 @@ export default function DailyPage() {
           const failedBody = (await response
             .json()
             .catch(() => null)) as FailedAnswerResponse | null;
+          // Stale snapshot: the slot moved on under us. Reconcile to the server's
+          // fresh slots and let the corrected current question re-render, rather
+          // than recording this answer against the wrong question. Clear the
+          // input since the refreshed question is a different prompt.
+          if (failedBody?.error === 'slot_changed' && Array.isArray(failedBody.slots)) {
+            const reconciledSlots = failedBody.slots;
+            setQueue((existing) =>
+              existing ? { ...existing, slots: reconciledSlots } : existing,
+            );
+            setAnswer('');
+            return;
+          }
           throw new Error(answerFailureMessage(failedBody));
         }
 


### PR DESCRIPTION
## What & why

Reported in-game: a player answered the Andrei Bolkonsky / Austerlitz question with **"The sky"** (the correct answer) but was marked wrong and shown the **next** question's answer (Omaha Beach / D-Day).

Root cause: the Daily Five client renders `slot.question_text` but submits only `slot_index`, while `POST /api/daily/answer` grades whatever question the slot's FK (`generated_question_id` / `question_id`) resolves to. Every slot-**creation** path writes `question_text` and the FK together, so the slots are consistent at write time — but the client holds a **snapshot** taken at load. When the stored queue is re-indexed after that load (a +2 bonus insert filters by `slot_index` and re-sorts), the index the client submits can now point at a different question. You answer the question you saw; the server grades a different one.

## The fix

Pin the displayed question end-to-end so a mismatched slot can never be graded:

- **Server** (`src/app/api/daily/answer/route.ts`): accept an optional `expected_question_id`; after resolving the slot by `slot_index`, verify it still resolves to that id. On mismatch, return **`409 slot_changed`** with the fresh slots — *before* grading, so no answer is scored and no mastery/feed side effects fire.
- **Client** (`src/app/daily/page.tsx`): send `expected_question_id` (the displayed slot's FK); on `slot_changed`, reconcile `queue.slots` to the server's fresh slots and clear the input, so the real current question re-renders instead of recording a bogus miss.

Backward-compatible: the guard only triggers when `expected_question_id` is present, so existing callers and the catch-up path (separate routes) are unaffected.

## Tests

`src/app/api/daily/answer/__tests__/route.test.ts` — two added:
- matching `expected_question_id` grades normally;
- mismatched id returns `409 slot_changed` with the fresh slots and fires no grading / DB update / mastery write.

All 14 tests in the file pass; typecheck clean on the touched files.

## Notes / follow-ups (not in this PR)

- This is a **guard** that makes the symptom impossible and self-heals the client; it does not remove the underlying re-index that lets a stale snapshot survive. Happy to chase that at the source (likely the bonus insert in `daily.ts`) in a follow-up.
- `/api/daily/skip` and `/api/daily/recheck` key on `slot_index` alone too and have the same theoretical staleness — the same `expected_question_id` guard could be extended to them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
