### PR TITLE
Remove duplicate eyebrows above authored questions heading

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -414,10 +414,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
       ) : null}
 
       {portrait.sectionVisibleTo.authored_questions ? (
-        <section className="mt-5" aria-label="Authored questions">
-          <p className="text-muted-foreground mb-3 text-xs font-medium tracking-[0.1em] uppercase">
-            Authored questions
-          </p>
+        <section aria-label="Authored questions">
           <AuthoredQuestionsFeed
             questions={authoredItems}
             friendDisplayName={portrait.user.displayName}

--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -286,10 +286,7 @@ export function AuthoredQuestionsFeed({
       aria-label={`Questions ${friendDisplayName} wrote`}
     >
       <div className="mb-4">
-        <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
-          Questions
-        </p>
-        <h2 className="mt-1 font-serif text-xl font-semibold">
+        <h2 className="font-serif text-xl font-semibold">
           Questions {friendDisplayName} wrote
         </h2>
       </div>


### PR DESCRIPTION
The profile authored-questions section stacked three labels: an
"Authored questions" eyebrow (parent page), a "Questions" eyebrow, and
the "Questions {name} wrote" heading. Drop the two redundant eyebrows
and keep only the heading.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ETgUVpvD88VXMc1VkBiLRu