### PR TITLE
fix(composer): make the question explanation field resizable (PLR-13)

### DIFF
--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -663,7 +663,7 @@ export function QuestionForm({
 
           <div>
             <label htmlFor="explanation" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Explanation</label>
-            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={4} maxLength={500} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="A short note that helps someone learn if they miss it." />
+            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={5} maxLength={500} readOnly={state.stage === 'SUBMITTING'} className="w-full resize-y min-h-[7.5rem] rounded-md border bg-background px-3 py-2 outline-none focus:border-primary" placeholder="A short note that helps someone learn if they miss it." />
             <p className="mt-1 text-right text-xs text-muted-foreground">{state.explanation.length}/500</p>
           </div>
 


### PR DESCRIPTION
## Summary

**PLR-13** — the question composer's *Explanation* field was a fixed `rows={4}` textarea with no resize affordance, so longer explanations scrolled inside a cramped box (audit: "tiny explanation field… requires internal scrolling").

## Change

`src/components/QuestionForm.tsx` — the explanation `<textarea>` is now:
- `rows={5}` with `min-h-[7.5rem]` (taller default)
- `resize-y` (author can drag to expand)

Scoped to the explanation field only; the 500-char cap and counter are unchanged.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `eslint src/components/QuestionForm.tsx` → clean
- `QuestionForm` tests (7) → pass

Tracker item PLR-13 (`CLEAN WIN`).

> Note: branched off `dev2` (independent of the open CONS-7 PR #933) so this lands as its own PR, per request.

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_