### PR TITLE
perf(measure): emit queryable [perf] logs across all §12.6 surfaces (B-PERF-04)

### DIFF
--- a/_docs/PERF-FINDINGS-01.md
+++ b/_docs/PERF-FINDINGS-01.md
@@ -143,6 +143,10 @@ Each item is independently shippable and leaves the codebase working.
 ### Structural (code / platform, days)
 
 - **B-PERF-04 — Stand up real load-time measurement (prerequisite for *enforcing* §12.6).** *(config + light code)* Enable Vercel Speed Insights / Web Analytics for field Core Web Vitals, and add structured per-route server timing logs (the `Server-Timing` proxy header already exists — extend to key routes / wire RUM). Without this, §0 stays true and every later perf claim is a guess. This is the real "Phase 1" the prompt wanted; it just has to be built before it can be run.
+  - **Status (2026-06-20): DONE (code side).** Both halves are now in place — see §6 for the query recipe.
+    - *Field RUM:* `<SpeedInsights/>` + `<Analytics/>` render in `src/app/layout.tsx` (Core Web Vitals + page views, beacon-only).
+    - *Server timing logs:* every §12.6 surface now emits one grep-able `[perf] { route, …_ms, … }` line to the Vercel function logs (the `Server-Timing` *header* only reaches the browser Network panel and never appears in logs, so it could not back a p50/p95 table on its own). Helpers live in `src/server/lib/server-timing.ts` (`logServerTiming`, `timeServerWork`). Covered routes/surfaces: `feed`, `daily/queue` (GET **and** the previously-untimed synchronous-build POST long pole), `knowledge`, `daily/answer`, and the home RSC (`home/todays-five`, `home/from-friends`).
+    - *Still config-only (not code):* confirm a real production `[perf]` line once a deploy is promoted (§0 — no production traffic has been logged yet), and optionally wire a Vercel log drain to compute the percentiles automatically.
 - **B-PERF-05 — (post-launch) Trim the boot-guard chain itself.** *(code, structural)* Even with `SKIP_BOOT_DB_GUARDS=1`, preview/dev cold starts pay the full ~70-round-trip chain. Gate the guard block behind a cheap schema-version / fingerprint check so it short-circuits when the DB is already current, instead of re-issuing every `IF NOT EXISTS` each boot. Defer until after launch; touches the most safety-critical file in the repo (read the `instrumentation.ts` header + `CLAUDE.md` migration rules first).
 - **B-PERF-06 — (conditional) Resolve the daily-page fetch waterfall.** *(code)* Only if the daily-page-load target is missed once B-PERF-04 is live: move the existing-queue read server-side (RSC) or prefetch it, so the page doesn't shell→hydrate→fetch. Skip if measurement shows it already clears 2s/4G.
 
@@ -161,6 +165,36 @@ Each item is independently shippable and leaves the codebase working.
 | **Housekeeping** | B-PERF-07 | post-traffic only |
 
 **Sequence:** 01 → 02 → 03 (cheap, immediate), then **04 early** (so 05/06 can be judged on data instead of guessed), then 05/06/07 as measurement dictates.
+
+## 6. Building the §12.6 p50/p95 table from `[perf]` logs (B-PERF-04)
+
+The §0 baseline table can be filled in once a production deploy is promoted and traffic flows. Each instrumented surface emits a single structured line per request:
+
+```
+[perf] { route: "feed", feed_ms: 12, filter: "all", items: 20 }
+[perf] { route: "daily/queue", queue_ms: 11 }
+[perf] { route: "daily/queue:POST", build_ms: 8421, total_ms: 8460, outcome: "built" }
+[perf] { route: "knowledge", knowledge_ms: 19 }
+[perf] { route: "daily/answer", grade_ms: 38, total_ms: 71, cold: false }
+[perf] { route: "home/todays-five", todays_five_ms: 14 }
+[perf] { route: "home/from-friends", home_edition_ms: 22 }
+```
+
+**Span key:** the per-route span is `<name>_ms`; `total_ms` (where present) is end-to-end. The `_ms` suffix matches the older `[daily/answer timings]` line, which is kept for its richer cold/load/persist/mastery breakdown — `[perf]` is the uniform tag for cross-route aggregation.
+
+**Route → §12.6 surface mapping:**
+
+| §12.6 surface | `[perf]` route(s) | Span to percentile-ise |
+|---|---|---|
+| Home screen load | `home/todays-five`, `home/from-friends` | `todays_five_ms`, `home_edition_ms` (server data fetch only; combine with Speed Insights LCP for true load) |
+| Daily Five reveal | `daily/queue` (warm read), `daily/queue:POST` (`outcome:"built"` = cold synchronous-LLM build) | `queue_ms`; `total_ms` for the build long pole |
+| Answer grading | `daily/answer` | `grade_ms` (split cold vs warm via the `cold` field) |
+| Feed load | `feed` | `feed_ms` |
+| Knowledge page load | `knowledge` | `knowledge_ms` |
+
+**To compute percentiles:** pull the function logs for the window (Vercel dashboard → Logs, or a configured log drain), filter to lines containing `[perf]`, group by `route`, and take p50/p95/p99 of the relevant `_ms` field. Field Core Web Vitals (LCP/INP/CLS/TTFB) come from the Speed Insights dashboard, route-attributed. Together these replace the "unmeasured" row in §0.
+
+---
 
 ## DO-NOT reminders honored
 - No code changed (diagnosis only).

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -20,7 +20,7 @@ import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/serve
 import { suggestAnswer } from '@/lib/llm';
 import { RECOVERY_STATE_WEIGHT } from '@/server/mastery/constants';
 import { selectInsideJokeForViewer } from '@/server/questions/inside-joke';
-import { createServerTiming } from '@/server/lib/server-timing';
+import { createServerTiming, logServerTiming } from '@/server/lib/server-timing';
 
 export const dynamic = 'force-dynamic';
 
@@ -62,14 +62,14 @@ function logStepTimings(marks: StepMarks) {
   }
 }
 
-// Build a Server-Timing header value from the step marks already captured on
-// the grading path (B-PERF-04). Reuses the same stamps logStepTimings reads —
+// Build a Server-Timing accumulator from the step marks already captured on the
+// grading path (B-PERF-04). Reuses the same stamps logStepTimings reads —
 // `grade` is the grader span (deterministic or LLM), `total` is end-to-end.
-function serverTimingFromMarks(marks: StepMarks): string {
+function serverTimingFromMarks(marks: StepMarks) {
   const timing = createServerTiming();
   if (marks.grade != null && marks.load != null) timing.add('grade', marks.grade - marks.load);
   timing.add('total', Date.now() - marks.start);
-  return timing.toHeader();
+  return timing;
 }
 
 type DailyAnswerErrorCode =
@@ -537,12 +537,17 @@ export async function POST(request: NextRequest) {
     // LLM is already split by the [daily/answer timings] log's cold/grade_ms)
     // and end-to-end total, derived from the marks already captured above — no
     // new timing work. Header-only; response body is unchanged.
-    response.headers.set('Server-Timing', serverTimingFromMarks(marks));
+    response.headers.set('Server-Timing', serverTimingFromMarks(marks).toHeader());
     return response;
   } catch (error) {
     console.error('[daily/answer] unexpected failure', error);
     return dailyAnswerErrorResponse(500, 'unexpected', 'Could not record that answer.');
   } finally {
     logStepTimings(marks);
+    // Uniform `[perf]` line (B-PERF-04) so a single log filter covers every
+    // §12.6 surface; the richer cold/persist/mastery breakdown stays in the
+    // `[daily/answer timings]` line above. Built from the same marks — `cold`
+    // included because grade latency is dominated by the first-request boot.
+    logServerTiming('daily/answer', serverTimingFromMarks(marks), { cold: marks.cold });
   }
 }

--- a/src/app/api/daily/queue/route.ts
+++ b/src/app/api/daily/queue/route.ts
@@ -6,7 +6,7 @@ import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { DailyQueueFillError, fillDailyQueueForUser } from '@/server/daily/queue-orchestrator';
 import { DAILY_QUEUE_MIN_SIZE, DAILY_QUEUE_SIZE, type QueueSlot } from '@/server/daily/types';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
-import { createServerTiming } from '@/server/lib/server-timing';
+import { createServerTiming, logServerTiming } from '@/server/lib/server-timing';
 
 export const dynamic = 'force-dynamic';
 // The POST path can fall through to synchronous LLM generation when the cron
@@ -95,6 +95,7 @@ export async function GET() {
   const withTiming = (response: NextResponse): NextResponse => {
     const timing = createServerTiming();
     timing.measure('queue', startedAt);
+    logServerTiming('daily/queue', timing);
     response.headers.set('Server-Timing', timing.toHeader());
     return response;
   };
@@ -135,6 +136,13 @@ export async function GET() {
 }
 
 export async function POST() {
+  // The POST path is the Daily Five reveal's worst case: when the cron hasn't
+  // pre-built today's queue it falls through to synchronous Sonnet generation
+  // (seconds), which the GET path never pays. Time the build span and the
+  // end-to-end total here (B-PERF-04) so this long pole is queryable in logs —
+  // the GET-only `Server-Timing` header never sees it.
+  const startedAt = Date.now();
+  const timing = createServerTiming();
   const userId = await requireUserId();
   if (!userId) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
@@ -142,6 +150,8 @@ export async function POST() {
     await fillDailyQueueForUser(userId);
   } catch (error) {
     if (error instanceof DailyQueueFillError) {
+      timing.measure('total', startedAt);
+      logServerTiming('daily/queue:POST', timing, { outcome: error.code });
       return NextResponse.json(
         { error: error.code, message: error.message },
         { status: error.code === 'no_knowledge_base' ? 409 : 503 },
@@ -149,6 +159,7 @@ export async function POST() {
     }
     throw error;
   }
+  timing.measure('build', startedAt);
 
   const [queue, prefs, totalQueues] = await Promise.all([
     getTodaysDailyQueue(userId),
@@ -157,8 +168,12 @@ export async function POST() {
   ]);
 
   if (!queue) {
+    timing.measure('total', startedAt);
+    logServerTiming('daily/queue:POST', timing, { outcome: 'queue_not_created' });
     return NextResponse.json({ error: 'queue_not_created' }, { status: 500 });
   }
 
+  timing.measure('total', startedAt);
+  logServerTiming('daily/queue:POST', timing, { outcome: 'built' });
   return NextResponse.json(serializeQueue(queue, prefs.difficulty, userId, totalQueues));
 }

--- a/src/app/api/feed/route.ts
+++ b/src/app/api/feed/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getSession } from '@/server/auth/session';
 import { type FeedCursor, type FeedFilter } from '@/server/db/queries/feed';
 import { decodeFeedCursor, getFeedPagePayload } from '@/server/feed/get-feed-page';
-import { createServerTiming } from '@/server/lib/server-timing';
+import { createServerTiming, logServerTiming } from '@/server/lib/server-timing';
 
 export const dynamic = 'force-dynamic';
 
@@ -67,6 +67,8 @@ export async function GET(request: NextRequest) {
         }
       : {}),
   });
+
+  logServerTiming('feed', timing, { filter: pagination.filter, items: payload.meta.page_item_count });
 
   const response = NextResponse.json(payload);
   response.headers.set('Server-Timing', timing.toHeader());

--- a/src/app/api/knowledge/route.ts
+++ b/src/app/api/knowledge/route.ts
@@ -7,7 +7,7 @@ import {
   loadKnowledgeInputs,
 } from '@/server/db/queries/knowledge';
 import { ensureAuthoredDomainsOpened } from '@/server/knowledge/open-domain';
-import { createServerTiming } from '@/server/lib/server-timing';
+import { createServerTiming, logServerTiming } from '@/server/lib/server-timing';
 
 export const dynamic = 'force-dynamic';
 
@@ -39,6 +39,7 @@ export async function GET() {
   ]);
   await ensureOpened;
   timing.measure('knowledge', startedAt);
+  logServerTiming('knowledge', timing);
 
   const response = NextResponse.json({ mastery, pageData });
   response.headers.set('Server-Timing', timing.toHeader());

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,7 @@ import { getBonusSlots } from '@/server/daily/bonus'
 import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/daily'
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
+import { timeServerWork } from '@/server/lib/server-timing'
 
 const FEED_PAGE_SIZE = 20
 
@@ -105,10 +106,12 @@ export default async function Home() {
 }
 
 async function TodaysFiveSection({ userId }: { userId: string }) {
-  const [queue, catchupItems] = await Promise.all([
-    getTodaysDailyQueue(userId),
-    getCatchupQuestions(userId),
-  ])
+  // Home is the #1 §12.6 surface (< 1.5s) but is a streamed RSC, so it can't
+  // set a Server-Timing header — log the server data-fetch span instead
+  // (B-PERF-04) so the home hot path is queryable alongside the API routes.
+  const [queue, catchupItems] = await timeServerWork('home/todays-five', 'todays_five', () =>
+    Promise.all([getTodaysDailyQueue(userId), getCatchupQuestions(userId)]),
+  )
 
   const status = buildDailyStatusSnapshot(queue)
 
@@ -153,7 +156,9 @@ async function FromYourFriendsSection({ userId }: { userId: string }) {
   // the overflow counts the question zones window against, the one rotating
   // panel, and the all-empty switch. FeedList renders this pre-budgeted edition
   // (no client-side selection, no infinite scroll, no temporal buckets).
-  const { edition, feedMeta } = await buildHomeEdition(userId)
+  const { edition, feedMeta } = await timeServerWork('home/from-friends', 'home_edition', () =>
+    buildHomeEdition(userId),
+  )
 
   // Seed FeedList with the served direct slice and the same meta the empty-state
   // copy / surface tabs read. has_more is false: the budget is the page; the

--- a/src/server/lib/__tests__/server-timing.test.ts
+++ b/src/server/lib/__tests__/server-timing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { createServerTiming } from '@/server/lib/server-timing';
+import { createServerTiming, logServerTiming, timeServerWork } from '@/server/lib/server-timing';
 
 describe('createServerTiming', () => {
   it('serializes a single span in the proxy-compatible format', () => {
@@ -35,5 +35,66 @@ describe('createServerTiming', () => {
 
   it('returns an empty string when no spans are recorded', () => {
     expect(createServerTiming().toHeader()).toBe('');
+  });
+
+  it('exposes spans as a `${name}_ms` metrics map for structured logging', () => {
+    const timing = createServerTiming();
+    timing.add('grade', 40);
+    timing.add('total', 95);
+    expect(timing.toMetrics()).toEqual({ grade_ms: 40, total_ms: 95 });
+  });
+
+  it('returns an empty metrics map when no spans are recorded', () => {
+    expect(createServerTiming().toMetrics()).toEqual({});
+  });
+});
+
+describe('logServerTiming', () => {
+  it('emits a single `[perf]` line with route, metrics, and extra fields', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const timing = createServerTiming();
+    timing.add('feed', 12);
+    logServerTiming('feed', timing, { filter: 'all', items: 20 });
+    expect(info).toHaveBeenCalledWith('[perf]', {
+      route: 'feed',
+      feed_ms: 12,
+      filter: 'all',
+      items: 20,
+    });
+    info.mockRestore();
+  });
+
+  it('never throws when logging fails (telemetry only)', () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {
+      throw new Error('log sink down');
+    });
+    expect(() => logServerTiming('feed', createServerTiming())).not.toThrow();
+    info.mockRestore();
+  });
+});
+
+describe('timeServerWork', () => {
+  it('returns the work result and emits one `[perf]` line for the span', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const result = await timeServerWork('home/todays-five', 'todays_five', async () => 'payload');
+    expect(result).toBe('payload');
+    expect(info).toHaveBeenCalledTimes(1);
+    const [tag, fields] = info.mock.calls[0];
+    expect(tag).toBe('[perf]');
+    expect(fields).toMatchObject({ route: 'home/todays-five' });
+    expect(fields).toHaveProperty('todays_five_ms');
+    info.mockRestore();
+  });
+
+  it('still logs the span and re-throws when work rejects', async () => {
+    const info = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const boom = new Error('query failed');
+    await expect(
+      timeServerWork('home/from-friends', 'home_edition', async () => {
+        throw boom;
+      }),
+    ).rejects.toBe(boom);
+    expect(info).toHaveBeenCalledWith('[perf]', expect.objectContaining({ route: 'home/from-friends' }));
+    info.mockRestore();
   });
 });

--- a/src/server/lib/server-timing.ts
+++ b/src/server/lib/server-timing.ts
@@ -24,6 +24,12 @@ export type ServerTiming = {
   add: (name: string, durationMs: number) => void;
   /** Serialize to a `Server-Timing` header value. Empty string when no spans recorded. */
   toHeader: () => string;
+  /**
+   * Span durations as a `${name}_ms` → ms map, for structured logging. The
+   * `_ms` suffix matches the `[daily/answer timings]` convention so every perf
+   * log reads uniformly (`{ feed_ms, total_ms, … }`).
+   */
+  toMetrics: () => Record<string, number>;
 };
 
 export function createServerTiming(): ServerTiming {
@@ -38,5 +44,55 @@ export function createServerTiming(): ServerTiming {
     toHeader() {
       return spans.map((s) => `${s.name};dur=${s.dur}`).join(', ');
     },
+    toMetrics() {
+      const metrics: Record<string, number> = {};
+      for (const s of spans) metrics[`${s.name}_ms`] = s.dur;
+      return metrics;
+    },
   };
+}
+
+/**
+ * Emit one structured, grep-able `[perf]` log line per request so per-route
+ * durations are queryable from Vercel function logs (B-PERF-04). The
+ * `Server-Timing` *header* only reaches the browser Network panel and never
+ * appears in function logs, so it cannot back the §12.6 p50/p95 table on its
+ * own. One consistent shape — `[perf] { route, …_ms, … }` — across every §12.6
+ * surface lets a log drain aggregate percentiles per `route`.
+ *
+ * Telemetry only: logging never throws and never alters a response.
+ */
+export function logServerTiming(
+  route: string,
+  timing: ServerTiming,
+  extra?: Record<string, string | number | boolean | null | undefined>,
+): void {
+  try {
+    console.info('[perf]', { route, ...timing.toMetrics(), ...extra });
+  } catch {
+    // telemetry only — swallow
+  }
+}
+
+/**
+ * Time an awaited unit of server work and emit its `[perf]` line (B-PERF-04).
+ * Intended for React Server Components — calling `Date.now()` directly in a
+ * component render trips the `react-hooks/purity` lint, so the stamps live here
+ * in a plain module function rather than in the component body. The span is
+ * recorded even when `work` rejects, then the error re-throws unchanged.
+ */
+export async function timeServerWork<T>(
+  route: string,
+  span: string,
+  work: () => Promise<T>,
+  extra?: Record<string, string | number | boolean | null | undefined>,
+): Promise<T> {
+  const startedAt = Date.now();
+  try {
+    return await work();
+  } finally {
+    const timing = createServerTiming();
+    timing.measure(span, startedAt);
+    logServerTiming(route, timing, extra);
+  }
 }


### PR DESCRIPTION
The Server-Timing header already on feed/daily-queue/knowledge/daily-answer
only reaches the browser Network panel — it never appears in Vercel function
logs, so it can't back the §12.6 p50/p95 table PERF-FINDINGS-01 §0 says does
not exist. Add structured, grep-able `[perf]` log lines (one shape per route:
`{ route, …_ms, … }`) so a log drain can aggregate percentiles per surface.

- server-timing: add toMetrics() (`${name}_ms` map), logServerTiming(), and
  timeServerWork() (RSC-safe wrapper that keeps Date.now() out of render so it
  doesn't trip react-hooks/purity).
- feed, daily/queue GET, knowledge: emit the [perf] line alongside the header.
- daily/queue POST: previously untimed — now times the synchronous-LLM build
  long pole (the worst-case Daily Five reveal) with build/total spans + outcome.
- daily/answer: add the uniform [perf] line; keep the richer
  [daily/answer timings] breakdown.
- home page (page.tsx): the #1 §12.6 surface had zero server instrumentation —
  time the todays-five and from-friends data fetches via timeServerWork.

Header behaviour and all response bodies/status codes unchanged; logging is
telemetry-only and never throws.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015W1Lw9bFcwoof7kCaPdL61