### PR TITLE
Drop gold accent from direct-send eyebrow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dev-stderr.txt
 .claude/settings.local.json
 audits/
 supabase/
+_scratch/

--- a/src/components/activity/ActivityIcon.tsx
+++ b/src/components/activity/ActivityIcon.tsx
@@ -241,6 +241,29 @@ export function QuestionTriangle({ solid, seed }: { solid: boolean; seed: string
   );
 }
 
+// A small hourglass — an orange triangle over a teal one, apex-to-apex. In the
+// "From Your Friends" mark vocabulary this is the "someone sends you a Q" sign
+// (StreamIconKind 'hourglass', activity-stream.ts). The activity stream itself
+// collapses it into the calm inward triangle, but the feed's direct-send card
+// uses the literal hourglass — flanking its eyebrow with a pair — since that IS
+// a question sent to you. Decorative (aria-hidden); the eyebrow copy carries it.
+export function HourglassMark({ size = 13 }: { size?: number }) {
+  const w = (size * 12) / 16; // viewBox is 12 wide × 16 tall
+  return (
+    <svg
+      width={w}
+      height={size}
+      viewBox="0 0 12 16"
+      fill="none"
+      aria-hidden="true"
+      style={{ display: 'block', flexShrink: 0 }}
+    >
+      <path d="M0,0 L12,0 L6,8 Z" fill="var(--tri-orange)" fillOpacity={FILL_OPACITY} />
+      <path d="M0,16 L12,16 L6,8 Z" fill="var(--tri-darkteal)" fillOpacity={FILL_OPACITY} />
+    </svg>
+  );
+}
+
 // Five-point star, each point its own palette triangle — one triangle per
 // question in the "first five" milestone. The five inner vertices meet at a
 // pentagon core that's left as background, so the mark reads as a star BUILT

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react'
 import Link from 'next/link'
 
+import { HourglassMark } from '@/components/activity/ActivityIcon'
+
 import { visibleFeedCategory } from './category'
 import { SparkleEnvelope } from './SparkleEnvelope'
 import type { DirectSentFeedItem } from './types'
@@ -44,12 +46,20 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, elevated }
       // Direct sends share the plain hairline-bordered tile with broadcasts
       // (the triangle mat is retired); the eyebrow is what marks them out.
       variant="bordered"
-      eyebrow="Sent directly to you"
-      // Direct-send is a recurring per-row marker, so it stays out of the gold
-      // accent (reserved per STYLE-GUIDE-COLOR §4 for the single standout in a
-      // view). The eyebrow text itself is the differentiator; semibold gives it
-      // a touch more weight than a broadcast within the quiet ink register.
-      eyebrowClassName="font-semibold text-[var(--brand-ink)] opacity-70"
+      // Centered flourish mirroring the milestone "star — line — star"
+      // treatment (MilestoneStar): a pair of hourglass marks flanks the eyebrow.
+      // The hourglass is the triangle family's "someone sends you a Q" sign, so
+      // it carries the direct-send meaning without spending the gold accent
+      // (reserved per STYLE-GUIDE-COLOR §4). Text stays in the quiet ink register
+      // (opacity on the text span only, so the marks keep their 80% fill).
+      eyebrow={
+        <span className="inline-flex items-center gap-[11px]">
+          <HourglassMark />
+          <span className="opacity-70">Sent directly to you</span>
+          <HourglassMark />
+        </span>
+      }
+      eyebrowClassName="flex justify-center font-semibold text-[var(--brand-ink)]"
       signal={signal}
       question={item.question}
       overflow={overflow}

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -45,8 +45,11 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, elevated }
       // (the triangle mat is retired); the eyebrow is what marks them out.
       variant="bordered"
       eyebrow="Sent directly to you"
-      // The direct-send marker reads in the brand gold accent.
-      eyebrowClassName="font-semibold text-[var(--accent-gold)]"
+      // Direct-send is a recurring per-row marker, so it stays out of the gold
+      // accent (reserved per STYLE-GUIDE-COLOR §4 for the single standout in a
+      // view). The eyebrow text itself is the differentiator; semibold gives it
+      // a touch more weight than a broadcast within the quiet ink register.
+      eyebrowClassName="font-semibold text-[var(--brand-ink)] opacity-70"
       signal={signal}
       question={item.question}
       overflow={overflow}


### PR DESCRIPTION
The 'Sent directly to you' eyebrow rendered in --accent-gold on every
direct-send card, which violates the locked gold-scarcity rule
(STYLE-GUIDE-COLOR §4): gold marks the single most notable moment in a
view, never a recurring per-row marker. Move it to the quiet ink register
(font-semibold text-[var(--brand-ink)] opacity-70), matching the other
feed eyebrows; the eyebrow text remains the differentiator.