### PR TITLE
Enlarge feed loading screen to fill viewport

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -152,7 +152,7 @@ export default function LoadingScreen({
     "isolate flex items-center justify-center overflow-hidden bg-[var(--brand-cream-page)]",
     fullScreen
       ? "fixed inset-0 z-[60]"
-      : "relative h-full w-full min-h-[70vh]",
+      : "relative h-full w-full min-h-[80vh]",
     className ?? "",
   ]
     .filter(Boolean)

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -152,7 +152,7 @@ export default function LoadingScreen({
     "isolate flex items-center justify-center overflow-hidden bg-[var(--brand-cream-page)]",
     fullScreen
       ? "fixed inset-0 z-[60]"
-      : "relative h-full w-full min-h-[480px]",
+      : "relative h-full w-full min-h-[70vh]",
     className ?? "",
   ]
     .filter(Boolean)


### PR DESCRIPTION
The non-fullScreen LoadingScreen (used only by the home FeedSkeleton)
fell back to a fixed min-h-[480px]. With no definite parent height that
floor was the rendered height, so the JOSHING feed loader read as a
small card beneath the top section rather than filling the page. Raise
the non-fullScreen floor to min-h-[70vh] so it fills the area beneath
the top card.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NmGAa7sKRV6x2jM396gerW