### PR TITLE
Make Recent activity render as From Friends cards on home feed

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -311,6 +311,14 @@ export function ActivityStreamItem({
   const playableCard =
     elevated && !nested && expandable && expand?.kind === 'milestone';
 
+  // Recent activity (the ambient texture rows) now shares the From Friends card
+  // chrome on the home feed — the same warm cream fill, light stroke, and soft
+  // drop shadow — so the two home zones read as one family of cards rather than
+  // a band of cards sitting above a flat hairline list. The playable milestones
+  // keep their editorial two-line headline + Play affordance (playableCard); the
+  // texture one-liners keep their body but now sit inside the same shell.
+  const elevatedCard = elevated && !nested;
+
   // On a playable milestone card the headline splits into two serif lines: the
   // person's NAME (large) and the rest of the sentence (medium) below it. The
   // milestone line is always built as [actor, ...predicate], so peel the leading
@@ -334,13 +342,15 @@ export function ActivityStreamItem({
   const containerStyle: CSSProperties = nested
     ? // Nested under a per-person heading: no border/fill, light padding.
       { padding: opened ? '6px 0' : '4px 0' }
-    : playableCard
+    : elevatedCard
       ? {
           padding: opened ? '16px 14px' : '14px',
-          // The "From Friends" playable milestone cards share the elevated feed
-          // fill token (defaults to the warm game-card cream) so the dev CARD
-          // COLOR cycler repaints them alongside the For You cards, and the same
-          // neutral hairline stroke as the Today's 5 card (no gold accent).
+          // Every elevated home-feed row — the "From Friends" playable milestone
+          // cards AND the "Recent activity" texture one-liners — shares the
+          // elevated feed fill token (defaults to the warm game-card cream) so
+          // the dev CARD COLOR cycler repaints them alongside the For You cards,
+          // and the same neutral hairline stroke as the Today's 5 card (no gold
+          // accent).
           background: 'var(--feed-card-elevated)',
           border: '1px solid var(--brand-border)',
           borderRadius: 4,


### PR DESCRIPTION
The home "What's Happening" feed had two visually distinct registers:
the From Friends playable milestone bundles read as elevated cream cards
(warm fill, light stroke, soft shadow), while the Recent activity texture
rows below them stayed flat one-liners divided by hairlines.

Extend the From Friends card chrome to every elevated, non-nested
activity row so the two home zones read as one family of cards. The
playable milestones keep their editorial two-line headline + Play
affordance; the texture one-liners keep their body but now sit inside the
same shell. The flat hairline treatment is retained for non-elevated
surfaces (the full /activities log), which never pass `elevated`.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RQpS9JNJgP9WfkfrRaeux2