### PR TITLE
Hide empty Zone-2 sections instead of honest per-section empty states

### DIFF
--- a/D-HOME-DASHBOARD-MODEL-01.md
+++ b/D-HOME-DASHBOARD-MODEL-01.md
@@ -29,8 +29,10 @@ The ambient band carries a single band-level label ("Past 7 days" or equivalent)
 **3. Spent cards disappear when exhausted (overrides §Q4).**
 A From Friends milestone bundle is **hidden once all its questions are played**. While answerable, it shows a remaining count ("1 of 4 questions"). This reverses `§Q4`'s "spent cards stay as hollow-triangle bundles for 30 days" — but only for the *fully exhausted* case. A partially-played bundle still appears (with its remaining count), so no answerable content is thrown away. The 30-day roll-off for spent cards is moot under this model because exhausted cards are removed on exhaustion, not on a timer.
 
-**4. Per-section honest empty states replace the all-or-nothing switch.**
+**4. Per-section honest empty states replace the all-or-nothing switch.** *(Treatment reverted 2026-06-15 — see note below.)*
 When a Zone 2 section has nothing in the 7-day window, it shows an honest empty state rather than being silently hidden or backfilled from history. This overrides `D-HOME-PACING-01 §9`'s "hide empty sections; one empty state only when all three are empty." Recent-or-nothing: no section reaches past 7 days to fill a quota.
+
+> **Update (2026-06-15):** the *honest per-section empty-state treatment* of point 4 was reverted. In practice the speech-bubble + "Nothing else this week." block read as orphaned clutter under the "Past 7 days" band. Empty Zone-2 sections (From Friends, Recent activity) are now **hidden outright** again, and the single "Past 7 days" band label is suppressed when the whole band resolves to nothing. The rest of the model is unchanged: recent-or-nothing windowing stands (no back-fill to a quota), and the whole-page empty state still wins only when everything is empty. The server still emits `emptySections` (`selectHomeEdition`); the renderer simply no longer draws a per-section empty, so re-enabling is a renderer-only change.
 
 **5. "View more" portals are bounded to the same 7-day window.**
 The `/from-friends` and `/activities` overflow pages render only the 7-day window, not the 35/90-day data window. They are no longer deep-history portals.

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -536,11 +536,12 @@ export type HomeBudget = {
   /** True when all three content zones are empty — drives the empty switch. */
   isAllEmpty: boolean
   /**
-   * D-HOME-DASHBOARD-MODEL-01 point 4 — per-section "this Zone-2 section is
-   * empty in-window" signal (emitted by `selectHomeEdition`). Drives the honest
-   * per-section empty states under the "Past 7 days" band instead of silently
-   * hiding a section. Optional so off-budget/legacy callers (and tests that
-   * don't exercise empties) keep the prior hide-when-empty behavior.
+   * Per-section "this Zone-2 section is empty in-window" signal (emitted by
+   * `selectHomeEdition`). Originally drove the honest per-section empty states
+   * of D-HOME-DASHBOARD-MODEL-01 point 4; that treatment was reverted on
+   * 2026-06-15 — empty Zone-2 sections are now hidden outright — so the
+   * renderer no longer reads this. Retained as part of the server edition
+   * contract (and to make the per-section treatment trivial to re-enable).
    */
   emptySections?: {
     fromFriends: boolean
@@ -839,34 +840,6 @@ function FeedSectionHeading({
     >
       {children}
     </h2>
-  )
-}
-
-// D-HOME-DASHBOARD-MODEL-01 point 4 — a Zone-2 section with nothing in the 7-day
-// window says so plainly rather than vanishing or back-filling from history. It
-// keeps its (subdued) sub-label so the band still reads as the same set of
-// zones, pairs the existing speech-bubble art with one calm "quiet this week"-
-// register line, and carries NO invite CTA — that belongs only to the whole-page
-// friends-empty state, not to every empty section.
-function SectionEmptyState({
-  unifiedHome,
-  sublabel,
-  copy,
-}: {
-  unifiedHome: boolean
-  sublabel: string
-  copy: string
-}) {
-  return (
-    <Fragment>
-      <FeedSectionHeading unifiedHome={unifiedHome} subdued>
-        {sublabel}
-      </FeedSectionHeading>
-      <div className={`flex items-center gap-3 py-2 ${unifiedHome ? 'pl-0.5' : ''}`}>
-        <SpeechBubbleIllustration className="h-10 w-auto opacity-70" />
-        <p className="font-serif text-base text-[var(--brand-ink-400)]">{copy}</p>
-      </div>
-    </Fragment>
   )
 }
 
@@ -1202,6 +1175,16 @@ function FeedListContent({
   // the window is relaxed and this flag flips false, so the label never asserts
   // a 7-day promise the page isn't keeping.
   const bandLabelVisible = Boolean(budget)
+
+  // Empty Zone-2 sub-sections are now hidden outright (treatment chosen
+  // 2026-06-15) rather than carrying an honest per-section empty state — this
+  // reverses D-HOME-DASHBOARD-MODEL-01 point 4. Because of that, the band can
+  // resolve to nothing on a page that still has Zone-1 "For you" content, so
+  // the single "Past 7 days" boundary label is gated on the band actually
+  // having something beneath it (a section's rows, or the quiet-week foot
+  // panel) and never heads an empty band.
+  const bandHasContent =
+    fromFriendsRows.length > 0 || restRows.length > 0 || Boolean(budget?.panel)
 
   const emptyCopy = useMemo(() => {
     if (loadingInitial) return 'Loading your Feed...'
@@ -2035,14 +2018,15 @@ function FeedListContent({
                   B-HOME-COLDSTART-06 hooks to suppress it when the window is
                   relaxed for a cold-start user, so it never asserts a false
                   7-day promise. */}
-              {bandLabelVisible ? (
+              {bandLabelVisible && bandHasContent ? (
                 <FeedSectionHeading unifiedHome={unifiedHome}>Past 7 days</FeedSectionHeading>
               ) : null}
               {/* From Friends — friends' playable milestone bundles. The server
                   capped the served slice (Playables 4); render it and surface the
-                  remainder as a quiet "N more →". Honest empty when nothing landed
-                  in-window. groupActivityByFriend is a pass-through (milestone
-                  rows never group). */}
+                  remainder as a quiet "N more →". Hidden outright when nothing
+                  landed in-window (no per-section empty state, 2026-06-15).
+                  groupActivityByFriend is a pass-through (milestone rows never
+                  group). */}
               {fromFriendsRows.length > 0 ? (
                 <Fragment key="from-friends">
                   <FeedSectionHeading unifiedHome={unifiedHome} subdued>
@@ -2057,18 +2041,13 @@ function FeedListContent({
                     />
                   ) : null}
                 </Fragment>
-              ) : budget.emptySections?.fromFriends ? (
-                <SectionEmptyState
-                  unifiedHome={unifiedHome}
-                  sublabel="From Friends"
-                  copy="No friend activity this week."
-                />
               ) : null}
               {/* Recent activity — the ambient texture stream (relationship
                   events, convergence, social moments) as full-sentence LONE
                   events (D-FEED-GROUP3-01 §2). The one rotating panel splices
                   after the lead rows (§2 slot 5); the "See all activity →" row
-                  closes the zone. Honest empty when nothing in-window. */}
+                  closes the zone. Hidden outright when nothing in-window
+                  (no per-section empty state, 2026-06-15). */}
               {restRows.length > 0 ? (
                 <Fragment key="texture">
                   <FeedSectionHeading unifiedHome={unifiedHome} subdued>
@@ -2083,12 +2062,6 @@ function FeedListContent({
                     href="/activities"
                   />
                 </Fragment>
-              ) : budget.emptySections?.texture ? (
-                <SectionEmptyState
-                  unifiedHome={unifiedHome}
-                  sublabel="Recent activity"
-                  copy="Nothing else this week."
-                />
               ) : null}
               {/* Quiet-week foot fallback — when the texture zone is empty the
                   single rotating panel still renders once, here, instead of

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -218,7 +218,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).not.toContain('Nothing else this week')
   })
 
-  it('partial-empty → ambient sections show honest empties, not silent hiding (model point 4)', () => {
+  it('partial-empty → empty ambient sections are hidden outright (point 4 reverted 2026-06-15)', () => {
     const html = render({
       unifiedHome: true,
       initialPage: {
@@ -240,15 +240,15 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
 
     expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('direct:robyn')
-    // The band still labels the windowed zones, and each empty ambient section
-    // renders an honest empty (with its sub-label) rather than vanishing.
+    // Empty ambient sections are hidden outright — no sub-label, no art, no
+    // "honest empty" copy. The band still labels itself because the quiet-week
+    // foot panel keeps content beneath the boundary.
     expect(html).toContain('Past 7 days')
-    expect(html).toContain('From Friends')
-    expect(html).toContain('No friend activity this week.')
-    expect(html).toContain('Recent activity')
-    expect(html).toContain('Nothing else this week.')
-    // NOT the whole-page promo (that is for total emptiness only), and the
-    // per-section empties carry no invite CTA (that belongs to the all-empty case).
+    expect(html).not.toContain('From Friends')
+    expect(html).not.toContain('No friend activity this week')
+    expect(html).not.toContain('Recent activity')
+    expect(html).not.toContain('Nothing else this week')
+    // NOT the whole-page promo (that is for total emptiness only).
     expect(html).not.toContain('Quiet today')
     expect(html).not.toContain('add friends →')
     // The texture see-more is hidden with its (empty) zone.
@@ -257,7 +257,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('PANEL:common_ground')
   })
 
-  it('asymmetric partial-empty → From Friends renders, Recent activity shows an honest empty', () => {
+  it('asymmetric partial-empty → From Friends renders, empty Recent activity is hidden', () => {
     const html = render({
       unifiedHome: true,
       initialPage: { viewer_user_id: 'me', meta: META, items: [], has_more: false, next_cursor: null },
@@ -276,9 +276,9 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('From Friends')
     expect(html).toContain('activity:p0:josh')
     expect(html).not.toContain('No friend activity this week')
-    // Recent activity is empty-in-window → honest empty, not hidden.
-    expect(html).toContain('Recent activity')
-    expect(html).toContain('Nothing else this week.')
+    // Recent activity is empty-in-window → hidden outright, no honest empty.
+    expect(html).not.toContain('Recent activity')
+    expect(html).not.toContain('Nothing else this week')
     expect(html).not.toContain('Quiet today')
   })
 })


### PR DESCRIPTION
The speech-bubble + "Nothing else this week." block read as orphaned
clutter under the "Past 7 days" band. Revert the per-section honest
empty-state treatment (D-HOME-DASHBOARD-MODEL-01 point 4): empty From
Friends / Recent activity sections are hidden outright again, and the
single "Past 7 days" band label is suppressed when the whole band
resolves to nothing (so it never heads an empty band).

Remove the now-unused SectionEmptyState component; the server still
emits emptySections so re-enabling is a renderer-only change. Update
the FeedListBudget tests and the model doc to match.

https://claude.ai/code/session_01VhrF9DtAZsEBxM49u8V2pv