### PR TITLE
Email-only reminder opt-in & first-time player summary preview

### DIFF
--- a/src/app/daily/summary/RoundReminderCard.tsx
+++ b/src/app/daily/summary/RoundReminderCard.tsx
@@ -3,11 +3,12 @@
 import Link from 'next/link'
 import { type CSSProperties, useState } from 'react'
 
+// SMS reminders aren't available, so the opt-in is email-only: the card shows
+// an email field inline (no "Yes, text me" / "Use email instead" fork) plus a
+// "No thanks" dismiss. The API still accepts smsOptIn for other callers; this
+// card just never sends it.
 type CardState =
-  | { kind: 'idle' }
-  | { kind: 'sms-saving' }
-  | { kind: 'sms-confirmed' }
-  | { kind: 'email-form'; value: string; error: string | null; saving: boolean }
+  | { kind: 'idle'; value: string; error: string | null; saving: boolean }
   | { kind: 'email-saved'; email: string }
   | { kind: 'dismissing' }
   | { kind: 'hidden' }
@@ -41,25 +42,14 @@ export function RoundReminderCard({
   title?: string
   description?: string
 } = {}) {
-  const [state, setState] = useState<CardState>({ kind: 'idle' })
+  const [state, setState] = useState<CardState>({
+    kind: 'idle',
+    value: '',
+    error: null,
+    saving: false,
+  })
 
   if (state.kind === 'hidden') return null
-
-  if (state.kind === 'sms-confirmed') {
-    return (
-      <section className="card mt-5 px-5 py-4">
-        <h2 style={titleStyle}>Reminders</h2>
-        <p className="text-foreground mt-2 text-sm leading-6">
-          We&apos;ve saved your preference. Texts will start when reminders launch.
-        </p>
-        <p className="text-muted-foreground mt-2 text-xs">
-          <Link href="/users/me#notifications" className="underline underline-offset-2">
-            Manage in settings
-          </Link>
-        </p>
-      </section>
-    )
-  }
 
   if (state.kind === 'email-saved') {
     return (
@@ -77,113 +67,78 @@ export function RoundReminderCard({
     )
   }
 
-  if (state.kind === 'email-form') {
-    return (
-      <section className="card mt-5 px-5 py-4">
-        <h2 style={titleStyle}>Email me when the next round opens</h2>
-        <form
-          className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-start"
-          onSubmit={async (event) => {
-            event.preventDefault()
-            const trimmed = state.value.trim()
-            if (!trimmed) {
-              setState({ ...state, error: 'Please enter an email address.' })
-              return
-            }
-            setState({ ...state, saving: true, error: null })
-            const ok = await patchReminders({ pendingEmail: trimmed })
-            if (!ok) {
-              setState({ ...state, saving: false, error: 'Could not save. Try again.' })
-              return
-            }
-            setState({ kind: 'email-saved', email: trimmed })
-          }}
-        >
-          <input
-            type="email"
-            inputMode="email"
-            autoComplete="email"
-            required
-            placeholder="you@example.com"
-            value={state.value}
-            disabled={state.saving}
-            onChange={(event) =>
-              setState({ ...state, value: event.target.value, error: null })
-            }
-            className="bg-[var(--brand-field)] flex-1 rounded-lg border border-[var(--accent-gold)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
-          />
-          <div className="flex gap-2">
-            <button
-              type="submit"
-              className="btn-primary"
-              disabled={state.saving}
-            >
-              {state.saving ? 'Saving…' : 'Save'}
-            </button>
-            <button
-              type="button"
-              className="btn-ghost"
-              disabled={state.saving}
-              onClick={() => setState({ kind: 'idle' })}
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-        {state.error ? (
-          <p className="mt-2 text-xs text-rose-700">{state.error}</p>
-        ) : null}
-        <p className="text-muted-foreground mt-3 text-xs leading-5">
-          We&apos;ll send a confirmation email once email reminders launch.
-        </p>
-      </section>
-    )
-  }
-
-  const sendingSms = state.kind === 'sms-saving'
   const dismissing = state.kind === 'dismissing'
-  const busy = sendingSms || dismissing
+  const saving = state.kind === 'idle' && state.saving
+  const busy = dismissing || saving
 
   return (
     <section className="card mt-5 px-5 py-4">
       <h2 style={titleStyle}>{title}</h2>
       <p className="text-foreground mt-2 text-sm leading-6">{description}</p>
-      <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-        <button
-          type="button"
-          className="btn-primary sm:flex-1"
-          disabled={busy}
-          onClick={async () => {
-            setState({ kind: 'sms-saving' })
-            const ok = await patchReminders({ smsOptIn: 'opted_in' })
-            setState(ok ? { kind: 'sms-confirmed' } : { kind: 'idle' })
-          }}
-        >
-          {sendingSms ? 'Saving…' : 'Yes, text me'}
-        </button>
-        <button
-          type="button"
-          className="btn-ghost sm:flex-1"
-          disabled={busy}
-          onClick={() =>
-            setState({ kind: 'email-form', value: '', error: null, saving: false })
+      <form
+        className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start"
+        onSubmit={async (event) => {
+          event.preventDefault()
+          if (state.kind !== 'idle') return
+          const trimmed = state.value.trim()
+          if (!trimmed) {
+            setState({ ...state, error: 'Please enter an email address.' })
+            return
           }
-        >
-          Use email instead
-        </button>
-        <button
-          type="button"
-          className="btn-ghost sm:flex-1"
+          setState({ ...state, saving: true, error: null })
+          const ok = await patchReminders({ pendingEmail: trimmed })
+          if (!ok) {
+            setState({ ...state, saving: false, error: 'Could not save. Try again.' })
+            return
+          }
+          setState({ kind: 'email-saved', email: trimmed })
+        }}
+      >
+        <input
+          type="email"
+          inputMode="email"
+          autoComplete="email"
+          required
+          placeholder="you@example.com"
+          value={state.kind === 'idle' ? state.value : ''}
           disabled={busy}
-          onClick={async () => {
-            setState({ kind: 'dismissing' })
-            const ok = await patchReminders({ dismissed: true })
-            setState(ok ? { kind: 'hidden' } : { kind: 'idle' })
-          }}
-        >
-          {dismissing ? 'Saving…' : 'No thanks'}
-        </button>
-      </div>
+          onChange={(event) =>
+            setState((prev) =>
+              prev.kind === 'idle'
+                ? { ...prev, value: event.target.value, error: null }
+                : prev,
+            )
+          }
+          className="bg-[var(--brand-field)] flex-1 rounded-lg border border-[var(--accent-gold)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
+        />
+        <div className="flex gap-2">
+          <button type="submit" className="btn-primary" disabled={busy}>
+            {saving ? 'Saving…' : 'Email me'}
+          </button>
+          <button
+            type="button"
+            className="btn-ghost"
+            disabled={busy}
+            onClick={async () => {
+              setState({ kind: 'dismissing' })
+              const ok = await patchReminders({ dismissed: true })
+              setState(
+                ok
+                  ? { kind: 'hidden' }
+                  : { kind: 'idle', value: '', error: null, saving: false },
+              )
+            }}
+          >
+            {dismissing ? 'Saving…' : 'No thanks'}
+          </button>
+        </div>
+      </form>
+      {state.kind === 'idle' && state.error ? (
+        <p className="mt-2 text-xs text-rose-700">{state.error}</p>
+      ) : null}
+      <p className="text-muted-foreground mt-3 text-xs leading-5">
+        We&apos;ll send a confirmation email once email reminders launch.
+      </p>
     </section>
   )
 }

--- a/src/app/dev/first-time-player/page.tsx
+++ b/src/app/dev/first-time-player/page.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { type CSSProperties } from 'react';
-import { ChevronLeft, Info } from 'lucide-react';
+import { ChevronLeft, Heart, Info, MoreHorizontal, Share2 } from 'lucide-react';
 
 /**
  * Dev tool: preview the first-time player experience.
@@ -10,13 +10,19 @@ import { ChevronLeft, Info } from 'lucide-react';
  * player sees after completing their very first Daily Five (see
  * `FirstSessionPanel` / `RoundReminderCard` / `first-session-recap.ts`).
  *
- * The full first-session panel is two stacked cards: the "first five complete"
- * note, then the reminder opt-in (reused from the returning-user prompt with a
- * first-timer title/description). The real components have side effects — the
- * panel fires a "seen" signal on mount and the reminder buttons PATCH account
- * settings — so we deliberately do NOT mount the live components here. This page
- * mirrors their markup and copy exactly but renders inert: a look-only preview
- * filled out as if a player had just finished everything.
+ * The live recap is NOT its own page — it renders inline at the top of the
+ * Daily Summary (`src/app/daily/summary/page.tsx`). So this preview reproduces
+ * that summary around made-up completed-game content: the summary header and
+ * score, the first-session panel inline beneath it, the growth recap, a couple
+ * of question cards, and the closing card. That way the panel is shown in the
+ * context it actually appears in.
+ *
+ * The real components have side effects — `FirstSessionPanel` fires a "seen"
+ * signal on mount and the reminder buttons PATCH account settings — so we
+ * deliberately do NOT mount the live components here. This page mirrors their
+ * markup and copy but renders inert: a look-only preview filled out as if a
+ * player had just finished their first five. The reminder card is email-only
+ * (SMS isn't available), matching the live `RoundReminderCard`.
  */
 
 // Mirrors RoundReminderCard's `titleStyle` so the reminder card reads identically
@@ -31,80 +37,330 @@ const reminderTitleStyle: CSSProperties = {
   letterSpacing: '0.05em',
 };
 
-export default function DevFirstTimePlayerPage() {
+// Mirrors the summary page's section-title style.
+const sectionTitleStyle: CSSProperties = {
+  fontFamily: 'var(--font-neutral), system-ui, sans-serif',
+  fontSize: '0.8rem',
+  fontWeight: 700,
+  color: 'var(--brand-ink)',
+  textTransform: 'uppercase',
+  letterSpacing: '0.1em',
+};
+
+// Made-up completed game: five questions, four correct. Mirrors the
+// QuestionRecap shape the live summary renders, trimmed to what the static
+// cards below need.
+const MOCK_QUESTIONS = [
+  { isCorrect: true, isSkipped: false },
+  { isCorrect: true, isSkipped: false },
+  { isCorrect: false, isSkipped: false },
+  { isCorrect: true, isSkipped: false },
+  { isCorrect: true, isSkipped: false },
+];
+
+const MOCK_CARDS = [
+  {
+    status: 'Correct' as const,
+    domain: 'World Geography',
+    author: 'The House',
+    question: 'Which river flows through the most countries in the world?',
+    youSaid: 'The Danube',
+    answer: 'The Danube',
+    explanation:
+      'The Danube passes through ten countries — more than any other river — from its source in Germany to the Black Sea.',
+  },
+  {
+    status: 'Not this time' as const,
+    domain: 'Modern Art',
+    author: 'The House',
+    question: 'Who painted the 1907 work "Les Demoiselles d’Avignon"?',
+    youSaid: 'Henri Matisse',
+    answer: 'Pablo Picasso',
+    explanation:
+      'Picasso’s "Les Demoiselles d’Avignon" is widely seen as a proto-Cubist breakthrough that broke with traditional perspective.',
+  },
+];
+
+function ResultDots() {
   return (
-    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
-      <Link
-        href="/users/me"
-        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-      >
-        <ChevronLeft className="size-4" />
-        Back
-      </Link>
+    <div className="flex items-center gap-2" aria-label="Question results">
+      {MOCK_QUESTIONS.map((question, index) => (
+        <span
+          key={index}
+          className="size-2.5 rounded-full border"
+          style={{
+            backgroundColor: question.isSkipped
+              ? 'color-mix(in srgb, var(--brand-ink) 24%, transparent)'
+              : question.isCorrect
+                ? 'color-mix(in srgb, var(--game-correct) 88%, var(--brand-card))'
+                : 'color-mix(in srgb, var(--game-wrong) 78%, var(--brand-card))',
+            borderColor: 'color-mix(in srgb, var(--brand-border) 72%, transparent)',
+            boxShadow: '0 0 0 2px var(--brand-card)',
+          }}
+        />
+      ))}
+    </div>
+  );
+}
 
-      <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
-        First time player
-      </h1>
+function QuestionCard({ card }: { card: (typeof MOCK_CARDS)[number] }) {
+  const isCorrect = card.status === 'Correct';
+  return (
+    <article className="relative overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] p-5 shadow-none">
+      <div
+        className="absolute inset-y-0 left-0 w-1"
+        style={{
+          backgroundColor: isCorrect
+            ? 'var(--game-correct)'
+            : 'color-mix(in srgb, var(--game-wrong) 76%, var(--brand-card))',
+        }}
+      />
 
-      {/* Information at top: what this preview is and how it differs from the
-          live experience. */}
-      <div className="mt-4 flex gap-3 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-card)] p-4 text-card-foreground">
-        <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
-        <div className="text-sm leading-6 text-muted-foreground">
-          <p className="font-medium text-foreground">
-            What a brand-new player sees.
+      <div className="flex items-start justify-between gap-3 pl-1">
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <span
+              className="rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold tracking-[0.05em]"
+              style={{
+                borderColor: isCorrect
+                  ? 'color-mix(in srgb, var(--game-correct) 28%, var(--brand-border))'
+                  : 'var(--brand-border)',
+                backgroundColor: isCorrect
+                  ? 'color-mix(in srgb, var(--game-correct) 8%, var(--brand-card))'
+                  : 'color-mix(in srgb, var(--brand-cream-page) 62%, var(--brand-card))',
+                color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink-700)',
+              }}
+            >
+              {card.status}
+            </span>
+            <p className="text-xs leading-5 text-muted-foreground">
+              <span>{card.domain}</span>
+              <span aria-hidden="true"> · </span>
+              <span>by {card.author}</span>
+            </p>
+          </div>
+        </div>
+
+        <span className="text-muted-foreground -mr-2 -mt-2 inline-flex size-10 shrink-0 items-center justify-center rounded-full">
+          <MoreHorizontal className="size-5" />
+        </span>
+      </div>
+
+      <p className="mt-4 pl-1 text-[1.12rem] leading-7 font-medium tracking-[-0.01em] text-[var(--brand-ink)]">
+        {card.question}
+      </p>
+
+      <div className="mt-5 grid gap-3 rounded-md border border-[var(--brand-border)] bg-[var(--brand-cream-page)] p-3 sm:grid-cols-2">
+        <div>
+          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            You said
           </p>
-          <p className="mt-1">
-            This is the full first-session recap that shows once, right after a
-            player finishes their very first Daily Five — the &ldquo;first five
-            complete&rdquo; note followed by the reminder opt-in. It&apos;s a
-            look-only preview: unlike the live panel it doesn&apos;t record the
-            &ldquo;seen&rdquo; signal, and the reminder buttons don&apos;t change
-            any account settings.
+          <p className="mt-1 text-sm leading-6 text-[var(--brand-ink)]">{card.youSaid}</p>
+        </div>
+        <div className="border-t border-[var(--brand-border)] pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-3">
+          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            Answer
+          </p>
+          <p
+            className="mt-1 text-sm leading-6 font-medium"
+            style={{ color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink)' }}
+          >
+            {card.answer}
           </p>
         </div>
       </div>
 
-      {/* Static replica of FirstSessionPanel's first-session card. Sample name
-          stands in for the real player's first name. */}
-      <section className="mt-6 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
-        <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-          First five complete
-        </p>
-        <h2 className="mt-2 font-serif text-2xl leading-tight text-[var(--brand-ink)]">
-          Nice start, Sam.
-        </h2>
+      <section className="mt-5 pl-1">
+        <h3 className="text-sm font-semibold text-[var(--brand-ink)]">
+          Why this is the answer
+        </h3>
         <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-          Five new questions come every day. Want different ones?{' '}
-          <span className="text-[var(--brand-link)] underline underline-offset-4">
-            Set your topics here
-          </span>
-          .
+          {card.explanation}
         </p>
       </section>
 
-      {/* Static replica of RoundReminderCard's idle state, with the first-timer
-          title/description FirstSessionPanel passes in. Inert: the live buttons
-          PATCH /api/account/reminders, so here they render but do nothing. */}
-      <section className="card mt-5 px-5 py-4">
-        <h2 style={reminderTitleStyle}>
-          Want a reminder when new questions land?
-        </h2>
-        <p className="text-foreground mt-2 text-sm leading-6">
-          One message a day, max. You can turn it off any time.
-        </p>
-        <div className="mt-4 flex flex-col gap-2 sm:flex-row">
-          <button type="button" className="btn-primary sm:flex-1">
-            Yes, text me
-          </button>
-          <button type="button" className="btn-ghost sm:flex-1">
-            Use email instead
-          </button>
-          <button type="button" className="btn-ghost sm:flex-1">
-            No thanks
-          </button>
+      <div className="mt-5 flex flex-wrap items-center gap-1 border-t border-[var(--brand-border)] pt-3 text-muted-foreground">
+        <span className="inline-flex min-h-9 items-center gap-1.5 rounded-full px-2.5 text-xs">
+          <Heart className="size-4" />
+          React
+        </span>
+        <span className="inline-flex min-h-9 items-center gap-1.5 rounded-full px-2.5 text-xs">
+          <Share2 className="size-4" />
+          Share
+        </span>
+      </div>
+    </article>
+  );
+}
+
+export default function DevFirstTimePlayerPage() {
+  const totalCorrect = MOCK_QUESTIONS.filter((q) => q.isCorrect).length;
+
+  return (
+    <main className="min-h-dvh bg-[var(--brand-cream-page)] px-4 py-6 text-[var(--brand-ink)]">
+      <div className="mx-auto max-w-3xl">
+        <Link
+          href="/users/me"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          Back
+        </Link>
+
+        <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
+          First time player
+        </h1>
+
+        {/* Information at top: what this preview is and how it differs from the
+            live experience. */}
+        <div className="mt-4 flex gap-3 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-card)] p-4 text-card-foreground">
+          <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+          <div className="text-sm leading-6 text-muted-foreground">
+            <p className="font-medium text-foreground">
+              What a brand-new player sees.
+            </p>
+            <p className="mt-1">
+              This is the full first-session recap, shown the way it appears in
+              the app: inline at the top of the Daily Summary, on top of a
+              completed game. The made-up game below is a stand-in for the
+              player&apos;s very first Daily Five. It&apos;s a look-only preview:
+              unlike the live panel it doesn&apos;t record the &ldquo;seen&rdquo;
+              signal, and the reminder field doesn&apos;t change any account
+              settings.
+            </p>
+          </div>
         </div>
-      </section>
+
+        {/* Static replica of the Daily Summary header (mirrors
+            src/app/daily/summary/page.tsx) around made-up completed-game content. */}
+        <div className="mt-8 rounded-2xl border border-dashed border-[var(--brand-border)] p-4">
+          <p className="mb-4 text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            Daily Summary · preview
+          </p>
+
+          <header className="pb-2">
+            <span className="text-muted-foreground inline-flex min-h-9 items-center text-sm font-medium">
+              Session recap
+            </span>
+            <div className="mt-4 flex items-start justify-between gap-4">
+              <div>
+                <h2 className="font-serif text-[2.75rem] leading-[0.95] tracking-[-0.03em] text-[var(--brand-ink)] sm:text-5xl">
+                  Today&rsquo;s Five
+                </h2>
+                <p className="mt-4 max-w-xl text-[1.02rem] leading-7 text-[var(--brand-ink-700)]">
+                  You found common ground in World Geography and opened a few new
+                  edges of the map.
+                </p>
+              </div>
+              <p className="shrink-0 pt-2 text-sm font-medium text-[var(--brand-ink-400)]">
+                {totalCorrect} / {MOCK_QUESTIONS.length}
+              </p>
+            </div>
+            <div className="mt-5 flex items-center justify-between gap-3">
+              <ResultDots />
+              <span className="inline-flex min-h-9 items-center gap-2 rounded-full border border-[var(--brand-border)] bg-[var(--brand-card)] px-3 text-sm font-medium text-[var(--brand-ink-700)]">
+                <Share2 className="size-4" />
+                Share your results
+              </span>
+            </div>
+            <p className="text-muted-foreground mt-4 text-sm leading-6 italic">
+              You found new ground in World Geography.
+            </p>
+          </header>
+
+          {/* Inline first-session panel — the actual first-time-player surface.
+              Static replica of FirstSessionPanel's first-session card; sample
+              name stands in for the real player's first name. */}
+          <section className="mt-6 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
+            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+              First five complete
+            </p>
+            <h2 className="mt-2 font-serif text-2xl leading-tight text-[var(--brand-ink)]">
+              Nice start, Sam.
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+              Five new questions come every day. Want different ones?{' '}
+              <span className="text-[var(--brand-link)] underline underline-offset-4">
+                Set your topics here
+              </span>
+              .
+            </p>
+          </section>
+
+          {/* Static replica of RoundReminderCard's idle state with the first-timer
+              title/description FirstSessionPanel passes in. Email-only (SMS isn't
+              available). Inert: the live field PATCHes /api/account/reminders, so
+              here it renders but does nothing. */}
+          <section className="card mt-5 px-5 py-4">
+            <h2 style={reminderTitleStyle}>
+              Want a reminder when new questions land?
+            </h2>
+            <p className="text-foreground mt-2 text-sm leading-6">
+              One message a day, max. You can turn it off any time.
+            </p>
+            <div className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start">
+              <input
+                type="email"
+                inputMode="email"
+                placeholder="you@example.com"
+                readOnly
+                className="bg-[var(--brand-field)] flex-1 rounded-lg border border-[var(--accent-gold)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
+              />
+              <div className="flex gap-2">
+                <button type="button" className="btn-primary">
+                  Email me
+                </button>
+                <button type="button" className="btn-ghost">
+                  No thanks
+                </button>
+              </div>
+            </div>
+            <p className="text-muted-foreground mt-3 text-xs leading-5">
+              We&apos;ll send a confirmation email once email reminders launch.
+            </p>
+          </section>
+
+          {/* Growth recap stub — present so the panel reads in its real context. */}
+          <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-4">
+            <h2 style={sectionTitleStyle}>Your Growth Recap</h2>
+            <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+              World Geography and Modern Art both moved up a notch today.
+            </p>
+          </section>
+
+          {/* Today's questions — made-up completed-game cards. */}
+          <section className="mt-8">
+            <div className="mb-4">
+              <h2 className="font-serif text-2xl leading-tight text-[var(--brand-ink)]">
+                Today&rsquo;s questions
+              </h2>
+              <p className="mt-1 text-sm leading-6 text-muted-foreground">
+                A few were yours. A few were new.
+              </p>
+            </div>
+            <div className="space-y-4">
+              {MOCK_CARDS.map((card, index) => (
+                <QuestionCard key={index} card={card} />
+              ))}
+            </div>
+          </section>
+
+          {/* Closing card. */}
+          <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-6 text-center">
+            <p className="text-[1.05rem] leading-7 text-[var(--brand-ink-700)]">
+              Wednesday&rsquo;s five arrive at noon.
+            </p>
+            <div className="mt-5 flex flex-col items-center gap-3">
+              <span className="btn-primary w-full sm:w-auto sm:min-w-56">
+                Back home
+              </span>
+              <span className="text-muted-foreground text-sm font-medium underline underline-offset-4">
+                See your knowledge map
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
     </main>
   );
 }


### PR DESCRIPTION
## Summary
Simplifies the reminder opt-in flow to email-only (SMS reminders aren't available yet) and expands the first-time player dev preview to show the recap in its actual context within the Daily Summary.

## Changes

**RoundReminderCard.tsx:**
- Removed SMS opt-in path (`sms-saving`, `sms-confirmed` states) — the card now shows only an email field inline
- Consolidated state: `idle` state now carries `value`, `error`, and `saving` fields directly instead of branching to a separate `email-form` state
- Simplified button layout: "Email me" + "No thanks" (removed "Yes, text me" and "Use email instead" fork)
- Added clarifying comment that SMS isn't available and the API still accepts `smsOptIn` for other callers

**first-time-player/page.tsx (dev preview):**
- Expanded preview to show the first-session panel in context: now renders a full Daily Summary mockup with header, score, result dots, growth recap, question cards, and closing card
- Added `ResultDots()` component to visualize question results (correct/incorrect/skipped)
- Added `QuestionCard()` component to render made-up completed-game cards with status badges, explanations, and action buttons (React/Share)
- Added mock data: `MOCK_QUESTIONS` (5-question game, 4 correct) and `MOCK_CARDS` (2 sample question cards)
- Updated info box to explain the preview now shows the recap as it appears in the app (inline at top of summary)
- Changed reminder card to email-only with a read-only email field (matching the live `RoundReminderCard` behavior)
- Added section-title style constant to match the summary page's styling
- Wrapped content in a dashed-border container labeled "Daily Summary · preview" to clarify the context

## Implementation notes
- The dev preview now accurately reflects how the first-time player surface appears in production: inline within the Daily Summary, not as a standalone panel
- Mock question cards use the same styling and structure as the live summary's question recaps
- The reminder card in the preview is email-only and inert (no API calls), matching the simplified `RoundReminderCard` behavior

https://claude.ai/code/session_0114BfVC7QjZA4T76FgtuY4a