### PR TITLE
Temporarily ungate developer tools (admin gate off)

### DIFF
--- a/src/app/dev/layout.tsx
+++ b/src/app/dev/layout.tsx
@@ -6,17 +6,20 @@ import { getSession } from '@/server/auth/session';
 
 export const dynamic = 'force-dynamic';
 
-// D-DESIGN-DEBT-STRUCTURAL-01, Phase 3 — gate the entire /dev tree.
+// TEMP (ungate): the /dev tree is currently session-gated only — any
+// authenticated user can reach the dev tools (reset-session, noon-reset,
+// points-diagnostic, flags, first-time-player, invite-login, …) by URL.
 //
-// Before this, /dev/* (reset-session, noon-reset, points-diagnostic, flags,
-// first-time-player, invite-login, loading-preview, test-game) was only
-// session-gated: any authenticated non-admin could reach the dev tools by URL,
-// even once the settings entry point was hidden. This mirrors the admin/reports
-// guard — members of the ADMIN_USER_IDS allowlist only; everyone else (incl.
-// authenticated non-admins) gets Next's 404, so the routes' existence is not
-// revealed. Unset env ⇒ no admins ⇒ always 404 (fail closed).
+// Normally (D-DESIGN-DEBT-STRUCTURAL-01, Phase 3) this is admin-gated against
+// the ADMIN_USER_IDS allowlist, mirroring the admin/reports guard, so non-admins
+// get Next's 404 and the routes' existence is not revealed. To restore that,
+// flip `DEV_ROUTES_UNGATED` back to `false`. The matching settings-menu gate
+// lives in src/components/profile/settings/AccountActions.tsx; revert both
+// together. (Unauthenticated visitors still 404 regardless.)
+const DEV_ROUTES_UNGATED = true;
+
 export default async function DevLayout({ children }: { children: ReactNode }) {
   const session = await getSession();
-  if (!session || !isAdminUser(session.userId)) notFound();
+  if (!session || (!DEV_ROUTES_UNGATED && !isAdminUser(session.userId))) notFound();
   return <>{children}</>;
 }

--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -452,8 +452,11 @@ describe('/users/[id] friend profile page', () => {
 
     expect(html).toContain('Privacy &amp; discovery')
     expect(html).toContain('Notifications')
-    // Developer tools are admin-gated (ADMIN_USER_IDS); a normal owner does not see them.
-    expect(html).not.toContain('Developer tools')
+    // Developer tools are temporarily ungated (DEV_TOOLS_UNGATED in
+    // AccountActions): every owner viewing their own profile sees them,
+    // regardless of ADMIN_USER_IDS. Flip back to expecting absence when the
+    // admin gate is restored.
+    expect(html).toContain('Developer tools')
     expect(html).toContain('Log out')
     expect(html).toContain('Delete account')
     expect(html).toContain('id="privacy-discovery"')

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -39,15 +39,23 @@ export async function logoutAndRedirect(navigate: (url: string) => void): Promis
   navigate('/login');
 }
 
+// TEMP (ungate): the Developer-tools section is currently shown to every owner
+// viewing their own profile, regardless of admin status. To restore the
+// ADMIN_USER_IDS gate (D-DESIGN-DEBT-STRUCTURAL-01, Phase 3), flip this back to
+// `false` — `showDeveloperTools` then falls back to the `isAdmin` prop. The
+// matching /dev route gate lives in src/app/dev/layout.tsx; revert both together.
+const DEV_TOOLS_UNGATED = true;
+
 /**
- * `isAdmin` gates the Developer-tools section (D-DESIGN-DEBT-STRUCTURAL-01,
- * Phase 3). Before this it rendered for every owner viewing their own profile,
- * so any normal user could reach /dev/* (reset-session, noon-reset, …). The
- * caller computes it server-side from `isAdminUser(session.userId)` — the same
- * ADMIN_USER_IDS allowlist that guards the report queue. Defaults to false:
- * fail closed, so a caller that forgets to pass it hides the tools.
+ * `isAdmin` normally gates the Developer-tools section via the ADMIN_USER_IDS
+ * allowlist (the caller computes it from `isAdminUser(session.userId)`).
+ * Defaults to false (fail closed). While `DEV_TOOLS_UNGATED` is true the gate
+ * is bypassed and the section renders for any profile owner. This component only
+ * mounts in the owner self-view, so the tools are never exposed on other
+ * people's profiles either way.
  */
 export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
+  const showDeveloperTools = DEV_TOOLS_UNGATED || isAdmin;
   const router = useRouter();
   const [confirmingLogout, setConfirmingLogout] = useState(false);
   const [loggingOut, setLoggingOut] = useState(false);
@@ -125,7 +133,7 @@ export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
 
   return (
     <>
-      {isAdmin ? (
+      {showDeveloperTools ? (
         <section className="mb-8">
           <h2 className="mb-3 font-serif text-2xl font-semibold">Developer tools</h2>
           <SettingsGroup>


### PR DESCRIPTION
## What

The Developer-tools settings section and the entire `/dev` route tree were admin-gated against `ADMIN_USER_IDS` (D-DESIGN-DEBT-STRUCTURAL-01, Phase 3), so reaching the dev tools — including the first-time-player preview — required being on the allowlist. This temporarily disables the admin gate so any signed-in user can reach them.

## Changes

- **`src/components/profile/settings/AccountActions.tsx`** — `DEV_TOOLS_UNGATED = true` shows the **Developer tools** section to any profile owner. The component only mounts in the owner self-view, so the tools are never exposed on other people's profiles.
- **`src/app/dev/layout.tsx`** — `DEV_ROUTES_UNGATED = true` keeps the **session (login) requirement** but drops the admin check, so `/dev/*` resolves for any authenticated user instead of 404ing. Unauthenticated visitors still 404.
- **`src/app/users/[id]/__tests__/page.test.tsx`** — updates the assertion that pinned the old "a normal owner can't see Developer tools" behavior.

Each gate is a **one-line revert** (flip the flag back to `false`) to restore the `ADMIN_USER_IDS` gate; the two flag comments point to each other.

Typecheck (`tsc -p tsconfig.typecheck.json`) and ESLint pass clean; the profile-page test file passes (11/11).

## ⚠️ Note
Ungating `/dev` also exposes the other dev tools (reset session, trigger noon reset, create test game, points diagnostic, staging flags) to **any** logged-in user on the deployment — fine for a preview environment, but the gate should be restored before this is in front of real users. Scoped intentionally as a temporary "for now" change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015wEHByDLt95NmyPNSSkCvt)_