### PR TITLE
Demote Unfriend/Unfollow to a quiet text link

### DIFF
--- a/src/components/friends/AddFriendButton.tsx
+++ b/src/components/friends/AddFriendButton.tsx
@@ -210,9 +210,12 @@ export function AddFriendButton({
               <button type="button" className="btn-ghost" disabled>
                 {relationship.state === 'friends' ? 'Friends ✓' : 'Following ✓'}
               </button>
+              {/* Demoted to a quiet text link so the destructive action recedes
+                  behind the "Friends ✓" status pill rather than reading as a
+                  co-equal CTA. */}
               <button
                 type="button"
-                className="btn-ghost"
+                className="text-muted-foreground hover:text-foreground self-center text-xs underline underline-offset-2 transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-45"
                 onClick={handleRemove}
                 disabled={pendingAction !== null}
               >


### PR DESCRIPTION
On the profile/friend surface, "Unfriend" sat as a full bordered ghost
button directly beside the "Friends ✓" status pill, reading as a co-equal
CTA and visually dominating once the disabled pill was de-emphasized.

Convert the standalone remove action to a small, muted underlined text
link so the destructive action recedes while staying reachable. The
inline confirm step (Remove/Keep) and copy are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0147WP9FvfKGWWLqF7AzsUVL