### PR TITLE
Standardize knowledge domain label capitalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "pool:health": "tsx scripts/pool-health.ts",
     "pool:embed-backfill": "tsx scripts/backfill-pool-embeddings.ts",
     "pool:embed-backfill:apply": "tsx scripts/backfill-pool-embeddings.ts --apply",
+    "knowledge:casing-backfill": "tsx scripts/backfill-domain-casing.ts",
+    "knowledge:casing-backfill:apply": "tsx scripts/backfill-domain-casing.ts --apply",
     "format": "node scripts/format-changed.mjs",
     "format:all": "prettier --write ."
   },

--- a/scripts/backfill-domain-casing.ts
+++ b/scripts/backfill-domain-casing.ts
@@ -1,0 +1,163 @@
+// One-time backfill: rewrite existing knowledge labels to the standardized
+// capitalization produced by titleCaseDomain — the same normalization now applied
+// at write time (normalizeDeclaredInterest) and display time (displayNameForDomain).
+// Targets DeclaredInterest.domain and PLAYER_MASTERY.canonical_subcategory.
+//
+// SAFE BY DESIGN:
+//   - Casing never affects territory matching (domainKey() lowercases before
+//     comparison), so restyling a label cannot fragment or merge mastery points.
+//   - Both tables have a UNIQUE(user, label) constraint. If re-casing a row would
+//     collide with another label the same user already has (e.g. they have both
+//     "Hip Hop" and "hip hop"), the row is SKIPPED and reported rather than
+//     merged — merging mastery rows is out of scope for a cosmetic backfill.
+//   - Idempotent: rows already in canonical casing are left untouched, so the
+//     script can be re-run safely.
+//
+// Usage:
+//   npx tsx scripts/backfill-domain-casing.ts            # dry run (counts + sample)
+//   npx tsx scripts/backfill-domain-casing.ts --apply    # write the changes
+import 'dotenv/config';
+
+import { eq } from 'drizzle-orm';
+
+import { db, pool, declaredInterests, playerMastery } from '../src/server/db';
+import { titleCaseDomain } from '../src/lib/knowledge/domain-casing';
+
+const APPLY = process.argv.slice(2).includes('--apply');
+
+type Row = { id: string; userId: string; name: string };
+type Update = { id: string; from: string; to: string };
+type Collision = { id: string; userId: string; from: string; wanted: string };
+
+type Plan = { updates: Update[]; collisions: Collision[] };
+
+// Build a safe rename plan for one table's rows. Rows are grouped per user so the
+// UNIQUE(user, label) constraint can be respected: a rename that would collide
+// with a label the user already holds is recorded as a collision, not an update.
+function planRenames(rows: Row[]): Plan {
+  const byUser = new Map<string, Row[]>();
+  for (const row of rows) {
+    const list = byUser.get(row.userId) ?? [];
+    list.push(row);
+    byUser.set(row.userId, list);
+  }
+
+  const updates: Update[] = [];
+  const collisions: Collision[] = [];
+
+  for (const userRows of byUser.values()) {
+    // Names currently claimed by this user (used to detect collisions).
+    const claimed = new Set(userRows.map((r) => r.name));
+    for (const row of userRows) {
+      const target = titleCaseDomain(row.name);
+      if (!target || target === row.name) continue; // already canonical / empty
+      if (claimed.has(target)) {
+        collisions.push({ id: row.id, userId: row.userId, from: row.name, wanted: target });
+        continue;
+      }
+      claimed.delete(row.name);
+      claimed.add(target);
+      updates.push({ id: row.id, from: row.name, to: target });
+    }
+  }
+
+  return { updates, collisions };
+}
+
+function report(label: string, rows: Row[], plan: Plan): void {
+  console.log(`\n[backfill-domain-casing] ${label}: ${rows.length} rows`);
+  console.log(
+    `[backfill-domain-casing] ${label}: ${plan.updates.length} to re-case, ${plan.collisions.length} skipped (would collide)`,
+  );
+  for (const u of plan.updates.slice(0, 20)) {
+    console.log(`    "${u.from}"  ->  "${u.to}"`);
+  }
+  if (plan.updates.length > 20) {
+    console.log(`    … and ${plan.updates.length - 20} more`);
+  }
+  for (const c of plan.collisions) {
+    console.log(
+      `    SKIP (collision) "${c.from}" -> "${c.wanted}" already held by user ${c.userId}`,
+    );
+  }
+}
+
+// Each table needs its own typed UPDATE (different column key), so the caller
+// passes a concrete writer. This keeps Drizzle's column types intact rather than
+// indexing a union table dynamically.
+async function applyUpdates(
+  updates: Update[],
+  write: (id: string, value: string) => Promise<unknown>,
+): Promise<number> {
+  let applied = 0;
+  for (const u of updates) {
+    try {
+      await write(u.id, u.to);
+      applied += 1;
+    } catch (err) {
+      // A residual UNIQUE violation (e.g. concurrent writes) — leave the row as-is.
+      console.warn(
+        `[backfill-domain-casing] skipped ${u.id} ("${u.from}" -> "${u.to}"):`,
+        String(err),
+      );
+    }
+  }
+  return applied;
+}
+
+async function main() {
+  console.log(`[backfill-domain-casing] ${APPLY ? 'APPLY' : 'DRY RUN'} mode`);
+
+  const interestRows: Row[] = (
+    await db
+      .select({
+        id: declaredInterests.id,
+        userId: declaredInterests.userId,
+        name: declaredInterests.domain,
+      })
+      .from(declaredInterests)
+  ).map((r) => ({ id: r.id, userId: r.userId, name: r.name }));
+
+  const masteryRows: Row[] = (
+    await db
+      .select({
+        id: playerMastery.id,
+        userId: playerMastery.userId,
+        name: playerMastery.canonicalSubcategory,
+      })
+      .from(playerMastery)
+  ).map((r) => ({ id: r.id, userId: r.userId, name: r.name }));
+
+  const interestPlan = planRenames(interestRows);
+  const masteryPlan = planRenames(masteryRows);
+
+  report('DeclaredInterest', interestRows, interestPlan);
+  report('PLAYER_MASTERY', masteryRows, masteryPlan);
+
+  if (!APPLY) {
+    console.log(
+      '\n[backfill-domain-casing] dry run only — re-run with --apply to write the changes.',
+    );
+    return;
+  }
+
+  const interestsApplied = await applyUpdates(interestPlan.updates, (id, value) =>
+    db.update(declaredInterests).set({ domain: value }).where(eq(declaredInterests.id, id)),
+  );
+  const masteryApplied = await applyUpdates(masteryPlan.updates, (id, value) =>
+    db.update(playerMastery).set({ canonicalSubcategory: value }).where(eq(playerMastery.id, id)),
+  );
+
+  console.log(
+    `\n[backfill-domain-casing] done. DeclaredInterest updated=${interestsApplied}, PLAYER_MASTERY updated=${masteryApplied}`,
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error('[backfill-domain-casing] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/lib/knowledge/domain-casing.test.ts
+++ b/src/lib/knowledge/domain-casing.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+
+import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
+
+describe('titleCaseDomain', () => {
+  it('title-cases all-lowercase input', () => {
+    expect(titleCaseDomain('russian literature')).toBe('Russian Literature');
+    expect(titleCaseDomain('space exploration')).toBe('Space Exploration');
+  });
+
+  it('normalizes SHOUTING input down to title case', () => {
+    expect(titleCaseDomain('RUSSIAN LITERATURE')).toBe('Russian Literature');
+    expect(titleCaseDomain('SPACE EXPLORATION')).toBe('Space Exploration');
+  });
+
+  it('keeps minor words lowercase except first/last', () => {
+    expect(titleCaseDomain('lord of the rings')).toBe('Lord of the Rings');
+    expect(titleCaseDomain('the lord of the rings')).toBe('The Lord of the Rings');
+    expect(titleCaseDomain('a tale of two cities')).toBe('A Tale of Two Cities');
+    // a minor word as the last word is still capitalized
+    expect(titleCaseDomain('something to live for')).toBe('Something to Live For');
+  });
+
+  it('does not produce "90S" for decade-style tokens', () => {
+    expect(titleCaseDomain('90s hip hop')).toBe('90s Hip Hop');
+    expect(titleCaseDomain('1990s rock')).toBe('1990s Rock');
+  });
+
+  it('handles iOS-autocorrected apostrophes and mixed casing', () => {
+    expect(titleCaseDomain("90's hip hop")).toBe("90's Hip Hop");
+    expect(titleCaseDomain("90's HIP HOP")).toBe("90's Hip Hop");
+    expect(titleCaseDomain('90’s Hip Hop')).toBe("90's Hip Hop");
+  });
+
+  it('up-cases multi-letter roman numerals', () => {
+    expect(titleCaseDomain('world war ii')).toBe('World War II');
+    expect(titleCaseDomain('final fantasy vii')).toBe('Final Fantasy VII');
+  });
+
+  it('applies canonical casing for common acronyms regardless of input casing', () => {
+    expect(titleCaseDomain('nba history')).toBe('NBA History');
+    expect(titleCaseDomain('history of nasa')).toBe('History of NASA');
+    expect(titleCaseDomain('NBA HISTORY')).toBe('NBA History');
+    expect(titleCaseDomain('wwii documentaries')).toBe('WWII Documentaries');
+  });
+
+  it('preserves a lone all-caps acronym the user typed', () => {
+    expect(titleCaseDomain('ESPN highlights')).toBe('ESPN Highlights');
+    expect(titleCaseDomain('the FIFA world cup')).toBe('The FIFA World Cup');
+  });
+
+  it('preserves hyphenated genres and stylized brands', () => {
+    expect(titleCaseDomain('hip-hop')).toBe('Hip-Hop');
+    expect(titleCaseDomain('k-pop')).toBe('K-Pop');
+    expect(titleCaseDomain('sci-fi films')).toBe('Sci-Fi Films');
+    expect(titleCaseDomain('spider-man comics')).toBe('Spider-Man Comics');
+    expect(titleCaseDomain('youtube creators')).toBe('YouTube Creators');
+    expect(titleCaseDomain('ios development')).toBe('iOS Development');
+  });
+
+  it('collapses whitespace and underscores', () => {
+    expect(titleCaseDomain('  space   exploration ')).toBe('Space Exploration');
+    expect(titleCaseDomain('space_exploration')).toBe('Space Exploration');
+  });
+
+  it('returns empty string for blank input', () => {
+    expect(titleCaseDomain('')).toBe('');
+    expect(titleCaseDomain('   ')).toBe('');
+  });
+});

--- a/src/lib/knowledge/domain-casing.ts
+++ b/src/lib/knowledge/domain-casing.ts
@@ -1,0 +1,210 @@
+// Smart, deterministic title-casing for knowledge domain labels (declared
+// interests and PlayerMastery canonical subcategories). Users — and pre-seeders —
+// type these in every casing under the sun ("russian literature", "RUSSIAN
+// LITERATURE", "90's HIP HOP", "lord of the rings"), and the old display path
+// just up-cased every word boundary, which produced "90S Hip Hop" and could not
+// fix minor words. This module standardizes them.
+//
+// It is intentionally rule-based (no LLM): zero latency/cost and fully
+// predictable. It cannot infer brand casing it has never seen ("iPhone") unless
+// the term is in CANONICAL_TERMS, but it nails the common cases the team
+// actually complained about.
+//
+// Casing does NOT affect territory matching — domainKey() lowercases everything
+// before comparison — so restyling a label never fragments a user's mastery.
+import { foldDomainPunctuation } from './domain-key';
+
+// Minor words kept lowercase in title case, unless they are the first or last
+// word of the label (a standard AP/Chicago-style short list).
+const SMALL_WORDS = new Set([
+  'a',
+  'an',
+  'and',
+  'as',
+  'at',
+  'but',
+  'by',
+  'for',
+  'from',
+  'in',
+  'into',
+  'nor',
+  'of',
+  'off',
+  'on',
+  'onto',
+  'or',
+  'over',
+  'per',
+  'the',
+  'to',
+  'vs',
+  'via',
+  'with',
+]);
+
+// Roman numerals we confidently up-case ("World War Ii" -> "World War II",
+// "Final Fantasy Vii" -> "Final Fantasy VII"). Single-letter numerals (I, V, X…)
+// are deliberately excluded — they collide with real words and initials.
+const ROMAN_NUMERALS = new Set([
+  'ii',
+  'iii',
+  'iv',
+  'vi',
+  'vii',
+  'viii',
+  'ix',
+  'xi',
+  'xii',
+  'xiii',
+  'xiv',
+  'xv',
+]);
+
+// Canonical casing for common acronyms and stylized terms, applied regardless of
+// how the user typed them ("nba" / "NBA" / "Nba" all land on "NBA"). Keep this
+// conservative: only entries whose lowercase form is not also a common English
+// word, so ordinary prose is never mangled.
+const CANONICAL_TERMS = new Map<string, string>([
+  // Sports / orgs
+  ['nba', 'NBA'],
+  ['nfl', 'NFL'],
+  ['nhl', 'NHL'],
+  ['mlb', 'MLB'],
+  ['ncaa', 'NCAA'],
+  ['mvp', 'MVP'],
+  ['fifa', 'FIFA'],
+  ['uefa', 'UEFA'],
+  ['nascar', 'NASCAR'],
+  ['f1', 'F1'],
+  // Geography / institutions
+  ['usa', 'USA'],
+  ['uk', 'UK'],
+  ['eu', 'EU'],
+  ['un', 'UN'],
+  ['ussr', 'USSR'],
+  ['uae', 'UAE'],
+  ['nasa', 'NASA'],
+  ['fbi', 'FBI'],
+  ['cia', 'CIA'],
+  ['nato', 'NATO'],
+  ['nyc', 'NYC'],
+  ['dc', 'DC'],
+  // Media / tech
+  ['tv', 'TV'],
+  ['hbo', 'HBO'],
+  ['bbc', 'BBC'],
+  ['cnn', 'CNN'],
+  ['mtv', 'MTV'],
+  ['espn', 'ESPN'],
+  ['nyt', 'NYT'],
+  ['ai', 'AI'],
+  ['diy', 'DIY'],
+  ['faq', 'FAQ'],
+  ['ceo', 'CEO'],
+  ['gdp', 'GDP'],
+  ['dna', 'DNA'],
+  ['ufo', 'UFO'],
+  ['edm', 'EDM'],
+  ['rpg', 'RPG'],
+  ['fps', 'FPS'],
+  ['dlc', 'DLC'],
+  // History
+  ['wwi', 'WWI'],
+  ['wwii', 'WWII'],
+  // Stylized brands / genres
+  ['youtube', 'YouTube'],
+  ['tiktok', 'TikTok'],
+  ['github', 'GitHub'],
+  ['javascript', 'JavaScript'],
+  ['ios', 'iOS'],
+  ['macos', 'macOS'],
+  ['iphone', 'iPhone'],
+  ['ipad', 'iPad'],
+  ['k-pop', 'K-Pop'],
+  ['j-pop', 'J-Pop'],
+  ['hip-hop', 'Hip-Hop'],
+  ['sci-fi', 'Sci-Fi'],
+  ['lo-fi', 'Lo-Fi'],
+  ['r&b', 'R&B'],
+]);
+
+// A token whose alphabetic characters are all uppercase, with at least two
+// letters ("NBA", "HBO", "WWII"). Used both to preserve a stray acronym the user
+// typed and to detect SHOUTING input.
+function isAcronymToken(token: string): boolean {
+  const letters = token.replace(/[^A-Za-z]/g, '');
+  return letters.length >= 2 && letters === letters.toUpperCase();
+}
+
+// Title-case a single hyphen-free, space-free chunk: capitalize the first letter
+// and lowercase the rest. Chunks that start with a digit ("90s", "1990s") keep
+// their trailing letters lowercase rather than producing "90S".
+function capitalizeChunk(chunk: string): string {
+  const lower = chunk.toLowerCase();
+  const firstLetter = lower.search(/[a-z]/);
+  if (firstLetter !== 0) return lower; // pure digits/symbols, or digit-led ("90s")
+  return lower[0].toUpperCase() + lower.slice(1);
+}
+
+type Position = 'first' | 'last' | 'mid';
+
+function normalizeToken(token: string, position: Position, shouting: boolean): string {
+  const lower = token.toLowerCase();
+
+  // 1) Curated canonical terms always win ("nba" -> "NBA", "k-pop" -> "K-Pop").
+  const canonical = CANONICAL_TERMS.get(lower);
+  if (canonical) return canonical;
+
+  // 2) Roman numerals up-case.
+  if (ROMAN_NUMERALS.has(lower)) return lower.toUpperCase();
+
+  // 3) Preserve a stray all-caps acronym the user typed ("NBA", "HBO"), but only
+  //    when the label is not SHOUTING — otherwise "RUSSIAN LITERATURE" would be
+  //    left untouched.
+  if (!shouting && isAcronymToken(token)) return token;
+
+  // 4) Minor words stay lowercase unless they anchor the title.
+  if (position === 'mid' && SMALL_WORDS.has(lower)) return lower;
+
+  // 5) Default: title-case each hyphen-separated part ("hip-hop" -> "Hip-Hop").
+  return lower.split('-').map(capitalizeChunk).join('-');
+}
+
+// Standardize the capitalization of a knowledge domain label.
+//   "russian literature"  -> "Russian Literature"
+//   "RUSSIAN LITERATURE"  -> "Russian Literature"
+//   "lord of the rings"   -> "Lord of the Rings"
+//   "90's hip hop"        -> "90's Hip Hop"
+//   "world war ii"        -> "World War II"
+//   "nba history"         -> "NBA History"
+export function titleCaseDomain(value: string): string {
+  // Fold curly apostrophes, turn underscores into spaces (slug artifacts), and
+  // collapse whitespace. Hyphens are preserved and handled per-part below.
+  const cleaned = foldDomainPunctuation(value).replace(/_+/g, ' ').replace(/\s+/g, ' ').trim();
+  if (!cleaned) return '';
+
+  const tokens = cleaned.split(' ');
+
+  // SHOUTING detection. If the label has no lowercase letters at all it was
+  // almost certainly typed in caps, so its words should NOT be preserved as
+  // acronyms. We also treat "two or more multi-letter all-caps words" as
+  // shouting, which rescues "90's HIP HOP" while still preserving a lone "NBA"
+  // in "NBA history". Curated terms and roman numerals are excluded from the
+  // count since they are handled explicitly.
+  const hasLower = /[a-z]/.test(cleaned);
+  const acronymish = tokens.filter(
+    (t) =>
+      isAcronymToken(t) &&
+      !ROMAN_NUMERALS.has(t.toLowerCase()) &&
+      !CANONICAL_TERMS.has(t.toLowerCase()),
+  ).length;
+  const shouting = !hasLower || acronymish >= 2;
+
+  return tokens
+    .map((token, i) => {
+      const position: Position = i === 0 ? 'first' : i === tokens.length - 1 ? 'last' : 'mid';
+      return normalizeToken(token, position, shouting);
+    })
+    .join(' ');
+}

--- a/src/server/db/queries/__tests__/add-declared-interest.test.ts
+++ b/src/server/db/queries/__tests__/add-declared-interest.test.ts
@@ -69,11 +69,12 @@ describe('addDeclaredInterest', () => {
 
   it('re-categorizes an uncategorized new interest', async () => {
     categorizeInterestDomainMock.mockResolvedValue('Finance');
+    // The label is standardized to title case before categorization/persistence.
     const result = await addDeclaredInterest('user-1', { label: 'Mortgage backed securities' });
-    expect(categorizeInterestDomainMock).toHaveBeenCalledWith('Mortgage backed securities');
+    expect(categorizeInterestDomainMock).toHaveBeenCalledWith('Mortgage Backed Securities');
     expect(result).toEqual({
       created: true,
-      domain: 'Mortgage backed securities',
+      domain: 'Mortgage Backed Securities',
       broadCategory: 'Finance',
     });
   });

--- a/src/server/db/queries/__tests__/save-declared-interests.test.ts
+++ b/src/server/db/queries/__tests__/save-declared-interests.test.ts
@@ -65,25 +65,28 @@ describe('saveDeclaredInterests categorization backstop', () => {
     expect(result).toEqual([{ label: 'Jazz', broadCategory: 'Music', description: null }]);
   });
 
+  // Labels are standardized to title case by normalizeDeclaredInterest before
+  // categorization, so both the categorizer call and the persisted label use the
+  // canonical casing regardless of how the interest was typed.
   it('re-categorizes a "General Knowledge" catch-all instead of persisting it', async () => {
     categorizeInterestDomainMock.mockResolvedValue('Music');
     const result = await saveDeclaredInterests('user-1', [
       { label: 'Romantic Era Classical symphony music', broadCategory: 'General Knowledge' },
     ]);
     expect(categorizeInterestDomainMock).toHaveBeenCalledWith(
-      'Romantic Era Classical symphony music',
+      'Romantic Era Classical Symphony Music',
     );
     expect(result).toEqual([
-      { label: 'Romantic Era Classical symphony music', broadCategory: 'Music', description: null },
+      { label: 'Romantic Era Classical Symphony Music', broadCategory: 'Music', description: null },
     ]);
   });
 
   it('re-categorizes a missing broad category', async () => {
     categorizeInterestDomainMock.mockResolvedValue('Finance');
     const result = await saveDeclaredInterests('user-1', [{ label: 'Mortgage backed securities' }]);
-    expect(categorizeInterestDomainMock).toHaveBeenCalledWith('Mortgage backed securities');
+    expect(categorizeInterestDomainMock).toHaveBeenCalledWith('Mortgage Backed Securities');
     expect(result).toEqual([
-      { label: 'Mortgage backed securities', broadCategory: 'Finance', description: null },
+      { label: 'Mortgage Backed Securities', broadCategory: 'Finance', description: null },
     ]);
   });
 
@@ -92,9 +95,9 @@ describe('saveDeclaredInterests categorization backstop', () => {
     const result = await saveDeclaredInterests('user-1', [
       { label: "90's ballywood", broadCategory: 'Other' },
     ]);
-    expect(categorizeInterestDomainMock).toHaveBeenCalledWith("90's ballywood");
+    expect(categorizeInterestDomainMock).toHaveBeenCalledWith("90's Ballywood");
     expect(result).toEqual([
-      { label: "90's ballywood", broadCategory: 'Film & Television', description: null },
+      { label: "90's Ballywood", broadCategory: 'Film & Television', description: null },
     ]);
   });
 

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -16,6 +16,7 @@ import {
 } from '@/server/db';
 import type { QueueSlot } from '@/server/daily/types';
 import { LLM_QUESTION_ATTRIBUTION, resolveAuthorDisplay } from '@/lib/questions-types';
+import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
 
 export type ArchiveSource = 'daily' | 'feed' | 'joshing_game' | 'sent_to_me' | 'written_by_me';
 export type ArchiveResultFilter = 'correct' | 'incorrect' | 'skipped';
@@ -78,11 +79,7 @@ function asQueueSlots(value: unknown): QueueSlot[] {
 }
 
 function displayNameForDomain(domain: string): string {
-  return domain
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (letter) => letter.toUpperCase()) || 'General';
+  return titleCaseDomain(domain) || 'General';
 }
 
 function questionDomain(question: typeof questions.$inferSelect | null | undefined): string {

--- a/src/server/db/queries/daily-summary.ts
+++ b/src/server/db/queries/daily-summary.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, lt, ne, sql } from 'drizzle-orm';
 
 import { getNextDailyResetBoundary } from '@/lib/games/timezone';
+import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
 import {
   dailyQueues,
   db,
@@ -106,11 +107,7 @@ function asQueueSlots(value: unknown): QueueSlot[] {
 }
 
 function displayNameForDomain(domain: string): string {
-  return domain
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .trim()
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  return titleCaseDomain(domain);
 }
 
 function dateStart(dateString: string): Date {

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -19,6 +19,7 @@ import { TIER_THRESHOLD_POINTS } from '@/server/mastery/tiers';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
 import { pgErrorCode } from '@/server/db/pg-error';
 import type { MasteryTier } from '@/types/db';
 
@@ -193,11 +194,10 @@ const STREAK_TIME_ZONE = 'America/New_York';
 const FRIEND_MEDIATED_CONTEXTS = ['feed', 'joshing_game'];
 
 function displayNameForDomain(domain: string): string {
-  return domain
-    .trim()
-    .replace(/[_-]+/g, ' ')
-    .replace(/\s+/g, ' ')
-    .replace(/\b\w/g, (letter) => letter.toUpperCase());
+  // Standardize capitalization at render time so legacy rows stored with messy
+  // casing ("russian literature", "90's HIP HOP") display consistently, the same
+  // way newly-written labels are normalized in normalizeDeclaredInterest.
+  return titleCaseDomain(domain);
 }
 
 function percent(value: number): number {

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -8,7 +8,7 @@ import {
   categorizeInterestDomain,
   isCatchAllBroadCategory,
 } from '@/server/llm/interests';
-import { foldDomainPunctuation } from '@/lib/knowledge/domain-key';
+import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
 import { assertSpecificInterest } from '@/lib/knowledge/interest-specificity';
 
 type User = InferSelectModel<typeof users>;
@@ -32,12 +32,15 @@ export type PreSeededInterestsForUser = {
 };
 
 function normalizeDeclaredInterest(interest: DeclaredInterestInput): DeclaredInterestInput | null {
-  // Fold curly apostrophes to ASCII so the stored declared interest and its
-  // seeded PlayerMastery row match the straight-apostrophe canonical
-  // subcategory the question pipeline emits. Without this, a label like
-  // "90's ballywood" (curly, from iOS auto-correct) and the questions answered
-  // against it split into two territories whose points never merge.
-  const label = foldDomainPunctuation(interest.label).trim().replace(/\s+/g, ' ');
+  // titleCaseDomain folds curly apostrophes to ASCII (so the stored declared
+  // interest and its seeded PlayerMastery row match the straight-apostrophe
+  // canonical subcategory the question pipeline emits — without this, a label
+  // like "90's ballywood" from iOS auto-correct splits into two territories
+  // whose points never merge), collapses whitespace, and standardizes the
+  // capitalization ("russian literature", "90's HIP HOP" -> "Russian Literature",
+  // "90's Hip Hop"). Casing does not affect territory matching — domainKey()
+  // lowercases before comparison — so restyling never fragments mastery.
+  const label = titleCaseDomain(interest.label);
   if (!label) return null;
 
   return {


### PR DESCRIPTION
## Summary
Introduces deterministic, rule-based title-casing for knowledge domain labels (declared interests and PlayerMastery canonical subcategories). Users type these labels in inconsistent casing ("russian literature", "RUSSIAN LITERATURE", "90's HIP HOP"), and this change standardizes them to a predictable format while preserving brand/acronym styling.

## Key Changes

- **New module `src/lib/knowledge/domain-casing.ts`**: Implements `titleCaseDomain()` function that:
  - Applies AP/Chicago-style title casing with a curated list of minor words (a, the, of, etc.)
  - Preserves multi-letter Roman numerals (II, VII, etc.)
  - Handles canonical acronyms and stylized terms (NBA, YouTube, K-Pop, etc.)
  - Detects SHOUTING input and normalizes it down
  - Handles decade-style tokens correctly ("90s" not "90S")
  - Folds curly apostrophes and collapses whitespace

- **Backfill script `scripts/backfill-domain-casing.ts`**: One-time migration to rewrite existing labels:
  - Safe by design: casing never affects territory matching (domainKey lowercases before comparison)
  - Respects UNIQUE(user, label) constraints; skips collisions rather than merging
  - Idempotent; can be re-run safely
  - Supports dry-run mode (default) and `--apply` flag for writes

- **Integration points**:
  - `normalizeDeclaredInterest()` in `src/server/db/queries/users.ts` now calls `titleCaseDomain()` at write time
  - `displayNameForDomain()` in `src/server/db/queries/knowledge.ts`, `archive.ts`, and `daily-summary.ts` now use `titleCaseDomain()` at render time (handles legacy rows with inconsistent casing)
  - Updated test expectations in `save-declared-interests.test.ts` and `add-declared-interest.test.ts` to reflect standardized casing

- **Test coverage**: Comprehensive test suite in `src/lib/knowledge/domain-casing.test.ts` covering:
  - All-lowercase and SHOUTING normalization
  - Minor word handling (first/last position exceptions)
  - Decade tokens, Roman numerals, acronyms
  - Hyphenated genres and stylized brands
  - Whitespace/underscore collapsing

- **Package.json**: Added npm scripts for the backfill:
  - `knowledge:casing-backfill` — dry run
  - `knowledge:casing-backfill:apply` — apply changes

## Implementation Details

The solution is intentionally rule-based (no LLM) for zero latency/cost and full predictability. It cannot infer brand casing it has never seen (e.g., "iPhone") unless the term is in `CANONICAL_TERMS`, but it handles the common cases the team complained about. The SHOUTING detection heuristic preserves lone acronyms ("NBA history") while normalizing multi-acronym input ("90's HIP HOP" → "90's Hip Hop").

Casing standardization is applied at three points:
1. **Write time** (normalizeDeclaredInterest): ensures new/updated labels are stored canonically
2. **Render time** (displayNameForDomain): handles legacy rows with inconsistent casing
3. **Backfill**: one-time migration of existing data

This layered approach ensures consistency across old and new data without requiring a migration before deployment.

https://claude.ai/code/session_017zcoqQXPrxngBNf4pevc11