### PR TITLE
docs(audits): final tracker updates — PLR-10/13/21 resolved

### DIFF
--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -49,11 +49,12 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 ## ⭐ Start here — open & important
 
-| ID | Item | Priority | Status | Disposition |
-|---|---|---|---|---|
-| PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` — copy decision (may be deliberate) |
+**No blockers and no open decisions left.** Both audits are burned down: every launch-blocker is `DONE`, ignored, or deferred. What remains is optional, feature-sized, or judgment work:
 
-**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13 ✅, PLR-21.
+- **PLR-21** (`CLEAN WIN`) — link styling on the summary page; code looks already-consistent, so this likely just needs a 30-sec live look.
+- **PLR-14** (`FIX VIA CANON`) — richer friend actions (no competition mechanics). A real P2 feature.
+- **PLR-3** — needs a live repro to confirm the "double-tap" exists.
+- **Partials (judgment, low urgency):** PLR-12, PLR-17, PLR-19, PLR-20, PLR-25.
 
 ---
 
@@ -72,7 +73,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-7 | Gear icon on Today's Five does nothing | P2 | `DONE` | `CLEAN WIN` | **Confirmed functional (2026-06-14):** the gear is a working `<Link href="/daily/setup">` with `aria-label="Set up daily round"` (`TodaysFiveCard.tsx:209–215`) — it opens the daily setup page, not a dead control. The reviewer's live "dead control" read doesn't hold against current code (older build / non-obvious destination). The `claude/fix-gear-icon-LZCOK` branch is unnecessary and can be closed. |
 | PLR-8 | Catch-up reveal, no confirmation | P1 | `WON'T DO` | — | **Not a bug per owner (2026-06-14), code-confirmed.** Premise ("reveal consumes a missed question") is false: `skipCurrent()` `useCatchupFlow.ts:424–463` makes **no server call** — purely a client-session `outcome:'revealed'`. The slot stays `answered:false`/`dismissed_at:null`, so `isCatchUpSlotEligible` (`catch-up-eligibility.ts:28–37`) keeps it eligible; it resurfaces in catch-up until answered correctly, dismissed, or it ages out (7-day window). Nothing is burned. |
 | PLR-9 | Privacy toggles lack context | P2 | `DONE` | `CLEAN WIN` | `419201a`; `SECTION_VISIBILITY_HELP` `users/[id]/page.tsx:546–565`. |
-| PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
+| PLR-10 | "Establishing" label unclear | — | `WON'T DO` | — | **Owner: deliberate (2026-06-14).** "Establishing" is intentional vocabulary (the tier name) — no rename, no tooltip. |
 | PLR-11 | Card-colour switcher confusing | — | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: dev `PaletteToggle` live for all `layout.tsx:7,72`.) |
 | PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
 | PLR-13 | Explanation field is a small scrolling textarea | — | `DONE` | `CLEAN WIN` | Shipped #934: explanation `<textarea>` is now `resize-y` with a taller default (`rows={5}`, `min-h-[7.5rem]`) — `QuestionForm.tsx:666`. |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -51,7 +51,6 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 
 **No blockers and no open decisions left.** Both audits are burned down: every launch-blocker is `DONE`, ignored, or deferred. What remains is optional, feature-sized, or judgment work:
 
-- **PLR-21** (`CLEAN WIN`) — link styling on the summary page; code looks already-consistent, so this likely just needs a 30-sec live look.
 - **PLR-14** (`FIX VIA CANON`) — richer friend actions (no competition mechanics). A real P2 feature.
 - **PLR-3** — needs a live repro to confirm the "double-tap" exists.
 - **Partials (judgment, low urgency):** PLR-12, PLR-17, PLR-19, PLR-20, PLR-25.
@@ -84,7 +83,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-18 | Frequency options lack micro-copy | P2 | `DONE` | `CLEAN WIN` | Per-zone `copy` `TerritorySetupClient.tsx:43–55`. |
 | PLR-19 | Invite flow generic (link/email/SMS unclear) | — | `PARTIAL` | — | Personal invite + copy link `InviteSomeoneNew.tsx:54–84`; no explicit SMS/email labelling. |
 | PLR-20 | Avatars initials-only; no photo upload | — | `OPEN` | — | `AvatarChip` initials-only; no upload anywhere. |
-| PLR-21 | Inconsistent link styling on summary page | — | `OPEN` | `CLEAN WIN` | Low-stakes. Underlined + button links coexist `summary/page.tsx:242,255,259,635,663`. |
+| PLR-21 | Inconsistent link styling on summary page | — | `DONE` | `CLEAN WIN` | **Resolved (2026-06-14).** Code is already consistent: every text link uses `underline underline-offset-4` (`summary/page.tsx:242,259,635,663`); `btn-primary`/`btn-ghost` are buttons (correctly not underlined). No color-only link exists. No change needed. |
 | PLR-22 | No dark mode | P3 | `DEFERRED` | `DO NOT DO` (for launch) | Not canon-violating, but reworks the cream/serif/illustration brand — large effort. Park post-launch. |
 | PLR-23 | Audio/haptic feedback on answers | P3 | `WON'T DO` | `DO NOT DO` | Wrong answer = discovery, not failure; an "incorrect" tone betrays the thesis. Skip. |
 | PLR-24 | Categories skew Western | P3 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not applicable: categories follow each person's declared interests — content is interest-matched by design, not a fixed seed corpus. No "skew" to correct. |

--- a/audits/AUDIT-TRACKER.md
+++ b/audits/AUDIT-TRACKER.md
@@ -53,7 +53,7 @@ One living ledger for the two audits currently being worked down. Edit the **Sta
 |---|---|---|---|---|
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` — copy decision (may be deliberate) |
 
-**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13, PLR-21.
+**Clean cheap-and-safe cluster (mostly already done):** PLR-5 ✅, PLR-6 ✅, PLR-7 ✅, PLR-9 ✅, PLR-13 ✅, PLR-21.
 
 ---
 
@@ -75,7 +75,7 @@ Source: `audits/2026-06-13-product-design-prelaunch-review.md`. Priority = the a
 | PLR-10 | "Establishing" label unclear | — | `NEEDS DECISION` | `FIX VIA CANON` | Treat as a **copy decision** (copy before pixels); "Establishing" may be deliberate vocabulary. Rename ideas ("In review") are direction, not a quick relabel. No tooltip today `TodaysFiveCard.tsx:49,58`. |
 | PLR-11 | Card-colour switcher confusing | — | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Not being tracked as actionable. (Code unchanged: dev `PaletteToggle` live for all `layout.tsx:7,72`.) |
 | PLR-12 | Profile editing hidden behind preview | — | `PARTIAL` | — | Inline click-to-edit fields, no explicit "Edit profile" `users/[id]/page.tsx:492–539`. |
-| PLR-13 | Explanation field is a small scrolling textarea | — | `OPEN` | `CLEAN WIN` | Low-stakes. `rows={4}`, no resize `QuestionForm.tsx:666`. |
+| PLR-13 | Explanation field is a small scrolling textarea | — | `DONE` | `CLEAN WIN` | Shipped #934: explanation `<textarea>` is now `resize-y` with a taller default (`rows={5}`, `min-h-[7.5rem]`) — `QuestionForm.tsx:666`. |
 | PLR-14 | Friend list lacks quick actions | P2 | `OPEN` | `FIX VIA CANON` | Richer friend actions are fine — but **no** streak count, leaderboards, "Challenge," or competition language. `FriendCard` is just a `<Link>` `FriendsList.tsx:108–122`. |
 | PLR-15 | No onboarding/tour for Knowledge Map | P1 | `DONE` | `FIX VIA CANON` | Reworked the post-first-five recap (`FirstSessionRecap.tsx`): Beat 2 now points to the **Knowledge** tab; new Beat 3 points to the **Questions** tab (write-questions); new Beat 4 carries the daily rhythm + the reminder email opt-in. Removed the invite beat (per owner). Copy avoids the mastery-size misstatement. Also moved the reminder opt-in **off onboarding** (`OnboardingFlow.tsx` — `reminders` step deleted; finishes straight to /daily). Typecheck/lint/tests green. |
 | PLR-16 | Overwhelming home feed | P1 | `WON'T DO` | — | **Ignored per owner (2026-06-14).** Budgeted "edition" already caps arrival volume (`build-edition.ts`, `page.tsx:118–161`); not tracking further. (Collapsible grouping remains banned regardless — see traps.) |


### PR DESCRIPTION
## Summary

Final audit-tracker updates so `dev2`'s ledger reflects the burned-down state. Docs-only (`audits/AUDIT-TRACKER.md`).

- **PLR-13 → DONE** — resizable explanation field shipped in #934.
- **PLR-10 → WON'T DO** — owner: "Establishing" is deliberate tier vocabulary; no rename/tooltip.
- **PLR-21 → DONE** — summary-page link styling is already consistent in code (all text links use `underline underline-offset-4`; `btn-primary`/`btn-ghost` are buttons). No change needed.
- Start-here section updated: no blockers and no open decisions remain.

## Where both audits stand

- **Audit #1 (Consistency):** fully resolved — CONS-7 shipped (#933); rest won't-do / tracked-elsewhere.
- **Audit #2 (Pre-Launch):** 9 shipped, every launch-blocker `DONE`/ignored/deferred. Remaining items are all optional/feature-sized/judgment: **PLR-14** (richer friend actions — no competition mechanics), **PLR-3** (needs live repro), and partials PLR-12/17/19/20/25.

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_