### PR TITLE
Implement phone-first invite login (D-AUTH-INVITE-PHONE-FIRST)

### DIFF
--- a/B-AUTH-INVITE-PHONE-FIRST-01.md
+++ b/B-AUTH-INVITE-PHONE-FIRST-01.md
@@ -1,0 +1,71 @@
+# B-AUTH-INVITE-PHONE-FIRST-01 — Phone-First Invite Login (BUILD)
+
+**Type:** Build. Implements the contract settled in `D-AUTH-INVITE-PHONE-FIRST-DESIGN-01`.
+**Predecessor (design):** `D-AUTH-INVITE-PHONE-FIRST-DESIGN-01` (cite for all decisions); ground-truth audit `D-AUTH-LOGIN-INVITE-AUDIT-01`.
+**Date:** 2026-06-16
+**Scope:** The FriendInvitation login path (`/invite/<token>` → `/login?invitationToken=<token>`). Does **not** touch OTP/possession/SMS wiring (Phase 2). `000000` stays the universal code.
+
+---
+
+## 0. Resolved open items (from the design §6)
+
+| Item | Resolution |
+|---|---|
+| §6.1 step shape | **Collapse** the `invite` arrival into the existing `phone` step (§4b), pre-filled with the full invited number and inviter context above the field. The `invite` step is retired. **Guardrail:** all prefill/inviter logic stays conditional on `invitePrefill` so the `/u/<handle>/<token>` per-user-link path (which also enters on `phone`) is undisturbed. |
+| §6.2 dead-end secondary action | **Dismiss / return to field.** "Ask {inviter} for a new invite" just closes the soft-state; no re-invite mechanism is built (none exists). |
+| §6.3 privacy boundary | **Confirmed surface:** `login/page.tsx` (what crosses to client), the client `InvitePrefill` shape in `LoginPanel.tsx`, and the server `InvitePrefill` comment in `invitations.ts`. Named explicitly below as Phase 0. |
+| §6.4 gate signal | **Server distinguishes.** `request-otp` returns a labeled `invite_phone_unclaimed` (403) for the invite path + edited number + no claim, so the client renders the warm dead-end. Gate is **not** loosened: no OTP is sent and the request is still rejected — only the label differs. |
+
+---
+
+## 1. Privacy boundary change (Phase 0 — call it out explicitly)
+
+Per design §2.3, the raw invited phone now crosses to the client **for the FriendInvitation path only**, gated by a valid invitation token resolved server-side at page load.
+
+1. `src/server/friends/invitations.ts` — `InvitePrefill.inviteePhone`: rewrite the "Never expose this to the client" comment to scope the exception to the invite-token-gated prefill path (do not delete it silently). The server type is unchanged in shape.
+2. `src/app/login/page.tsx` — the client `invitePrefill` object now carries the full `inviteePhone` (replacing `maskedPhone`, which the client no longer needs). Update the `// Only the masked form crosses…` comment.
+3. `src/app/login/LoginPanel.tsx` — client `InvitePrefill` type swaps `maskedPhone` → `inviteePhone`.
+
+---
+
+## 2. Client (`LoginPanel.tsx`)
+
+- **Step union:** drop `'invite'`. Initial step is always `'phone'`.
+- **Prefill:** `phone` initialises to `formatUsPhoneInput(invitePrefill.inviteePhone)` when present, else `''`.
+- **Retire:** the `invite` step render block, `sendCodeToInvitePhone`, `invitePhoneMode` state, `maskedPhone` state, and `buildInviteVerifyOtpRequestBody`. Verify always uses `buildVerifyOtpRequestBody(phone, code, searchParams)` — the submitted phone is authoritative (design §4 default stance); the token is re-validated against it server-side by the untouched `getValidInvitationForPhone` / `acceptFriendInvitation` (preserves §2.4).
+- **request-otp body:** `continueWithPhone` now also sends `invitationToken` (so the server can emit the §6.4 soft signal). Null on the cold / per-user-link paths — no behavior change there.
+- **Dead-end (Screen 1b):** when `request-otp` returns `error: 'invite_phone_unclaimed'` and `invitePrefill?.inviteePhone` exists, do not advance — render an inline warm panel (neutral/gold, **not** destructive-red; state carried by wording per accessibility canon):
+  > This invite was sent to {full number}. We can use that number, or you can ask {inviter} for a new invite.
+  - Primary **Use the invited number** → restores the field to the invited number and proceeds (shared `requestCodeForPhone` helper).
+  - Secondary **Ask {inviter} for a new invite** → dismiss (clears the dead-end, returns to the field).
+  - Editing the field clears the dead-end.
+- **Code step:** display always `formatPhoneForDisplay(phone)` (no more masked branch).
+
+## 3. Server (`request-otp/route.ts`) — the only server change
+
+In the new-user gate-fail branch, when a `invitationToken` is present, return a distinguishable signal instead of the generic 403:
+
+```ts
+if (!invitedByPhone && !invitedByLink) {
+  if (parsed.data.invitationToken) {
+    return NextResponse.json(
+      { error: 'invite_phone_unclaimed', message: INVITE_REQUIRED_MESSAGE },
+      { status: 403 },
+    );
+  }
+  return NextResponse.json(
+    { error: 'invite_required', message: INVITE_REQUIRED_MESSAGE },
+    { status: 403 },
+  );
+}
+```
+
+No OTP is sent on either branch; the gate is unchanged. `verify-otp` is **not** touched.
+
+## 4. What must NOT change (design §5)
+`verifyOtp`/`000000`; `acceptFriendInvitation`'s `inviteePhone === verifiedPhone`; the cold-visit and `/u/` paths; returning-player path & `proxy.ts`; existing SMS-implying copy (and add no new "we'll text you" promise — "Continue" makes none).
+
+## 5. Tests
+- `LoginPanel.test.ts`: drop the `buildInviteVerifyOtpRequestBody` cases (function removed).
+- `request-otp/.../route.test.ts`: add a case asserting `invite_phone_unclaimed` (403, no OTP) when a token is present on a no-claim phone; the generic-403 cold-path case stays.
+- `verify-otp` tests: unchanged (server untouched).

--- a/src/app/api/auth/request-otp/__tests__/route.test.ts
+++ b/src/app/api/auth/request-otp/__tests__/route.test.ts
@@ -115,6 +115,21 @@ describe('/api/auth/request-otp invite gate', () => {
     expect(requestOtpMock).not.toHaveBeenCalled()
   })
 
+  it('returns the warm invite_phone_unclaimed signal when a token rides along but the (edited) phone has no claim', async () => {
+    // Phone-first invite path: the invitee edited the pre-filled number to one
+    // with no claim of its own. The gate still rejects (no OTP), but with a
+    // distinguishable label so the client can render the warm dead-end.
+    const response = await POST(
+      jsonRequest({ phone: NEW_PHONE, invitationToken: 'tok-1' }),
+    )
+
+    expect(response.status).toBe(403)
+    expect(await response.json()).toMatchObject({
+      error: 'invite_phone_unclaimed',
+    })
+    expect(requestOtpMock).not.toHaveBeenCalled()
+  })
+
   it('does not require an invitation for an existing user', async () => {
     findUserSelectMock.mockResolvedValue([{ id: 'user-1' }])
 

--- a/src/app/api/auth/request-otp/route.ts
+++ b/src/app/api/auth/request-otp/route.ts
@@ -98,6 +98,19 @@ export async function POST(request: Request) {
         ? Boolean(await resolveInviteLink(userInvite.handle, userInvite.token))
         : false;
       if (!invitedByPhone && !invitedByLink) {
+        // Phone-first invite path (D-AUTH-INVITE-PHONE-FIRST §6.4): when a
+        // FriendInvitation token rode along, an edited number with no claim of
+        // its own is a benign correction, not an intrusion. Return a
+        // distinguishable signal so the client can render the warm
+        // "use the invited number" dead-end instead of a generic invite-only
+        // error. The gate is NOT loosened — no OTP is sent and the request is
+        // still rejected; only the label differs.
+        if (parsed.data.invitationToken) {
+          return NextResponse.json(
+            { error: 'invite_phone_unclaimed', message: INVITE_REQUIRED_MESSAGE },
+            { status: 403 },
+          );
+        }
         return NextResponse.json(
           { error: 'invite_required', message: INVITE_REQUIRED_MESSAGE },
           { status: 403 },

--- a/src/app/dev/invite-login/page.tsx
+++ b/src/app/dev/invite-login/page.tsx
@@ -1,0 +1,122 @@
+'use client';
+
+import { Suspense, useState } from 'react';
+import Link from 'next/link';
+import { ChevronLeft, Info } from 'lucide-react';
+
+import LoginPanel from '@/app/login/LoginPanel';
+
+/**
+ * Dev tool: preview the phone-first invite login (D-AUTH-INVITE-PHONE-FIRST).
+ *
+ * Linked from the Developer tools section of the profile page. It renders the
+ * real `LoginPanel` with synthetic invite data so the two new surfaces — the
+ * pre-filled phone screen (Screen 1) and the warm "no claim" dead-end
+ * (Screen 1b) — can be inspected WITHOUT minting a real invitation or sending
+ * an OTP. It is look-only: the synthetic token doesn't resolve server-side, so
+ * the buttons won't complete a login (no account is created). The dead-end is
+ * seeded via LoginPanel's dev-only `previewDeadEnd` prop rather than a live
+ * failed gate round-trip.
+ */
+
+// Synthetic prefill — the (734) 555-6819 number matches the design spec's
+// worked example. `inviterUserId`/`inviterAvatarColor` are only used by the
+// (unrendered-here) inviter avatar, so placeholder values are fine.
+const PREVIEW_INVITER = {
+  inviterName: 'Greg Sample',
+  inviterUserId: 'dev-preview-inviter',
+  inviterAvatarColor: null,
+};
+const PREVIEW_PREFILL = { ...PREVIEW_INVITER, inviteePhone: '+17345556819' };
+
+type PreviewScreen = 'phone' | 'deadEnd';
+
+export default function DevInviteLoginPage() {
+  const [screen, setScreen] = useState<PreviewScreen>('phone');
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
+      <Link
+        href="/users/me"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Back
+      </Link>
+
+      <h1 className="mt-6 font-serif text-3xl leading-tight font-semibold">
+        Phone-first invite login
+      </h1>
+
+      <div className="mt-4 flex gap-3 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-card)] p-4 text-card-foreground">
+        <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+        <div className="text-sm leading-6 text-muted-foreground">
+          <p className="font-medium text-foreground">
+            What an invited friend sees when they tap their invite link.
+          </p>
+          <p className="mt-1">
+            The phone field arrives pre-filled with the invited number so they
+            can confirm or correct it. If they change it to a number with no
+            invite of its own, they get the warm dead-end instead of a hard
+            error. This is a look-only preview with synthetic data &mdash; no
+            invitation is created and no code is sent, so the buttons won&apos;t
+            complete a real login.
+          </p>
+        </div>
+      </div>
+
+      {/* Toggle between the two new surfaces. */}
+      <div className="mt-6 flex gap-2" role="tablist" aria-label="Preview screen">
+        <PreviewTab
+          active={screen === 'phone'}
+          onClick={() => setScreen('phone')}
+          label="Screen 1 — pre-filled phone"
+        />
+        <PreviewTab
+          active={screen === 'deadEnd'}
+          onClick={() => setScreen('deadEnd')}
+          label="Screen 1b — warm dead-end"
+        />
+      </div>
+
+      {/* Render the real LoginPanel so the preview can never drift from prod.
+          `key` remounts it on toggle so the seeded step/dead-end state resets. */}
+      <div className="mt-6 flex justify-center">
+        <Suspense fallback={null}>
+          <LoginPanel
+            key={screen}
+            invitePrefill={PREVIEW_PREFILL}
+            inviteContext={PREVIEW_INVITER}
+            previewDeadEnd={screen === 'deadEnd'}
+          />
+        </Suspense>
+      </div>
+    </main>
+  );
+}
+
+function PreviewTab({
+  active,
+  onClick,
+  label,
+}: {
+  active: boolean;
+  onClick: () => void;
+  label: string;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      onClick={onClick}
+      className={`rounded-full border px-4 py-1.5 text-sm font-medium transition-colors ${
+        active
+          ? 'border-[var(--brand-navy)] bg-[var(--brand-navy)] text-white'
+          : 'border-[var(--brand-border)] text-muted-foreground hover:text-foreground'
+      }`}
+    >
+      {label}
+    </button>
+  );
+}

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -75,38 +75,27 @@ export function buildVerifyOtpRequestBody(
   };
 }
 
-/**
- * Verify-OTP payload for the invite-prefill flow: no phone is sent — the
- * server resolves the recipient phone from the invitation token. `userInvite`
- * is forwarded so a per-user invite link is still honored if present.
- */
-export function buildInviteVerifyOtpRequestBody(
-  code: string,
-  invitationToken: string,
-  searchParams: URLSearchParams,
-) {
-  return {
-    code,
-    invitationToken,
-    useInvitePhone: true,
-    userInvite: readUserInvite(searchParams),
-  };
-}
-
 type InviteContext = {
   inviterName: string;
   inviterUserId: string;
   inviterAvatarColor: string | null;
 };
 
-type InvitePrefill = InviteContext & { maskedPhone: string };
+// Phone-first invite path: the full invited number crosses to the client so
+// the phone field arrives pre-filled and editable (D-AUTH-INVITE-PHONE-FIRST
+// §2.3). It is the invitee's own number, gated by a valid invitation token.
+type InvitePrefill = InviteContext & { inviteePhone: string };
 
 type LoginPanelProps = {
   invitePrefill?: InvitePrefill | null;
   inviteContext?: InviteContext | null;
+  // Dev-preview only (`/dev/invite-login`): seed the warm dead-end (Screen 1b)
+  // so it can be inspected without a real failed gate round-trip. Never passed
+  // by the production login page.
+  previewDeadEnd?: boolean;
 };
 
-type Step = 'invite' | 'phone' | 'code' | 'profile';
+type Step = 'phone' | 'code' | 'profile';
 
 type VerifiedIdentity = {
   displayName: string;
@@ -174,13 +163,19 @@ function InviteContextCard({ invite }: { invite: InviteContext }) {
 export default function LoginPanel({
   invitePrefill = null,
   inviteContext = null,
+  previewDeadEnd = false,
 }: LoginPanelProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const invitationToken = readInvitationToken(searchParams);
   const userInvite = readUserInvite(searchParams);
 
-  const [phone, setPhone] = useState('');
+  // Phone-first invite path: pre-fill the editable field with the full invited
+  // number so the invitee can confirm or correct it before continuing
+  // (D-AUTH-INVITE-PHONE-FIRST §2.2). Empty on the cold / per-user-link paths.
+  const [phone, setPhone] = useState(() =>
+    invitePrefill?.inviteePhone ? formatUsPhoneInput(invitePrefill.inviteePhone) : '',
+  );
   const [code, setCode] = useState('');
   const [displayName, setDisplayName] = useState('');
   const [handle, setHandle] = useState('');
@@ -192,14 +187,14 @@ export default function LoginPanel({
     displayName: '',
     handle: '',
   });
-  // Start on the invite confirmation step only when the link resolved to a
-  // recipient phone; otherwise fall straight through to manual entry.
-  const [step, setStep] = useState<Step>(invitePrefill?.maskedPhone ? 'invite' : 'phone');
-  // True once the OTP was sent to the invite's phone (so the code step and
-  // verify call use the masked phone + token instead of a typed number).
-  const [invitePhoneMode, setInvitePhoneMode] = useState(false);
-  // Masked phone to display on the code step while in invite-phone mode.
-  const [maskedPhone, setMaskedPhone] = useState(invitePrefill?.maskedPhone ?? '');
+  // The invite arrival is now phone-first: it collapses into the `phone` step
+  // with the field pre-filled, rather than a separate masked confirmation card
+  // (D-AUTH-INVITE-PHONE-FIRST §4b / §6.1).
+  const [step, setStep] = useState<Step>('phone');
+  // Inline warm dead-end (Screen 1b): set when the invitee edits the invited
+  // number to one with no claim of its own. Carried by wording, not an error
+  // banner (D-AUTH-INVITE-PHONE-FIRST §2.6).
+  const [inviteDeadEnd, setInviteDeadEnd] = useState(previewDeadEnd);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Controls the bottom-card transition: the title card (in page.tsx) stays
@@ -348,51 +343,14 @@ export default function LoginPanel({
     }
   }
 
-  async function sendCodeToInvitePhone(event: FormEvent) {
-    event.preventDefault();
+  // Single OTP-request path for every entry (cold, per-user-link, and the
+  // phone-first invite). The submitted phone is authoritative for the gate;
+  // the invitation token rides along as the credential, re-validated against
+  // that phone server-side (D-AUTH-INVITE-PHONE-FIRST §4 default stance).
+  async function requestCodeForPhone(normalized: string) {
     setError(null);
+    setInviteDeadEnd(false);
 
-    if (!invitationToken) {
-      // No token to resolve a phone from — fall back to manual entry.
-      setInvitePhoneMode(false);
-      swapStep('phone');
-      return;
-    }
-
-    sendTelemetry('friend_invite_auth_started');
-
-    setLoading(true);
-    try {
-      const response = await fetch('/api/auth/request-otp', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        // No phone: the server resolves the recipient phone from the invite
-        // token and texts the code there. We only ever receive a masked form.
-        body: JSON.stringify({ invitationToken, useInvitePhone: true, userInvite }),
-      });
-      const data = await response.json().catch(() => ({}));
-
-      if (!response.ok) {
-        // The invite no longer resolves to a sendable phone — drop to manual
-        // entry so the user isn't stranded, carrying the reason onto the step.
-        setInvitePhoneMode(false);
-        swapStep('phone', data?.message ?? 'Enter your phone number to continue.');
-        return;
-      }
-
-      if (typeof data?.maskedPhone === 'string') setMaskedPhone(data.maskedPhone);
-      setInvitePhoneMode(true);
-      swapStep('code');
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  async function continueWithPhone(event: FormEvent) {
-    event.preventDefault();
-    setError(null);
-
-    const normalized = normalizePhone(phone.trim());
     if (!US_E164_REGEX.test(normalized)) {
       setError('Use a US phone number.');
       return;
@@ -405,14 +363,23 @@ export default function LoginPanel({
       const response = await fetch('/api/auth/request-otp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        // Forward the per-user invite link so request-otp can satisfy the
-        // invite gate for a brand-new phone that arrived via /u/<handle>/<token>
-        // (the invitation isn't phone-targeted, so the gate can't infer it).
-        body: JSON.stringify({ phone: normalized, userInvite }),
+        // Forward the invitation token (so the server can return the warm
+        // dead-end signal for an edited no-claim number) and the per-user
+        // invite link (so request-otp can satisfy the gate for a brand-new
+        // phone that arrived via /u/<handle>/<token>).
+        body: JSON.stringify({ phone: normalized, invitationToken, userInvite }),
       });
       const data = await response.json().catch(() => ({}));
 
       if (!response.ok) {
+        // Invite path + edited number with no claim of its own: render the
+        // warm dead-end (Screen 1b) instead of a generic error
+        // (D-AUTH-INVITE-PHONE-FIRST §1b / §6.4).
+        if (data?.error === 'invite_phone_unclaimed' && invitePrefill?.inviteePhone) {
+          setPhone(formatUsPhoneInput(normalized));
+          setInviteDeadEnd(true);
+          return;
+        }
         setError(data?.message ?? 'Unable to continue.');
         return;
       }
@@ -422,6 +389,19 @@ export default function LoginPanel({
     } finally {
       setLoading(false);
     }
+  }
+
+  async function continueWithPhone(event: FormEvent) {
+    event.preventDefault();
+    await requestCodeForPhone(normalizePhone(phone.trim()));
+  }
+
+  // Dead-end primary action: restore the field to the invited number and
+  // proceed down the normal Continue path (D-AUTH-INVITE-PHONE-FIRST §1b).
+  function useInvitedNumber() {
+    if (!invitePrefill?.inviteePhone) return;
+    setPhone(formatUsPhoneInput(invitePrefill.inviteePhone));
+    void requestCodeForPhone(normalizePhone(invitePrefill.inviteePhone));
   }
 
   async function verifyCode(event: FormEvent) {
@@ -436,10 +416,11 @@ export default function LoginPanel({
 
     setLoading(true);
     try {
-      const body =
-        invitePhoneMode && invitationToken
-          ? buildInviteVerifyOtpRequestBody(trimmedCode, invitationToken, searchParams)
-          : buildVerifyOtpRequestBody(phone, trimmedCode, searchParams);
+      // The field is always pre-filled or typed, so we always have a real
+      // submitted phone — no separate no-phone invite payload is needed. The
+      // server re-validates the token against this phone
+      // (D-AUTH-INVITE-PHONE-FIRST §4).
+      const body = buildVerifyOtpRequestBody(phone, trimmedCode, searchParams);
       const response = await fetch('/api/auth/verify-otp', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -583,66 +564,7 @@ export default function LoginPanel({
         transition: 'opacity 200ms ease, transform 200ms ease',
       }}
     >
-      {step === 'invite' ? (
-        <form className="space-y-3.5" onSubmit={sendCodeToInvitePhone}>
-          {/* Texting glyph (the two-tone speech bubble) — this step is about us
-              sending a code by text, so it mirrors the OTP step's mark. */}
-          <svg className="mx-auto h-14 w-auto" viewBox="-3 -3 54 44" aria-hidden="true">
-            <g fill="var(--brand-navy)">
-              <ellipse cx="15" cy="15" rx="15" ry="12" />
-              <path d="M3 22 L11 26.5 L1 31 Z" />
-            </g>
-            <g
-              fill="var(--brand-cream-card)"
-              transform="translate(32 23) scale(1.14) translate(-32 -23)"
-            >
-              <ellipse cx="32" cy="23" rx="15" ry="12" />
-              <path d="M44 30 L36 34.5 L46.5 39 Z" />
-            </g>
-            <g fill="var(--brand-orange)">
-              <ellipse cx="32" cy="23" rx="15" ry="12" />
-              <path d="M44 30 L36 34.5 L46.5 39 Z" />
-            </g>
-          </svg>
-          {inviteContext ? (
-            <InviteContextCard invite={inviteContext} />
-          ) : (
-            <p className="block text-center text-[17px] leading-[26px] font-medium tracking-[1.7px] text-black">
-              {invitePrefill?.inviterName ?? 'A friend'} invited you to Joshing.
-            </p>
-          )}
-          <p className="text-center text-[15px] leading-6 text-black/70">
-            We&rsquo;ll text a code to{' '}
-            <span className="font-medium whitespace-nowrap text-black">{maskedPhone}</span>.
-          </p>
-
-          {/* Button + divider + secondary action form a tight 6px cluster,
-              matching the OTP step's rhythm. */}
-          <div className="space-y-1.5">
-            <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
-              {loading ? 'Sending…' : 'Send code'}
-            </button>
-
-            <div className="flex items-center gap-3" aria-hidden="true">
-              <span className="h-px flex-1 bg-[var(--brand-navy)]/15" />
-              <span className="text-[17px] font-medium text-black">or</span>
-              <span className="h-px flex-1 bg-[var(--brand-navy)]/15" />
-            </div>
-
-            <button
-              type="button"
-              className="mx-auto block text-sm leading-5 font-medium tracking-[0.56px] text-[var(--brand-orange)] uppercase underline underline-offset-4 disabled:opacity-60"
-              onClick={() => {
-                setInvitePhoneMode(false);
-                swapStep('phone');
-              }}
-              disabled={loading}
-            >
-              Use a different number
-            </button>
-          </div>
-        </form>
-      ) : step === 'phone' ? (
+      {step === 'phone' ? (
         <form className="space-y-3.5" onSubmit={continueWithPhone}>
           {/* Solid filled handset, matching the Figma black phone glyph
               (and the filled treatment of the OTP step's bubble icon).
@@ -667,12 +589,50 @@ export default function LoginPanel({
             placeholder="(555) 123-4567"
             maxLength={14}
             value={phone}
-            onChange={(event) => setPhone(formatUsPhoneInput(event.target.value))}
+            onChange={(event) => {
+              // Editing clears any standing dead-end so Continue returns.
+              if (inviteDeadEnd) setInviteDeadEnd(false);
+              setPhone(formatUsPhoneInput(event.target.value));
+            }}
             disabled={loading}
           />
-          <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
-            {loading ? 'Continuing…' : 'Continue'}
-          </button>
+          {inviteDeadEnd && invitePrefill?.inviteePhone ? (
+            // Warm dead-end (Screen 1b): the edited number has no claim of its
+            // own. Carried by wording, not an error banner — full number shown
+            // per D-AUTH-INVITE-PHONE-FIRST §2.7.
+            <div className="space-y-3 rounded-[8px] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
+              <p className="text-[15px] leading-6 text-black/75">
+                This invite was sent to{' '}
+                <span className="font-medium whitespace-nowrap text-black">
+                  {formatUsPhoneInput(invitePrefill.inviteePhone)}
+                </span>
+                . We can use that number, or you can ask{' '}
+                {inviterFirstName(invitePrefill.inviterName)} for a new invite.
+              </p>
+              <div className="space-y-1.5">
+                <button
+                  type="button"
+                  className={SUBMIT_CLASS}
+                  onClick={useInvitedNumber}
+                  disabled={loading}
+                >
+                  {loading ? 'Continuing…' : 'Use the invited number'}
+                </button>
+                <button
+                  type="button"
+                  className="mx-auto block text-sm leading-5 font-medium tracking-[0.56px] text-[var(--brand-orange)] uppercase underline underline-offset-4 disabled:opacity-60"
+                  onClick={() => setInviteDeadEnd(false)}
+                  disabled={loading}
+                >
+                  Ask {inviterFirstName(invitePrefill.inviterName)} for a new invite
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
+              {loading ? 'Continuing…' : 'Continue'}
+            </button>
+          )}
         </form>
       ) : step === 'code' ? (
         <form className="space-y-3.5" onSubmit={verifyCode}>
@@ -704,9 +664,7 @@ export default function LoginPanel({
             htmlFor="code"
           >
             Enter your code for{' '}
-            <span className="whitespace-nowrap">
-              {invitePhoneMode ? maskedPhone : formatPhoneForDisplay(phone)}
-            </span>
+            <span className="whitespace-nowrap">{formatPhoneForDisplay(phone)}</span>
           </label>
           <input
             id="code"
@@ -738,8 +696,6 @@ export default function LoginPanel({
               className="mx-auto block text-sm leading-5 font-medium tracking-[0.56px] text-[var(--brand-orange)] uppercase underline underline-offset-4 disabled:opacity-60"
               onClick={() => {
                 setCode('');
-                // Leaving the invite phone behind — collect a number manually.
-                setInvitePhoneMode(false);
                 swapStep('phone');
               }}
               disabled={loading}

--- a/src/app/login/__tests__/LoginPanel.test.ts
+++ b/src/app/login/__tests__/LoginPanel.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
 import {
-  buildInviteVerifyOtpRequestBody,
   buildVerifyOtpRequestBody,
   readInvitationToken,
   readVerifiedIdentity,
@@ -49,41 +48,6 @@ describe('LoginPanel invitation token query aliases', () => {
       code: '000000',
       invitationToken: null,
       userInvite: null,
-    })
-  })
-})
-
-describe('LoginPanel invite-phone verify payload', () => {
-  it('omits the phone and flags useInvitePhone so the server resolves it from the token', () => {
-    expect(
-      buildInviteVerifyOtpRequestBody(
-        '000000',
-        'invite-token',
-        new URLSearchParams()
-      )
-    ).toEqual({
-      code: '000000',
-      invitationToken: 'invite-token',
-      useInvitePhone: true,
-      userInvite: null,
-    })
-  })
-
-  it('still forwards a per-user invite link when present', () => {
-    expect(
-      buildInviteVerifyOtpRequestBody(
-        '000000',
-        'invite-token',
-        new URLSearchParams([
-          ['inviteHandle', 'jpalay'],
-          ['inviteUserToken', 'user-token'],
-        ])
-      )
-    ).toEqual({
-      code: '000000',
-      invitationToken: 'invite-token',
-      useInvitePhone: true,
-      userInvite: { handle: 'jpalay', token: 'user-token' },
     })
   })
 })

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -55,8 +55,10 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
   const invitationToken = readInvitationToken(params);
   const userInvite = readUserInvite(params);
   // Resolve the invite's recipient phone server-side so the login panel can
-  // skip manual phone entry. Only the masked form crosses to the client — the
-  // raw phone never leaves the server.
+  // pre-fill it. Deliberate privacy exception (D-AUTH-INVITE-PHONE-FIRST §2.3):
+  // the full invited number crosses to the client on this invite-token-gated
+  // path so the phone-first field arrives pre-populated and editable. The
+  // invitee's own number is not a secret from them.
   const prefill = invitationToken ? await getInvitePrefillByToken(invitationToken) : null;
   const userInviteResolution = userInvite
     ? await resolveInviteLink(userInvite.handle, userInvite.token)
@@ -66,7 +68,9 @@ export default async function LoginPage({ searchParams }: LoginPageProps) {
         inviterName: prefill.inviterName,
         inviterUserId: prefill.inviterUserId,
         inviterAvatarColor: prefill.inviterAvatarColor,
-        maskedPhone: prefill.maskedPhone,
+        // Full number (not masked): the phone-first field pre-fills it so the
+        // invitee can confirm or correct it (D-AUTH-INVITE-PHONE-FIRST §2.3).
+        inviteePhone: prefill.inviteePhone,
       }
     : null;
   const inviteContext = prefill

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   LogOut,
   RefreshCw,
+  Smartphone,
   Sparkles,
   Sun,
 } from 'lucide-react';
@@ -157,6 +158,12 @@ export function AccountActions() {
             title="Show me the first time player"
             subtitle="Preview the first-session experience a new player sees"
             href="/dev/first-time-player"
+          />
+          <SettingsRow
+            icon={<Smartphone className="size-5" />}
+            title="Phone-first invite login"
+            subtitle="Preview the invite login screens without sending an invite"
+            href="/dev/invite-login"
           />
         </SettingsGroup>
         {resetGameError ? <p className="mt-2 text-sm text-destructive">{resetGameError}</p> : null}

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -40,8 +40,12 @@ export type InvitePrefill = {
   inviterName: string
   inviterUserId: string
   inviterAvatarColor: string | null
-  // Server-only: the recipient's E.164 phone resolved from the invite token.
-  // Never expose this to the client — surface `maskedPhone` instead.
+  // Recipient's E.164 phone resolved from the invite token. Default posture is
+  // server-only (surface `maskedPhone` instead). Deliberate exception
+  // (D-AUTH-INVITE-PHONE-FIRST §2.3): the phone-first FriendInvitation login
+  // path pre-fills this full number into an editable field, so `login/page.tsx`
+  // crosses it to the client — but ONLY for that invite-token-gated case. The
+  // invitee's own number is not a secret from them. Do not widen this exposure.
   inviteePhone: string
   maskedPhone: string
 }


### PR DESCRIPTION
## Summary

Implements the phone-first invite login flow from the design spec `D-AUTH-INVITE-PHONE-FIRST-DESIGN-01`. Collapses the separate invite confirmation step into the phone entry step with pre-filled, editable number and adds a warm dead-end surface when an invitee edits their invited number to one with no claim of its own.

## Key Changes

**Client (`LoginPanel.tsx`)**
- Retire the `'invite'` step; initial step is always `'phone'`
- Pre-fill the phone field with the full invited number when `invitePrefill.inviteePhone` is present (phone-first invite path only)
- Remove `sendCodeToInvitePhone`, `invitePhoneMode` state, `maskedPhone` state, and `buildInviteVerifyOtpRequestBody`
- Unify OTP request into single `requestCodeForPhone` helper that always sends the submitted phone (authoritative for the gate); invitation token rides along for server-side re-validation
- Add warm dead-end (Screen 1b): when `request-otp` returns `error: 'invite_phone_unclaimed'` and an invited number exists, render an inline neutral panel offering to use the invited number or ask the inviter for a new invite
- Editing the phone field clears any standing dead-end state
- Code step always displays `formatPhoneForDisplay(phone)` (no masked branch)

**Server (`request-otp/route.ts`)**
- When a new user fails the invite gate and an `invitationToken` is present, return `{ error: 'invite_phone_unclaimed', status: 403 }` instead of generic `invite_required`. This distinguishable signal allows the client to render the warm dead-end instead of a hard error
- Gate is not loosened: no OTP is sent and the request is still rejected; only the label differs

**Privacy boundary (`login/page.tsx`, `invitations.ts`)**
- The full invited phone (`inviteePhone`) now crosses to the client for the FriendInvitation path only, gated by a valid invitation token resolved server-side at page load
- Updated comments to explicitly scope this exception to the invite-token-gated prefill path
- Client `InvitePrefill` type swaps `maskedPhone` → `inviteePhone`

**Dev preview tool (`dev/invite-login/page.tsx`)**
- New dev-only page at `/dev/invite-login` to preview the two new surfaces (pre-filled phone screen and warm dead-end) without minting a real invitation or sending an OTP
- Renders the real `LoginPanel` with synthetic invite data; the `previewDeadEnd` prop seeds the dead-end state for inspection
- Linked from the Developer tools section of the profile page

**Tests**
- Remove `buildInviteVerifyOtpRequestBody` test cases (function removed)
- Add test case asserting `invite_phone_unclaimed` (403, no OTP) when a token is present on a no-claim phone
- Generic cold-path 403 case unchanged

## Implementation Details

- The invite arrival now uses the existing `phone` step with conditional prefill logic, keeping the cold-visit and per-user-link paths (`/u/<handle>/<token>`) undisturbed
- Dead-end is carried by wording in a neutral/gold panel, not a destructive error banner, per accessibility canon
- The server's `getValidInvitationForPhone` / `acceptFriendInvitation` logic is unchanged; the token is re-validated against the submitted phone server-side (design §4 default stance)
- All prefill/inviter logic remains conditional on `invitePrefill` to avoid affecting other entry paths

https://claude.ai/code/session_01DLTf78cdrB7quBRkqpooad