### PR TITLE
Fix phantom scroll / stranded bottom nav on short pages

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -385,6 +385,24 @@
     }
 }
 
+/* App shell height model — unlayered so it overrides the Tailwind `min-h-dvh`
+   utility that every page's <main> carries.
+
+   The <body> is a single dynamic-viewport-tall flex column (see layout.tsx).
+   Previously each <main> independently claimed `min-h-dvh` (100dvh) while the
+   top header sat in normal flow ABOVE it, so the document was always taller than
+   the viewport by the header's height. That phantom overflow let short pages
+   scroll past their content and, on mobile Safari, stranded the fixed bottom nav
+   mid-screen with dead space below it as the toolbar collapsed.
+
+   Letting <main> grow to fill the remaining column height instead means a short
+   page is exactly one viewport tall (no phantom scroll, nav pinned at the
+   bottom), while a tall page still scrolls naturally. */
+body > main {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
 @layer components {
   .card {
     @apply rounded-[var(--radius-card)] border bg-card text-card-foreground shadow-[var(--shadow-card)];

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
       lang="en"
       className={`font-sans ${josefin.variable} ${montserrat.variable} ${cormorant.variable}`}
     >
-      <body className={josefin.className}>
+      <body className={`${josefin.className} flex min-h-dvh flex-col`}>
         {/* HIDDEN — dev design-choice bar. Uncomment the boot <script> and the
             <PaletteToggle/> below (plus its import above) to bring it back.
             The script applies the saved card-background choice before paint so


### PR DESCRIPTION
The top header (rendered by Nav) sits in normal flow above each page's
<main className="min-h-dvh">, so the document was always taller than the
viewport by the header's height. On short pages this let the page scroll
past its content, and on mobile Safari it stranded the fixed bottom nav
mid-screen with dead space below it as the toolbar collapsed.

Make <body> a single dynamic-viewport-tall flex column and let <main>
grow to fill the remaining height instead of independently forcing its
own 100dvh on top of the header. Short pages are now exactly one viewport
tall (no phantom scroll, nav pinned to the bottom); tall pages still
scroll naturally.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01FMETPrwYpEW5irPR5nJSVA