### PR TITLE
Show removed question text in catch-up dismiss notice

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -66,7 +66,7 @@ export type ChatMessage =
       subhead?: string | null;
       badges?: Array<{ label: string; tone?: 'muted' | 'warning' }>;
     }
-  | { id: string; kind: 'dismiss_notice'; onUndo: () => Promise<void> }
+  | { id: string; kind: 'dismiss_notice'; questionText: string; onUndo: () => Promise<void> }
   | { id: string; kind: 'user'; text: string }
   | { id: string; kind: 'typing' }
   | {
@@ -238,8 +238,29 @@ function SystemRow({ text }: { text: string }) {
 // dimmed). Mirrors NewTerritoryUndo's self-contained optimistic state: the undo
 // is awaited, "Undoing…" shows while in flight, and a rejection surfaces an
 // inline retry hint without losing the dismissal.
-function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
+// Pull a short, recognisable fragment from the removed question so the notice
+// says *which* question left catch-up (e.g. "Removed "Under Robert's Rules
+// of Order…"") rather than an anonymous "Removed from catch up". Collapses
+// whitespace and clips on a word boundary so the snippet never dangles a
+// half-word before the ellipsis.
+function questionSnippet(questionText: string, maxLength = 42): string {
+  const normalized = questionText.replace(/\s+/g, ' ').trim();
+  if (normalized.length <= maxLength) return normalized;
+  const clipped = normalized.slice(0, maxLength);
+  const lastSpace = clipped.lastIndexOf(' ');
+  const head = lastSpace > 0 ? clipped.slice(0, lastSpace) : clipped;
+  return `${head.replace(/[.,;:!?'"]+$/, '')}…`;
+}
+
+function DismissNoticeRow({
+  questionText,
+  onUndo,
+}: {
+  questionText: string;
+  onUndo: () => Promise<void>;
+}) {
   const [state, setState] = useState<'idle' | 'undoing' | 'error'>('idle');
+  const snippet = questionSnippet(questionText);
 
   const handleUndo = async () => {
     if (state === 'undoing') return;
@@ -264,7 +285,13 @@ function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
           ...monoStyle,
           display: 'inline-flex',
           alignItems: 'center',
+          justifyContent: 'center',
+          flexWrap: 'wrap',
+          // The quoted question fragment can push the line past a narrow viewport;
+          // cap the chip and let it wrap to a second row rather than overflow.
+          maxWidth: 'min(20rem, 90%)',
           fontSize: '0.58rem',
+          lineHeight: 1.4,
           color: 'var(--text-muted)',
           textAlign: 'center',
           background: 'var(--surface)',
@@ -273,7 +300,10 @@ function DismissNoticeRow({ onUndo }: { onUndo: () => Promise<void> }) {
           padding: '4px 10px',
         }}
       >
-        <span>Removed from catch up</span>
+        <span>
+          Removed {snippet ? <span style={{ opacity: 0.85 }}>“{snippet}”</span> : null} from
+          catch up
+        </span>
         <span style={{ margin: '0 6px', opacity: 0.6 }}>·</span>
         {state === 'undoing' ? (
           <span style={{ opacity: 0.7 }}>Undoing…</span>
@@ -1463,7 +1493,7 @@ export function GameplayChatThread({
           case 'system':
             return <SystemRow key={m.id} text={m.text} />;
           case 'dismiss_notice':
-            return <DismissNoticeRow key={m.id} onUndo={m.onUndo} />;
+            return <DismissNoticeRow key={m.id} questionText={m.questionText} onUndo={m.onUndo} />;
           case 'question':
             return (
               <QuestionRow

--- a/src/components/play/__tests__/useCatchupFlow.message.test.tsx
+++ b/src/components/play/__tests__/useCatchupFlow.message.test.tsx
@@ -179,6 +179,25 @@ describe('useCatchupFlow result message (B-9: commentary + aside reach the rende
     expect(rendered).not.toContain('Recheck my answer');
   });
 
+  it('names the removed question in the dismiss notice so undo has context', () => {
+    const rendered = html([
+      {
+        id: 'd-1',
+        kind: 'dismiss_notice',
+        questionText:
+          'Under Robert’s Rules of Order, when a motion is on the floor and a member wants to set a future time?',
+        onUndo: async () => {},
+      },
+    ]);
+
+    // The notice should quote a recognisable fragment of the question (clipped on
+    // a word boundary) rather than an anonymous "Removed from catch up", and keep
+    // the Undo affordance.
+    expect(rendered).toContain('Under Robert');
+    expect(rendered).toContain('from catch up');
+    expect(rendered).toContain('Undo');
+  });
+
   it('renders no aside when the server gated it out (selectInsideJokeForViewer returned null)', () => {
     const rendered = html([
       buildCatchupResultMessage({

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -533,7 +533,12 @@ export function useCatchupFlow() {
         );
         return [
           ...retired,
-          { id: newMessageId(), kind: 'dismiss_notice', onUndo: () => undismissItem(item) },
+          {
+            id: newMessageId(),
+            kind: 'dismiss_notice',
+            questionText: item.questionText,
+            onUndo: () => undismissItem(item),
+          },
         ];
       });
       // A dismissed item leaves the answerable round (it won't be answered), so


### PR DESCRIPTION
## Summary
When a question is dismissed from catch-up, the notice now displays a recognizable fragment of the removed question text (e.g., "Removed "Under Robert's Rules…" from catch up") instead of a generic "Removed from catch up" message. This gives users context about which question was dismissed when they consider undoing the action.

## Changes
- **Type definition:** Added `questionText: string` field to the `dismiss_notice` chat message type
- **Snippet extraction:** Implemented `questionSnippet()` utility function that:
  - Normalizes whitespace in the question text
  - Clips to a maximum length (42 chars by default)
  - Breaks on word boundaries to avoid dangling half-words
  - Strips trailing punctuation before the ellipsis
- **UI updates:** Modified `DismissNoticeRow` component to:
  - Accept and display the question snippet
  - Add responsive layout constraints (`maxWidth: min(20rem, 90%)`) to prevent overflow on narrow viewports
  - Improve text wrapping with `flexWrap: 'wrap'` and adjusted `lineHeight`
- **Data flow:** Updated `useCatchupFlow` to pass `item.questionText` when creating dismiss notice messages
- **Tests:** Added test case verifying the notice displays a recognizable question fragment with the undo affordance

## Implementation Details
The `questionSnippet()` function uses `lastIndexOf(' ')` to find the last space within the clipped text, ensuring the displayed fragment never ends mid-word. Trailing punctuation is stripped to keep the ellipsis clean. The UI uses `opacity: 0.85` on the quoted snippet to visually distinguish it from the surrounding text while maintaining readability.

https://claude.ai/code/session_01SknS5oo2Qb9wSEEnQbRVBX