### PR TITLE
Soften 'Not this time' grading red to the muted brick register

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -701,8 +701,11 @@ function AnsweredHistory({
           // sits in this answered list); treat anything but 'incorrect' as right.
           const isCorrect = r ? r.isCorrect : q.priorResult !== 'incorrect';
           // Result reads in the app's semantic answer colors: green for correct,
-          // red for "not this time" — same tokens the AnswerFeedbackSheet uses.
-          const resultColor = isCorrect ? 'var(--game-correct)' : 'var(--game-wrong-strong)';
+          // red for "not this time". This is the *quiet* answered-history line, so
+          // it uses the calm grading registers — base green --game-correct paired
+          // with the muted brick red --game-wrong (text/wrong), not the loud
+          // --game-wrong-strong SIGNAL reserved for the live in-play verdict.
+          const resultColor = isCorrect ? 'var(--game-correct)' : 'var(--game-wrong)';
           return (
             // Hollow triangle = already answered (spent), matching the bundle
             // mark's hollow state, so the viewer sees which ones they've done.

--- a/src/components/replay/ReplaySummary.tsx
+++ b/src/components/replay/ReplaySummary.tsx
@@ -87,7 +87,7 @@ export function ReplaySummary({ results, hasMore, onPlayNext, loadingNext }: Pro
                 className={`rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] ${
                   isCorrect
                     ? 'border-[color-mix(in_srgb,var(--game-correct)_30%,var(--border))] bg-[color-mix(in_srgb,var(--game-correct)_10%,var(--card))] text-[var(--game-correct)]'
-                    : 'border-[color-mix(in_srgb,var(--game-wrong)_28%,var(--border))] bg-[color-mix(in_srgb,var(--game-wrong)_8%,var(--card))] text-[var(--game-wrong-strong)]'
+                    : 'border-[color-mix(in_srgb,var(--game-wrong)_28%,var(--border))] bg-[color-mix(in_srgb,var(--game-wrong)_8%,var(--card))] text-[var(--game-wrong)]'
                 }`}
               >
                 {isCorrect ? 'CORRECT' : 'WRONG'}


### PR DESCRIPTION
The quiet answered-history labels in the feed (ActivityStreamItem) and the
replay recap chip (ReplaySummary) were painting wrong results with
--game-wrong-strong (#c1121f), the loud SIGNAL red reserved for the live
in-play verdict. On both surfaces the 'Correct' side already uses the calm
base green (--game-correct), so the wrong side now uses the calm base red
--game-wrong (#a93b3b, the system's text/wrong register) for a symmetric,
less harsh pairing. Grading stays reserved and label-paired per
STYLE-GUIDE-COLOR.