### PR TITLE
Return app background to #ffffff and condense catch-up header

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -51,38 +51,38 @@ export default function DailyCatchupPage() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-lg flex-col bg-[var(--surface)] px-0">
       <header
-        className="sticky top-0 z-20 border-b px-4 py-3"
+        className="sticky top-0 z-20 border-b px-4 py-2"
         style={{
           borderColor: 'var(--border)',
           background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
           backdropFilter: 'blur(8px)',
         }}
       >
-        <div className="flex items-center justify-end gap-3">
-          <Link
-            href="/"
-            aria-label="Close"
-            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
-          >
-            <X className="size-5" strokeWidth={1.9} />
-          </Link>
-        </div>
-        <div className="mt-2 flex items-end justify-between gap-3">
-          <div>
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
             <p className="text-xs font-medium tracking-[0.12em] text-[var(--text-muted)] uppercase">
               Catch up
             </p>
-            <h1 className="font-serif text-xl font-semibold text-[var(--text)]">
+            <h1 className="font-serif text-lg font-semibold text-[var(--text)]">
               {loading
                 ? 'Missed questions'
                 : `${initialTotal} missed ${initialTotal === 1 ? 'question' : 'questions'} from the past week`}
             </h1>
           </div>
-          {!loading && hasItems && !showSummary ? (
-            <p className="shrink-0 text-right text-[0.65rem] font-medium tracking-[0.1em] text-[var(--text-muted)] uppercase">
-              {remainingLabel}
-            </p>
-          ) : null}
+          <div className="flex shrink-0 items-center gap-2">
+            {!loading && hasItems && !showSummary ? (
+              <p className="text-right text-[0.65rem] font-medium tracking-[0.1em] text-[var(--text-muted)] uppercase">
+                {remainingLabel}
+              </p>
+            ) : null}
+            <Link
+              href="/"
+              aria-label="Close"
+              className="-mr-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+            >
+              <X className="size-5" strokeWidth={1.9} />
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -715,7 +715,7 @@ export default function DailyPage() {
   }, [queue, currentSlot, submitting]);
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-lg flex-col px-0">
+    <main className="mx-auto flex min-h-dvh max-w-lg flex-col bg-[var(--surface)] px-0">
       <header
         className="sticky top-0 z-20 flex items-center justify-between gap-3 border-b px-4 py-3"
         style={{

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,7 @@
     --brand-link:        #4a5d75;  /* Link — inline links                      */
     --brand-orange:      #d15e36;  /* triangle/orange — accent links           */
     --brand-cream:       #f8e6c7;  /* triangle/cream                           */
-    --brand-cream-page:  #ffffff;  /* Color/Game/Background — app page surface  */
+    --brand-cream-page:  #fcf8f2;  /* Color/Game/Background — app page surface  */
     --brand-card:        #fdfcfb;  /* cream/50 — content card surface          */
     --brand-cream-card:  #fbf5e9;  /* warm cream card (login screens only)     */
     --brand-border:      #e9e2d2;  /* warm hairline border                     */
@@ -158,7 +158,7 @@
     --play-thread-card-width: 88%;
     /* ──────────────────────────────────────────────────────────────────────
        Conventions:
-       • Cream tones — `--brand-cream-page` (#ffffff) is the app background;
+       • Cream tones — `--brand-cream-page` (#fcf8f2) is the app background;
          `--brand-card` (#fdfcfb, near-white) is the default CONTENT card;
          `--brand-cream-card` (#fbf5e9, warmer) is reserved for ENTRY/branded
          surfaces (login, knowledge portrait, sparkle envelope).

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,7 +64,7 @@
     --brand-link:        #4a5d75;  /* Link — inline links                      */
     --brand-orange:      #d15e36;  /* triangle/orange — accent links           */
     --brand-cream:       #f8e6c7;  /* triangle/cream                           */
-    --brand-cream-page:  #fcf8f2;  /* Color/Game/Background — app page surface  */
+    --brand-cream-page:  #ffffff;  /* Color/Game/Background — app page surface  */
     --brand-card:        #fdfcfb;  /* cream/50 — content card surface          */
     --brand-cream-card:  #fbf5e9;  /* warm cream card (login screens only)     */
     --brand-border:      #e9e2d2;  /* warm hairline border                     */
@@ -158,7 +158,7 @@
     --play-thread-card-width: 88%;
     /* ──────────────────────────────────────────────────────────────────────
        Conventions:
-       • Cream tones — `--brand-cream-page` (#fcf8f2) is the app background;
+       • Cream tones — `--brand-cream-page` (#ffffff) is the app background;
          `--brand-card` (#fdfcfb, near-white) is the default CONTENT card;
          `--brand-cream-card` (#fbf5e9, warmer) is reserved for ENTRY/branded
          surfaces (login, knowledge portrait, sparkle envelope).


### PR DESCRIPTION
- Set --brand-cream-page (the app page-surface token) from #fcf8f2 to
  #ffffff so the page background reverts to white.
- Condense the daily catch-up header: merge the standalone close-button
  row into the title row, drop py-3 → py-2, and ease the heading to
  text-lg. Keeps the 44px close target and the remaining-count label.