### PR TITLE
Redesign daily reminder email as a quiet editorial note

### DIFF
--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -14,6 +14,8 @@ import { isCronAuthorized } from '@/server/auth/cron';
 import { sendSms } from '@/server/sms';
 import { sendEmail } from '@/server/email/client';
 import { buildDailyReminderTemplate } from '@/server/email/templates/daily-reminder';
+import { formatActivityForEmail, topicsForReminder } from '@/server/email/daily-reminder-data';
+import { getRecentActivityForHome } from '@/server/db/queries/activity';
 
 export const dynamic = 'force-dynamic';
 // Scheduled at 17:05 UTC by GitHub Actions (.github/workflows/external-crons.yml)
@@ -124,14 +126,21 @@ export async function GET(request: NextRequest) {
       // already finished today is skipped. sendEmail never throws (returns a
       // discriminated union), so a provider failure counts as a skipped email.
       if (queue && user.emailOptIn === 'opted_in' && user.emailVerified && user.email) {
-        const teaserSlot = asQueueSlots(queue.slots).find(
+        const slots = asQueueSlots(queue.slots);
+        const teaserSlot = slots.find(
           (slot) => !slot.answered && !slot.skipped && slot.question_text,
         );
         // Claim before send so concurrent retries race on the DB, not the
         // provider; a losing claim (already sent today) skips silently.
         if (teaserSlot && (await claimDailyEmailReminder(queue.id))) {
+          // Quiet, people-first "Meanwhile" lines from the same home-eligible
+          // activity Home surfaces; empty → the section is omitted downstream.
+          const activity = formatActivityForEmail(await getRecentActivityForHome(user.id, 3));
           const template = buildDailyReminderTemplate({
             dailyUrl: `${baseUrl}/daily`,
+            interestsUrl: `${baseUrl}/daily/setup`,
+            topics: topicsForReminder(slots),
+            activity,
             teaser: { questionText: teaserSlot.question_text, domain: teaserSlot.domain },
           });
           const emailResult = await sendEmail({

--- a/src/server/email/__tests__/daily-reminder.test.ts
+++ b/src/server/email/__tests__/daily-reminder.test.ts
@@ -1,0 +1,181 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildDailyReminderTemplate } from '@/server/email/templates/daily-reminder';
+import { formatActivityForEmail, topicsForReminder } from '@/server/email/daily-reminder-data';
+import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { QueueSlot } from '@/server/daily/types';
+
+function slot(partial: Partial<QueueSlot>): QueueSlot {
+  return {
+    domain: 'Trivia',
+    question_text: 'A question?',
+    answered: false,
+    ...partial,
+  } as QueueSlot;
+}
+
+function activity(partial: Partial<ActivityItemView>): ActivityItemView {
+  return {
+    id: 'a1',
+    userId: 'u1',
+    actorUserId: 'actor',
+    referenceId: null,
+    referenceType: null,
+    read: false,
+    createdAt: new Date(),
+    type: 'friend_answered_your_question',
+    actor: { displayName: 'Robyn' },
+    reference: {},
+    ...partial,
+  } as ActivityItemView;
+}
+
+describe('topicsForReminder', () => {
+  it('returns unanswered, non-skipped domains in order, deduped, capped at 5', () => {
+    const slots = [
+      slot({ domain: 'Virginia Woolf' }),
+      slot({ domain: 'Beethoven', answered: true }),
+      slot({ domain: 'The Progressive Era', skipped: true }),
+      slot({ domain: 'Film Noir' }),
+      slot({ domain: 'Film Noir' }), // duplicate
+      slot({ domain: 'The Space Race' }),
+      slot({ domain: 'Jazz' }),
+      slot({ domain: 'Cartography' }),
+      slot({ domain: 'Mycology' }),
+    ];
+    expect(topicsForReminder(slots)).toEqual([
+      'Virginia Woolf',
+      'Film Noir',
+      'The Space Race',
+      'Jazz',
+      'Cartography',
+    ]);
+  });
+
+  it('trims and drops empty domains', () => {
+    expect(topicsForReminder([slot({ domain: '  Beethoven  ' }), slot({ domain: '   ' })])).toEqual([
+      'Beethoven',
+    ]);
+  });
+
+  it('returns an empty array when there is nothing playable', () => {
+    expect(topicsForReminder([slot({ answered: true }), slot({ skipped: true })])).toEqual([]);
+  });
+});
+
+describe('formatActivityForEmail', () => {
+  it('renders one plain, people-first sentence per supported type', () => {
+    const views = [
+      activity({ id: '1', type: 'friend_answered_your_question', actor: { displayName: 'Robyn' } }),
+      activity({ id: '2', type: 'reaction_received', actor: { displayName: 'Sadie' } }),
+      activity({ id: '3', type: 'received_direct_question', actor: { displayName: 'Josh' } }),
+    ];
+    expect(formatActivityForEmail(views)).toEqual([
+      'Robyn answered one of your questions.',
+      'Sadie reacted to your answer.',
+      'Josh sent you a question.',
+    ]);
+  });
+
+  it('folds the domain into mastery and promotion lines', () => {
+    const views = [
+      activity({
+        id: '1',
+        type: 'friend_mastery',
+        actor: { displayName: 'Mara' },
+        reference: { masteryEvent: { domain: 'Film Noir', tier: null } },
+      }),
+      activity({
+        id: '2',
+        type: 'declared_promoted',
+        actor: { displayName: 'Theo' },
+        reference: { declaredPromoted: { domain: 'The Space Race', questionText: 'q' } },
+      }),
+    ];
+    expect(formatActivityForEmail(views)).toEqual([
+      'Mara went deep on Film Noir.',
+      'Theo opened The Space Race.',
+    ]);
+  });
+
+  it('skips viewer-own broadcasts and unknown types', () => {
+    const views = [
+      activity({ id: '1', type: 'authored_question_shared' }),
+      activity({ id: '2', type: 'ceremony_ready' }),
+    ];
+    expect(formatActivityForEmail(views)).toEqual([]);
+  });
+
+  it('falls back to "A friend" when the actor is missing', () => {
+    expect(
+      formatActivityForEmail([activity({ type: 'reaction_received', actor: null })]),
+    ).toEqual(['A friend reacted to your answer.']);
+  });
+
+  it('caps the output at three items', () => {
+    const views = Array.from({ length: 5 }, (_, i) =>
+      activity({ id: String(i), type: 'received_direct_question', actor: { displayName: `P${i}` } }),
+    );
+    expect(formatActivityForEmail(views)).toHaveLength(3);
+  });
+});
+
+describe('buildDailyReminderTemplate', () => {
+  const base = {
+    dailyUrl: 'https://joshing.app/daily',
+    interestsUrl: 'https://joshing.app/daily/setup',
+    topics: ['Virginia Woolf', 'Beethoven', 'Film Noir'],
+  };
+
+  it('rotates the subject across the four approved lines', () => {
+    const subject = buildDailyReminderTemplate(base).subject;
+    expect([
+      'Your Daily Five is ready',
+      'Today’s five are waiting',
+      'Five questions for today',
+      'Your Daily Five',
+    ]).toContain(subject);
+  });
+
+  it('includes the preheader, both links, and the topic labels', () => {
+    const { html } = buildDailyReminderTemplate(base);
+    expect(html).toContain('Five questions from the knowledge you share.');
+    expect(html).toContain('https://joshing.app/daily');
+    expect(html).toContain('https://joshing.app/daily/setup');
+    expect(html).toContain('Not quite your mix? Update your interests →');
+    expect(html).toContain('Virginia Woolf');
+    expect(html).toContain('Play today’s five');
+  });
+
+  it('falls back to a single line when there are no topics', () => {
+    const { html, text } = buildDailyReminderTemplate({ ...base, topics: [] });
+    expect(html).toContain('Today’s five are ready.');
+    expect(text).toContain('Today’s five are ready.');
+  });
+
+  it('omits Meanwhile when there is no activity and renders it when present', () => {
+    const without = buildDailyReminderTemplate(base);
+    expect(without.html).not.toContain('Meanwhile');
+
+    const withActivity = buildDailyReminderTemplate({
+      ...base,
+      activity: ['Robyn answered one of your questions.'],
+    });
+    expect(withActivity.html).toContain('Meanwhile');
+    expect(withActivity.html).toContain('Robyn answered one of your questions.');
+  });
+
+  it('omits A Glimpse without a teaser and shows a truncated, answer-free preview with one', () => {
+    expect(buildDailyReminderTemplate(base).html).not.toContain('A glimpse');
+
+    const long = 'x'.repeat(200);
+    const { html } = buildDailyReminderTemplate({
+      ...base,
+      teaser: { questionText: long, domain: 'Film Noir' },
+    });
+    expect(html).toContain('A glimpse');
+    expect(html).toContain('One of today’s five.');
+    expect(html).toContain('…'); // elegantly truncated
+    expect(html).not.toContain(long); // never the full text
+  });
+});

--- a/src/server/email/daily-reminder-data.ts
+++ b/src/server/email/daily-reminder-data.ts
@@ -1,0 +1,77 @@
+/**
+ * Pure data shaping for the daily reminder email. NO database imports — the cron
+ * route (src/app/api/cron/daily-assignments/route.ts) runs the queries and feeds
+ * the results here, which keeps these transforms unit-testable without a DB and
+ * keeps the email template (daily-reminder.ts) presentational.
+ */
+
+import type { ActivityItemView } from '@/server/db/queries/activity';
+import type { QueueSlot } from '@/server/daily/types';
+
+/**
+ * Today's five topic/domain labels for the email's TODAY section: the canonical
+ * `domain` of each unanswered, non-skipped slot, trimmed, de-duplicated (order
+ * preserved), capped at five. An empty result lets the template fall back to the
+ * generic "Today's five are ready." line.
+ */
+export function topicsForReminder(slots: QueueSlot[]): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const slot of slots) {
+    if (slot.answered || slot.skipped) continue;
+    const domain = slot.domain?.trim();
+    if (!domain || seen.has(domain)) continue;
+    seen.add(domain);
+    out.push(domain);
+    if (out.length === 5) break;
+  }
+  return out;
+}
+
+function actorName(view: ActivityItemView): string {
+  return view.actor?.displayName?.trim() || 'A friend';
+}
+
+/**
+ * The email's MEANWHILE section: at most three quiet, people-first one-liners
+ * drawn from the viewer's recent home-eligible activity. The input is expected to
+ * already be filtered to HOME_TOP3_ELIGIBLE_TYPES (e.g. via
+ * getRecentActivityForHome). Viewer-own broadcasts (authored_question_shared) are
+ * dropped here because the section is meant to read as "people did something with
+ * your stuff", not "here's what you did". Returns plain sentences, never markup.
+ */
+export function formatActivityForEmail(views: ActivityItemView[]): string[] {
+  const out: string[] = [];
+  for (const view of views) {
+    const line = activityLine(view);
+    if (line) out.push(line);
+    if (out.length === 3) break;
+  }
+  return out;
+}
+
+function activityLine(view: ActivityItemView): string | null {
+  const name = actorName(view);
+  switch (view.type) {
+    case 'friend_answered_your_question':
+      return `${name} answered one of your questions.`;
+    case 'reaction_received':
+      return `${name} reacted to your answer.`;
+    case 'received_direct_question':
+      return `${name} sent you a question.`;
+    case 'question_curated':
+      return `${name} saved one of your questions.`;
+    case 'friend_mastery': {
+      const domain = view.reference.masteryEvent?.domain?.trim();
+      return domain ? `${name} went deep on ${domain}.` : `${name} made progress in a new area.`;
+    }
+    case 'declared_promoted': {
+      const domain = view.reference.declaredPromoted?.domain?.trim();
+      return domain ? `${name} opened ${domain}.` : `${name} opened a new area.`;
+    }
+    // authored_question_shared and anything else: viewer-own or not a people-first
+    // invitation back into the product — leave it out of the email.
+    default:
+      return null;
+  }
+}

--- a/src/server/email/templates/daily-reminder.ts
+++ b/src/server/email/templates/daily-reminder.ts
@@ -1,95 +1,193 @@
 export type DailyReminderTemplateParams = {
+  /** Daily Five route — the primary "Play today's five" action. */
   dailyUrl: string;
+  /** Daily Five setup route — the quiet "Update your interests" secondary link. */
+  interestsUrl: string;
   /**
-   * A no-spoiler teaser drawn from the user's freshly built queue: the first
-   * slot's question_text (+ optional domain label). Safe to show because a
-   * newly built slot carries no reveal_canonical_answer yet. When absent (empty
-   * or short queue), the email gracefully falls back to the generic nudge.
+   * Today's five topic/domain labels, already de-duplicated and ordered (see
+   * topicsForReminder). Rendered as plain editorial lines under TODAY. Empty →
+   * the template falls back to a single "Today's five are ready." line.
+   */
+  topics: string[];
+  /**
+   * Up to three quiet, people-first activity sentences (see formatActivityForEmail).
+   * When empty/absent the MEANWHILE section is omitted entirely — no placeholder.
+   */
+  activity?: string[] | null;
+  /**
+   * Optional no-spoiler teaser for the small "A glimpse" section: the first
+   * slot's question_text (+ optional domain). Safe to show because a freshly
+   * built slot carries no reveal yet. Absent → the section is omitted.
    */
   teaser?: { questionText: string; domain?: string | null } | null;
 };
 
-// The daily "your five for today" nudge, sent from the daily-assignments cron
-// to opted-in + verified users right after the 17:00 UTC reset. Mirrors the SMS
-// copy ("Your five for today") and the Ink-on-Cream styling of verify-email.ts,
-// and previews today's first question to make the open worth it.
+// Ink-on-Cream palette (mirrors verify-email.ts and the in-app design system).
+const CREAM = '#f7f5f0';
+const INK = '#1f1d1a';
+const INK_SOFT = '#6b6760';
+const INK_FAINT = '#8a857b';
+const RULE = '#e5e1d8';
+const BUTTON = '#111111';
+
+const SERIF = "Georgia,'Times New Roman',serif";
+const SANS = "-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+
+// Rotated daily so a recipient doesn't read the same subject line every morning,
+// but deterministic on the UTC date so a single send (the cron may replay) is
+// stable. Drops the old question-in-subject behavior.
+const SUBJECTS = [
+  'Your Daily Five is ready',
+  'Today’s five are waiting',
+  'Five questions for today',
+  'Your Daily Five',
+] as const;
+
+const PREHEADER = 'Five questions from the knowledge you share.';
+const FOOTER_LINE = 'Joshing is about the knowledge that connects people.';
+
+// The daily "Your Daily Five" nudge, sent from the daily-assignments cron to
+// opted-in + verified users right after the 17:00 UTC reset. A quiet editorial
+// note — typography-led, no large question card — not a marketing newsletter.
 export function buildDailyReminderTemplate(params: DailyReminderTemplateParams): {
   subject: string;
   html: string;
   text: string;
 } {
-  const { dailyUrl, teaser } = params;
+  const { dailyUrl, interestsUrl, topics, activity, teaser } = params;
 
+  const cleanTopics = topics.map((t) => t.trim()).filter(Boolean);
+  const cleanActivity = (activity ?? []).map((a) => a.trim()).filter(Boolean).slice(0, 3);
   const teaserText = teaser?.questionText?.trim() || null;
-  const teaserDomain = teaser?.domain?.trim() || null;
 
-  const subject = teaserText
-    ? `Today’s five: ${truncate(teaserText, 60)}`
-    : 'Your five for today';
+  const subject = SUBJECTS[epochDay() % SUBJECTS.length];
 
-  const text = [
-    'Your five for today are ready.',
+  return {
+    subject,
+    text: buildText({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText }),
+    html: buildHtml({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText }),
+  };
+}
+
+function buildText(params: {
+  dailyUrl: string;
+  interestsUrl: string;
+  topics: string[];
+  activity: string[];
+  teaserText: string | null;
+}): string {
+  const { dailyUrl, interestsUrl, topics, activity, teaserText } = params;
+  const lines: string[] = [
+    'Joshing',
     '',
-    teaserText
-      ? `First up${teaserDomain ? ` (${teaserDomain})` : ''}: ${teaserText}`
-      : 'Five fresh questions, picked for what you know and what you’re curious about.',
+    'Your Daily Five',
+    'Five questions from the knowledge you share.',
     '',
     `Play today’s five: ${dailyUrl}`,
     '',
+    'TODAY',
+  ];
+
+  if (topics.length > 0) {
+    for (const topic of topics) lines.push(topic);
+  } else {
+    lines.push('Today’s five are ready.');
+  }
+  lines.push('', `Not quite your mix? Update your interests: ${interestsUrl}`);
+
+  if (activity.length > 0) {
+    lines.push('', 'MEANWHILE');
+    for (const item of activity) lines.push(item);
+  }
+
+  if (teaserText) {
+    lines.push('', 'A GLIMPSE', `“${truncate(teaserText, 100)}”`, 'One of today’s five.');
+  }
+
+  lines.push(
+    '',
+    `Play today’s five: ${dailyUrl}`,
+    '',
+    FOOTER_LINE,
     'You can turn these reminders off any time from your profile settings.',
-  ].join('\n');
+  );
 
-  const teaserBlock = teaserText
-    ? `<tr>
-              <td style="padding-bottom:24px;">
-                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f7f5f0;border:1px solid #e5e1d8;border-radius:10px;padding:18px 20px;">
-                  ${
-                    teaserDomain
-                      ? `<tr><td style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:#8a857b;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">First up · ${escapeHtml(teaserDomain)}</td></tr>`
-                      : `<tr><td style="font-size:11px;letter-spacing:0.06em;text-transform:uppercase;color:#8a857b;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">First up</td></tr>`
-                  }
-                  <tr><td style="font-size:17px;line-height:1.5;color:#1f1d1a;">${escapeHtml(teaserText)}</td></tr>
-                </table>
-              </td>
-            </tr>`
-    : `<tr>
-              <td style="font-size:15px;line-height:1.55;padding-bottom:24px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-                Five fresh questions are waiting — picked for what you know and what you’re curious about.
-              </td>
-            </tr>`;
+  return lines.join('\n');
+}
 
-  const html = `<!doctype html>
+function buildHtml(params: {
+  dailyUrl: string;
+  interestsUrl: string;
+  topics: string[];
+  activity: string[];
+  teaserText: string | null;
+}): string {
+  const { dailyUrl, interestsUrl, topics, activity, teaserText } = params;
+
+  const topicsBlock =
+    topics.length > 0
+      ? topics
+          .map(
+            (topic) =>
+              `<tr><td style="font-family:${SERIF};font-size:19px;line-height:1.7;color:${INK};">${escapeHtml(topic)}</td></tr>`,
+          )
+          .join('')
+      : `<tr><td style="font-family:${SERIF};font-size:19px;line-height:1.7;color:${INK};">Today’s five are ready.</td></tr>`;
+
+  const meanwhileSection =
+    activity.length > 0
+      ? `${divider()}
+            ${eyebrow('Meanwhile')}
+            ${activity
+              .map(
+                (item) =>
+                  `<tr><td style="font-family:${SERIF};font-size:16px;line-height:1.6;color:${INK};padding-bottom:6px;">${escapeHtml(item)}</td></tr>`,
+              )
+              .join('')}`
+      : '';
+
+  const glimpseSection = teaserText
+    ? `${divider()}
+            ${eyebrow('A glimpse')}
+            <tr><td style="font-family:${SERIF};font-size:18px;line-height:1.6;color:${INK};font-style:italic;padding-bottom:6px;">“${escapeHtml(truncate(teaserText, 100))}”</td></tr>
+            <tr><td style="font-family:${SANS};font-size:12px;color:${INK_FAINT};">One of today’s five.</td></tr>`
+    : '';
+
+  return `<!doctype html>
 <html lang="en">
-  <body style="margin:0;padding:0;background:#f7f5f0;font-family:Georgia,'Times New Roman',serif;color:#1f1d1a;">
-    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:#f7f5f0;padding:32px 16px;">
+  <body style="margin:0;padding:0;background:${CREAM};font-family:${SERIF};color:${INK};">
+    <span style="display:none;max-height:0;overflow:hidden;opacity:0;color:transparent;visibility:hidden;">${PREHEADER}</span>
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:${CREAM};padding:40px 16px;">
       <tr>
         <td align="center">
-          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:520px;background:#ffffff;border:1px solid #e5e1d8;border-radius:12px;padding:32px;">
+          <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:480px;background:${CREAM};">
             <tr>
-              <td style="font-size:24px;font-weight:700;padding-bottom:16px;">Your five for today</td>
-            </tr>
-            ${teaserBlock}
-            <tr>
-              <td align="left" style="padding-bottom:24px;">
-                <a href="${dailyUrl}" style="display:inline-block;background:#111111;color:#ffffff;text-decoration:none;padding:12px 20px;border-radius:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;font-size:14px;font-weight:600;">
-                  Play today’s five
-                </a>
-              </td>
+              <td style="font-family:${SANS};font-size:13px;letter-spacing:0.04em;color:${INK_SOFT};padding-bottom:20px;">Joshing</td>
             </tr>
             <tr>
-              <td style="font-size:13px;color:#6b6760;line-height:1.55;padding-bottom:8px;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-                Or paste this link into your browser:
-              </td>
+              <td style="font-family:${SERIF};font-size:30px;line-height:1.25;font-weight:700;padding-bottom:10px;">Your Daily Five</td>
             </tr>
             <tr>
-              <td style="font-size:12px;color:#6b6760;word-break:break-all;font-family:ui-monospace,Menlo,Consolas,monospace;padding-bottom:24px;">
-                ${dailyUrl}
+              <td style="font-family:${SERIF};font-size:17px;line-height:1.5;color:${INK_SOFT};padding-bottom:26px;">Five questions from the knowledge you share.</td>
+            </tr>
+            ${ctaRow(dailyUrl)}
+            ${divider()}
+            ${eyebrow('Today')}
+            ${topicsBlock}
+            <tr>
+              <td style="padding-top:16px;">
+                <a href="${interestsUrl}" style="font-family:${SANS};font-size:13px;color:${INK_SOFT};text-decoration:underline;">Not quite your mix? Update your interests →</a>
               </td>
             </tr>
+            ${meanwhileSection}
+            ${glimpseSection}
+            ${divider()}
+            ${ctaRow(dailyUrl)}
             <tr>
-              <td style="font-size:12px;color:#8a857b;line-height:1.55;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;">
-                You can turn these reminders off any time from your profile settings.
-              </td>
+              <td style="font-family:${SERIF};font-size:14px;line-height:1.6;color:${INK_SOFT};padding-top:8px;padding-bottom:10px;">${FOOTER_LINE}</td>
+            </tr>
+            <tr>
+              <td style="font-family:${SANS};font-size:12px;line-height:1.55;color:${INK_FAINT};">You can turn these reminders off any time from your profile settings.</td>
             </tr>
           </table>
         </td>
@@ -97,8 +195,28 @@ export function buildDailyReminderTemplate(params: DailyReminderTemplateParams):
     </table>
   </body>
 </html>`;
+}
 
-  return { subject, html, text };
+function ctaRow(dailyUrl: string): string {
+  return `<tr>
+              <td style="padding-bottom:28px;">
+                <a href="${dailyUrl}" style="display:inline-block;background:${BUTTON};color:#ffffff;text-decoration:none;padding:13px 22px;border-radius:8px;font-family:${SANS};font-size:14px;font-weight:600;">Play today’s five</a>
+              </td>
+            </tr>`;
+}
+
+function divider(): string {
+  return `<tr><td style="padding:24px 0;"><div style="height:1px;line-height:1px;font-size:0;background:${RULE};">&nbsp;</div></td></tr>`;
+}
+
+function eyebrow(label: string): string {
+  return `<tr><td style="font-family:${SANS};font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:${INK_FAINT};padding-bottom:14px;">${escapeHtml(label)}</td></tr>`;
+}
+
+// UTC epoch-day index — stable within a calendar day, increments daily, so the
+// subject rotation is deterministic per send but varies morning to morning.
+function epochDay(): number {
+  return Math.floor(Date.now() / 86_400_000);
 }
 
 function truncate(value: string, max: number): string {


### PR DESCRIPTION
Replace the full-question teaser card with a typography-led layout: brand
line, serif "Your Daily Five" headline, primary "Play today's five" CTA,
today's five topic labels as plain editorial text, a quiet "Update your
interests" link to /daily/setup, an optional people-first "Meanwhile"
section (max 3 items), and an optional small "A glimpse" teaser.

- Widen DailyReminderTemplateParams (topics, interestsUrl, activity) and
  rebuild the HTML/text around thin dividers and the Ink-on-Cream palette.
- Rotate the subject deterministically across four approved lines; add a
  hidden preheader.
- Add pure, DB-free helpers (topicsForReminder, formatActivityForEmail)
  and plumb topics + getRecentActivityForHome through the daily cron.
- Graceful fallbacks: empty topics -> "Today's five are ready."; no
  activity -> omit Meanwhile; no teaser -> omit A Glimpse.
- Unit tests for the helpers and template rendering.

https://claude.ai/code/session_01F2HcxWBAZVwkwz6sV1PvhA