### PR TITLE
Add close button to daily summary page

### DIFF
--- a/src/app/daily/summary/page.tsx
+++ b/src/app/daily/summary/page.tsx
@@ -158,7 +158,14 @@ export default function DailySummaryPage() {
 
   return (
     <main className="min-h-dvh bg-[var(--brand-cream-page)] px-4 py-6 text-[var(--brand-ink)]">
-      <div className="mx-auto max-w-3xl">
+      <div className="relative mx-auto max-w-3xl">
+        <Link
+          href="/"
+          aria-label="Close session recap"
+          className="text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:ring-ring absolute top-0 right-0 z-10 inline-flex size-10 items-center justify-center rounded-full transition focus-visible:ring-2 focus-visible:outline-none"
+        >
+          <X className="size-5" />
+        </Link>
         {/* B-FirstRecap-1: greet first-time players before anything else — the
             congrats panel is the very first thing on the page on their first
             completed round. */}


### PR DESCRIPTION
## Summary
Added a close button (X icon) to the daily summary page that allows users to navigate back to the home page.

## Changes
- Added a `relative` positioning context to the main container div
- Inserted a close button link in the top-right corner that:
  - Links to the home page (`/`)
  - Uses semantic `aria-label` for accessibility ("Close session recap")
  - Displays an X icon from the icon library
  - Includes focus-visible ring styling for keyboard navigation
  - Has hover state styling with muted/foreground color transitions
  - Positioned absolutely with `z-10` to appear above content

## Implementation Details
- The button follows the project's design system conventions with `text-muted-foreground`, `hover:bg-muted`, and `focus-visible:ring-ring` tokens
- Uses a `size-10` circular button container with `rounded-full` for consistent UI
- Includes proper focus management with `focus-visible:ring-2` and `focus-visible:outline-none`
- The X icon is sized at `size-5` for visual balance within the button

https://claude.ai/code/session_0142ZTS4vdMTLUKEZWEa3KNn