### PR TITLE
feat(visual): CONS-7 Option B — shadow elevation tokens

### DIFF
--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -51,7 +51,7 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| CONS-7 | Shadow / elevation drift | — | `NEEDS DECISION` | Option A (uniform flat) vs B (two registers) |
+| CONS-7 | Shadow / elevation drift | — | `OPEN` (decided: B) | Two registers chosen → token-snap; fold into `B-VISUAL-TOKEN-BUDGET-01` |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` — copy decision (may be deliberate) |
 
 **Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13, PLR-21.
@@ -104,7 +104,7 @@ Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 
 | CONS-4 | Duplicate modals & bottom sheets | `WON'T DO` | Canon — same as CONS-2 |
 | CONS-5 | Multiple spacing systems | `TRACKED ELSEWHERE` | Folds into token-budget inventory |
 | CONS-6 | Varying corner radii | `TRACKED ELSEWHERE` | Covered by token-budget |
-| CONS-7 | Inconsistent elevation / shadows | `NEEDS DECISION` | **Real (low)** per 2026-06-13 live-code check: blurred drop shadows (`0 4px 12px`, `0 8px 32px`, `0 12px 28px` — ActivityStreamItem, modals, ceremony, knowledge cards) coexist with flat `Npx Npx 0` offsets; nothing uses `1px 1px 0`. Offline pass against the prototype read this as intentional flat letterpress — that prototype evidence is the case **for Option A** (uniform flat letterpress = intended; blurred shadows = drift to remove). Decide A vs B (two registers) before any prompt. |
+| CONS-7 | Inconsistent elevation / shadows | `OPEN` (decided: B) | **Decision (2026-06-14): Option B — two intentional registers.** Live inventory: (A) flat letterpress `N N 0` on inline/printed artifacts — `ShareCard:134` (4px), `SharePortraitCard:245` (3px), `OverlapMap:34,298` (6/4px), `KnowledgeOverviewClient:310` (2px), `knowledge/page:641`, feed-card border accent `2px 2px 0 var(--brand-ink)`; (B) blurred elevation on floating surfaces — feed cards / `KnowledgeCard` / `RecentlyExploring`/`Expanding` / `ActivityStreamItem` (`0 4px 12px`), `GameplayChat:418` (`0 8px 20px`), `TerritorySetupClient` (`0 8px 22px`/`0 10px 30px`/`0 12px 28px`), `QuickAddQuestionModal:131` (`0 8px 32px`), `knowledge/page` (`0 8px 24px`/`0 18px 48px`), `PortraitCircles:309` (`0 1px 3px`), token `--shadow-paper-rest` (`0 1px 2px`). Feed cards intentionally combine both. **Plan:** define ~3 tokens — `--shadow-press` (flat), `--shadow-card` (`0 4px 12px`), `--shadow-overlay` (one heavy blur for modals/dialogs) — and snap the ~4 offsets + ~11 blur values to them. Folds into `B-VISUAL-TOKEN-BUDGET-01` (also reduces off-system rgba count). |
 | CONS-8 | Non-standard typography hierarchy | `WON'T DO` | Generic — font tokens defined |
 | CONS-9 | Mixed illustration styles | `WON'T DO` | Generic — no screens cited |
 | CONS-10 | Inconsistent form controls | `WON'T DO` | Generic — no surface cited |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -51,7 +51,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 | ID | Item | Priority | Status | Disposition |
 |---|---|---|---|---|
-| CONS-7 | Shadow / elevation drift | — | `OPEN` (decided: B) | Two registers chosen → token-snap; fold into `B-VISUAL-TOKEN-BUDGET-01` |
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` — copy decision (may be deliberate) |
 
 **Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13, PLR-21.
@@ -104,7 +103,7 @@ Source: dispositioned in `D-CONSISTENCY-AUDIT-DISPOSITION-01.md` (code-verified 
 | CONS-4 | Duplicate modals & bottom sheets | `WON'T DO` | Canon — same as CONS-2 |
 | CONS-5 | Multiple spacing systems | `TRACKED ELSEWHERE` | Folds into token-budget inventory |
 | CONS-6 | Varying corner radii | `TRACKED ELSEWHERE` | Covered by token-budget |
-| CONS-7 | Inconsistent elevation / shadows | `OPEN` (decided: B) | **Decision (2026-06-14): Option B — two intentional registers.** Live inventory: (A) flat letterpress `N N 0` on inline/printed artifacts — `ShareCard:134` (4px), `SharePortraitCard:245` (3px), `OverlapMap:34,298` (6/4px), `KnowledgeOverviewClient:310` (2px), `knowledge/page:641`, feed-card border accent `2px 2px 0 var(--brand-ink)`; (B) blurred elevation on floating surfaces — feed cards / `KnowledgeCard` / `RecentlyExploring`/`Expanding` / `ActivityStreamItem` (`0 4px 12px`), `GameplayChat:418` (`0 8px 20px`), `TerritorySetupClient` (`0 8px 22px`/`0 10px 30px`/`0 12px 28px`), `QuickAddQuestionModal:131` (`0 8px 32px`), `knowledge/page` (`0 8px 24px`/`0 18px 48px`), `PortraitCircles:309` (`0 1px 3px`), token `--shadow-paper-rest` (`0 1px 2px`). Feed cards intentionally combine both. **Plan:** define ~3 tokens — `--shadow-press` (flat), `--shadow-card` (`0 4px 12px`), `--shadow-overlay` (one heavy blur for modals/dialogs) — and snap the ~4 offsets + ~11 blur values to them. Folds into `B-VISUAL-TOKEN-BUDGET-01` (also reduces off-system rgba count). |
+| CONS-7 | Inconsistent elevation / shadows | `DONE` (Option B) | **Implemented (2026-06-14).** Added registers to `globals.css`: `--shadow-card` (`0 4px 12px` .04), `--shadow-card-strong` (.10), `--shadow-overlay` (`0 12px 28px rgba(26,18,8,.16)`). Snapped the **card** family (8 identical usages, zero visual change) — `FeedCardShell`, `DismissedFeedBar`, `TodaysFiveCard`, `KnowledgeCard`, `RecentlyExploringSection`, `RecentlyExpanding`, `ActivityStreamItem` — and the warm-brown **overlay** cluster in `TerritorySetupClient` (3 usages → one token; 789 was exact, 857/974 unify slightly heavier). Color ratchet 147 (↓, under 180 ceiling); typecheck/lint/tests green. **Deferred (own surfaces, not collapsed):** differently-hued overlays — `GameplayChat` navy `0 8px 20px`, `knowledge/page` black `0 8px 24px`/`0 18px 48px`, `QuickAddQuestionModal` `0 8px 32px` — and the flat **press** register (`#3a3a3a` share buttons, canvas/OG `ShareCard`/`SharePortraitCard`/`OverlapMap` which can't read CSS vars). Those are color/palette calls for `B-VISUAL-TOKEN-BUDGET-01`. |
 | CONS-8 | Non-standard typography hierarchy | `WON'T DO` | Generic — font tokens defined |
 | CONS-9 | Mixed illustration styles | `WON'T DO` | Generic — no screens cited |
 | CONS-10 | Inconsistent form controls | `WON'T DO` | Generic — no surface cited |

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -786,7 +786,7 @@ function DragPreview({ domain }: { domain: TerritoryDomain }) {
         diameter={58}
         tint={color.primary}
         border={`1px solid color-mix(in srgb, ${color.primary} 33%, transparent)`}
-        style={{ boxShadow: '0 12px 28px rgba(26,18,8,0.16)' }}
+        style={{ boxShadow: 'var(--shadow-overlay)' }}
       >
         {domain.correctAnswerCount > 0 ? (
           <span
@@ -854,7 +854,7 @@ function TerritoryZone({
   return (
     <section
       ref={setRef}
-      className={`rounded-[2rem] border bg-white/40 p-4 transition ${highlighted ? 'border-[var(--ink)] shadow-[0_10px_30px_rgba(26,18,8,0.12)]' : 'border-[var(--border-warm)]'}`}
+      className={`rounded-[2rem] border bg-white/40 p-4 transition ${highlighted ? 'border-[var(--ink)] shadow-[var(--shadow-overlay)]' : 'border-[var(--border-warm)]'}`}
     >
       <div className="mb-4">
         <h2 className="font-serif text-2xl font-semibold text-[var(--ink)]">{zone.title}</h2>
@@ -971,7 +971,7 @@ function TerritoryCircle({
         diameter={size}
         tint={color.primary}
         border={`1px solid color-mix(in srgb, ${color.primary} 27%, transparent)`}
-        style={{ boxShadow: '0 8px 22px rgba(26,18,8,0.08)' }}
+        style={{ boxShadow: 'var(--shadow-overlay)' }}
       >
         {correctCount > 0 ? (
           <span

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -281,6 +281,14 @@
     --radius-md: 0.5rem;
     --radius-lg: 0.625rem;
     --shadow-paper-rest: 0 1px 2px rgb(0 0 0 / 0.05);
+    /* Elevation registers (CONS-7, Option B — two intentional registers).
+       card / card-strong = the soft rest/raised lift for cards;
+       overlay = the single heavy blur for modals, dialogs, and overlays.
+       (The flat "press" register's only live usages are two #3a3a3a buttons —
+       a color-drift item left to B-VISUAL-TOKEN-BUDGET-01, not a shadow snap.) */
+    --shadow-card: 0 4px 12px rgba(40, 32, 30, 0.04);
+    --shadow-card-strong: 0 4px 12px rgba(40, 32, 30, 0.1);
+    --shadow-overlay: 0 12px 28px rgba(26, 18, 8, 0.16);
 }
 
 .dark {

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -201,7 +201,7 @@ export default function TodaysFiveCard({
       : 'Ready when you are!'
 
   return (
-    <div className="text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-5 shadow-[0_4px_12px_rgba(40,32,30,0.04)]">
+    <div className="text-card-foreground w-full rounded-[4px] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-5 shadow-[var(--shadow-card)]">
       <div className="flex items-start justify-between gap-2">
         <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
           Today&apos;s Five

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -341,7 +341,7 @@ export function ActivityStreamItem({
           background: 'var(--feed-card-elevated)',
           border: '1px solid var(--brand-border)',
           borderRadius: 4,
-          boxShadow: '0 4px 12px rgba(40, 32, 30, 0.1)',
+          boxShadow: 'var(--shadow-card-strong)',
         }
       : opened
         ? // Opened reveal: a soft paper wash defines the expanded cluster, with

--- a/src/components/feed/DismissedFeedBar.tsx
+++ b/src/components/feed/DismissedFeedBar.tsx
@@ -34,7 +34,7 @@ export function DismissedFeedBar({
     <div
       role="status"
       aria-live="polite"
-      className="relative overflow-hidden rounded-[4px] border border-[var(--brand-rule)] bg-[var(--game-card-question)] px-4 py-3 shadow-[0_4px_12px_rgba(40,32,30,0.04)]"
+      className="relative overflow-hidden rounded-[4px] border border-[var(--brand-rule)] bg-[var(--game-card-question)] px-4 py-3 shadow-[var(--shadow-card)]"
     >
       <div className="flex items-center justify-between gap-3">
         <span className="text-muted-foreground text-sm italic">Dismissed</span>

--- a/src/components/feed/FeedCardShell.tsx
+++ b/src/components/feed/FeedCardShell.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils'
 // 'triangle' variant for the envelope motif.
 
 const FEED_CARD_RADIUS = 'rounded-[4px]'
-const FEED_CARD_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.04)]'
+const FEED_CARD_SHADOW = 'shadow-[var(--shadow-card)]'
 
 // Resting (non-elevated) home-feed card fill. Warm cream (--warm-cream #f5f0e8)
 // chosen over the near-white --brand-card for the feed surface — a product call
@@ -34,7 +34,7 @@ const FEED_CARD_RESTING_FILL = 'bg-[var(--warm-cream)]'
 // --brand-border (not the editorial accent gold).
 const FEED_CARD_ELEVATED_FILL = 'bg-[var(--feed-card-elevated)]'
 const FEED_CARD_ELEVATED_STROKE = 'border-[var(--brand-border)]'
-const FEED_CARD_ELEVATED_SHADOW = 'shadow-[0_4px_12px_rgba(40,32,30,0.10)]'
+const FEED_CARD_ELEVATED_SHADOW = 'shadow-[var(--shadow-card-strong)]'
 
 export type FeedCardShellProps = {
   children: ReactNode

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -497,12 +497,12 @@ describe('FeedCardShell (shared C7 shell)', () => {
       </FeedCardShell>
     )
     expect(rendered).toContain('bg-[var(--warm-cream)]')
-    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).toContain('shadow-[var(--shadow-card)]')
     expect(rendered).toContain('border-[var(--brand-rule)]')
     expect(rendered).not.toContain('bg-[var(--game-card-question)]')
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     // No elevated lift on the resting card.
-    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
+    expect(rendered).not.toContain('shadow-[var(--shadow-card-strong)]')
     expect(rendered).not.toContain('border-[rgba(40,32,30,0.22)]')
   })
 
@@ -514,8 +514,8 @@ describe('FeedCardShell (shared C7 shell)', () => {
     )
     expect(rendered).toContain('bg-[var(--feed-card-elevated)]')
     // Deeper drop shadow (10% ink) than the ambient cards' 4%.
-    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
-    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).toContain('shadow-[var(--shadow-card-strong)]')
+    expect(rendered).not.toContain('shadow-[var(--shadow-card)]')
     // Hairline stroke matching the Today's 5 card replaces the faint rule
     // (no gold accent border on the elevated card).
     expect(rendered).toContain('border-[var(--brand-border)]')
@@ -533,8 +533,8 @@ describe('FeedCardShell (shared C7 shell)', () => {
     )
     // Mat image intact; the matted card carries the deeper drop shadow.
     expect(rendered).toContain('/images/Variant4.png')
-    expect(rendered).toContain('shadow-[0_4px_12px_rgba(40,32,30,0.10)]')
-    expect(rendered).not.toContain('shadow-[0_4px_12px_rgba(40,32,30,0.04)]')
+    expect(rendered).toContain('shadow-[var(--shadow-card-strong)]')
+    expect(rendered).not.toContain('shadow-[var(--shadow-card)]')
     expect(rendered).not.toContain('shadow-[2px_2px_0_var(--brand-ink)]')
     // Inner panel carries the elevated fill instead of the resting fill.
     expect(rendered).toContain('bg-[var(--feed-card-elevated)]')

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -142,7 +142,7 @@ const boxStyle: CSSProperties = {
   background: 'var(--brand-cream-card)',
   border: '1px solid var(--brand-border)',
   borderRadius: 12,
-  boxShadow: '0 4px 12px rgba(40, 32, 30, 0.04)',
+  boxShadow: 'var(--shadow-card)',
   padding: '1.05rem 0.95rem 0.95rem',
   display: 'grid',
   gap: '0.85rem',

--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -195,7 +195,7 @@ const boxStyle: CSSProperties = {
   background: 'var(--brand-cream-card)',
   border: '1px solid var(--brand-border)',
   borderRadius: 12,
-  boxShadow: '0 4px 12px rgba(40, 32, 30, 0.04)',
+  boxShadow: 'var(--shadow-card)',
   padding: '1.05rem 0.95rem 0.65rem',
   display: 'grid',
   gap: '0.75rem',

--- a/src/components/profile/RecentlyExploringSection.tsx
+++ b/src/components/profile/RecentlyExploringSection.tsx
@@ -91,7 +91,7 @@ const boxStyle: CSSProperties = {
   background: 'var(--brand-cream-card)',
   border: '1px solid var(--brand-border)',
   borderRadius: 12,
-  boxShadow: '0 4px 12px rgba(40, 32, 30, 0.04)',
+  boxShadow: 'var(--shadow-card)',
   padding: '1.05rem 0.95rem 0.65rem',
   display: 'grid',
   gap: '0.75rem',


### PR DESCRIPTION
## Summary

Implements **CONS-7 → Option B** (two intentional shadow registers). Introduces elevation tokens in `globals.css` and snaps the duplicated/related shadow values to them.

## Tokens added (`globals.css`)

- `--shadow-card: 0 4px 12px rgba(40, 32, 30, 0.04)` — soft card rest
- `--shadow-card-strong: 0 4px 12px rgba(40, 32, 30, 0.1)` — raised/hover card
- `--shadow-overlay: 0 12px 28px rgba(26, 18, 8, 0.16)` — modals / dialogs / overlays

## Snapped

- **Card register — zero visual change** (8 identical `0 4px 12px` usages): `FeedCardShell`, `DismissedFeedBar`, `TodaysFiveCard`, `KnowledgeCard`, `RecentlyExploringSection`, `RecentlyExpanding`, `ActivityStreamItem`.
- **Overlay register** — the warm-brown `TerritorySetupClient` cluster (3 usages) collapses to one token. `:789` was an exact match (no change); `:857` (`0 10px 30px .12`) and `:974` (`0 8px 22px .08`) unify to the slightly heavier `--shadow-overlay` — **worth an eyeball on the setup screen in preview.**
- `FeedCards.test.tsx` updated to assert the token classes.

## Deferred (intentionally not collapsed)

These use distinct hues/contexts and are really color-palette calls for `B-VISUAL-TOKEN-BUDGET-01`, not a shadow snap:
- Differently-hued overlays: `GameplayChat` navy `0 8px 20px`, `knowledge/page` black `0 8px 24px` / `0 18px 48px`, `QuickAddQuestionModal` `0 8px 32px`.
- Flat **press** register: the two `#3a3a3a` share buttons, and canvas/OG surfaces (`ShareCard`, `SharePortraitCard`, `OverlapMap`) which can't read CSS vars.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `npm run check:colors` → **147** off-system occurrences (was higher; ceiling 180) — the snap removed rgba literals
- `eslint` changed files → clean (2 pre-existing unrelated warnings in `TodaysFiveCard`)
- Tests: `FeedCards` (42), `NewTerritoryUndo`, `recently-*` → pass

Tracker: CONS-7 → DONE.

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_