### PR TITLE
feat(daily): honor domain frequency + cross-day variety in custom mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "pool:embed-backfill:apply": "tsx scripts/backfill-pool-embeddings.ts --apply",
     "knowledge:casing-backfill": "tsx scripts/backfill-domain-casing.ts",
     "knowledge:casing-backfill:apply": "tsx scripts/backfill-domain-casing.ts --apply",
+    "knowledge:broad-category-backfill": "tsx scripts/normalize-broad-category.ts",
+    "knowledge:broad-category-backfill:apply": "tsx scripts/normalize-broad-category.ts --apply",
     "format": "node scripts/format-changed.mjs",
     "format:all": "prettier --write ."
   },

--- a/scripts/normalize-broad-category.ts
+++ b/scripts/normalize-broad-category.ts
@@ -1,0 +1,68 @@
+// One-off backfill: fold existing GeneratedQuestion.broad_category and
+// Question.broad_category to their canonical form (Change 3). Idempotent — only
+// rows whose label actually changes are touched; re-running is a no-op.
+//
+// Usage:
+//   npx tsx scripts/normalize-broad-category.ts          # dry-run (what would change)
+//   npx tsx scripts/normalize-broad-category.ts --apply   # write the folds
+import 'dotenv/config';
+
+import { eq } from 'drizzle-orm';
+
+import { db, pool, generatedQuestions, questions } from '../src/server/db';
+import { normalizeBroadCategory } from '../src/server/questions/broad-category';
+
+const APPLY = process.argv.slice(2).includes('--apply');
+
+type TableName = 'GeneratedQuestion' | 'Question';
+
+async function foldTable(
+  name: TableName,
+  table: typeof generatedQuestions | typeof questions,
+): Promise<void> {
+  const rows = await db
+    .select({ broadCategory: table.broadCategory })
+    .from(table);
+
+  // Distinct label → normalized label, only where they differ.
+  const counts = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.broadCategory) continue;
+    counts.set(row.broadCategory, (counts.get(row.broadCategory) ?? 0) + 1);
+  }
+
+  const changes: Array<{ from: string; to: string; n: number }> = [];
+  for (const [label, n] of counts) {
+    const normalized = normalizeBroadCategory(label);
+    if (normalized !== label) changes.push({ from: label, to: normalized, n });
+  }
+  changes.sort((a, b) => b.n - a.n);
+
+  console.log(`\n[${name}] ${changes.length} label(s) would fold (${changes.reduce((s, c) => s + c.n, 0)} rows):`);
+  for (const c of changes) {
+    console.log(`  "${c.from}" → "${c.to}"  (${c.n} rows)`);
+  }
+
+  if (APPLY) {
+    for (const c of changes) {
+      await db.update(table).set({ broadCategory: c.to }).where(eq(table.broadCategory, c.from));
+    }
+    console.log(`[${name}] applied ${changes.length} fold(s).`);
+  }
+}
+
+async function main() {
+  console.log(`[normalize-broad-category] ${APPLY ? 'APPLY' : 'DRY RUN'} mode`);
+  await foldTable('GeneratedQuestion', generatedQuestions);
+  await foldTable('Question', questions);
+  if (!APPLY) console.log('\n[normalize-broad-category] dry run only — re-run with --apply to write.');
+}
+
+main()
+  .catch((err) => {
+    console.error('[normalize-broad-category] fatal:', err);
+    process.exitCode = 1;
+  })
+  .finally(async () => {
+    await pool.end();
+  });

--- a/src/server/daily/__tests__/domain-selection.test.ts
+++ b/src/server/daily/__tests__/domain-selection.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from 'vitest';
+
+import { domainKey } from '@/lib/knowledge/domain-key';
+import {
+  domainWeeklyCap,
+  selectCustomDomainsForRound,
+  weightedSampleWithoutReplacement,
+} from '@/server/daily/domain-selection';
+
+// Deterministic PRNG (mulberry32) so the statistical assertions below are
+// reproducible — no Math.random, no flake.
+function seeded(seed: number): () => number {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const recent = (entries: Record<string, number>): Map<string, number> => {
+  const m = new Map<string, number>();
+  for (const [domain, n] of Object.entries(entries)) m.set(domainKey(domain), n);
+  return m;
+};
+
+describe('weightedSampleWithoutReplacement', () => {
+  it('draws distinct items, clamped to availability', () => {
+    const items = ['a', 'b', 'c'].map((item) => ({ item, weight: 1 }));
+    const out = weightedSampleWithoutReplacement(items, 10, seeded(1));
+    expect(out).toHaveLength(3);
+    expect(new Set(out).size).toBe(3);
+  });
+
+  it('skips non-positive weights entirely', () => {
+    const items = [
+      { item: 'keep', weight: 1 },
+      { item: 'zero', weight: 0 },
+      { item: 'neg', weight: -3 },
+    ];
+    const out = weightedSampleWithoutReplacement(items, 5, seeded(2));
+    expect(out).toEqual(['keep']);
+  });
+
+  it('favors heavier items over many seeded draws', () => {
+    let heavyFirst = 0;
+    const TRIALS = 2000;
+    for (let i = 0; i < TRIALS; i += 1) {
+      const out = weightedSampleWithoutReplacement(
+        [
+          { item: 'heavy', weight: 9 },
+          { item: 'light', weight: 1 },
+        ],
+        1,
+        seeded(i + 1),
+      );
+      if (out[0] === 'heavy') heavyFirst += 1;
+    }
+    // ~90% expected; assert a comfortable majority to avoid flake.
+    expect(heavyFirst / TRIALS).toBeGreaterThan(0.8);
+  });
+});
+
+describe('selectCustomDomainsForRound', () => {
+  const freq: Record<string, string> = {
+    Often: 'often',
+    Sometimes: 'sometimes',
+    BlueMoon: 'blue_moon',
+  };
+  const domains = ['Often', 'Sometimes', 'BlueMoon'];
+
+  it('returns min(count, eligible) distinct domains', () => {
+    const out = selectCustomDomainsForRound(domains, freq, new Map(), 2, seeded(7));
+    expect(out).toHaveLength(2);
+    expect(new Set(out).size).toBe(2);
+    out.forEach((d) => expect(domains).toContain(d));
+  });
+
+  it('returns [] for an empty selection', () => {
+    expect(selectCustomDomainsForRound([], freq, new Map(), 5)).toEqual([]);
+  });
+
+  it('honors frequency tags proportionally (often > sometimes > blue_moon)', () => {
+    const picks: Record<string, number> = { Often: 0, Sometimes: 0, BlueMoon: 0 };
+    const TRIALS = 3000;
+    for (let i = 0; i < TRIALS; i += 1) {
+      // Pick ONE domain per round so the share reflects the weighting.
+      const [chosen] = selectCustomDomainsForRound(domains, freq, new Map(), 1, seeded(i + 1));
+      picks[chosen] += 1;
+    }
+    expect(picks.Often).toBeGreaterThan(picks.Sometimes);
+    expect(picks.Sometimes).toBeGreaterThan(picks.BlueMoon);
+  });
+
+  it('deprioritizes a domain mined hard this week (recency fold)', () => {
+    // Two equal-frequency domains; one already has 4 recent questions.
+    const f = { Fresh: 'sometimes', Hot: 'sometimes' };
+    const recentCounts = recent({ Hot: 4 });
+    let freshFirst = 0;
+    const TRIALS = 2000;
+    for (let i = 0; i < TRIALS; i += 1) {
+      const [chosen] = selectCustomDomainsForRound(['Fresh', 'Hot'], f, recentCounts, 1, seeded(i + 1));
+      if (chosen === 'Fresh') freshFirst += 1;
+    }
+    expect(freshFirst / TRIALS).toBeGreaterThan(0.6);
+  });
+
+  it('excludes a domain at its frequency-scaled weekly cap', () => {
+    // 'sometimes' cap is 3. Sometimes-domain already has 3 → excluded; a fresh
+    // 'often' domain is always chosen.
+    const f = { Capped: 'sometimes', Open: 'often' };
+    const recentCounts = recent({ Capped: 3 });
+    for (let i = 0; i < 50; i += 1) {
+      const out = selectCustomDomainsForRound(['Capped', 'Open'], f, recentCounts, 1, seeded(i + 1));
+      expect(out).toEqual(['Open']);
+    }
+  });
+
+  it('falls back to the full set when the cap would empty the palette', () => {
+    // Every domain is over its cap → starvation guard returns the uncapped set.
+    const f = { A: 'blue_moon', B: 'blue_moon' };
+    const recentCounts = recent({ A: 2, B: 5 });
+    const out = selectCustomDomainsForRound(['A', 'B'], f, recentCounts, 2, seeded(3));
+    expect(new Set(out)).toEqual(new Set(['A', 'B']));
+  });
+});
+
+describe('domainWeeklyCap', () => {
+  it('maps tags to caps and defaults untagged to the flat cap', () => {
+    expect(domainWeeklyCap('often')).toBe(7);
+    expect(domainWeeklyCap('sometimes')).toBe(3);
+    expect(domainWeeklyCap('blue_moon')).toBe(1);
+    expect(domainWeeklyCap(undefined)).toBe(5);
+    expect(domainWeeklyCap('garbage')).toBe(5);
+  });
+});

--- a/src/server/daily/domain-selection.ts
+++ b/src/server/daily/domain-selection.ts
@@ -1,0 +1,114 @@
+/**
+ * Pure domain-selection helpers (Change 1+2). No DB / LLM imports, so this is
+ * directly unit-testable and safe to load anywhere. generate-questions.ts wires
+ * these into the per-round palette; the orchestrator owns the intra-day cap.
+ */
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+// Historic flat weekly cap — still the default for UNTAGGED domains so this
+// doesn't silently tighten behavior for players who never set frequency tags.
+export const DOMAIN_PER_WEEK_CAP = 5;
+
+// Per-domain frequency knobs (Game settings: often / sometimes / blue_moon /
+// resting). 'resting' is filtered out upstream — it never reaches selection.
+//
+// Base sampling weight: how strongly a domain competes to be in a given day's
+// palette. 'often' draws ~2x a 'sometimes' domain, ~4x a 'blue_moon' one. Unset
+// is treated as 'sometimes' (the neutral middle).
+const DOMAIN_FREQUENCY_WEIGHT: Record<string, number> = {
+  often: 4,
+  sometimes: 2,
+  blue_moon: 1,
+};
+const DEFAULT_DOMAIN_WEIGHT = DOMAIN_FREQUENCY_WEIGHT.sometimes;
+
+// Frequency-scaled weekly cap: hard backstop on how many questions a single
+// domain may yield in the trailing 7 days, so a fact-rich domain can't dominate
+// the rotation regardless of sampling luck.
+const DOMAIN_WEEKLY_CAP_BY_FREQUENCY: Record<string, number> = {
+  often: 7,
+  sometimes: 3,
+  blue_moon: 1,
+};
+
+export function domainFrequencyWeight(frequency: string | undefined): number {
+  return (frequency && DOMAIN_FREQUENCY_WEIGHT[frequency]) || DEFAULT_DOMAIN_WEIGHT;
+}
+
+export function domainWeeklyCap(frequency: string | undefined): number {
+  return (frequency && DOMAIN_WEEKLY_CAP_BY_FREQUENCY[frequency]) || DOMAIN_PER_WEEK_CAP;
+}
+
+// Kill switch for the custom-mode weighted daily pick (Change 1+2). Defaults ON;
+// set CUSTOM_DOMAIN_WEIGHTING=0 (or false) to fall back to the prior
+// order-the-whole-list behavior without a redeploy. Mirrors isEmbeddingEnabled's
+// env-only gate.
+export function isCustomDomainWeightingEnabled(): boolean {
+  const raw = process.env.CUSTOM_DOMAIN_WEIGHTING?.trim().toLowerCase();
+  return raw !== '0' && raw !== 'false';
+}
+
+/**
+ * Weighted sample WITHOUT replacement: draw up to `count` distinct items, each
+ * item's chance of being drawn proportional to its weight. Non-positive weights
+ * are skipped. Deterministic only under a seeded `rng` (tests pass one); defaults
+ * to Math.random in production where per-day variety is the goal.
+ */
+export function weightedSampleWithoutReplacement<T>(
+  items: ReadonlyArray<{ item: T; weight: number }>,
+  count: number,
+  rng: () => number = Math.random,
+): T[] {
+  const pool = items.filter((entry) => entry.weight > 0).map((entry) => ({ ...entry }));
+  const picked: T[] = [];
+  while (picked.length < count && pool.length > 0) {
+    const total = pool.reduce((sum, entry) => sum + entry.weight, 0);
+    let threshold = rng() * total;
+    let index = 0;
+    for (; index < pool.length; index += 1) {
+      threshold -= pool[index].weight;
+      if (threshold <= 0) break;
+    }
+    const [chosen] = pool.splice(Math.min(index, pool.length - 1), 1);
+    picked.push(chosen.item);
+  }
+  return picked;
+}
+
+/**
+ * Custom-mode daily domain palette (Change 1+2). Replaces "order all 30 selected
+ * domains and let the LLM pick" — which gravitated to fact-rich domains and
+ * ignored the player's frequency tags — with a deterministic, frequency-weighted,
+ * recency-aware sample of just the day's domains. Handing generation a SHORT list
+ * (≈ the round's count) is what stops the model from over-mining the meaty few.
+ *
+ * Per domain: drop it if it already hit its frequency-scaled weekly cap, then
+ * weight it by `frequencyWeight / (1 + recentCount7d)` so a domain mined hard this
+ * week sinks and fresh ones rise (cross-day rotation). If the cap empties the set,
+ * fall back to the uncapped list rather than starve the queue.
+ */
+export function selectCustomDomainsForRound(
+  selectedDomains: string[],
+  frequencyByDomain: Record<string, string>,
+  recentCounts: ReadonlyMap<string, number>,
+  count: number,
+  rng: () => number = Math.random,
+): string[] {
+  if (selectedDomains.length === 0) return [];
+
+  const recentFor = (domain: string) => recentCounts.get(domainKey(domain)) ?? 0;
+  const underCap = (domain: string) =>
+    recentFor(domain) < domainWeeklyCap(frequencyByDomain[domain]);
+
+  // Apply the weekly cap, but never let it empty the palette (starvation guard).
+  const eligible = selectedDomains.some(underCap)
+    ? selectedDomains.filter(underCap)
+    : selectedDomains;
+
+  const weighted = eligible.map((domain) => ({
+    item: domain,
+    weight: domainFrequencyWeight(frequencyByDomain[domain]) / (1 + recentFor(domain)),
+  }));
+
+  return weightedSampleWithoutReplacement(weighted, count, rng);
+}

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -43,6 +43,12 @@ import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interes
 import { planFirstRunDomains } from '@/server/daily/first-run-seeding';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import { normalizeBroadCategory } from '@/server/questions/broad-category';
+import {
+  domainWeeklyCap,
+  isCustomDomainWeightingEnabled,
+  selectCustomDomainsForRound,
+} from '@/server/daily/domain-selection';
 import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/server/answers/canonical-answer';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { normalizeFactKey } from '@/server/questions/fact-key';
@@ -488,7 +494,10 @@ function parseBaseQuestion(item: unknown): LlmQuestion | null {
   if (!item || typeof item !== 'object') return null;
   const rec = item as Record<string, unknown>;
   const canonical = asString(rec.canonical_subcategory);
-  const broad = asString(rec.broad_category);
+  // Fold drifting LLM broad-category synonyms to one canonical bucket (Change 3)
+  // at the single point all generated rows enter the system, so every downstream
+  // write (generated row, canonical Question, analytics) sees the stable label.
+  const broad = normalizeBroadCategory(asString(rec.broad_category));
   const questionText = asString(rec.question_text);
   const answer = asString(rec.answer);
   const explainer = asString(rec.explainer);
@@ -1397,7 +1406,6 @@ export async function generateDailyQuestions(
 }
 
 const DECLARED_DOMAIN_WEIGHT = 0.5;
-const DOMAIN_PER_WEEK_CAP = 5;
 
 /**
  * Order a custom-mode domain list least-recently-generated first.
@@ -1433,14 +1441,16 @@ function selectDiverseDomains(
   knowledgeBase: Awaited<ReturnType<typeof getKnowledgeBase>>,
   count: number,
   recentCounts: ReadonlyMap<string, number> = new Map(),
+  frequencyByDomain: Record<string, string> = {},
 ): string[] {
-  // Apply the soft cap: drop any domain that has already produced
-  // DOMAIN_PER_WEEK_CAP questions in the last 7 days. If every domain is
-  // over cap, fall back to the full set rather than starve the queue.
+  // Apply the soft cap: drop any domain that has already produced its
+  // frequency-scaled weekly quota of questions in the last 7 days (Change 2).
+  // Untagged domains keep the historic flat DOMAIN_PER_WEEK_CAP. If every domain
+  // is over cap, fall back to the full set rather than starve the queue.
   // recentCounts is keyed by domainKey() (see getRecentDomainCounts); fold the
   // KB domain to the same key so spelling variants share one weekly tally.
   const overCap = (d: { domain: string }): boolean =>
-    (recentCounts.get(domainKey(d.domain)) ?? 0) >= DOMAIN_PER_WEEK_CAP;
+    (recentCounts.get(domainKey(d.domain)) ?? 0) >= domainWeeklyCap(frequencyByDomain[d.domain]);
   const eligibleKb = knowledgeBase.some((d) => !overCap(d))
     ? knowledgeBase.filter((d) => !overCap(d))
     : knowledgeBase;
@@ -1448,7 +1458,7 @@ function selectDiverseDomains(
   // Group by broad category so we can pick one domain per category
   const byCategory = new Map<string, (typeof eligibleKb)[number][]>();
   for (const d of eligibleKb) {
-    const cat = d.broadCategory ?? 'General Knowledge';
+    const cat = normalizeBroadCategory(d.broadCategory) ?? 'General Knowledge';
     const arr = byCategory.get(cat) ?? [];
     arr.push(d);
     byCategory.set(cat, arr);
@@ -1543,23 +1553,36 @@ export async function generateDailyQuestionsFromKnowledgeBase(
     // Leading with the least-mined domains steers generation (and the bank-pick
     // pass, which walks this list in order) toward the picks that still have
     // unseen facts, keeping the queue full and the rotation honest.
-    const ordered = orderCustomDomainsByLeastRecent(
-      preferences.selectedDomains.filter((domain) => allDomains.includes(domain)),
-      recentDomainCounts,
-    );
+    const selectable = preferences.selectedDomains.filter((domain) => allDomains.includes(domain));
     const frequencyByDomain = preferences.domainPreferenceFrequency ?? {};
-    // Order most-wanted first so generation (which walks this list) favors them:
-    // 'often' leads, 'sometimes' (and unset) in the middle, 'blue_moon' trails so
-    // those domains are drawn least. 'resting' never reaches here — it's filtered
-    // out of selectedDomains upstream.
-    const frequencyRank = (domain: string) => {
-      const frequency = frequencyByDomain[domain];
-      if (frequency === 'often') return 0;
-      if (frequency === 'blue_moon') return 2;
-      return 1;
-    };
-    const weightedOrder = [...ordered].sort((a, b) => frequencyRank(a) - frequencyRank(b));
-    domainsForRound = weightedOrder.length > 0 ? weightedOrder : allDomains;
+    if (isCustomDomainWeightingEnabled()) {
+      // Change 1+2: deterministic, frequency-weighted, recency-aware sample of
+      // just the day's domains. Handing generation a SHORT palette (≈ count) is
+      // what stops the model gravitating to the fact-rich few and finally makes
+      // the 'often'/'sometimes'/'blue_moon' tags proportionally honored across
+      // days. Falls back to the full set inside the helper if the weekly cap
+      // would otherwise empty the palette.
+      const sampled = selectCustomDomainsForRound(
+        selectable,
+        frequencyByDomain,
+        recentDomainCounts,
+        count,
+      );
+      domainsForRound = sampled.length > 0 ? sampled : (selectable.length > 0 ? selectable : allDomains);
+    } else {
+      // Legacy path (CUSTOM_DOMAIN_WEIGHTING=0): order the WHOLE list least-recent
+      // first, then by frequency rank, and hand it all to generation. Kept as an
+      // instant, no-redeploy rollback for the weighted pick above.
+      const ordered = orderCustomDomainsByLeastRecent(selectable, recentDomainCounts);
+      const frequencyRank = (domain: string) => {
+        const frequency = frequencyByDomain[domain];
+        if (frequency === 'often') return 0;
+        if (frequency === 'blue_moon') return 2;
+        return 1;
+      };
+      const weightedOrder = [...ordered].sort((a, b) => frequencyRank(a) - frequencyRank(b));
+      domainsForRound = weightedOrder.length > 0 ? weightedOrder : allDomains;
+    }
   } else {
     // Random mode: pick one domain per category for cross-category variety,
     // with a soft per-domain frequency cap applied via recentDomainCounts.
@@ -1594,7 +1617,7 @@ export async function generateDailyQuestionsFromKnowledgeBase(
 
     domainsForRound = firstRunPlan.length > 0
       ? firstRunPlan
-      : selectDiverseDomains(eligibleKb, count, recentDomainCounts);
+      : selectDiverseDomains(eligibleKb, count, recentDomainCounts, frequencyByDomain);
   }
 
   const domainDifficultyOverrides = preferences.difficulty === 'adaptive'

--- a/src/server/questions/__tests__/broad-category.test.ts
+++ b/src/server/questions/__tests__/broad-category.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { normalizeBroadCategory } from '@/server/questions/broad-category';
+
+describe('normalizeBroadCategory', () => {
+  it('folds known Literature synonyms onto one canonical label', () => {
+    expect(normalizeBroadCategory('Literature & Drama')).toBe('Literature');
+    expect(normalizeBroadCategory('Literature & Poetry')).toBe('Literature');
+    expect(normalizeBroadCategory('Fiction & Literature')).toBe('Literature');
+    expect(normalizeBroadCategory('Literature')).toBe('Literature');
+  });
+
+  it('folds Theater / Musical Theatre variants', () => {
+    expect(normalizeBroadCategory('Musical Theater')).toBe('Theater & Musicals');
+    expect(normalizeBroadCategory('Musical Theatre')).toBe('Theater & Musicals');
+    expect(normalizeBroadCategory('Theater')).toBe('Theater & Musicals');
+  });
+
+  it('folds Film / Television variants', () => {
+    expect(normalizeBroadCategory('Television')).toBe('Film & Television');
+    expect(normalizeBroadCategory('Television & Animation')).toBe('Film & Television');
+    expect(normalizeBroadCategory('Film & Television')).toBe('Film & Television');
+  });
+
+  it('folds Classical Music variants', () => {
+    expect(normalizeBroadCategory('Classical Music & Opera')).toBe('Classical Music');
+    expect(normalizeBroadCategory('Classical Music')).toBe('Classical Music');
+  });
+
+  it('normalizes " and " to " & " and collapses whitespace/case for aliases', () => {
+    expect(normalizeBroadCategory('literature  and   drama')).toBe('Literature');
+    expect(normalizeBroadCategory('  Musical   Theatre ')).toBe('Theater & Musicals');
+  });
+
+  it('passes unknown labels through with only cosmetic normalization', () => {
+    expect(normalizeBroadCategory('Science & Nature')).toBe('Science & Nature');
+    expect(normalizeBroadCategory('Science  and  Nature')).toBe('Science & Nature');
+    expect(normalizeBroadCategory('Sports')).toBe('Sports');
+    // Genuinely distinct categories are never guessed into a merge.
+    expect(normalizeBroadCategory('Botany & Plant Science')).toBe('Botany & Plant Science');
+  });
+
+  it('leaves null / undefined / blank untouched', () => {
+    expect(normalizeBroadCategory(null)).toBeNull();
+    expect(normalizeBroadCategory(undefined)).toBeUndefined();
+    expect(normalizeBroadCategory('')).toBe('');
+  });
+});

--- a/src/server/questions/broad-category.ts
+++ b/src/server/questions/broad-category.ts
@@ -1,0 +1,63 @@
+/**
+ * Broad-category normalization (Change 3).
+ *
+ * `broad_category` on generated/canonical questions is FREE-FORM LLM output — the
+ * model emits drifting synonyms for the same bucket ("Literature" vs
+ * "Literature & Drama" vs "Literature & Poetry"; "Musical Theatre" vs
+ * "Theater & Musicals"). That fragments the one-domain-per-category diversity
+ * grouping in selectDiverseDomains and muddies per-category analytics.
+ *
+ * There is no authoritative broad-category taxonomy in this repo, so this is a
+ * deliberately CONSERVATIVE fold: it (a) canonicalizes whitespace, ampersands and
+ * casing, then (b) maps a small set of obviously-equivalent labels onto one
+ * canonical form. Anything not in the alias map passes through with only the
+ * cosmetic normalization applied — we never guess at merging genuinely-distinct
+ * categories (e.g. "Science & Nature" is left alone, not folded into "Botany").
+ */
+
+/** Cosmetic pass: trim, collapse internal whitespace, normalize " and " → " & ". */
+function canonicalizeShape(value: string): string {
+  return value
+    .replace(/\s+/g, ' ')
+    .trim()
+    .replace(/\s*&\s*/g, ' & ')
+    .replace(/\s+and\s+/gi, ' & ');
+}
+
+// Alias map keyed by the lowercased, shape-canonicalized label → canonical label.
+// Keep additions to clearly-equivalent variants only.
+const BROAD_CATEGORY_ALIASES: Record<string, string> = {
+  // Literature family
+  'literature & drama': 'Literature',
+  'literature & poetry': 'Literature',
+  'fiction & literature': 'Literature',
+  'literature & fiction': 'Literature',
+  'drama & literature': 'Literature',
+  // Theater / musical theater family
+  'musical theater': 'Theater & Musicals',
+  'musical theatre': 'Theater & Musicals',
+  'theater': 'Theater & Musicals',
+  'theatre': 'Theater & Musicals',
+  'theater & musicals': 'Theater & Musicals',
+  'theatre & musicals': 'Theater & Musicals',
+  // Film / television family
+  'television': 'Film & Television',
+  'film & tv': 'Film & Television',
+  'tv & film': 'Film & Television',
+  'television & animation': 'Film & Television',
+  'film & television': 'Film & Television',
+  // Classical music family
+  'classical music & opera': 'Classical Music',
+  'classical music': 'Classical Music',
+};
+
+/**
+ * Fold a broad-category label to its canonical form. Null/blank/undefined pass
+ * through unchanged (callers decide the fallback bucket).
+ */
+export function normalizeBroadCategory<T extends string | null | undefined>(value: T): T {
+  if (!value) return value;
+  const shaped = canonicalizeShape(value);
+  const alias = BROAD_CATEGORY_ALIASES[shaped.toLowerCase()];
+  return (alias ?? shaped) as T;
+}


### PR DESCRIPTION
Custom-mode Daily Five handed all selected domains to the generator with no weekly cap; the LLM gravitated to fact-rich domains, so "sometimes"-tagged Shakespeare/Opera/Sondheim dominated while "often"-tagged domains were starved.

- Change 1: selectCustomDomainsForRound() weighted-samples just the day's palette (frequency weight over 1 + recentCount7d) and hands generation a SHORT list so it can no longer over-mine the meaty few.
- Change 2: frequency-scaled weekly cap (often=7/sometimes=3/blue_moon=1); untagged keeps the historic flat 5. Applied in custom + random selection with a starvation fallback.
- Change 3: normalizeBroadCategory() folds drifting LLM broad_category synonyms at the parse choke point + diversity grouping; backfill script for old rows.

Gated behind CUSTOM_DOMAIN_WEIGHTING (default on; =0 reverts without redeploy). Pure helpers extracted to domain-selection.ts. 25 new tests, tsc clean.