### PR TITLE
Add save-success feedback and privacy-scope micro-copy

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -79,6 +79,10 @@ type ActiveModal =
   | { type: 'write-question' }
   | { type: 'tidy' };
 
+// How long the write-question modal stays open after a successful save so the
+// QuestionForm's in-form success confirmation registers before we close it.
+const SUCCESS_HOLD_MS = 1100;
+
 function asTier(value: string): MasteryTier {
   if (value === 'familiar' || value === 'solid' || value === 'mastery') return value;
   return 'establishing';
@@ -479,7 +483,6 @@ function KnowledgePageContent() {
     });
     const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
     if (!response.ok) throw new Error(body?.message ?? 'Could not save that question.');
-    setActiveModal(null);
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setQuestionToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
@@ -492,6 +495,9 @@ function KnowledgePageContent() {
       setQuestionToast('Saved to your bank.');
     }
     window.setTimeout(() => setQuestionToast(null), 2500);
+    // Hold the modal open briefly so the form's in-form success state shows
+    // before it closes; the toast above carries the destination detail.
+    window.setTimeout(() => setActiveModal(null), SUCCESS_HOLD_MS);
   };
 
   const reinstateDomain = async (domain: string) => {

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -24,6 +24,10 @@ type DrawerState =
   | { mode: 'create'; intent: CreateIntent | null; prefillText?: string; autoSubmit?: boolean }
   | { mode: 'edit'; question: QuestionView };
 
+// How long the composer drawer stays open after a successful save so the
+// QuestionForm's in-form success confirmation registers before we close it.
+const SUCCESS_HOLD_MS = 1100;
+
 function parseIntent(raw: string | null): CreateIntent | null {
   return raw === 'bank' || raw === 'followers' || raw === 'specific' ? raw : null;
 }
@@ -274,7 +278,6 @@ function QuestionsPageContent() {
     const body = await response.json().catch(() => null) as CreateQuestionResponse | null;
     if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not save that question.');
     setQuestions((current) => [body.question!, ...current]);
-    closeDrawer();
     if (values.sendToFriendIds.length > 0) {
       const n = values.sendToFriendIds.length;
       setToast(`Sent to ${n} ${n === 1 ? 'friend' : 'friends'}.`);
@@ -286,6 +289,9 @@ function QuestionsPageContent() {
     } else {
       setToast('Saved to your bank.');
     }
+    // Hold the drawer open a beat so the form's in-form success state is seen
+    // before we close it; the toast above is the destination-aware companion.
+    window.setTimeout(closeDrawer, SUCCESS_HOLD_MS);
   }
 
   async function saveEdit(questionId: string, values: QuestionFormValues) {
@@ -298,8 +304,8 @@ function QuestionsPageContent() {
     const body = await response.json().catch(() => null) as { question?: QuestionView; error?: string; message?: string } | null;
     if (!response.ok || !body?.question) throw new Error(body?.message ?? body?.error ?? 'Could not update that question.');
     setQuestions((current) => current.map((question) => question.id === questionId ? body.question! : question));
-    closeDrawer();
     setToast('Question updated.');
+    window.setTimeout(closeDrawer, SUCCESS_HOLD_MS);
   }
 
   async function confirmDelete(question: QuestionView) {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -539,6 +539,31 @@ function ProfileHeaderCard({
   )
 }
 
+// Per-scope helper micro-copy shown beneath each section's visibility toggle,
+// so the owner can see exactly what each choice exposes. "Public" stays
+// link-scoped ("with your profile link") rather than "indexed/searchable":
+// profiles are never publicly indexed (PRD §8.6.1), only reachable by link.
+const SECTION_VISIBILITY_HELP: Record<
+  'knowledge_base' | 'authored_questions' | 'friends_list',
+  Record<'public' | 'friends' | 'private', string>
+> = {
+  knowledge_base: {
+    private: 'Only you can see your knowledge base.',
+    friends: "Friends you've added on Joshing can see it.",
+    public: 'Anyone with your profile link can see it.',
+  },
+  authored_questions: {
+    private: "Only you can see the questions you've written.",
+    friends: "Friends you've added on Joshing can see them.",
+    public: 'Anyone with your profile link can see them.',
+  },
+  friends_list: {
+    private: 'Only you can see your friends list.',
+    friends: "Friends you've added on Joshing can see it.",
+    public: 'Anyone with your profile link can see it.',
+  },
+}
+
 // Settings-style row that renders a 3-level visibility toggle on the
 // right instead of a chevron. Reused for each toggle in the Privacy
 // section of the owner self-view.
@@ -578,6 +603,7 @@ function PrivacyRow({
           initialVisibility={visibility}
           size="compact"
           fullWidth
+          help={SECTION_VISIBILITY_HELP[section]}
         />
       </div>
     </div>

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -514,6 +514,22 @@ export function QuestionForm({
   const critique = state.critiqueResult;
   const counter = remainingCopy(state);
   const canShowAnswering = state.stage === 'ANSWERING' || state.stage === 'SUBMITTING' || mode === 'edit';
+
+  // Save-success confirmation. The save lands, the form flips to DONE, and this
+  // panel replaces the fields so the writer gets an unmistakable in-form
+  // confirmation (the host page also fires its destination-aware toast as it
+  // closes the drawer a beat later). `Save to bank` is always forced on, so the
+  // create-mode baseline is always literally true regardless of sharing choices.
+  if (state.stage === 'DONE') {
+    return (
+      <div className="space-y-5">
+        <div className="flex flex-col items-center justify-center gap-2 py-12 text-center" role="status" aria-live="polite">
+          <span className="text-3xl leading-none text-[var(--success)]" aria-hidden="true">✓</span>
+          <p className="m-0 text-base font-medium text-[var(--success)]">{mode === 'edit' ? 'Question updated.' : 'Saved to your bank.'}</p>
+        </div>
+      </div>
+    );
+  }
   // The form lives inside a scrollable drawer/modal (questions + knowledge
   // pages). Keep the action buttons pinned to the bottom on an opaque,
   // composited footer: the backdrop-blur layer prevents the iOS Safari
@@ -796,7 +812,18 @@ export function QuestionForm({
           ) : null}
 
           <div className={actionBarClass}>
-            <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">{submitDisabled ? loadingLabel : resolvedSubmitLabel}</button>
+            <button type="button" disabled={submitDisabled} onClick={() => void finalSave()} className="btn-primary">
+              {submitDisabled ? (
+                <span className="inline-flex items-center">
+                  {loadingLabel.replace(/[.…]+$/, '')}
+                  <span className="ml-0.5 inline-flex gap-0.5" aria-hidden="true">
+                    <span className="triangle-loader-dot inline-block" style={{ animation: 'loading-dot 1.2s ease-in-out 0s infinite' }}>.</span>
+                    <span className="triangle-loader-dot inline-block" style={{ animation: 'loading-dot 1.2s ease-in-out 0.2s infinite' }}>.</span>
+                    <span className="triangle-loader-dot inline-block" style={{ animation: 'loading-dot 1.2s ease-in-out 0.4s infinite' }}>.</span>
+                  </span>
+                </span>
+              ) : resolvedSubmitLabel}
+            </button>
             {onCancel ? <button type="button" onClick={onCancel} className="btn-ghost" disabled={submitDisabled}>Cancel</button> : null}
           </div>
         </>

--- a/src/components/profile/SectionVisibilityToggle.tsx
+++ b/src/components/profile/SectionVisibilityToggle.tsx
@@ -26,6 +26,11 @@ type Props = {
   // instead of sizing to content. Useful when the toggle is stacked
   // below a label rather than placed inline beside it.
   fullWidth?: boolean;
+  // Optional per-scope helper micro-copy. When provided, the line for the
+  // currently-selected scope renders under the pill row so the player can see
+  // what each choice exposes. Tracks the optimistic local state, so it updates
+  // the instant a scope is tapped.
+  help?: Record<SectionVisibility, string>;
 };
 
 // Generalization of DomainVisibilityToggle (which is per-knowledge-domain).
@@ -40,6 +45,7 @@ export function SectionVisibilityToggle({
   onSaved,
   size = 'default',
   fullWidth = false,
+  help,
 }: Props) {
   const [visibility, setVisibility] = useState<SectionVisibility>(initialVisibility);
   const [isSaving, setIsSaving] = useState(false);
@@ -100,6 +106,7 @@ export function SectionVisibilityToggle({
           </button>
         ))}
       </div>
+      {help ? <p className="mt-1.5 text-xs text-muted-foreground">{help[visibility]}</p> : null}
       {error ? <p className="mt-1 text-xs text-destructive">{error}</p> : null}
     </div>
   );


### PR DESCRIPTION
(A) QuestionForm save flow now shows an animated in-flight spinner on the
Save button and an in-form success confirmation (DONE state) before the
host drawer/modal closes. The questions and knowledge pages hold their
drawer open briefly so the confirmation registers; their existing
destination-aware toasts remain the companion signal. Failure copy was
already specific and is unchanged.

(B) The three profile-section visibility toggles (Knowledge base,
Questions, Friends list) now render per-scope helper micro-copy under the
pill row via a new optional `help` prop on SectionVisibilityToggle.
Public stays link-scoped ("with your profile link"), never implying a
publicly indexed profile (PRD section 8.6.1). No change to visibility
behavior, defaults, or the PATCH contract.