### PR TITLE
Add line break in login terms agreement text

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -824,7 +824,8 @@ export default function LoginPanel({
 
       {step !== 'profile' ? (
         <p className="mt-4 text-center text-xs leading-5 text-black/60">
-          By signing in you agree to our{' '}
+          By signing in you agree to our
+          <br />
           <a
             href="/terms"
             target="_blank"


### PR DESCRIPTION
## Summary
Improves the layout of the terms agreement text in the login panel by adding a line break before the terms link.

## Changes
- Added `<br />` element in the LoginPanel terms agreement paragraph to separate "By signing in you agree to our" from the terms link on a new line
- This prevents the link from appearing on the same line as the preceding text, improving readability on smaller screens

## Implementation details
- Modified `src/app/login/LoginPanel.tsx` at the terms agreement text section
- The change is purely presentational and does not affect functionality or logic

https://claude.ai/code/session_014M9hGGYBRbfbagykZr4sdK