### PR TITLE
Drop hollow "Someone answered your question" activity rows

### DIFF
--- a/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
+++ b/src/server/activity/__tests__/build-stream-hollow-degraded.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// D-ACCOUNT-DELETION-TERRITORY-01 follow-up (2026-06-16): a degraded
+// "{actor} answered your question" row whose actor is unknown (the friend/
+// stranger deleted their account, so actorUserId was nulled) AND whose question
+// can't be shown renders as "Someone answered your question" with nothing to see
+// or open. buildActivityStream must drop it. We mock filter-utility (identity),
+// the pure transforms (echo the item), and the lately queries (empty) so the
+// hollow-row filter is the only thing acting on the crafted activity rows.
+const { getActivitiesForUserMock } = vi.hoisted(() => ({
+  getActivitiesForUserMock: vi.fn(async () => [] as unknown[]),
+}));
+
+vi.mock('@/app/activities/filter-utility-activities', () => ({
+  filterUtilityActivities: (items: unknown[]) => items,
+}));
+vi.mock('@/lib/activity-stream', () => ({
+  activityToStreamItem: (x: { id: string }) => x,
+  momentToStreamItem: (x: unknown) => x,
+  convergenceToStreamItem: (_c: unknown, questions: unknown) => ({ kind: 'convergence', questions }),
+  friendActivityToStreamItem: (card: { id: string }, questions: unknown) => ({ kind: 'milestone', id: card.id, questions }),
+}));
+vi.mock('@/lib/lately', () => ({
+  sortByProminence: (items: unknown[]) => items,
+  convergenceCaptionTemplate: () => '',
+}));
+vi.mock('@/lib/lately-milestones', () => ({ MILESTONE_CARD_QUESTION_CAP: 5 }));
+vi.mock('@/server/db/queries/activity', () => ({ getActivitiesForUser: getActivitiesForUserMock }));
+vi.mock('@/server/db/queries/content-reports', () => ({
+  getViewerHiddenQuestionIds: vi.fn(async () => new Set<string>()),
+}));
+vi.mock('@/server/db/queries/lately', () => ({
+  getLatelyMoments: vi.fn(async () => []),
+  getLatelyConvergences: vi.fn(async () => []),
+  getFriendActivity: vi.fn(async () => []),
+  getMilestoneQuestionText: vi.fn(async () => new Map()),
+  getViewerPriorAnswerResults: vi.fn(async () => new Map()),
+}));
+
+import { buildActivityStream } from '@/server/activity/build-stream';
+
+function row(over: Record<string, unknown>) {
+  return { id: 'x', actorUserId: 'friend-1', reference: {}, ...over };
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('buildActivityStream — hollow degraded "answered your question" rows', () => {
+  it('drops a friend_answered_your_question with no actor and no question to show', async () => {
+    getActivitiesForUserMock.mockResolvedValue([
+      row({ id: 'hollow', type: 'friend_answered_your_question', actorUserId: null, reference: {} }),
+      row({ id: 'has-actor', type: 'friend_answered_your_question', actorUserId: 'friend-1', reference: {} }),
+      row({ id: 'has-content', type: 'friend_answered_your_question', actorUserId: null, reference: { friendAnsweredQuestion: { questionText: 'what year?' } } }),
+    ]);
+
+    const stream = (await buildActivityStream('viewer-1')) as unknown as Array<{ id: string }>;
+    const ids = stream.map((s) => s.id);
+
+    expect(ids).not.toContain('hollow');
+    expect(ids).toContain('has-actor'); // actor known → keep ("you can see who")
+    expect(ids).toContain('has-content'); // question openable → keep ("you can see what")
+  });
+
+  it('drops a niche_match_answered_your_question with no actor and no question, but keeps unrelated null-actor rows', async () => {
+    getActivitiesForUserMock.mockResolvedValue([
+      row({ id: 'niche-hollow', type: 'niche_match_answered_your_question', actorUserId: null, reference: {} }),
+      row({ id: 'niche-content', type: 'niche_match_answered_your_question', actorUserId: null, reference: { nicheMatch: { questionText: 'q' } } }),
+      // A friendless aggregate row (e.g. "You shared…") legitimately has a null
+      // actor and is NOT one of the filtered types — it must survive.
+      row({ id: 'aggregate', type: 'authored_shared_to_friends', actorUserId: null, reference: {} }),
+    ]);
+
+    const stream = (await buildActivityStream('viewer-1')) as unknown as Array<{ id: string }>;
+    const ids = stream.map((s) => s.id);
+
+    expect(ids).not.toContain('niche-hollow');
+    expect(ids).toContain('niche-content');
+    expect(ids).toContain('aggregate');
+  });
+});

--- a/src/server/activity/build-stream.ts
+++ b/src/server/activity/build-stream.ts
@@ -85,9 +85,26 @@ export async function buildActivityStream(
     getViewerHiddenQuestionIds(userId, allQuestionIds),
   ]);
 
-  const utilityItems = filterUtilityActivities(items, moments).map(
-    activityToStreamItem,
-  );
+  const utilityItems = filterUtilityActivities(items, moments)
+    // Drop dead-end degraded rows. An "{actor} answered your question" card whose
+    // actor is unknown (the friend/stranger deleted their account, so actorUserId
+    // was nulled) AND whose question can't be shown renders as "Someone answered
+    // your question" with nothing to see and nothing to open — remove it rather
+    // than surface the hollow row (product call 2026-06-16). Consistent with
+    // Decision D stripping the equivalent FeedItem actor cards
+    // (D-ACCOUNT-DELETION-TERRITORY-01): a card you can't attribute AND can't
+    // expand is not worth showing.
+    .filter((item) => {
+      if (item.actorUserId) return true;
+      if (item.type === 'friend_answered_your_question') {
+        return Boolean(item.reference.friendAnsweredQuestion?.questionText);
+      }
+      if (item.type === 'niche_match_answered_your_question') {
+        return Boolean(item.reference.nicheMatch?.questionText);
+      }
+      return true;
+    })
+    .map(activityToStreamItem);
   const momentItems = moments.map(momentToStreamItem);
   const friendActivityItems = friendCards
     .map((card, i) => {


### PR DESCRIPTION
## What & why

Follow-up to the merged #995 (`D-ACCOUNT-DELETION-TERRITORY-01`), from product feedback on the preview: the "Recent Activity" stream rendered **"Someone answered your question"** cards with no name and nothing to open — a dead end. You can't see *who* (the friend/stranger deleted their account, so `actorUserId` was nulled) and can't see *what* (the question doesn't hydrate).

This also fixes an inconsistency in #995: Decision D **strips** the equivalent hollow `FeedItem` actor cards, but the `ActivityItem` path only **nulled** the actor — leaving the "Someone…" row.

(#995 had already merged by the time this fix was pushed, so it's a separate PR rather than part of that branch.)

## Change

`buildActivityStream` now drops a degraded "{actor} answered your question" row when **both**: the actor is unknown (`actorUserId` null) **and** the question can't be shown (no openable text). Applies to `friend_answered_your_question` and `niche_match_answered_your_question`.

- **Keeps** rows that still have an actor (you can see who) or an openable question (you can see what).
- **Keeps** friendless aggregate rows of other types ("You shared…").
- New test `build-stream-hollow-degraded.test.ts` covers the drop + both keep-paths.

## Verification

Typecheck (`tsconfig.typecheck.json`) clean; ESLint clean; new test + full activity suite green. Rebased cleanly onto current `dev2`.

https://claude.ai/code/session_01HyEn9LEQf7MVcxMJWe3CVn

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyEn9LEQf7MVcxMJWe3CVn)_