### PR TITLE
Enforce unique display names: DB query, API check, server validation, and client UX

### DIFF
--- a/src/app/api/account/display-name/check/route.ts
+++ b/src/app/api/account/display-name/check/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { findDisplayNameMatches } from '@/server/db/queries/account';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const url = new URL(request.url);
+  const displayName = (url.searchParams.get('displayName') ?? '').trim();
+
+  if (displayName.length < 1 || displayName.length > 60) {
+    return NextResponse.json(
+      { error: 'invalid_display_name', message: 'Display name must be 1–60 characters.' },
+      { status: 400 },
+    );
+  }
+
+  const matches = await findDisplayNameMatches(displayName, session.userId);
+  return NextResponse.json({ duplicate: matches.length > 0, count: matches.length });
+}

--- a/src/app/api/account/profile/route.ts
+++ b/src/app/api/account/profile/route.ts
@@ -2,10 +2,7 @@ import { NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
-import {
-  getEditableProfile,
-  updateProfileFields,
-} from '@/server/db/queries/account';
+import { getEditableProfile, updateProfileFields } from '@/server/db/queries/account';
 
 export const dynamic = 'force-dynamic';
 
@@ -53,11 +50,12 @@ export async function PATCH(request: Request) {
   if (!result.ok) {
     const messages: Record<typeof result.reason, string> = {
       invalid_display_name: 'Display name must be 1–60 characters.',
+      duplicate_display_name: 'That display name is already taken.',
       empty_patch: 'At least one field is required.',
     };
     return NextResponse.json(
       { error: result.reason, message: messages[result.reason] },
-      { status: 400 },
+      { status: result.reason === 'duplicate_display_name' ? 409 : 400 },
     );
   }
 

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -119,6 +119,12 @@ type HandleStatus =
   | { state: 'available' }
   | { state: 'unavailable'; reason: 'format' | 'reserved' | 'taken' };
 
+type DisplayNameDuplicateStatus =
+  | { state: 'idle' }
+  | { state: 'checking' }
+  | { state: 'unique' }
+  | { state: 'duplicate'; count: number };
+
 type VerifyOtpUserPayload = {
   display_name?: unknown;
   displayName?: unknown;
@@ -182,6 +188,8 @@ export default function LoginPanel({
   const [handle, setHandle] = useState('');
   const [handleManuallyEdited, setHandleManuallyEdited] = useState(false);
   const [handleStatus, setHandleStatus] = useState<HandleStatus>({ state: 'idle' });
+  const [displayNameDuplicateStatus, setDisplayNameDuplicateStatus] =
+    useState<DisplayNameDuplicateStatus>({ state: 'idle' });
   const [verifiedIdentity, setVerifiedIdentity] = useState<VerifiedIdentity>({
     displayName: '',
     handle: '',
@@ -199,6 +207,60 @@ export default function LoginPanel({
   // Controls the bottom-card transition: the title card (in page.tsx) stays
   // fixed; only this form card animates out, swaps content, then animates in.
   const [entering, setEntering] = useState(true);
+
+  useEffect(() => {
+    if (step !== 'profile') return;
+
+    const candidate = displayName.trim();
+    const controller = new AbortController();
+
+    const immediate = window.setTimeout(() => {
+      if (candidate.length < 1 || candidate.length > 60) {
+        setDisplayNameDuplicateStatus({ state: 'idle' });
+        return;
+      }
+      setDisplayNameDuplicateStatus({ state: 'checking' });
+    }, 0);
+
+    const debounced = window.setTimeout(async () => {
+      if (candidate.length < 1 || candidate.length > 60) return;
+
+      try {
+        const response = await fetch(
+          `/api/account/display-name/check?displayName=${encodeURIComponent(candidate)}`,
+          {
+            credentials: 'include',
+            signal: controller.signal,
+          },
+        );
+        const data = await response.json().catch(() => ({}));
+
+        if (!response.ok) {
+          setDisplayNameDuplicateStatus({ state: 'idle' });
+          return;
+        }
+
+        if (data?.duplicate === true) {
+          setDisplayNameDuplicateStatus({
+            state: 'duplicate',
+            count: typeof data?.count === 'number' ? data.count : 1,
+          });
+        } else {
+          setDisplayNameDuplicateStatus({ state: 'unique' });
+        }
+      } catch (fetchError) {
+        if (!(fetchError instanceof DOMException && fetchError.name === 'AbortError')) {
+          setDisplayNameDuplicateStatus({ state: 'idle' });
+        }
+      }
+    }, 300);
+
+    return () => {
+      controller.abort();
+      window.clearTimeout(immediate);
+      window.clearTimeout(debounced);
+    };
+  }, [displayName, step]);
 
   useEffect(() => {
     if (step !== 'profile') return;
@@ -397,6 +459,7 @@ export default function LoginPanel({
       setHandle(identity.handle);
       setHandleManuallyEdited(Boolean(identity.handle));
       setHandleStatus({ state: 'idle' });
+      setDisplayNameDuplicateStatus({ state: 'idle' });
 
       if (shouldCollectProfileIdentity(identity)) {
         setLoading(false);
@@ -426,6 +489,21 @@ export default function LoginPanel({
 
     if (!trimmedDisplayName) {
       setError('Enter your display name.');
+      return;
+    }
+
+    if (trimmedDisplayName.length > 60) {
+      setError('Display name must be 60 characters or fewer.');
+      return;
+    }
+
+    if (displayNameDuplicateStatus.state === 'checking') {
+      setError('Please wait while we check that display name.');
+      return;
+    }
+
+    if (displayNameDuplicateStatus.state === 'duplicate') {
+      setError('Choose a display name that is not already taken.');
       return;
     }
 
@@ -695,7 +773,14 @@ export default function LoginPanel({
               value={displayName}
               onChange={(event) => updateDisplayName(event.target.value)}
               disabled={loading}
+              maxLength={60}
             />
+            {displayNameDuplicateStatus.state === 'duplicate' ? (
+              <p className="rounded-md border border-[color-mix(in_srgb,var(--accent-gold)_45%,var(--brand-rule))] bg-[color-mix(in_srgb,var(--accent-gold)_12%,var(--brand-card))] px-3 py-2 text-center text-sm leading-5 text-[var(--brand-ink)]">
+                That display name is already taken. Choose a distinctive name so friends can find
+                the right account.
+              </p>
+            ) : null}
           </div>
           <div className="space-y-2">
             <label className="block text-center text-sm font-medium text-black" htmlFor="handle">
@@ -746,7 +831,11 @@ export default function LoginPanel({
             type="submit"
             className={SUBMIT_CLASS}
             disabled={
-              loading || handleStatus.state === 'checking' || handleStatus.state === 'unavailable'
+              loading ||
+              displayNameDuplicateStatus.state === 'checking' ||
+              displayNameDuplicateStatus.state === 'duplicate' ||
+              handleStatus.state === 'checking' ||
+              handleStatus.state === 'unavailable'
             }
           >
             {loading ? 'Saving…' : 'Enter Joshing'}

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -1,4 +1,4 @@
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, ne, sql } from 'drizzle-orm';
 
 import {
   contactHashes,
@@ -72,6 +72,30 @@ function fallbackDisplayName(phoneNumber: string): string {
   return lastFour ? `Player ${lastFour}` : 'Player';
 }
 
+export type DisplayNameMatch = {
+  id: string;
+  displayName: string | null;
+};
+
+export async function findDisplayNameMatches(
+  displayName: string,
+  excludeUserId?: string,
+): Promise<DisplayNameMatch[]> {
+  const trimmed = displayName.trim();
+  if (!trimmed) return [];
+
+  const conditions = [sql`lower(${users.displayName}) = lower(${trimmed})`];
+  if (excludeUserId) conditions.push(ne(users.id, excludeUserId));
+
+  return db
+    .select({
+      id: users.id,
+      displayName: users.displayName,
+    })
+    .from(users)
+    .where(and(...conditions));
+}
+
 export async function getUserProfile(userId: string): Promise<UserProfile | null> {
   const [user] = await db
     .select({
@@ -126,7 +150,10 @@ export type ProfileFieldsPatch = {
 
 export type ProfileFieldsUpdateResult =
   | { ok: true }
-  | { ok: false; reason: 'invalid_display_name' | 'empty_patch' };
+  | {
+      ok: false;
+      reason: 'invalid_display_name' | 'duplicate_display_name' | 'empty_patch';
+    };
 
 // Updates the editable profile fields. Migration 0054 dropped bio,
 // tagline, and location, leaving only displayName editable on the
@@ -142,6 +169,10 @@ export async function updateProfileFields(
     const displayName = patch.displayName.trim();
     if (displayName.length < 1 || displayName.length > 60) {
       return { ok: false, reason: 'invalid_display_name' };
+    }
+    const displayNameMatches = await findDisplayNameMatches(displayName, userId);
+    if (displayNameMatches.length > 0) {
+      return { ok: false, reason: 'duplicate_display_name' };
     }
     set.displayName = displayName;
   }


### PR DESCRIPTION
### Motivation
- Prevent multiple accounts from sharing the same display name and provide immediate feedback when a user picks a display name during signup/profile completion.  
- Ensure server-side enforcement of uniqueness on profile updates so race conditions or bypasses are rejected.  
- Improve the signup/profile UX by surfacing duplicate status and disabling submission while a display-name check is pending or the name is taken.

### Description
- Added a new DB helper `findDisplayNameMatches` and `DisplayNameMatch` type in `src/server/db/queries/account.ts` to query case-insensitive display name matches and return matching user ids.  
- Updated `updateProfileFields` in `src/server/db/queries/account.ts` to check for duplicates and include a new failure reason `duplicate_display_name`.  
- Added a new API endpoint `GET /api/account/display-name/check` at `src/app/api/account/display-name/check/route.ts` to validate display name length, require authentication, and return `{ duplicate, count }`.  
- Adjusted `PATCH /api/account/profile` in `src/app/api/account/profile/route.ts` to map `duplicate_display_name` to an explanatory message and return `409 Conflict` for that case.  
- Enhanced the client in `src/app/login/LoginPanel.tsx` to perform debounced checks against the new API while on the profile step, expose a `displayNameDuplicateStatus` state, show a UI warning when a name is duplicate, add `maxLength={60}` to the input, and prevent form submission while a duplicate check is pending or the name is taken.

### Testing
- Ran the TypeScript build and existing automated test suite against the modified codebase; the test suite completed successfully.  
- Exercised the new API during development by simulating authenticated requests and verified correct JSON responses for valid, invalid-length, and duplicate display names.  
- Verified client behavior manually in the profile/signup flow to ensure debounced checks, UI messaging, and submit blocking behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5a1fb0e0832e94b711074ac2d054)