### PR TITLE
perf: cut home/feed DB query fan-out (N+1, indexes, dedup)

### DIFF
--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -50,6 +50,7 @@ vi.mock('drizzle-orm', () => ({
   ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
   notExists: vi.fn((query) => ({ op: 'notExists', query })),
   or: vi.fn((...parts) => ({ op: 'or', parts })),
+  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({ op: 'sql', strings, values })),
 }));
 
 vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));

--- a/src/app/api/feed/__tests__/route.test.ts
+++ b/src/app/api/feed/__tests__/route.test.ts
@@ -140,6 +140,7 @@ describe('GET /api/feed', () => {
       nextCursor: null,
       hasMore: false,
       totalCount: 1,
+      dismissedDomains: [],
     });
   });
 
@@ -190,6 +191,7 @@ describe('GET /api/feed', () => {
       nextCursor: null,
       hasMore: false,
       totalCount: 1,
+      dismissedDomains: [],
     });
 
     const response = await GET(new NextRequest('https://joshing.example/api/feed?filter=sent-to-me'));
@@ -241,6 +243,7 @@ describe('GET /api/feed', () => {
       nextCursor: null,
       hasMore: false,
       totalCount: 1,
+      dismissedDomains: [],
     });
 
     const response = await GET(new NextRequest('https://joshing.example/api/feed'));
@@ -307,6 +310,7 @@ describe('GET /api/feed', () => {
       nextCursor: null,
       hasMore: false,
       totalCount: 1,
+      dismissedDomains: [],
     });
 
     const response = await GET(new NextRequest('https://joshing.example/api/feed'));

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -181,6 +181,10 @@ export type PaginatedFeedResult = {
   nextCursor: FeedCursor | null;
   hasMore: boolean;
   totalCount: number;
+  // The viewer's dismissed domains, surfaced so callers (getFeedPagePayload)
+  // can reuse them for the `has_dismissed_domains` flag instead of issuing a
+  // second identical getDismissedDomains query on the same request.
+  dismissedDomains: string[];
 };
 
 const DEFAULT_FEED_LIMIT = 20;
@@ -436,6 +440,7 @@ export async function getFeedForUser(userId: string, options: FeedForUserOptions
       : null,
     hasMore: nonPinnedRaw.length > limit,
     totalCount: countRows[0]?.value ?? 0,
+    dismissedDomains,
   };
 }
 

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -13,7 +13,6 @@ import { db, feedItems, follows, masteryEvents, questions, users } from '@/serve
 import { checkBankedQuestions } from '@/server/db/queries/bank';
 import {
   feedItemVisibilityPredicate,
-  getDismissedDomains,
   getFeedForUser,
   type CollapsedFeedItem,
   type FeedCursor,
@@ -174,7 +173,6 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
   const [
     feedPage,
     friendCount,
-    dismissedDomains,
     totalItemCount,
     preFilterActiveCount,
     broadcastsItemCount,
@@ -192,7 +190,9 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         eq(follows.state, 'approved'),
       ))
       .then((rows) => rows[0]?.value ?? 0),
-    getDismissedDomains(viewerUserId),
+    // dismissedDomains is no longer fetched here — getFeedForUser already
+    // queries it (to filter the page) and now returns it, so we reuse that
+    // result rather than firing a second identical query on the same request.
     db
       .select({ value: count() })
       .from(feedItems)
@@ -238,7 +238,7 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
     viewer_user_id: viewerUserId,
     meta: {
       has_friends: friendCount > 0,
-      has_dismissed_domains: dismissedDomains.length > 0,
+      has_dismissed_domains: feedPage.dismissedDomains.length > 0,
       total_item_count: totalItemCount,
       active_item_count: activeItemCount,
       pre_filter_active_count: preFilterActiveCount,

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -7,7 +7,7 @@
  * to hydrate <FeedList /> with the first page (no client round-trip).
  */
 
-import { and, count, eq, inArray, isNull, ne, notExists, or } from 'drizzle-orm';
+import { and, count, eq, inArray, isNull, ne, notExists, or, sql } from 'drizzle-orm';
 
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
 import { checkBankedQuestions } from '@/server/db/queries/bank';
@@ -131,20 +131,30 @@ export type FeedPageOptions = {
   filter: FeedFilter;
 };
 
-// Count of items the viewer can still act on in a given surface, mirroring the
-// visibility rules getFeedForUser applies (active/skipped state, source-type
-// visibility, question visibility, not-self-authored, and the already-answered
-// hide for non-direct_sent). Used for the per-tab badge counts and the active
-// filter's pre_filter_active_count.
-function surfaceActionableCount(viewerUserId: string, filter: FeedFilter): Promise<number> {
-  return db
-    .select({ value: count() })
+// Counts of items the viewer can still act on, mirroring the visibility rules
+// getFeedForUser applies (active/skipped state, source-type visibility, question
+// visibility, not-self-authored, and the already-answered hide for
+// non-direct_sent). The three surfaces share one identical base predicate and
+// differ only by source-type, so a single query with conditional FILTER
+// aggregates yields all three in one round-trip instead of three near-identical
+// queries (each carrying the heavy NOT EXISTS already-answered subquery).
+//   all          — no source filter (feedFilterSourcePredicate('all') is a no-op)
+//   broadcasts    — the 'from-friends' surface (authored_shared + thumbs_upped)
+//   sent          — the 'sent-to-me' surface (direct_sent)
+type SurfaceActionableCounts = { all: number; broadcasts: number; sent: number };
+
+async function surfaceActionableCounts(viewerUserId: string): Promise<SurfaceActionableCounts> {
+  const rows = await db
+    .select({
+      all: sql<number>`count(*)::int`,
+      broadcasts: sql<number>`(count(*) filter (where ${feedItems.sourceType} in ('authored_shared', 'thumbs_upped')))::int`,
+      sent: sql<number>`(count(*) filter (where ${feedItems.sourceType} = 'direct_sent'))::int`,
+    })
     .from(feedItems)
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
     .where(and(
       eq(feedItems.recipientUserId, viewerUserId),
       visibleSourcePredicate,
-      feedFilterSourcePredicate(filter),
       inArray(feedItems.state, ['active', 'skipped']),
       feedItemVisibilityPredicate(viewerUserId),
       or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
@@ -161,8 +171,17 @@ function surfaceActionableCount(viewerUserId: string, filter: FeedFilter): Promi
             )),
         ),
       ),
-    ))
-    .then((rows) => rows[0]?.value ?? 0);
+    ));
+  const row = rows[0];
+  return { all: row?.all ?? 0, broadcasts: row?.broadcasts ?? 0, sent: row?.sent ?? 0 };
+}
+
+// The active filter's actionable count is one of the three surface counts above
+// (feedFilterSourcePredicate maps each filter to the matching source subset).
+function actionableCountForFilter(counts: SurfaceActionableCounts, filter: FeedFilter): number {
+  if (filter === 'from-friends') return counts.broadcasts;
+  if (filter === 'sent-to-me') return counts.sent;
+  return counts.all;
 }
 
 export type FeedPagePayload = Awaited<ReturnType<typeof getFeedPagePayload>>;
@@ -174,9 +193,7 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
     feedPage,
     friendCount,
     totalItemCount,
-    preFilterActiveCount,
-    broadcastsItemCount,
-    sentItemCount,
+    actionableCounts,
   ] = await Promise.all([
     getFeedForUser(viewerUserId, { limit, cursor, filter }),
     // "has_friends" empty-state signal: people I follow are exactly the
@@ -205,13 +222,15 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         or(isNull(questions.creatorId), ne(questions.creatorId, viewerUserId)),
       ))
       .then((rows) => rows[0]?.value ?? 0),
-    // Active filter's actionable count (drives the focused-feed empty state).
-    surfaceActionableCount(viewerUserId, filter),
-    // D-1 Stage 5: both tab badges must be live on every response, regardless of
-    // which surface is active.
-    surfaceActionableCount(viewerUserId, 'from-friends'),
-    surfaceActionableCount(viewerUserId, 'sent-to-me'),
+    // The active filter's count plus both tab badges (from-friends / sent-to-me)
+    // in one query — D-1 Stage 5 requires both badges live on every response.
+    surfaceActionableCounts(viewerUserId),
   ]);
+
+  // Active filter's actionable count (drives the focused-feed empty state).
+  const preFilterActiveCount = actionableCountForFilter(actionableCounts, filter);
+  const broadcastsItemCount = actionableCounts.broadcasts;
+  const sentItemCount = actionableCounts.sent;
 
   const activeItemCount = feedPage.totalCount;
   const feed = feedPage.items;


### PR DESCRIPTION
## Why

Reported symptom: the app feels slow, page loads take a long time. The home/feed render path fans out many DB queries that compete for the `max: 5` Postgres pool (Supabase PgBouncer constraint), so they queue. This branch removes redundant/expensive queries on that path and adds the two indexes the remaining queries need.

## Changes

| Commit | Fix | Impact |
|--------|-----|--------|
| `fc01cc2` | **N+1 → single query** in activity-stream `hydrateMasteryEvents` | Fired one `PlayerMastery` lookup per mastery-event activity item (~100 round-trips on a home render). `PlayerMastery` is unique on `(user_id, canonical_subcategory)`, so the per-row lookups collapse into one query over the distinct pairs. |
| `179f72f` | **Migration `0078`: two composite indexes** | `MASTERY_EVENTS(user_id, source_type, answer_state, created_at)` for the "Lately" lookback; `Follow(followerId, followeeId, state)` as a covering index for the friends-visibility `EXISTS` on the feed path. |
| `89d74be` | **Drop duplicate `getDismissedDomains`** | `getFeedForUser` already queried it (to filter the page) and now returns it, so `getFeedPagePayload` reuses that result instead of firing an identical second query. −1 round-trip per feed load. |
| `8531a7c` | **Collapse 3 surface-count queries → 1** | `surfaceActionableCount` ran three times per feed load (active filter + two tab badges) over the same heavy base predicate, differing only by source-type. Now one query with conditional `FILTER` aggregates. −2 round-trips per feed load. |

Net: the home/feed path drops ~4 round-trips per load, easing pool contention.

## Migration note

`0078_perf_lookup_indexes.sql` is hand-written and journaled in lockstep (`drizzle/meta/_journal.json`, `when` stepped +1 day past 0077 per the repo's synthetic-dating convention), with mirrored idempotent boot guards in `src/instrumentation.ts`. Indexes are additive, idempotent (`IF NOT EXISTS`), non-destructive, no `CONCURRENTLY` (the migrator runs in a transaction). **It applies automatically at next boot, or run `npm run db:migrate`** — the indexes only help once present.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- ESLint clean on all touched files
- `vitest`: feed query + `/api/feed` route + activity-stream tests pass (21 total)
- Migration reviewed by the repo's drizzle-migration-reviewer (numbering, schema parity, identifier length, idempotency) — approved, no blockers

## Not included (follow-up)

If loads are still slow after this lands, the next lever is verifying PgBouncer `pool_size` vs worker count before reconsidering `max: 5` — deliberately left alone per CLAUDE.md's "don't raise blindly" guidance.

https://claude.ai/code/session_012S6WoMJguUKFj5Tk5HAhkj

---
_Generated by [Claude Code](https://claude.ai/code/session_012S6WoMJguUKFj5Tk5HAhkj)_