### PR TITLE
Replace Today’s Five gear icon with visible “Customize” pill

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import Link from 'next/link'
-import { Settings } from 'lucide-react'
+import { SlidersHorizontal } from 'lucide-react'
 import { useEffect, useRef, useState, useSyncExternalStore } from 'react'
 
 import { formatNextResetDayTimeLocal } from '@/lib/games/timezone'
@@ -208,10 +208,15 @@ export default function TodaysFiveCard({
         </p>
         <Link
           href="/daily/setup"
-          className="text-[var(--brand-ink-400)] transition-colors hover:text-[var(--brand-ink)]"
-          aria-label="Set up daily round"
+          className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--brand-ink)_16%,transparent)] bg-[color-mix(in_srgb,var(--brand-cream)_88%,white)] px-4 py-2 text-[13px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)] shadow-[0_2px_8px_color-mix(in_srgb,var(--brand-ink)_14%,transparent),inset_0_1px_0_rgba(255,255,255,0.72)] transition-[background-color,border-color,box-shadow,transform] hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,transparent)] hover:bg-[color-mix(in_srgb,var(--brand-cream)_96%,white)] focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 focus-visible:outline-none active:translate-y-px sm:px-5 sm:text-sm"
+          aria-label="Customize your Daily Five"
         >
-          <Settings className="size-4" aria-hidden="true" />
+          <SlidersHorizontal
+            className="size-5 sm:size-[22px]"
+            strokeWidth={2.4}
+            aria-hidden="true"
+          />
+          <span>Customize</span>
         </Link>
       </div>
 

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -45,6 +45,16 @@ type TodaysFiveCardProps = {
   initialMissedCount?: number
 }
 
+const CUSTOMIZE_DAILY_LINK_CLASS = [
+  'inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full',
+  'border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-2',
+  'text-[13px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)]',
+  'shadow-[var(--shadow-card)] transition-[background-color,border-color,box-shadow,transform]',
+  'hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,var(--brand-border))] hover:bg-[var(--brand-cream-page)]',
+  'focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 focus-visible:outline-none',
+  'active:translate-y-px sm:px-5 sm:text-sm',
+].join(' ')
+
 const DIFFICULTY_LABELS: Record<string, string> = {
   normal: 'Establishing',
   moderate: 'Familiar',
@@ -208,7 +218,7 @@ export default function TodaysFiveCard({
         </p>
         <Link
           href="/daily/setup"
-          className="inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full border border-[color-mix(in_srgb,var(--brand-ink)_16%,transparent)] bg-[color-mix(in_srgb,var(--brand-cream)_88%,white)] px-4 py-2 text-[13px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)] shadow-[0_2px_8px_color-mix(in_srgb,var(--brand-ink)_14%,transparent),inset_0_1px_0_rgba(255,255,255,0.72)] transition-[background-color,border-color,box-shadow,transform] hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,transparent)] hover:bg-[color-mix(in_srgb,var(--brand-cream)_96%,white)] focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 focus-visible:outline-none active:translate-y-px sm:px-5 sm:text-sm"
+          className={CUSTOMIZE_DAILY_LINK_CLASS}
           aria-label="Customize your Daily Five"
         >
           <SlidersHorizontal


### PR DESCRIPTION
### Motivation
- The small gear icon was not prominent enough as the entry to Daily Five customization, so the control must be made more visible and understandable while keeping existing behavior. 
- The change implements the approved cream/navy pill treatment from the mockup and preserves the Today's Five card layout and visual hierarchy. 

### Description
- Replaced the gear icon import with `SlidersHorizontal` from `lucide-react` and swapped the small icon link for a horizontal utility pill that contains the sliders icon and the label `Customize`. 
- The pill uses existing design tokens for colors, border, shadow, spacing, and typography and is implemented as an inline `Link` to `/daily/setup` so it triggers the exact same flow as the previous control. 
- Accessibility and interaction were preserved and improved by adding `aria-label="Customize your Daily Five"`, ensuring a `min-h-11` tap target (~44px) and keyboard focus styles, and keeping the control clearly secondary to the `Play now` CTA. 
- No new global styles or routes were introduced; the change is limited to the Today’s Five card component at `src/components/TodaysFiveCard.tsx`. 

### Testing
- Ran `npm run lint`, which completed successfully but reported pre-existing unrelated warnings about off-system colors. 
- Ran type-checking with `npx tsc --noEmit`, which succeeded with no type errors. 
- Launched the app with `npm run dev`, which started the server but encountered a local DB migration `ECONNREFUSED` due to the environment; the server still served pages for inspection. 
- Attempted visual verification screenshots using Playwright and installing Chromium, but `npx playwright install chromium` and `apt-get install chromium` failed due to 403/blocked downloads in this environment so desktop/mobile screenshots could not be captured.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3009b8f0a8832e8d63d8aeb1021a27)