### PR TITLE
Fix home triangle band: native-size background + global overflow clamp

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
       lang="en"
       className={`font-sans ${josefin.variable} ${montserrat.variable} ${cormorant.variable}`}
     >
-      <body className={`${josefin.className} flex min-h-dvh flex-col`}>
+      <body className={`${josefin.className} flex min-h-dvh flex-col overflow-x-clip`}>
         {/* HIDDEN — dev design-choice bar. Uncomment the boot <script> and the
             <PaletteToggle/> below (plus its import above) to bring it back.
             The script applies the saved card-background choice before paint so

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -22,22 +22,26 @@ export default async function Home() {
 
   return (
     <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 overflow-x-clip px-4 py-6 pb-32 md:py-10">
-      {/* Top triangle band (Variant4-TOP, grain baked in; lower portion
-          transparent so cream shows through). Bounded to the content-column
-          width (inset-x-0 inside the max-w-2xl main) — the same width the
-          original banner used — and rendered at its INTRINSIC size (centered &
-          clipped, never scaled). The first card sits over it. */}
+      {/* Top triangle band (Variant4-TOP, 1120x160, grain baked in; lower portion
+          transparent so cream shows through). Rendered as a BACKGROUND image, not
+          an <img>: background-size:auto pins it to its INTRINSIC size (so its
+          triangles match the side clusters, which are also native), center-top
+          shows the middle portion, and the box clips the rest. The previous
+          <img max-w-none -translate-x-1/2> approach (a) scaled inconsistently and
+          (b) its transform escaped overflow:hidden on iOS WebKit, widening the
+          page; a background can do neither — it never participates in layout or
+          scroll width. Height pinned to the band's native 160px (h-40). The first
+          card sits over the transparent lower portion. */}
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 -z-10 overflow-hidden"
-      >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          src="/images/Variant4-TOP.png"
-          alt=""
-          className="relative left-1/2 block max-w-none -translate-x-1/2"
-        />
-      </div>
+        className="pointer-events-none absolute inset-x-0 top-0 -z-10 h-40 overflow-hidden"
+        style={{
+          backgroundImage: 'url(/images/Variant4-TOP.png)',
+          backgroundSize: 'auto',
+          backgroundPosition: 'center top',
+          backgroundRepeat: 'no-repeat',
+        }}
+      />
 
       {/* Today's Five — a card, so it can ride over the top triangle band. */}
       {session ? (


### PR DESCRIPTION
Two related commits closing out the iOS home-page width/triangle issues.

## 1. Top triangle band → native-size background image (`1911741`)

Reported from device: the top band rendered the whole graphic scaled down (triangles smaller than the side clusters', which are native), and on iOS WebKit its centering transform escaped `overflow:hidden` and widened the page.

Root context: the top graphic was swapped from **1120×1280 → 1120×160** (git history), but both are 1120px wide, so the image swap isn't the cause — rendering a 1120px-wide `<img max-w-none ... -translate-x-1/2>` is.

Fix: render it as a CSS background — `background-size:auto` pins it to its intrinsic 1120×160 (triangles now match the side clusters; all three images share an 80px triangle height), `center top` shows the middle portion, and the box (`h-40`, `inset-x-0`, `overflow-hidden`) clips the rest. A background never participates in layout/scroll width, so it can't overflow and can't be scaled by a stray `max-width`.

## 2. Global horizontal-overflow clamp (`637d1f9`)

A real iPhone screenshot showed the header fix worked but the content column was still shifted ~16px right (cards clipped at the screen edge). The decorative layers are `absolute`, negatively-inset, and transformed; on iOS WebKit transforms escape an ancestor's clip, so the `<main>`-level clip (#1113) wasn't enough. `overflow-x-clip` on `<body>` (the outermost scroll container) is the catch-all — and `clip` (not `hidden`) doesn't create a scroll container or break `sticky`/`fixed`, and leaves `overflow-y` visible.

## Verification

Device-only (only reproduces on iOS WebKit). After deploy on a real iPhone: triangle scales match across top + sides, the top band shows a native-size slice, the cards regain a symmetric right margin, and nothing clips/zooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG