### PR TITLE
Add daily-reminder email opt-in beat to onboarding ceremony

### DIFF
--- a/drizzle/0077_email_verification_opt_in_intent.sql
+++ b/drizzle/0077_email_verification_opt_in_intent.sql
@@ -1,0 +1,21 @@
+-- Migration: add EmailVerificationToken.opt_in_on_confirm — carries the
+-- "turn email reminders on the moment this link is confirmed" intent across
+-- the async verification gap.
+--
+-- The onboarding "Daily reminders" beat captures opt-in intent the instant the
+-- user submits their email, but emailOptIn can only ever be 'opted_in' once
+-- emailVerified = true (enforced in updateReminderPreferences). Rather than
+-- relax that invariant, the intent rides on the verification token: when the
+-- token was minted with opt_in_on_confirm = true, consumeVerificationToken
+-- promotes pendingEmail → email AND sets emailOptIn = 'opted_in' in the same
+-- transaction. Sending stays double-gated on emailVerified, so nothing goes
+-- out before the user confirms. Profile-originated tokens default to false, so
+-- their verify-then-toggle flow is unchanged.
+--
+-- Additive column with a non-null default — safe. Mirrored by a defensive
+-- guard in src/instrumentation.ts (precedent: 0075's email_reminder_sent_at
+-- guard) so a preview/production database that records this migration without
+-- the column present still boots.
+--
+-- Rollback: ALTER TABLE "EmailVerificationToken" DROP COLUMN IF EXISTS "opt_in_on_confirm";
+ALTER TABLE "EmailVerificationToken" ADD COLUMN IF NOT EXISTS "opt_in_on_confirm" boolean DEFAULT false NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -533,6 +533,20 @@
       "when": 1783036800000,
       "tag": "0075_daily_queue_email_reminder",
       "breakpoints": true
+    },
+    {
+      "idx": 76,
+      "version": "7",
+      "when": 1783123200000,
+      "tag": "0076_first_game_recap_seen",
+      "breakpoints": true
+    },
+    {
+      "idx": 77,
+      "version": "7",
+      "when": 1783209600000,
+      "tag": "0077_email_verification_opt_in_intent",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/daily-assignments/route.ts
+++ b/src/app/api/cron/daily-assignments/route.ts
@@ -16,6 +16,7 @@ import { sendEmail } from '@/server/email/client';
 import { buildDailyReminderTemplate } from '@/server/email/templates/daily-reminder';
 import { formatActivityForEmail, topicsForReminder } from '@/server/email/daily-reminder-data';
 import { getRecentActivityForHome } from '@/server/db/queries/activity';
+import { createUnsubscribeToken } from '@/server/email/unsubscribe-token';
 
 export const dynamic = 'force-dynamic';
 // Scheduled at 17:05 UTC by GitHub Actions (.github/workflows/external-crons.yml)
@@ -136,18 +137,30 @@ export async function GET(request: NextRequest) {
           // Quiet, people-first "Meanwhile" lines from the same home-eligible
           // activity Home surfaces; empty → the section is omitted downstream.
           const activity = formatActivityForEmail(await getRecentActivityForHome(user.id, 3));
+          // Session-less unsubscribe: the footer link points at the friendly
+          // /unsubscribe page; the List-Unsubscribe header at the RFC 8058
+          // one-click POST endpoint. Both verify the same signed token. Gmail/
+          // Yahoo bulk-sender rules expect this header on reminder mail.
+          const unsubToken = createUnsubscribeToken(user.id);
+          const unsubscribeUrl = `${baseUrl}/unsubscribe?token=${unsubToken}`;
+          const oneClickUrl = `${baseUrl}/api/email/unsubscribe?token=${unsubToken}`;
           const template = buildDailyReminderTemplate({
             dailyUrl: `${baseUrl}/daily`,
             interestsUrl: `${baseUrl}/daily/setup`,
             topics: topicsForReminder(slots),
             activity,
             teaser: { questionText: teaserSlot.question_text, domain: teaserSlot.domain },
+            unsubscribeUrl,
           });
           const emailResult = await sendEmail({
             to: user.email,
             subject: template.subject,
             html: template.html,
             text: template.text,
+            headers: {
+              'List-Unsubscribe': `<${oneClickUrl}>`,
+              'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+            },
           });
           if (emailResult.ok) {
             results.emailSent += 1;

--- a/src/app/api/email/unsubscribe/route.ts
+++ b/src/app/api/email/unsubscribe/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+
+import { updateReminderPreferences } from '@/server/db/queries/account';
+import { verifyUnsubscribeToken } from '@/server/email/unsubscribe-token';
+
+export const dynamic = 'force-dynamic';
+
+// RFC 8058 one-click unsubscribe target. Gmail/Yahoo bulk senders POST here with
+// body `List-Unsubscribe=One-Click` straight from the inbox UI (no session), so
+// we authenticate purely on the signed token in the query string. GET hits the
+// same path so a plain link click also works; both just flip emailOptIn to
+// opted_out (always allowed — no verification gate on opting *out*).
+async function optOut(token: string | null): Promise<boolean> {
+  if (!token) return false;
+  const userId = verifyUnsubscribeToken(token);
+  if (!userId) return false;
+  const result = await updateReminderPreferences(userId, { emailOptIn: 'opted_out' });
+  return result.ok;
+}
+
+export async function POST(request: Request) {
+  const token = new URL(request.url).searchParams.get('token');
+  const ok = await optOut(token);
+  // One-click clients ignore the body; a 200 is the signal they want.
+  return NextResponse.json({ ok }, { status: ok ? 200 : 400 });
+}
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const token = url.searchParams.get('token');
+  // Send link-clickers to the friendly confirmation page, preserving the token.
+  return NextResponse.redirect(new URL(`/unsubscribe?token=${token ?? ''}`, url.origin));
+}

--- a/src/app/api/onboarding/email-reminder/route.ts
+++ b/src/app/api/onboarding/email-reminder/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { updateReminderPreferences } from '@/server/db/queries/account';
+import { sendVerificationEmail } from '@/server/email/send-verification';
+
+export const dynamic = 'force-dynamic';
+
+// The onboarding "Daily reminders" beat: the user typed an email to opt into
+// daily reminders. We stash it as pendingEmail and fire a confirm link minted
+// with optInOnConfirm — so confirming the link both verifies the address and
+// flips emailOptIn on, with no second trip to the profile toggle. Verification
+// is async and off-page, so this never blocks finishing onboarding; the caller
+// proceeds to /daily regardless of whether/when the link is clicked.
+const bodySchema = z.object({
+  email: z.string().trim().email(),
+});
+
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const json = await request.json().catch(() => null);
+  const parsed = bodySchema.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_body', message: 'Enter a valid email address.' },
+      { status: 400 },
+    );
+  }
+
+  // Also mark the reminder prompt dismissed: the user engaged with the ask
+  // here, so the profile reminder banner shouldn't nag them about it later.
+  const result = await updateReminderPreferences(session.userId, {
+    pendingEmail: parsed.data.email,
+    dismissed: true,
+  });
+  if (!result.ok) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  const sendResult = await sendVerificationEmail(session.userId, {
+    optInOnConfirm: true,
+  });
+  if (!sendResult.ok) {
+    // The address is saved; surface a soft failure so the client can show a
+    // "we couldn't send the email" note without trapping the user in onboarding.
+    console.warn('[onboarding/email-reminder] verification send failed:', sendResult.reason);
+    return NextResponse.json({ ok: true, sent: false });
+  }
+
+  return NextResponse.json({ ok: true, sent: true });
+}

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -7,8 +7,11 @@ import { Loader2, X } from 'lucide-react'
 import { AddTopicField, type AddTopicError } from '@/components/interests/AddTopicField'
 
 // Condensed onboarding: name → handle → one interests screen (warm-up is an
-// optional expander there; the cultural-anchor/background step was removed).
-type CurrentStep = 'display-name' | 'handle' | 'review'
+// optional expander there; the cultural-anchor/background step was removed) →
+// an optional daily-reminder email opt-in. The reminders beat is post-
+// completion bonus: picking areas already marks onboarding complete and starts
+// question generation, so the email ask never blocks finishing.
+type CurrentStep = 'display-name' | 'handle' | 'review' | 'reminders'
 
 export type WarmupAnswers = {
   deepDive?: string
@@ -86,7 +89,10 @@ const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
   { step: 'display-name', label: 'Name' },
   { step: 'handle', label: 'Handle' },
   { step: 'review', label: 'Areas' },
+  { step: 'reminders', label: 'Reminders' },
 ]
+
+const REMINDER_EMAIL_FORMAT = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const MIN_INTERESTS = 3
 // Onboarding caps the starting-areas selection at 12 (per product spec). The cap
@@ -257,6 +263,11 @@ export default function OnboardingFlow({
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loadingCopyIndex, setLoadingCopyIndex] = useState(0)
+  const [reminderEmail, setReminderEmail] = useState('')
+  const [savingReminderEmail, setSavingReminderEmail] = useState(false)
+  const [reminderError, setReminderError] = useState<string | null>(null)
+  // null = not yet submitted; true/false = whether the confirmation email sent.
+  const [reminderSent, setReminderSent] = useState<boolean | null>(null)
   const displayInviterName = inviterName?.trim()
     ? inviterName.trim()
     : 'A friend'
@@ -629,11 +640,10 @@ export default function OnboardingFlow({
       }
 
       // Kick off first-round generation in the background so it's ready (or
-      // nearly) when the player lands in /daily, then take them straight into
-      // gameplay instead of the homepage. keepalive lets the POST survive the
-      // client navigation; the queue route is idempotent, so /daily's own load
-      // won't double-generate. A freshly-declared interest list guarantees a
-      // knowledge base, so /daily won't bounce to setup.
+      // nearly) when the player lands in /daily. keepalive lets the POST survive
+      // the client navigation; the queue route is idempotent, so /daily's own
+      // load won't double-generate. A freshly-declared interest list guarantees
+      // a knowledge base, so /daily won't bounce to setup.
       void fetch('/api/daily/queue', {
         method: 'POST',
         credentials: 'include',
@@ -641,11 +651,56 @@ export default function OnboardingFlow({
         keepalive: true,
       }).catch(() => {})
 
-      router.push('/daily')
+      // Onboarding is now complete (save-interests set the flag). Advance to the
+      // optional daily-reminder beat rather than jumping straight to /daily —
+      // skipping or submitting there both land in gameplay.
+      setCurrentStep('reminders')
     } catch {
       setError('Unable to save interests.')
     } finally {
       setIsLoading(false)
+    }
+  }
+
+  function finishOnboarding() {
+    router.push('/daily')
+  }
+
+  async function submitReminderEmail() {
+    const trimmed = reminderEmail.trim()
+    if (!REMINDER_EMAIL_FORMAT.test(trimmed)) {
+      setReminderError('Enter a valid email address.')
+      return
+    }
+
+    setReminderError(null)
+    setSavingReminderEmail(true)
+
+    try {
+      const response = await fetch('/api/onboarding/email-reminder', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmed }),
+      })
+      const data = await response.json().catch(() => ({}))
+
+      if (!response.ok || data?.ok !== true) {
+        setReminderError(
+          typeof data?.message === 'string'
+            ? data.message
+            : "We couldn't save that email. Try again.",
+        )
+        return
+      }
+
+      // Address saved either way; data.sent tells us whether the confirm email
+      // actually went out (provider hiccups still let onboarding finish).
+      setReminderSent(data.sent === true)
+    } catch {
+      setReminderError("We couldn't save that email. Try again.")
+    } finally {
+      setSavingReminderEmail(false)
     }
   }
 
@@ -939,6 +994,91 @@ export default function OnboardingFlow({
                   {isLoading ? 'Saving…' : startCtaCopy(selectedInterests.length)}
                 </button>
               </div>
+            </div>
+          ) : null}
+
+          {currentStep === 'reminders' ? (
+            <div className="flex flex-1 flex-col justify-center gap-8">
+              {reminderSent === null ? (
+                <>
+                  <StepHeader
+                    title="Want a daily nudge?"
+                    subtitle="New questions land every day. Drop your email and we'll send a daily reminder — with a no-spoiler peek at your first question — so you never miss a round."
+                  />
+
+                  <form
+                    className="space-y-4"
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      if (!savingReminderEmail) void submitReminderEmail()
+                    }}
+                  >
+                    <label className="block">
+                      <span className="text-sm font-medium">Your email</span>
+                      <input
+                        type="email"
+                        inputMode="email"
+                        autoComplete="email"
+                        className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
+                        placeholder="you@example.com"
+                        autoFocus
+                        value={reminderEmail}
+                        onChange={(event) => {
+                          setReminderEmail(event.target.value)
+                          if (reminderError) setReminderError(null)
+                        }}
+                      />
+                    </label>
+
+                    <p className="text-muted-foreground text-sm">
+                      We&apos;ll send one confirmation link to make sure it&apos;s
+                      you — reminders switch on the moment you tap it. Unsubscribe
+                      any time.
+                    </p>
+
+                    {reminderError ? (
+                      <p className="text-destructive text-sm">{reminderError}</p>
+                    ) : null}
+
+                    <button
+                      type="submit"
+                      className="btn-primary h-12 w-full"
+                      disabled={
+                        savingReminderEmail ||
+                        !REMINDER_EMAIL_FORMAT.test(reminderEmail.trim())
+                      }
+                    >
+                      {savingReminderEmail ? 'Sending…' : 'Send confirmation & finish'}
+                    </button>
+                    <button
+                      type="button"
+                      className="btn-ghost h-12 w-full"
+                      onClick={finishOnboarding}
+                      disabled={savingReminderEmail}
+                    >
+                      Skip for now
+                    </button>
+                  </form>
+                </>
+              ) : (
+                <div className="flex flex-1 flex-col justify-center gap-8">
+                  <StepHeader
+                    title={reminderSent ? 'Check your inbox' : "You're all set"}
+                    subtitle={
+                      reminderSent
+                        ? `We sent a confirmation link to ${reminderEmail.trim()}. Tap it and your daily reminders switch on automatically — no need to wait here.`
+                        : "We saved your email but couldn't send the confirmation just now. You can resend it any time from your profile."
+                    }
+                  />
+                  <button
+                    type="button"
+                    className="btn-primary h-12 w-full"
+                    onClick={finishOnboarding}
+                  >
+                    Start today&apos;s five
+                  </button>
+                </div>
+              )}
             </div>
           ) : null}
 

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -1,0 +1,63 @@
+import Link from 'next/link';
+
+import { updateReminderPreferences } from '@/server/db/queries/account';
+import { verifyUnsubscribeToken } from '@/server/email/unsubscribe-token';
+
+export const dynamic = 'force-dynamic';
+
+type SearchParams = Promise<{ token?: string | string[] }>;
+
+function extractToken(value: string | string[] | undefined): string | null {
+  if (Array.isArray(value)) return value[0]?.trim() || null;
+  return value?.trim() || null;
+}
+
+// The visible footer link from the daily-reminder email. Flips emailOptIn to
+// opted_out on load (opting out is always allowed) and confirms it. No session
+// required — the signed token in the URL is the authentication.
+export default async function UnsubscribePage({
+  searchParams,
+}: {
+  searchParams: SearchParams;
+}) {
+  const params = await searchParams;
+  const token = extractToken(params.token);
+  const userId = token ? verifyUnsubscribeToken(token) : null;
+
+  let success = false;
+  if (userId) {
+    const result = await updateReminderPreferences(userId, { emailOptIn: 'opted_out' });
+    success = result.ok;
+  }
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-md flex-col items-center justify-center px-4 py-16">
+      <div className="w-full rounded-xl border bg-card p-8 text-card-foreground">
+        {success ? (
+          <>
+            <h1 className="font-serif text-2xl font-semibold">You&apos;re unsubscribed</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              We&apos;ve turned off your daily reminder emails. You can turn them
+              back on any time from your profile settings.
+            </p>
+          </>
+        ) : (
+          <>
+            <h1 className="font-serif text-2xl font-semibold">Link not recognized</h1>
+            <p className="mt-3 text-sm text-muted-foreground">
+              This unsubscribe link is invalid. Open your profile and switch off
+              &ldquo;Email reminders&rdquo; to stop the daily emails.
+            </p>
+          </>
+        )}
+
+        <Link
+          href="/users/me"
+          className="btn-primary mt-6 inline-flex w-full items-center justify-center text-sm"
+        >
+          Go to profile
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -24,6 +24,7 @@ export default async function VerifyEmailPage({
     : ({ ok: false, reason: 'invalid_or_expired' } as const);
 
   const success = result.ok;
+  const optedIn = result.ok && result.optedIn;
   const alreadyInUse = !result.ok && result.reason === 'email_already_in_use';
 
   return (
@@ -31,10 +32,13 @@ export default async function VerifyEmailPage({
       <div className="w-full rounded-xl border bg-card p-8 text-card-foreground">
         {success ? (
           <>
-            <h1 className="font-serif text-2xl font-semibold">Email confirmed</h1>
+            <h1 className="font-serif text-2xl font-semibold">
+              {optedIn ? 'Daily reminders are on' : 'Email confirmed'}
+            </h1>
             <p className="mt-3 text-sm text-muted-foreground">
-              {result.email} is now your reminder address. Head to your profile to
-              turn on email reminders whenever you&apos;re ready.
+              {optedIn
+                ? `We'll email ${result.email} each day when your five are ready. You can turn this off any time in your profile.`
+                : `${result.email} is now your reminder address. Head to your profile to turn on email reminders whenever you're ready.`}
             </p>
           </>
         ) : alreadyInUse ? (

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -286,7 +286,7 @@ export function NotificationsForm({ initialState, phone }: Props) {
         ) : null}
         {hasVerifiedEmail && emailOn ? (
           <p className="mt-3 text-xs text-muted-foreground">
-            Saved. Emails will start when reminders launch.
+            On. We&apos;ll email you each day when your five are ready.
           </p>
         ) : null}
         {resendNotice ? (
@@ -298,8 +298,8 @@ export function NotificationsForm({ initialState, phone }: Props) {
       </section>
 
       <p className="text-xs text-muted-foreground">
-        Daily reminders aren&apos;t sending yet — we&apos;re still wiring up message delivery.
-        Verifying your email now means you&apos;ll be ready as soon as they launch.
+        Once your email is confirmed and reminders are on, we&apos;ll send a daily
+        nudge when your five are ready — with a no-spoiler peek at the first question.
       </p>
     </div>
   );

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -281,6 +281,20 @@ export async function register() {
       // DailyQueue table may not exist yet — migrate() handles initial creation.
     }
 
+    // Migration 0077 adds EmailVerificationToken.opt_in_on_confirm — the
+    // "turn reminders on when this link is confirmed" intent the onboarding
+    // beat sets and consumeVerificationToken reads. A preview/production DB
+    // that records 0077 without the column present would break token consume;
+    // pre-apply it idempotently (precedent: 0075's guard above).
+    try {
+      await db.execute(sql`
+        ALTER TABLE "EmailVerificationToken"
+          ADD COLUMN IF NOT EXISTS "opt_in_on_confirm" boolean NOT NULL DEFAULT false
+      `);
+    } catch {
+      // EmailVerificationToken may not exist yet — migrate() handles initial creation.
+    }
+
     // Migration 0028 adds the Category.general_knowledge enum value and migration
     // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
     // migrations in one transaction, but Postgres requires a newly-added enum value

--- a/src/server/db/queries/email-verification.ts
+++ b/src/server/db/queries/email-verification.ts
@@ -26,6 +26,7 @@ export type CreateVerificationTokenResult =
 export async function createVerificationToken(
   userId: string,
   email: string,
+  options: { optInOnConfirm?: boolean } = {},
 ): Promise<CreateVerificationTokenResult> {
   const now = Date.now();
 
@@ -54,6 +55,7 @@ export async function createVerificationToken(
     email,
     tokenHash,
     expiresAt,
+    optInOnConfirm: options.optInOnConfirm ?? false,
   });
 
   return { ok: true, token, expiresAt };
@@ -75,7 +77,7 @@ export async function invalidateUserTokens(userId: string): Promise<void> {
 }
 
 export type ConsumeVerificationTokenResult =
-  | { ok: true; email: string; userId: string }
+  | { ok: true; email: string; userId: string; optedIn: boolean }
   | { ok: false; reason: 'invalid_or_expired' | 'email_already_in_use' };
 
 // Consumes a token in a single transaction with the User row promotion:
@@ -101,6 +103,7 @@ export async function consumeVerificationToken(
         email: emailVerificationTokens.email,
         expiresAt: emailVerificationTokens.expiresAt,
         consumedAt: emailVerificationTokens.consumedAt,
+        optInOnConfirm: emailVerificationTokens.optInOnConfirm,
       })
       .from(emailVerificationTokens)
       .where(eq(emailVerificationTokens.tokenHash, tokenHash))
@@ -122,6 +125,11 @@ export async function consumeVerificationToken(
       return { ok: false, reason: 'invalid_or_expired' };
     }
 
+    // The onboarding beat captures opt-in intent up front (the user typed their
+    // email to *get* reminders), so a token minted with opt_in_on_confirm flips
+    // emailOptIn on in the same transaction that verifies the address — no
+    // second trip to the profile toggle. Sending is still gated on
+    // emailVerified (which we set here), so nothing went out before this point.
     try {
       await tx
         .update(users)
@@ -129,6 +137,7 @@ export async function consumeVerificationToken(
           email: row.email,
           emailVerified: true,
           pendingEmail: null,
+          ...(row.optInOnConfirm ? { emailOptIn: 'opted_in' as const } : {}),
           updatedAt: new Date(),
         })
         .where(eq(users.id, row.userId));
@@ -144,6 +153,6 @@ export async function consumeVerificationToken(
       .set({ consumedAt: new Date() })
       .where(eq(emailVerificationTokens.id, row.id));
 
-    return { ok: true, email: row.email, userId: row.userId };
+    return { ok: true, email: row.email, userId: row.userId, optedIn: row.optInOnConfirm };
   });
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -575,6 +575,10 @@ export const emailVerificationTokens = pgTable(
     tokenHash: text('token_hash').notNull(),
     expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
     consumedAt: timestamp('consumed_at', { withTimezone: true }),
+    // When true, confirming this token also flips emailOptIn → 'opted_in'
+    // (the onboarding beat captures the user's intent up front). Profile-issued
+    // tokens leave this false: verifying only confirms the address there.
+    optInOnConfirm: boolean('opt_in_on_confirm').notNull().default(false),
     createdAt: createdAt(),
   },
   (table) => [

--- a/src/server/email/client.ts
+++ b/src/server/email/client.ts
@@ -13,6 +13,10 @@ export type SendEmailParams = {
   subject: string;
   html: string;
   text: string;
+  // Optional extra SMTP headers, forwarded to Resend verbatim. Used to set
+  // List-Unsubscribe / List-Unsubscribe-Post (RFC 8058 one-click) on bulk
+  // reminder emails.
+  headers?: Record<string, string>;
 };
 
 export type SendEmailResult =
@@ -45,6 +49,7 @@ export async function sendEmail(params: SendEmailParams): Promise<SendEmailResul
         subject: params.subject,
         html: params.html,
         text: params.text,
+        ...(params.headers ? { headers: params.headers } : {}),
       }),
     });
 

--- a/src/server/email/send-verification.ts
+++ b/src/server/email/send-verification.ts
@@ -29,11 +29,14 @@ function appBaseUrl(): string {
 // Best-effort: mints a verification token for the user's current
 // pendingEmail and sends the confirm-link email. Never throws — returns
 // a discriminated union so the caller can decide whether to surface the
-// failure. Used by both:
+// failure. Used by:
 //   - POST /api/account/email/verify/send (explicit resend)
 //   - PATCH /api/account/reminders (auto-trigger on pendingEmail change)
+//   - POST /api/onboarding/email-reminder (passes optInOnConfirm so confirming
+//     the link also flips emailOptIn on — the onboarding beat's single action)
 export async function sendVerificationEmail(
   userId: string,
+  options: { optInOnConfirm?: boolean } = {},
 ): Promise<SendVerificationEmailResult> {
   const [row] = await db
     .select({ pendingEmail: users.pendingEmail })
@@ -45,7 +48,9 @@ export async function sendVerificationEmail(
     return { ok: false, reason: 'no_pending_email' };
   }
 
-  const tokenResult = await createVerificationToken(userId, row.pendingEmail);
+  const tokenResult = await createVerificationToken(userId, row.pendingEmail, {
+    optInOnConfirm: options.optInOnConfirm,
+  });
   if (!tokenResult.ok) {
     return { ok: false, reason: 'rate_limited', retryAfterMs: tokenResult.retryAfterMs };
   }

--- a/src/server/email/templates/daily-reminder.ts
+++ b/src/server/email/templates/daily-reminder.ts
@@ -20,6 +20,13 @@ export type DailyReminderTemplateParams = {
    * built slot carries no reveal yet. Absent → the section is omitted.
    */
   teaser?: { questionText: string; domain?: string | null } | null;
+  /**
+   * Signed, session-less unsubscribe URL (see unsubscribe-token.ts). Rendered
+   * as the footer one-click opt-out and mirrored into the List-Unsubscribe
+   * header by the caller. Falls back to "turn off in profile settings" copy
+   * when absent (e.g. a preview send without a real recipient).
+   */
+  unsubscribeUrl?: string | null;
 };
 
 // Ink-on-Cream palette (mirrors verify-email.ts and the in-app design system).
@@ -54,7 +61,8 @@ export function buildDailyReminderTemplate(params: DailyReminderTemplateParams):
   html: string;
   text: string;
 } {
-  const { dailyUrl, interestsUrl, topics, activity, teaser } = params;
+  const { dailyUrl, interestsUrl, topics, activity, teaser, unsubscribeUrl } = params;
+  const unsubUrl = unsubscribeUrl?.trim() || null;
 
   const cleanTopics = topics.map((t) => t.trim()).filter(Boolean);
   const cleanActivity = (activity ?? []).map((a) => a.trim()).filter(Boolean).slice(0, 3);
@@ -64,8 +72,8 @@ export function buildDailyReminderTemplate(params: DailyReminderTemplateParams):
 
   return {
     subject,
-    text: buildText({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText }),
-    html: buildHtml({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText }),
+    text: buildText({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText, unsubUrl }),
+    html: buildHtml({ dailyUrl, interestsUrl, topics: cleanTopics, activity: cleanActivity, teaserText, unsubUrl }),
   };
 }
 
@@ -75,8 +83,9 @@ function buildText(params: {
   topics: string[];
   activity: string[];
   teaserText: string | null;
+  unsubUrl: string | null;
 }): string {
-  const { dailyUrl, interestsUrl, topics, activity, teaserText } = params;
+  const { dailyUrl, interestsUrl, topics, activity, teaserText, unsubUrl } = params;
   const lines: string[] = [
     'Joshing',
     '',
@@ -109,7 +118,9 @@ function buildText(params: {
     `Play today’s five: ${dailyUrl}`,
     '',
     FOOTER_LINE,
-    'You can turn these reminders off any time from your profile settings.',
+    unsubUrl
+      ? `Don’t want these? Unsubscribe: ${unsubUrl}`
+      : 'You can turn these reminders off any time from your profile settings.',
   );
 
   return lines.join('\n');
@@ -121,8 +132,9 @@ function buildHtml(params: {
   topics: string[];
   activity: string[];
   teaserText: string | null;
+  unsubUrl: string | null;
 }): string {
-  const { dailyUrl, interestsUrl, topics, activity, teaserText } = params;
+  const { dailyUrl, interestsUrl, topics, activity, teaserText, unsubUrl } = params;
 
   const topicsBlock =
     topics.length > 0
@@ -187,7 +199,11 @@ function buildHtml(params: {
               <td style="font-family:${SERIF};font-size:14px;line-height:1.6;color:${INK_SOFT};padding-top:8px;padding-bottom:10px;">${FOOTER_LINE}</td>
             </tr>
             <tr>
-              <td style="font-family:${SANS};font-size:12px;line-height:1.55;color:${INK_FAINT};">You can turn these reminders off any time from your profile settings.</td>
+              <td style="font-family:${SANS};font-size:12px;line-height:1.55;color:${INK_FAINT};">${
+                unsubUrl
+                  ? `Don’t want these emails? <a href="${unsubUrl}" style="color:${INK_FAINT};text-decoration:underline;">Unsubscribe</a> — or manage reminders in your profile settings.`
+                  : 'You can turn these reminders off any time from your profile settings.'
+              }</td>
             </tr>
           </table>
         </td>

--- a/src/server/email/unsubscribe-token.ts
+++ b/src/server/email/unsubscribe-token.ts
@@ -1,0 +1,41 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+// Stateless, signed unsubscribe tokens so the daily-reminder footer link (and
+// the RFC 8058 one-click List-Unsubscribe header) work without a logged-in
+// session — the recipient clicks straight from their inbox. We HMAC the userId
+// with JWT_SECRET under a dedicated context string (domain separation from
+// session tokens), so no DB column or expiry is needed: the link stays valid
+// as long as the secret does, which is exactly what an unsubscribe link wants.
+const CONTEXT = 'email-unsubscribe:v1';
+
+function secret(): string {
+  const value = process.env.JWT_SECRET;
+  if (!value) {
+    throw new Error('JWT_SECRET is required to sign unsubscribe links');
+  }
+  return value;
+}
+
+function sign(userId: string): string {
+  return createHmac('sha256', secret()).update(`${CONTEXT}:${userId}`).digest('hex');
+}
+
+export function createUnsubscribeToken(userId: string): string {
+  return `${encodeURIComponent(userId)}.${sign(userId)}`;
+}
+
+// Returns the userId when the signature checks out, null otherwise. Constant-
+// time compare so a forged token can't be brute-forced by timing.
+export function verifyUnsubscribeToken(token: string): string | null {
+  const dot = token.lastIndexOf('.');
+  if (dot <= 0) return null;
+
+  const userId = decodeURIComponent(token.slice(0, dot));
+  const provided = Buffer.from(token.slice(dot + 1));
+  const expected = Buffer.from(sign(userId));
+
+  if (provided.length !== expected.length) return null;
+  if (!timingSafeEqual(provided, expected)) return null;
+
+  return userId;
+}


### PR DESCRIPTION
Adds a final, fully skippable "Daily reminders" step after Areas. Picking
areas still completes onboarding and starts question generation, so the
email ask never blocks finishing — skip or submit, both land in /daily.

Auto-on-after-verify: the beat captures opt-in intent up front, carried on
the verification token (new EmailVerificationToken.opt_in_on_confirm). When
the user confirms the link, consumeVerificationToken promotes the address
AND flips emailOptIn on in the same transaction. Sending stays double-gated
on emailVerified, so nothing goes out before confirmation. Profile-issued
tokens default the flag off, so that verify-then-toggle flow is unchanged.

Unsubscribe: signed, session-less unsubscribe links (HMAC over JWT_SECRET)
power a footer link on the daily-reminder email plus the RFC 8058 one-click
List-Unsubscribe header, as Gmail/Yahoo bulk-sender rules expect. Adds the
/unsubscribe page and /api/email/unsubscribe one-click endpoint.

Also: journal 0076 + 0077 (0076 was never journaled and would be missed on
a fresh prod DB under SKIP_BOOT_DB_GUARDS=1), and refresh the now-stale
"reminders aren't sending yet" copy on the profile notifications form.