### PR TITLE
perf(daily): pre-warm the Daily Five queue + add load-time telemetry

### DIFF
--- a/src/app/api/auth/verify-otp/route.ts
+++ b/src/app/api/auth/verify-otp/route.ts
@@ -7,6 +7,7 @@ import { colorForUser } from '@/components/feed/visual'
 import { normalizeToE164 } from '@/lib/phone-e164'
 import { verifyOtp } from '@/server/auth'
 import { createSession } from '@/server/auth/session'
+import { prewarmDailyQueue } from '@/server/daily/prewarm'
 import { db, users } from '@/server/db'
 import { hashPhoneNumber } from '@/server/lib/phone-hashing'
 import {
@@ -17,6 +18,13 @@ import {
   INVITE_REQUIRED_MESSAGE,
 } from '@/server/friends/invitations'
 import { acceptUserInviteLink } from '@/server/friends/user-invite-token'
+
+// Headroom for the post-response Daily Five pre-warm (prewarmDailyQueue) on the
+// returning-user path. The background build can take seconds of Sonnet
+// generation, and on Vercel `after()` work counts toward this function's
+// duration budget — the default ceiling would kill the build mid-flight. The
+// login response itself still returns immediately; this is only a ceiling.
+export const maxDuration = 90
 
 type VerifyOtpBody = {
   phone?: unknown
@@ -209,6 +217,17 @@ export async function POST(request: Request) {
         invitationAccepted: true,
         onboardingComplete: existingUser.onboardingComplete,
       })
+
+      // Returning, onboarded users: pre-warm today's Daily Five in the
+      // background so /daily is already built by the time they tap in. Usually a
+      // cheap no-op (the daily cron has built it, so fillDailyQueueForUser
+      // early-returns), but it closes the post-reset window where the cron
+      // hasn't yet covered an evening-US / APAC user. New users (onboardingComplete
+      // false) are skipped here — they have no knowledge base to build from yet,
+      // and are pre-warmed at onboarding completion instead.
+      if (existingUser.onboardingComplete) {
+        prewarmDailyQueue(existingUser.id, 'login')
+      }
 
       return NextResponse.json({
         user: {

--- a/src/app/api/onboarding/save-interests/route.ts
+++ b/src/app/api/onboarding/save-interests/route.ts
@@ -4,6 +4,7 @@ import {
   getSession,
   refreshSessionOnboardingClaim,
 } from '@/server/auth/session';
+import { prewarmDailyQueue } from '@/server/daily/prewarm';
 import { normalizeBroadCategory } from '@/lib/knowledge/broad-category';
 import { logTelemetry } from '@/server/telemetry';
 import {
@@ -18,6 +19,12 @@ type SaveInterestsBody = {
   interests?: unknown;
   telemetry?: unknown;
 };
+
+// Headroom for the post-response Daily Five pre-warm (prewarmDailyQueue). The
+// background build can take seconds of Sonnet generation, and on Vercel
+// `after()` work counts toward this function's duration budget — the default
+// ceiling would kill the build mid-flight. Mirrors /api/daily/queue's 90s.
+export const maxDuration = 90;
 
 // Onboarding's build-your-world screen caps the selection at 12 (per product
 // spec); the client mirrors this with MAX_INTERESTS in OnboardingFlow. This is
@@ -117,6 +124,14 @@ export async function POST(request: Request) {
     await saveDeclaredInterests(session.userId, interests);
     await markOnboardingComplete(session.userId);
     await refreshSessionOnboardingClaim();
+
+    // Pre-warm the player's first Daily Five now that their knowledge base
+    // exists. This is the highest-value pre-warm: a brand-new user walks
+    // straight from here into their first round before the daily cron has ever
+    // run for them, so without this they hit the full synchronous generation
+    // (the worst-case loading screen, on their first impression). Fire-and-forget
+    // after the response — they read the welcome/intro screens while it builds.
+    prewarmDailyQueue(session.userId, 'onboarding');
 
     if (telemetry.inviteInterestCount > 0) {
       const event = telemetry.inviteSelectedCount === 0

--- a/src/app/api/telemetry/route.ts
+++ b/src/app/api/telemetry/route.ts
@@ -2,7 +2,12 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 
 import { getSession } from '@/server/auth/session'
-import { logTelemetry, type TelemetryEventName } from '@/server/telemetry'
+import {
+  logLatency,
+  logTelemetry,
+  type LatencyMetric,
+  type TelemetryEventName,
+} from '@/server/telemetry'
 
 export const dynamic = 'force-dynamic'
 
@@ -13,8 +18,19 @@ const CLIENT_TELEMETRY_EVENTS = [
   'friend_invite_auth_started',
 ] as const satisfies readonly TelemetryEventName[]
 
+// Latency metrics the client is allowed to report (RUM). Kept to an explicit
+// allowlist so a public surface can't flood arbitrary latency channels.
+const CLIENT_LATENCY_METRICS = ['daily_load'] as const satisfies readonly LatencyMetric[]
+
 const bodySchema = z.object({
   event: z.enum(CLIENT_TELEMETRY_EVENTS),
+  metadata: z.unknown().optional(),
+})
+
+const latencySchema = z.object({
+  metric: z.enum(CLIENT_LATENCY_METRICS),
+  // Bounded to the route's own ceiling so a bogus value can't skew aggregates.
+  ms: z.number().int().nonnegative().max(600_000),
   metadata: z.unknown().optional(),
 })
 
@@ -38,8 +54,22 @@ function parseMetadata(value: unknown) {
 }
 
 export async function POST(request: Request) {
-  const parsed = bodySchema.safeParse(await request.json().catch(() => null))
+  const raw = await request.json().catch(() => null)
 
+  // Latency (RUM) reports go through the latency channel; product events go
+  // through the event channel. Try latency first since the two shapes are
+  // disjoint (one has `metric`, the other `event`).
+  const latency = latencySchema.safeParse(raw)
+  if (latency.success) {
+    const session = await getSession()
+    logLatency(latency.data.metric, latency.data.ms, {
+      ...parseMetadata(latency.data.metadata),
+      user_id: session?.userId ?? null,
+    })
+    return NextResponse.json({ ok: true })
+  }
+
+  const parsed = bodySchema.safeParse(raw)
   if (!parsed.success) {
     return NextResponse.json(
       { error: 'invalid_event', message: 'Unsupported telemetry event.' },

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -221,9 +221,38 @@ export default function DailyPage() {
     }
   }, []);
 
+  // Client RUM for the perceived Daily Five load (B-PERF measurement). Reports
+  // the wall-clock from loadQueue start to a playable queue on screen, plus
+  // whether this load had to synchronously generate the queue (`generated`) —
+  // the difference between a warm pre-built open and the slow path. Posted to
+  // /api/telemetry as a `daily_load` latency metric; best-effort and never
+  // allowed to affect the player. `keepalive` lets it flush even if the player
+  // immediately starts answering.
+  const reportDailyLoad = useCallback(
+    (ms: number, meta: { generated: boolean; attempts: number }) => {
+      try {
+        void fetch('/api/telemetry', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          keepalive: true,
+          body: JSON.stringify({
+            metric: 'daily_load',
+            ms: Math.round(ms),
+            metadata: { generated: meta.generated, attempts: meta.attempts },
+          }),
+        }).catch(() => {});
+      } catch {
+        // Best-effort RUM only.
+      }
+    },
+    [],
+  );
+
   const loadQueue = useCallback(async () => {
     setLoading(true);
     setError(null);
+    const loadStartedAt = Date.now();
     try {
       const response = await fetch('/api/daily/queue', {
         cache: 'no-store',
@@ -239,7 +268,9 @@ export default function DailyPage() {
         // genuinely has nothing to generate from — that's terminal; send them
         // to setup rather than retrying.
         let createdQueue: QueueResponse | null = null;
+        let createAttempts = 0;
         for (let attempt = 1; attempt <= MAX_QUEUE_CREATE_ATTEMPTS; attempt += 1) {
+          createAttempts = attempt;
           setGeneratingAttempt(attempt);
           const createResponse = await fetch('/api/daily/queue', {
             method: 'POST',
@@ -290,6 +321,7 @@ export default function DailyPage() {
           slots: createdSlots,
         });
         maybeShowFirstRunIntro(createdQueue.is_first_daily);
+        reportDailyLoad(Date.now() - loadStartedAt, { generated: true, attempts: createAttempts });
         setLoading(false);
         return;
       }
@@ -315,13 +347,16 @@ export default function DailyPage() {
         slots,
       });
       maybeShowFirstRunIntro(body.is_first_daily);
+      // Warm open: today's queue already existed (built by the cron or a
+      // post-login/onboarding pre-warm), so no synchronous generation was needed.
+      reportDailyLoad(Date.now() - loadStartedAt, { generated: false, attempts: 0 });
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load today.');
     } finally {
       setGeneratingAttempt(null);
       setLoading(false);
     }
-  }, [router, maybeShowFirstRunIntro]);
+  }, [router, maybeShowFirstRunIntro, reportDailyLoad]);
 
   useEffect(() => {
     const initialTimer = window.setTimeout(() => {

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -178,6 +178,34 @@ export default function TodaysFiveCard({
     }
   }, [])
 
+  // Background pre-build of today's Daily Five from Home (B-PERF prewarm,
+  // option 3). When the server-resolved status shows no queue built yet
+  // (queueId === null) and the round isn't already complete, kick off the
+  // idempotent generation POST so /daily is warm by the time the player taps
+  // "Play now" — turning the long synchronous loading screen into an instant
+  // open. `keepalive` lets the request survive the navigation to /daily.
+  //
+  // Safe and bounded: fillDailyQueueForUser is idempotent and persists through a
+  // (userId, queueDate) upsert, so this racing the daily cron, the login/
+  // onboarding pre-warm, or the /daily POST can't produce a duplicate or partial
+  // queue — the only cost of a lost race is one re-billed build. Fires at most
+  // once per mount.
+  const prefetchedRef = useRef(false)
+  useEffect(() => {
+    if (prefetchedRef.current) return
+    if (!status) return
+    if (status.queueId || status.isComplete || status.questionsRemaining <= 0) return
+    prefetchedRef.current = true
+    void fetch('/api/daily/queue', {
+      method: 'POST',
+      credentials: 'include',
+      cache: 'no-store',
+      keepalive: true,
+    }).catch(() => {
+      // Best-effort warm-up — a failure just means /daily builds on open as before.
+    })
+  }, [status])
+
   const effectiveStatus = status ?? FALLBACK_STATUS
   const answered = Math.max(0, Math.min(effectiveStatus.questionsAnswered, 5))
   const isComplete =

--- a/src/server/daily/prewarm.ts
+++ b/src/server/daily/prewarm.ts
@@ -1,0 +1,75 @@
+import { after } from 'next/server';
+
+import { logLatency } from '@/server/telemetry';
+
+/**
+ * Fire-and-forget pre-warm of a user's Daily Five queue.
+ *
+ * Scheduled via next/server `after()` so it runs AFTER the response is flushed:
+ * the caller (login, onboarding completion) returns immediately and the
+ * seconds-long Sonnet generation happens in the background. By the time the
+ * player reaches `/daily`, the queue is already built — so they never wait at
+ * the loading screen for work that could have happened while they were still
+ * reading the welcome screen.
+ *
+ * Safe to call redundantly. `fillDailyQueueForUser` is idempotent (it
+ * early-returns when today's queue already exists / carries an unplayed one
+ * forward) and `persistDailyQueue` writes through a `(userId, queueDate)`
+ * upsert — so a pre-warm racing the daily cron or the page-load POST cannot
+ * create a duplicate or partial queue. The only cost of a lost race is one
+ * re-billed build; the player is never blocked because the `/daily` POST is the
+ * synchronous fallback for every case this misses.
+ *
+ * The Daily Five orchestrator (and its DB query graph) is imported LAZILY inside
+ * the deferred callback rather than at module top level, so the hot auth /
+ * onboarding routes that schedule a pre-warm don't pull that whole graph into
+ * their own module graph at import time. It's only loaded when a pre-warm
+ * actually runs — at request time, when `@/server/db` is already initialized.
+ *
+ * IMPORTANT: the route that calls this MUST set `maxDuration` high enough for a
+ * full build (90s, matching `/api/daily/queue`). On Vercel, `after()` work
+ * counts toward the function's duration budget, so the default ceiling would
+ * kill generation mid-flight.
+ */
+export function prewarmDailyQueue(userId: string, trigger: 'login' | 'onboarding'): void {
+  try {
+    after(async () => {
+      const startedAt = Date.now();
+      const orchestrator = await import('@/server/daily/queue-orchestrator').catch((error) => {
+        console.error('[daily/prewarm] failed to load orchestrator', {
+          userId,
+          trigger,
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return null;
+      });
+      if (!orchestrator) return;
+
+      try {
+        await orchestrator.fillDailyQueueForUser(userId);
+        logLatency('daily_queue_prewarm', Date.now() - startedAt, { trigger, outcome: 'ok' });
+      } catch (error) {
+        // `no_knowledge_base` is benign — there's simply nothing to build from yet
+        // (e.g. a brand-new user at login before onboarding). Anything else is a
+        // real generation failure worth a stack. Either way the player is never
+        // blocked: the synchronous `/daily` POST regenerates on demand.
+        const isFillError = error instanceof orchestrator.DailyQueueFillError;
+        const outcome = isFillError ? error.code : 'error';
+        logLatency('daily_queue_prewarm', Date.now() - startedAt, { trigger, outcome });
+        if (!isFillError) {
+          console.error('[daily/prewarm] failed', {
+            userId,
+            trigger,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    });
+  } catch {
+    // `after()` requires an active request context. If it's unavailable (a
+    // non-request caller, or a test harness invoking the route handler
+    // directly), skip the pre-warm rather than failing the caller — the
+    // synchronous `/daily` POST is always there as the fallback.
+    console.warn('[daily/prewarm] could not schedule pre-warm', { userId, trigger });
+  }
+}

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -32,6 +32,7 @@ import {
 } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { commitPendingRefineDecisions } from '@/server/refine/commit';
+import { logLatency } from '@/server/telemetry';
 
 export type DailyQueueFillErrorCode = 'no_knowledge_base' | 'generation_failed';
 
@@ -592,6 +593,17 @@ export async function fillDailyQueueForUser(userId: string): Promise<void> {
   }
 
   await persistDailyQueue(userId, slots, generatedQuestionIds);
+
+  // Server timing for the slow path. Logged only when a full build actually ran
+  // (the existing-queue / carry-forward early returns above never reach here),
+  // so `[latency] daily_queue_generated` measures real generation cost — the
+  // long pole behind the /daily loading screen — across every caller (cron,
+  // synchronous POST, and the post-login/onboarding pre-warm).
+  logLatency('daily_queue_generated', Date.now() - startedAt, {
+    slots: slots.length,
+    top_up_rounds: topUpRounds,
+    first_run: isFirstRun,
+  });
 }
 
 // Map a ranked friend-domain candidate to the slot's presence attribution: the

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -50,3 +50,27 @@ export function logTelemetry(
     ...sanitizeMetadata(metadata),
   })
 }
+
+// --- Latency / performance telemetry --------------------------------------
+// A separate channel from product events. Emitted as `[latency] <metric>` so
+// production runtime logs can be filtered into a per-metric p50/p95 table —
+// the measurement PERF-FINDINGS-01 §0 / B-PERF-04 flagged as missing (the
+// project had numeric §12.6 latency targets but no way to observe them). Both
+// server timings (queue generation) and client RUM (/daily perceived load)
+// funnel through here so they share one log shape.
+export type LatencyMetric =
+  | 'daily_queue_generated' // server: a full Daily Five build (the slow path)
+  | 'daily_queue_prewarm' // server: background pre-warm after login/onboarding
+  | 'daily_load' // client RUM: /daily mount → first question on screen
+
+export function logLatency(
+  metric: LatencyMetric,
+  ms: number,
+  metadata: TelemetryMetadata = {}
+): void {
+  console.info(`[latency] ${metric}`, {
+    metric,
+    ms: Math.max(0, Math.round(ms)),
+    ...sanitizeMetadata(metadata),
+  })
+}


### PR DESCRIPTION
## Why

The `/daily` loading screen is slow because opening it triggers **synchronous Sonnet generation** of the five-question queue (`fillDailyQueueForUser`, up to ~90s with retries). A daily cron pre-builds queues for covered users, but brand-new users (first game, before the cron has ever run for them) and users in the post-reset window still hit the full cold generation — the worst case landing on a first impression.

## What

Three layered, **idempotent** pre-warms move generation off the critical path, plus the load-time measurement `PERF-FINDINGS-01` flagged as missing.

### Pre-warms
Safe to overlap: `fillDailyQueueForUser` early-returns when today's queue exists, and `persistDailyQueue` is a `(userId, queueDate)` upsert — so a race can only ever re-bill one build, never produce a duplicate or partial queue.

1. **Onboarding completion** (`save-interests`) — build the first Daily Five the moment the knowledge base exists. Highest value: fixes the cold-first-game case. *(Option 1)*
2. **Login** (`verify-otp`) — pre-warm for returning, onboarded users; closes the post-reset window the cron hasn't covered. New users skipped (no KB yet). *(Option 2)*
3. **Home** (`TodaysFiveCard`) — when today's queue isn't built, fire the idempotent build POST (`keepalive`) so `/daily` is warm by tap-in. *(Option 3)*

Server pre-warms run via Next 16 `after()` (response returns immediately); the orchestrator graph is **lazy-imported** so the hot auth routes stay light. Both routes set `maxDuration = 90` so `after()` generation isn't platform-killed. Every failure path degrades silently to the existing synchronous `/daily` fallback.

### Telemetry
New `[latency]` channel (`logLatency`) → Vercel runtime logs, filterable into per-metric p50/p95:
- `daily_queue_generated` — real build cost across **every** caller (cron / sync POST / pre-warm).
- `daily_queue_prewarm` — background pre-warm outcomes.
- `daily_load` — **client RUM** for perceived `/daily` load, tagged `generated: true/false` so the warm-vs-cold split proves the pre-warms land. Ingested via `/api/telemetry` (bounded, allowlisted).

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean
- ESLint on changed files — clean
- `vitest` route + daily suites — **452 passed**, 8 skipped, 0 failures

## How to measure the win post-deploy
Filter production runtime logs for `[latency] daily_load`: `generated:false` = warm opens (pre-warm worked), `generated:true` = cold ones still hitting sync generation. The ratio shifting toward `false` is the proof; `[latency] daily_queue_generated` gives raw build p50/p95.

## Notes
- Comments reference `PERF-FINDINGS-01` (the diagnosis doc on `claude/perf-findings-01`); the code is self-contained and doesn't depend on that doc merging.
- Did **not** add `@vercel/speed-insights` for field Core Web Vitals — kept this PR to log-based telemetry to avoid scope creep; easy follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
