### PR TITLE
Hide metrics line for questions with no activity

### DIFF
--- a/src/components/questions/MyQuestionCard.tsx
+++ b/src/components/questions/MyQuestionCard.tsx
@@ -34,6 +34,12 @@ export function MyQuestionCard({
   const answerersLine = question.isOwnAuthored && question.answerers
     ? formatAnswerersLine(question.answerers)
     : null;
+  // Hide the metrics line entirely for a question that's never been played:
+  // "0 answers · 0% correct · 0 games" is noise, not information.
+  const hasMetrics =
+    question.timesAnswered > 0 ||
+    question.correctRate > 0 ||
+    question.usedInGamesCount > 0;
 
   return (
     <article
@@ -82,13 +88,15 @@ export function MyQuestionCard({
             {answerersLine}
           </p>
         ) : null}
-        <p className={`${answerersLine ? 'mt-1' : 'mt-2'} text-[13px] leading-snug`}>
-          <Stat value={`${question.timesAnswered}`} label="answers" />
-          <StatSeparator />
-          <Stat value={`${question.correctRate}%`} label="correct" />
-          <StatSeparator />
-          <Stat value={`${question.usedInGamesCount}`} label="games" />
-        </p>
+        {hasMetrics ? (
+          <p className={`${answerersLine ? 'mt-1' : 'mt-2'} text-[13px] leading-snug`}>
+            <Stat value={`${question.timesAnswered}`} label="answers" />
+            <StatSeparator />
+            <Stat value={`${question.correctRate}%`} label="correct" />
+            <StatSeparator />
+            <Stat value={`${question.usedInGamesCount}`} label="games" />
+          </p>
+        ) : null}
         {question.reportState ? <ReportStateNotice state={question.reportState} /> : null}
         {cardError ? (
           <p className="mt-2 text-[13px] text-destructive">{cardError}</p>


### PR DESCRIPTION
## Summary
Hide the metrics line (answers, correct rate, games) on question cards when a question has never been played or answered. This removes noise from the UI by not displaying "0 answers · 0% correct · 0 games" for unused questions.

## Changes
- Added `hasMetrics` boolean that checks if any of the three metrics (`timesAnswered`, `correctRate`, `usedInGamesCount`) have non-zero values
- Wrapped the metrics paragraph in a conditional render that only displays when `hasMetrics` is true
- Preserved the existing spacing logic (mt-1 or mt-2) for when the metrics line is shown

## Implementation Details
The metrics line is now only rendered when at least one of the following conditions is true:
- `question.timesAnswered > 0`
- `question.correctRate > 0`
- `question.usedInGamesCount > 0`

This prevents the display of all-zero metrics which provide no useful information to the user.

https://claude.ai/code/session_01V2fYtArmYSLVHoPwkA8mPs