### PR TITLE
fix(daily/catchup): stop catch-up recovery from overwriting the live daily-five verdict

### DIFF
--- a/scripts/daily-catchup.smoke.ts
+++ b/scripts/daily-catchup.smoke.ts
@@ -12,6 +12,7 @@ import {
   minusUtcDays,
   replaceQueueSlot,
 } from '../src/server/daily/catchup';
+import { isCatchUpSlotEligible } from '../src/server/play/catch-up-eligibility';
 import type { QueueSlot } from '../src/server/daily/types';
 
 assert.equal(minusUtcDays('2026-05-01', 7), '2026-04-24');
@@ -54,6 +55,38 @@ const dismissed = replaceQueueSlot(slots, 3, (slot) => ({
 }));
 
 assert.equal(dismissed[0].dismissed_at, '2026-05-01T12:00:00.000Z');
+
+// Catch-up recovery must NOT rewrite the live daily-five verdict, and a
+// recovered slot must drop out of catch-up. Regression guard for the
+// "wrong-in-daily-5 → right-in-catch-up shows a green dot" bug.
+const wrongLiveSlot: QueueSlot = {
+  slot_index: 4,
+  source: 'bot',
+  generated_question_id: 'generated-4',
+  domain: '1980s Animation',
+  question_text: 'Who composed the Mass in B minor?',
+  answered: true,
+  answer_state: 'incorrect',
+  submitted_answer: 'Mozart',
+};
+assert.equal(isCatchUpSlotEligible(wrongLiveSlot), true);
+
+const recoveredSlot: QueueSlot = {
+  ...wrongLiveSlot,
+  // catch-up wrote only its own fields; the live verdict is untouched.
+  catchup_answer_state: 'correct',
+  catchup_submitted_answer: 'Bach',
+  catchup_awarded_points: 25,
+};
+// The live dot stays red — answer_state is still 'incorrect'.
+assert.equal(recoveredSlot.answer_state, 'incorrect');
+assert.equal(recoveredSlot.submitted_answer, 'Mozart');
+// And the slot no longer surfaces in catch-up.
+assert.equal(isCatchUpSlotEligible(recoveredSlot), false);
+
+// A wrong catch-up attempt leaves the slot re-attemptable.
+const missedAgainSlot: QueueSlot = { ...wrongLiveSlot, catchup_answer_state: 'incorrect' };
+assert.equal(isCatchUpSlotEligible(missedAgainSlot), true);
 
 const duplicateCatchupItems = [
   {

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -132,8 +132,16 @@ async function handleDailyCatchupAnswer({
       refresh_required: true,
     });
   }
-  // A slot previously answered correctly is not eligible — only wrong/skipped/
-  // untouched slots show up in catch-up after the expanded eligibility rules.
+  // Already recovered in a prior catch-up attempt — closed for good. Keyed on
+  // catchup_answer_state because recovery leaves the live answer_state intact.
+  if (slot.catchup_answer_state === 'correct') {
+    return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
+      refresh_required: true,
+    });
+  }
+  // A slot previously answered correctly IN THE LIVE ROUND is not eligible —
+  // only wrong/skipped/untouched slots show up in catch-up after the expanded
+  // eligibility rules.
   if (slot.answered && slot.answer_state !== 'incorrect') {
     return catchUpErrorResponse(400, 'catch_up_not_eligible', 'catch-up item is already closed', {
       refresh_required: true,
@@ -265,10 +273,17 @@ async function handleDailyCatchupAnswer({
   const nextSlots = replaceQueueSlot(slots, catchupItem.slotIndex, (item) => {
     return {
       ...item,
-      answered: true,
-      answer_state: answerState,
-      submitted_answer: submittedAnswer,
-      awarded_points: pointsAwarded,
+      // Record the catch-up outcome in its OWN fields. We deliberately do NOT
+      // touch `answered`, `answer_state`, `submitted_answer`, or
+      // `awarded_points` — those carry the live daily-five verdict that drives
+      // the progress dots and the summary totals. Re-answering a wrong (or
+      // skipped) slot in catch-up must not retroactively turn the live red dot
+      // green or inflate the live score; the original result stays put. (Mirrors
+      // the feed catch-up path, which preserves the original feed-card history.)
+      catchup_answer_state: answerState,
+      catchup_submitted_answer: submittedAnswer,
+      catchup_awarded_points: pointsAwarded,
+      catchup_answered_at: new Date().toISOString(),
       reveal_canonical_answer: catchupItem.correctAnswer,
       reveal_explainer: catchupItem.explanation ?? '',
       reveal_quip: grade.consolation,

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -73,6 +73,21 @@ export const queueSlotSchema = z.object({
   dismissed_at: z.string().optional(),
   dismissed_reason: z.enum(['not_interested', 'too_old', 'unclear']).optional(),
   /**
+   * Catch-up recovery state — kept SEPARATE from the live `answer_state`,
+   * `submitted_answer`, and `awarded_points` above. Re-answering a slot in
+   * catch-up must never rewrite the live-round verdict (that drives the daily
+   * progress dots and the summary totals); the original wrong/skipped result
+   * stays put. A `catchup_answer_state` of 'correct' closes the slot for
+   * catch-up (see isCatchUpSlotEligible); 'incorrect' leaves it re-attemptable.
+   */
+  catchup_answer_state: queueSlotAnswerStateSchema.optional(),
+  /** Text the player typed in their most recent catch-up attempt. */
+  catchup_submitted_answer: z.string().optional(),
+  /** Points earned in catch-up (the recovery weight), distinct from the live awarded_points. */
+  catchup_awarded_points: z.number().optional(),
+  /** ISO timestamp of the most recent catch-up attempt on this slot. */
+  catchup_answered_at: z.string().optional(),
+  /**
    * True when the effective difficulty for this slot's domain was stepped up above the
    * user's base preference due to mastery progress. Used by the UI to show "Getting harder".
    */

--- a/src/server/play/catch-up-eligibility.ts
+++ b/src/server/play/catch-up-eligibility.ts
@@ -31,6 +31,11 @@ export function isCatchUpSlotEligible(slot: QueueSlot): boolean {
   // question_id (the canonical Question.id). Either is sufficient to
   // re-serve the slot in catch-up.
   if (!slot.generated_question_id && !slot.question_id) return false;
+  // Already recovered in a prior catch-up attempt — a correct catch-up answer
+  // closes the slot for good. We key off catchup_answer_state (NOT answer_state)
+  // because recovery deliberately leaves the live verdict untouched so the
+  // daily-five dots keep showing the original wrong/skipped result.
+  if (slot.catchup_answer_state === 'correct') return false;
   // Wrong daily-5 answers are eligible for re-attempt; correct ones are not.
   if (slot.answered) return slot.answer_state === 'incorrect';
   return true;


### PR DESCRIPTION
## Problem
Questions answered **wrong** in the live Daily Five were showing a **green dot** after being recovered in catch-up. Both the live answer route and the catch-up route wrote to the same `QueueSlot.answer_state` field in the shared `DailyQueue.slots` JSONB, and the progress dots read that field — so a correct catch-up answer overwrote the original wrong verdict (and also rewrote the live summary's `submitted_answer` and `awarded_points`).

## Fix
Catch-up recovery now records its outcome in **separate** `catchup_*` slot fields and never touches the live verdict:
- `src/server/daily/types.ts` — added `catchup_answer_state` / `catchup_submitted_answer` / `catchup_awarded_points` / `catchup_answered_at` to `queueSlotSchema` (JSONB, optional — no migration).
- `src/app/api/daily/catchup/answer/route.ts` — write the `catchup_*` fields; leave `answered` / `answer_state` / `submitted_answer` / `awarded_points` as the live round left them. Guard against re-submitting an already-recovered slot.
- `src/server/play/catch-up-eligibility.ts` — a slot drops out of catch-up when `catchup_answer_state === 'correct'` (a wrong attempt stays re-attemptable). Needed because we no longer flip `answer_state`, which used to close it.
- `scripts/daily-catchup.smoke.ts` — regression assertion: wrong-live → correct-catchup keeps `answer_state: 'incorrect'` and becomes catch-up-ineligible.

Mirrors the **feed** catch-up path, which already preserves the original history.

## Verification
Smoke test passes, typecheck clean, lint clean.

## Note
Rows already corrupted by the old code aren't repaired by this change (the original `answer_state` was overwritten in the DB). A one-off backfill from the `live_*` vs `catchup_correct` mastery events could repaint those dots if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)