### PR TITLE
fix(security): enable RLS on all public tables (B-SECURITY-RLS-01)

### DIFF
--- a/.claude/skills/new-migration/SKILL.md
+++ b/.claude/skills/new-migration/SKILL.md
@@ -16,6 +16,7 @@ Create the next Drizzle migration for: **$ARGUMENTS**
 - Schema source of truth: `src/server/db/schema.ts`.
 - Migrations are auto-applied at boot via `src/instrumentation.ts`.
 - Postgres pool is capped at `max: 5` in `src/server/db/index.ts:24` (Supabase PgBouncer constraint — see commit 2aafbb1). Don't write migrations that assume a higher connection count.
+- **RLS on every new table (B-SECURITY-RLS-01).** Tables in `public` are auto-granted to Supabase's `anon`/`authenticated` Data API roles by default privileges, so a new table is readable/writable over the public Data API the moment it's created. Every `CREATE TABLE` migration MUST be followed by `ALTER TABLE "X" ENABLE ROW LEVEL SECURITY;` (no policies — the app connects as the owner `postgres`, which bypasses RLS). See migration `0081_enable_rls_public_tables`. Skipping this re-opens the hole 0081 closed and trips the Supabase `rls_disabled` advisor.
 
 ## Steps
 
@@ -27,6 +28,7 @@ Create the next Drizzle migration for: **$ARGUMENTS**
    - `DROP COLUMN` or `DROP TABLE` on a table that may have production data
    - `ALTER COLUMN ... TYPE` changes that aren't trivially safe
    - `CREATE INDEX` on a large table without `CONCURRENTLY`
-5. Check `src/instrumentation.ts`. Migrations 0006 and 0009 set a precedent — if this migration depends on data being in a particular shape, add a defensive guard there. Reference the precedent explicitly.
-6. Add a header comment at the top of the generated `.sql` file: one paragraph explaining the change in human terms, plus the rollback plan in one or two sentences.
-7. Do NOT run the migration. Tell the user to run `npm run db:migrate` themselves when ready.
+5. If the migration creates any new table, append `ALTER TABLE "<name>" ENABLE ROW LEVEL SECURITY;` for each new table (see the RLS convention above and migration `0081`). `drizzle-kit generate` does NOT emit this — it must be added by hand.
+6. Check `src/instrumentation.ts`. Migrations 0006 and 0009 set a precedent — if this migration depends on data being in a particular shape, add a defensive guard there. Reference the precedent explicitly.
+7. Add a header comment at the top of the generated `.sql` file: one paragraph explaining the change in human terms, plus the rollback plan in one or two sentences.
+8. Do NOT run the migration. Tell the user to run `npm run db:migrate` themselves when ready.

--- a/drizzle/0081_enable_rls_public_tables.sql
+++ b/drizzle/0081_enable_rls_public_tables.sql
@@ -1,0 +1,101 @@
+-- Security: enable Row Level Security on every public table (B-SECURITY-RLS-01).
+--
+-- Supabase exposes a PostgREST Data API to the `anon` and `authenticated` roles,
+-- and Supabase's default privileges GRANT those roles full DML on every table in
+-- `public` (confirmed: anon had SELECT/INSERT/UPDATE on "User", incl. plaintext
+-- phone_number, OtpCode, SmsLog, sessions). With RLS disabled, anyone holding the
+-- project's anon key could read or modify every row over that API. The Supabase
+-- security advisor flags this as `rls_disabled` (critical).
+--
+-- This app NEVER uses the Data API / supabase-js — it reaches Postgres only
+-- through Drizzle over DATABASE_URL, which connects as `postgres`. `postgres`
+-- both OWNS every public table and has rolbypassrls=true, so it bypasses RLS
+-- entirely. Enabling RLS *without* FORCE therefore:
+--   - denies anon/authenticated (no policies => deny-all over the Data API), and
+--   - leaves the app's `postgres` connection completely unaffected.
+-- No policies are added by design: the only intended database client is the
+-- owner connection, which bypasses RLS. If a Data-API consumer is ever added,
+-- add per-table policies then.
+--
+-- Idempotent: ENABLE ROW LEVEL SECURITY is a no-op when already enabled, so this
+-- is safe to re-run (incl. the boot guard chain and a re-applied migration).
+--
+-- Rollback (re-exposes the tables — do not run without restoring grants/policy):
+--   ALTER TABLE "User" DISABLE ROW LEVEL SECURITY;  -- ...and so on per table.
+ALTER TABLE "ActivityItem" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "BiweeklyCeremony" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "ContactHash" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "ContentReport" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "CreatorNote" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "CritiqueUsageDaily" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DAILY_REFINE_DECISION" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DailyPreference" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DailyQueue" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "DeclaredInterest" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "EmailVerificationToken" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "FeedDismissedDomain" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "FeedItem" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "Follow" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "FriendInvitation" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "Friendship" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "GeneratedQuestion" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "GradeDispute" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "JoshingGame" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "JoshingGameQuestion" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "JoshingGameRecipient" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "JoshingGameResponse" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "MASTERY_EVENTS" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "OtpCode" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "PLAYER_MASTERY" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "PROFILE_DOMAIN_VISIBILITY" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "PROFILE_SECTION_VISIBILITY" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "Question" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "QuestionAudienceTag" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "QuestionFeedback" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "QuestionRating" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "QuestionReaction" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "SkippedDailyQuestion" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "SmsLog" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "USER_DOMAIN_DIFFICULTY" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "USER_DOMAIN_EXCLUSIONS" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "User" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "UserQuestionBank" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+ALTER TABLE "UserSession" ENABLE ROW LEVEL SECURITY;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -568,6 +568,13 @@
       "when": 1783468800000,
       "tag": "0080_question_author_deleted",
       "breakpoints": true
+    },
+    {
+      "idx": 81,
+      "version": "7",
+      "when": 1783555200000,
+      "tag": "0081_enable_rls_public_tables",
+      "breakpoints": true
     }
   ]
 }


### PR DESCRIPTION
## What

The Supabase security advisor flags `rls_disabled` (critical) on every public table. Verified the exposure is **real**, not a false positive, using `has_table_privilege`:

- The public `anon` role has **SELECT, INSERT, and UPDATE** on `"User"` (including plaintext `phone_number`), plus SELECT on `OtpCode`, `SmsLog`, `UserSession`, etc.
- `pg_default_acl` auto-grants those roles full DML on every **future** `public` table too — so each new Drizzle migration's tables get exposed.

Anyone holding the project's anon key could read or modify the entire database over Supabase's PostgREST Data API.

## Why this fix is safe

The app **never uses the Data API / supabase-js** — it reaches Postgres only through Drizzle over `DATABASE_URL`, which connects as the `postgres` role. All 40 public tables are owned by `postgres`, and `postgres` has `rolbypassrls = true`. So enabling RLS **without `FORCE`**:

- denies `anon`/`authenticated` (no policies ⇒ deny-all over the Data API), and
- leaves the app's owner connection completely unaffected (owner + bypassrls).

No policies are added by design — the only intended DB client is the bypassing owner. `ENABLE ROW LEVEL SECURITY` is idempotent, so it's safe under the boot guard chain and a re-applied migration.

## Changes

- `drizzle/0081_enable_rls_public_tables.sql` — `ENABLE ROW LEVEL SECURITY` on all 39 tables that lacked it (`__drizzle_migrations` already had it). Journaled as `idx 81` with a strictly-increasing `when`.
- `.claude/skills/new-migration/SKILL.md` — every future `CREATE TABLE` migration must enable RLS, so the default-privilege grant can't silently re-expose new tables.

## Applying

`migrate()` runs at boot even with `SKIP_BOOT_DB_GUARDS=1`, so deploying applies it. Because the hole is open now, recommend also running it immediately (Supabase SQL editor, or `npm run db:migrate` with the prod env). I can re-run `get_advisors(security)` to confirm `rls_disabled` clears once applied.

## Follow-up (optional)

This closes the data exposure on all current + future tables. The underlying Supabase *default privileges* still grant `anon`/`authenticated` on new tables (now harmless under RLS + the convention). A follow-up `ALTER DEFAULT PRIVILEGES … REVOKE` could remove them entirely — happy to add if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)