### PR TITLE
B-FROMFRIENDS-STREAK-HEADER-01: bundle-as-header, cards-as-children

### DIFF
--- a/src/app/from-friends/PendingPlayablesList.tsx
+++ b/src/app/from-friends/PendingPlayablesList.tsx
@@ -2,26 +2,24 @@
 
 import { useRouter } from 'next/navigation'
 
-import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
-import { formatRelativeTime } from '@/components/feed/visual'
+import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak'
 import type { StreamItem } from '@/lib/activity-stream'
 
-// The full pending-playables queue, answerable in place. Each bundle renders
-// through the exact home-zone treatment (elevated cream card, timestamp-free,
-// tap-to-open with the existing InlineAnswerFlow) — no new answer interaction.
+// The full pending-playables queue, answerable in place. Each streak renders
+// through the exact home-zone treatment (B-FROMFRIENDS-STREAK-HEADER-01: a
+// header + per-question answer/dismiss cards in the DirectSentCard register),
+// so the From Friends zone reads identically on Home and on this overflow page.
 // Resolving a question refreshes the router cache so Home recomputes its
-// served top-4 and overflow count on return (D-HOME-PACING-01 §7); the card
-// itself stays open here as its in-session answered state.
+// served top-4 and overflow count on return (D-HOME-PACING-01 §7); the cards
+// themselves stay in place as their in-session spent state.
 export function PendingPlayablesList({ items }: { items: StreamItem[] }) {
   const router = useRouter()
   return (
     <section className="space-y-3">
       {items.map((item) => (
-        <ActivityStreamItem
+        <FromFriendsStreak
           key={item.id}
           item={item}
-          timestamp={formatRelativeTime(item.sortAt)}
-          showTimestamp={false}
           elevated
           onQuestionResolved={() => router.refresh()}
         />

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -26,6 +26,7 @@ import { SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
+import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak'
 import { PersonActivityCard } from '@/components/activity/PersonActivityCard'
 import { groupActivityByFriend, type GroupInputRow, type GroupedRow } from '@/components/feed/person-grouping'
 import { EditorialFeature } from '@/components/feed/EditorialFeature'
@@ -1759,6 +1760,21 @@ function FeedListContent({
       if (embed?.kind === 'recently_expanding') {
         return <RecentlyExpandingFeature key={`e-${row.item.id}`} embed={embed} />
       }
+      // From Friends milestone streaks render as a header + per-question
+      // answer/dismiss cards (B-FROMFRIENDS-STREAK-HEADER-01) on the home zones
+      // (Home + the /from-friends overflow, both `homeZoneCards`). The flat
+      // /activities log keeps the collapsed one-liner bundle via
+      // ActivityStreamItem below. Server budget is unchanged — whole streaks
+      // only, never split.
+      if (row.item.expand?.kind === 'milestone' && homeZoneCards) {
+        return (
+          <FromFriendsStreak
+            key={`ff-${row.item.id}`}
+            item={row.item}
+            elevated={homeZoneCards}
+          />
+        )
+      }
       // Everything else renders as a one-liner row, with its bundle triangle
       // mark + tap-to-answer expansion living inside ActivityStreamItem. On the
       // home feed the playable milestone bundles take the cream card treatment
@@ -2102,9 +2118,11 @@ function FeedListContent({
                   </FeedSectionHeading>
                   {groupActivityByFriend(fromFriendsRows).map(renderRow)}
                   {budget.playablesOverflowCount > 0 ? (
+                    // D-B: overflow counts BUNDLES (whole streaks), not
+                    // questions — playablesOverflowCount is the bundle remainder.
                     <OverflowRow
                       unifiedHome={unifiedHome}
-                      label={`${budget.playablesOverflowCount} more →`}
+                      label={`${budget.playablesOverflowCount} more from friends →`}
                       href="/from-friends"
                     />
                   ) : null}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -2112,7 +2112,7 @@ function FeedListContent({
                     unifiedHome={unifiedHome}
                     prominent
                     windowLabel={bandLabelVisible && bandHasContent ? 'Past 7 days' : undefined}
-                    subtitle="Play the questions your friends have aced."
+                    subtitle="Answer the questions your friends have aced."
                   >
                     From Friends
                   </FeedSectionHeading>

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -48,6 +48,15 @@ vi.mock('@/components/activity/ActivityStreamItem', () => ({
   ),
 }))
 
+// From Friends milestone streaks now render through FromFriendsStreak on the home
+// zones (B-FROMFRIENDS-STREAK-HEADER-01); stub it to a marker so this test
+// exercises the budgeted SECTIONING, not the card internals.
+vi.mock('@/components/feed/FromFriendsStreak', () => ({
+  FromFriendsStreak: ({ item }: { item: { id: string; friendId?: string | null } }) => (
+    <div data-streak={item.id}>streak:{item.id}:{item.friendId ?? 'none'}</div>
+  ),
+}))
+
 vi.mock('@/components/activity/PersonActivityCard', () => ({
   PersonActivityCard: () => <div data-person />,
 }))
@@ -164,7 +173,9 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('questions your friends created or sent directly to you')
     expect(html).toContain('From Friends')
     expect(html).toContain('4 more from friends →')
-    expect(html).toContain('3 more →')
+    // From Friends overflow counts BUNDLES and reads "{N} more from friends →"
+    // (D-B); both question zones share the phrasing, so anchor on the count.
+    expect(html).toContain('3 more from friends →')
     // The 7-day boundary is folded onto the "From Friends" heading as a quiet
     // "(Past 7 days)" qualifier — stated once, only on that heading. Zone 1
     // (the directed "For you" descriptor) still sits ABOVE it, outside the band.
@@ -181,9 +192,9 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html.indexOf('Past 7 days')).toBeGreaterThan(html.indexOf('From Friends'))
     expect(html).toContain('href="/for-you"')
     expect(html).toContain('href="/from-friends"')
-    // Served direct cards and playables both rendered.
+    // Served direct cards and playables both rendered (playables now as streaks).
     expect(html).toContain('direct:robyn')
-    expect(html).toContain('activity:p0:josh')
+    expect(html).toContain('streak:p0:josh')
     // Texture row rendered, and NO temporal recency bucket heading (§4 removed).
     expect(html).toContain('activity:t0:tex-friend')
     expect(html).not.toContain('Today')
@@ -279,7 +290,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('Past 7 days')
     // From Friends has content → real rows, no honest empty there.
     expect(html).toContain('From Friends')
-    expect(html).toContain('activity:p0:josh')
+    expect(html).toContain('streak:p0:josh')
     expect(html).not.toContain('No friend activity this week')
     // Recent activity is empty-in-window → hidden outright, no honest empty.
     expect(html).not.toContain('Recent activity')

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -183,8 +183,9 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html.match(/Past 7 days/g) ?? []).toHaveLength(1)
     expect(html).toContain('Recent activity')
     // From Friends is promoted to a peer of "For you" and carries a descriptive
-    // subtitle beneath its heading.
-    expect(html).toContain('Play the questions your friends have aced')
+    // subtitle beneath its heading — the verb is "Answer" now that the cards
+    // carry an answer/dismiss affordance, not a single "Play" (Phase 4).
+    expect(html).toContain('Answer the questions your friends have aced')
     expect(html.indexOf('questions your friends created or sent directly to you')).toBeLessThan(
       html.indexOf('Past 7 days'),
     )

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -48,6 +48,15 @@ vi.mock('@/components/activity/ActivityStreamItem', () => ({
   ),
 }))
 
+// From Friends milestone streaks render through FromFriendsStreak on the home
+// zones (B-FROMFRIENDS-STREAK-HEADER-01); stub it to a marker so this round-trip
+// asserts the windowing/sectioning, not the per-card internals.
+vi.mock('@/components/feed/FromFriendsStreak', () => ({
+  FromFriendsStreak: ({ item }: { item: { id: string; friendId?: string | null } }) => (
+    <div data-streak={item.id}>streak:{item.id}:{item.friendId ?? 'none'}</div>
+  ),
+}))
+
 vi.mock('@/components/activity/PersonActivityCard', () => ({
   PersonActivityCard: () => <div data-person />,
 }))
@@ -170,10 +179,10 @@ describe('overflow subpages — §7 state sync (Home is a window onto the pendin
     const pending = [0, 1, 2, 3, 4, 5].map((i) => bundle(i, [null]))
 
     const before = renderHome([], pending)
-    expect(before).toContain('activity:p0:friend0')
-    expect(before).toContain('activity:p3:friend3')
-    expect(before).not.toContain('activity:p4:friend4') // beyond the served window
-    expect(before).toContain('2 more →')
+    expect(before).toContain('streak:p0:friend0')
+    expect(before).toContain('streak:p3:friend3')
+    expect(before).not.toContain('streak:p4:friend4') // beyond the served window
+    expect(before).toContain('2 more from friends →')
     expect(before).toContain('href="/from-friends"')
 
     // The subpage answer records the viewer's result on p0's last open question.
@@ -182,9 +191,9 @@ describe('overflow subpages — §7 state sync (Home is a window onto the pendin
     const afterAnswer = [bundle(0, ['correct']), ...pending.slice(1)]
 
     const after = renderHome([], afterAnswer)
-    expect(after).toContain('activity:p0:friend0') // still here (now spent)
-    expect(after).not.toContain('activity:p4:friend4') // still beyond the served window
-    expect(after).toContain('2 more →') // count unchanged — nothing was consumed
+    expect(after).toContain('streak:p0:friend0') // still here (now spent)
+    expect(after).not.toContain('streak:p4:friend4') // still beyond the served window
+    expect(after).toContain('2 more from friends →') // count unchanged — nothing was consumed
   })
 })
 

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -17,51 +17,20 @@ import type {
 import { DirectQuestionAnswer } from './DirectQuestionAnswer';
 import { InlineAnswerFlow } from './InlineAnswerFlow';
 import { ActivityIcon, QuestionTriangle, specForIcon } from './ActivityIcon';
+import { ActorLink, Line, QuestionProvenance } from './stream-card-helpers';
 import { FF, FM, INK, INK2, INK3, PAPER, RULE } from '@/components/lately/tokens';
 import { assertNever } from '@/lib/assert-never';
-import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
 
-// Friend names render in the activity-blue from Figma (--brand-link #4a5d75),
-// linked or not, so the actor reads as the warm social anchor of the row.
-const ACTOR_BLUE = 'var(--brand-link)';
-
+// The pure one-liner / provenance renderers live in ./stream-card-helpers so the
+// From Friends streak cards can reuse them without importing this whole module.
+// Re-exported here for the existing consumers that import them from this path.
+export { ActorLink, Line, QuestionProvenance, questionProvenance } from './stream-card-helpers';
 
 // An opened reveal indents to sit UNDER the row's header text, not flush to the
 // far-left edge below the icon. This is exactly the ActivityIcon column width —
 // MARK_W (24) + GAP (8) — so the expansion's left rule lines up with where the
 // actor name / update copy begins, reading as a clear child of the update.
 const EXPANSION_INDENT = 32;
-
-export function ActorLink({
-  name,
-  userId,
-  style,
-}: {
-  name: string;
-  userId: string | null;
-  // Optional override for surfaces that render the actor in a different voice
-  // (e.g. the playable milestone headline, where the name reads in the large
-  // Editorial serif rather than the default activity-blue sans link).
-  style?: CSSProperties;
-}) {
-  if (!userId) return <b style={{ fontWeight: 600, color: ACTOR_BLUE, ...style }}>{name}</b>;
-  return (
-    <Link
-      href={`/users/${userId}`}
-      onClick={(e) => e.stopPropagation()}
-      style={{
-        color: ACTOR_BLUE,
-        fontWeight: 600,
-        textDecoration: 'underline',
-        textDecorationColor: RULE,
-        textUnderlineOffset: 3,
-        ...style,
-      }}
-    >
-      {name}
-    </Link>
-  );
-}
 
 // Strip the leading connective space from a milestone predicate so it reads
 // cleanly as its own second line under the name ("went deep on …", not
@@ -86,46 +55,6 @@ const HEADLINE_NAME_STYLE: CSSProperties = {
   textDecoration: 'none',
 };
 
-export function Line({ parts, plain = false }: { parts: StreamLinePart[]; plain?: boolean }) {
-  return (
-    <>
-      {parts.map((part, i) => {
-        if (part.t === 'actor') {
-          return <ActorLink key={i} name={part.name} userId={part.userId} />;
-        }
-        if (part.t === 'category') {
-          // `plain` (the ambient activity stream): the category stays in the
-          // row's own sans face so the one-liner reads in a single voice — only
-          // a touch of weight + the secondary ink set it apart from the sentence.
-          if (plain) {
-            return (
-              <span key={i} style={{ fontWeight: 600, color: INK2 }}>
-                {part.v}
-              </span>
-            );
-          }
-          // Default (editorial surfaces): category names read in the Editorial
-          // serif (STYLE-GUIDE-TYPE §5) — warm, in their stored title case
-          // ("Shakespearean Tragedy"), a register away from the sans sentence.
-          return (
-            <span
-              key={i}
-              style={{
-                fontFamily: 'var(--font-serif)',
-                fontSize: '1.05em',
-                color: INK2,
-              }}
-            >
-              {part.v}
-            </span>
-          );
-        }
-        return <span key={i}>{part.v}</span>;
-      })}
-    </>
-  );
-}
-
 function questionBacked(expand: StreamExpand | null): boolean {
   if (!expand) return false;
   switch (expand.kind) {
@@ -147,38 +76,6 @@ function questionBacked(expand: StreamExpand | null): boolean {
 // One in-session answer to a milestone question: what the viewer typed and
 // whether it was scored correct. Drives the calm "Answered" history copy.
 type Resolution = { submitted: string; isCorrect: boolean };
-
-// D-FEED-GROUP3-01 §4 (honesty, load-bearing): when a row expands to reveal its
-// question, a house/LLM-authored question MUST be marked — never rendered as if
-// a person wrote it. Returns the marker text, or null when no marker is needed:
-//   - authorIsHouse        → the house identity ("Joshing · Editorial")
-//   - authorName === null  → a non-person LLM-origin question (LLM_QUESTION_ATTRIBUTION)
-//   - human name / undefined → null (the row frame already attributes it; a
-//                              human author needs no machine-honesty marker)
-function questionProvenance(q: StreamQuestion): string | null {
-  if (q.authorIsHouse) return `${HOUSE_AUTHOR.displayName} · ${HOUSE_AUTHOR.label}`;
-  if (q.authorName === null) return LLM_QUESTION_ATTRIBUTION;
-  return null;
-}
-
-function QuestionProvenance({ q, style }: { q: StreamQuestion; style?: CSSProperties }) {
-  const label = questionProvenance(q);
-  if (!label) return null;
-  return (
-    <p
-      style={{
-        margin: '4px 0 0',
-        fontFamily: FM,
-        fontSize: 10,
-        letterSpacing: 1,
-        color: INK3,
-        ...style,
-      }}
-    >
-      {label.toUpperCase()}
-    </p>
-  );
-}
 
 export function ActivityStreamItem({
   item,

--- a/src/components/activity/InlineAnswerFlow.tsx
+++ b/src/components/activity/InlineAnswerFlow.tsx
@@ -1,35 +1,19 @@
 'use client';
 
-import { useState } from 'react';
-
-import { AnswerFeedbackSheet } from '@/components/feed/AnswerFeedbackSheet';
-import { AnswerSheet } from '@/components/feed/AnswerSheet';
 import type { StreamQuestion } from '@/lib/activity-stream';
-import type { InsideJokeKind } from '@/lib/questions-types';
 
 import { FM, INK } from '@/components/lately/tokens';
 
-type Feedback = {
-  isCorrect: boolean;
-  pointsAwarded: number | null;
-  correctAnswer: string;
-  explanation: string | null;
-  creatorNote: string | null;
-  insideJoke: string | null;
-  insideJokeKind: InsideJokeKind | null;
-  authorName: string | null;
-  authorIsHouse: boolean;
-  openedNewTerritory: boolean;
-  openedTerritoryDomain: string | null;
-};
+import { useMilestoneAnswer } from './use-milestone-answer';
 
 // D-4 CORRECTION 2 (revised): this drives a single still-unanswered milestone
 // question. The opened milestone stacks one of these per unanswered question, so
 // the viewer can play any of them; each reads as live and playable (upright navy
 // serif, slightly larger, behind a thin left rule) with an inline text action,
-// not a boxed button. The result is reported up only AFTER the feedback pop-up
-// closes, so the parent can retire this question into the quiet "Answered"
-// history (carrying the submitted answer + correctness) and the stack above
+// not a boxed button. The grade/result flow itself lives in useMilestoneAnswer,
+// shared with the From Friends streak cards (B-FROMFRIENDS-STREAK-HEADER-01); the
+// result is reported up only AFTER the feedback pop-up closes, so the parent can
+// retire this question into the quiet "Answered" history and the stack above
 // shrinks to just the questions still left to play.
 export function InlineAnswerFlow({
   question,
@@ -38,84 +22,7 @@ export function InlineAnswerFlow({
   question: StreamQuestion;
   onResolved: (questionId: string, submitted: string, isCorrect: boolean) => void;
 }) {
-  const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
-  const [loading, setLoading] = useState(false);
-  const [submitted, setSubmitted] = useState('');
-  const [feedback, setFeedback] = useState<Feedback | null>(null);
-
-  async function submit(answer: string) {
-    setLoading(true);
-    try {
-      const res = await fetch('/api/lately/milestone/answer', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ questionId: question.questionId, submitted_answer: answer }),
-      });
-      const body = (await res.json().catch(() => null)) as
-        | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
-            masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
-          })
-        | null;
-      if (!res.ok || !body) throw new Error('Could not score that answer.');
-      setSubmitted(answer);
-      setFeedback({
-        isCorrect: body.isCorrect,
-        pointsAwarded: body.pointsAwarded,
-        correctAnswer: body.correctAnswer,
-        explanation: body.explanation,
-        creatorNote: body.creatorNote,
-        insideJoke: body.insideJoke,
-        insideJokeKind: body.insideJokeKind,
-        authorName: body.authorName,
-        authorIsHouse: body.authorIsHouse,
-        openedNewTerritory: Boolean(body.masteryDelta?.openedNewTerritory),
-        openedTerritoryDomain: body.masteryDelta?.openedNewTerritory
-          ? body.masteryDelta?.domain ?? null
-          : null,
-      });
-      setPhase('result');
-    } catch {
-      // Leave the input sheet open so the viewer can retry.
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  // Recheck (dispute the grade) on a wrong milestone answer: re-grade through the
-  // milestone recheck route (anchored on the synthetic catch-up FeedItem the
-  // answer route wrote). On accept, reflect the win locally so the sheet flips to
-  // "Correct!" and finish() retires the question as correct.
-  async function submitRecheck(): Promise<{ accepted: boolean; message: string }> {
-    const res = await fetch('/api/lately/milestone/recheck', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ questionId: question.questionId }),
-    });
-    const body = (await res.json().catch(() => null)) as
-      | { accepted?: boolean; status?: string; reason?: string; pointsAwarded?: number; message?: string }
-      | null;
-    if (!res.ok) throw new Error(body?.message ?? 'Could not recheck that answer.');
-    const accepted = Boolean(body?.accepted);
-    const points = typeof body?.pointsAwarded === 'number' ? body.pointsAwarded : 0;
-    if (accepted) {
-      setFeedback((current) => (current ? { ...current, isCorrect: true, pointsAwarded: points } : current));
-      return { accepted: true, message: `Recheck accepted — +${points} ${points === 1 ? 'point' : 'points'}.` };
-    }
-    if (body?.status === 'needs_human') {
-      return { accepted: false, message: body.reason ?? 'Flagged for a human look.' };
-    }
-    return { accepted: false, message: body?.reason ?? 'Rechecked and still marked wrong.' };
-  }
-
-  // Hand the resolution up only once the viewer dismisses the result pop-up, so
-  // this block stays mounted (and the sheet visible) through the reveal, then
-  // the parent moves the question into the answered history.
-  function finish() {
-    setPhase('closed');
-    if (feedback) onResolved(question.questionId, submitted, feedback.isCorrect);
-  }
+  const answer = useMilestoneAnswer(question, onResolved);
 
   return (
     <div>
@@ -137,7 +44,7 @@ export function InlineAnswerFlow({
       <div style={{ marginTop: 10, display: 'flex', justifyContent: 'flex-end' }}>
         <button
           type="button"
-          onClick={() => setPhase('input')}
+          onClick={answer.open}
           style={{
             display: 'inline-flex',
             alignItems: 'center',
@@ -156,39 +63,7 @@ export function InlineAnswerFlow({
         </button>
       </div>
 
-      {phase === 'input' ? (
-        <AnswerSheet
-          question={question.text}
-          category={question.domain}
-          loading={loading}
-          onSubmit={(answer) => void submit(answer)}
-          onClose={() => setPhase('closed')}
-        />
-      ) : null}
-
-      {phase === 'result' && feedback ? (
-        <AnswerFeedbackSheet
-          question={question.text}
-          category={question.domain}
-          isCorrect={feedback.isCorrect}
-          pointsAwarded={feedback.pointsAwarded}
-          correctAnswer={feedback.correctAnswer}
-          submittedAnswer={submitted}
-          explanation={feedback.explanation}
-          creatorNote={feedback.creatorNote}
-          insideJoke={feedback.insideJoke}
-          insideJokeKind={feedback.insideJokeKind}
-          authorName={feedback.authorName}
-          authorIsHouse={feedback.authorIsHouse}
-          openedNewTerritory={feedback.openedNewTerritory}
-          openedTerritoryDomain={feedback.openedTerritoryDomain}
-          questionId={question.questionId}
-          feedItemId={`milestone:${question.questionId}`}
-          report={{ target: { questionId: question.questionId }, surface: 'lately_result' }}
-          onRecheck={feedback.isCorrect ? null : submitRecheck}
-          onClose={finish}
-        />
-      ) : null}
+      {answer.sheets}
     </div>
   );
 }

--- a/src/components/activity/PersonActivityCard.tsx
+++ b/src/components/activity/PersonActivityCard.tsx
@@ -5,7 +5,7 @@ import type { ReactNode } from 'react';
 import type { StreamItem } from '@/lib/activity-stream';
 import { FF, INK, INK2, INK3 } from '@/components/lately/tokens';
 
-import { Line } from './ActivityStreamItem';
+import { Line } from './stream-card-helpers';
 import { ActivityIcon } from './ActivityIcon';
 
 // Width of the shape column (mark 24 + gap 8), so the rolled-up lines indent to

--- a/src/components/activity/stream-card-helpers.tsx
+++ b/src/components/activity/stream-card-helpers.tsx
@@ -1,0 +1,119 @@
+import Link from 'next/link';
+import type { CSSProperties } from 'react';
+
+import { FM, INK2, INK3, RULE } from '@/components/lately/tokens';
+import type { StreamLinePart, StreamQuestion } from '@/lib/activity-stream';
+import { HOUSE_AUTHOR, LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
+
+// Pure, presentational stream-card helpers shared across the activity surfaces
+// (ActivityStreamItem, PersonActivityCard) and the From Friends streak cards
+// (B-FROMFRIENDS-STREAK-HEADER-01). Kept dependency-light — no answer flow, no
+// sheets — so the streak cards can reuse the one-liner renderer and the honest
+// provenance marker without pulling in the whole ActivityStreamItem tree.
+
+// Friend names render in the activity-blue from Figma (--brand-link #4a5d75),
+// linked or not, so the actor reads as the warm social anchor of the row.
+export const ACTOR_BLUE = 'var(--brand-link)';
+
+export function ActorLink({
+  name,
+  userId,
+  style,
+}: {
+  name: string;
+  userId: string | null;
+  // Optional override for surfaces that render the actor in a different voice
+  // (e.g. the playable milestone headline, where the name reads in the large
+  // Editorial serif rather than the default activity-blue sans link).
+  style?: CSSProperties;
+}) {
+  if (!userId) return <b style={{ fontWeight: 600, color: ACTOR_BLUE, ...style }}>{name}</b>;
+  return (
+    <Link
+      href={`/users/${userId}`}
+      onClick={(e) => e.stopPropagation()}
+      style={{
+        color: ACTOR_BLUE,
+        fontWeight: 600,
+        textDecoration: 'underline',
+        textDecorationColor: RULE,
+        textUnderlineOffset: 3,
+        ...style,
+      }}
+    >
+      {name}
+    </Link>
+  );
+}
+
+export function Line({ parts, plain = false }: { parts: StreamLinePart[]; plain?: boolean }) {
+  return (
+    <>
+      {parts.map((part, i) => {
+        if (part.t === 'actor') {
+          return <ActorLink key={i} name={part.name} userId={part.userId} />;
+        }
+        if (part.t === 'category') {
+          // `plain` (the ambient activity stream): the category stays in the
+          // row's own sans face so the one-liner reads in a single voice — only
+          // a touch of weight + the secondary ink set it apart from the sentence.
+          if (plain) {
+            return (
+              <span key={i} style={{ fontWeight: 600, color: INK2 }}>
+                {part.v}
+              </span>
+            );
+          }
+          // Default (editorial surfaces): category names read in the Editorial
+          // serif (STYLE-GUIDE-TYPE §5) — warm, in their stored title case
+          // ("Shakespearean Tragedy"), a register away from the sans sentence.
+          return (
+            <span
+              key={i}
+              style={{
+                fontFamily: 'var(--font-serif)',
+                fontSize: '1.05em',
+                color: INK2,
+              }}
+            >
+              {part.v}
+            </span>
+          );
+        }
+        return <span key={i}>{part.v}</span>;
+      })}
+    </>
+  );
+}
+
+// D-FEED-GROUP3-01 §4 (honesty, load-bearing): when a row expands to reveal its
+// question, a house/LLM-authored question MUST be marked — never rendered as if
+// a person wrote it. Returns the marker text, or null when no marker is needed:
+//   - authorIsHouse        → the house identity ("Joshing · Editorial")
+//   - authorName === null  → a non-person LLM-origin question (LLM_QUESTION_ATTRIBUTION)
+//   - human name / undefined → null (the row frame already attributes it; a
+//                              human author needs no machine-honesty marker)
+export function questionProvenance(q: StreamQuestion): string | null {
+  if (q.authorIsHouse) return `${HOUSE_AUTHOR.displayName} · ${HOUSE_AUTHOR.label}`;
+  if (q.authorName === null) return LLM_QUESTION_ATTRIBUTION;
+  return null;
+}
+
+export function QuestionProvenance({ q, style }: { q: StreamQuestion; style?: CSSProperties }) {
+  const label = questionProvenance(q);
+  if (!label) return null;
+  return (
+    <p
+      style={{
+        margin: '4px 0 0',
+        fontFamily: FM,
+        fontSize: 10,
+        letterSpacing: 1,
+        color: INK3,
+        ...style,
+      }}
+    >
+      {label.toUpperCase()}
+    </p>
+  );
+}

--- a/src/components/activity/use-milestone-answer.tsx
+++ b/src/components/activity/use-milestone-answer.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import { useState, type ReactNode } from 'react';
+
+import { AnswerFeedbackSheet } from '@/components/feed/AnswerFeedbackSheet';
+import { AnswerSheet } from '@/components/feed/AnswerSheet';
+import type { StreamQuestion } from '@/lib/activity-stream';
+import type { InsideJokeKind } from '@/lib/questions-types';
+
+type Feedback = {
+  isCorrect: boolean;
+  pointsAwarded: number | null;
+  correctAnswer: string;
+  explanation: string | null;
+  creatorNote: string | null;
+  insideJoke: string | null;
+  insideJokeKind: InsideJokeKind | null;
+  authorName: string | null;
+  authorIsHouse: boolean;
+  openedNewTerritory: boolean;
+  openedTerritoryDomain: string | null;
+};
+
+// The milestone answer/grade flow, lifted out of InlineAnswerFlow so the From
+// Friends streak cards (B-FROMFRIENDS-STREAK-HEADER-01) and the inline list row
+// share ONE implementation rather than re-deriving the fetch + sheet wiring.
+// Behavior is unchanged from the original InlineAnswerFlow: answers post to
+// /api/lately/milestone/answer, the result is reported up only AFTER the
+// feedback pop-up closes (so the parent can retire the question), and a wrong
+// answer can be rechecked through /api/lately/milestone/recheck.
+//
+// The consumer owns the trigger (an "ANSWER →" link, a card's Answer button)
+// and just calls `open()`; `sheets` is the conditionally-rendered AnswerSheet /
+// AnswerFeedbackSheet pair to drop into the tree.
+export function useMilestoneAnswer(
+  question: StreamQuestion,
+  onResolved: (questionId: string, submitted: string, isCorrect: boolean) => void,
+): { open: () => void; isOpen: boolean; sheets: ReactNode } {
+  const [phase, setPhase] = useState<'closed' | 'input' | 'result'>('closed');
+  const [loading, setLoading] = useState(false);
+  const [submitted, setSubmitted] = useState('');
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  async function submit(answer: string) {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/lately/milestone/answer', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ questionId: question.questionId, submitted_answer: answer }),
+      });
+      const body = (await res.json().catch(() => null)) as
+        | (Omit<Feedback, 'openedNewTerritory' | 'openedTerritoryDomain'> & {
+            masteryDelta?: { openedNewTerritory?: boolean; domain?: string | null };
+          })
+        | null;
+      if (!res.ok || !body) throw new Error('Could not score that answer.');
+      setSubmitted(answer);
+      setFeedback({
+        isCorrect: body.isCorrect,
+        pointsAwarded: body.pointsAwarded,
+        correctAnswer: body.correctAnswer,
+        explanation: body.explanation,
+        creatorNote: body.creatorNote,
+        insideJoke: body.insideJoke,
+        insideJokeKind: body.insideJokeKind,
+        authorName: body.authorName,
+        authorIsHouse: body.authorIsHouse,
+        openedNewTerritory: Boolean(body.masteryDelta?.openedNewTerritory),
+        openedTerritoryDomain: body.masteryDelta?.openedNewTerritory
+          ? (body.masteryDelta?.domain ?? null)
+          : null,
+      });
+      setPhase('result');
+    } catch {
+      // Leave the input sheet open so the viewer can retry.
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Recheck (dispute the grade) on a wrong milestone answer: re-grade through the
+  // milestone recheck route (anchored on the synthetic catch-up FeedItem the
+  // answer route wrote). On accept, reflect the win locally so the sheet flips to
+  // "Correct!" and finish() retires the question as correct.
+  async function submitRecheck(): Promise<{ accepted: boolean; message: string }> {
+    const res = await fetch('/api/lately/milestone/recheck', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ questionId: question.questionId }),
+    });
+    const body = (await res.json().catch(() => null)) as {
+      accepted?: boolean;
+      status?: string;
+      reason?: string;
+      pointsAwarded?: number;
+      message?: string;
+    } | null;
+    if (!res.ok) throw new Error(body?.message ?? 'Could not recheck that answer.');
+    const accepted = Boolean(body?.accepted);
+    const points = typeof body?.pointsAwarded === 'number' ? body.pointsAwarded : 0;
+    if (accepted) {
+      setFeedback((current) =>
+        current ? { ...current, isCorrect: true, pointsAwarded: points } : current,
+      );
+      return {
+        accepted: true,
+        message: `Recheck accepted — +${points} ${points === 1 ? 'point' : 'points'}.`,
+      };
+    }
+    if (body?.status === 'needs_human') {
+      return { accepted: false, message: body.reason ?? 'Flagged for a human look.' };
+    }
+    return { accepted: false, message: body?.reason ?? 'Rechecked and still marked wrong.' };
+  }
+
+  // Hand the resolution up only once the viewer dismisses the result pop-up, so
+  // the sheet stays visible through the reveal, then the parent moves the
+  // question into its answered/spent state.
+  function finish() {
+    setPhase('closed');
+    if (feedback) onResolved(question.questionId, submitted, feedback.isCorrect);
+  }
+
+  const sheets = (
+    <>
+      {phase === 'input' ? (
+        <AnswerSheet
+          question={question.text}
+          category={question.domain}
+          loading={loading}
+          onSubmit={(answer) => void submit(answer)}
+          onClose={() => setPhase('closed')}
+        />
+      ) : null}
+
+      {phase === 'result' && feedback ? (
+        <AnswerFeedbackSheet
+          question={question.text}
+          category={question.domain}
+          isCorrect={feedback.isCorrect}
+          pointsAwarded={feedback.pointsAwarded}
+          correctAnswer={feedback.correctAnswer}
+          submittedAnswer={submitted}
+          explanation={feedback.explanation}
+          creatorNote={feedback.creatorNote}
+          insideJoke={feedback.insideJoke}
+          insideJokeKind={feedback.insideJokeKind}
+          authorName={feedback.authorName}
+          authorIsHouse={feedback.authorIsHouse}
+          openedNewTerritory={feedback.openedNewTerritory}
+          openedTerritoryDomain={feedback.openedTerritoryDomain}
+          questionId={question.questionId}
+          feedItemId={`milestone:${question.questionId}`}
+          report={{ target: { questionId: question.questionId }, surface: 'lately_result' }}
+          onRecheck={feedback.isCorrect ? null : submitRecheck}
+          onClose={finish}
+        />
+      ) : null}
+    </>
+  );
+
+  return { open: () => setPhase('input'), isOpen: phase !== 'closed', sheets };
+}

--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -1,0 +1,239 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+
+import { QuestionTriangle } from '@/components/activity/ActivityIcon';
+import {
+  Line,
+  QuestionProvenance,
+  questionProvenance,
+} from '@/components/activity/stream-card-helpers';
+import { useMilestoneAnswer } from '@/components/activity/use-milestone-answer';
+import { FS, INK, INK3 } from '@/components/lately/tokens';
+import type { StreamItem, StreamQuestion } from '@/lib/activity-stream';
+
+import { SparkleEnvelope } from './SparkleEnvelope';
+import { useStreakResolutions, type StreakResolution } from './use-streak-resolutions';
+
+// B-FROMFRIENDS-STREAK-HEADER-01 — bundle-as-header, cards-as-children.
+//
+// The From Friends zone used to collapse a friend's milestone streak into ONE
+// one-liner ("X of 5 questions" + a single Play that expanded inline). This
+// renders the same StreamItem as a lightweight section HEADER (the friend's
+// streak line, once) followed by one ANSWER/DISMISS card per question, in the
+// exact `DirectSentCard` register — one card language for "answer or pass",
+// whether a question was sent directly or surfaced through a friend's streak.
+//
+// Decisions this builds to (DECISIONS.md, do not re-litigate):
+//   D-A  header + per-question cards in the DirectSentCard register.
+//   D-C  single-question bundles get NO header; the card carries a compact
+//        "via {friend}'s streak" line instead. Header renders only at size ≥ 2.
+//   D-D  each card renders honest human/house provenance PRE-answer; no generic
+//        "A friend" fallback for machine content.
+// The budget/server layer is untouched: whole streaks only, never split.
+export function FromFriendsStreak({
+  item,
+  elevated = false,
+  onQuestionResolved,
+}: {
+  item: StreamItem;
+  elevated?: boolean;
+  // Fires after a card is answered in place. The /from-friends overflow subpage
+  // (B-HOME-OVERFLOW-02 §7) uses it to refresh the router cache so Home recomputes
+  // its served window on return; Home itself omits it.
+  onQuestionResolved?: () => void;
+}) {
+  const expand = item.expand;
+  const questions = expand && expand.kind === 'milestone' ? expand.questions : [];
+  // The shared per-card answered-state (Phase 2): one resolution set for the
+  // whole streak, so answering one card resolves only that card and persists
+  // across the result-sheet close + re-render. Called unconditionally to keep
+  // the hook order stable; the early return below guards the render.
+  const { isResolved, resolve, resolutions } = useStreakResolutions(questions, onQuestionResolved);
+
+  if (!expand || expand.kind !== 'milestone' || questions.length === 0) return null;
+
+  // D-C: ≥2 questions get the streak header; a lone question stands alone and
+  // carries the compact "via {friend}'s streak" line on its card instead.
+  const showHeader = questions.length >= 2;
+
+  return (
+    <div className="space-y-3">
+      {showHeader ? <StreakHeader item={item} /> : null}
+      {questions.map((q) => (
+        <StreakQuestionCard
+          key={q.questionId}
+          question={q}
+          friendName={expand.friendName}
+          friendId={expand.friendId}
+          showViaLine={!showHeader}
+          elevated={elevated}
+          resolved={isResolved(q.questionId)}
+          resolution={resolutions.get(q.questionId) ?? null}
+          onResolved={resolve}
+        />
+      ))}
+    </div>
+  );
+}
+
+// The streak line as a lightweight editorial header — the friend's name + the
+// rolled-up domains the builder already composed (e.g. "Joshua P has been on a
+// tear through Tennis Fundamentals, Early 20th Century American History and 3
+// others"). It stands alone above the cards rather than introducing a Play
+// affordance. The triangle answered-state is owned per-card, not here.
+function StreakHeader({ item }: { item: StreamItem }) {
+  return (
+    <p
+      style={{
+        margin: 0,
+        fontFamily: FS,
+        fontSize: 18,
+        lineHeight: 1.4,
+        letterSpacing: 0.2,
+        color: INK,
+      }}
+    >
+      <Line parts={item.line} />
+    </p>
+  );
+}
+
+// One answerable question, rendered as a DirectSentCard-register card: the
+// bordered SparkleEnvelope frame, an Answer primary button, and a Dismiss link.
+// Once answered or dismissed it reads as a calm spent card (not removed).
+function StreakQuestionCard({
+  question,
+  friendName,
+  friendId,
+  showViaLine,
+  elevated,
+  resolved,
+  resolution,
+  onResolved,
+}: {
+  question: StreamQuestion;
+  friendName: string;
+  friendId: string | null;
+  showViaLine: boolean;
+  elevated: boolean;
+  resolved: boolean;
+  resolution: StreakResolution | null;
+  onResolved: (questionId: string, submitted: string, isCorrect: boolean) => void;
+}) {
+  // The same milestone answer/grade flow the inline list row uses; the card's
+  // Answer button just opens it. Hook is called unconditionally (the spent
+  // branch below still mounts the component).
+  const answer = useMilestoneAnswer(question, onResolved);
+  // Dismiss is view-state only ("pass"): mark the card spent locally, matching
+  // the directed card's Dismiss. No milestone has a server "pass" — passing is
+  // simply declining to play, and the card stays as a spent (passed) tile.
+  const [passed, setPassed] = useState(false);
+
+  if (resolved || passed) {
+    return (
+      <SpentStreakCard
+        question={question}
+        resolution={resolution}
+        passed={passed && !resolved}
+        elevated={elevated}
+      />
+    );
+  }
+
+  // The per-card mark: a solid triangle leads the signal row (unplayed),
+  // flipping to hollow on the spent card — preserving the solid→hollow
+  // answered-state the bundle line used to carry, now once per card.
+  const signal = (
+    <span className="inline-flex items-center gap-2">
+      <QuestionTriangle solid seed={question.questionId} />
+      {showViaLine ? (
+        <span>
+          via{' '}
+          {friendId ? (
+            <Link
+              href={`/users/${friendId}`}
+              className="font-semibold text-[var(--brand-link)] hover:opacity-70"
+            >
+              {friendName}
+            </Link>
+          ) : (
+            <span className="font-semibold text-[var(--brand-link)]">{friendName}</span>
+          )}
+          &rsquo;s streak
+        </span>
+      ) : null}
+    </span>
+  );
+
+  // D-D (canon): honest provenance PRE-answer — house/LLM marked, human shows
+  // nothing (the streak already attributes the answerer; authorship is a
+  // separate fact and only the machine cases need a marker). Rendered above the
+  // Answer action, exactly as the send-onward path does. Only passed when there
+  // is a real marker, so a human-authored card never renders an empty slot — and
+  // never the generic "A friend" string.
+  const viaAttribution = questionProvenance(question) ? (
+    <QuestionProvenance q={question} style={{ margin: 0 }} />
+  ) : undefined;
+
+  return (
+    <>
+      <SparkleEnvelope
+        variant="bordered"
+        signal={signal}
+        question={question.text}
+        onAnswer={answer.open}
+        answerAsButton
+        onDismiss={() => setPassed(true)}
+        viaAttribution={viaAttribution}
+        elevated={elevated}
+      />
+      {answer.sheets}
+    </>
+  );
+}
+
+// The calm spent treatment for a settled card (matching AnsweredByYouCard's
+// register): the bordered frame at reduced emphasis, a hollow triangle, and a
+// quiet result line — "Correct" / "Not this time" (in the semantic answer
+// colors) or "Passed" for a dismissed card. The card stays in place, spent, not
+// removed (Phase 2).
+function SpentStreakCard({
+  question,
+  resolution,
+  passed,
+  elevated,
+}: {
+  question: StreamQuestion;
+  resolution: StreakResolution | null;
+  passed: boolean;
+  elevated: boolean;
+}) {
+  // priorResult is non-null when the server already had this attempt on load (we
+  // lack the submitted text then); an in-session resolution carries both.
+  const isCorrect = resolution ? resolution.isCorrect : question.priorResult !== 'incorrect';
+  const label = passed ? 'Passed' : isCorrect ? 'Correct' : 'Not this time';
+  const color = passed ? INK3 : isCorrect ? 'var(--game-correct)' : 'var(--game-wrong)';
+
+  const signal = (
+    <span className="inline-flex items-center gap-2 font-semibold" style={{ color }}>
+      <QuestionTriangle solid={false} seed={question.questionId} />
+      <span>
+        {label}
+        {resolution ? ` — ${resolution.submitted}` : ''}
+      </span>
+    </span>
+  );
+
+  return (
+    <div style={{ opacity: 0.7 }}>
+      <SparkleEnvelope
+        variant="bordered"
+        signal={signal}
+        question={question.text}
+        elevated={elevated}
+      />
+    </div>
+  );
+}

--- a/src/components/feed/__tests__/FromFriendsStreak.test.tsx
+++ b/src/components/feed/__tests__/FromFriendsStreak.test.tsx
@@ -1,0 +1,119 @@
+import type * as React from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import type { StreamItem, StreamQuestion } from '@/lib/activity-stream';
+
+vi.mock('next/link', () => ({
+  default: ({ href, children }: { href: string; children: React.ReactNode }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+// The answer/grade flow is exercised by its own surfaces; stub it so this test
+// stays on FromFriendsStreak's own rendering (header fork, card frame, spent
+// state, provenance) and doesn't pull in the answer sheets.
+vi.mock('@/components/activity/use-milestone-answer', () => ({
+  useMilestoneAnswer: () => ({ open: () => {}, isOpen: false, sheets: null }),
+}));
+
+import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak';
+
+const q = (questionId: string, overrides: Partial<StreamQuestion> = {}): StreamQuestion => ({
+  questionId,
+  text: `Question ${questionId}`,
+  domain: 'Tennis Fundamentals',
+  priorResult: null,
+  ...overrides,
+});
+
+function streakItem(
+  questions: StreamQuestion[],
+  friendName = 'Joshua P',
+  friendId = 'friend-1',
+): StreamItem {
+  return {
+    id: 'm-1',
+    sortAt: new Date('2026-06-20T12:00:00Z'),
+    tier: 0,
+    friendId,
+    homeEligible: true,
+    line: [
+      { t: 'actor', name: friendName, userId: friendId },
+      { t: 'text', v: ' has been on a tear through ' },
+      { t: 'category', v: 'Tennis Fundamentals' },
+    ],
+    secondLine: null,
+    anchorId: null,
+    action: null,
+    icon: 'bundle',
+    expand: { kind: 'milestone', friendId, friendName, questions },
+  };
+}
+
+// Count the active answer cards: SparkleEnvelope renders Answer as a btn-primary
+// button, present only on still-answerable cards (spent cards drop the actions).
+function answerCardCount(html: string): number {
+  return (html.match(/btn-primary/g) ?? []).length;
+}
+
+describe('FromFriendsStreak — header-presence fork (D-C)', () => {
+  it('renders a header + one card per question for a ≥2 bundle', () => {
+    const html = renderToStaticMarkup(<FromFriendsStreak item={streakItem([q('a'), q('b')])} />);
+    // The streak line renders as a header (the friend + the rolled-up domains).
+    expect(html).toContain('has been on a tear through');
+    expect(html).toContain('Tennis Fundamentals');
+    // One answerable card per question.
+    expect(answerCardCount(html)).toBe(2);
+    expect(html).toContain('Question a');
+    expect(html).toContain('Question b');
+    // No per-card "via" line when the header carries the attribution.
+    expect(html).not.toContain('via ');
+  });
+
+  it('renders a single card with NO header and a "via {friend}’s streak" line for a 1-question bundle', () => {
+    const html = renderToStaticMarkup(<FromFriendsStreak item={streakItem([q('solo')])} />);
+    // No header: the streak predicate / domain roll-up is absent.
+    expect(html).not.toContain('has been on a tear through');
+    expect(html).not.toContain('Tennis Fundamentals');
+    // The lone card carries the compact answerer-streak attribution instead.
+    expect(html).toContain('via ');
+    expect(html).toContain('Joshua P');
+    expect(html).toContain('streak');
+    expect(answerCardCount(html)).toBe(1);
+  });
+});
+
+describe('FromFriendsStreak — per-card spent state (Phase 2)', () => {
+  it('renders a seeded (prior-result) card as spent and leaves the others answerable', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' }), q('fresh')])} />,
+    );
+    // The settled card reads as spent ("Correct"), not as an answer card; only
+    // the fresh question keeps its Answer button. Resolving one card never
+    // collapses the others.
+    expect(html).toContain('Correct');
+    expect(answerCardCount(html)).toBe(1);
+  });
+});
+
+describe('FromFriendsStreak — honest provenance pre-answer (D-D canon)', () => {
+  it('marks house/LLM authorship and never falls back to "A friend"', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([
+          q('house', { authorIsHouse: true, authorName: 'Joshing' }),
+          q('llm', { authorName: null }),
+          q('human', { authorName: 'Sam Rivera', authorIsHouse: false }),
+        ])}
+      />,
+    );
+    // House content shows the house marker; LLM content shows the machine label.
+    expect(html).toContain('JOSHING · EDITORIAL');
+    expect(html).toContain('MAID ACASA');
+    // Canon gate: machine content NEVER renders as if a person wrote it.
+    expect(html).not.toContain('A friend');
+    // All three cards are answerable (provenance renders pre-answer).
+    expect(answerCardCount(html)).toBe(3);
+  });
+});

--- a/src/components/feed/__tests__/use-streak-resolutions.test.tsx
+++ b/src/components/feed/__tests__/use-streak-resolutions.test.tsx
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { useStreakResolutions } from '@/components/feed/use-streak-resolutions';
+import type { StreamQuestion } from '@/lib/activity-stream';
+
+// The per-card resolution state for a From Friends streak
+// (B-FROMFRIENDS-STREAK-HEADER-01, Phase 2). The load-bearing behavior is the
+// SEED/lock: a question carrying ANY prior result (right OR wrong) mounts as
+// resolved, so it persists as spent across a re-render rather than re-offering
+// a second swing; a fresh question mounts open. We drive the hook through a
+// static-render harness (the suite runs in a node env with no DOM), which
+// exercises exactly that seed.
+
+const q = (questionId: string, priorResult: StreamQuestion['priorResult']): StreamQuestion => ({
+  questionId,
+  text: questionId,
+  domain: null,
+  priorResult,
+});
+
+function Harness({ questions }: { questions: StreamQuestion[] }) {
+  const { isResolved, answeredCount } = useStreakResolutions(questions);
+  return (
+    <div>
+      <span>count:{answeredCount}</span>
+      {questions.map((question) => (
+        <span key={question.questionId}>
+          {question.questionId}:{isResolved(question.questionId) ? 'spent' : 'open'}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+describe('useStreakResolutions', () => {
+  it('seeds any prior result (correct OR incorrect) as resolved, fresh as open', () => {
+    const html = renderToStaticMarkup(
+      <Harness questions={[q('a', 'correct'), q('b', 'incorrect'), q('c', null)]} />,
+    );
+    expect(html).toContain('a:spent');
+    // A prior WRONG attempt locks the card the same way a correct one does — a
+    // single attempt is the viewer's only swing in the feed.
+    expect(html).toContain('b:spent');
+    expect(html).toContain('c:open');
+    // answeredCount counts every settled question (server-prior + in-session).
+    expect(html).toContain('count:2');
+  });
+
+  it('starts an all-fresh streak fully open with a zero count', () => {
+    const html = renderToStaticMarkup(<Harness questions={[q('a', null), q('b', null)]} />);
+    expect(html).toContain('a:open');
+    expect(html).toContain('b:open');
+    expect(html).toContain('count:0');
+  });
+});

--- a/src/components/feed/use-streak-resolutions.ts
+++ b/src/components/feed/use-streak-resolutions.ts
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+
+import type { StreamQuestion } from '@/lib/activity-stream';
+
+// One in-session answer to a streak question: what the viewer typed and whether
+// it was scored correct. Drives the per-card spent treatment's result line.
+export type StreakResolution = { submitted: string; isCorrect: boolean };
+
+export type StreakResolutions = {
+  /** Settled (answered right OR wrong) — no longer answerable this session. */
+  isResolved: (questionId: string) => boolean;
+  /** Record an in-session answer; locks the question and ticks the count. */
+  resolve: (questionId: string, submitted: string, isCorrect: boolean) => void;
+  /** Per-question submitted answer + correctness, for the spent card's read-back. */
+  resolutions: Map<string, StreakResolution>;
+  /** How many of the streak's questions are settled (server-prior + in-session). */
+  answeredCount: number;
+};
+
+// The per-card answered-state for a From Friends streak
+// (B-FROMFRIENDS-STREAK-HEADER-01, Phase 2). Lifted from the milestone bundle
+// logic that ActivityStreamItem owned, so all the cards in one streak share a
+// single resolution set: answering one card resolves only that card, persists
+// across the result-sheet close + re-render (the useState(Set/Map) seed pattern),
+// and does not collapse the others.
+//
+// A question with ANY prior result (correct OR incorrect) is seeded as resolved
+// at mount — a single attempt is the viewer's only swing in the feed, so any
+// prior result locks the card the same way an in-session answer does.
+export function useStreakResolutions(
+  questions: StreamQuestion[],
+  onResolved?: () => void,
+): StreakResolutions {
+  const [serverAnswered] = useState<Set<string>>(
+    () => new Set(questions.filter((q) => q.priorResult !== null).map((q) => q.questionId)),
+  );
+  const [resolutions, setResolutions] = useState<Map<string, StreakResolution>>(() => new Map());
+
+  function isResolved(questionId: string): boolean {
+    return serverAnswered.has(questionId) || resolutions.has(questionId);
+  }
+
+  function resolve(questionId: string, submitted: string, isCorrect: boolean) {
+    setResolutions((prev) => {
+      const next = new Map(prev);
+      next.set(questionId, { submitted, isCorrect });
+      return next;
+    });
+    onResolved?.();
+  }
+
+  const answeredCount = questions.filter((q) => isResolved(q.questionId)).length;
+
+  return { isResolved, resolve, resolutions, answeredCount };
+}


### PR DESCRIPTION
Replace the collapsed From Friends milestone bundle (one-liner + "X of 5"
+ a single Play that expands inline) with a lightweight streak header plus
one answer/dismiss card per question, in the DirectSentCard register.

- New FromFriendsStreak component (D-A): ≥2 questions render a header +
  per-question cards; a 1-question bundle renders one card with no header
  and a compact "via {friend}'s streak" line (D-C). Cards reuse the
  bordered SparkleEnvelope frame (Answer button + Dismiss link).
- Per-card answered/dismissed state + solid→hollow triangle preserved via
  a shared useStreakResolutions hook lifted from ActivityStreamItem; an
  answered/passed card reads as a calm spent tile, not removed (Phase 2).
- Honest provenance rendered pre-answer on each card (D-D canon): house/
  LLM marked, human shows nothing, never a generic "A friend" fallback.
- Extract the pure one-liner / provenance renderers into
  stream-card-helpers, and the milestone answer/grade flow into
  useMilestoneAnswer, so the streak cards reuse them without re-deriving
  behavior. InlineAnswerFlow now wraps the shared hook (behavior unchanged).
- FeedList routes home-zone milestone rows through FromFriendsStreak; the
  /from-friends overflow (PendingPlayablesList) matches. From Friends
  overflow now reads "{N} more from friends →" and counts bundles (D-B).

Budget/server layer untouched — PLAYABLE_SERVE_CAP stays 4, whole streaks
never split. The flat /activities log keeps the collapsed bundle.

Phase 4 (final header/"via" copy + F-COUNT) ships F-COUNT (a) — the cards
are the count, no explicit "X of 5" — pending Robyn's register read.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SWkzz1x8UHWCh88SV6rumN