### PR TITLE
Link author name in catch-up recap (parity with daily summary)

### DIFF
--- a/src/app/api/daily/catchup/route.ts
+++ b/src/app/api/daily/catchup/route.ts
@@ -31,6 +31,7 @@ export async function GET() {
       expiresSoon: item.expiresSoon,
       difficultyEstimate: item.difficultyEstimate,
       authorName: item.authorName,
+      authorId: item.authorId,
       authorIsHouse: item.authorIsHouse,
     })),
     introCopy: first

--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -9,6 +9,8 @@ import { GameplayChatThread } from '@/components/play/GameplayChat';
 import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import { ThreadCard } from '@/components/play/ThreadCard';
 import { useCatchupFlow, type CatchupBatchRecord } from '@/components/play/useCatchupFlow';
+import { AuthorName } from '@/components/AuthorName';
+import { EditorialBadge } from '@/components/EditorialBadge';
 import { CATCH_UP_EMPTY_COPY } from '@/server/play/catch-up-copy';
 
 export default function DailyCatchupPage() {
@@ -383,7 +385,11 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
           {record.authorName ? (
             <>
               <span aria-hidden="true"> · </span>
-              <span>by {record.authorName}</span>
+              <span>by </span>
+              {/* Parity with the daily-five summary: human authors link to their
+                  profile; house/editorial render plain text + the Editorial badge. */}
+              <AuthorName name={record.authorName} authorId={record.authorId} />
+              {record.authorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
             </>
           ) : null}
         </p>

--- a/src/app/daily/summary/__tests__/AuthorName.test.tsx
+++ b/src/app/daily/summary/__tests__/AuthorName.test.tsx
@@ -13,7 +13,7 @@ vi.mock('next/link', () => ({
 // B5/D9: summary-page author attribution. Human authors link to their profile;
 // house/editorial authors (no users.id) stay plain text. Everyone with an
 // authorId gets the link (no friend/stranger gating — per product decision).
-import { AuthorName } from '@/app/daily/summary/page'
+import { AuthorName } from '@/components/AuthorName'
 
 function html(node: React.ReactElement): string {
   return renderToStaticMarkup(node)

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -15,6 +15,7 @@ import {
 
 import { SendQuestionAction } from '@/components/SendQuestionAction'
 import { AddToBankAction } from '@/components/AddToBankAction'
+import { AuthorName } from '@/components/AuthorName'
 import { EditorialBadge } from '@/components/EditorialBadge'
 import { CategoryGainsDisplay } from '@/components/review/CategoryGainsDisplay'
 import MasteryMoment from '@/components/review/MasteryMoment'
@@ -415,36 +416,6 @@ function bridgeSentence(bridge: NonNullable<DailySummaryView['recentFriendBridge
     default:
       return `${friendName} is around today.`
   }
-}
-
-// B5/D9: on the summary page (unlike the gameplay chat, which stays plain text)
-// author names link to the author's profile. Only human authors carry an
-// authorId; house/editorial names render as plain text.
-export function AuthorName({
-  name,
-  authorId,
-  weight,
-}: {
-  name: string
-  authorId: string | null
-  weight?: number
-}) {
-  if (!authorId) {
-    return <span style={{ fontWeight: weight }}>{name}</span>
-  }
-  return (
-    <Link
-      href={`/users/${encodeURIComponent(authorId)}`}
-      style={{
-        fontWeight: weight,
-        color: 'var(--brand-link)',
-        textDecoration: 'underline',
-        textUnderlineOffset: 2,
-      }}
-    >
-      {name}
-    </Link>
-  )
 }
 
 function InterpretiveLine({ text }: { text: string }) {

--- a/src/components/AuthorName.tsx
+++ b/src/components/AuthorName.tsx
@@ -1,0 +1,36 @@
+import Link from 'next/link'
+import type { CSSProperties } from 'react'
+
+// B5/D9: on recap surfaces (the daily-five summary and the catch-up recap, unlike
+// the gameplay chat which stays plain text) author names link to the author's
+// profile. Only human authors carry an authorId; house/editorial and LLM-origin
+// names render as plain text.
+export function AuthorName({
+  name,
+  authorId,
+  weight,
+  style,
+}: {
+  name: string
+  authorId: string | null
+  weight?: number
+  style?: CSSProperties
+}) {
+  if (!authorId) {
+    return <span style={{ fontWeight: weight, ...style }}>{name}</span>
+  }
+  return (
+    <Link
+      href={`/users/${encodeURIComponent(authorId)}`}
+      style={{
+        fontWeight: weight,
+        color: 'var(--brand-link)',
+        textDecoration: 'underline',
+        textUnderlineOffset: 2,
+        ...style,
+      }}
+    >
+      {name}
+    </Link>
+  )
+}

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -36,6 +36,8 @@ export type CatchupQueueItem = {
   difficultyEstimate?: 'accessible' | 'moderate' | 'specialist' | null;
   /** Human author's name, the house name ('Joshing'), or null for LLM-origin questions (rendered non-relationally). */
   authorName?: string | null;
+  /** Human author's `users.id`, so the recap can link the name to their profile. Null for house/LLM-origin. */
+  authorId?: string | null;
   /** D-3: the author is the non-human house/editorial author (renders the Editorial badge, no relational copy). */
   authorIsHouse?: boolean;
 };
@@ -97,6 +99,8 @@ export type CatchupBatchRecord = {
   explanation: string | null;
   domainDisplayName: string;
   authorName: string | null;
+  /** Human author's `users.id` for the recap profile link. Null for house/LLM-origin. */
+  authorId: string | null;
   authorIsHouse: boolean;
   /**
    * Author's "why I asked" commentary. The live thread defers this to keep its
@@ -451,6 +455,7 @@ export function useCatchupFlow() {
         explanation: item.explanation,
         domainDisplayName: item.domainDisplayName,
         authorName: item.authorName ?? null,
+        authorId: item.authorId ?? null,
         authorIsHouse: item.authorIsHouse ?? false,
         authorNote: null,
       });
@@ -652,6 +657,7 @@ export function useCatchupFlow() {
           explanation: data.explanation ?? data.explainer ?? item.explanation ?? null,
           domainDisplayName: item.domainDisplayName,
           authorName: item.authorName ?? null,
+          authorId: item.authorId ?? null,
           authorIsHouse: item.authorIsHouse ?? false,
           authorNote: data.creatorNote ?? null,
         });

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -111,6 +111,12 @@ export type CatchupQueueItem = {
    */
   authorName: string | null;
   /**
+   * Human author's `users.id`, so the recap can link the name to their profile
+   * (parity with the daily-five summary's `authorId`). Null for house/editorial
+   * and LLM-origin questions, which have no `users.id` to link to.
+   */
+  authorId: string | null;
+  /**
    * D-3: the author is the non-human house/editorial author. `authorName` is the
    * house name ('Joshing') and the client renders the persistent Editorial badge
    * with no relational copy. Set explicitly (not inferred from the name string).
@@ -617,6 +623,7 @@ async function getDailyCatchupItems(
           // generatedQuestions has no question_type column — factual by construction.
           questionType: 'factual',
           authorName: null, // daily-generated: LLM origin, no human author
+          authorId: null,
           authorIsHouse: false,
         } satisfies CatchupQuestion;
       }
@@ -657,6 +664,7 @@ async function getDailyCatchupItems(
         submittedAnswer: slot.submitted_answer ?? null,
         wasSkipped: Boolean(slot.skipped),
         questionType: question.questionType,
+        authorId: question.creatorId ?? null,
         ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
       } satisfies CatchupQuestion;
     })
@@ -739,6 +747,7 @@ async function getFeedCatchupItems(
         submittedAnswer: feedItem.submittedAnswer ?? null,
         wasSkipped: false,
         questionType: question.questionType,
+        authorId: question.creatorId ?? null,
         ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
       } satisfies CatchupQuestion;
     })


### PR DESCRIPTION
The catch-up recap showed the question author as plain text and omitted
the Editorial badge for house questions, unlike the daily-five summary
which links the human author's name to their profile. The cause was that
authorId was never threaded through the catch-up pipeline.

Carry authorId from the catch-up query (CatchupQueueItem) through the GET
route and the client record (CatchupBatchRecord), following the same path
authorName already takes, then render it via a shared AuthorName component
extracted from the summary page, plus EditorialBadge for house questions.

https://claude.ai/code/session_01JEo9vBQ7c7Js1trikxRPGy