### PR TITLE
Remove category from direct-send card header

### DIFF
--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -3,7 +3,6 @@ import Link from 'next/link'
 
 import { HourglassMark } from '@/components/activity/ActivityIcon'
 
-import { visibleFeedCategory } from './category'
 import { SparkleEnvelope } from './SparkleEnvelope'
 import type { DirectSentFeedItem } from './types'
 
@@ -17,12 +16,12 @@ type DirectSentCardProps = {
 }
 
 export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribution, elevated }: DirectSentCardProps) {
-  const visibleCategory = visibleFeedCategory(item.category)
   const senderName = item.senderName || item.avatarName || 'A friend'
   const senderHref = item.senderHref ?? item.authorHref ?? null
 
   // Figma header line: actor in the link slate, the rest in black, with the
-  // optional personal note in italic serif beneath.
+  // optional personal note in italic serif beneath. The category is
+  // deliberately omitted from this header (B-category-removal-josh).
   const signal = (
     <>
       {senderHref ? (
@@ -32,8 +31,7 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribu
       ) : (
         <span className="font-semibold text-[var(--brand-link)]">{senderName}</span>
       )}{' '}
-      thought you&rsquo;d like this
-      {visibleCategory ? <> about {visibleCategory}</> : null}.
+      thought you&rsquo;d like this.
       {item.personalMessage ? (
         <span className="mt-1 block font-serif text-sm italic leading-snug text-[var(--brand-ink-700)]">
           &ldquo;{item.personalMessage}&rdquo;

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -76,7 +76,8 @@ describe('Feed card preview fixtures', () => {
 
     const directSent = html(<DirectSentCard item={fixtures.directSentUnanswered} />)
     expect(directSent).toContain('Maya')
-    expect(directSent).toContain('Food &amp; Drink')
+    // The category is intentionally omitted from the direct-send header.
+    expect(directSent).not.toContain('Food &amp; Drink')
     expect(directSent).toContain('SCOBY')
 
     const friendAdded = html(<FriendAddedCard item={fixtures.friendAddedWroteQuestion} />)


### PR DESCRIPTION
The "Sent directly to you" card header read "<sender> thought you'd
like this about <category>." Drop the "about <category>" clause so it
now reads "<sender> thought you'd like this." Removes the now-unused
visibleFeedCategory wiring and updates the card test to assert the
category is absent from the header.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FT2MaCC2559TsAyo9Qv76S