### PR TITLE
B-CATEGORY-AUTHORED-RECONCILE-01 Phase 1: shadow-log authored-domain reconcile (flag-off)

### DIFF
--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -9,7 +9,9 @@ const {
   getFriendsMock,
   getQuestionMock,
   getSessionMock,
+  isReconcileAuthoredDomainsEnabledMock,
   openKBDomainMock,
+  reconcileAuthoredDomainMock,
   rollOffOldItemsMock,
   state,
   userHasQuestionInBlockingFeedMock,
@@ -50,7 +52,9 @@ const {
     getFriendsMock: vi.fn(),
     getQuestionMock: vi.fn(),
     getSessionMock: vi.fn(),
+    isReconcileAuthoredDomainsEnabledMock: vi.fn(),
     openKBDomainMock: vi.fn(),
+    reconcileAuthoredDomainMock: vi.fn(),
     rollOffOldItemsMock: vi.fn(),
     state,
     userHasQuestionInBlockingFeedMock: vi.fn(),
@@ -128,6 +132,11 @@ vi.mock('@/server/knowledge/open-domain', () => ({
   openKBDomain: openKBDomainMock,
 }))
 
+vi.mock('@/server/questions/reconcile-authored-domain', () => ({
+  reconcileAuthoredDomain: reconcileAuthoredDomainMock,
+  isReconcileAuthoredDomainsEnabled: isReconcileAuthoredDomainsEnabledMock,
+}))
+
 vi.mock('@/server/questions/llm-difficulty', () => ({
   assessQuestionDifficulty: assessQuestionDifficultyMock,
   fallbackQuestionDifficulty: () => ({ tier: 'solid', difficulty: 3 }),
@@ -167,6 +176,18 @@ describe('POST /api/questions shareToFeed', () => {
       broad_category: 'Arts & Literature',
       subcategory: 'Victorian Literature',
     })
+    // Phase 1 default: flag off and reconcile reports no fold — strict no-op.
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(false)
+    reconcileAuthoredDomainMock.mockImplementation(async (proposed: string) => ({
+      proposed,
+      canonicalDomain: proposed,
+      reconciled: false,
+      differs: false,
+      method: 'none',
+      trgmExactLabel: null,
+      trgmFuzzyCandidates: [],
+      llmReconciled: false,
+    }))
     assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
     createQuestionMock.mockResolvedValue({ id: 'question-1' })
     generateInsideJokeMock.mockResolvedValue(null)
@@ -470,6 +491,17 @@ describe('POST /api/questions category leak handling', () => {
     state.questionUpdateValues = []
 
     getSessionMock.mockResolvedValue({ userId: 'creator-1' })
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(false)
+    reconcileAuthoredDomainMock.mockImplementation(async (proposed: string) => ({
+      proposed,
+      canonicalDomain: proposed,
+      reconciled: false,
+      differs: false,
+      method: 'none',
+      trgmExactLabel: null,
+      trgmFuzzyCandidates: [],
+      llmReconciled: false,
+    }))
     assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
     createQuestionMock.mockResolvedValue({ id: 'question-1' })
     generateInsideJokeMock.mockResolvedValue(null)
@@ -579,5 +611,133 @@ describe('POST /api/questions category leak handling', () => {
     const createArgs = createQuestionMock.mock.calls[0]?.[0] as { publicStatus: string }
     // verdictToPublicStatus maps needs_review → not_scored (never eligible/public).
     expect(createArgs.publicStatus).toBe('not_scored')
+  })
+})
+
+describe('POST /api/questions authored domain reconcile (B-CATEGORY-AUTHORED-RECONCILE-01)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    state.dismissedRows = []
+    state.feedInsertValues = []
+    state.questionUpdateValues = []
+
+    getSessionMock.mockResolvedValue({ userId: 'creator-1' })
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'Hamlet',
+    })
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(false)
+    reconcileAuthoredDomainMock.mockImplementation(async (proposed: string) => ({
+      proposed,
+      canonicalDomain: proposed,
+      reconciled: false,
+      differs: false,
+      method: 'none',
+      trgmExactLabel: null,
+      trgmFuzzyCandidates: [],
+      llmReconciled: false,
+    }))
+    assessQuestionDifficultyMock.mockResolvedValue({ difficulty: 3, tier: 'moderate' })
+    createQuestionMock.mockResolvedValue({ id: 'question-1' })
+    generateInsideJokeMock.mockResolvedValue(null)
+    getQuestionMock.mockResolvedValue({ id: 'question-1' })
+    openKBDomainMock.mockResolvedValue({ opened: true })
+    rollOffOldItemsMock.mockResolvedValue(0)
+    userHasQuestionInBlockingFeedMock.mockResolvedValue(false)
+    vetQuestionMock.mockResolvedValue({ status: 'approved', score: 0.8, reason: 'looks good' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+  })
+
+  function foldOutcome(proposed: string, canonicalDomain: string, method: 'trgm-exact' | 'llm') {
+    return {
+      proposed,
+      canonicalDomain,
+      reconciled: true,
+      differs: true,
+      method,
+      trgmExactLabel: method === 'trgm-exact' ? canonicalDomain : null,
+      trgmFuzzyCandidates: [],
+      llmReconciled: method === 'llm',
+    }
+  }
+
+  it('shadow-logs the reconcile but is a strict no-op on the written label when the flag is OFF', async () => {
+    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => undefined)
+    // Reconcile WOULD fold Hamlet → Shakespearean Tragedy, but the flag is off.
+    reconcileAuthoredDomainMock.mockResolvedValue(foldOutcome('Hamlet', 'Shakespearean Tragedy', 'llm'))
+
+    const response = await POST(questionRequest({ text: 'Who skull does Hamlet hold?', correctAnswer: 'Yorick' }))
+
+    expect(response.status).toBe(201)
+    // Flag off → the blind label is still what gets written.
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { canonicalSubcategory: string }
+    expect(createArgs.canonicalSubcategory).toBe('Hamlet')
+    // …but the shadow-log records what the fold WOULD have been.
+    const shadowLog = infoSpy.mock.calls.find((c) => c[0] === '[questions/authored-reconcile]')
+    expect(shadowLog?.[1]).toMatchObject({
+      proposed: 'Hamlet',
+      reconciled: 'Shakespearean Tragedy',
+      differs: true,
+      flagEnabled: false,
+      applied: false,
+    })
+  })
+
+  it('writes the reconciled domain (trgm exact) across canonical_subcategory/subcategory/domain when the flag is ON', async () => {
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(true)
+    reconcileAuthoredDomainMock.mockResolvedValue(foldOutcome('Hamlet', 'Shakespearean Tragedy', 'trgm-exact'))
+
+    const response = await POST(questionRequest({ text: 'Who skull does Hamlet hold?', correctAnswer: 'Yorick' }))
+
+    expect(response.status).toBe(201)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as {
+      canonicalSubcategory: string
+      subcategory: string
+      domain: string
+    }
+    // The authored "Hamlet" folds onto the existing "Shakespearean Tragedy"
+    // instead of minting a sibling — written consistently everywhere.
+    expect(createArgs.canonicalSubcategory).toBe('Shakespearean Tragedy')
+    expect(createArgs.subcategory).toBe('Shakespearean Tragedy')
+    expect(createArgs.domain).toBe('Shakespearean Tragedy')
+    // Phase 3: the KB domain opened for the author uses the reconciled label, so
+    // mastery credit lands on the reconciled domain, not the blind duplicate.
+    expect(openKBDomainMock).toHaveBeenCalledWith(
+      expect.objectContaining({ domain: 'Shakespearean Tragedy', via: 'authorship' }),
+    )
+  })
+
+  it('writes the reconciled domain from the Haiku (llm) fold when the flag is ON', async () => {
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(true)
+    categorizeQuestionMock.mockResolvedValue({
+      broad_category: 'Arts & Literature',
+      subcategory: 'The Bard’s Tragedies',
+    })
+    reconcileAuthoredDomainMock.mockResolvedValue(
+      foldOutcome('The Bard’s Tragedies', 'Shakespearean Tragedy', 'llm'),
+    )
+
+    const response = await POST(questionRequest({ text: 'Who skull does Hamlet hold?', correctAnswer: 'Yorick' }))
+
+    expect(response.status).toBe(201)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { canonicalSubcategory: string }
+    expect(createArgs.canonicalSubcategory).toBe('Shakespearean Tragedy')
+  })
+
+  it('falls through to the proposed label (never throws) if reconcile yields a generic label, even flag ON', async () => {
+    isReconcileAuthoredDomainsEnabledMock.mockReturnValue(true)
+    // A would-be fold onto a generic bucket the F4.5 write-guard forbids.
+    reconcileAuthoredDomainMock.mockResolvedValue(foldOutcome('Hamlet', 'General Knowledge', 'llm'))
+
+    const response = await POST(questionRequest({ text: 'Who skull does Hamlet hold?', correctAnswer: 'Yorick' }))
+
+    expect(response.status).toBe(201)
+    const createArgs = createQuestionMock.mock.calls[0]?.[0] as { canonicalSubcategory: string }
+    // Guard preserved: we keep the already-validated proposed label.
+    expect(createArgs.canonicalSubcategory).toBe('Hamlet')
   })
 })

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -27,6 +27,7 @@ import { readCreateQuestionPayload } from '@/server/questions/create-payload';
 import { textContainsAnswer } from '@/server/questions/self-answering';
 import { assessQuestionDifficulty, fallbackQuestionDifficulty } from '@/server/questions/llm-difficulty';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
+import { isReconcileAuthoredDomainsEnabled, reconcileAuthoredDomain } from '@/server/questions/reconcile-authored-domain';
 
 export const dynamic = 'force-dynamic';
 
@@ -148,7 +149,40 @@ export async function POST(request: NextRequest) {
       answer: value.correctAnswer,
     });
   }
-  const canonicalSubcategory = normalizedSubcategory;
+  // B-CATEGORY-AUTHORED-RECONCILE-01: the authored path historically wrote the
+  // blind categorizer label, unlike the generated/onboarding paths which
+  // reconcile against existing domains. Fold the proposal onto an existing
+  // domain (C: trgm-exact first, Haiku on miss; silent) so an authored "Hamlet"
+  // reuses the player's "Shakespearean Tragedy" instead of minting a sibling.
+  //
+  // Phase 1 ships flag-OFF: we ALWAYS compute + shadow-log the outcome to
+  // quantify pre-fix duplication, but only ADOPT it when RECONCILE_AUTHORED_DOMAINS
+  // is enabled — flag-off is a strict no-op on the written label.
+  const reconcileOutcome = await reconcileAuthoredDomain(normalizedSubcategory, session.userId);
+  const reconcileFlagEnabled = isReconcileAuthoredDomainsEnabled();
+  // Preserve the F4.5 write-boundary guard: never adopt a reconciled label the
+  // guard would reject — fall through to the already-validated proposed label
+  // rather than letting createQuestion throw.
+  const reconciledTooGeneric =
+    reconcileOutcome.differs && isGenericSubcategory(reconcileOutcome.canonicalDomain);
+  const applyReconcile = reconcileFlagEnabled && reconcileOutcome.differs && !reconciledTooGeneric;
+  console.info('[questions/authored-reconcile]', {
+    userId: session.userId,
+    proposed: normalizedSubcategory,
+    reconciled: reconcileOutcome.canonicalDomain,
+    differs: reconcileOutcome.differs,
+    method: reconcileOutcome.method,
+    trgmExact: reconcileOutcome.trgmExactLabel,
+    trgmFuzzy: reconcileOutcome.trgmFuzzyCandidates,
+    llmReconciled: reconcileOutcome.llmReconciled,
+    flagEnabled: reconcileFlagEnabled,
+    reconciledTooGeneric,
+    applied: applyReconcile,
+  });
+  // broad_category is intentionally kept from the categorizer (matches the
+  // generated path, which swaps only the domain label on reconcile); reconcile
+  // does not emit a broad category.
+  const canonicalSubcategory = applyReconcile ? reconcileOutcome.canonicalDomain : normalizedSubcategory;
   const questionFields = {
     ...rawQuestionFields,
     category,

--- a/src/server/questions/__tests__/reconcile-authored-domain.test.ts
+++ b/src/server/questions/__tests__/reconcile-authored-domain.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const convergeDomain = vi.fn();
+const reconcileProposedDomain = vi.fn();
+
+vi.mock('@/server/knowledge/converge-domain', () => ({
+  convergeDomain: (...args: unknown[]) => convergeDomain(...args),
+}));
+
+vi.mock('@/lib/questions/categorization', () => ({
+  reconcileProposedDomain: (...args: unknown[]) => reconcileProposedDomain(...args),
+}));
+
+import {
+  isReconcileAuthoredDomainsEnabled,
+  reconcileAuthoredDomain,
+} from '@/server/questions/reconcile-authored-domain';
+
+function convergeResult(candidates: Array<{ label: string; kind: string; similarity: number; broadCategory?: string | null }>) {
+  return {
+    raw: 'x',
+    candidates: candidates.map((c) => ({ broadCategory: null, ...c })),
+  };
+}
+
+describe('reconcileAuthoredDomain', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    convergeDomain.mockResolvedValue(convergeResult([{ label: 'Hamlet', kind: 'new', similarity: 0 }]));
+    reconcileProposedDomain.mockResolvedValue({ canonicalDomain: 'Hamlet', reconciled: false });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('adopts a trgm exact-key corpus match and never calls the LLM', async () => {
+    convergeDomain.mockResolvedValue(
+      convergeResult([
+        { label: 'Shakespearean Tragedy', kind: 'exact', similarity: 1 },
+        { label: 'Shakespeare Plays', kind: 'fuzzy', similarity: 0.6 },
+      ]),
+    );
+
+    const outcome = await reconcileAuthoredDomain('shakespearean tragedy', 'user-1');
+
+    expect(outcome.method).toBe('trgm-exact');
+    expect(outcome.canonicalDomain).toBe('Shakespearean Tragedy');
+    expect(outcome.reconciled).toBe(true);
+    expect(outcome.differs).toBe(true);
+    expect(outcome.trgmFuzzyCandidates).toEqual([{ label: 'Shakespeare Plays', similarity: 0.6 }]);
+    // trgm-first means the LLM is skipped entirely on an exact hit.
+    expect(reconcileProposedDomain).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the Haiku semantic reconcile on a trgm-exact miss', async () => {
+    convergeDomain.mockResolvedValue(
+      convergeResult([{ label: 'The Bard’s Tragedies', kind: 'fuzzy', similarity: 0.5 }]),
+    );
+    reconcileProposedDomain.mockResolvedValue({ canonicalDomain: 'Shakespearean Tragedy', reconciled: true });
+
+    const outcome = await reconcileAuthoredDomain('The Bard’s Tragedies', 'user-1');
+
+    expect(reconcileProposedDomain).toHaveBeenCalledWith('The Bard’s Tragedies', 'user-1');
+    expect(outcome.method).toBe('llm');
+    expect(outcome.canonicalDomain).toBe('Shakespearean Tragedy');
+    expect(outcome.differs).toBe(true);
+    expect(outcome.llmReconciled).toBe(true);
+    // fuzzy candidate is surfaced for telemetry but was NOT auto-applied.
+    expect(outcome.trgmFuzzyCandidates).toEqual([{ label: 'The Bard’s Tragedies', similarity: 0.5 }]);
+  });
+
+  it('reports no fold when neither pass matches', async () => {
+    const outcome = await reconcileAuthoredDomain('Hamlet', 'user-1');
+    expect(outcome.method).toBe('none');
+    expect(outcome.differs).toBe(false);
+    expect(outcome.canonicalDomain).toBe('Hamlet');
+  });
+
+  it('adopts the LLM per-user exact-casing fold even when reconciled=false', async () => {
+    reconcileProposedDomain.mockResolvedValue({ canonicalDomain: 'Hamlet', reconciled: false });
+    const outcome = await reconcileAuthoredDomain('HAMLET', 'user-1');
+    expect(outcome.differs).toBe(true);
+    expect(outcome.canonicalDomain).toBe('Hamlet');
+    expect(outcome.method).toBe('llm');
+  });
+
+  it('degrades to the proposal when convergeDomain throws', async () => {
+    convergeDomain.mockRejectedValue(new Error('pg_trgm down'));
+    reconcileProposedDomain.mockResolvedValue({ canonicalDomain: 'Hamlet', reconciled: false });
+    const outcome = await reconcileAuthoredDomain('Hamlet', 'user-1');
+    expect(outcome.canonicalDomain).toBe('Hamlet');
+    expect(outcome.method).toBe('none');
+  });
+
+  it('reads the RECONCILE_AUTHORED_DOMAINS flag with the repo boolean convention', () => {
+    vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', '');
+    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
+    for (const truthy of ['true', '1', 'yes', 'on', 'TRUE']) {
+      vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', truthy);
+      expect(isReconcileAuthoredDomainsEnabled()).toBe(true);
+    }
+    vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', 'false');
+    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
+  });
+});

--- a/src/server/questions/reconcile-authored-domain.ts
+++ b/src/server/questions/reconcile-authored-domain.ts
@@ -1,0 +1,141 @@
+/**
+ * B-CATEGORY-AUTHORED-RECONCILE-01 — reconcile a user-authored question's blind
+ * category label against domains that already exist, the way the generated/daily
+ * path (reconcileProposedDomain) and the onboarding path (convergeDomain) already
+ * do, so an authored "Hamlet" question folds onto the player's existing
+ * "Shakespearean Tragedy" / "Hamlet" instead of minting a near-duplicate sibling.
+ *
+ * Mechanism (Josh's fork resolution): **(C) both — pg_trgm first, Haiku on miss**,
+ * applied **silently** (no author confirm step). We deliberately do NOT reimplement
+ * either reconcile primitive — we compose the two existing ones:
+ *
+ *   1. convergeDomain() — deterministic pg_trgm convergence against the cross-game
+ *      PLAYER_MASTERY corpus. We auto-adopt ONLY its exact-key candidate. Its fuzzy
+ *      candidates are LEXICAL ("Roman Empire" ~ "Holy Roman Empire") and per that
+ *      module's contract are never auto-applied — we log them for the shadow-log
+ *      review but do not fold on them silently.
+ *   2. reconcileProposedDomain() — Haiku semantic reconcile against the player's OWN
+ *      existing domains, run ONLY on a trgm-exact miss. Folds synonyms trgm can't
+ *      ("The Bard's Tragedies" → "Shakespearean Tragedy").
+ *
+ * Both primitives already swallow their own infra faults (pg_trgm absent, LLM
+ * timeout) and degrade to "no fold", so a reconcile fault never blocks a save.
+ */
+
+import { reconcileProposedDomain } from '@/lib/questions/categorization';
+import { convergeDomain } from '@/server/knowledge/converge-domain';
+
+export type AuthoredReconcileMethod = 'trgm-exact' | 'llm' | 'none';
+
+export type AuthoredReconcileOutcome = {
+  /** The blind label the categorizer proposed (post-normalization). */
+  proposed: string;
+  /** The label that WOULD be written if the fold is applied (proposed when no fold). */
+  canonicalDomain: string;
+  /** Whether the reconcile folded onto a different existing domain. */
+  reconciled: boolean;
+  /**
+   * True iff the reconciled label differs from the proposed RAW spelling (the
+   * apply gate). Raw, not domainKey: PLAYER_MASTERY is keyed on the stored
+   * canonical_subcategory string, so converging "hamlet" → "Hamlet" collapses a
+   * real duplicate row even though both fold to the same domainKey. (A
+   * trgm-exact match shares the input's domainKey by construction — a domainKey
+   * gate would make it a permanent no-op.)
+   */
+  differs: boolean;
+  method: AuthoredReconcileMethod;
+  /** The trgm exact-key corpus label, if one matched (telemetry). */
+  trgmExactLabel: string | null;
+  /** trgm fuzzy candidates — logged for shadow-log review, NEVER auto-applied. */
+  trgmFuzzyCandidates: Array<{ label: string; similarity: number }>;
+  /** Whether the Haiku pass reported a semantic fold. */
+  llmReconciled: boolean;
+};
+
+/**
+ * Phase 1 ships flag-OFF: the authored path always COMPUTES + shadow-logs this
+ * outcome (to quantify pre-fix duplication) but only ADOPTS it when this flag is
+ * enabled. Mirrors the boolean-env convention in create-payload.ts.
+ */
+export function isReconcileAuthoredDomainsEnabled(): boolean {
+  const raw = process.env.RECONCILE_AUTHORED_DOMAINS?.trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+export async function reconcileAuthoredDomain(
+  proposedDomain: string,
+  userId: string,
+): Promise<AuthoredReconcileOutcome> {
+  const proposed = proposedDomain;
+  const base: AuthoredReconcileOutcome = {
+    proposed,
+    canonicalDomain: proposed,
+    reconciled: false,
+    differs: false,
+    method: 'none',
+    trgmExactLabel: null,
+    trgmFuzzyCandidates: [],
+    llmReconciled: false,
+  };
+
+  // ── Pass 1: deterministic pg_trgm convergence (cheap, no LLM) ──────────────
+  let trgmExactLabel: string | null = null;
+  let trgmFuzzyCandidates: Array<{ label: string; similarity: number }> = [];
+  try {
+    const converge = await convergeDomain(proposed);
+    trgmExactLabel = converge.candidates.find((c) => c.kind === 'exact')?.label ?? null;
+    trgmFuzzyCandidates = converge.candidates
+      .filter((c) => c.kind === 'fuzzy')
+      .map((c) => ({ label: c.label, similarity: c.similarity }));
+  } catch (error) {
+    // convergeDomain already degrades internally when pg_trgm is absent; this is
+    // a belt-and-suspenders guard so a corpus query fault never blocks a save.
+    console.warn('[authored-reconcile] converge failed (non-fatal)', {
+      proposed,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Exact-key matches are the only trgm candidates safe to fold silently. An
+  // exact-key hit means this domain already exists canonically, so we short-
+  // circuit the LLM regardless — adopting the corpus spelling when it differs.
+  if (trgmExactLabel) {
+    const differs = trgmExactLabel !== proposed;
+    return {
+      ...base,
+      canonicalDomain: trgmExactLabel,
+      reconciled: differs,
+      differs,
+      method: differs ? 'trgm-exact' : 'none',
+      trgmExactLabel,
+      trgmFuzzyCandidates,
+    };
+  }
+
+  // ── Pass 2: Haiku semantic reconcile, on trgm-exact miss only ──────────────
+  // reconcileProposedDomain returns the player's existing spelling on a fold
+  // (semantic OR its own per-user exact-casing short-circuit), else the proposal.
+  let llm = { canonicalDomain: proposed, reconciled: false };
+  try {
+    llm = await reconcileProposedDomain(proposed, userId);
+  } catch (error) {
+    console.warn('[authored-reconcile] llm reconcile failed (non-fatal)', {
+      proposed,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  // Adopt the pass-2 label whenever it actually differs (covers both the Haiku
+  // semantic fold and the helper's per-user exact-casing fold, which reports
+  // reconciled=false but still hands back the existing spelling).
+  const folded = llm.canonicalDomain !== proposed;
+  return {
+    ...base,
+    canonicalDomain: folded ? llm.canonicalDomain : proposed,
+    reconciled: folded,
+    differs: folded,
+    method: folded ? 'llm' : 'none',
+    trgmFuzzyCandidates,
+    llmReconciled: llm.reconciled,
+  };
+}


### PR DESCRIPTION
## What & why

The user-authored path (`POST /api/questions`) categorized **blind** — unlike the generated path (Haiku `reconcileProposedDomain`) and the onboarding path (pg_trgm `convergeDomain`), it never reconciled against domains that already exist. So an authored "Hamlet" question could mint a near-duplicate sibling of an existing "Shakespearean Tragedy" / "Hamlet", inflating the portrait's long-tail territory count without adding real distinct knowledge. This closes that gap (the audit's `CATEGORY-HIERARCHY-FINDINGS-01`).

**No schema change. No hierarchy/roll-up.** This only makes the authored path reuse existing canonical domains the way the other two paths already do.

## Fork resolution (Josh)

- **Mechanism: (C) both** — pg_trgm exact first, Haiku reconcile on miss.
- **UX: silent** — no author confirm step; `categoryOverridden` behavior preserved (untouched).

## This PR is Phase 1 only — and ships safe with the flag OFF

`RECONCILE_AUTHORED_DOMAINS` defaults **off**, so in production this is a **strict no-op on the written label**. It always *computes and shadow-logs* the outcome so the gate review can quantify pre-fix duplication before Phase 2 flips the flag.

```
[questions/authored-reconcile] { proposed, reconciled, differs, method,
  trgmExact, trgmFuzzy, llmReconciled, flagEnabled, reconciledTooGeneric, applied }
```

Per the prompt, the flag is **not** flipped in this PR — shadow-log review is the Phase 2 gate.

## Changes

- **`src/server/questions/reconcile-authored-domain.ts`** (new) — composes the two *existing* primitives (`convergeDomain` + `reconcileProposedDomain`); no reconcile reimplemented. trgm **fuzzy** candidates are logged but **never auto-folded** (lexical, unsafe to fold silently per `converge-domain`'s contract); only trgm **exact-key** and the Haiku **semantic** fold apply.
- **`src/app/api/questions/route.ts`** — computes + shadow-logs always; adopts the reconciled label only when the flag is on.

### Two judgment calls worth a look

1. **Raw-string apply gate, not `domainKey`.** A trgm exact-key match shares the input's `domainKey` by construction, so a `domainKey` gate would make the entire trgm pass a *permanent no-op*. PLAYER_MASTERY is keyed on the stored string, so converging `hamlet → Hamlet` collapses a real duplicate row. (A unit test caught this.)
2. **`broad_category` kept from the categorizer** on a fold — matches the generated path, which swaps only the domain label on reconcile. The regex-derived broad-header (audit incidental #1) is left untouched as instructed.

### Write-boundary guard preserved (F4.5)

A reconciled label that would be generic falls through to the already-validated proposed label rather than letting `createQuestion` throw.

## Phase 3 consumer-side trace (verified statically; no credit split)

Every downstream consumer reads the single `question.canonical_subcategory` / `player_mastery.canonical_subcategory` field that now holds the reconciled label — there is **no second path that re-derives the label** from the original blind text:

- `openKBDomain({ via: 'authorship' })` seeds PLAYER_MASTERY on the reconciled label (`open-domain.ts`).
- The answer-path mastery write uses `domain: question.canonicalSubcategory` (`daily/answer/route.ts:477,487,492`).
- The portrait aggregates by `domainKey()` (`buildMasteryByDomain`), folding the reconciled label onto the existing domain's circle.

**Residual (an improvement, not a regression), noted for Phase 2:** a trgm-exact fold onto a *cross-game* canonical spelling the player holds under a different case creates a second PLAYER_MASTERY row that the portrait folds at render (points sum, one circle). The Haiku pass avoids this (it returns the player's *own* spelling). Net: reconcile reduces row fragmentation versus the blind path.

## Tests (24 passing) · `tsc` + `eslint` clean

- Orchestrator: trgm-exact short-circuits the LLM; LLM fold on miss; fuzzy never auto-applied; per-user exact-casing fold; converge fault degrades to the proposal; flag reader.
- Route: flag **off** = no-op + shadow-log fires; flag **on** writes the reconciled label across `canonical_subcategory`/`subcategory`/`domain` and opens the KB domain on the reconciled label; generic fall-through.

## DO-NOT (honored)

No middle tier / parent-child / mastery roll-up; generated and onboarding paths untouched; reconcile not reimplemented; flag not flipped in this PR.

https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt)_