### PR TITLE
fix: mobile page-width zoom-out caused by the dev design-audit bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -361,6 +361,11 @@
     }
   body {
     @apply bg-background text-foreground;
+    /* Defensive guard: never let a stray over-wide element (e.g. a dev tool bar)
+       force the document wider than the device, which makes mobile Safari zoom
+       the whole app out to fit. `clip` (not `hidden`) avoids establishing a
+       scroll container, so position:sticky/fixed chrome is unaffected. */
+    overflow-x: clip;
     }
   html {
     @apply font-sans;

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -130,6 +130,14 @@ export function PaletteToggle() {
         zIndex: 60,
         display: 'flex',
         alignItems: 'center',
+        // Wrap onto a second row on narrow (mobile) viewports instead of
+        // overflowing horizontally. Without this the non-shrinkable row
+        // (label + buttons + 8 swatches) is wider than a phone, which forces
+        // the whole document wider than the device and makes mobile Safari
+        // zoom the entire app out to fit — surfacing as a "narrow page with a
+        // dead zone on the right" on every route.
+        flexWrap: 'wrap',
+        maxWidth: '100%',
         gap: 12,
         padding: '6px 16px',
         fontSize: 12,


### PR DESCRIPTION
## What & why

The Knowledge and Friends pages (and in fact **every** route) looked "strangely narrow" on mobile — content compressed into the left ~80% of the screen with a dead zone on the right.

The cause wasn't either page. It was the global dev **`PaletteToggle`** bar (the dark "⚠ CARD COLOR / Flat / swatches" strip rendered for every route in `layout.tsx`):

- It's a single flex row that **can't wrap or shrink** — a label, two buttons, and 8 swatches, all `whiteSpace: nowrap`.
- Its min-content width exceeds a phone viewport, so it forced the **whole document** wider than the device.
- Mobile Safari responds to an over-wide document by zooming the entire page out to fit → the "narrow page with empty space on the right" symptom, on every page.

Diagnosed by measuring the reported screenshot: the header, the Knowledge card, and the palette bar's own dark background were all clipped to the left ~80%, with the bar's swatches visibly spilling onto the cream dead zone.

## Changes

1. **`PaletteToggle.tsx`** — add `flexWrap: 'wrap'` + `maxWidth: '100%'` so the bar wraps onto a second row on narrow screens instead of overflowing horizontally. (Dev-only chrome; no app surface touched.)
2. **`globals.css`** — defensive backstop: `overflow-x: clip` on `body` so any future stray over-wide element can't force the document past the device width. `clip` (not `hidden`) avoids establishing a scroll container, so the sticky/fixed app chrome is unaffected.

## Testing

Diagnosis was done from the user's screenshot (pixel-measured the compressed column + overflow dead zone). Local lint/typecheck couldn't run in the fresh container (no `node_modules`), but the changes are a small inline-style addition and one CSS property — CI will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XzcRtzRi5HtaSDXRwqFx9D)_