### PR TITLE
Hide 'Questions created' line when count is zero

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -121,16 +121,20 @@ function FriendCard({ person }: { person: Person }) {
       <p className="text-muted-foreground mt-1 text-sm leading-6">{friendSecondary(person)}</p>
       {/* Two warm activity facts (PLR-14): what they've contributed and what
           you've engaged with — kept on one line as a quiet shared ledger,
-          never a ranking. Friends are not sorted or compared by these. */}
-      <p className="text-muted-foreground mt-2 text-xs">
-        Questions created{" "}
-        <span className="text-foreground font-medium tabular-nums">{person.authoredCount}</span> (you
-        answered{" "}
-        <span className="text-foreground font-medium tabular-nums">
-          {person.answeredByViewerCount}
-        </span>
-        )
-      </p>
+          never a ranking. Friends are not sorted or compared by these.
+          Suppressed entirely when the friend hasn't authored anything yet —
+          a zero count reads as a scoreboard, which this line is not. */}
+      {person.authoredCount > 0 && (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Questions created{" "}
+          <span className="text-foreground font-medium tabular-nums">{person.authoredCount}</span> (you
+          answered{" "}
+          <span className="text-foreground font-medium tabular-nums">
+            {person.answeredByViewerCount}
+          </span>
+          )
+        </p>
+      )}
     </Link>
   );
 }


### PR DESCRIPTION
A zero count reads as an empty scoreboard, which this line is not meant to
be. Suppress the activity-facts line entirely for friends who haven't
authored any questions yet.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012PG9LGbAuAkYxMbyeM3E9h