### PR TITLE
feat(login): animate the trailing ellipsis on pressed primary buttons

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -468,6 +468,16 @@
   animation: loading-dot 1.4s ease-in-out infinite;
 }
 
+/* The trailing "…" on a pressed primary button (login "Continuing"/"Verifying")
+   broken into three dots that pulse on the shared loading-dot keyframe, so the
+   submit reads as in-flight rather than frozen. Per-dot delays are set inline.
+   Reuses the grading-dot motion; kept as its own class so its reduced-motion
+   reset and any future tuning stay independent. */
+.loading-ellipsis-dot {
+  display: inline-block;
+  animation: loading-dot 1.4s ease-in-out infinite;
+}
+
 /* B-GRADE-PERCEIVED-1 — the result card eases up as it replaces the grading
    indicator, so the verdict lands as an intentional reveal rather than a
    jump-cut. Kept short to never delay the perceived result. */
@@ -525,6 +535,10 @@
   }
 
   .grading-dot {
+    animation: none !important;
+  }
+
+  .loading-ellipsis-dot {
     animation: none !important;
   }
 

--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -154,6 +154,30 @@ function inviterFirstName(name: string): string {
   return trimmed.split(/\s+/)[0];
 }
 
+// In-flight label for a pressed primary button: the verb stays put while the
+// trailing "…" is split into three dots that pulse on the shared loading-dot
+// keyframe (see .loading-ellipsis-dot in globals.css), so the wait reads as
+// alive rather than a frozen static ellipsis. The dots are aria-hidden and the
+// verb itself carries the meaning for screen readers.
+function LoadingLabel({ verb }: { verb: string }) {
+  return (
+    <span className="inline-flex items-baseline">
+      {verb}
+      <span aria-hidden="true">
+        {[0, 1, 2].map((i) => (
+          <span
+            key={i}
+            className="loading-ellipsis-dot"
+            style={{ animationDelay: `${i * 0.16}s` }}
+          >
+            .
+          </span>
+        ))}
+      </span>
+    </span>
+  );
+}
+
 function InviteContextCard({ invite }: { invite: InviteContext }) {
   return (
     <div className="space-y-3 rounded-[var(--radius-md)] border border-[var(--accent-gold)]/40 bg-white/55 p-4 text-center">
@@ -664,7 +688,7 @@ export default function LoginPanel({
                 disabled={loading}
               />
               <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
-                {loading ? 'Continuing…' : 'Continue'}
+                {loading ? <LoadingLabel verb="Continuing" /> : 'Continue'}
               </button>
             </>
           )}
@@ -717,7 +741,7 @@ export default function LoginPanel({
               Frame 3), separate from the 14px rhythm of the fields above. */}
           <div className="space-y-1.5">
             <button type="submit" className={SUBMIT_CLASS} disabled={loading}>
-              {loading ? 'Verifying…' : 'Continue'}
+              {loading ? <LoadingLabel verb="Verifying" /> : 'Continue'}
             </button>
 
             <div className="flex items-center gap-3" aria-hidden="true">


### PR DESCRIPTION
The "Continuing…"/"Verifying…" labels on the phone and OTP steps showed a
static "…" while the request was in flight, which read as frozen. Split the
ellipsis into three dots that pulse on the shared loading-dot keyframe via a
new .loading-ellipsis-dot class, reusing the grading-indicator motion. Dots
are aria-hidden (the verb carries meaning) and reset under prefers-reduced-motion.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01VgVFy165X1FBUkgdzYdCqf