### PR TITLE
Raise alternate-answer cap from 5 to 6 (allow seven accepted answers)

### DIFF
--- a/src/app/api/questions/[id]/route.ts
+++ b/src/app/api/questions/[id]/route.ts
@@ -14,6 +14,7 @@ import {
   updateQuestion,
 } from '@/server/db/queries/questions';
 import { resolveActiveIncorrectReportsForQuestion } from '@/server/db/queries/content-reports';
+import { MAX_ALTERNATE_ANSWERS } from '@/lib/questions-types';
 
 type RouteContext = {
   params: Promise<{ id: string }>;
@@ -56,7 +57,7 @@ const patchSchema = z.object({
   text: z.string().transform((s) => s.trim()).pipe(z.string().min(1).max(300)).optional(),
   correctAnswer: z.string().transform((s) => s.trim()).pipe(z.string().min(1).max(200)).optional(),
   alternateAnswers: z
-    .preprocess((v) => (v === undefined ? undefined : splitAlternates(v) ?? []), z.array(z.string().max(200)).max(5))
+    .preprocess((v) => (v === undefined ? undefined : splitAlternates(v) ?? []), z.array(z.string().max(200)).max(MAX_ALTERNATE_ANSWERS))
     .optional(),
   explanation: z.string().catch('').transform((s) => s.trim()).pipe(z.string().max(500)).optional(),
 });

--- a/src/components/QuestionForm.tsx
+++ b/src/components/QuestionForm.tsx
@@ -2,6 +2,7 @@
 
 import { Search, X } from 'lucide-react';
 import { useEffect, useMemo, useReducer, useRef, useState } from 'react';
+import { MAX_ALTERNATE_ANSWERS } from '@/lib/questions-types';
 
 export type QuestionFormValues = {
   text: string;
@@ -202,7 +203,7 @@ function reducer(state: State, action: Action): State {
 }
 
 function alternateAnswersFrom(text: string): string[] {
-  return text.split(',').map((answer) => answer.trim()).filter(Boolean).slice(0, 5);
+  return text.split(',').map((answer) => answer.trim()).filter(Boolean).slice(0, MAX_ALTERNATE_ANSWERS);
 }
 
 // Small inline loader shown while the LLM suggestion is being fetched, so the
@@ -243,7 +244,7 @@ function validate(state: State): string | null {
   if (state.questionText.trim().length > 300) return 'Question text must be 300 characters or fewer.';
   if (!state.userAnswer.trim()) return 'Correct answer is required.';
   if (state.userAnswer.trim().length > 200) return 'Correct answer must be 200 characters or fewer.';
-  if (alternateAnswers.length > 5) return 'Use at most 5 alternate answers.';
+  if (alternateAnswers.length > MAX_ALTERNATE_ANSWERS) return `Use at most ${MAX_ALTERNATE_ANSWERS} alternate answers.`;
   if (alternateAnswers.some((answer) => answer.length > 200)) return 'Alternate answers must be 200 characters or fewer.';
   if (state.explanation.length > 500) return 'Explanation must be 500 characters or fewer.';
   if (state.creatorNote.length > 200) return 'Between us text must be 200 characters or fewer.';
@@ -661,7 +662,7 @@ export function QuestionForm({
           <div>
             <label htmlFor="alternate-answers" className="mb-1 block text-xs uppercase tracking-[0.1em] text-muted-foreground">Alternate answers</label>
             <input id="alternate-answers" value={state.alternateText} onChange={(event) => dispatch({ type: 'FIELD', field: 'alternateText', value: event.target.value })} readOnly={state.stage === 'SUBMITTING'} className="w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-3 py-2 outline-none focus:border-[var(--brand-navy)]" placeholder="Accepted variations, separated by commas" />
-            <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/5 alternates</p>
+            <p className="mt-1 text-xs text-muted-foreground">{alternateAnswers.length}/{MAX_ALTERNATE_ANSWERS} alternates</p>
           </div>
 
           {/* The explanation is written by Joshing's answer suggestion and is

--- a/src/lib/questions-types.ts
+++ b/src/lib/questions-types.ts
@@ -183,6 +183,14 @@ export const CATEGORIES = [
 
 export const VISIBILITIES = ['private', 'public'] as const;
 
+// Maximum number of accepted alternate answers an author may supply. Combined
+// with the single correct answer this is the count of acceptable answers a
+// question can carry — e.g. a "name one of the seven heavenly virtues" question
+// needs all seven accepted, i.e. 1 correct + 6 alternates. Enforced on the
+// author form, the create payload parser, and the PATCH edit schema; keep those
+// in lockstep via this constant.
+export const MAX_ALTERNATE_ANSWERS = 6;
+
 export const QUESTION_TYPES = ['factual', 'personal', 'ambiguous', 'factual_uncertain'] as const;
 
 export const ANSWER_SOURCES = ['llm_suggested', 'creator_written', 'llm_edited'] as const;

--- a/src/server/questions/create-payload.ts
+++ b/src/server/questions/create-payload.ts
@@ -1,4 +1,5 @@
 import { questionContainsAnswer } from '@/server/questions/self-answering';
+import { MAX_ALTERNATE_ANSWERS } from '@/lib/questions-types';
 
 function readBoolean(value: unknown): boolean {
   if (value === true) return true;
@@ -33,7 +34,7 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
     : typeof body?.answer_text === 'string'
       ? body.answer_text.trim()
       : '';
-  const alternateAnswers = splitAlternates(body?.alternateAnswers ?? body?.accepted_alternatives).slice(0, 5);
+  const alternateAnswers = splitAlternates(body?.alternateAnswers ?? body?.accepted_alternatives).slice(0, MAX_ALTERNATE_ANSWERS);
   const explanation = typeof body?.explanation === 'string'
     ? body.explanation.trim() || null
     : null;
@@ -70,7 +71,7 @@ export function readCreateQuestionPayload(body: Record<string, unknown> | null) 
   }
   if (!text || text.length > 300) errors.push('text');
   if (!correctAnswer || correctAnswer.length > 200) errors.push('correctAnswer');
-  if (alternateAnswers.length > 5 || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
+  if (alternateAnswers.length > MAX_ALTERNATE_ANSWERS || alternateAnswers.some((answer) => answer.length > 200)) errors.push('alternateAnswers');
   if (explanation && explanation.length > 500) errors.push('explanation');
   if (creatorNote && creatorNote.length > 200) errors.push('creatorNote');
   if (verified === null) errors.push('verified');


### PR DESCRIPTION
Questions like "name one of the seven heavenly virtues" need all seven
answers accepted: one correct answer plus six alternates. The cap of five
alternates only allowed six total options. Bump the limit to six and route
the author form, create-payload parser, and PATCH edit schema through a
single shared MAX_ALTERNATE_ANSWERS constant so they stay in lockstep.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HN7jpgAFD72Upfdh64oDLX