### PR TITLE
Refactor Territory Setup section styling and layout

### DIFF
--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -786,7 +786,7 @@ function TerritoryZone({
 
   return (
     <section ref={setRef} className="transition">
-      <div className="mb-3">
+      <div className="mb-4 border-b border-[var(--border-light)] pb-3">
         <h2 className="font-serif text-2xl font-semibold text-[var(--ink)]">{zone.title}</h2>
         <p className="mt-1 text-sm leading-6 text-[var(--text-muted-warm)]">{zone.copy}</p>
       </div>

--- a/src/app/daily/setup/TerritorySetupClient.tsx
+++ b/src/app/daily/setup/TerritorySetupClient.tsx
@@ -529,8 +529,8 @@ export function TerritorySetupClient({
           </section>
         ) : null}
 
-        <section className="mb-8 rounded-[2rem] border border-[var(--border-light)] bg-white/35 p-5">
-          <div className="mb-4">
+        <section className="mb-10">
+          <div className="mb-4 border-b border-[var(--border-light)] pb-3">
             <h2 className="font-serif text-2xl font-semibold text-[var(--ink)]">Add a Territory</h2>
             <p className="mt-1 text-sm leading-6 text-[var(--text-muted-warm)]">
               {nearbyTerritories.length > 0
@@ -785,15 +785,14 @@ function TerritoryZone({
   const categoryGroups = useMemo(() => groupByCategory(domains), [domains]);
 
   return (
-    <section
-      ref={setRef}
-      className={`rounded-[2rem] border bg-white/40 p-4 transition ${highlighted ? 'border-[var(--ink)] shadow-[var(--shadow-overlay)]' : 'border-[var(--border-warm)]'}`}
-    >
-      <div className="mb-4">
+    <section ref={setRef} className="transition">
+      <div className="mb-3">
         <h2 className="font-serif text-2xl font-semibold text-[var(--ink)]">{zone.title}</h2>
         <p className="mt-1 text-sm leading-6 text-[var(--text-muted-warm)]">{zone.copy}</p>
       </div>
-      <div className="min-h-28 space-y-4 rounded-[1.5rem] border border-dashed border-[var(--border-light)] bg-[var(--cream)]/50 p-3">
+      <div
+        className={`min-h-28 space-y-4 rounded-[1.5rem] border border-dashed p-3 transition ${highlighted ? 'border-[var(--ink)] bg-[var(--cream)]/70 shadow-[var(--shadow-overlay)]' : 'border-[var(--border-light)] bg-[var(--cream)]/50'}`}
+      >
         {categoryGroups.length > 0 ? (
           categoryGroups.map(({ category, domains: groupDomains }) => (
             <div key={category}>


### PR DESCRIPTION
## Summary
Simplifies the visual styling of the "Add a Territory" section and TerritoryZone components by removing decorative background and border styling, replacing it with a cleaner underline-based header design. The highlight state is now applied only to the content area rather than the entire section.

## Key Changes
- **"Add a Territory" section:** Removed rounded border container styling (`rounded-[2rem] border bg-white/35 p-5`) and replaced with a simple underlined header (`border-b pb-3`)
- **TerritoryZone component:** 
  - Removed decorative section-level styling (rounded border, background, conditional border color)
  - Applied the same underlined header pattern to zone titles
  - Moved the highlight state (`border-[var(--ink)] shadow-[var(--shadow-overlay)]`) from the section wrapper to the content area (dashed border box), making it more focused on the interactive content rather than the entire zone
  - Adjusted highlight background opacity from `/50` to `/70` for better visual feedback

## Implementation Details
- Both sections now use a consistent header pattern: `border-b border-[var(--border-light)] pb-3`
- The TerritoryZone highlight state is now scoped to the content container with a `transition` class for smooth state changes
- Maintains all existing functionality while reducing visual complexity and improving focus hierarchy

https://claude.ai/code/session_015aS5NDKrBTcVcFHGewYfXG