### PR TITLE
fix(daily): pin gameplay header by fixing scroll-shell layout

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -50,7 +50,7 @@ export default function DailyCatchupPage() {
   }
 
   return (
-    <main className="mx-auto flex min-h-dvh max-w-lg flex-col bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
+    <main className="mx-auto flex h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
       <header
         className="sticky top-0 z-20 border-b px-4 py-2"
         style={{
@@ -88,7 +88,7 @@ export default function DailyCatchupPage() {
       </header>
 
       <section
-        className="flex-1 overflow-y-auto px-4 py-4"
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
         style={{
           paddingBottom:
             currentItem && phase === 'playing'

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -812,7 +812,7 @@ export default function DailyPage() {
   }, [queue, currentSlot, submitting]);
 
   return (
-    <main className="relative mx-auto flex min-h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
+    <main className="relative mx-auto flex h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
       {/* Brand triangle pattern (same artwork as the login screen / home feed)
           tiled full-strength behind the game. No cream scrim — the gameplay
           thread is entirely cards, which sit opaque on top; the sticky header
@@ -852,7 +852,7 @@ export default function DailyPage() {
       </header>
 
       <section
-        className="flex-1 overflow-y-auto px-4 py-4"
+        className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
         style={{
           paddingBottom:
             currentSlot && !loading


### PR DESCRIPTION
The Daily Five and Catch-up headers carried sticky top-0 but still
scrolled away on mobile. The <main> shell was min-h-dvh (a minimum, so
it grows) while the scrolling <section> was a flex child with the
default min-height: auto, so a tall thread grew the section to fit its
content instead of scrolling internally. That pushed <main> past the
viewport, the whole page scrolled, and the header — sticky relative to
<main>, not the section — went with it.

Switch <main> to a definite h-dvh app-shell height and give the
scrolling <section> min-h-0 so it scrolls internally. The header now
stays pinned at the top.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J4xDCcW2Ur1AAM6fVimtzp