### PR TITLE
Remove dismissed catch-up cards from the thread instead of dimming them

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -63,8 +63,6 @@ export type ChatMessage =
       presenceSourceName?: string | null;
       presenceSourceExtraCount?: number;
       isNew?: boolean;
-      /** When true the card is shown as a dimmed, non-interactive ghost — set when the question is dismissed and the inline "Dismissed · Undo" notice takes over. */
-      faded?: boolean;
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
     }
@@ -235,10 +233,11 @@ function SystemRow({ text }: { text: string }) {
   );
 }
 
-// Inline "Dismissed · Undo" line shown after a question is dropped from
-// catch-up. Mirrors NewTerritoryUndo's self-contained optimistic state: the
-// undo is awaited, "Undoing…" shows while in flight, and a rejection surfaces
-// an inline retry hint without losing the dismissal.
+// Inline "Removed from catch up · Undo" line shown in place of a question that
+// was dropped from catch-up (the card itself is removed from the thread, not
+// dimmed). Mirrors NewTerritoryUndo's self-contained optimistic state: the undo
+// is awaited, "Undoing…" shows while in flight, and a rejection surfaces an
+// inline retry hint without losing the dismissal.
 function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
   const [state, setState] = useState<'idle' | 'undoing' | 'error'>('idle');
 
@@ -264,7 +263,7 @@ function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
           textAlign: 'center',
         }}
       >
-        <span>Dismissed</span>
+        <span>Removed from catch up</span>
         <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
         {state === 'undoing' ? (
           <span style={{ opacity: 0.7 }}>Undoing…</span>
@@ -308,7 +307,6 @@ function QuestionRow({
   presenceSourceName = null,
   presenceSourceExtraCount = 0,
   isNew = false,
-  faded = false,
   onGiveUp,
   giveUpDisabled = false,
   onDismiss,
@@ -324,7 +322,6 @@ function QuestionRow({
   presenceSourceName?: string | null;
   presenceSourceExtraCount?: number;
   isNew?: boolean;
-  faded?: boolean;
   onGiveUp?: () => void;
   giveUpDisabled?: boolean;
   onDismiss?: () => void;
@@ -350,11 +347,9 @@ function QuestionRow({
     <div
       className="flex flex-col gap-0.5"
       style={
-        faded
-          ? { opacity: 0.35, transition: 'opacity 0.4s ease', pointerEvents: 'none' }
-          : isNew
-            ? { opacity: visible ? 1 : 0, transition: 'opacity 0.3s ease' }
-            : undefined
+        isNew
+          ? { opacity: visible ? 1 : 0, transition: 'opacity 0.3s ease' }
+          : undefined
       }
     >
       {subhead ? (
@@ -522,7 +517,7 @@ function QuestionRow({
           ) : null}
         </div>
       </div>
-      {!faded && (onGiveUp || onDismiss || onMutePresence) ? (
+      {onGiveUp || onDismiss || onMutePresence ? (
         <div
           style={{
             display: 'flex',
@@ -1429,7 +1424,6 @@ export function GameplayChatThread({
                 presenceSourceName={m.presenceSourceName}
                 presenceSourceExtraCount={m.presenceSourceExtraCount}
                 isNew={m.isNew}
-                faded={m.faded}
                 subhead={m.subhead}
                 badges={m.badges}
                 onGiveUp={onGiveUp && m.id === activeQuestionId ? onGiveUp : undefined}

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -194,29 +194,28 @@ function questionMessage(item: CatchupQueueItem): ChatMessage {
   };
 }
 
-// Once the player engages the next turn (answers, skips, or dismisses again),
-// a lingering "Dismissed · Undo" notice is retired to a plain "Dismissed." line
-// so undo can't rewind across a resolved turn.
+// Once the player engages the next turn (answers, skips, or dismisses again), a
+// lingering "Removed from catch up · Undo" notice is retired to a plain
+// "Removed from catch up." line so undo can't rewind across a resolved turn.
 function retireDismissNotices(messages: ChatMessage[]): ChatMessage[] {
   return messages.map((message) =>
     message.kind === 'dismiss_notice'
-      ? { id: message.id, kind: 'system' as const, text: 'Dismissed.' }
+      ? { id: message.id, kind: 'system' as const, text: 'Removed from catch up.' }
       : message,
   );
 }
 
 // Rebuilds the introduced/result-posted sequencing sets from a thread, used
-// after an undo rewinds (truncates) the thread: every shown question is
-// "introduced", and a question is "resolved" once it has a result after it or
-// is a dismissed (faded) card. Anything truncated away drops out of both sets
-// so it gets re-introduced cleanly when the queue reaches it again.
+// after an undo drops the notice: every still-shown question is "introduced",
+// and a question is "resolved" once it has a result after it. A dismissed
+// question's card is removed from the thread entirely, so it appears in neither
+// set and gets re-introduced cleanly when the queue reaches it again.
 function deriveCatchupRefs(messages: ChatMessage[]): { introduced: Set<string>; resultPosted: Set<string> } {
   const introduced = new Set<string>();
   const resultPosted = new Set<string>();
   for (const message of messages) {
     if (message.kind === 'question') {
       introduced.add(message.assignmentId);
-      if (message.faded) resultPosted.add(message.assignmentId);
     } else if (message.kind === 'result') {
       resultPosted.add(message.assignmentId);
     }
@@ -462,10 +461,11 @@ export function useCatchupFlow() {
     }, 1200);
   }, [currentItem, finishTurn, isResolvingTurn, submitting]);
 
-  // Reverses a dismissal: un-dismisses server-side, then rewinds the thread back
-  // to the dismissed question (dropping the notice and the auto-introduced next
-  // card) so it becomes the active question again. Throws on failure so the
-  // notice row can surface a retry without losing the dismissal.
+  // Reverses a dismissal: un-dismisses server-side, then drops the notice and
+  // puts the item back at the front of the queue so the introduce effect re-adds
+  // its card as the active question. (The card was removed from the thread on
+  // dismiss, so there is nothing to un-fade.) Throws on failure so the notice
+  // row can surface a retry without losing the dismissal.
   const undismissItem = useCallback(async (item: CatchupQueueItem) => {
     const itemId = item.dailyQueueItemId;
     setSubmitting(true);
@@ -488,18 +488,15 @@ export function useCatchupFlow() {
       batchStartRemainingRef.current += 1;
       setPhase('playing');
       setMessages((existing) => {
-        const questionId = `catchup-q-${itemId}`;
-        const index = existing.findIndex((message) => message.id === questionId);
-        if (index === -1) return existing;
-        const rewound = existing.slice(0, index + 1).map((message) =>
-          message.id === questionId && message.kind === 'question'
-            ? { ...message, faded: false }
-            : message,
-        );
-        const refs = deriveCatchupRefs(rewound);
+        // Drop the active "Removed from catch up · Undo" notice; the restored
+        // item is back at the front of the queue, so re-deriving the sequencing
+        // sets from the remaining thread leaves it un-introduced and the
+        // introduce effect re-adds its card as the current question.
+        const withoutNotice = existing.filter((message) => message.kind !== 'dismiss_notice');
+        const refs = deriveCatchupRefs(withoutNotice);
         introducedItemIdsRef.current = refs.introduced;
         resultPostedItemIdsRef.current = refs.resultPosted;
-        return rewound;
+        return withoutNotice;
       });
     } finally {
       setSubmitting(false);
@@ -528,10 +525,11 @@ export function useCatchupFlow() {
       resultPostedItemIdsRef.current.add(itemId);
       setStats((existing) => ({ ...existing, dismissed: existing.dismissed + 1 }));
       setMessages((existing) => {
-        const retired = retireDismissNotices(existing).map((message) =>
-          message.kind === 'question' && message.assignmentId === itemId
-            ? { ...message, faded: true }
-            : message,
+        // Remove the dismissed question's card from the thread outright (it must
+        // not linger as a dimmed ghost) and leave a "Removed from catch up ·
+        // Undo" notice in its place. Undo re-introduces the card via the queue.
+        const retired = retireDismissNotices(existing).filter(
+          (message) => !(message.kind === 'question' && message.assignmentId === itemId),
         );
         return [
           ...retired,


### PR DESCRIPTION
Dismissing a catch-up question left the card in the thread as a 35%-opacity
ghost with a "Dismissed - Undo" notice. The card needs to be gone, not shaded.

- dismissCurrent now filters the question card out of the thread and leaves a
  stronger "Removed from catch up - Undo" notice in its place.
- undismissItem re-introduces the card via the queue (the card no longer
  exists to un-fade): it drops the notice, re-derives the sequencing sets, and
  the introduce effect re-adds the restored question as the current item.
- Drop the now-dead 'faded' ghost path from ChatMessage/QuestionRow.

Dismissed items were already filtered out of future loads server-side
(catchupResolvedAt / dismissed_at), so they stay gone across reloads.