### PR TITLE
B-CATEGORY-AUTHORED-RECONCILE-01 follow-up: telemetry aggregator + Phase 2 flag-on

### DIFF
--- a/scripts/authored-reconcile-telemetry.mjs
+++ b/scripts/authored-reconcile-telemetry.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// B-CATEGORY-AUTHORED-RECONCILE-01 — Phase 2 gate aggregator.
+//
+// The authored path shadow-logs one line per authored question (flag-off):
+//   [questions/authored-reconcile] {"proposed":"Hamlet","reconciled":"…",…}
+// (src/app/api/questions/route.ts). The payload is a JSON string by design, so
+// this script can parse exported logs deterministically — no util.inspect
+// guessing. It summarizes how bad the pre-fix duplication is so the Phase 2
+// flag flip is a data-backed decision, not a guess.
+//
+// Usage:
+//   vercel logs <deployment> | node scripts/authored-reconcile-telemetry.mjs
+//   node scripts/authored-reconcile-telemetry.mjs path/to/exported-logs.txt
+//   cat logs/*.ndjson | node scripts/authored-reconcile-telemetry.mjs --json
+//
+// Input is line-oriented text from ANY source. Each line is scanned for the
+// marker; everything from the first '{' after it to the matching end is parsed
+// as JSON. Lines that are themselves JSON log objects (Vercel log drains wrap
+// the console output in a `message` field) are unwrapped first via --json or
+// auto-detected. Non-matching lines are ignored.
+
+import { readFileSync } from 'node:fs';
+
+const MARKER = '[questions/authored-reconcile]';
+
+const args = process.argv.slice(2);
+const forceJson = args.includes('--json');
+const topN = (() => {
+  const i = args.indexOf('--top');
+  const n = i >= 0 ? Number(args[i + 1]) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : 15;
+})();
+const fileArg = args.find((a) => !a.startsWith('--') && a !== String(topN));
+
+function readInput() {
+  if (fileArg) return readFileSync(fileArg, 'utf8');
+  try {
+    return readFileSync(0, 'utf8'); // stdin
+  } catch {
+    return '';
+  }
+}
+
+// Pull the JSON object that follows the marker out of one raw log line. Log
+// drains often wrap the line as {"message":"[…] {…}"} — when the line parses as
+// JSON with a string `message`, recurse into it. Brace-matching (not greedy to
+// end-of-line) so trailing log decoration after the object is tolerated.
+function extractPayload(line, allowUnwrap = true) {
+  // A fully-JSON line is a log-drain record that wraps the console output in a
+  // `message`/`text`/`log` field — unwrap it FIRST, before trying to brace-match
+  // the (escaped) inner payload, which would otherwise fail to parse.
+  if (allowUnwrap) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith('{')) {
+      try {
+        const rec = JSON.parse(trimmed);
+        const msg = typeof rec?.message === 'string' ? rec.message
+          : typeof rec?.text === 'string' ? rec.text
+            : typeof rec?.log === 'string' ? rec.log : null;
+        if (msg) return extractPayload(msg, false);
+      } catch {
+        // Not a wrapper record — fall through to plain marker extraction.
+      }
+    }
+  }
+  const markerAt = line.indexOf(MARKER);
+  if (markerAt < 0) return null;
+  const braceAt = line.indexOf('{', markerAt);
+  if (braceAt < 0) return null;
+  // Scan to the matching close brace, respecting strings/escapes.
+  let depth = 0;
+  let inStr = false;
+  let esc = false;
+  for (let i = braceAt; i < line.length; i++) {
+    const ch = line[i];
+    if (esc) { esc = false; continue; }
+    if (ch === '\\') { esc = true; continue; }
+    if (ch === '"') { inStr = !inStr; continue; }
+    if (inStr) continue;
+    if (ch === '{') depth++;
+    else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        const slice = line.slice(braceAt, i + 1);
+        try { return JSON.parse(slice); } catch { return null; }
+      }
+    }
+  }
+  return null;
+}
+
+function pct(n, d) {
+  if (!d) return '0.0%';
+  return `${((n / d) * 100).toFixed(1)}%`;
+}
+
+function topEntries(map, n) {
+  return [...map.entries()].sort((a, b) => b[1] - a[1]).slice(0, n);
+}
+
+const input = readInput();
+const lines = input.split(/\r?\n/);
+
+let total = 0;
+let differs = 0;
+let applied = 0;
+let tooGeneric = 0;
+const byMethod = new Map();        // method -> count
+const foldPairs = new Map();       // "proposed → reconciled" -> count (only when differs)
+const fuzzyNearMiss = new Map();   // similarity band -> count (fuzzy candidates on a non-fold)
+let withFuzzy = 0;
+let malformed = 0;
+
+for (const line of lines) {
+  if (!line.includes(MARKER) && !forceJson && !line.trim().startsWith('{')) continue;
+  const p = extractPayload(line);
+  if (!p) {
+    if (line.includes(MARKER)) malformed++;
+    continue;
+  }
+  total++;
+  byMethod.set(p.method ?? 'unknown', (byMethod.get(p.method ?? 'unknown') ?? 0) + 1);
+  if (p.differs) {
+    differs++;
+    foldPairs.set(`${p.proposed} → ${p.reconciled}`, (foldPairs.get(`${p.proposed} → ${p.reconciled}`) ?? 0) + 1);
+  }
+  if (p.applied) applied++;
+  if (p.reconciledTooGeneric) tooGeneric++;
+  if (Array.isArray(p.trgmFuzzy) && p.trgmFuzzy.length > 0) {
+    withFuzzy++;
+    if (!p.differs) {
+      // Near-misses we deliberately did NOT auto-fold — useful for threshold tuning.
+      const best = Math.max(...p.trgmFuzzy.map((c) => Number(c.similarity) || 0));
+      const band = best >= 0.8 ? '≥0.80' : best >= 0.7 ? '0.70–0.79' : best >= 0.6 ? '0.60–0.69' : '<0.60';
+      fuzzyNearMiss.set(band, (fuzzyNearMiss.get(band) ?? 0) + 1);
+    }
+  }
+}
+
+if (total === 0) {
+  console.error(`No "${MARKER}" records found in input.`);
+  console.error('Pipe Vercel/exported logs in, or pass a log file path. Try --json for log-drain NDJSON.');
+  process.exit(1);
+}
+
+const out = [];
+out.push(`\n${MARKER} — Phase 2 gate summary`);
+out.push('='.repeat(52));
+out.push(`authored questions logged : ${total}`);
+out.push(`would fold (differs=true) : ${differs}  (${pct(differs, total)})   ← duplication being closed`);
+out.push(`actually applied          : ${applied}  (${pct(applied, total)})   ← nonzero only once the flag is ON`);
+out.push(`reconciled-too-generic    : ${tooGeneric}  (guard fall-through; expect ~0)`);
+if (malformed > 0) out.push(`malformed marker lines    : ${malformed}  (skipped)`);
+
+out.push('\nmethod histogram');
+out.push('-'.repeat(52));
+for (const [method, count] of topEntries(byMethod, 10)) {
+  out.push(`  ${method.padEnd(12)} ${String(count).padStart(6)}  ${pct(count, total)}`);
+}
+
+out.push(`\ntop folds (proposed → reconciled), n=${topN}`);
+out.push('-'.repeat(52));
+if (foldPairs.size === 0) {
+  out.push('  (none — no folds observed)');
+} else {
+  for (const [pair, count] of topEntries(foldPairs, topN)) {
+    out.push(`  ${String(count).padStart(4)} × ${pair}`);
+  }
+}
+
+if (fuzzyNearMiss.size > 0) {
+  out.push('\ntrgm fuzzy near-misses on non-folds (threshold-tuning signal)');
+  out.push('-'.repeat(52));
+  for (const band of ['≥0.80', '0.70–0.79', '0.60–0.69', '<0.60']) {
+    if (fuzzyNearMiss.has(band)) out.push(`  ${band.padEnd(12)} ${String(fuzzyNearMiss.get(band)).padStart(6)}`);
+  }
+  out.push(`  (${withFuzzy} records carried fuzzy candidates total)`);
+}
+
+out.push('');
+console.log(out.join('\n'));

--- a/src/app/api/questions/__tests__/route.test.ts
+++ b/src/app/api/questions/__tests__/route.test.ts
@@ -676,9 +676,10 @@ describe('POST /api/questions authored domain reconcile (B-CATEGORY-AUTHORED-REC
     // Flag off → the blind label is still what gets written.
     const createArgs = createQuestionMock.mock.calls[0]?.[0] as { canonicalSubcategory: string }
     expect(createArgs.canonicalSubcategory).toBe('Hamlet')
-    // …but the shadow-log records what the fold WOULD have been.
+    // …but the shadow-log records what the fold WOULD have been. The payload is
+    // a JSON string (deterministically parseable from exported logs).
     const shadowLog = infoSpy.mock.calls.find((c) => c[0] === '[questions/authored-reconcile]')
-    expect(shadowLog?.[1]).toMatchObject({
+    expect(JSON.parse(shadowLog?.[1] as string)).toMatchObject({
       proposed: 'Hamlet',
       reconciled: 'Shakespearean Tragedy',
       differs: true,

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -166,7 +166,10 @@ export async function POST(request: NextRequest) {
   const reconciledTooGeneric =
     reconcileOutcome.differs && isGenericSubcategory(reconcileOutcome.canonicalDomain);
   const applyReconcile = reconcileFlagEnabled && reconcileOutcome.differs && !reconciledTooGeneric;
-  console.info('[questions/authored-reconcile]', {
+  // Emitted as a JSON string (not the inspected-object form) so the Phase 2
+  // gate aggregator can parse it deterministically from exported logs — see
+  // scripts/authored-reconcile-telemetry.mjs.
+  console.info('[questions/authored-reconcile]', JSON.stringify({
     userId: session.userId,
     proposed: normalizedSubcategory,
     reconciled: reconcileOutcome.canonicalDomain,
@@ -178,7 +181,7 @@ export async function POST(request: NextRequest) {
     flagEnabled: reconcileFlagEnabled,
     reconciledTooGeneric,
     applied: applyReconcile,
-  });
+  }));
   // broad_category is intentionally kept from the categorizer (matches the
   // generated path, which swaps only the domain label on reconcile); reconcile
   // does not emit a broad category.

--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -155,9 +155,9 @@ export async function POST(request: NextRequest) {
   // domain (C: trgm-exact first, Haiku on miss; silent) so an authored "Hamlet"
   // reuses the player's "Shakespearean Tragedy" instead of minting a sibling.
   //
-  // Phase 1 ships flag-OFF: we ALWAYS compute + shadow-log the outcome to
-  // quantify pre-fix duplication, but only ADOPT it when RECONCILE_AUTHORED_DOMAINS
-  // is enabled — flag-off is a strict no-op on the written label.
+  // We ALWAYS compute + shadow-log the outcome (telemetry on every authored
+  // question). Phase 2: RECONCILE_AUTHORED_DOMAINS now defaults ON, so the
+  // reconciled label is also ADOPTED; set it falsey to revert to log-only.
   const reconcileOutcome = await reconcileAuthoredDomain(normalizedSubcategory, session.userId);
   const reconcileFlagEnabled = isReconcileAuthoredDomainsEnabled();
   // Preserve the F4.5 write-boundary guard: never adopt a reconciled label the

--- a/src/server/questions/__tests__/reconcile-authored-domain.test.ts
+++ b/src/server/questions/__tests__/reconcile-authored-domain.test.ts
@@ -93,14 +93,18 @@ describe('reconcileAuthoredDomain', () => {
     expect(outcome.method).toBe('none');
   });
 
-  it('reads the RECONCILE_AUTHORED_DOMAINS flag with the repo boolean convention', () => {
+  it('defaults the RECONCILE_AUTHORED_DOMAINS flag ON (Phase 2), with explicit falsey opt-out', () => {
+    // Graduated to default-on: unset / empty / any non-falsey value enables.
     vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', '');
-    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
-    for (const truthy of ['true', '1', 'yes', 'on', 'TRUE']) {
+    expect(isReconcileAuthoredDomainsEnabled()).toBe(true);
+    for (const truthy of ['true', '1', 'yes', 'on', 'TRUE', 'anything']) {
       vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', truthy);
       expect(isReconcileAuthoredDomainsEnabled()).toBe(true);
     }
-    vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', 'false');
-    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
+    // Only an explicit falsey value disables (the production revert lever).
+    for (const falsey of ['false', '0', 'no', 'off', 'FALSE']) {
+      vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', falsey);
+      expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
+    }
   });
 });

--- a/src/server/questions/reconcile-authored-domain.ts
+++ b/src/server/questions/reconcile-authored-domain.ts
@@ -53,13 +53,18 @@ export type AuthoredReconcileOutcome = {
 };
 
 /**
- * Phase 1 ships flag-OFF: the authored path always COMPUTES + shadow-logs this
- * outcome (to quantify pre-fix duplication) but only ADOPTS it when this flag is
- * enabled. Mirrors the boolean-env convention in create-payload.ts.
+ * Phase 2 (B-CATEGORY-AUTHORED-RECONCILE-01): the flag has GRADUATED to default
+ * ON — the authored path now adopts the reconciled domain (folding an authored
+ * "Hamlet" onto the player's existing "Shakespearean Tragedy" instead of minting
+ * a sibling). The shadow-log still fires on every authored question regardless.
+ * Set RECONCILE_AUTHORED_DOMAINS to a falsey value (false/0/no/off) to disable —
+ * the revert lever if a bad fold surfaces in production. Mirrors the boolean-env
+ * convention in create-payload.ts, inverted to default-on.
  */
 export function isReconcileAuthoredDomainsEnabled(): boolean {
   const raw = process.env.RECONCILE_AUTHORED_DOMAINS?.trim().toLowerCase();
-  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+  if (raw === undefined || raw === '') return true;
+  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
 }
 
 export async function reconcileAuthoredDomain(


### PR DESCRIPTION
Follow-up to #901 (Phase 1, already merged into `dev2`). Two discrete, independently revertable commits on the same branch:

### 1. Telemetry — structured shadow-log + Phase 2 gate aggregator (`95ce435`)
- The `[questions/authored-reconcile]` payload is now emitted as a **JSON string** instead of the inspected-object form, so exported logs parse deterministically (no `util.inspect` single-quote/unquoted-key guessing). #901 shipped the object form, so this is worth landing before traffic accumulates.
- **`scripts/authored-reconcile-telemetry.mjs`** — reads piped/exported logs (plain text **or** log-drain NDJSON wrappers) and reports: would-fold (`differs`) rate, method histogram (`trgm-exact` / `llm` / `none`), top `proposed → reconciled` folds, `applied` count, guard fall-through count, and trgm fuzzy near-miss bands for threshold tuning.

### 2. Phase 2 — graduate `RECONCILE_AUTHORED_DOMAINS` to default-ON (`ecc7200`)
- Flips the authored path from shadow-only to **live**: the reconciled canonical domain is what gets written, so an authored "Hamlet" folds onto the player's existing "Shakespearean Tragedy" instead of minting a sibling.
- The apply path + write-boundary-guard fall-through already shipped (gated) in Phase 1 — this commit **only inverts the flag default**.
- **Revert lever:** set `RECONCILE_AUTHORED_DOMAINS` to a falsey value (`false`/`0`/`no`/`off`) to disable, no redeploy of code needed.
- Shadow-log still fires on every authored question regardless of the flag.

## ⚠️ Gate note — read before merging commit 2
The prompt makes **shadow-log review the Phase 2 gate**. No deployment traffic has been observed yet (Phase 1 only just merged), so commit `ecc7200` is the *ready-to-merge* flip, not a flip backed by data. Recommended sequencing:

1. Merge **commit 1 (telemetry)** now — safe, no behavior change.
2. Let deployed Phase 1 accumulate `[questions/authored-reconcile]` logs; run `scripts/authored-reconcile-telemetry.mjs` over them.
3. If the `differs` rate and fold quality look right, merge/deploy **commit 2** (or just keep `RECONCILE_AUTHORED_DOMAINS` unset, since it now defaults on). If you'd rather hold commit 2, I can split it into its own PR.

I have **not** merged anything — sequencing is yours.

## Verification
- 24 tests pass; `tsc` + `eslint` clean.
- Phase 2 write-path assertions (written `canonical_subcategory` equals the existing domain; KB domain opened on the reconciled label) already exist in the route test from Phase 1.
- Flag-reader unit test updated for the inverted default (unset/empty/non-falsey → on; explicit falsey → off).
- Phase 3 consumer trace (no credit split) documented in #901 and unchanged.

https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt)_