### PR TITLE
Shrink Customize pill so it takes less Today's Five header room

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -46,13 +46,13 @@ type TodaysFiveCardProps = {
 }
 
 const CUSTOMIZE_DAILY_LINK_CLASS = [
-  'inline-flex min-h-11 shrink-0 items-center justify-center gap-2 rounded-full',
-  'border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-4 py-2',
-  'text-[13px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)]',
+  'inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full',
+  'border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-3 py-2',
+  'text-[12px] font-bold tracking-[0.01em] whitespace-nowrap text-[var(--brand-ink)]',
   'transition-[background-color,border-color,transform]',
   'hover:border-[color-mix(in_srgb,var(--brand-ink)_24%,var(--brand-border))] hover:bg-[var(--brand-card)]',
   'focus-visible:ring-2 focus-visible:ring-[var(--brand-ink)] focus-visible:ring-offset-2 focus-visible:outline-none',
-  'active:translate-y-px sm:px-5 sm:text-sm',
+  'active:translate-y-px sm:px-3.5 sm:text-[13px]',
 ].join(' ')
 
 const DIFFICULTY_LABELS: Record<string, string> = {
@@ -232,7 +232,7 @@ export default function TodaysFiveCard({
           aria-label="Customize your Daily Five"
         >
           <SlidersHorizontal
-            className="size-5 sm:size-[22px]"
+            className="size-4 sm:size-[18px]"
             strokeWidth={2.4}
             aria-hidden="true"
           />


### PR DESCRIPTION
## Summary
Follow-up to #981 (merged). The refined Customize pill was taking up too much horizontal room in the Today's Five card header. This makes the label and the pill itself more compact.

## Changes
- **Label:** `13px` → `12px` (and the `sm` size from `14px` → `13px`)
- **Icon:** sliders glyph `20/22px` → `16/18px`, kept proportional to the smaller text
- **Spacing:** gap `8px` → `6px`; horizontal padding `16/20px` → `12/14px`

## Preserved
- 44px min-height tap target and `shrink-0`
- rounded-full pill radius (distinct from Play now's `--radius-xs`)
- sliders icon + "Customize" label
- the quiet, integrated styling from #981 (softened border, cream fill, no shadow)

Tokens-only; no color changes (color ratchet unaffected).

https://claude.ai/code/session_01E9eGdoTwWBY6vhBJrmYfLE

---
_Generated by [Claude Code](https://claude.ai/code/session_01E9eGdoTwWBY6vhBJrmYfLE)_