### PR TITLE
fix(profile): make name + handle obviously editable (PLR-12)

### DIFF
--- a/src/components/profile/InlineEditableField.tsx
+++ b/src/components/profile/InlineEditableField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Loader2, Pencil } from 'lucide-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 // Generic in-place text editor for the unified profile header card.
@@ -224,7 +224,7 @@ export function InlineEditableField({
       <button
         type="button"
         aria-label={`Edit ${label.toLowerCase()}`}
-        className="block w-full rounded-md px-1 py-0.5 text-left hover:bg-muted/40"
+        className="group/edit flex w-full items-center gap-2 rounded-md px-1 py-0.5 text-left hover:bg-muted/40"
         onClick={beginEdit}
       >
         {trimmed.length > 0 ? (
@@ -232,6 +232,10 @@ export function InlineEditableField({
         ) : (
           <span className="text-muted-foreground">{placeholder}</span>
         )}
+        <Pencil
+          className="size-4 shrink-0 text-muted-foreground transition-opacity group-hover/edit:opacity-100"
+          aria-hidden="true"
+        />
       </button>
       {variant === 'plain' && status !== 'idle' ? (
         <div className="mt-1">

--- a/src/components/profile/InlineHandleField.tsx
+++ b/src/components/profile/InlineHandleField.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Check, Loader2 } from 'lucide-react';
+import { Check, Loader2, Pencil } from 'lucide-react';
 import { useState } from 'react';
 
 // Handle editing has its own endpoint (PATCH /api/account/handle owns the
@@ -177,10 +177,11 @@ export function InlineHandleField({
       <button
         type="button"
         aria-label="Edit handle"
-        className="block w-full rounded-md px-1 py-0.5 text-left text-sm text-muted-foreground hover:bg-muted/40"
+        className="group/edit flex w-full items-center gap-1.5 rounded-md px-1 py-0.5 text-left text-sm text-muted-foreground hover:bg-muted/40"
         onClick={beginEdit}
       >
-        {trimmed.length > 0 ? `@${trimmed}` : <span>Pick a handle</span>}
+        <span>{trimmed.length > 0 ? `@${trimmed}` : 'Pick a handle'}</span>
+        <Pencil className="size-3.5 shrink-0" aria-hidden="true" />
       </button>
       {variant === 'plain' && status !== 'idle' ? (
         <div className="mt-1">


### PR DESCRIPTION
## Summary

**PLR-12** — the profile header's **name** and **handle** were already click-to-edit (`InlineEditableField` / `InlineHandleField`), but they rendered as plain text (only a hover background), so the edit affordance was undiscoverable. This adds a small **pencil cue** to each field's display state so they read as editable.

Lighter and more precise than the audit's "separate Edit-profile button + modal" — it shows *exactly* what's editable, and the inline-edit flow already works.

## Changes

- `src/components/profile/InlineEditableField.tsx` — pencil icon in the display button (used for display name).
- `src/components/profile/InlineHandleField.tsx` — matching pencil in the handle display button.

Both components are **profile-only** (no other usages), so blast radius is contained. No behavior change beyond the visible cue; the existing `aria-label="Edit …"` is unchanged.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `eslint` (changed files) → clean
- (No tests exist for these components.)

Tracker item PLR-12 (`PARTIAL` → resolves the discoverability gap).

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_