### PR TITLE
Match From-Friends card shadow to the Today card (--shadow-card)

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -369,7 +369,12 @@ export function ActivityStreamItem({
           background: 'var(--feed-card-elevated)',
           border: '1px solid var(--brand-border)',
           borderRadius: 4,
-          boxShadow: 'var(--shadow-card-strong)',
+          // Match the Today's 5 card's shadow (--shadow-card) rather than the
+          // stronger raised tier. The strong shadow shares the same blur but at
+          // 10% vs 4% opacity, so its visible halo bled ~15px past the right
+          // edge and made these cards read as WIDER than the Today card even
+          // though the box edges align to the pixel.
+          boxShadow: 'var(--shadow-card)',
         }
       : opened
         ? // Opened reveal: a soft paper wash defines the expanded cluster, with

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -92,7 +92,7 @@ describe('ActivityStreamItem — playable milestone card on the home feed', () =
     expect(html).toContain('var(--feed-card-elevated)'); // shared elevated fill token
     expect(html).toContain('var(--brand-border)'); // neutral hairline stroke (matches Today's 5)
     expect(html).not.toContain('var(--accent-gold)'); // no gold accent stroke
-    expect(html).toContain('var(--shadow-card-strong)'); // the soft drop shadow (tokenized)
+    expect(html).toContain('var(--shadow-card)'); // matches the Today's 5 card's drop shadow (tokenized)
   });
 
   it('keeps the row flat when not elevated (the full /activities log)', () => {


### PR DESCRIPTION
The playable From-Friends milestone cards used --shadow-card-strong while
the Today's 5 card uses --shadow-card. Both tokens share the same blur
geometry (0 4px 12px, no spread) but differ in opacity (10% vs 4%), so the
strong shadow rendered a visible ~15px halo past the right edge and made the
friend cards read as WIDER than the Today card even though their box borders
align to the pixel. Drop them to --shadow-card so all home cards share one
visual footprint. Update the MilestoneStreamItem assertion to match.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG