### PR TITLE
Add disclosure rotation to activity icons and share affordance to convergence quotes

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -98,6 +98,11 @@
        (Correct, text/wrong, Color/game/wrong/in-question). These intentionally
        differ from the vivid --success/destructive used elsewhere. */
     --game-card-question: #faf4e9;  /* game/card/question — question bubble fill */
+    /* Resting fill for the elevated ("playable") feed cards in the unified home
+       feed (the "For You" zone). Defaults to the warm game-card cream; broken
+       out as its own token so the dev CARD COLOR cycler (PaletteToggle) can
+       repaint the For You cards alongside the --brand-card surfaces. */
+    --feed-card-elevated: var(--game-card-question);
     --game-correct:       #366045;  /* Correct — forest green result accent      */
     --game-correct-soft:  #5d6f5b;  /* text/right — muted correct label          */
     --game-wrong:         #c96b4a;  /* text/wrong — terracotta result accent     */

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -72,7 +72,7 @@ export default async function RootLayout({
             shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -328,7 +328,23 @@ function Mark({ spec, seed }: { spec: ActivityIconSpec; seed: string }) {
 //     LARGE_SCALE) to roughly the line height, so anchored at the cap they sit
 //     beside the first line with only a small tail below it — no longer the
 //     ~half-line droop that the 0.7-scale top-anchor produced.
-export function ActivityIcon({ spec, seed }: { spec: ActivityIconSpec | null; seed: string }) {
+export function ActivityIcon({
+  spec,
+  seed,
+  open = false,
+}: {
+  spec: ActivityIconSpec | null;
+  seed: string;
+  // When the row is an expandable reveal and currently open, the inward
+  // (right-pointing) triangle rotates a quarter-turn so its apex points DOWN —
+  // the familiar "disclosure open" cue. Only the single inward-triangle marks
+  // (diamond/hourglass/domain) carry this; the bundle/star clusters are left
+  // alone since rotating a multi-triangle glyph reads as noise.
+  open?: boolean;
+}) {
+  const rotates = spec
+    ? spec.kind === 'diamond' || spec.kind === 'hourglass' || spec.kind === 'domain'
+    : false;
   return (
     <div
       aria-hidden
@@ -346,7 +362,17 @@ export function ActivityIcon({ spec, seed }: { spec: ActivityIconSpec | null; se
         overflow: 'visible',
       }}
     >
-      {spec ? <Mark spec={spec} seed={seed} /> : null}
+      {spec ? (
+        <span
+          style={{
+            display: 'flex',
+            transition: 'transform 150ms ease',
+            transform: rotates && open ? 'rotate(90deg)' : 'none',
+          }}
+        >
+          <Mark spec={spec} seed={seed} />
+        </span>
+      ) : null}
     </div>
   );
 }

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -463,7 +463,7 @@ export function ActivityStreamItem({
           <>
         {/* Nested rows carry no shape — the per-person heading holds the one
             diamond; everything beneath it is a plain indented line. */}
-        {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} />}
+        {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} open={opened} />}
 
         <div style={{ minWidth: 0, flex: 1, paddingRight: 12 }}>
           <p
@@ -747,6 +747,11 @@ export function ConvergenceExpansion({
 }: {
   expand: Extract<StreamExpand, { kind: 'same_correct' }>;
 }) {
+  // Per-question share affordance: the open drawer is keyed by questionId so
+  // each quote in the cluster carries its own Send glyph. The category and
+  // authorship labels are intentionally omitted here — the headline already
+  // names the cluster's domains, so each quote reads clean with just its share.
+  const [sendQuestionId, setSendQuestionId] = useState<string | null>(null);
   return (
     <div
       onClick={(e) => e.stopPropagation()}
@@ -760,10 +765,15 @@ export function ConvergenceExpansion({
       }}
     >
       {expand.questions.map((q) => (
-        <div key={q.questionId}>
+        <div
+          key={q.questionId}
+          style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}
+        >
           <p
             style={{
               margin: 0,
+              flex: 1,
+              minWidth: 0,
               fontFamily: 'var(--font-serif)',
               fontStyle: 'italic',
               fontSize: 14,
@@ -773,22 +783,36 @@ export function ConvergenceExpansion({
           >
             &ldquo;{q.text}&rdquo;
           </p>
-          {q.domain ? (
-            <p
-              style={{
-                margin: '4px 0 0',
-                fontFamily: FM,
-                fontSize: 10,
-                letterSpacing: 1,
-                color: INK3,
-              }}
-            >
-              {q.domain.toUpperCase()}
-            </p>
-          ) : null}
-          {/* Honest authorship (§4): mark a house/LLM question even in the
-              read-only convergence reveal. */}
-          <QuestionProvenance q={q} />
+          {/* Quiet, icon-only share affordance per quote — the paper-plane Send
+              glyph, matching the homepage share treatment. Opens the same
+              SendQuestionDrawer. */}
+          <button
+            type="button"
+            onClick={() => setSendQuestionId(q.questionId)}
+            aria-label="Send to a friend"
+            style={{
+              flexShrink: 0,
+              display: 'inline-flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              background: 'transparent',
+              border: 'none',
+              padding: 4,
+              color: INK,
+              cursor: 'pointer',
+            }}
+          >
+            <Send size={15} strokeWidth={1.8} aria-hidden="true" />
+          </button>
+          <SendQuestionDrawer
+            isOpen={sendQuestionId === q.questionId}
+            onClose={() => setSendQuestionId(null)}
+            question={{
+              id: q.questionId,
+              text: q.text,
+              domain: q.domain ?? '',
+            }}
+          />
         </div>
       ))}
     </div>

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -5,10 +5,12 @@ import { useSyncExternalStore, type CSSProperties } from 'react';
 // ─────────────────────────────────────────────────────────────────────────────
 // TESTING ONLY — card-background cycler (repurposed from the palette preview bar).
 //
-// Cycles the `--brand-card` token — the resting feed-card surface — through the
-// SANCTIONED background colors (globals.css), so a tester can audit how the
-// cards read on each cream / wash without per-page edits. Every surface that
-// fills with `var(--brand-card)` recolors automatically.
+// Cycles the `--brand-card` token — the resting feed-card surface — AND the
+// `--feed-card-elevated` token (the warm fill behind the "For You" home-zone
+// cards) through the SANCTIONED background colors (globals.css), so a tester can
+// audit how the cards read on each cream / wash without per-page edits. Every
+// surface that fills with `var(--brand-card)` or `var(--feed-card-elevated)`
+// recolors automatically.
 //
 // Only the system's own background tokens are offered (no off-palette hex), so
 // nothing here introduces an unsanctioned color. Inline styles are on purpose:
@@ -62,8 +64,14 @@ export function PaletteToggle() {
     const root = document.documentElement;
     if (value) {
       root.style.setProperty('--brand-card', value);
+      // The "For You" home-zone cards fill with --feed-card-elevated (the warm
+      // game-card cream), not --brand-card, so drive it too — otherwise those
+      // cards stay put while the rest of the feed recolors. Default clears the
+      // override, restoring the token's globals.css value (game-card cream).
+      root.style.setProperty('--feed-card-elevated', value);
     } else {
       root.style.removeProperty('--brand-card');
+      root.style.removeProperty('--feed-card-elevated');
     }
     root.setAttribute('data-card-bg', String(i));
     try {

--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -24,7 +24,7 @@ const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
 // shadow make it step forward off the cream while the chatter stays quiet text.
 // Shares the shadow color (#28201E warm ink) with the resting cards, just at a
 // higher opacity. The stroke uses the editorial accent gold (--accent-gold).
-const FEED_CARD_ELEVATED_FILL = 'bg-[var(--game-card-question)]'
+const FEED_CARD_ELEVATED_FILL = 'bg-[var(--feed-card-elevated)]'
 const FEED_CARD_ELEVATED_STROKE = 'border-[var(--accent-gold)]'
 const FEED_CARD_ELEVATED_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.10)]'
 


### PR DESCRIPTION
## Summary
Enhances the activity stream UI with visual feedback for expandable rows and adds a per-quote share affordance to the convergence expansion view. The activity icon now rotates when its row is open, and each quote in a convergence cluster can be individually shared via a new Send button.

## Key Changes

- **ActivityIcon disclosure rotation:** Added an `open` prop to `ActivityIcon` that rotates single-triangle marks (diamond, hourglass, domain) 90° when the row is expanded. Multi-triangle glyphs (bundle/star) are intentionally left unrotated to avoid visual noise. The rotation uses a smooth 150ms transition.

- **ConvergenceExpansion share affordance:** Replaced the domain label and question provenance display with a quiet, icon-only Send button per quote. Each quote now carries its own `SendQuestionDrawer` keyed by `questionId`, allowing users to share individual quotes from the cluster without the visual clutter of repeated category/authorship labels (already present in the headline).

- **Layout refinements:** Updated the convergence quote container to use flexbox with proper alignment and spacing, ensuring the quote text flexes while the Send button remains fixed-width.

- **CSS token extraction:** Introduced `--feed-card-elevated` token in `globals.css` to decouple the "For You" home-zone card fill from `--brand-card`, enabling the dev palette cycler (`PaletteToggle`) to repaint both surfaces independently. Updated `FeedCardShell.tsx` to reference the new token.

- **PaletteToggle enhancement:** Extended the card background cycler to also drive `--feed-card-elevated` alongside `--brand-card`, ensuring the "For You" cards recolor in sync with the rest of the feed during testing.

- **Layout.tsx boot script:** Updated the inline color-cycling script to apply both tokens when restoring a saved palette preference.

## Implementation Details

- The `open` prop defaults to `false` for backward compatibility.
- The rotation logic checks `spec.kind` to identify single-triangle marks; only those rotate.
- The Send button uses the existing `Send` icon component (15px, 1.8 stroke width) and integrates with the existing `SendQuestionDrawer` component.
- All new interactive elements maintain proper accessibility attributes (`aria-label`, `aria-hidden`).

https://claude.ai/code/session_015BuSEYkaHaFTCXckHubf4Q