### PR TITLE
Remove AI classification box; auto-submit prefilled questions from home

### DIFF
--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -21,7 +21,7 @@ type DrawerState =
   // intent is null for the page's own "Write a question" buttons (and the
   // legacy `?create=1` link), which keep the form's existing defaults. Only the
   // CreateChooser supplies an explicit intent.
-  | { mode: 'create'; intent: CreateIntent | null; prefillText?: string }
+  | { mode: 'create'; intent: CreateIntent | null; prefillText?: string; autoSubmit?: boolean }
   | { mode: 'edit'; question: QuestionView };
 
 function parseIntent(raw: string | null): CreateIntent | null {
@@ -152,6 +152,9 @@ function QuestionsPageContent() {
           // The feed's "what would you like to be asked?" prompt rides the idea
           // in via ?text= so the composer opens pre-filled with the reader's words.
           prefillText: searchParams.get('text')?.trim() || undefined,
+          // ?submit=1 (also from that prompt) tells the composer to run review +
+          // answer suggestion and save without a second Save click.
+          autoSubmit: searchParams.get('submit') === '1',
         }
       : { mode: 'closed' };
   const [confirmingId, setConfirmingId] = useState<string | null>(null);
@@ -215,7 +218,7 @@ function QuestionsPageContent() {
   // this separate lets the FAB reopen the composer with a fresh ?create=1 push —
   // a same-URL push would otherwise be a no-op and leave the drawer closed.
   const clearComposerParams = useCallback(() => {
-    if (searchParams.has('create') || searchParams.has('intent') || searchParams.has('text')) {
+    if (searchParams.has('create') || searchParams.has('intent') || searchParams.has('text') || searchParams.has('submit')) {
       router.replace(pathname, { scroll: false });
     }
   }, [pathname, router, searchParams]);
@@ -504,6 +507,7 @@ function QuestionsPageContent() {
                 ? initialValues(drawer.question)
                 : { ...createFormProps(drawer.intent).initialValues, ...(drawer.prefillText ? { text: drawer.prefillText } : {}) }}
               initialSpecificMode={drawer.mode === 'create' ? createFormProps(drawer.intent).initialSpecificMode : undefined}
+              autoSubmit={drawer.mode === 'create' ? drawer.autoSubmit : undefined}
               onSubmit={drawer.mode === 'edit' ? (values) => saveEdit(drawer.question.id, values) : saveCreate}
               onCancel={closeDrawer}
             />

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -656,11 +656,15 @@ function FeedSurfaceTabs({
 // composer opens pre-filled (see app/questions/page.tsx). "Invite a friend"
 // survives as a secondary link so we don't lose that path.
 // The reader's typed idea rides to the composer via ?text=; an empty box still
-// opens the writer. Pure so the two branches stay test-covered without a DOM.
+// opens the writer. When an idea is supplied the reader has effectively already
+// "written" the question here, so we also pass &submit=1: the composer runs the
+// review + answer suggestion and saves it without a second Save click (see
+// QuestionForm's autoSubmit). An empty box opens the writer to fill in manually.
+// Pure so the branches stay test-covered without a DOM.
 export function buildQuestionWriterHref(idea: string): string {
   const trimmed = idea.trim()
   return trimmed
-    ? `/questions?create=1&intent=bank&text=${encodeURIComponent(trimmed)}`
+    ? `/questions?create=1&intent=bank&text=${encodeURIComponent(trimmed)}&submit=1`
     : '/questions?create=1&intent=bank'
 }
 

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -40,6 +40,13 @@ type Props = {
   mode?: 'create' | 'edit';
   initialValues?: Partial<QuestionFormValues>;
   initialSpecificMode?: boolean;
+  // When true (create-mode only), a prefilled question is carried all the way
+  // through on its own: the form runs the review + answer suggestion and saves
+  // without waiting for a manual Continue/Save click. Used by the home feed's
+  // "what would you like to be asked?" prompt, where the reader has already
+  // "written" the question. Falls back to the manual flow if the review surfaces
+  // issues or the answer suggestion is unavailable.
+  autoSubmit?: boolean;
   onSubmit: (values: QuestionFormValues) => Promise<void>;
   submitLabel?: string;
   loadingLabel?: string;
@@ -269,6 +276,7 @@ export function QuestionForm({
   mode = 'create',
   initialValues,
   initialSpecificMode = false,
+  autoSubmit = false,
   onSubmit,
   submitLabel,
   loadingLabel = 'Saving...',
@@ -277,6 +285,11 @@ export function QuestionForm({
   const [state, dispatch] = useReducer(reducer, undefined, () => initialState(initialValues, initialSpecificMode));
   const questionRef = useRef<HTMLTextAreaElement | null>(null);
   const lastSuggestionQuestionTextRef = useRef<string | null>(initialValues?.llmSuggestedAnswer ? (initialValues.text ?? '').trim() : null);
+  // autoSubmit drives the form through review → suggestion → save on its own.
+  // These guards keep each leg firing exactly once: `started` kicks the review,
+  // `submitted` fires the save once an answer exists. Reset on every new prefill.
+  const autoSubmitStartedRef = useRef(false);
+  const autoSubmittedRef = useRef(false);
 
   // PRD §16.12: first-time-author orientation panel. Shown on the first
   // create-mode mount for an account that has never authored a non-deleted
@@ -298,6 +311,8 @@ export function QuestionForm({
 
   useEffect(() => {
     lastSuggestionQuestionTextRef.current = initialValues?.llmSuggestedAnswer ? (initialValues.text ?? '').trim() : null;
+    autoSubmitStartedRef.current = false;
+    autoSubmittedRef.current = false;
     dispatch({ type: 'RESET', state: initialState(initialValues, initialSpecificMode) });
   }, [initialValues, initialSpecificMode]);
 
@@ -473,6 +488,29 @@ export function QuestionForm({
     }
   }
 
+  // autoSubmit leg 1: kick the review once for the prefilled question. The
+  // existing ANSWERING effect then auto-requests the answer suggestion. If the
+  // review surfaces issues (CRITIQUED) we stop here and let the author decide —
+  // we don't silently save a flagged question.
+  useEffect(() => {
+    if (!autoSubmit || mode !== 'create' || autoSubmitStartedRef.current) return;
+    if (state.stage !== 'WRITING' || !state.questionText.trim()) return;
+    autoSubmitStartedRef.current = true;
+    void runCritique();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoSubmit, mode, state.stage, state.questionText]);
+
+  // autoSubmit leg 2: once we're answering and the suggested answer has landed,
+  // save without a manual click. The userAnswer guard means a failed suggestion
+  // (no answer) leaves the author in the normal manual flow rather than blocking.
+  useEffect(() => {
+    if (!autoSubmit || mode !== 'create' || autoSubmittedRef.current) return;
+    if (state.stage !== 'ANSWERING' || state.suggesting || !state.userAnswer.trim()) return;
+    autoSubmittedRef.current = true;
+    void finalSave();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoSubmit, mode, state.stage, state.suggesting, state.userAnswer]);
+
   const critique = state.critiqueResult;
   const counter = remainingCopy(state);
   const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'SUBMITTING' || mode === 'edit';
@@ -601,11 +639,6 @@ export function QuestionForm({
             <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Creator note</label>
             <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="Optional context for recipients" />
             <p className="mt-1 text-right text-xs text-muted-foreground">{state.creatorNote.length}/200</p>
-          </div>
-
-          <div className="rounded-md border bg-muted/30 p-3">
-            <p className="text-xs uppercase tracking-[0.1em] text-muted-foreground">AI classification</p>
-            <p className="mt-1 text-sm text-muted-foreground">Joshing will read the question and answer when you save, then use the LLM to choose the broad category, precise domain, and difficulty.</p>
           </div>
 
           {state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (

--- a/src/components/__tests__/buildQuestionWriterHref.test.ts
+++ b/src/components/__tests__/buildQuestionWriterHref.test.ts
@@ -11,9 +11,9 @@ describe('buildQuestionWriterHref', () => {
     expect(buildQuestionWriterHref('   ')).toBe('/questions?create=1&intent=bank')
   })
 
-  it('carries a trimmed, encoded idea through as ?text=', () => {
+  it('carries a trimmed, encoded idea through as ?text= and requests auto-submit', () => {
     expect(buildQuestionWriterHref('  Which Broadway musical opened in 1957?  ')).toBe(
-      '/questions?create=1&intent=bank&text=Which%20Broadway%20musical%20opened%20in%201957%3F'
+      '/questions?create=1&intent=bank&text=Which%20Broadway%20musical%20opened%20in%201957%3F&submit=1'
     )
   })
 })


### PR DESCRIPTION
- Drop the "AI classification" explainer box from the question composer
  (QuestionForm) — it added noise without action.
- Home feed's "Your Turn" prompt now carries &submit=1 alongside the
  prefilled ?text=. The composer (QuestionForm.autoSubmit) runs the
  review + answer suggestion and saves without a second Save click, so
  writing a question on the home page and hitting "Add question" no
  longer requires submitting again. Falls back to the manual flow if the
  review surfaces issues or the answer suggestion is unavailable.