### PR TITLE
Add inactivity "add categories" nudge to Refine Your Game

### DIFF
--- a/src/components/review/RefineItemCard.tsx
+++ b/src/components/review/RefineItemCard.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useState } from 'react';
 import type { CSSProperties } from 'react';
 
@@ -12,7 +13,29 @@ const actionStyle: CSSProperties = {
   background: 'color-mix(in srgb, var(--brand-orange) 8%, transparent)',
 };
 
+const ACTION_CLASS =
+  'inline-flex min-h-11 items-center justify-center self-start rounded-[var(--radius-xs)] border px-4 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60 sm:self-auto';
+
+const ROW_CLASS = 'flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4';
+
 export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: string }) {
+  // Navigational nudge (add_territories): links out instead of staging a
+  // decision, so it skips the resolve/undo round-trip entirely.
+  if (item.href) {
+    return (
+      <div className={ROW_CLASS}>
+        <p className="text-foreground flex-1 text-sm leading-6">{item.openText}</p>
+        <Link href={item.href} style={actionStyle} className={ACTION_CLASS}>
+          {item.actionVerb}
+        </Link>
+      </div>
+    );
+  }
+
+  return <RefineDecisionCard item={item} queueId={queueId} />;
+}
+
+function RefineDecisionCard({ item, queueId }: { item: RefineItem; queueId: string }) {
   const [resolved, setResolved] = useState(item.state === 'resolved');
   const [busy, setBusy] = useState(false);
 
@@ -57,7 +80,7 @@ export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: s
   }
 
   return (
-    <div className="flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+    <div className={ROW_CLASS}>
       {resolved ? (
         <>
           <p className="text-muted-foreground flex-1 text-sm leading-6">
@@ -83,7 +106,7 @@ export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: s
             onClick={resolve}
             disabled={busy}
             style={actionStyle}
-            className="inline-flex min-h-11 items-center justify-center self-start rounded-[var(--radius-xs)] border px-4 text-sm font-semibold transition hover:opacity-90 disabled:opacity-60 sm:self-auto"
+            className={ACTION_CLASS}
           >
             {item.actionVerb}
           </button>

--- a/src/server/db/queries/refine.ts
+++ b/src/server/db/queries/refine.ts
@@ -6,9 +6,15 @@
  * decisions) and assembles the RefineSectionView consumed by the daily summary.
  */
 
-import { and, desc, eq, gt, inArray, isNull } from 'drizzle-orm';
+import { and, desc, eq, gt, inArray, isNull, sql } from 'drizzle-orm';
 
-import { db, dailyRefineDecisions, masteryEvents, userDomainDifficulties } from '@/server/db';
+import {
+  db,
+  dailyRefineDecisions,
+  declaredInterests,
+  masteryEvents,
+  userDomainDifficulties,
+} from '@/server/db';
 import type { QueueSlot } from '@/server/daily/types';
 import { getBonusCount } from '@/server/daily/bonus';
 import { getKnowledgeBase } from '@/server/db/queries/daily';
@@ -18,17 +24,30 @@ import {
   deriveStrugglePruning,
   type MissStreak,
 } from '@/server/refine/derive';
-import { openText, resolvedText, subdomainLabel } from '@/server/refine/copy';
+import {
+  ADD_TERRITORIES_OPEN_TEXT,
+  ADD_TERRITORIES_RESOLVED_TEXT,
+  openText,
+  resolvedText,
+  subdomainLabel,
+} from '@/server/refine/copy';
 import { selectRefineCandidates } from '@/server/refine/select';
 import {
+  REFINE_MAX_ITEMS,
   REFINE_VERB,
   refineItemKey,
+  shouldNudgeAddTerritories,
   type RefineCandidate,
   type RefineItem,
   type RefineItemType,
   type RefineMissTier,
   type RefineSectionView,
 } from '@/server/refine/types';
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/** Where the add_territories nudge sends the player (same as Customize / Settings). */
+const ADD_TERRITORIES_HREF = '/daily/setup';
 
 /** Lowercased canonical subcategories the player currently owns (knowledge base). */
 export async function getOwnedSubcategories(userId: string): Promise<Set<string>> {
@@ -235,6 +254,38 @@ export async function deriveSelectedRefineCandidates(
   return selected;
 }
 
+/**
+ * Whole-number days since the player last added an active territory, or null if
+ * they've never added one. The signal is the most recent DeclaredInterest the
+ * player still owns — adding a category writes a fresh `declaredAt`, so this
+ * resets the moment they act (which is what retires the nudge).
+ */
+export async function getDaysSinceLastTerritoryAdd(userId: string): Promise<number | null> {
+  const [row] = await db
+    .select({ last: sql<string | null>`max(${declaredInterests.declaredAt})` })
+    .from(declaredInterests)
+    .where(and(eq(declaredInterests.userId, userId), eq(declaredInterests.isActive, true)));
+  if (!row?.last) return null;
+  const lastMs = new Date(row.last).getTime();
+  if (Number.isNaN(lastMs)) return null;
+  return Math.floor((Date.now() - lastMs) / DAY_MS);
+}
+
+/** The navigational "add some categories?" nudge — global, never staged. */
+function buildAddTerritoriesItem(queueId: string): RefineItem {
+  return {
+    id: `${queueId}:add_territories`,
+    type: 'add_territories',
+    subdomainId: '',
+    subdomainLabel: '',
+    openText: ADD_TERRITORIES_OPEN_TEXT,
+    resolvedText: ADD_TERRITORIES_RESOLVED_TEXT,
+    actionVerb: REFINE_VERB.add_territories,
+    state: 'open',
+    href: ADD_TERRITORIES_HREF,
+  };
+}
+
 /** Assemble the RefineSectionView for the daily summary. */
 export async function buildRefineSection(
   userId: string,
@@ -242,12 +293,19 @@ export async function buildRefineSection(
   slots: QueueSlot[],
 ): Promise<RefineSectionView> {
   if (slots.length === 0) return { queueId, items: [] };
-  const [selected, pendingKeys] = await Promise.all([
+  const [selected, pendingKeys, daysSinceLastAdd] = await Promise.all([
     deriveSelectedRefineCandidates(userId, slots),
     getPendingDecisionKeys(userId, queueId),
+    getDaysSinceLastTerritoryAdd(userId),
   ]);
-  return {
-    queueId,
-    items: selected.map((candidate) => candidateToItem(candidate, queueId, pendingKeys)),
-  };
+  const items = selected.map((candidate) => candidateToItem(candidate, queueId, pendingKeys));
+
+  // Inactivity nudge fills any room the evidence-based items leave open: if the
+  // player hasn't added a territory recently, offer to add some. Lowest priority,
+  // so an engaged day with three evidence items crowds it out.
+  if (items.length < REFINE_MAX_ITEMS && shouldNudgeAddTerritories(daysSinceLastAdd)) {
+    items.push(buildAddTerritoriesItem(queueId));
+  }
+
+  return { queueId, items };
 }

--- a/src/server/refine/__tests__/add-territories-nudge.test.ts
+++ b/src/server/refine/__tests__/add-territories-nudge.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { openText, resolvedText, ADD_TERRITORIES_OPEN_TEXT } from '../copy';
+import {
+  ADD_TERRITORIES_INACTIVITY_DAYS,
+  REFINE_PRIORITY,
+  REFINE_VERB,
+  shouldNudgeAddTerritories,
+  type RefineCandidate,
+} from '../types';
+
+describe('shouldNudgeAddTerritories', () => {
+  it('fires when the player has never added a territory', () => {
+    expect(shouldNudgeAddTerritories(null)).toBe(true);
+  });
+
+  it('fires once inactivity reaches the threshold', () => {
+    expect(shouldNudgeAddTerritories(ADD_TERRITORIES_INACTIVITY_DAYS)).toBe(true);
+    expect(shouldNudgeAddTerritories(ADD_TERRITORIES_INACTIVITY_DAYS + 30)).toBe(true);
+  });
+
+  it('stays quiet while a recent add is inside the window', () => {
+    expect(shouldNudgeAddTerritories(0)).toBe(false);
+    expect(shouldNudgeAddTerritories(ADD_TERRITORIES_INACTIVITY_DAYS - 1)).toBe(false);
+  });
+});
+
+describe('add_territories copy + tables', () => {
+  const candidate: RefineCandidate = {
+    type: 'add_territories',
+    subdomainId: '',
+    subdomainLabel: '',
+  };
+
+  it('uses the fixed nudge prose', () => {
+    expect(openText(candidate)).toBe(ADD_TERRITORIES_OPEN_TEXT);
+    expect(resolvedText(candidate)).toMatch(/categories/i);
+  });
+
+  it('is the lowest-priority item and carries the Add categories verb', () => {
+    expect(REFINE_VERB.add_territories).toBe('Add categories');
+    const others = [
+      REFINE_PRIORITY.friend_expansion,
+      REFINE_PRIORITY.difficulty_escalation,
+      REFINE_PRIORITY.struggle_pruning,
+    ];
+    expect(Math.max(...others)).toBeLessThan(REFINE_PRIORITY.add_territories);
+  });
+});

--- a/src/server/refine/commit.ts
+++ b/src/server/refine/commit.ts
@@ -37,6 +37,10 @@ const COOLDOWN_MS: Record<RefineItemType, number> = {
   // heads-up doesn't re-fire while the freeze is active.
   difficulty_escalation: 30 * DAY_MS,
   struggle_pruning: 7 * DAY_MS,
+  // Navigational nudge — never staged, committed, or defaulted (it's added only
+  // in buildRefineSection, not in deriveSelectedRefineCandidates), so this is
+  // never read at runtime. Present only for Record exhaustiveness.
+  add_territories: 0,
 };
 
 const FREEZE_MS = 30 * DAY_MS;
@@ -90,6 +94,9 @@ async function applyResolvedEffect(userId: string, row: DecisionRow, until: Date
     }
     case 'difficulty_escalation':
       await freezeDomainDifficulty(userId, domain, until);
+      return;
+    case 'add_territories':
+      // Navigational nudge with no durable effect; never reaches commit.
       return;
   }
 }

--- a/src/server/refine/copy.ts
+++ b/src/server/refine/copy.ts
@@ -9,6 +9,15 @@
 import type { RefineCandidate } from './types';
 
 /**
+ * Inactivity nudge copy. This item is global (no subdomain) and navigational, so
+ * its text is fixed rather than evidence-templated. resolvedText is never shown —
+ * tapping it links out to /daily/setup — but it's kept for switch exhaustiveness.
+ */
+export const ADD_TERRITORIES_OPEN_TEXT =
+  "You haven't added anything new in a while. Want to add some categories to your game?";
+export const ADD_TERRITORIES_RESOLVED_TEXT = 'Opening your categories…';
+
+/**
  * Human-readable subdomain phrase for prose. Replaces separators and collapses
  * whitespace but preserves the source casing so proper nouns ("Sondheim") and
  * snake_case domains ("subprime_mortgage" → "subprime mortgage") both read well.
@@ -29,6 +38,8 @@ export function openText(candidate: RefineCandidate): string {
       return `You're mastering ${label}, so its questions are getting harder. Ease off?`;
     case 'struggle_pruning':
       return `You've missed the last ${candidate.missCount ?? 0} ${label} questions. Rest them for now?`;
+    case 'add_territories':
+      return ADD_TERRITORIES_OPEN_TEXT;
   }
 }
 
@@ -42,5 +53,7 @@ export function resolvedText(candidate: RefineCandidate): string {
       return `We'll keep ${label} at this level for the next month.`;
     case 'struggle_pruning':
       return `Moving ${label} to Never for now — it won't be asked.`;
+    case 'add_territories':
+      return ADD_TERRITORIES_RESOLVED_TEXT;
   }
 }

--- a/src/server/refine/types.ts
+++ b/src/server/refine/types.ts
@@ -8,9 +8,13 @@
  * (src/server/refine/select.ts) depend on. Everything here is pure.
  */
 
-export type RefineItemType = 'friend_expansion' | 'difficulty_escalation' | 'struggle_pruning';
+export type RefineItemType =
+  | 'friend_expansion'
+  | 'difficulty_escalation'
+  | 'struggle_pruning'
+  | 'add_territories';
 
-export type RefineActionVerb = 'Add' | 'Ease off' | 'Rest';
+export type RefineActionVerb = 'Add' | 'Ease off' | 'Rest' | 'Add categories';
 
 export type RefineItemState = 'open' | 'resolved';
 
@@ -42,6 +46,12 @@ export interface RefineItem {
   resolvedText: string;
   actionVerb: RefineActionVerb;
   state: RefineItemState;
+  /**
+   * Navigational items (the add_territories nudge) link out instead of staging a
+   * decision. When set, the client renders the action verb as a link to this
+   * route and skips the resolve/undo round-trip entirely.
+   */
+  href?: string;
 }
 
 export interface RefineSectionView {
@@ -58,16 +68,35 @@ export const REFINE_PRIORITY: Record<RefineItemType, number> = {
   friend_expansion: 0,
   difficulty_escalation: 1,
   struggle_pruning: 2,
+  // Lowest priority: the inactivity nudge only fills space the evidence-based
+  // items leave open, so on an engaged day it steps aside.
+  add_territories: 3,
 };
 
 export const REFINE_VERB: Record<RefineItemType, RefineActionVerb> = {
   friend_expansion: 'Add',
   difficulty_escalation: 'Ease off',
   struggle_pruning: 'Rest',
+  add_territories: 'Add categories',
 };
 
 /** Max items shown at once. */
 export const REFINE_MAX_ITEMS = 3;
+
+/**
+ * Days of "no new territory added" before the add_territories nudge fires. The
+ * signal is the most recent active DeclaredInterest.declaredAt — adding a
+ * category resets it, so the nudge disappears the moment the player acts.
+ */
+export const ADD_TERRITORIES_INACTIVITY_DAYS = 5;
+
+/**
+ * Whether to surface the "add some categories?" nudge. Fires when the player has
+ * never added a territory (`null`) or hasn't in ADD_TERRITORIES_INACTIVITY_DAYS.
+ */
+export function shouldNudgeAddTerritories(daysSinceLastAdd: number | null): boolean {
+  return daysSinceLastAdd === null || daysSinceLastAdd >= ADD_TERRITORIES_INACTIVITY_DAYS;
+}
 
 /**
  * Stable identity / cooldown key for a candidate or decision row. Subdomain is


### PR DESCRIPTION
Surface a fourth Refine Your Game option that fires when the player
hasn't added a territory recently (no active DeclaredInterest in the last
5 days, or none ever). Unlike the three evidence-based items, this one is
global and navigational: it links to /daily/setup instead of staging a
decision, so it skips the resolve/undo + commit/cooldown machinery
entirely.

- New `add_territories` refine item type, lowest priority so it only
  fills room the evidence-based items leave open on an engaged day.
- `getDaysSinceLastTerritoryAdd` reads max(DeclaredInterest.declaredAt);
  adding a category resets the signal and retires the nudge.
- RefineItem gains an optional `href`; the card renders a link variant
  for navigational items (hooks kept unconditional via a split component).
- Unit tests for the threshold helper and copy/priority tables.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013HpZGX4c9fHukP47gbVCcG