### PR TITLE
perf(questions): batch question stats to kill GET /api/questions N+1

### DIFF
--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -2,10 +2,9 @@ import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import {
-  getProgressionLandscape,
   getKnowledgePageData,
-  getUserAnswerStreak,
   getUserMasteryOverview,
+  loadKnowledgeInputs,
 } from '@/server/db/queries/knowledge';
 import { ensureAuthoredDomainsOpened } from '@/server/knowledge/open-domain';
 
@@ -18,21 +17,24 @@ export async function GET() {
   // Self-heal any authored questions whose territory failed to open during
   // /api/questions creation (the openKBDomain try/catch swallows transient
   // failures so the question save isn't blocked). Idempotent and cheap when
-  // there's nothing to backfill. Failure here must not block the page render
-  // — fall through to the read queries either way.
-  await ensureAuthoredDomainsOpened(session.userId).catch((error) => {
+  // there's nothing to backfill. Failure here must not block the page render.
+  // Runs concurrently with the read queries: its inserts are rare, and a
+  // one-request-stale read of a just-opened domain is acceptable.
+  const ensureOpened = ensureAuthoredDomainsOpened(session.userId).catch((error) => {
     console.error('[knowledge/GET] ensureAuthoredDomainsOpened failed; continuing', {
       userId: session.userId,
       message: error instanceof Error ? error.message : String(error),
     });
   });
 
-  const [mastery, streak, pageData, progressionLandscape] = await Promise.all([
-    getUserMasteryOverview(session.userId),
-    getUserAnswerStreak(session.userId),
-    getKnowledgePageData(session.userId),
-    getProgressionLandscape(session.userId),
+  // Both the mastery overview and the page data derive from the same declared
+  // interests / mastery rows / events / hidden keys — fetch them once and share.
+  const inputs = await loadKnowledgeInputs(session.userId);
+  const [mastery, pageData] = await Promise.all([
+    getUserMasteryOverview(session.userId, inputs),
+    getKnowledgePageData(session.userId, inputs),
   ]);
+  await ensureOpened;
 
-  return NextResponse.json({ mastery, streak, portraitData: null, progressionLandscape, pageData });
+  return NextResponse.json({ mastery, pageData });
 }

--- a/src/app/api/nav/route.ts
+++ b/src/app/api/nav/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { getSession } from '@/server/auth/session';
+import { getUserOnboardingProfile } from '@/server/db/queries/users';
+import { getBellBadgeCount } from '@/server/db/queries/activity';
+import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes';
+
+export const dynamic = 'force-dynamic';
+
+// Nav badge summary: the display name (for the account-initials avatar), the
+// activity-bell unread count, and whether the Friends tab should show its
+// discovery dot. The root layout used to await these three queries before
+// streaming any HTML on every hard navigation; Nav now fetches them client-side
+// after mount so the page shell streams immediately and the badges pop in
+// slightly later. No request input, so there's nothing to Zod-validate (matches
+// the sibling /api/friends/has-new-discovery probe).
+export async function GET() {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const [profile, bellBadgeCount, discoveryStatus] = await Promise.all([
+    getUserOnboardingProfile(session.userId),
+    getBellBadgeCount(session.userId).catch(() => 0),
+    getNewDiscoveryStatus(session.userId).catch(() => ({ hasNew: false, count: 0 })),
+  ]);
+
+  return NextResponse.json({
+    userId: session.userId,
+    displayName: profile?.displayName ?? null,
+    bellBadgeCount,
+    friendsDotVisible: discoveryStatus.hasNew,
+  });
+}

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -120,7 +120,11 @@ function answerFailureMessage(body: FailedAnswerResponse | null): string {
 // state with the attempt counter (the server has already burned its own
 // internal top-up rounds by the time we see this, so these are fresh attempts).
 const MAX_QUEUE_CREATE_ATTEMPTS = 4;
-const QUEUE_CREATE_BACKOFF_MS = [2000, 4000, 8000];
+// Each retry re-runs a full synchronous generation pass (seconds of real work),
+// so the inter-attempt sleep only needs to debounce transient low-yield rounds,
+// not wait out a long backend job. Halved from the old [2000, 4000, 8000] (14s of
+// pure dead time worst-case) to a gentler 1→2→4s ramp.
+const QUEUE_CREATE_BACKOFF_MS = [1000, 2000, 4000];
 
 // Shown after the auto-retries are exhausted — kept warm and retryable rather
 // than alarming, since the most common cause is slow generation, not a fault.
@@ -231,6 +235,7 @@ export default function DailyPage() {
         // "still working" state. 409 (no_knowledge_base) means the user
         // genuinely has nothing to generate from — that's terminal; send them
         // to setup rather than retrying.
+        let createdQueue: QueueResponse | null = null;
         for (let attempt = 1; attempt <= MAX_QUEUE_CREATE_ATTEMPTS; attempt += 1) {
           setGeneratingAttempt(attempt);
           const createResponse = await fetch('/api/daily/queue', {
@@ -238,7 +243,13 @@ export default function DailyPage() {
             credentials: 'include',
             cache: 'no-store',
           });
-          if (createResponse.ok) break;
+          // A successful POST already returns the fully-built queue (the same
+          // serializeQueue shape as GET), so capture it and skip the follow-up
+          // GET round-trip entirely.
+          if (createResponse.ok) {
+            createdQueue = (await createResponse.json().catch(() => null)) as QueueResponse | null;
+            break;
+          }
 
           const createBody = await createResponse.json().catch(() => null);
           if (createResponse.status === 409) {
@@ -263,26 +274,19 @@ export default function DailyPage() {
           );
         }
         setGeneratingAttempt(null);
-        const refetchResponse = await fetch('/api/daily/queue', {
-          cache: 'no-store',
-          credentials: 'include',
-        });
-        const refetchBody = await refetchResponse.json().catch(() => null);
-        if (!refetchResponse.ok) {
-          throw new Error(refetchBody?.message ?? 'Could not load today.');
-        }
-        if (!refetchBody?.queue_id) {
+
+        if (!createdQueue?.queue_id) {
           setQueue(null);
           setLoading(false);
           return;
         }
-        const refetchSlots = Array.isArray(refetchBody.slots) ? refetchBody.slots : [];
+        const createdSlots = Array.isArray(createdQueue.slots) ? createdQueue.slots : [];
         setQueue({
-          queue_id: refetchBody.queue_id,
-          queue_date: refetchBody.queue_date,
-          slots: refetchSlots,
+          queue_id: createdQueue.queue_id,
+          queue_date: createdQueue.queue_date,
+          slots: createdSlots,
         });
-        maybeShowFirstRunIntro(refetchBody.is_first_daily);
+        maybeShowFirstRunIntro(createdQueue.is_first_daily);
         setLoading(false);
         return;
       }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,9 +6,6 @@ import { Nav } from "@/components/Nav";
 // Remove this import + the <PaletteToggle/> + boot script before shipping.
 import { PaletteToggle } from "@/components/dev/PaletteToggle";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
-import { getUserOnboardingProfile } from '@/server/db/queries/users';
-import { getBellBadgeCount } from '@/server/db/queries/activity';
-import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes';
 
 // Intentional product choice (2026-05-16): Montserrat is the body font.
 // PRD §typography spec'd Inter, but Montserrat ships. Update PRD to reflect this.
@@ -52,15 +49,12 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  // Only the cheap JWT read stays in the blocking path; the DB-backed Nav badge
+  // values (display name, bell count, friends dot) are fetched client-side by Nav
+  // after mount (GET /api/nav) so the page shell streams immediately on every hard
+  // navigation instead of waiting on three queries just to render nav badges.
   const sessionToken = await getSessionToken()
   const claims = await readSessionClaims(sessionToken)
-  const [profile, bellBadgeCount, discoveryStatus] = claims
-    ? await Promise.all([
-        getUserOnboardingProfile(claims.userId),
-        getBellBadgeCount(claims.userId).catch(() => 0),
-        getNewDiscoveryStatus(claims.userId).catch(() => ({ hasNew: false, count: 0 })),
-      ])
-    : [null, 0, { hasNew: false, count: 0 }]
   return (
     <html
       lang="en"
@@ -76,12 +70,7 @@ export default async function RootLayout({
           }}
         />
         <PaletteToggle />
-        <Nav
-          initialUserId={claims?.userId ?? null}
-          initialDisplayName={profile?.displayName ?? null}
-          bellBadgeCount={bellBadgeCount}
-          friendsDotVisible={discoveryStatus.hasNew}
-        />
+        <Nav initialUserId={claims?.userId ?? null} />
         {children}
       </body>
     </html>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import { Bell, Brain, Home, Pencil, Plus, User, Users } from 'lucide-react';
@@ -62,9 +62,35 @@ export function Nav({
 }) {
   const pathname = usePathname();
   const router = useRouter();
-  const accountInitials = initialDisplayName ? initialsFor(initialDisplayName) || null : null;
   const currentUserId = initialUserId;
   const [createChooserOpen, setCreateChooserOpen] = useState(false);
+
+  // Badge values seed from props (kept for any caller that still passes them) and
+  // are refreshed client-side after mount. The root layout no longer blocks HTML
+  // streaming on these DB queries — it passes only initialUserId — so Nav pulls
+  // them from GET /api/nav once mounted. Badges pop in slightly late by design.
+  const [displayName, setDisplayName] = useState(initialDisplayName);
+  const [badgeCount, setBadgeCount] = useState(bellBadgeCount);
+  const [friendsDot, setFriendsDot] = useState(friendsDotVisible);
+
+  useEffect(() => {
+    if (!initialUserId) return;
+    let active = true;
+    fetch('/api/nav', { credentials: 'include' })
+      .then((response) => (response.ok ? response.json() : null))
+      .then((data: { displayName?: string | null; bellBadgeCount?: number; friendsDotVisible?: boolean } | null) => {
+        if (!active || !data) return;
+        setDisplayName(data.displayName ?? null);
+        setBadgeCount(typeof data.bellBadgeCount === 'number' ? data.bellBadgeCount : 0);
+        setFriendsDot(Boolean(data.friendsDotVisible));
+      })
+      .catch(() => {});
+    return () => {
+      active = false;
+    };
+  }, [initialUserId]);
+
+  const accountInitials = displayName ? initialsFor(displayName) || null : null;
   // On Home and the Questions page the FAB is a dedicated "add a question"
   // shortcut: it drops straight into the composer (?create=1) rather than the
   // generic three-way Create chooser. The composer still surfaces every
@@ -124,8 +150,8 @@ export function Nav({
     return false;
   }
 
-  const showBadge = bellBadgeCount > 0;
-  const badgeText = formatBadgeCount(bellBadgeCount);
+  const showBadge = badgeCount > 0;
+  const badgeText = formatBadgeCount(badgeCount);
 
   return (
     <>
@@ -144,7 +170,7 @@ export function Nav({
             <Link
               href="/activities"
               aria-label={
-                showBadge ? `Activity, ${bellBadgeCount} unread` : 'Activity'
+                showBadge ? `Activity, ${badgeCount} unread` : 'Activity'
               }
               className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
@@ -233,7 +259,7 @@ export function Nav({
                   )}
                   {/* Discovery indicator for the Friends tab — muted neutral
                       so it doesn't compete with the bell badge accent. */}
-                  {friendsDotVisible && label === 'Friends' ? (
+                  {friendsDot && label === 'Friends' ? (
                     <span
                       className="absolute -right-1 -top-1 size-2 rounded-full"
                       style={{ backgroundColor: '#8a8a9a' }}

--- a/src/server/db/queries/__tests__/knowledge-aggregates.test.ts
+++ b/src/server/db/queries/__tests__/knowledge-aggregates.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type DomainAggregateRow,
+  deriveExpandingDomains,
+  mergeDomainStats,
+} from '@/server/db/queries/knowledge';
+
+// These cover the pure JS side of the SQL-aggregation refactor: the per-domain
+// GROUP BY rows are merged by domainKey() (which SQL can't replicate) before the
+// page consumes them. The DB-side FILTER/GROUP BY math is exercised by the live
+// query; here we pin the merge + momentum semantics.
+
+const DAY = 24 * 60 * 60 * 1000;
+const ago = (days: number) => new Date(Date.now() - days * DAY);
+
+function aggregate(overrides: Partial<DomainAggregateRow> & { canonicalSubcategory: string }): DomainAggregateRow {
+  return {
+    answered: 0,
+    correct: 0,
+    lastAnsweredAt: null,
+    demonstrated: false,
+    firstAt: null,
+    latestAt: null,
+    recentAnswered: 0,
+    recentPoints: 0,
+    wrongAnswers: 0,
+    socialEvents: 0,
+    savedEvents: 0,
+    ...overrides,
+  };
+}
+
+describe('mergeDomainStats', () => {
+  it('folds rows that share a domainKey, summing counts and taking the latest activity', () => {
+    const older = ago(5);
+    const newer = ago(1);
+    const { statsByDomain } = mergeDomainStats([
+      aggregate({ canonicalSubcategory: 'Jazz', answered: 3, correct: 2, lastAnsweredAt: older }),
+      aggregate({ canonicalSubcategory: 'jazz', answered: 1, correct: 1, lastAnsweredAt: newer }),
+    ]);
+
+    expect(statsByDomain.size).toBe(1);
+    const stats = statsByDomain.get('jazz');
+    expect(stats).toMatchObject({ answered: 4, correct: 3 });
+    expect(stats?.lastActivityAt?.getTime()).toBe(newer.getTime());
+  });
+
+  it('omits domains with no answered events but still records demonstrated', () => {
+    const { statsByDomain, demonstratedDomains, demonstratedLabels } = mergeDomainStats([
+      aggregate({ canonicalSubcategory: 'Heraldry', answered: 0, demonstrated: true }),
+    ]);
+
+    expect(statsByDomain.has('heraldry')).toBe(false);
+    expect(demonstratedDomains.has('heraldry')).toBe(true);
+    expect(demonstratedLabels.get('heraldry')).toBe('Heraldry');
+  });
+
+  it('coerces string counts from pg', () => {
+    const { statsByDomain } = mergeDomainStats([
+      aggregate({
+        canonicalSubcategory: 'Opera',
+        answered: '5' as unknown as number,
+        correct: '4' as unknown as number,
+      }),
+    ]);
+    expect(statsByDomain.get('opera')).toMatchObject({ answered: 5, correct: 4 });
+  });
+});
+
+describe('deriveExpandingDomains', () => {
+  it('scores a freshly-opened domain as a new discovery', () => {
+    const [top] = deriveExpandingDomains([
+      aggregate({
+        canonicalSubcategory: 'Weimar Cinema',
+        firstAt: ago(1),
+        latestAt: ago(1),
+        recentAnswered: 2,
+        recentPoints: 12,
+      }),
+    ]);
+    expect(top.domain).toBe('Weimar Cinema');
+    expect(top.reason).toBe('new-discovery');
+    expect(top.momentumScore).toBeGreaterThan(0);
+  });
+
+  it('collapses same-key rows into one entry', () => {
+    const result = deriveExpandingDomains([
+      aggregate({ canonicalSubcategory: 'Bebop', firstAt: ago(2), latestAt: ago(2), recentAnswered: 1 }),
+      aggregate({ canonicalSubcategory: 'bebop', firstAt: ago(40), latestAt: ago(1), recentAnswered: 1 }),
+    ]);
+    expect(result).toHaveLength(1);
+    // firstAt folds to the older (40d ago) so novelty is off; recent activity keeps it surfaced.
+    expect(result[0].reason).not.toBe('new-discovery');
+    expect(result[0].momentumScore).toBeGreaterThan(0);
+  });
+
+  it('drops stale domains with no recent momentum and caps at five', () => {
+    const stale = aggregate({ canonicalSubcategory: 'Dormant', firstAt: ago(120), latestAt: ago(90) });
+    const live = Array.from({ length: 7 }, (_, i) =>
+      aggregate({ canonicalSubcategory: `Live ${i}`, firstAt: ago(3), latestAt: ago(1), recentAnswered: 3 }),
+    );
+    const result = deriveExpandingDomains([stale, ...live]);
+    expect(result.length).toBe(5);
+    expect(result.some((d) => d.domain === 'Dormant')).toBe(false);
+  });
+});

--- a/src/server/db/queries/__tests__/question-stats.test.ts
+++ b/src/server/db/queries/__tests__/question-stats.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { mergeQuestionStats } from '@/server/db/queries/questions';
+
+// mergeQuestionStats is the pure core of the batched readQuestionStatsForIds: it
+// merges the three GROUP BY result sets (joshing-game responses, "Send to friend"
+// feed answers, and game-usage rows) into per-question stats. These tests pin the
+// count-combining, correctRate rounding, and zero-fill semantics that the old
+// per-question readQuestionStats used to produce one row at a time.
+
+const lastUsed = new Date('2026-01-15T12:00:00.000Z');
+
+describe('mergeQuestionStats', () => {
+  it('sums response and feed answers for the same question', () => {
+    const stats = mergeQuestionStats(
+      ['q1'],
+      [{ questionId: 'q1', timesAnswered: 4, timesCorrect: 3 }],
+      [{ questionId: 'q1', timesAnswered: 2, timesCorrect: 1 }],
+      [{ questionId: 'q1', lastUsedAt: lastUsed, usedInGamesCount: 5 }],
+    );
+
+    expect(stats.get('q1')).toEqual({
+      timesAnswered: 6,
+      timesCorrect: 4,
+      correctRate: 67, // round(4 / 6 * 100)
+      lastUsedAt: lastUsed.toISOString(),
+      usedInGamesCount: 5,
+    });
+  });
+
+  it('zero-fills every requested id with no answers or usage', () => {
+    const stats = mergeQuestionStats(['q1', 'q2'], [], [], [
+      { questionId: 'q1', lastUsedAt: lastUsed, usedInGamesCount: 1 },
+    ]);
+
+    expect(stats.get('q1')).toEqual({
+      timesAnswered: 0,
+      timesCorrect: 0,
+      correctRate: 0,
+      lastUsedAt: lastUsed.toISOString(),
+      usedInGamesCount: 1,
+    });
+    // q2 has no rows at all — still present, fully zero-filled.
+    expect(stats.get('q2')).toEqual({
+      timesAnswered: 0,
+      timesCorrect: 0,
+      correctRate: 0,
+      lastUsedAt: null,
+      usedInGamesCount: 0,
+    });
+  });
+
+  it('keeps stats partitioned per question (no cross-contamination)', () => {
+    const stats = mergeQuestionStats(
+      ['q1', 'q2'],
+      [
+        { questionId: 'q1', timesAnswered: 1, timesCorrect: 1 },
+        { questionId: 'q2', timesAnswered: 3, timesCorrect: 0 },
+      ],
+      [{ questionId: 'q2', timesAnswered: 1, timesCorrect: 1 }],
+      [],
+    );
+
+    expect(stats.get('q1')).toMatchObject({ timesAnswered: 1, timesCorrect: 1, correctRate: 100 });
+    expect(stats.get('q2')).toMatchObject({
+      timesAnswered: 4,
+      timesCorrect: 1,
+      correctRate: 25,
+      usedInGamesCount: 0,
+    });
+  });
+
+  it('coerces string counts from pg and ignores null questionIds', () => {
+    const stats = mergeQuestionStats(
+      ['q1'],
+      // pg returns count(*) as a string; null questionId rows must be skipped.
+      [
+        { questionId: 'q1', timesAnswered: '3' as unknown as number, timesCorrect: '2' as unknown as number },
+        { questionId: null, timesAnswered: 99, timesCorrect: 99 },
+      ],
+      [],
+      [{ questionId: null, lastUsedAt: lastUsed, usedInGamesCount: 7 }],
+    );
+
+    expect(stats.get('q1')).toEqual({
+      timesAnswered: 3,
+      timesCorrect: 2,
+      correctRate: 67,
+      lastUsedAt: null,
+      usedInGamesCount: 0,
+    });
+  });
+
+  it('returns an empty map when no ids are requested', () => {
+    expect(mergeQuestionStats([], [], [], []).size).toBe(0);
+  });
+});

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -3,7 +3,13 @@ import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 import { writeActivity } from '@/server/activity/write-activity';
 import { db, feedItems, joshingGameResponses, questions, userQuestionBank, users } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
-import { bankQuestionSelectColumns, type QuestionView, toQuestionView } from '@/server/db/queries/questions';
+import {
+  bankQuestionSelectColumns,
+  buildQuestionView,
+  EMPTY_QUESTION_STATS,
+  type QuestionView,
+  readQuestionStatsForIds,
+} from '@/server/db/queries/questions';
 
 export type BankContextType = 'feed' | 'joshing_game' | 'manual';
 
@@ -214,13 +220,20 @@ export async function getBankedQuestions(
     .where(and(...filters))
     .orderBy(desc(userQuestionBank.addedAt));
 
-  const answerersByQuestion = await getAnswerersForQuestions(
-    rows.map((row) => row.question.id),
-    userId,
-  );
+  const questionIds = rows.map((row) => row.question.id);
+  // Two batched lookups instead of per-row aggregate queries: the answerer rollup
+  // and all question stats (3 GROUP BY queries total via readQuestionStatsForIds)
+  // — avoids an N+1 that fired ~3 queries per banked question through the max-5 pool.
+  const [answerersByQuestion, statsByQuestion] = await Promise.all([
+    getAnswerersForQuestions(questionIds, userId),
+    readQuestionStatsForIds(questionIds),
+  ]);
 
-  return Promise.all(rows.map(async (row) => {
-    const view = await toQuestionView(row.question);
+  return rows.map((row) => {
+    const view = buildQuestionView(
+      row.question,
+      statsByQuestion.get(row.question.id) ?? EMPTY_QUESTION_STATS,
+    );
     const answerers = answerersByQuestion.get(row.question.id);
     return {
       ...view,
@@ -231,5 +244,5 @@ export async function getBankedQuestions(
       authorName: row.question.creatorId === userId ? 'You' : displayName(row.author.displayName),
       answerers: answerers && answerers.total > 0 ? answerers : undefined,
     };
-  }));
+  });
 }

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -78,23 +78,6 @@ export type MasteryOverview = {
   recentActivity: RecentActivity[];
 };
 
-export type ProgressionView = {
-  canonicalSubcategory: string;
-  canonicalSubcategorySlug: string;
-  broadCategory: string | null;
-  currentTier: MasteryTier | null;
-  correctAnswerCount: number;
-  authoredCount: number;
-  iconKey: string;
-  territoryType: 'declared' | 'demonstrated';
-};
-
-export type StreakData = {
-  currentStreak: number;
-  longestStreak: number;
-  lastActivityDate: string | null;
-};
-
 export type DomainVisibility = 'public' | 'friends' | 'private';
 
 export type MasteryEvent = {
@@ -190,7 +173,6 @@ async function getPlayerMasteryRows(userId: string, orderByPoints = false): Prom
 }
 
 const TIER_ORDER: MasteryTier[] = ['establishing', 'familiar', 'solid', 'mastery'];
-const STREAK_TIME_ZONE = 'America/New_York';
 const FRIEND_MEDIATED_CONTEXTS = ['feed', 'joshing_game'];
 
 function displayNameForDomain(domain: string): string {
@@ -414,8 +396,15 @@ function buildMasteryByDomain(
   return byKey;
 }
 
-export async function getUserMasteryOverview(userId: string): Promise<MasteryOverview> {
-  const [declaredRows, masteryRows, eventRows, recentRows, hiddenDomainKeys] = await Promise.all([
+// Shared per-request fetch for the knowledge route, which renders both the
+// mastery overview and the knowledge page data. Both derivations read the same
+// declared interests, player-mastery rows, mastery events, and hidden-domain
+// keys, so we fetch them once (4 queries) and hand the same inputs to both
+// builders instead of each re-fetching independently (which doubled the query
+// count against the max-5 pool). Events are ordered createdAt desc so the
+// overview can take the 10 most recent without a second LIMIT query.
+export async function loadKnowledgeInputs(userId: string) {
+  const [declaredRows, masteryRows, eventRows, hiddenDomainKeys] = await Promise.all([
     getActiveDeclaredInterests(userId),
     getPlayerMasteryRows(userId, true),
     db
@@ -429,23 +418,23 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
         createdAt: masteryEvents.createdAt,
       })
       .from(masteryEvents)
-      .where(eq(masteryEvents.userId, userId)),
-    db
-      .select({
-        canonicalSubcategory: masteryEvents.canonicalSubcategory,
-        sourceType: masteryEvents.sourceType,
-        questionId: masteryEvents.questionId,
-        awardedPoints: masteryEvents.awardedPoints,
-        answerState: masteryEvents.answerState,
-        sessionContext: masteryEvents.sessionContext,
-        createdAt: masteryEvents.createdAt,
-      })
-      .from(masteryEvents)
       .where(eq(masteryEvents.userId, userId))
-      .orderBy(desc(masteryEvents.createdAt))
-      .limit(10),
+      .orderBy(desc(masteryEvents.createdAt)),
     getHiddenDomainKeys(userId),
   ]);
+  return { declaredRows, masteryRows, eventRows, hiddenDomainKeys };
+}
+
+export type KnowledgeInputs = Awaited<ReturnType<typeof loadKnowledgeInputs>>;
+
+export async function getUserMasteryOverview(
+  userId: string,
+  inputs?: KnowledgeInputs,
+): Promise<MasteryOverview> {
+  const { declaredRows, masteryRows, eventRows, hiddenDomainKeys } =
+    inputs ?? (await loadKnowledgeInputs(userId));
+  // eventRows arrive createdAt desc; the 10 most recent are the recent-activity feed.
+  const recentRows = eventRows.slice(0, 10);
 
   const totalPoints = masteryRows.reduce((sum, row) => sum + Number(row.totalPoints ?? 0), 0);
   const overall = getMasteryTierDisplay(totalPoints);
@@ -533,23 +522,12 @@ export async function getUserMasteryOverview(userId: string): Promise<MasteryOve
   };
 }
 
-export async function getKnowledgePageData(userId: string): Promise<KnowledgePageData> {
-  const [declaredRows, masteryRows, eventRows, hiddenDomainKeys] = await Promise.all([
-    getActiveDeclaredInterests(userId),
-    getPlayerMasteryRows(userId, true),
-    db
-      .select({
-        canonicalSubcategory: masteryEvents.canonicalSubcategory,
-        sourceType: masteryEvents.sourceType,
-        answerState: masteryEvents.answerState,
-        sessionContext: masteryEvents.sessionContext,
-        awardedPoints: masteryEvents.awardedPoints,
-        createdAt: masteryEvents.createdAt,
-      })
-      .from(masteryEvents)
-      .where(eq(masteryEvents.userId, userId)),
-    getHiddenDomainKeys(userId),
-  ]);
+export async function getKnowledgePageData(
+  userId: string,
+  inputs?: KnowledgeInputs,
+): Promise<KnowledgePageData> {
+  const { declaredRows, masteryRows, eventRows, hiddenDomainKeys } =
+    inputs ?? (await loadKnowledgeInputs(userId));
 
   const statsByDomain = new Map<string, AnswerStats>();
   for (const event of eventRows) {
@@ -645,27 +623,6 @@ export async function getExpandingDomains(userId: string): Promise<ExpandingDoma
     .from(masteryEvents)
     .where(eq(masteryEvents.userId, userId));
   return deriveExpandingDomains(eventRows);
-}
-
-export async function getProgressionLandscape(userId: string): Promise<ProgressionView[]> {
-  const pageData = await getKnowledgePageData(userId);
-
-  return pageData.allDomains
-    .map((domain) => ({
-      canonicalSubcategory: domain.displayName,
-      canonicalSubcategorySlug: toCanonicalDomainSlug(domain.domain),
-      broadCategory: domain.broadCategory,
-      currentTier: domain.tier as MasteryTier,
-      correctAnswerCount: domain.questionsCorrect,
-      authoredCount: domain.questionsAnswered,
-      iconKey: domain.iconKey,
-      territoryType: domain.territoryType,
-    }))
-    .sort((a, b) => {
-      const tierDiff = TIER_ORDER.indexOf(b.currentTier ?? 'establishing') - TIER_ORDER.indexOf(a.currentTier ?? 'establishing');
-      if (tierDiff !== 0) return tierDiff;
-      return b.correctAnswerCount - a.correctAnswerCount || a.canonicalSubcategory.localeCompare(b.canonicalSubcategory);
-    });
 }
 
 export async function getDomainDetail(userId: string, domain: string): Promise<DomainDetail | null> {
@@ -1040,69 +997,3 @@ export async function removeKnowledgeDomain(userId: string, domain: string): Pro
   return { removed };
 }
 
-function calendarDay(value: Date): string {
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: STREAK_TIME_ZONE,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(value);
-}
-
-function addDays(day: string, amount: number): string {
-  const [year, month, date] = day.split('-').map(Number);
-  const current = new Date(Date.UTC(year, month - 1, date));
-  current.setUTCDate(current.getUTCDate() + amount);
-  return current.toISOString().slice(0, 10);
-}
-
-export async function getUserAnswerStreak(userId: string): Promise<StreakData> {
-  const [dailyRows, gameRows] = await Promise.all([
-    db
-      .select({ answeredAt: masteryEvents.createdAt })
-      .from(masteryEvents)
-      .where(and(
-        eq(masteryEvents.userId, userId),
-        eq(masteryEvents.sessionContext, 'daily'),
-        isNotNull(masteryEvents.answerState),
-      )),
-    db
-      .select({ answeredAt: joshingGameResponses.answeredAt })
-      .from(joshingGameResponses)
-      .where(and(
-        eq(joshingGameResponses.userId, userId),
-        isNotNull(joshingGameResponses.answeredAt),
-      )),
-  ]);
-
-  const days = new Set<string>();
-  for (const row of [...dailyRows, ...gameRows]) {
-    if (!row.answeredAt) continue;
-    days.add(calendarDay(row.answeredAt));
-  }
-
-  const sortedDays = [...days].sort();
-  if (sortedDays.length === 0) {
-    return { currentStreak: 0, longestStreak: 0, lastActivityDate: null };
-  }
-
-  let currentStreak = 0;
-  let cursor = calendarDay(new Date());
-  while (days.has(cursor)) {
-    currentStreak += 1;
-    cursor = addDays(cursor, -1);
-  }
-
-  let longestStreak = 1;
-  let run = 1;
-  for (let index = 1; index < sortedDays.length; index += 1) {
-    run = addDays(sortedDays[index - 1], 1) === sortedDays[index] ? run + 1 : 1;
-    longestStreak = Math.max(longestStreak, run);
-  }
-
-  return {
-    currentStreak,
-    longestStreak,
-    lastActivityDate: sortedDays.at(-1) ?? null,
-  };
-}

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -173,7 +173,6 @@ async function getPlayerMasteryRows(userId: string, orderByPoints = false): Prom
 }
 
 const TIER_ORDER: MasteryTier[] = ['establishing', 'familiar', 'solid', 'mastery'];
-const FRIEND_MEDIATED_CONTEXTS = ['feed', 'joshing_game'];
 
 function displayNameForDomain(domain: string): string {
   // Standardize capitalization at render time so legacy rows stored with messy
@@ -204,14 +203,39 @@ function sourceLabel(row: SourceLabelRow): string {
 
 
 
-type ExpansionEvent = {
+// Per-domain aggregate row: one GROUP BY canonical_subcategory query over a
+// user's MASTERY_EVENTS computes every stat the knowledge surfaces need, so row
+// transfer stops scaling with lifetime event count. Grouping is by the raw
+// canonical_subcategory spelling (SQL can't replicate domainKey() folding); rows
+// that share a domainKey are merged in JS (mergeDomainStats /
+// deriveExpandingDomains), of which there are far fewer than raw events.
+export type DomainAggregateRow = {
   canonicalSubcategory: string;
-  sourceType?: string | null;
-  answerState?: string | null;
-  sessionContext?: string | null;
-  awardedPoints?: number | string | null;
-  createdAt: Date;
+  answered: number;
+  correct: number;
+  lastAnsweredAt: Date | string | null;
+  demonstrated: boolean;
+  firstAt: Date | string | null;
+  latestAt: Date | string | null;
+  recentAnswered: number;
+  recentPoints: number;
+  wrongAnswers: number;
+  socialEvents: number;
+  savedEvents: number;
 };
+
+// Recency window (days) for the "Recently Expanding" momentum heuristic.
+const EXPANSION_WINDOW_DAYS = 21;
+
+function expansionWindowStart(now: number = Date.now()): Date {
+  return new Date(now - EXPANSION_WINDOW_DAYS * 24 * 60 * 60 * 1000);
+}
+
+function toDate(value: Date | string | null | undefined): Date | null {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
 
 function supportingTextFor(reason: ExpandingDomain['reason']): string {
   switch (reason) {
@@ -229,14 +253,17 @@ function supportingTextFor(reason: ExpandingDomain['reason']): string {
   }
 }
 
-function deriveExpandingDomains(events: ExpansionEvent[]): ExpandingDomain[] {
+// Merge per-domain aggregate rows (grouped by raw canonical_subcategory in SQL)
+// into the momentum heuristic, folding rows that share a domainKey. The windowed
+// counts (recent*/wrong/social/saved within EXPANSION_WINDOW_DAYS) are computed in
+// SQL; recency/novelty derive from the first/last activity timestamps here.
+export function deriveExpandingDomains(rows: DomainAggregateRow[]): ExpandingDomain[] {
   const now = Date.now();
   const dayMs = 24 * 60 * 60 * 1000;
   const byDomain = new Map<string, {
     domain: string;
-    firstAt: Date;
-    latestAt: Date;
-    answered: number;
+    firstAt: Date | null;
+    latestAt: Date | null;
     recentAnswered: number;
     recentPoints: number;
     wrongAnswers: number;
@@ -244,16 +271,16 @@ function deriveExpandingDomains(events: ExpansionEvent[]): ExpandingDomain[] {
     savedEvents: number;
   }>();
 
-  for (const event of events) {
-    const domain = event.canonicalSubcategory.trim().replace(/\s+/g, ' ');
-    if (!domain || !event.createdAt) continue;
+  for (const row of rows) {
+    const domain = row.canonicalSubcategory.trim().replace(/\s+/g, ' ');
+    if (!domain) continue;
     const key = domainKey(domain);
-    const ageDays = Math.max(0, (now - event.createdAt.getTime()) / dayMs);
+    const firstAt = toDate(row.firstAt);
+    const latestAt = toDate(row.latestAt);
     const existing = byDomain.get(key) ?? {
       domain,
-      firstAt: event.createdAt,
-      latestAt: event.createdAt,
-      answered: 0,
+      firstAt,
+      latestAt,
       recentAnswered: 0,
       recentPoints: 0,
       wrongAnswers: 0,
@@ -261,25 +288,20 @@ function deriveExpandingDomains(events: ExpansionEvent[]): ExpandingDomain[] {
       savedEvents: 0,
     };
 
-    if (event.createdAt < existing.firstAt) existing.firstAt = event.createdAt;
-    if (event.createdAt > existing.latestAt) existing.latestAt = event.createdAt;
-    if (event.answerState) existing.answered += 1;
-    if (event.answerState && ageDays <= 21) existing.recentAnswered += 1;
-    if (ageDays <= 21) existing.recentPoints += Number(event.awardedPoints ?? 0);
-    if (event.answerState === 'incorrect' && ageDays <= 21) existing.wrongAnswers += 1;
-    if (event.sessionContext && FRIEND_MEDIATED_CONTEXTS.includes(event.sessionContext) && ageDays <= 21) {
-      existing.socialEvents += 1;
-    }
-    if ((event.sourceType === 'authored' || event.sourceType === 'author_credit') && ageDays <= 21) {
-      existing.savedEvents += 1;
-    }
+    if (firstAt && (!existing.firstAt || firstAt < existing.firstAt)) existing.firstAt = firstAt;
+    if (latestAt && (!existing.latestAt || latestAt > existing.latestAt)) existing.latestAt = latestAt;
+    existing.recentAnswered += Number(row.recentAnswered ?? 0);
+    existing.recentPoints += Number(row.recentPoints ?? 0);
+    existing.wrongAnswers += Number(row.wrongAnswers ?? 0);
+    existing.socialEvents += Number(row.socialEvents ?? 0);
+    existing.savedEvents += Number(row.savedEvents ?? 0);
     byDomain.set(key, existing);
   }
 
   return [...byDomain.values()]
     .map((domain) => {
-      const latestAgeDays = Math.max(0, (now - domain.latestAt.getTime()) / dayMs);
-      const firstAgeDays = Math.max(0, (now - domain.firstAt.getTime()) / dayMs);
+      const latestAgeDays = domain.latestAt ? Math.max(0, (now - domain.latestAt.getTime()) / dayMs) : Infinity;
+      const firstAgeDays = domain.firstAt ? Math.max(0, (now - domain.firstAt.getTime()) / dayMs) : Infinity;
       const recency = Math.max(0, (30 - latestAgeDays) / 30);
       const novelty = firstAgeDays <= 14 ? 1 : 0;
       const reason: ExpandingDomain['reason'] = novelty
@@ -396,33 +418,100 @@ function buildMasteryByDomain(
   return byKey;
 }
 
+// Single GROUP BY canonical_subcategory pass that computes every per-domain stat
+// the knowledge surfaces need — answered/correct counts, last-answered timestamp,
+// the friend-mediated "demonstrated" flag, and the windowed momentum inputs — so
+// only one row per domain crosses the wire instead of every lifetime event. The
+// 'feed'/'joshing_game' session contexts and the 'authored'/'author_credit' source
+// types are the friend-mediated and saved-question signals respectively. Filtered
+// by user_id (MASTERY_EVENTS_user_id_idx); the aggregation is the row-transfer win.
+async function loadDomainAggregates(userId: string, since: Date): Promise<DomainAggregateRow[]> {
+  return db
+    .select({
+      canonicalSubcategory: masteryEvents.canonicalSubcategory,
+      answered: sql<number>`count(*) filter (where ${masteryEvents.answerState} is not null)`,
+      correct: sql<number>`count(*) filter (where ${masteryEvents.answerState} is not null and ${masteryEvents.answerState} <> 'incorrect')`,
+      lastAnsweredAt: sql<Date | null>`max(${masteryEvents.createdAt}) filter (where ${masteryEvents.answerState} is not null)`,
+      demonstrated: sql<boolean>`coalesce(bool_or(${masteryEvents.answerState} is not null and ${masteryEvents.answerState} <> 'incorrect' and ${masteryEvents.questionId} is not null and ${masteryEvents.sessionContext} in ('feed', 'joshing_game')), false)`,
+      firstAt: sql<Date | null>`min(${masteryEvents.createdAt})`,
+      latestAt: sql<Date | null>`max(${masteryEvents.createdAt})`,
+      recentAnswered: sql<number>`count(*) filter (where ${masteryEvents.answerState} is not null and ${masteryEvents.createdAt} >= ${since})`,
+      recentPoints: sql<number>`coalesce(sum(${masteryEvents.awardedPoints}) filter (where ${masteryEvents.createdAt} >= ${since}), 0)`,
+      wrongAnswers: sql<number>`count(*) filter (where ${masteryEvents.answerState} = 'incorrect' and ${masteryEvents.createdAt} >= ${since})`,
+      socialEvents: sql<number>`count(*) filter (where ${masteryEvents.sessionContext} in ('feed', 'joshing_game') and ${masteryEvents.createdAt} >= ${since})`,
+      savedEvents: sql<number>`count(*) filter (where ${masteryEvents.sourceType} in ('authored', 'author_credit') and ${masteryEvents.createdAt} >= ${since})`,
+    })
+    .from(masteryEvents)
+    .where(eq(masteryEvents.userId, userId))
+    .groupBy(masteryEvents.canonicalSubcategory);
+}
+
+export type MergedDomainStats = {
+  statsByDomain: Map<string, AnswerStats>;
+  demonstratedDomains: Set<string>;
+  demonstratedLabels: Map<string, string>;
+};
+
+// Fold the SQL aggregate rows (keyed by raw canonical_subcategory) into the
+// domainKey()-normalized stats the page consumes. statsByDomain only carries
+// domains with at least one answered event (mirrors the old `if (!answerState)
+// continue` guard); a domain is demonstrated if any of its rows set the flag.
+export function mergeDomainStats(rows: DomainAggregateRow[]): MergedDomainStats {
+  const statsByDomain = new Map<string, AnswerStats>();
+  const demonstratedDomains = new Set<string>();
+  const demonstratedLabels = new Map<string, string>();
+
+  for (const row of rows) {
+    const key = domainKey(row.canonicalSubcategory);
+    const answered = Number(row.answered ?? 0);
+    if (answered > 0) {
+      const existing = statsByDomain.get(key) ?? { answered: 0, correct: 0, lastActivityAt: null };
+      existing.answered += answered;
+      existing.correct += Number(row.correct ?? 0);
+      const last = toDate(row.lastAnsweredAt);
+      if (last && (!existing.lastActivityAt || last > existing.lastActivityAt)) {
+        existing.lastActivityAt = last;
+      }
+      statsByDomain.set(key, existing);
+    }
+    if (row.demonstrated) {
+      demonstratedDomains.add(key);
+      if (!demonstratedLabels.has(key)) demonstratedLabels.set(key, row.canonicalSubcategory);
+    }
+  }
+
+  return { statsByDomain, demonstratedDomains, demonstratedLabels };
+}
+
 // Shared per-request fetch for the knowledge route, which renders both the
 // mastery overview and the knowledge page data. Both derivations read the same
-// declared interests, player-mastery rows, mastery events, and hidden-domain
-// keys, so we fetch them once (4 queries) and hand the same inputs to both
+// declared interests, player-mastery rows, per-domain mastery aggregates, and
+// hidden-domain keys, so we fetch them once and hand the same inputs to both
 // builders instead of each re-fetching independently (which doubled the query
-// count against the max-5 pool). Events are ordered createdAt desc so the
-// overview can take the 10 most recent without a second LIMIT query.
+// count against the max-5 pool). The mastery events themselves are no longer
+// pulled in full — aggregated per-domain in SQL — except the 10 most recent rows
+// the overview needs for its recent-activity feed.
 export async function loadKnowledgeInputs(userId: string) {
-  const [declaredRows, masteryRows, eventRows, hiddenDomainKeys] = await Promise.all([
+  const since = expansionWindowStart();
+  const [declaredRows, masteryRows, domainAggregates, recentEvents, hiddenDomainKeys] = await Promise.all([
     getActiveDeclaredInterests(userId),
     getPlayerMasteryRows(userId, true),
+    loadDomainAggregates(userId, since),
     db
       .select({
         canonicalSubcategory: masteryEvents.canonicalSubcategory,
         sourceType: masteryEvents.sourceType,
-        questionId: masteryEvents.questionId,
         awardedPoints: masteryEvents.awardedPoints,
-        answerState: masteryEvents.answerState,
         sessionContext: masteryEvents.sessionContext,
         createdAt: masteryEvents.createdAt,
       })
       .from(masteryEvents)
       .where(eq(masteryEvents.userId, userId))
-      .orderBy(desc(masteryEvents.createdAt)),
+      .orderBy(desc(masteryEvents.createdAt))
+      .limit(10),
     getHiddenDomainKeys(userId),
   ]);
-  return { declaredRows, masteryRows, eventRows, hiddenDomainKeys };
+  return { declaredRows, masteryRows, domainAggregates, recentEvents, hiddenDomainKeys };
 }
 
 export type KnowledgeInputs = Awaited<ReturnType<typeof loadKnowledgeInputs>>;
@@ -431,43 +520,16 @@ export async function getUserMasteryOverview(
   userId: string,
   inputs?: KnowledgeInputs,
 ): Promise<MasteryOverview> {
-  const { declaredRows, masteryRows, eventRows, hiddenDomainKeys } =
+  const { declaredRows, masteryRows, domainAggregates, recentEvents, hiddenDomainKeys } =
     inputs ?? (await loadKnowledgeInputs(userId));
-  // eventRows arrive createdAt desc; the 10 most recent are the recent-activity feed.
-  const recentRows = eventRows.slice(0, 10);
+  const recentRows = recentEvents;
 
   const totalPoints = masteryRows.reduce((sum, row) => sum + Number(row.totalPoints ?? 0), 0);
   const overall = getMasteryTierDisplay(totalPoints);
   const nextOverallTier = nextTierFor(overall.tier);
   const nextThreshold = nextOverallTier ? TIER_THRESHOLD_POINTS[nextOverallTier] : null;
-  const statsByDomain = new Map<string, AnswerStats>();
-  const demonstratedDomains = new Set<string>();
-  const demonstratedDomainLabels = new Map<string, string>();
-
-  for (const event of eventRows) {
-    if (!event.answerState) continue;
-    if (
-      event.answerState !== 'incorrect'
-      && event.questionId
-      && FRIEND_MEDIATED_CONTEXTS.includes(event.sessionContext ?? '')
-    ) {
-      const key = domainKey(event.canonicalSubcategory);
-      demonstratedDomains.add(key);
-      demonstratedDomainLabels.set(key, event.canonicalSubcategory);
-    }
-    const key = domainKey(event.canonicalSubcategory);
-    const existing = statsByDomain.get(key) ?? {
-      answered: 0,
-      correct: 0,
-      lastActivityAt: null,
-    };
-    existing.answered += 1;
-    if (event.answerState !== 'incorrect') existing.correct += 1;
-    if (!existing.lastActivityAt || event.createdAt > existing.lastActivityAt) {
-      existing.lastActivityAt = event.createdAt;
-    }
-    statsByDomain.set(key, existing);
-  }
+  const { statsByDomain, demonstratedDomains, demonstratedLabels: demonstratedDomainLabels } =
+    mergeDomainStats(domainAggregates);
 
   const masteryByDomain = buildMasteryByDomain(masteryRows);
   const knowledgeDomainNames = new Map<string, {
@@ -526,25 +588,10 @@ export async function getKnowledgePageData(
   userId: string,
   inputs?: KnowledgeInputs,
 ): Promise<KnowledgePageData> {
-  const { declaredRows, masteryRows, eventRows, hiddenDomainKeys } =
+  const { declaredRows, masteryRows, domainAggregates, hiddenDomainKeys } =
     inputs ?? (await loadKnowledgeInputs(userId));
 
-  const statsByDomain = new Map<string, AnswerStats>();
-  for (const event of eventRows) {
-    if (!event.answerState) continue;
-    const key = domainKey(event.canonicalSubcategory);
-    const existing = statsByDomain.get(key) ?? {
-      answered: 0,
-      correct: 0,
-      lastActivityAt: null,
-    };
-    existing.answered += 1;
-    if (event.answerState !== 'incorrect') existing.correct += 1;
-    if (!existing.lastActivityAt || event.createdAt > existing.lastActivityAt) {
-      existing.lastActivityAt = event.createdAt;
-    }
-    statsByDomain.set(key, existing);
-  }
+  const { statsByDomain } = mergeDomainStats(domainAggregates);
 
   const masteryByDomain = buildMasteryByDomain(masteryRows);
   const knowledgeDomainNames = new Map<string, {
@@ -566,7 +613,7 @@ export async function getKnowledgePageData(
     });
   }
 
-  for (const row of eventRows) {
+  for (const row of domainAggregates) {
     const domain = row.canonicalSubcategory.trim().replace(/\s+/g, ' ');
     if (!domain) continue;
     const key = domainKey(domain);
@@ -575,7 +622,9 @@ export async function getKnowledgePageData(
       domain: existing?.domain ?? domain,
       broadCategory: existing?.broadCategory ?? null,
       isDeclared: existing?.isDeclared ?? false,
-      isDemonstrated: existing?.isDemonstrated ?? Boolean(row.answerState),
+      // A domain present only in events is "demonstrated" when it has any answered
+      // event (statsByDomain carries exactly those).
+      isDemonstrated: existing?.isDemonstrated ?? statsByDomain.has(key),
     });
   }
 
@@ -600,7 +649,7 @@ export async function getKnowledgePageData(
 
   return {
     allDomains,
-    expandingDomains: deriveExpandingDomains(eventRows),
+    expandingDomains: deriveExpandingDomains(domainAggregates),
     declaredInterests: declaredRows
       .map((row) => row.domain.trim().replace(/\s+/g, ' '))
       .filter(Boolean),
@@ -611,18 +660,8 @@ export async function getKnowledgePageData(
 // knowledge page uses, but without the mastery / declared / hidden joins, so the
 // home-feed promo (getRecentlyExpandingPromo) can read it cheaply.
 export async function getExpandingDomains(userId: string): Promise<ExpandingDomain[]> {
-  const eventRows = await db
-    .select({
-      canonicalSubcategory: masteryEvents.canonicalSubcategory,
-      sourceType: masteryEvents.sourceType,
-      answerState: masteryEvents.answerState,
-      sessionContext: masteryEvents.sessionContext,
-      awardedPoints: masteryEvents.awardedPoints,
-      createdAt: masteryEvents.createdAt,
-    })
-    .from(masteryEvents)
-    .where(eq(masteryEvents.userId, userId));
-  return deriveExpandingDomains(eventRows);
+  const aggregates = await loadDomainAggregates(userId, expansionWindowStart());
+  return deriveExpandingDomains(aggregates);
 }
 
 export async function getDomainDetail(userId: string, domain: string): Promise<DomainDetail | null> {

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -177,58 +177,129 @@ function toIso(value: Date | string | null | undefined): string | null {
   return value instanceof Date ? value.toISOString() : new Date(value).toISOString();
 }
 
-async function readQuestionStats(questionId: string) {
-  const [responseStats, feedStats, gameStats] = await Promise.all([
+export type QuestionStats = {
+  timesAnswered: number;
+  timesCorrect: number;
+  correctRate: number;
+  lastUsedAt: string | null;
+  usedInGamesCount: number;
+};
+
+export const EMPTY_QUESTION_STATS: QuestionStats = {
+  timesAnswered: 0,
+  timesCorrect: 0,
+  correctRate: 0,
+  lastUsedAt: null,
+  usedInGamesCount: 0,
+};
+
+type StatCountRow = { questionId: string | null; timesAnswered: number; timesCorrect: number };
+type GameUsageRow = { questionId: string | null; lastUsedAt: Date | null; usedInGamesCount: number };
+
+// Pure merge of the three GROUP BY result sets into per-question stats. Extracted
+// from readQuestionStatsForIds so the count-combining and correctRate rounding is
+// unit-testable without a DB. Every requested id is present in the result (zero-
+// filled when it has no answers/usage rows).
+export function mergeQuestionStats(
+  questionIds: string[],
+  responseRows: StatCountRow[],
+  feedRows: StatCountRow[],
+  gameRows: GameUsageRow[],
+): Map<string, QuestionStats> {
+  const answered = new Map<string, number>();
+  const correct = new Map<string, number>();
+  for (const row of [...responseRows, ...feedRows]) {
+    if (!row.questionId) continue;
+    answered.set(row.questionId, (answered.get(row.questionId) ?? 0) + Number(row.timesAnswered ?? 0));
+    correct.set(row.questionId, (correct.get(row.questionId) ?? 0) + Number(row.timesCorrect ?? 0));
+  }
+
+  const usage = new Map<string, { lastUsedAt: string | null; usedInGamesCount: number }>();
+  for (const row of gameRows) {
+    if (!row.questionId) continue;
+    usage.set(row.questionId, {
+      lastUsedAt: toIso(row.lastUsedAt ?? null),
+      usedInGamesCount: Number(row.usedInGamesCount ?? 0),
+    });
+  }
+
+  const result = new Map<string, QuestionStats>();
+  for (const id of questionIds) {
+    const timesAnswered = answered.get(id) ?? 0;
+    const timesCorrect = correct.get(id) ?? 0;
+    const use = usage.get(id);
+    result.set(id, {
+      timesAnswered,
+      timesCorrect,
+      correctRate: timesAnswered > 0 ? Math.round((timesCorrect / timesAnswered) * 100) : 0,
+      lastUsedAt: use?.lastUsedAt ?? null,
+      usedInGamesCount: use?.usedInGamesCount ?? 0,
+    });
+  }
+  return result;
+}
+
+// Set-based replacement for the per-question readQuestionStats N+1: computes the
+// same stats for every id in 3 GROUP BY question_id queries total. The pg pool is
+// capped at max 5 (src/server/db/index.ts), so collapsing round-trips matters more
+// than parallelism. Note: questions.asked_count/correct_count are NOT a substitute
+// here — they only track joshing-game answers (joshing-game.ts), while these stats
+// also count "Send to friend" answers recorded in feedItems.
+export async function readQuestionStatsForIds(
+  questionIds: string[],
+): Promise<Map<string, QuestionStats>> {
+  const ids = [...new Set(questionIds)].filter(Boolean);
+  if (ids.length === 0) return new Map();
+
+  const [responseRows, feedRows, gameRows] = await Promise.all([
     db
       .select({
+        questionId: joshingGameResponses.questionId,
         timesAnswered: sql<number>`count(*)`,
         timesCorrect: sql<number>`count(*) filter (where ${joshingGameResponses.isCorrect} = true)`,
       })
       .from(joshingGameResponses)
       .where(and(
-        eq(joshingGameResponses.questionId, questionId),
+        inArray(joshingGameResponses.questionId, ids),
         sql`${joshingGameResponses.answeredAt} is not null`,
-      )),
+      ))
+      .groupBy(joshingGameResponses.questionId),
     // Answers submitted via "Send to friend" land in feedItems, not joshingGameResponses.
     // joshingGameId is null filters out feed items that mirror an already-counted game response.
     db
       .select({
+        questionId: feedItems.questionId,
         timesAnswered: sql<number>`count(*)`,
         timesCorrect: sql<number>`count(*) filter (where ${feedItems.answerResult} = 'correct')`,
       })
       .from(feedItems)
       .where(and(
-        eq(feedItems.questionId, questionId),
+        inArray(feedItems.questionId, ids),
         sql`${feedItems.answerResult} is not null`,
         isNull(feedItems.joshingGameId),
-      )),
+      ))
+      .groupBy(feedItems.questionId),
     db
       .select({
+        questionId: joshingGameQuestions.questionId,
         lastUsedAt: sql<Date | null>`max(${joshingGames.createdAt})`,
         usedInGamesCount: countDistinct(joshingGameQuestions.gameId),
       })
       .from(joshingGameQuestions)
       .innerJoin(joshingGames, eq(joshingGameQuestions.gameId, joshingGames.id))
-      .where(eq(joshingGameQuestions.questionId, questionId)),
+      .where(inArray(joshingGameQuestions.questionId, ids))
+      .groupBy(joshingGameQuestions.questionId),
   ]);
 
-  const timesAnswered =
-    Number(responseStats[0]?.timesAnswered ?? 0) + Number(feedStats[0]?.timesAnswered ?? 0);
-  const timesCorrect =
-    Number(responseStats[0]?.timesCorrect ?? 0) + Number(feedStats[0]?.timesCorrect ?? 0);
-  const usedInGamesCount = Number(gameStats[0]?.usedInGamesCount ?? 0);
-
-  return {
-    timesAnswered,
-    timesCorrect,
-    correctRate: timesAnswered > 0 ? Math.round((timesCorrect / timesAnswered) * 100) : 0,
-    lastUsedAt: toIso(gameStats[0]?.lastUsedAt ?? null),
-    usedInGamesCount,
-  };
+  return mergeQuestionStats(ids, responseRows, feedRows, gameRows);
 }
 
-export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView> {
-  const stats = await readQuestionStats(row.id);
+async function readQuestionStats(questionId: string): Promise<QuestionStats> {
+  const stats = await readQuestionStatsForIds([questionId]);
+  return stats.get(questionId) ?? EMPTY_QUESTION_STATS;
+}
+
+export function buildQuestionView(row: QuestionViewRow, stats: QuestionStats): QuestionView {
   const domain = row.canonicalSubcategory ?? row.category;
   const createdAt = toIso(row.createdAt) ?? new Date().toISOString();
   const updatedAt = toIso(row.updatedAt) ?? createdAt;
@@ -275,6 +346,11 @@ export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView
     llmSuggestedAnswer: row.llmSuggestedAnswer ?? null,
     critiqueIterations: row.critiqueIterations ?? 0,
   };
+}
+
+export async function toQuestionView(row: QuestionViewRow): Promise<QuestionView> {
+  const stats = await readQuestionStats(row.id);
+  return buildQuestionView(row, stats);
 }
 
 export async function getQuestionsForUser(userId: string): Promise<QuestionView[]> {


### PR DESCRIPTION
getBankedQuestions mapped every banked row through toQuestionView, and each
call ran readQuestionStats (3 aggregate queries) — ~3 queries per question
through the max-5 pg pool, multi-second for a 50-question bank.

Add set-based readQuestionStatsForIds(ids) that computes the same stats for
all questions in 3 GROUP BY question_id queries total, plus a pure
mergeQuestionStats core and a synchronous buildQuestionView. getBankedQuestions
now fetches stats once and builds views without per-row awaits. Single-row
toQuestionView/getQuestion keep working via a thin readQuestionStats wrapper.

QuestionView shape and the API response are unchanged. asked_count/correct_count
are intentionally not substituted: they only track joshing-game answers and miss
"Send to friend" feed answers that these stats count.

Unit tests cover the merge semantics (count combining, correctRate rounding,
zero-fill, null-id skipping).