### PR TITLE
fix(daily): persist Daily Five atomically so a mid-build read can't serve a partial queue

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -11,7 +11,8 @@
       "mcp__supabase__list_tables",
       "mcp__plugin_figma_figma__get_metadata",
       "mcp__vercel__web_fetch_vercel_url",
-      "mcp__plugin_figma_figma__get_variable_defs"
+      "mcp__plugin_figma_figma__get_variable_defs",
+      "mcp__plugin_figma_figma__search_design_system"
     ]
   },
   "hooks": {

--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -4,7 +4,7 @@ import { getSession } from '@/server/auth/session';
 import { countDailyQueues, getTodaysDailyQueue } from '@/server/db/queries/daily';
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
-import { DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
+import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 
 export const dynamic = 'force-dynamic';
@@ -95,6 +95,28 @@ export async function GET() {
 
   if (!queue) {
     return NextResponse.json({ queue: null, slots: [] });
+  }
+
+  // Read floor (B-DAILY-PARTIAL-QUEUE-01). A queue below the minimum servable
+  // size that the player hasn't started yet is treated as "still building"
+  // rather than served as a degenerate 1–2 question round. The client's
+  // null-handling re-POSTs, which awaits a full synchronous build (and, with
+  // atomic persistence, observes the completed queue). The orchestrator never
+  // PERSISTS below the floor, so in practice this only catches a transient read
+  // that raced a build, or legacy partial data. Only applied on GET — POST has
+  // just awaited a full build and a genuinely short (≥ floor) low-yield queue
+  // there is valid and should be served.
+  const rawSlots = asQueueSlots(queue.slots);
+  const { kept: keptSlots } = partitionGenericSlots(rawSlots);
+  const untouched = rawSlots.every((slot) => !slot.answered && !slot.skipped);
+  if (untouched && keptSlots.length < DAILY_QUEUE_MIN_SIZE) {
+    console.warn('[daily/queue] withholding sub-floor untouched queue (treating as building)', {
+      userId,
+      queueDate: queue.queueDate,
+      kept: keptSlots.length,
+      persistedSlots: rawSlots.length,
+    });
+    return NextResponse.json({ queue: null, slots: [], building: true });
   }
 
   return NextResponse.json(serializeQueue(queue, prefs.difficulty, userId, totalQueues));

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -195,6 +195,8 @@ export default function DailyPage() {
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
   const [showFirstRunIntro, setShowFirstRunIntro] = useState(false);
   const answerInputRef = useRef<HTMLInputElement>(null);
+  // Guards the one-shot end-of-round revalidation below (B-DAILY-PARTIAL-QUEUE-01).
+  const revalidatedEndRef = useRef(false);
 
   // Show the first-run intro once, only for the server-flagged first untouched
   // queue and only if this device hasn't already dismissed it.
@@ -336,6 +338,45 @@ export default function DailyPage() {
   // match the real number of questions rather than always showing five.
   const queueLength = queue && queue.slots.length > 0 ? queue.slots.length : DAILY_QUEUE_SIZE;
   const allDone = Boolean(queue && queue.slots.length > 0 && !actualCurrentSlot);
+
+  // Defense-in-depth against a partial queue snapshot (B-DAILY-PARTIAL-QUEUE-01).
+  // If the round looks complete, re-fetch once to confirm the server agrees. A
+  // queue read mid-build could have handed us fewer slots than were ultimately
+  // persisted; without this the player hits "Tomorrow's another five" with
+  // unanswered questions still sitting in the queue. If the server now has more
+  // slots with something still pending, adopt them and the round continues.
+  useEffect(() => {
+    if (!allDone || loading || error || !queue) return;
+    if (revalidatedEndRef.current) return;
+    revalidatedEndRef.current = true;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const response = await fetch('/api/daily/queue', {
+          cache: 'no-store',
+          credentials: 'include',
+        });
+        const body = await response.json().catch(() => null);
+        if (cancelled || !response.ok || !body?.queue_id) return;
+        const serverSlots: QueueSlot[] = Array.isArray(body.slots) ? body.slots : [];
+        if (serverSlots.length > queue.slots.length && hasPendingSlot(serverSlots)) {
+          setQueue({
+            queue_id: body.queue_id,
+            queue_date: body.queue_date,
+            slots: serverSlots,
+          });
+          // Re-arm so the next end-of-round (after the newly-revealed slots are
+          // played) revalidates again; convergence is bounded by the server count.
+          revalidatedEndRef.current = false;
+        }
+      } catch {
+        // Best-effort — a failed revalidation just leaves the session-close as-is.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [allDone, loading, error, queue]);
 
   const requestRecheck = useCallback(
     async (slotIndex: number): Promise<RecheckActionResult> => {

--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -15,10 +15,7 @@ const mocks = vi.hoisted(() => ({
   getKnowledgeBase: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
-  createDailyQueueItem: vi.fn(),
-  createDailyQueueItemFromAuthored: vi.fn(),
-  createDailyQueueItemFromHouse: vi.fn(),
-  createDailyQueueItemFromPresence: vi.fn(),
+  persistDailyQueue: vi.fn(),
   getDailyPreferences: vi.fn(),
   getFriendAndFoFUserIds: vi.fn(),
   getFriendDomainsForBonus: vi.fn(),
@@ -27,6 +24,9 @@ const mocks = vi.hoisted(() => ({
   isGenericSubcategory: vi.fn(),
 }));
 
+// The orchestrator assembles the queue in memory via pure slot builders, then
+// persists it once via persistDailyQueue (atomic write). Provide faithful pure
+// builders so the slots handed to persistDailyQueue carry the asserted fields.
 vi.mock('@/server/db/queries/daily', () => ({
   getTodaysDailyQueue: mocks.getTodaysDailyQueue,
   carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
@@ -35,10 +35,19 @@ vi.mock('@/server/db/queries/daily', () => ({
   getKnowledgeBase: mocks.getKnowledgeBase,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
-  createDailyQueueItem: mocks.createDailyQueueItem,
-  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
-  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
-  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+  persistDailyQueue: mocks.persistDailyQueue,
+  buildAuthoredSlot: (a: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'friend', question_id: a.id, domain: a.canonicalSubcategory, question_text: a.questionText, answered: false,
+  }),
+  buildHouseSlot: (h: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'house', question_id: h.id, domain: h.canonicalSubcategory, question_text: h.questionText, answered: false,
+  }),
+  buildBotSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, answered: false,
+  }),
+  buildPresenceSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, presence: { sourceId: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, presence_source_id: presence?.sourceId, answered: false,
+  }),
 }));
 
 vi.mock('@/server/db/queries/daily-preferences', () => ({
@@ -87,15 +96,18 @@ function authoredPick(id: string, subcategory: string) {
   } as never;
 }
 
+// The single atomic persist call's slots argument.
+function persistedSlots(): Array<Record<string, unknown>> {
+  expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+  return mocks.persistDailyQueue.mock.calls[0][1] as Array<Record<string, unknown>>;
+}
+/** Generated (bot) core slots only — excludes authored, house, and +2 bonus. */
+function persistedBotSlots(): Array<Record<string, unknown>> {
+  return persistedSlots().filter((slot) => slot.source === 'bot' && !slot.presence_source_id);
+}
 /** The canonicalSubcategory each generated slot was persisted under, in slot order. */
-function persistedGeneratedDomains(generatedRows: ReturnType<typeof genq>[]): string[] {
-  const byId = new Map(
-    generatedRows.map((row) => {
-      const q = row as unknown as { id: string; canonicalSubcategory: string };
-      return [q.id, q.canonicalSubcategory] as const;
-    }),
-  );
-  return mocks.createDailyQueueItem.mock.calls.map((call) => byId.get(call[1] as string) ?? '?');
+function persistedGeneratedDomains(): string[] {
+  return persistedBotSlots().map((slot) => (slot.domain as string) ?? '?');
 }
 
 beforeEach(() => {
@@ -131,10 +143,7 @@ beforeEach(() => {
 
   mocks.isGenericSubcategory.mockReturnValue(false);
 
-  mocks.createDailyQueueItem.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue(undefined);
 });
 
 describe('fillDailyQueueForUser — intra-day diversity cap', () => {
@@ -157,8 +166,8 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
 
     await fillDailyQueueForUser(USER);
 
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
-    const domains = persistedGeneratedDomains(rows);
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    const domains = persistedGeneratedDomains();
     // Exactly the cap of botany; b3 was deflected and never needed (the round
     // brought diverse material), so it does not appear.
     expect(domains.filter((d) => d === 'Botany').length).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
@@ -181,11 +190,8 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
 
     await fillDailyQueueForUser(USER);
 
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
-    const domains = mocks.createDailyQueueItem.mock.calls.map((call) => {
-      const id = call[1] as string;
-      return id.startsWith('b') ? 'Botany' : id;
-    });
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    const domains = persistedGeneratedDomains();
     const botanyCount = domains.filter((d) => d === 'Botany').length;
     // No more than the cap, and the freed slots are filled by other subcategories.
     expect(botanyCount).toBe(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
@@ -209,13 +215,10 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     await fillDailyQueueForUser(USER);
 
     // Only two Hamlet authored slots persisted (cap), not three.
-    expect(mocks.createDailyQueueItemFromAuthored).toHaveBeenCalledTimes(
-      DAILY_QUEUE_MAX_PER_SUBCATEGORY,
-    );
+    const authoredSlots = persistedSlots().filter((slot) => slot.source === 'friend');
+    expect(authoredSlots).toHaveLength(DAILY_QUEUE_MAX_PER_SUBCATEGORY);
     // Generation backfilled the slot the cap freed, so the queue is still full.
-    const totalSlots =
-      mocks.createDailyQueueItemFromAuthored.mock.calls.length +
-      mocks.createDailyQueueItem.mock.calls.length;
+    const totalSlots = authoredSlots.length + persistedBotSlots().length;
     expect(totalSlots).toBe(DAILY_QUEUE_SIZE);
   });
 
@@ -240,7 +243,7 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     await fillDailyQueueForUser(USER);
 
     // All five botany slots persisted — not capped at DAILY_QUEUE_MAX_PER_SUBCATEGORY.
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
   });
 
   it('still caps OTHER subcategories while an "often" one runs free', async () => {
@@ -264,11 +267,8 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
 
     await fillDailyQueueForUser(USER);
 
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
-    const domains = mocks.createDailyQueueItem.mock.calls.map((call) => {
-      const id = call[1] as string;
-      return id.startsWith('b') ? 'Botany' : 'Jazz';
-    });
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
+    const domains = persistedGeneratedDomains();
     // Botany (often) exceeds the base cap; Jazz (unset) is held at it.
     expect(domains.filter((d) => d === 'Botany').length).toBeGreaterThan(
       DAILY_QUEUE_MAX_PER_SUBCATEGORY,
@@ -294,6 +294,6 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
 
     // A full five-question queue still builds — the cap degraded gracefully.
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
   });
 });

--- a/src/server/daily/__tests__/queue-floor.test.ts
+++ b/src/server/daily/__tests__/queue-floor.test.ts
@@ -16,10 +16,7 @@ const mocks = vi.hoisted(() => ({
   getKnowledgeBase: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
-  createDailyQueueItem: vi.fn(),
-  createDailyQueueItemFromAuthored: vi.fn(),
-  createDailyQueueItemFromHouse: vi.fn(),
-  createDailyQueueItemFromPresence: vi.fn(),
+  persistDailyQueue: vi.fn(),
   getDailyPreferences: vi.fn(),
   getFriendAndFoFUserIds: vi.fn(),
   getFriendDomainsForBonus: vi.fn(),
@@ -28,6 +25,9 @@ const mocks = vi.hoisted(() => ({
   isGenericSubcategory: vi.fn(),
 }));
 
+// The orchestrator assembles the queue in memory via pure slot builders, then
+// persists it once via persistDailyQueue (atomic write). Provide faithful pure
+// builders so the slots handed to persistDailyQueue carry the asserted fields.
 vi.mock('@/server/db/queries/daily', () => ({
   getTodaysDailyQueue: mocks.getTodaysDailyQueue,
   carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
@@ -36,10 +36,19 @@ vi.mock('@/server/db/queries/daily', () => ({
   getKnowledgeBase: mocks.getKnowledgeBase,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
-  createDailyQueueItem: mocks.createDailyQueueItem,
-  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
-  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
-  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+  persistDailyQueue: mocks.persistDailyQueue,
+  buildAuthoredSlot: (a: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'friend', question_id: a.id, domain: a.canonicalSubcategory, question_text: a.questionText, answered: false,
+  }),
+  buildHouseSlot: (h: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'house', question_id: h.id, domain: h.canonicalSubcategory, question_text: h.questionText, answered: false,
+  }),
+  buildBotSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, answered: false,
+  }),
+  buildPresenceSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, presence: { sourceId: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, presence_source_id: presence?.sourceId, answered: false,
+  }),
 }));
 
 vi.mock('@/server/db/queries/daily-preferences', () => ({
@@ -104,11 +113,19 @@ beforeEach(() => {
 
   mocks.isGenericSubcategory.mockReturnValue(false);
 
-  mocks.createDailyQueueItem.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue(undefined);
 });
+
+// The single atomic persist call's slots argument, with the generated (bot) core
+// slots in slot order — the post-refactor equivalent of the old per-slot
+// createDailyQueueItem call list.
+function persistedSlots(): Array<Record<string, unknown>> {
+  expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+  return mocks.persistDailyQueue.mock.calls[0][1] as Array<Record<string, unknown>>;
+}
+function persistedBotSlots(): Array<Record<string, unknown>> {
+  return persistedSlots().filter((slot) => slot.source === 'bot' && !slot.presence_source_id);
+}
 
 describe('fillDailyQueueForUser — minimum-size floor', () => {
   it('fails retryably (and persists nothing) when only one question survives the gates', async () => {
@@ -122,7 +139,7 @@ describe('fillDailyQueueForUser — minimum-size floor', () => {
     await expect(fillDailyQueueForUser(USER)).rejects.toBeInstanceOf(DailyQueueFillError);
 
     // A degenerate one-question queue must never be persisted.
-    expect(mocks.createDailyQueueItem).not.toHaveBeenCalled();
+    expect(mocks.persistDailyQueue).not.toHaveBeenCalled();
   });
 
   it('stops topping up once a round recovers nothing (tapped-out pool)', async () => {
@@ -143,10 +160,15 @@ describe('fillDailyQueueForUser — minimum-size floor', () => {
 
     await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
 
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_MIN_SIZE);
-    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(1, USER, 'q1', 0);
-    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(2, USER, 'q2', 1);
-    expect(mocks.createDailyQueueItem).toHaveBeenNthCalledWith(3, USER, 'q3', 2);
+    // Persisted once, atomically, with exactly the floor's worth of bot slots in
+    // order — the equivalent of the old three createDailyQueueItem(USER, id, pos).
+    const bots = persistedBotSlots();
+    expect(bots).toHaveLength(DAILY_QUEUE_MIN_SIZE);
+    expect(bots.map((slot) => [slot.generated_question_id, slot.slot_index])).toEqual([
+      ['q1', 0],
+      ['q2', 1],
+      ['q3', 2],
+    ]);
   });
 
   it('loops top-up rounds until it reaches the full five', async () => {
@@ -160,6 +182,6 @@ describe('fillDailyQueueForUser — minimum-size floor', () => {
 
     // One initial generation + two top-up rounds reaching the target.
     expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(3);
-    expect(mocks.createDailyQueueItem).toHaveBeenCalledTimes(DAILY_QUEUE_SIZE);
+    expect(persistedBotSlots()).toHaveLength(DAILY_QUEUE_SIZE);
   });
 });

--- a/src/server/daily/__tests__/resting-domains.test.ts
+++ b/src/server/daily/__tests__/resting-domains.test.ts
@@ -17,10 +17,7 @@ const mocks = vi.hoisted(() => ({
   getKnowledgeBase: vi.fn(),
   pickEligibleAuthoredQuestions: vi.fn(),
   pickHouseQuestions: vi.fn(),
-  createDailyQueueItem: vi.fn(),
-  createDailyQueueItemFromAuthored: vi.fn(),
-  createDailyQueueItemFromHouse: vi.fn(),
-  createDailyQueueItemFromPresence: vi.fn(),
+  persistDailyQueue: vi.fn(),
   getDailyPreferences: vi.fn(),
   getFriendAndFoFUserIds: vi.fn(),
   getFriendDomainsForBonus: vi.fn(),
@@ -29,6 +26,10 @@ const mocks = vi.hoisted(() => ({
   isGenericSubcategory: vi.fn(),
 }));
 
+// Pure slot builders are unmocked-in-spirit: the orchestrator assembles the
+// queue in memory via these, then persists it once via persistDailyQueue. Provide
+// faithful-enough pure impls so the slots handed to persistDailyQueue carry the
+// fields the assertions read (source, ids, domain, slot_index).
 vi.mock('@/server/db/queries/daily', () => ({
   getTodaysDailyQueue: mocks.getTodaysDailyQueue,
   carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
@@ -37,10 +38,19 @@ vi.mock('@/server/db/queries/daily', () => ({
   getKnowledgeBase: mocks.getKnowledgeBase,
   pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
   pickHouseQuestions: mocks.pickHouseQuestions,
-  createDailyQueueItem: mocks.createDailyQueueItem,
-  createDailyQueueItemFromAuthored: mocks.createDailyQueueItemFromAuthored,
-  createDailyQueueItemFromHouse: mocks.createDailyQueueItemFromHouse,
-  createDailyQueueItemFromPresence: mocks.createDailyQueueItemFromPresence,
+  persistDailyQueue: mocks.persistDailyQueue,
+  buildAuthoredSlot: (a: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'friend', question_id: a.id, domain: a.canonicalSubcategory, question_text: a.questionText, answered: false,
+  }),
+  buildHouseSlot: (h: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'house', question_id: h.id, domain: h.canonicalSubcategory, question_text: h.questionText, answered: false,
+  }),
+  buildBotSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, answered: false,
+  }),
+  buildPresenceSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, presence: { sourceId: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, presence_source_id: presence?.sourceId, answered: false,
+  }),
 }));
 
 vi.mock('@/server/db/queries/daily-preferences', () => ({
@@ -98,10 +108,7 @@ beforeEach(() => {
     Array.from({ length: DAILY_QUEUE_SIZE }, (_, i) => genq(`q${i}`)),
   );
 
-  mocks.createDailyQueueItem.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromAuthored.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromHouse.mockResolvedValue(undefined);
-  mocks.createDailyQueueItemFromPresence.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue(undefined);
 });
 
 describe('fillDailyQueueForUser — Game settings categories drive selection', () => {

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -1,13 +1,14 @@
 import {
+  buildAuthoredSlot,
+  buildBotSlot,
+  buildHouseSlot,
+  buildPresenceSlot,
   carryForwardUntouchedDailyQueue,
   clearStaleShortTodayQueue,
   countDailyQueues,
-  createDailyQueueItem,
-  createDailyQueueItemFromAuthored,
-  createDailyQueueItemFromHouse,
-  createDailyQueueItemFromPresence,
   getKnowledgeBase,
   getTodaysDailyQueue,
+  persistDailyQueue,
   pickEligibleAuthoredQuestions,
   pickHouseQuestions,
   type BonusPresence,
@@ -519,20 +520,29 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
     });
   }
 
-  // Persist in source order (authored → house → generated), each group already
-  // diversity-capped and reserve-backfilled above. Slice defensively so the core
-  // never exceeds DAILY_QUEUE_SIZE even if a source over-supplied.
+  // Assemble the COMPLETE queue (core + bonus) in memory, then persist it as a
+  // SINGLE atomic write (persistDailyQueue). The prior approach persisted each
+  // slot in its own transaction and the +2 bonus in a separate later pass, which
+  // left DailyQueue.slots observable in partial states for the whole build — a
+  // concurrent GET could read 2 of 6 slots and the player would play that partial
+  // set to "completion" (B-DAILY-PARTIAL-QUEUE-01). Building the full array first
+  // means a reader sees either the pre-build state or the whole queue, never a
+  // prefix. Source order (authored → house → generated) and the defensive slices
+  // (core never exceeds DAILY_QUEUE_SIZE) are unchanged.
+  const slots: QueueSlot[] = [];
+  const generatedQuestionIds: string[] = [];
   let position = 0;
   for (const pick of coreAuthored.slice(0, DAILY_QUEUE_SIZE - position)) {
-    await createDailyQueueItemFromAuthored(userId, pick, position);
+    slots.push(buildAuthoredSlot(pick, position));
     position += 1;
   }
   for (const pick of coreHouse.slice(0, DAILY_QUEUE_SIZE - position)) {
-    await createDailyQueueItemFromHouse(userId, pick, position);
+    slots.push(buildHouseSlot(pick, position));
     position += 1;
   }
   for (const question of coreGenerated.slice(0, DAILY_QUEUE_SIZE - position)) {
-    await createDailyQueueItem(userId, question.id, position);
+    slots.push(buildBotSlot(question, position));
+    generatedQuestionIds.push(question.id);
     position += 1;
   }
 
@@ -549,26 +559,39 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   // Resting domains are excluded from the +2 pool too, so "This is {Name}'s bag
   // but not mine" (which parks the domain in Resting) stops it surfacing as a
   // bonus, not just in the core five.
-  const bonusDomains = await getFriendDomainsForBonus(userId, DAILY_BONUS_SLOT_MAX, restingDomains);
-  if (bonusDomains.length > 0) {
-    const presenceByDomain = new Map(
-      bonusDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
-    );
-    const generatedBonus = await generateBonusQuestionsForDomains(
+  //
+  // Generated BEFORE the single persist so the whole queue (core + bonus) lands
+  // atomically. Wrapped so a bonus-generation failure degrades to a core-only
+  // queue instead of losing the entire build.
+  try {
+    const bonusDomains = await getFriendDomainsForBonus(
       userId,
-      bonusDomains.map((candidate) => candidate.domain),
+      DAILY_BONUS_SLOT_MAX,
+      restingDomains,
     );
-    for (const { domain, question } of generatedBonus) {
-      const candidate = presenceByDomain.get(domain.toLowerCase());
-      await createDailyQueueItemFromPresence(
-        userId,
-        question.id,
-        toBonusPresence(candidate),
-        position,
+    if (bonusDomains.length > 0) {
+      const presenceByDomain = new Map(
+        bonusDomains.map((candidate) => [candidate.domain.toLowerCase(), candidate]),
       );
-      position += 1;
+      const generatedBonus = await generateBonusQuestionsForDomains(
+        userId,
+        bonusDomains.map((candidate) => candidate.domain),
+      );
+      for (const { domain, question } of generatedBonus) {
+        const candidate = presenceByDomain.get(domain.toLowerCase());
+        slots.push(buildPresenceSlot(question, toBonusPresence(candidate), position));
+        generatedQuestionIds.push(question.id);
+        position += 1;
+      }
     }
+  } catch (error) {
+    console.warn('[daily/queue-orchestrator] +2 bonus generation failed; serving core only', {
+      userId,
+      error: error instanceof Error ? error.message : String(error),
+    });
   }
+
+  await persistDailyQueue(userId, slots, generatedQuestionIds);
 }
 
 // Map a ranked friend-domain candidate to the slot's presence attribution: the

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -754,6 +754,36 @@ async function getFeedCatchupItems(
     .filter((item): item is CatchupQuestion => Boolean(item));
 }
 
+/**
+ * Pure QueueSlot builder for a bot (LLM-generated) core slot. Extracted so the
+ * orchestrator can assemble the whole queue in memory and persist it atomically
+ * (persistDailyQueue) instead of one transaction per slot. The structural param
+ * type accepts a full GeneratedQuestionRow.
+ */
+export function buildBotSlot(
+  question: {
+    id: string;
+    questionText: string;
+    canonicalSubcategory: string;
+    broadCategory: string | null;
+    difficultyEstimate: string | null;
+  },
+  position: number,
+): QueueSlot {
+  return {
+    slot_index: position,
+    source: 'bot',
+    generated_question_id: question.id,
+    domain: question.canonicalSubcategory,
+    broad_category: question.broadCategory,
+    category: null,
+    question_text: question.questionText,
+    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate),
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+}
+
 export async function createDailyQueueItem(
   userId: string,
   generatedQuestionId: string,
@@ -774,18 +804,7 @@ export async function createDailyQueueItem(
     throw new Error('Generated question not found for user.');
   }
 
-  const slot: QueueSlot = {
-    slot_index: position,
-    source: 'bot',
-    generated_question_id: question.id,
-    domain: question.canonicalSubcategory,
-    broad_category: question.broadCategory,
-    category: null,
-    question_text: question.questionText,
-    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate),
-    answered: false,
-    difficulty_stepped_up: false,
-  };
+  const slot = buildBotSlot(question, position);
 
   return db.transaction(async (tx) => {
     const [existing] = await tx
@@ -829,6 +848,64 @@ export async function createDailyQueueItem(
   });
 }
 
+/**
+ * Atomically persist a freshly-built Daily Five (core + bonus) as a SINGLE write.
+ *
+ * Why this exists (B-DAILY-PARTIAL-QUEUE-01): the per-slot createDailyQueueItem*
+ * helpers each commit in their own transaction, and the +2 bonus is generated in
+ * a separate later pass — so during a build the DailyQueue.slots JSONB is
+ * observable in partial states. A concurrent GET /api/daily/queue could read 2 of
+ * 6 slots and the player would play that partial set to "completion." Writing the
+ * complete slots array in one statement closes that window: a reader sees either
+ * the pre-build state or the whole queue, never an intermediate prefix.
+ *
+ * Concurrency guard: ON CONFLICT only overwrites an UNTOUCHED row (no answered or
+ * skipped slot). A second builder that raced the first therefore can't clobber a
+ * session the player has already started — the started queue stands.
+ */
+export async function persistDailyQueue(
+  userId: string,
+  slots: QueueSlot[],
+  generatedQuestionIds: string[],
+): Promise<DailyQueueRow | null> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+  return db.transaction(async (tx) => {
+    // True only when the EXISTING conflicting row has no answered/skipped slot.
+    // Referencing the table name (not EXCLUDED) reads the pre-update row.
+    const untouched = sql`not exists (
+      select 1 from jsonb_array_elements(${dailyQueues.slots}) as elem
+      where (elem->>'answered')::boolean is true or (elem->>'skipped')::boolean is true
+    )`;
+    const [row] = await tx
+      .insert(dailyQueues)
+      .values({ userId, queueDate: assignmentDateStr, slots })
+      .onConflictDoUpdate({
+        target: [dailyQueues.userId, dailyQueues.queueDate],
+        set: { slots },
+        setWhere: untouched,
+      })
+      .returning();
+
+    if (row && generatedQuestionIds.length > 0) {
+      await tx
+        .update(generatedQuestions)
+        .set({ usedInQueue: true })
+        .where(inArray(generatedQuestions.id, generatedQuestionIds));
+    }
+
+    if (row) return row;
+
+    // Conflict hit a started (touched) row, so DO UPDATE was a no-op and
+    // RETURNING produced nothing. Hand back the existing started queue unchanged.
+    const [existing] = await tx
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.userId, userId), eq(dailyQueues.queueDate, assignmentDateStr)))
+      .limit(1);
+    return existing ?? null;
+  });
+}
+
 /** Presence attribution for a Daily Five +2 bonus slot (D-4 §B). */
 export type BonusPresence = {
   sourceId: string;
@@ -843,6 +920,35 @@ export type BonusPresence = {
  * carrying presence_* attribution ("from {Name}'s world") instead of a literal
  * answerer. Replaces createDailyQueueItemFromAnswerer.
  */
+/** Pure QueueSlot builder for a Daily Five +2 bonus slot (presence-attributed). */
+export function buildPresenceSlot(
+  question: {
+    id: string;
+    questionText: string;
+    canonicalSubcategory: string;
+    broadCategory: string | null;
+    difficultyEstimate: string | null;
+  },
+  presence: BonusPresence,
+  position: number,
+): QueueSlot {
+  return {
+    slot_index: position,
+    source: 'bot',
+    generated_question_id: question.id,
+    domain: question.canonicalSubcategory,
+    broad_category: question.broadCategory,
+    category: null,
+    question_text: question.questionText,
+    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate),
+    presence_source_id: presence.sourceId,
+    presence_source_name: presence.sourceName,
+    presence_source_extra_count: presence.extraCount > 0 ? presence.extraCount : undefined,
+    answered: false,
+    difficulty_stepped_up: false,
+  };
+}
+
 export async function createDailyQueueItemFromPresence(
   userId: string,
   generatedQuestionId: string,
@@ -864,21 +970,7 @@ export async function createDailyQueueItemFromPresence(
     throw new Error('Generated bonus question not found for user.');
   }
 
-  const slot: QueueSlot = {
-    slot_index: position,
-    source: 'bot',
-    generated_question_id: question.id,
-    domain: question.canonicalSubcategory,
-    broad_category: question.broadCategory,
-    category: null,
-    question_text: question.questionText,
-    difficulty_estimate: asQueueSlotDifficulty(question.difficultyEstimate),
-    presence_source_id: presence.sourceId,
-    presence_source_name: presence.sourceName,
-    presence_source_extra_count: presence.extraCount > 0 ? presence.extraCount : undefined,
-    answered: false,
-    difficulty_stepped_up: false,
-  };
+  const slot = buildPresenceSlot(question, presence, position);
 
   return db.transaction(async (tx) => {
     const [existing] = await tx
@@ -1131,14 +1223,9 @@ export async function pickEligibleAuthoredQuestions(
  * which only handles bot-generated questions. The QueueSlot schema
  * already supports both shapes (src/server/daily/types.ts).
  */
-export async function createDailyQueueItemFromAuthored(
-  userId: string,
-  authored: AuthoredPick,
-  position: number,
-): Promise<DailyQueueRow> {
-  const { assignmentDateStr } = getDailyAssignmentBounds();
-
-  const slot: QueueSlot = {
+/** Pure QueueSlot builder for a vetted user-authored ('friend') core slot. */
+export function buildAuthoredSlot(authored: AuthoredPick, position: number): QueueSlot {
+  return {
     slot_index: position,
     source: 'friend',
     question_id: authored.id,
@@ -1153,6 +1240,16 @@ export async function createDailyQueueItemFromAuthored(
     answered: false,
     difficulty_stepped_up: false,
   };
+}
+
+export async function createDailyQueueItemFromAuthored(
+  userId: string,
+  authored: AuthoredPick,
+  position: number,
+): Promise<DailyQueueRow> {
+  const { assignmentDateStr } = getDailyAssignmentBounds();
+
+  const slot = buildAuthoredSlot(authored, position);
 
   return db.transaction(async (tx) => {
     const [existing] = await tx


### PR DESCRIPTION
## Problem

A player was served only **2 of their 6** Daily Five questions and hit *"Tomorrow's another five"* with 4 unanswered slots still sitting in the queue. (`B-DAILY-PARTIAL-QUEUE-01`)

### Root cause

Diagnosed against live data + Vercel logs for the affected queue:

- The queue was persisted **slot-by-slot in separate transactions** (`createDailyQueueItem*`), and the **+2 bonus** question was generated and written in a **separate later wave** (~3.5s after the core). So `DailyQueue.slots` was observable mid-build in partial states.
- `GET /api/daily/queue` had **no floor** — it served whatever slot count existed at read time (it even logged `served short queue` and served it anyway).
- A read that interleaved with the in-progress build handed the client a **2-slot snapshot**, and the play page derives "round complete" purely from the slots it received — so it showed session-close while the DB finished filling to 6.

The build-time floor (`DAILY_QUEUE_MIN_SIZE = 3`) only protected the build, not a concurrent read.

## Fixes (defense in depth)

1. **Atomic persist (root cause)** — assemble the complete core+bonus slots array in memory and write it in a **single statement/transaction** via new `persistDailyQueue()`. Pure slot builders extracted (`buildBotSlot` / `buildAuthoredSlot` / `buildPresenceSlot`; `buildHouseSlot` already existed) and the per-slot `createDailyQueueItem*` helpers refactored to share them. A reader now sees the pre-build state or the whole queue, never a prefix. The +2 bonus is generated **before** the single persist (wrapped so a bonus failure degrades to core-only).
2. **Concurrent-build guard** — `INSERT … ON CONFLICT (user_id, queue_date) DO UPDATE` only overwrites an **untouched** row (no answered/skipped slot), so a racing builder can't clobber a started session or produce a partial.
3. **Read floor** — `GET` withholds a sub-floor *untouched* queue as `{ building: true }` so the client re-POSTs and awaits a full build instead of rendering a degenerate 1–2 question round. Only on `GET`; `POST` has already awaited a full build.
4. **Client revalidation** — the play page re-fetches once when the round looks complete and adopts any newly-revealed pending slots before showing session-close.

## Tests

- Orchestrator suites (`queue-floor`, `diversity-cap`, `resting-domains`) now assert on the single `persistDailyQueue` call's slots array — `toHaveBeenCalledTimes(1)` is itself the atomicity guarantee.
- ✅ `npx tsc -p tsconfig.typecheck.json` clean
- ✅ `eslint` clean on changed files
- ✅ 672 tests passing across `src/server/daily`, `src/server/db/queries`, `src/app/api/daily`, `src/app/daily`

## Note on the already-stuck queue

The reported queue already has all 6 slots in the DB (2 answered). With this change the player can simply **reload `/daily`** to resume at question 3 — no data fix required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)