### PR TITLE
Design-debt structural workstream: audit + primitives, card/chip consolidation, dev-tools gating, skeletons

### DIFF
--- a/src/app/activities/loading.tsx
+++ b/src/app/activities/loading.tsx
@@ -1,4 +1,5 @@
 import { CREAM, FS, HILITE, INK } from '@/components/lately/tokens';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 // Route-level fallback for /activities ("Lately"). Mirrors the page shell —
 // cream canvas, the italic "Lately." headline, then a few quiet one-line
@@ -46,14 +47,12 @@ export default function Loading() {
         </div>
 
         <div
-          className="animate-pulse"
           aria-hidden="true"
           style={{ display: 'flex', flexDirection: 'column', gap: 18, marginTop: 24 }}
         >
           {Array.from({ length: 6 }).map((_, i) => (
-            <div
+            <Skeleton
               key={i}
-              className="bg-black/[0.06]"
               style={{
                 height: 16,
                 width: `${85 - i * 6}%`,

--- a/src/app/dev/layout.tsx
+++ b/src/app/dev/layout.tsx
@@ -1,0 +1,22 @@
+import { notFound } from 'next/navigation';
+import type { ReactNode } from 'react';
+
+import { isAdminUser } from '@/server/auth/admin';
+import { getSession } from '@/server/auth/session';
+
+export const dynamic = 'force-dynamic';
+
+// D-DESIGN-DEBT-STRUCTURAL-01, Phase 3 — gate the entire /dev tree.
+//
+// Before this, /dev/* (reset-session, noon-reset, points-diagnostic, flags,
+// first-time-player, invite-login, loading-preview, test-game) was only
+// session-gated: any authenticated non-admin could reach the dev tools by URL,
+// even once the settings entry point was hidden. This mirrors the admin/reports
+// guard — members of the ADMIN_USER_IDS allowlist only; everyone else (incl.
+// authenticated non-admins) gets Next's 404, so the routes' existence is not
+// revealed. Unset env ⇒ no admins ⇒ always 404 (fail closed).
+export default async function DevLayout({ children }: { children: ReactNode }) {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+  return <>{children}</>;
+}

--- a/src/app/for-you/loading.tsx
+++ b/src/app/for-you/loading.tsx
@@ -1,22 +1,21 @@
+import { Skeleton } from '@/components/ui/Skeleton';
+
 // Route-level fallback for /for-you. Mirrors the page shell (max-w-2xl column +
 // OverflowSubpageHeader + a stack of feed cards) so the layout holds steady
 // while buildPendingDirectQueue resolves, instead of a blank screen.
 export default function Loading() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
-      <div className="animate-pulse" aria-hidden="true">
-        <div className="h-3 w-20 rounded bg-black/[0.06]" />
-        <div className="mt-3 h-8 w-56 rounded bg-black/[0.08]" />
+      <div aria-hidden="true">
+        <Skeleton className="h-3 w-20" />
+        <Skeleton className="mt-3 h-8 w-56" />
       </div>
       <section className="flex flex-col gap-5" aria-hidden="true">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="animate-pulse rounded-[12px] bg-black/[0.04] p-5 ring-1 ring-black/5"
-          >
-            <div className="h-3 w-24 rounded bg-black/[0.06]" />
-            <div className="mt-4 h-5 w-full rounded bg-black/[0.08]" />
-            <div className="mt-2 h-5 w-3/4 rounded bg-black/[0.08]" />
+          <div key={i} className="rounded-[var(--radius-card)] border p-5">
+            <Skeleton className="h-3 w-24" />
+            <Skeleton className="mt-4 h-5 w-full" />
+            <Skeleton className="mt-2 h-5 w-3/4" />
           </div>
         ))}
       </section>

--- a/src/app/friends/find/page.tsx
+++ b/src/app/friends/find/page.tsx
@@ -92,7 +92,7 @@ export default async function FindFriendsPage() {
 
         {/* Block 3 — Existing-invite reflection */}
         {reflections.length > 0 ? (
-          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+          <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
             <h2 className="font-serif text-lg font-semibold">
               People you invited
             </h2>
@@ -140,7 +140,7 @@ export default async function FindFriendsPage() {
 
         {/* Block 5 — Suggested via mutual friends (placeholder; hidden when opted out) */}
         {viewer.discoverableByMutualFriends ? (
-          <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+          <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
             <h2 className="font-serif text-lg font-semibold">
               Suggested via mutual friends
             </h2>

--- a/src/app/from-friends/loading.tsx
+++ b/src/app/from-friends/loading.tsx
@@ -1,21 +1,20 @@
+import { Skeleton } from '@/components/ui/Skeleton';
+
 // Route-level fallback for /from-friends. Mirrors the page shell (max-w-2xl
 // column + OverflowSubpageHeader + a stack of friend-activity cards) so the
 // layout holds steady while buildFriendActivityQueue resolves.
 export default function Loading() {
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
-      <div className="animate-pulse" aria-hidden="true">
-        <div className="h-3 w-24 rounded bg-black/[0.06]" />
-        <div className="mt-3 h-8 w-52 rounded bg-black/[0.08]" />
+      <div aria-hidden="true">
+        <Skeleton className="h-3 w-24" />
+        <Skeleton className="mt-3 h-8 w-52" />
       </div>
       <div className="flex flex-col gap-5" aria-hidden="true">
         {Array.from({ length: 4 }).map((_, i) => (
-          <div
-            key={i}
-            className="animate-pulse rounded-[12px] bg-black/[0.04] p-5 ring-1 ring-black/5"
-          >
-            <div className="h-3 w-32 rounded bg-black/[0.06]" />
-            <div className="mt-4 h-5 w-5/6 rounded bg-black/[0.08]" />
+          <div key={i} className="rounded-[var(--radius-card)] border p-5">
+            <Skeleton className="h-3 w-32" />
+            <Skeleton className="mt-4 h-5 w-5/6" />
           </div>
         ))}
       </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -295,6 +295,14 @@
     --radius-sm: 0.375rem;
     --radius-md: 0.5rem;
     --radius-lg: 0.625rem;
+    /* Canonical CARD radius (D-DESIGN-DEBT-STRUCTURAL-01, Phase 1). One corner for
+       every content card so the feed shell, section cards (friends/profile/
+       settings), and card skeletons stop drifting across rounded-lg/2xl/3xl/[2rem]
+       (audit §1b/§5). Aliased to --radius-xs (4px) — the value the feed already
+       consolidated onto in FeedCardShell (C7). GEOMETRY ONLY; no color. The three
+       elevation tiers it pairs with already exist below: --shadow-card (rest),
+       --shadow-card-strong (raised), --shadow-overlay (modals). */
+    --radius-card: var(--radius-xs);
     --shadow-paper-rest: 0 1px 2px rgb(0 0 0 / 0.05);
     /* Elevation registers (CONS-7, Option B — two intentional registers).
        card / card-strong = the soft rest/raised lift for cards;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -485,11 +485,33 @@
   animation: feed-card-collapse 200ms ease forwards;
 }
 
+/* Branded skeleton shimmer (D-DESIGN-DEBT-STRUCTURAL-01, Phase 3). One neutral
+   loading treatment for the <Skeleton> primitive: a muted base with a soft light
+   sweep built from existing surface tokens (no new color, no triangle motif, no
+   color-state meaning). Replaces the per-route animate-pulse grey boxes. */
+@keyframes skeleton-shimmer {
+  from { background-position: 150% 0; }
+  to   { background-position: -150% 0; }
+}
+.skeleton {
+  background-color: var(--muted);
+  background-image: linear-gradient(
+    90deg,
+    transparent 0%,
+    color-mix(in srgb, var(--card) 55%, transparent) 50%,
+    transparent 100%
+  );
+  background-size: 200% 100%;
+  background-repeat: no-repeat;
+  animation: skeleton-shimmer 1.6s ease-in-out infinite;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .triangle-loader-tri,
   .triangle-loader-sweep,
   .triangle-loader-dot,
-  .loading-message {
+  .loading-message,
+  .skeleton {
     animation: none !important;
   }
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -369,7 +369,7 @@
 
 @layer components {
   .card {
-    @apply rounded-lg border bg-card text-card-foreground shadow-sm;
+    @apply rounded-[var(--radius-card)] border bg-card text-card-foreground shadow-[var(--shadow-card)];
   }
 
   /* Canonical button system. One family of utilities (primary / ghost / danger /

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -44,7 +44,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
           </h1>
           <Link
             href="/login"
-            className="inline-flex h-11 w-full items-center justify-center rounded-md border px-4 text-sm font-medium"
+            className="btn-ghost w-full"
           >
             Go to login
           </Link>
@@ -66,10 +66,7 @@ export default async function InvitePage({ params }: InvitePageProps) {
           <p className="text-muted-foreground text-sm leading-6">
             Log in with your phone number to continue to Joshing.
           </p>
-          <Link
-            href="/login"
-            className="bg-primary text-primary-foreground inline-flex h-11 w-full items-center justify-center rounded-md px-4 text-sm font-medium"
-          >
+          <Link href="/login" className="btn-primary w-full">
             Go to login
           </Link>
         </div>

--- a/src/app/invite/[token]/page.tsx
+++ b/src/app/invite/[token]/page.tsx
@@ -15,7 +15,7 @@ function inviteLoginHref(token: string) {
 function InviteShell({ children }: { children: ReactNode }) {
   return (
     <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="bg-card w-full max-w-sm rounded-2xl border p-5 shadow-sm">
+      <section className="bg-card w-full max-w-sm rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
         {children}
       </section>
     </main>

--- a/src/app/knowledge/[domain]/page.tsx
+++ b/src/app/knowledge/[domain]/page.tsx
@@ -5,6 +5,7 @@ import { useParams, useRouter } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 
 import { DomainVisibilityToggle, type DomainVisibility } from '@/components/knowledge/DomainVisibilityToggle';
+import { Skeleton } from '@/components/ui/Skeleton';
 import { TierProgressBar } from '@/components/progression/TierProgressBar';
 import { AddToBankAction } from '@/components/AddToBankAction';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
@@ -87,10 +88,10 @@ function relativeTime(value: string | null): string {
 function LoadingState() {
   return (
     <main className="mx-auto min-h-dvh max-w-4xl px-4 py-6 pb-24">
-      <div className="mb-6 h-36 animate-pulse rounded-lg border bg-muted" />
+      <Skeleton className="mb-6 h-36 border" />
       <div className="grid gap-4 sm:grid-cols-2">
-        <div className="h-44 animate-pulse rounded-lg border bg-muted" />
-        <div className="h-44 animate-pulse rounded-lg border bg-muted" />
+        <Skeleton className="h-44 border" />
+        <Skeleton className="h-44 border" />
       </div>
     </main>
   );

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -133,7 +133,7 @@ function emptyDomain(domain: string): DomainMastery {
 
 function LoadingSkeleton() {
   return (
-    <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
+    <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
       <div className="grid gap-3.5" aria-hidden="true">
         <Skeleton className="h-36" />
         <div className="grid gap-3.5 sm:grid-cols-2">
@@ -549,7 +549,7 @@ function KnowledgePageContent() {
 
   if (error || !data) {
     return (
-      <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
+      <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
         <section className="bg-[var(--brand-card)] border border-[var(--border-warm)] p-4">
           <p className="m-0 text-[0.72rem] uppercase tracking-[0.08em] text-[var(--text-muted)]">Knowledge</p>
           <h1 className="mt-1.5 text-[clamp(1.1rem,2.5vw,1.55rem)] leading-[1.35] text-[var(--warm-ink)] font-[var(--font-neutral)] font-semibold">Could not load your map</h1>
@@ -560,7 +560,7 @@ function KnowledgePageContent() {
   }
 
   return (
-    <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
+    <main className="w-[min(672px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
       <h1 className="m-0 px-1 font-serif text-[2rem] font-medium leading-tight text-[var(--brand-ink)]">
         Knowledge
       </h1>

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -4,6 +4,7 @@ import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { Combine, Plus, Repeat2, Trash2, X } from 'lucide-react';
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
+import { Skeleton } from '@/components/ui/Skeleton';
 
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
@@ -133,9 +134,16 @@ function emptyDomain(domain: string): DomainMastery {
 function LoadingSkeleton() {
   return (
     <main className="w-[min(760px,94vw)] mx-auto pt-5 pb-10 grid gap-3.5">
-      <section className="bg-[var(--brand-card)] border border-[var(--border-warm)] p-4">
-        <p className="m-0 text-[var(--text-muted-warm)]">Loading...</p>
-      </section>
+      <div className="grid gap-3.5" aria-hidden="true">
+        <Skeleton className="h-36" />
+        <div className="grid gap-3.5 sm:grid-cols-2">
+          <Skeleton className="h-44" />
+          <Skeleton className="h-44" />
+        </div>
+      </div>
+      <span className="sr-only" role="status">
+        Loading your knowledge map…
+      </span>
     </main>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,6 +1,7 @@
 import { Suspense } from 'react'
 import FeedList from '@/components/FeedList'
 import LoadingScreen from '@/components/LoadingScreen'
+import { Skeleton } from '@/components/ui/Skeleton'
 import TodaysFiveCard, {
   type DailyPreferences,
   type DailyStatus,
@@ -213,13 +214,7 @@ function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDail
 }
 
 function CardSkeleton({ minHeight }: { minHeight: string }) {
-  return (
-    <div
-      className="bg-card rounded-lg border p-4"
-      style={{ minHeight }}
-      aria-hidden="true"
-    />
-  )
+  return <Skeleton className="border" style={{ minHeight }} />
 }
 
 function FeedSkeleton() {

--- a/src/app/u/[handle]/[token]/page.tsx
+++ b/src/app/u/[handle]/[token]/page.tsx
@@ -28,7 +28,7 @@ type InvitePageProps = {
 function InviteShell({ children }: { children: ReactNode }) {
   return (
     <main className="bg-background text-foreground flex min-h-screen items-center justify-center px-4 py-10">
-      <section className="bg-card w-full max-w-sm rounded-2xl border p-5 shadow-sm">
+      <section className="bg-card w-full max-w-sm rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
         {children}
       </section>
     </main>

--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -450,7 +450,8 @@ describe('/users/[id] friend profile page', () => {
 
     expect(html).toContain('Privacy &amp; discovery')
     expect(html).toContain('Notifications')
-    expect(html).toContain('Developer tools')
+    // Developer tools are admin-gated (ADMIN_USER_IDS); a normal owner does not see them.
+    expect(html).not.toContain('Developer tools')
     expect(html).toContain('Log out')
     expect(html).toContain('Delete account')
     expect(html).toContain('id="privacy-discovery"')
@@ -458,6 +459,76 @@ describe('/users/[id] friend profile page', () => {
     expect(html).toContain('Your invite link')
     expect(html).not.toContain('href="/account"')
     expect(html).not.toContain('href="/account/')
+  })
+
+  it('shows Developer tools to an admin owner (ADMIN_USER_IDS)', async () => {
+    const prevAdmins = process.env.ADMIN_USER_IDS
+    process.env.ADMIN_USER_IDS = 'self-1'
+    try {
+      getSessionMock.mockResolvedValueOnce({ userId: 'self-1' })
+      getEditableProfileMock.mockResolvedValueOnce({
+        id: 'self-1',
+        displayName: 'Owner',
+        handle: 'owner',
+        handleLastChangedAt: null,
+        phoneNumber: '+15555550100',
+      })
+      getDiscoverabilityMock.mockResolvedValueOnce({
+        discoverableByContacts: false,
+        discoverableByMutualFriends: true,
+      })
+      getReminderStateMock.mockResolvedValueOnce({
+        phoneNumber: '+15555550100',
+        smsOptIn: 'not_asked',
+        emailOptIn: 'not_asked',
+        email: null,
+        pendingEmail: null,
+        emailVerified: false,
+      })
+      getOrCreateInviteTokenMock.mockResolvedValueOnce({
+        handle: 'owner',
+        token: 'invite-token-abc',
+      })
+      getFriendPortraitDataMock.mockResolvedValueOnce({
+        user: {
+          id: 'self-1',
+          displayName: 'Owner',
+          handle: 'owner',
+          memberSince: new Date('2026-01-01T00:00:00.000Z'),
+        },
+        visibility: 'self',
+        friendship: null,
+        interests: [],
+        sharedInterests: [],
+        viewerSoloInterests: [],
+        friendSoloInterests: [],
+        mutualFriends: [],
+        mutualFriendsOverflow: 0,
+        isOwnerView: true,
+        sectionSettings: {
+          knowledge_base: 'public',
+          friends_list: 'friends',
+          authored_questions: 'public',
+        },
+        sectionVisibleTo: {
+          knowledge_base: true,
+          friends_list: true,
+          authored_questions: true,
+        },
+        previewedAs: null,
+      })
+
+      const element = await UserProfilePage({
+        params: Promise.resolve({ id: 'self-1' }),
+        searchParams: Promise.resolve({}),
+      })
+      const html = renderToStaticMarkup(element)
+
+      expect(html).toContain('Developer tools')
+    } finally {
+      if (prevAdmins === undefined) delete process.env.ADMIN_USER_IDS
+      else process.env.ADMIN_USER_IDS = prevAdmins
+    }
   })
 
   it('ignores invalid previewAs (resolved to null) and renders normally', async () => {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,118 +1,101 @@
-import {
-  Brain,
-  Globe,
-  type LucideIcon,
-  Pencil,
-  Users as UsersIcon,
-} from 'lucide-react'
-import Link from 'next/link'
-import { headers } from 'next/headers'
-import { notFound } from 'next/navigation'
+import { Brain, Globe, type LucideIcon, Pencil, Users as UsersIcon } from 'lucide-react';
+import Link from 'next/link';
+import { headers } from 'next/headers';
+import { notFound } from 'next/navigation';
 
-import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard'
-import { AuthoredQuestionsFeed } from '@/components/profile/AuthoredQuestionsFeed'
-import { CommonGround } from '@/components/profile/CommonGround'
-import { InlineEditableField } from '@/components/profile/InlineEditableField'
-import { InlineHandleField } from '@/components/profile/InlineHandleField'
-import { MutualFriendsSection } from '@/components/profile/MutualFriendsSection'
-import { PreviewBanner } from '@/components/profile/PreviewBanner'
-import { ProfileFriendButton } from '@/components/profile/ProfileFriendButton'
-import { RecentlyExploringSection } from '@/components/profile/RecentlyExploringSection'
-import { SectionVisibilityToggle } from '@/components/profile/SectionVisibilityToggle'
-import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow'
-import { AccountActions } from '@/components/profile/settings/AccountActions'
-import { NotificationsForm } from '@/components/profile/settings/NotificationsForm'
-import { PrivacyForm } from '@/components/profile/settings/PrivacyForm'
-import { formatUsPhoneInput } from '@/lib/phone-e164'
-import { getSession } from '@/server/auth/session'
+import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
+import { AuthoredQuestionsFeed } from '@/components/profile/AuthoredQuestionsFeed';
+import { CommonGround } from '@/components/profile/CommonGround';
+import { InlineEditableField } from '@/components/profile/InlineEditableField';
+import { InlineHandleField } from '@/components/profile/InlineHandleField';
+import { MutualFriendsSection } from '@/components/profile/MutualFriendsSection';
+import { PreviewBanner } from '@/components/profile/PreviewBanner';
+import { ProfileFriendButton } from '@/components/profile/ProfileFriendButton';
+import { RecentlyExploringSection } from '@/components/profile/RecentlyExploringSection';
+import { SectionVisibilityToggle } from '@/components/profile/SectionVisibilityToggle';
+import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
+import { AccountActions } from '@/components/profile/settings/AccountActions';
+import { NotificationsForm } from '@/components/profile/settings/NotificationsForm';
+import { PrivacyForm } from '@/components/profile/settings/PrivacyForm';
+import { formatUsPhoneInput } from '@/lib/phone-e164';
+import { isAdminUser } from '@/server/auth/admin';
+import { getSession } from '@/server/auth/session';
 import {
   getDiscoverability,
   getEditableProfile,
   getReminderState,
   HANDLE_CHANGE_COOLDOWN_DAYS,
-} from '@/server/db/queries/account'
-import { getCommonGround } from '@/server/db/queries/common-ground'
-import {
-  getKnowledgePageData,
-  getUserMasteryOverview,
-} from '@/server/db/queries/knowledge'
-import { getAuthoredQuestionsForUser } from '@/server/db/queries/questions'
-import { getFriendPortraitData } from '@/server/profile/friend'
-import {
-  toKnowledgeCardDomain,
-  topPointPositiveDomains,
-} from '@/server/profile/knowledge-view'
-import { resolvePreviewAs } from '@/server/profile/preview'
-import { selectRecentlyExploring } from '@/server/profile/recently-exploring'
+} from '@/server/db/queries/account';
+import { getCommonGround } from '@/server/db/queries/common-ground';
+import { getKnowledgePageData, getUserMasteryOverview } from '@/server/db/queries/knowledge';
+import { getAuthoredQuestionsForUser } from '@/server/db/queries/questions';
+import { getFriendPortraitData } from '@/server/profile/friend';
+import { toKnowledgeCardDomain, topPointPositiveDomains } from '@/server/profile/knowledge-view';
+import { resolvePreviewAs } from '@/server/profile/preview';
+import { selectRecentlyExploring } from '@/server/profile/recently-exploring';
 import {
   buildInviteUrl,
   getBaseUrl,
   getOrCreateInviteToken,
-} from '@/server/friends/user-invite-token'
+} from '@/server/friends/user-invite-token';
 
-const APP_VERSION = 'v1.0.0'
+const APP_VERSION = 'v1.0.0';
 
-export const dynamic = 'force-dynamic'
+export const dynamic = 'force-dynamic';
 
 type UserProfilePageProps = {
-  params: Promise<{ id: string }>
-  searchParams: Promise<{ previewAs?: string }>
-}
+  params: Promise<{ id: string }>;
+  searchParams: Promise<{ previewAs?: string }>;
+};
 
 function formatMemberSince(value: Date) {
   return new Intl.DateTimeFormat(undefined, {
     month: 'long',
     year: 'numeric',
-  }).format(value)
+  }).format(value);
 }
 
 function firstName(displayName: string): string {
-  const trimmed = displayName.trim()
-  if (!trimmed) return 'They'
-  const [first] = trimmed.split(/\s+/)
-  return first ?? trimmed
+  const trimmed = displayName.trim();
+  if (!trimmed) return 'They';
+  const [first] = trimmed.split(/\s+/);
+  return first ?? trimmed;
 }
 
 // Builds the auto-generated tagline rendered at the top of every profile.
 // Replaces the manual `tagline` field that was dropped in migration 0054.
-function buildMindStatement(
-  displayName: string,
-  topDomains: { displayName: string }[],
-): string {
-  const subject = displayName.trim() || 'A mind'
-  const top = topDomains.slice(0, 3).map((d) => d.displayName)
+function buildMindStatement(displayName: string, topDomains: { displayName: string }[]): string {
+  const subject = displayName.trim() || 'A mind';
+  const top = topDomains.slice(0, 3).map((d) => d.displayName);
   if (top.length >= 2) {
-    return `${subject} is building around ${top.slice(0, -1).join(', ')} and ${top.at(-1)}.`
+    return `${subject} is building around ${top.slice(0, -1).join(', ')} and ${top.at(-1)}.`;
   }
   if (top.length === 1) {
-    return `${subject} is building around ${top[0]}.`
+    return `${subject} is building around ${top[0]}.`;
   }
-  return `${subject}'s mind will take shape as they answer and write questions.`
+  return `${subject}'s mind will take shape as they answer and write questions.`;
 }
 
-export default async function UserProfilePage({
-  params,
-  searchParams,
-}: UserProfilePageProps) {
-  const session = await getSession()
-  if (!session) notFound()
+export default async function UserProfilePage({ params, searchParams }: UserProfilePageProps) {
+  const session = await getSession();
+  if (!session) notFound();
 
-  const { id } = await params
-  const { previewAs: rawPreviewAs } = await searchParams
+  const { id } = await params;
+  const { previewAs: rawPreviewAs } = await searchParams;
   // resolvePreviewAs enforces owner-only — non-owner requests return null
   // even if the URL has ?previewAs=… so a shared URL is inert.
-  const previewAs = await resolvePreviewAs(rawPreviewAs, id, session.userId)
-  const portrait = await getFriendPortraitData(id, session.userId, previewAs)
-  if (!portrait) notFound()
+  const previewAs = await resolvePreviewAs(rawPreviewAs, id, session.userId);
+  const portrait = await getFriendPortraitData(id, session.userId, previewAs);
+  if (!portrait) notFound();
 
   // isOwnerView: the requester is the real profile owner, regardless of
   // any active preview. Drives owner-only chrome.
   // ownerSelfView: the owner is on their own profile WITHOUT any active
   // preview — this is the settings-style management view.
-  const isOwnerView = portrait.isOwnerView
-  const ownerSelfView = isOwnerView && !portrait.previewedAs
-  const isStranger = portrait.visibility === 'stranger'
-  const friendFirstName = firstName(portrait.user.displayName)
+  const isOwnerView = portrait.isOwnerView;
+  const ownerSelfView = isOwnerView && !portrait.previewedAs;
+  const isStranger = portrait.visibility === 'stranger';
+  const friendFirstName = firstName(portrait.user.displayName);
 
   // The simulated viewer's label for the banner. 'public' is the new
   // user-facing word for what the preview module still calls 'stranger'.
@@ -120,8 +103,8 @@ export default async function UserProfilePage({
     ? null
     : portrait.previewedAs === 'stranger'
       ? 'public'
-      : 'a friend'
-  const exitPreviewHref = `/users/${portrait.user.id}`
+      : 'a friend';
+  const exitPreviewHref = `/users/${portrait.user.id}`;
 
   const [
     mastery,
@@ -137,9 +120,7 @@ export default async function UserProfilePage({
     getKnowledgePageData(portrait.user.id),
     // Common ground compares the viewer's full mastery base to this profile's.
     // Never rendered on the owner's own profile, so skip the reads there.
-    isOwnerView
-      ? Promise.resolve(null)
-      : getCommonGround(session.userId, portrait.user.id),
+    isOwnerView ? Promise.resolve(null) : getCommonGround(session.userId, portrait.user.id),
     getAuthoredQuestionsForUser({
       userId: portrait.user.id,
       limit: 25,
@@ -156,35 +137,32 @@ export default async function UserProfilePage({
     isOwnerView ? getDiscoverability(session.userId) : Promise.resolve(null),
     isOwnerView ? getReminderState(session.userId) : Promise.resolve(null),
     isOwnerView ? getOrCreateInviteToken(session.userId) : Promise.resolve(null),
-  ])
+  ]);
 
-  let inviteUrl: string | null = null
+  let inviteUrl: string | null = null;
   if (isOwnerView && inviteTokenResult?.handle) {
-    const requestHeaders = await headers()
+    const requestHeaders = await headers();
     inviteUrl = buildInviteUrl(
       getBaseUrl(requestHeaders),
       inviteTokenResult.handle,
       inviteTokenResult.token,
-    )
+    );
   }
 
   const sortedDomains = [...pageData.allDomains].sort(
-    (a, b) =>
-      b.points - a.points || a.displayName.localeCompare(b.displayName),
-  )
-  const topDomains = topPointPositiveDomains(sortedDomains, 5)
-  const totalPointPositiveDomains = sortedDomains.filter(
-    (domain) => domain.points > 0,
-  ).length
+    (a, b) => b.points - a.points || a.displayName.localeCompare(b.displayName),
+  );
+  const topDomains = topPointPositiveDomains(sortedDomains, 5);
+  const totalPointPositiveDomains = sortedDomains.filter((domain) => domain.points > 0).length;
   // Activity-based presence: which domains the user has been answering in
   // lately (recent masteryEvents), distinct from the points-sorted knowledge
   // map above and from declared interests. Per-domain hidden domains are
   // already filtered out by `isHidden`.
-  const recentlyExploring = selectRecentlyExploring(pageData.allDomains)
-  const mindStatement = buildMindStatement(portrait.user.displayName, topDomains)
+  const recentlyExploring = selectRecentlyExploring(pageData.allDomains);
+  const mindStatement = buildMindStatement(portrait.user.displayName, topDomains);
   const tierSignature = `${new Intl.NumberFormat().format(
     Math.round(mastery.totalPoints),
-  )} knowledge points across ${sortedDomains.length} territories`
+  )} knowledge points across ${sortedDomains.length} territories`;
 
   // Owner self-view: the consolidated profile + settings surface. Header
   // card, visibility toggles, preview links, discovery + invite, reminder
@@ -255,21 +233,16 @@ export default async function UserProfilePage({
         </section>
 
         <section className="mb-8" id="privacy-discovery">
-          <h2 className="mb-3 font-serif text-2xl font-semibold">
-            Privacy &amp; discovery
-          </h2>
-          <p className="mb-3 text-sm text-muted-foreground">
+          <h2 className="mb-3 font-serif text-2xl font-semibold">Privacy &amp; discovery</h2>
+          <p className="text-muted-foreground mb-3 text-sm">
             Choose how other people can find you on Joshing.
           </p>
-          <PrivacyForm
-            initialState={discoverability}
-            initialInviteUrl={inviteUrl}
-          />
+          <PrivacyForm initialState={discoverability} initialInviteUrl={inviteUrl} />
         </section>
 
         <section className="mb-8" id="notifications">
           <h2 className="mb-3 font-serif text-2xl font-semibold">Notifications</h2>
-          <p className="mb-3 text-sm text-muted-foreground">
+          <p className="text-muted-foreground mb-3 text-sm">
             We&apos;ll only message you when a new round opens. One per day, max.
           </p>
           <NotificationsForm
@@ -278,22 +251,18 @@ export default async function UserProfilePage({
           />
         </section>
 
-        <AccountActions />
+        <AccountActions isAdmin={isAdminUser(session.userId)} />
 
-        <footer className="mt-auto pt-6 text-center text-xs text-muted-foreground">
-          <Link
-            href="/terms"
-            className="font-medium underline-offset-4 hover:underline"
-          >
+        <footer className="text-muted-foreground mt-auto pt-6 text-center text-xs">
+          <Link href="/terms" className="font-medium underline-offset-4 hover:underline">
             Terms &amp; Disclaimer
           </Link>
           <span className="mt-2 block">
-            Joshing {APP_VERSION} · On Joshing since{' '}
-            {formatMemberSince(portrait.user.memberSince)}.
+            Joshing {APP_VERSION} · On Joshing since {formatMemberSince(portrait.user.memberSince)}.
           </span>
         </footer>
       </main>
-    )
+    );
   }
 
   // Stranger short-circuit: non-friend viewers (and the owner previewing
@@ -339,11 +308,11 @@ export default async function UserProfilePage({
         />
 
         <p className="text-muted-foreground mt-6 text-sm">
-          Become friends to see {friendFirstName}’s knowledge portrait,
-          interests, and authored questions.
+          Become friends to see {friendFirstName}’s knowledge portrait, interests, and authored
+          questions.
         </p>
       </main>
-    )
+    );
   }
 
   // Friend view (also reached when the owner previews as a friend): show
@@ -357,8 +326,8 @@ export default async function UserProfilePage({
     difficulty: question.difficulty,
     createdAt: question.createdAt,
     viewerAnswered: question.viewerAnswered,
-  }))
-  const isSelf = portrait.visibility === 'self'
+  }));
+  const isSelf = portrait.visibility === 'self';
 
   return (
     <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5 pb-28">
@@ -416,10 +385,7 @@ export default async function UserProfilePage({
                 playerDisplayName={portrait.user.displayName}
                 portraitStatement={mindStatement}
                 domains={topDomains.map(toKnowledgeCardDomain)}
-                overflowCount={Math.max(
-                  0,
-                  totalPointPositiveDomains - topDomains.length,
-                )}
+                overflowCount={Math.max(0, totalPointPositiveDomains - topDomains.length)}
                 tierSignature={tierSignature}
                 rarestTerritory={null}
                 rarestTerritorySolo={false}
@@ -430,9 +396,7 @@ export default async function UserProfilePage({
               />
             </div>
           ) : (
-            <p className="text-muted-foreground mt-2 text-sm leading-6">
-              {tierSignature}.
-            </p>
+            <p className="text-muted-foreground mt-2 text-sm leading-6">{tierSignature}.</p>
           )}
           <Link
             href={`/users/${portrait.user.id}/knowledge`}
@@ -445,17 +409,13 @@ export default async function UserProfilePage({
         </section>
       ) : null}
 
-      {portrait.sectionVisibleTo.knowledge_base &&
-      recentlyExploring.length > 0 ? (
-        <RecentlyExploringSection
-          domains={recentlyExploring}
-          friendFirstName={friendFirstName}
-        />
+      {portrait.sectionVisibleTo.knowledge_base && recentlyExploring.length > 0 ? (
+        <RecentlyExploringSection domains={recentlyExploring} friendFirstName={friendFirstName} />
       ) : null}
 
       {portrait.sectionVisibleTo.authored_questions ? (
         <section className="mt-5" aria-label="Authored questions">
-          <p className="mb-3 text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
+          <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
             Authored questions
           </p>
           <AuthoredQuestionsFeed
@@ -467,7 +427,7 @@ export default async function UserProfilePage({
         </section>
       ) : null}
     </main>
-  )
+  );
 }
 
 // Header card shown at the top of every profile variant. The mind
@@ -483,14 +443,14 @@ function ProfileHeaderCard({
   friendshipFormedAt = null,
   friendButton = null,
 }: {
-  displayName: string
-  handle: string | null
-  handleLastChangedAt: string | null
-  mindStatement: string
-  memberSince: Date
-  editable: boolean
-  friendshipFormedAt?: Date | null
-  friendButton?: React.ReactNode
+  displayName: string;
+  handle: string | null;
+  handleLastChangedAt: string | null;
+  mindStatement: string;
+  memberSince: Date;
+  editable: boolean;
+  friendshipFormedAt?: Date | null;
+  friendButton?: React.ReactNode;
 }) {
   return (
     <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
@@ -511,9 +471,7 @@ function ProfileHeaderCard({
               />
             </div>
           ) : (
-            <h1 className="text-foreground font-serif text-3xl font-semibold">
-              {displayName}
-            </h1>
+            <h1 className="text-foreground font-serif text-3xl font-semibold">{displayName}</h1>
           )}
 
           {editable ? (
@@ -528,9 +486,7 @@ function ProfileHeaderCard({
             <p className="text-muted-foreground mt-1 text-sm">@{handle}</p>
           ) : null}
 
-          <p className="text-muted-foreground mt-2 text-sm italic leading-6">
-            {mindStatement}
-          </p>
+          <p className="text-muted-foreground mt-2 text-sm leading-6 italic">{mindStatement}</p>
 
           <p className="text-muted-foreground mt-2 text-sm leading-6">
             On Joshing since {formatMemberSince(memberSince)}.
@@ -544,7 +500,7 @@ function ProfileHeaderCard({
         </div>
       </div>
     </section>
-  )
+  );
 }
 
 // Per-scope helper micro-copy shown beneath each section's visibility toggle,
@@ -570,7 +526,7 @@ const SECTION_VISIBILITY_HELP: Record<
     friends: "Friends you've added on Joshing can see it.",
     public: 'Anyone with your profile link can see it.',
   },
-}
+};
 
 // Settings-style row that renders a 3-level visibility toggle on the
 // right instead of a chevron. Reused for each toggle in the Privacy
@@ -582,26 +538,24 @@ function PrivacyRow({
   section,
   visibility,
 }: {
-  icon: LucideIcon
-  title: string
-  subtitle: string
-  section: 'knowledge_base' | 'authored_questions' | 'friends_list'
-  visibility: 'public' | 'friends' | 'private'
+  icon: LucideIcon;
+  title: string;
+  subtitle: string;
+  section: 'knowledge_base' | 'authored_questions' | 'friends_list';
+  visibility: 'public' | 'friends' | 'private';
 }) {
   return (
     <div className="flex w-full flex-col gap-3 px-4 py-4">
       <div className="flex w-full items-center gap-4">
         <span
-          className="grid size-10 flex-none place-items-center rounded-full bg-muted text-foreground/70"
+          className="bg-muted text-foreground/70 grid size-10 flex-none place-items-center rounded-full"
           aria-hidden="true"
         >
           <Icon className="size-5" />
         </span>
         <span className="flex min-w-0 flex-1 flex-col">
-          <span className="font-serif text-base font-semibold leading-tight">
-            {title}
-          </span>
-          <span className="mt-0.5 text-sm text-muted-foreground">{subtitle}</span>
+          <span className="font-serif text-base leading-tight font-semibold">{title}</span>
+          <span className="text-muted-foreground mt-0.5 text-sm">{subtitle}</span>
         </span>
       </div>
       <div className="pl-14">
@@ -615,5 +569,5 @@ function PrivacyRow({
         />
       </div>
     </div>
-  )
+  );
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -493,7 +493,7 @@ function ProfileHeaderCard({
   friendButton?: React.ReactNode
 }) {
   return (
-    <section className="bg-card text-card-foreground rounded-3xl border p-5 shadow-sm">
+    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
       <div className="flex items-start gap-4">
         <div className="bg-primary/10 text-primary flex h-16 w-16 shrink-0 items-center justify-center rounded-2xl font-serif text-3xl font-semibold">
           {displayName.slice(0, 1).toUpperCase() || 'J'}

--- a/src/components/AddFriendInvite.tsx
+++ b/src/components/AddFriendInvite.tsx
@@ -2,6 +2,7 @@
 
 import { FormEvent, ReactNode, useEffect, useRef, useState } from 'react';
 
+import { Chip } from '@/components/ui/Chip';
 import { formatUsPhoneInput } from '@/lib/phone-e164';
 
 const INTEREST_PLACEHOLDERS = ['Sondheim', 'Mrs. Dalloway', '1980s Saturday morning cartoons'];
@@ -501,9 +502,9 @@ export default function AddFriendInvite({
               if (!suggestion) {
                 return (
                   <div key={`${original}-${index}`} className="text-foreground text-sm">
-                    <span className="bg-primary/5 border-primary/10 inline-block rounded-full border px-3 py-1 shadow-sm">
+                    <Chip className="bg-primary/5 border border-primary/10 px-3 text-sm shadow-sm">
                       {idea}
-                    </span>
+                    </Chip>
                   </div>
                 );
               }
@@ -586,12 +587,12 @@ export default function AddFriendInvite({
           {result.suggestedInterests.length > 0 ? (
             <div className="flex flex-wrap gap-2">
               {result.suggestedInterests.map((interest) => (
-                <span
+                <Chip
                   key={interest}
-                  className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm shadow-sm"
+                  className="bg-primary/5 border border-primary/10 px-3 text-sm shadow-sm"
                 >
                   {interest}
-                </span>
+                </Chip>
               ))}
             </div>
           ) : (
@@ -657,7 +658,7 @@ export default function AddFriendInvite({
   }
 
   return (
-    <section className="bg-card text-card-foreground mb-5 rounded-2xl border p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-sm">
+    <section className="bg-card text-card-foreground mb-5 rounded-[var(--radius-card)] border p-4 pb-[max(1rem,env(safe-area-inset-bottom))] shadow-[var(--shadow-card)]">
       {inviteContent}
     </section>
   );

--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -18,7 +18,7 @@ export default function FriendsHubPage() {
         <h1 className="text-foreground font-serif text-3xl font-semibold">Friends</h1>
       </header>
 
-      <section className="border-primary/15 bg-primary/5 text-card-foreground mb-5 rounded-[2rem] border p-6 shadow-sm">
+      <section className="border-primary/15 bg-primary/5 text-card-foreground mb-5 rounded-[var(--radius-card)] border p-6 shadow-[var(--shadow-card)]">
         {!inviteOpen ? (
           <>
             <p className="text-muted-foreground text-xs font-medium tracking-[0.14em] uppercase">

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -151,7 +151,7 @@ function PendingInviteCard({
   const canMessage = invite.message && invite.inviteePhoneForActions;
 
   return (
-    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <article className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h3 className="text-foreground font-serif text-lg font-semibold leading-tight">{invitationName(invite)}</h3>
@@ -226,7 +226,7 @@ function IncomingRequestCard({
   const busy = pendingRequestId === request.id;
 
   return (
-    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <article className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h3 className="text-foreground font-medium">{request.requesterName}</h3>
@@ -287,7 +287,7 @@ function OutboundRequestCard({
   const busy = pendingRequestId === request.id;
 
   return (
-    <article className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <article className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <div className="flex items-start justify-between gap-3">
         <div className="min-w-0">
           <h3 className="text-foreground font-medium">{request.recipientName}</h3>
@@ -648,11 +648,11 @@ export default function FriendsList() {
               )}
             </>
           ) : pendingInvites.length > 0 ? (
-            <p className="bg-card text-muted-foreground rounded-2xl border p-4 text-sm shadow-sm">
+            <p className="bg-card text-muted-foreground rounded-[var(--radius-card)] border p-4 text-sm shadow-[var(--shadow-card)]">
               Accepted invitations will appear here.
             </p>
           ) : (
-            <div className="bg-card text-card-foreground rounded-2xl border p-5 shadow-sm">
+            <div className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-5 shadow-[var(--shadow-card)]">
               <h3 className="font-serif text-xl font-semibold">You haven’t invited anyone yet.</h3>
               <p className="text-muted-foreground mt-2 text-sm leading-6">
                 Start with someone who shares part of your world.

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
+import { Chip } from '@/components/ui/Chip'
+
 type InviteStatus = 'pending' | 'accepted' | 'expired' | 'cancelled'
 
 type OutgoingInvite = {
@@ -205,7 +207,7 @@ export default function PeopleYouInvited() {
   }
 
   return (
-    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       {error ? (
         <p className="text-destructive mb-3 text-sm font-medium">{error}</p>
       ) : null}
@@ -238,9 +240,7 @@ export default function PeopleYouInvited() {
                     {invite.inviteePhoneMasked}
                   </p>
                 </div>
-                <span className="bg-muted text-foreground rounded-full px-3 py-1 text-xs font-medium">
-                  {STATUS_COPY[invite.status]}
-                </span>
+                <Chip className="px-3">{STATUS_COPY[invite.status]}</Chip>
               </div>
             )
 
@@ -263,12 +263,12 @@ export default function PeopleYouInvited() {
                 {invite.suggestedInterests.length > 0 ? (
                   <div className="mt-3 flex flex-wrap gap-2">
                     {invite.suggestedInterests.map((interest) => (
-                      <span
+                      <Chip
                         key={interest}
-                        className="bg-primary/5 text-foreground border-primary/10 rounded-full border px-3 py-1 text-sm"
+                        className="bg-primary/5 border border-primary/10 px-3 text-sm"
                       >
                         {interest}
-                      </span>
+                      </Chip>
                     ))}
                   </div>
                 ) : (

--- a/src/components/SendQuestionDrawer.tsx
+++ b/src/components/SendQuestionDrawer.tsx
@@ -3,6 +3,8 @@
 import { Check, Search, Send, X } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
+import { Chip } from '@/components/ui/Chip';
+
 export type SendableQuestion = {
   id: string;
   text: string;
@@ -169,7 +171,7 @@ export function SendQuestionDrawer({ isOpen, onClose, question, onSent }: SendQu
 
           <div className="flex-1 overflow-y-auto p-5">
             <section className="rounded-lg border bg-card p-4">
-              <span className="inline-flex rounded-full bg-secondary px-2.5 py-1 text-xs text-secondary-foreground">{question.domain}</span>
+              <Chip className="bg-secondary text-secondary-foreground">{question.domain}</Chip>
               <p className="mt-3 text-sm font-medium leading-6 text-card-foreground">{question.text}</p>
             </section>
 

--- a/src/components/feed/AnswerFeedbackSheet.tsx
+++ b/src/components/feed/AnswerFeedbackSheet.tsx
@@ -9,6 +9,7 @@ import { FeedActionLink } from './FeedActionLink'
 import { NewTerritoryUndo } from './NewTerritoryUndo'
 import { visibleFeedCategory } from './category'
 import { type InsideJokeKind } from '@/lib/questions-types'
+import { Chip } from '@/components/ui/Chip'
 import { CreatorNote, pickCreatorNote } from '@/components/CreatorNote'
 import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/ReportReasonSheet'
 
@@ -234,12 +235,12 @@ export function AnswerFeedbackSheet({
               {isCorrect ? 'Correct!' : 'Not quite'}
             </p>
             {isCorrect && points > 0 ? (
-              <span
-                className="ml-auto inline-flex items-center rounded-full px-3 py-1 text-sm font-semibold text-white"
+              <Chip
+                className="ml-auto px-3 text-sm font-semibold text-white"
                 style={{ backgroundColor: 'var(--game-correct)' }}
               >
                 +{points} {points === 1 ? 'pt' : 'pts'}
-              </span>
+              </Chip>
             ) : null}
           </div>
 
@@ -255,15 +256,17 @@ export function AnswerFeedbackSheet({
               </p>
             ) : null}
             {unverified ? (
-              <span
-                className="inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[0.62rem] font-semibold uppercase tracking-[0.14em]"
+              <Chip
+                size="sm"
+                uppercase
+                className="px-2 py-0.5 text-[0.62rem] font-semibold tracking-[0.14em]"
                 style={{
                   color: GOLD_INK,
                   backgroundColor: 'color-mix(in srgb, var(--accent-gold) 16%, var(--brand-card))',
                 }}
               >
                 Unverified answer
-              </span>
+              </Chip>
             ) : null}
             {!isCorrect ? (
               <p

--- a/src/components/friends/ContactMatchBlock.tsx
+++ b/src/components/friends/ContactMatchBlock.tsx
@@ -70,7 +70,7 @@ export function ContactMatchBlock({
 
   if (!supportsContactsAPI()) {
     return (
-      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
         <h2 className="font-serif text-lg font-semibold">
           Find friends already on Joshing
         </h2>
@@ -84,7 +84,7 @@ export function ContactMatchBlock({
 
   if (!discoverableByContacts) {
     return (
-      <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+      <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
         <h2 className="font-serif text-lg font-semibold">
           Find friends already on Joshing
         </h2>
@@ -174,7 +174,7 @@ export function ContactMatchBlock({
   }
 
   return (
-    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <div className="flex items-center justify-between gap-3">
         <h2 className="font-serif text-lg font-semibold">
           {matches.length > 0 ? 'Contacts on Joshing' : 'Find friends already on Joshing'}

--- a/src/components/friends/FindFriendsSearch.tsx
+++ b/src/components/friends/FindFriendsSearch.tsx
@@ -104,7 +104,7 @@ export function FindFriendsSearch() {
   const swatch = match ? match.avatarColor || colorForUser(match.id) : null
 
   return (
-    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <h2 className="font-serif text-lg font-semibold">Search</h2>
       <p className="text-muted-foreground mt-1 text-sm">
         By @handle or US phone number. Exact matches only.

--- a/src/components/friends/InviteSomeoneNew.tsx
+++ b/src/components/friends/InviteSomeoneNew.tsx
@@ -52,7 +52,7 @@ export function InviteSomeoneNew() {
   }
 
   return (
-    <section className="bg-card text-card-foreground rounded-2xl border p-4 shadow-sm">
+    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
       <h2 className="font-serif text-lg font-semibold">Invite someone new</h2>
       <p className="text-muted-foreground mt-1 text-sm">
         Text a personal note to someone&rsquo;s phone, or copy a link you can share anywhere.

--- a/src/components/profile/SettingsRow.tsx
+++ b/src/components/profile/SettingsRow.tsx
@@ -69,7 +69,7 @@ export function SettingsRow(props: LinkProps | ButtonProps): ReactNode {
 
 export function SettingsGroup({ children }: { children: ReactNode }) {
   return (
-    <div className="divide-y rounded-xl border bg-card text-card-foreground shadow-sm">
+    <div className="divide-y rounded-[var(--radius-card)] border bg-card text-card-foreground shadow-[var(--shadow-card)]">
       {children}
     </div>
   );

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -26,9 +26,7 @@ import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
  *
  * `navigate` is injected so the chain is testable without a DOM.
  */
-export async function logoutAndRedirect(
-  navigate: (url: string) => void,
-): Promise<void> {
+export async function logoutAndRedirect(navigate: (url: string) => void): Promise<void> {
   const response = await fetch('/api/account/logout', {
     method: 'POST',
     credentials: 'include',
@@ -41,7 +39,15 @@ export async function logoutAndRedirect(
   navigate('/login');
 }
 
-export function AccountActions() {
+/**
+ * `isAdmin` gates the Developer-tools section (D-DESIGN-DEBT-STRUCTURAL-01,
+ * Phase 3). Before this it rendered for every owner viewing their own profile,
+ * so any normal user could reach /dev/* (reset-session, noon-reset, …). The
+ * caller computes it server-side from `isAdminUser(session.userId)` — the same
+ * ADMIN_USER_IDS allowlist that guards the report queue. Defaults to false:
+ * fail closed, so a caller that forgets to pass it hides the tools.
+ */
+export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
   const router = useRouter();
   const [confirmingLogout, setConfirmingLogout] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
@@ -119,55 +125,59 @@ export function AccountActions() {
 
   return (
     <>
-      <section className="mb-8">
-        <h2 className="mb-3 font-serif text-2xl font-semibold">Developer tools</h2>
-        <SettingsGroup>
-          <SettingsRow
-            icon={<FlaskConical className="size-5" />}
-            title={resettingGame ? 'Resetting…' : 'Create test game'}
-            subtitle="Reset today's game and play again"
-            onClick={() => void createTestGame()}
-            disabled={resettingGame}
-          />
-          <SettingsRow
-            icon={<RefreshCw className="size-5" />}
-            title="Reset session"
-            subtitle="Clear current session data"
-            href="/dev/reset-session"
-          />
-          <SettingsRow
-            icon={<Sun className="size-5" />}
-            title="Trigger noon reset"
-            subtitle="Simulate daily reset"
-            href="/dev/noon-reset"
-          />
-          <SettingsRow
-            icon={<Code2 className="size-5" />}
-            title="View staging flags"
-            subtitle="See feature flag status"
-            href="/dev/flags"
-          />
-          <SettingsRow
-            icon={<BarChart3 className="size-5" />}
-            title="Points diagnostic"
-            subtitle="Inspect a user's mastery events and where points came from"
-            href="/dev/points-diagnostic"
-          />
-          <SettingsRow
-            icon={<Sparkles className="size-5" />}
-            title="Show me the first time player"
-            subtitle="Preview the first-session experience a new player sees"
-            href="/dev/first-time-player"
-          />
-          <SettingsRow
-            icon={<Smartphone className="size-5" />}
-            title="Phone-first invite login"
-            subtitle="Preview the invite login screens without sending an invite"
-            href="/dev/invite-login"
-          />
-        </SettingsGroup>
-        {resetGameError ? <p className="mt-2 text-sm text-destructive">{resetGameError}</p> : null}
-      </section>
+      {isAdmin ? (
+        <section className="mb-8">
+          <h2 className="mb-3 font-serif text-2xl font-semibold">Developer tools</h2>
+          <SettingsGroup>
+            <SettingsRow
+              icon={<FlaskConical className="size-5" />}
+              title={resettingGame ? 'Resetting…' : 'Create test game'}
+              subtitle="Reset today's game and play again"
+              onClick={() => void createTestGame()}
+              disabled={resettingGame}
+            />
+            <SettingsRow
+              icon={<RefreshCw className="size-5" />}
+              title="Reset session"
+              subtitle="Clear current session data"
+              href="/dev/reset-session"
+            />
+            <SettingsRow
+              icon={<Sun className="size-5" />}
+              title="Trigger noon reset"
+              subtitle="Simulate daily reset"
+              href="/dev/noon-reset"
+            />
+            <SettingsRow
+              icon={<Code2 className="size-5" />}
+              title="View staging flags"
+              subtitle="See feature flag status"
+              href="/dev/flags"
+            />
+            <SettingsRow
+              icon={<BarChart3 className="size-5" />}
+              title="Points diagnostic"
+              subtitle="Inspect a user's mastery events and where points came from"
+              href="/dev/points-diagnostic"
+            />
+            <SettingsRow
+              icon={<Sparkles className="size-5" />}
+              title="Show me the first time player"
+              subtitle="Preview the first-session experience a new player sees"
+              href="/dev/first-time-player"
+            />
+            <SettingsRow
+              icon={<Smartphone className="size-5" />}
+              title="Phone-first invite login"
+              subtitle="Preview the invite login screens without sending an invite"
+              href="/dev/invite-login"
+            />
+          </SettingsGroup>
+          {resetGameError ? (
+            <p className="text-destructive mt-2 text-sm">{resetGameError}</p>
+          ) : null}
+        </section>
+      ) : null}
 
       <section className="mb-8">
         <h2 className="mb-3 font-serif text-2xl font-semibold">Account</h2>
@@ -185,7 +195,7 @@ export function AccountActions() {
           />
         </SettingsGroup>
         {confirmingLogout ? (
-          <div className="mt-3 rounded-xl border border-destructive/30 bg-card p-4 text-card-foreground">
+          <div className="border-destructive/30 bg-card text-card-foreground mt-3 rounded-xl border p-4">
             <p className="text-sm font-medium">Are you sure you want to log out?</p>
             <div className="mt-3 flex gap-2">
               <button
@@ -206,16 +216,19 @@ export function AccountActions() {
                 Cancel
               </button>
             </div>
-            {logoutError ? <p className="mt-2 text-sm text-destructive">{logoutError}</p> : null}
+            {logoutError ? <p className="text-destructive mt-2 text-sm">{logoutError}</p> : null}
           </div>
         ) : null}
 
         <div className="mt-6">
           {confirmingDelete ? (
-            <div className="rounded-xl border border-destructive bg-destructive/5 p-4">
-              <p className="text-sm font-semibold text-destructive">Delete your account permanently?</p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                This removes your account, sessions, stats, authored questions, games, and friend connections. This cannot be undone.
+            <div className="border-destructive bg-destructive/5 rounded-xl border p-4">
+              <p className="text-destructive text-sm font-semibold">
+                Delete your account permanently?
+              </p>
+              <p className="text-muted-foreground mt-1 text-xs">
+                This removes your account, sessions, stats, authored questions, games, and friend
+                connections. This cannot be undone.
               </p>
               <label className="mt-3 block text-xs font-medium" htmlFor="delete-confirmation">
                 Type DELETE to confirm.
@@ -227,7 +240,7 @@ export function AccountActions() {
                   setDeleteConfirmation(event.target.value);
                   setDeleteError(null);
                 }}
-                className="mt-1 h-10 w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 text-sm outline-none focus:border-destructive"
+                className="focus:border-destructive mt-1 h-10 w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 text-sm outline-none"
                 autoComplete="off"
                 disabled={deletingAccount}
               />
@@ -254,12 +267,12 @@ export function AccountActions() {
                   Cancel
                 </button>
               </div>
-              {deleteError ? <p className="mt-2 text-sm text-destructive">{deleteError}</p> : null}
+              {deleteError ? <p className="text-destructive mt-2 text-sm">{deleteError}</p> : null}
             </div>
           ) : (
             <button
               type="button"
-              className="text-xs font-medium text-muted-foreground underline-offset-2 hover:text-destructive hover:underline"
+              className="text-muted-foreground hover:text-destructive text-xs font-medium underline-offset-2 hover:underline"
               onClick={() => {
                 setConfirmingDelete(true);
                 setConfirmingLogout(false);

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -4,7 +4,6 @@ import { Lock, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 import { visibleFeedCategory } from '@/components/feed/category';
-import { Chip } from '@/components/ui/Chip';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
 import type { QuestionView } from '@/server/db/queries/questions';
@@ -56,15 +55,13 @@ export function MyQuestionCard({
               {visibleCategory}
             </span>
           ) : null}
-          <Chip
-            size="sm"
-            uppercase
-            className="bg-[rgba(0,0,0,0.06)] tracking-wide"
+          <span
+            className="rounded-full bg-[rgba(0,0,0,0.06)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
             style={{ color: 'var(--ink)', opacity: 0.7 }}
             aria-label={`LLM-rated difficulty: ${difficultyLabel}`}
           >
             {difficultyLabel}
-          </Chip>
+          </span>
         </div>
 
         <p className="mt-2 font-serif text-[20px] font-semibold leading-[28px] tracking-[0.04em] text-[var(--brand-ink)]">

--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -4,6 +4,7 @@ import { Lock, MoreHorizontal, Trash2 } from 'lucide-react';
 import { useEffect, useId, useRef, useState } from 'react';
 
 import { visibleFeedCategory } from '@/components/feed/category';
+import { Chip } from '@/components/ui/Chip';
 import { SendQuestionAction } from '@/components/SendQuestionAction';
 import { difficultyCopyFromValue } from '@/lib/questions/difficulty-copy';
 import type { QuestionView } from '@/server/db/queries/questions';
@@ -55,13 +56,15 @@ export function MyQuestionCard({
               {visibleCategory}
             </span>
           ) : null}
-          <span
-            className="rounded-full bg-[rgba(0,0,0,0.06)] px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide"
+          <Chip
+            size="sm"
+            uppercase
+            className="bg-[rgba(0,0,0,0.06)] tracking-wide"
             style={{ color: 'var(--ink)', opacity: 0.7 }}
             aria-label={`LLM-rated difficulty: ${difficultyLabel}`}
           >
             {difficultyLabel}
-          </span>
+          </Chip>
         </div>
 
         <p className="mt-2 font-serif text-[20px] font-semibold leading-[28px] tracking-[0.04em] text-[var(--brand-ink)]">

--- a/src/components/replay/ReplaySummary.tsx
+++ b/src/components/replay/ReplaySummary.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import type { CSSProperties } from 'react';
 
+import { Chip } from '@/components/ui/Chip';
 import type { ReplayItem } from '@/server/replay/session';
 
 export type ReplaySessionResult = {
@@ -83,15 +84,17 @@ export function ReplaySummary({ results, hasMore, onPlayNext, loadingNext }: Pro
               <p style={{ ...monoStyle, color: 'var(--text-muted)' }}>
                 {item.domainDisplayName} · originally missed {item.queueDate}
               </p>
-              <span
-                className={`rounded-sm border px-2 py-1 text-[0.65rem] font-semibold uppercase tracking-[0.08em] ${
+              <Chip
+                size="sm"
+                uppercase
+                className={`border px-2 py-1 text-[0.65rem] font-semibold ${
                   isCorrect
                     ? 'border-[color-mix(in_srgb,var(--game-correct)_30%,var(--border))] bg-[color-mix(in_srgb,var(--game-correct)_10%,var(--card))] text-[var(--game-correct)]'
                     : 'border-[color-mix(in_srgb,var(--game-wrong)_28%,var(--border))] bg-[color-mix(in_srgb,var(--game-wrong)_8%,var(--card))] text-[var(--game-wrong)]'
                 }`}
               >
                 {isCorrect ? 'CORRECT' : 'WRONG'}
-              </span>
+              </Chip>
             </div>
             <p className="mt-3 font-medium leading-snug text-[var(--text)]">{item.questionText}</p>
             <div className="mt-3 space-y-1 text-sm">

--- a/src/components/ui/Chip.tsx
+++ b/src/components/ui/Chip.tsx
@@ -1,0 +1,87 @@
+import type { CSSProperties, ReactNode } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// One chip/tag primitive for the app (D-DESIGN-DEBT-STRUCTURAL-01, Phase 1).
+//
+// Before this, chips were ad-hoc inline `rounded-full` pills scattered across the
+// feed, questions, friends, and play surfaces — each re-picking its own radius,
+// padding, font size, and casing (see D-DESIGN-DEBT-STRUCTURAL-AUDIT-01-FINDINGS
+// §2: radius rounded-full vs rounded-sm, padding px-2/px-2.5/px-3/px-3.5, sizes
+// text-[9px]→text-sm, mixed casing). This consolidates the GEOMETRY and
+// TYPOGRAPHY down to two intentional sizes.
+//
+// Scope is deliberately structural. Surface COLOR stays a caller concern and is
+// deferred to the palette pass (audit CH-2): `variant` maps only to EXISTING
+// neutral semantic tokens, and a caller that needs a category/status hue passes
+// it via `className`/`style`. No new color and no state→color mapping is baked
+// in here.
+//
+// Canon invariant (PRODUCT-CANON; STYLE-GUIDE-COLOR §1): a chip NEVER conveys
+// state by color alone. `children` (the label) is REQUIRED, so every chip always
+// carries a signal independent of hue. Any color a caller adds must be in
+// ADDITION to the label, never instead of it.
+//
+// Not absorbed here (intentionally distinct primitives): `AvatarChip` (initials
+// avatar) and `EditorialBadge` (the house-author semantic marker).
+
+type ChipSize = 'sm' | 'md';
+
+// Surface treatments resolve to existing neutral semantic tokens only.
+type ChipVariant = 'neutral' | 'outline';
+
+const SIZE_CLASSES: Record<ChipSize, string> = {
+  // The padding + type ramp distilled from the audited render sites.
+  sm: 'px-2 py-0.5 text-[10px]',
+  md: 'px-2.5 py-1 text-xs',
+};
+
+const VARIANT_CLASSES: Record<ChipVariant, string> = {
+  neutral: 'bg-muted text-foreground',
+  outline: 'border border-border text-foreground',
+};
+
+export type ChipProps = {
+  /** The label. REQUIRED — a chip never signals state by color alone. */
+  children: ReactNode;
+  size?: ChipSize;
+  variant?: ChipVariant;
+  /** Caps + letterspacing label signature (System voice, STYLE-GUIDE-TYPE §2). */
+  uppercase?: boolean;
+  /** Optional leading element (e.g. a small icon). Decorative only. */
+  leading?: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+  title?: string;
+  'aria-label'?: string;
+};
+
+export function Chip({
+  children,
+  size = 'md',
+  variant = 'neutral',
+  uppercase = false,
+  leading,
+  className,
+  style,
+  title,
+  'aria-label': ariaLabel,
+}: ChipProps) {
+  return (
+    <span
+      title={title}
+      aria-label={ariaLabel}
+      className={cn(
+        'inline-flex items-center gap-1 whitespace-nowrap rounded-full font-medium leading-none',
+        SIZE_CLASSES[size],
+        VARIANT_CLASSES[variant],
+        uppercase && 'uppercase tracking-[0.08em]',
+        className,
+      )}
+      style={style}
+    >
+      {leading}
+      {children}
+    </span>
+  );
+}

--- a/src/components/ui/Skeleton.tsx
+++ b/src/components/ui/Skeleton.tsx
@@ -1,0 +1,31 @@
+import type { CSSProperties } from 'react';
+
+import { cn } from '@/lib/utils';
+
+// One branded skeleton primitive (D-DESIGN-DEBT-STRUCTURAL-01, Phase 3).
+//
+// Replaces the per-route animate-pulse grey boxes the audit flagged (§5:
+// rounded-[12px] vs rounded-lg, bg-black/[0.04] vs bg-muted, ad-hoc ring
+// treatments) with a single shimmer treatment — the `.skeleton` class in
+// globals.css: a muted base + a soft light sweep built from existing surface
+// tokens. Neutral by design: no color conveys state, no triangle motif, and it
+// honours prefers-reduced-motion (the sweep stops).
+//
+// Default radius is the canonical --radius-card so a skeleton block matches the
+// real card it stands in for; pass `className` (h-*, w-*) to size each piece.
+// Decorative, so always aria-hidden — callers pair it with an sr-only status.
+export function Skeleton({
+  className,
+  style,
+}: {
+  className?: string;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      aria-hidden
+      className={cn('skeleton rounded-[var(--radius-card)]', className)}
+      style={style}
+    />
+  );
+}


### PR DESCRIPTION
Full design-debt structural workstream (audit + build), color-agnostic throughout. `globals.css` color tokens, the palette, and `PaletteToggle` are untouched; all color normalization is deferred to `B-VISUAL-PALETTE-PROMOTE-01`. `SharePortraitCard` untouched.

> Replacement for #1033 (same content; opened due to an issue on #1033).

## D-DESIGN-DEBT-STRUCTURAL-AUDIT-01 (read-only audit)
`D-DESIGN-DEBT-STRUCTURAL-AUDIT-01-FINDINGS.md` — inventory of cards/chips/buttons/skeletons, the `/questions` list, and dev-tools gating vs. canon. Headline: `ADMIN_USER_IDS` gated only `/admin/reports`; dev tools + `PaletteToggle` were session-only/ungated.

## B-DESIGN-DEBT-STRUCTURAL-01 (build)

**Phase 1 — primitives & tokens**
- `--radius-card` (geometry alias of `--radius-xs`/4px) — the single canonical card radius; confirmed the three existing shadow tiers.
- New `src/components/ui/Chip.tsx`: one chip primitive (geometry/typography); label always required so no state is color-alone. Buttons stay the `.btn-*` utilities (documented primitive; no React Button reintroduced).

**Phase 2 — apply primitives**
- Chips → `<Chip>` at the audited sites (SendQuestionDrawer, PeopleYouInvited ×2, AddFriendInvite ×2, AnswerFeedbackSheet ×2, ReplaySummary status — also retired the lone `rounded-sm` outlier). Fills preserved verbatim.
- All 18 section cards + the `.card` utility → `rounded-[var(--radius-card)]` + `shadow-[var(--shadow-card)]`.
- `/invite/[token]` button one-offs → `.btn-*`.
- `/questions` intentionally **out of scope** — reverted to identical-to-`dev2`.

**Phase 3 — structural surfaces**
- Dev-tools gating: `AccountActions` Developer-tools section behind `isAdmin`; new `src/app/dev/layout.tsx` admin-gates the whole `/dev` tree (404 for non-admins). Closes the exposure. Gate is strict `ADMIN_USER_IDS` (no non-prod escape hatch).
- Branded `<Skeleton>` primitive (`.skeleton` shimmer from existing tokens; no triangle, no color-state) replacing the per-route grey boxes on `/for-you`, `/from-friends`, `/activities`, home, and Knowledge loaders.
- Knowledge column aligned to `max-w-2xl` (672px) to match the feed surfaces' gutter.

## Verification
Typecheck clean · ESLint clean (pre-existing warnings only) · **1346 tests pass** · ratchets all under ceiling and net-favorable: color flat at 148/180, radius **9→6**, spacing 0/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myd6G1ih1GnKpbAF4W8yLD

---
_Generated by [Claude Code](https://claude.ai/code/session_01Myd6G1ih1GnKpbAF4W8yLD)_