### PR TITLE
feat(onboarding): teach Knowledge/Questions tabs in first-five recap; move reminders out of signup

### DIFF
--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -51,7 +51,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
 | CONS-7 | Shadow / elevation drift | — | `NEEDS DECISION` | Option A (uniform flat) vs B (two registers) |
 
@@ -79,7 +78,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
 | PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
 | PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |
-| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` | **Planned approach (owner):** add a beat to the post-first-five recap ceremony (`src/app/daily/summary/FirstSessionRecap.tsx`, B-FirstRecap-1) explaining knowledge is recorded on the Knowledge tab (and possibly a beat for writing questions). Beat 2 already says "your knowledge map has its first marks." **Copy must not misstate mastery** (author 0.5× / catch-up 0.25× / live full) — "bigger = more answered" is wrong. |
+| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `DONE` | `FIX VIA CANON` | Reworked the post-first-five recap (`FirstSessionRecap.tsx`): Beat 2 now points to the **Knowledge** tab; new Beat 3 points to the **Questions** tab (write-questions); new Beat 4 carries the daily rhythm + the reminder email opt-in. Removed the invite beat (per owner). Copy avoids the mastery-size misstatement. Also moved the reminder opt-in **off onboarding** (`OnboardingFlow.tsx` — `reminders` step deleted; finishes straight to /daily). Typecheck/lint/tests green. |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` | Budgeted "edition" caps volume (`build-edition.ts`, `page.tsx:118–161`). Real signal = too many CTAs at arrival → **stagger/sequence**, NOT collapsible grouping (banned, see traps). |
 | PLR-17 | Catch-up lacks closure/celebration | — | `PARTIAL` | `DO NOT DO` (confetti) | `RoundSummary` closing state exists `catchup/page.tsx:173–311`. A closure beat is OK in the quiet-warmth voice; **no** game-win celebration/confetti. |
 | PLR-18 | Frequency options lack micro-copy | P2 | `DONE` | `CLEAN WIN` | Per-zone `copy` `TerritorySetupClient.tsx:43–55`. |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -53,7 +53,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
 | PLR-8 | Catch-up reveal consumes a question, no confirmation | P1 | `OPEN` | `FIX VIA CANON` — the important half of #3/#8; aligns with fail-toward-player |
-| PLR-11 | "Card Color" PaletteToggle dev tool still shipped to all | — | `OPEN` | — (ship gate; pull before launch, like PLR-1) |
 | PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
 | PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` — audit seed bank + interest taxonomy, not a content drive |
@@ -79,7 +78,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-8 | Catch-up reveal, no confirmation | P1 | `OPEN` | `FIX VIA CANON` | The more important of #3/#8. `onGiveUp={() => skipCurrent()}` `catchup/page.tsx:138`. Add a confirm before a reveal burns a question (fail-toward-player). |
 | PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
-| PLR-11 | Card-colour switcher confusing | — | `OPEN` | — | Dev `PaletteToggle` live for all `layout.tsx:7,72` ("remove before shipping"). Ship gate alongside PLR-1. |
+| PLR-11 | Card-colour switcher confusing | — | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: dev `PaletteToggle` live for all `layout.tsx:7,72`.) |
 | PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
 | PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
 | PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -43,7 +43,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 | #14 + "Opportunities" | Leaderboards, streak-as-pressure, "Challenge Blake," competition-register words ("beat," "called," "challenge") | Anti-competition is foundational. Friend actions can be richer **without** any of this. |
 | #23 | Audio/haptic chime on correct **and a tone on "incorrect"** | A wrong answer is a connection/discovery event, not a failure — a sad tone betrays the thesis. |
 | #16 | Collapsible grouping of the home feed | Clustering was tried on Group 3, rejected (fragment-copy), and `B-FEED-GROUP3-FIX-01` enforces a straight chronological stream. Real fix = sequencing/staggering CTAs, not grouping. |
-| #3 | "Simplify reveal to one tap" / make revealing faster | Reveal in catch-up **consumes** a question; grading must fail toward the player. Resolve via PLR-8 (add confirmation), don't make reveal more accidental. |
 | #17 | Confetti / game-win celebration on catch-up close | A closure state is fine, but in the quiet-warmth ("knows it down cold") voice — not a celebration-of-correctness register. |
 
 ---
@@ -52,7 +51,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| PLR-8 | Catch-up reveal consumes a question, no confirmation | P1 | `OPEN` | `FIX VIA CANON` — the important half of #3/#8; aligns with fail-toward-player |
 | PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
 | PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` — audit seed bank + interest taxonomy, not a content drive |
@@ -70,12 +68,12 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 |---|---|---|---|---|---|
 | PLR-1 | Dev tools visible to all users | P0 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: unconditional in `AccountActions.tsx:102–135`.) |
 | PLR-2 | Intermittent 404 on root during sign-in | P0 | `DONE` | `CLEAN WIN` | Fixed `304215b8` (#922): re-login now mints the real `onb` claim (`verify-otp/route.ts:50,213`), removing the `refresh-onboarding-claim` redirect hop that opened the 404 window. Regression test added. Diagnosed root cause; a live smoke confirms. |
-| PLR-3 | "Show me the answer" duplication | P1 | `OPEN` | `FIX VIA CANON` | Text reveal `GameplayChat.tsx:541`. **Resolve only in light of PLR-8** — do NOT make reveal faster/more accidental. |
+| PLR-3 | "Show me the answer" duplication | P1 | `OPEN` | `CLEAN WIN` | Text reveal `GameplayChat.tsx:541`. The "double action" wasn't found in code — needs a live repro. Cost concern removed: reveal is non-destructive (see PLR-8), so simplifying it is low-risk. |
 | PLR-4 | Auto-generated tagline misrepresents new users | P1 | `DONE` | `FIX VIA CANON` | Portrait must be *earned by play*, not auto-assigned. Canon-correct fix shipped: `buildMindStatement()` `users/[id]/page.tsx:78–91` derives from real mastery + neutral placeholder for new users. |
 | PLR-5 | "Use this" artefact in rewrite suggestions | P1 | `DONE` | `CLEAN WIN` | `75eb625`; separate block spans `QuestionForm.tsx:280–291`. (Generation prompt is the biggest quality lever — good it's clean.) |
 | PLR-6 | No success feedback after saving a question | — | `DONE` | `CLEAN WIN` | `419201a`; "✓ Saved" panel `QuestionForm.tsx:541–549` + host toast. |
 | PLR-7 | Gear icon on Today's Five does nothing | P2 | `OPEN` (verify) | `CLEAN WIN` | **Discrepancy:** code shows a working `<Link href="/daily/setup">` `TodaysFiveCard.tsx:209–215`, but the live-app reviewer read it as a dead control. Re-verify on live: is the destination non-obvious, or a different build? Remove/clarify accordingly. **Fix in flight:** branch `claude/fix-gear-icon-LZCOK` (not yet merged to dev2). |
-| PLR-8 | Catch-up reveal, no confirmation | P1 | `OPEN` | `FIX VIA CANON` | The more important of #3/#8. `onGiveUp={() => skipCurrent()}` `catchup/page.tsx:138`. Add a confirm before a reveal burns a question (fail-toward-player). |
+| PLR-8 | Catch-up reveal, no confirmation | P1 | `WON'T DO` | — | **Not a bug per owner (2026-06-14), code-confirmed.** Premise ("reveal consumes a missed question") is false: `skipCurrent()` `useCatchupFlow.ts:424–463` makes **no server call** — purely a client-session `outcome:'revealed'`. The slot stays `answered:false`/`dismissed_at:null`, so `isCatchUpSlotEligible` (`catch-up-eligibility.ts:28–37`) keeps it eligible; it resurfaces in catch-up until answered correctly, dismissed, or it ages out (7-day window). Nothing is burned. |
 | PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
 | PLR-11 | Card-colour switcher confusing | — | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: dev `PaletteToggle` live for all `layout.tsx:7,72`.) |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -53,7 +53,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 |---|---|---|---|---|
 | PLR-15 | No onboarding/tour for the Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` — tie to B-FirstRecap-1 / B-HomeSeed-1; explanation must match the mastery model |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
-| PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` — audit seed bank + interest taxonomy, not a content drive |
 | CONS-7 | Shadow / elevation drift | — | `NEEDS DECISION` | Option A (uniform flat) vs B (two registers) |
 
 **Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 (re-verify), PLR-9 ✅, PLR-13, PLR-21.
@@ -80,7 +79,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
 | PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
 | PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |
-| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` | Real gap; B-FirstRecap-1 / B-HomeSeed-1 exist. **Tooltip must not misstate mastery** (author 0.5× / catch-up 0.25× / live full) — "bigger = more answered" is wrong. |
+| PLR-15 | No onboarding/tour for Knowledge Map | P1 | `OPEN` | `FIX VIA CANON` | **Planned approach (owner):** add a beat to the post-first-five recap ceremony (`src/app/daily/summary/FirstSessionRecap.tsx`, B-FirstRecap-1) explaining knowledge is recorded on the Knowledge tab (and possibly a beat for writing questions). Beat 2 already says "your knowledge map has its first marks." **Copy must not misstate mastery** (author 0.5× / catch-up 0.25× / live full) — "bigger = more answered" is wrong. |
 | PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` | Budgeted "edition" caps volume (`build-edition.ts`, `page.tsx:118–161`). Real signal = too many CTAs at arrival → **stagger/sequence**, NOT collapsible grouping (banned, see traps). |
 | PLR-17 | Catch-up lacks closure/celebration | — | `PARTIAL` | `DO NOT DO` (confetti) | `RoundSummary` closing state exists `catchup/page.tsx:173–311`. A closure beat is OK in the quiet-warmth voice; **no** game-win celebration/confetti. |
 | PLR-18 | Frequency options lack micro-copy | P2 | `DONE` | `CLEAN WIN` | Per-zone `copy` `TerritorySetupClient.tsx:43–55`. |
@@ -89,7 +88,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-21 | Inconsistent link styling on summary page | — | `OPEN` | `CLEAN WIN` | Low-stakes. Underlined + button links coexist `summary/page.tsx:242,255,259,635,663`. |
 | PLR-22 | No dark mode | P3 | `DEFERRED` | `DO NOT DO` (for launch) | Not canon-violating, but reworks the cream/serif/illustration brand — large effort. Park post-launch. |
 | PLR-23 | Audio/haptic feedback on answers | P3 | `WON'T DO` | `DO NOT DO` | Wrong answer = discovery, not failure; an "incorrect" tone betrays the thesis. Skip. |
-| PLR-24 | Categories skew Western | P3 | `NEEDS DECISION` | `PRODUCT CONVERSATION` | Genuine strategic question. Skew (if real) lives in seed/bank content + declared-interest taxonomy. Fix = **audit those for skew**, NOT a diversity content drive (content is friend-authored/declared, `interests.ts:219,269`). |
+| PLR-24 | Categories skew Western | P3 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not applicable: categories follow each person's declared interests — content is interest-matched by design, not a fixed seed corpus. No "skew" to correct. |
 | PLR-25 | Missing first-run micro-copy (streaks/points/ritual) | P3 | `PARTIAL` | — | Intro exists `daily/page.tsx:807–855`; omits those concepts. (Note: "streaks/points" framing — keep it ritual/warmth, not pressure.) |
 
 ---

--- a/src/app/daily/summary/FirstSessionRecap.tsx
+++ b/src/app/daily/summary/FirstSessionRecap.tsx
@@ -9,12 +9,15 @@
  * server-computed FirstSessionRecapView with the same null-omit discipline the
  * ceremony uses: a beat with no content is simply not pushed.
  *
+ * Beats: 1) nice start  2) Knowledge tab  3) Questions tab  4) daily rhythm +
+ * reminder opt-in. The reminder email opt-in lives here (moved off the
+ * onboarding flow) so the ask lands once the player has actually felt the loop.
+ *
  * Fires once: the seen-signal is persisted as soon as the overlay mounts, so
  * re-entry/refresh/catch-up never re-trigger it.
  */
 
 import { useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from 'react';
-import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
 
 import { formatNextResetDayTimeLocal } from '@/lib/games/timezone';
@@ -22,16 +25,17 @@ import { formatNextResetDayTimeLocal } from '@/lib/games/timezone';
 // useSyncExternalStore inputs for the client-only reset-time label, mirroring
 // the daily summary page: null during SSR keeps hydration stable, and the
 // snapshot is read on the client without a setState-in-effect. The label is
-// day-aware ("today at 1 PM" / "tomorrow at 1 PM") so the close copy stays
+// day-aware ("today at 1 PM" / "tomorrow at 1 PM") so the rhythm copy stays
 // correct when the next reset falls later on the current local day.
 const subscribeNoop = () => () => {};
 const getResetTimeSnapshot = () => formatNextResetDayTimeLocal();
 const getResetTimeServerSnapshot = (): string | null => null;
 import type {
   FirstSessionRecapBeat2,
-  FirstSessionRecapBeat3,
   FirstSessionRecapView,
 } from '@/server/daily/first-session-recap';
+
+const REMINDER_EMAIL_FORMAT = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
 type BeatNode = { key: string; content: ReactNode };
 
@@ -60,58 +64,155 @@ function Beat2({ beat }: { beat: FirstSessionRecapBeat2 }) {
       <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
         Your knowledge map has its first marks.
       </p>
-      {beat.offTheGroundDomain ? (
-        <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          {beat.offTheGroundDomain} is already off the ground.
-        </p>
-      ) : null}
-      {beat.newTerritoryDomain ? (
-        <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-300 sm:text-xl">
-          {beat.newTerritoryDomain} is new territory &mdash; that&rsquo;s where the map grows.
-        </p>
-      ) : null}
+      <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-300 sm:text-xl">
+        Find your full map any time on the{' '}
+        <span className="font-medium text-stone-100">Knowledge</span> tab.
+      </p>
     </div>
   );
 }
 
-function Beat3({ beat, onInvite }: { beat: FirstSessionRecapBeat3; onInvite: () => void }) {
-  if (beat.kind === 'no_inviter') {
+// Beat 3 — mirrors Beat 2's eyebrow → serif headline → supporting line shape,
+// pointing at the Questions tab.
+function Beat3() {
+  return (
+    <div className="mx-auto max-w-2xl text-center">
+      <p className="text-sm tracking-[0.16em] text-stone-400 uppercase">Your turn</p>
+      <h1 className="mt-4 font-serif text-4xl leading-tight font-semibold tracking-normal sm:text-6xl">
+        Ask something only you would ask.
+      </h1>
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+        Write a question for the friends you choose &mdash; that&rsquo;s how the map fills in for
+        both of you.
+      </p>
+      <p className="mx-auto mt-3 max-w-2xl text-lg leading-8 text-stone-300 sm:text-xl">
+        Everything you write lives on the{' '}
+        <span className="font-medium text-stone-100">Questions</span> tab.
+      </p>
+    </div>
+  );
+}
+
+// Beat 4 — daily rhythm + the reminder email opt-in (moved here from onboarding).
+// Self-contained state; the form controls stopPropagation so taps don't advance
+// the overlay while the player is typing. "Maybe later" / the post-send button
+// close straight to the summary; a backdrop tap advances to the end card.
+function Beat4({ onClose }: { onClose: () => void }) {
+  const resetDayTime = useSyncExternalStore(
+    subscribeNoop,
+    getResetTimeSnapshot,
+    getResetTimeServerSnapshot,
+  );
+  const [email, setEmail] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [sent, setSent] = useState<boolean | null>(null);
+
+  async function submit() {
+    const trimmed = email.trim();
+    if (!REMINDER_EMAIL_FORMAT.test(trimmed)) {
+      setError('Enter a valid email address.');
+      return;
+    }
+    setError(null);
+    setSaving(true);
+    try {
+      const response = await fetch('/api/onboarding/email-reminder', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: trimmed }),
+      });
+      const data = await response.json().catch(() => ({}));
+      if (!response.ok || data?.ok !== true) {
+        setError(
+          typeof data?.message === 'string' ? data.message : "We couldn't save that email. Try again.",
+        );
+        return;
+      }
+      setSent(data.sent === true);
+    } catch {
+      setError("We couldn't save that email. Try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (sent !== null) {
     return (
       <div className="mx-auto max-w-2xl text-center">
         <h1 className="font-serif text-4xl leading-tight font-semibold tracking-normal sm:text-6xl">
-          Invite someone whose questions you&rsquo;d want to see.
+          {sent ? 'Check your inbox.' : "You're all set."}
         </h1>
-        <button
-          type="button"
-          className="mt-10 inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-6 text-sm font-medium text-stone-950 transition hover:bg-white"
-          onClick={(event) => {
-            event.stopPropagation();
-            onInvite();
-          }}
-        >
-          Invite a friend →
-        </button>
+        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+          {sent
+            ? 'Tap the confirmation link and your daily reminders switch on automatically.'
+            : 'We saved your email but couldn’t send the confirmation just now — you can resend it any time from your profile.'}
+        </p>
+        <div className="mt-10 flex justify-center" onClick={(event) => event.stopPropagation()}>
+          <button
+            type="button"
+            className="inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-8 text-sm font-medium text-stone-950 transition hover:bg-white"
+            onClick={onClose}
+          >
+            View summary →
+          </button>
+        </div>
       </div>
     );
   }
 
-  const { inviterName } = beat;
   return (
     <div className="mx-auto max-w-2xl text-center">
-      <h1 className="font-serif text-4xl leading-tight font-semibold tracking-normal sm:text-6xl">
-        {inviterName} invited you here.
+      <p className="text-sm tracking-[0.16em] text-stone-400 uppercase">Every day</p>
+      <h1 className="mt-4 font-serif text-4xl leading-tight font-semibold tracking-normal sm:text-6xl">
+        Five new questions, every day.
       </h1>
-      {beat.kind === 'inviter_present' ? (
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          {inviterName}&rsquo;s been playing &mdash; their last few questions are already waiting
-          for you on your home screen. You&rsquo;ll start to see where your maps overlap.
+      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
+        Your next five land {resetDayTime ?? 'tomorrow'} &mdash; then a fresh five every day.
+      </p>
+
+      <form
+        className="mx-auto mt-8 max-w-sm space-y-3 text-left"
+        onClick={(event) => event.stopPropagation()}
+        onSubmit={(event) => {
+          event.preventDefault();
+          if (!saving) void submit();
+        }}
+      >
+        <p className="text-center text-sm text-stone-400">
+          Want a nudge? Drop your email for a daily reminder &mdash; with a no-spoiler peek at your
+          next question.
         </p>
-      ) : (
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          As {inviterName} plays, their questions show up on your home screen, and you&rsquo;ll see
-          where your maps overlap.
-        </p>
-      )}
+        <input
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          className="h-12 w-full rounded-md border border-white/20 bg-white/10 px-3 text-base text-stone-50 placeholder:text-stone-400 transition outline-none focus:ring-2 focus:ring-white/40"
+          placeholder="you@example.com"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            if (error) setError(null);
+          }}
+        />
+        {error ? <p className="text-sm text-rose-300">{error}</p> : null}
+        <button
+          type="submit"
+          className="inline-flex h-12 w-full items-center justify-center rounded-md bg-stone-100 px-6 text-sm font-medium text-stone-950 transition hover:bg-white disabled:opacity-50"
+          disabled={saving || !REMINDER_EMAIL_FORMAT.test(email.trim())}
+        >
+          {saving ? 'Sending…' : 'Turn on reminders'}
+        </button>
+        <button
+          type="button"
+          className="h-11 w-full text-sm text-stone-400 transition hover:text-stone-200"
+          onClick={onClose}
+          disabled={saving}
+        >
+          Maybe later
+        </button>
+      </form>
     </div>
   );
 }
@@ -123,14 +224,7 @@ export function FirstSessionRecap({
   recap: FirstSessionRecapView;
   onDismiss: () => void;
 }) {
-  const router = useRouter();
   const [currentIndex, setCurrentIndex] = useState(0);
-  // Client-only day-aware reset label for the close copy; null during SSR.
-  const resetDayTime = useSyncExternalStore(
-    subscribeNoop,
-    getResetTimeSnapshot,
-    getResetTimeServerSnapshot,
-  );
 
   // Persist the seen-signal the moment the recap is shown — re-entry, refresh,
   // and replaying catch-up must never re-trigger it. Fire-and-forget.
@@ -141,29 +235,19 @@ export function FirstSessionRecap({
     }).catch(() => undefined);
   }, []);
 
-  const invite = () => {
-    onDismiss();
-    router.push('/friends');
-  };
-
   const beats = useMemo<BeatNode[]>(() => {
     const nodes: BeatNode[] = [];
     // Beat 1 always renders.
     nodes.push({ key: 'beat1', content: <Beat1 firstName={recap.firstName} /> });
     // Beat 2 omitted only in the defensive empty-session case.
     if (recap.beat2) {
-      nodes.push({
-        key: 'beat2',
-        content: <Beat2 beat={recap.beat2} />,
-      });
+      nodes.push({ key: 'beat2', content: <Beat2 beat={recap.beat2} /> });
     }
-    // Beat 3 always renders (no-inviter variant when there is no inviter).
-    nodes.push({
-      key: 'beat3',
-      content: <Beat3 beat={recap.beat3} onInvite={invite} />,
-    });
+    // Beat 3 (Questions tab) and Beat 4 (rhythm + reminders) always render.
+    nodes.push({ key: 'beat3', content: <Beat3 /> });
+    nodes.push({ key: 'beat4', content: <Beat4 onClose={onDismiss} /> });
     return nodes;
-    // openMap/invite are stable enough for this short-lived overlay.
+    // onDismiss is stable; recap is the only meaningful input.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [recap]);
 
@@ -180,8 +264,8 @@ export function FirstSessionRecap({
   }
 
   // Story-style tap navigation: a tap on the left third steps back, anywhere
-  // else advances. Buttons inside beats stopPropagation, so this only fires on
-  // the backdrop.
+  // else advances. Buttons/forms inside beats stopPropagation, so this only
+  // fires on the backdrop.
   function handleTap(event: React.MouseEvent<HTMLElement>) {
     const width = event.currentTarget.clientWidth;
     if (width > 0 && event.clientX < width * 0.3) {
@@ -212,18 +296,13 @@ export function FirstSessionRecap({
 
       <div key={currentIndex} className="relative z-10 w-full animate-[fadeIn_0.4s_ease]">
         {isEnd ? (
-          <div className="mx-auto max-w-2xl text-center">
-            <h1 className="font-serif text-4xl leading-tight font-semibold tracking-normal sm:text-6xl">
-              Come back {resetDayTime ?? 'tomorrow'} for five new questions.
-            </h1>
-            <div className="mt-10 flex justify-center">
+          <div className="mx-auto max-w-2xl text-center" onClick={(event) => event.stopPropagation()}>
+            <p className="text-lg text-stone-300">You&rsquo;re all set.</p>
+            <div className="mt-8 flex justify-center">
               <button
                 type="button"
                 className="inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-8 text-sm font-medium text-stone-950 transition hover:bg-white"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  done();
-                }}
+                onClick={done}
               >
                 View summary →
               </button>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -7,11 +7,12 @@ import { Loader2, X } from 'lucide-react'
 import { AddTopicField, type AddTopicError } from '@/components/interests/AddTopicField'
 
 // Condensed onboarding: name → handle → one interests screen (warm-up is an
-// optional expander there; the cultural-anchor/background step was removed) →
-// an optional daily-reminder email opt-in. The reminders beat is post-
-// completion bonus: picking areas already marks onboarding complete and starts
-// question generation, so the email ask never blocks finishing.
-type CurrentStep = 'display-name' | 'handle' | 'review' | 'reminders'
+// optional expander there; the cultural-anchor/background step was removed).
+// Picking areas marks onboarding complete, kicks off question generation, and
+// lands the player straight in /daily. The daily-reminder email opt-in moved
+// off this flow into the post-first-five recap (FirstSessionRecap), so the ask
+// arrives once the player has actually felt the loop.
+type CurrentStep = 'display-name' | 'handle' | 'review'
 
 export type WarmupAnswers = {
   deepDive?: string
@@ -89,10 +90,7 @@ const STEP_DOTS: Array<{ step: CurrentStep; label: string }> = [
   { step: 'display-name', label: 'Name' },
   { step: 'handle', label: 'Handle' },
   { step: 'review', label: 'Areas' },
-  { step: 'reminders', label: 'Reminders' },
 ]
-
-const REMINDER_EMAIL_FORMAT = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
 const MIN_INTERESTS = 3
 // Onboarding caps the starting-areas selection at 12 (per product spec). The cap
@@ -263,11 +261,6 @@ export default function OnboardingFlow({
   const [isGenerating, setIsGenerating] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [loadingCopyIndex, setLoadingCopyIndex] = useState(0)
-  const [reminderEmail, setReminderEmail] = useState('')
-  const [savingReminderEmail, setSavingReminderEmail] = useState(false)
-  const [reminderError, setReminderError] = useState<string | null>(null)
-  // null = not yet submitted; true/false = whether the confirmation email sent.
-  const [reminderSent, setReminderSent] = useState<boolean | null>(null)
   const displayInviterName = inviterName?.trim()
     ? inviterName.trim()
     : 'A friend'
@@ -651,56 +644,14 @@ export default function OnboardingFlow({
         keepalive: true,
       }).catch(() => {})
 
-      // Onboarding is now complete (save-interests set the flag). Advance to the
-      // optional daily-reminder beat rather than jumping straight to /daily —
-      // skipping or submitting there both land in gameplay.
-      setCurrentStep('reminders')
+      // Onboarding is now complete (save-interests set the flag) and the queue
+      // is generating in the background — land the player straight in /daily.
+      // The daily-reminder opt-in now lives in the post-first-five recap.
+      router.push('/daily')
     } catch {
       setError('Unable to save interests.')
     } finally {
       setIsLoading(false)
-    }
-  }
-
-  function finishOnboarding() {
-    router.push('/daily')
-  }
-
-  async function submitReminderEmail() {
-    const trimmed = reminderEmail.trim()
-    if (!REMINDER_EMAIL_FORMAT.test(trimmed)) {
-      setReminderError('Enter a valid email address.')
-      return
-    }
-
-    setReminderError(null)
-    setSavingReminderEmail(true)
-
-    try {
-      const response = await fetch('/api/onboarding/email-reminder', {
-        method: 'POST',
-        credentials: 'include',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: trimmed }),
-      })
-      const data = await response.json().catch(() => ({}))
-
-      if (!response.ok || data?.ok !== true) {
-        setReminderError(
-          typeof data?.message === 'string'
-            ? data.message
-            : "We couldn't save that email. Try again.",
-        )
-        return
-      }
-
-      // Address saved either way; data.sent tells us whether the confirm email
-      // actually went out (provider hiccups still let onboarding finish).
-      setReminderSent(data.sent === true)
-    } catch {
-      setReminderError("We couldn't save that email. Try again.")
-    } finally {
-      setSavingReminderEmail(false)
     }
   }
 
@@ -994,91 +945,6 @@ export default function OnboardingFlow({
                   {isLoading ? 'Saving…' : startCtaCopy(selectedInterests.length)}
                 </button>
               </div>
-            </div>
-          ) : null}
-
-          {currentStep === 'reminders' ? (
-            <div className="flex flex-1 flex-col justify-center gap-8">
-              {reminderSent === null ? (
-                <>
-                  <StepHeader
-                    title="Want a daily nudge?"
-                    subtitle="New questions land every day. Drop your email and we'll send a daily reminder — with a no-spoiler peek at your first question — so you never miss a round."
-                  />
-
-                  <form
-                    className="space-y-4"
-                    onSubmit={(event) => {
-                      event.preventDefault()
-                      if (!savingReminderEmail) void submitReminderEmail()
-                    }}
-                  >
-                    <label className="block">
-                      <span className="text-sm font-medium">Your email</span>
-                      <input
-                        type="email"
-                        inputMode="email"
-                        autoComplete="email"
-                        className="bg-card placeholder:text-muted-foreground/70 focus:ring-ring mt-2 h-12 w-full rounded-md border px-3 text-base transition outline-none focus:ring-2"
-                        placeholder="you@example.com"
-                        autoFocus
-                        value={reminderEmail}
-                        onChange={(event) => {
-                          setReminderEmail(event.target.value)
-                          if (reminderError) setReminderError(null)
-                        }}
-                      />
-                    </label>
-
-                    <p className="text-muted-foreground text-sm">
-                      We&apos;ll send one confirmation link to make sure it&apos;s
-                      you — reminders switch on the moment you tap it. Unsubscribe
-                      any time.
-                    </p>
-
-                    {reminderError ? (
-                      <p className="text-destructive text-sm">{reminderError}</p>
-                    ) : null}
-
-                    <button
-                      type="submit"
-                      className="btn-primary h-12 w-full"
-                      disabled={
-                        savingReminderEmail ||
-                        !REMINDER_EMAIL_FORMAT.test(reminderEmail.trim())
-                      }
-                    >
-                      {savingReminderEmail ? 'Sending…' : 'Send confirmation & finish'}
-                    </button>
-                    <button
-                      type="button"
-                      className="btn-ghost h-12 w-full"
-                      onClick={finishOnboarding}
-                      disabled={savingReminderEmail}
-                    >
-                      Skip for now
-                    </button>
-                  </form>
-                </>
-              ) : (
-                <div className="flex flex-1 flex-col justify-center gap-8">
-                  <StepHeader
-                    title={reminderSent ? 'Check your inbox' : "You're all set"}
-                    subtitle={
-                      reminderSent
-                        ? `We sent a confirmation link to ${reminderEmail.trim()}. Tap it and your daily reminders switch on automatically — no need to wait here.`
-                        : "We saved your email but couldn't send the confirmation just now. You can resend it any time from your profile."
-                    }
-                  />
-                  <button
-                    type="button"
-                    className="btn-primary h-12 w-full"
-                    onClick={finishOnboarding}
-                  >
-                    Start today&apos;s five
-                  </button>
-                </div>
-              )}
             </div>
           ) : null}
 


### PR DESCRIPTION
## Summary

Lands PLR-15 (Knowledge Map onboarding) by reworking the **post-first-five recap** into a tab-teaching arc, and moves the **daily-reminder email opt-in off the signup flow** into that recap so the ask arrives after the player has felt the loop. Also carries audit-tracker updates for items dispositioned in this session (PLR-8/11/24).

## First-Session Recap (`src/app/daily/summary/FirstSessionRecap.tsx`)

New beat arc: **Start → Knowledge tab → Questions tab → Daily rhythm + reminders → End**

- **Beat 2 (Knowledge)** now points to the **Knowledge** tab ("Find your full map any time on the Knowledge tab").
- **Beat 3 (Questions) — new**, mirroring Beat 2's eyebrow → serif headline → supporting-line shape: "Ask something only you would ask… Everything you write lives on the **Questions** tab."
- **Beat 4 (Daily rhythm + reminders) — new**: "Five new questions, every day. Your next five land {today/tomorrow at 1 PM}…" and carries the full reminder **email opt-in** (input → confirmation state, or "Maybe later"). Form controls `stopPropagation` so taps don't advance the overlay while typing.
- **End** simplified to "You're all set → View summary" (the old "come back tomorrow" rhythm line folded into Beat 4).
- **Invite beat removed** (per owner) along with the now-unused router/invite code.

Copy intentionally avoids overstating the mastery model (no "bigger circle = more answered").

## Onboarding (`src/app/onboarding/OnboardingFlow.tsx`)

- Flow is now **Name → Handle → Areas**, then straight to `/daily`.
- Removed the `reminders` step, its progress dot, its state, and the `submitReminderEmail` handler. The opt-in reuses the same `/api/onboarding/email-reminder` endpoint from the recap (session-only, so it works post-onboarding).
- **Funnel note:** the reminder ask now reaches only players who *finish* their first five (vs. everyone at signup). Intentional — the ask lands once the loop is felt.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `eslint` on both changed files → clean
- `first-session-recap` (16) + onboarding tests (13) → pass

**Not covered:** the recap UI has no component test yet (only the server view builder is tested), so the new Beat 3/4 + email opt-in aren't under automated test. Happy to add a render test in a follow-up.

## Tracker

`audits/AUDIT-TRACKER.md`: PLR-15 → DONE; PLR-8 → WON'T DO (reveal is non-destructive, code-confirmed); PLR-11 & PLR-24 → WON'T DO (ignored per owner).

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_