### PR TITLE
perf(questions): cache, paginate, and index the Questions tab

### DIFF
--- a/drizzle/0082_question_bank_added_at_idx.sql
+++ b/drizzle/0082_question_bank_added_at_idx.sql
@@ -1,0 +1,23 @@
+-- Performance: composite index for the authored / banked question list (the
+-- Questions tab, getBankedQuestions in src/server/db/queries/bank.ts).
+--
+-- The query filters equality on UserQuestionBank.user_id and orders by
+-- added_at DESC (the "most recently banked first" list). Only single-column
+-- indexes existed (user_id, question_id), so Postgres located the user's rows
+-- by the user_id index but then sorted the whole result set by added_at in
+-- memory on every Questions-tab load. The composite (user_id, added_at) lets
+-- the planner satisfy both the filter and the ordering from the index (a
+-- backward scan covers ORDER BY added_at DESC), removing the sort.
+--
+-- Pure index addition — additive, non-destructive, and idempotent
+-- (CREATE INDEX IF NOT EXISTS). No CONCURRENTLY: the runtime migrator wraps
+-- statements in a transaction (CONCURRENTLY is illegal there), matching every
+-- existing CREATE INDEX migration in this repo. Mirrored by a defensive guard
+-- in src/instrumentation.ts (precedent: 0079) so a preview/production database
+-- that records this migration without the index present still gets it on next
+-- boot.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS "UserQuestionBank_user_id_added_at_idx";
+CREATE INDEX IF NOT EXISTS "UserQuestionBank_user_id_added_at_idx"
+  ON "UserQuestionBank" ("user_id", "added_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -575,6 +575,13 @@
       "when": 1783555200000,
       "tag": "0081_enable_rls_public_tables",
       "breakpoints": true
+    },
+    {
+      "idx": 82,
+      "version": "7",
+      "when": 1783641600000,
+      "tag": "0082_question_bank_added_at_idx",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/questions/answered/route.ts
+++ b/src/app/api/questions/answered/route.ts
@@ -1,18 +1,35 @@
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
 import { getArchiveForUser } from '@/server/db/queries/archive';
 
 export const dynamic = 'force-dynamic';
 
-export async function GET() {
+// Keyset pagination for the Questions → Answered tab. cursor is the opaque
+// token returned as nextCursor; limit caps a page (the archive query clamps to
+// its own MAX_LIMIT regardless).
+const QuerySchema = z.object({
+  cursor: z.string().min(1).optional(),
+  limit: z.coerce.number().int().min(1).max(100).optional(),
+});
+
+export async function GET(request: NextRequest) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const params = request.nextUrl.searchParams;
+  const parsed = QuerySchema.safeParse({
+    cursor: params.get('cursor') ?? undefined,
+    limit: params.get('limit') ?? undefined,
+  });
+  if (!parsed.success) return NextResponse.json({ error: 'bad_request' }, { status: 400 });
 
   const archive = await getArchiveForUser({
     userId: session.userId,
     kind: 'answered',
-    limit: 100,
+    limit: parsed.data.limit ?? 50,
+    cursor: parsed.data.cursor,
   });
 
   const items = archive.items.map((item) => ({

--- a/src/app/questions/page.tsx
+++ b/src/app/questions/page.tsx
@@ -2,7 +2,7 @@
 
 import { ChevronDown, Plus, Search, X } from 'lucide-react';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { QuestionForm, type QuestionFormValues } from '@/components/QuestionForm';
 import { MyQuestionCard } from '@/components/questions/MyQuestionCard';
@@ -54,8 +54,22 @@ function createFormProps(intent: CreateIntent | null): {
 
 type AnsweredApiResponse = {
   items?: AnsweredQuestionItem[];
+  nextCursor?: string | null;
   error?: string;
   message?: string;
+};
+
+// Stale-while-revalidate cache for the Questions tab. Both endpoints are
+// cache:'no-store', so without this every remount of /questions and every
+// sub-tab switch re-ran the full server load (an unbounded bank join plus the
+// archive scan) before painting anything. Holding the last result at module
+// scope lets a warm tab paint instantly and revalidate in the background;
+// authored mutations (create/edit/delete) write through so it never goes stale
+// behind an edit.
+type AnsweredCache = { items: AnsweredQuestionItem[]; nextCursor: string | null };
+const questionsTabCache: { authored: QuestionView[] | null; answered: AnsweredCache | null } = {
+  authored: null,
+  answered: null,
 };
 
 type QuestionsApiResponse = {
@@ -132,12 +146,17 @@ function QuestionsPageContent() {
   const router = useRouter();
   const pathname = usePathname();
   const [tab, setTab] = useState<Tab>('authored');
-  const [questions, setQuestions] = useState<QuestionView[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [questions, setQuestions] = useState<QuestionView[]>(() => questionsTabCache.authored ?? []);
+  const [loading, setLoading] = useState(() => questionsTabCache.authored === null);
   const [error, setError] = useState<string | null>(null);
-  const [answered, setAnswered] = useState<AnsweredQuestionItem[] | null>(null);
+  const [answered, setAnswered] = useState<AnsweredQuestionItem[] | null>(() => questionsTabCache.answered?.items ?? null);
+  const [answeredCursor, setAnsweredCursor] = useState<string | null>(() => questionsTabCache.answered?.nextCursor ?? null);
   const [answeredLoading, setAnsweredLoading] = useState(false);
+  const [answeredLoadingMore, setAnsweredLoadingMore] = useState(false);
   const [answeredError, setAnsweredError] = useState<string | null>(null);
+  // Ensures the answered tab kicks exactly one load per mount (cold → skeleton,
+  // warm → silent background revalidate over the cached paint).
+  const answeredKicked = useRef(false);
   const [orderMode, setOrderMode] = useState<OrderMode>('recency');
   const [sortMode, setSortMode] = useState<SortMode>('newest');
   const [search, setSearch] = useState('');
@@ -167,17 +186,21 @@ function QuestionsPageContent() {
   const [toast, setToast] = useState<string | null>(null);
 
   const loadQuestions = useCallback(async () => {
-    setLoading(true);
+    // Cold load shows the skeleton; a warm cache revalidates silently underneath
+    // the already-painted list.
+    if (questionsTabCache.authored === null) setLoading(true);
     setError(null);
     try {
       const response = await fetch('/api/questions', { cache: 'no-store', credentials: 'include' });
       const body = await response.json().catch(() => null) as QuestionsApiResponse | null;
       if (isNoQuestionsResponse(response, body)) {
         setQuestions([]);
+        questionsTabCache.authored = [];
         return;
       }
       if (!response.ok || !Array.isArray(body?.questions)) throw new Error(body?.message ?? body?.error ?? 'Could not load your questions.');
       setQuestions(body.questions);
+      questionsTabCache.authored = body.questions;
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not load your questions.');
     } finally {
@@ -189,8 +212,16 @@ function QuestionsPageContent() {
     void Promise.resolve().then(loadQuestions);
   }, [loadQuestions]);
 
+  // Write authored mutations (create/edit/delete) through to the cache once it
+  // has been populated, so the next visit reflects them. Guarded on a non-null
+  // cache so the pre-load empty array never clobbers a warm cache.
+  useEffect(() => {
+    if (questionsTabCache.authored !== null) questionsTabCache.authored = questions;
+  }, [questions]);
+
   const loadAnswered = useCallback(async () => {
-    setAnsweredLoading(true);
+    // Cold load shows the skeleton; a warm cache revalidates silently.
+    if (questionsTabCache.answered === null) setAnsweredLoading(true);
     setAnsweredError(null);
     try {
       const response = await fetch('/api/questions/answered', { cache: 'no-store', credentials: 'include' });
@@ -198,7 +229,10 @@ function QuestionsPageContent() {
       if (!response.ok || !Array.isArray(body?.items)) {
         throw new Error(body?.message ?? body?.error ?? 'Could not load your answered questions.');
       }
+      const nextCursor = body.nextCursor ?? null;
       setAnswered(body.items);
+      setAnsweredCursor(nextCursor);
+      questionsTabCache.answered = { items: body.items, nextCursor };
     } catch (caught) {
       setAnsweredError(caught instanceof Error ? caught.message : 'Could not load your answered questions.');
     } finally {
@@ -206,11 +240,35 @@ function QuestionsPageContent() {
     }
   }, []);
 
+  const loadMoreAnswered = useCallback(async () => {
+    if (!answeredCursor || answeredLoadingMore) return;
+    setAnsweredLoadingMore(true);
+    setAnsweredError(null);
+    try {
+      const response = await fetch(`/api/questions/answered?cursor=${encodeURIComponent(answeredCursor)}`, { cache: 'no-store', credentials: 'include' });
+      const body = await response.json().catch(() => null) as AnsweredApiResponse | null;
+      if (!response.ok || !Array.isArray(body?.items)) {
+        throw new Error(body?.message ?? body?.error ?? 'Could not load more answers.');
+      }
+      const nextCursor = body.nextCursor ?? null;
+      setAnswered((current) => {
+        const next = [...(current ?? []), ...body.items!];
+        questionsTabCache.answered = { items: next, nextCursor };
+        return next;
+      });
+      setAnsweredCursor(nextCursor);
+    } catch (caught) {
+      setAnsweredError(caught instanceof Error ? caught.message : 'Could not load more answers.');
+    } finally {
+      setAnsweredLoadingMore(false);
+    }
+  }, [answeredCursor, answeredLoadingMore]);
+
   useEffect(() => {
-    if (tab !== 'answered') return;
-    if (answered !== null || answeredLoading) return;
+    if (tab !== 'answered' || answeredKicked.current) return;
+    answeredKicked.current = true;
     void Promise.resolve().then(loadAnswered);
-  }, [tab, answered, answeredLoading, loadAnswered]);
+  }, [tab, loadAnswered]);
 
   useEffect(() => {
     if (!toast) return;
@@ -340,7 +398,7 @@ function QuestionsPageContent() {
 
   if (loading && tab === 'authored') return <LoadingSkeleton />;
 
-  if (error && tab === 'authored') {
+  if (error && tab === 'authored' && questions.length === 0) {
     return (
       <main className="mx-auto flex min-h-dvh max-w-2xl flex-col items-center justify-center px-4 py-10 text-center">
         <h1 className="font-serif text-3xl font-semibold">Could not load your questions</h1>
@@ -470,7 +528,7 @@ function QuestionsPageContent() {
           <header className="mb-5 border-b pb-5">
             <h1 className="font-serif text-3xl font-semibold">Answered</h1>
             <p className="mt-1 text-sm text-muted-foreground">
-              {answered === null ? 'Loading…' : `${answered.length} answered`}
+              {answered === null ? 'Loading…' : `${answered.length}${answeredCursor ? '+' : ''} answered`}
             </p>
           </header>
 
@@ -489,7 +547,21 @@ function QuestionsPageContent() {
               </button>
             </section>
           ) : (
-            <AnsweredQuestionsList items={answered ?? []} />
+            <>
+              <AnsweredQuestionsList items={answered ?? []} />
+              {answeredCursor ? (
+                <div className="mt-5 flex justify-center">
+                  <button
+                    type="button"
+                    className="btn-ghost inline-flex items-center gap-2"
+                    onClick={() => void loadMoreAnswered()}
+                    disabled={answeredLoadingMore}
+                  >
+                    {answeredLoadingMore ? 'Loading…' : 'Load more'}
+                  </button>
+                </div>
+              ) : null}
+            </>
           )}
         </>
       )}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1486,6 +1486,21 @@ export async function register() {
       // FeedItem / ActivityItem may not exist yet on a fresh database —
       // migrate() creates them before this migration runs.
     }
+
+    // Migration 0082 adds the composite index backing the Questions-tab list
+    // (getBankedQuestions: filter user_id, ORDER BY added_at DESC). Pure index
+    // addition — a preview/production database that records the migration
+    // without the index present must still get it (precedent: 0079).
+    // CREATE INDEX IF NOT EXISTS is idempotent; re-running is a no-op.
+    try {
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "UserQuestionBank_user_id_added_at_idx"
+          ON "UserQuestionBank" ("user_id", "added_at")
+      `);
+    } catch {
+      // UserQuestionBank may not exist yet on a fresh database — migrate()
+      // creates it before this migration runs.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -427,6 +427,10 @@ export const userQuestionBank = pgTable(
     unique('UserQuestionBank_user_id_question_id_key').on(table.userId, table.questionId),
     index('UserQuestionBank_user_id_idx').on(table.userId),
     index('UserQuestionBank_question_id_idx').on(table.questionId),
+    // Backs the Questions-tab list (getBankedQuestions): filter on user_id,
+    // ORDER BY added_at DESC. Lets the planner serve both from one index
+    // instead of sorting the whole bank in memory per load (0082).
+    index('UserQuestionBank_user_id_added_at_idx').on(table.userId, table.addedAt),
   ],
 );
 


### PR DESCRIPTION
The Questions tab re-ran its full server load on every visit and tab
switch, and re-fetched everything with cache:'no-store', so even
revisiting a page felt slow.

Three changes:

- Index: composite (user_id, added_at) on UserQuestionBank so the
  authored-list join (getBankedQuestions) serves filter + ORDER BY
  added_at DESC from one index instead of sorting the whole bank in
  memory per load. Migration 0082 + schema parity + idempotent boot
  guard (precedent: 0078/0079) + journal entry.

- Stale-while-revalidate cache: both sub-tabs hold their last result at
  module scope, so a warm tab paints instantly and revalidates in the
  background instead of blocking on a cold skeleton. Authored mutations
  write through; a failed background revalidate keeps the cached list.

- Pagination: the Answered tab now consumes the nextCursor its endpoint
  already returned (previously discarded, silently capping at one page)
  via a Load more button; the route validates cursor/limit with Zod.

The authored tab keeps loading its full set because its hardest/
easiest/most-answered sorts are computed client-side over all rows;
it's optimized here via the index + cache rather than paginated.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XTRxYiSzyJWQzquJpmNx3w