### PR TITLE
fix: use box-shadow mask for Safari autofill yellow

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -574,19 +574,24 @@ body > main {
 /* Safari/Chrome paint autofilled fields with their own UA background — a muddy
    yellow that overrode the login phone field's bg-white and made it read as a
    yellow box (reported on Safari). There's no real `background` property to
-   reset; the UA draws it via an animated transition. Giving background-color an
-   effectively infinite transition keeps each field pinned to its OWN
-   author-specified background (white here, transparent/cream elsewhere), so this
-   stays color-agnostic and safe across every input in the app. Pin the typed
-   text to its own color too, since autofill recolors that as well. */
+   reset; the UA draws it on a pseudo-layer. Safari ignores the long-transition
+   trick that quiets Chrome, so the reliable cross-browser fix is to mask the
+   UA layer with a large inset box-shadow in the field-surface color. Every
+   autofillable field in the app sits on that surface — login uses bg-white and
+   the rest use bg-[var(--brand-field)], and --brand-field is itself #ffffff —
+   so a single token-colored mask is correct everywhere. The transition is kept
+   alongside as belt-and-suspenders for Chrome; text is pinned to its own color
+   since autofill recolors that too. */
 input:-webkit-autofill,
 input:-webkit-autofill:hover,
 input:-webkit-autofill:focus,
 input:-webkit-autofill:active,
 textarea:-webkit-autofill,
 select:-webkit-autofill {
-  transition: background-color 100000s ease-in-out 0s;
+  -webkit-box-shadow: 0 0 0 1000px var(--brand-field) inset;
+  box-shadow: 0 0 0 1000px var(--brand-field) inset;
   -webkit-text-fill-color: currentColor;
+  transition: background-color 100000s ease-in-out 0s;
 }
 
 @keyframes territory-settle {


### PR DESCRIPTION
## Why

The login phone field still rendered **yellow in Safari** after the previous fix (#1110) merged. That fix relied on the long `background-color` transition trick, which suppresses the autofill background in **Chrome** but is **ignored by Safari** — exactly the browser reported.

## Fix

Switch to the cross-browser-reliable **inset `box-shadow` mask**, which paints over the UA's autofill layer in the field-surface color:

```css
input:-webkit-autofill, … {
  -webkit-box-shadow: 0 0 0 1000px var(--brand-field) inset;
  box-shadow: 0 0 0 1000px var(--brand-field) inset;
  -webkit-text-fill-color: currentColor;
  transition: background-color 100000s ease-in-out 0s; /* Chrome belt-and-suspenders */
}
```

`--brand-field` is `#ffffff`, which matches **both** input families in the app — the login fields (`bg-white`) and every other autofillable form input (`bg-[var(--brand-field)]`) — so a single token-colored mask is correct everywhere. Text is pinned to `currentColor` since autofill also recolors the typed value.

## Notes

- Color ratchet passes (148/180; the mask uses the on-system `--brand-field` token, no new hex).
- I couldn't reproduce in a live iOS Safari from this environment, but the box-shadow mask is the canonical, well-established remedy for this exact symptom and is the technique that works where the transition trick does not. Worth a quick confirm on a real device once the preview deploys.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bi9TWpeQootRZkkvuLzgM7)_