### PR TITLE
perf: trim answer-submit critical path, overlap activity-stream batch, dedupe session reads, add overflow loading states

### DIFF
--- a/src/app/activities/loading.tsx
+++ b/src/app/activities/loading.tsx
@@ -1,0 +1,72 @@
+import { CREAM, FS, HILITE, INK } from '@/components/lately/tokens';
+
+// Route-level fallback for /activities ("Lately"). Mirrors the page shell —
+// cream canvas, the italic "Lately." headline, then a few quiet one-line
+// placeholders — so the frame holds while buildActivityStream resolves.
+export default function Loading() {
+  return (
+    <main style={{ background: CREAM, color: INK, minHeight: '100dvh' }}>
+      <div
+        style={{
+          maxWidth: 420,
+          margin: '0 auto',
+          padding: '18px 20px 100px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <div style={{ marginBottom: 6 }}>
+          <h1
+            style={{
+              fontSize: 46,
+              fontFamily: FS,
+              fontWeight: 400,
+              fontStyle: 'italic',
+              lineHeight: 1,
+              margin: 0,
+              letterSpacing: -1.5,
+              position: 'relative',
+              display: 'inline-block',
+            }}
+          >
+            Lately.
+            <span
+              aria-hidden
+              style={{
+                position: 'absolute',
+                left: 0,
+                right: '30%',
+                bottom: 4,
+                height: 8,
+                background: HILITE,
+                zIndex: -1,
+                opacity: 0.85,
+              }}
+            />
+          </h1>
+        </div>
+
+        <div
+          className="animate-pulse"
+          aria-hidden="true"
+          style={{ display: 'flex', flexDirection: 'column', gap: 18, marginTop: 24 }}
+        >
+          {Array.from({ length: 6 }).map((_, i) => (
+            <div
+              key={i}
+              className="bg-black/[0.06]"
+              style={{
+                height: 16,
+                width: `${85 - i * 6}%`,
+                borderRadius: 4,
+              }}
+            />
+          ))}
+        </div>
+
+        <span className="sr-only" role="status">
+          Loading what&rsquo;s happening…
+        </span>
+      </div>
+    </main>
+  );
+}

--- a/src/app/api/joshing-games/[id]/answer/route.ts
+++ b/src/app/api/joshing-games/[id]/answer/route.ts
@@ -115,51 +115,65 @@ export async function POST(request: NextRequest, context: RouteContext) {
     ));
 
     const newlyComplete = completion.userComplete && !beforeCompletion.userComplete;
-    const creator = await getSmsUser(existingView.game.creatorId);
-    const actor = await getSmsUser(session.userId);
-    const baseUrl = getBaseUrl(request);
+    const newlyAllComplete = completion.allComplete && !beforeCompletion.allComplete;
 
-    if (newlyComplete && !completion.allComplete) {
-      if (creator?.phoneNumber && creator.smsOptIn !== 'opted_out') {
-        const actorName = actor?.displayName?.trim() || 'Someone';
-        await sendSms(
-          creator.phoneNumber,
-          `${actorName} played ${existingView.game.title}. ${completion.completedUserIds.length} of ${existingView.recipients.length} have played. ${baseUrl}/games/${id}/summary`,
-          'joshing_game_progress',
-          creator.id,
-        );
-      }
+    // Creator notifications, the played-state feed flip, and the creator-facing
+    // activity rows are all downstream side effects — none of them feed the
+    // player's own response. Defer them to `after()` so the player isn't held
+    // behind Twilio round-trips and extra writes; the only thing gating their
+    // grade is the grade itself. The two SMS-user lookups run in parallel
+    // rather than back-to-back.
+    if (newlyComplete || newlyAllComplete) {
+      const baseUrl = getBaseUrl(request);
+      after(async () => {
+        const [creator, actor] = await Promise.all([
+          getSmsUser(existingView.game.creatorId),
+          getSmsUser(session.userId),
+        ]);
 
-      await writeActivity({
-        userId: existingView.game.creatorId,
-        type: 'joshing_game_progress',
-        actorUserId: session.userId,
-        referenceId: id,
-        referenceType: 'joshing_game',
-      });
-    }
+        if (newlyComplete && !completion.allComplete) {
+          if (creator?.phoneNumber && creator.smsOptIn !== 'opted_out') {
+            const actorName = actor?.displayName?.trim() || 'Someone';
+            await sendSms(
+              creator.phoneNumber,
+              `${actorName} played ${existingView.game.title}. ${completion.completedUserIds.length} of ${existingView.recipients.length} have played. ${baseUrl}/games/${id}/summary`,
+              'joshing_game_progress',
+              creator.id,
+            );
+          }
 
-    if (completion.allComplete && !beforeCompletion.allComplete) {
-      if (creator?.phoneNumber && creator.smsOptIn !== 'opted_out') {
-        await sendSms(
-          creator.phoneNumber,
-          `Everyone played ${existingView.game.title}. See the full results. ${baseUrl}/games/${id}/summary`,
-          'joshing_game_complete',
-          creator.id,
-        );
-      }
+          await writeActivity({
+            userId: existingView.game.creatorId,
+            type: 'joshing_game_progress',
+            actorUserId: session.userId,
+            referenceId: id,
+            referenceType: 'joshing_game',
+          });
+        }
 
-      await db
-        .update(feedItems)
-        .set({ state: 'played' })
-        .where(and(eq(feedItems.joshingGameId, id), eq(feedItems.sourceType, 'joshing_game')));
+        if (newlyAllComplete) {
+          if (creator?.phoneNumber && creator.smsOptIn !== 'opted_out') {
+            await sendSms(
+              creator.phoneNumber,
+              `Everyone played ${existingView.game.title}. See the full results. ${baseUrl}/games/${id}/summary`,
+              'joshing_game_complete',
+              creator.id,
+            );
+          }
 
-      await writeActivity({
-        userId: existingView.game.creatorId,
-        type: 'joshing_game_result',
-        actorUserId: session.userId,
-        referenceId: id,
-        referenceType: 'joshing_game',
+          await db
+            .update(feedItems)
+            .set({ state: 'played' })
+            .where(and(eq(feedItems.joshingGameId, id), eq(feedItems.sourceType, 'joshing_game')));
+
+          await writeActivity({
+            userId: existingView.game.creatorId,
+            type: 'joshing_game_result',
+            actorUserId: session.userId,
+            referenceId: id,
+            referenceType: 'joshing_game',
+          });
+        }
       });
     }
 

--- a/src/app/for-you/loading.tsx
+++ b/src/app/for-you/loading.tsx
@@ -1,0 +1,28 @@
+// Route-level fallback for /for-you. Mirrors the page shell (max-w-2xl column +
+// OverflowSubpageHeader + a stack of feed cards) so the layout holds steady
+// while buildPendingDirectQueue resolves, instead of a blank screen.
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-[18px] px-4 py-6 pb-32 md:py-10">
+      <div className="animate-pulse" aria-hidden="true">
+        <div className="h-3 w-20 rounded bg-black/[0.06]" />
+        <div className="mt-3 h-8 w-56 rounded bg-black/[0.08]" />
+      </div>
+      <section className="flex flex-col gap-[18px]" aria-hidden="true">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-[12px] bg-black/[0.04] p-5 ring-1 ring-black/5"
+          >
+            <div className="h-3 w-24 rounded bg-black/[0.06]" />
+            <div className="mt-4 h-5 w-full rounded bg-black/[0.08]" />
+            <div className="mt-2 h-5 w-3/4 rounded bg-black/[0.08]" />
+          </div>
+        ))}
+      </section>
+      <span className="sr-only" role="status">
+        Loading your questions…
+      </span>
+    </main>
+  );
+}

--- a/src/app/from-friends/loading.tsx
+++ b/src/app/from-friends/loading.tsx
@@ -1,0 +1,27 @@
+// Route-level fallback for /from-friends. Mirrors the page shell (max-w-2xl
+// column + OverflowSubpageHeader + a stack of friend-activity cards) so the
+// layout holds steady while buildFriendActivityQueue resolves.
+export default function Loading() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-[18px] px-4 py-6 pb-32 md:py-10">
+      <div className="animate-pulse" aria-hidden="true">
+        <div className="h-3 w-24 rounded bg-black/[0.06]" />
+        <div className="mt-3 h-8 w-52 rounded bg-black/[0.08]" />
+      </div>
+      <div className="flex flex-col gap-[18px]" aria-hidden="true">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div
+            key={i}
+            className="animate-pulse rounded-[12px] bg-black/[0.04] p-5 ring-1 ring-black/5"
+          >
+            <div className="h-3 w-32 rounded bg-black/[0.06]" />
+            <div className="mt-4 h-5 w-5/6 rounded bg-black/[0.08]" />
+          </div>
+        ))}
+      </div>
+      <span className="sr-only" role="status">
+        Loading activity from friends…
+      </span>
+    </main>
+  );
+}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1,12 +1,11 @@
 'use client'
 
 import { Fragment, Suspense, useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react'
+import dynamic from 'next/dynamic'
 import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
 import {
   AnsweredByYouCard,
-  AnswerFeedbackSheet,
-  AnswerSheet,
   DirectSentCard,
   DismissedFeedBar,
   FeedCardSwipe,
@@ -38,6 +37,22 @@ import {
   ANSWER_GRADER_RETRY_MESSAGE,
   submitAnswerWithRetry,
 } from '@/lib/answer-submit'
+
+// Both answer sheets are bottom-of-tree modals gated by component state: the
+// answer sheet only mounts when a card is tapped, and the feedback sheet only
+// after a grade returns (its chunk loads in parallel during the grading
+// round-trip, so the split adds no perceived latency). Code-splitting them keeps
+// their subtrees — AnswerFeedbackSheet alone pulls ReportReasonSheet,
+// NewTerritoryUndo and lucide icons — out of the initial JS shipped to home,
+// /for-you and /from-friends. ssr:false is safe: neither ever renders during SSR.
+const AnswerSheet = dynamic(
+  () => import('@/components/feed/AnswerSheet').then((m) => m.AnswerSheet),
+  { ssr: false },
+)
+const AnswerFeedbackSheet = dynamic(
+  () => import('@/components/feed/AnswerFeedbackSheet').then((m) => m.AnswerFeedbackSheet),
+  { ssr: false },
+)
 
 type FriendResult = {
   userId: string

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -32,9 +32,15 @@ import {
 } from '@/server/db/queries/lately';
 
 export async function buildActivityStream(userId: string): Promise<StreamItem[]> {
-  const [items, moments, friendCards, convergences] = await Promise.all([
-    getActivitiesForUser(userId),
-    getLatelyMoments(userId),
+  // The dependent question-resolution batch below only needs friendCards +
+  // convergences (to know which question IDs to resolve). Activities and moments
+  // are independent, so let them resolve alongside that batch instead of gating
+  // it behind all four upstream queries — the critical path becomes
+  // max(friendCards, convergences) + the dependent batch, with items/moments
+  // overlapping rather than adding to it.
+  const itemsPromise = getActivitiesForUser(userId);
+  const momentsPromise = getLatelyMoments(userId);
+  const [friendCards, convergences] = await Promise.all([
     getFriendActivity(userId),
     getLatelyConvergences(userId),
   ]);
@@ -54,7 +60,9 @@ export async function buildActivityStream(userId: string): Promise<StreamItem[]>
       ...convergences.flatMap((c) => c.questionIds),
     ]),
   ];
-  const [textById, priorById, hiddenIds] = await Promise.all([
+  const [items, moments, textById, priorById, hiddenIds] = await Promise.all([
+    itemsPromise,
+    momentsPromise,
     getMilestoneQuestionText(allQuestionIds),
     getViewerPriorAnswerResults(userId, allQuestionIds),
     // B-Report-3: durable self-hide — a question the viewer reported as

--- a/src/server/auth/session.ts
+++ b/src/server/auth/session.ts
@@ -7,6 +7,7 @@ import { randomBytes } from 'crypto';
 import { eq } from 'drizzle-orm';
 import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
+import { cache } from 'react';
 
 import { db } from '@/server/db';
 import { userSessions } from '@/server/db/schema';
@@ -329,7 +330,12 @@ export async function validateSessionToken(
   return { user_id: session.userId, session_id: session.id };
 }
 
-export async function getSession(): Promise<Session | null> {
+// Request-scoped memoization: a single page render commonly resolves the session
+// several times (layout + page + nested server components), and each call hits
+// the DB via validateSessionToken. `cache` collapses those to one lookup per
+// request. It is request-scoped — the cookie can't change mid-request — so there
+// is no cross-request staleness; login/logout land on a fresh request.
+export const getSession = cache(async (): Promise<Session | null> => {
   const token = await getSessionToken();
   if (!token) return null;
 
@@ -340,7 +346,7 @@ export async function getSession(): Promise<Session | null> {
     id: session.session_id,
     userId: session.user_id,
   };
-}
+});
 
 /**
  * Delete the session (logout): remove from DB and clear cookie.

--- a/src/server/db/queries/users.ts
+++ b/src/server/db/queries/users.ts
@@ -101,12 +101,15 @@ export async function getUserByPhone(phone: string) {
   return user ?? null;
 }
 
-export async function getUserById(id: string) {
+// Request-scoped memoization: the viewer's own user row is read by multiple
+// server components in a single render (page + nav + profile sections). `cache`
+// dedupes those to one query per request without any cross-request staleness.
+export const getUserById = cache(async (id: string) => {
   const user = await db.query.users.findFirst({
     where: eq(users.id, id),
   });
   return user ?? null;
-}
+});
 
 export function createUser(phone: string) {
   return db


### PR DESCRIPTION
- joshing-games answer route: defer creator SMS, played-state feed flip, and
  creator-facing activity writes into after() so the player's response only
  waits on grading; parallelize the two getSmsUser lookups.
- build-stream: kick off the dependent question-resolution batch as soon as
  friendCards+convergences resolve, overlapping the independent items/moments
  queries instead of gating the batch behind all four upstream reads.
- getSession / getUserById: wrap in React.cache for request-scoped dedup of
  the per-render repeated session + viewer-row lookups (no cross-request
  staleness — request-scoped only).
- /for-you, /from-friends, /activities: add loading.tsx skeletons matching
  each page shell so overflow pages no longer block on a blank screen.