### PR TITLE
Skip invite interstitial, redirect straight to login

### DIFF
--- a/src/app/invite/[token]/__tests__/page.test.tsx
+++ b/src/app/invite/[token]/__tests__/page.test.tsx
@@ -1,12 +1,20 @@
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getFriendInvitationLandingByTokenMock } = vi.hoisted(() => ({
+const { getFriendInvitationLandingByTokenMock, redirectMock } = vi.hoisted(() => ({
   getFriendInvitationLandingByTokenMock: vi.fn(),
+  redirectMock: vi.fn((url: string) => {
+    // Mirror Next's real redirect(): throw to halt rendering.
+    throw new Error(`NEXT_REDIRECT:${url}`);
+  }),
 }));
 
 vi.mock('@/server/friends/invitations', () => ({
   getFriendInvitationLandingByToken: getFriendInvitationLandingByTokenMock,
+}));
+
+vi.mock('next/navigation', () => ({
+  redirect: redirectMock,
 }));
 
 import InvitePage from '@/app/invite/[token]/page';
@@ -21,38 +29,18 @@ describe('/invite/[token] landing QA states', () => {
     vi.clearAllMocks();
   });
 
-  it('opens a valid invite landing with inviter name and auth continuation, but does NOT leak pre-seeded interests (F1.5)', async () => {
+  it('sends a valid invite straight to the login screen with the invite context attached (no interstitial)', async () => {
     getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
       status: 'valid',
       inviterName: 'Alex Inviter',
     });
 
-    const html = await renderInvite('valid-token');
+    await expect(renderInvite('valid-token')).rejects.toThrow(
+      'NEXT_REDIRECT:/login?invitationToken=valid-token',
+    );
 
     expect(getFriendInvitationLandingByTokenMock).toHaveBeenCalledWith('valid-token');
-    expect(html).toContain('A friend thought of you');
-    expect(html).toContain('Alex Inviter thought of you for Joshing.');
-    expect(html).toContain('Continue to Joshing');
-    expect(html).not.toContain('A note from a friend');
-    expect(html).not.toContain('See the note');
-    expect(html).toContain('href="/login?invitationToken=valid-token"');
-    expect(html).not.toContain('href="/login"');
-    expect(html).not.toMatch(/leaderboard|ranking|score|points?|percent|%/i);
-  });
-
-  it('never renders pre-seeded interest labels even if a stale payload includes them (defensive)', async () => {
-    // Defends against a regression where the type is reverted: even if the
-    // landing query somehow ships labels, the page must not render them.
-    getFriendInvitationLandingByTokenMock.mockResolvedValueOnce({
-      status: 'valid',
-      inviterName: 'Alex Inviter',
-      // @ts-expect-error - field is intentionally not on the type
-      suggestedInterests: [{ label: 'Jazz' }, { label: 'Poetry' }],
-    });
-
-    const html = await renderInvite('valid-token');
-    expect(html).not.toContain('Jazz');
-    expect(html).not.toContain('Poetry');
+    expect(redirectMock).toHaveBeenCalledWith('/login?invitationToken=valid-token');
   });
 
   it.each([

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -1,7 +1,7 @@
 import type { ReactNode } from 'react';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 
-import { AvatarChip } from '@/components/AvatarChip';
 import { getFriendInvitationLandingByToken } from '@/server/friends/invitations';
 
 type InvitePageProps = {
@@ -10,25 +10,6 @@ type InvitePageProps = {
 
 function inviteLoginHref(token: string) {
   return `/login?invitationToken=${encodeURIComponent(token)}`;
-}
-
-function InviterIdentity({
-  name,
-  userId,
-  avatarColor,
-}: {
-  name: string;
-  userId: string | null;
-  avatarColor: string | null;
-}) {
-  if (!userId) return null;
-
-  return (
-    <div className="mb-4 flex items-center gap-3">
-      <AvatarChip displayName={name} userId={userId} color={avatarColor} size="lg" />
-      <span className="text-sm font-semibold">{name}</span>
-    </div>
-  );
 }
 
 function InviteShell({ children }: { children: ReactNode }) {
@@ -46,32 +27,9 @@ export default async function InvitePage({ params }: InvitePageProps) {
   const invitation = await getFriendInvitationLandingByToken(token);
 
   if (invitation.status === 'valid') {
-    return (
-      <InviteShell>
-        <div className="space-y-5">
-          <div>
-            <InviterIdentity
-              name={invitation.inviterName}
-              userId={invitation.inviterUserId}
-              avatarColor={invitation.inviterAvatarColor}
-            />
-            <p className="text-muted-foreground text-xs font-medium tracking-wide uppercase">
-              A friend thought of you
-            </p>
-            <h1 className="mt-2 font-serif text-3xl leading-tight font-semibold">
-              {invitation.inviterName} thought of you for Joshing.
-            </h1>
-          </div>
-
-          <Link
-            href={inviteLoginHref(token)}
-            className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
-          >
-            Continue to Joshing
-          </Link>
-        </div>
-      </InviteShell>
-    );
+    // Skip the interstitial — drop the invitee straight onto the login screen,
+    // which carries the invite context (the reworded "verify your phone" card).
+    redirect(inviteLoginHref(token));
   }
 
   if (invitation.status === 'expired') {

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -4,7 +4,6 @@ import { useCallback, useEffect, useState } from 'react';
 import type { FormEvent } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
-import { AvatarChip } from '@/components/AvatarChip';
 import { formatUsPhoneInput } from '@/lib/phone-e164';
 
 const US_E164_REGEX = /^\+1\d{10}$/;
@@ -154,21 +153,19 @@ export function shouldCollectProfileIdentity(identity: VerifiedIdentity): boolea
   return !identity.displayName || !identity.handle;
 }
 
+function inviterFirstName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) return 'A friend';
+  // Handle-style names (e.g. "@craig") have no spaces — keep them whole.
+  return trimmed.split(/\s+/)[0];
+}
+
 function InviteContextCard({ invite }: { invite: InviteContext }) {
   return (
     <div className="space-y-3 rounded-[8px] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
-      <div className="flex items-center justify-center gap-3">
-        <AvatarChip
-          displayName={invite.inviterName}
-          userId={invite.inviterUserId}
-          color={invite.inviterAvatarColor}
-          size="lg"
-        />
-        <span className="text-[17px] leading-6 font-semibold text-black">{invite.inviterName}</span>
-      </div>
       <p className="text-[15px] leading-6 text-black/75">
-        {invite.inviterName} invited you to Joshing. Enter your phone number to join and start
-        answering their questions.
+        {inviterFirstName(invite.inviterName)} invited you to Joshing, a new trivia game. We just
+        need to verify your phone number and then you can start playing.
       </p>
     </div>
   );


### PR DESCRIPTION
## Summary
Removes the invite landing page interstitial and redirects valid invitations directly to the login screen, which now displays the invite context inline. This simplifies the user flow by eliminating an unnecessary intermediate step.

## Key changes
- **Invite page (`src/app/invite/[token]/page.tsx`):**
  - Removed `InviterIdentity` component and the entire valid invite landing UI
  - Replaced with a server-side `redirect()` to the login screen with the invitation token attached
  - Removed unused `AvatarChip` import

- **Login panel (`src/app/login/LoginPanel.tsx`):**
  - Removed `AvatarChip` from `InviteContextCard` (no longer displays inviter avatar/name)
  - Added `inviterFirstName()` helper to extract first name from inviter name (handles handle-style names like "@craig")
  - Updated invite context card copy to be more generic: "A friend invited you to Joshing, a new trivia game. We just need to verify your phone number and then you can start playing."
  - Simplified card layout to focus on the verification message rather than inviter identity

- **Tests (`src/app/invite/[token]/__tests__/page.test.tsx`):**
  - Added mock for `next/navigation.redirect()` that throws to halt rendering (mirrors Next's real behavior)
  - Updated test expectations: valid invites now throw a redirect error instead of rendering HTML
  - Removed tests for inviter name/avatar rendering and pre-seeded interests (no longer applicable)
  - Simplified test to verify redirect URL is correct and `getFriendInvitationLandingByToken` is called

## Implementation details
- The redirect happens at the server level, so the interstitial is never rendered
- Invite context is preserved via URL query parameter (`invitationToken`) and passed through to the login form
- The invite card on login now uses just the inviter's first name, reducing visual prominence of inviter identity while still acknowledging the referral

https://claude.ai/code/session_01XkWthvixrNMTCWTf1YZfwP