### PR TITLE
Revert overflow-x-clip clamps (they regressed the card layout)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
       lang="en"
       className={`font-sans ${josefin.variable} ${montserrat.variable} ${cormorant.variable}`}
     >
-      <body className={`${josefin.className} flex min-h-dvh flex-col overflow-x-clip`}>
+      <body className={`${josefin.className} flex min-h-dvh flex-col`}>
         {/* HIDDEN — dev design-choice bar. Uncomment the boot <script> and the
             <PaletteToggle/> below (plus its import above) to bring it back.
             The script applies the saved card-background choice before paint so

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -21,7 +21,7 @@ export default async function Home() {
   const session = await getSession()
 
   return (
-    <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 overflow-x-clip px-4 py-6 pb-32 md:py-10">
+    <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
       {/* Top triangle band (Variant4-TOP, 1120x160, grain baked in; lower portion
           transparent so cream shows through). Rendered as a BACKGROUND image, not
           an <img>: background-size:auto pins it to its INTRINSIC size (so its


### PR DESCRIPTION
## What

Removes `overflow-x-clip` from both `<main>` and `<body>` — reverting #1113/#1114's clamps.

## Why

A real-device A/B comparison was decisive:
- **Yesterday** (header `w-full` from #1111, **no clips**): home cards symmetric — x51→x1154, 51px gutter on **both** sides. ✅
- **Today** (after the #1113 `main` clip + #1114 `body` clip): cards shifted ~16px right — x51→x1205, **right gutter gone**, "Customize" and friend-card text clipping at the screen edge. ❌

The clips were added against earlier captures that turned out to be the pre-#1111 (shrink-wrapped-header) state or stale full-page PDF exports. Once the header `w-full` fix landed, there was **no real horizontal overflow left to clip** — and `overflow-x: clip` paired with `overflow-y: visible` mis-renders on iOS WebKit, *introducing* the rightward shift. (The bonus-dots row, measured at ~234px inside a ~353px card interior, fits comfortably, so it was never the cause either.)

## Kept

The genuinely-correct triangle fixes from #1113/#1114 stay, since neither participates in horizontal layout:
- DUO side triangle at native `w-[70px]` (was 2× upscaled).
- Top band as a native-size background image (was an `<img max-w-none>` that scaled/escaped clipping).

## Verification

Device-only. After deploy on a real iPhone the cards should be symmetric again (matching yesterday), with nothing clipping on the right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG

---
_Generated by [Claude Code](https://claude.ai/code/session_01MGSdSD6b1KCgEb3Lw7ThtG)_