### PR TITLE
Scroll login page to top after phone continue

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -327,7 +327,10 @@ export default function LoginPanel({
   const swapStep = useCallback((next: Step, nextError: string | null = null) => {
     // Return to the top so the title card is back in view after the button
     // press — on mobile the focused input scrolls the page down, and landing
-    // mid-page on the next step looks unpolished.
+    // mid-page on the next step looks unpolished. Blur first so the keyboard
+    // closes and the browser stops anchoring the viewport to the focused field,
+    // which otherwise fights the scroll-to-top and leaves the page mid-screen.
+    (document.activeElement as HTMLElement | null)?.blur();
     window.scrollTo({ top: 0, behavior: 'smooth' });
     setEntering(false); // exit: fade + slide down
     window.setTimeout(() => {


### PR DESCRIPTION
Blur the focused field before scrolling so the mobile keyboard closes and
the browser stops anchoring the viewport to the phone input, which was
fighting the scroll-to-top and leaving the next step landing mid-page.