### PR TITLE
Fix iOS-WebKit header shrink-wrap (add w-full to header row)

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -159,7 +159,12 @@ export function Nav({
         className="z-40 border-b bg-background/95 backdrop-blur"
         aria-label="Primary header"
       >
-        <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
+        {/* w-full is load-bearing on iOS WebKit: a block-level `display:flex`
+            element with `margin:auto` (mx-auto) gets shrink-wrapped to its
+            content width on iOS (Safari + all iOS browsers, incl. Chrome),
+            collapsing the header to ~2/3 width while the body cards stay full.
+            Explicit w-full stops the shrink-wrap; it's a no-op everywhere else. */}
+        <div className="mx-auto flex w-full max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
             className="font-wordmark text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"


### PR DESCRIPTION
## What

Adds `w-full` to the header's inner flex row in `Nav.tsx`.

## Why

The header renders correctly on every desktop engine (Blink-verified via `getComputedStyle`: header inner and `main` are pixel-identical — both 672px @ 818px viewport, both 390px @ 390px viewport), but on **iOS WebKit** (Safari *and* Chrome on iPhone, which is WebKit under the hood) the header collapsed to ~⅔ width — the bell/avatar stopped well short of the right edge, so it read as "header narrower than the body."

Cause: a block-level `display:flex` element with `margin:auto` (`mx-auto`) is shrink-wrapped to its content width on iOS WebKit instead of filling the row. `main` escapes this because it's a *column* flex held open by its `w-full` children. Adding an explicit `w-full` stops the shrink-wrap on WebKit and is a no-op on every other engine (`width:100%` is already capped by `max-w-2xl` and centered by `mx-auto`).

## Verification

- Desktop/Blink: no visual change (header already filled correctly).
- iOS/WebKit: header should now span the full content width, matching the cards.

This is device-only, so it can't be confirmed in desktop responsive mode (still Blink) — needs a real iPhone after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG)_