### PR TITLE
fix(invite): name the invite methods — text vs link (PLR-19)

### DIFF
--- a/src/components/friends/InviteSomeoneNew.tsx
+++ b/src/components/friends/InviteSomeoneNew.tsx
@@ -55,7 +55,7 @@ export function InviteSomeoneNew() {
     <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
       <h2 className="font-serif text-lg font-semibold">Invite someone new</h2>
       <p className="text-muted-foreground mt-1 text-sm">
-        A personal note for someone specific, or a casual link you can share anywhere.
+        Text a personal note to someone&rsquo;s phone, or copy a link you can share anywhere.
       </p>
       <div className="mt-3 grid grid-cols-1 gap-2 sm:grid-cols-2">
         <button
@@ -63,7 +63,7 @@ export function InviteSomeoneNew() {
           onClick={openPersonalInvite}
           className="btn-primary px-4"
         >
-          Send a personal invite
+          Text a personal invite
         </button>
         <button
           type="button"


### PR DESCRIPTION
## Summary

**PLR-19** — the "Invite someone new" card didn't say *how* an invite is sent ("a personal note for someone specific, or a casual link"). There are two concrete methods, so this names them:

- **Personal invite = a text.** The modal collects a US mobile number and opens a prefilled `sms:` message (`AddFriendInvite.tsx` — `buildSmsHref`, "Use a US mobile number").
- **Link = shareable anywhere** (the per-user invite token URL).

There is **no email path**, so none is implied (the audit floated link/email/SMS — only text + link exist).

## Change (`src/components/friends/InviteSomeoneNew.tsx`)

- Subcopy → "Text a personal note to someone's phone, or copy a link you can share anywhere."
- Primary button "Send a personal invite" → **"Text a personal invite."**

Copy-only; no behavior change.

## Verification

- `npx tsc -p tsconfig.typecheck.json` → clean
- `eslint` (changed file) → clean
- No tests referenced the old label.

Tracker item PLR-19 (`PARTIAL` → resolved). This was the last open Pre-Launch item.

https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb

---
_Generated by [Claude Code](https://claude.ai/code/session_01JwBJNxdNkhnCSw3aqMHsDb)_