### PR TITLE
Standardize buttons on the daily-five primary-CTA style

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -617,7 +617,7 @@ export function TerritorySetupClient({
           ) : (
             <button
               type="button"
-              className="mb-5 flex w-full items-center justify-center gap-2 rounded-full border border-dashed border-[var(--border-warm)] bg-[var(--cream-warm)] px-4 py-3 font-serif text-base text-[var(--ink)] transition hover:bg-[var(--cream)] disabled:opacity-40"
+              className="mb-5 flex w-full items-center justify-center gap-2 rounded-[4px] border border-dashed border-[var(--border-warm)] bg-[var(--cream-warm)] px-4 py-3 font-serif text-base text-[var(--ink)] transition hover:bg-[var(--cream)] disabled:opacity-40"
               disabled={addingTopic}
               onClick={openCreateTopic}
             >


### PR DESCRIPTION
## What & why

Standardizes button styling across the app on the homepage **daily-five** look, so prominent actions all read as one system instead of a scatter of hand-rolled heights, radii, and colors.

## Changes

**Canonical recipes (`src/app/globals.css`)**
- `.btn-primary` now *is* the daily-five primary CTA: `min-h-12` (48px), `rounded-[4px]`, `bg-[var(--brand-link)]`, `text-base font-bold tracking-[0.04em]`, white text.
- The `4px` corner radius is aligned across the whole `btn-*` family (`ghost`/`danger`/`icon`) so they read as one system. Per the agreed scope, the distinctive size/weight/fill treatment stays on **primary CTAs only** — ghost/danger keep their 44px height and `text-sm` weight as secondary actions.

**Call sites normalized to the recipes (~25 files)**
- Stripped now-redundant/conflicting overrides from `btn-*` usages: `rounded-full` pills, custom `min-h-*`/`h-*` heights, `text-sm`/`text-base`, inline brand-link/white colors, `px-5` — across friends, invite, onboarding, settings, knowledge, and daily surfaces.
- Converted remaining ad-hoc/inline buttons to recipes: FeedList submit → `btn-primary`; AccountActions log-out/delete → `btn-danger`, cancels → `btn-ghost`; QuestionForm critique actions → `btn-ghost`.
- The territory-setup **"+ Create your own"** add-affordance keeps its intentional dashed/cream/serif identity but swaps `rounded-full` → `rounded-[4px]` to join the family.

**Deliberately left alone**
- The immersive daily *room* screens (`daily/page`, `catchup`, `summary`) keep their own theme-token icon/close/transcript controls — forcing the global ink-on-cream recipes onto them would clash.

**Merge**
- Merged `dev2`; resolved a modify/delete conflict in `OnboardingFlow.tsx` (dev2 removed the `reminders` onboarding step, so that dead block was dropped while the other onboarding button normalizations were kept).

## Verification
- Strict typecheck: 0 errors
- ESLint: 0 errors (11 pre-existing color warnings, under the 16 ceiling)
- Color ratchet: 153/180 (down — inline colors consolidated into the recipe)
- Font ratchet: 0/0
- Production build reaches and clears CSS/Tailwind compilation (only fails on Google Fonts network fetch in the sandbox, unrelated to these changes)

## Follow-up (not in this PR)
- `_docs/DESIGN-SYSTEM.md` §6.1–6.4 still documents older button specs (h-8/h-9 sizes, `rounded-lg`) that predate the current recipes; worth reconciling separately.

https://claude.ai/code/session_0188WtrPrWhYXyUgpdikYTaq

---
_Generated by [Claude Code](https://claude.ai/code/session_0188WtrPrWhYXyUgpdikYTaq)_