### PR TITLE
Make Josefin Sans the default sans; keep the Joshing wordmark in Mont…

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -7,6 +7,10 @@
 @theme inline {
     --font-heading: var(--font-sans);
     --font-serif: var(--font-cormorant, Georgia, "Times New Roman", serif);
+    /* Brand wordmark ("Joshing") stays Montserrat even though body sans is now
+       Josefin. Surfaces the `font-wordmark` utility; mirrored in :root below so
+       inline-style consumers can read var(--font-wordmark) too. */
+    --font-wordmark: var(--font-montserrat, ui-sans-serif, system-ui, -apple-system, sans-serif);
     --color-sidebar-ring: var(--sidebar-ring);
     --color-sidebar-border: var(--sidebar-border);
     --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
@@ -50,6 +54,11 @@
 
 :root {
     --font-sans: var(--font-sans-body, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+
+    /* Re-declared here (not only in @theme inline) so inline `style` consumers —
+       e.g. the knowledge-card wordmarks — can resolve var(--font-wordmark). The
+       "Joshing" wordmark stays Montserrat; everything else uses Josefin Sans. */
+    --font-wordmark: var(--font-montserrat, ui-sans-serif, system-ui, -apple-system, sans-serif);
 
     /* ── Joshing brand foundation ───────────────────────────────────────────
        Sourced from the Figma design system (JOSHING DESIGN SYSTEM): navy ink
@@ -507,18 +516,4 @@ html[data-flat="1"] *:not(.palette-bar, .palette-bar *)::before,
 html[data-flat="1"] *:not(.palette-bar, .palette-bar *)::after {
     border-radius: 0 !important;
     box-shadow: none !important;
-}
-
-/* TESTING ONLY — Josefin Sans mode (driven by the dev design bar's "Josefin"
-   toggle; see src/components/dev/PaletteToggle.tsx). When on, <html> carries
-   data-josefin="1": repoint the sans body font at the Josefin Sans variable.
-   Setting --font-sans-body cascades to --font-sans, --font-neutral and
-   --font-mono (all read --font-sans-body); the body rule overrides the literal
-   Montserrat className applied to <body> in layout.tsx so inherited text swaps
-   too. Remove this block with the PaletteToggle bar before shipping. */
-html[data-josefin="1"] {
-    --font-sans-body: var(--font-josefin);
-}
-html[data-josefin="1"] body {
-    font-family: var(--font-josefin), ui-sans-serif, system-ui, -apple-system, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,11 +9,23 @@ import { Nav } from "@/components/Nav";
 import { PaletteToggle } from "@/components/dev/PaletteToggle";
 import { getSessionToken, readSessionClaims } from '@/server/auth/session';
 
-// Intentional product choice (2026-05-16): Montserrat is the body font.
-// PRD §typography spec'd Inter, but Montserrat ships. Update PRD to reflect this.
-const montserrat = Montserrat({
+// Josefin Sans is the app's body/UI sans font (2026-06-16). It drives
+// --font-sans-body, which cascades to --font-sans, --font-neutral and
+// --font-mono. The one exception is the "Joshing" wordmark, which stays in
+// Montserrat (loaded below as --font-montserrat / surfaced as font-wordmark).
+const josefin = Josefin_Sans({
   subsets: ['latin'],
   variable: '--font-sans-body',
+  display: 'swap',
+})
+
+// Montserrat is now reserved for the "Joshing" brand wordmark only (Nav,
+// LoadingScreen, login title, knowledge-card wordmarks). Exposed via
+// --font-montserrat and surfaced to Tailwind as `font-wordmark` in globals.css.
+// (Previously the app-wide body font; replaced by Josefin Sans 2026-06-16.)
+const montserrat = Montserrat({
+  subsets: ['latin'],
+  variable: '--font-montserrat',
   display: 'swap',
 })
 
@@ -41,17 +53,6 @@ const cormorant = Cormorant_Garamond({
   display: 'swap',
 })
 
-// TESTING ONLY — alternate sans register for the design-audit bar's "Josefin"
-// toggle (see PaletteToggle). When data-josefin="1" is set on <html>, globals.css
-// repoints --font-sans-body (and body's own font-family) at this variable so the
-// whole app's sans text swaps to Josefin Sans. Remove with the toggle before
-// shipping.
-const josefin = Josefin_Sans({
-  subsets: ['latin'],
-  variable: '--font-josefin',
-  display: 'swap',
-})
-
 export const metadata: Metadata = {
   title: 'Joshing',
   description: 'A daily knowledge game',
@@ -71,15 +72,15 @@ export default async function RootLayout({
   return (
     <html
       lang="en"
-      className={`font-sans ${montserrat.variable} ${playfair.variable} ${cormorant.variable} ${josefin.variable}`}
+      className={`font-sans ${josefin.variable} ${montserrat.variable} ${playfair.variable} ${cormorant.variable}`}
     >
-      <body className={montserrat.className}>
+      <body className={josefin.className}>
         {/* TESTING ONLY — apply the saved card-background choice before paint so
             there's no flash on navigation. Remove with <PaletteToggle/> before
             shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}if(localStorage.getItem('joshing-josefin')==='1'){document.documentElement.setAttribute('data-josefin','1');}}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -32,7 +32,7 @@ function readUserInvite(
 function TitleCard() {
   return (
     <section className="w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
-      <h1 className="font-sans text-5xl leading-[52px] font-bold tracking-[4.8px] text-[var(--brand-ink-950)]">
+      <h1 className="font-wordmark text-5xl leading-[52px] font-bold tracking-[4.8px] text-[var(--brand-ink-950)]">
         JOSHING
       </h1>
       <div

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -189,7 +189,7 @@ export default function LoadingScreen({
       />
 
       <div className="relative z-10 mx-6 w-full max-w-sm rounded-[var(--radius-md)] bg-[var(--brand-cream-card)] px-12 py-7 text-center shadow-[0_4px_4px_0_rgba(0,0,0,0.25),0_4px_12px_0_rgba(40,32,30,0.04)] ring-1 ring-black/5">
-        <p className="font-sans text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
+        <p className="font-wordmark text-5xl font-bold leading-[52px] tracking-[4.8px] text-[var(--brand-ink-950)]">
           JOSHING
         </p>
         <div

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -162,7 +162,7 @@ export function Nav({
         <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
-            className="font-sans text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"
+            className="font-wordmark text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"
           >
             Joshing
           </Link>

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -48,9 +48,6 @@ const CARD_BG_EVENT = 'joshing-card-bg-change';
 const FLAT_KEY = 'joshing-flat';
 const FLAT_EVENT = 'joshing-flat-change';
 
-const JOSEFIN_KEY = 'joshing-josefin';
-const JOSEFIN_EVENT = 'joshing-josefin-change';
-
 // Read the live choice straight off the <html> attribute (the source of truth,
 // also set by the boot script before paint). useSyncExternalStore keeps the
 // control in sync without an effect-setState and without a hydration mismatch —
@@ -81,24 +78,9 @@ function serverFlat(): boolean {
   return false;
 }
 
-// Josefin toggle — mirrors the flat store, reading the live choice off the
-// <html> `data-josefin` attribute (also set pre-paint by the boot script). When
-// on, globals.css repoints the sans body font at Josefin Sans app-wide.
-function subscribeJosefin(onChange: () => void) {
-  window.addEventListener(JOSEFIN_EVENT, onChange);
-  return () => window.removeEventListener(JOSEFIN_EVENT, onChange);
-}
-function readJosefin(): boolean {
-  return document.documentElement.getAttribute('data-josefin') === '1';
-}
-function serverJosefin(): boolean {
-  return false;
-}
-
 export function PaletteToggle() {
   const index = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
   const flat = useSyncExternalStore(subscribeFlat, readFlat, serverFlat);
-  const josefin = useSyncExternalStore(subscribeJosefin, readJosefin, serverJosefin);
 
   function toggleFlat() {
     const next = !flat;
@@ -111,19 +93,6 @@ export function PaletteToggle() {
       /* private mode / disabled storage — non-fatal */
     }
     window.dispatchEvent(new Event(FLAT_EVENT));
-  }
-
-  function toggleJosefin() {
-    const next = !josefin;
-    const root = document.documentElement;
-    if (next) root.setAttribute('data-josefin', '1');
-    else root.removeAttribute('data-josefin');
-    try {
-      localStorage.setItem(JOSEFIN_KEY, next ? '1' : '0');
-    } catch {
-      /* private mode / disabled storage — non-fatal */
-    }
-    window.dispatchEvent(new Event(JOSEFIN_EVENT));
   }
 
   function apply(next: number) {
@@ -195,17 +164,6 @@ export function PaletteToggle() {
         style={{ ...flatStyle, ...(flat ? flatStyleOn : null) }}
       >
         {flat ? '▣' : '▢'} Flat
-      </button>
-
-      {/* Josefin toggle: swap the sans-serif body font to Josefin Sans app-wide. */}
-      <button
-        type="button"
-        onClick={toggleJosefin}
-        aria-pressed={josefin}
-        aria-label={`Josefin Sans font: ${josefin ? 'on' : 'off'}. Tap to toggle.`}
-        style={{ ...flatStyle, ...(josefin ? flatStyleOn : null) }}
-      >
-        {josefin ? '▣' : '▢'} Josefin
       </button>
 
       {/* Jump straight to any background. */}

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -167,7 +167,7 @@ const titleStyle: CSSProperties = {
 
 const wordmarkStyle: CSSProperties = {
   margin: 0,
-  fontFamily: 'var(--font-sans-body), system-ui, sans-serif',
+  fontFamily: 'var(--font-wordmark), system-ui, sans-serif',
   fontWeight: 700,
   fontSize: '0.92rem',
   color: 'var(--brand-ink)',

--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -210,7 +210,7 @@ const headerStyle: CSSProperties = {
 
 const wordmarkStyle: CSSProperties = {
   margin: 0,
-  fontFamily: 'var(--font-sans-body), system-ui, sans-serif',
+  fontFamily: 'var(--font-wordmark), system-ui, sans-serif',
   fontWeight: 700,
   fontSize: '0.92rem',
   color: 'var(--brand-ink)',


### PR DESCRIPTION
…serrat

Promotes Josefin Sans from the dev-bar toggle to the app's default body/UI sans: it now drives --font-sans-body, cascading to --font-sans/--font-neutral/ --font-mono and the <body> className. Montserrat is retained solely for the "Joshing" brand wordmark via a new --font-wordmark token (font-wordmark utility), applied to the Nav, LoadingScreen, login title, and the knowledge-card wordmarks. The share cards keep their own monospace JOSHING treatment and are untouched.

Removes the now-redundant testing-only Josefin toggle (button, data-josefin CSS/boot-script) since Josefin is the default; the card-bg and Flat dev toggles remain.


Claude-Session: https://claude.ai/code/session_01F34aB76JP15bPS9LiVbLYE