### PR TITLE
Add 'Recent activity' eyebrow over the home texture stream

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1986,6 +1986,16 @@ function FeedListContent({
             // section headings; the page header carries the one title.
             restRows.length > 0 ? (
               <Fragment key="texture">
+                {/* Quiet eyebrow over the ambient texture stream so it reads as
+                    its own zone under "From Friends" (and its "N more →"
+                    overflow), not a continuation of it. Budget-only: the
+                    pendingQueue subpages carry no texture and let their page
+                    header hold the one title. */}
+                {budget ? (
+                  <FeedSectionHeading unifiedHome={unifiedHome}>
+                    Recent activity
+                  </FeedSectionHeading>
+                ) : null}
                 {restRows.slice(0, TEXTURE_LEAD_COUNT).map(renderRow)}
                 {/* §2 slot 5 (tuned 2026-06-12) — the one rotating panel per
                     load now runs as a mid-zone interlude after the lead texture


### PR DESCRIPTION
The ambient texture rows ('You and X are on the same wavelength lately')
rendered directly under the From Friends 'N more →' overflow with no
heading, reading as a continuation of that zone. Add a quiet
FeedSectionHeading eyebrow so it reads as its own zone. Budget-only — the
pendingQueue overflow subpages keep their page header as the one title.

https://claude.ai/code/session_01EotsVKwxjoqH9d4osSo1FJ