### PR TITLE
Dedupe friends in common ground promo carousel

### DIFF
--- a/src/server/activity/__tests__/common-ground-promo.test.ts
+++ b/src/server/activity/__tests__/common-ground-promo.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// The home-only "Shared Ground" carousel promo: one slide per friend the viewer
+// shares latent common ground with. We mock the two queries it reads so we can
+// assert the per-friend shape (and the dedupe guard) without a DB.
+const { getFriendsMock, getCommonGroundMock } = vi.hoisted(() => ({
+  getFriendsMock: vi.fn(),
+  getCommonGroundMock: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriends: getFriendsMock,
+}));
+
+vi.mock('@/server/db/queries/common-ground', () => ({
+  getCommonGround: getCommonGroundMock,
+}));
+
+import { getCommonGroundPromo } from '@/server/activity/common-ground-promo';
+import type { StreamEmbed } from '@/lib/activity-stream';
+
+const NOW = new Date('2026-06-08T12:00:00Z');
+
+function friend(id: string, displayName: string) {
+  // The promo only reads id + displayName off the User row.
+  return { id, displayName } as never;
+}
+
+function latentDomain(label: string, points = 100) {
+  return {
+    canonical_subcategory: label,
+    broad_category: null,
+    viewer: { mastery_points: points, current_tier: 'curious' as const, proven: false },
+    friend: { mastery_points: points, current_tier: 'curious' as const, proven: true },
+    kind: 'latent' as const,
+  };
+}
+
+function ground(...labels: string[]) {
+  return {
+    proven: [],
+    latent: labels.map((l) => latentDomain(l)),
+    isEmpty: labels.length === 0,
+  };
+}
+
+function commonGroundEmbed(item: NonNullable<Awaited<ReturnType<typeof getCommonGroundPromo>>>) {
+  return item.embed as Extract<StreamEmbed, { kind: 'common_ground' }>;
+}
+
+describe('getCommonGroundPromo', () => {
+  beforeEach(() => {
+    getFriendsMock.mockReset();
+    getCommonGroundMock.mockReset();
+  });
+
+  it('returns null when the viewer has no friends', async () => {
+    getFriendsMock.mockResolvedValue([]);
+    expect(await getCommonGroundPromo('user-1', NOW)).toBeNull();
+    expect(getCommonGroundMock).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no friend has latent common ground', async () => {
+    getFriendsMock.mockResolvedValue([friend('f1', 'Robyn')]);
+    getCommonGroundMock.mockResolvedValue(ground());
+    expect(await getCommonGroundPromo('user-1', NOW)).toBeNull();
+  });
+
+  it('builds one carousel slide per distinct friend', async () => {
+    getFriendsMock.mockResolvedValue([friend('f1', 'Robyn Lee'), friend('f2', 'Sam')]);
+    getCommonGroundMock.mockImplementation((_viewer: string, friendId: string) =>
+      Promise.resolve(friendId === 'f1' ? ground('Star Wars') : ground('Jazz')),
+    );
+
+    const item = await getCommonGroundPromo('user-1', NOW);
+    const embed = commonGroundEmbed(item!);
+    // Order rotates by day seed, so compare as a set; the point is one slide each.
+    expect([...embed.friends].map((f) => f.friendId).sort()).toEqual(['f1', 'f2']);
+    expect(new Map(embed.friends.map((f) => [f.friendId, f.friendFirstName]))).toEqual(
+      new Map([
+        ['f1', 'Robyn'],
+        ['f2', 'Sam'],
+      ]),
+    );
+  });
+
+  it('never places the same friend on two carousel slides (duplicate follow edges)', async () => {
+    // getMutualFollows can return the same person twice when there are duplicate
+    // approved follow edges. The carousel tours PEOPLE, so the dedupe guard must
+    // collapse the repeat instead of surfacing it as a second station.
+    getFriendsMock.mockResolvedValue([
+      friend('f1', 'Testing'),
+      friend('f1', 'Testing'),
+      friend('f2', 'Robyn'),
+    ]);
+    getCommonGroundMock.mockImplementation((_viewer: string, friendId: string) =>
+      Promise.resolve(friendId === 'f1' ? ground('Star Wars') : ground('Jazz')),
+    );
+
+    const item = await getCommonGroundPromo('user-1', NOW);
+    const embed = commonGroundEmbed(item!);
+    // f1 appears once, not twice — distinct people, one slide each.
+    expect([...embed.friends].map((f) => f.friendId).sort()).toEqual(['f1', 'f2']);
+    // The duplicate friend is probed once, not twice.
+    expect(getCommonGroundMock).toHaveBeenCalledWith('user-1', 'f1');
+    expect(getCommonGroundMock.mock.calls.filter((c) => c[1] === 'f1')).toHaveLength(1);
+  });
+});

--- a/src/server/activity/common-ground-promo.ts
+++ b/src/server/activity/common-ground-promo.ts
@@ -32,6 +32,20 @@ const MAX_DOMAINS_PER_FRIEND = 2;
 // users with many friends; the rotation still cycles through everyone over time.
 const MAX_CANDIDATES = 4;
 
+// Keep the first occurrence of each id, preserving order. Guards the carousel
+// against a friend surfacing on more than one slide when getMutualFollows
+// returns duplicate rows for them.
+function dedupeById<T extends { id: string }>(rows: T[]): T[] {
+  const seen = new Set<string>();
+  const out: T[] = [];
+  for (const row of rows) {
+    if (seen.has(row.id)) continue;
+    seen.add(row.id);
+    out.push(row);
+  }
+  return out;
+}
+
 function firstName(displayName: string | null): string {
   const trimmed = (displayName ?? '').trim();
   if (!trimmed) return 'They';
@@ -51,7 +65,11 @@ export async function getCommonGroundPromo(
 ): Promise<StreamItem | null> {
   // First-class module: render deterministically whenever there's latent common
   // ground to surface (the data-existence guards below are the only gate).
-  const friends = await getFriends(userId);
+  // Dedupe by id first: getMutualFollows can return the same person more than
+  // once when there are duplicate approved follow edges, and the carousel is a
+  // tour of PEOPLE (one slide per friend) — the same friend must never occupy
+  // two stations. See CommonGroundFeature.
+  const friends = dedupeById(await getFriends(userId));
   if (friends.length === 0) return null;
 
   const seed = daySeed(now);


### PR DESCRIPTION
## Summary
Adds deduplication logic to the common ground promo to prevent the same friend from appearing on multiple carousel slides when duplicate follow edges exist in the database.

## Changes
- **Added `dedupeById()` helper function** in `common-ground-promo.ts` that preserves order while removing duplicate entries by id. This guards against a friend surfacing on more than one slide when `getMutualFollows` returns duplicate rows.
- **Applied deduplication** to the friends list before processing in `getCommonGroundPromo()`, with explanatory comments noting that the carousel is a tour of PEOPLE (one slide per friend).
- **Added comprehensive test suite** (`common-ground-promo.test.ts`) covering:
  - Null return when viewer has no friends
  - Null return when no friend has latent common ground
  - One carousel slide per distinct friend
  - Deduplication of duplicate follow edges (same friend appears once, not twice)

## Implementation Details
The deduplication happens early in the promo generation pipeline, before querying common ground data for each friend. This ensures we only probe the database once per unique friend and build exactly one carousel slide per person, even if the underlying follow edges table contains duplicates.

https://claude.ai/code/session_01PW8bxhbXZZP1dz5h31NY7K