### PR TITLE
Condense-on-scroll gameplay header + progress dots on Catch-up

### DIFF
--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -1,14 +1,16 @@
 'use client';
 
-import { useState } from 'react';
-import Link from 'next/link';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { X } from 'lucide-react';
 
 import { GameplayChatThread } from '@/components/play/GameplayChat';
 import { AnswerInputBar } from '@/components/play/AnswerInputBar';
+import { GeometricProgress } from '@/components/play/GeometricProgress';
+import { PlayHeader } from '@/components/play/PlayHeader';
+import { useCondensedOnScroll } from '@/components/play/useCondensedOnScroll';
 import { ThreadCard } from '@/components/play/ThreadCard';
 import { useCatchupFlow, type CatchupBatchRecord } from '@/components/play/useCatchupFlow';
+import { CATCH_UP_BATCH_SIZE } from '@/lib/game-constants';
 import { AuthorName } from '@/components/AuthorName';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { CreatorNote, pickCreatorNote } from '@/components/CreatorNote';
@@ -24,7 +26,6 @@ export default function DailyCatchupPage() {
     submitting,
     isResolvingTurn,
     error,
-    remainingLabel,
     phase,
     batchRecords,
     remainingCount,
@@ -37,10 +38,31 @@ export default function DailyCatchupPage() {
     dismissCurrent,
   } = useCatchupFlow();
   const [answer, setAnswer] = useState('');
+  // Collapses the header's title block once the player scrolls into the thread,
+  // leaving just the progress dots + close (shared with the Daily Five surface).
+  const { condensed, onScroll } = useCondensedOnScroll();
 
   const hasItems = initialTotal > 0;
   const showSummary = phase === 'summary';
   const roundComplete = phase === 'round_complete';
+
+  // Round-scoped progress dots (D-decision: current round, up to CATCH_UP_BATCH_SIZE,
+  // mirroring the Daily Five round dots — not the whole catch-up session). The
+  // round started with `remainingCount + batchRecords.length` items still on the
+  // board (answered/skipped turns are recorded in batchRecords; dismissed/stale
+  // items leave the round and correctly shrink the count), so its size is that,
+  // capped at the batch size. Per-dot results come straight from this round's
+  // records; revealed (gave-up) reads as a neutral/expired dot.
+  const roundSize = Math.min(CATCH_UP_BATCH_SIZE, remainingCount + batchRecords.length);
+  const roundResults = useMemo(() => {
+    const map: Record<number, 'correct' | 'wrong' | 'expired'> = {};
+    batchRecords.forEach((record, index) => {
+      map[index + 1] =
+        record.outcome === 'correct' ? 'correct' : record.outcome === 'wrong' ? 'wrong' : 'expired';
+    });
+    return map;
+  }, [batchRecords]);
+  const roundCurrent = batchRecords.length + 1;
 
   async function handleSubmit() {
     const submitted = answer.trim();
@@ -51,43 +73,28 @@ export default function DailyCatchupPage() {
 
   return (
     <main className="mx-auto flex h-dvh max-w-lg flex-col overflow-hidden bg-[var(--surface)] bg-[url('/images/Variant4.png')] bg-repeat px-0">
-      <header
-        className="sticky top-0 z-20 border-b px-4 py-2"
-        style={{
-          borderColor: 'var(--border)',
-          background: 'color-mix(in srgb, var(--surface) 94%, transparent)',
-          backdropFilter: 'blur(8px)',
-        }}
-      >
-        <div className="flex items-start justify-between gap-3">
-          <div className="min-w-0">
-            <p className="text-xs font-medium tracking-[0.12em] text-[var(--text-muted)] uppercase">
-              Catch up
-            </p>
-            <h1 className="font-serif text-lg font-semibold text-[var(--text)]">
-              {loading
-                ? 'Missed questions'
-                : `${initialTotal} missed ${initialTotal === 1 ? 'question' : 'questions'} from the past week`}
-            </h1>
-          </div>
-          <div className="flex shrink-0 items-center gap-2">
-            {!loading && hasItems && !showSummary ? (
-              <p className="text-right text-[0.65rem] font-medium tracking-[0.1em] text-[var(--text-muted)] uppercase">
-                {remainingLabel}
-              </p>
-            ) : null}
-            <Link
-              href="/"
-              aria-label="Close"
-              className="-mr-2 inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
-            >
-              <X className="size-5" strokeWidth={1.9} />
-            </Link>
-          </div>
-        </div>
-      </header>
+      <PlayHeader
+        eyebrow="Catch up"
+        title={
+          loading
+            ? 'Missed questions'
+            : `${initialTotal} missed ${initialTotal === 1 ? 'question' : 'questions'} from the past week`
+        }
+        condensed={condensed}
+        dots={
+          !loading && hasItems && phase === 'playing' ? (
+            <GeometricProgress
+              coreCount={roundSize}
+              bonusCount={0}
+              current={roundCurrent}
+              results={roundResults}
+            />
+          ) : undefined
+        }
+      />
 
       <section
+        onScroll={onScroll}
         className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
         style={{
           paddingBottom:

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -1,9 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { X } from 'lucide-react';
 
 import {
   GameplayChatThread,
@@ -18,6 +16,8 @@ import {
   submitAnswerWithRetry,
 } from '@/lib/answer-submit';
 import { GeometricProgress } from '@/components/play/GeometricProgress';
+import { PlayHeader } from '@/components/play/PlayHeader';
+import { useCondensedOnScroll } from '@/components/play/useCondensedOnScroll';
 import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import LoadingScreen from '@/components/LoadingScreen';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
@@ -198,6 +198,9 @@ export default function DailyPage() {
   const answerInputRef = useRef<HTMLInputElement>(null);
   // Guards the one-shot end-of-round revalidation below (B-DAILY-PARTIAL-QUEUE-01).
   const revalidatedEndRef = useRef(false);
+  // Collapses the header's title block once the player scrolls into the thread,
+  // leaving just the progress dots + close (shared with the Catch-up surface).
+  const { condensed, onScroll } = useCondensedOnScroll();
 
   // Show the first-run intro once, only for the server-flagged first untouched
   // queue and only if this device hasn't already dismissed it.
@@ -817,41 +820,22 @@ export default function DailyPage() {
           tiled full-strength behind the game. No cream scrim — the gameplay
           thread is entirely cards, which sit opaque on top; the sticky header
           stays opaque too. */}
-      <header
-        className="sticky top-0 z-20 flex items-center justify-between gap-3 border-b px-4 py-3"
-        style={{
-          borderColor: 'var(--border)',
-          background: 'var(--surface)',
-        }}
-      >
-        <div className="flex items-center gap-3">
-          <div>
-            <p className="text-xs tracking-[0.1em] text-[var(--text-muted)] uppercase">
-              Daily Five
-            </p>
-            <h1 className="font-serif text-xl font-semibold text-[var(--text)]">
-              Today&apos;s five
-            </h1>
-          </div>
-        </div>
-        <div className="flex items-center gap-2">
+      <PlayHeader
+        eyebrow="Daily Five"
+        title={<>Today&apos;s five</>}
+        condensed={condensed}
+        dots={
           <GeometricProgress
             coreCount={coreDotCount}
             bonusCount={bonusDotCount}
             current={Math.min(completedCount + 1, queueLength)}
             results={results}
           />
-          <Link
-            href="/"
-            aria-label="Close"
-            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
-          >
-            <X className="size-5" strokeWidth={1.9} />
-          </Link>
-        </div>
-      </header>
+        }
+      />
 
       <section
+        onScroll={onScroll}
         className="min-h-0 flex-1 overflow-y-auto px-4 py-4"
         style={{
           paddingBottom:

--- a/src/components/play/PlayHeader.tsx
+++ b/src/components/play/PlayHeader.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Link from 'next/link';
+import { X } from 'lucide-react';
+import type { ReactNode } from 'react';
+
+/**
+ * Shared sticky header for the gameplay surfaces (Daily Five + Catch-up).
+ *
+ * The progress dots and the close button stay pinned at all times; the
+ * eyebrow/title block collapses when `condensed` is set (driven by
+ * useCondensedOnScroll), so scrolling into the thread reclaims the vertical
+ * space the two-line title would otherwise hold. The collapse animates via a
+ * 1fr→0fr grid row so it eases to the title's real height without a hard-coded
+ * max-height guess (titles here wrap to two lines on narrow screens).
+ *
+ * Opaque --surface (not a translucent blur) so the thread cards scrolling
+ * underneath never bleed through the header.
+ */
+export function PlayHeader({
+  eyebrow,
+  title,
+  dots,
+  condensed,
+  closeHref = '/',
+  closeLabel = 'Close',
+}: {
+  eyebrow: string;
+  title: ReactNode;
+  dots?: ReactNode;
+  condensed: boolean;
+  closeHref?: string;
+  closeLabel?: string;
+}) {
+  return (
+    <header
+      className="sticky top-0 z-20 border-b px-4"
+      style={{ borderColor: 'var(--border)', background: 'var(--surface)' }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <div
+          className="min-w-0 grid transition-[grid-template-rows,opacity] duration-200 ease-out"
+          style={{
+            gridTemplateRows: condensed ? '0fr' : '1fr',
+            opacity: condensed ? 0 : 1,
+          }}
+        >
+          <div className="min-h-0 overflow-hidden">
+            <div className="py-2.5">
+              <p className="text-xs tracking-[0.1em] text-[var(--text-muted)] uppercase">
+                {eyebrow}
+              </p>
+              <h1 className="font-serif text-xl font-semibold text-[var(--text)]">{title}</h1>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2 py-1.5">
+          {dots}
+          <Link
+            href={closeHref}
+            aria-label={closeLabel}
+            className="inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-[var(--text-muted)] transition hover:bg-[var(--surface-2)] hover:text-[var(--text)] focus-visible:ring-2 focus-visible:ring-[var(--accent)] focus-visible:ring-offset-2 focus-visible:outline-none"
+          >
+            <X className="size-5" strokeWidth={1.9} />
+          </Link>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/play/useCondensedOnScroll.ts
+++ b/src/components/play/useCondensedOnScroll.ts
@@ -1,0 +1,31 @@
+'use client';
+
+import { useCallback, useState, type UIEvent } from 'react';
+
+/**
+ * Drives the gameplay header's condense-on-scroll behaviour. Returns a
+ * `condensed` flag and an `onScroll` handler to attach to the scrolling region
+ * (the play <section>). Uses asymmetric thresholds (condense once you've scrolled
+ * past `condenseAt`, only re-expand once you're back above `expandAt`) so the
+ * header doesn't flicker open/closed around a single trip point as the layout
+ * reflows when it collapses.
+ */
+export function useCondensedOnScroll(options?: { condenseAt?: number; expandAt?: number }) {
+  const condenseAt = options?.condenseAt ?? 40;
+  const expandAt = options?.expandAt ?? 8;
+  const [condensed, setCondensed] = useState(false);
+
+  const onScroll = useCallback(
+    (event: UIEvent<HTMLElement>) => {
+      const top = event.currentTarget.scrollTop;
+      setCondensed((prev) => {
+        if (!prev && top > condenseAt) return true;
+        if (prev && top < expandAt) return false;
+        return prev;
+      });
+    },
+    [condenseAt, expandAt],
+  );
+
+  return { condensed, onScroll };
+}


### PR DESCRIPTION
## What & why

The two-line title block on the gameplay screens ate a lot of vertical space once you scrolled into the thread. This makes the header **condense on scroll** and brings progress dots to the **Catch-up** screen (which previously only had a "3 of 7 remaining" text label).

> Note: the earlier scroll-shell fix that actually pins the header (`min-h-dvh → h-dvh` + `min-h-0` on the scrolling section) already landed via #1121. This PR builds on that.

## Changes

- **`PlayHeader`** (new, shared): sticky gameplay header where the progress dots + close button stay pinned at all times, but the eyebrow/title block collapses when `condensed`. The collapse animates via a `1fr → 0fr` grid row so it eases to the title's real height (titles wrap to two lines on narrow screens). Opaque `--surface` so thread cards scrolling underneath don't bleed through.
- **`useCondensedOnScroll`** (new, shared): maps the scroll region's position to a `condensed` flag, with asymmetric thresholds (condense past 40px, re-expand under 8px) so it doesn't flicker as the layout reflows on collapse.
- **Daily Five** (`src/app/daily/page.tsx`) and **Catch-up** (`src/app/daily/catchup/page.tsx`): both now use `PlayHeader` + the scroll hook.
- **Catch-up dots**: added `GeometricProgress` scoped to the **current round** (up to `CATCH_UP_BATCH_SIZE`), mirroring the Daily Five round dots — derived from this round's records + remaining count. Correct/wrong color the dots; a gave-up reveal reads as a neutral dot. The total ("N missed") stays in the expanded title.

## Behavior

- Top of thread → full header (eyebrow + title + dots + close).
- Scroll down → title collapses, leaving a thin dots + close bar.
- Scroll back up → re-expands.

## Verification

- `npx tsc -p tsconfig.typecheck.json` — 0 errors (changed files and `src/` overall).
- `npx eslint` on all 4 files — clean.
- No existing tests reference the changed headers.

Manual on-device pass still recommended for the collapse animation feel on iOS Safari.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J4xDCcW2Ur1AAM6fVimtzp)_