### PR TITLE
Add spelling review step for friend invitation interests

### DIFF
--- a/src/app/api/friend-invitations/review/route.ts
+++ b/src/app/api/friend-invitations/review/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { proofreadInterestLabels } from '@/server/llm/interests';
+
+// Inline Haiku call; keep a modest budget above the default so a slow proofread
+// completes rather than being platform-killed.
+export const maxDuration = 30;
+
+const bodySchema = z.object({
+  interests: z.array(z.string().trim().min(1).max(60)).max(3),
+});
+
+// Pre-send double-check for the interest labels an inviter suggests on a friend
+// invitation. Catches obvious spelling typos ("Obama-Era poicy" -> "Obama-Era
+// Policy") so the inviter can confirm or fix a suggestion before it ships.
+// Proofreading fails open (see proofreadInterestLabels), so an LLM outage returns
+// no corrections and the invite flow proceeds with the typed labels unchanged.
+export async function POST(request: Request) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'invalid_request', message: 'Send up to three short ideas.' },
+      { status: 400 },
+    );
+  }
+
+  const results = await proofreadInterestLabels(parsed.data.interests);
+  return NextResponse.json({ results });
+}

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -15,7 +15,14 @@ const ERROR_COPY: Record<string, string> = {
   invite_cooldown: 'Give this invite a little breathing room before trying again.',
 };
 
-type Step = 'identity' | 'interests' | 'handoff';
+type Step = 'identity' | 'interests' | 'review' | 'handoff';
+
+// One proofread outcome from POST /api/friend-invitations/review: the idea as
+// typed plus a spelling correction when one was found (else null).
+type ProofreadResult = {
+  original: string;
+  suggestion: string | null;
+};
 
 type InviteResult = {
   ok: boolean;
@@ -76,6 +83,12 @@ export default function AddFriendInvite({
   const [error, setError] = useState<string | null>(null);
   const [copyLabel, setCopyLabel] = useState('Copy message');
   const [submitting, setSubmitting] = useState(false);
+  const [checking, setChecking] = useState(false);
+  // The normalized ideas being confirmed on the review step, plus the proofread
+  // corrections aligned to them by index. reviewIdeas[i] holds the inviter's
+  // current pick (typed label or accepted suggestion).
+  const [reviewIdeas, setReviewIdeas] = useState<string[]>([]);
+  const [proofread, setProofread] = useState<ProofreadResult[]>([]);
   const [contactsSupported, setContactsSupported] = useState<boolean | null>(null);
   const [isIos, setIsIos] = useState(false);
   const messageRef = useRef<HTMLTextAreaElement | null>(null);
@@ -108,6 +121,8 @@ export default function AddFriendInvite({
       setMessageText('');
       setError(null);
       setCopyLabel('Copy message');
+      setReviewIdeas([]);
+      setProofread([]);
     }
 
     window.addEventListener('friend-invitations:create-new', prefillInvite);
@@ -180,6 +195,9 @@ export default function AddFriendInvite({
     setError(null);
     setCopyLabel('Copy message');
     setSubmitting(false);
+    setChecking(false);
+    setReviewIdeas([]);
+    setProofread([]);
   }
 
   function updateInterest(index: number, value: string) {
@@ -203,10 +221,61 @@ export default function AddFriendInvite({
     setStep('interests');
   }
 
-  async function createInvite(event: FormEvent<HTMLFormElement>) {
+  // Step 2 submit: proofread the typed ideas for spelling typos first. If any
+  // come back with a suggested fix, route to the review step so the inviter can
+  // confirm or correct; otherwise create the invite straight away. Proofreading
+  // is best-effort — any failure falls through to creating the invite as typed.
+  async function reviewAndCreate(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     const currentInterests = normalizeInterestList(interests);
 
+    if (currentInterests.length > 3) {
+      setError(ERROR_COPY.too_many_suggested_interests);
+      return;
+    }
+
+    if (currentInterests.length === 0) {
+      await submitInvite([]);
+      return;
+    }
+
+    setChecking(true);
+    setError(null);
+
+    let corrections: ProofreadResult[] = [];
+    try {
+      const response = await fetch('/api/friend-invitations/review', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ interests: currentInterests }),
+      });
+      const body = (await response.json().catch(() => null)) as { results?: ProofreadResult[] } | null;
+      if (response.ok && body && Array.isArray(body.results)) {
+        corrections = body.results;
+      }
+    } catch {
+      corrections = [];
+    } finally {
+      setChecking(false);
+    }
+
+    if (corrections.some((item) => item.suggestion)) {
+      setReviewIdeas(currentInterests);
+      setProofread(corrections);
+      setStep('review');
+      return;
+    }
+
+    await submitInvite(currentInterests);
+  }
+
+  // Apply (or undo) a proofread suggestion for one idea on the review step.
+  function chooseIdea(index: number, value: string) {
+    setReviewIdeas((current) => current.map((idea, i) => (i === index ? value : idea)));
+  }
+
+  async function submitInvite(currentInterests: string[]) {
     if (currentInterests.length > 3) {
       setError(ERROR_COPY.too_many_suggested_interests);
       return;
@@ -360,7 +429,7 @@ export default function AddFriendInvite({
       ) : null}
 
       {step === 'interests' ? (
-        <form className="space-y-5" onSubmit={createInvite}>
+        <form className="space-y-5" onSubmit={reviewAndCreate}>
           <div>
             <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
               For {trimmedName}
@@ -396,9 +465,9 @@ export default function AddFriendInvite({
             <button
               type="submit"
               className="btn-primary w-full"
-              disabled={submitting}
+              disabled={submitting || checking}
             >
-              {submitting ? 'Warming it up…' : 'Make the note'}
+              {checking ? 'Double-checking…' : submitting ? 'Warming it up…' : 'Make the note'}
             </button>
             <button
               type="button"
@@ -409,6 +478,93 @@ export default function AddFriendInvite({
             </button>
           </div>
         </form>
+      ) : null}
+
+      {step === 'review' ? (
+        <div className="space-y-5">
+          <div>
+            <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+              For {trimmedName}
+            </p>
+            <h2 className="text-foreground mt-2 font-serif text-2xl font-semibold">
+              Double-check these spellings
+            </h2>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">
+              A couple of these look like typos. Pick the spelling you meant, or keep yours.
+            </p>
+          </div>
+
+          <div className="space-y-4">
+            {reviewIdeas.map((idea, index) => {
+              const suggestion = proofread[index]?.suggestion ?? null;
+              const original = proofread[index]?.original ?? idea;
+              if (!suggestion) {
+                return (
+                  <div key={`${original}-${index}`} className="text-foreground text-sm">
+                    <span className="bg-primary/5 border-primary/10 inline-block rounded-full border px-3 py-1 shadow-sm">
+                      {idea}
+                    </span>
+                  </div>
+                );
+              }
+              const keptOriginal = idea === original;
+              return (
+                <div key={`${original}-${index}`} className="space-y-2">
+                  <p className="text-muted-foreground text-sm">
+                    Did you mean <span className="text-foreground font-medium">{suggestion}</span>?
+                  </p>
+                  <div className="flex flex-wrap gap-2">
+                    <button
+                      type="button"
+                      onClick={() => chooseIdea(index, suggestion)}
+                      className={`rounded-full border px-3 py-1 text-sm transition ${
+                        !keptOriginal
+                          ? 'border-[var(--brand-navy)] bg-[var(--brand-navy)] text-[var(--cream)]'
+                          : 'border-[var(--accent-gold)] bg-[var(--brand-field)] text-foreground'
+                      }`}
+                    >
+                      {suggestion}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => chooseIdea(index, original)}
+                      className={`rounded-full border px-3 py-1 text-sm transition ${
+                        keptOriginal
+                          ? 'border-[var(--brand-navy)] bg-[var(--brand-navy)] text-[var(--cream)]'
+                          : 'border-[var(--accent-gold)] bg-[var(--brand-field)] text-foreground'
+                      }`}
+                    >
+                      Keep “{original}”
+                    </button>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          {error ? <p className="text-destructive text-sm font-medium">{error}</p> : null}
+
+          <div className="space-y-3">
+            <button
+              type="button"
+              className="btn-primary w-full"
+              disabled={submitting}
+              onClick={() => void submitInvite(normalizeInterestList(reviewIdeas))}
+            >
+              {submitting ? 'Warming it up…' : 'Looks good — make the note'}
+            </button>
+            <button
+              type="button"
+              className="text-muted-foreground w-full text-sm"
+              onClick={() => {
+                setError(null);
+                setStep('interests');
+              }}
+            >
+              Back to edit
+            </button>
+          </div>
+        </div>
       ) : null}
 
       {step === 'handoff' && result ? (

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -328,6 +328,76 @@ Respond in JSON only: { "suggested": "...", "broadCategory": "...", "explanation
   };
 }
 
+export type InterestProofread = {
+  /** The label as typed (trimmed and whitespace-collapsed). */
+  original: string;
+  /**
+   * A spelling correction when the typed label is an obvious misspelling of a
+   * recognizable subject ("Obama-Era poicy" -> "Obama-Era Policy"), else null.
+   * Only fixes typos — never rewrites meaning, scope, specificity, or casing —
+   * so an inviter can confirm before a suggested area ships misspelled.
+   */
+  suggestion: string | null;
+};
+
+/**
+ * Proofread inviter-suggested interest labels for obvious spelling typos before
+ * they are attached to a friend invitation. Returns a correction only when the
+ * model is confident the input is a misspelling of a real, recognizable subject;
+ * otherwise suggestion is null and the typed wording stands. One batched Haiku
+ * call covers all (up to three) labels.
+ *
+ * FAILS OPEN: an absent client, an outage, or a malformed response yields
+ * all-null suggestions, so the invite flow proceeds with the typed labels
+ * unchanged. This is a convenience double-check, never a gate.
+ */
+export async function proofreadInterestLabels(labels: string[]): Promise<InterestProofread[]> {
+  const cleaned = labels
+    .map((label) => label.trim().replace(/\s+/g, ' ').slice(0, 80))
+    .filter((label) => label.length > 0);
+  const base: InterestProofread[] = cleaned.map((original) => ({ original, suggestion: null }));
+  if (cleaned.length === 0) return [];
+
+  const client = getAnthropicClient();
+  if (!client) return base;
+
+  const systemPrompt = `You proofread short trivia-interest labels for spelling typos only.
+For each input label, decide whether it is an obvious misspelling of a real, recognizable subject (a person, place, work, era, field, team, or movement).
+Rules:
+- Only correct clear spelling typos ("poicy" -> "Policy", "Beethovan" -> "Beethoven", "Brutalst" -> "Brutalist").
+- Preserve the rest of the label exactly — never change meaning, scope, specificity, or word order, and never add or remove words beyond fixing the typo.
+- If the label is already spelled correctly, or you are not confident it is a typo, return null for that label.
+- Keep the label's existing capitalization style.
+Respond in JSON array only, no markdown, one object per input label in the same order: [ { "suggestion": "..." | null } ]${INSTRUCTION_USER_INPUT_GUIDANCE}`;
+
+  try {
+    const numbered = cleaned.map((label, index) => `${index + 1}. ${label}`).join('\n');
+    const response = await loggedMessagesCreate(client, 'interests-proofread', {
+      model: CANONICALIZE_MODEL,
+      max_tokens: 300,
+      temperature: 0,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: wrapUserInput('interest_labels', numbered) }],
+    });
+
+    const parsed = parseJsonArray(extractTextContent(response.content));
+    if (!parsed) return base;
+
+    return base.map((entry, index) => {
+      const item = parsed[index];
+      if (!item || typeof item !== 'object' || Array.isArray(item)) return entry;
+      const suggestion = asTrimmedString((item as Record<string, unknown>).suggestion);
+      // Ignore non-corrections: a missing field, or an echo of the typed label.
+      if (!suggestion || suggestion.toLowerCase() === entry.original.toLowerCase()) {
+        return entry;
+      }
+      return { original: entry.original, suggestion: suggestion.slice(0, 80) };
+    });
+  } catch {
+    return base;
+  }
+}
+
 export type ExpandedInterest = {
   label: string;
   // null when categorization is unavailable or the model returns a catch-all;


### PR DESCRIPTION
## Summary
Adds a new "review" step to the friend invitation flow that proofreads interest labels for spelling typos before submission. When obvious misspellings are detected (e.g., "poicy" → "Policy"), the inviter is prompted to confirm or correct them before the invitation is created. Proofreading fails open—any LLM outage or error allows the flow to proceed with typed labels unchanged.

## Changes

**Frontend (`src/components/AddFriendInvite.tsx`)**
- Added `'review'` step to the `Step` type and new `ProofreadResult` type to represent spelling suggestions
- Added state for tracking proofreading status (`checking`), review-step ideas (`reviewIdeas`), and correction suggestions (`proofread`)
- Renamed `createInvite()` to `reviewAndCreate()` to clarify its new two-phase behavior:
  - Calls `/api/friend-invitations/review` to proofread typed interests
  - Routes to review step if corrections are found; otherwise submits directly
  - Extracted invite submission logic into new `submitInvite()` function
- Added `chooseIdea()` handler to let inviters accept or reject spelling suggestions
- Added new review step UI with side-by-side buttons for each suggestion (accept correction or keep original)
- Updated submit button to show "Double-checking…" state during proofreading

**Backend (`src/server/llm/interests.ts`)**
- Added `InterestProofread` type with `original` and `suggestion` fields
- Implemented `proofreadInterestLabels()` function that:
  - Batches up to three labels in a single Haiku call
  - Uses a zero-temperature system prompt to detect only clear spelling typos
  - Preserves capitalization, meaning, and scope—never rewrites
  - Returns null suggestions for correctly spelled or ambiguous labels
  - Fails open (returns all-null suggestions on any error)

**API Route (`src/app/api/friend-invitations/review/route.ts`)**
- New POST endpoint at `/api/friend-invitations/review`
- Validates request body (array of 1–3 strings, max 60 chars each)
- Requires authentication
- Returns `{ results: InterestProofread[] }` with spelling suggestions
- Set `maxDuration = 30` to allow slower proofreading calls to complete

## Implementation Details
- Proofreading is a convenience double-check, never a gate—the flow proceeds with typed labels if the LLM is unavailable or returns malformed data
- The review step only appears if at least one suggestion is found; otherwise the invite is created immediately
- Inviters can return to the interests step to re-edit before final submission
- State is reset on successful submission or when starting a new invitation

https://claude.ai/code/session_018F2T4Cjf7ppAq4otzwsg4A