### PR TITLE
Remove cream card behind loading-screen wordmark

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -188,7 +188,7 @@ export default function LoadingScreen({
         aria-hidden="true"
       />
 
-      <div className="relative z-10 mx-6 w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
+      <div className="relative z-10 mx-6 w-full max-w-sm px-12 py-7 text-center">
         <p className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
           JOSHING
         </p>


### PR DESCRIPTION
Drop the opaque card chrome (background, shadow, ring, rounded corners) behind the `JOSHING` wordmark in `LoadingScreen` so the wordmark and rotating status copy float directly over the animated triangle pattern.

Only the wrapper styling changed — the text, the amber rule, the rotating messages, and the animation are untouched.

https://claude.ai/code/session_015aS5NDKrBTcVcFHGewYfXG

---
_Generated by [Claude Code](https://claude.ai/code/session_015aS5NDKrBTcVcFHGewYfXG)_