### PR TITLE
docs(type): reflect Josefin Sans as the live body/UI sans

### DIFF
--- a/_docs/STYLE-GUIDE-TYPE.md
+++ b/_docs/STYLE-GUIDE-TYPE.md
@@ -1,6 +1,6 @@
 # Joshing Style Guide — Type (Part 1 of 2)
 
-**Status:** architecture locked; faces resolved by `D-STYLE-AUDIT-01`. Confirmed: Editorial = Cormorant Garamond (the serif), System + Interface = Montserrat (the sans), differentiated by treatment not by face. The typewriter face (Courier New) that once carried the System voice has been **retired app-wide** — see §2 and §6. The role architecture is stable and safe to build against.
+**Status:** architecture locked; faces resolved by `D-STYLE-AUDIT-01`. Confirmed: Editorial = Cormorant Garamond (the serif), System + Interface = **Josefin Sans** (the sans, since 2026-06-16), differentiated by treatment not by face. **Montserrat is no longer the body/UI sans** — as of 2026-06-16 it is reserved for the "Joshing" brand wordmark only (Nav, LoadingScreen, login title, knowledge-card wordmarks); the app-wide sans is now Josefin Sans. The typewriter face (Courier New) that once carried the System voice has been **retired app-wide** — see §2 and §6. The role architecture is stable and safe to build against.
 
 -----
 
@@ -15,7 +15,7 @@ There are four voices — but only **two faces** carry them. Editorial gets the 
 |**Editorial**|the serif                     |The content — the thing the product is *for*|Warm, considered, literary. The loud voice.             |
 |**System**   |the sans — UPPERCASE + tracking|The machine labeling and structuring itself |Mechanical, quiet, precise. Never competes with content.|
 |**Interface**|the sans — sentence case       |Text you *act on* rather than read          |Tappable, clear, functional.                            |
-|**Brand**    |the script                    |Logo and brand moments only                 |Special — and stays special by being rare.              |
+|**Brand**    |Montserrat (the wordmark)     |Logo and brand moments only                 |Special — and stays special by being rare.              |
 
 This maps directly onto the product thesis: **the content is loud, the interface is quiet.** The serif-vs-sans split is the warmth-vs-precision distinction made visible. The System and Interface voices share the sans on purpose — the *machine* reading of a System label is carried by its caps + letterspacing, not by a typewriter face. (The earlier monospace, Courier New, was retired app-wide; see §2 and §6.) If the warm/quiet split ever stops reading as intentional, the type system has failed.
 
@@ -85,16 +85,16 @@ This maps directly onto the product thesis: **the content is loud, the interface
 
 -----
 
-## 4. BRAND — the script (Caveat)
+## 4. BRAND — the wordmark (Montserrat)
 
-**The brand voice.** Rare by design.
+**The brand voice.** Rare by design. The script face (Caveat) that once carried this voice was removed; the "Joshing" wordmark is now set in **Montserrat** (uppercase, tracked — e.g. the login title `JOSHING`), routed through `--font-wordmark` / the `font-wordmark` utility. Montserrat is *only* the wordmark now (it was the app-wide body sans until 2026-06-16); keeping it to brand moments is what keeps the brand voice rare.
 
 **Used for**
 
 - The Joshing logo / wordmark
 - Deliberate brand moments (a ceremony flourish, a hero beat) — sparingly
 
-**Never use the script for:** body copy, any interactive element, any label, any name in a feed, anything functional. The instant Caveat does a job, it stops being a brand mark and becomes noise. If you’re reaching for it to solve a layout problem, you’ve found the wrong tool.
+**Never use the wordmark face for:** body copy, any interactive element, any label, any name in a feed, anything functional. The instant the wordmark Montserrat does a job other than the brand mark, it stops being a brand mark and becomes noise. If you’re reaching for it to solve a layout problem, you’ve found the wrong tool. (Body/UI sans is Josefin Sans — see §3.)
 
 -----
 
@@ -113,7 +113,7 @@ A single friend-activity card spans **three voices**, and that is the system wor
 
 **What live code actually does:**
 
-- The **descriptor sentence body** renders in **Montserrat**, not a serif italic. Leave it as-is; the warmth is carried by the *words*, and Montserrat here reads as quiet connective tissue around the two things that do carry voice (the serif name, the serif category).
+- The **descriptor sentence body** renders in the **sans** (Josefin Sans), not a serif italic. Leave it as-is; the warmth is carried by the *words*, and the sans here reads as quiet connective tissue around the two things that do carry voice (the serif name, the serif category).
 - The **category names embedded in the line** render in the **Editorial serif** in their stored title case (`ActivityStreamItem.tsx`, the `category` branch of `Line`). They were briefly routed to the System mono register, but the typewriter look read as costume on what is really the warm answer to *which territory* — so they sit with the name in the serif now, a register apart from the sans sentence around them.
 - The **triangle hue is decorative**, not category — a deterministic hash of `rowId:position` over a 6-color palette. Don’t build meaning on its color. The one bit it *does* carry is **solid vs. hollow = unanswered vs. answered** — and that’s a color-half problem, not type: solid currently renders in near-WRONG orange, which Part 2 must de-collide.
 
@@ -131,11 +131,12 @@ Apply it to the name, not to “names” as a category. The same name can be Edi
 
 |Role     |Token         |Face                  |Notes                                                                                                                                                                                                                                                             |
 |---------|--------------|----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|Editorial|`--font-serif`|**Cormorant Garamond**|Rename `--font-literata` → `--font-serif` (it already resolves to Cormorant). Replace all hardcoded `'Georgia, serif'` with this token. Name vs. descriptor handled by weight + color, never italic. Display moments use Cormorant (display weight or its loaded italic) — this is the app's only editorial serif; the former second serif (Playfair Display) was retired by B-TYPE-SERIF-CONSOLIDATION-01.|
-|System   |`--font-mono` |**Montserrat** (caps + tracking)|Typewriter face retired. `--font-mono` now resolves to the sans stack (`globals.css:240`), so every `var(--font-mono)` / `FM` consumer renders the System voice in the sans, carrying its label signature by caps + letterspacing. The token name is kept (not renamed) purely as the single routing point for its ~40 consumers; treat it as “the System-label register,” not a monospace.|
-|Interface|`--font-sans` |**Montserrat**        |Confirmed (F4.2 resolved); `--font-neutral` aliases it. Same face as System now — the two are separated by casing/treatment, not by font. Clean the self-referential `--font-sans: var(--font-sans)` at `globals.css:9`. Fold the two stray Inter uses into Montserrat.|
+|Editorial|`--font-serif`|**Cormorant Garamond**|Loaded as `--font-cormorant`; `--font-serif` resolves to it (`globals.css:9`). Replace all hardcoded `'Georgia, serif'` with this token. Name vs. descriptor handled by weight + color, never italic. Display moments use Cormorant (display weight or its loaded italic) — this is the app's only editorial serif; the former second serif (Playfair Display) was retired by B-TYPE-SERIF-CONSOLIDATION-01.|
+|System   |`--font-mono` |**Josefin Sans** (caps + tracking)|Typewriter face retired. `--font-mono` resolves to the body sans stack (`var(--font-sans-body)`, `globals.css:288`), so every `var(--font-mono)` / `FM` consumer renders the System voice in the sans, carrying its label signature by caps + letterspacing. The token name is kept (not renamed) purely as the single routing point for its ~40 consumers; treat it as “the System-label register,” not a monospace.|
+|Interface|`--font-sans` |**Josefin Sans**      |The app-wide body/UI sans (2026-06-16). Loaded as `--font-sans-body` and applied to `<body>` in `layout.tsx`; `--font-sans` (`globals.css:56`), `--font-neutral` (`globals.css:281`), `--font-mono` (`globals.css:288`) and `--font-heading` (`globals.css:8`) all resolve to it. Same face as System now — the two are separated by casing/treatment, not by font.|
+|Brand    |`--font-wordmark`|**Montserrat**       |The "Joshing" wordmark only (Nav, LoadingScreen, login title, knowledge-card wordmarks). Loaded as `--font-montserrat`; surfaced to Tailwind as `font-wordmark` (`globals.css:13`/`:61`). Was the app-wide body sans until 2026-06-16; now rare-by-design, like the old Brand voice — see §4.|
 
-No `--font-script` token. Caveat removed; do not re-add a script face without a recurring job. **No live monospace face** — the one deliberate exception is the share-receipt raster (`SharePortraitCard.tsx`), which hardcodes `'Courier New'` for its html2canvas snapshot aesthetic and is intentionally outside this token system.
+No `--font-script` token. Caveat removed; do not re-add a script face without a recurring job — the Brand voice is now carried by Montserrat caps (the wordmark), not a script. **No live monospace face** — the one deliberate exception is the share-receipt raster (`SharePortraitCard.tsx`), which hardcodes `'Courier New'` for its html2canvas snapshot aesthetic and is intentionally outside this token system.
 
 **The fix-list this produces (type only):**
 
@@ -143,7 +144,7 @@ No `--font-script` token. Caveat removed; do not re-add a script face without a 
 1. Rename `--font-literata` → `--font-serif`; repoint consumers.
 1. Replace hardcoded `'Georgia, serif'` (6+ sites) with `--font-serif` for Editorial — **including** the descriptor-line category names, which read as content (§5).
 1. Retire the typewriter face: point `--font-mono` at the sans stack so the System voice is carried by caps + tracking, not a monospace; route any remaining Courier literals through the token (except the share-receipt raster).
-1. Fold the two Inter uses into Montserrat; clean the self-referential sans var.
+1. Fold the two Inter uses into the body sans (now Josefin Sans, `--font-sans-body`); clean the self-referential sans var.
 
 These are the type half of the eventual `B-VISUAL-STYLE-GUIDE` build prompt. Each is a token-routing change, not a redesign — low risk, high drift-reduction.
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -754,7 +754,7 @@ function FeedContributeFooter() {
   return (
     // Add-a-Question prompt — now composes the shared EditorialFeature so it
     // reads as one family with the feed's other invitation blocks (parchment
-    // wash, eyebrow, serif prompt) instead of re-rolling its own chrome. The
+    // wash, serif prompt) instead of re-rolling its own chrome. The
     // <footer> keeps the feed's bottom spacing; EditorialFeature self-manages
     // its own -mx-4/-my-1.5 bleed, so there's no horizontal margin to double up.
     // The composer is the "artwork" and the submit button rides inside its
@@ -763,7 +763,6 @@ function FeedContributeFooter() {
     <footer className="pb-8">
       <EditorialFeature
         tone="parchment"
-        eyebrow="Ask Someone"
         headline="Sometimes the best way to show you know someone is to ask them a question."
         artwork={
           <form onSubmit={handleSubmit} className="flex flex-col gap-4">

--- a/src/components/feed/EditorialFeature.tsx
+++ b/src/components/feed/EditorialFeature.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react'
 import { cn } from '@/lib/utils'
 
 // The three feed "featured moment" treatments. Each maps to a subtle full-bleed
-// background wash (--editorial-* in globals.css) plus an eyebrow accent color
+// background wash (--editorial-* in globals.css) plus a CTA accent color
 // borrowed from the brand palette. Add a tone here (and the matching CSS var +
 // accent) when a new editorial module joins the feed.
 export type EditorialTone = 'parchment' | 'sage' | 'slate'
@@ -23,14 +23,9 @@ const TONE_ACCENT: Record<EditorialTone, string> = {
 
 interface EditorialFeatureProps {
   tone: EditorialTone
-  // Small uppercase label (e.g. "Overlap"). Rendered uppercase; pass it in
-  // natural case.
-  eyebrow: string
-  // Optional mark beside the eyebrow (e.g. a filled bookmark), inheriting the
-  // tone accent color.
-  eyebrowIcon?: ReactNode
   // Large editorial headline. A node, so callers can weave an inline link (e.g.
-  // the friend's name) into it.
+  // the friend's name) into it. The editorial moments lead with the headline —
+  // there is deliberately no small-caps eyebrow above it.
   headline: ReactNode
   // The hero artwork slot (circles, avatar cluster, territory rows…).
   artwork: ReactNode
@@ -59,8 +54,6 @@ interface EditorialFeatureProps {
  */
 export function EditorialFeature({
   tone,
-  eyebrow,
-  eyebrowIcon,
   headline,
   artwork,
   supporting,
@@ -72,26 +65,11 @@ export function EditorialFeature({
       // -mx-4 escapes the home <main>'s px-4 gutter so the wash reaches the feed
       // column edges; -my-1.5 absorbs the feed's space-y-3 so the band meets its
       // neighbors edge to edge. Inner content is re-padded with px-8 (not
-      // px-4) so the eyebrow/headline/artwork line up with the feed cards' text,
+      // px-4) so the headline/artwork line up with the feed cards' text,
       // which sits at the 16px gutter + the card's own 14px padding = 30px.
       className={cn('-mx-4 -my-1.5 px-8 py-12 md:py-14', TONE_BG[tone])}
     >
-      <p
-        // The eyebrow uses the same ink register as the home zone headings
-        // ("From Friends" / "For you") rather than the tone accent, so editorial
-        // moments share one quiet small-caps label treatment. The tonal accent
-        // survives on the CTA link below.
-        className="flex items-center gap-1.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase"
-      >
-        {eyebrowIcon ? (
-          <span aria-hidden="true" className="inline-flex">
-            {eyebrowIcon}
-          </span>
-        ) : null}
-        {eyebrow}
-      </p>
-
-      <h2 className="mt-4 max-w-[20ch] font-serif text-[26px] leading-[1.15] font-medium text-[var(--brand-ink)] md:text-[32px]">
+      <h2 className="max-w-[20ch] font-serif text-[26px] leading-[1.15] font-medium text-[var(--brand-ink)] md:text-[32px]">
         {headline}
       </h2>
 

--- a/src/components/feed/EditorialPromos.tsx
+++ b/src/components/feed/EditorialPromos.tsx
@@ -26,7 +26,7 @@ const SHARED_GROUND_CIRCLE_SCALE = 1.35;
 const INVITE_CLUSTER_SEEDS = ['circle-a', 'circle-b', 'circle-c', 'circle-d'];
 
 // Promo HEADLINE pools (D-FEED-GROUP3-01 Pool 4). Only the headline rotates —
-// eyebrow, CTA, and supporting copy stay fixed (functional wayfinding). The
+// the CTA and supporting copy stay fixed (functional wayfinding). The
 // rotation is by the embed's day-seeded `headlineIndex`, not an event hash, so
 // a promo that recurs as the same type still varies day to day. `{friend}` in
 // the common-ground pool is rendered as a link (see CommonGroundFeature).
@@ -91,7 +91,6 @@ export function CommonGroundFeature({
   return (
     <EditorialFeature
       tone="parchment"
-      eyebrow="Overlap"
       headline={
         onInviteSlide ? (
           COMMON_GROUND_INVITE_HEADLINE
@@ -197,7 +196,6 @@ export function GrowYourCircleFeature({
   return (
     <EditorialFeature
       tone="sage"
-      eyebrow="Grow Your Circle"
       headline={rotate(ADD_FRIENDS_HEADLINES, embed.headlineIndex)}
       artwork={
         embed.variant === 'suggestions' ? (
@@ -265,7 +263,6 @@ export function RecentlyExpandingFeature({
   return (
     <EditorialFeature
       tone="slate"
-      eyebrow="Your World Is Expanding"
       headline={rotate(RECENTLY_EXPANDING_HEADLINES, embed.headlineIndex)}
       artwork={
         <div className="flex flex-col gap-3">

--- a/src/components/feed/__tests__/EditorialFeature.test.tsx
+++ b/src/components/feed/__tests__/EditorialFeature.test.tsx
@@ -17,7 +17,6 @@ describe('EditorialFeature', () => {
     return renderToStaticMarkup(
       <EditorialFeature
         tone="parchment"
-        eyebrow="Overlap"
         headline={<>You and Robyn keep finding one another here.</>}
         artwork={<div data-mock="art" />}
         supporting="2 shared interests"
@@ -27,12 +26,18 @@ describe('EditorialFeature', () => {
     )
   }
 
-  it('renders the eyebrow, headline, supporting line, and artwork', () => {
+  it('renders the headline, supporting line, and artwork', () => {
     const html = render()
-    expect(html).toContain('Overlap')
     expect(html).toContain('You and Robyn keep finding one another here.')
     expect(html).toContain('2 shared interests')
     expect(html).toContain('data-mock="art"')
+  })
+
+  it('leads with the headline — no small-caps eyebrow above it', () => {
+    const html = render()
+    // The editorial tiles deliberately dropped their eyebrow labels; the serif
+    // headline is the first thing in the band.
+    expect(html).not.toContain('uppercase')
   })
 
   it('renders the CTA as a single text link (no button) to the given href', () => {


### PR DESCRIPTION
Montserrat stopped being the app-wide sans on 2026-06-16 (Josefin Sans
now drives --font-sans-body, cascading to --font-sans/--font-neutral/
--font-mono/--font-heading). Update STYLE-GUIDE-TYPE.md so the System and
Interface voices name Josefin Sans, and document Montserrat as the
wordmark-only Brand face (--font-wordmark). Refresh §6 token table with
current globals.css line refs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01URG5Ak3TPAX8LCNc4KzQri