### PR TITLE
Style question action links as opaque chips on pattern

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -522,8 +522,8 @@ function QuestionRow({
           style={{
             display: 'flex',
             flexWrap: 'wrap',
-            gap: '14px',
-            marginTop: '4px',
+            gap: '10px',
+            marginTop: '8px',
             paddingLeft: '2px',
           }}
         >
@@ -563,22 +563,25 @@ function QuestionRow({
   );
 }
 
-// Shared style for the muted mono action links beneath a question card
-// ("Show me the answer", "Dismiss").
+// Shared style for the mono action links beneath a question card
+// ("Show me the answer", "Dismiss"). These render OUTSIDE the card, directly on
+// the full-strength triangle pattern (see daily/page.tsx), so they need their
+// own opaque chip — bare muted text is illegible against the multicolor tiles
+// (no single text color clears it). The chip keeps them inside the "everything
+// is an opaque card on top of the pattern" rule the surface relies on.
 const questionActionLinkStyle: CSSProperties = {
   alignSelf: 'flex-start',
-  background: 'none',
-  border: 'none',
-  padding: 0,
+  background: 'var(--surface)',
+  border: '1px solid var(--border)',
+  borderRadius: 'var(--radius-sm)',
+  padding: '4px 9px',
   cursor: 'pointer',
   fontFamily: 'var(--font-mono)',
   fontSize: '0.58rem',
   textTransform: 'uppercase',
   letterSpacing: '0.06em',
   color: 'var(--text-muted)',
-  textDecoration: 'underline',
-  textUnderlineOffset: '2px',
-  opacity: 0.7,
+  textDecoration: 'none',
 };
 
 function UserRow({ text }: { text: string }) {


### PR DESCRIPTION
## Summary
Restyle the "Show me the answer" and "Dismiss" action links beneath question cards to render as opaque chips instead of bare muted text. These links render directly on the full-strength triangle pattern (not inside the card), making bare text illegible. Adding an opaque chip background keeps them consistent with the "everything is an opaque card on top of the pattern" design rule.

## Changes
- **Action link styling:** Convert from underlined muted text to bordered chip with surface background
  - Add `background: 'var(--surface)'` and `border: '1px solid var(--border)'`
  - Add `borderRadius: 'var(--radius-sm)'` and padding (`4px 9px`)
  - Remove `textDecoration: 'underline'`, `textUnderlineOffset`, and `opacity: 0.7`
  - Keep `color: 'var(--text-muted)'` for visual hierarchy

- **Question row spacing:** Tighten layout slightly
  - Reduce `gap` from `14px` to `10px`
  - Increase `marginTop` from `4px` to `8px`

- **Documentation:** Expand comment explaining why the chip is necessary (rendering context and legibility constraints)

## Implementation Details
The action links now use CSS variables (`--surface`, `--border`, `--radius-sm`) to maintain design system consistency. The chip approach ensures readability against the multicolor tile pattern while preserving the muted text color for visual hierarchy within the card context.

https://claude.ai/code/session_0143Wbzo5szwGkAJHqDskGt4