### PR TITLE
Replace hardcoded rounded-[8px] with --radius-md token

### DIFF
--- a/scripts/check-radius-ratchet.mjs
+++ b/scripts/check-radius-ratchet.mjs
@@ -25,7 +25,9 @@ import { join, relative } from 'node:path';
 // pervasive `rounded-[4px]` is the button/card corner — a candidate for a
 // `--radius-xs` token (added 2026-06-15) — burn-down 1 snapped the nine
 // `rounded-[4px]` to `rounded-[var(--radius-xs)]`, lowering this 25 → 16.
-const CEILING = 16;
+// Burn-down 2 (2026-06-16) snapped the six `rounded-[8px]` (an exact 0.5rem /
+// --radius-md match) to `rounded-[var(--radius-md)]`, lowering this 16 → 11.
+const CEILING = 11;
 
 // ── Exemptions (mirrors the color/font/spacing ratchets) ────────────────────
 const EXEMPT = [

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -19,7 +19,7 @@ function formatPhoneForDisplay(e164: string): string {
 }
 
 const CARD_CLASS =
-  'w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-12 py-8 shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5';
+  'w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-8 shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5';
 const INPUT_CLASS =
   'h-11 w-full rounded-[var(--radius-xs)] border border-[var(--accent-gold)] bg-white px-3 text-center text-base tracking-wide text-[var(--brand-navy)] outline-none transition-colors focus:border-[var(--brand-navy)]';
 const SUBMIT_CLASS =
@@ -151,7 +151,7 @@ function inviterFirstName(name: string): string {
 
 function InviteContextCard({ invite }: { invite: InviteContext }) {
   return (
-    <div className="space-y-3 rounded-[8px] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
+    <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
       <p className="text-[15px] leading-6 text-black/75">
         {inviterFirstName(invite.inviterName)} invited you to Joshing, a new trivia game. We just
         need to verify your phone number and then you can start playing.
@@ -600,7 +600,7 @@ export default function LoginPanel({
             // Warm dead-end (Screen 1b): the edited number has no claim of its
             // own. Carried by wording, not an error banner — full number shown
             // per D-AUTH-INVITE-PHONE-FIRST §2.7.
-            <div className="space-y-3 rounded-[8px] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
+            <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
               <p className="text-[15px] leading-6 text-black/75">
                 This invite was sent to{' '}
                 <span className="font-medium whitespace-nowrap text-black">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -31,7 +31,7 @@ function readUserInvite(
 
 function TitleCard() {
   return (
-    <section className="w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
+    <section className="w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
       <h1 className="font-sans text-5xl leading-[52px] font-bold tracking-[4.8px] text-[var(--brand-ink-950)]">
         JOSHING
       </h1>

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -770,7 +770,7 @@ function FeedContributeFooter() {
               onChange={(event) => setIdea(event.target.value)}
               aria-label="What question would you like to be asked?"
               rows={5}
-              className="min-h-[180px] w-full resize-none rounded-[8px] border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 py-3 text-base text-[var(--brand-ink)] outline-none focus:border-[var(--brand-navy)]"
+              className="min-h-[180px] w-full resize-none rounded-[var(--radius-md)] border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 py-3 text-base text-[var(--brand-ink)] outline-none focus:border-[var(--brand-navy)]"
             />
             {idea.trim() === '' ? (
               <span

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -188,7 +188,7 @@ export default function LoadingScreen({
         aria-hidden="true"
       />
 
-      <div className="relative z-10 mx-6 w-full max-w-sm rounded-[8px] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
+      <div className="relative z-10 mx-6 w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
         <p className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
           JOSHING
         </p>


### PR DESCRIPTION
## Summary
Standardizes border radius values across the codebase by replacing six instances of hardcoded `rounded-[8px]` with the `rounded-[var(--radius-md)]` design token, bringing the radius ratchet ceiling down from 16 to 11.

## Changes
- **LoginPanel.tsx**: Updated `CARD_CLASS` and two `InviteContextCard` instances to use `--radius-md` token
- **page.tsx**: Updated `TitleCard` section to use `--radius-md` token
- **FeedList.tsx**: Updated textarea in `FeedContributeFooter` to use `--radius-md` token
- **LoadingScreen.tsx**: Updated card container to use `--radius-md` token
- **check-radius-ratchet.mjs**: Lowered `CEILING` from 16 to 11 and documented the burn-down in comments

## Implementation Details
All six `rounded-[8px]` instances were exact matches for the `--radius-md` token (0.5rem), making this a straightforward substitution. The radius ratchet script now correctly reflects the reduced count of arbitrary radius values in the codebase, supporting the design system's token-based approach.

https://claude.ai/code/session_01HoFnGn4GqE8boVAnUJVd9E