### PR TITLE
Allow editing a pending friend invitation before it is accepted

### DIFF
--- a/src/app/api/friend-invitations/__tests__/route.test.ts
+++ b/src/app/api/friend-invitations/__tests__/route.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 const {
   cancelFriendInvitationMock,
   createFriendInvitationMock,
+  updateFriendInvitationMock,
+  getPendingInvitationForPhoneMock,
   dbMock,
   getSessionMock,
   sendSmsMock,
@@ -54,6 +56,8 @@ const {
   return {
     cancelFriendInvitationMock: vi.fn(),
     createFriendInvitationMock: vi.fn(),
+    updateFriendInvitationMock: vi.fn(),
+    getPendingInvitationForPhoneMock: vi.fn(),
     dbMock,
     getSessionMock: vi.fn(),
     sendSmsMock: vi.fn(),
@@ -105,6 +109,8 @@ vi.mock('@/server/db', () => ({
 vi.mock('@/server/friends/invitations', () => ({
   cancelFriendInvitation: cancelFriendInvitationMock,
   createFriendInvitation: createFriendInvitationMock,
+  updateFriendInvitation: updateFriendInvitationMock,
+  getPendingInvitationForPhone: getPendingInvitationForPhoneMock,
   listOutgoingFriendInvitations: vi.fn(async () => []),
 }))
 
@@ -113,6 +119,7 @@ vi.mock('@/server/sms', () => ({
 }))
 
 import {
+  PATCH,
   POST,
   buildFriendInvitationMessage,
   validateCreateFriendInvitationBody,
@@ -562,5 +569,184 @@ describe('friend invitation validation and message QA contract', () => {
         error: 'too_many_suggested_interests',
       })
     )
+  })
+})
+
+describe('PATCH /api/friend-invitations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resetFriendInvitationRateLimitForTests()
+    getSessionMock.mockResolvedValue({ userId: 'user-inviter' })
+    state.existingUser = null
+    state.updateValues = undefined
+    getPendingInvitationForPhoneMock.mockResolvedValue(null)
+    process.env.NEXT_PUBLIC_APP_URL = 'https://joshing.example'
+  })
+
+  function patchRequest(body: unknown) {
+    return new Request('https://joshing.example/api/friend-invitations', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+  }
+
+  it('edits a pending invite phone, name, and interests and rebuilds the message', async () => {
+    updateFriendInvitationMock.mockResolvedValueOnce({
+      id: 'inv-1',
+      token: 'token-1',
+      inviteeDisplayName: 'Dad',
+      inviteePhone: '+17345559999',
+      personalMessage: null,
+      expiresAt,
+    })
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: ' Dad ',
+        phone: '(734) 555-9999',
+        suggestedInterests: [' Sondheim '],
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(updateFriendInvitationMock).toHaveBeenCalledWith({
+      invitationId: 'inv-1',
+      inviterUserId: 'user-inviter',
+      inviteePhone: '+17345559999',
+      inviteeDisplayName: 'Dad',
+      preSeededInterests: ['Sondheim'],
+    })
+    expect(body).toEqual(
+      expect.objectContaining({
+        id: 'inv-1',
+        invitationId: 'inv-1',
+        inviteUrl: 'https://joshing.example/invite/token-1',
+        inviteePhone: '+17345559999',
+        inviteeDisplayName: 'Dad',
+        suggestedInterests: ['Sondheim'],
+      })
+    )
+    expect(body.message).toBe(
+      'Hey — I thought you’d like this corner of Joshing. I added a few ideas that made me think of you — Sondheim. Keep, edit, or ignore them. No app to download — just tap this: https://joshing.example/invite/token-1'
+    )
+  })
+
+  it('rejects editing toward a number already on Joshing', async () => {
+    state.existingUser = { id: 'user-other' }
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '7345559999',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('already_on_joshing')
+    expect(updateFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects editing toward the inviter’s own number', async () => {
+    state.existingUser = { id: 'user-inviter' }
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '7345559999',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('self_invite')
+    expect(updateFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects collapsing onto a different existing pending note for the same number', async () => {
+    getPendingInvitationForPhoneMock.mockResolvedValueOnce({ id: 'inv-other' })
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '7345559999',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(409)
+    expect(body.error).toBe('duplicate_pending')
+    expect(updateFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('allows editing when the only pending note for that number is the one being edited', async () => {
+    getPendingInvitationForPhoneMock.mockResolvedValueOnce({ id: 'inv-1' })
+    updateFriendInvitationMock.mockResolvedValueOnce({
+      id: 'inv-1',
+      token: 'token-1',
+      inviteeDisplayName: 'Dad',
+      inviteePhone: '+17345559999',
+      personalMessage: null,
+      expiresAt,
+    })
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '7345559999',
+      })
+    )
+
+    expect(response.status).toBe(200)
+    expect(updateFriendInvitationMock).toHaveBeenCalled()
+  })
+
+  it('returns 404 when the invite is no longer pending', async () => {
+    updateFriendInvitationMock.mockResolvedValueOnce(null)
+
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '7345559999',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(404)
+    expect(body.error).toBe('not_found')
+  })
+
+  it('rejects a missing invitationId', async () => {
+    const response = await PATCH(
+      patchRequest({ inviteeDisplayName: 'Dad', phone: '7345559999' })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('missing_invitation_id')
+    expect(updateFriendInvitationMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an invalid phone before touching the database', async () => {
+    const response = await PATCH(
+      patchRequest({
+        invitationId: 'inv-1',
+        inviteeDisplayName: 'Dad',
+        phone: '123',
+      })
+    )
+    const body = await response.json()
+
+    expect(response.status).toBe(400)
+    expect(body.error).toBe('invalid_phone')
+    expect(updateFriendInvitationMock).not.toHaveBeenCalled()
   })
 })

--- a/src/app/api/friend-invitations/route.ts
+++ b/src/app/api/friend-invitations/route.ts
@@ -8,7 +8,9 @@ import {
   cancelFriendInvitation,
   createFriendInvitation,
   deleteFriendInvitation,
+  getPendingInvitationForPhone,
   listOutgoingFriendInvitations,
+  updateFriendInvitation,
   type OutgoingFriendInvitation,
 } from '@/server/friends/invitations'
 import { createOrReusePendingFriendshipRequest } from '@/server/friends/friendships'
@@ -486,6 +488,134 @@ export async function DELETE(request: Request) {
     console.error('[friend-invitations] cancel failed', error)
     return NextResponse.json(
       { error: 'server_error', message: 'Unable to cancel friend invitation.' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function PATCH(request: Request) {
+  const session = await getSession()
+  if (!session)
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const rawBody = (await request.json().catch(() => null)) as Record<
+    string,
+    unknown
+  > | null
+  const invitationId =
+    typeof rawBody?.invitationId === 'string' ? rawBody.invitationId.trim() : ''
+
+  if (!invitationId) {
+    return NextResponse.json(
+      { error: 'missing_invitation_id', message: 'invitationId is required.' },
+      { status: 400 }
+    )
+  }
+
+  const parsed = validateCreateFriendInvitationBody(rawBody)
+  if (!parsed.ok) {
+    return NextResponse.json(
+      { error: parsed.error, message: parsed.message },
+      { status: parsed.status }
+    )
+  }
+
+  try {
+    const { inviteeDisplayName, phone, suggestedInterests } = parsed.value
+
+    // Editing toward a number that already belongs to a Joshing account isn't
+    // an SMS invite anymore — it'd need to become a follow request. Keep edit
+    // semantics simple: send them back through the add-friend flow instead.
+    const existingUser = await getUserByPhone(phone)
+    if (existingUser) {
+      if (existingUser.id === session.userId) {
+        return NextResponse.json(
+          { error: 'self_invite', message: 'You cannot invite yourself.' },
+          { status: 400 }
+        )
+      }
+
+      return NextResponse.json(
+        {
+          error: 'already_on_joshing',
+          message:
+            'That number already belongs to someone on Joshing. Set this note aside and send them a friend request instead.',
+        },
+        { status: 409 }
+      )
+    }
+
+    // Guard against collapsing two pending notes onto the same number: if the
+    // inviter already has a different pending invitation for the new phone,
+    // editing this one to match would leave two live links for one person.
+    const conflicting = await getPendingInvitationForPhone({
+      inviterUserId: session.userId,
+      inviteePhone: phone,
+    })
+    if (conflicting && conflicting.id !== invitationId) {
+      return NextResponse.json(
+        {
+          error: 'duplicate_pending',
+          message: 'You already have a pending note out to that number.',
+        },
+        { status: 409 }
+      )
+    }
+
+    const invitation = await updateFriendInvitation({
+      invitationId,
+      inviterUserId: session.userId,
+      inviteePhone: phone,
+      inviteeDisplayName,
+      preSeededInterests: suggestedInterests,
+    })
+
+    if (!invitation) {
+      return NextResponse.json(
+        {
+          error: 'not_found',
+          message:
+            'This note can no longer be edited — it may have been accepted, set aside, or expired.',
+        },
+        { status: 404 }
+      )
+    }
+
+    const inviteUrl = `${getBaseUrl(request)}/invite/${invitation.token}`
+    const message = buildFriendInvitationMessage({
+      inviteUrl,
+      suggestedInterests,
+    })
+
+    if (invitation.personalMessage !== message) {
+      await db
+        .update(friendInvitations)
+        .set({ personalMessage: message })
+        .where(eq(friendInvitations.id, invitation.id))
+    }
+
+    logTelemetry('add_friend_invite_edited', {
+      inviter_user_id: session.userId,
+      invitation_id: invitation.id,
+      suggested_interest_count: suggestedInterests.length,
+    })
+
+    return NextResponse.json({
+      ok: true,
+      type: 'friend_invitation',
+      id: invitation.id,
+      invitationId: invitation.id,
+      inviteUrl,
+      message,
+      inviteeDisplayName: invitation.inviteeDisplayName ?? inviteeDisplayName,
+      inviteePhone: invitation.inviteePhone,
+      suggestedInterests,
+      expiresAt: invitation.expiresAt.toISOString(),
+    })
+  } catch (error) {
+    console.error('[friend-invitations] edit failed', error)
+    return NextResponse.json(
+      { error: 'server_error', message: 'Unable to edit friend invitation.' },
       { status: 500 }
     )
   }

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -4,6 +4,19 @@ import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
 import { Chip } from '@/components/ui/Chip'
+import { formatUsPhoneInput } from '@/lib/phone-e164'
+
+const EDIT_ERROR_COPY: Record<string, string> = {
+  invalid_phone: 'Use a US mobile number.',
+  too_many_suggested_interests: 'Choose up to three ideas.',
+  missing_invitee_display_name: 'Add their name first.',
+  invalid_invitee_display_name: 'Use a shorter, real display name.',
+  invalid_suggested_interests: 'Keep each idea short and friendly.',
+  already_on_joshing:
+    'That number already belongs to someone on Joshing. Set this note aside and send them a friend request instead.',
+  duplicate_pending: 'You already have a pending note out to that number.',
+  self_invite: 'You cannot invite yourself.',
+}
 
 type InviteStatus = 'pending' | 'accepted' | 'expired' | 'cancelled'
 
@@ -79,6 +92,12 @@ export default function PeopleYouInvited() {
   const [copyingId, setCopyingId] = useState<string | null>(null)
   const [cancellingId, setCancellingId] = useState<string | null>(null)
   const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [editingId, setEditingId] = useState<string | null>(null)
+  const [editName, setEditName] = useState('')
+  const [editPhone, setEditPhone] = useState('')
+  const [editInterests, setEditInterests] = useState<string[]>(['', '', ''])
+  const [savingEdit, setSavingEdit] = useState(false)
+  const [editError, setEditError] = useState<string | null>(null)
 
   const loadInvites = useCallback(async () => {
     setError(null)
@@ -193,6 +212,75 @@ export default function PeopleYouInvited() {
     }
   }
 
+  function startEdit(invite: OutgoingInvite) {
+    setEditingId(invite.id)
+    setEditName(invite.inviteeDisplayName)
+    setEditPhone(formatUsPhoneInput(invite.inviteePhoneForActions ?? ''))
+    setEditInterests([
+      invite.suggestedInterests[0] ?? '',
+      invite.suggestedInterests[1] ?? '',
+      invite.suggestedInterests[2] ?? '',
+    ])
+    setEditError(null)
+  }
+
+  function cancelEdit() {
+    setEditingId(null)
+    setEditError(null)
+    setSavingEdit(false)
+  }
+
+  async function saveEdit(invite: OutgoingInvite) {
+    const trimmedName = editName.trim()
+    if (!trimmedName) {
+      setEditError(EDIT_ERROR_COPY.missing_invitee_display_name)
+      return
+    }
+
+    const suggestedInterests = editInterests
+      .map((interest) => interest.trim())
+      .filter(Boolean)
+
+    setSavingEdit(true)
+    setEditError(null)
+
+    try {
+      const response = await fetch('/api/friend-invitations', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          invitationId: invite.id,
+          inviteeDisplayName: trimmedName,
+          phone: editPhone,
+          suggestedInterests,
+        }),
+      })
+      const body = (await response.json().catch(() => null)) as {
+        error?: string
+        message?: string
+      } | null
+
+      if (!response.ok) {
+        const apiError = body?.error
+        throw new Error(
+          (apiError && EDIT_ERROR_COPY[apiError]) ??
+            body?.message ??
+            'Could not save your changes.'
+        )
+      }
+
+      setEditingId(null)
+      await loadInvites()
+    } catch (caught) {
+      setEditError(
+        caught instanceof Error ? caught.message : 'Could not save your changes.'
+      )
+    } finally {
+      setSavingEdit(false)
+    }
+  }
+
   function createNewInvite(invite: OutgoingInvite) {
     window.dispatchEvent(
       new CustomEvent('friend-invitations:create-new', {
@@ -260,6 +348,93 @@ export default function PeopleYouInvited() {
                   header
                 )}
 
+                {editingId === invite.id ? (
+                  <form
+                    className="mt-3 space-y-3"
+                    onSubmit={(event) => {
+                      event.preventDefault()
+                      void saveEdit(invite)
+                    }}
+                  >
+                    <label className="text-foreground block text-sm font-medium">
+                      Name
+                      <input
+                        className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] mt-1 h-11 w-full rounded-xl border border-[var(--accent-gold)] px-3 text-base transition outline-none"
+                        value={editName}
+                        onChange={(event) => {
+                          setEditName(event.target.value)
+                          setEditError(null)
+                        }}
+                        autoComplete="name"
+                        maxLength={60}
+                        placeholder="Their name"
+                      />
+                    </label>
+                    <label className="text-foreground block text-sm font-medium">
+                      Phone number
+                      <input
+                        className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] mt-1 h-11 w-full rounded-xl border border-[var(--accent-gold)] px-3 text-base transition outline-none"
+                        value={editPhone}
+                        onChange={(event) => {
+                          setEditPhone(formatUsPhoneInput(event.target.value))
+                          setEditError(null)
+                        }}
+                        autoComplete="tel"
+                        inputMode="tel"
+                        maxLength={14}
+                        placeholder="(555) 123-4567"
+                      />
+                    </label>
+                    <div className="space-y-2">
+                      <span className="text-foreground block text-sm font-medium">
+                        Ideas (up to three)
+                      </span>
+                      {editInterests.map((interest, index) => (
+                        <input
+                          key={index}
+                          className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] h-11 w-full rounded-full border border-[var(--accent-gold)] px-4 text-base transition outline-none"
+                          value={interest}
+                          onChange={(event) => {
+                            const next = event.target.value
+                            setEditInterests((current) =>
+                              current.map((value, i) =>
+                                i === index ? next : value
+                              )
+                            )
+                            setEditError(null)
+                          }}
+                          maxLength={60}
+                          placeholder={`Idea ${index + 1}`}
+                        />
+                      ))}
+                    </div>
+
+                    {editError ? (
+                      <p className="text-destructive text-sm font-medium">
+                        {editError}
+                      </p>
+                    ) : null}
+
+                    <div className="flex gap-3">
+                      <button
+                        type="submit"
+                        className="btn-primary flex-1"
+                        disabled={savingEdit}
+                      >
+                        {savingEdit ? 'Saving…' : 'Save changes'}
+                      </button>
+                      <button
+                        type="button"
+                        className="btn-ghost flex-1"
+                        onClick={cancelEdit}
+                        disabled={savingEdit}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </form>
+                ) : (
+                  <>
                 {invite.suggestedInterests.length > 0 ? (
                   <div className="mt-3 flex flex-wrap gap-2">
                     {invite.suggestedInterests.map((interest) => (
@@ -335,6 +510,13 @@ export default function PeopleYouInvited() {
                       <button
                         type="button"
                         className="text-muted-foreground text-sm"
+                        onClick={() => startEdit(invite)}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="text-muted-foreground text-sm"
                         onClick={() => cancelInvite(invite)}
                         disabled={cancellingId === invite.id}
                       >
@@ -345,6 +527,8 @@ export default function PeopleYouInvited() {
                     </div>
                   </div>
                 ) : null}
+                  </>
+                )}
               </article>
             )
           })}

--- a/src/server/friends/__tests__/invitations.test.ts
+++ b/src/server/friends/__tests__/invitations.test.ts
@@ -174,6 +174,7 @@ import {
   getInvitationByToken,
   getInvitePrefillByToken,
   getPendingInvitationForPhone,
+  updateFriendInvitation,
 } from '@/server/friends/invitations'
 import { parsePreSeededInterests } from '@/server/db/queries/users'
 
@@ -559,6 +560,35 @@ describe('friend invitation helpers', () => {
       expect.objectContaining({
         id: 'inv-1',
         inviteeDisplayName: null,
+      })
+    )
+  })
+
+  it('edits a pending invitation in place, normalizing name and preserving the token', async () => {
+    setInvitation({ token: 'keep-this-token' })
+
+    const updated = await updateFriendInvitation({
+      invitationId: 'inv-1',
+      inviterUserId: 'user-inviter',
+      inviteePhone: '+17345559999',
+      inviteeDisplayName: '  Dad  Palay ',
+      preSeededInterests: [{ label: 'Sondheim' }],
+      now,
+    })
+
+    expect(updated).toEqual(
+      expect.objectContaining({
+        id: 'inv-1',
+        token: 'keep-this-token',
+        inviteePhone: '+17345559999',
+        inviteeDisplayName: 'Dad Palay',
+        preSeededInterests: [{ label: 'Sondheim' }],
+      })
+    )
+    expect(state.updateValues).toEqual(
+      expect.objectContaining({
+        inviteePhone: '+17345559999',
+        inviteeDisplayName: 'Dad Palay',
       })
     )
   })

--- a/src/server/friends/invitations.ts
+++ b/src/server/friends/invitations.ts
@@ -455,6 +455,64 @@ export async function listOutgoingFriendInvitations({
   }))
 }
 
+export type UpdateFriendInvitationInput = {
+  invitationId: string
+  inviterUserId: string
+  inviteePhone: string
+  inviteeDisplayName: string
+  preSeededInterests?: unknown
+  personalMessage?: string | null
+  now?: Date
+}
+
+/**
+ * Edit a still-pending outgoing invitation in place (B-Friends edit-before-click).
+ * Only the inviter who created it may edit, and only while it is genuinely
+ * pending — not accepted, not cancelled, not expired. The token (and therefore
+ * the share link) is intentionally preserved so a link the inviter has already
+ * copied but not yet sent stays valid; acceptance still gates on the (possibly
+ * corrected) `inviteePhone`. Returns null when no row matched the pending guard.
+ */
+export async function updateFriendInvitation({
+  invitationId,
+  inviterUserId,
+  inviteePhone,
+  inviteeDisplayName,
+  preSeededInterests = null,
+  personalMessage = null,
+  now = new Date(),
+}: UpdateFriendInvitationInput): Promise<FriendInvitation | null> {
+  const normalizedInviteePhone = normalizeRequiredText(
+    inviteePhone,
+    'inviteePhone'
+  )
+  const normalizedInviteeDisplayName = normalizeRequiredText(
+    inviteeDisplayName,
+    'inviteeDisplayName'
+  )
+
+  const [invitation] = await db
+    .update(friendInvitations)
+    .set({
+      inviteePhone: normalizedInviteePhone,
+      inviteeDisplayName: normalizedInviteeDisplayName,
+      preSeededInterests,
+      personalMessage,
+    })
+    .where(
+      and(
+        eq(friendInvitations.id, invitationId),
+        eq(friendInvitations.inviterUserId, inviterUserId),
+        isNull(friendInvitations.acceptedAt),
+        isNull(friendInvitations.cancelledAt),
+        gt(friendInvitations.expiresAt, now)
+      )
+    )
+    .returning()
+
+  return invitation ?? null
+}
+
 export async function cancelFriendInvitation({
   invitationId,
   inviterUserId,

--- a/src/server/telemetry.ts
+++ b/src/server/telemetry.ts
@@ -5,6 +5,7 @@ export type TelemetryEventName =
   | 'add_friend_invite_created'
   | 'add_friend_invite_cancelled'
   | 'add_friend_invite_deleted'
+  | 'add_friend_invite_edited'
   | 'add_friend_invite_rate_limited'
   | 'add_friend_message_copied'
   | 'add_friend_sms_handoff_opened'


### PR DESCRIPTION
When someone fat-fingers an invitee's phone number there was no way to
fix it — the only options were "set aside" (cancel) or send a fresh note.
This adds in-place editing of a still-pending invitation's phone number,
display name, and suggested ideas.

- PATCH /api/friend-invitations: edit phone/name/interests while the
  invite is pending (not accepted, cancelled, or expired). Reuses the
  create-body validation, rebuilds the share message, and preserves the
  token so an already-copied (but unsent) link stays valid.
- Guards: refuses to edit toward a number that already belongs to a
  Joshing account (409 already_on_joshing) or the inviter's own number
  (400 self_invite), and refuses to collapse onto a different existing
  pending note for the same number (409 duplicate_pending).
- updateFriendInvitation() server helper, scoped to the inviter and the
  pending guard so a raced acceptance can't be overwritten.
- PeopleYouInvited: inline "Edit" affordance on pending notes.
- Tests for the route and the helper.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SdkEN5WxjVJheugSmN34Kk