### PR TITLE
docs(audits): audit tracker — canon dispositions + re-verification

### DIFF
--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -3,98 +3,123 @@
 One living ledger for the two audits currently being worked down. Edit the **Status** column as you take items off the board.
 
 **Last code-verification pass:** 2026-06-13 (against branch `claude/audit-items-tracking-kp59my`).
+**Canon disposition pass (audit #2):** 2026-06-13 — every Pre-Launch item sorted against product canon (see Disposition column + guardrails).
 
 ## How to use this file
 
 - **Take an item down:** change its **Status** and, if useful, drop a note + commit SHA in the **Notes** column.
-- **Re-run the code check:** ask me in this session — "re-verify the audit tracker" (or just the items you touched). I re-read the current code, update the Status/Notes columns, and note a fresh "Last verification pass" date. The check is a read-only pass; it never changes app code.
-- **Add a new item:** add a row to the relevant table with the next free ID (e.g. `PLR-26`, `CONS-16`), or a new `MISC-n` row in the *Other / ad-hoc* table at the bottom. Or tell me "add X to the tracker" and I'll slot it in. New audits get their own table + ID prefix.
+- **Re-run the code check:** ask me in this session — "re-verify the audit tracker" (or just the items you touched). Read-only pass; never changes app code.
+- **Add a new item:** add a row with the next free ID (`PLR-26`, `CONS-16`), or a `MISC-n` row in *Other / ad-hoc*. Or tell me "add X" and I'll slot it in.
 
-### Status legend
+### Status legend (what the code shows)
 
 | Status | Meaning |
 |---|---|
 | `DONE` | Verified fixed in code. |
-| `PARTIAL` | Substantially addressed; a residual gap remains (see Notes). |
+| `PARTIAL` | Substantially addressed; a residual gap remains. |
 | `OPEN` | Not addressed yet. |
-| `NEEDS DECISION` | Real finding, but a product/design call is required before any work. |
-| `TRACKED ELSEWHERE` | Genuine signal, already owned by another workstream. |
-| `WON'T DO` | Dismissed — contradicts canon, describes a surface we don't have, or generic boilerplate. |
+| `NEEDS DECISION` | Real, but a product/design/copy call is required before work. |
+| `DEFERRED` | Valid but parked (post-launch). |
+| `TRACKED ELSEWHERE` | Genuine signal, owned by another workstream. |
+| `WON'T DO` | Dismissed — contradicts canon, invented, or generic boilerplate. |
+
+### Disposition legend (whether / how to act — canon lens)
+
+| Disposition | Meaning |
+|---|---|
+| `CLEAN WIN` | Canon-aligned; fix as written. |
+| `FIX VIA CANON` | Real signal, but the reviewer's recommendation must be rerouted through canon — see note. |
+| `PRODUCT CONVERSATION` | Strategic question, not a quick fix; discuss before acting. |
+| `DO NOT DO` | Contradicts a load-bearing product decision. |
+
+> **Provenance note:** Audit #2 (Pre-Launch Review) was written against the **live app** (`joshing-11.vercel.app`) and names real surfaces — most of it is real signal, unlike audit #1. Where its static-code Status and live-app observation disagree (e.g. PLR-7), trust the live observation enough to re-verify. The numeric scores (Vision 9, Craftsmanship 6, …) are a generic rubric — **ignore the numbers, keep the specific observations.**
+
+---
+
+## 🚫 Canon traps — do NOT act on these (even though the audit recommends them)
+
+| From | Trap | Why it's banned |
+|---|---|---|
+| #14 + "Opportunities" | Leaderboards, streak-as-pressure, "Challenge Blake," competition-register words ("beat," "called," "challenge") | Anti-competition is foundational. Friend actions can be richer **without** any of this. |
+| #23 | Audio/haptic chime on correct **and a tone on "incorrect"** | A wrong answer is a connection/discovery event, not a failure — a sad tone betrays the thesis. |
+| #16 | Collapsible grouping of the home feed | Clustering was tried on Group 3, rejected (fragment-copy), and `B-FEED-GROUP3-FIX-01` enforces a straight chronological stream. Real fix = sequencing/staggering CTAs, not grouping. |
+| #3 | "Simplify reveal to one tap" / make revealing faster | Reveal in catch-up **consumes** a question; grading must fail toward the player. Resolve via PLR-8 (add confirmation), don't make reveal more accidental. |
+| #17 | Confetti / game-win celebration on catch-up close | A closure state is fine, but in the quiet-warmth ("knows it down cold") voice — not a celebration-of-correctness register. |
 
 ---
 
 ## ⭐ Start here — open & important
 
-The items most worth attention right now (open launch blockers + the one decision gate):
-
-| ID | Item | Priority | Status |
-|---|---|---|---|
-| PLR-1 | Developer tools (test game / reset / noon reset / staging flags / points diagnostic) visible to all users | P0 | `OPEN` |
-| PLR-11 | "Card Color" PaletteToggle dev tool still shipped to all users (code comment: "remove before shipping") | — | `OPEN` |
-| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` (runtime verify) |
-| PLR-3 | "Show me the answer" double-action / duplication | P1 | `OPEN` (runtime verify) |
-| PLR-8 | Catch-up answer-reveal consumes a missed question with no confirmation | P1 | `OPEN` |
-| PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` |
-| PLR-16 | Overwhelming home feed after the daily five | P1 | `PARTIAL` |
-| CONS-7 | Shadow / elevation drift (flat letterpress vs. blurred shadows coexist) | — | `NEEDS DECISION` |
-
----
-
-## Audit #2 — Product Design Pre-Launch Review
-
-Source: `audits/2026-06-13-product-design-prelaunch-review.md` (25 improvements + launch blockers). Priority = the audit's own launch-blocker ranking (blank = not on the blocker list; rank by impact).
-
-| ID | Item | Priority | Status | Notes (evidence @ 2026-06-13) |
+| ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| PLR-1 | Dev tools visible to all users | P0 | `OPEN` | Rendered unconditionally in `src/components/profile/settings/AccountActions.tsx:102–135`; no `NODE_ENV`/admin guard. |
-| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` | `page.tsx`/`proxy.ts` redirect logic looks correct; a 404 *flash* is a runtime/network timing observation — needs a live repro. |
-| PLR-3 | "Show me the answer" duplication (double action) | P1 | `OPEN` | Text reveal at `src/components/play/GameplayChat.tsx:541`; the exact "button-inside-button, same label" wasn't found in code — needs a live repro to confirm/close. |
-| PLR-4 | Auto-generated tagline misrepresents new users | P1 | `DONE` | `buildMindStatement()` `src/app/users/[id]/page.tsx:78–91` now derives the line from real mastery; new users get a neutral placeholder, not random subcultures. |
-| PLR-5 | "Use this" artefact in rewrite suggestions | P1 | `DONE` | Fixed in `75eb625`; "Use this" + text are separate block spans in `src/components/QuestionForm.tsx:280–291`. |
-| PLR-6 | No success feedback after saving a question | — | `DONE` | `419201a`; "✓ Saved to your bank" panel (`role=status`, `aria-live=polite`) at `src/components/QuestionForm.tsx:541–549` + host toast. |
-| PLR-7 | Gear icon on Today's Five card does nothing | P2 | `DONE` | It's a `<Link href="/daily/setup">` (`aria-label="Set up daily round"`) at `src/components/TodaysFiveCard.tsx:209–215`. |
-| PLR-8 | Catch-up reveal consumes a missed question, no confirmation | P1 | `OPEN` | `onGiveUp={() => skipCurrent()}` with no confirm step — `src/app/daily/catchup/page.tsx:138`. |
-| PLR-9 | Privacy toggles lack per-section context | P2 | `DONE` | `419201a`; `SECTION_VISIBILITY_HELP` per-scope copy `src/app/users/[id]/page.tsx:546–565`, wired via `help` prop (`:606`). |
-| PLR-10 | "Establishing" label unclear | — | `OPEN` | Rendered with no tooltip — `src/components/TodaysFiveCard.tsx:49,58`; tier name also at `TerritorySetupClient.tsx:181`. |
-| PLR-11 | Card-colour switcher confusing / unexplained | — | `OPEN` | `PaletteToggle` is a **dev tool still live for everyone** — `src/app/layout.tsx:7,72` with comment "Remove … before shipping." Treat as a ship gate alongside PLR-1. |
-| PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | Inline click-to-edit fields (`InlineEditableField`, `InlineHandleField`) `src/app/users/[id]/page.tsx:492–539`; no explicit "Edit profile" affordance — discoverable only by tapping. |
-| PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `rows={4}`, no `resize-y` — `src/components/QuestionForm.tsx:666`. |
-| PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FriendCard` is just a `<Link>` to profile — `src/components/FriendsList.tsx:108–122`; no play/message/unfriend. |
-| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `OPEN` | No first-run tour/intro in `src/app/knowledge/page.tsx` or children. |
-| PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | Budgeted "edition" caps volume (`src/server/home/build-edition.ts`, `src/app/page.tsx:118–161`, D-HOME-PACING-01) — but no collapsible grouping as the audit asked. |
-| PLR-17 | Catch-up flow lacks closure/celebration | — | `PARTIAL` | `RoundSummary` closing state w/ score dots + recap + CTAs `src/app/daily/catchup/page.tsx:173–311`; no celebratory animation. |
-| PLR-18 | Knowledge frequency options lack micro-copy | P2 | `DONE` | Each zone has explanatory `copy` — `src/app/daily/setup/TerritorySetupClient.tsx:43–55`. |
-| PLR-19 | Invite flow generic; unclear link/email/SMS | — | `PARTIAL` | "Send a personal invite" + "Copy invite link" with "share anywhere" copy — `src/components/friends/InviteSomeoneNew.tsx:54–84`; no explicit SMS/email labelling. |
-| PLR-20 | Avatars are initials-only; no photo upload | — | `OPEN` | `AvatarChip` is initials-only; no upload input/API anywhere. |
-| PLR-21 | Inconsistent link styling on summary page | — | `OPEN` | Underlined + button-styled links coexist — `src/app/daily/summary/page.tsx:242,255,259,635,663`. |
-| PLR-22 | No dark mode | P3 | `OPEN` | No `prefers-color-scheme: dark` block / dark tokens in `src/app/globals.css`. |
-| PLR-23 | No audio/haptic feedback on answers | P3 | `OPEN` | No `navigator.vibrate` / `AudioContext` anywhere in `src/`. |
-| PLR-24 | Knowledge categories skew Western | P3 | `OPEN` | Pool is LLM-generated against user interests; prompts acknowledge cultural context (`src/server/llm/interests.ts:219,269`). Needs live data analysis to judge skew. |
-| PLR-25 | Missing first-run micro-copy (streaks/points/"Daily Five is sacred") | P3 | `PARTIAL` | First-run intro exists (`src/app/daily/page.tsx:807–855`) but doesn't cover streaks/points/the ritual framing. |
+| PLR-1 | Dev tools visible to all users | P0 | `OPEN` | `CLEAN WIN` — gate behind `ADMIN_USER_IDS` (same allowlist as content reporting) |
+| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` | `CLEAN WIN` — trace root-route redirect race in `src/proxy.ts` |
+| PLR-8 | Catch-up reveal consumes a question, no confirmation | P1 | `OPEN` | `FIX VIA CANON` — the important half of #3/#8; aligns with fail-toward-player |
+| PLR-11 | "Card Color" PaletteToggle dev tool still shipped to all | — | `OPEN` | — (ship gate; pull before launch, like PLR-1) |
+| PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
+| PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
+| PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` — audit seed bank + interest taxonomy, not a content drive |
+| CONS-7 | Shadow / elevation drift | — | `NEEDS DECISION` | Option A (uniform flat) vs B (two registers) |
+
+**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 (re-verify), PLR-9 ✅, PLR-13, PLR-21.
 
 ---
 
-## Audit #1 — Design Consistency Audit ("…and Polish Plan")
+## Audit #2 — Product Design Pre-Launch Review (25 items)
 
-Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (15 items, code-verified 2026-06-13). Net: only **CONS-7** is a live finding; the rest are closed.
+Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the audit's own launch-blocker ranking.
+
+| ID | Item | Priority | Status | Disposition | Notes |
+|---|---|---|---|---|---|
+| PLR-1 | Dev tools visible to all users | P0 | `OPEN` | `CLEAN WIN` | Unconditional in `AccountActions.tsx:102–135`. Gate behind `ADMIN_USER_IDS` allowlist (reuse the content-reporting gate). |
+| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` | `CLEAN WIN` | Real instability. Likely a root-route redirect race; auth routes via `src/proxy.ts`. Trace before launch. |
+| PLR-3 | "Show me the answer" duplication | P1 | `OPEN` | `FIX VIA CANON` | Text reveal `GameplayChat.tsx:541`. **Resolve only in light of PLR-8** — do NOT make reveal faster/more accidental. |
+| PLR-4 | Auto-generated tagline misrepresents new users | P1 | `DONE` | `FIX VIA CANON` | Portrait must be *earned by play*, not auto-assigned. Canon-correct fix shipped: `buildMindStatement()` `users/[id]/page.tsx:78–91` derives from real mastery + neutral placeholder for new users. |
+| PLR-5 | "Use this" artefact in rewrite suggestions | P1 | `DONE` | `CLEAN WIN` | `75eb625`; separate block spans `QuestionForm.tsx:280–291`. (Generation prompt is the biggest quality lever — good it's clean.) |
+| PLR-6 | No success feedback after saving a question | — | `DONE` | `CLEAN WIN` | `419201a`; "✓ Saved" panel `QuestionForm.tsx:541–549` + host toast. |
+| PLR-7 | Gear icon on Today's Five does nothing | P2 | `OPEN` (verify) | `CLEAN WIN` | **Discrepancy:** code shows a working `<Link href="/daily/setup">` `TodaysFiveCard.tsx:209–215`, but the live-app reviewer read it as a dead control. Re-verify on live: is the destination non-obvious, or a different build? Remove/clarify accordingly. |
+| PLR-8 | Catch-up reveal, no confirmation | P1 | `OPEN` | `FIX VIA CANON` | The more important of #3/#8. `onGiveUp={() => skipCurrent()}` `catchup/page.tsx:138`. Add a confirm before a reveal burns a question (fail-toward-player). |
+| PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
+| PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
+| PLR-11 | Card-colour switcher confusing | — | `OPEN` | — | Dev `PaletteToggle` live for all `layout.tsx:7,72` ("remove before shipping"). Ship gate alongside PLR-1. |
+| PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
+| PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
+| PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |
+| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` | Real gap; B-FirstRecap-1 / B-HomeSeed-1 exist. **Tooltip must not misstate mastery** (author 0.5× / catch-up 0.25× / live full) — "bigger = more answered" is wrong. |
+| PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` | Budgeted "edition" caps volume (`build-edition.ts`, `page.tsx:118–161`). Real signal = too many CTAs at arrival → **stagger/sequence**, NOT collapsible grouping (banned, see traps). |
+| PLR-17 | Catch-up lacks closure/celebration | — | `PARTIAL` | `DO NOT DO` (confetti) | `RoundSummary` closing state exists `catchup/page.tsx:173–311`. A closure beat is OK in the quiet-warmth voice; **no** game-win celebration/confetti. |
+| PLR-18 | Frequency options lack micro-copy | P2 | `DONE` | `CLEAN WIN` | Per-zone `copy` `TerritorySetupClient.tsx:43–55`. |
+| PLR-19 | Invite flow generic (link/email/SMS unclear) | — | `PARTIAL` | — | Personal invite + copy link `InviteSomeoneNew.tsx:54–84`; no explicit SMS/email labelling. |
+| PLR-20 | Avatars initials-only; no photo upload | — | `OPEN` | — | `AvatarChip` initials-only; no upload anywhere. |
+| PLR-21 | Inconsistent link styling on summary page | — | `OPEN` | `CLEAN WIN` | Low-stakes. Underlined + button links coexist `summary/page.tsx:242,255,259,635,663`. |
+| PLR-22 | No dark mode | P3 | `DEFERRED` | `DO NOT DO` (for launch) | Not canon-violating, but reworks the cream/serif/illustration brand — large effort. Park post-launch. |
+| PLR-23 | Audio/haptic feedback on answers | P3 | `WON'T DO` | `DO NOT DO` | Wrong answer = discovery, not failure; an "incorrect" tone betrays the thesis. Skip. |
+| PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` | Genuine strategic question. Skew (if real) lives in seed/bank content + declared-interest taxonomy. Fix = **audit those for skew**, NOT a diversity content drive (content is friend-authored/declared, `interests.ts:219,269`). |
+| PLR-25 | Missing first-run micro-copy (streaks/points/ritual) | P3 | `PARTIAL` | — | Intro exists `daily/page.tsx:807–855`; omits those concepts. (Note: "streaks/points" framing — keep it ritual/warmth, not pressure.) |
+
+---
+
+## Audit #1 — Design Consistency Audit (15 items)
+
+Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 2026-06-13). Template-style audit run against screenshots, not the live tree — only **CONS-7** is a live finding.
 
 | ID | Item | Status | Notes |
 |---|---|---|---|
-| CONS-1 | Inconsistent button styling | `TRACKED ELSEWHERE` | Misreads the "blue = action CTA only" rule; the one real sub-point (hardcoded vs. token) lives in `B-VISUAL-TOKEN-BUDGET-01`. |
-| CONS-2 | Duplicate card patterns | `WON'T DO` | Canon: card-tier work deferred to `B-VISUAL-CARD-TIERS-01`; `LoadingScreen`/`OverlapMap` are intentional bespoke primitives. |
-| CONS-3 | Inconsistent iconography | `WON'T DO` | Generic — no Joshing surface cited. |
-| CONS-4 | Duplicate modals & bottom sheets | `WON'T DO` | Canon — same as CONS-2; deferred card/primitive decisions. |
-| CONS-5 | Multiple spacing systems | `TRACKED ELSEWHERE` | Folds into the token-budget literal inventory. |
-| CONS-6 | Varying corner radii | `TRACKED ELSEWHERE` | Same files re-literalize values; covered by token-budget. |
-| CONS-7 | Inconsistent elevation / shadows | `NEEDS DECISION` | **Real (low).** Flat `Npx Npx 0` offsets coexist with blurred drop shadows; nothing uses `1px 1px 0`. Decide **Option A** (uniform flat letterpress) vs **Option B** (two intentional registers) before any prompt. |
-| CONS-8 | Non-standard typography hierarchy | `WON'T DO` | Generic — font tokens defined; complaint ungrounded. |
-| CONS-9 | Mixed illustration styles | `WON'T DO` | Generic — no screens cited. |
-| CONS-10 | Inconsistent form controls | `WON'T DO` | Generic — no surface cited. |
-| CONS-11 | Multiple progress-indicator styles | `WON'T DO` | Generic — progress already unified (`GeometricProgress`, Daily Five dots). |
-| CONS-12 | Duplicate tag/chip/badge components | `WON'T DO` | Generic — no instances cited. |
-| CONS-13 | Uneven navigation patterns | `WON'T DO` | Invented — one consistent bottom nav (`src/components/Nav.tsx`); no drawer/top-tab conflict. |
-| CONS-14 | Different animation language | `WON'T DO` | Generic — no interactions cited. |
-| CONS-15 | Knowledge-visualisation inconsistency | `WON'T DO` | Canon — category colours are identity signals, not a palette to normalize. The underlying collision was already fixed/promoted. |
+| CONS-1 | Inconsistent button styling | `TRACKED ELSEWHERE` | Real sub-point owned by `B-VISUAL-TOKEN-BUDGET-01` |
+| CONS-2 | Duplicate card patterns | `WON'T DO` | Canon — card tiers deferred; bespoke primitives intentional |
+| CONS-3 | Inconsistent iconography | `WON'T DO` | Generic — no surface cited |
+| CONS-4 | Duplicate modals & bottom sheets | `WON'T DO` | Canon — same as CONS-2 |
+| CONS-5 | Multiple spacing systems | `TRACKED ELSEWHERE` | Folds into token-budget inventory |
+| CONS-6 | Varying corner radii | `TRACKED ELSEWHERE` | Covered by token-budget |
+| CONS-7 | Inconsistent elevation / shadows | `NEEDS DECISION` | **Real (low).** Option A (uniform flat letterpress) vs B (two intentional registers) before any prompt |
+| CONS-8 | Non-standard typography hierarchy | `WON'T DO` | Generic — font tokens defined |
+| CONS-9 | Mixed illustration styles | `WON'T DO` | Generic — no screens cited |
+| CONS-10 | Inconsistent form controls | `WON'T DO` | Generic — no surface cited |
+| CONS-11 | Multiple progress-indicator styles | `WON'T DO` | Generic — progress already unified |
+| CONS-12 | Duplicate tag/chip/badge components | `WON'T DO` | Generic — no instances cited |
+| CONS-13 | Uneven navigation patterns | `WON'T DO` | Invented — one consistent bottom nav |
+| CONS-14 | Different animation language | `WON'T DO` | Generic — no interactions cited |
+| CONS-15 | Knowledge-visualisation inconsistency | `WON'T DO` | Canon — category colours are identity signals; underlying collision already fixed |
 
 ---
 

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -2,7 +2,7 @@
 
 One living ledger for the two audits currently being worked down. Edit the **Status** column as you take items off the board.
 
-**Last code-verification pass:** 2026-06-13 (against branch `claude/audit-items-tracking-kp59my`).
+**Last code-verification pass:** 2026-06-14 (re-verified against `origin/dev2`). Delta since 2026-06-13: **PLR-2 (root 404) → DONE** (fix `304215b8` merged via #922).
 **Canon disposition pass (audit #2):** 2026-06-13 — every Pre-Launch item sorted against product canon (see Disposition column + guardrails).
 
 ## How to use this file
@@ -52,8 +52,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| PLR-1 | Dev tools visible to all users | P0 | `OPEN` | `CLEAN WIN` — gate behind `ADMIN_USER_IDS` (same allowlist as content reporting) |
-| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` | `CLEAN WIN` — trace root-route redirect race in `src/proxy.ts` |
 | PLR-8 | Catch-up reveal consumes a question, no confirmation | P1 | `OPEN` | `FIX VIA CANON` — the important half of #3/#8; aligns with fail-toward-player |
 | PLR-11 | "Card Color" PaletteToggle dev tool still shipped to all | — | `OPEN` | — (ship gate; pull before launch, like PLR-1) |
 | PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
@@ -71,13 +69,13 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 
 | ID | Item | Priority | Status | Disposition | Notes |
 |---|---|---|---|---|---|
-| PLR-1 | Dev tools visible to all users | P0 | `OPEN` | `CLEAN WIN` | Unconditional in `AccountActions.tsx:102–135`. Gate behind `ADMIN_USER_IDS` allowlist (reuse the content-reporting gate). |
-| PLR-2 | Intermittent 404 on root during sign-in | P0 | `OPEN` | `CLEAN WIN` | Real instability. Likely a root-route redirect race; auth routes via `src/proxy.ts`. Trace before launch. |
+| PLR-1 | Dev tools visible to all users | P0 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: unconditional in `AccountActions.tsx:102–135`.) |
+| PLR-2 | Intermittent 404 on root during sign-in | P0 | `DONE` | `CLEAN WIN` | Fixed `304215b8` (#922): re-login now mints the real `onb` claim (`verify-otp/route.ts:50,213`), removing the `refresh-onboarding-claim` redirect hop that opened the 404 window. Regression test added. Diagnosed root cause; a live smoke confirms. |
 | PLR-3 | "Show me the answer" duplication | P1 | `OPEN` | `FIX VIA CANON` | Text reveal `GameplayChat.tsx:541`. **Resolve only in light of PLR-8** — do NOT make reveal faster/more accidental. |
 | PLR-4 | Auto-generated tagline misrepresents new users | P1 | `DONE` | `FIX VIA CANON` | Portrait must be *earned by play*, not auto-assigned. Canon-correct fix shipped: `buildMindStatement()` `users/[id]/page.tsx:78–91` derives from real mastery + neutral placeholder for new users. |
 | PLR-5 | "Use this" artefact in rewrite suggestions | P1 | `DONE` | `CLEAN WIN` | `75eb625`; separate block spans `QuestionForm.tsx:280–291`. (Generation prompt is the biggest quality lever — good it's clean.) |
 | PLR-6 | No success feedback after saving a question | — | `DONE` | `CLEAN WIN` | `419201a`; "✓ Saved" panel `QuestionForm.tsx:541–549` + host toast. |
-| PLR-7 | Gear icon on Today's Five does nothing | P2 | `OPEN` (verify) | `CLEAN WIN` | **Discrepancy:** code shows a working `<Link href="/daily/setup">` `TodaysFiveCard.tsx:209–215`, but the live-app reviewer read it as a dead control. Re-verify on live: is the destination non-obvious, or a different build? Remove/clarify accordingly. |
+| PLR-7 | Gear icon on Today's Five does nothing | P2 | `OPEN` (verify) | `CLEAN WIN` | **Discrepancy:** code shows a working `<Link href="/daily/setup">` `TodaysFiveCard.tsx:209–215`, but the live-app reviewer read it as a dead control. Re-verify on live: is the destination non-obvious, or a different build? Remove/clarify accordingly. **Fix in flight:** branch `claude/fix-gear-icon-LZCOK` (not yet merged to dev2). |
 | PLR-8 | Catch-up reveal, no confirmation | P1 | `OPEN` | `FIX VIA CANON` | The more important of #3/#8. `onGiveUp={() => skipCurrent()}` `catchup/page.tsx:138`. Add a confirm before a reveal burns a question (fail-toward-player). |
 | PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -101,7 +101,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 
 ## Audit #1 — Design Consistency Audit (15 items)
 
-Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 2026-06-13). Template-style audit run against screenshots, not the live tree — only **CONS-7** is a live finding.
+Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 2026-06-13). Template-style audit run against screenshots, not the live tree — only **CONS-7** is a live finding. A second offline pass (against PRDs/prototype/screenshots) corroborated this disposition on 14 of 15 items; it diverged only on CONS-7, which the live-code check had already flipped from "intentional flat" to a real low finding.
 
 | ID | Item | Status | Notes |
 |---|---|---|---|
@@ -111,7 +111,7 @@ Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 
 | CONS-4 | Duplicate modals & bottom sheets | `WON'T DO` | Canon — same as CONS-2 |
 | CONS-5 | Multiple spacing systems | `TRACKED ELSEWHERE` | Folds into token-budget inventory |
 | CONS-6 | Varying corner radii | `TRACKED ELSEWHERE` | Covered by token-budget |
-| CONS-7 | Inconsistent elevation / shadows | `NEEDS DECISION` | **Real (low).** Option A (uniform flat letterpress) vs B (two intentional registers) before any prompt |
+| CONS-7 | Inconsistent elevation / shadows | `NEEDS DECISION` | **Real (low)** per 2026-06-13 live-code check: blurred drop shadows (`0 4px 12px`, `0 8px 32px`, `0 12px 28px` — ActivityStreamItem, modals, ceremony, knowledge cards) coexist with flat `Npx Npx 0` offsets; nothing uses `1px 1px 0`. Offline pass against the prototype read this as intentional flat letterpress — that prototype evidence is the case **for Option A** (uniform flat letterpress = intended; blurred shadows = drift to remove). Decide A vs B (two registers) before any prompt. |
 | CONS-8 | Non-standard typography hierarchy | `WON'T DO` | Generic — font tokens defined |
 | CONS-9 | Mixed illustration styles | `WON'T DO` | Generic — no screens cited |
 | CONS-10 | Inconsistent form controls | `WON'T DO` | Generic — no surface cited |


### PR DESCRIPTION
## What this is

A single living ledger (`audits/AUDIT-TRACKER.md`) for the two audits currently being worked down, plus the verbatim source of the one that wasn't yet in the repo.

## Contents

- **`audits/AUDIT-TRACKER.md`** — one tracker covering both audits, with a code **Status** column and a canon **Disposition** column, a 🚫 *Canon traps* guardrail block, and a ⭐ *Start here* shortlist.
- **`audits/2026-06-13-product-design-prelaunch-review.md`** — the Product Design Pre-Launch Review saved verbatim (it had only been uploaded to chat, not committed).

## How statuses were set

Every code-checkable item was verified against the tree; notes carry `file:line` evidence.

- **Audit #1 — Design Consistency (CONS-1…15):** dispositioned via `D-CONSISTENCY-AUDIT-DISPOSITION-01.md`. 14 closed (won't-do / tracked-elsewhere); only **CONS-7 (shadow drift)** is live → `NEEDS DECISION` (Option A uniform flat letterpress vs. B two registers).
- **Audit #2 — Pre-Launch Review (PLR-1…25):** every item carries a canon disposition (`CLEAN WIN` / `FIX VIA CANON` / `PRODUCT CONVERSATION` / `DO NOT DO`). The traps block records what *not* to do even though the audit recommends it (no leaderboards/streaks/competition, no incorrect-answer sound, no collapsible feed grouping, no faster/accidental answer reveal, no confetti close).

## Re-verification (2026-06-14, against dev2)

- **PLR-2 (root 404) → DONE** — fix `304215b8` (#922) mints the real onboarding claim on re-login, removing the `refresh-onboarding-claim` redirect hop. (dev2 merged in so the fix and tracker sit together.)
- **PLR-1 (dev tools) → WON'T DO** — ignored per owner.
- **PLR-7** — notes the in-flight `claude/fix-gear-icon-LZCOK` branch.

## How to use it going forward

Edit the **Status** column as items are taken down; ask to "re-verify the tracker" to refresh against code (read-only — never touches app code); add rows with the next free ID or the *Other / ad-hoc* table.

Docs-only change.

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_