### PR TITLE
Add "Add someone" lookup to Friends hub with invite hand-off

### DIFF
--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -4,12 +4,20 @@ import { useState } from 'react';
 
 import AddFriendInvite from '@/components/AddFriendInvite';
 import FriendsList from '@/components/FriendsList';
+import { FindFriendsSearch } from '@/components/friends/FindFriendsSearch';
+import type { QueryClassification } from '@/components/friends/add-someone';
 
 export default function FriendsHubPage() {
   const [inviteOpen, setInviteOpen] = useState(false);
 
-  function openInviteFlow() {
-    window.dispatchEvent(new CustomEvent('friend-invitations:create-new', { detail: {} }));
+  function openInviteFlow(detail: Record<string, unknown> = {}) {
+    window.dispatchEvent(new CustomEvent('friend-invitations:create-new', { detail }));
+  }
+
+  // No-match invite from the lookup. A US number can seed the SMS invite; a
+  // handle isn't a phone (or a real name), so it opens the invite flow blank.
+  function handleLookupInvite(query: string, classification: QueryClassification) {
+    openInviteFlow(classification === 'phone' ? { phone: query } : {});
   }
 
   return (
@@ -21,22 +29,25 @@ export default function FriendsHubPage() {
       <section className="border-primary/15 bg-primary/5 text-card-foreground mb-5 rounded-[var(--radius-card)] border p-6 shadow-[var(--shadow-card)]">
         {!inviteOpen ? (
           <>
-            <p className="text-muted-foreground text-xs font-medium tracking-[0.14em] uppercase">
-              Invite
-            </p>
-            <h2 className="text-foreground mt-3 font-serif text-3xl leading-tight font-semibold">
-              Who shares your world?
-            </h2>
-            <p className="text-muted-foreground mt-3 text-base leading-7">
-              Invite someone who would enjoy the questions and discoveries happening here.
-            </p>
-            <button
-              type="button"
-              className="btn-primary mt-5 w-full sm:w-auto"
-              onClick={openInviteFlow}
-            >
-              Invite Someone
-            </button>
+            <FindFriendsSearch variant="add" onInvite={handleLookupInvite} />
+            <div className="border-primary/15 mt-6 border-t pt-6">
+              <p className="text-muted-foreground text-xs font-medium tracking-[0.14em] uppercase">
+                Invite
+              </p>
+              <h2 className="text-foreground mt-3 font-serif text-3xl leading-tight font-semibold">
+                Who shares your world?
+              </h2>
+              <p className="text-muted-foreground mt-3 text-base leading-7">
+                Invite someone who would enjoy the questions and discoveries happening here.
+              </p>
+              <button
+                type="button"
+                className="btn-primary mt-5 w-full sm:w-auto"
+                onClick={() => openInviteFlow()}
+              >
+                Invite Someone
+              </button>
+            </div>
           </>
         ) : null}
         <AddFriendInvite embedded onExpandedChange={setInviteOpen} />

--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { formatRelativeTime } from '@/components/feed/visual';
+import { ADD_SOMEONE_SEED_EVENT } from '@/components/friends/FindFriendsSearch';
+import { classifyQuery } from '@/components/friends/add-someone';
 
 type FriendSort = 'name_asc' | 'name_desc' | 'recent';
 
@@ -475,6 +477,25 @@ export default function FriendsList() {
     setFriendSearch('');
   }
 
+  // When the local friends filter finds no one, offer to add the typed term as a
+  // friend. A handle/number is handed to the hub's "Add someone" lookup to
+  // find-or-invite; a plain name can't be resolved by lookup (stranger-by-name
+  // search is out of scope), so it opens the invite flow with the name prefilled.
+  function addTypedTermAsFriend() {
+    const term = friendSearch.trim();
+    if (!term) return;
+    const classification = classifyQuery(term);
+    if (classification === 'handle' || classification === 'phone') {
+      window.dispatchEvent(new CustomEvent(ADD_SOMEONE_SEED_EVENT, { detail: { query: term } }));
+    } else {
+      window.dispatchEvent(
+        new CustomEvent('friend-invitations:create-new', {
+          detail: { inviteeDisplayName: term },
+        }),
+      );
+    }
+  }
+
   const pendingInvites = useMemo(
     () => invites.filter((invite) => invite.status === 'pending'),
     [invites],
@@ -641,6 +662,18 @@ export default function FriendsList() {
               ) : (
                 <p className="text-muted-foreground py-8 text-center text-sm">
                   No friends match your filter.{' '}
+                  {friendSearch.trim() ? (
+                    <>
+                      <button
+                        type="button"
+                        className="text-primary underline"
+                        onClick={addTypedTermAsFriend}
+                      >
+                        Add “{friendSearch.trim()}” as a friend
+                      </button>{' '}
+                      ·{' '}
+                    </>
+                  ) : null}
                   <button
                     type="button"
                     className="text-primary underline"

--- a/src/components/friends/AddFriendButton.tsx
+++ b/src/components/friends/AddFriendButton.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react'
 
 import { AddFriendRequestModal } from '@/components/friends/AddFriendRequestModal'
+import { addSuccessToast } from '@/components/friends/add-someone'
 import type { RelationshipResult } from '@/server/db/queries/friend-requests'
 
 type Props = {
@@ -66,8 +67,12 @@ export function AddFriendButton({
     setModalOpen(true)
   }
 
-  function handleSent() {
-    setToast('Sent.')
+  function handleSent(_friendshipId: string, sentState?: string) {
+    // Reflect what actually happened: a pending request reads "Request sent",
+    // while a public account that auto-approved reads "You're now following"
+    // (or "friends" if this completed a mutual follow). `relationship.state` is
+    // the pre-send relationship, which disambiguates the auto-approved case.
+    setToast(addSuccessToast(sentState, relationship.state))
     onChange?.()
   }
 

--- a/src/components/friends/AddFriendRequestModal.tsx
+++ b/src/components/friends/AddFriendRequestModal.tsx
@@ -9,9 +9,12 @@ type Props = {
   onClose: () => void
   targetUserId: string
   targetDisplayName: string
-  // Called with the new friendship id after a successful send. The parent
-  // typically flips its UI to "pending_outbound" and refreshes.
-  onSent: (friendshipId: string) => void
+  // Called with the new friendship id and the state the POST returned after a
+  // successful send. `state` is 'created' (approval required → pending) or
+  // 'auto_approved' (public account → landed immediately); the parent uses it
+  // to speak plainly ("Request sent" vs "You're now following/friends") and to
+  // flip its UI / refresh.
+  onSent: (friendshipId: string, state?: string) => void
 }
 
 type SendErrorKey =
@@ -95,7 +98,7 @@ export function AddFriendRequestModal({
         }),
       })
       const body = (await response.json().catch(() => null)) as
-        | { ok: boolean; friendship?: { id: string } }
+        | { ok: boolean; state?: string; friendship?: { id: string } }
         | { error: SendErrorKey; message?: string }
         | null
 
@@ -106,7 +109,7 @@ export function AddFriendRequestModal({
         )
         return
       }
-      onSent(body.friendship.id)
+      onSent(body.friendship.id, body.state)
       onClose()
     } catch {
       setError(describeError('network'))

--- a/src/components/friends/FindFriendsSearch.tsx
+++ b/src/components/friends/FindFriendsSearch.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useRef, useState } from 'react'
 
 import { AddFriendButton } from '@/components/friends/AddFriendButton'
+import {
+  resolveAddSomeoneOutcome,
+  type QueryClassification,
+} from '@/components/friends/add-someone'
 import { colorForUser, formatRelativeTime } from '@/components/feed/visual'
 import type { RelationshipResult } from '@/server/db/queries/friend-requests'
 
@@ -17,6 +21,22 @@ type Match = {
 
 type SearchResponse = { match: Match | null }
 
+// Other surfaces can ask the hub lookup to run a term on their behalf (e.g. the
+// FriendsList empty-filter "add <term>" hand-off). The 'add' variant listens.
+export const ADD_SOMEONE_SEED_EVENT = 'add-someone:seed'
+
+type Props = {
+  // 'find' (default): the standalone /friends/find card — header "Search", and a
+  // plain "invite them below" hint on no-match.
+  // 'add': the Friends-hub block — warm framing, an inline Invite CTA on
+  //   no-match, and it listens for ADD_SOMEONE_SEED_EVENT to run a seeded term.
+  variant?: 'find' | 'add'
+  // Only used by the 'add' variant: invoked when the user chooses to invite a
+  // no-match. The classification lets the parent prefill the invite flow
+  // (phone → SMS invite; handle/name → blank/name).
+  onInvite?: (query: string, classification: QueryClassification) => void
+}
+
 const DEBOUNCE_MS = 400
 
 function initialsFor(name: string | null, fallback: string): string {
@@ -27,7 +47,7 @@ function initialsFor(name: string | null, fallback: string): string {
   return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase()
 }
 
-export function FindFriendsSearch() {
+export function FindFriendsSearch({ variant = 'find', onInvite }: Props = {}) {
   const [query, setQuery] = useState('')
   const [searching, setSearching] = useState(false)
   const [match, setMatch] = useState<Match | null>(null)
@@ -35,6 +55,7 @@ export function FindFriendsSearch() {
   const [error, setError] = useState<string | null>(null)
   const requestSeq = useRef(0)
   const debounceRef = useRef<number | null>(null)
+  const sectionRef = useRef<HTMLElement>(null)
 
   async function runSearch(value: string) {
     const trimmed = value.trim()
@@ -86,6 +107,22 @@ export function FindFriendsSearch() {
     }
   }, [query])
 
+  // The 'add' variant accepts seeded terms from elsewhere on the page (the
+  // FriendsList empty-filter hand-off). Setting the query lets the debounce
+  // effect run the search; we just scroll the lookup into view so the result
+  // lands where the user can see it.
+  useEffect(() => {
+    if (variant !== 'add') return
+    function onSeed(event: Event) {
+      const seeded = (event as CustomEvent<{ query?: string }>).detail?.query?.trim()
+      if (!seeded) return
+      setQuery(seeded)
+      sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+    }
+    window.addEventListener(ADD_SOMEONE_SEED_EVENT, onSeed)
+    return () => window.removeEventListener(ADD_SOMEONE_SEED_EVENT, onSeed)
+  }, [variant])
+
   function handleQueryChange(value: string) {
     setQuery(value)
     if (!value.trim()) {
@@ -102,13 +139,47 @@ export function FindFriendsSearch() {
   const matchDisplayName = match ? match.displayName?.trim() || `@${match.handle ?? ''}` : ''
   const initials = match ? initialsFor(match.displayName, match.handle ?? '?') : ''
   const swatch = match ? match.avatarColor || colorForUser(match.id) : null
+  const outcome = resolveAddSomeoneOutcome({
+    query,
+    searching,
+    searched,
+    error: error !== null,
+    match,
+  })
+
+  // The 'add' variant lives inside the hub's card, so it drops the card chrome
+  // and brings its own warm framing; the standalone 'find' page keeps the card.
+  const isAdd = variant === 'add'
 
   return (
-    <section className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
-      <h2 className="font-serif text-lg font-semibold">Search</h2>
-      <p className="text-muted-foreground mt-1 text-sm">
-        By @handle or US phone number. Exact matches only.
-      </p>
+    <section
+      ref={sectionRef}
+      className={
+        isAdd
+          ? ''
+          : 'bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]'
+      }
+    >
+      {isAdd ? (
+        <>
+          <p className="text-muted-foreground text-xs font-medium tracking-[0.14em] uppercase">
+            Add someone
+          </p>
+          <h2 className="text-foreground mt-3 font-serif text-2xl leading-tight font-semibold">
+            Already here?
+          </h2>
+          <p className="text-muted-foreground mt-2 text-sm leading-6">
+            Find a friend by their @handle or US number — exact matches only.
+          </p>
+        </>
+      ) : (
+        <>
+          <h2 className="font-serif text-lg font-semibold">Search</h2>
+          <p className="text-muted-foreground mt-1 text-sm">
+            By @handle or US phone number. Exact matches only.
+          </p>
+        </>
+      )}
       <input
         type="search"
         value={query}
@@ -124,11 +195,11 @@ export function FindFriendsSearch() {
       />
 
       <div className="mt-3 min-h-[44px]">
-        {searching ? (
+        {outcome.kind === 'searching' ? (
           <p className="text-muted-foreground text-sm">Searching…</p>
-        ) : error ? (
+        ) : outcome.kind === 'error' ? (
           <p className="text-destructive text-sm">{error}</p>
-        ) : match ? (
+        ) : outcome.kind === 'match' && match ? (
           <article className="bg-background flex items-start gap-3 rounded-xl border p-3">
             <span
               aria-hidden
@@ -153,10 +224,25 @@ export function FindFriendsSearch() {
               onChange={refreshAfterAction}
             />
           </article>
-        ) : searched ? (
-          <p className="text-muted-foreground text-sm">
-            No one by that name. They may not be on Joshing yet — you can invite them below.
-          </p>
+        ) : outcome.kind === 'no_match' ? (
+          isAdd ? (
+            <div className="bg-background rounded-xl border p-3">
+              <p className="text-muted-foreground text-sm">
+                No one by that call sign or number yet — they may not be on Joshing.
+              </p>
+              <button
+                type="button"
+                className="btn-ghost mt-2"
+                onClick={() => onInvite?.(query.trim(), outcome.classification)}
+              >
+                Invite them
+              </button>
+            </div>
+          ) : (
+            <p className="text-muted-foreground text-sm">
+              No one by that name. They may not be on Joshing yet — you can invite them below.
+            </p>
+          )
         ) : null}
       </div>
     </section>

--- a/src/components/friends/__tests__/add-someone.test.ts
+++ b/src/components/friends/__tests__/add-someone.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  addSuccessToast,
+  classifyQuery,
+  describeMatchStatus,
+  resolveAddSomeoneOutcome,
+} from '@/components/friends/add-someone'
+import type { RelationshipState } from '@/server/db/queries/friend-requests'
+
+describe('classifyQuery', () => {
+  it('treats blank input as empty', () => {
+    expect(classifyQuery('')).toBe('empty')
+    expect(classifyQuery('   ')).toBe('empty')
+  })
+
+  it('recognizes @handles and bare handles', () => {
+    expect(classifyQuery('@josh')).toBe('handle')
+    expect(classifyQuery('josh_palay')).toBe('handle')
+  })
+
+  it('recognizes US phone numbers, formatted or bare', () => {
+    expect(classifyQuery('(415) 555-1234')).toBe('phone')
+    expect(classifyQuery('7346578284')).toBe('phone')
+    expect(classifyQuery('1 734 657 8284')).toBe('phone')
+  })
+
+  it('falls back to name for free text', () => {
+    expect(classifyQuery('Sarah Connor')).toBe('name')
+    // Leading digit means it is not a valid handle, and 4 digits is not a phone.
+    expect(classifyQuery('123')).toBe('name')
+  })
+})
+
+describe('describeMatchStatus', () => {
+  const cases: Array<[RelationshipState, string]> = [
+    ['none', 'add'],
+    ['follows_you', 'add'],
+    ['pending_outbound', 'pending'],
+    ['pending_inbound', 'respond'],
+    ['friends', 'connected'],
+    ['following', 'connected'],
+  ]
+  it.each(cases)('maps %s to %s', (state, expected) => {
+    expect(describeMatchStatus(state)).toBe(expected)
+  })
+})
+
+describe('resolveAddSomeoneOutcome', () => {
+  const base = { query: '@josh', searching: false, searched: false, error: false, match: null }
+
+  it('is idle before any search resolves', () => {
+    expect(resolveAddSomeoneOutcome(base)).toEqual({ kind: 'idle' })
+  })
+
+  it('reports searching while in flight', () => {
+    expect(resolveAddSomeoneOutcome({ ...base, searching: true })).toEqual({ kind: 'searching' })
+  })
+
+  it('reports error', () => {
+    expect(resolveAddSomeoneOutcome({ ...base, searched: true, error: true })).toEqual({
+      kind: 'error',
+    })
+  })
+
+  it('surfaces a match with its add status', () => {
+    expect(
+      resolveAddSomeoneOutcome({
+        ...base,
+        searched: true,
+        match: { relationship: { state: 'none' } },
+      }),
+    ).toEqual({ kind: 'match', status: 'add' })
+  })
+
+  it('surfaces an already-pending match without offering a duplicate send', () => {
+    expect(
+      resolveAddSomeoneOutcome({
+        ...base,
+        searched: true,
+        match: { relationship: { state: 'pending_outbound' } },
+      }),
+    ).toEqual({ kind: 'match', status: 'pending' })
+  })
+
+  it('surfaces an already-connected match with no add action', () => {
+    expect(
+      resolveAddSomeoneOutcome({
+        ...base,
+        searched: true,
+        match: { relationship: { state: 'friends' } },
+      }),
+    ).toEqual({ kind: 'match', status: 'connected' })
+  })
+
+  it('falls to no_match carrying the classification for the invite hand-off', () => {
+    expect(
+      resolveAddSomeoneOutcome({ ...base, query: '(415) 555-1234', searched: true }),
+    ).toEqual({ kind: 'no_match', classification: 'phone' })
+    expect(resolveAddSomeoneOutcome({ ...base, query: '@ghost', searched: true })).toEqual({
+      kind: 'no_match',
+      classification: 'handle',
+    })
+  })
+})
+
+describe('addSuccessToast', () => {
+  it('reads as a pending request for an approval-required account', () => {
+    expect(addSuccessToast('created', 'none')).toBe('Request sent.')
+    expect(addSuccessToast(undefined, 'none')).toBe('Request sent.')
+  })
+
+  it('reads as a one-way follow when auto-approved from a cold start', () => {
+    expect(addSuccessToast('auto_approved', 'none')).toBe("You're now following.")
+  })
+
+  it('reads as a mutual friendship when auto-approved while following back', () => {
+    expect(addSuccessToast('auto_approved', 'follows_you')).toBe("You're now friends.")
+  })
+})

--- a/src/components/friends/add-someone.ts
+++ b/src/components/friends/add-someone.ts
@@ -1,0 +1,94 @@
+// Pure, UI-free logic for the "Add someone" lookup on the Friends hub. Kept
+// out of the component so the result-state branches can be unit-tested without
+// rendering (the hub lookup and the FriendsList empty-filter hand-off both
+// import from here, so the classification stays in one place).
+import type { RelationshipState } from '@/server/db/queries/friend-requests'
+
+export type QueryClassification = 'empty' | 'handle' | 'phone' | 'name'
+
+// Mirrors HANDLE_QUERY_PATTERN in src/server/db/queries/friend-search.ts:20
+// (leading letter required) so the client classifies a query the same way the
+// search endpoint will route it.
+const HANDLE_QUERY_PATTERN = /^@?[a-z][a-z0-9_]{2,19}$/i
+
+// Mirrors looksLikeUsMobileNumber in AddFriendInvite and the server-side
+// isUsPhoneNumber: 10 digits, or 11 digits starting with a US country code.
+function looksLikeUsPhone(value: string): boolean {
+  const digits = value.replace(/\D/g, '')
+  return digits.length === 10 || (digits.length === 11 && digits.startsWith('1'))
+}
+
+// Classify a typed lookup term. Handle is checked before phone to match the
+// server's branch order (a bare digit string can't satisfy the handle pattern's
+// leading-letter requirement, so the two never collide). Anything that is
+// neither a handle nor a US number is treated as a free-text name — the search
+// endpoint can't resolve those (stranger-by-name lookup is out of scope), so
+// callers route them to the invite flow instead.
+export function classifyQuery(value: string): QueryClassification {
+  const trimmed = value.trim()
+  if (!trimmed) return 'empty'
+  if (HANDLE_QUERY_PATTERN.test(trimmed)) return 'handle'
+  if (looksLikeUsPhone(trimmed)) return 'phone'
+  return 'name'
+}
+
+// What the lookup should offer for a matched account, derived from the existing
+// relationship. The match card delegates to AddFriendButton for the actual
+// controls; this is the honest top-level summary the branches are tested on.
+export type MatchStatus =
+  | 'add' // not connected yet — offer to follow / follow back
+  | 'pending' // we already have an outbound request — no duplicate send
+  | 'respond' // they already asked us — approve / not now
+  | 'connected' // already friends or following — no add action
+
+export function describeMatchStatus(state: RelationshipState): MatchStatus {
+  switch (state) {
+    case 'none':
+    case 'follows_you':
+      return 'add'
+    case 'pending_outbound':
+      return 'pending'
+    case 'pending_inbound':
+      return 'respond'
+    case 'friends':
+    case 'following':
+      return 'connected'
+  }
+}
+
+// The five honest result states of the lookup, collapsed to one descriptor the
+// component renders from (and the tests assert against).
+export type AddSomeoneOutcome =
+  | { kind: 'idle' } // nothing searched yet
+  | { kind: 'searching' }
+  | { kind: 'error' }
+  | { kind: 'match'; status: MatchStatus }
+  | { kind: 'no_match'; classification: QueryClassification }
+
+export function resolveAddSomeoneOutcome(input: {
+  query: string
+  searching: boolean
+  searched: boolean
+  error: boolean
+  match: { relationship: { state: RelationshipState } } | null
+}): AddSomeoneOutcome {
+  if (input.searching) return { kind: 'searching' }
+  if (input.error) return { kind: 'error' }
+  if (input.match) return { kind: 'match', status: describeMatchStatus(input.match.relationship.state) }
+  if (input.searched) return { kind: 'no_match', classification: classifyQuery(input.query) }
+  return { kind: 'idle' }
+}
+
+// Toast copy after a successful add, reflecting the state the POST returned.
+// `auto_approved` means the request landed immediately (a public account); if we
+// were following them back it's now a mutual friendship, otherwise a one-way
+// follow. `created` means an approval-required request is now pending.
+export function addSuccessToast(
+  sentState: string | undefined,
+  priorState: RelationshipState,
+): string {
+  if (sentState === 'auto_approved') {
+    return priorState === 'follows_you' ? "You're now friends." : "You're now following."
+  }
+  return 'Request sent.'
+}


### PR DESCRIPTION
## Summary
Refactors the friend-search lookup into a reusable "Add someone" component that lives on the Friends hub, with a hand-off to the invite flow for no-match results. Adds pure logic layer (`add-someone.ts`) for testable query classification and outcome resolution, and integrates the lookup with the FriendsList empty-filter state to let users add typed search terms as friends.

## Key Changes

- **New `add-someone.ts` module** — Pure, UI-free logic for query classification (handle/phone/name), relationship-state-to-action mapping, and outcome resolution. Extracted to enable unit testing without rendering and to share classification logic across surfaces.

- **`FindFriendsSearch` refactored to support two variants:**
  - `'find'` (default): Standalone `/friends/find` card with "Search" header
  - `'add'`: Embedded in Friends hub with warm framing ("Already here?"), inline invite CTA on no-match, and event-driven seeding from FriendsList empty-filter

- **FriendsHubPage restructured** — Moves the lookup into the invite section, replaces the static "Who shares your world?" prompt with the lookup card, and routes no-match invites to the invite flow (seeding phone field for US numbers, opening blank for handles/names).

- **FriendsList empty-filter hand-off** — When the local filter finds no matches, offers "Add '{term}' as a friend" button that either seeds the hub lookup (for handles/phone numbers) or opens the invite flow with the name prefilled (for free text).

- **AddFriendButton toast messaging** — Now reflects the actual outcome: "Request sent" for approval-required accounts, "You're now following" for auto-approved public accounts, or "You're now friends" if auto-approved while following back. Passes the POST response's `state` field up through `AddFriendRequestModal.onSent()`.

## Implementation Details

- Query classification mirrors server-side logic (`HANDLE_QUERY_PATTERN`, `looksLikeUsPhone`) so client and server agree on routing.
- Outcome resolution collapses five state branches (idle/searching/error/match/no-match) into a single discriminated union for testable rendering logic.
- Event-driven seeding (`ADD_SOMEONE_SEED_EVENT`) lets FriendsList trigger the hub lookup without tight coupling; scrolls the result into view on mobile.
- All new logic is unit-tested in `add-someone.test.ts` (120 lines covering classification, status mapping, outcome resolution, and toast copy).

https://claude.ai/code/session_015orxLp43oEvTvtLknqpfFF