### PR TITLE
docs(audits): ignore PLR-16; confirm PLR-7 functional

### DIFF
--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -51,10 +51,10 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` — stagger CTAs; **do not** reintroduce grouping |
 | CONS-7 | Shadow / elevation drift | — | `NEEDS DECISION` | Option A (uniform flat) vs B (two registers) |
+| PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` — copy decision (may be deliberate) |
 
-**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 (re-verify), PLR-9 ✅, PLR-13, PLR-21.
+**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13, PLR-21.
 
 ---
 
@@ -70,7 +70,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-4 | Auto-generated tagline misrepresents new users | P1 | `DONE` | `FIX VIA CANON` | Portrait must be *earned by play*, not auto-assigned. Canon-correct fix shipped: `buildMindStatement()` `users/[id]/page.tsx:78–91` derives from real mastery + neutral placeholder for new users. |
 | PLR-5 | "Use this" artefact in rewrite suggestions | P1 | `DONE` | `CLEAN WIN` | `75eb625`; separate block spans `QuestionForm.tsx:280–291`. (Generation prompt is the biggest quality lever — good it's clean.) |
 | PLR-6 | No success feedback after saving a question | — | `DONE` | `CLEAN WIN` | `419201a`; "✓ Saved" panel `QuestionForm.tsx:541–549` + host toast. |
-| PLR-7 | Gear icon on Today's Five does nothing | P2 | `OPEN` (verify) | `CLEAN WIN` | **Discrepancy:** code shows a working `<Link href="/daily/setup">` `TodaysFiveCard.tsx:209–215`, but the live-app reviewer read it as a dead control. Re-verify on live: is the destination non-obvious, or a different build? Remove/clarify accordingly. **Fix in flight:** branch `claude/fix-gear-icon-LZCOK` (not yet merged to dev2). |
+| PLR-7 | Gear icon on Today's Five does nothing | P2 | `DONE` | `CLEAN WIN` | **Confirmed functional (2026-06-14):** the gear is a working `<Link href="/daily/setup">` with `aria-label="Set up daily round"` (`TodaysFiveCard.tsx:209–215`) — it opens the daily setup page, not a dead control. The reviewer's live "dead control" read doesn't hold against current code (older build / non-obvious destination). The `claude/fix-gear-icon-LZCOK` branch is unnecessary and can be closed. |
 | PLR-8 | Catch-up reveal, no confirmation | P1 | `WON'T DO` | — | **Not a bug per owner (2026-06-14), code-confirmed.** Premise ("reveal consumes a missed question") is false: `skipCurrent()` `useCatchupFlow.ts:424–463` makes **no server call** — purely a client-session `outcome:'revealed'`. The slot stays `answered:false`/`dismissed_at:null`, so `isCatchUpSlotEligible` (`catch-up-eligibility.ts:28–37`) keeps it eligible; it resurfaces in catch-up until answered correctly, dismissed, or it ages out (7-day window). Nothing is burned. |
 | PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
@@ -79,7 +79,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
 | PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |
 | PLR-15 | No onboarding/tour for Knowledge Map | P1 | `DONE` | `FIX VIA CANON` | Reworked the post-first-five recap (`FirstSessionRecap.tsx`): Beat 2 now points to the **Knowledge** tab; new Beat 3 points to the **Questions** tab (write-questions); new Beat 4 carries the daily rhythm + the reminder email opt-in. Removed the invite beat (per owner). Copy avoids the mastery-size misstatement. Also moved the reminder opt-in **off onboarding** (`OnboardingFlow.tsx` — `reminders` step deleted; finishes straight to /daily). Typecheck/lint/tests green. |
-| PLR-16 | Overwhelming home feed | P1 | `PARTIAL` | `FIX VIA CANON` | Budgeted "edition" caps volume (`build-edition.ts`, `page.tsx:118–161`). Real signal = too many CTAs at arrival → **stagger/sequence**, NOT collapsible grouping (banned, see traps). |
+| PLR-16 | Overwhelming home feed | P1 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Budgeted "edition" already caps arrival volume (`build-edition.ts`, `page.tsx:118–161`); not tracking further. (Collapsible grouping remains banned regardless — see traps.) |
 | PLR-17 | Catch-up lacks closure/celebration | — | `PARTIAL` | `DO NOT DO` (confetti) | `RoundSummary` closing state exists `catchup/page.tsx:173–311`. A closure beat is OK in the quiet-warmth voice; **no** game-win celebration/confetti. |
 | PLR-18 | Frequency options lack micro-copy | P2 | `DONE` | `CLEAN WIN` | Per-zone `copy` `TerritorySetupClient.tsx:43–55`. |
 | PLR-19 | Invite flow generic (link/email/SMS unclear) | — | `PARTIAL` | — | Personal invite + copy link `InviteSomeoneNew.tsx:54–84`; no explicit SMS/email labelling. |


### PR DESCRIPTION
## Summary

Audit-tracker dispositions from this session's review pass.

- **PLR-16 (overwhelming home feed) → `WON'T DO`** — ignored per owner. The budgeted "edition" already caps arrival volume (`build-edition.ts`, `page.tsx:118–161`); not tracking further. Collapsible grouping stays banned regardless (canon trap).
- **PLR-7 (gear icon "does nothing") → `DONE`** — confirmed functional: the gear is a working `<Link href="/daily/setup">` with `aria-label="Set up daily round"` (`TodaysFiveCard.tsx:209–215`), i.e. it opens the daily setup page, not a dead control. The reviewer's live "dead control" read doesn't hold against current code. The `claude/fix-gear-icon-LZCOK` branch is unnecessary and can be closed.

Docs-only (`audits/AUDIT-TRACKER.md`).

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_