### PR TITLE
Revert Phase 2 (RECONCILE_AUTHORED_DOMAINS default-on) — hold until shadow-log gate

### DIFF
--- a/src/app/api/questions/route.ts
+++ b/src/app/api/questions/route.ts
@@ -155,9 +155,9 @@ export async function POST(request: NextRequest) {
   // domain (C: trgm-exact first, Haiku on miss; silent) so an authored "Hamlet"
   // reuses the player's "Shakespearean Tragedy" instead of minting a sibling.
   //
-  // We ALWAYS compute + shadow-log the outcome (telemetry on every authored
-  // question). Phase 2: RECONCILE_AUTHORED_DOMAINS now defaults ON, so the
-  // reconciled label is also ADOPTED; set it falsey to revert to log-only.
+  // Phase 1 ships flag-OFF: we ALWAYS compute + shadow-log the outcome to
+  // quantify pre-fix duplication, but only ADOPT it when RECONCILE_AUTHORED_DOMAINS
+  // is enabled — flag-off is a strict no-op on the written label.
   const reconcileOutcome = await reconcileAuthoredDomain(normalizedSubcategory, session.userId);
   const reconcileFlagEnabled = isReconcileAuthoredDomainsEnabled();
   // Preserve the F4.5 write-boundary guard: never adopt a reconciled label the

--- a/src/server/questions/__tests__/reconcile-authored-domain.test.ts
+++ b/src/server/questions/__tests__/reconcile-authored-domain.test.ts
@@ -93,18 +93,14 @@ describe('reconcileAuthoredDomain', () => {
     expect(outcome.method).toBe('none');
   });
 
-  it('defaults the RECONCILE_AUTHORED_DOMAINS flag ON (Phase 2), with explicit falsey opt-out', () => {
-    // Graduated to default-on: unset / empty / any non-falsey value enables.
+  it('reads the RECONCILE_AUTHORED_DOMAINS flag with the repo boolean convention', () => {
     vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', '');
-    expect(isReconcileAuthoredDomainsEnabled()).toBe(true);
-    for (const truthy of ['true', '1', 'yes', 'on', 'TRUE', 'anything']) {
+    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
+    for (const truthy of ['true', '1', 'yes', 'on', 'TRUE']) {
       vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', truthy);
       expect(isReconcileAuthoredDomainsEnabled()).toBe(true);
     }
-    // Only an explicit falsey value disables (the production revert lever).
-    for (const falsey of ['false', '0', 'no', 'off', 'FALSE']) {
-      vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', falsey);
-      expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
-    }
+    vi.stubEnv('RECONCILE_AUTHORED_DOMAINS', 'false');
+    expect(isReconcileAuthoredDomainsEnabled()).toBe(false);
   });
 });

--- a/src/server/questions/reconcile-authored-domain.ts
+++ b/src/server/questions/reconcile-authored-domain.ts
@@ -53,18 +53,13 @@ export type AuthoredReconcileOutcome = {
 };
 
 /**
- * Phase 2 (B-CATEGORY-AUTHORED-RECONCILE-01): the flag has GRADUATED to default
- * ON — the authored path now adopts the reconciled domain (folding an authored
- * "Hamlet" onto the player's existing "Shakespearean Tragedy" instead of minting
- * a sibling). The shadow-log still fires on every authored question regardless.
- * Set RECONCILE_AUTHORED_DOMAINS to a falsey value (false/0/no/off) to disable —
- * the revert lever if a bad fold surfaces in production. Mirrors the boolean-env
- * convention in create-payload.ts, inverted to default-on.
+ * Phase 1 ships flag-OFF: the authored path always COMPUTES + shadow-logs this
+ * outcome (to quantify pre-fix duplication) but only ADOPTS it when this flag is
+ * enabled. Mirrors the boolean-env convention in create-payload.ts.
  */
 export function isReconcileAuthoredDomainsEnabled(): boolean {
   const raw = process.env.RECONCILE_AUTHORED_DOMAINS?.trim().toLowerCase();
-  if (raw === undefined || raw === '') return true;
-  return !(raw === 'false' || raw === '0' || raw === 'no' || raw === 'off');
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
 }
 
 export async function reconcileAuthoredDomain(


### PR DESCRIPTION
## Revert Phase 2 — hold the flag flip until the shadow-log gate is reviewed

PR #906 merged the full reconcile branch into `dev2`, which **included the Phase 2 commit (`ecc7200`)** that graduated `RECONCILE_AUTHORED_DOMAINS` to **default-ON**. That was premature: the Phase 2 flip is gated on reviewing the shadow-log data first, and no data has been collected yet. With it on, the authored path would start **writing** reconciled labels — including any wrong folds — before the gate review.

This reverts only `ecc7200`, restoring the flag to **default-OFF**. It keeps **Phase 1 + telemetry** intact (both already in `dev2`):

- The `[questions/authored-reconcile]` shadow-log still fires on **every** authored question — it does not depend on the flag — so we keep collecting the `differs` rate + fold-quality data with no loss.
- The authored path goes back to writing the **blind** label (no reconciled write applied), which is the intended pre-gate behavior.

### What this restores
- `isReconcileAuthoredDomainsEnabled()` → default OFF (only an explicit truthy `RECONCILE_AUTHORED_DOMAINS` enables it).
- The route + module comments back to the Phase 1 ("flag-OFF") wording.
- The flag unit test back to the default-off expectation.

### Re-enabling later (the actual Phase 2)
Once enough shadow-log data is in and the folds look correct, flip it back on — either by re-applying the Phase 2 graduation, or simply by setting `RECONCILE_AUTHORED_DOMAINS=true` in the deployed env.

Tests (24) pass; `tsc` + `eslint` clean.

https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt

---
_Generated by [Claude Code](https://claude.ai/code/session_019RXhFG7Sz5EFP221teSKDt)_