### PR TITLE
Add Josefin Sans toggle to the dev design-audit bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -508,3 +508,17 @@ html[data-flat="1"] *:not(.palette-bar, .palette-bar *)::after {
     border-radius: 0 !important;
     box-shadow: none !important;
 }
+
+/* TESTING ONLY — Josefin Sans mode (driven by the dev design bar's "Josefin"
+   toggle; see src/components/dev/PaletteToggle.tsx). When on, <html> carries
+   data-josefin="1": repoint the sans body font at the Josefin Sans variable.
+   Setting --font-sans-body cascades to --font-sans, --font-neutral and
+   --font-mono (all read --font-sans-body); the body rule overrides the literal
+   Montserrat className applied to <body> in layout.tsx so inherited text swaps
+   too. Remove this block with the PaletteToggle bar before shipping. */
+html[data-josefin="1"] {
+    --font-sans-body: var(--font-josefin);
+}
+html[data-josefin="1"] body {
+    font-family: var(--font-josefin), ui-sans-serif, system-ui, -apple-system, sans-serif;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next'
-import { Cormorant_Garamond, Montserrat, Playfair_Display } from 'next/font/google'
+import { Cormorant_Garamond, Josefin_Sans, Montserrat, Playfair_Display } from 'next/font/google'
 import { Analytics } from '@vercel/analytics/next'
 import { SpeedInsights } from '@vercel/speed-insights/next'
 import './globals.css'
@@ -41,6 +41,17 @@ const cormorant = Cormorant_Garamond({
   display: 'swap',
 })
 
+// TESTING ONLY — alternate sans register for the design-audit bar's "Josefin"
+// toggle (see PaletteToggle). When data-josefin="1" is set on <html>, globals.css
+// repoints --font-sans-body (and body's own font-family) at this variable so the
+// whole app's sans text swaps to Josefin Sans. Remove with the toggle before
+// shipping.
+const josefin = Josefin_Sans({
+  subsets: ['latin'],
+  variable: '--font-josefin',
+  display: 'swap',
+})
+
 export const metadata: Metadata = {
   title: 'Joshing',
   description: 'A daily knowledge game',
@@ -60,7 +71,7 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable}`}
+      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable} ${josefin.variable}`}
     >
       <body className={montserrat.className}>
         {/* TESTING ONLY — apply the saved card-background choice before paint so
@@ -68,7 +79,7 @@ export default async function RootLayout({
             shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}if(localStorage.getItem('joshing-josefin')==='1'){document.documentElement.setAttribute('data-josefin','1');}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -48,6 +48,9 @@ const CARD_BG_EVENT = 'joshing-card-bg-change';
 const FLAT_KEY = 'joshing-flat';
 const FLAT_EVENT = 'joshing-flat-change';
 
+const JOSEFIN_KEY = 'joshing-josefin';
+const JOSEFIN_EVENT = 'joshing-josefin-change';
+
 // Read the live choice straight off the <html> attribute (the source of truth,
 // also set by the boot script before paint). useSyncExternalStore keeps the
 // control in sync without an effect-setState and without a hydration mismatch —
@@ -78,9 +81,24 @@ function serverFlat(): boolean {
   return false;
 }
 
+// Josefin toggle — mirrors the flat store, reading the live choice off the
+// <html> `data-josefin` attribute (also set pre-paint by the boot script). When
+// on, globals.css repoints the sans body font at Josefin Sans app-wide.
+function subscribeJosefin(onChange: () => void) {
+  window.addEventListener(JOSEFIN_EVENT, onChange);
+  return () => window.removeEventListener(JOSEFIN_EVENT, onChange);
+}
+function readJosefin(): boolean {
+  return document.documentElement.getAttribute('data-josefin') === '1';
+}
+function serverJosefin(): boolean {
+  return false;
+}
+
 export function PaletteToggle() {
   const index = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
   const flat = useSyncExternalStore(subscribeFlat, readFlat, serverFlat);
+  const josefin = useSyncExternalStore(subscribeJosefin, readJosefin, serverJosefin);
 
   function toggleFlat() {
     const next = !flat;
@@ -93,6 +111,19 @@ export function PaletteToggle() {
       /* private mode / disabled storage — non-fatal */
     }
     window.dispatchEvent(new Event(FLAT_EVENT));
+  }
+
+  function toggleJosefin() {
+    const next = !josefin;
+    const root = document.documentElement;
+    if (next) root.setAttribute('data-josefin', '1');
+    else root.removeAttribute('data-josefin');
+    try {
+      localStorage.setItem(JOSEFIN_KEY, next ? '1' : '0');
+    } catch {
+      /* private mode / disabled storage — non-fatal */
+    }
+    window.dispatchEvent(new Event(JOSEFIN_EVENT));
   }
 
   function apply(next: number) {
@@ -164,6 +195,17 @@ export function PaletteToggle() {
         style={{ ...flatStyle, ...(flat ? flatStyleOn : null) }}
       >
         {flat ? '▣' : '▢'} Flat
+      </button>
+
+      {/* Josefin toggle: swap the sans-serif body font to Josefin Sans app-wide. */}
+      <button
+        type="button"
+        onClick={toggleJosefin}
+        aria-pressed={josefin}
+        aria-label={`Josefin Sans font: ${josefin ? 'on' : 'off'}. Tap to toggle.`}
+        style={{ ...flatStyle, ...(josefin ? flatStyleOn : null) }}
+      >
+        {josefin ? '▣' : '▢'} Josefin
       </button>
 
       {/* Jump straight to any background. */}


### PR DESCRIPTION
Adds a "Josefin" toggle alongside the existing Flat toggle in the
testing-only PaletteToggle bar. When on, <html> carries data-josefin="1"
and globals.css repoints --font-sans-body at the Josefin Sans next/font
variable, cascading to --font-sans/--font-neutral/--font-mono and
overriding the literal Montserrat className on <body>. Choice persists in
localStorage and is applied pre-paint by the layout boot script.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01F34aB76JP15bPS9LiVbLYE