### PR TITLE
Drive the From Friends playable cards from the card-color token

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -329,7 +329,10 @@ export function ActivityStreamItem({
     : playableCard
       ? {
           padding: opened ? '16px 14px' : '14px',
-          background: 'var(--game-card-question)',
+          // The "From Friends" playable milestone cards share the elevated feed
+          // fill token (defaults to the warm game-card cream) so the dev CARD
+          // COLOR cycler repaints them alongside the For You cards.
+          background: 'var(--feed-card-elevated)',
           border: '1px solid var(--accent-gold)',
           borderRadius: 4,
           boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',


### PR DESCRIPTION
The "From Friends" home zone renders elevated milestone bundles via ActivityStreamItem, whose playable-card background was a hardcoded var(--game-card-question) — so the dev CARD COLOR cycler never touched them. Point that fill at the shared --feed-card-elevated token (same game-card cream default) so it recolors with the rest of the home feed.

https://claude.ai/code/session_015BuSEYkaHaFTCXckHubf4Q