### PR TITLE
Revert flex-column <body> (b4c528ce) — fix iOS narrow header

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -385,23 +385,6 @@
     }
 }
 
-/* App shell height model — unlayered so it overrides the Tailwind `min-h-dvh`
-   utility that every page's <main> carries.
-
-   The <body> is a single dynamic-viewport-tall flex column (see layout.tsx).
-   Previously each <main> independently claimed `min-h-dvh` (100dvh) while the
-   top header sat in normal flow ABOVE it, so the document was always taller than
-   the viewport by the header's height. That phantom overflow let short pages
-   scroll past their content and, on mobile Safari, stranded the fixed bottom nav
-   mid-screen with dead space below it as the toolbar collapsed.
-
-   Letting <main> grow to fill the remaining column height instead means a short
-   page is exactly one viewport tall (no phantom scroll, nav pinned at the
-   bottom), while a tall page still scrolls naturally. */
-body > main {
-  flex: 1 1 auto;
-  min-height: 0;
-}
 
 @layer components {
   .card {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
       lang="en"
       className={`font-sans ${josefin.variable} ${montserrat.variable} ${cormorant.variable}`}
     >
-      <body className={`${josefin.className} flex min-h-dvh flex-col`}>
+      <body className={josefin.className}>
         {/* HIDDEN — dev design-choice bar. Uncomment the boot <script> and the
             <PaletteToggle/> below (plus its import above) to bring it back.
             The script applies the saved card-background choice before paint so


### PR DESCRIPTION
**Guaranteed fix** for the iOS-only narrow header. Bisect (on your iPhone): **PR #1097 fine, PR #1098 (`b4c528ce`) broken.** That commit made `<body>` a flex column, turning `<header>` into a flex item — iOS Safari then shrink-wraps the header's `margin:auto` flex row to ~2/3 width. Desktop renders it correctly, so it only showed on the phone.

A `w-full` on the header row did **not** fix it on iOS (confirmed), so this removes the trigger entirely by restoring the normal block `<body>` — i.e. exactly the layout state of #1097, which you confirmed is fine.

Net diff: 1 line in `layout.tsx` + the `body > main` rule removed from `globals.css`. Nothing else.

**Trade-off:** re-introduces the minor phantom-scroll / short-page behavior that #1098 was trying to fix. I'll re-solve that separately without making `<body>` a flex container. A correct header outranks it.

**Test on iPhone:** open this PR's preview — header bell/avatar should reach the right edge.