### PR TITLE
Add faded brand motif to daily page and serif font to score

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { X } from 'lucide-react';
@@ -756,13 +757,24 @@ export default function DailyPage() {
   }, [queue, currentSlot, submitting]);
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-lg flex-col bg-[var(--surface)] px-0">
+    <main className="relative mx-auto flex min-h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] px-0">
+      {/* Faded brand triangle motif (same artwork as the login screen) behind the
+          game. Sits below the content via -z-10; the header stays opaque so it
+          reads as plain white. */}
+      <Image
+        src="/images/Variant4.png"
+        alt=""
+        aria-hidden
+        fill
+        priority
+        sizes="(max-width: 32rem) 100vw, 32rem"
+        className="pointer-events-none -z-10 object-cover object-center opacity-[0.10] select-none"
+      />
       <header
         className="sticky top-0 z-20 flex items-center justify-between gap-3 border-b px-4 py-3"
         style={{
           borderColor: 'var(--border)',
-          background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
-          backdropFilter: 'blur(6px)',
+          background: 'var(--surface)',
         }}
       >
         <div className="flex items-center gap-3">

--- a/src/components/play/SessionCloseMessage.tsx
+++ b/src/components/play/SessionCloseMessage.tsx
@@ -28,7 +28,7 @@ export function SessionCloseMessage({
 
   return (
     <>
-      <p className="text-[1.22rem] text-[var(--text)] leading-relaxed">{scoreLine}</p>
+      <p className="font-serif text-[1.22rem] text-[var(--text)] leading-relaxed">{scoreLine}</p>
       {interpretiveLine ? (
         <p
           className="mt-1 text-[1.05rem] text-[var(--text-muted)] leading-relaxed"


### PR DESCRIPTION
## Summary
Enhances the visual design of the daily game page by adding a faded background brand motif and improving typography for score messaging.

## Key changes
- **Daily page background:** Added a faded `Variant4.png` brand triangle motif behind the game content (matching the login screen aesthetic). The image sits at `-z-10` opacity `0.10` so it doesn't interfere with readability, while the header remains opaque at `z-20` to preserve contrast.
- **Header styling:** Removed the semi-transparent blur effect (`color-mix` + `backdropFilter`) from the sticky header and switched to solid `var(--surface)` background for cleaner appearance against the new background motif.
- **Score typography:** Applied `font-serif` class to the score line in `SessionCloseMessage` to use the Editorial voice (per the type style guide) for this prominent messaging.

## Implementation details
- The background image uses Next.js `Image` component with `fill`, `priority`, and appropriate `sizes` prop for responsive sizing.
- Image is marked `aria-hidden` and `select-none` since it's purely decorative.
- The `pointer-events-none` class ensures the background doesn't interfere with interactive elements.
- Header z-index hierarchy maintained: background at `-z-10`, content at `z-20`.

https://claude.ai/code/session_01AYnsCsrAa2ErWo4kjnrKPw