### PR TITLE
Add shadow cycler control to design audit bar

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -541,14 +541,44 @@
 
 /* TESTING ONLY — flat mode (driven by the dev design bar's "Flat" toggle; see
    src/components/dev/PaletteToggle.tsx). When the toggle is on, <html> carries
-   data-flat="1": strip every corner radius and drop shadow so a tester can read
-   the layout without rounding / elevation. Covers literal radii (rounded-[4px],
-   rounded-full) and inline styles too, which token overrides would miss. The dev
-   bar's own chrome (.palette-bar) is excluded so the controls stay legible.
+   data-flat="1": strip every corner radius (cards and everything else) so a
+   tester can read the layout without rounding. Covers literal radii
+   (rounded-[4px], rounded-full) and inline styles too, which token overrides
+   would miss. Drop shadow is NO LONGER touched here — it has its own three-state
+   control (data-shadow, below). The dev bar's own chrome (.palette-bar) is
+   excluded so the controls stay legible.
    Remove this block with the PaletteToggle bar before shipping. */
 html[data-flat="1"] *:not(.palette-bar, .palette-bar *),
 html[data-flat="1"] *:not(.palette-bar, .palette-bar *)::before,
 html[data-flat="1"] *:not(.palette-bar, .palette-bar *)::after {
     border-radius: 0 !important;
+}
+
+/* TESTING ONLY — drop-shadow register (driven by the dev design bar's "Shadow"
+   cycler; see src/components/dev/PaletteToggle.tsx). Three states:
+     • current (no attribute) — leave the design-system elevation as shipped.
+     • data-shadow="subtle"   — dial the canonical --shadow-* elevation tokens
+       down so card lift is barely-there. Token-driven surfaces (.card, the feed
+       shell, modals) recolor automatically; stray Tailwind shadow-* utilities
+       keep their own value.
+     • data-shadow="none"     — zero the tokens AND blanket-strip every box-shadow
+       app-wide (matching how flat mode used to), so NOTHING casts a shadow,
+       including inline styles and shadow-* utilities.
+   Remove this block with the PaletteToggle bar before shipping. */
+html[data-shadow="subtle"] {
+    --shadow-paper-rest: 0 1px 1px rgb(0 0 0 / 0.03);
+    --shadow-card: 0 1px 2px rgba(40, 32, 30, 0.03);
+    --shadow-card-strong: 0 1px 3px rgba(40, 32, 30, 0.05);
+    --shadow-overlay: 0 3px 8px rgba(26, 18, 8, 0.08);
+}
+html[data-shadow="none"] {
+    --shadow-paper-rest: none;
+    --shadow-card: none;
+    --shadow-card-strong: none;
+    --shadow-overlay: none;
+}
+html[data-shadow="none"] *:not(.palette-bar, .palette-bar *),
+html[data-shadow="none"] *:not(.palette-bar, .palette-bar *)::before,
+html[data-shadow="none"] *:not(.palette-bar, .palette-bar *)::after {
     box-shadow: none !important;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -80,7 +80,7 @@ export default async function RootLayout({
             shipping. The token map mirrors CARD_BGS in PaletteToggle. */}
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}}catch(e){}`,
+            __html: `try{var i=+localStorage.getItem('joshing-card-bg')||0;var m=['','var(--brand-cream-page)','var(--brand-cream-card)','var(--brand-cream)','var(--game-card-question)','var(--editorial-parchment)','var(--editorial-sage)','var(--editorial-slate)'];if(i>0&&m[i]){document.documentElement.style.setProperty('--brand-card',m[i]);document.documentElement.style.setProperty('--feed-card-elevated',m[i]);document.documentElement.setAttribute('data-card-bg',String(i));}if(localStorage.getItem('joshing-flat')==='1'){document.documentElement.setAttribute('data-flat','1');}var s=localStorage.getItem('joshing-shadow');if(s==='subtle'||s==='none'){document.documentElement.setAttribute('data-shadow',s);}}catch(e){}`,
           }}
         />
         <PaletteToggle />

--- a/src/components/dev/PaletteToggle.tsx
+++ b/src/components/dev/PaletteToggle.tsx
@@ -5,7 +5,7 @@ import { useSyncExternalStore, type CSSProperties } from 'react';
 // ─────────────────────────────────────────────────────────────────────────────
 // TESTING ONLY — design audit bar (repurposed from the palette preview bar).
 //
-// Two controls, both for auditing the design system without per-page edits:
+// Three controls, all for auditing the design system without per-page edits:
 //
 //  1. Card-background cycler — cycles the `--brand-card` token (the resting
 //     feed-card surface) AND `--feed-card-elevated` (the warm fill behind the
@@ -14,17 +14,25 @@ import { useSyncExternalStore, type CSSProperties } from 'react';
 //     `var(--feed-card-elevated)` recolors automatically.
 //
 //  2. Flat toggle — sets `data-flat="1"` on <html>, which the globals.css flat
-//     rule reads to strip every corner radius and drop shadow app-wide, so a
-//     tester can read the layout without rounding / elevation. The bar's own
-//     chrome is excluded (it carries `palette-bar`) so the controls stay legible.
+//     rule reads to strip every corner radius app-wide (cards included), so a
+//     tester can read the layout without rounding. It NO LONGER touches drop
+//     shadow — that moved to its own control (#3). The bar's own chrome is
+//     excluded (it carries `palette-bar`) so the controls stay legible.
+//
+//  3. Shadow cycler — cycles `data-shadow` on <html> through current → subtle →
+//     none, which the globals.css shadow rules read. "Subtle" dials the
+//     canonical --shadow-* elevation tokens down; "none" zeroes them and
+//     blanket-strips every box-shadow app-wide. Lets a tester compare elevation
+//     registers without per-component edits.
 //
 // Only the system's own background tokens are offered (no off-palette hex), so
 // nothing here introduces an unsanctioned color. Inline styles are on purpose:
 // this is chrome, not app surface, so it sits outside the brand-token lint.
 //
 // Remove this component (and the boot script in layout.tsx, plus the
-// `html[data-flat]` rule in globals.css) before merging to a shipping branch.
-// The boot script applies the saved choices pre-paint.
+// `html[data-flat]` and `html[data-shadow]` rules in globals.css) before
+// merging to a shipping branch. The boot script applies the saved choices
+// pre-paint.
 // ─────────────────────────────────────────────────────────────────────────────
 
 type CardBg = { label: string; value: string; swatch: string };
@@ -47,6 +55,16 @@ const CARD_BG_EVENT = 'joshing-card-bg-change';
 
 const FLAT_KEY = 'joshing-flat';
 const FLAT_EVENT = 'joshing-flat-change';
+
+// Shadow cycler — three states. Index maps to the `data-shadow` attribute value
+// ('' / index 0 clears the attribute, restoring the shipped elevation).
+const SHADOW_MODES: { label: string; value: string }[] = [
+  { label: 'Current', value: '' },
+  { label: 'Subtle', value: 'subtle' },
+  { label: 'None', value: 'none' },
+];
+const SHADOW_KEY = 'joshing-shadow';
+const SHADOW_EVENT = 'joshing-shadow-change';
 
 // Read the live choice straight off the <html> attribute (the source of truth,
 // also set by the boot script before paint). useSyncExternalStore keeps the
@@ -78,9 +96,39 @@ function serverFlat(): boolean {
   return false;
 }
 
+// Shadow cycler — mirrors the flat store, reading the live mode index off the
+// <html> `data-shadow` attribute (also set pre-paint by the boot script).
+function subscribeShadow(onChange: () => void) {
+  window.addEventListener(SHADOW_EVENT, onChange);
+  return () => window.removeEventListener(SHADOW_EVENT, onChange);
+}
+function readShadow(): number {
+  const raw = document.documentElement.getAttribute('data-shadow');
+  const i = SHADOW_MODES.findIndex((m) => m.value === (raw ?? ''));
+  return i >= 0 ? i : 0;
+}
+function serverShadow(): number {
+  return 0;
+}
+
 export function PaletteToggle() {
   const index = useSyncExternalStore(subscribe, readSnapshot, serverSnapshot);
   const flat = useSyncExternalStore(subscribeFlat, readFlat, serverFlat);
+  const shadowIndex = useSyncExternalStore(subscribeShadow, readShadow, serverShadow);
+
+  function cycleShadow() {
+    const next = (shadowIndex + 1) % SHADOW_MODES.length;
+    const { value } = SHADOW_MODES[next];
+    const root = document.documentElement;
+    if (value) root.setAttribute('data-shadow', value);
+    else root.removeAttribute('data-shadow');
+    try {
+      localStorage.setItem(SHADOW_KEY, value);
+    } catch {
+      /* private mode / disabled storage — non-fatal */
+    }
+    window.dispatchEvent(new Event(SHADOW_EVENT));
+  }
 
   function toggleFlat() {
     const next = !flat;
@@ -163,15 +211,26 @@ export function PaletteToggle() {
         <span aria-hidden style={{ opacity: 0.6 }}>→</span>
       </button>
 
-      {/* Flat toggle: strip every corner radius and drop shadow app-wide. */}
+      {/* Flat toggle: strip every corner radius app-wide (cards included). */}
       <button
         type="button"
         onClick={toggleFlat}
         aria-pressed={flat}
-        aria-label={`Flat mode (no rounded corners or shadows): ${flat ? 'on' : 'off'}. Tap to toggle.`}
+        aria-label={`Flat mode (no rounded corners): ${flat ? 'on' : 'off'}. Tap to toggle.`}
         style={{ ...flatStyle, ...(flat ? flatStyleOn : null) }}
       >
         {flat ? '▣' : '▢'} Flat
+      </button>
+
+      {/* Shadow cycler: current → subtle → none. */}
+      <button
+        type="button"
+        onClick={cycleShadow}
+        aria-label={`Drop shadow: ${SHADOW_MODES[shadowIndex].label}. Tap to cycle.`}
+        style={{ ...flatStyle, ...(shadowIndex > 0 ? flatStyleOn : null) }}
+      >
+        Shadow: {SHADOW_MODES[shadowIndex].label}
+        <span aria-hidden style={{ opacity: 0.6, marginLeft: 6 }}>→</span>
       </button>
 
       {/* Jump straight to any background. */}


### PR DESCRIPTION
## Summary
Extends the PaletteToggle design audit bar with a third control to cycle drop-shadow elevation registers independently of the flat-mode toggle. This decouples shadow testing from corner-radius testing, allowing designers to audit elevation without per-component edits.

## Changes

**PaletteToggle.tsx:**
- Updated component documentation to reflect three controls instead of two
- Clarified that the flat toggle now only strips corner radii (shadow handling moved to new control)
- Added `SHADOW_MODES` constant with three states: "Current" (shipped), "Subtle" (dialed-down tokens), and "None" (zeroed)
- Implemented shadow store functions (`subscribeShadow`, `readShadow`, `serverShadow`) mirroring the flat-mode pattern
- Added `cycleShadow()` function to cycle through shadow modes, persist to localStorage, and dispatch change events
- Added new shadow cycler button UI with aria-label and visual indicator
- Updated flat toggle aria-label to remove shadow reference

**globals.css:**
- Removed drop-shadow stripping from the `html[data-flat="1"]` rule (now only strips border-radius)
- Added new `html[data-shadow]` rule block with three states:
  - `data-shadow="subtle"`: dials down `--shadow-*` elevation tokens to barely-perceptible values
  - `data-shadow="none"`: zeros tokens and blanket-strips all box-shadow properties app-wide
- Updated comments to clarify the separation of concerns

**layout.tsx:**
- Extended the boot script to also restore the saved shadow mode from localStorage before paint (matching the card-bg and flat-mode pattern)

## Implementation Details
- Shadow state is stored in `localStorage` under key `joshing-shadow` and read from the `data-shadow` HTML attribute (source of truth)
- Uses `useSyncExternalStore` for hydration-safe state management, consistent with existing controls
- The dev bar's own chrome (`.palette-bar`) is excluded from shadow stripping in "none" mode, keeping controls legible
- All three controls now follow the same pattern: localStorage persistence, pre-paint boot restoration, and event-driven synchronization

https://claude.ai/code/session_013X3xa9xi5MGx2WGjs28Ze6