### PR TITLE
Fix build: drop orphaned FeedSkeleton referencing unimported LoadingScreen

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -246,15 +246,3 @@ function buildDailyStatusSnapshot(queue: Awaited<ReturnType<typeof getTodaysDail
 function CardSkeleton({ minHeight }: { minHeight: string }) {
   return <Skeleton className="border" style={{ minHeight }} />
 }
-
-function FeedSkeleton() {
-  // Break out of the centered max-w-2xl content column so the loader spans the
-  // full viewport width (it read as too narrow when clipped to the column).
-  // left-1/2 + -translate-x-1/2 on a w-screen block re-centers it on the
-  // viewport regardless of the column's padding.
-  return (
-    <div className="relative left-1/2 w-screen -translate-x-1/2 overflow-hidden">
-      <LoadingScreen label="Loading feed" />
-    </div>
-  )
-}


### PR DESCRIPTION
A merge reintroduced the FeedSkeleton helper that commit 8b81e90
("Remove loading screen from home feed") had deleted, but kept the
LoadingScreen import removed and the Suspense fallback at null. The
result was dead code referencing an unimported name, failing the
production typecheck with "Cannot find name 'LoadingScreen'".

The home feed deliberately no longer shows the loader, so remove the
orphaned FeedSkeleton function rather than re-adding the import.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011w6pYXk8pY8dH7QrieZp3K