### PR TITLE
fix(auth): mint accurate onboarding claim on login to stop root 404 hop

### DIFF
--- a/src/app/api/auth/verify-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/verify-otp/__tests__/route.test.ts
@@ -64,6 +64,7 @@ vi.mock('@/server/db', () => ({
     displayName: 'users.displayName',
     handle: 'users.handle',
     timezone: 'users.timezone',
+    onboardingComplete: 'users.onboardingComplete',
   },
 }))
 
@@ -87,6 +88,7 @@ const EXISTING_USER = {
   displayName: null,
   handle: null,
   timezone: 'America/New_York',
+  onboardingComplete: false,
 }
 
 const NEW_USER = {
@@ -95,6 +97,7 @@ const NEW_USER = {
   displayName: null,
   handle: null,
   timezone: 'America/New_York',
+  onboardingComplete: false,
 }
 
 const VALID_INVITATION = {
@@ -173,6 +176,28 @@ describe('/api/auth/verify-otp invitation gate', () => {
         onboardingComplete: false,
       })
       expect(hasAcceptedInvitationForUserMock).not.toHaveBeenCalled()
+    })
+
+    it('mints the session with the user real onboardingComplete on re-login (B-ROOT-404: avoids the refresh-onboarding-claim redirect hop on /)', async () => {
+      // A fully-onboarded user re-logging in must get onb:true straight away.
+      // Previously the route hardcoded onboardingComplete:false, so the first
+      // post-login GET / was bounced through /api/auth/refresh-onboarding-claim
+      // to re-mint the claim — a redirect hop that intermittently 404'd on /.
+      findUserSelectMock.mockResolvedValueOnce([
+        { ...EXISTING_USER, onboardingComplete: true },
+      ])
+
+      const response = await POST(
+        jsonRequest({ phone: '+15551234567', code: '000000' })
+      )
+      const body = await response.json()
+
+      expect(response.status).toBe(200)
+      expect(body.user.onboardingComplete).toBe(true)
+      expect(createSessionMock).toHaveBeenCalledWith('user-1', {
+        invitationAccepted: true,
+        onboardingComplete: true,
+      })
     })
 
     it('allows re-login when accepting a new invitation', async () => {

--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -41,6 +41,7 @@ type AuthUser = {
   displayName: string | null
   handle: string | null
   timezone: string
+  onboardingComplete: boolean
 }
 
 const USER_SELECTION = {
@@ -49,6 +50,12 @@ const USER_SELECTION = {
   displayName: users.displayName,
   handle: users.handle,
   timezone: users.timezone,
+  // Read the real onboarding state so the re-login session is minted with the
+  // correct `onb` claim. Without this every login minted onb:false and the
+  // first post-login GET / was bounced through the
+  // /api/auth/refresh-onboarding-claim route handler to re-mint the claim —
+  // a redirect hop that opened an intermittent 404 window on / (B-ROOT-404).
+  onboardingComplete: users.onboardingComplete,
 }
 
 async function findUserByPhone(
@@ -200,7 +207,7 @@ export async function POST(request: Request) {
 
       await createSession(existingUser.id, {
         invitationAccepted: true,
-        onboardingComplete: false,
+        onboardingComplete: existingUser.onboardingComplete,
       })
 
       return NextResponse.json({
@@ -210,7 +217,7 @@ export async function POST(request: Request) {
           display_name: existingUser.displayName,
           handle: existingUser.handle,
           timezone: existingUser.timezone,
-          onboardingComplete: false,
+          onboardingComplete: existingUser.onboardingComplete,
         },
         invitation: invitationResult,
       })


### PR DESCRIPTION
verify-otp hardcoded onboardingComplete:false on every session mint, so a
fully-onboarded user re-logging in got a JWT with onb:false. The first
post-login soft navigation to / (router.replace('/')) then hit the proxy,
which — seeing onb:false — redirected the RSC request for / into the
/api/auth/refresh-onboarding-claim route handler to re-mint the claim and
bounce back to /. That redirect-through-an-API-route hop is the window in
which the intermittent root 404 surfaced (widest on cold start, where the
refresh endpoint runs behind the boot DB guards + 3 DB round-trips).

Mint the real onboardingComplete value so the post-login / request is served
by the proxy's first decision (Home for onboarded, /onboarding for not) with
no refresh detour. New users stay false (correct: just provisioned). The
refresh endpoints remain for genuinely-legacy pre-onb cookies; this only
removes them from the fresh-login fast path. Where unauthenticated/unonboarded
users are sent is unchanged.

Adds a regression test asserting an onboarded re-login mints onb:true.

https://claude.ai/code/session_01Ubrr2jgQxF8avu75JoFVun