### PR TITLE
perf(daily/answer): parallelize the slot write and mastery-event write

### DIFF
--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -472,13 +472,18 @@ export async function POST(request: NextRequest) {
       } satisfies QueueSlot;
     });
 
-    await db
-      .update(dailyQueues)
-      .set({ slots: nextSlots })
-      .where(eq(dailyQueues.id, queue.id));
-
     const propagationKey = question.generatedId ?? question.canonicalId ?? canonicalQuestionId;
-    const masteryDelta = await recordAnswerSideEffects({
+    // The slot write (marks the slot answered) and the mastery-event write are
+    // independent — masteryDelta is returned in the response but is never written
+    // into nextSlots — so run them concurrently to shave a DB round-trip off the
+    // user-blocking answer path. Both are still awaited before the verdict returns.
+    // recordAnswerSideEffects swallows its own errors (null masteryDelta on
+    // failure), so the slot update is the only call here that can reject; the
+    // mastery event's sourceId ON CONFLICT dedup keeps a client retry after such a
+    // rejection from double-counting.
+    const [, masteryDelta] = await Promise.all([
+      db.update(dailyQueues).set({ slots: nextSlots }).where(eq(dailyQueues.id, queue.id)),
+      recordAnswerSideEffects({
       userId: session.userId,
       isCorrect,
       logTag: 'daily/answer',
@@ -506,7 +511,8 @@ export async function POST(request: NextRequest) {
             feedSourceId: `daily:${propagationKey}:${session.userId}`,
           }
         : null,
-    });
+      }),
+    ]);
     marks.mastery = Date.now();
 
     const response = NextResponse.json({


### PR DESCRIPTION
## What
After grading, `POST /api/daily/answer` wrote the queue slot (marking it answered) and *then* awaited the mastery-event write **serially**. The two are independent — `masteryDelta` is returned in the response but is never written into `nextSlots` — so they now run concurrently via `Promise.all`, shaving one DB round-trip (~20–40ms warm) off the user-blocking answer path.

## Why this is the change
Part of a grading-latency review. The bigger levers were already done or infeasible:
- Fast-path widening + `gradedVia` instrumentation (B-GRADE-FASTPATH-01), prompt trim, and cold-start/region pinning are **shipped**.
- The perceived-latency decoupling (B-GRADE-PERCEIVED-01) is **shipped** — all non-verdict side effects (`deferSideEffects`, author credit, friend fan-out, adaptive difficulty) are already off the path.
- A measured fast-path hit rate of **29.8%** (453 real production submissions) confirms ~70% of answers must hit Haiku for legitimate reasons (paraphrase, word-order, phonetic misspelling) — so dodging the LLM more isn't safely available.

This parallelization is the one remaining safe server-side micro-optimization on the daily answer path.

## Safety
- Both writes are still awaited before the verdict returns → **response payload unchanged**.
- `recordAnswerSideEffects` swallows its own errors (returns `null` masteryDelta on failure), so the slot update is the only call that can reject.
- On the rare slot-write rejection, the mastery event may still record — but its `sourceId` `ON CONFLICT` dedup makes the client's retry idempotent, so no double-counting.

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean
- `daily/answer` route suite — 32 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)