### PR TITLE
Fix 'Use this' label concatenating into composer reformulation text

### DIFF
--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -272,6 +272,24 @@ export function scopeSignpost(visibility: 'public' | 'friends' | 'private'): str
   }
 }
 
+// A single critique reformulation option. The "Use this" affordance label and
+// the reformulated question are rendered as two discrete block elements so the
+// label can never share a text node with — and run together into — the
+// suggestion value (the "Use this Which American city…" artifact,
+// B-COMPOSER-SUGGESTION-ARTIFACT-01). The reformulation value owns its own node.
+export function ReformulationOption({ text, onUse }: { text: string; onUse: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onUse}
+      className="block w-full rounded-md border bg-background px-3 py-2 text-left text-sm hover:bg-muted"
+    >
+      <span className="block font-medium">Use this</span>
+      <span className="block">{text}</span>
+    </button>
+  );
+}
+
 export function QuestionForm({
   mode = 'create',
   initialValues,
@@ -574,9 +592,7 @@ export function QuestionForm({
           <p className="mt-3 font-medium">Try one of these instead:</p>
           <div className="mt-2 space-y-2">
             {critique.reformulations.map((text) => (
-              <button key={text} type="button" onClick={() => dispatch({ type: 'USE_REFORMULATION', text })} className="block w-full rounded-md border bg-background px-3 py-2 text-left text-sm hover:bg-muted">
-                <span className="font-medium">Use this</span> {text}
-              </button>
+              <ReformulationOption key={text} text={text} onUse={() => dispatch({ type: 'USE_REFORMULATION', text })} />
             ))}
           </div>
           <div className="mt-3 flex flex-wrap gap-2">

--- a/src/components/__tests__/QuestionForm.test.tsx
+++ b/src/components/__tests__/QuestionForm.test.tsx
@@ -1,6 +1,7 @@
+import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
-import { scopeSignpost } from '@/components/QuestionForm';
+import { ReformulationOption, scopeSignpost } from '@/components/QuestionForm';
 
 // B5 / D9 (PRD-D-5 §5.1): the authoring signpost is a feature, not a privacy
 // warning. Public is the default and reads as a reward (others can play this);
@@ -34,5 +35,30 @@ describe('scopeSignpost (D9 authoring signpost)', () => {
 
   it('keeps private author-only', () => {
     expect(scopeSignpost('private')).toMatch(/only you/i);
+  });
+});
+
+// B-COMPOSER-SUGGESTION-ARTIFACT-01: the "Use this" affordance label must never
+// concatenate with the reformulation value into a single run-on string
+// ("Use this Which American city…"). The label and value are discrete elements;
+// the value owns its own node and is never a bare sibling text node of the label.
+describe('ReformulationOption (B-COMPOSER-SUGGESTION-ARTIFACT-01)', () => {
+  const value = 'Which American city is the capital of New York State?';
+
+  it('renders the reformulation value intact alongside the "Use this" label', () => {
+    const html = renderToStaticMarkup(<ReformulationOption text={value} onUse={() => {}} />);
+    expect(html).toContain('Use this');
+    expect(html).toContain(value);
+  });
+
+  it('wraps the value in its own element so the label can never run into it', () => {
+    const html = renderToStaticMarkup(<ReformulationOption text={value} onUse={() => {}} />);
+    const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    // The value must begin a fresh element's content (e.g. `<span ...>Which…`),
+    // never trail the label as a bare text node (`Use this</span> Which…`).
+    expect(html).toMatch(new RegExp(`<[a-z]+[^>]*>${escaped}`));
+    // And the two must never collapse into one literal run-on string.
+    expect(html).not.toContain(`Use this ${value}`);
+    expect(html).not.toContain(`Use this${value}`);
   });
 });


### PR DESCRIPTION
The critique reformulation button rendered the 'Use this' affordance label
and the reformulated-question value into a single inline text flow
(<span>Use this</span> {text}), producing the run-on artifact
'Use this Which American city…' on the question composer.

Extract the option into a discrete ReformulationOption component that
renders the label and value as separate block elements, so the affordance
can never share a text node with the suggestion value. Add a render-level
regression test asserting the value owns its own element and never
re-concatenates with the label.

B-COMPOSER-SUGGESTION-ARTIFACT-01

https://claude.ai/code/session_018Y7ExY2kdHFqPC6xXJVYwo