### PR TITLE
Standardize buttons on the daily-five primary-CTA style

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -288,7 +288,7 @@ function RoundSummary({
           {hasMore ? (
             <button
               type="button"
-              className="btn-primary w-full rounded-full sm:w-auto sm:min-w-56"
+              className="btn-primary w-full sm:w-auto sm:min-w-56"
               onClick={onPlayNext}
             >
               Play the next {nextBatchSize}
@@ -299,7 +299,7 @@ function RoundSummary({
             className={
               hasMore
                 ? 'text-muted-foreground hover:text-foreground text-sm font-medium underline underline-offset-4 transition'
-                : 'btn-primary w-full rounded-full sm:w-auto sm:min-w-56'
+                : 'btn-primary w-full sm:w-auto sm:min-w-56'
             }
             onClick={onHome}
           >

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -688,12 +688,12 @@ export function TerritorySetupClient({
 
       <div className="fixed inset-x-0 bottom-0 z-50 border-t border-[var(--border-warm)] bg-[var(--cream)]/95 px-4 py-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] backdrop-blur">
         <div className="mx-auto flex max-w-3xl items-center gap-3">
-          <Link href="/" className="btn-ghost min-h-11 px-5">
+          <Link href="/" className="btn-ghost">
             Home
           </Link>
           <button
             type="button"
-            className="btn-primary min-h-11 flex-1 justify-center"
+            className="btn-primary flex-1 justify-center"
             disabled={!canSave}
             onClick={() => void saveForNextRound()}
           >
@@ -760,12 +760,12 @@ export function TerritorySetupClient({
             <div className="mt-6 flex items-center justify-end gap-3">
               <button
                 type="button"
-                className="btn-ghost min-h-11 px-5"
+                className="btn-ghost"
                 onClick={() => setPendingRemoval(null)}
               >
                 Keep it
               </button>
-              <button type="button" className="btn-danger px-5" onClick={confirmRemoval}>
+              <button type="button" className="btn-danger" onClick={confirmRemoval}>
                 Throw out
               </button>
             </div>

--- a/src/app/daily/summary/RoundReminderCard.tsx
+++ b/src/app/daily/summary/RoundReminderCard.tsx
@@ -106,14 +106,14 @@ export function RoundReminderCard() {
           <div className="flex gap-2">
             <button
               type="submit"
-              className="btn-primary text-sm"
+              className="btn-primary"
               disabled={state.saving}
             >
               {state.saving ? 'Saving…' : 'Save'}
             </button>
             <button
               type="button"
-              className="btn-ghost text-sm"
+              className="btn-ghost"
               disabled={state.saving}
               onClick={() => setState({ kind: 'idle' })}
             >
@@ -144,7 +144,7 @@ export function RoundReminderCard() {
       <div className="mt-4 flex flex-col gap-2 sm:flex-row">
         <button
           type="button"
-          className="btn-primary text-sm sm:flex-1"
+          className="btn-primary sm:flex-1"
           disabled={busy}
           onClick={async () => {
             setState({ kind: 'sms-saving' })
@@ -156,7 +156,7 @@ export function RoundReminderCard() {
         </button>
         <button
           type="button"
-          className="btn-ghost text-sm sm:flex-1"
+          className="btn-ghost sm:flex-1"
           disabled={busy}
           onClick={() =>
             setState({ kind: 'email-form', value: '', error: null, saving: false })
@@ -166,7 +166,7 @@ export function RoundReminderCard() {
         </button>
         <button
           type="button"
-          className="btn-ghost text-sm sm:flex-1"
+          className="btn-ghost sm:flex-1"
           disabled={busy}
           onClick={async () => {
             setState({ kind: 'dismissing' })

--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -252,7 +252,7 @@ export default function DailySummaryPage() {
             Tomorrow’s five arrive at noon.
           </p>
           <div className="mt-5 flex flex-col items-center gap-3">
-            <Link className="btn-primary w-full rounded-full sm:w-auto sm:min-w-56" href="/">
+            <Link className="btn-primary w-full sm:w-auto sm:min-w-56" href="/">
               Back home
             </Link>
             <Link

--- a/src/app/games/[id]/play-client.tsx
+++ b/src/app/games/[id]/play-client.tsx
@@ -371,7 +371,7 @@ export function JoshingGamePlayClient({ game, viewerId }: { game: JoshingGameVie
             />
             <button
               type="submit"
-              className="btn-primary font-serif text-base font-semibold"
+              className="btn-primary"
               disabled={pending || pausingAfterAnswer || !answer.trim()}
             >
               {pending ? '...' : 'Answer'}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -342,23 +342,27 @@
   }
 
   /* Canonical button system. One family of utilities (primary / ghost / danger /
-     icon), all 44px-tall (min-h-11) for touch, all with a focus-visible ring.
+     icon), all sharing the 4px corner radius and a focus-visible ring.
+     `.btn-primary` is the daily-five call-to-action: 48px-tall (min-h-12),
+     brand-link fill, bold base type with 0.04em tracking — the single standard
+     for prominent primary CTAs. Ghost / danger / icon stay 44px-tall (min-h-11)
+     with text-sm so they read as secondary next to a primary CTA.
      The shadcn ui/button was removed in favor of these — see the 2026-05-30
      design audit (C6, button consolidation). */
   .btn-primary {
-    @apply inline-flex min-h-11 items-center justify-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
+    @apply inline-flex min-h-12 items-center justify-center rounded-[4px] bg-[var(--brand-link)] px-4 py-2 text-base font-bold tracking-[0.04em] text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
   }
 
   .btn-ghost {
-    @apply inline-flex min-h-11 items-center justify-center rounded-md border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
+    @apply inline-flex min-h-11 items-center justify-center rounded-[4px] border bg-background px-4 py-2 text-sm font-medium text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
   }
 
   .btn-danger {
-    @apply inline-flex min-h-11 items-center justify-center rounded-md bg-destructive px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
+    @apply inline-flex min-h-11 items-center justify-center rounded-[4px] bg-destructive px-4 py-2 text-sm font-medium text-white transition hover:opacity-90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
   }
 
   .btn-icon {
-    @apply inline-flex size-11 shrink-0 items-center justify-center rounded-md text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
+    @apply inline-flex size-11 shrink-0 items-center justify-center rounded-[4px] text-foreground transition hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45;
   }
 }
 

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -766,7 +766,7 @@ export default function OnboardingFlow({
 
                 <button
                   type="submit"
-                  className="btn-primary h-12 w-full"
+                  className="btn-primary w-full"
                   disabled={
                     isSavingDisplayName ||
                     displayName.trim().length < DISPLAY_NAME_MIN
@@ -850,7 +850,7 @@ export default function OnboardingFlow({
 
                 <button
                   type="submit"
-                  className="btn-primary h-12 w-full"
+                  className="btn-primary w-full"
                   disabled={
                     isSavingHandle ||
                     handle.length < HANDLE_MIN ||
@@ -928,7 +928,7 @@ export default function OnboardingFlow({
                 {!showWarmup ? (
                   <button
                     type="button"
-                    className="btn-ghost h-11 w-full"
+                    className="btn-ghost w-full"
                     onClick={() => setShowWarmup(true)}
                   >
                     Need ideas? Answer a couple quick questions
@@ -958,7 +958,7 @@ export default function OnboardingFlow({
                     <div className="flex gap-2">
                       <button
                         type="button"
-                        className="btn-primary h-11 flex-1"
+                        className="btn-primary flex-1"
                         onClick={generateProposals}
                         disabled={!canGenerate || isGenerating}
                       >
@@ -966,7 +966,7 @@ export default function OnboardingFlow({
                       </button>
                       <button
                         type="button"
-                        className="btn-ghost h-11 px-4"
+                        className="btn-ghost px-4"
                         onClick={() => setShowWarmup(false)}
                       >
                         Hide
@@ -987,7 +987,7 @@ export default function OnboardingFlow({
                 </p>
                 <button
                   type="button"
-                  className="btn-primary h-12 w-full"
+                  className="btn-primary w-full"
                   onClick={() => saveInterests()}
                   disabled={selectedInterests.length < MIN_INTERESTS || isLoading}
                 >
@@ -1042,7 +1042,7 @@ export default function OnboardingFlow({
 
                     <button
                       type="submit"
-                      className="btn-primary h-12 w-full"
+                      className="btn-primary w-full"
                       disabled={
                         savingReminderEmail ||
                         !REMINDER_EMAIL_FORMAT.test(reminderEmail.trim())
@@ -1052,7 +1052,7 @@ export default function OnboardingFlow({
                     </button>
                     <button
                       type="button"
-                      className="btn-ghost h-12 w-full"
+                      className="btn-ghost w-full"
                       onClick={finishOnboarding}
                       disabled={savingReminderEmail}
                     >
@@ -1072,7 +1072,7 @@ export default function OnboardingFlow({
                   />
                   <button
                     type="button"
-                    className="btn-primary h-12 w-full"
+                    className="btn-primary w-full"
                     onClick={finishOnboarding}
                   >
                     Start today&apos;s five

--- a/src/app/unsubscribe/page.tsx
+++ b/src/app/unsubscribe/page.tsx
@@ -53,7 +53,7 @@ export default async function UnsubscribePage({
 
         <Link
           href="/users/me"
-          className="btn-primary mt-6 inline-flex w-full items-center justify-center text-sm"
+          className="btn-primary mt-6 inline-flex w-full items-center justify-center"
         >
           Go to profile
         </Link>

--- a/src/app/verify-email/page.tsx
+++ b/src/app/verify-email/page.tsx
@@ -61,7 +61,7 @@ export default async function VerifyEmailPage({
 
         <Link
           href="/users/me"
-          className="btn-primary mt-6 inline-flex w-full items-center justify-center text-sm"
+          className="btn-primary mt-6 inline-flex w-full items-center justify-center"
         >
           Return to profile
         </Link>

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -296,7 +296,7 @@ export default function AddFriendInvite({
             <button
               type="button"
               onClick={pickContact}
-              className="btn-ghost min-h-11 w-full rounded-full text-sm"
+              className="btn-ghost w-full"
             >
               Pick from contacts
             </button>
@@ -345,7 +345,7 @@ export default function AddFriendInvite({
           {error ? <p className="text-destructive text-sm font-medium">{error}</p> : null}
 
           <div className="space-y-3">
-            <button type="submit" className="btn-primary min-h-12 w-full rounded-full">
+            <button type="submit" className="btn-primary w-full">
               Next
             </button>
             <button
@@ -395,7 +395,7 @@ export default function AddFriendInvite({
           <div className="space-y-3">
             <button
               type="submit"
-              className="btn-primary min-h-12 w-full rounded-full"
+              className="btn-primary w-full"
               disabled={submitting}
             >
               {submitting ? 'Warming it up…' : 'Make the note'}
@@ -463,14 +463,14 @@ export default function AddFriendInvite({
           <div className="space-y-3">
             <button
               type="button"
-              className="btn-primary min-h-12 w-full rounded-full"
+              className="btn-primary w-full"
               onClick={copyMessage}
             >
               {copyLabel}
             </button>
             {smsHref ? (
               <a
-                className="btn-ghost min-h-12 w-full rounded-full"
+                className="btn-ghost w-full"
                 href={smsHref}
                 onClick={() =>
                   sendTelemetry('add_friend_sms_handoff_opened', {

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -772,7 +772,7 @@ function FeedContributeFooter() {
           </div>
           <button
             type="submit"
-            className="text-primary-foreground flex min-h-11 w-full items-center justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] transition hover:opacity-90"
+            className="btn-primary w-full"
           >
             Write a Question
           </button>

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -32,7 +32,7 @@ export default function FriendsHubPage() {
             </p>
             <button
               type="button"
-              className="btn-primary mt-5 min-h-12 w-full rounded-full px-5 text-base sm:w-auto"
+              className="btn-primary mt-5 w-full sm:w-auto"
               onClick={openInviteFlow}
             >
               Invite Someone

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -164,7 +164,7 @@ function PendingInviteCard({
       {canMessage ? (
         <div className="mt-4 space-y-2">
           <a
-            className="btn-primary flex min-h-11 w-full items-center justify-center rounded-full"
+            className="btn-primary flex w-full items-center justify-center"
             href={buildSmsHref(invite.inviteePhoneForActions!, invite.message!)}
           >
             Send message
@@ -242,7 +242,7 @@ function IncomingRequestCard({
       <div className="mt-4 flex items-center gap-3">
         <button
           type="button"
-          className="btn-primary flex min-h-11 flex-1 items-center justify-center rounded-full"
+          className="btn-primary flex flex-1 items-center justify-center"
           onClick={() => onApprove(request)}
           disabled={busy}
         >

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -292,7 +292,7 @@ export default function PeopleYouInvited() {
                   <div className="mt-3">
                     <button
                       type="button"
-                      className="btn-ghost min-h-11 w-full rounded-full"
+                      className="btn-ghost w-full"
                       onClick={() => createNewInvite(invite)}
                     >
                       Write a fresh note
@@ -316,7 +316,7 @@ export default function PeopleYouInvited() {
                 {canMessage ? (
                   <div className="mt-3 space-y-2">
                     <a
-                      className="btn-primary flex min-h-11 w-full items-center justify-center rounded-full"
+                      className="btn-primary flex w-full items-center justify-center"
                       href={buildSmsHref(
                         invite.inviteePhoneForActions!,
                         invite.message!

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -612,8 +612,8 @@ export function QuestionForm({
             ))}
           </div>
           <div className="mt-3 flex flex-wrap gap-2">
-            <button type="button" className="rounded-md border px-3 py-2 text-sm" onClick={() => dispatch({ type: 'KEEP_VERSION' })}>Keep my version anyway</button>
-            <button type="button" className="rounded-md border px-3 py-2 text-sm" onClick={() => dispatch({ type: 'EDIT_RECHECK' })}>Edit and recheck</button>
+            <button type="button" className="btn-ghost" onClick={() => dispatch({ type: 'KEEP_VERSION' })}>Keep my version anyway</button>
+            <button type="button" className="btn-ghost" onClick={() => dispatch({ type: 'EDIT_RECHECK' })}>Edit and recheck</button>
           </div>
         </div>
       ) : null}

--- a/src/components/SendQuestionDrawer.tsx
+++ b/src/components/SendQuestionDrawer.tsx
@@ -231,7 +231,7 @@ export function SendQuestionDrawer({ isOpen, onClose, question, onSent }: SendQu
 
           <footer className="border-t p-5">
             <button
-              className="btn-primary inline-flex h-11 w-full items-center justify-center gap-2"
+              className="btn-primary inline-flex w-full items-center justify-center gap-2"
               type="button"
               disabled={selectedIds.length === 0 || sending}
               onClick={() => void sendQuestion()}

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -309,7 +309,7 @@ export default function TodaysFiveCard({
             <>
               <Link
                 href="/questions?create=1&intent=specific"
-                className="btn-primary flex min-h-12 w-full items-center justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"
+                className="btn-primary w-full"
               >
                 Send a friend a question →
               </Link>
@@ -335,7 +335,7 @@ export default function TodaysFiveCard({
         <>
           <Link
             href={playHref}
-            className="btn-primary mt-4 min-h-12 w-full justify-center rounded-[4px] bg-[var(--brand-link)] text-base font-bold tracking-[0.04em] text-white"
+            className="btn-primary mt-4 w-full"
           >
             {actionLabel}
           </Link>

--- a/src/components/friends/ContactMatchBlock.tsx
+++ b/src/components/friends/ContactMatchBlock.tsx
@@ -94,7 +94,7 @@ export function ContactMatchBlock({
         </p>
         <Link
           href="/users/me#privacy-discovery"
-          className="btn-primary mt-3 inline-flex h-11 items-center rounded-full px-4 text-sm"
+          className="btn-primary mt-3 inline-flex items-center px-4"
         >
           Open privacy settings
         </Link>
@@ -201,7 +201,7 @@ export function ContactMatchBlock({
             type="button"
             onClick={() => void matchContacts()}
             disabled={matching}
-            className="btn-primary mt-3 inline-flex h-11 items-center rounded-full px-4 text-sm"
+            className="btn-primary mt-3 inline-flex items-center px-4"
           >
             {matching ? 'Matching…' : 'Match my contacts'}
           </button>

--- a/src/components/friends/InviteSomeoneNew.tsx
+++ b/src/components/friends/InviteSomeoneNew.tsx
@@ -61,7 +61,7 @@ export function InviteSomeoneNew() {
         <button
           type="button"
           onClick={openPersonalInvite}
-          className="btn-primary min-h-11 rounded-full px-4 text-sm"
+          className="btn-primary px-4"
         >
           Send a personal invite
         </button>
@@ -69,7 +69,7 @@ export function InviteSomeoneNew() {
           type="button"
           onClick={() => void copyInviteLink()}
           disabled={copying}
-          className="btn-ghost min-h-11 rounded-full px-4 text-sm"
+          className="btn-ghost px-4"
         >
           {copying ? 'Loading…' : 'Copy invite link'}
         </button>

--- a/src/components/interests/AddTopicField.tsx
+++ b/src/components/interests/AddTopicField.tsx
@@ -31,7 +31,7 @@ type ConvergeApiCandidate = {
 // same field matches differently-themed surfaces (e.g. the top-up modal).
 const DEFAULT_INPUT_CLASS =
   'min-h-12 flex-1 rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-4 text-sm text-[var(--ink)] placeholder:text-[var(--text-muted-warm)]/60 focus-visible:ring-2 focus-visible:ring-[var(--ink)] focus-visible:ring-offset-2 focus-visible:outline-none disabled:opacity-60';
-const DEFAULT_BUTTON_CLASS = 'btn-ghost min-h-12 px-5';
+const DEFAULT_BUTTON_CLASS = 'btn-ghost';
 const DEFAULT_CHIP_CLASS =
   'rounded-full border border-[var(--border-warm)] bg-[var(--cream)] px-3 py-1.5 text-sm text-[var(--ink)] transition-colors hover:bg-[var(--cream-warm)] disabled:opacity-50';
 const DEFAULT_MUTED_CLASS = 'text-sm text-[var(--text-muted-warm)]';

--- a/src/components/knowledge/AskFriendForDomain.tsx
+++ b/src/components/knowledge/AskFriendForDomain.tsx
@@ -259,14 +259,14 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
             <div className="flex flex-col gap-3 sm:flex-row">
               <button
                 type="button"
-                className="btn-primary min-h-12 flex-1 rounded-full"
+                className="btn-primary flex-1"
                 onClick={() => void copyMessage()}
               >
                 {copyLabel}
               </button>
               {smsHref ? (
                 <a
-                  className="btn-ghost min-h-12 flex-1 rounded-full"
+                  className="btn-ghost flex-1"
                   href={smsHref}
                 >
                   Open Messages
@@ -397,7 +397,7 @@ export function AskFriendForDomain({ domain, onClose }: Props) {
                 <div className="flex items-center gap-3">
                   <button
                     type="submit"
-                    className="btn-primary min-h-12 flex-1 rounded-full"
+                    className="btn-primary flex-1"
                     disabled={submitting}
                   >
                     {submitting ? 'Warming it up…' : 'Make the note'}

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -156,7 +156,7 @@ export function AccountActions() {
             <p className="text-sm font-medium">Are you sure you want to log out?</p>
             <div className="mt-3 flex gap-2">
               <button
-                className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md border border-destructive px-3 text-sm font-medium text-destructive hover:bg-destructive/10"
+                className="btn-danger gap-2"
                 type="button"
                 onClick={() => void confirmLogout()}
                 disabled={loggingOut}
@@ -165,7 +165,7 @@ export function AccountActions() {
                 Log out
               </button>
               <button
-                className="rounded-md border px-3 text-sm"
+                className="btn-ghost"
                 type="button"
                 onClick={() => setConfirmingLogout(false)}
                 disabled={loggingOut}
@@ -200,7 +200,7 @@ export function AccountActions() {
               />
               <div className="mt-3 flex gap-2">
                 <button
-                  className="inline-flex min-h-10 items-center justify-center gap-2 rounded-md bg-destructive px-3 text-sm font-medium text-destructive-foreground hover:bg-destructive/90 disabled:cursor-not-allowed disabled:opacity-60"
+                  className="btn-danger gap-2"
                   type="button"
                   onClick={() => void confirmDeleteAccount()}
                   disabled={!canDeleteAccount || deletingAccount}
@@ -209,7 +209,7 @@ export function AccountActions() {
                   Permanently delete account
                 </button>
                 <button
-                  className="rounded-md border px-3 text-sm"
+                  className="btn-ghost"
                   type="button"
                   onClick={() => {
                     setConfirmingDelete(false);

--- a/src/components/profile/settings/NotificationsForm.tsx
+++ b/src/components/profile/settings/NotificationsForm.tsx
@@ -238,7 +238,7 @@ export function NotificationsForm({ initialState, phone }: Props) {
             />
             <button
               type="button"
-              className="btn-primary text-sm"
+              className="btn-primary"
               onClick={() => void saveEmail()}
               disabled={savingEmail}
             >

--- a/src/components/profile/settings/PrivacyForm.tsx
+++ b/src/components/profile/settings/PrivacyForm.tsx
@@ -211,7 +211,7 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
             <button
               type="button"
               onClick={() => void copyInviteUrl()}
-              className="btn-primary min-h-9 rounded-full px-4 text-sm"
+              className="btn-primary px-4"
             >
               Copy
             </button>
@@ -221,7 +221,7 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
                   type="button"
                   onClick={() => void rotateInviteUrl()}
                   disabled={rotating}
-                  className="btn-danger min-h-9 rounded-full px-4 text-sm"
+                  className="btn-danger px-4"
                 >
                   {rotating ? 'Rotating…' : 'Rotate — old link stops working'}
                 </button>
@@ -229,7 +229,7 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
                   type="button"
                   onClick={() => setConfirmingRotate(false)}
                   disabled={rotating}
-                  className="btn-ghost min-h-9 rounded-full px-4 text-sm"
+                  className="btn-ghost px-4"
                 >
                   Cancel
                 </button>
@@ -238,7 +238,7 @@ export function PrivacyForm({ initialState, initialInviteUrl }: Props) {
               <button
                 type="button"
                 onClick={() => setConfirmingRotate(true)}
-                className="btn-ghost min-h-9 rounded-full px-4 text-sm"
+                className="btn-ghost px-4"
               >
                 Rotate link
               </button>

--- a/src/components/review/RefineItemCard.tsx
+++ b/src/components/review/RefineItemCard.tsx
@@ -83,7 +83,7 @@ export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: s
             onClick={resolve}
             disabled={busy}
             style={actionStyle}
-            className="inline-flex min-h-11 items-center justify-center self-start rounded-full border px-4 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60 sm:self-auto"
+            className="inline-flex min-h-11 items-center justify-center self-start rounded-[4px] border px-4 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60 sm:self-auto"
           >
             {item.actionVerb}
           </button>


### PR DESCRIPTION
Make the homepage daily-five button the single standard for prominent
primary CTAs by folding its look into the canonical `.btn-primary` recipe
(48px min-height, 4px radius, brand-link fill, bold base type with 0.04em
tracking, white text). Align the 4px corner radius across the whole btn-*
family (ghost/danger/icon) so the buttons read as one system; ghost/danger
keep their 44px height and text-sm weight as secondary actions.

Normalize call sites to the recipes: strip the now-redundant inline
overrides (rounded-full pills, custom min-h/h heights, text-sm/base, inline
brand-link/white colors, px-5) from btn-* usages across friends, invite,
onboarding, settings, knowledge and daily surfaces, and convert the few
remaining ad-hoc/inline buttons (FeedList submit, AccountActions
log-out/delete/cancel, QuestionForm critique actions) to btn-primary/
btn-ghost/btn-danger. The immersive daily room screens keep their own
theme-token icon/close controls.

Verified: color ratchet (153/180, down from inline-color consolidation),
font ratchet (0/0), eslint (0 errors), strict typecheck (0 errors).

https://claude.ai/code/session_0188WtrPrWhYXyUgpdikYTaq