### PR TITLE
B-DIRECTSENT-SIMPLIFY-01: thread authored provenance onto direct-send card

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -347,6 +347,7 @@ function toTypedFeedItem(item: FeedApiItem, hideTimestamp = false) {
       type: 'direct_sent' as const,
       senderName: item.source_friend_display_name,
       senderHref: item.source_profile_href ?? profileHref(item.source_user_id),
+      authoredBySender: item.question_source === 'authored',
     } satisfies DirectSentFeedItem
   }
 

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -18,20 +18,37 @@ type DirectSentCardProps = {
 export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribution, elevated }: DirectSentCardProps) {
   const senderName = item.senderName || item.avatarName || 'A friend'
   const senderHref = item.senderHref ?? item.authorHref ?? null
+  const authoredBySender = item.authoredBySender === true
 
-  // Figma header line: actor in the link slate, the rest in black, with the
-  // optional personal note in italic serif beneath. The category is
-  // deliberately omitted from this header (B-category-removal-josh).
+  // Single left-aligned signal row: one hourglass (reinforcement on the text
+  // line, never the sole carrier of "directed"), the sender, then the verb
+  // clause. Honest attribution — "question they wrote" only on the authored
+  // path; curated sends get the plain "sent you this" (B-DIRECTSENT-SIMPLIFY-01).
+  // The category is deliberately omitted from this header (B-category-removal-josh).
   const signal = (
     <>
-      {senderHref ? (
-        <Link href={senderHref} className="font-semibold text-[var(--brand-link)] hover:opacity-70">
-          {senderName}
-        </Link>
-      ) : (
-        <span className="font-semibold text-[var(--brand-link)]">{senderName}</span>
-      )}{' '}
-      thought you&rsquo;d like this.
+      <span className="inline-flex items-center gap-2">
+        <HourglassMark />
+        <span>
+          {senderHref ? (
+            <Link href={senderHref} className="font-semibold text-[var(--brand-link)] hover:opacity-70">
+              {senderName}
+            </Link>
+          ) : (
+            <span className="font-semibold text-[var(--brand-link)]">{senderName}</span>
+          )}{' '}
+          {authoredBySender ? (
+            <>
+              sent you a{' '}
+              {/* Teal reinforces the words, which already carry the meaning —
+                  reuse the hourglass's teal token, never a hex literal. */}
+              <span className="text-[var(--tri-darkteal)]">question they wrote</span>
+            </>
+          ) : (
+            <>sent you this</>
+          )}
+        </span>
+      </span>
       {item.personalMessage ? (
         <span className="mt-1 block font-serif text-sm italic leading-snug text-[var(--brand-ink-700)]">
           &ldquo;{item.personalMessage}&rdquo;
@@ -43,22 +60,8 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribu
   return (
     <SparkleEnvelope
       // Direct sends share the plain hairline-bordered tile with broadcasts
-      // (the triangle mat is retired); the eyebrow is what marks them out.
+      // (the triangle mat is retired); the signal row carries the directed cue.
       variant="bordered"
-      // Centered flourish mirroring the milestone "star — line — star"
-      // treatment (MilestoneStar): a pair of hourglass marks flanks the eyebrow.
-      // The hourglass is the triangle family's "someone sends you a Q" sign, so
-      // it carries the direct-send meaning without spending the gold accent
-      // (reserved per STYLE-GUIDE-COLOR §4). Text stays in the quiet ink register
-      // (opacity on the text span only, so the marks keep their 80% fill).
-      eyebrow={
-        <span className="inline-flex items-center gap-3">
-          <HourglassMark />
-          <span className="opacity-70">Sent directly to you</span>
-          <HourglassMark />
-        </span>
-      }
-      eyebrowClassName="flex justify-center font-semibold text-[var(--brand-ink)]"
       signal={signal}
       question={item.question}
       overflow={overflow}

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -92,17 +92,38 @@ describe('Feed card preview fixtures', () => {
     expect(answeredByYou).toContain('You both had it')
   })
 
-  it('marks direct sends with the eyebrow on the plain bordered tile (no triangle mat)', () => {
+  it('marks direct sends with the hourglass signal row on the plain bordered tile (no triangle mat)', () => {
     const directSent = html(
       <DirectSentCard item={feedCardPreviewFixtures.directSentUnanswered} />
     )
-    expect(directSent).toContain('Sent directly to you')
+    // The single hourglass on the signal line reinforces "directed" (the old
+    // centered eyebrow is retired); the curated fixture reads "sent you this".
+    expect(directSent).toContain('<svg')
+    expect(directSent).toContain('sent you this')
+    expect(directSent).not.toContain('Sent directly to you')
     expect(directSent).not.toContain('/images/Variant4.png')
+    // Curated path must not borrow the authored verb or the teal text cue.
+    // (--tri-darkteal also fills the hourglass, so assert on the text class.)
+    expect(directSent).not.toContain('question they wrote')
+    expect(directSent).not.toContain('text-[var(--tri-darkteal)]')
 
     const friendAdded = html(
       <FriendAddedCard item={feedCardPreviewFixtures.friendAddedWroteQuestion} />
     )
-    expect(friendAdded).not.toContain('Sent directly to you')
+    expect(friendAdded).not.toContain('sent you this')
+  })
+
+  it('renders the authored-provenance verb with the teal cue when the sender wrote the question', () => {
+    const authored = html(
+      <DirectSentCard
+        item={{ ...feedCardPreviewFixtures.directSentUnanswered, authoredBySender: true }}
+      />
+    )
+    // Authored sends say "question they wrote" and reinforce it with the
+    // hourglass's teal token — honest attribution, never a curated fallback.
+    expect(authored).toContain('question they wrote')
+    expect(authored).toContain('text-[var(--tri-darkteal)]')
+    expect(authored).not.toContain('sent you this')
   })
 
   it('drops the "has knowledge to share" phrasing from the unanswered question card', () => {

--- a/src/components/feed/types.ts
+++ b/src/components/feed/types.ts
@@ -20,6 +20,10 @@ export type DirectSentFeedItem = FeedCardBaseItem & {
   type: 'direct_sent'
   senderName: string
   senderHref?: string | null
+  /** Resolved provenance: true when the sender authored the question themselves
+   *  (question_source === 'authored'), false/absent when curated. Resolved at
+   *  the builder so the card stays dumb (B-DIRECTSENT-SIMPLIFY-01). */
+  authoredBySender?: boolean
 }
 
 export type FriendAddedFeedItem = FeedCardBaseItem & {


### PR DESCRIPTION
The provenance signal (question_source === 'authored') lived on FeedApiItem
but was never carried onto DirectSentFeedItem, so DirectSentCard couldn't tell
an authored send from a curated one and hardcoded "thought you'd like this."

- types.ts: add resolved `authoredBySender?: boolean` to DirectSentFeedItem
  (resolved boolean, not the raw source string — keeps the card dumb).
- FeedList.tsx: set authoredBySender from item.question_source === 'authored'
  in the direct_sent builder (the one construction site).
- DirectSentCard.tsx: drop the centered eyebrow ("Sent directly to you"),
  rewrite the signal to one left-aligned row — a single hourglass, the sender
  (linked when senderHref), then the verb clause: "sent you a question they
  wrote" (authored) or "sent you this" (curated). On the authored path only,
  "question they wrote" gets the hourglass's teal token (--tri-darkteal) as a
  quiet reinforcement — the words already carry the meaning. No hex literals.
- FeedCards.test.tsx: update the eyebrow assertion to the new signal copy and
  add an authored-path case (teal text cue + "question they wrote").

Honest attribution preserved: machine/curated content never implies a human
wrote it. Single hourglass reinforces "directed" on the text line, never the
sole carrier.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013dBTX9m2jZ3Zk8QnC8CTXG