### PR TITLE
Restrict elevated card styling to playable milestones only

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -311,13 +311,12 @@ export function ActivityStreamItem({
   const playableCard =
     elevated && !nested && expandable && expand?.kind === 'milestone';
 
-  // Recent activity (the ambient texture rows) now shares the From Friends card
-  // chrome on the home feed — the same warm cream fill, light stroke, and soft
-  // drop shadow — so the two home zones read as one family of cards rather than
-  // a band of cards sitting above a flat hairline list. The playable milestones
-  // keep their editorial two-line headline + Play affordance (playableCard); the
-  // texture one-liners keep their body but now sit inside the same shell.
-  const elevatedCard = elevated && !nested;
+  // Only the playable milestone bundles take the elevated cream-card chrome on
+  // the home feed (the warm fill, light stroke, soft drop shadow) so they step
+  // forward as the thing you can play. The Recent-activity texture one-liners
+  // stay FLAT — a hairline-divided list, never their own cards — so the ambient
+  // band reads as quiet texture beneath the playable From Friends cards.
+  const elevatedCard = playableCard;
 
   // On a playable milestone card the headline splits into two serif lines: the
   // person's NAME (large) and the rest of the sentence (medium) below it. The
@@ -345,12 +344,10 @@ export function ActivityStreamItem({
     : elevatedCard
       ? {
           padding: opened ? '16px 14px' : '14px',
-          // Every elevated home-feed row — the "From Friends" playable milestone
-          // cards AND the "Recent activity" texture one-liners — shares the
-          // elevated feed fill token (defaults to the warm game-card cream) so
-          // the dev CARD COLOR cycler repaints them alongside the For You cards,
-          // and the same neutral hairline stroke as the Today's 5 card (no gold
-          // accent).
+          // The playable "From Friends" milestone cards take the elevated feed
+          // fill token (defaults to the warm game-card cream) so the dev CARD
+          // COLOR cycler repaints them alongside the For You cards, and the same
+          // neutral hairline stroke as the Today's 5 card (no gold accent).
           background: 'var(--feed-card-elevated)',
           border: '1px solid var(--brand-border)',
           borderRadius: 4,


### PR DESCRIPTION
## Summary
Reverts the recent decision to apply elevated card styling (cream fill, light stroke, soft shadow) to both playable milestone bundles and recent activity texture rows on the home feed. Now only playable milestones receive the elevated card treatment, while recent activity items remain as a flat, hairline-divided list to read as quiet texture beneath the interactive cards.

## Changes
- **`elevatedCard` logic:** Changed from `elevated && !nested` to `playableCard` so only playable milestone bundles receive elevated styling
- **Comment updates:** Clarified that only playable "From Friends" milestone cards take the elevated feed fill token, while recent activity texture one-liners stay flat as a hairline-divided list

## Implementation Details
This change refines the visual hierarchy on the home feed by reserving the elevated card chrome (warm cream background, light border, drop shadow) exclusively for interactive playable milestone cards. Recent activity items now render as a flat list with hairline dividers, creating a clearer distinction between actionable content (playable cards) and ambient texture (activity feed).

https://claude.ai/code/session_01H2VkB3XtCvPhjKWbEJDTBT