### PR TITLE
Reveal copy & spacing: state-aware milestone verb + looser answer sheet

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -317,25 +317,16 @@ export function ActivityStreamItem({
   const headlinePredicate = headlineActor
     ? trimLeadingPredicate(item.line.slice(1))
     : null;
-  // The lower-right affordance names the friend whose questions the bundle
-  // opens — their first name, from the headline actor (or the expand).
-  const playFirstName =
-    headlineActor?.name.split(/\s+/)[0] ??
-    (expand?.kind === 'milestone' ? expand.friendName.split(/\s+/)[0] : null);
-  // The verb tracks the card's state: "Play" while there are still questions to
-  // answer, but "Revisit" once they're all answered — at that point opening the
-  // bundle only reveals the read-only AnsweredHistory, so there's nothing left
-  // to play, only to look back at. While the bundle is open the label becomes a
-  // plain "Close" affordance (in step with the chevron flipping up).
+  // The lower-right affordance is a bare verb that tracks the card's state. The
+  // friend's name already headlines the card directly above it, so the link
+  // doesn't re-state it — it lands on the action instead. "Play" while there are
+  // questions left to answer, "Revisit" once they're all answered (opening then
+  // only reveals the read-only AnsweredHistory — nothing left to play, only to
+  // look back at), and "Close" while the bundle is open (in step with the
+  // chevron flipping up).
   const allAnswered =
     !!milestoneProgress && milestoneProgress.answered >= milestoneProgress.total;
-  const playAffordanceLabel = open
-    ? 'Close'
-    : playFirstName
-      ? `${allAnswered ? 'Revisit' : 'Play'} ${playFirstName}'s q's`
-      : allAnswered
-        ? 'Revisit'
-        : 'Play';
+  const playAffordanceLabel = open ? 'Close' : allAnswered ? 'Revisit' : 'Play';
 
   const containerStyle: CSSProperties = nested
     ? // Nested under a per-person heading: no border/fill, light padding.

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -207,8 +207,8 @@ export function AnswerFeedbackSheet({
           </div>
         </div>
 
-        <div className="flex-1 overflow-y-auto px-5 pb-2">
-          <div className="flex items-center gap-3 pb-2">
+        <div className="flex flex-1 flex-col gap-4 overflow-y-auto px-5 pb-4">
+          <div className="flex items-center gap-3">
             <span
               className="inline-flex size-9 items-center justify-center rounded-full"
               style={{
@@ -237,14 +237,7 @@ export function AnswerFeedbackSheet({
             ) : null}
           </div>
 
-          {showTerritoryUndo && openedTerritoryDomain ? (
-            <NewTerritoryUndo
-              domain={openedTerritoryDomain}
-              category={visibleCategory}
-            />
-          ) : null}
-
-          <div className="space-y-1 pb-2">
+          <div className="space-y-1.5">
             {correctAnswer ? (
               <p
                 style={{
@@ -282,20 +275,20 @@ export function AnswerFeedbackSheet({
 
           {/* The question reads as context for the answer, so it sits below the
               answer headline (not above it). De-boxed: plain text, no panel. */}
-          <p className="pb-2 font-serif text-lg leading-6 text-[var(--brand-ink)]">
+          <p className="font-serif text-lg leading-7 text-[var(--brand-ink)]">
             {question}
           </p>
 
           {explanation ? (
             // Match the daily-5 game's reveal: a single-sentence explainer under
             // the answer, not the full paragraph (which ran too long here).
-            <p className="pb-2 font-serif text-[15px] leading-6 text-[var(--brand-ink-700)]">
+            <p className="font-serif text-[15px] leading-7 text-[var(--brand-ink-700)]">
               {firstSentence(explanation)}
             </p>
           ) : null}
 
           {insideJoke ? (
-            <div className="pt-1">
+            <div>
               <p
                 className="text-[0.62rem] font-semibold tracking-[0.18em] uppercase"
                 style={{ color: GOLD_INK }}
@@ -309,7 +302,7 @@ export function AnswerFeedbackSheet({
           ) : null}
 
           {creatorNote ? (
-            <div className="pt-3">
+            <div>
               <p className="text-[0.62rem] font-semibold tracking-[0.18em] uppercase text-muted-foreground">
                 Why they asked
               </p>
@@ -320,7 +313,7 @@ export function AnswerFeedbackSheet({
           ) : null}
 
           {onRecheck ? (
-            <div className="space-y-2 pt-3">
+            <div className="space-y-2">
               {!isCorrect && recheckState !== 'done' ? (
                 <div className="flex items-center justify-between gap-3">
                   <p className="text-xs text-muted-foreground">
@@ -367,7 +360,7 @@ export function AnswerFeedbackSheet({
           ) : null}
 
           {!isCorrect ? (
-            <div className="pt-3 text-xs text-muted-foreground">
+            <div className="text-xs text-muted-foreground">
               {bankState === 'saving' ? (
                 <span>Saving to your practice bank…</span>
               ) : null}
@@ -391,6 +384,17 @@ export function AnswerFeedbackSheet({
                 <span style={{ color: 'var(--game-wrong-strong)' }}>Could not update your practice bank.</span>
               ) : null}
             </div>
+          ) : null}
+
+          {/* "Knowledge updated" sits at the foot of the reveal: it's a follow-up
+              action (dial how often this new domain recurs), not part of reading
+              the answer, so it trails the answer/question/explanation content and
+              rests just above the Done button. */}
+          {showTerritoryUndo && openedTerritoryDomain ? (
+            <NewTerritoryUndo
+              domain={openedTerritoryDomain}
+              category={visibleCategory}
+            />
           ) : null}
         </div>
 


### PR DESCRIPTION
Polish pass on two reveal surfaces, driven by screenshots in chat.

## 1. Home-feed milestone affordance verb (`ActivityStreamItem.tsx`)
The playable "From Friends" milestone card always read **Play {name}'s q's**, even when:
- every question was already answered (e.g. "2 of 2") — opening then only reveals the read-only `AnsweredHistory`, so there's nothing left to *play*; and
- the bundle was already expanded — the label stayed stale while only the chevron flipped.

The affordance is now a bare verb that tracks the card's state:
- **Play** while questions remain to answer
- **Revisit** once all are answered
- **Close** while the bundle is open (in step with the chevron)

The friend's name was dropped from the link: it already headlines the card directly above, so repeating it was redundant — the link now lands on the action. (The humanizing stays in the headline + sentence.)

## 2. Answer-feedback sheet (`AnswerFeedbackSheet.tsx`)
- **Moved "Knowledge updated" to the foot of the reveal.** The `NewTerritoryUndo` card sat under the Correct!/points header, pushing the answer, question, and explanation down. It's a follow-up action (dial how often a newly-opened domain recurs), not part of reading the result, so it now trails the content and rests just above the **Done** button.
- **Loosened the cramped spacing.** The scroll body stacked blocks with only `pb-2` (8px) gaps and tight `leading-6`. Switched the scroll container to one consistent flex-column rhythm (`gap-4`), dropped the ad-hoc per-block paddings, and bumped the question/explanation body to `leading-7`.

`NewTerritoryUndo` itself is unchanged (its internal margin is shared with the `GameplayChat` reveal) — only its position in this sheet moved.

## Verification
- `tsc -p tsconfig.typecheck.json` — clean
- `eslint` on both files — no new errors (2 pre-existing color-token warnings on untouched lines of the sheet)
- `NewTerritoryUndo` component tests pass

https://claude.ai/code/session_01P5ZK59EnR8SMwAPECb1mjd

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5ZK59EnR8SMwAPECb1mjd)_