### PR TITLE
B-Report-6: blocked/actioned review + reversal UI & logic

### DIFF
--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -3,26 +3,80 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import type { AdminReviewReport } from '@/server/db/queries/content-reports';
+import type { AdminReviewReport, BlockedReviewItem } from '@/server/db/queries/content-reports';
+import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
-// Deliberately minimal — an internal ops tool, not a product surface. Two actions
-// (uphold / dismiss), the full review context including admin-only reporter identity.
-export function AdminReportsClient({ reports }: { reports: AdminReviewReport[] }) {
+// Deliberately minimal — an internal ops tool, not a product surface. Two views:
+// the OPEN report queue (uphold / dismiss) and the BLOCKED / actioned list
+// (un-block / reverse). Both expose admin-only context.
+export function AdminReportsClient({
+  reports,
+  blocked,
+}: {
+  reports: AdminReviewReport[];
+  blocked: BlockedReviewItem[];
+}) {
+  const [view, setView] = useState<'open' | 'blocked'>('open');
+
   return (
     <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
       <header className="mb-5">
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Report queue</h1>
-        <p className="text-muted-foreground mt-1 text-sm">
-          {reports.length === 0 ? 'Nothing open.' : `${reports.length} open`}
-        </p>
+        <div className="mt-3 flex gap-2">
+          <TabButton active={view === 'open'} onClick={() => setView('open')}>
+            Open reports ({reports.length})
+          </TabButton>
+          <TabButton active={view === 'blocked'} onClick={() => setView('blocked')}>
+            Blocked / actioned ({blocked.length})
+          </TabButton>
+        </div>
       </header>
 
-      <div className="space-y-3">
-        {reports.map((report) => (
-          <ReportRow key={report.id} report={report} />
-        ))}
-      </div>
+      {view === 'open' ? (
+        <div className="space-y-3">
+          {reports.length === 0 ? (
+            <p className="text-muted-foreground text-sm">Nothing open.</p>
+          ) : (
+            reports.map((report) => <ReportRow key={report.id} report={report} />)
+          )}
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {blocked.length === 0 ? (
+            <p className="text-muted-foreground text-sm">Nothing blocked.</p>
+          ) : (
+            blocked.map((item) => (
+              <BlockedRow key={`${item.target.table}:${item.target.id}`} item={item} />
+            ))
+          )}
+        </div>
+      )}
     </main>
+  );
+}
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-md border px-3 py-1.5 text-sm font-medium"
+      style={
+        active
+          ? { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
+          : { borderColor: 'var(--border)', color: 'var(--text-muted)' }
+      }
+    >
+      {children}
+    </button>
   );
 }
 
@@ -123,6 +177,132 @@ function ReportRow({ report }: { report: AdminReviewReport }) {
           {pending === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
         </button>
       </div>
+      {error ? <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>{error}</p> : null}
+    </article>
+  );
+}
+
+// Human vs. house vs. LLM, derived server-side from source/creatorId (never
+// string-matched on the client). Generated rows carry authorName=null and are
+// LLM-origin; house questions carry authorIsHouse=true.
+function authorBadge(item: BlockedReviewItem): { label: string; tone: 'human' | 'house' | 'llm' } {
+  if (item.authorIsHouse) return { label: 'House · editorial', tone: 'house' };
+  if (item.target.table === 'generated' || item.authorName === null) {
+    return { label: `LLM · ${LLM_QUESTION_ATTRIBUTION}`, tone: 'llm' };
+  }
+  return { label: `Human · ${item.authorName}`, tone: 'human' };
+}
+
+function BlockedRow({ item }: { item: BlockedReviewItem }) {
+  const router = useRouter();
+  const [reviewReason, setReviewReason] = useState('');
+  const [confirming, setConfirming] = useState(false);
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function unblock() {
+    if (pending) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/content-reports', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          action: 'reverse',
+          target: item.target,
+          reviewReason: reviewReason.trim() || undefined,
+        }),
+      });
+      if (!res.ok) {
+        setError(`Un-block failed (${res.status}).`);
+        setPending(false);
+        return;
+      }
+      router.refresh();
+    } catch {
+      setError('Un-block failed.');
+      setPending(false);
+    }
+  }
+
+  const badge = authorBadge(item);
+  const badgeStyle =
+    badge.tone === 'human'
+      ? { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
+      : badge.tone === 'house'
+        ? { borderColor: 'var(--accent-gold)', color: 'var(--accent-gold)' }
+        : { borderColor: 'var(--border)', color: 'var(--text-muted)' };
+
+  return (
+    <article className="rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span
+          className="rounded-sm border px-2 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
+          style={badgeStyle}
+        >
+          {badge.label}
+        </span>
+        <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
+          {item.target.table}
+          {item.actionedAt ? ` · removed ${new Date(item.actionedAt).toLocaleString()}` : ' · removed (vet/cron)'}
+        </span>
+      </div>
+
+      <p className="mt-2 font-medium text-[var(--brand-ink)]">{item.questionText ?? '(question unavailable)'}</p>
+      {item.correctAnswer ? (
+        <p className="text-muted-foreground mt-0.5">Answer: {item.correctAnswer}</p>
+      ) : null}
+
+      {!confirming ? (
+        <div className="mt-3">
+          <button
+            type="button"
+            onClick={() => setConfirming(true)}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
+            style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+          >
+            Un-block
+          </button>
+        </div>
+      ) : (
+        <div className="mt-3 space-y-2">
+          <p className="text-[13px] text-[var(--brand-ink-700)]">
+            Un-block this {item.target.table === 'question' ? 'question (restores to public)' : 'generated question'}?
+          </p>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              type="text"
+              value={reviewReason}
+              onChange={(e) => setReviewReason(e.target.value)}
+              placeholder="Reason (optional)"
+              className="min-w-0 flex-1 rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-2 py-1 text-sm focus:border-[var(--brand-navy)]"
+            />
+            <button
+              type="button"
+              onClick={() => void unblock()}
+              disabled={pending}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+            >
+              {pending ? 'Un-blocking…' : 'Confirm un-block'}
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setConfirming(false);
+                setError(null);
+              }}
+              disabled={pending}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
       {error ? <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>{error}</p> : null}
     </article>
   );

--- a/src/app/admin/reports/page.tsx
+++ b/src/app/admin/reports/page.tsx
@@ -2,19 +2,26 @@ import { notFound } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
-import { getOpenReportsForReview } from '@/server/db/queries/content-reports';
+import {
+  getBlockedQuestionsForReview,
+  getOpenReportsForReview,
+} from '@/server/db/queries/content-reports';
 
 import { AdminReportsClient } from './AdminReportsClient';
 
 export const dynamic = 'force-dynamic';
 
-// B-Report-5: the content-report review queue. Reachable ONLY to ADMIN_USER_IDS
-// members; everyone else (incl. authenticated non-admins) gets Next's 404 — the
-// route's existence is not revealed. Unset env ⇒ no admins ⇒ always 404.
+// B-Report-5/6: the content-report review queue + the blocked/actioned review.
+// Reachable ONLY to ADMIN_USER_IDS members; everyone else (incl. authenticated
+// non-admins) gets Next's 404 — the route's existence is not revealed. Unset env
+// ⇒ no admins ⇒ always 404.
 export default async function AdminReportsPage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
-  const reports = await getOpenReportsForReview();
-  return <AdminReportsClient reports={reports} />;
+  const [reports, blocked] = await Promise.all([
+    getOpenReportsForReview(),
+    getBlockedQuestionsForReview(),
+  ]);
+  return <AdminReportsClient reports={reports} blocked={blocked} />;
 }

--- a/src/app/api/admin/content-reports/route.ts
+++ b/src/app/api/admin/content-reports/route.ts
@@ -3,15 +3,24 @@ import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
-import { dismissReport, upholdReport } from '@/server/db/queries/content-reports';
+import { dismissReport, reverseBlock, upholdReport } from '@/server/db/queries/content-reports';
 
 export const dynamic = 'force-dynamic';
 
-const bodySchema = z.object({
-  reportId: z.string().trim().min(1),
-  action: z.enum(['uphold', 'dismiss']),
-  reviewReason: z.string().trim().max(500).optional(),
-});
+const reviewReason = z.string().trim().max(500).optional();
+
+// uphold/dismiss act on an OPEN report (keyed by reportId); reverse un-blocks an
+// already-actioned target (keyed by the question/generated id), so it carries a
+// target instead of a reportId.
+const bodySchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('uphold'), reportId: z.string().trim().min(1), reviewReason }),
+  z.object({ action: z.literal('dismiss'), reportId: z.string().trim().min(1), reviewReason }),
+  z.object({
+    action: z.literal('reverse'),
+    target: z.object({ table: z.enum(['question', 'generated']), id: z.string().trim().min(1) }),
+    reviewReason,
+  }),
+]);
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -25,11 +34,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'validation' }, { status: 400 });
   }
 
-  const { reportId, action, reviewReason } = parsed.data;
+  const data = parsed.data;
   const result =
-    action === 'uphold'
-      ? await upholdReport(reportId, reviewReason)
-      : await dismissReport(reportId, reviewReason);
+    data.action === 'uphold'
+      ? await upholdReport(data.reportId, data.reviewReason)
+      : data.action === 'dismiss'
+        ? await dismissReport(data.reportId, data.reviewReason)
+        : await reverseBlock(data.target, data.reviewReason);
 
   if (!result.ok) {
     return NextResponse.json(

--- a/src/server/db/queries/__tests__/blocked-generated.test.ts
+++ b/src/server/db/queries/__tests__/blocked-generated.test.ts
@@ -1,0 +1,129 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Generated (LLM-origin) questions have no `visibility` column — their terminal
+// hard-block is an upheld-inappropriate ContentReport, the generated equivalent
+// of visibility='blocked'. There is NO owner exception (creatorId is null for
+// generated content). Mirrors content-reports-suppression.test.ts: mock the
+// drizzle operators structurally + capture the WHERE so we can assert the
+// category='inappropriate' AND status='upheld' scope (and the absence of any
+// creator/owner clause), which is the correctness-critical invariant here.
+let capturedWhere: unknown = null;
+let chainRows: Array<{ generatedQuestionId: string | null }> = [];
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => {
+  const makeChain = () => {
+    const chain: Record<string, unknown> = {
+      select: vi.fn(() => chain),
+      from: vi.fn(() => chain),
+      innerJoin: vi.fn(() => chain),
+      where: vi.fn((cond: unknown) => {
+        capturedWhere = cond;
+        return chain;
+      }),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(chainRows)),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(chainRows),
+    };
+    return chain;
+  };
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+    contentReports: {
+      id: 'contentReports.id',
+      questionId: 'contentReports.questionId',
+      generatedQuestionId: 'contentReports.generatedQuestionId',
+      category: 'contentReports.category',
+      status: 'contentReports.status',
+      createdAt: 'contentReports.createdAt',
+    },
+    generatedQuestions: { id: 'generatedQuestions.id' },
+    questions: { id: 'questions.id' },
+    users: { id: 'users.id' },
+  };
+});
+
+import {
+  getUpheldInappropriateGeneratedIds,
+  notBlockedGeneratedByContentReport,
+} from '@/server/db/queries/content-reports';
+
+type Op = { op: string; parts?: unknown[]; column?: unknown; value?: unknown; query?: { op: string } };
+
+beforeEach(() => {
+  capturedWhere = null;
+  chainRows = [];
+});
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('notBlockedGeneratedByContentReport (SQL predicate — daily catch-up path)', () => {
+  it('builds a NOT EXISTS over upheld-inappropriate reports for the generated id', () => {
+    const predicate = notBlockedGeneratedByContentReport('generatedQuestions.id' as never) as Op;
+    expect(predicate.op).toBe('notExists');
+
+    // category='inappropriate' AND status='upheld' AND target = the generated id.
+    expect(capturedWhere).toMatchObject({
+      op: 'and',
+      parts: expect.arrayContaining([
+        { op: 'eq', column: 'contentReports.generatedQuestionId', value: 'generatedQuestions.id' },
+        { op: 'eq', column: 'contentReports.category', value: 'inappropriate' },
+        { op: 'eq', column: 'contentReports.status', value: 'upheld' },
+      ]),
+    });
+  });
+
+  it('is the terminal upheld-only state — NOT the reversible open|upheld suppression', () => {
+    notBlockedGeneratedByContentReport('generatedQuestions.id' as never);
+    const serialized = JSON.stringify(capturedWhere);
+    // A merely-open (or dismissed) report must NOT hard-block; only an upheld one.
+    expect(serialized).toContain('"value":"upheld"');
+    expect(serialized).not.toContain('"value":"open"');
+  });
+
+  it('has NO owner/creator exception (generated content has a null author)', () => {
+    notBlockedGeneratedByContentReport('generatedQuestions.id' as never);
+    expect(JSON.stringify(capturedWhere)).not.toContain('creatorId');
+  });
+});
+
+describe('getUpheldInappropriateGeneratedIds (set form — archive daily slot path)', () => {
+  it('3. returns the ids of generated questions carrying an upheld-inappropriate report (EXCLUDED)', async () => {
+    chainRows = [{ generatedQuestionId: 'g-1' }, { generatedQuestionId: 'g-2' }];
+    const blocked = await getUpheldInappropriateGeneratedIds(['g-1', 'g-2', 'g-3']);
+
+    // g-1/g-2 are dropped by the caller; g-3 (no upheld report) is unaffected.
+    expect([...blocked].sort()).toEqual(['g-1', 'g-2']);
+    expect(blocked.has('g-3')).toBe(false);
+
+    // Scope: inappropriate + upheld only.
+    expect(capturedWhere).toMatchObject({
+      op: 'and',
+      parts: expect.arrayContaining([
+        { op: 'inArray', column: 'contentReports.generatedQuestionId', values: ['g-1', 'g-2', 'g-3'] },
+        { op: 'eq', column: 'contentReports.category', value: 'inappropriate' },
+        { op: 'eq', column: 'contentReports.status', value: 'upheld' },
+      ]),
+    });
+  });
+
+  it('short-circuits to an empty set with no query for an empty id list', async () => {
+    const blocked = await getUpheldInappropriateGeneratedIds([]);
+    expect(blocked.size).toBe(0);
+    expect(capturedWhere).toBeNull();
+  });
+});

--- a/src/server/db/queries/__tests__/catchup-blocked.test.ts
+++ b/src/server/db/queries/__tests__/catchup-blocked.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Per-surface wiring test for daily catch-up — the second VERIFIED leak surface.
+// We drive getCatchupQuestions with eligible queue slots (one canonical, one
+// generated), capture each query's WHERE keyed by the table it selects FROM, and
+// assert the real predicates wired in:
+//   - canonical (authored) query carries a bare notBlocked() ne-visibility-blocked
+//   - generated query carries the notExists upheld-inappropriate terminal block.
+type Row = { visibility: string; creatorId: string | null };
+interface Node {
+  op: string;
+  column?: unknown;
+  value?: unknown;
+  parts?: Node[];
+  query?: Node;
+  test?: (row: Row) => boolean;
+}
+
+// Hoisted so the (hoisted) vi.mock factories below can reference them.
+const { TABLES, captures, rowsByTable } = vi.hoisted(() => ({
+  TABLES: {
+    dailyQueues: { id: 'dq.id', userId: 'dq.userId', queueDate: 'dq.queueDate' },
+    questions: { id: 'q.id', visibility: 'visibility', creatorId: 'creatorId', deletedAt: 'deletedAt' },
+    generatedQuestions: { id: 'gq.id', userId: 'gq.userId' },
+    feedItems: { id: 'fi.id', recipientUserId: 'fi.recip', state: 'fi.state', answerResult: 'fi.res', catchupResolvedAt: 'fi.resolved', sourceEventAt: 'fi.evt', questionId: 'fi.q' },
+    contentReports: { questionId: 'cr.q', generatedQuestionId: 'cr.gq', category: 'cr.category', status: 'cr.status' },
+    users: { id: 'u.id', displayName: 'u.name' },
+  },
+  captures: [] as Array<{ from: unknown; where: Node }>,
+  rowsByTable: new Map<unknown, unknown[]>(),
+}));
+
+vi.mock('drizzle-orm', () => {
+  const evaluable = {
+    eq: vi.fn((column, value) => ({ op: 'eq', column, value, test: (r: Row) => (r as Record<string, unknown>)[column as string] === value })),
+    ne: vi.fn((column, value) => ({ op: 'ne', column, value, test: (r: Row) => (r as Record<string, unknown>)[column as string] !== value })),
+    or: vi.fn((...parts: Node[]) => ({ op: 'or', parts, test: (r: Row) => parts.some((p) => typeof p.test === 'function' && p.test(r)) })),
+    and: vi.fn((...parts: Node[]) => ({ op: 'and', parts, test: (r: Row) => parts.every((p) => (typeof p.test === 'function' ? p.test(r) : true)) })),
+  };
+  return {
+    ...evaluable,
+    asc: vi.fn((column) => ({ op: 'asc', column })),
+    desc: vi.fn((column) => ({ op: 'desc', column })),
+    gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+    lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+    inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+    isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+    isNull: vi.fn((column) => ({ op: 'isNull', column })),
+    notExists: vi.fn((query) => ({ op: 'notExists', query })),
+    sql: vi.fn(() => ({ op: 'sql', as: vi.fn(() => ({ op: 'sqlAs' })) })),
+  };
+});
+
+vi.mock('@/server/db', () => {
+  const rowsFor = (table: unknown) => (rowsByTable.get(table) ?? []) as unknown[];
+  const makeChain = () => {
+    let fromTable: unknown = null;
+    const chain: Record<string, unknown> = {
+      select: vi.fn(() => chain),
+      from: vi.fn((t: unknown) => {
+        fromTable = t;
+        return chain;
+      }),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(rowsFor(fromTable))),
+      where: vi.fn((cond: Node) => {
+        captures.push({ from: fromTable, where: cond });
+        return chain;
+      }),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(rowsFor(fromTable)),
+    };
+    return chain;
+  };
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+    dailyQueues: TABLES.dailyQueues,
+    questions: TABLES.questions,
+    generatedQuestions: TABLES.generatedQuestions,
+    feedItems: TABLES.feedItems,
+    contentReports: TABLES.contentReports,
+    users: TABLES.users,
+    // tables imported by daily.ts but unused on the catch-up read path
+    dailyPreferences: {}, declaredInterests: {}, masteryEvents: {}, playerMastery: {},
+    skippedDailyQuestions: {}, userDomainExclusions: {},
+  };
+});
+
+vi.mock('@/lib/games/timezone', () => ({
+  getDailyAssignmentBounds: () => ({ assignmentDateStr: '2026-06-16', assignmentDate: new Date('2026-06-16T00:00:00Z') }),
+}));
+vi.mock('@/server/play/catch-up-eligibility', () => ({
+  isCatchUpQueueDateEligible: () => true,
+  isCatchUpSlotEligible: () => true,
+  catchUpExpiresAt: () => '2026-07-01',
+  expiresWithin24Hours: () => false,
+  queueAgeInDays: () => 0,
+}));
+vi.mock('@/server/daily/catchup', () => ({
+  CATCHUP_LOOKBACK_DAYS: 30,
+  asQueueSlots: (v: unknown) => (Array.isArray(v) ? v : []),
+  dailyQueueItemId: () => 'item-id',
+  feedCatchupItemId: () => 'feed-item-id',
+  minusUtcDays: () => new Date('2026-06-01T00:00:00Z'),
+}));
+
+import { getCatchupQuestions } from '@/server/db/queries/daily';
+
+function findNe(node: Node | null | undefined, column: string, value: unknown): Node | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  if (node.op === 'ne' && node.column === column && node.value === value) return node;
+  for (const child of [...(node.parts ?? []), node.query]) {
+    const found = findNe(child, column, value);
+    if (found) return found;
+  }
+  return undefined;
+}
+function findOp(node: Node | null | undefined, op: string): Node | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  if (node.op === op) return node;
+  for (const child of [...(node.parts ?? []), node.query]) {
+    const found = findOp(child, op);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+beforeEach(() => {
+  captures.length = 0;
+  rowsByTable.clear();
+  // One queue with an eligible canonical slot and an eligible generated slot.
+  rowsByTable.set(TABLES.dailyQueues, [
+    {
+      id: 'queue-1',
+      queueDate: '2026-06-10',
+      slots: [
+        { slot_index: 0, question_id: 'cq-1', answered: true },
+        { slot_index: 1, generated_question_id: 'gq-1', answered: true },
+      ],
+    },
+  ]);
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('getCatchupQuestions wires the hard-block into the daily canonical + generated reads', () => {
+  it('canonical (authored) query EXCLUDES blocked and leaves public unaffected (bare notBlocked)', async () => {
+    await getCatchupQuestions('viewer-2');
+    const canonical = captures.filter((c) => c.from === TABLES.questions);
+    expect(canonical.length).toBeGreaterThan(0);
+
+    const ne = findNe(canonical[0].where, 'visibility', 'blocked');
+    expect(ne).toBeDefined();
+    expect(ne!.test!({ visibility: 'blocked', creatorId: 'anyone' })).toBe(false); // 1. excluded
+    expect(ne!.test!({ visibility: 'public', creatorId: 'anyone' })).toBe(true); // 4. unaffected
+  });
+
+  it('generated query carries the upheld-inappropriate notExists terminal block', async () => {
+    await getCatchupQuestions('viewer-2');
+    const generated = captures.find((c) => c.from === TABLES.generatedQuestions);
+    expect(generated).toBeDefined();
+    expect(findOp(generated!.where, 'notExists')).toBeDefined(); // 3. generated terminal block
+  });
+});

--- a/src/server/db/queries/__tests__/content-reports-reverse.test.ts
+++ b/src/server/db/queries/__tests__/content-reports-reverse.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// B-Report-6: the blocked/actioned list + reversal. Structural drizzle mock (like
+// content-reports-admin.test.ts), extended so selects resolve per FROM-table and
+// updates support .returning(). Asserts: the blocked list carries source/creatorId
+// for the human-vs-house badge; reverse restores authored visibility→public AND
+// dismisses the upheld report; generated reverse dismisses the upheld report.
+const { CONTENT_REPORTS, QUESTIONS, GENERATED, USERS, state } = vi.hoisted(() => ({
+  CONTENT_REPORTS: { __t: 'contentReports', id: 'cr.id', status: 'cr.status', category: 'cr.category', questionId: 'cr.questionId', generatedQuestionId: 'cr.generatedQuestionId', reviewDecision: 'cr.reviewDecision', reviewReason: 'cr.reviewReason', reviewedAt: 'cr.reviewedAt' },
+  QUESTIONS: { __t: 'questions', id: 'q.id', questionText: 'q.questionText', answerText: 'q.answerText', visibility: 'q.visibility', creatorId: 'q.creatorId', source: 'q.source', deletedAt: 'q.deletedAt', updatedAt: 'q.updatedAt' },
+  GENERATED: { __t: 'generatedQuestions', id: 'g.id', questionText: 'g.questionText', answer: 'g.answer' },
+  USERS: { __t: 'users', id: 'u.id', displayName: 'u.displayName' },
+  state: {
+    rowsByTable: new Map<unknown, unknown[]>(),
+    updates: [] as Array<{ table: unknown; set: Record<string, unknown>; where: unknown }>,
+    returningRows: [] as unknown[],
+  },
+}));
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql' })),
+}));
+
+vi.mock('@/server/db', () => {
+  const rowsFor = (table: unknown) => state.rowsByTable.get(table) ?? [];
+  const makeSelect = () => {
+    let fromTable: unknown = null;
+    const chain: Record<string, unknown> = {
+      from: (t: unknown) => {
+        fromTable = t;
+        return chain;
+      },
+      leftJoin: () => chain,
+      innerJoin: () => chain,
+      where: () => chain,
+      orderBy: () => chain,
+      limit: () => Promise.resolve(rowsFor(fromTable)),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(rowsFor(fromTable)),
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: () => makeSelect(),
+      update: (table: unknown) => ({
+        set: (vals: Record<string, unknown>) => ({
+          where: (cond: unknown) => {
+            state.updates.push({ table, set: vals, where: cond });
+            const result: Record<string, unknown> = {
+              returning: () => Promise.resolve(state.returningRows),
+              then: (resolve: (v: unknown) => unknown) => resolve(undefined),
+            };
+            return result;
+          },
+        }),
+      }),
+    },
+    contentReports: CONTENT_REPORTS,
+    questions: QUESTIONS,
+    generatedQuestions: GENERATED,
+    users: USERS,
+  };
+});
+
+import {
+  getBlockedQuestionsForReview,
+  reverseBlock,
+} from '@/server/db/queries/content-reports';
+
+const questionUpdates = () => state.updates.filter((u) => u.table === QUESTIONS);
+const reportUpdates = () => state.updates.filter((u) => u.table === CONTENT_REPORTS);
+
+beforeEach(() => {
+  state.rowsByTable.clear();
+  state.updates.length = 0;
+  state.returningRows = [];
+});
+
+describe('getBlockedQuestionsForReview', () => {
+  it('lists blocked authored + upheld-inappropriate generated, carrying source/creatorId and a human/house/LLM badge', async () => {
+    state.rowsByTable.set(QUESTIONS, [
+      { id: 'q1', questionText: 'human q', answer: 'A', source: 'authored', creatorId: 'user-1', authorName: 'Alice' },
+      { id: 'qh', questionText: 'house q', answer: 'H', source: 'house_authored', creatorId: null, authorName: null },
+    ]);
+    state.rowsByTable.set(GENERATED, [
+      { id: 'g1', questionText: 'gen q', answer: 'G', reportId: 'r-g1', reviewedAt: new Date('2026-06-10') },
+    ]);
+    // The authored upheld-inappropriate report lookup.
+    state.rowsByTable.set(CONTENT_REPORTS, [
+      { questionId: 'q1', id: 'r-q1', reviewedAt: new Date('2026-06-09') },
+    ]);
+
+    const items = await getBlockedQuestionsForReview();
+
+    const human = items.find((i) => i.target.table === 'question' && i.target.id === 'q1')!;
+    expect(human).toMatchObject({
+      source: 'authored', // the open-report query omits this; it's required here
+      creatorId: 'user-1',
+      authorName: 'Alice',
+      authorIsHouse: false,
+      reportId: 'r-q1',
+    });
+
+    const house = items.find((i) => i.target.table === 'question' && i.target.id === 'qh')!;
+    expect(house).toMatchObject({ authorIsHouse: true, authorName: 'Joshing' });
+
+    const generated = items.find((i) => i.target.table === 'generated')!;
+    expect(generated).toMatchObject({
+      target: { table: 'generated', id: 'g1' },
+      source: null, // LLM-origin: no source/creator
+      creatorId: null,
+      authorName: null,
+      authorIsHouse: false,
+      reportId: 'r-g1',
+    });
+  });
+
+  it('returns nothing when no content is blocked', async () => {
+    expect(await getBlockedQuestionsForReview()).toEqual([]);
+  });
+});
+
+describe('reverseBlock — authored', () => {
+  it('restores visibility to public AND dismisses the upheld report (admin_reversed)', async () => {
+    state.rowsByTable.set(QUESTIONS, [{ visibility: 'blocked' }]);
+
+    const result = await reverseBlock({ table: 'question', id: 'q1' }, 'cleared on review');
+
+    expect(result).toEqual({ ok: true, action: 'reversed', table: 'question', restoredVisibility: 'public' });
+    expect(questionUpdates()[0]?.set).toMatchObject({ visibility: 'public' });
+    expect(reportUpdates()[0]?.set).toMatchObject({
+      status: 'dismissed',
+      reviewDecision: 'admin_reversed',
+      reviewReason: 'cleared on review',
+    });
+  });
+
+  it('is a no-op for a missing question', async () => {
+    state.rowsByTable.set(QUESTIONS, []);
+    expect(await reverseBlock({ table: 'question', id: 'missing' })).toEqual({ ok: false, reason: 'not_found' });
+    expect(state.updates).toHaveLength(0);
+  });
+
+  it('refuses to act on a question that is not blocked', async () => {
+    state.rowsByTable.set(QUESTIONS, [{ visibility: 'public' }]);
+    expect(await reverseBlock({ table: 'question', id: 'q1' })).toEqual({ ok: false, reason: 'not_blocked' });
+    expect(state.updates).toHaveLength(0);
+  });
+});
+
+describe('reverseBlock — generated', () => {
+  it('dismisses the upheld-inappropriate report (the terminal state) and reports success', async () => {
+    state.returningRows = [{ id: 'r-g1' }];
+
+    const result = await reverseBlock({ table: 'generated', id: 'g1' });
+
+    expect(result).toEqual({ ok: true, action: 'reversed', table: 'generated', restoredVisibility: null });
+    expect(reportUpdates()[0]?.set).toMatchObject({ status: 'dismissed', reviewDecision: 'admin_reversed' });
+    // No visibility column exists for generated content.
+    expect(questionUpdates()).toHaveLength(0);
+  });
+
+  it('is a no-op when there is no upheld report to reverse', async () => {
+    state.returningRows = [];
+    expect(await reverseBlock({ table: 'generated', id: 'gX' })).toEqual({ ok: false, reason: 'not_found' });
+  });
+});

--- a/src/server/db/queries/__tests__/lately-moments-blocked.test.ts
+++ b/src/server/db/queries/__tests__/lately-moments-blocked.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Per-surface wiring test for Lately moments — one of the two VERIFIED leak
+// surfaces. We mock drizzle as EVALUABLE operators, run getLatelyMoments, capture
+// the real WHERE it builds (which includes the live notBlockedForViewer call),
+// extract the blocked node and assert the four-point matrix on THIS surface:
+//   1. blocked + non-owner → EXCLUDED   2. blocked + owner → INCLUDED   4. public → unaffected.
+type Row = { visibility: string; creatorId: string | null };
+interface Node {
+  op: string;
+  column?: unknown;
+  value?: unknown;
+  parts?: Node[];
+  query?: Node;
+  test?: (row: Row) => boolean;
+}
+
+let capturedWhere: Node | null = null;
+
+vi.mock('drizzle-orm', () => {
+  const evaluable = {
+    eq: vi.fn((column, value) => ({ op: 'eq', column, value, test: (r: Row) => (r as Record<string, unknown>)[column as string] === value })),
+    ne: vi.fn((column, value) => ({ op: 'ne', column, value, test: (r: Row) => (r as Record<string, unknown>)[column as string] !== value })),
+    or: vi.fn((...parts: Node[]) => ({ op: 'or', parts, test: (r: Row) => parts.some((p) => typeof p.test === 'function' && p.test(r)) })),
+    and: vi.fn((...parts: Node[]) => ({ op: 'and', parts, test: (r: Row) => parts.every((p) => (typeof p.test === 'function' ? p.test(r) : true)) })),
+  };
+  return {
+    ...evaluable,
+    desc: vi.fn((column) => ({ op: 'desc', column })),
+    gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+    inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+    isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+    isNull: vi.fn((column) => ({ op: 'isNull', column })),
+    sql: vi.fn(() => ({ op: 'sql', as: vi.fn(() => ({ op: 'sqlAs' })) })),
+  };
+});
+
+vi.mock('@/server/db', () => {
+  const chain: Record<string, unknown> = {};
+  for (const m of ['select', 'from', 'innerJoin', 'orderBy']) chain[m] = vi.fn(() => chain);
+  chain.where = vi.fn((cond: Node) => {
+    capturedWhere = cond;
+    return chain;
+  });
+  chain.limit = vi.fn(() => Promise.resolve([]));
+  return {
+    db: { select: vi.fn(() => chain) },
+    feedItems: { sourceUserId: 'sourceUserId', recipientUserId: 'recipientUserId', sourceType: 'sourceType', sourceResult: 'sourceResult', questionId: 'questionId', sourceEventAt: 'sourceEventAt', sourceAnswerId: 'sourceAnswerId', joshingGameId: 'joshingGameId' },
+    follows: { followeeId: 'followeeId', followerId: 'followerId', state: 'state' },
+    masteryEvents: { id: 'meId', userId: 'meUserId', sourceType: 'meSourceType', answerState: 'meAnswerState', questionId: 'meQuestionId', createdAt: 'meCreatedAt', answeredByUserId: 'meAnsweredBy' },
+    questions: { id: 'id', creatorId: 'creatorId', questionText: 'questionText', canonicalSubcategory: 'canonicalSubcategory', broadCategory: 'broadCategory', category: 'category', visibility: 'visibility', source: 'source', trustTier: 'trustTier' },
+    users: { id: 'usersId', displayName: 'displayName' },
+  };
+});
+
+import { getLatelyMoments } from '@/server/db/queries/lately';
+
+// Find the owner-aware blocked node: an `or` whose parts include `ne visibility blocked`.
+function findBlockedOr(node: Node | null): Node | undefined {
+  if (!node || typeof node !== 'object') return undefined;
+  if (
+    node.op === 'or' &&
+    (node.parts ?? []).some((p) => p.op === 'ne' && p.column === 'visibility' && p.value === 'blocked')
+  ) {
+    return node;
+  }
+  for (const child of [...(node.parts ?? []), node.query]) {
+    const found = findBlockedOr(child ?? null);
+    if (found) return found;
+  }
+  return undefined;
+}
+
+const VIEWER = 'viewer-2';
+
+beforeEach(() => {
+  capturedWhere = null;
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('getLatelyMoments wires in the visibility=blocked hard-block', () => {
+  it('includes an owner-aware notBlockedForViewer predicate in its WHERE', async () => {
+    await getLatelyMoments(VIEWER);
+    const blocked = findBlockedOr(capturedWhere);
+    expect(blocked).toBeDefined();
+  });
+
+  it('1. EXCLUDES a blocked question authored by someone else', async () => {
+    await getLatelyMoments(VIEWER);
+    const blocked = findBlockedOr(capturedWhere)!;
+    expect(blocked.test!({ visibility: 'blocked', creatorId: 'author-1' })).toBe(false);
+  });
+
+  it('2. INCLUDES a blocked question the VIEWER authored (they_got_you owner case)', async () => {
+    await getLatelyMoments(VIEWER);
+    const blocked = findBlockedOr(capturedWhere)!;
+    expect(blocked.test!({ visibility: 'blocked', creatorId: VIEWER })).toBe(true);
+  });
+
+  it('4. leaves a normal public question visible', async () => {
+    await getLatelyMoments(VIEWER);
+    const blocked = findBlockedOr(capturedWhere)!;
+    expect(blocked.test!({ visibility: 'public', creatorId: 'author-1' })).toBe(true);
+  });
+});

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -15,6 +15,8 @@ import {
   users,
 } from '@/server/db';
 import type { QueueSlot } from '@/server/daily/types';
+import { getUpheldInappropriateGeneratedIds } from '@/server/db/queries/content-reports';
+import { isBlockedForViewer, notBlockedForViewer } from '@/server/feed/visibility';
 import { LLM_QUESTION_ATTRIBUTION, resolveAuthorDisplay } from '@/lib/questions-types';
 import { titleCaseDomain } from '@/lib/knowledge/domain-casing';
 
@@ -196,9 +198,27 @@ async function readDailyItems(userId: string): Promise<ArchiveItem[]> {
     : [];
   const creatorById = new Map(creatorRows.map((row) => [row.id, row.displayName]));
 
+  // Safety hard-block applied at the SLOT level: the daily reader renders
+  // `slot.question_text` (a denormalized snapshot) even when the underlying row
+  // is absent, so filtering the queries above would not suppress a blocked
+  // question — the slot itself must be dropped. Authored questions use the
+  // owner-aware check (the author keeps their own); generated questions use the
+  // unconditional upheld-inappropriate terminal block (no owner exception).
+  const blockedQuestionIds = new Set(
+    questionRows.filter((q) => isBlockedForViewer(q, userId)).map((q) => q.id),
+  );
+  const blockedGeneratedIds = await getUpheldInappropriateGeneratedIds([...new Set(generatedIds)]);
+
   return queues.flatMap((queue) =>
     asQueueSlots(queue.slots)
-      .filter((slot) => slot.answered || slot.skipped)
+      .filter((slot) => {
+        if (!(slot.answered || slot.skipped)) return false;
+        if (slot.question_id && blockedQuestionIds.has(slot.question_id)) return false;
+        if (slot.generated_question_id && blockedGeneratedIds.has(slot.generated_question_id)) {
+          return false;
+        }
+        return true;
+      })
       .map((slot) => {
         const generated = slot.generated_question_id ? generatedById.get(slot.generated_question_id) : null;
         const bankQuestion = slot.question_id ? questionById.get(slot.question_id) : null;
@@ -255,7 +275,13 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
     .innerJoin(questions, eq(feedItems.questionId, questions.id))
     .innerJoin(users, eq(feedItems.sourceUserId, users.id))
     .leftJoin(creatorUsers, eq(questions.creatorId, creatorUsers.id))
-    .where(and(eq(feedItems.recipientUserId, userId), eq(feedItems.state, 'answered')))
+    .where(and(
+      eq(feedItems.recipientUserId, userId),
+      eq(feedItems.state, 'answered'),
+      // Safety hard-block: a question blocked after the viewer answered it drops
+      // from their archive, except for the author viewing their own — owner exception.
+      notBlockedForViewer(userId),
+    ))
     .orderBy(desc(feedItems.sourceEventAt));
 
   const relevantRows = rows.filter((row) => {
@@ -332,7 +358,12 @@ async function readJoshingGameItems(userId: string): Promise<ArchiveItem[]> {
     .innerJoin(questions, eq(joshingGameResponses.questionId, questions.id))
     .innerJoin(joshingGames, eq(joshingGameResponses.gameId, joshingGames.id))
     .leftJoin(creatorUsers, eq(questions.creatorId, creatorUsers.id))
-    .where(eq(joshingGameResponses.userId, userId))
+    .where(and(
+      eq(joshingGameResponses.userId, userId),
+      // Safety hard-block: blocked questions drop from the archive, except for
+      // the author viewing their own — owner exception.
+      notBlockedForViewer(userId),
+    ))
     .orderBy(desc(joshingGameResponses.answeredAt));
 
   return rows.map(({ response, question, game, creatorUser }) => {

--- a/src/server/db/queries/bank.ts
+++ b/src/server/db/queries/bank.ts
@@ -2,6 +2,7 @@ import { and, desc, eq, inArray, isNull, ne, sql } from 'drizzle-orm';
 
 import { writeActivity } from '@/server/activity/write-activity';
 import { db, feedItems, joshingGameResponses, questions, userQuestionBank, users } from '@/server/db';
+import { notBlockedForViewer } from '@/server/feed/visibility';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import {
   bankQuestionSelectColumns,
@@ -200,7 +201,14 @@ export async function getBankedQuestions(
   userId: string,
   options?: { onlyAuthored?: boolean },
 ): Promise<BankedQuestion[]> {
-  const filters = [eq(userQuestionBank.userId, userId), isNull(questions.deletedAt)];
+  // Safety hard-block: a banked question that was later blocked must drop out,
+  // except for the author viewing their own (the `onlyAuthored` author surface
+  // backs the "this was removed" state) — the owner exception.
+  const filters = [
+    eq(userQuestionBank.userId, userId),
+    isNull(questions.deletedAt),
+    notBlockedForViewer(userId),
+  ];
   if (options?.onlyAuthored) {
     filters.push(eq(questions.creatorId, userId));
   }

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -1,8 +1,9 @@
-import { and, asc, desc, eq, gte, inArray, ne, notExists, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gte, inArray, isNull, ne, notExists, or, sql } from 'drizzle-orm';
 import type { AnyPgColumn } from 'drizzle-orm/pg-core';
 
 import { contentReports, db, generatedQuestions, questions, users } from '@/server/db';
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
+import { type QuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 
 // B-Report-2: write + read helpers for ContentReport. Mirrors the house style in
 // ratings.ts — db + schema imports from '@/server/db', explicit field assignment,
@@ -496,4 +497,218 @@ export async function dismissReport(reportId: string, reviewReason?: string): Pr
     .where(and(eq(contentReports.id, reportId), eq(contentReports.status, 'open')));
 
   return { ok: true, action: 'dismissed', category: report.category, hardRemoved: false };
+}
+
+// ─── B-Report-6: blocked / actioned review + reversal ────────────────────────
+//
+// The review queue above shows only OPEN reports. This pair backs the
+// already-removed view: list currently-blocked content and let an admin REVERSE
+// a decision. Unlike getOpenReportsForReview, this list carries `source` +
+// `creatorId` so the admin surface can badge a real author's question apart from
+// house/LLM content. Reversal is content-only and gated by the same isAdminUser
+// allowlist at the route.
+
+export type BlockedReviewItem = {
+  target: { table: 'question'; id: string } | { table: 'generated'; id: string };
+  questionText: string | null;
+  correctAnswer: string | null;
+  // Provenance for the human-vs-house/LLM badge (the open-report query omits these).
+  // Generated rows are LLM-origin by construction: source/creatorId are null.
+  source: QuestionSource | null;
+  creatorId: string | null;
+  authorName: string | null; // null ⇒ client renders the LLM attribution
+  authorIsHouse: boolean;
+  // The upheld-inappropriate report behind the block. Always present for
+  // generated; may be null for authored (a vet verdict or cron sweep can block
+  // without a report).
+  reportId: string | null;
+  actionedAt: Date | null;
+};
+
+export async function getBlockedQuestionsForReview(): Promise<BlockedReviewItem[]> {
+  const [authoredRows, generatedRows] = await Promise.all([
+    db
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        answer: questions.answerText,
+        source: questions.source,
+        creatorId: questions.creatorId,
+        authorName: users.displayName,
+      })
+      .from(questions)
+      .leftJoin(users, eq(questions.creatorId, users.id))
+      .where(and(eq(questions.visibility, 'blocked'), isNull(questions.deletedAt))),
+    db
+      .select({
+        id: generatedQuestions.id,
+        questionText: generatedQuestions.questionText,
+        answer: generatedQuestions.answer,
+        reportId: contentReports.id,
+        reviewedAt: contentReports.reviewedAt,
+      })
+      .from(generatedQuestions)
+      .innerJoin(
+        contentReports,
+        and(
+          eq(contentReports.generatedQuestionId, generatedQuestions.id),
+          eq(contentReports.category, 'inappropriate'),
+          eq(contentReports.status, 'upheld'),
+        ),
+      ),
+  ]);
+
+  // The upheld-inappropriate report behind each authored block, if any.
+  const authoredIds = authoredRows.map((r) => r.id);
+  const authoredReports = authoredIds.length
+    ? await db
+        .select({
+          questionId: contentReports.questionId,
+          id: contentReports.id,
+          reviewedAt: contentReports.reviewedAt,
+        })
+        .from(contentReports)
+        .where(
+          and(
+            inArray(contentReports.questionId, authoredIds),
+            eq(contentReports.category, 'inappropriate'),
+            eq(contentReports.status, 'upheld'),
+          ),
+        )
+        .orderBy(desc(contentReports.reviewedAt))
+    : [];
+  const authoredReportByQuestion = new Map<string, { id: string; reviewedAt: Date | null }>();
+  for (const r of authoredReports) {
+    if (r.questionId && !authoredReportByQuestion.has(r.questionId)) {
+      authoredReportByQuestion.set(r.questionId, { id: r.id, reviewedAt: r.reviewedAt });
+    }
+  }
+
+  const items: BlockedReviewItem[] = [];
+
+  for (const row of authoredRows) {
+    const rep = authoredReportByQuestion.get(row.id) ?? null;
+    items.push({
+      target: { table: 'question', id: row.id },
+      questionText: row.questionText,
+      correctAnswer: row.answer,
+      source: row.source,
+      creatorId: row.creatorId,
+      ...resolveAuthorDisplay(row.creatorId, row.source, row.authorName),
+      reportId: rep?.id ?? null,
+      actionedAt: rep?.reviewedAt ?? null,
+    });
+  }
+
+  // One generated question can carry more than one upheld report; keep the most
+  // recent as the representative row.
+  const generatedById = new Map<
+    string,
+    { questionText: string; answer: string; reportId: string; reviewedAt: Date | null }
+  >();
+  for (const row of generatedRows) {
+    const prev = generatedById.get(row.id);
+    const newer =
+      !prev ||
+      (row.reviewedAt != null &&
+        (prev.reviewedAt == null || row.reviewedAt > prev.reviewedAt));
+    if (newer) {
+      generatedById.set(row.id, {
+        questionText: row.questionText,
+        answer: row.answer,
+        reportId: row.reportId,
+        reviewedAt: row.reviewedAt,
+      });
+    }
+  }
+  for (const [id, g] of generatedById) {
+    items.push({
+      target: { table: 'generated', id },
+      questionText: g.questionText,
+      correctAnswer: g.answer,
+      source: null,
+      creatorId: null,
+      authorName: null,
+      authorIsHouse: false,
+      reportId: g.reportId,
+      actionedAt: g.reviewedAt,
+    });
+  }
+
+  // Most-recently actioned first; vet/cron blocks (no report ⇒ null) sort last.
+  items.sort((a, b) => (b.actionedAt?.getTime() ?? 0) - (a.actionedAt?.getTime() ?? 0));
+  return items;
+}
+
+export type ReverseActionResult =
+  | { ok: true; action: 'reversed'; table: 'question' | 'generated'; restoredVisibility: 'public' | null }
+  | { ok: false; reason: 'not_found' | 'not_blocked' };
+
+// Reverse a terminal block (content-only; mirrors the uphold/dismiss audit
+// fields: reviewDecision='admin_reversed', reviewReason, reviewedAt).
+//   - authored: visibility 'blocked' → 'public' AND dismiss the upheld
+//     inappropriate report(s), so B-Report-3 suppression (open|upheld) also lifts.
+//     NOTE: the pre-block visibility is not persisted anywhere (the block write
+//     overwrites it), so we restore to the column default 'public'. Re-scoping to
+//     a tighter audience is a manual follow-up.
+//   - generated: there is no visibility column — the upheld report IS the
+//     terminal state, so dismissing it reverses the block.
+export async function reverseBlock(
+  target: { table: 'question' | 'generated'; id: string },
+  reviewReason?: string,
+): Promise<ReverseActionResult> {
+  const reason = reviewReason?.trim() || null;
+
+  if (target.table === 'question') {
+    const [q] = await db
+      .select({ visibility: questions.visibility })
+      .from(questions)
+      .where(eq(questions.id, target.id))
+      .limit(1);
+    if (!q) return { ok: false, reason: 'not_found' };
+    if (q.visibility !== 'blocked') return { ok: false, reason: 'not_blocked' };
+
+    await db
+      .update(questions)
+      .set({ visibility: 'public', updatedAt: new Date() })
+      .where(eq(questions.id, target.id));
+
+    await db
+      .update(contentReports)
+      .set({
+        status: 'dismissed',
+        reviewDecision: 'admin_reversed',
+        reviewReason: reason,
+        reviewedAt: new Date(),
+      })
+      .where(
+        and(
+          eq(contentReports.questionId, target.id),
+          eq(contentReports.category, 'inappropriate'),
+          eq(contentReports.status, 'upheld'),
+        ),
+      );
+
+    return { ok: true, action: 'reversed', table: 'question', restoredVisibility: 'public' };
+  }
+
+  const updated = await db
+    .update(contentReports)
+    .set({
+      status: 'dismissed',
+      reviewDecision: 'admin_reversed',
+      reviewReason: reason,
+      reviewedAt: new Date(),
+    })
+    .where(
+      and(
+        eq(contentReports.generatedQuestionId, target.id),
+        eq(contentReports.category, 'inappropriate'),
+        eq(contentReports.status, 'upheld'),
+      ),
+    )
+    .returning({ id: contentReports.id });
+
+  if (updated.length === 0) return { ok: false, reason: 'not_found' };
+  return { ok: true, action: 'reversed', table: 'generated', restoredVisibility: null };
 }

--- a/src/server/db/queries/content-reports.ts
+++ b/src/server/db/queries/content-reports.ts
@@ -119,6 +119,57 @@ export function notSuppressedByContentReport(
   );
 }
 
+// The generated-question equivalent of visibility='blocked': an upheld
+// inappropriate report is the TERMINAL hard-block for LLM-origin content, which
+// has no `visibility` column to set. Unconditional — there is no owner exception
+// because generated questions carry a null creatorId. Kept DISTINCT from the
+// authored blocked predicate (feed/visibility.ts) and from the reversible
+// open|upheld suppression layer above: this matches only category='inappropriate'
+// AND status='upheld', the irreversible state, so history/replay reads stay
+// untouched by the (reversible, reporter-scoped) suppression machinery.
+export function notBlockedGeneratedByContentReport(generatedIdColumn: AnyPgColumn) {
+  return notExists(
+    db
+      .select({ one: sql`1` })
+      .from(contentReports)
+      .where(
+        and(
+          eq(contentReports.generatedQuestionId, generatedIdColumn),
+          eq(contentReports.category, 'inappropriate'),
+          eq(contentReports.status, 'upheld'),
+        ),
+      ),
+  );
+}
+
+// Set form of the predicate above, for JS read paths that materialize a slot
+// snapshot (archive's daily reader renders `slot.question_text` even when the
+// row is filtered out of the query, so the block must be applied at the slot
+// level). Of the given generated ids, returns those with an upheld-inappropriate
+// report — the terminal hard-block to drop.
+export async function getUpheldInappropriateGeneratedIds(
+  generatedQuestionIds: string[],
+): Promise<Set<string>> {
+  const blocked = new Set<string>();
+  if (generatedQuestionIds.length === 0) return blocked;
+
+  const rows = await db
+    .select({ generatedQuestionId: contentReports.generatedQuestionId })
+    .from(contentReports)
+    .where(
+      and(
+        inArray(contentReports.generatedQuestionId, generatedQuestionIds),
+        eq(contentReports.category, 'inappropriate'),
+        eq(contentReports.status, 'upheld'),
+      ),
+    );
+
+  for (const row of rows) {
+    if (row.generatedQuestionId) blocked.add(row.generatedQuestionId);
+  }
+  return blocked;
+}
+
 // Runtime check for JS paths (feed propagation, direct send) where we hold a raw
 // id whose table may be either. Matches the id against both FK columns so a report
 // on a GeneratedQuestion still blocks a send that would mint it into a curated

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -17,7 +17,8 @@ import {
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import type { GradableQuestionType } from '@/server/grading';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
-import { notSuppressedByContentReport } from '@/server/db/queries/content-reports';
+import { notBlockedGeneratedByContentReport, notSuppressedByContentReport } from '@/server/db/queries/content-reports';
+import { notBlocked } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
 import { CATEGORIES, categoryLabel, HOUSE_AUTHOR, resolveAuthorDisplay } from '@/lib/questions-types';
 import { CATCHUP_LOOKBACK_DAYS, asQueueSlots, dailyQueueItemId, feedCatchupItemId, minusUtcDays } from '@/server/daily/catchup';
@@ -568,13 +569,23 @@ async function getDailyCatchupItems(
           .where(and(
             eq(generatedQuestions.userId, userId),
             inArray(generatedQuestions.id, generatedIds),
+            // Terminal hard-block for LLM-origin content: an upheld-inappropriate
+            // report is the generated equivalent of visibility='blocked'.
+            notBlockedGeneratedByContentReport(generatedQuestions.id),
           ))
       : Promise.resolve<typeof generatedQuestions.$inferSelect[]>([]),
     canonicalIds.length > 0
       ? db
           .select()
           .from(canonicalQuestions)
-          .where(inArray(canonicalQuestions.id, canonicalIds))
+          .where(and(
+            inArray(canonicalQuestions.id, canonicalIds),
+            // Safety hard-block: a question blocked after assignment (cron re-vet,
+            // upheld report) must not resurface in catch-up. Bare form — catch-up
+            // is an answer surface and never carries the viewer's own authored
+            // question (you aren't assigned your own questions to answer).
+            notBlocked(),
+          ))
       : Promise.resolve<typeof canonicalQuestions.$inferSelect[]>([]),
   ]);
   const generatedById = new Map(generatedRows.map((question) => [question.id, question]));

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,7 +1,7 @@
 import { and, count, desc, eq, exists, inArray, isNull, lt, ne, notExists, notInArray, or, sql } from 'drizzle-orm';
 
 import { db, feedDismissedDomains, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
-import { visibleFeedSourcePredicate } from '@/server/feed/visibility';
+import { notBlocked, visibleFeedSourcePredicate } from '@/server/feed/visibility';
 import { pgErrorCode, pgErrorMessage } from '@/server/db/pg-error';
 
 export type FeedItem = typeof feedItems.$inferSelect;
@@ -296,7 +296,7 @@ export function questionVisibilityPredicate(viewerUserId: string) {
 // and stay in sync with what actually renders.
 export function feedItemVisibilityPredicate(viewerUserId: string) {
   return and(
-    ne(questions.visibility, 'blocked'),
+    notBlocked(),
     or(
       eq(feedItems.sourceType, 'direct_sent'),
       questionVisibilityPredicate(viewerUserId),

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -24,7 +24,7 @@ import {
   type TrustTier,
 } from '@/server/daily/verification-gating';
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
-import { SOCIAL_FEED_SOURCE_TYPE } from '@/server/feed/visibility';
+import { SOCIAL_FEED_SOURCE_TYPE, notBlockedForViewer } from '@/server/feed/visibility';
 
 export type LatelyDirection = 'they_got_you' | 'you_got_them';
 
@@ -124,6 +124,10 @@ export async function getLatelyMoments(
         inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
         isNotNull(masteryEvents.questionId),
         gte(masteryEvents.createdAt, windowStart),
+        // Safety hard-block: a blocked question must not resurface as a moment,
+        // except to its own author (they_got_you rows are the viewer's own
+        // authored question) — the owner exception.
+        notBlockedForViewer(userId),
         or(
           and(eq(questions.creatorId, userId), ne(masteryEvents.userId, userId)),
           and(eq(masteryEvents.userId, userId), ne(questions.creatorId, userId)),
@@ -220,6 +224,9 @@ export async function getLatelyMilestones(
         eq(feedItems.sourceResult, 'correct'),
         isNotNull(feedItems.questionId),
         gte(feedItems.sourceEventAt, windowStart),
+        // Safety hard-block: blocked questions never anchor a milestone (the
+        // owner exception is moot here — viewer-authored is excluded below).
+        notBlockedForViewer(userId),
         // Never surface the viewer's OWN authored questions here. The milestone
         // expansion offers each question to ANSWER (full credit via
         // /api/lately/milestone/answer), but you can't answer your own question —
@@ -359,6 +366,10 @@ export async function getFriendActivity(
         eq(feedItems.sourceResult, 'correct'),
         isNotNull(feedItems.questionId),
         gte(feedItems.sourceEventAt, windowStart),
+        // Safety hard-block: a blocked question must not resurface in the
+        // From-Friends log, except to its own author (a friend answering the
+        // viewer's own question lands here as a spent card) — the owner exception.
+        notBlockedForViewer(userId),
       ),
     )
     .orderBy(desc(feedItems.sourceEventAt))

--- a/src/server/feed/__tests__/blocked-visibility.test.ts
+++ b/src/server/feed/__tests__/blocked-visibility.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { vi } from 'vitest';
+
+// The visibility='blocked' leak fix funnels every authored read path through a
+// single shared predicate (notBlocked / notBlockedForViewer) plus a pure JS
+// mirror (isBlockedForViewer). Mirrors question-visibility.test.ts, but instead
+// of only asserting predicate SHAPE we mock the drizzle operators as EVALUABLE
+// nodes — each carries a .test(row) — so we can assert the actual
+// included/excluded BEHAVIOR the four-point matrix calls for:
+//   1. blocked + non-owner viewer  → EXCLUDED
+//   2. blocked + owner (creator===viewer) → INCLUDED (the "this was removed" view)
+//   3. (generated → blocked-generated.test.ts; no owner case)
+//   4. public question → unaffected
+type Row = { visibility: string; creatorId: string | null };
+type Node = { op: string; test: (row: Row) => boolean };
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column: keyof Row, value: unknown) => ({
+    op: 'eq',
+    test: (row: Row) => row[column] === value,
+  })),
+  ne: vi.fn((column: keyof Row, value: unknown) => ({
+    op: 'ne',
+    test: (row: Row) => row[column] !== value,
+  })),
+  or: vi.fn((...parts: Node[]) => ({
+    op: 'or',
+    test: (row: Row) => parts.some((p) => p.test(row)),
+  })),
+}));
+
+// Columns keyed to the fixture row's own field names, so a predicate built over
+// `questions.visibility` evaluates `row.visibility`.
+vi.mock('@/server/db', () => ({
+  questions: {
+    visibility: 'visibility',
+    creatorId: 'creatorId',
+    id: 'id',
+    source: 'source',
+    deletedAt: 'deletedAt',
+    canonicalSubcategory: 'canonicalSubcategory',
+    broadCategory: 'broadCategory',
+    category: 'category',
+  },
+  feedItems: { sourceType: 'sourceType' },
+}));
+
+import {
+  isBlockedForViewer,
+  notBlocked,
+  notBlockedForViewer,
+} from '@/server/feed/visibility';
+
+const OWNER = 'author-1';
+const OTHER = 'viewer-2';
+
+const blockedByOwner: Row = { visibility: 'blocked', creatorId: OWNER };
+const publicByOwner: Row = { visibility: 'public', creatorId: OWNER };
+
+describe('notBlockedForViewer (owner-aware history/own-content predicate)', () => {
+  it('1. EXCLUDES a blocked question for a non-owner viewer', () => {
+    const pred = notBlockedForViewer(OTHER) as unknown as Node;
+    expect(pred.test(blockedByOwner)).toBe(false);
+  });
+
+  it('2. INCLUDES the same blocked question for its owner (creatorId === viewerId)', () => {
+    const pred = notBlockedForViewer(OWNER) as unknown as Node;
+    expect(pred.test(blockedByOwner)).toBe(true);
+  });
+
+  it('4. leaves a normal public question visible to everyone', () => {
+    expect((notBlockedForViewer(OTHER) as unknown as Node).test(publicByOwner)).toBe(true);
+    expect((notBlockedForViewer(OWNER) as unknown as Node).test(publicByOwner)).toBe(true);
+  });
+
+  it('reduces to a pure blocked check when the viewer is not the creator (safe on friend-only surfaces)', () => {
+    // On milestones / from-friends the row is never viewer-authored, so the
+    // owner clause never fires and the predicate behaves exactly like notBlocked().
+    const pred = notBlockedForViewer(OTHER) as unknown as Node;
+    expect(pred.test({ visibility: 'blocked', creatorId: 'someone-else' })).toBe(false);
+    expect(pred.test({ visibility: 'public', creatorId: 'someone-else' })).toBe(true);
+  });
+});
+
+describe('notBlocked (bare broadcast/feed predicate — NO owner exception)', () => {
+  it('EXCLUDES a blocked question even from its own author', () => {
+    // The feed is a broadcast surface: a blocked question must never resurface
+    // for anyone, including the author. This is why feed keeps the bare form.
+    expect((notBlocked() as unknown as Node).test(blockedByOwner)).toBe(false);
+  });
+
+  it('leaves a public question visible', () => {
+    expect((notBlocked() as unknown as Node).test(publicByOwner)).toBe(true);
+  });
+});
+
+describe('isBlockedForViewer (JS mirror, for the archive daily slot-snapshot path)', () => {
+  it('1. reports a blocked question as blocked for a non-owner viewer', () => {
+    expect(isBlockedForViewer({ visibility: 'blocked', creatorId: OWNER }, OTHER)).toBe(true);
+  });
+
+  it('2. does NOT block the owner from their own blocked question', () => {
+    expect(isBlockedForViewer({ visibility: 'blocked', creatorId: OWNER }, OWNER)).toBe(false);
+  });
+
+  it('4. never blocks a public question', () => {
+    expect(isBlockedForViewer({ visibility: 'public', creatorId: OWNER }, OTHER)).toBe(false);
+  });
+});

--- a/src/server/feed/visibility.ts
+++ b/src/server/feed/visibility.ts
@@ -1,8 +1,9 @@
-import { eq, or } from 'drizzle-orm';
+import { eq, ne, or } from 'drizzle-orm';
 
 import { assertNever } from '@/lib/assert-never';
 import type { QuestionSource } from '@/lib/questions-types';
-import type { feedItems, questions } from '@/server/db';
+import { questions } from '@/server/db';
+import type { feedItems } from '@/server/db';
 
 export const SOCIAL_FEED_SOURCE_TYPE = 'friend_answered' as const;
 export const DIRECT_SENT_FEED_SOURCE_TYPE = 'direct_sent' as const;
@@ -37,6 +38,50 @@ const SUPPRESSED_CATEGORY_LABELS = new Set(['other', 'uncategorized', 'unknown',
 
 type QuestionLike = Pick<typeof questions.$inferSelect, 'creatorId' | 'source' | 'visibility' | 'canonicalSubcategory' | 'broadCategory' | 'category' | 'deletedAt'>;
 type FeedItemsVisibilityColumns = Pick<typeof feedItems, 'sourceType'>;
+
+// ─── visibility='blocked' hard-block (authored questions) ────────────────────
+//
+// 'blocked' is the terminal safety removal — set by a vet verdict or an upheld
+// offensive report (content-reports.ts) — and must be honored on EVERY read
+// path, not just the feed. These two predicates are the single source of truth
+// for that filter so reads don't scatter inline `ne(visibility,'blocked')`
+// checks. Both reference the `questions` table directly, so they drop into any
+// query that selects/joins it (including daily.ts's `questions as
+// canonicalQuestions`, which is the same table object).
+//
+// Generated (LLM-origin) questions have no `visibility` column; their terminal
+// block is an upheld-inappropriate ContentReport, handled by a SEPARATE,
+// creator-less predicate in content-reports.ts — do not fold it in here.
+
+// Bare form — no owner exception. For broadcast/feed gates where a blocked
+// question must never surface to ANYONE, including its own author.
+export function notBlocked() {
+  return ne(questions.visibility, 'blocked');
+}
+
+// Owner-aware form — for history / own-content reads. Hides blocked questions
+// EXCEPT from their own author, who must keep seeing their blocked question on
+// author-facing surfaces (the "this was removed" state, their archive, their
+// own Lately moments). The owner exception is NOT centralized on a shared read
+// path (A1: it's enforced per-read by `creatorId = viewer` scoping), so this
+// predicate carries it explicitly. On surfaces that can never contain the
+// viewer's own authored question the creatorId clause is simply never satisfied,
+// so this reduces to notBlocked() and is safe to use uniformly across history.
+export function notBlockedForViewer(viewerUserId: string) {
+  return or(ne(questions.visibility, 'blocked'), eq(questions.creatorId, viewerUserId))!;
+}
+
+// JS mirror of notBlockedForViewer, for read paths that materialize a slot
+// snapshot and so must apply the block in code rather than the query (archive's
+// daily reader renders `slot.question_text` even when the canonical row is
+// filtered out). Returns true when the question is blocked AND the viewer is not
+// its author — i.e. the row must be dropped.
+export function isBlockedForViewer(
+  question: Pick<QuestionLike, 'visibility' | 'creatorId'>,
+  viewerUserId: string,
+): boolean {
+  return question.visibility === 'blocked' && question.creatorId !== viewerUserId;
+}
 
 export type FeedEventEligibilityInput = {
   answerIsCorrect: boolean;


### PR DESCRIPTION
## Summary
Implements the admin interface for reviewing and reversing terminal content blocks (visibility='blocked' for authored questions, upheld-inappropriate reports for generated questions). Adds a second view to the reports queue showing currently-blocked content with human/house/LLM attribution, and allows admins to un-block with audit trails.

## Key Changes

**Database queries** (`src/server/db/queries/content-reports.ts`):
- Added `notBlockedGeneratedByContentReport()` — SQL predicate for the terminal hard-block on LLM-origin content (upheld-inappropriate reports, no owner exception)
- Added `getUpheldInappropriateGeneratedIds()` — set form for JS read paths (archive daily reader) that materialize slot snapshots
- Added `getBlockedQuestionsForReview()` — lists currently-blocked authored + generated questions with source/creatorId for human-vs-house/LLM badging
- Added `reverseBlock()` — reverses a terminal block: restores authored visibility to 'public' AND dismisses upheld reports; for generated, dismisses the upheld report (the terminal state)
- Added `BlockedReviewItem` and `ReverseActionResult` types

**Visibility predicates** (`src/server/feed/visibility.ts`):
- Extracted `notBlocked()` — bare broadcast/feed predicate (no owner exception; blocks for everyone)
- Extracted `notBlockedForViewer()` — owner-aware history/own-content predicate (owner sees their own blocked questions)
- Added `isBlockedForViewer()` — pure JS mirror for archive daily reader slot filtering

**Admin UI** (`src/app/admin/reports/AdminReportsClient.tsx`):
- Converted to two-view layout: "Open reports" (uphold/dismiss) and "Blocked / actioned" (un-block/reverse)
- Added `BlockedRow` component showing question text, author badge (human/house/LLM), removal timestamp, and un-block action
- Added `TabButton` for view switching
- Integrated `authorBadge()` helper to derive human-vs-house/LLM from source/creatorId

**API route** (`src/app/api/admin/content-reports/route.ts`):
- Extended to handle `reverse` action alongside `uphold`/`dismiss`
- Uses discriminated union schema to route reportId-based actions vs. target-based reversal

**Page** (`src/app/admin/reports/page.tsx`):
- Fetches both open reports and blocked questions
- Passes both to client component

**Integration** (daily.ts, archive.ts, lately.ts, bank.ts, feed.ts):
- Wired `notBlocked()` into daily catch-up canonical query
- Wired `notBlockedGeneratedByContentReport()` into daily catch-up generated query
- Applied `isBlockedForViewer()` at slot level in archive daily reader (denormalized snapshot filtering)
- Applied `notBlockedForViewer()` in Lately moments query
- Applied `notBlockedForViewer()` in bank query

## Notable Implementation Details

- **Terminal vs. reversible:** Upheld-inappropriate reports are the irreversible hard-block (distinct from the reversible open|upheld suppression layer); reversal dismisses the report with `reviewDecision='admin_reversed'`
- **No owner exception for generated:** Generated questions carry null creatorId; the upheld-inappropriate block applies unconditionally (no author can see their own blocked generated content)
- **Authored visibility restoration:** Pre-block visibility is not persisted, so reversal restores to the column default 'public' (re-scoping to tighter audience is a manual follow-up)
- **Slot-level filtering:** Archive daily reader filters at the slot level (not query level) because it renders denormalized `slot.question_text` even when the row is absent
- **Most-recent report:** When a generated question carries multiple upheld reports, the blocked list shows the most-recently-actioned one as representative

## Tests
Added comprehensive test suites:
- `content-reports-reverse.test.ts` — blocked list structure + reversal

https://claude.ai/code/session_01YQTwHH9CsV9dBnqTDuNJQ3