### PR TITLE
Unify home cards: warm-cream fill + hairline stroke

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -201,7 +201,7 @@ export default function TodaysFiveCard({
       : 'Ready when you are!'
 
   return (
-    <div className="bg-card text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
+    <div className="text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
       <div className="flex items-start justify-between gap-2">
         <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
           Today&apos;s Five

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -331,9 +331,10 @@ export function ActivityStreamItem({
           padding: opened ? '16px 14px' : '14px',
           // The "From Friends" playable milestone cards share the elevated feed
           // fill token (defaults to the warm game-card cream) so the dev CARD
-          // COLOR cycler repaints them alongside the For You cards.
+          // COLOR cycler repaints them alongside the For You cards, and the same
+          // neutral hairline stroke as the Today's 5 card (no gold accent).
           background: 'var(--feed-card-elevated)',
-          border: '1px solid var(--accent-gold)',
+          border: '1px solid var(--brand-border)',
           borderRadius: 4,
           boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
         }

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -90,7 +90,8 @@ describe('ActivityStreamItem — playable milestone card on the home feed', () =
       <ActivityStreamItem item={MILESTONE_ITEM} timestamp="2:00 PM" elevated showTimestamp={false} />,
     );
     expect(html).toContain('var(--feed-card-elevated)'); // shared elevated fill token
-    expect(html).toContain('var(--accent-gold)'); // the gold accent stroke
+    expect(html).toContain('var(--brand-border)'); // neutral hairline stroke (matches Today's 5)
+    expect(html).not.toContain('var(--accent-gold)'); // no gold accent stroke
     expect(html).toContain('rgba(40, 32, 30, 0.1)'); // the soft drop shadow
   });
 


### PR DESCRIPTION
## Summary

Follow-up to #882 (already merged). Brings every card on the homepage to one consistent treatment — the warm-cream `--feed-card-elevated` fill and the neutral `--brand-border` hairline stroke — and removes the leftover gold accent border that was still showing on the "From Friends" cards.

Per the design call: **every homepage card** shares this treatment **except** the editorial panels ("Shared Ground" and siblings, which are full-bleed washes, not cards) and the "Your Turn" contribute footer.

## Changes

- **From Friends milestone cards** (`ActivityStreamItem`): dropped the `--accent-gold` accent stroke for the `--brand-border` hairline, matching the For You cards. This was the gold outline still visible in the feed — these cards are a separate component from the For You `FeedCardShell` path, so they weren't covered by the earlier stroke change. Also points their fill at the shared `--feed-card-elevated` token so the dev CARD COLOR cycler repaints them.

- **For You cards** (`FeedCardShell` elevated): swapped the gold elevated stroke for the `--brand-border` hairline.

- **Today's Five card** (`TodaysFiveCard`): swapped its near-white `--brand-card` fill for the warm-cream `--feed-card-elevated` token (keeps its existing hairline border and shadow), so it no longer reads as a different color from the cards below it — and now tracks the CARD COLOR cycler too.

## Tests

- Updated `FeedCards.test.tsx` and `MilestoneStreamItem.test.tsx` for the shared `--feed-card-elevated` fill token and the new hairline stroke (no gold).
- All affected tests pass; typecheck, lint, and the color ratchet are clean.

## Notes

- Each card keeps its existing drop shadow (Today's Five is slightly softer at 0.04 vs the playable cards' 0.10) — only fill and border were unified, as requested.

https://claude.ai/code/session_015BuSEYkaHaFTCXckHubf4Q

---
_Generated by [Claude Code](https://claude.ai/code/session_015BuSEYkaHaFTCXckHubf4Q)_