### PR TITLE
Fix missing FROM clause for questions table in feed query

### DIFF
--- a/src/server/feed/via-answerers.ts
+++ b/src/server/feed/via-answerers.ts
@@ -20,7 +20,7 @@
 
 import { and, desc, eq, inArray, isNotNull, ne } from 'drizzle-orm';
 
-import { db, feedItems, follows, users } from '@/server/db';
+import { db, feedItems, follows, questions, users } from '@/server/db';
 import { SOCIAL_FEED_SOURCE_TYPE, notBlockedForViewer } from '@/server/feed/visibility';
 
 /** A raw answerer row as read from the DB (one per friend_answered event). */
@@ -136,6 +136,10 @@ export async function getViaAnswerersForQuestions(
       ),
     )
     .innerJoin(users, eq(users.id, feedItems.sourceUserId))
+    // notBlockedForViewer() below references the `questions` table, so it must
+    // be in the FROM clause — without this join Postgres 42P01s ("missing
+    // FROM-clause entry for table Question"). Mirrors lately.ts:218,360.
+    .innerJoin(questions, eq(questions.id, feedItems.questionId))
     .where(
       and(
         eq(feedItems.recipientUserId, viewerUserId),


### PR DESCRIPTION
## Summary
Adds a missing `innerJoin` on the `questions` table in `getViaAnswerersForQuestions()` to fix a Postgres error when `notBlockedForViewer()` references the `questions` table.

## Changes
- Import `questions` table from `@/server/db`
- Add `innerJoin(questions, eq(questions.id, feedItems.questionId))` to the query builder chain
- Include explanatory comment noting that `notBlockedForViewer()` requires the `questions` table to be in the FROM clause, with reference to similar patterns in `lately.ts`

## Details
The `notBlockedForViewer()` function references the `questions` table in its visibility checks, but the table was not included in the query's FROM clause. This caused Postgres error 42P01 ("missing FROM-clause entry for table Question"). The fix mirrors the pattern already established in `lately.ts` at lines 218 and 360.

https://claude.ai/code/session_011xy5sAgRnZpPFXksTib2tJ