### PR TITLE
Refine question form UX: share defaults, explanation display, and labels

### DIFF
--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -121,7 +121,10 @@ function initialState(initialValues?: Partial<QuestionFormValues>, initialSpecif
     suggestionError: null,
     suggesting: false,
     specificMode: initialSpecificMode,
-    shareToFeed: initialValues?.shareToFeed ?? !initialSpecificMode,
+    // Sharing with all friends is opt-in: default the broadcast off unless a
+    // caller explicitly seeds it on (e.g. the "followers" create intent). The
+    // author turns it on deliberately rather than having it pre-checked.
+    shareToFeed: initialValues?.shareToFeed ?? false,
     visibility: initialValues?.visibility ?? 'public',
     friends: [],
     friendsLoading: false,
@@ -243,7 +246,7 @@ function validate(state: State): string | null {
   if (alternateAnswers.length > 5) return 'Use at most 5 alternate answers.';
   if (alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
   if (state.explanation.length > 500) return 'Explanation must be 500 characters or fewer.';
-  if (state.creatorNote.length > 200) return 'Creator note must be 200 characters or fewer.';
+  if (state.creatorNote.length > 200) return 'Between us text must be 200 characters or fewer.';
   if (state.sendToFriendIds.length > 20) return 'You can send to at most 20 friends at once.';
   return null;
 }
@@ -661,16 +664,25 @@ export function QuestionForm({
             <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/5 alternates</p>
           </div>
 
-          <div>
-            <label htmlFor="explanation" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Explanation</label>
-            <textarea id="explanation" value={state.explanation} onChange={(event) => dispatch({ type: 'FIELD', field: 'explanation', value: event.target.value.slice(0, 500) })} rows={5} maxLength={500} readOnly={state.stage === 'SUBMITTING'} className="w-full resize-y min-h-[7.5rem] rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2 outline-none focus:border-[var(--brand-navy)]" placeholder="A short note that helps someone learn if they miss it." />
-            <p className="mt-1 text-right text-xs text-muted-foreground">{state.explanation.length}/500</p>
-          </div>
+          {/* The explanation is written by Joshing's answer suggestion and is
+              shown read-only — the author confirms it rather than editing it.
+              Hidden until there's something to show (e.g. before the
+              suggestion lands). */}
+          {state.explanation.trim() ? (
+            <div>
+              <p className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Explanation</p>
+              <div className="w-full whitespace-pre-wrap rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2">{state.explanation}</div>
+              <p className="mt-1 text-xs text-muted-foreground">Written by Joshing.</p>
+            </div>
+          ) : null}
 
           <div>
-            <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Creator note</label>
-            <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2 outline-none focus:border-[var(--brand-navy)]" placeholder="Optional context for recipients" />
-            <p className="mt-1 text-right text-xs text-muted-foreground">{state.creatorNote.length}/200</p>
+            <label htmlFor="creator-note" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Between us text</label>
+            <textarea id="creator-note" value={state.creatorNote} onChange={(event) => dispatch({ type: 'FIELD', field: 'creatorNote', value: event.target.value.slice(0, 200) })} rows={3} maxLength={200} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2 outline-none focus:border-[var(--brand-navy)]" placeholder="A note just for your friends" />
+            <div className="mt-1 flex items-center justify-between gap-3 text-xs text-muted-foreground">
+              <span>Only friends see this.</span>
+              <span>{state.creatorNote.length}/200</span>
+            </div>
           </div>
 
           {state.llmSuggestedAnswer && !answersMatch(state.userAnswer, state.llmSuggestedAnswer) ? (

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -272,11 +272,12 @@ export function scopeSignpost(visibility: 'public' | 'friends' | 'private'): str
   }
 }
 
-// A single critique reformulation option. The "Use this" affordance label and
-// the reformulated question are rendered as two discrete block elements so the
-// label can never share a text node with — and run together into — the
-// suggestion value (the "Use this Which American city…" artifact,
-// B-COMPOSER-SUGGESTION-ARTIFACT-01). The reformulation value owns its own node.
+// A single critique reformulation option. The whole button is the "use this"
+// affordance — the shared "Try one of these instead:" header already states the
+// intent, so the per-option "Use this" label was redundant and is no longer
+// rendered. The reformulation value still owns its own element node so it can
+// never run together with surrounding text into a single run-on string (the
+// "Use this Which American city…" artifact, B-COMPOSER-SUGGESTION-ARTIFACT-01).
 export function ReformulationOption({ text, onUse }: { text: string; onUse: () => void }) {
   return (
     <button
@@ -284,7 +285,6 @@ export function ReformulationOption({ text, onUse }: { text: string; onUse: () =
       onClick={onUse}
       className="block w-full rounded-md border bg-background px-3 py-2 text-left text-sm hover:bg-muted"
     >
-      <span className="block font-medium">Use this</span>
       <span className="block">{text}</span>
     </button>
   );

--- a/src/components/__tests__/QuestionForm.test.tsx
+++ b/src/components/__tests__/QuestionForm.test.tsx
@@ -38,27 +38,23 @@ describe('scopeSignpost (D9 authoring signpost)', () => {
   });
 });
 
-// B-COMPOSER-SUGGESTION-ARTIFACT-01: the "Use this" affordance label must never
-// concatenate with the reformulation value into a single run-on string
-// ("Use this Which American city…"). The label and value are discrete elements;
-// the value owns its own node and is never a bare sibling text node of the label.
+// B-COMPOSER-SUGGESTION-ARTIFACT-01: the per-option "Use this" label is no
+// longer rendered (the shared "Try one of these instead:" header carries the
+// intent). The reformulation value still owns its own element node so it can
+// never run together with surrounding text into a single run-on string.
 describe('ReformulationOption (B-COMPOSER-SUGGESTION-ARTIFACT-01)', () => {
   const value = 'Which American city is the capital of New York State?';
 
-  it('renders the reformulation value intact alongside the "Use this" label', () => {
+  it('renders the reformulation value without a redundant per-option label', () => {
     const html = renderToStaticMarkup(<ReformulationOption text={value} onUse={() => {}} />);
-    expect(html).toContain('Use this');
     expect(html).toContain(value);
+    expect(html).not.toContain('Use this');
   });
 
-  it('wraps the value in its own element so the label can never run into it', () => {
+  it('wraps the value in its own element so it never runs into surrounding text', () => {
     const html = renderToStaticMarkup(<ReformulationOption text={value} onUse={() => {}} />);
     const escaped = value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    // The value must begin a fresh element's content (e.g. `<span ...>Which…`),
-    // never trail the label as a bare text node (`Use this</span> Which…`).
+    // The value must begin a fresh element's content (e.g. `<span ...>Which…`).
     expect(html).toMatch(new RegExp(`<[a-z]+[^>]*>${escaped}`));
-    // And the two must never collapse into one literal run-on string.
-    expect(html).not.toContain(`Use this ${value}`);
-    expect(html).not.toContain(`Use this${value}`);
   });
 });


### PR DESCRIPTION
## Summary
Updates the question form to improve user experience around sharing, explanation display, and field labeling. The changes make sharing opt-in by default, display AI-generated explanations as read-only content, and clarify the purpose of the "creator note" field with better naming and helper text.

## Key Changes

- **Share-to-feed defaults to off:** Changed `shareToFeed` initial state from `!initialSpecificMode` to `false`. Sharing with all friends is now opt-in rather than pre-checked, requiring deliberate author action. Added explanatory comment clarifying this is intentional UX (e.g., the "followers" create intent can explicitly seed it on).

- **Explanation field is now read-only display:** 
  - Converted from editable textarea to read-only display (rendered as a `<div>` with `whitespace-pre-wrap`)
  - Only shown when explanation content exists (hidden until suggestion lands)
  - Added "Written by Joshing." attribution text
  - Updated comment to clarify the explanation is written by the suggestion system and author confirms rather than edits

- **Renamed "Creator note" to "Between us text":**
  - Updated label, validation error message, and placeholder text
  - Changed placeholder from "Optional context for recipients" to "A note just for your friends"
  - Added helper text "Only friends see this." alongside character count
  - Reorganized character count display into a flex layout with the helper text

- **Simplified suggestion UI:**
  - Removed redundant per-option "Use this" label from `ReformulationOption` component
  - The shared "Try one of these instead:" header now carries the intent
  - Kept the value wrapped in its own element node to prevent text run-on artifacts (B-COMPOSER-SUGGESTION-ARTIFACT-01)
  - Updated component comment and test descriptions to reflect the change

## Implementation Details

- The explanation display uses `state.explanation.trim()` to conditionally render only when content exists
- Character count display for "Between us text" now uses a flex layout with `justify-between` to separate the helper text from the counter
- All validation and state management logic remains unchanged; only UI presentation and defaults were modified
- Test expectations updated to verify the "Use this" label is no longer rendered while the value remains intact

https://claude.ai/code/session_01FtxaKADjDEbBXa22rAAfwS