### PR TITLE
fix(catchup): close the round when the last missed question is dismissed (PLR-17)

### DIFF
--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -482,6 +482,11 @@ export function useCatchupFlow() {
       }
       setStats((existing) => ({ ...existing, dismissed: Math.max(0, existing.dismissed - 1) }));
       setItems((existing) => [item, ...existing.filter((entry) => entry.dailyQueueItemId !== itemId)]);
+      // Undo returns this question to the answerable round, so restore the round
+      // target and re-enter 'playing' (a dismissal of the last item may have
+      // closed the round — see dismissCurrent / PLR-17).
+      batchStartRemainingRef.current += 1;
+      setPhase('playing');
       setMessages((existing) => {
         const questionId = `catchup-q-${itemId}`;
         const index = existing.findIndex((message) => message.id === questionId);
@@ -533,13 +538,24 @@ export function useCatchupFlow() {
           { id: newMessageId(), kind: 'dismiss_notice', onUndo: () => undismissItem(item) },
         ];
       });
+      // A dismissed item leaves the answerable round (it won't be answered), so
+      // mirror dropStaleItem: shrink the round target and, if dismissing empties
+      // the queue (or meets the shrunken target), close the round. Without this
+      // the thread dead-ends with no current question and no input after the last
+      // missed question is dismissed (PLR-17).
+      const emptiesQueue = items.length <= 1;
       advancePast(itemId);
+      batchStartRemainingRef.current = Math.max(0, batchStartRemainingRef.current - 1);
+      const roundSize = Math.min(CATCH_UP_BATCH_SIZE, batchStartRemainingRef.current);
+      if (emptiesQueue || answeredInBatchRef.current >= roundSize) {
+        setPhase('round_complete');
+      }
     } catch {
       applyCatchupSubmitFailure(item, parseCatchUpAnswerErrorBody({ code: 'network' }));
     } finally {
       setSubmitting(false);
     }
-  }, [advancePast, applyCatchupSubmitFailure, currentItem, isResolvingTurn, submitting, undismissItem]);
+  }, [advancePast, applyCatchupSubmitFailure, currentItem, isResolvingTurn, items.length, submitting, undismissItem]);
 
   // Re-grade a wrong daily-slot answer via the shared /api/daily/recheck route.
   // On accept we flip this turn's tally + recap entry to correct; GameplayChat's


### PR DESCRIPTION
## Summary

**PLR-17** — the catch-up flow already has a warm closer (`RoundCloseCard` → "That's the round… You're all caught up", plus the full `RoundSummary`), but one exit path slipped through: **dismissing the last missed question dead-ended the thread** — no current question, no input bar, no closer. That's the audit's "after *dismissing*… the page simply closes."

## Root cause

`dismissCurrent` only called `advancePast(item)` and never completed the round. The analogous "advance without answering" path, `dropStaleItem`, already guards this (its comment: *"End the round if the queue is now empty (otherwise the thread dead-ends with no current question and no input)"*). Dismiss was missing the same guard.

## Fix (`src/components/play/useCatchupFlow.ts`)

- **`dismissCurrent`** — a dismissed item leaves the answerable round, so (mirroring `dropStaleItem`) shrink the round target and set `phase: 'round_complete'` when the dismissal empties the queue or meets the shrunken target. The existing quiet `RoundCloseCard` then lands — **no confetti**, reusing the warm closer (canon).
- **`undismissItem`** (Undo) — restore the round target and re-enter `'playing'`, so undoing a last-item dismissal can't leave the closer stranded over a restored question.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `eslint` (changed file) → clean
- `useCatchupFlow.message` + `catch-up-eligibility` tests → pass (13)

Tracker item PLR-17 (`PARTIAL` → resolves the dismiss-path dead-end).

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_