### PR TITLE
Refactor activity marks & feed styling for unified ambient stream

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from 'next'
 import { Cormorant_Garamond, Montserrat, Playfair_Display } from 'next/font/google'
 import './globals.css'
 import { Nav } from "@/components/Nav";
-// TESTING ONLY — proposed-palette preview bar (see _docs/STYLE-GUIDE-COLOR.md).
+// TESTING ONLY — card-background cycler bar (see PaletteToggle).
 // Remove this import + the <PaletteToggle/> + boot script before shipping.
 import { PaletteToggle } from "@/components/dev/PaletteToggle";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
@@ -67,11 +67,12 @@ export default async function RootLayout({
       className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable}`}
     >
       <body className={montserrat.className}>
-        {/* TESTING ONLY — apply the saved palette choice before paint so there's
-            no flash on navigation. Remove with <PaletteToggle/> before shipping. */}
+        {/* TESTING ONLY — apply the saved card-background choice before paint so
+            there's no flash on navigation. Remove with <PaletteToggle/> before
+            shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{if(localStorage.getItem('joshing-palette')==='proposed')document.documentElement.setAttribute('data-palette','proposed')}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -142,7 +142,7 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
           header and the shapes share one left edge. The day labels indent
           further (pl-[34px], past the icon column) to meet the row copy. */}
       <p className="mb-2 pl-[2px] text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
-        What&rsquo;s happening
+        For you
       </p>
       <FeedList
         pageSize={FEED_PAGE_SIZE}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -702,14 +702,14 @@ function FeedContributeFooter() {
   }
 
   return (
-    <footer className="pt-6 pb-8">
+    <footer className="pb-8">
       {/* Add-a-Question prompt — the same full-bleed editorial wash language as
           the feed's other featured moments (no card, border, or triangle
           mosaic): a parchment band that bleeds to the feed edges, with an
           eyebrow, the serif prompt, and the composer. The box stays an input:
           the reader's typed idea rides to the writer via ?text=
           (buildQuestionWriterHref). */}
-      <div className="-mx-4 mt-6 bg-[var(--editorial-parchment)] px-[30px] py-12 md:py-14">
+      <div className="-mx-4 bg-[var(--editorial-parchment)] px-[30px] py-12 md:py-14">
         <p className="text-[11px] font-semibold tracking-[0.14em] text-[var(--brand-orange)] uppercase">
           Your Turn
         </p>
@@ -1899,7 +1899,9 @@ function FeedListContent({
               group), keeping the render path uniform. */}
           {forYouRows.length > 0 ? (
             <Fragment key="for-you">
-              <FeedSectionHeading unifiedHome={unifiedHome}>For You</FeedSectionHeading>
+              <FeedSectionHeading unifiedHome={unifiedHome}>
+                questions your friends created or sent directly to you
+              </FeedSectionHeading>
               {groupActivityByFriend(forYouRows).map(renderRow)}
               {/* D-HOME-PACING-01 §3 — quiet overflow row. Abundance, never
                   obligation; the subpage it will open is B-HOME-OVERFLOW-02. */}

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -161,7 +161,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
 
     // Both question zones render their headings and overflow affordances,
     // each linking to its zone's overflow subpage (B-HOME-OVERFLOW-02).
-    expect(html).toContain('For You')
+    expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('From Friends')
     expect(html).toContain('4 more from friends →')
     expect(html).toContain('3 more →')
@@ -199,7 +199,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('Quiet today')
     // No panel double-invite, no zone headings.
     expect(html).not.toContain('PANEL')
-    expect(html).not.toContain('For You')
+    expect(html).not.toContain('questions your friends created or sent directly to you')
     expect(html).not.toContain('From Friends')
   })
 
@@ -222,7 +222,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
       },
     })
 
-    expect(html).toContain('For You')
+    expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('direct:robyn')
     // The empty playable zone is omitted entirely — no heading, no placeholder.
     expect(html).not.toContain('From Friends')

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -207,7 +207,7 @@ describe('FeedList — pendingQueue subpage mode (/for-you)', () => {
     for (let i = 0; i < 5; i++) expect(html).toContain(`direct:sender${i}`)
     // No surface tabs, no home section headings, no recency buckets.
     expect(html).not.toContain('Broadcasts')
-    expect(html).not.toContain('For You')
+    expect(html).not.toContain('questions your friends created or sent directly to you')
     expect(html).not.toContain('Today')
     // No overflow affordance — nothing is windowed here — and no texture
     // see-more row (the subpage has no texture zone).

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -12,9 +12,10 @@
 //                                 Unanswered = filled, answered = hollow outline.
 //   star     → five-point star     a friend you invited played their first five.
 //                                 Five palette triangles, one point per question.
-//   diamond  → rhombus             someone answered ("got") a question.
-//   hourglass→ two triangles apex-to-apex   someone sends you a question.
-//   domain   → half-triangles split on a diagonal   a new domain opened.
+//   diamond / hourglass / domain → a single triangle POINTING IN at the copy.
+//                                 The ambient one-liners (someone answered, saved
+//                                 your question, a new domain opened) all share
+//                                 this one calm inward triangle.
 //
 // COLOR: each individual triangle's fill is picked at random from the triangle
 // palette — but deterministically, hashed from a stable seed (the row id + the
@@ -56,23 +57,11 @@ const STAR_FILL_OPACITY = 1;
 const MARK_W = 24;
 const GAP = 8;
 const LINE_H = 22.5; // first text line: 15px × 1.5
-// The stacked single-shape marks (diamond / hourglass / domain) are a vertical
-// pair of triangles. Each half is base=height (24×24) so the triangles stay
-// isosceles and un-smushed — matching the BundleMark invariant below. The pair's
-// viewBox is therefore 24×48 (a 1:2 aspect). We render it at LARGE_SCALE so its
-// HEIGHT lands at ~the text line height (48 × 0.5 = 24 ≈ LINE_H 22.5) and the
-// mark sits TUCKED INSIDE the first line when vertically centered (see
-// ActivityIcon) instead of drooping far below it. Width = 24 × 0.5 = 12, which
-// matches a single BundleMark triangle, so the two icon families read as one set.
-// (Keep the halves base=height — drawing them shorter squishes the rhombus and
-// was reverted; the fix for "too tall" is the scale + centering here, not the
-// geometry.)
-const LARGE_SCALE = 0.5;
 // The 'star' mark (a friend you invited cleared their first five) is drawn in a
 // square 24×24 viewBox and rendered at STAR_SCALE so its height lands at ~the
-// text line height, sitting on a single-line row like the diamond. A point-up
-// five-point star is wider than the single stacked marks; this scale keeps its
-// footprint close to the old cluster it replaces (~20px) without dominating.
+// text line height, sitting on a single-line row like the inward triangle. A
+// point-up five-point star is wider than the single triangle; this scale keeps
+// its footprint close to the old cluster it replaces (~20px) without dominating.
 const STAR_SCALE = 0.85;
 // Five-point star geometry (centered in the 24×24 viewBox). Outer points touch
 // the box; the inner vertices sit at INNER_RATIO of the outer radius — large
@@ -81,10 +70,6 @@ const STAR_CX = 12;
 const STAR_CY = 12;
 const STAR_RO = 12;
 const STAR_INNER_RATIO = 0.4;
-// Height of each half of a stacked mark, and the total viewBox height of the
-// pair. base=height (= MARK_W) keeps the triangles un-smushed.
-const STACK_HALF = 24;
-const STACK_H = STACK_HALF * 2; // 48
 // Every mark TOP-ANCHORS its top near the first line's cap height (the top of
 // "R"), not the line-box top above it — so the top of the shape lines up with
 // the top of the letter beside it. The line's half-leading is ((22.5 − 15) / 2
@@ -297,63 +282,18 @@ export function MilestoneStar({ seed }: { seed: string }) {
   );
 }
 
-// Rhombus: upward triangle over downward triangle, shared base. Each half a
-// random palette colour.
-function DiamondMark({ seed }: { seed: string }) {
+// A single triangle POINTING IN toward the row copy (apex to the right), one
+// random palette colour. This is the ambient activity row's mark — it replaces
+// the diamond / hourglass / domain stacked marks so every one-liner (someone
+// answered, saved your question, a new domain opened) reads with the same calm
+// inward triangle rather than a distinct stacked glyph per event.
+function InwardTriangleMark({ seed }: { seed: string }) {
+  const S = 14; // base = height, a hair larger than one bundle triangle
   return (
-    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
-      <path
-        d={`M12,0 L0,${STACK_HALF} L24,${STACK_HALF} Z`}
-        fill={colorFor(seed, 0)}
-        fillOpacity={FILL_OPACITY}
-      />
-      <path
-        d={`M0,${STACK_HALF} L24,${STACK_HALF} L12,${STACK_H} Z`}
-        fill={colorFor(seed, 1)}
-        fillOpacity={FILL_OPACITY}
-      />
-    </MarkSvg>
-  );
-}
-
-// Two triangles meeting apex-to-apex at the center, tips touching. A question
-// sent your way.
-function HourglassMark({ seed }: { seed: string }) {
-  return (
-    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
-      <path
-        d={`M0,0 L24,0 L12,${STACK_HALF} Z`}
-        fill={colorFor(seed, 0)}
-        fillOpacity={FILL_OPACITY}
-      />
-      <path
-        d={`M12,${STACK_HALF} L0,${STACK_H} L24,${STACK_H} Z`}
-        fill={colorFor(seed, 1)}
-        fillOpacity={FILL_OPACITY}
-      />
-    </MarkSvg>
-  );
-}
-
-// The hourglass split apart on a diagonal: a half top-right and a half
-// bottom-left. Divergence = a new domain opened. The two halves are pulled in
-// toward the centerline (each shifted 6 units off the viewBox edge instead of
-// sitting flush against it) so the diagonal gap between them reads tighter —
-// they still split on the same diagonal and stay rotationally symmetric.
-function DomainMark({ seed }: { seed: string }) {
-  return (
-    <MarkSvg h={STACK_H} scale={LARGE_SCALE}>
-      <path
-        d={`M18,0 L6,0 L18,${STACK_HALF} Z`}
-        fill={colorFor(seed, 0)}
-        fillOpacity={FILL_OPACITY}
-      />
-      <path
-        d={`M6,${STACK_HALF} L18,${STACK_H} L6,${STACK_H} Z`}
-        fill={colorFor(seed, 1)}
-        fillOpacity={FILL_OPACITY}
-      />
-    </MarkSvg>
+    <svg width={S} height={S} viewBox={`0 0 ${S} ${S}`} fill="none">
+      {/* Apex on the right edge, base on the left — points "in" at the copy. */}
+      <path d={`M0,0 L${S},${S / 2} L0,${S} Z`} fill={colorFor(seed, 0)} fillOpacity={FILL_OPACITY} />
+    </svg>
   );
 }
 
@@ -367,12 +307,12 @@ function Mark({ spec, seed }: { spec: ActivityIconSpec; seed: string }) {
       // sibling of the diamond, but its radial silhouette sets the milestone
       // apart from the rest of the triangle family.
       return <StarMark seed={seed} />;
+    // The ambient one-liner events all share one calm mark now: a single
+    // palette triangle pointing in toward the copy.
     case 'diamond':
-      return <DiamondMark seed={seed} />;
     case 'hourglass':
-      return <HourglassMark seed={seed} />;
     case 'domain':
-      return <DomainMark seed={seed} />;
+      return <InwardTriangleMark seed={seed} />;
   }
 }
 

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -16,7 +16,7 @@ import type {
 
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
-import { ActivityIcon, MilestoneStar, QuestionTriangle, specForIcon } from './ActivityIcon';
+import { ActivityIcon, QuestionTriangle, specForIcon } from './ActivityIcon';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
 import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
@@ -86,7 +86,7 @@ const HEADLINE_NAME_STYLE: CSSProperties = {
   textDecoration: 'none',
 };
 
-export function Line({ parts }: { parts: StreamLinePart[] }) {
+export function Line({ parts, plain = false }: { parts: StreamLinePart[]; plain?: boolean }) {
   return (
     <>
       {parts.map((part, i) => {
@@ -94,10 +94,19 @@ export function Line({ parts }: { parts: StreamLinePart[] }) {
           return <ActorLink key={i} name={part.name} userId={part.userId} />;
         }
         if (part.t === 'category') {
-          // Category names read in the Editorial serif (STYLE-GUIDE-TYPE §5):
-          // warm, in their stored title case ("Shakespearean Tragedy"), a clear
-          // register away from the sans sentence around them — no caps, no
-          // tracking, no typewriter face (the System mono voice was retired).
+          // `plain` (the ambient activity stream): the category stays in the
+          // row's own sans face so the one-liner reads in a single voice — only
+          // a touch of weight + the secondary ink set it apart from the sentence.
+          if (plain) {
+            return (
+              <span key={i} style={{ fontWeight: 600, color: INK2 }}>
+                {part.v}
+              </span>
+            );
+          }
+          // Default (editorial surfaces): category names read in the Editorial
+          // serif (STYLE-GUIDE-TYPE §5) — warm, in their stored title case
+          // ("Shakespearean Tragedy"), a register away from the sans sentence.
           return (
             <span
               key={i}
@@ -271,14 +280,6 @@ export function ActivityStreamItem({
       : null;
   const iconSpec = specForIcon(item.icon, bundleCounts);
 
-  // The "invited friend played their first five" star is a celebratory
-  // announcement, not a normal left-aligned event row: it renders centered with
-  // a star flourish on each side (star — line — star) instead of a single mark
-  // in the left icon column. It carries no action/expansion/second line, so the
-  // centered branch is a self-contained one-liner. Nested rows keep the plain
-  // indented form.
-  const centeredStar = !nested && item.icon === 'star';
-
   function toggle() {
     if (expandable) setOpen((v) => !v);
   }
@@ -357,33 +358,12 @@ export function ActivityStreamItem({
         onKeyDown={handleKeyDown}
         style={{
           display: 'flex',
-          alignItems: centeredStar ? 'center' : 'flex-start',
-          justifyContent: centeredStar ? 'center' : undefined,
-          gap: centeredStar ? 10 : undefined,
+          alignItems: 'flex-start',
           cursor: expandable ? 'pointer' : 'default',
           WebkitTapHighlightColor: 'transparent',
         }}
       >
-        {centeredStar ? (
-          // Celebratory announcement: a star flourish on each side of the
-          // centered line (star — line — star).
-          <>
-            <MilestoneStar seed={item.id} />
-            <p
-              style={{
-                margin: 0,
-                fontSize: 15,
-                lineHeight: 1.5,
-                letterSpacing: 0.2,
-                color: INK,
-                textAlign: 'center',
-              }}
-            >
-              <Line parts={item.line} />
-            </p>
-            <MilestoneStar seed={`${item.id}-end`} />
-          </>
-        ) : playableCard ? (
+        {playableCard ? (
           // Playable milestone card (home "What's Happening"): an editorial
           // two-line headline — the person's NAME in the large serif, the rest
           // of the sentence in a medium serif below it — with the play
@@ -456,15 +436,20 @@ export function ActivityStreamItem({
                   display: 'inline-flex',
                   alignItems: 'center',
                   gap: 5,
-                  fontSize: 12.5,
+                  // Same text treatment as the "Answer →" feed action: the
+                  // Editorial serif at 18px in the link slate, underlined.
+                  fontFamily: 'var(--font-serif)',
+                  fontSize: 18,
                   fontWeight: 600,
-                  letterSpacing: 0.2,
-                  color: INK,
+                  letterSpacing: '0.05em',
+                  color: 'var(--brand-link)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 4,
                 }}
               >
                 {playFirstName ? `Play ${playFirstName}'s q's` : 'Play'}
                 <ChevronDown
-                  size={15}
+                  size={16}
                   aria-hidden
                   style={{
                     transition: 'transform 150ms ease',
@@ -490,15 +475,17 @@ export function ActivityStreamItem({
               color: INK,
             }}
           >
-            <Line parts={item.line} />
+            {/* `plain` keeps the whole one-liner in the row's sans face — no
+                serif category run — so the ambient stream reads in one voice. */}
+            <Line parts={item.line} plain />
           </p>
           {item.secondLine ? (
             <p
               style={{
                 margin: '2px 0 0',
-                // Voice follows content (STYLE-GUIDE-TYPE §5): domain/label
-                // metadata is System mono with the caps + tracking label
-                // signature (§2); question text / sentences are Editorial serif.
+                // Domain/label metadata stays System mono with the caps +
+                // tracking label signature (§2); everything else stays in the
+                // row's sans face (no serif), so the stream reads in one voice.
                 ...(item.secondLineVoice === 'system'
                   ? {
                       fontFamily: 'var(--font-mono)',
@@ -507,7 +494,6 @@ export function ActivityStreamItem({
                       letterSpacing: 1,
                     }
                   : {
-                      fontFamily: 'var(--font-serif)',
                       fontSize: 14,
                     }),
                 lineHeight: 1.45,
@@ -554,20 +540,8 @@ export function ActivityStreamItem({
               {timestamp}
             </span>
           ) : null}
-          {/* Decorative disclosure chevron — demoted; the row itself is the
-              button (aria-expanded above). */}
-          {expandable ? (
-            <ChevronDown
-              size={16}
-              aria-hidden
-              style={{
-                color: INK3,
-                opacity: 0.5,
-                transition: 'transform 150ms ease',
-                transform: open ? 'rotate(180deg)' : 'none',
-              }}
-            />
-          ) : null}
+          {/* No disclosure chevron — the whole row is the button (aria-expanded
+              above); the ambient one-liners read clean on the right edge. */}
         </div>
           </>
         )}

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -3,69 +3,78 @@
 import { useSyncExternalStore, type CSSProperties } from 'react';
 
 // ─────────────────────────────────────────────────────────────────────────────
-// TESTING ONLY — proposed-palette preview switch (see _docs/STYLE-GUIDE-COLOR.md).
+// TESTING ONLY — card-background cycler (repurposed from the palette preview bar).
 //
-// Flips the `data-palette` attribute on <html>. The `:root[data-palette="proposed"]`
-// override block in globals.css repoints the color *tokens*, so every surface
-// that reads a token recolors automatically — no per-page edits. Surfaces still
-// on hardcoded hex (the category systems, some golds) won't flip until they're
-// routed onto tokens; that routing is the actual color build.
+// Cycles the `--brand-card` token — the resting feed-card surface — through the
+// SANCTIONED background colors (globals.css), so a tester can audit how the
+// cards read on each cream / wash without per-page edits. Every surface that
+// fills with `var(--brand-card)` recolors automatically.
 //
-// Colors here are inline (not Tailwind classes) on purpose: this is chrome, not
-// app surface, so it deliberately sits outside the brand-token lint.
+// Only the system's own background tokens are offered (no off-palette hex), so
+// nothing here introduces an unsanctioned color. Inline styles are on purpose:
+// this is chrome, not app surface, so it sits outside the brand-token lint.
 //
-// Remove this component (and the globals.css block) before merging to a shipping
-// branch. The boot script in layout.tsx applies the saved choice pre-paint.
+// Remove this component (and the boot script in layout.tsx) before merging to a
+// shipping branch. The boot script applies the saved choice pre-paint.
 // ─────────────────────────────────────────────────────────────────────────────
 
-type Palette = 'current' | 'proposed';
+type CardBg = { label: string; value: string; swatch: string };
 
-const STORAGE_KEY = 'joshing-palette';
-
-// What the toggle visibly changes, so a tester knows where to look. Extend this
-// as more color jobs (category, gold) get routed onto tokens.
-const CHANGES: Array<{ label: string; from: string; to: string }> = [
-  { label: 'WRONG WASH', from: '#c96b4a', to: '#a93b3b' },
-  { label: 'WRONG TEXT', from: '#c33d14', to: '#c1121f' },
-  { label: 'LITERATURE', from: '#c0392b', to: '#7d2c3f' },
-  { label: 'LANGUAGE', from: '#4a7a5a', to: '#2e6e7e' },
+// Each entry is a sanctioned background token. 'Default' clears the override
+// (back to --brand-card's own value, #fdfcfb).
+const CARD_BGS: CardBg[] = [
+  { label: 'Default', value: '', swatch: '#fdfcfb' },
+  { label: 'Cream page', value: 'var(--brand-cream-page)', swatch: 'var(--brand-cream-page)' },
+  { label: 'Warm cream', value: 'var(--brand-cream-card)', swatch: 'var(--brand-cream-card)' },
+  { label: 'Cream accent', value: 'var(--brand-cream)', swatch: 'var(--brand-cream)' },
+  { label: 'Question', value: 'var(--game-card-question)', swatch: 'var(--game-card-question)' },
+  { label: 'Parchment', value: 'var(--editorial-parchment)', swatch: 'var(--editorial-parchment)' },
+  { label: 'Sage', value: 'var(--editorial-sage)', swatch: 'var(--editorial-sage)' },
+  { label: 'Slate', value: 'var(--editorial-slate)', swatch: 'var(--editorial-slate)' },
 ];
 
-const PALETTE_EVENT = 'joshing-palette-change';
+const STORAGE_KEY = 'joshing-card-bg';
+const CARD_BG_EVENT = 'joshing-card-bg-change';
 
-// Read the live palette straight off the <html> attribute (the source of truth,
+// Read the live choice straight off the <html> attribute (the source of truth,
 // also set by the boot script before paint). useSyncExternalStore keeps the
 // control in sync without an effect-setState and without a hydration mismatch —
-// the server snapshot is always 'current'.
+// the server snapshot is always the default (index 0).
 function subscribe(onChange: () => void) {
-  window.addEventListener(PALETTE_EVENT, onChange);
-  return () => window.removeEventListener(PALETTE_EVENT, onChange);
+  window.addEventListener(CARD_BG_EVENT, onChange);
+  return () => window.removeEventListener(CARD_BG_EVENT, onChange);
 }
-function readSnapshot(): Palette {
-  return document.documentElement.getAttribute('data-palette') === 'proposed' ? 'proposed' : 'current';
+function readSnapshot(): number {
+  const raw = document.documentElement.getAttribute('data-card-bg');
+  const i = raw ? Number(raw) : 0;
+  return Number.isInteger(i) && i >= 0 && i < CARD_BGS.length ? i : 0;
 }
-function serverSnapshot(): Palette {
-  return 'current';
+function serverSnapshot(): number {
+  return 0;
 }
 
 export function PaletteToggle() {
-  const palette = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
+  const index = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
 
-  function apply(next: Palette) {
-    if (next === 'proposed') {
-      document.documentElement.setAttribute('data-palette', 'proposed');
+  function apply(next: number) {
+    const i = ((next % CARD_BGS.length) + CARD_BGS.length) % CARD_BGS.length;
+    const { value } = CARD_BGS[i];
+    const root = document.documentElement;
+    if (value) {
+      root.style.setProperty('--brand-card', value);
     } else {
-      document.documentElement.removeAttribute('data-palette');
+      root.style.removeProperty('--brand-card');
     }
+    root.setAttribute('data-card-bg', String(i));
     try {
-      localStorage.setItem(STORAGE_KEY, next);
+      localStorage.setItem(STORAGE_KEY, String(i));
     } catch {
       /* private mode / disabled storage — non-fatal */
     }
-    window.dispatchEvent(new Event(PALETTE_EVENT));
+    window.dispatchEvent(new Event(CARD_BG_EVENT));
   }
 
-  const proposed = palette === 'proposed';
+  const current = CARD_BGS[index];
 
   return (
     <div
@@ -85,58 +94,63 @@ export function PaletteToggle() {
       }}
     >
       <span style={{ fontWeight: 700, letterSpacing: '0.08em', whiteSpace: 'nowrap' }}>
-        ⚠ PALETTE TEST
+        ⚠ CARD COLOR
       </span>
 
-      <div
-        role="group"
-        aria-label="Color palette preview"
-        style={{
-          display: 'inline-flex',
-          padding: 2,
-          gap: 2,
-          borderRadius: 999,
-          background: 'rgba(255,255,255,0.08)',
-        }}
+      {/* The toggle: each tap advances to the next background color. */}
+      <button
+        type="button"
+        onClick={() => apply(index + 1)}
+        aria-label={`Card background: ${current.label}. Tap to cycle.`}
+        style={cycleStyle}
       >
-        <button type="button" onClick={() => apply('current')} style={segStyle(!proposed)}>
-          Current
-        </button>
-        <button type="button" onClick={() => apply('proposed')} style={segStyle(proposed)}>
-          Proposed
-        </button>
-      </div>
+        <Swatch color={current.swatch} active />
+        {current.label}
+        <span aria-hidden style={{ opacity: 0.6 }}>→</span>
+      </button>
 
-      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 14, minWidth: 0 }}>
-        {CHANGES.map((c) => (
-          <span key={c.label} style={{ display: 'inline-flex', alignItems: 'center', gap: 6, whiteSpace: 'nowrap' }}>
-            <span style={{ opacity: 0.8, letterSpacing: '0.04em' }}>{c.label}</span>
-            <Swatch color={c.from} dim={proposed} />
-            <span style={{ opacity: 0.5 }}>→</span>
-            <Swatch color={c.to} dim={!proposed} />
-          </span>
+      {/* Jump straight to any background. */}
+      <div style={{ marginLeft: 'auto', display: 'flex', alignItems: 'center', gap: 8, minWidth: 0 }}>
+        {CARD_BGS.map((bg, i) => (
+          <button
+            key={bg.label}
+            type="button"
+            onClick={() => apply(i)}
+            aria-label={bg.label}
+            title={bg.label}
+            style={{
+              appearance: 'none',
+              border: 'none',
+              background: 'transparent',
+              padding: 0,
+              cursor: 'pointer',
+              lineHeight: 0,
+            }}
+          >
+            <Swatch color={bg.swatch} active={i === index} />
+          </button>
         ))}
       </div>
     </div>
   );
 }
 
-function segStyle(active: boolean): CSSProperties {
-  return {
-    appearance: 'none',
-    border: 'none',
-    cursor: 'pointer',
-    borderRadius: 999,
-    padding: '3px 12px',
-    fontSize: 12,
-    fontWeight: 600,
-    background: active ? '#e7e1d4' : 'transparent',
-    color: active ? '#11161c' : '#e7e1d4',
-    transition: 'background 120ms ease, color 120ms ease',
-  };
-}
+const cycleStyle: CSSProperties = {
+  appearance: 'none',
+  border: 'none',
+  cursor: 'pointer',
+  borderRadius: 999,
+  padding: '3px 12px 3px 6px',
+  display: 'inline-flex',
+  alignItems: 'center',
+  gap: 8,
+  fontSize: 12,
+  fontWeight: 600,
+  background: '#e7e1d4',
+  color: '#11161c',
+};
 
-function Swatch({ color, dim }: { color: string; dim: boolean }) {
+function Swatch({ color, active }: { color: string; active: boolean }) {
   return (
     <span
       aria-hidden="true"
@@ -147,9 +161,9 @@ function Swatch({ color, dim }: { color: string; dim: boolean }) {
         height: 14,
         borderRadius: 3,
         background: color,
-        boxShadow: 'inset 0 0 0 1px rgba(255,255,255,0.25)',
-        opacity: dim ? 0.35 : 1,
-        transition: 'opacity 120ms ease',
+        boxShadow: active
+          ? '0 0 0 2px #e7e1d4, 0 0 0 3px #11161c'
+          : 'inset 0 0 0 1px rgba(255,255,255,0.25)',
       }}
     />
   );

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -45,6 +45,8 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, elevated }
       // (the triangle mat is retired); the eyebrow is what marks them out.
       variant="bordered"
       eyebrow="Sent directly to you"
+      // The direct-send marker reads in the brand gold accent.
+      eyebrowClassName="font-semibold text-[var(--accent-gold)]"
       signal={signal}
       question={item.question}
       overflow={overflow}

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Bookmark } from 'lucide-react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -91,9 +90,10 @@ export function CommonGroundFeature({
   const friendHref = activeFriend?.friendHref ?? embed.friendHref;
   return (
     <EditorialFeature
-      tone="parchment"
+      // Sage tone (the green accent + soft green wash) — "shared ground" reads
+      // as earthy/green, and it moves the eyebrow + CTA off the brand orange.
+      tone="sage"
       eyebrow="Shared Ground"
-      eyebrowIcon={<Bookmark size={13} strokeWidth={0} fill="currentColor" />}
       headline={
         onInviteSlide ? (
           COMMON_GROUND_INVITE_HEADLINE
@@ -158,7 +158,7 @@ export function CommonGroundFeature({
                 {INVITE_CLUSTER_SEEDS.map((seed, i) => (
                   <span
                     key={seed}
-                    className="size-12 rounded-full ring-4 ring-[var(--editorial-parchment)]"
+                    className="size-12 rounded-full ring-4 ring-[var(--editorial-sage)]"
                     style={{ background: colorForUser(seed), marginLeft: i === 0 ? 0 : -16 }}
                   />
                 ))}

--- a/src/components/feed/SparkleEnvelope.tsx
+++ b/src/components/feed/SparkleEnvelope.tsx
@@ -9,6 +9,12 @@ import { FeedDismissButton } from './FeedDismissButton'
 type SparkleEnvelopeProps = {
   /** Small-caps line above the attribution — e.g. "Sent directly to you". */
   eyebrow?: ReactNode
+  /**
+   * Color/weight override for the eyebrow. Defaults to the quiet muted-ink
+   * register; "Sent directly to you" passes the gold accent so the direct-send
+   * marker reads in the brand gold.
+   */
+  eyebrowClassName?: string
   /** Attribution line — e.g. "<actor> thought you'd like this about <category>." */
   signal: ReactNode
   question: string
@@ -41,6 +47,7 @@ type SparkleEnvelopeProps = {
  */
 export function SparkleEnvelope({
   eyebrow,
+  eyebrowClassName = 'text-[var(--brand-ink)] opacity-70',
   signal,
   question,
   overflow,
@@ -58,7 +65,12 @@ export function SparkleEnvelope({
           <div className="min-w-0 flex-1">
             {eyebrow ? (
               // Same small-caps eyebrow rhythm as the AnsweredByYouCard header.
-              <p className="mb-2 text-[11px] uppercase leading-none tracking-[0.08em] text-[var(--brand-ink)] opacity-70">
+              <p
+                className={cn(
+                  'mb-2 text-[11px] uppercase leading-none tracking-[0.08em]',
+                  eyebrowClassName,
+                )}
+              >
                 {eyebrow}
               </p>
             ) : null}


### PR DESCRIPTION
## Summary
Consolidates the activity stream's visual language by unifying three distinct event marks (diamond/hourglass/domain) into a single inward-pointing triangle, simplifies the card-background testing tool, and adjusts feed typography to read in a consistent sans voice throughout the ambient activity stream.

## Key Changes

### Activity Icon System (`ActivityIcon.tsx`)
- **Unified ambient marks:** Replaced three separate stacked-triangle marks (`DiamondMark`, `HourglassMark`, `DomainMark`) with a single `InwardTriangleMark` — a calm triangle pointing inward toward the row copy. All one-liner events (someone answered, saved your question, a new domain opened) now share this consistent visual treatment.
- **Removed geometry constants:** Deleted `LARGE_SCALE`, `STACK_HALF`, and `STACK_H` constants that were specific to the stacked-mark layout.
- **Simplified mark selection:** The `Mark()` function now routes `diamond`, `hourglass`, and `domain` cases to the same `InwardTriangleMark` component.

### Activity Stream Item (`ActivityStreamItem.tsx`)
- **Removed centered-star layout:** Deleted the `centeredStar` branch that rendered the "invited friend played their first five" milestone as a centered announcement with flanking stars. The star now renders inline with the ambient stream.
- **Unified typography:** Added `plain` prop to `Line()` component to keep category names in the row's sans face (with weight + secondary ink) rather than switching to Editorial serif, so the entire ambient stream reads in one consistent voice.
- **Removed serif from second line:** Deleted the `fontFamily: 'var(--font-serif)'` override for non-system second lines, keeping them in sans.
- **Removed disclosure chevron:** Deleted the decorative chevron that appeared on the right edge of expandable rows; the row itself is now the only affordance.
- **Updated play action styling:** Changed the "Play" CTA from small sans (12.5px) to Editorial serif (18px) with link slate color and underline, matching the "Answer →" feed action treatment.

### Card Background Testing Tool (`PaletteToggle.tsx`)
- **Repurposed from palette preview:** Renamed from palette-flip tool to card-background cycler. Now cycles the `--brand-card` CSS token through sanctioned background colors instead of flipping a `data-palette` attribute.
- **Simplified data model:** Changed from `Palette` enum (`'current' | 'proposed'`) to numeric index into `CARD_BGS` array. Each entry specifies a label, CSS value, and swatch color.
- **New UI pattern:** Replaced two-button segment control with a single cycle button (shows current label + arrow) and a row of swatch buttons for direct selection.
- **Token-based colors:** All offered backgrounds are sanctioned tokens from `globals.css` (cream page, warm cream, question, parchment, sage, slate), ensuring no unsanctioned colors are introduced.
- **Updated storage & events:** Changed `STORAGE_KEY` to `'joshing-card-bg'` and event name to `'joshing-card-bg-change'`; attribute changed to `data-card-bg`.

### Feed & Editorial Components
- **SparkleEnvelope:** Added `eyebrowClassName` prop to allow color/weight overrides on the eyebrow (e.g., gold accent for "Sent directly to you").
- **DirectSentCard:** Now passes `eyebrowClassName` with gold accent class to mark direct-send messages.
- **CommonGroundFeature:** Changed tone from "parchment" to "sage" (green accent + soft green wash) and removed the bookmark icon, so the shared-ground feature reads in earthy green rather than orange.
- **FeedList:** Removed top padding (`pt-6`) from the contribute footer to tighten spacing.
- **Test expectations:** Updated test snapshot to expect the new "questions your friends created or sent directly to you" heading text.

### Layout & Boot Script (`layout.tsx`)
- **Updated comments:** Changed references from "proposed-palette preview bar" to "card-background cycler bar" and clarified that the boot script applies

https://claude.ai/code/session_01QWUqjMxw52mmsdinFHxJdy