### PR TITLE
fix(grading): accept phonetically-identical answers regardless of exact spelling

### DIFF
--- a/src/lib/llm.grading.test.ts
+++ b/src/lib/llm.grading.test.ts
@@ -149,4 +149,20 @@ describe('gradeAnswerWithLLM', () => {
     expect(systemPrompt).toMatch(/parenthetical generic descriptor/i)
     expect(systemPrompt).toMatch(/thing|thingy|thingamajig/i)
   })
+
+  it('includes the exact-spelling-not-required leniency rule in the system prompt', async () => {
+    // Regression guard: "kwiky mart" for "The Kwik-E-Mart" was marked "close but not
+    // quite" purely on spelling. The rule below says exact spelling is not required when
+    // the submission is recognizably the same name aloud. If it's deleted, that bug returns.
+    createMessageMock.mockResolvedValueOnce(
+      anthropicTextResponse({ result: 'correct', confidence: 0.9, reason: 'ok', consolation: null }),
+    )
+
+    const gradeAnswerWithLLM = await importGrader()
+    await gradeAnswerWithLLM('q', 'The Kwik-E-Mart', 'kwiky mart', 'factual')
+
+    const systemArg = (createMessageMock.mock.calls[0]![0] as { system: string | Array<{ text: string }> }).system
+    const systemPrompt = typeof systemArg === 'string' ? systemArg : systemArg[0]!.text
+    expect(systemPrompt).toMatch(/exact spelling is not required/i)
+  })
 })

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -597,7 +597,7 @@ Your job is to determine whether a submitted answer is correct, and — when the
 
 LENIENCY RULES — mark as correct if:
 - The answer conveys the same meaning, even if worded differently
-- There are spelling errors that don't change the meaning (e.g. "Bucephelus" for "Bucephalus" is correct)
+- There are spelling errors that don't change the meaning (e.g. "Bucephelus" for "Bucephalus" is correct). Exact spelling is NOT required: if the submission is recognizably the same name when read aloud, accept it regardless of misspellings, dropped or added letters, hyphenation, spacing, or punctuation (e.g. "kwiky mart" or "quick e mart" for "The Kwik-E-Mart" is correct; "Andy Warhall" for "Andy Warhol" is correct). Only reject a misspelling when it actually points to a different, distinguishable thing.
 - The answer is a reasonable abbreviation or shortened form (e.g. "Eroica" for "The Eroica" is correct)
 - For list questions: the answer meets the minimum required count and all included items are correct
 - The answer is phonetically close and contextually plausible (account for voice transcription errors)


### PR DESCRIPTION
## What

The trivia answer grader marked **"kwiky mart"** as *"Close, but not quite"* for the canonical answer **"The Kwik-E-Mart"** — rejecting a phonetically-identical answer purely on spelling.

The grader's leniency prompt *intended* to be spelling-tolerant, but its only example was a single-letter typo (`"Bucephelus"` → `"Bucephalus"`), so Haiku still treated heavier-but-unambiguous spellings as wrong.

## Change

- **`src/lib/llm.ts`** — Strengthen the leniency rule: exact spelling is **not** required when the submission is recognizably the same name read aloud (misspellings, dropped/added letters, hyphenation, spacing, punctuation). The Kwik-E-Mart case is now an explicit example. Only reject when the misspelling points to a different, distinguishable thing.
- **`src/lib/llm.grading.test.ts`** — Regression guard mirroring the existing parenthetical-descriptor test, asserting the rule stays in the system prompt.

## Notes

- This is a prompt nudge, not a deterministic rule — it shifts Haiku's judgment rather than guaranteeing every variant. The reported case is now covered by both the rule and an example.
- With this fix the answer should score **correct**, so the "Close, but not quite." headline (one of three rotating wrong-answer headlines in `GameplayChat.tsx`) won't appear for cases like this.

## Test

`npx vitest run src/lib/llm.grading.test.ts` → 14/14 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)