### PR TITLE
Make milestone-bundle affordance verb track card state

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -317,11 +317,25 @@ export function ActivityStreamItem({
   const headlinePredicate = headlineActor
     ? trimLeadingPredicate(item.line.slice(1))
     : null;
-  // The "Play {first}'s q's" affordance names the friend whose questions the
-  // bundle opens — their first name, from the headline actor (or the expand).
+  // The lower-right affordance names the friend whose questions the bundle
+  // opens — their first name, from the headline actor (or the expand).
   const playFirstName =
     headlineActor?.name.split(/\s+/)[0] ??
     (expand?.kind === 'milestone' ? expand.friendName.split(/\s+/)[0] : null);
+  // The verb tracks the card's state: "Play" while there are still questions to
+  // answer, but "Revisit" once they're all answered — at that point opening the
+  // bundle only reveals the read-only AnsweredHistory, so there's nothing left
+  // to play, only to look back at. While the bundle is open the label becomes a
+  // plain "Close" affordance (in step with the chevron flipping up).
+  const allAnswered =
+    !!milestoneProgress && milestoneProgress.answered >= milestoneProgress.total;
+  const playAffordanceLabel = open
+    ? 'Close'
+    : playFirstName
+      ? `${allAnswered ? 'Revisit' : 'Play'} ${playFirstName}'s q's`
+      : allAnswered
+        ? 'Revisit'
+        : 'Play';
 
   const containerStyle: CSSProperties = nested
     ? // Nested under a per-person heading: no border/fill, light padding.
@@ -451,7 +465,7 @@ export function ActivityStreamItem({
                   textUnderlineOffset: 4,
                 }}
               >
-                {playFirstName ? `Play ${playFirstName}'s q's` : 'Play'}
+                {playAffordanceLabel}
                 <ChevronDown
                   size={16}
                   aria-hidden


### PR DESCRIPTION
The home-feed playable milestone card always read "Play {name}'s q's",
even when every question was already answered (opening only reveals the
read-only AnsweredHistory) and even while the bundle was expanded.

- "Play {name}'s q's" while questions remain to answer
- "Revisit {name}'s q's" once all are answered (nothing left to play)
- "Close" while the bundle is open (in step with the chevron flip)

https://claude.ai/code/session_01P5ZK59EnR8SMwAPECb1mjd