### PR TITLE
Render Beat 3 (social) in first-session panel

### DIFF
--- a/src/app/daily/summary/FirstSessionPanel.tsx
+++ b/src/app/daily/summary/FirstSessionPanel.tsx
@@ -23,7 +23,10 @@
 import Link from 'next/link'
 import { type CSSProperties, useEffect, useMemo, useState } from 'react'
 
-import type { FirstSessionRecapView } from '@/server/daily/first-session-recap'
+import type {
+  FirstSessionRecapBeat3,
+  FirstSessionRecapView,
+} from '@/server/daily/first-session-recap'
 
 // Mirrors RoundReminderCard's `titleStyle` so the merged reminder ask reads
 // identically to the standalone opt-in.
@@ -34,6 +37,72 @@ const reminderTitleStyle: CSSProperties = {
   color: '#111111',
   textTransform: 'uppercase',
   letterSpacing: '0.05em',
+}
+
+// Beat 3 (social). Pure presentation over the server-computed `beat3` branch:
+// connect a new player to whoever (if anyone) invited them, or — for organic
+// signups — fall back to an invite-a-friend CTA. Styled to match the reminder
+// block below so the two reads as one register.
+function SocialBeat({ beat3 }: { beat3: FirstSessionRecapBeat3 }) {
+  if (beat3.kind === 'inviter_present') {
+    const { inviterName } = beat3
+    return (
+      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+        <h3 style={reminderTitleStyle}>{inviterName} is already in your game</h3>
+        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+          Some of the questions in your feed are ones {inviterName} answered —
+          look for the{' '}
+          <span className="font-semibold text-[var(--brand-ink)]">
+            Via {inviterName}
+          </span>{' '}
+          label, and answer one back.
+        </p>
+        <p className="mt-3 text-sm leading-6">
+          <Link
+            href="/#feed"
+            className="text-[var(--brand-link)] underline underline-offset-4"
+          >
+            Go to your feed
+          </Link>
+        </p>
+      </div>
+    )
+  }
+
+  if (beat3.kind === 'inviter_future') {
+    const { inviterName } = beat3
+    return (
+      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+        <h3 style={reminderTitleStyle}>You&apos;re connected with {inviterName}</h3>
+        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+          When {inviterName} plays, their questions will land in your feed marked{' '}
+          <span className="font-semibold text-[var(--brand-ink)]">
+            Via {inviterName}
+          </span>
+          .
+        </p>
+      </div>
+    )
+  }
+
+  // no_inviter — copy is DRAFT, pending review (see PR).
+  return (
+    <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+      <h3 style={reminderTitleStyle}>Joshing is better with a friend in it</h3>
+      <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+        Bring someone you like to outsmart — their questions show up in your feed,
+        and yours in theirs.
+      </p>
+      <p className="mt-3 text-sm leading-6">
+        <Link
+          href="/friends"
+          className="text-[var(--brand-link)] underline underline-offset-4"
+        >
+          Invite a friend
+        </Link>
+      </p>
+    </div>
+  )
 }
 
 type EmailState =
@@ -86,6 +155,8 @@ export function FirstSessionPanel({ recap }: { recap: FirstSessionRecapView }) {
         </Link>{' '}
         page.
       </p>
+
+      <SocialBeat beat3={recap.beat3} />
 
       {/* Reminder opt-in, merged into the same card. Email-only, no dismiss. */}
       <div className="mt-5 border-t border-[var(--brand-border)] pt-5">

--- a/src/app/dev/first-time-player/page.tsx
+++ b/src/app/dev/first-time-player/page.tsx
@@ -38,6 +38,65 @@ const reminderTitleStyle: CSSProperties = {
   letterSpacing: '0.05em',
 };
 
+// Static replica of FirstSessionPanel's `SocialBeat` (Beat 3). Mirrors the live
+// markup/copy for each branch so this preview stays faithful after the panel
+// gained its social beat; rendered inert (links are spans, like the rest of
+// this page). `name` is unused for the no_inviter branch.
+function SocialBeatPreview({
+  kind,
+  name,
+}: {
+  kind: 'inviter_present' | 'inviter_future' | 'no_inviter';
+  name?: string;
+}) {
+  if (kind === 'inviter_present') {
+    return (
+      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+        <h3 style={reminderTitleStyle}>{name} is already in your game</h3>
+        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+          Some of the questions in your feed are ones {name} answered — look for
+          the{' '}
+          <span className="font-semibold text-[var(--brand-ink)]">Via {name}</span>{' '}
+          label, and answer one back.
+        </p>
+        <p className="mt-3 text-sm leading-6">
+          <span className="text-[var(--brand-link)] underline underline-offset-4">
+            Go to your feed
+          </span>
+        </p>
+      </div>
+    );
+  }
+
+  if (kind === 'inviter_future') {
+    return (
+      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+        <h3 style={reminderTitleStyle}>You&apos;re connected with {name}</h3>
+        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+          When {name} plays, their questions will land in your feed marked{' '}
+          <span className="font-semibold text-[var(--brand-ink)]">Via {name}</span>.
+        </p>
+      </div>
+    );
+  }
+
+  // no_inviter — copy is DRAFT, pending review.
+  return (
+    <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
+      <h3 style={reminderTitleStyle}>Joshing is better with a friend in it</h3>
+      <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
+        Bring someone you like to outsmart — their questions show up in your feed,
+        and yours in theirs.
+      </p>
+      <p className="mt-3 text-sm leading-6">
+        <span className="text-[var(--brand-link)] underline underline-offset-4">
+          Invite a friend
+        </span>
+      </p>
+    </div>
+  );
+}
+
 // Mirrors the summary page's section-title style.
 const sectionTitleStyle: CSSProperties = {
   fontFamily: 'var(--font-neutral), system-ui, sans-serif',
@@ -263,6 +322,11 @@ export default function DevFirstTimePlayerPage() {
               page.
             </p>
 
+            {/* Beat 3 (social). This preview shows the inviter_present branch —
+                the canonical path for a player who arrived via someone's profile
+                link. The other two branches are shown for reference below. */}
+            <SocialBeatPreview kind="inviter_present" name="Maya" />
+
             <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
               <h3 style={reminderTitleStyle}>
                 Get notified when the next batch is available
@@ -356,6 +420,34 @@ export default function DevFirstTimePlayerPage() {
                 See your knowledge map
               </span>
             </div>
+          </section>
+        </div>
+
+        {/* Beat 3 — other social states. The card above shows inviter_present;
+            these are the two branches a player sees instead depending on whether
+            their inviter has played yet, or whether they arrived with no inviter
+            at all. Shown here so every Beat 3 state is reviewable in one place. */}
+        <div className="mt-10 rounded-2xl border border-dashed border-[var(--brand-border)] p-4">
+          <p className="mb-1 text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+            Beat 3 · other social states
+          </p>
+          <p className="mb-4 text-sm leading-6 text-muted-foreground">
+            Only one of these (including the inviter_present card above) renders
+            for a given player.
+          </p>
+
+          <section className="rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
+            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+              Inviter hasn&apos;t played yet
+            </p>
+            <SocialBeatPreview kind="inviter_future" name="Maya" />
+          </section>
+
+          <section className="mt-4 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
+            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+              No inviter on record · <span className="text-amber-700">draft copy</span>
+            </p>
+            <SocialBeatPreview kind="no_inviter" />
           </section>
         </div>
       </div>


### PR DESCRIPTION
## What

`FirstSessionPanel` receives `recap: FirstSessionRecapView` but dropped `recap.beat3` — it only rendered the greeting, the daily-cadence note, and the email reminder opt-in. The server (`src/server/daily/first-session-recap.ts`) already computes and ships `beat3`; it just wasn't rendered. This wires it in, and updates the dev preview so the first-time-player walkthrough reflects it.

## Changes

**`src/app/daily/summary/FirstSessionPanel.tsx`** (the live panel)
- Widen the type import to also pull in `FirstSessionRecapBeat3`.
- Add a `SocialBeat({ beat3 })` component switching on `beat3.kind`:
  - **`inviter_present`** → "{inviterName} is already in your game"; points to **Via {inviterName}** feed items and prompts a reply; links to `/#feed` ("Go to your feed").
  - **`inviter_future`** → "You're connected with {inviterName}"; future-tense connection note; no link.
  - **`no_inviter`** → "Joshing is better with a friend in it"; invite pitch; links to `/friends` ("Invite a friend").
- Mount `<SocialBeat beat3={recap.beat3} />` between the daily-cadence paragraph and the reminder opt-in block.
- Styling matches the reminder block's register (`mt-5 border-t border-[var(--brand-border)] pt-5`, `reminderTitleStyle` headings, `text-sm leading-6 text-[var(--brand-ink-700)]` body, `font-semibold text-[var(--brand-ink)]` for the "Via {name}" span).

**`src/app/dev/first-time-player/page.tsx`** (the dev preview, linked from the profile Developer tools)
- This page is a hand-maintained static replica of the panel and went stale when the panel gained Beat 3. Mirror the new social beat into it: the `inviter_present` branch inline in the recap card (the canonical path for a player who arrived via a profile link), plus a reference block below showing `inviter_future` and `no_inviter` so every Beat 3 state is reviewable in one place.

Pure presentation — no API, server, or schema changes. `npx tsc -p tsconfig.typecheck.json` passes clean; ESLint clean on both files.

## ⚠️ Needs review
- The **`no_inviter`** copy is a **draft** — wording is a placeholder pending review (flagged in both the panel and the dev preview). Easier to settle here than relitigate later.
- Visual fit against the redesigned card is **unconfirmed** — types verified, but not yet eyeballed in a browser (no database in the build env to drive the real signup→Daily-Five→recap flow). Worth checking once the Vercel preview builds: from your profile → **Developer tools → First time player** renders the full first-time experience including all three Beat 3 states.

🤖 Generated with [Claude Code](https://claude.com/claude-code)