### PR TITLE
Home chrome: align footer width + gate bonus dots until round start

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -233,6 +233,11 @@ export default function TodaysFiveCard({
   const isComplete =
     effectiveStatus.isComplete || effectiveStatus.questionsRemaining <= 0
   const hasStartedRound = Boolean(effectiveStatus.queueId) && answered > 0
+  // Bonus dots are an in-progress/after-the-fact detail: before the player has
+  // touched today's round we show just the clean five (hiding the +N friend
+  // bonus group). Once they've started — or finished — the bonus group appears.
+  const showBonusDots =
+    effectiveStatus.bonusOutcomes.length > 0 && (hasStartedRound || isComplete)
   const playHref = isComplete
     ? '/daily/summary'
     : '/daily'
@@ -312,7 +317,7 @@ export default function TodaysFiveCard({
         {effectiveStatus.slotOutcomes.slice(0, 5).map((outcome, index) => (
           <OutcomeDot key={`core-${index}`} outcome={outcome} label={outcomeLabel(outcome)} />
         ))}
-        {effectiveStatus.bonusOutcomes.length > 0 ? (
+        {showBonusDots ? (
           <>
             <span
               aria-hidden

--- a/src/components/__tests__/TodaysFiveCard.test.tsx
+++ b/src/components/__tests__/TodaysFiveCard.test.tsx
@@ -47,6 +47,39 @@ describe('TodaysFiveCard dot track', () => {
     expect(html).toContain('Bonus 2 of 2, from friends')
   })
 
+  it('before the round starts: shows only the five dots, hides the bonus group', () => {
+    const html = renderToStaticMarkup(
+      <TodaysFiveCard
+        initialStatus={status({
+          isComplete: false,
+          questionsRemaining: 5,
+          questionsAnswered: 0,
+          queueId: 'q1',
+          bonusOutcomes: ['unanswered', 'unanswered'],
+        })}
+      />,
+    )
+    expect((html.match(DOT) ?? []).length).toBe(5)
+    expect(html).not.toContain('w-px')
+    expect(html).not.toContain('friend bonus')
+  })
+
+  it('once the round is in progress: reveals the bonus group', () => {
+    const html = renderToStaticMarkup(
+      <TodaysFiveCard
+        initialStatus={status({
+          isComplete: false,
+          questionsRemaining: 3,
+          questionsAnswered: 2,
+          queueId: 'q1',
+          bonusOutcomes: ['unanswered', 'unanswered'],
+        })}
+      />,
+    )
+    expect((html.match(DOT) ?? []).length).toBe(7)
+    expect(html).toContain('+2 friend bonus')
+  })
+
   it('the spoken count stays "of 5" even with bonus dots present', () => {
     const html = renderToStaticMarkup(
       <TodaysFiveCard


### PR DESCRIPTION
## What

Two home-chrome fixes for the Daily Five surface:

1. **Footer width alignment** — the footer bottom-nav used `max-w-2xl` with no horizontal padding, so its tab row spanned 32px wider than the header bar and the page cards (both `max-w-2xl px-4`). Added `px-4` to the footer container so all three chrome widths line up.

2. **Hide the bonus dots until the round starts** — on the home "Today's Five" card, the `+N friend bonus` group (separator, bonus dots, label) now appears only once the round is in progress or complete. Before the player has touched today's Daily Five, the card shows just the clean five dots. The spoken count stays "of 5" throughout.

## Notes

- The full-bleed home interlude bands (Overlap / Find Friends / Write grounds) intentionally bleed past the gutter via `-mx-4` (B-HOME-INTERLUDE-TYPE-01) — left unchanged.
- Adds render tests for the before-play (5 dots, no bonus) and in-progress (7 dots + label) home-card states.
- Lint + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TB7zX6MtoUiRBD3E8L3YjL)_