### PR TITLE
Recolor all cards via the toggle; refine feed groups & answer reveal

### DIFF
--- a/src/app/api/lately/milestone/recheck/route.ts
+++ b/src/app/api/lately/milestone/recheck/route.ts
@@ -1,0 +1,186 @@
+import { and, eq } from 'drizzle-orm';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { writeActivity } from '@/server/activity/write-activity';
+import { db, feedItems, gradeDisputes, questions } from '@/server/db';
+import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
+import { getBasePoints } from '@/server/mastery/scoring';
+import { recheckAnswerWithLLM } from '@/server/llm/recheck';
+
+export const dynamic = 'force-dynamic';
+
+// "Challenge the response" for a milestone question the viewer just missed.
+//
+// A wrong milestone answer persists a synthetic `milestone_missed` FeedItem
+// (see /api/lately/milestone/answer), keyed deterministically by
+// (recipientUserId, sourceAnswerId='milestone-miss:<questionId>'). That row
+// carries the submitted answer + the incorrect verdict, so a recheck here is
+// the exact same flow as the feed recheck — we just resolve the row by its
+// milestone key instead of a feed-item id. Mirrors
+// /api/feed/[feedItemId]/recheck.
+const recheckSchema = z.object({
+  questionId: z.string().trim().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session) {
+      return NextResponse.json(
+        { error: 'unauthorized', message: 'Please sign in to request a recheck.' },
+        { status: 401 },
+      );
+    }
+
+    const parsed = recheckSchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: 'validation', message: 'questionId is required.' },
+        { status: 400 },
+      );
+    }
+    const { questionId } = parsed.data;
+
+    // Resolve the viewer's own milestone-miss row by its deterministic key.
+    const [row] = await db
+      .select({ feedItem: feedItems, question: questions })
+      .from(feedItems)
+      .innerJoin(questions, eq(feedItems.questionId, questions.id))
+      .where(
+        and(
+          eq(feedItems.recipientUserId, session.userId),
+          eq(feedItems.sourceAnswerId, `milestone-miss:${questionId}`),
+        ),
+      )
+      .limit(1);
+
+    if (!row) {
+      return NextResponse.json(
+        { error: 'not_found', message: 'We could not find that answer to recheck.' },
+        { status: 404 },
+      );
+    }
+
+    const { feedItem, question } = row;
+
+    if (feedItem.state !== 'answered' || !feedItem.submittedAnswer) {
+      return NextResponse.json(
+        { error: 'invalid_state', message: 'Answer the question before requesting a recheck.' },
+        { status: 400 },
+      );
+    }
+    if (feedItem.answerResult === 'correct') {
+      return NextResponse.json(
+        { error: 'invalid_state', message: 'That answer is already marked correct.' },
+        { status: 400 },
+      );
+    }
+
+    const answerId = `milestone:${questionId}:${session.userId}`;
+    const [existingDispute] = await db
+      .select({ id: gradeDisputes.id })
+      .from(gradeDisputes)
+      .where(eq(gradeDisputes.answerId, answerId))
+      .limit(1);
+
+    if (existingDispute) {
+      return NextResponse.json(
+        { error: 'invalid_state', message: 'That answer has already been rechecked.' },
+        { status: 400 },
+      );
+    }
+
+    const canonicalAnswer = question.answerText;
+    const review = await recheckAnswerWithLLM({
+      questionText: question.questionText,
+      canonicalAnswer,
+      submittedAnswer: feedItem.submittedAnswer,
+      questionType: 'factual',
+      acceptedAlternatives: question.acceptedAlternatives ?? [],
+    });
+
+    const accepted = review.decision === 'accept';
+    const recheckStatus = accepted ? 'accepted' : review.decision === 'reject' ? 'rejected' : 'needs_human';
+    const disputeStatus = accepted ? 'alternative_added' : 'pending';
+    const reviewedAt = accepted ? new Date() : null;
+    const domain = question.canonicalSubcategory || question.broadCategory || question.category;
+
+    let pointsAwarded = 0;
+    if (accepted) {
+      pointsAwarded = getBasePoints(question.calibratedDifficulty ?? question.llmDifficulty ?? null, 'first_correct');
+    }
+
+    const disputeId = await db.transaction(async (tx) => {
+      if (accepted) {
+        await tx
+          .update(feedItems)
+          .set({ answerResult: 'correct', pointsAwarded })
+          .where(eq(feedItems.id, feedItem.id));
+      }
+
+      const [inserted] = await tx
+        .insert(gradeDisputes)
+        .values({
+          answerId,
+          questionId: question.id,
+          creatorId: session.userId,
+          submittedAnswer: feedItem.submittedAnswer ?? '',
+          canonicalAnswer,
+          questionText: question.questionText,
+          surface: 'milestone',
+          reviewDecision: review.decision,
+          reviewReason: review.reason,
+          acceptedAlternative: review.acceptedAlternative,
+          status: disputeStatus,
+          reviewedAt,
+        })
+        .returning({ id: gradeDisputes.id });
+      return inserted?.id ?? null;
+    });
+
+    // §8.22 dispute path: notify the question's author so they can review.
+    if (disputeId && question.creatorId && question.creatorId !== session.userId) {
+      await writeActivity({
+        userId: question.creatorId,
+        type: 'grade_dispute_filed',
+        actorUserId: session.userId,
+        referenceId: disputeId,
+        referenceType: 'grade_dispute',
+      });
+    }
+
+    if (accepted) {
+      await writeMasteryEvent({
+        userId: session.userId,
+        questionId: question.id,
+        domain,
+        answerState: 'first_correct',
+        pointsAwarded,
+        sourceType: 'feed',
+        sourceId: `milestone:${questionId}:recheck`,
+        broadCategory: question.broadCategory,
+        eventQuestionId: question.id,
+        basePoints: pointsAwarded,
+        weight: 1,
+      }).catch((error: unknown) => {
+        console.warn('[lately/milestone/recheck] writeMasteryEvent failed', error instanceof Error ? error.message : error);
+      });
+    }
+
+    return NextResponse.json({
+      accepted,
+      status: recheckStatus,
+      reason: review.reason,
+      pointsAwarded,
+      correctAnswer: canonicalAnswer,
+    });
+  } catch (error) {
+    console.error('[lately/milestone/recheck] unexpected', error);
+    return NextResponse.json(
+      { error: 'unexpected', message: 'Could not recheck that answer.' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default async function RootLayout({
             shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){var t=['--brand-card','--game-card-question'];for(var k=0;k<t.length;k++)document.documentElement.style.setProperty(t[k],m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,10 +140,14 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
       {/* Sit the header on the feed's left gutter — the same 2px the activity
           rows pad in (where the fixed icon column / shape marks begin), so the
           header and the shapes share one left edge. The day labels indent
-          further (pl-[34px], past the icon column) to meet the row copy. */}
-      <p className="mb-2 pl-[2px] text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
-        For you
-      </p>
+          further (pl-[34px], past the icon column) to meet the row copy.
+          Suppressed when there's nothing under it — no served direct/broadcast
+          cards — so the header never strands above the next group. */}
+      {edition.direct.served.length > 0 ? (
+        <p className="mb-2 pl-[2px] text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+          For you
+        </p>
+      ) : null}
       <FeedList
         pageSize={FEED_PAGE_SIZE}
         initialPage={initialPage}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -802,16 +802,18 @@ function FeedGroupHeading({
   subtitle,
 }: {
   title: string
-  subtitle: string
+  subtitle?: string
 }) {
   return (
     <div className="pt-4 pl-[2px] first:pt-0">
       <p className="text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
         {title}
       </p>
-      <p className="text-muted-foreground/70 mt-1 text-[11px] font-medium tracking-[0.12em] uppercase">
-        {subtitle}
-      </p>
+      {subtitle ? (
+        <p className="text-muted-foreground/70 mt-1 text-[11px] font-medium tracking-[0.12em] uppercase">
+          {subtitle}
+        </p>
+      ) : null}
     </div>
   )
 }
@@ -1949,10 +1951,7 @@ function FeedListContent({
           {fromFriendsRows.length > 0 ? (
             <Fragment key="from-friends">
               {unifiedHome ? (
-                <FeedGroupHeading
-                  title="Friends&rsquo; Mastery"
-                  subtitle="questions your friends have answered — play along"
-                />
+                <FeedGroupHeading title="From Friends" />
               ) : (
                 <FeedSectionHeading unifiedHome={unifiedHome}>From Friends</FeedSectionHeading>
               )}

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -162,7 +162,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     // Both question zones render their headings and overflow affordances,
     // each linking to its zone's overflow subpage (B-HOME-OVERFLOW-02).
     expect(html).toContain('questions your friends created or sent directly to you')
-    expect(html).toContain('Friends’ Mastery')
+    expect(html).toContain('From Friends')
     // The activity stream is the third labelled group.
     expect(html).toContain('Lately')
     expect(html).toContain('4 more from friends →')
@@ -202,7 +202,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     // No panel double-invite, no zone headings.
     expect(html).not.toContain('PANEL')
     expect(html).not.toContain('questions your friends created or sent directly to you')
-    expect(html).not.toContain('Friends’ Mastery')
+    expect(html).not.toContain('From Friends')
   })
 
   it('partial-empty → empty zones omitted, populated zones shown (§9)', () => {
@@ -227,7 +227,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('direct:robyn')
     // The empty playable zone is omitted entirely — no heading, no placeholder.
-    expect(html).not.toContain('Friends’ Mastery')
+    expect(html).not.toContain('From Friends')
     expect(html).not.toContain('Quiet today')
     // Empty texture zone → no "Lately" group heading, and its see-more row is
     // hidden with it (§9).

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -78,6 +78,41 @@ export function InlineAnswerFlow({
     }
   }
 
+  // "Challenge the response" on a wrong answer — a second look at the verdict.
+  // A wrong milestone answer is persisted as a `milestone_missed` row keyed by
+  // its question, so the recheck route resolves it by questionId. Mirrors the
+  // feed's recheck affordance; the AnswerFeedbackSheet only surfaces it when the
+  // answer was wrong.
+  async function recheck(): Promise<{ accepted: boolean; message: string }> {
+    const res = await fetch('/api/lately/milestone/recheck', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ questionId: question.questionId }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      accepted?: boolean;
+      status?: string;
+      reason?: string;
+      pointsAwarded?: number;
+      message?: string;
+    } | null;
+    if (!res.ok) throw new Error(body?.message ?? 'Could not recheck that answer.');
+    if (body?.accepted) {
+      const points = typeof body.pointsAwarded === 'number' ? body.pointsAwarded : 0;
+      // Reflect the overturned verdict locally so the result reads as correct.
+      setFeedback((prev) => (prev ? { ...prev, isCorrect: true, pointsAwarded: points } : prev));
+      return {
+        accepted: true,
+        message: `Recheck accepted — +${points} ${points === 1 ? 'point' : 'points'}.`,
+      };
+    }
+    if (body?.status === 'needs_human') {
+      return { accepted: false, message: body.reason ?? 'Flagged for a human look.' };
+    }
+    return { accepted: false, message: body?.reason ?? 'Rechecked and still marked wrong.' };
+  }
+
   // Hand the resolution up only once the viewer dismisses the result pop-up, so
   // this block stays mounted (and the sheet visible) through the reveal, then
   // the parent moves the question into the answered history.
@@ -148,6 +183,7 @@ export function InlineAnswerFlow({
           openedTerritoryDomain={feedback.openedTerritoryDomain}
           questionId={question.questionId}
           feedItemId={`milestone:${question.questionId}`}
+          onRecheck={feedback.isCorrect ? null : recheck}
           report={{ target: { questionId: question.questionId }, surface: 'lately_result' }}
           onClose={finish}
         />

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -5,10 +5,12 @@ import { useSyncExternalStore, type CSSProperties } from 'react';
 // ─────────────────────────────────────────────────────────────────────────────
 // TESTING ONLY — card-background cycler (repurposed from the palette preview bar).
 //
-// Cycles the `--brand-card` token — the resting feed-card surface — through the
-// SANCTIONED background colors (globals.css), so a tester can audit how the
-// cards read on each cream / wash without per-page edits. Every surface that
-// fills with `var(--brand-card)` recolors automatically.
+// Cycles the card-surface tokens — the resting card fill (`--brand-card`) AND
+// the elevated/"playable" card fill (`--game-card-question`) — through the
+// SANCTIONED background colors (globals.css), so a tester can audit how EVERY
+// card reads on each cream / wash without per-page edits. Every surface that
+// fills with one of these tokens (the Daily Five card, the feed cards, the
+// playable bundles, …) recolors automatically.
 //
 // Only the system's own background tokens are offered (no off-palette hex), so
 // nothing here introduces an unsanctioned color. Inline styles are on purpose:
@@ -32,6 +34,12 @@ const CARD_BGS: CardBg[] = [
   { label: 'Sage', value: 'var(--editorial-sage)', swatch: 'var(--editorial-sage)' },
   { label: 'Slate', value: 'var(--editorial-slate)', swatch: 'var(--editorial-slate)' },
 ];
+
+// The card-surface tokens, overridden together so every card recolors: the
+// resting fill (`--brand-card`, also feeds `--card`) and the elevated/"playable"
+// fill (`--game-card-question`). Mirror any change here in the boot script
+// (layout.tsx) that pre-applies the saved choice before paint.
+const CARD_SURFACE_TOKENS = ['--brand-card', '--game-card-question'] as const;
 
 const STORAGE_KEY = 'joshing-card-bg';
 const CARD_BG_EVENT = 'joshing-card-bg-change';
@@ -60,10 +68,15 @@ export function PaletteToggle() {
     const i = ((next % CARD_BGS.length) + CARD_BGS.length) % CARD_BGS.length;
     const { value } = CARD_BGS[i];
     const root = document.documentElement;
-    if (value) {
-      root.style.setProperty('--brand-card', value);
-    } else {
-      root.style.removeProperty('--brand-card');
+    // Override every card-surface token together so ALL cards recolor — not just
+    // the resting `--brand-card` ones (the Daily Five card), but the elevated
+    // `--game-card-question` fill the feed cards / playable bundles use.
+    for (const token of CARD_SURFACE_TOKENS) {
+      if (value) {
+        root.style.setProperty(token, value);
+      } else {
+        root.style.removeProperty(token);
+      }
     }
     root.setAttribute('data-card-bg', String(i));
     try {

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -50,7 +50,9 @@ type BankState = 'idle' | 'saving' | 'saved' | 'undoing' | 'undone' | 'error'
 type RecheckState = 'idle' | 'submitting' | 'done' | 'error'
 
 export function AnswerFeedbackSheet({
-  question,
+  // `question` is intentionally not destructured/rendered — the sheet no longer
+  // restates the question (the viewer just answered it). Kept on the props type
+  // so call sites can keep passing it without churn.
   category,
   isCorrect,
   pointsAwarded,
@@ -267,25 +269,26 @@ export function AnswerFeedbackSheet({
               </span>
             ) : null}
             {!isCorrect ? (
-              <p
-                className="text-[13px] italic"
-                style={{
-                  fontFamily: 'var(--font-serif)',
-                  color: 'var(--ink)',
-                  opacity: 0.7,
-                }}
-              >
-                Your answer: {submittedAnswer}
-              </p>
+              // Surface what they actually typed clearly — labelled, full-
+              // strength, in the wrong-verdict color — so a wrong result always
+              // shows their own answer back to them (not a faint aside).
+              <div className="pt-0.5">
+                <p className="text-[0.62rem] font-semibold tracking-[0.16em] uppercase text-[var(--brand-ink-400)]">
+                  Your answer
+                </p>
+                <p
+                  className="mt-0.5 font-serif text-[17px] leading-6"
+                  style={{ color: 'var(--game-wrong-strong)' }}
+                >
+                  {submittedAnswer}
+                </p>
+              </div>
             ) : null}
           </div>
 
-          {/* The question reads as context for the answer, so it sits below the
-              answer headline (not above it). De-boxed: plain text, no panel. */}
-          <p className="pb-2 font-serif text-lg leading-6 text-[var(--brand-ink)]">
-            {question}
-          </p>
-
+          {/* The question itself is NOT restated here — the viewer just answered
+              it moments ago, so repeating it only adds noise. The answer + a
+              one-line explainer carry the reveal. */}
           {explanation ? (
             // Match the daily-5 game's reveal: a single-sentence explainer under
             // the answer, not the full paragraph (which ran too long here).


### PR DESCRIPTION
Stacks on #873 (base is `claude/awesome-heisenberg-gi6oy1`, so this PR shows **only** the new batch of changes; GitHub will retarget it to `main` once #873 merges).

## Card colors
- The dev card-color toggle now overrides **both** card-surface tokens — the resting `--brand-card` **and** the elevated `--game-card-question` the feed cards / playable bundles use — so **every** card recolors, not just the Daily Five. The pre-paint boot script in `layout.tsx` was updated to match.

## Feed groups
- **Hide the "For you" header when there's nothing under it** (no served direct/broadcast cards), so it never strands above the next group.
- **Drop "Friends' Mastery" back to a plain "From Friends"** group label (the subtitle is removed; `FeedGroupHeading` subtitle is now optional).

## Answer feedback sheet
- **Stop restating the question** — the viewer just answered it, so repeating it only added noise.
- **Show the player's own answer prominently** on a wrong result (labelled "Your answer", full-strength, in the wrong-verdict color) instead of a faint italic aside.
- **"Challenge the response"** on milestone questions: a recheck affordance, wired through a new `POST /api/lately/milestone/recheck` route. A wrong milestone answer already persists a `milestone_missed` FeedItem keyed by `(recipientUserId, 'milestone-miss:<questionId>')`, so the new route resolves that row by its deterministic key and reuses the **same** recheck flow as `/api/feed/[feedItemId]/recheck` (LLM recheck → grade dispute → mastery on accept). On accept, the result flips to correct in place.

## Verification
- `tsc` typecheck clean, ESLint 0 errors, color ratchet 153/180, font ratchet 0/0.
- 109 tests pass across the milestone/feed/activity/feedlist suites.
- ⚠️ The new recheck route mirrors the (untested) feed recheck route and does LLM + DB writes; it has no route-level integration test (consistent with the existing feed route) and should be smoke-tested against a live DB.

https://claude.ai/code/session_01QWUqjMxw52mmsdinFHxJdy

---
_Generated by [Claude Code](https://claude.ai/code/session_01QWUqjMxw52mmsdinFHxJdy)_