### PR TITLE
fix(home): From Friends keeps answered cards (chronological log, not a pending queue)

### DIFF
--- a/src/app/from-friends/page.tsx
+++ b/src/app/from-friends/page.tsx
@@ -2,31 +2,31 @@ import { redirect } from 'next/navigation'
 
 import { OverflowSubpageHeader } from '@/components/home/OverflowSubpageHeader'
 import { getSession } from '@/server/auth/session'
-import { buildPendingPlayablesQueue } from '@/server/home/build-edition'
+import { buildFriendActivityQueue } from '@/server/home/build-edition'
 
 import { PendingPlayablesList } from './PendingPlayablesList'
 
-// B-HOME-OVERFLOW-02 — the pending-playables overflow subpage. Renders the
-// FULL pending playable queue (friends' answerable milestone bundles with at
-// least one question left to play), in the same actor-interleaved order Home
-// windows its served top-4 from. Lighter ambient register than /for-you — the
-// bundles keep the exact rendering the home zone already uses. Reached only
-// from Home's "N more →" row; never a nav tab.
+// B-HOME-OVERFLOW-02 — the From Friends overflow subpage. Renders the FULL
+// chronological friend-activity log (every milestone bundle, pending OR already
+// answered), newest-first, the same order Home windows its served top-4 from.
+// Answered bundles stay as spent cards (D-FEED-FRIEND-ACTIVITY-01 §Q4). Lighter
+// ambient register than /for-you — the bundles keep the exact rendering the home
+// zone already uses. Reached only from Home's "N more →" row; never a nav tab.
 export default async function FromFriendsPage() {
   const session = await getSession()
   if (!session) redirect('/login')
 
-  const items = await buildPendingPlayablesQueue(session.userId)
+  const items = await buildFriendActivityQueue(session.userId)
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-[18px] px-4 py-6 pb-32 md:py-10">
       <OverflowSubpageHeader
         eyebrow="From Friends"
-        title={items.length > 0 ? `${items.length} more to play` : 'More to play'}
+        title={items.length > 0 ? `${items.length} from friends` : 'From friends'}
       />
       {items.length === 0 ? (
         <p className="font-serif text-lg font-medium text-[var(--brand-ink)]">
-          You are all caught up!
+          Nothing from friends yet.
         </p>
       ) : (
         <PendingPlayablesList items={items} />

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -166,7 +166,7 @@ describe('overflow subpages — §7 state sync (Home is a window onto the pendin
     expect(after).toContain('1 more from friends →')
   })
 
-  it('finishing a playable bundle on the subpage promotes the next bundle and decrements the count on Home', () => {
+  it('keeps a finished From Friends bundle on Home as a spent card (chronological log, Q4)', () => {
     const pending = [0, 1, 2, 3, 4, 5].map((i) => bundle(i, [null]))
 
     const before = renderHome([], pending)
@@ -176,14 +176,15 @@ describe('overflow subpages — §7 state sync (Home is a window onto the pendin
     expect(before).toContain('2 more →')
     expect(before).toContain('href="/from-friends"')
 
-    // The subpage answer records the viewer's result on p0's last open
-    // question, so the bundle is no longer pending on Home's next read.
+    // The subpage answer records the viewer's result on p0's last open question.
+    // Unlike the old pending-queue, the bundle does NOT leave — it stays as a
+    // spent card in the same slot, and the overflow count is unchanged.
     const afterAnswer = [bundle(0, ['correct']), ...pending.slice(1)]
 
     const after = renderHome([], afterAnswer)
-    expect(after).not.toContain('activity:p0:friend0')
-    expect(after).toContain('activity:p4:friend4') // promoted into the freed slot
-    expect(after).toContain('1 more →')
+    expect(after).toContain('activity:p0:friend0') // still here (now spent)
+    expect(after).not.toContain('activity:p4:friend4') // still beyond the served window
+    expect(after).toContain('2 more →') // count unchanged — nothing was consumed
   })
 })
 

--- a/src/server/home/__tests__/select-edition.test.ts
+++ b/src/server/home/__tests__/select-edition.test.ts
@@ -6,9 +6,8 @@ import {
   PLAYABLE_SERVE_CAP,
   TEXTURE_SOFT_CAP,
   interleaveByActor,
-  isPendingPlayable,
   orderBySenderRotation,
-  orderPendingPlayables,
+  orderFriendActivity,
   selectHomeEdition,
   type FeedEditionItem,
 } from '@/server/home/select-edition'
@@ -199,16 +198,10 @@ describe('selectHomeEdition — serve-and-overflow', () => {
   })
 })
 
-// --- pending-playable definition (B-HOME-OVERFLOW-02 §7) ----------------------
+// --- From Friends chronological log (D-FEED-FRIEND-ACTIVITY-01 §Q4) -----------
 
-describe('isPendingPlayable / orderPendingPlayables — §7 pending definition', () => {
-  it('a bundle is pending only while ≥1 question is unanswered', () => {
-    expect(isPendingPlayable(bundleWithResults('b-fresh', 'f0', [null, null]))).toBe(true)
-    expect(isPendingPlayable(bundleWithResults('b-partial', 'f0', ['correct', null]))).toBe(true)
-    expect(isPendingPlayable(bundleWithResults('b-spent', 'f0', ['correct', 'incorrect']))).toBe(false)
-  })
-
-  it('fully-answered bundles leave the playable queue, the count, and texture', () => {
+describe('orderFriendActivity — chronological log keeps answered bundles', () => {
+  it('retains a fully-answered bundle (it stays as a spent card, not consumed)', () => {
     const edition = selectHomeEdition({
       feedItems: [],
       activityItems: [
@@ -218,29 +211,35 @@ describe('isPendingPlayable / orderPendingPlayables — §7 pending definition',
       promos: { sharedGround: null, expanding: null, growCircle: null },
       now: NOW,
     })
-    // 5 pending bundles: served 4 + 1 overflow — the spent one counts nowhere.
-    expect(edition.playables.served.map((p) => p.id)).not.toContain('b-spent')
-    expect(edition.playables.overflowCount).toBe(1)
-    // Consumed, not texture: it does not fall through as an ambient row.
+    // 6 bundles total (1 spent + 5 pending): all retained, served 4 + 2 overflow.
+    // Equal sortAt → stable order → the spent bundle (first in input) is served.
+    expect(edition.playables.served.map((p) => p.id)).toContain('b-spent')
+    expect(edition.playables.overflowCount).toBe(2)
+    expect(edition.playables.served.length + edition.playables.overflowCount).toBe(6)
+    // Still never a texture row.
     expect(edition.texture.map((t) => t.id)).not.toContain('b-spent')
   })
 
-  it('answering the last question of a served bundle promotes the next one (§7 round trip)', () => {
-    const queue = (items: StreamItem[]) => orderPendingPlayables(items).map((i) => i.id)
+  it('does NOT drop a bundle when its last question is answered (Q4)', () => {
+    const queue = (items: StreamItem[]) => orderFriendActivity(items).map((i) => i.id)
     const before = [
       bundleWithResults('p0', 'f0', [null]),
       ...Array.from({ length: 5 }, (_, i) => playable(`p${i + 1}`, `f${i + 1}`)),
     ]
-    expect(queue(before).slice(0, PLAYABLE_SERVE_CAP)).toContain('p0')
-    // The viewer answers p0's only question on the subpage → next read shows it spent.
-    const after = [
-      bundleWithResults('p0', 'f0', ['correct']),
-      ...before.slice(1),
-    ]
-    const served = queue(after).slice(0, PLAYABLE_SERVE_CAP)
-    expect(served).not.toContain('p0')
-    expect(served).toContain('p4') // promoted into the freed slot
-    expect(queue(after)).toHaveLength(5)
+    expect(queue(before)).toContain('p0')
+    // The viewer answers p0's only question → it stays (now spent), still in the log.
+    const after = [bundleWithResults('p0', 'f0', ['correct']), ...before.slice(1)]
+    expect(queue(after)).toContain('p0')
+    expect(queue(after)).toHaveLength(6)
+  })
+
+  it('orders newest-first by sortAt', () => {
+    const ordered = orderFriendActivity([
+      playable('old', 'f0', 'milestone', '2026-06-09T12:00:00Z'),
+      playable('new', 'f1', 'milestone', '2026-06-11T12:00:00Z'),
+      playable('mid', 'f2', 'milestone', '2026-06-10T12:00:00Z'),
+    ])
+    expect(ordered.map((i) => i.id)).toEqual(['new', 'mid', 'old'])
   })
 })
 

--- a/src/server/home/build-edition.ts
+++ b/src/server/home/build-edition.ts
@@ -20,7 +20,7 @@ import { getRecentlyExpandingPromo } from '@/server/activity/recently-expanding-
 import { getFeedPagePayload } from '@/server/feed/get-feed-page'
 import {
   orderDirectPending,
-  orderPendingPlayables,
+  orderFriendActivity,
   selectHomeEdition,
   type HomeEdition,
 } from '@/server/home/select-edition'
@@ -97,13 +97,13 @@ export async function buildPendingDirectQueue(userId: string): Promise<{
 }
 
 /**
- * B-HOME-OVERFLOW-02 §7 — the full pending-playables queue, in the same
- * actor-interleaved order the home edition windows. Home shows the top 4 of
- * exactly this list; the /from-friends subpage renders all of it. A bundle
- * leaves the queue once every question in it has been answered (see
- * isPendingPlayable).
+ * The full From Friends activity log, newest-first, in the same order the home
+ * edition windows. Home shows the top 4; the /from-friends subpage renders all
+ * of it. Every milestone bundle is retained — an answered bundle stays as a
+ * spent card and drifts down by recency rather than leaving the surface
+ * (D-FEED-FRIEND-ACTIVITY-01 §Q4).
  */
-export async function buildPendingPlayablesQueue(userId: string): Promise<StreamItem[]> {
+export async function buildFriendActivityQueue(userId: string): Promise<StreamItem[]> {
   const activityItems = await buildActivityStream(userId)
-  return orderPendingPlayables(activityItems.filter(isHomeActivityItem))
+  return orderFriendActivity(activityItems.filter(isHomeActivityItem))
 }

--- a/src/server/home/select-edition.ts
+++ b/src/server/home/select-edition.ts
@@ -51,8 +51,10 @@ export type HomeEdition = {
    */
   direct: ServedZone<FeedEditionItem>
   /**
-   * Playable friend activity — answerable milestone bundles. Cap 4, actor-
-   * interleaved so one chatty friend can't hold consecutive slots (§5).
+   * From Friends activity log — milestone bundles (pending OR answered),
+   * newest-first. Cap 4, serve-and-overflow; answered bundles stay as spent
+   * cards and drift down by recency (D-FEED-FRIEND-ACTIVITY-01 §Q4). The field
+   * name stays `playables` for the page/FeedList contract it already feeds.
    */
   playables: ServedZone<StreamItem>
   /**
@@ -210,22 +212,6 @@ function isMilestoneBundle(item: StreamItem): boolean {
 }
 
 /**
- * §7 pending definition: a bundle is PENDING only while the viewer still has at
- * least one unanswered question in it. build-stream keeps answered questions in
- * the bundle (they render as spent triangles), so questions.length alone would
- * keep a fully-played bundle in the queue forever — holding a served slot,
- * inflating the "N more →" count, and never leaving the overflow subpage.
- * Shared by Home, the overflow counts, and the pending-playables subpage so the
- * three views can't disagree about what "pending" means.
- */
-export function isPendingPlayable(item: StreamItem): boolean {
-  return (
-    item.expand?.kind === 'milestone' &&
-    item.expand.questions.some((q) => !q.priorResult)
-  )
-}
-
-/**
  * §5 zone order for the direct ("For You") queue — the one ordering Home's
  * served slice, the overflow count, and the /for-you subpage all window.
  */
@@ -240,23 +226,20 @@ export function orderDirectPending(
 }
 
 /**
- * §5 zone order for the pending-playables queue — filters to pending bundles
- * (see isPendingPlayable) and actor-interleaves. Home serves the top 4 of this;
- * the /from-friends subpage renders all of it.
+ * Zone order for the From Friends activity log (D-FEED-FRIEND-ACTIVITY-01):
+ * EVERY friend-activity bundle — pending OR fully answered — newest-first. A
+ * played bundle stays put as a spent card and drifts down by recency rather than
+ * leaving the surface; this is the chronological-log model, and it deliberately
+ * reverses the old §7 "pending-only" filter that consumed a bundle the moment
+ * its last question was answered. Home serves the top 4 of this; the
+ * /from-friends subpage renders all of it.
  */
-export function orderPendingPlayables(
+export function orderFriendActivity(
   items: readonly StreamItem[],
 ): StreamItem[] {
-  return interleaveByActor(
-    items.filter(isPendingPlayable),
-    (item) => item.friendId ?? null,
-    playableType,
-  )
-}
-
-/** Event-type key for the playable interleave's degenerate-case variety. */
-function playableType(item: StreamItem): string {
-  return item.relationship ?? item.expand?.kind ?? 'milestone'
+  return [...items]
+    .filter(isMilestoneBundle)
+    .sort((a, b) => ms(b.sortAt) - ms(a.sortAt))
 }
 
 function serve<T>(ordered: readonly T[], cap: number, totalPending?: number): ServedZone<T> {
@@ -299,22 +282,18 @@ export function selectHomeEdition(input: SelectHomeEditionInput): HomeEdition {
   const directOrdered = orderDirectPending(input.feedItems)
   const direct = serve(directOrdered, DIRECT_SERVE_CAP, input.directPendingTotal)
 
-  // Split the activity stream into pending playables (answerable milestone
-  // bundles with ≥1 unanswered question), texture (everything else non-feed),
-  // and consumed bundles. A fully-answered bundle is consumed: it is no longer
-  // pending (§7 — it left the queue) and it is not a texture moment either (the
-  // archive surfaces own anything cumulative), so it drops from the edition.
-  const playablePool: StreamItem[] = []
+  // From Friends activity log: EVERY milestone bundle (pending OR fully answered)
+  // is retained and ordered newest-first — an answered bundle stays as a spent
+  // card (D-FEED-FRIEND-ACTIVITY-01 §Q4) instead of being consumed. Non-milestone
+  // social events remain texture (locked Group 3 chronological treatment).
+  const friendActivityPool: StreamItem[] = []
   const texturePool: StreamItem[] = []
   for (const item of input.activityItems) {
-    if (isMilestoneBundle(item)) {
-      if (isPendingPlayable(item)) playablePool.push(item)
-    } else {
-      texturePool.push(item)
-    }
+    if (isMilestoneBundle(item)) friendActivityPool.push(item)
+    else texturePool.push(item)
   }
 
-  const playables = serve(orderPendingPlayables(playablePool), PLAYABLE_SERVE_CAP)
+  const playables = serve(orderFriendActivity(friendActivityPool), PLAYABLE_SERVE_CAP)
 
   const texture = boundTexture(texturePool, now)
 
@@ -322,11 +301,11 @@ export function selectHomeEdition(input: SelectHomeEditionInput): HomeEdition {
   // Direct uses the full pending pool (not the served slice) so a page that is
   // merely over-budget never reads as empty.
   const isAllEmpty =
-    directOrdered.length === 0 && playablePool.length === 0 && texture.length === 0
+    directOrdered.length === 0 && friendActivityPool.length === 0 && texture.length === 0
 
   // A quiet page biases the panel to Grow Your Circle; the all-empty page gets
   // no panel (the empty state already carries the one invitation, §9).
-  const isQuiet = playablePool.length + texturePool.length <= 2
+  const isQuiet = friendActivityPool.length + texturePool.length <= 2
   const panel = isAllEmpty ? null : selectPanel(input.promos, isQuiet)
 
   return { direct, playables, texture, panel, isAllEmpty }


### PR DESCRIPTION
## The bug you hit

On the home tab, a question you'd just played vanished, and **Robyn — your most recent and most active friend (69 correct items in 35 days)** — produced no card at all, while less-active friends showed fine.

## Root cause (confirmed against the dev2 DB)

The grouping wiring (#884) was correct, but the **home page** runs that output through a separate budget layer (`select-edition.ts`) that I hadn't touched. That layer treated "From Friends" as an **action queue**: `isPendingPlayable` dropped any bundle the instant its last question was answered —

```ts
item.expand.questions.some((q) => !q.priorResult)   // keep only if ≥1 UNanswered
```

You and Robyn share interests and play the same questions, so you'd already answered **every** question in each of her bundles (e.g. Sondheim correct at 19:09, Shakespearean wrong at 19:10 — finishing that 06-12 bundle). Every Robyn bundle was therefore "fully answered" → filtered out. That's the exact opposite of the chronological-log design (D-FEED-FRIEND-ACTIVITY-01 §Q4: *answered stays as a spent card, drifts down by recency*).

## The fix

Turn the home From Friends zone from a pending queue into the **chronological log**:

- **`select-edition.ts`** — new `orderFriendActivity`: every milestone bundle (pending **or** fully answered), newest-first. Removed `isPendingPlayable` / `orderPendingPlayables` / `playableType`. `selectHomeEdition` now pools all milestone bundles; the empty/quiet switches count the full pool.
- **`build-edition.ts`** — `buildPendingPlayablesQueue` → `buildFriendActivityQueue`; the `/from-friends` overflow subpage now shows the full log (answered included).
- **`from-friends/page.tsx`** — copy reflects "from friends" rather than "to play".
- **Tests** — updated to the new contract: a finished bundle **stays** as a spent card (home + overflow round-trip), and the log orders newest-first.

## Tradeoff (intended)

The home From Friends zone is no longer an "only things you can still play" action queue — it's "what friends recently played," answered cards included, newest-first. That's the behavior you asked for. The 4 served home slots are now the 4 most-recent cards (some may be fully spent); the playable ones remain, just ordered by recency. I dropped the old actor-interleave in favor of strict recency to match the spec's "newest on top" — say the word if you'd rather re-add a light anti-flood interleave so one very active friend can't fill all 4 home slots.

## Verification

- [x] `tsc -p tsconfig.typecheck.json` → 0 errors
- [x] eslint clean on touched files
- [x] vitest: `src/server/home` + `OverflowSubpageSync` + `build-stream-self-hide` → green
- [ ] **Not run:** live DB / end-to-end — verify on your dev2 copy that Robyn now leads the From Friends zone and your played Sondheim card stays as spent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)