### PR TITLE
Make /terms page publicly accessible without auth loops

### DIFF
--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -41,6 +41,31 @@ describe('proxy unauthenticated route preservation', () => {
     expect(response.headers.get('location')).toBeNull()
   })
 
+  it('passes the public /terms page through logged-out instead of looping it back to login', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce(null)
+
+    const response = await proxy(makeRequest('/terms'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('location')).toBeNull()
+  })
+
+  it('lets authenticated readers reach /terms without onboarding/login redirects', async () => {
+    readSessionClaimsMock.mockResolvedValueOnce({
+      userId: 'u1',
+      sessionId: 's1',
+      invitationAccepted: true,
+      onboardingComplete: true,
+    })
+
+    const response = await proxy(makeRequest('/terms'))
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('x-middleware-next')).toBe('1')
+    expect(response.headers.get('location')).toBeNull()
+  })
+
   it('redirects other unauthenticated pages to login, preserving the original path via next', async () => {
     readSessionClaimsMock.mockResolvedValueOnce(null)
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,6 +1,8 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 
+import { getSession } from '@/server/auth/session';
+
 export const metadata: Metadata = {
   title: 'Terms & Disclaimer · Joshing',
   description: 'The common-sense terms for using Joshing.',
@@ -41,15 +43,23 @@ const CLAUSES: { lead: string; body: string }[] = [
   },
 ];
 
-export default function TermsPage() {
+export default async function TermsPage() {
+  // The page is public (it is linked from the logged-out /login card), so the
+  // back link can't assume a profile: /users/me is auth-gated and would bounce
+  // a logged-out reader to /login. Point signed-out visitors back to sign-in
+  // instead, and only offer the profile link to authenticated readers.
+  const session = await getSession();
+  const backHref = session ? '/users/me' : '/login';
+  const backLabel = session ? '← Back to profile' : '← Back to sign in';
+
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-10 pb-28">
       <div className="mb-6">
         <Link
-          href="/users/me"
+          href={backHref}
           className="text-sm font-medium text-muted-foreground underline-offset-4 hover:underline"
         >
-          ← Back to profile
+          {backLabel}
         </Link>
       </div>
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -31,6 +31,15 @@ export async function middleware(request: NextRequest) {
 
   const { pathname, search } = request.nextUrl
   const isApi = pathname.startsWith('/api/')
+
+  // Terms & Disclaimer is a standalone public page: it is linked from the
+  // logged-out /login card (opened in a new tab), so it must resolve without
+  // a session — otherwise the proxy bounces the unauthenticated reader to
+  // /login?next=/terms, a loop back into the very screen they came from. It
+  // is equally readable when authenticated, so allow it through for everyone
+  // before any auth/onboarding routing runs.
+  if (pathname === '/terms') return tagTiming(NextResponse.next(), startedAt)
+
   const isLoginPage = pathname === '/login'
   // Both invite landing surfaces must be reachable logged-out so the invitee
   // can carry their invite into /login: /invite/<token> (FriendInvitation,


### PR DESCRIPTION
## Summary
The `/terms` page is now properly accessible as a public page without triggering authentication redirects or login loops. This allows logged-out users to read the terms when linked from the login card, and authenticated users to access it without onboarding/login redirects.

## Changes

- **Proxy middleware (`src/proxy.ts`):** Added early-exit logic to allow `/terms` through before any auth/onboarding routing runs. This prevents the middleware from bouncing unauthenticated readers to `/login?next=/terms` (which would loop them back to the login screen they came from).

- **Terms page (`src/app/terms/page.tsx`):** 
  - Made the component async to fetch the session
  - Added conditional back-link logic: authenticated users see "← Back to profile" (linking to `/users/me`), while logged-out users see "← Back to sign in" (linking to `/login`)
  - This prevents logged-out users from hitting the auth-gated `/users/me` endpoint

- **Tests (`src/__tests__/proxy.test.ts`):** Added two test cases:
  - Logged-out users can access `/terms` without redirect loops
  - Authenticated users can access `/terms` without onboarding/login redirects

## Implementation Details
The `/terms` page is treated as a standalone public surface (similar to invite landing pages) that must resolve without a session, since it's linked from the logged-out login card. The early-exit in the proxy ensures it bypasses all downstream auth/onboarding routing logic.

https://claude.ai/code/session_011qLHS7fMbtsWq98Q4kQZa3