### PR TITLE
Fix iOS-only narrow header: revert flex-column <body> (b4c528ce)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -385,23 +385,6 @@
     }
 }
 
-/* App shell height model — unlayered so it overrides the Tailwind `min-h-dvh`
-   utility that every page's <main> carries.
-
-   The <body> is a single dynamic-viewport-tall flex column (see layout.tsx).
-   Previously each <main> independently claimed `min-h-dvh` (100dvh) while the
-   top header sat in normal flow ABOVE it, so the document was always taller than
-   the viewport by the header's height. That phantom overflow let short pages
-   scroll past their content and, on mobile Safari, stranded the fixed bottom nav
-   mid-screen with dead space below it as the toolbar collapsed.
-
-   Letting <main> grow to fill the remaining column height instead means a short
-   page is exactly one viewport tall (no phantom scroll, nav pinned at the
-   bottom), while a tall page still scrolls naturally. */
-body > main {
-  flex: 1 1 auto;
-  min-height: 0;
-}
 
 @layer components {
   .card {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -65,7 +65,7 @@ export default async function RootLayout({
       lang="en"
       className={`font-sans ${josefin.variable} ${montserrat.variable} ${cormorant.variable}`}
     >
-      <body className={`${josefin.className} flex min-h-dvh flex-col`}>
+      <body className={josefin.className}>
         {/* HIDDEN — dev design-choice bar. Uncomment the boot <script> and the
             <PaletteToggle/> below (plus its import above) to bring it back.
             The script applies the saved card-background choice before paint so

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -159,12 +159,7 @@ export function Nav({
         className="z-40 border-b bg-background/95 backdrop-blur"
         aria-label="Primary header"
       >
-        {/* w-full is load-bearing on iOS WebKit: a block-level `display:flex`
-            element with `margin:auto` (mx-auto) gets shrink-wrapped to its
-            content width on iOS (Safari + all iOS browsers, incl. Chrome),
-            collapsing the header to ~2/3 width while the body cards stay full.
-            Explicit w-full stops the shrink-wrap; it's a no-op everywhere else. */}
-        <div className="mx-auto flex w-full max-w-2xl items-center justify-between px-4 py-3">
+        <div className="mx-auto flex max-w-2xl items-center justify-between px-4 py-3">
           <Link
             href="/"
             className="font-wordmark text-[22px] font-semibold leading-none tracking-[0.05em] text-foreground"


### PR DESCRIPTION
Confirmed fix for the iOS Safari narrow-header bug, into `dev2`.

**Root cause (bisect, on-device):** PR #1097 fine, **PR #1098 (`b4c528ce`) broken.** `b4c528ce` made `<body>` a flex column, turning `<header>` into a flex item — iOS Safari then shrink-wraps the header's `margin:auto` flex row to ~2/3 width (bell/avatar stop short of the right edge). Desktop Chrome/WebKit render it correctly, so it only showed on a real iPhone. **Confirmed fixed on-device** by restoring the normal block `<body>`.

**Changes:**
- `layout.tsx`: `<body>` back to a normal block (drop `flex min-h-dvh flex-col`).
- `globals.css`: remove the `body > main { flex:1 1 auto }` rule that paired with it.
- `Nav.tsx`: remove the earlier `w-full` header attempt + its now-false comment (w-full did **not** fix the iOS shrink-wrap when tested on-device).

**Trade-off:** re-introduces the minor short-page phantom-scroll / stranded-bottom-nav that `b4c528ce` was addressing. Follow-up: re-solve that without making `<body>` a flex container. A correct header outranks it.

Production counterpart: #1118 (same revert, based on `main`).