### PR TITLE
Use sans typeface for action links per style guide

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -446,8 +446,9 @@ export function ActivityStreamItem({
                   alignItems: 'center',
                   gap: 5,
                   // Same text treatment as the "Answer →" feed action: the
-                  // Editorial serif at 18px in the link slate, underlined.
-                  fontFamily: 'var(--font-serif)',
+                  // sans (Interface voice) at 18px in the link slate, underlined.
+                  // A tappable affordance never takes the Editorial serif.
+                  fontFamily: 'var(--font-sans)',
                   fontSize: 18,
                   fontWeight: 600,
                   letterSpacing: '0.05em',

--- a/src/components/feed/EditorialFeature.tsx
+++ b/src/components/feed/EditorialFeature.tsx
@@ -95,7 +95,7 @@ export function EditorialFeature({
       <Link
         href={cta.href}
         className={cn(
-          'mt-5 inline-flex min-h-11 items-center font-serif text-lg font-semibold tracking-[0.05em] underline underline-offset-4 transition hover:opacity-70 active:opacity-90',
+          'mt-5 inline-flex min-h-11 items-center text-lg font-semibold tracking-[0.05em] underline underline-offset-4 transition hover:opacity-70 active:opacity-90',
           TONE_ACCENT[tone],
         )}
       >

--- a/src/components/feed/FeedActionLink.tsx
+++ b/src/components/feed/FeedActionLink.tsx
@@ -4,7 +4,7 @@ import { cn } from '@/lib/utils'
 
 type FeedActionLinkProps = ButtonHTMLAttributes<HTMLButtonElement> & {
   /**
-   * 'lg' (default) — the 18px serif primary action (Answer → / Try again →).
+   * 'lg' (default) — the 18px sans primary action (Answer → / Try again →).
    * 'sm' — the quiet 13px sans secondary action (Play these → / View N more).
    */
   size?: 'lg' | 'sm'
@@ -14,11 +14,13 @@ type FeedActionLinkProps = ButtonHTMLAttributes<HTMLButtonElement> & {
  * The feed's primary inline action (Answer → / Try again → / Recheck →).
  *
  * Standardizes what used to be three hand-rolled text buttons across FeedCard,
- * SparkleEnvelope, and AnsweredByYouCard: one 18px serif size, a 44px minimum
+ * SparkleEnvelope, and AnsweredByYouCard: one 18px sans size, a 44px minimum
  * tap target (`min-h-11`), a visible keyboard `focus-visible` ring, and a
- * consistent active/disabled treatment. Renders a real <button>, so callers
- * just pass `onClick`, `disabled`, and the label as children. The 'sm' size is
- * the secondary register (territory-card CTA, "View N more") at 13px sans.
+ * consistent active/disabled treatment. The face is the sans (Montserrat): a
+ * link is something you act on (Interface voice), so it never takes the
+ * Editorial serif — see _docs/STYLE-GUIDE-TYPE.md §3. Renders a real <button>,
+ * so callers just pass `onClick`, `disabled`, and the label as children. The
+ * 'sm' size is the secondary register (territory-card CTA, "View N more") at 13px.
  */
 export function FeedActionLink({ className, type, size = 'lg', ...props }: FeedActionLinkProps) {
   return (
@@ -27,7 +29,7 @@ export function FeedActionLink({ className, type, size = 'lg', ...props }: FeedA
       className={cn(
         'inline-flex min-h-11 items-center text-[var(--brand-link)] underline underline-offset-4 transition',
         size === 'lg'
-          ? 'font-serif text-lg font-semibold tracking-[0.05em]'
+          ? 'text-lg font-semibold tracking-[0.05em]'
           : 'text-[13px] font-medium tracking-[0.04em]',
         'hover:opacity-70 active:opacity-90',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--ring)] focus-visible:ring-offset-2 focus-visible:ring-offset-[var(--brand-card)]',

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -344,7 +344,7 @@ describe('Feed answered states', () => {
       />
     )
     expect(rendered).toContain('Recheck →')
-    // Brand action-link treatment (matches "Answer →"): serif, slate, underlined — no offset-shadow box.
+    // Brand action-link treatment (matches "Answer →"): sans, slate, underlined — no offset-shadow box.
     expect(rendered).toContain('text-[var(--brand-link)]')
     expect(rendered).not.toContain('3px 3px 0 var(--ink)')
   })
@@ -372,7 +372,7 @@ describe('Answer feedback sheet recheck affordance', () => {
       />
     )
     expect(rendered).toContain('Recheck →')
-    // Reuses the shared serif slate action link, not a hand-rolled button.
+    // Reuses the shared sans slate action link, not a hand-rolled button.
     expect(rendered).toContain('text-[var(--brand-link)]')
   })
 

--- a/src/components/home/MissedQuestionsCard.tsx
+++ b/src/components/home/MissedQuestionsCard.tsx
@@ -29,7 +29,7 @@ export function MissedQuestionsCard({
       </div>
       <Link
         href="/daily/catchup"
-        className="font-serif text-lg leading-[24px] font-semibold tracking-[0.05em] whitespace-nowrap text-[var(--brand-link)] underline underline-offset-4"
+        className="text-lg leading-[24px] font-semibold tracking-[0.05em] whitespace-nowrap text-[var(--brand-link)] underline underline-offset-4"
         aria-label={`Catch up on ${missedLabel}`}
       >
         Play →


### PR DESCRIPTION
## Summary
Updates all action links and CTAs across the feed and activity components to use the sans typeface (Montserrat/Interface voice) instead of serif, aligning with the type style guide which specifies that tappable affordances should never use the Editorial serif.

## Changes
- **FeedActionLink**: Removed `font-serif` class from the 'lg' size variant (18px action links like "Answer →" / "Try again →")
- **ActivityStreamItem**: Changed `fontFamily` from `var(--font-serif)` to `var(--font-sans)` for the 18px action link treatment
- **EditorialFeature**: Removed `font-serif` from the CTA link styling
- **MissedQuestionsCard**: Removed `font-serif` from the "Play →" link
- **Test comments**: Updated documentation in `FeedCards.test.tsx` to reflect the sans typeface change

## Implementation Details
Per `_docs/STYLE-GUIDE-TYPE.md` §3, the Interface voice (sans) is the correct choice for interactive elements because "a link is something you act on" — tappable affordances should never take the Editorial serif. This change ensures consistency across all primary and secondary action links in the feed and activity streams.

https://claude.ai/code/session_01RfCPCQSVjY9zLeeMnXcixe