### PR TITLE
Make Recent activity read like From Friends on the home feed

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -311,38 +311,54 @@ export function ActivityStreamItem({
   const playableCard =
     elevated && !nested && expandable && expand?.kind === 'milestone';
 
-  // Recent activity (the ambient texture rows) now shares the From Friends card
-  // chrome on the home feed — the same warm cream fill, light stroke, and soft
-  // drop shadow — so the two home zones read as one family of cards rather than
-  // a band of cards sitting above a flat hairline list. The playable milestones
-  // keep their editorial two-line headline + Play affordance (playableCard); the
-  // texture one-liners keep their body but now sit inside the same shell.
-  const elevatedCard = elevated && !nested;
+  // Recent activity (the ambient texture rows) now reads like From Friends on the
+  // home feed: the same warm cream card shell AND the same editorial two-line
+  // serif headline — the actor's NAME large, the rest of the sentence in a medium
+  // serif below it — so the two home zones are one family of cards, not a band of
+  // editorial cards above a flat sans list. The playable milestones keep their
+  // "X of Y questions" progress + Play affordance (playableCard); the texture
+  // rows reuse the headline treatment but carry no milestone progress and only
+  // surface a disclosure affordance when there's actually something to reveal.
+  const editorialCard = elevated && !nested;
 
-  // On a playable milestone card the headline splits into two serif lines: the
-  // person's NAME (large) and the rest of the sentence (medium) below it. The
-  // milestone line is always built as [actor, ...predicate], so peel the leading
-  // actor part off here and render the remainder as the second line.
+  // On any elevated card the headline splits into two serif lines: the person's
+  // NAME (large) and the rest of the sentence (medium) below it. Both milestone
+  // and texture lines are built as [actor, ...predicate], so peel the leading
+  // actor part off here and render the remainder as the second line. Lines with
+  // no leading actor (e.g. "You and Craig both …") fall back to the whole line in
+  // the large serif (see the headline render below).
   const headlineActor =
-    playableCard && item.line[0]?.t === 'actor' ? item.line[0] : null;
+    editorialCard && item.line[0]?.t === 'actor' ? item.line[0] : null;
   const headlinePredicate = headlineActor
     ? trimLeadingPredicate(item.line.slice(1))
     : null;
   // The lower-right affordance is a bare verb that tracks the card's state. The
   // friend's name already headlines the card directly above it, so the link
-  // doesn't re-state it — it lands on the action instead. "Play" while there are
-  // questions left to answer, "Revisit" once they're all answered (opening then
-  // only reveals the read-only AnsweredHistory — nothing left to play, only to
-  // look back at), and "Close" while the bundle is open (in step with the
-  // chevron flipping up).
+  // doesn't re-state it — it lands on the action instead. On a playable milestone:
+  // "Play" while questions remain, "Revisit" once they're all answered (opening
+  // then only reveals the read-only AnsweredHistory), and "Close" while open. On
+  // an expandable texture card (a convergence / send-onward reveal): a quiet
+  // "See" → "Close". Non-expandable texture cards carry no affordance row at all
+  // (the headline is the whole card).
   const allAnswered =
     !!milestoneProgress && milestoneProgress.answered >= milestoneProgress.total;
-  const playAffordanceLabel = open ? 'Close' : allAnswered ? 'Revisit' : 'Play';
+  const playAffordanceLabel = playableCard
+    ? open
+      ? 'Close'
+      : allAnswered
+        ? 'Revisit'
+        : 'Play'
+    : open
+      ? 'Close'
+      : 'See';
+  // Whether the editorial card shows the lower-right disclosure row: always for a
+  // playable milestone, and for a texture card only when it actually expands.
+  const showCardAffordance = playableCard || (editorialCard && expandable);
 
   const containerStyle: CSSProperties = nested
     ? // Nested under a per-person heading: no border/fill, light padding.
       { padding: opened ? '6px 0' : '4px 0' }
-    : elevatedCard
+    : editorialCard
       ? {
           padding: opened ? '16px 14px' : '14px',
           // Every elevated home-feed row — the "From Friends" playable milestone
@@ -385,11 +401,13 @@ export function ActivityStreamItem({
           WebkitTapHighlightColor: 'transparent',
         }}
       >
-        {playableCard ? (
-          // Playable milestone card (home "What's Happening"): an editorial
-          // two-line headline — the person's NAME in the large serif, the rest
-          // of the sentence in a medium serif below it — with the play
-          // affordance in the lower-right corner (replacing the bare chevron).
+        {editorialCard ? (
+          // Elevated home card (From Friends milestones AND Recent activity
+          // texture): an editorial two-line headline — the person's NAME in the
+          // large serif, the rest of the sentence in a medium serif below it.
+          // Milestones add the "X of Y questions" progress + a Play affordance in
+          // the lower-right; texture cards add a quiet disclosure only when they
+          // expand, and otherwise end on the headline.
           <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
             <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
               <ActivityIcon spec={iconSpec} seed={item.id} />
@@ -441,47 +459,81 @@ export function ActivityStreamItem({
                     {milestoneProgress.total} questions
                   </p>
                 ) : null}
+                {/* Texture cards may carry supplementary metadata (a domain, a
+                    quoted question) as a secondLine — kept in its System mono /
+                    serif voice below the headline. Milestones set secondLine
+                    null, so this never renders on a From Friends card. */}
+                {item.secondLine ? (
+                  <p
+                    style={{
+                      margin: '6px 0 0',
+                      ...(item.secondLineVoice === 'system'
+                        ? {
+                            fontFamily: 'var(--font-mono)',
+                            fontSize: 11,
+                            textTransform: 'uppercase' as const,
+                            letterSpacing: 1,
+                          }
+                        : {
+                            fontFamily: 'var(--font-serif)',
+                            fontSize: 14,
+                          }),
+                      lineHeight: 1.45,
+                      color: INK2,
+                      display: '-webkit-box',
+                      WebkitLineClamp: 2,
+                      WebkitBoxOrient: 'vertical',
+                      overflow: 'hidden',
+                    }}
+                  >
+                    {item.secondLine}
+                  </p>
+                ) : null}
               </div>
             </div>
-            {/* Lower-right play affordance. The whole card is the button
+            {/* Lower-right disclosure affordance. The whole card is the button
                 (aria-expanded on the wrapper), so this is a styled label, not a
-                nested button; the disclosure arrow flips as the bundle opens. */}
-            <div
-              style={{
-                display: 'flex',
-                justifyContent: 'flex-end',
-                alignItems: 'center',
-                marginTop: 12,
-              }}
-            >
-              <span
+                nested button; the disclosure arrow flips as the card opens. Only
+                shown when the card actually reveals something (a playable
+                milestone, or an expandable texture card). */}
+            {showCardAffordance ? (
+              <div
                 style={{
-                  display: 'inline-flex',
+                  display: 'flex',
+                  justifyContent: 'flex-end',
                   alignItems: 'center',
-                  gap: 5,
-                  // Same text treatment as the "Answer →" feed action: the
-                  // sans (Interface voice) at 14px in the link slate, underlined,
-                  // matching the Today's Five card link. A tappable affordance
-                  // never takes the Editorial serif.
-                  fontFamily: 'var(--font-sans)',
-                  fontSize: 14,
-                  fontWeight: 500,
-                  color: 'var(--brand-link)',
-                  textDecoration: 'underline',
-                  textUnderlineOffset: 4,
+                  marginTop: 12,
                 }}
               >
-                {playAffordanceLabel}
-                <ChevronDown
-                  size={16}
-                  aria-hidden
+                <span
                   style={{
-                    transition: 'transform 150ms ease',
-                    transform: open ? 'rotate(180deg)' : 'none',
+                    display: 'inline-flex',
+                    alignItems: 'center',
+                    gap: 5,
+                    // Same text treatment as the "Answer →" feed action: the
+                    // sans (Interface voice) at 14px in the link slate, underlined,
+                    // matching the Today's Five card link. A tappable affordance
+                    // never takes the Editorial serif.
+                    fontFamily: 'var(--font-sans)',
+                    fontSize: 14,
+                    fontWeight: 500,
+                    color: 'var(--brand-link)',
+                    textDecoration: 'underline',
+                    textUnderlineOffset: 4,
                   }}
-                />
-              </span>
-            </div>
+                >
+                  {playAffordanceLabel}
+                  <ChevronDown
+                    size={16}
+                    aria-hidden
+                    style={{
+                      transition: 'transform 150ms ease',
+                      transform: open ? 'rotate(180deg)' : 'none',
+                    }}
+                  />
+                </span>
+              </div>
+            ) : null}
           </div>
         ) : (
           <>


### PR DESCRIPTION
## What & why

On the home "What's Happening" feed, **From Friends** milestone bundles rendered as elevated cream cards with an editorial two-line serif headline, while **Recent activity** (the ambient texture rows) sat below them as flat sans one-liners divided by hairlines. The two zones read as different registers. This makes Recent activity look like From Friends.

## Changes

All in `src/components/activity/ActivityStreamItem.tsx`:

- **Card chrome** — every elevated, non-nested home-feed row now shares the From Friends shell: the `--feed-card-elevated` cream fill, a `--brand-border` stroke, `4px` radius, and `--shadow-card-strong` (so the dev CARD COLOR cycler repaints them alongside the For You cards).
- **Editorial headline** — those rows now use the same two-line serif layout the milestones use: the actor's NAME in the large serif, the rest of the sentence in a medium serif below it. Lines with no leading actor fall back to the whole line in the large serif.
- **Texture-specific behavior** — texture cards keep their supplementary `secondLine` metadata in its existing mono/serif voice, show **no** "X of Y questions" progress (milestone-only), and surface the lower-right disclosure affordance **only when they actually expand** (convergence / send-onward reveals); a non-expandable event ends on its headline.
- **Unchanged surfaces** — the flat, timestamped one-liner is retained for non-elevated surfaces (the full `/activities` log) and nested per-person rows, which never pass `elevated`. From Friends milestone items carry `secondLine: null`, so the new secondLine render never touches them.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — clean
- `npm run lint` scope (`ActivityStreamItem.tsx`) — clean
- Tests — `FeedListBudget`, `OverflowSubpageSync`, `src/server/activity`, `activity-stream-friend-activity` (35 tests) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RQpS9JNJgP9WfkfrRaeux2)_