### PR TITLE
Friends filter: labeled exit to Add-someone, no term carryover (B-FRIENDS-FILTER-EXIT-FIX-01)

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -5,8 +5,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { formatRelativeTime } from '@/components/feed/visual';
-import { ADD_SOMEONE_SEED_EVENT } from '@/components/friends/FindFriendsSearch';
-import { classifyQuery } from '@/components/friends/add-someone';
+import { buildAddSomeoneHandoff } from '@/components/friends/add-someone';
 
 type FriendSort = 'name_asc' | 'name_desc' | 'recent';
 
@@ -477,23 +476,14 @@ export default function FriendsList() {
     setFriendSearch('');
   }
 
-  // When the local friends filter finds no one, offer to add the typed term as a
-  // friend. A handle/number is handed to the hub's "Add someone" lookup to
-  // find-or-invite; a plain name can't be resolved by lookup (stranger-by-name
-  // search is out of scope), so it opens the invite flow with the name prefilled.
-  function addTypedTermAsFriend() {
-    const term = friendSearch.trim();
-    if (!term) return;
-    const classification = classifyQuery(term);
-    if (classification === 'handle' || classification === 'phone') {
-      window.dispatchEvent(new CustomEvent(ADD_SOMEONE_SEED_EVENT, { detail: { query: term } }));
-    } else {
-      window.dispatchEvent(
-        new CustomEvent('friend-invitations:create-new', {
-          detail: { inviteeDisplayName: term },
-        }),
-      );
-    }
+  // The friends filter is an in-memory substring match over your *existing*
+  // friends. When it finds no one, it's not an add-path — it's a labeled exit to
+  // the "Add someone" block. We deliberately pass NO term: the filter fragment is
+  // a name, and the lookup is exact handle-or-phone only, so carrying it across
+  // would dead-end. Hand the user to the right tool with an empty, focused input.
+  function goToAddSomeone() {
+    const { type, detail } = buildAddSomeoneHandoff();
+    window.dispatchEvent(new CustomEvent(type, { detail }));
   }
 
   const pendingInvites = useMemo(
@@ -661,19 +651,21 @@ export default function FriendsList() {
                 </div>
               ) : (
                 <p className="text-muted-foreground py-8 text-center text-sm">
-                  No friends match your filter.{' '}
                   {friendSearch.trim() ? (
                     <>
+                      No one in your friends by that. Looking for someone new?{' '}
                       <button
                         type="button"
                         className="text-primary underline"
-                        onClick={addTypedTermAsFriend}
+                        onClick={goToAddSomeone}
                       >
-                        Add “{friendSearch.trim()}” as a friend
+                        Add someone →
                       </button>{' '}
                       ·{' '}
                     </>
-                  ) : null}
+                  ) : (
+                    <>No friends match your filter. </>
+                  )}
                   <button
                     type="button"
                     className="text-primary underline"

--- a/src/components/friends/FindFriendsSearch.tsx
+++ b/src/components/friends/FindFriendsSearch.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from 'react'
 
 import { AddFriendButton } from '@/components/friends/AddFriendButton'
 import {
+  ADD_SOMEONE_FOCUS_EVENT,
   resolveAddSomeoneOutcome,
   type QueryClassification,
 } from '@/components/friends/add-someone'
@@ -21,15 +22,16 @@ type Match = {
 
 type SearchResponse = { match: Match | null }
 
-// Other surfaces can ask the hub lookup to run a term on their behalf (e.g. the
-// FriendsList empty-filter "add <term>" hand-off). The 'add' variant listens.
-export const ADD_SOMEONE_SEED_EVENT = 'add-someone:seed'
+// The 'add' variant listens for ADD_SOMEONE_FOCUS_EVENT (defined in
+// ./add-someone) — a focus-only hand-off from the FriendsList empty-filter exit
+// that carries no search term.
 
 type Props = {
   // 'find' (default): the standalone /friends/find card — header "Search", and a
   // plain "invite them below" hint on no-match.
   // 'add': the Friends-hub block — warm framing, an inline Invite CTA on
-  //   no-match, and it listens for ADD_SOMEONE_SEED_EVENT to run a seeded term.
+  //   no-match, and it listens for ADD_SOMEONE_FOCUS_EVENT to take focus (the
+  //   FriendsList empty-filter exit, which carries no term).
   variant?: 'find' | 'add'
   // Only used by the 'add' variant: invoked when the user chooses to invite a
   // no-match. The classification lets the parent prefill the invite flow
@@ -56,6 +58,7 @@ export function FindFriendsSearch({ variant = 'find', onInvite }: Props = {}) {
   const requestSeq = useRef(0)
   const debounceRef = useRef<number | null>(null)
   const sectionRef = useRef<HTMLElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
 
   async function runSearch(value: string) {
     const trimmed = value.trim()
@@ -107,20 +110,22 @@ export function FindFriendsSearch({ variant = 'find', onInvite }: Props = {}) {
     }
   }, [query])
 
-  // The 'add' variant accepts seeded terms from elsewhere on the page (the
-  // FriendsList empty-filter hand-off). Setting the query lets the debounce
-  // effect run the search; we just scroll the lookup into view so the result
-  // lands where the user can see it.
+  // The 'add' variant accepts a focus hand-off from elsewhere on the page (the
+  // FriendsList empty-filter exit). It brings the user to a blank lookup and
+  // focuses the input — deliberately carrying NO term, so they're prompted for a
+  // call sign or number instead of being handed a dead name fragment.
   useEffect(() => {
     if (variant !== 'add') return
-    function onSeed(event: Event) {
-      const seeded = (event as CustomEvent<{ query?: string }>).detail?.query?.trim()
-      if (!seeded) return
-      setQuery(seeded)
+    function onFocusRequest() {
+      setQuery('')
+      setMatch(null)
+      setSearched(false)
+      setError(null)
       sectionRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+      inputRef.current?.focus({ preventScroll: true })
     }
-    window.addEventListener(ADD_SOMEONE_SEED_EVENT, onSeed)
-    return () => window.removeEventListener(ADD_SOMEONE_SEED_EVENT, onSeed)
+    window.addEventListener(ADD_SOMEONE_FOCUS_EVENT, onFocusRequest)
+    return () => window.removeEventListener(ADD_SOMEONE_FOCUS_EVENT, onFocusRequest)
   }, [variant])
 
   function handleQueryChange(value: string) {
@@ -181,6 +186,7 @@ export function FindFriendsSearch({ variant = 'find', onInvite }: Props = {}) {
         </>
       )}
       <input
+        ref={inputRef}
         type="search"
         value={query}
         onChange={(event) => handleQueryChange(event.target.value)}

--- a/src/components/friends/__tests__/add-someone.test.ts
+++ b/src/components/friends/__tests__/add-someone.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  ADD_SOMEONE_FOCUS_EVENT,
   addSuccessToast,
+  buildAddSomeoneHandoff,
   classifyQuery,
   describeMatchStatus,
   resolveAddSomeoneOutcome,
@@ -101,6 +103,19 @@ describe('resolveAddSomeoneOutcome', () => {
       kind: 'no_match',
       classification: 'handle',
     })
+  })
+})
+
+describe('buildAddSomeoneHandoff', () => {
+  it('targets the Add-someone block', () => {
+    expect(buildAddSomeoneHandoff().type).toBe(ADD_SOMEONE_FOCUS_EVENT)
+  })
+
+  it('carries no search term into the lookup path', () => {
+    // The friends-filter term is a name; the lookup is exact handle-or-phone
+    // only. The exit must hand the user off with an empty input, never seed the
+    // typed fragment — so the event detail stays undefined.
+    expect(buildAddSomeoneHandoff().detail).toBeUndefined()
   })
 })
 

--- a/src/components/friends/add-someone.ts
+++ b/src/components/friends/add-someone.ts
@@ -4,6 +4,18 @@
 // import from here, so the classification stays in one place).
 import type { RelationshipState } from '@/server/db/queries/friend-requests'
 
+// The friends-filter empty state hands off to the hub's "Add someone" lookup.
+// This is a focus request only: the lookup is exact handle-or-phone, the filter
+// term is a name, so carrying the term across would dead-end. The dispatcher
+// (FriendsList) and the listener (FindFriendsSearch) both read the contract from
+// here so the "no term carried" guarantee lives in one tested place.
+export const ADD_SOMEONE_FOCUS_EVENT = 'add-someone:focus'
+
+export function buildAddSomeoneHandoff(): { type: string; detail: undefined } {
+  // detail is intentionally undefined — no search term, no classification.
+  return { type: ADD_SOMEONE_FOCUS_EVENT, detail: undefined }
+}
+
 export type QueryClassification = 'empty' | 'handle' | 'phone' | 'name'
 
 // Mirrors HANDLE_QUERY_PATTERN in src/server/db/queries/friend-search.ts:20


### PR DESCRIPTION
## Summary
Corrective follow-up to the merged add-someone work (#1053). The friends-filter empty state was wired to "add the typed search term as a friend," carrying a name fragment into a path that only accepts an exact handle or phone. This replaces it with a clean **labeled exit** to the Add-someone block — no term carryover.

## The defect (as merged)
The friends filter is an in-memory substring match over your *existing* friends' names/interests. Its empty state offered `Add "<term>" as a friend`, which:
- seeded a handle/phone fragment into the **exact-match lookup**, or
- prefilled a name fragment into the invite flow.

Either way it carried a name fragment across into a tool that resolves exact handle-or-phone only — the dead-end-that-reads-as-broken this workstream exists to kill (and the alternative "fix" — widening the lookup to match partial names — is display-name stranger search, explicitly out of scope).

## The fix
- **Empty state is now a labeled exit, not an add attempt:** *"No one in your friends by that. Looking for someone new?"* + **`Add someone →`**.
- The action dispatches a **focus-only** hand-off (`ADD_SOMEONE_FOCUS_EVENT`, **no term**). The Add-someone lookup scrolls into view, **resets to a blank input, and focuses it** — prompting the user fresh for a call sign or number.
- Term carryover removed: `addTypedTermAsFriend` and the `classifyQuery` import are gone from the FriendsList exit path.
- The hand-off contract moved into the pure `add-someone.ts` (`ADD_SOMEONE_FOCUS_EVENT` + `buildAddSomeoneHandoff`) so the "no term carried" guarantee is unit-tested in one place.

## Canon check
The exact-match lookup (`searchFriendByHandleOrPhone`) was **never widened** — confirmed still exact handle-or-phone only, untouched here. This was a UI rewire, not a revert.

## Tests
New unit tests assert the empty-state action **targets the Add block** and **carries no search term** (no route-200s). 24/24 tests pass; full typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015orxLp43oEvTvtLknqpfFF

---
_Generated by [Claude Code](https://claude.ai/code/session_015orxLp43oEvTvtLknqpfFF)_