### PR TITLE
Replace Today's Five completed-with-misses headline with 'Contain more multitudes'

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -259,7 +259,7 @@ export default function TodaysFiveCard({
   // Play Missed Questions sage button answers; Branch B keeps "Today, done."
   const headline = isComplete
     ? missedCount > 0
-      ? 'Nice going — now learn from your misses'
+      ? 'Contain more multitudes'
       : 'Today, done.'
     : hasStartedRound
       ? 'Pick up where you left off'


### PR DESCRIPTION
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RfgLDwK2txbHWWhwuoKoQR