### PR TITLE
Fix circle alignment in CommonGround shared domains layout

### DIFF
--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -116,20 +116,25 @@ export function CommonGroundFeature({
             ...embed.friends.map((f) => (
               <div key={f.friendId} className="flex flex-col gap-4">
                 {/* One or two shared areas side by side — each circle motif with
-                    its area label underneath, bottom-aligned so the labels share
-                    a baseline whatever the circle heights. */}
-                <div className="flex items-end gap-10">
+                    its area label underneath. The circles sit on a shared
+                    fixed-height baseline row and the columns top-align, so both
+                    the circles and the labels line up horizontally whatever the
+                    circle heights or the label line counts (h-[76px] = the max
+                    scaled circle diameter, MAX_DIAMETER * SHARED_GROUND_CIRCLE_SCALE). */}
+                <div className="flex items-start gap-10">
                   {f.domains.map((d) => (
                     <span key={d.label} className="flex flex-col gap-2">
-                      <DomainCircleSvg
-                        viewerPoints={d.viewer.points}
-                        friendPoints={d.friend.points}
-                        viewerTier={d.viewer.tier}
-                        friendTier={d.friend.tier}
-                        datasetMax={datasetMax}
-                        scale={SHARED_GROUND_CIRCLE_SCALE}
-                        ariaLabel={`${d.label}: shared with ${f.friendFirstName}, still untested`}
-                      />
+                      <span className="flex h-[76px] items-end">
+                        <DomainCircleSvg
+                          viewerPoints={d.viewer.points}
+                          friendPoints={d.friend.points}
+                          viewerTier={d.viewer.tier}
+                          friendTier={d.friend.tier}
+                          datasetMax={datasetMax}
+                          scale={SHARED_GROUND_CIRCLE_SCALE}
+                          ariaLabel={`${d.label}: shared with ${f.friendFirstName}, still untested`}
+                        />
+                      </span>
                       <span className="max-w-[150px] font-serif text-[13px] leading-snug text-[var(--brand-ink-400)]">
                         {d.label}
                       </span>


### PR DESCRIPTION
## Summary
Fixes the vertical alignment of domain circles and their labels in the CommonGround feature to ensure consistent baseline alignment regardless of circle or label heights.

## Changes
- Changed parent container from `items-end` to `items-start` to top-align columns
- Wrapped each `DomainCircleSvg` in a fixed-height container (`h-[76px]`) with `items-end` to bottom-align circles within that space
- Updated layout comments to clarify the new two-tier alignment strategy: columns top-align while circles sit on a shared baseline row

## Implementation Details
The fix uses a nested flexbox approach:
1. Outer container (`items-start`) top-aligns the domain columns
2. Inner span (`h-[76px] items-end`) creates a fixed baseline row for circles, where `76px` equals `MAX_DIAMETER * SHARED_GROUND_CIRCLE_SCALE`
3. Labels below the circles naturally align horizontally since they're in top-aligned columns

This ensures both circles and labels line up horizontally regardless of circle heights or label line counts.

https://claude.ai/code/session_01VeNPMaBDGuM878LNs9d1Ve