### PR TITLE
Wire From Friends to the chronological activity log + flattering copy

### DIFF
--- a/_docs/D-FEED-FRIEND-ACTIVITY-01.md
+++ b/_docs/D-FEED-FRIEND-ACTIVITY-01.md
@@ -1,10 +1,24 @@
 # D-FEED-FRIEND-ACTIVITY-01 — "From Friends" as a chronological activity log
 
-**Status:** Spec, agreed in discussion 2026-06-12. Not yet built. Supersedes the
-deep/breadth **domain** grouping of the From Friends surface (`PRD-D-4` §A,
-`src/lib/lately-milestones.ts`). The underlying read-derived, additive,
-correct-`friend_answered`-only data source is unchanged — only the grouping,
-ordering, and lifecycle of the cards change.
+**Status:** Spec agreed in discussion 2026-06-12. **Cut-1 wired** — the surface
+now derives from `getFriendActivity` / `deriveFriendActivity` instead of the
+deep/breadth milestone grouping (`PRD-D-4` §A, `src/lib/lately-milestones.ts`).
+The underlying read-derived, additive, correct-`friend_answered`-only data source
+is unchanged — only the grouping, ordering, and lifecycle of the cards change.
+
+**Cut-1 scope (what's wired vs deferred).** Grouping, ordering, and held-singles
+are live and pure. Two lifecycle nuances are **deferred to a persistence
+follow-up** because a pure re-derivation can't tell "answered *before* the card
+existed" from "answered *in-place*" without a frozen surfaced-at record:
+- **§3 pre-answered exclusion** is NOT applied in cut-1. `playableForViewer`
+  excludes only the viewer's *own authored* questions; already-answered questions
+  stay in the bundle and render as spent triangles (carrying their prior result).
+  This is exactly today's behavior and is what keeps an answered-in-place card
+  alive (§5 / Q4) without persistence — at the cost of also showing cards whose
+  fresh questions you happen to have all played elsewhere.
+- **Static membership** is approximate: the bundle re-derives each load. A card
+  doesn't vanish when you answer it (the answered questions remain as spent), but
+  its membership isn't truly frozen. True freezing is the same persistence item.
 
 ## Why
 

--- a/src/lib/__tests__/activity-stream-friend-activity.test.ts
+++ b/src/lib/__tests__/activity-stream-friend-activity.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { friendActivityToStreamItem, type StreamQuestion } from '@/lib/activity-stream';
+import type { FriendActivityCard } from '@/lib/friend-activity';
+
+// The From Friends card keeps the flattering, topic-attached voice ("…has been
+// killing it in {Geography}…") even though grouping is now time/burst-based: the
+// domains come from the burst's questions, not a single milestone domain.
+
+function lineText(parts: { v?: string; name?: string }[]): string {
+  return parts.map((p) => p.v ?? p.name ?? '').join('');
+}
+
+function card(over: Partial<FriendActivityCard> = {}): FriendActivityCard {
+  return {
+    id: 'burst:f-robyn:1',
+    friendId: 'f-robyn',
+    friendName: 'Robyn Hitchcock',
+    friendFirstName: 'Robyn',
+    context: 'feed',
+    questionIds: ['q1', 'q2'],
+    effectiveAt: new Date('2026-06-01T00:00:00Z'),
+    heldSolo: false,
+    ...over,
+  };
+}
+
+function q(id: string, domain: string | null): StreamQuestion {
+  return { questionId: id, text: `Q ${id}`, domain, priorResult: null };
+}
+
+describe('friendActivityToStreamItem copy', () => {
+  it('names the burst domains in the flattering voice', () => {
+    const item = friendActivityToStreamItem(card(), [q('q1', 'Geography'), q('q2', 'History')]);
+    const text = lineText(item.line);
+    expect(text).toContain('Robyn Hitchcock');
+    expect(text).toContain('Geography');
+    expect(text).toContain('History');
+  });
+
+  it('rolls up extra domains as "and N others"', () => {
+    const item = friendActivityToStreamItem(card(), [
+      q('q1', 'Geography'),
+      q('q2', 'History'),
+      q('q3', 'Music'),
+      q('q4', 'Film'),
+    ]);
+    expect(lineText(item.line)).toContain('others');
+  });
+
+  it('falls back to a topic-less compliment when no domain resolves', () => {
+    const item = friendActivityToStreamItem(card(), [q('q1', null), q('q2', null)]);
+    const text = lineText(item.line);
+    // No domain named; still complimentary.
+    expect(text).toMatch(/killing it|streak of wisdom|on a roll/);
+  });
+
+  it('sorts on the card effectiveAt (chronological), not a prominence key', () => {
+    const item = friendActivityToStreamItem(card(), [q('q1', 'Geography')]);
+    expect(item.sortAt).toEqual(new Date('2026-06-01T00:00:00Z'));
+    expect(item.icon).toBe('bundle');
+    expect(item.expand?.kind).toBe('milestone');
+  });
+});

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -849,38 +849,65 @@ export function milestoneToStreamItem(
 
 // --- From Friends activity card (D-FEED-FRIEND-ACTIVITY-01) -------------------
 
-// Per-context lead copy for the chronological From Friends card. PLACEHOLDER —
-// flagged for product sign-off (same soft-copy rule as the milestone leads: warm,
-// non-competitive, no "mastered"/"beat"/"crushed"). Unlike milestones these name
-// no domain — the card is a time/burst roll-up, not a topic roll-up. One lead is
-// picked per card id so a stack of same-context cards still reads varied.
-const FRIEND_ACTIVITY_LEADS: Record<FriendActivityCard['context'], readonly string[]> = {
-  daily: [' played their daily five', ' got through their daily five', ' did their five for the day'],
-  catchup: [' caught up on a few', ' went back and caught up', ' cleared a few they had missed'],
-  joshing_game: [' played a game', ' got through a game', ' sat down for a game'],
-  feed: [' has been playing', ' worked through a few', ' has been on a little run'],
-  profile: [' has been playing', ' worked through a few', ' has been on a little run'],
-  mixed: [' has been playing', ' has been chipping away', ' has been keeping busy'],
-};
+// Flattering, topic-attached leads for the From Friends card. Warm, complimentary
+// register (no "mastered"/"beat"/"crushed"). Each ends on a preposition so the
+// domain(s) the friend played in this burst follow as serif `category` parts —
+// e.g. "{Name} has been killing it in {Geography} and {History}". One lead is
+// picked per card id so a stack reads varied.
+const FRIEND_ACTIVITY_LEADS = [
+  ' has been killing it in ',
+  ' has been on a streak of wisdom in ',
+  ' is amazing answering questions about ',
+  ' has been all over ',
+  " can't get enough of ",
+  ' has been on a tear through ',
+] as const;
+
+// Fallback when none of the burst's questions resolved a domain — keep the same
+// complimentary voice without naming a topic.
+const FRIEND_ACTIVITY_LEADS_NO_TOPIC = [
+  ' has been killing it',
+  ' has been on a streak of wisdom',
+  ' is on a roll',
+] as const;
+
+// Distinct domains the friend played in this card, most-recent first (the
+// questions arrive most-recent first). Drives the topic tail.
+function friendActivityDomains(questions: StreamQuestion[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const q of questions) {
+    const d = q.domain?.trim();
+    if (d && !seen.has(d)) {
+      seen.add(d);
+      out.push(d);
+    }
+  }
+  return out;
+}
 
 // One From Friends play burst/batch, expanded to its answerable questions. Mirrors
 // `milestoneToStreamItem` (same StreamItem shape, same 'milestone' expand the feed
-// already renders) but sorts on the card's chronological `effectiveAt` and carries
-// time-based copy instead of deep/breadth domain copy.
+// already renders) but sorts on the card's chronological `effectiveAt`. The copy
+// keeps the flattering breadth voice — a complimentary lead + the burst's domains
+// rolled up "A, B and N others" — even though grouping is now time-based.
 export function friendActivityToStreamItem(
   card: FriendActivityCard,
   questions: StreamQuestion[],
 ): StreamItem {
   const friend = act(card.friendName, card.friendId);
-  const leads = FRIEND_ACTIVITY_LEADS[card.context];
-  const lead = leads[djb2(card.id) % leads.length];
+  const domains = friendActivityDomains(questions);
+  const tail: StreamLinePart[] =
+    domains.length > 0
+      ? breadthTail(domains, FRIEND_ACTIVITY_LEADS[djb2(card.id) % FRIEND_ACTIVITY_LEADS.length])
+      : [txt(FRIEND_ACTIVITY_LEADS_NO_TOPIC[djb2(card.id) % FRIEND_ACTIVITY_LEADS_NO_TOPIC.length])];
   return {
     id: card.id,
     sortAt: card.effectiveAt,
     tier: LATELY_TIER.MILESTONE,
     friendId: card.friendId,
     homeEligible: true,
-    line: [friend, txt(lead)],
+    line: [friend, ...tail],
     secondLine: null,
     anchorId: null,
     action: null,

--- a/src/lib/activity-stream.ts
+++ b/src/lib/activity-stream.ts
@@ -24,6 +24,7 @@ import type { MasteryTier } from '@/types/db';
 import type { LatelyMoment } from '@/server/db/queries/lately';
 import { LATELY_TIER, latelyTierForMomentDir, djb2 } from '@/lib/lately';
 import type { LatelyMilestone } from '@/lib/lately-milestones';
+import type { FriendActivityCard } from '@/lib/friend-activity';
 import type { Convergence } from '@/lib/convergence';
 import type { RelationshipResult } from '@/server/db/queries/friend-requests';
 
@@ -841,6 +842,53 @@ export function milestoneToStreamItem(
       kind: 'milestone',
       friendId: milestone.friendId,
       friendName: milestone.friendName,
+      questions,
+    },
+  };
+}
+
+// --- From Friends activity card (D-FEED-FRIEND-ACTIVITY-01) -------------------
+
+// Per-context lead copy for the chronological From Friends card. PLACEHOLDER —
+// flagged for product sign-off (same soft-copy rule as the milestone leads: warm,
+// non-competitive, no "mastered"/"beat"/"crushed"). Unlike milestones these name
+// no domain — the card is a time/burst roll-up, not a topic roll-up. One lead is
+// picked per card id so a stack of same-context cards still reads varied.
+const FRIEND_ACTIVITY_LEADS: Record<FriendActivityCard['context'], readonly string[]> = {
+  daily: [' played their daily five', ' got through their daily five', ' did their five for the day'],
+  catchup: [' caught up on a few', ' went back and caught up', ' cleared a few they had missed'],
+  joshing_game: [' played a game', ' got through a game', ' sat down for a game'],
+  feed: [' has been playing', ' worked through a few', ' has been on a little run'],
+  profile: [' has been playing', ' worked through a few', ' has been on a little run'],
+  mixed: [' has been playing', ' has been chipping away', ' has been keeping busy'],
+};
+
+// One From Friends play burst/batch, expanded to its answerable questions. Mirrors
+// `milestoneToStreamItem` (same StreamItem shape, same 'milestone' expand the feed
+// already renders) but sorts on the card's chronological `effectiveAt` and carries
+// time-based copy instead of deep/breadth domain copy.
+export function friendActivityToStreamItem(
+  card: FriendActivityCard,
+  questions: StreamQuestion[],
+): StreamItem {
+  const friend = act(card.friendName, card.friendId);
+  const leads = FRIEND_ACTIVITY_LEADS[card.context];
+  const lead = leads[djb2(card.id) % leads.length];
+  return {
+    id: card.id,
+    sortAt: card.effectiveAt,
+    tier: LATELY_TIER.MILESTONE,
+    friendId: card.friendId,
+    homeEligible: true,
+    line: [friend, txt(lead)],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'bundle',
+    expand: {
+      kind: 'milestone',
+      friendId: card.friendId,
+      friendName: card.friendName,
       questions,
     },
   };

--- a/src/server/activity/__tests__/build-stream-self-hide.test.ts
+++ b/src/server/activity/__tests__/build-stream-self-hide.test.ts
@@ -18,7 +18,7 @@ vi.mock('@/lib/activity-stream', () => ({
   activityToStreamItem: (x: unknown) => x,
   momentToStreamItem: (x: unknown) => x,
   convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
-  milestoneToStreamItem: (m: { id: string }, questions: unknown) => ({ kind: 'milestone', id: m.id, questions }),
+  friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({ kind: 'milestone', id: card.id, questions }),
 }));
 vi.mock('@/lib/lately', () => ({
   sortByProminence: (items: unknown[]) => items,
@@ -32,7 +32,7 @@ vi.mock('@/server/db/queries/content-reports', () => ({
 vi.mock('@/server/db/queries/lately', () => ({
   getLatelyMoments: vi.fn(async () => []),
   getLatelyConvergences: vi.fn(async () => []),
-  getLatelyMilestones: vi.fn(async () => [{ id: 'm1', questionIds: ['q-keep', 'q-hidden'] }]),
+  getFriendActivity: vi.fn(async () => [{ id: 'm1', questionIds: ['q-keep', 'q-hidden'] }]),
   getMilestoneQuestionText: vi.fn(async (ids: string[]) =>
     new Map(ids.map((id) => [id, { questionId: id, text: `text ${id}`, domain: 'history' }])),
   ),

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -14,7 +14,7 @@ import { filterUtilityActivities } from '@/app/activities/filter-utility-activit
 import {
   activityToStreamItem,
   convergenceToStreamItem,
-  milestoneToStreamItem,
+  friendActivityToStreamItem,
   momentToStreamItem,
   type StreamItem,
   type StreamQuestion,
@@ -24,32 +24,33 @@ import { MILESTONE_CARD_QUESTION_CAP } from '@/lib/lately-milestones';
 import { getActivitiesForUser } from '@/server/db/queries/activity';
 import { getViewerHiddenQuestionIds } from '@/server/db/queries/content-reports';
 import {
+  getFriendActivity,
   getLatelyConvergences,
-  getLatelyMilestones,
   getLatelyMoments,
   getMilestoneQuestionText,
   getViewerPriorAnswerResults,
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
-  const [items, moments, milestones, convergences] = await Promise.all([
+  const [items, moments, friendCards, convergences] = await Promise.all([
     getActivitiesForUser(userId),
     getLatelyMoments(userId),
-    getLatelyMilestones(userId),
+    getFriendActivity(userId),
     getLatelyConvergences(userId),
   ]);
 
-  // Resolve every milestone's first ≤5 literal questions and every
-  // convergence's 3 cluster questions in one batch (text + display domain), and
-  // the viewer's prior result on each (right OR wrong) — so a question the
-  // viewer already attempted stays locked in the expansion across reloads.
-  const cappedIdsByMilestone = milestones.map((m) => ({
-    id: m.id,
-    ids: m.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
+  // Resolve every From Friends card's first ≤5 literal questions (most-recent
+  // first) and every convergence's 3 cluster questions in one batch (text +
+  // display domain), and the viewer's prior result on each (right OR wrong) — so
+  // a question the viewer already attempted stays locked in the expansion across
+  // reloads (an answered-in-place card keeps its spent triangles, Q4).
+  const cappedIdsByCard = friendCards.map((c) => ({
+    id: c.id,
+    ids: c.questionIds.slice(0, MILESTONE_CARD_QUESTION_CAP),
   }));
   const allQuestionIds = [
     ...new Set([
-      ...cappedIdsByMilestone.flatMap((m) => m.ids),
+      ...cappedIdsByCard.flatMap((c) => c.ids),
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
@@ -65,17 +66,17 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
     activityToStreamItem,
   );
   const momentItems = moments.map(momentToStreamItem);
-  const milestoneItems = milestones
-    .map((m, i) => {
-      const questions: StreamQuestion[] = cappedIdsByMilestone[i].ids
+  const friendActivityItems = friendCards
+    .map((card, i) => {
+      const questions: StreamQuestion[] = cappedIdsByCard[i].ids
         .map((id) => textById.get(id))
         .filter((q): q is NonNullable<typeof q> => Boolean(q))
         .filter((q) => !hiddenIds.has(q.questionId))
-        // Keep EVERY one of the friend's questions in the bundle — including the
-        // ones the viewer already answered. Each carries its prior result, so the
-        // answered ones render as spent (hollow) triangles in the expansion and
-        // the title stays stable across reloads (answered questions don't vanish,
-        // and the triangle count doesn't shrink as you play).
+        // Keep EVERY question in the bundle — including the ones the viewer
+        // already answered. Each carries its prior result, so the answered ones
+        // render as spent (hollow) triangles in the expansion and the card stays
+        // put after you play it (Q4), drifting down by recency rather than
+        // vanishing.
         .map((q) => ({
           questionId: q.questionId,
           text: q.text,
@@ -84,9 +85,9 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
           authorName: q.authorName,
           authorIsHouse: q.authorIsHouse,
         }));
-      // A milestone whose questions all collapse out is a contentless streak
-      // card — suppress it rather than render an empty triangle.
-      return questions.length > 0 ? milestoneToStreamItem(m, questions) : null;
+      // A card whose questions all collapse out (deleted / hidden) is contentless
+      // — suppress it rather than render an empty triangle.
+      return questions.length > 0 ? friendActivityToStreamItem(card, questions) : null;
     })
     .filter((item): item is StreamItem => item !== null);
   const convergenceItems = convergences.map((c) => {
@@ -114,7 +115,7 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
 
   return sortByProminence([
     ...momentItems,
-    ...milestoneItems,
+    ...friendActivityItems,
     ...convergenceItems,
     ...utilityItems,
   ]);

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -1,11 +1,17 @@
 import { and, desc, eq, gte, inArray, isNotNull, isNull, ne, or, sql } from 'drizzle-orm';
 
 import {
-  collectMilestoneQuestionIds,
   deriveLatelyMilestones,
   type LatelyMilestone,
   type MilestoneAnswerRow,
 } from '@/lib/lately-milestones';
+import {
+  collectFriendActivityQuestionIds,
+  deriveFriendActivity,
+  type FriendActivityCard,
+  type FriendPlayRow,
+  type PlayContext,
+} from '@/lib/friend-activity';
 import {
   deriveConvergences,
   type Convergence,
@@ -240,6 +246,129 @@ export async function getLatelyMilestones(userId: string): Promise<LatelyMilesto
   return deriveLatelyMilestones(answerRows);
 }
 
+// --- From Friends activity log (D-FEED-FRIEND-ACTIVITY-01) --------------------
+
+// Wider than the milestone window so a play can still reach its held-singles
+// 5-day solo release before its source row ages out of the scan.
+const FRIEND_ACTIVITY_WINDOW_DAYS = 35;
+
+// Map the FeedItem `sourceAnswerId` prefix to the originating play surface.
+// Unknown / legacy / null ids fall back to 'feed' (a time-gap burst) so no play
+// is dropped. The full id format lives in create-feed-items-for-answer.ts.
+function parsePlayContext(sourceAnswerId: string | null): PlayContext {
+  if (!sourceAnswerId) return 'feed';
+  const prefix = sourceAnswerId.slice(0, sourceAnswerId.indexOf(':'));
+  switch (prefix) {
+    case 'daily':
+      return 'daily';
+    case 'catchup':
+      return 'catchup';
+    case 'joshing_game':
+      return 'joshing_game';
+    case 'profile':
+      return 'profile';
+    default:
+      return 'feed';
+  }
+}
+
+// The natural-unit batch key for daily/catchup/game; null for feed/profile
+// (those sessionize into time-gap bursts in the pure derivation). NOTE: the
+// `sourceAnswerId` daily form is `daily:${propagationKey}:${userId}` — NOT a
+// day — so the daily/catchup batch is keyed on the calendar day of the answer.
+// Cut-1 uses the UTC day; a late-night play near midnight could split across
+// days under the viewer's tz (open: switch to the app display tz).
+function batchKeyFor(
+  context: PlayContext,
+  answeredAt: Date,
+  joshingGameId: string | null,
+): string | null {
+  switch (context) {
+    case 'daily':
+    case 'catchup':
+      return answeredAt.toISOString().slice(0, 10);
+    case 'joshing_game':
+      return joshingGameId ?? `game:${answeredAt.toISOString().slice(0, 10)}`;
+    case 'feed':
+    case 'profile':
+      return null;
+  }
+}
+
+/**
+ * From Friends — the chronological activity log that replaces the deep/breadth
+ * milestone grouping on this surface (D-FEED-FRIEND-ACTIVITY-01). Same correct-
+ * `friend_answered`-from-someone-I-follow rows as `getLatelyMilestones`, but
+ * routed by play context into time-and-context cards by the pure
+ * `deriveFriendActivity`.
+ *
+ * Cut-1 scope: `playableForViewer` excludes only the viewer's OWN authored
+ * questions (the dead "ANSWER →" button case). Already-answered questions stay
+ * in the bundle — build-stream renders them as spent triangles via their prior
+ * result, which is what keeps an answered-in-place card alive (Q4). Excluding
+ * pre-answered questions and freezing card membership both need persistence and
+ * are the documented follow-up (see the spec's Open section).
+ */
+export async function getFriendActivity(userId: string): Promise<FriendActivityCard[]> {
+  const windowStart = new Date(
+    Date.now() - FRIEND_ACTIVITY_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  );
+
+  const rows = await db
+    .select({
+      friendId: feedItems.sourceUserId,
+      friendDisplayName: users.displayName,
+      questionId: feedItems.questionId,
+      sourceAnswerId: feedItems.sourceAnswerId,
+      joshingGameId: feedItems.joshingGameId,
+      creatorId: questions.creatorId,
+      answeredAt: feedItems.sourceEventAt,
+    })
+    .from(feedItems)
+    .innerJoin(
+      follows,
+      and(
+        eq(follows.followeeId, feedItems.sourceUserId),
+        eq(follows.followerId, userId),
+        eq(follows.state, 'approved'),
+      ),
+    )
+    .innerJoin(questions, eq(questions.id, feedItems.questionId))
+    .innerJoin(users, eq(users.id, feedItems.sourceUserId))
+    .where(
+      and(
+        eq(feedItems.recipientUserId, userId),
+        eq(feedItems.sourceType, SOCIAL_FEED_SOURCE_TYPE),
+        eq(feedItems.sourceResult, 'correct'),
+        isNotNull(feedItems.questionId),
+        gte(feedItems.sourceEventAt, windowStart),
+      ),
+    )
+    .orderBy(desc(feedItems.sourceEventAt))
+    .limit(500);
+
+  const playRows: FriendPlayRow[] = [];
+  for (const row of rows) {
+    if (!row.questionId || !row.answeredAt) continue;
+    const context = parsePlayContext(row.sourceAnswerId);
+    const friendName = row.friendDisplayName?.trim() || 'A friend';
+    playRows.push({
+      friendId: row.friendId,
+      friendName,
+      friendFirstName: firstName(row.friendDisplayName, friendName),
+      questionId: row.questionId,
+      answeredAt: row.answeredAt,
+      context,
+      batchKey: batchKeyFor(context, row.answeredAt, row.joshingGameId),
+      // Authored-by-viewer questions are unplayable (the answer route 403s on
+      // your own question). Already-answered questions stay (rendered spent).
+      playableForViewer: row.creatorId !== userId,
+    });
+  }
+
+  return deriveFriendActivity(playRows, new Date());
+}
+
 // A friend's literal question, shaped for the seeded play session (the Lately
 // milestone click-through). Practice-only — carries everything needed to render
 // and grade, nothing about scoring.
@@ -267,7 +396,7 @@ export async function getSeededPlayQuestions(
 ): Promise<SeededPlayQuestion[]> {
   if (requestedIds.length === 0) return [];
 
-  const allowed = collectMilestoneQuestionIds(await getLatelyMilestones(userId));
+  const allowed = collectFriendActivityQuestionIds(await getFriendActivity(userId));
   const authorizedIds = requestedIds.filter((id) => allowed.has(id));
   if (authorizedIds.length === 0) return [];
 


### PR DESCRIPTION
Follow-up to #879 (spec + derivation sketch, now merged into `dev2`). This is the **wiring + copy** — the From Friends surface now renders from the time/context grouping instead of the deep/breadth domain milestones. Supersedes #881 (whose base branch was merged).

## Wiring

- **`getFriendActivity(userId)`** (`src/server/db/queries/lately.ts`) — same correct-`friend_answered`-from-someone-I-follow rows as the old milestone query, now also selecting `sourceAnswerId` + `joshingGameId` + `creatorId`, windowed at **35 days**. Routes each play to a **context** (`parsePlayContext` on the `sourceAnswerId` prefix) and a **batchKey** (calendar day for daily/catchup, `joshingGameId` for games, `null`→burst for feed/profile), and feeds the pure `deriveFriendActivity(rows, now)`. Seeded-play authorization repointed to `collectFriendActivityQuestionIds`.
- **`friendActivityToStreamItem`** (`src/lib/activity-stream.ts`) — same `StreamItem` shape and `'milestone'` expand the feed already renders (so FeedList's From Friends section picks it up), but sorts on the card's chronological `effectiveAt`.
- **`build-stream.ts`** — only the source + mapper swap; the hydrate / self-hide / prior-result plumbing is unchanged, so an answered-in-place card keeps its spent triangles and stays put (Q4).

## Copy

Flattering, topic-attached voice — a complimentary lead + the burst's domains rolled up:

> **Robyn** has been killing it in *Geography* and *History*
> **Sadie** is amazing answering questions about *Music*, *Film* and 2 others

Lead rotates per card id (six variants); domains come from the card's questions (deduped, most-recent first) via `breadthTail`; topic-less fallback when no domain resolves.

## Cut-1 scope (deferred to a persistence follow-up)

A pure re-derivation can't tell "answered before the card existed" from "answered in-place" without a frozen surfaced-at record, so:
- **§3 pre-answered exclusion is not applied** — `playableForViewer` excludes only viewer-authored questions; already-answered questions stay (rendered spent). This is today's behavior and is what keeps answered cards alive without persistence.
- **Static membership is approximate** (re-derives each load).

Old milestone machinery (`getLatelyMilestones` / `deriveLatelyMilestones` / `milestoneToStreamItem`) left in place, unused in prod, for a fast-follow cleanup.

## Verification

- [x] `tsc -p tsconfig.typecheck.json` → 0 errors
- [x] eslint clean on touched files
- [x] vitest: friend-activity + copy + build-stream-self-hide + milestone suites → green
- [ ] **Not run:** live DB / end-to-end — no database in this environment. Smoke on a real feed before merge.

## Open (in the spec)

Burst gap (30 vs 60 min) · batchKey timezone · held-singles persistence · completed-card fate · `mixed` flush rule · single-burst copy tone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)