### PR TITLE
Revert Shared Ground feed module to its original parchment tone

### DIFF
--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -90,9 +90,7 @@ export function CommonGroundFeature({
   const friendHref = activeFriend?.friendHref ?? embed.friendHref;
   return (
     <EditorialFeature
-      // Sage tone (the green accent + soft green wash) — "shared ground" reads
-      // as earthy/green, and it moves the eyebrow + CTA off the brand orange.
-      tone="sage"
+      tone="parchment"
       eyebrow="Shared Ground"
       headline={
         onInviteSlide ? (


### PR DESCRIPTION
The Shared Ground editorial module was switched from parchment to sage
in 2083c15. Restore the original parchment tone (warm wash + orange
accent) for that one module; other sage/slate features are untouched.