### PR TITLE
Nest creator note inside result card in gameplay reveal

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1205,8 +1205,8 @@ function ResultRow({
             {pointsLabel ? ` - ${pointsLabel}` : ''}
           </p>
         ) : null}
+        {note ? <CreatorNote text={note.text} provenance={note.provenance} /> : null}
       </ThreadCard>
-      {note ? <CreatorNote text={note.text} provenance={note.provenance} /> : null}
       {correct && openedTerritoryDomain ? (
         <NewTerritoryUndo domain={openedTerritoryDomain} category={canonicalSubcategory} />
       ) : null}


### PR DESCRIPTION
## Summary

Follow-up fix to the creator-note unification (#980). In the gameplay result reveal (`GameplayChat.tsx`), the unified `CreatorNote` was rendered **after** `</ThreadCard>`, so it floated in the gap between the result card and the next question card instead of belonging to the card it annotates.

This moves the note **inside** `ThreadCard` — matching the daily-summary surface, which already nested it — so both treatments now read as part of the original card:
- the editorial **"Between us!"** bronze aside, and
- the human **"Between you and {Name}"** inverted block.

## Change

One-line move: the `{note ? <CreatorNote /> : null}` render now sits before `</ThreadCard>` rather than after it.

## Verification

- `GameplayChat.result.test.tsx` + `GameplayChat.house.test.tsx`: 10/10 pass (assertions are content-presence based, unaffected by the position change)
- `tsc -p tsconfig.typecheck.json`: clean
- `eslint src/components/play/GameplayChat.tsx`: clean

https://claude.ai/code/session_01TYauRbKJ6xPYPcRaV2Jqub

---
_Generated by [Claude Code](https://claude.ai/code/session_01TYauRbKJ6xPYPcRaV2Jqub)_