### PR TITLE
fix(logout): hard-navigate after logout so cleared session takes effect

### DIFF
--- a/src/app/api/account/logout/__tests__/route.test.ts
+++ b/src/app/api/account/logout/__tests__/route.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { getSessionMock, destroySessionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  destroySessionMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+  destroySession: destroySessionMock,
+}));
+
+import { POST } from '@/app/api/account/logout/route';
+
+describe('POST /api/account/logout (B-LOGOUT-CONFIRM-FIX-01)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getSessionMock.mockReset();
+    destroySessionMock.mockReset();
+  });
+
+  it('destroys the session (clears joshing_session cookie) for an authed user', async () => {
+    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' });
+    destroySessionMock.mockResolvedValueOnce(undefined);
+
+    const res = await POST();
+
+    expect(destroySessionMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+  });
+
+  it('returns 401 and does not touch the session when there is no session', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+
+    const res = await POST();
+
+    expect(res.status).toBe(401);
+    expect(destroySessionMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -14,6 +14,31 @@ import { useState } from 'react';
 
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
 
+/**
+ * Log out, then redirect. `destroySession()` clears the `joshing_session`
+ * cookie server-side; the redirect MUST be a hard navigation so the cleared
+ * cookie takes effect and no stale authenticated client tree (App Router
+ * cache) survives. A soft `router.push` left the user looking signed-in until
+ * they manually navigated (B-LOGOUT-CONFIRM-FIX-01). 401 means the session was
+ * already gone, which is still a successful logout.
+ *
+ * `navigate` is injected so the chain is testable without a DOM.
+ */
+export async function logoutAndRedirect(
+  navigate: (url: string) => void,
+): Promise<void> {
+  const response = await fetch('/api/account/logout', {
+    method: 'POST',
+    credentials: 'include',
+  });
+
+  if (!response.ok && response.status !== 401) {
+    throw new Error('Could not log out.');
+  }
+
+  navigate('/login');
+}
+
 export function AccountActions() {
   const router = useRouter();
   const [confirmingLogout, setConfirmingLogout] = useState(false);
@@ -56,16 +81,10 @@ export function AccountActions() {
     setLogoutError(null);
 
     try {
-      const response = await fetch('/api/account/logout', {
-        method: 'POST',
-        credentials: 'include',
+      // Hard navigation (not router.push): see logoutAndRedirect above.
+      await logoutAndRedirect((url) => {
+        window.location.assign(url);
       });
-
-      if (!response.ok && response.status !== 401) {
-        throw new Error('Could not log out.');
-      }
-
-      router.push('/login');
     } catch (caught) {
       setLogoutError(caught instanceof Error ? caught.message : 'Could not log out.');
       setLoggingOut(false);

--- a/src/components/profile/settings/__tests__/AccountActions.logout.test.tsx
+++ b/src/components/profile/settings/__tests__/AccountActions.logout.test.tsx
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { logoutAndRedirect } from '@/components/profile/settings/AccountActions';
+
+describe('logoutAndRedirect (B-LOGOUT-CONFIRM-FIX-01)', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('POSTs to /api/account/logout (the route that clears joshing_session) and redirects to /login', async () => {
+    const fetchMock = vi
+      .spyOn(global, 'fetch')
+      .mockResolvedValue(new Response(JSON.stringify({ ok: true }), { status: 200 }));
+    const navigate = vi.fn();
+
+    await logoutAndRedirect(navigate);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    expect(url).toBe('/api/account/logout');
+    expect(init).toMatchObject({ method: 'POST', credentials: 'include' });
+    expect(navigate).toHaveBeenCalledExactlyOnceWith('/login');
+  });
+
+  it('treats 401 (session already gone) as a successful logout and still redirects', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'unauthorized' }), { status: 401 }),
+    );
+    const navigate = vi.fn();
+
+    await logoutAndRedirect(navigate);
+
+    expect(navigate).toHaveBeenCalledExactlyOnceWith('/login');
+  });
+
+  it('throws and does NOT redirect when the logout request fails server-side', async () => {
+    vi.spyOn(global, 'fetch').mockResolvedValue(
+      new Response('', { status: 500 }),
+    );
+    const navigate = vi.fn();
+
+    await expect(logoutAndRedirect(navigate)).rejects.toThrow('Could not log out.');
+    expect(navigate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
Confirming "Log out" cleared the joshing_session cookie server-side
(destroySession) but redirected with router.push('/login') — a soft App
Router navigation that left the stale authenticated client tree in place,
so the user appeared still signed in until a manual hard navigation.

Switch the post-logout redirect to a hard window.location.assign('/login')
and extract the fetch+redirect into a testable logoutAndRedirect helper.
Add tests for the client chain (route + redirect, 401 = success, 500 =
no redirect) and the route handler (destroySession called / 401 when no
session).

Note: src/app/api/auth/logout/route.ts has no callers — redundant, flag
for separate cleanup (not deleted here).

https://claude.ai/code/session_01EahAje5dEeG1ByMo5afFXx