### PR TITLE
Refine "Customize Daily" pill styling and header alignment

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -47,10 +47,10 @@ type TodaysFiveCardProps = {
 
 const CUSTOMIZE_DAILY_LINK_CLASS = [
   'inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full',
-  'border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-2',
+  'border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-4 py-2',
   'text-[13px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)]',
-  'shadow-[var(--shadow-card)] transition-[background-color,border-color,box-shadow,transform]',
-  'hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,var(--brand-border))] hover:bg-[var(--brand-cream-page)]',
+  'transition-[background-color,border-color,transform]',
+  'hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,var(--brand-border))] hover:bg-[var(--brand-card)]',
   'focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 focus-visible:outline-none',
   'active:translate-y-px sm:px-5 sm:text-sm',
 ].join(' ')
@@ -212,18 +212,20 @@ export default function TodaysFiveCard({
 
   return (
     <div className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-5 shadow-[var(--shadow-card)]">
-      <div className="flex items-start justify-between gap-2">
+      <div className="flex items-center justify-between gap-2">
         <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
           Today&apos;s Five
         </p>
-        {/* Customize pill — the entry point for tuning the Daily Five. A warm-
+        {/* Customize pill — the entry point for tuning the Daily Five. A quiet
             cream utility pill (sliders icon + label) replacing the easy-to-miss
-            gear: prominent enough to notice, clearly secondary to the Play now
-            CTA (rounded-full utility shape, not the primary button's radius;
-            navy --brand-ink on the elevated cream + hairline border + subtle
-            card shadow). Same destination as before (/daily/setup). The 44px
-            min height keeps the tap target accessible; `shrink-0` protects it
-            from being squeezed by the eyebrow on narrow widths. */}
+            gear: noticeable but clearly secondary to the Play now CTA (rounded-
+            full utility shape, not the primary button's radius; navy --brand-ink
+            on a near-card cream fill + softened hairline border, no shadow so it
+            reads as part of the header rather than a floating chip). The row is
+            items-center so the pill sits on the "Today's Five" eyebrow baseline.
+            Same destination as before (/daily/setup). The 44px min height keeps
+            the tap target accessible; `shrink-0` protects it from being squeezed
+            by the eyebrow on narrow widths. */}
         <Link
           href="/daily/setup"
           className={CUSTOMIZE_DAILY_LINK_CLASS}


### PR DESCRIPTION
## Summary
Updates the "Customize Daily" pill styling in the Today's Five card to be more visually subtle and integrated with the header, while improving vertical alignment.

## Key Changes
- **Border styling:** Changed from solid `--brand-border` to a softened `color-mix(in_srgb,var(--brand-border)_60%,transparent)` for a hairline effect
- **Background color:** Swapped from `--brand-card` to `--brand-cream-page` in the default state, with hover state now using `--brand-card` (inverted from before)
- **Shadow removal:** Removed `shadow-[var(--shadow-card)]` so the pill reads as part of the header rather than a floating chip
- **Transition optimization:** Removed `box-shadow` from the transition list since shadow is no longer animated
- **Header alignment:** Changed container from `items-start` to `items-center` so the pill sits on the "Today's Five" eyebrow baseline
- **Documentation:** Expanded the inline comment to clarify the design intent: a quiet, noticeable-but-secondary utility pill with no shadow, integrated into the header rather than floating

## Implementation Details
The changes maintain the 44px minimum height and `shrink-0` protection for the pill, preserving tap target accessibility and preventing squeeze on narrow widths. The color inversion (cream default → card hover) creates a subtle interactive feedback while the removed shadow and softened border make the element feel more integrated with the header structure.

https://claude.ai/code/session_01E9eGdoTwWBY6vhBJrmYfLE