### PR TITLE
Collapse stacked home eyebrows; promote From Friends section

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -140,10 +140,15 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
       {/* Sit the header on the feed's left gutter — the same 2px the activity
           rows pad in (where the fixed icon column / shape marks begin), so the
           header and the shapes share one left edge. The day labels indent
-          further (pl-9, past the icon column) to meet the row copy. */}
-      <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
-        For you
-      </p>
+          further (pl-9, past the icon column) to meet the row copy.
+          Only rendered when the directed "For you" zone actually has content —
+          an empty section should not carry a heading (it read as a stranded
+          eyebrow above the "From Friends" band). */}
+      {edition.direct.served.length > 0 ? (
+        <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+          For you
+        </p>
+      ) : null}
       <FeedList
         pageSize={FEED_PAGE_SIZE}
         initialPage={initialPage}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -561,7 +561,7 @@ type UnifiedRow = GroupInputRow<FeedApiItem>
 // D-HOME-PACING-01 §2 (tuned 2026-06-12): on the budgeted home, the texture
 // zone runs this many rows, then the rotating panel as a mid-zone interlude,
 // then the remaining rows (the server caps the set at TEXTURE_SOFT_CAP = 8),
-// closed by the "See all activity →" row.
+// closed by the "See more activity →" row.
 const TEXTURE_LEAD_COUNT = 3
 
 // Wrap a promo/panel StreamItem as an activity row so the single rotating panel
@@ -815,6 +815,9 @@ const FROM_FRIENDS_STEP = 10
 function FeedSectionHeading({
   unifiedHome,
   subdued = false,
+  prominent = false,
+  windowLabel,
+  subtitle,
   children,
 }: {
   unifiedHome: boolean
@@ -823,23 +826,54 @@ function FeedSectionHeading({
   // quiet sub-labels: a notch quieter and tighter to the band label above them,
   // reusing the same small-caps token family rather than a new visual system.
   subdued?: boolean
+  // Same register as the page's top-level "For you" eyebrow (bold, ink-toned).
+  // "From Friends" is promoted to this so it reads as a peer of "For you"
+  // rather than a faint sub-label under a separate "Past 7 days" band row.
+  prominent?: boolean
+  // The 7-day boundary, folded onto the heading as a quiet "(Past 7 days)"
+  // qualifier instead of stacking as its own eyebrow row above the section.
+  windowLabel?: string
+  // Optional one-line descriptor rendered tight beneath the eyebrow (the way
+  // "For you" pairs with its descriptor). When present the heading + subtitle
+  // are wrapped together so the wrapper — not the bare h2 — is the feed's
+  // space-y child, and the subtitle's small margin isn't overridden by it.
+  subtitle?: string
   children: ReactNode
 }) {
-  return (
-    <h2
-      className={`font-medium uppercase ${
-        subdued
-          ? 'text-muted-foreground/50 pt-1 text-[10px] tracking-[0.14em]'
-          : 'text-muted-foreground/70 pt-4 text-[11px] tracking-[0.12em] first:pt-0'
-      } ${
-        // On the unified-home feed, the label sits flush left on the feed's left
-        // gutter — the same 2px the activity rows pad in (where the shape column
-        // begins) — rather than indenting past the icon column to the row copy.
-        unifiedHome ? 'pl-0.5' : ''
-      }`}
-    >
+  // On the unified-home feed the label sits flush left on the feed's left
+  // gutter — the same 2px the activity rows pad in (where the shape column
+  // begins) — rather than indenting past the icon column to the row copy.
+  const gutter = unifiedHome ? 'pl-0.5' : ''
+  // Top separation belongs on whichever node is the section's direct child: the
+  // bare h2 normally, or the wrapper div when a subtitle pairs with it.
+  const padClasses = subdued ? 'pt-1' : 'pt-4 first:pt-0'
+  const typeClasses = prominent
+    ? 'text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)]'
+    : subdued
+      ? 'text-muted-foreground/50 text-[10px] font-medium tracking-[0.14em]'
+      : 'text-muted-foreground/70 text-[11px] font-medium tracking-[0.12em]'
+
+  const heading = (
+    <h2 className={`uppercase ${typeClasses} ${subtitle ? '' : padClasses} ${gutter}`}>
       {children}
+      {windowLabel ? (
+        <span className="font-normal opacity-60"> ({windowLabel})</span>
+      ) : null}
     </h2>
+  )
+
+  if (!subtitle) return heading
+
+  return (
+    <div className={padClasses}>
+      {heading}
+      <p
+        className={`text-muted-foreground mt-1 text-[13px] italic ${gutter}`}
+        style={{ fontFamily: 'var(--font-display), Georgia, serif' }}
+      >
+        {subtitle}
+      </p>
+    </div>
   )
 }
 
@@ -2006,21 +2040,16 @@ function FeedListContent({
             </Fragment>
           ) : null}
           {/* Zone 2 — the ambient band, bounded to the rolling 7-day window
-              (D-HOME-DASHBOARD-MODEL-01). On the budget home a single band-level
-              "Past 7 days" label states the boundary once; From Friends and
-              Recent activity are demoted to quiet sub-labels beneath it, and a
-              section with nothing in-window shows an honest empty rather than
-              vanishing (model point 4). The pendingQueue subpages and the
-              off-budget standalone Feed keep their own (un-banded) treatments. */}
+              (D-HOME-DASHBOARD-MODEL-01). The 7-day boundary is no longer its
+              own eyebrow row (that read as a third stacked eyebrow above "From
+              Friends"); it is folded onto the lead section heading as a quiet
+              "(Past 7 days)" qualifier — From Friends when present, else Recent
+              activity. From Friends is promoted to the prominent "For you"
+              register (a peer, not a sub-label); Recent activity stays subdued.
+              The pendingQueue subpages and the off-budget standalone Feed keep
+              their own (un-banded) treatments. */}
           {budget ? (
             <Fragment key="past-7-days">
-              {/* The stated boundary, once. bandLabelVisible is the seam
-                  B-HOME-COLDSTART-06 hooks to suppress it when the window is
-                  relaxed for a cold-start user, so it never asserts a false
-                  7-day promise. */}
-              {bandLabelVisible && bandHasContent ? (
-                <FeedSectionHeading unifiedHome={unifiedHome}>Past 7 days</FeedSectionHeading>
-              ) : null}
               {/* From Friends — friends' playable milestone bundles. The server
                   capped the served slice (Playables 4); render it and surface the
                   remainder as a quiet "N more →". Hidden outright when nothing
@@ -2029,7 +2058,12 @@ function FeedListContent({
                   group). */}
               {fromFriendsRows.length > 0 ? (
                 <Fragment key="from-friends">
-                  <FeedSectionHeading unifiedHome={unifiedHome} subdued>
+                  <FeedSectionHeading
+                    unifiedHome={unifiedHome}
+                    prominent
+                    windowLabel={bandLabelVisible && bandHasContent ? 'Past 7 days' : undefined}
+                    subtitle="Play the questions your friends have aced."
+                  >
                     From Friends
                   </FeedSectionHeading>
                   {groupActivityByFriend(fromFriendsRows).map(renderRow)}
@@ -2045,12 +2079,20 @@ function FeedListContent({
               {/* Recent activity — the ambient texture stream (relationship
                   events, convergence, social moments) as full-sentence LONE
                   events (D-FEED-GROUP3-01 §2). The one rotating panel splices
-                  after the lead rows (§2 slot 5); the "See all activity →" row
+                  after the lead rows (§2 slot 5); the "See more activity →" row
                   closes the zone. Hidden outright when nothing in-window
                   (no per-section empty state, 2026-06-15). */}
               {restRows.length > 0 ? (
                 <Fragment key="texture">
-                  <FeedSectionHeading unifiedHome={unifiedHome} subdued>
+                  <FeedSectionHeading
+                    unifiedHome={unifiedHome}
+                    subdued
+                    windowLabel={
+                      bandLabelVisible && bandHasContent && fromFriendsRows.length === 0
+                        ? 'Past 7 days'
+                        : undefined
+                    }
+                  >
                     Recent activity
                   </FeedSectionHeading>
                   {restRows.slice(0, TEXTURE_LEAD_COUNT).map(renderRow)}
@@ -2058,7 +2100,7 @@ function FeedListContent({
                   {restRows.slice(TEXTURE_LEAD_COUNT).map(renderRow)}
                   <OverflowRow
                     unifiedHome={unifiedHome}
-                    label="See all activity →"
+                    label="See more activity →"
                     href="/activities"
                   />
                 </Fragment>

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -165,16 +165,20 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('From Friends')
     expect(html).toContain('4 more from friends →')
     expect(html).toContain('3 more →')
-    // B-HOME-BAND-LABEL-04 — one "Past 7 days" band label governs the ambient
-    // zones, stated once, and Zone 1 (the directed "For you" eyebrow) sits ABOVE
-    // it, outside the windowed band. The per-zone labels are demoted beneath it.
+    // The 7-day boundary is folded onto the "From Friends" heading as a quiet
+    // "(Past 7 days)" qualifier — stated once, only on that heading. Zone 1
+    // (the directed "For you" descriptor) still sits ABOVE it, outside the band.
     expect(html).toContain('Past 7 days')
     expect(html.match(/Past 7 days/g) ?? []).toHaveLength(1)
     expect(html).toContain('Recent activity')
+    // From Friends is promoted to a peer of "For you" and carries a descriptive
+    // subtitle beneath its heading.
+    expect(html).toContain('Play the questions your friends have aced')
     expect(html.indexOf('questions your friends created or sent directly to you')).toBeLessThan(
       html.indexOf('Past 7 days'),
     )
-    expect(html.indexOf('Past 7 days')).toBeLessThan(html.indexOf('From Friends'))
+    // The qualifier trails the "From Friends" label on the same heading.
+    expect(html.indexOf('Past 7 days')).toBeGreaterThan(html.indexOf('From Friends'))
     expect(html).toContain('href="/for-you"')
     expect(html).toContain('href="/from-friends"')
     // Served direct cards and playables both rendered.
@@ -185,15 +189,15 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).not.toContain('Today')
     expect(html).not.toContain('Past two weeks')
     // Texture's see-more goes to Lately (the archive of this stream) — no third
-    // subpage (§4); the revived "See all activity →" row closes the zone.
-    expect(html).toContain('See all activity →')
+    // subpage (§4); the "See more activity →" row closes the zone.
+    expect(html).toContain('See more activity →')
     expect(html).toContain('href="/activities"')
     // Exactly one rotating panel, interleaved after the third texture row
     // (§2 slot 5, tuned 2026-06-12): t0 t1 t2, panel, t3 t4, see-all.
     const panelAt = html.indexOf('PANEL:add_friends')
     expect(panelAt).toBeGreaterThan(html.indexOf('activity:t2:'))
     expect(panelAt).toBeLessThan(html.indexOf('activity:t3:'))
-    expect(html.indexOf('See all activity →')).toBeGreaterThan(html.indexOf('activity:t4:'))
+    expect(html.indexOf('See more activity →')).toBeGreaterThan(html.indexOf('activity:t4:'))
     expect(html.lastIndexOf('PANEL:')).toBe(panelAt) // one panel, not two
   })
 
@@ -241,9 +245,10 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('direct:robyn')
     // Empty ambient sections are hidden outright — no sub-label, no art, no
-    // "honest empty" copy. The band still labels itself because the quiet-week
-    // foot panel keeps content beneath the boundary.
-    expect(html).toContain('Past 7 days')
+    // "honest empty" copy. With both ambient sections gone, the "(Past 7 days)"
+    // qualifier has no heading to ride on, so the lone quiet-week foot panel
+    // renders without a boundary label.
+    expect(html).not.toContain('Past 7 days')
     expect(html).not.toContain('From Friends')
     expect(html).not.toContain('No friend activity this week')
     expect(html).not.toContain('Recent activity')
@@ -252,7 +257,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).not.toContain('Quiet today')
     expect(html).not.toContain('add friends →')
     // The texture see-more is hidden with its (empty) zone.
-    expect(html).not.toContain('See all activity')
+    expect(html).not.toContain('See more activity')
     // The populated page still gets its one panel (quiet-week foot fallback).
     expect(html).toContain('PANEL:common_ground')
   })

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -213,7 +213,7 @@ describe('FeedList — pendingQueue subpage mode (/for-you)', () => {
     // No overflow affordance — nothing is windowed here — and no texture
     // see-more row (the subpage has no texture zone).
     expect(html).not.toContain('more from friends →')
-    expect(html).not.toContain('See all activity')
+    expect(html).not.toContain('See more activity')
   })
 
   it('renders the caught-up empty state when the queue is empty', () => {


### PR DESCRIPTION
The home feed stacked three eyebrows in a row ("For you", "Past 7 days",
"From Friends") whenever the directed zone was empty. Tidy the header
hierarchy:

- Hide the "For you" eyebrow when the directed zone has no served content,
  so it no longer strands above the band.
- Promote "From Friends" to the same prominent register as "For you" (a
  peer, not a faint sub-label) and fold the 7-day boundary onto it as a
  quiet "(Past 7 days)" qualifier instead of its own standalone row. When
  From Friends is empty the qualifier rides Recent activity instead.
- Add a one-line descriptor beneath "From Friends": "Play the questions
  your friends have aced."
- Rename the texture overflow link "See all activity →" to
  "See more activity →".

FeedSectionHeading gains prominent/windowLabel/subtitle props; the
subtitle is wrapped with its heading so Tailwind's space-y doesn't
override its tight margin.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PbMnhU5LEdusn2M7YxQ2Z3