### PR TITLE
Edit a pending friend invitation on the Friends hub

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -6,6 +6,8 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { formatRelativeTime } from '@/components/feed/visual';
 import { buildAddSomeoneHandoff } from '@/components/friends/add-someone';
+import { saveInviteEdit } from '@/components/friends/invite-edit';
+import { formatUsPhoneInput } from '@/lib/phone-e164';
 
 type FriendSort = 'name_asc' | 'name_desc' | 'recent';
 
@@ -146,14 +148,63 @@ function PendingInviteCard({
   cancellingId,
   onCopy,
   onCancel,
+  onSaved,
 }: {
   invite: OutgoingInvite;
   copyingId: string | null;
   cancellingId: string | null;
   onCopy: (invite: OutgoingInvite) => void;
   onCancel: (invite: OutgoingInvite) => void;
+  onSaved: () => Promise<void> | void;
 }) {
   const canMessage = invite.message && invite.inviteePhoneForActions;
+
+  const [editing, setEditing] = useState(false);
+  const [editName, setEditName] = useState('');
+  const [editPhone, setEditPhone] = useState('');
+  const [editInterests, setEditInterests] = useState<string[]>(['', '', '']);
+  const [savingEdit, setSavingEdit] = useState(false);
+  const [editError, setEditError] = useState<string | null>(null);
+
+  function startEdit() {
+    setEditName(invite.inviteeDisplayName);
+    setEditPhone(formatUsPhoneInput(invite.inviteePhoneForActions ?? ''));
+    setEditInterests([
+      invite.suggestedInterests[0] ?? '',
+      invite.suggestedInterests[1] ?? '',
+      invite.suggestedInterests[2] ?? '',
+    ]);
+    setEditError(null);
+    setEditing(true);
+  }
+
+  async function saveEdit() {
+    const trimmedName = editName.trim();
+    if (!trimmedName) {
+      setEditError('Add their name first.');
+      return;
+    }
+
+    setSavingEdit(true);
+    setEditError(null);
+
+    const result = await saveInviteEdit({
+      invitationId: invite.id,
+      inviteeDisplayName: trimmedName,
+      phone: editPhone,
+      suggestedInterests: editInterests.map((interest) => interest.trim()).filter(Boolean),
+    });
+
+    setSavingEdit(false);
+
+    if (!result.ok) {
+      setEditError(result.message);
+      return;
+    }
+
+    setEditing(false);
+    await onSaved();
+  }
 
   return (
     <article className="bg-card text-card-foreground rounded-[var(--radius-card)] border p-4 shadow-[var(--shadow-card)]">
@@ -167,46 +218,124 @@ function PendingInviteCard({
         </span>
       </div>
 
-      {invite.suggestedInterests.length > 0 ? (
-        <div className="mt-3 flex flex-wrap gap-2">
-          {invite.suggestedInterests.map((interest) => (
-            <span
-              key={interest}
-              className="border-primary/10 bg-primary/5 text-foreground rounded-full border px-3 py-1 text-sm"
-            >
-              {interest}
-            </span>
-          ))}
-        </div>
-      ) : null}
+      {editing ? (
+        <form
+          className="mt-4 space-y-3"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void saveEdit();
+          }}
+        >
+          <label className="text-foreground block text-sm font-medium">
+            Name
+            <input
+              className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] mt-1 h-11 w-full rounded-xl border border-[var(--accent-gold)] px-3 text-base transition outline-none"
+              value={editName}
+              onChange={(event) => {
+                setEditName(event.target.value);
+                setEditError(null);
+              }}
+              autoComplete="name"
+              maxLength={60}
+              placeholder="Their name"
+            />
+          </label>
+          <label className="text-foreground block text-sm font-medium">
+            Phone number
+            <input
+              className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] mt-1 h-11 w-full rounded-xl border border-[var(--accent-gold)] px-3 text-base transition outline-none"
+              value={editPhone}
+              onChange={(event) => {
+                setEditPhone(formatUsPhoneInput(event.target.value));
+                setEditError(null);
+              }}
+              autoComplete="tel"
+              inputMode="tel"
+              maxLength={14}
+              placeholder="(555) 123-4567"
+            />
+          </label>
+          <div className="space-y-2">
+            <span className="text-foreground block text-sm font-medium">Ideas (up to three)</span>
+            {editInterests.map((interest, index) => (
+              <input
+                key={index}
+                className="bg-[var(--brand-field)] focus:border-[var(--brand-navy)] h-11 w-full rounded-full border border-[var(--accent-gold)] px-4 text-base transition outline-none"
+                value={interest}
+                onChange={(event) => {
+                  const next = event.target.value;
+                  setEditInterests((current) => current.map((value, i) => (i === index ? next : value)));
+                  setEditError(null);
+                }}
+                maxLength={60}
+                placeholder={`Idea ${index + 1}`}
+              />
+            ))}
+          </div>
 
-      {canMessage ? (
-        <div className="mt-4 space-y-2">
-          <a
-            className="btn-primary flex w-full items-center justify-center"
-            href={buildSmsHref(invite.inviteePhoneForActions!, invite.message!)}
-          >
-            Send message
-          </a>
-          <div className="flex justify-center gap-6">
-            <button
-              type="button"
-              className="text-muted-foreground text-sm"
-              onClick={() => onCopy(invite)}
-            >
-              {copyingId === invite.id ? 'Copied ✓' : 'Copy instead'}
+          {editError ? <p className="text-destructive text-sm font-medium">{editError}</p> : null}
+
+          <div className="flex gap-3">
+            <button type="submit" className="btn-primary flex-1" disabled={savingEdit}>
+              {savingEdit ? 'Saving…' : 'Save changes'}
             </button>
             <button
               type="button"
-              className="text-muted-foreground text-sm"
-              onClick={() => onCancel(invite)}
-              disabled={cancellingId === invite.id}
+              className="btn-ghost flex-1"
+              onClick={() => setEditing(false)}
+              disabled={savingEdit}
             >
-              {cancellingId === invite.id ? 'Setting aside…' : 'Set aside'}
+              Cancel
             </button>
           </div>
-        </div>
-      ) : null}
+        </form>
+      ) : (
+        <>
+          {invite.suggestedInterests.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {invite.suggestedInterests.map((interest) => (
+                <span
+                  key={interest}
+                  className="border-primary/10 bg-primary/5 text-foreground rounded-full border px-3 py-1 text-sm"
+                >
+                  {interest}
+                </span>
+              ))}
+            </div>
+          ) : null}
+
+          {canMessage ? (
+            <div className="mt-4 space-y-2">
+              <a
+                className="btn-primary flex w-full items-center justify-center"
+                href={buildSmsHref(invite.inviteePhoneForActions!, invite.message!)}
+              >
+                Send message
+              </a>
+              <div className="flex justify-center gap-6">
+                <button
+                  type="button"
+                  className="text-muted-foreground text-sm"
+                  onClick={() => onCopy(invite)}
+                >
+                  {copyingId === invite.id ? 'Copied ✓' : 'Copy instead'}
+                </button>
+                <button type="button" className="text-muted-foreground text-sm" onClick={startEdit}>
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  className="text-muted-foreground text-sm"
+                  onClick={() => onCancel(invite)}
+                  disabled={cancellingId === invite.id}
+                >
+                  {cancellingId === invite.id ? 'Setting aside…' : 'Set aside'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+        </>
+      )}
     </article>
   );
 }
@@ -589,6 +718,7 @@ export default function FriendsList() {
                 cancellingId={cancellingId}
                 onCopy={copyInvite}
                 onCancel={cancelInvite}
+                onSaved={loadInvites}
               />
             ))}
             {outboundRequests.map((request) => (

--- a/src/components/PeopleYouInvited.tsx
+++ b/src/components/PeopleYouInvited.tsx
@@ -3,20 +3,9 @@
 import Link from 'next/link'
 import { useCallback, useEffect, useState } from 'react'
 
+import { saveInviteEdit } from '@/components/friends/invite-edit'
 import { Chip } from '@/components/ui/Chip'
 import { formatUsPhoneInput } from '@/lib/phone-e164'
-
-const EDIT_ERROR_COPY: Record<string, string> = {
-  invalid_phone: 'Use a US mobile number.',
-  too_many_suggested_interests: 'Choose up to three ideas.',
-  missing_invitee_display_name: 'Add their name first.',
-  invalid_invitee_display_name: 'Use a shorter, real display name.',
-  invalid_suggested_interests: 'Keep each idea short and friendly.',
-  already_on_joshing:
-    'That number already belongs to someone on Joshing. Set this note aside and send them a friend request instead.',
-  duplicate_pending: 'You already have a pending note out to that number.',
-  self_invite: 'You cannot invite yourself.',
-}
 
 type InviteStatus = 'pending' | 'accepted' | 'expired' | 'cancelled'
 
@@ -233,52 +222,31 @@ export default function PeopleYouInvited() {
   async function saveEdit(invite: OutgoingInvite) {
     const trimmedName = editName.trim()
     if (!trimmedName) {
-      setEditError(EDIT_ERROR_COPY.missing_invitee_display_name)
+      setEditError('Add their name first.')
       return
     }
-
-    const suggestedInterests = editInterests
-      .map((interest) => interest.trim())
-      .filter(Boolean)
 
     setSavingEdit(true)
     setEditError(null)
 
-    try {
-      const response = await fetch('/api/friend-invitations', {
-        method: 'PATCH',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({
-          invitationId: invite.id,
-          inviteeDisplayName: trimmedName,
-          phone: editPhone,
-          suggestedInterests,
-        }),
-      })
-      const body = (await response.json().catch(() => null)) as {
-        error?: string
-        message?: string
-      } | null
+    const result = await saveInviteEdit({
+      invitationId: invite.id,
+      inviteeDisplayName: trimmedName,
+      phone: editPhone,
+      suggestedInterests: editInterests
+        .map((interest) => interest.trim())
+        .filter(Boolean),
+    })
 
-      if (!response.ok) {
-        const apiError = body?.error
-        throw new Error(
-          (apiError && EDIT_ERROR_COPY[apiError]) ??
-            body?.message ??
-            'Could not save your changes.'
-        )
-      }
+    setSavingEdit(false)
 
-      setEditingId(null)
-      await loadInvites()
-    } catch (caught) {
-      setEditError(
-        caught instanceof Error ? caught.message : 'Could not save your changes.'
-      )
-    } finally {
-      setSavingEdit(false)
+    if (!result.ok) {
+      setEditError(result.message)
+      return
     }
+
+    setEditingId(null)
+    await loadInvites()
   }
 
   function createNewInvite(invite: OutgoingInvite) {

--- a/src/components/friends/invite-edit.ts
+++ b/src/components/friends/invite-edit.ts
@@ -1,0 +1,59 @@
+// Shared client logic for editing a still-pending friend invitation. Two
+// surfaces let you fix a fat-fingered invite — the standalone "People you
+// invited" card (PeopleYouInvited) and the Friends hub's "Waiting for Response"
+// section (FriendsList) — so the PATCH call and its error copy live here to keep
+// the two from drifting. The server contract is PATCH /api/friend-invitations
+// (see src/app/api/friend-invitations/route.ts).
+
+export const INVITE_EDIT_ERROR_COPY: Record<string, string> = {
+  invalid_phone: 'Use a US mobile number.',
+  too_many_suggested_interests: 'Choose up to three ideas.',
+  missing_invitee_display_name: 'Add their name first.',
+  invalid_invitee_display_name: 'Use a shorter, real display name.',
+  invalid_suggested_interests: 'Keep each idea short and friendly.',
+  already_on_joshing:
+    'That number already belongs to someone on Joshing. Set this note aside and send them a friend request instead.',
+  duplicate_pending: 'You already have a pending note out to that number.',
+  self_invite: 'You cannot invite yourself.',
+}
+
+export type SaveInviteEditInput = {
+  invitationId: string
+  inviteeDisplayName: string
+  phone: string
+  suggestedInterests: string[]
+}
+
+export type SaveInviteEditResult = { ok: true } | { ok: false; message: string }
+
+export async function saveInviteEdit(
+  input: SaveInviteEditInput
+): Promise<SaveInviteEditResult> {
+  try {
+    const response = await fetch('/api/friend-invitations', {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify(input),
+    })
+    const body = (await response.json().catch(() => null)) as {
+      error?: string
+      message?: string
+    } | null
+
+    if (!response.ok) {
+      const apiError = body?.error
+      return {
+        ok: false,
+        message:
+          (apiError && INVITE_EDIT_ERROR_COPY[apiError]) ??
+          body?.message ??
+          'Could not save your changes.',
+      }
+    }
+
+    return { ok: true }
+  } catch {
+    return { ok: false, message: 'Could not save your changes.' }
+  }
+}


### PR DESCRIPTION
## Why

If you fat-finger an invitee's phone number when adding a friend, there's no way to fix it — the only options were to *set aside* (cancel) or send a fresh note. This adds an **Edit** affordance to pending invitations so you can correct the phone number, name, or suggested ideas in place.

The backing `PATCH /api/friend-invitations` endpoint and the standalone "People you invited" card edit UI landed earlier (merged via #1128). This PR extends the same capability to the **Friends tab → "Waiting for Response"** section, which is rendered by a separate component (`FriendsList.tsx`) and was still missing the button.

## What changed

- **`src/components/friends/invite-edit.ts`** (new) — shared client helper holding the `PATCH` call and its error copy, so the two edit surfaces can't drift apart.
- **`FriendsList.tsx`** — `PendingInviteCard` now has an inline **Edit** form (name, phone, up to three ideas) that reloads invites on save.
- **`PeopleYouInvited.tsx`** — refactored onto the shared helper (no behavior change).

Editing is allowed while the invite is still pending; the existing endpoint guards against editing toward a number already on Joshing, your own number, or a duplicate pending note, and preserves the invite token so an already-copied link stays valid.

## Testing

- Typecheck (`tsc -p tsconfig.typecheck.json`) and ESLint clean on the changed files.
- Friend-invitation API/helper tests green (53 passing).
- The two touched files are untested UI components (consistent with the repo); the `PATCH` contract behind the button is covered by the route tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01SdkEN5WxjVJheugSmN34Kk)_