### PR TITLE
Add dedicated Requests Sent section to friends hub

### DIFF
--- a/src/components/FriendsList.tsx
+++ b/src/components/FriendsList.tsx
@@ -701,7 +701,29 @@ export default function FriendsList() {
         </section>
       ) : null}
 
-      {!loading && (pendingInvites.length > 0 || outboundRequests.length > 0) ? (
+      {!loading && outboundRequests.length > 0 ? (
+        <section aria-labelledby="requests-sent" className="space-y-3">
+          <h2
+            id="requests-sent"
+            className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase"
+          >
+            Requests Sent{' '}
+            <span className="text-foreground tabular-nums">({outboundRequests.length})</span>
+          </h2>
+          <div className="space-y-3">
+            {outboundRequests.map((request) => (
+              <OutboundRequestCard
+                key={request.id}
+                request={request}
+                pendingRequestId={pendingRequestId}
+                onCancel={cancelRequest}
+              />
+            ))}
+          </div>
+        </section>
+      ) : null}
+
+      {!loading && pendingInvites.length > 0 ? (
         <section aria-labelledby="waiting-for-response" className="space-y-3">
           <h2
             id="waiting-for-response"
@@ -719,14 +741,6 @@ export default function FriendsList() {
                 onCopy={copyInvite}
                 onCancel={cancelInvite}
                 onSaved={loadInvites}
-              />
-            ))}
-            {outboundRequests.map((request) => (
-              <OutboundRequestCard
-                key={request.id}
-                request={request}
-                pendingRequestId={pendingRequestId}
-                onCancel={cancelRequest}
               />
             ))}
           </div>


### PR DESCRIPTION
Split outbound friend requests out of the combined 'Waiting for Response'
section into their own 'Requests Sent' section so users can see every
pending request they've sent and retract any of them. SMS invites keep
their own 'Waiting for Response' section. The heading shows a live count.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01S8gDTs71w1xxu5RwFthNUs