### PR TITLE
feat(feed): backfill a new friend's recent activity on a normal friend-add

### DIFF
--- a/src/server/feed/__tests__/backfill-inviter-feed.test.ts
+++ b/src/server/feed/__tests__/backfill-inviter-feed.test.ts
@@ -59,6 +59,7 @@ vi.mock('@/server/db', () => ({
 vi.mock('@/server/feed/visibility', () => ({ SOCIAL_FEED_SOURCE_TYPE: 'friend_answered' }));
 
 import {
+  backfillFollowedUserFeedItems,
   backfillInviterFeedItems,
   backfillSourceAnswerId,
   dropAlreadyPresent,
@@ -197,6 +198,35 @@ describe('backfillInviterFeedItems (hook)', () => {
 
   it('no-ops when inviter and invitee are the same user', async () => {
     const result = await backfillInviterFeedItems({ inviterUserId: INVITER, inviteeUserId: INVITER });
+    expect(result).toEqual({ created: 0 });
+    expect(dbMock.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('backfillFollowedUserFeedItems (friend-add hook)', () => {
+  const ANSWERER = 'followee-1';
+  const RECIPIENT = 'follower-1';
+
+  it('seeds the follower with the followee\'s recent answers, attributed to the followee', async () => {
+    const rows = [answerRow(1, { questionId: 'q-a' }), answerRow(2, { questionId: 'q-b' })];
+    state.selectResults = [masteryDbRows(rows), /* existing */ []];
+
+    const result = await backfillFollowedUserFeedItems({
+      answererUserId: ANSWERER,
+      recipientUserId: RECIPIENT,
+    });
+
+    expect(result).toEqual({ created: 2 });
+    expect(state.inserted.every((r) => r.sourceUserId === ANSWERER)).toBe(true);
+    expect(state.inserted.every((r) => r.recipientUserId === RECIPIENT)).toBe(true);
+    expect(state.inserted.every((r) => r.sourceType === 'friend_answered')).toBe(true);
+  });
+
+  it('no-ops when the followee and follower are the same user', async () => {
+    const result = await backfillFollowedUserFeedItems({
+      answererUserId: ANSWERER,
+      recipientUserId: ANSWERER,
+    });
     expect(result).toEqual({ created: 0 });
     expect(dbMock.select).not.toHaveBeenCalled();
   });

--- a/src/server/feed/backfill-inviter-feed.ts
+++ b/src/server/feed/backfill-inviter-feed.ts
@@ -124,27 +124,38 @@ export function toBackfillFeedItemRows(
 }
 
 /**
- * Inviter-only, one-time backfill. Best-effort: any failure is swallowed so a
- * backfill hiccup can never break invitation acceptance / signup. Returns the
- * number of feed items created (0 when the inviter has no qualifying answers, or
- * when everything was already backfilled).
+ * Backfill a follower's feed with the most recent correct daily/catchup answers
+ * of someone they just started following (`answererUserId` = the followee whose
+ * activity propagates, `recipientUserId` = the follower who now sees it).
+ *
+ * Honest under the forward-propagation model for the SAME reason the invite seed
+ * is: forward propagation only fires for answers the answerer gives AFTER the
+ * follow edge exists, so these rows reconstruct exactly what WOULD have
+ * propagated had the edge existed when the answerer answered — same source_type,
+ * same attribution, same true answer time. Used by both the invite auto-friendship
+ * (B-HomeSeed-1) and a normal friend-add (an approved follow edge).
+ *
+ * Best-effort: any failure is swallowed so a backfill hiccup can never break
+ * invitation acceptance, signup, or friend-request approval. Returns the number
+ * of feed items created (0 when the answerer has no qualifying answers, or when
+ * everything was already backfilled).
  */
-export async function backfillInviterFeedItems({
-  inviterUserId,
-  inviteeUserId,
+export async function backfillFollowedUserFeedItems({
+  answererUserId,
+  recipientUserId,
   limit = INVITER_BACKFILL_MAX_ITEMS,
 }: {
-  inviterUserId: string;
-  inviteeUserId: string;
+  answererUserId: string;
+  recipientUserId: string;
   limit?: number;
 }): Promise<{ created: number }> {
   try {
-    if (!inviterUserId || !inviteeUserId || inviterUserId === inviteeUserId) {
+    if (!answererUserId || !recipientUserId || answererUserId === recipientUserId) {
       return { created: 0 };
     }
 
-    // The inviter's correct daily/catchup answers, newest first, joined to a
-    // feed-eligible question (public, not deleted, not authored by the invitee —
+    // The answerer's correct daily/catchup answers, newest first, joined to a
+    // feed-eligible question (public, not deleted, not authored by the recipient —
     // the milestone surface 403s "answer your own question", so don't seed it).
     const rows = await db
       .select({
@@ -156,12 +167,12 @@ export async function backfillInviterFeedItems({
       .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
       .where(
         and(
-          eq(masteryEvents.userId, inviterUserId),
+          eq(masteryEvents.userId, answererUserId),
           inArray(masteryEvents.sourceType, DAILY_SURFACE_SOURCE_TYPES),
           inArray(masteryEvents.answerState, CORRECT_ANSWER_STATES),
           eq(questions.visibility, 'public'),
           isNull(questions.deletedAt),
-          or(isNull(questions.creatorId), ne(questions.creatorId, inviteeUserId)),
+          or(isNull(questions.creatorId), ne(questions.creatorId, recipientUserId)),
         ),
       )
       .orderBy(desc(masteryEvents.createdAt))
@@ -186,8 +197,8 @@ export async function backfillInviterFeedItems({
       .from(feedItems)
       .where(
         and(
-          eq(feedItems.recipientUserId, inviteeUserId),
-          eq(feedItems.sourceUserId, inviterUserId),
+          eq(feedItems.recipientUserId, recipientUserId),
+          eq(feedItems.sourceUserId, answererUserId),
           inArray(feedItems.questionId, candidateQuestionIds),
         ),
       );
@@ -198,15 +209,36 @@ export async function backfillInviterFeedItems({
     );
     if (toInsert.length === 0) return { created: 0 };
 
-    await db.insert(feedItems).values(toBackfillFeedItemRows(inviterUserId, inviteeUserId, toInsert));
+    await db.insert(feedItems).values(toBackfillFeedItemRows(answererUserId, recipientUserId, toInsert));
 
     return { created: toInsert.length };
   } catch (error) {
-    console.error('[backfillInviterFeedItems] suppressed error:', {
-      inviterUserId,
-      inviteeUserId,
+    console.error('[backfillFollowedUserFeedItems] suppressed error:', {
+      answererUserId,
+      recipientUserId,
       error: error instanceof Error ? error.message : String(error),
     });
     return { created: 0 };
   }
+}
+
+/**
+ * Inviter-only, one-time backfill (B-HomeSeed-1). Thin alias over
+ * backfillFollowedUserFeedItems preserving the invite call sites' naming: the
+ * inviter is the answerer whose activity seeds the new invitee's feed.
+ */
+export async function backfillInviterFeedItems({
+  inviterUserId,
+  inviteeUserId,
+  limit = INVITER_BACKFILL_MAX_ITEMS,
+}: {
+  inviterUserId: string;
+  inviteeUserId: string;
+  limit?: number;
+}): Promise<{ created: number }> {
+  return backfillFollowedUserFeedItems({
+    answererUserId: inviterUserId,
+    recipientUserId: inviteeUserId,
+    limit,
+  });
 }

--- a/src/server/friends/__tests__/friendships.test.ts
+++ b/src/server/friends/__tests__/friendships.test.ts
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Friend-add backfill wiring: these tests lock the follow DIRECTION — a fresh
+// approved edge seeds the FOLLOWER's feed with the FOLLOWEE's recent activity
+// (answerer = followee, recipient = follower). Getting this backwards would seed
+// the wrong person, so it is the highest-value thing to pin.
+
+const { dbMock, state, writeActivityMock, backfillMock } = vi.hoisted(() => {
+  const writeActivityMock = vi.fn(async () => undefined)
+  const backfillMock = vi.fn(async () => ({ created: 0 }))
+  const state = {
+    // The row returned by createOrReusePendingFriendshipRequest's pre-check
+    // select (an existing edge) and the inserted/updated edge.
+    existingEdge: undefined as Record<string, unknown> | undefined,
+    targetPrivacy: 'public' as 'public' | 'private',
+    returnedEdge: undefined as Record<string, unknown> | undefined,
+    updateReturnsEdge: true,
+  }
+
+  // db.select() is used twice in createOrReuse: 1st for the existing edge, 2nd
+  // for the target's followPrivacy. Resolve in call order via a queue.
+  const selectQueue: unknown[][] = []
+  function makeSelect() {
+    const rows = selectQueue.shift() ?? []
+    const limited = { limit: vi.fn(async () => rows) }
+    return { from: vi.fn(() => ({ where: vi.fn(() => limited) })) }
+  }
+
+  const dbMock = {
+    _selectQueue: selectQueue,
+    select: vi.fn(() => makeSelect()),
+    insert: vi.fn(() => ({
+      values: vi.fn(() => ({ returning: vi.fn(async () => [state.returnedEdge]) })),
+    })),
+    update: vi.fn(() => ({
+      set: vi.fn(() => ({
+        where: vi.fn(() => ({
+          returning: vi.fn(async () => (state.updateReturnsEdge ? [state.returnedEdge] : [])),
+        })),
+      })),
+    })),
+  }
+
+  return { dbMock, state, writeActivityMock, backfillMock }
+})
+
+vi.mock('@/server/db', () => ({
+  db: dbMock,
+  follows: { id: 'follows.id', followerId: 'follows.followerId', followeeId: 'follows.followeeId', state: 'follows.state' },
+  users: { id: 'users.id', followPrivacy: 'users.followPrivacy' },
+}))
+
+vi.mock('@/server/activity/write-activity', () => ({ writeActivity: writeActivityMock }))
+
+vi.mock('@/server/feed/backfill-inviter-feed', () => ({
+  backfillFollowedUserFeedItems: backfillMock,
+}))
+
+import { acceptPendingFriendshipRequest, createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
+
+const FOLLOWER = 'follower-1' // the requester / viewer who adds a friend
+const FOLLOWEE = 'followee-1' // the friend being added, whose activity backfills
+
+beforeEach(() => {
+  state.existingEdge = undefined
+  state.targetPrivacy = 'public'
+  state.returnedEdge = undefined
+  state.updateReturnsEdge = true
+  dbMock._selectQueue.length = 0
+  writeActivityMock.mockClear()
+  backfillMock.mockClear()
+})
+
+describe('createOrReusePendingFriendshipRequest backfill', () => {
+  it('backfills the followee\'s activity into the follower\'s feed when auto-approved', async () => {
+    // No existing edge, public target -> auto-approved edge is created.
+    dbMock._selectQueue.push([], [{ followPrivacy: 'public' }])
+    state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }
+
+    const result = await createOrReusePendingFriendshipRequest({
+      inviterUserId: FOLLOWER,
+      inviteeUserId: FOLLOWEE,
+    })
+
+    expect(result.state).toBe('auto_approved')
+    expect(backfillMock).toHaveBeenCalledTimes(1)
+    expect(backfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWEE, recipientUserId: FOLLOWER })
+  })
+
+  it('does NOT backfill when the request lands pending (private target)', async () => {
+    dbMock._selectQueue.push([], [{ followPrivacy: 'private' }])
+    state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'pending' }
+
+    const result = await createOrReusePendingFriendshipRequest({
+      inviterUserId: FOLLOWER,
+      inviteeUserId: FOLLOWEE,
+    })
+
+    expect(result.state).toBe('created')
+    expect(backfillMock).not.toHaveBeenCalled()
+  })
+
+  it('does NOT backfill when the edge already exists (already_following)', async () => {
+    dbMock._selectQueue.push([{ id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }])
+
+    const result = await createOrReusePendingFriendshipRequest({
+      inviterUserId: FOLLOWER,
+      inviteeUserId: FOLLOWEE,
+    })
+
+    expect(result.state).toBe('already_following')
+    expect(backfillMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('acceptPendingFriendshipRequest backfill', () => {
+  it('backfills the approver\'s (followee\'s) activity into the requester\'s (follower\'s) feed', async () => {
+    state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }
+
+    const edge = await acceptPendingFriendshipRequest({ friendshipId: 'edge-1', userId: FOLLOWEE })
+
+    expect(edge).not.toBeNull()
+    expect(backfillMock).toHaveBeenCalledTimes(1)
+    expect(backfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWEE, recipientUserId: FOLLOWER })
+  })
+
+  it('does NOT backfill when there is no matching pending edge to approve', async () => {
+    state.updateReturnsEdge = false
+
+    const edge = await acceptPendingFriendshipRequest({ friendshipId: 'missing', userId: FOLLOWEE })
+
+    expect(edge).toBeNull()
+    expect(backfillMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -2,6 +2,7 @@ import { and, eq } from 'drizzle-orm'
 
 import { writeActivity } from '@/server/activity/write-activity'
 import { db, follows, users } from '@/server/db'
+import { backfillFollowedUserFeedItems } from '@/server/feed/backfill-inviter-feed'
 
 export type Follow = typeof follows.$inferSelect
 
@@ -100,6 +101,18 @@ export async function createOrReusePendingFriendshipRequest({
     referenceType: 'follow',
   })
 
+  // Friend-add backfill: a freshly approved follow seeds the follower's feed
+  // with the followee's recent activity (what would have propagated had the edge
+  // already existed). Only the auto-approved (public-target) branch creates an
+  // approved edge here; the pending branch backfills on approval instead. The
+  // backfill is best-effort internally — it cannot throw.
+  if (autoApprove) {
+    await backfillFollowedUserFeedItems({
+      answererUserId: followeeId,
+      recipientUserId: followerId,
+    })
+  }
+
   return { friendship: edge, state: autoApprove ? 'auto_approved' : 'created' }
 }
 
@@ -136,6 +149,15 @@ export async function acceptPendingFriendshipRequest({
     actorUserId: userId,
     referenceId: edge.id,
     referenceType: 'follow',
+  })
+
+  // Friend-add backfill: now that the request is approved, seed the requester's
+  // (follower's) feed with the approver's (followee's) recent activity — what
+  // would have propagated had the follow edge existed when they answered.
+  // Best-effort internally — it cannot throw, so it can't affect the approval.
+  await backfillFollowedUserFeedItems({
+    answererUserId: edge.followeeId,
+    recipientUserId: edge.followerId,
   })
 
   return edge


### PR DESCRIPTION
Adding a friend now seeds the follower's feed with the followee's most
recent correct daily/catchup answers — the same mechanism the invite
auto-friendship already used (B-HomeSeed-1), now extended to organic
follows. Previously only invitation acceptance backfilled; a normal
friend-add showed nothing until the new friend next answered.

- Generalize backfillInviterFeedItems into backfillFollowedUserFeedItems
  ({ answererUserId, recipientUserId }); keep backfillInviterFeedItems as
  a thin alias so the invite call sites and their tests are untouched.
- Wire the backfill into both approved-edge paths in friendships.ts:
  auto-approved (public target) follows, and pending requests on approval.
  Direction: answerer = followee (the friend), recipient = follower (me),
  matching the via-answerers follow gate. Best-effort — cannot throw.
- Honesty preserved: rows reconstruct exactly what forward propagation
  would have written had the follow edge existed when they answered
  (same source_type, attribution, and true answer time). Surfaces as
  Lately milestones in the unified home feed, like the invite seed.
- Tests: generic friend-add backfill entry point, plus a friendships
  wiring test locking the follow-direction mapping for both paths.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NFaoAwWhTAVu6tRFPwZagf