### PR TITLE
Align footer bottom-nav width with the header and cards

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -221,7 +221,7 @@ export function Nav({
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}
       >
         <div
-          className="mx-auto grid max-w-2xl"
+          className="mx-auto grid max-w-2xl px-4"
           style={{ gridTemplateColumns: `repeat(${navItems.length}, minmax(0, 1fr))` }}
           role="list"
         >


### PR DESCRIPTION
## What

The footer bottom-nav row was rendering wider than the rest of the app chrome. The header bar and the home content/cards both use `max-w-2xl px-4` (a 16px side gutter), but the footer nav container used `max-w-2xl` with **no** horizontal padding — so its tab row spanned 32px wider than the header and the cards.

This adds `px-4` to the footer nav container (`Nav.tsx`) so all three chrome widths line up.

## Why

Reported as "the cards look much wider than the header." Root cause turned out to be the **footer**, not the cards: the header and cards already share the identical `max-w-2xl px-4` container, while the footer was the outlier missing the gutter.

## Notes

- The full-bleed home interlude bands (Overlap / Find Friends / Write grounds) intentionally bleed past the gutter via `-mx-4` (B-HOME-INTERLUDE-TYPE-01) — left unchanged.
- Single-line CSS change; lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB7zX6MtoUiRBD3E8L3YjL)_