### PR TITLE
fix(daily): stop a concurrent build from swapping the served Daily Five

### DIFF
--- a/src/server/daily/__tests__/queue-build-race.test.ts
+++ b/src/server/daily/__tests__/queue-build-race.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DAILY_QUEUE_SIZE } from '@/server/daily/types';
+
+// B-DAILY-QUEUE-SWAP-01 regression. The login pre-warm (after()) and the
+// /daily page's synchronous POST both call fillDailyQueueForUser for the SAME
+// user within seconds. Before the fix, two concurrent builds each generated a
+// (different, non-deterministic) set and the second persist overwrote the
+// queue the player was already answering — they answered question 1 and an
+// entirely new five appeared. The in-process single-flight here is the first
+// line of defence: concurrent same-user builds in one instance coalesce into a
+// single generation + single persist, so they yield ONE queue. (The
+// cross-instance guarantee lives in persistDailyQueue's first-writer-wins ON
+// CONFLICT DO NOTHING — covered in persist-first-writer-wins.test.ts.)
+//
+// Same mock surface as queue-floor.test.ts: fillDailyQueueForUser pulls in the
+// whole DB + LLM graph, which throws at import without a connection. Mock it
+// all so this exercises ONLY the coalescing wrapper.
+const mocks = vi.hoisted(() => ({
+  getTodaysDailyQueue: vi.fn(),
+  carryForwardUntouchedDailyQueue: vi.fn(),
+  clearStaleShortTodayQueue: vi.fn(),
+  countDailyQueues: vi.fn(),
+  getKnowledgeBase: vi.fn(),
+  pickEligibleAuthoredQuestions: vi.fn(),
+  pickHouseQuestions: vi.fn(),
+  persistDailyQueue: vi.fn(),
+  getDailyPreferences: vi.fn(),
+  getFriendAndFoFUserIds: vi.fn(),
+  getFriendDomainsForBonus: vi.fn(),
+  generateDailyQuestionsFromKnowledgeBase: vi.fn(),
+  generateBonusQuestionsForDomains: vi.fn(),
+  isGenericSubcategory: vi.fn(),
+  commitPendingRefineDecisions: vi.fn(),
+  logLatency: vi.fn(),
+}));
+
+vi.mock('@/server/db/queries/daily', () => ({
+  getTodaysDailyQueue: mocks.getTodaysDailyQueue,
+  carryForwardUntouchedDailyQueue: mocks.carryForwardUntouchedDailyQueue,
+  clearStaleShortTodayQueue: mocks.clearStaleShortTodayQueue,
+  countDailyQueues: mocks.countDailyQueues,
+  getKnowledgeBase: mocks.getKnowledgeBase,
+  pickEligibleAuthoredQuestions: mocks.pickEligibleAuthoredQuestions,
+  pickHouseQuestions: mocks.pickHouseQuestions,
+  persistDailyQueue: mocks.persistDailyQueue,
+  buildAuthoredSlot: (a: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'friend', question_id: a.id, domain: a.canonicalSubcategory, question_text: a.questionText, answered: false,
+  }),
+  buildHouseSlot: (h: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'house', question_id: h.id, domain: h.canonicalSubcategory, question_text: h.questionText, answered: false,
+  }),
+  buildBotSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, answered: false,
+  }),
+  buildPresenceSlot: (q: { id: string; canonicalSubcategory: string; questionText: string }, presence: { sourceId: string }, position: number) => ({
+    slot_index: position, source: 'bot', generated_question_id: q.id, domain: q.canonicalSubcategory, question_text: q.questionText, presence_source_id: presence?.sourceId, answered: false,
+  }),
+}));
+
+vi.mock('@/server/db/queries/daily-preferences', () => ({
+  getDailyPreferences: mocks.getDailyPreferences,
+}));
+
+vi.mock('@/server/db/queries/friends', () => ({
+  getFriendAndFoFUserIds: mocks.getFriendAndFoFUserIds,
+}));
+
+vi.mock('@/server/db/queries/friend-presence-domains', () => ({
+  getFriendDomainsForBonus: mocks.getFriendDomainsForBonus,
+}));
+
+vi.mock('@/server/daily/generate-questions', () => ({
+  generateDailyQuestionsFromKnowledgeBase: mocks.generateDailyQuestionsFromKnowledgeBase,
+  generateBonusQuestionsForDomains: mocks.generateBonusQuestionsForDomains,
+}));
+
+vi.mock('@/server/questions/canonical-subcategory', () => ({
+  isGenericSubcategory: mocks.isGenericSubcategory,
+}));
+
+vi.mock('@/server/refine/commit', () => ({
+  commitPendingRefineDecisions: mocks.commitPendingRefineDecisions,
+}));
+
+vi.mock('@/server/telemetry', () => ({
+  logLatency: mocks.logLatency,
+}));
+
+import { fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
+
+const USER = 'user-1';
+
+// A distinct generated question per id. The orchestrator only reads id,
+// questionText, and canonicalSubcategory. Distinct subcategories keep every
+// question under the intra-day diversity cap so all of them survive into the
+// core (the test asserts on identity, not gating).
+function genq(id: string) {
+  return { id, questionText: `Question ${id}`, canonicalSubcategory: id } as never;
+}
+
+// A generation result with more than enough distinct questions to fill the core
+// in a single pass — no top-up rounds — so generate is called exactly once per
+// build and the call count cleanly reflects how many builds actually ran.
+function fullGeneration(prefix: string) {
+  return Array.from({ length: DAILY_QUEUE_SIZE + 2 }, (_unused, i) => genq(`${prefix}-q${i}`));
+}
+
+// Resolve only when signalled, so two builds can be held concurrently in flight
+// and we can prove the second coalesces onto the first before either settles.
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mocks.getTodaysDailyQueue.mockResolvedValue(null);
+  mocks.carryForwardUntouchedDailyQueue.mockResolvedValue(false);
+  mocks.clearStaleShortTodayQueue.mockResolvedValue(false);
+  mocks.countDailyQueues.mockResolvedValue(3);
+  mocks.getKnowledgeBase.mockResolvedValue([{ domain: 'Jazz' }]);
+  mocks.getDailyPreferences.mockResolvedValue({
+    difficulty: 'adaptive',
+    domainMode: 'random',
+    selectedDomains: [],
+  });
+  mocks.pickEligibleAuthoredQuestions.mockResolvedValue([]);
+  mocks.pickHouseQuestions.mockResolvedValue([]);
+  mocks.getFriendAndFoFUserIds.mockResolvedValue({ direct: new Set(), extended: new Set() });
+  mocks.getFriendDomainsForBonus.mockResolvedValue([]);
+  mocks.generateBonusQuestionsForDomains.mockResolvedValue([]);
+  mocks.isGenericSubcategory.mockReturnValue(false);
+  mocks.commitPendingRefineDecisions.mockResolvedValue(undefined);
+  mocks.persistDailyQueue.mockResolvedValue(undefined);
+});
+
+describe('fillDailyQueueForUser — concurrent build coalescing (B-DAILY-QUEUE-SWAP-01)', () => {
+  it('two concurrent same-user builds generate once and persist once (one queue)', async () => {
+    const gate = deferred<ReturnType<typeof fullGeneration>>();
+    // Hold the first build inside generation so the second call lands while the
+    // first is still in flight — the exact pre-warm-vs-POST overlap.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockReturnValue(gate.promise as never);
+
+    const first = fillDailyQueueForUser(USER);
+    const second = fillDailyQueueForUser(USER);
+
+    // Identical promise: the second caller coalesced onto the first's build.
+    expect(second).toBe(first);
+
+    gate.resolve(fullGeneration('build-a'));
+    await expect(Promise.all([first, second])).resolves.toEqual([undefined, undefined]);
+
+    // The whole point: ONE generation, ONE persist — not two racing builds whose
+    // second persist clobbers the first's served queue.
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(1);
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+
+    const persistedSlots = mocks.persistDailyQueue.mock.calls[0][1] as Array<Record<string, unknown>>;
+    expect(persistedSlots.map((slot) => slot.generated_question_id)).toEqual(
+      fullGeneration('build-a').slice(0, DAILY_QUEUE_SIZE).map((q) => (q as { id: string }).id),
+    );
+  });
+
+  it('releases the in-flight entry on settle so a later build still runs', async () => {
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue(fullGeneration('build-a'));
+
+    await fillDailyQueueForUser(USER);
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(1);
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+
+    // A genuinely later build (e.g. tomorrow's, or after the player finished) must
+    // not be suppressed by a stale single-flight entry.
+    await fillDailyQueueForUser(USER);
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(2);
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears the in-flight entry when the build rejects, so a retry can rebuild', async () => {
+    // First build throws after generation (knowledge base disappeared); the
+    // single-flight entry must still clear so a retry isn't permanently wedged.
+    mocks.getKnowledgeBase.mockResolvedValueOnce([]);
+    await expect(fillDailyQueueForUser(USER)).rejects.toMatchObject({ code: 'no_knowledge_base' });
+
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue(fullGeneration('build-a'));
+    await expect(fillDailyQueueForUser(USER)).resolves.toBeUndefined();
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not coalesce builds for different users', async () => {
+    const gate = deferred<ReturnType<typeof fullGeneration>>();
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockReturnValue(gate.promise as never);
+
+    const a = fillDailyQueueForUser('user-a');
+    const b = fillDailyQueueForUser('user-b');
+    expect(b).not.toBe(a);
+
+    gate.resolve(fullGeneration('shared'));
+    await Promise.all([a, b]);
+
+    // Distinct users never share a build — each gets its own generation + persist.
+    expect(mocks.generateDailyQuestionsFromKnowledgeBase).toHaveBeenCalledTimes(2);
+    expect(mocks.persistDailyQueue).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -116,7 +116,35 @@ const GENERATION_OVERPROVISION = 2;
 const overRequest = (needed: number) =>
   Math.min(needed * GENERATION_OVERPROVISION, DAILY_QUEUE_SIZE * 2);
 
-export async function fillDailyQueueForUser(userId: string): Promise<void> {
+// In-process single-flight de-dupe (B-DAILY-QUEUE-SWAP-01). The login pre-warm
+// (after()) and the /daily page's synchronous POST routinely fire a build for
+// the SAME user within seconds of each other. Coalescing concurrent same-user
+// builds in this instance means the common race spends ONE generation instead
+// of two — every caller awaits the same promise and observes the same queue.
+//
+// This is a cost optimization, not the correctness boundary: two builds on
+// DIFFERENT instances skip this map entirely, and the real swap-proofing lives
+// in persistDailyQueue's first-writer-wins ON CONFLICT DO NOTHING (so a
+// cross-instance loser still can't overwrite the served queue). We deliberately
+// do NOT use a DB advisory lock held across generation: the daily cron runs
+// USER_CONCURRENCY=4 builds against the max:5 pool, and pinning a connection per
+// build for its whole duration would starve that pool.
+const inFlightFills = new Map<string, Promise<void>>();
+
+export function fillDailyQueueForUser(userId: string): Promise<void> {
+  const inFlight = inFlightFills.get(userId);
+  if (inFlight) return inFlight;
+
+  const promise = buildDailyQueueForUser(userId).finally(() => {
+    // Clear on settle (success OR failure) so the next genuine build for this
+    // user isn't blocked by a stale entry — a rejected build must be retryable.
+    inFlightFills.delete(userId);
+  });
+  inFlightFills.set(userId, promise);
+  return promise;
+}
+
+async function buildDailyQueueForUser(userId: string): Promise<void> {
   const startedAt = Date.now();
 
   // Commit point for Refine Your Game: staged decisions from the prior daily's

--- a/src/server/db/queries/__tests__/persist-daily-queue-race.test.ts
+++ b/src/server/db/queries/__tests__/persist-daily-queue-race.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// B-DAILY-QUEUE-SWAP-01 — the cross-instance correctness boundary. The
+// orchestrator's in-process single-flight only coalesces same-instance builds;
+// two builds on different serverless instances both reach persistDailyQueue.
+// This proves persist is FIRST-WRITER-WINS: a second builder that finds an
+// existing (user, queueDate) row leaves it untouched and returns the queue that
+// won — it can never overwrite the five the player is already answering. (The
+// old setWhere:untouched rule overwrote a served-but-unanswered queue, which is
+// exactly how a returning user got a brand-new set after answering question 1.)
+
+// Capture every insert builder call so we can assert the conflict STRATEGY, not
+// just the outcome — a regression back to onConflictDoUpdate must fail loudly.
+const insertCalls: Array<{
+  values: unknown;
+  conflict: 'doNothing' | 'doUpdate' | null;
+  conflictArg: unknown;
+}> = [];
+
+// Staged result of the insert's RETURNING: [row] = this builder won (inserted),
+// [] = it lost the race (ON CONFLICT DO NOTHING produced no row).
+let returningRows: unknown[] = [];
+// What the post-conflict fallback SELECT finds — the queue that actually won.
+let existingRow: unknown = null;
+const updateSets: unknown[] = [];
+
+function makeInsertChain() {
+  const call: (typeof insertCalls)[number] = { values: undefined, conflict: null, conflictArg: undefined };
+  insertCalls.push(call);
+  const chain = {
+    values(v: unknown) {
+      call.values = v;
+      return chain;
+    },
+    onConflictDoNothing(arg: unknown) {
+      call.conflict = 'doNothing';
+      call.conflictArg = arg;
+      return chain;
+    },
+    onConflictDoUpdate(arg: unknown) {
+      call.conflict = 'doUpdate';
+      call.conflictArg = arg;
+      return chain;
+    },
+    returning() {
+      return Promise.resolve(returningRows);
+    },
+  };
+  return chain;
+}
+
+function makeSelectChain() {
+  const chain = {
+    from: () => chain,
+    where: () => chain,
+    limit: () => Promise.resolve(existingRow ? [existingRow] : []),
+  };
+  return chain;
+}
+
+const tx = {
+  insert: () => makeInsertChain(),
+  update: () => ({
+    set: (vals: unknown) => ({
+      where: () => {
+        updateSets.push(vals);
+        return Promise.resolve([]);
+      },
+    }),
+  }),
+  select: () => makeSelectChain(),
+};
+
+vi.mock('@/server/db', () => ({
+  db: {
+    transaction: (cb: (t: typeof tx) => Promise<unknown>) => cb(tx),
+  },
+  dailyQueues: { id: 'id', userId: 'user_id', queueDate: 'queue_date', slots: 'slots' },
+  generatedQuestions: { id: 'gq_id' },
+  // The rest of daily.ts's table imports — unused on the persist path but
+  // referenced at module load.
+  dailyPreferences: {},
+  declaredInterests: {},
+  feedItems: {},
+  masteryEvents: {},
+  playerMastery: {},
+  questions: {},
+  skippedDailyQuestions: {},
+  userDomainExclusions: {},
+  users: {},
+}));
+
+vi.mock('@/lib/games/timezone', async (importActual) => ({
+  ...(await importActual<Record<string, unknown>>()),
+  getDailyAssignmentBounds: vi.fn(() => ({
+    assignmentDateStr: '2026-06-18',
+    assignmentDate: new Date('2026-06-18T00:00:00Z'),
+    expiresAt: new Date('2026-06-19T17:00:00Z'),
+  })),
+}));
+
+import { persistDailyQueue } from '@/server/db/queries/daily';
+
+const USER = 'user-1';
+const slotsA = [{ slot_index: 0, source: 'bot', generated_question_id: 'a1', answered: false }] as never;
+
+beforeEach(() => {
+  insertCalls.length = 0;
+  updateSets.length = 0;
+  returningRows = [];
+  existingRow = null;
+  vi.clearAllMocks();
+});
+
+describe('persistDailyQueue — first-writer-wins (B-DAILY-QUEUE-SWAP-01)', () => {
+  it('uses ON CONFLICT DO NOTHING keyed on (userId, queueDate) — never DO UPDATE', async () => {
+    returningRows = [{ id: 'q', userId: USER, queueDate: '2026-06-18', slots: slotsA }];
+
+    await persistDailyQueue(USER, slotsA, []);
+
+    expect(insertCalls).toHaveLength(1);
+    expect(insertCalls[0].conflict).toBe('doNothing');
+    // Crucially NOT an overwrite — that's the regression we're guarding against.
+    expect(insertCalls[0].conflict).not.toBe('doUpdate');
+    expect(insertCalls[0].conflictArg).toEqual({ target: ['user_id', 'queue_date'] });
+  });
+
+  it('winner: returns the freshly inserted row and flags its generated questions used', async () => {
+    const inserted = { id: 'winner', userId: USER, queueDate: '2026-06-18', slots: slotsA };
+    returningRows = [inserted];
+
+    const result = await persistDailyQueue(USER, slotsA, ['a1']);
+
+    expect(result).toBe(inserted);
+    // Its generated questions are marked used because they made it into the queue.
+    expect(updateSets).toEqual([{ usedInQueue: true }]);
+  });
+
+  it('loser: returns the EXISTING winning queue and does NOT flag its discarded questions used', async () => {
+    // RETURNING empty = the conflict row already existed (the winner). The loser
+    // must hand back that winning queue unchanged...
+    returningRows = [];
+    existingRow = { id: 'winner', userId: USER, queueDate: '2026-06-18', slots: slotsA };
+
+    const result = await persistDailyQueue(USER, [{ slot_index: 0, generated_question_id: 'b1' }] as never, ['b1']);
+
+    expect(result).toBe(existingRow);
+    // ...and must NOT mark its own (discarded) generated questions as used —
+    // they never entered the persisted queue.
+    expect(updateSets).toEqual([]);
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -870,9 +870,23 @@ export async function createDailyQueueItem(
  * complete slots array in one statement closes that window: a reader sees either
  * the pre-build state or the whole queue, never an intermediate prefix.
  *
- * Concurrency guard: ON CONFLICT only overwrites an UNTOUCHED row (no answered or
- * skipped slot). A second builder that raced the first therefore can't clobber a
- * session the player has already started — the started queue stands.
+ * Concurrency guard — FIRST WRITER WINS (B-DAILY-QUEUE-SWAP-01): ON CONFLICT DO
+ * NOTHING. Once a row exists for (user, queueDate), a second builder that raced
+ * the first leaves it untouched and returns the existing queue. This is stronger
+ * than the previous "overwrite an untouched row" rule, which clobbered a queue
+ * that had been SERVED but not yet answered — the exact window the login pre-warm
+ * (commit 09585230) opened: a returning user was served build A, and build B
+ * (the background pre-warm) overwrote it with a different question set while they
+ * were still reading question 1, so their answer 409'd as `slot_changed` and an
+ * entirely new five appeared. Two concurrent builds are non-deterministic and
+ * produce DIFFERENT sets, so the only safe rule is that whichever lands first
+ * stands. The single legitimate "regenerate today" paths (preference change →
+ * invalidateUntouchedDailyQueues, stale-short → clearStaleShortTodayQueue) DELETE
+ * the row first, so they insert cleanly and never reach this conflict.
+ *
+ * The only cost of a lost race is one re-billed build whose questions are
+ * discarded; the loser's generatedQuestionIds are intentionally NOT flagged
+ * usedInQueue, since they never entered the persisted queue.
  */
 export async function persistDailyQueue(
   userId: string,
@@ -881,19 +895,11 @@ export async function persistDailyQueue(
 ): Promise<DailyQueueRow | null> {
   const { assignmentDateStr } = getDailyAssignmentBounds();
   return db.transaction(async (tx) => {
-    // True only when the EXISTING conflicting row has no answered/skipped slot.
-    // Referencing the table name (not EXCLUDED) reads the pre-update row.
-    const untouched = sql`not exists (
-      select 1 from jsonb_array_elements(${dailyQueues.slots}) as elem
-      where (elem->>'answered')::boolean is true or (elem->>'skipped')::boolean is true
-    )`;
     const [row] = await tx
       .insert(dailyQueues)
       .values({ userId, queueDate: assignmentDateStr, slots })
-      .onConflictDoUpdate({
+      .onConflictDoNothing({
         target: [dailyQueues.userId, dailyQueues.queueDate],
-        set: { slots },
-        setWhere: untouched,
       })
       .returning();
 
@@ -906,8 +912,9 @@ export async function persistDailyQueue(
 
     if (row) return row;
 
-    // Conflict hit a started (touched) row, so DO UPDATE was a no-op and
-    // RETURNING produced nothing. Hand back the existing started queue unchanged.
+    // Conflict hit an existing row, so DO NOTHING was a no-op and RETURNING
+    // produced nothing. This build lost the race; hand back the queue that won
+    // (unchanged) so the caller serves the one the player is already on.
     const [existing] = await tx
       .select()
       .from(dailyQueues)


### PR DESCRIPTION
## What

A returning user reported answering Daily Five question 1 and then being shown an **entirely new set of five** (account +17342776819, 2026-06-18). Root cause confirmed against production data: the login pre-warm (commit `09585230`) and the `/daily` page's synchronous build race each other.

Both calls pass the *"does today's queue exist?"* check before either persists, generate **different** (non-deterministic) question sets, and the loser's `persistDailyQueue` overwrote the queue the player was already answering. The first answer then resolved against the swapped slot and 409'd as `slot_changed`, surfacing the new set. The old `setWhere: untouched` persist guard only protected a queue *after* its first answer was recorded — not during the read-and-first-answer window the pre-warm lands in.

## Fix

- **`persistDailyQueue` → first-writer-wins** (`ON CONFLICT DO NOTHING`). Once a row exists for `(user, queueDate)`, a racing build can't overwrite it; the loser returns the winning queue. This is the cross-instance correctness boundary. The legitimate "regenerate today" paths (`invalidateUntouchedDailyQueues`, `clearStaleShortTodayQueue`) `DELETE` first, so they insert cleanly and never hit this conflict.
- **`fillDailyQueueForUser` → in-process single-flight** so the common pre-warm-vs-POST race spends one generation instead of two. Cost optimization, not the correctness boundary.
- **No DB advisory lock**, deliberately: the daily cron runs `USER_CONCURRENCY=4` builds against the `max: 5` pool, and a lock held across generation would starve it.

## Tests

- `queue-build-race.test.ts` — two concurrent same-user builds generate once / persist once; in-flight entry clears on success **and** rejection; distinct users don't coalesce.
- `persist-daily-queue-race.test.ts` — asserts `onConflictDoNothing` keyed on `(userId, queueDate)` (fails if reverted to `doUpdate`); winner returns the inserted row; loser returns the existing winning queue and doesn't flag its discarded questions used.

Typecheck, ESLint, and the daily/answer-route suites pass.

## Base

Stacked on `dev2` (which already carries the prewarm commit this fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)