### PR TITLE
From Friends streak: nest cards under header, inline attribution, drop solved questions

### DIFF
--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -2,7 +2,12 @@
 
 import { useState } from 'react';
 
-import { ActorLink, Line, QuestionProvenance } from '@/components/activity/stream-card-helpers';
+import {
+  ActorLink,
+  Line,
+  QuestionProvenance,
+  questionProvenance,
+} from '@/components/activity/stream-card-helpers';
 import { useMilestoneAnswer } from '@/components/activity/use-milestone-answer';
 import { FF, FM, FS, INK, INK2, INK3 } from '@/components/lately/tokens';
 import type { StreamItem, StreamQuestion } from '@/lib/activity-stream';
@@ -17,6 +22,11 @@ import { useStreakResolutions, type StreakResolution } from './use-streak-resolu
 // pulls from the established category-color system (colorForCategory → the
 // --cat-* / portrait scale the feed already uses), so no hex is hand-picked here.
 const TEAL = 'var(--tri-darkteal)';
+
+// The card stack indents under the streak header so the cards read as children
+// of it. Aligns the cards' left edge with the header TEXT (past the header's
+// hourglass mark + gap), the way an expansion sits under its row.
+const CARD_INDENT = 20;
 
 // B-FROMFRIENDS-STREAK-HEADER-01 — bundle-as-header, cards-as-children.
 //
@@ -55,26 +65,53 @@ export function FromFriendsStreak({
 
   if (!expand || expand.kind !== 'milestone' || questions.length === 0) return null;
 
-  // D-C: ≥2 questions get the streak header; a lone question stands alone and
-  // carries the compact "via {friend}'s streak" line on its card instead.
+  // New paradigm: a question the viewer has gotten CORRECT drops out of the
+  // streak entirely (server-prior or in-session) — "I got it, I don't need to
+  // see it again." A miss stays as a spent card; an unanswered one stays
+  // answerable. When nothing's left to show, the whole streak (header included)
+  // disappears.
+  const answeredCorrect = (q: StreamQuestion): boolean => {
+    const r = resolutions.get(q.questionId);
+    return r ? r.isCorrect : q.priorResult === 'correct';
+  };
+  const visible = questions.filter((q) => !answeredCorrect(q));
+  if (visible.length === 0) return null;
+
+  // D-C: a streak whose ORIGINAL bundle holds ≥2 questions gets the header; a
+  // lone-question bundle stands alone with the compact "via {friend}'s streak"
+  // line instead. Keyed on the original size so the header doesn't flip to the
+  // via-line mid-session as questions resolve away.
   const showHeader = questions.length >= 2;
+
+  const cards = visible.map((q) => (
+    <StreakQuestionCard
+      key={q.questionId}
+      question={q}
+      friendName={expand.friendName}
+      friendId={expand.friendId}
+      showViaLine={!showHeader}
+      elevated={elevated}
+      resolved={isResolved(q.questionId)}
+      resolution={resolutions.get(q.questionId) ?? null}
+      onResolved={resolve}
+    />
+  ));
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
       {showHeader ? <StreakHeader item={item} /> : null}
-      {questions.map((q) => (
-        <StreakQuestionCard
-          key={q.questionId}
-          question={q}
-          friendName={expand.friendName}
-          friendId={expand.friendId}
-          showViaLine={!showHeader}
-          elevated={elevated}
-          resolved={isResolved(q.questionId)}
-          resolution={resolutions.get(q.questionId) ?? null}
-          onResolved={resolve}
-        />
-      ))}
+      {/* Indent the card stack under the header so the cards read as its
+          children (request: "look like they're under the Jaime heading"). */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          marginLeft: showHeader ? CARD_INDENT : 0,
+        }}
+      >
+        {cards}
+      </div>
     </div>
   );
 }
@@ -181,6 +218,7 @@ function StreakQuestionCard({
   const [passed, setPassed] = useState(false);
 
   const category = question.domain?.trim() || null;
+  const hasProvenance = questionProvenance(question) !== null;
 
   if (passed && !resolved) {
     return (
@@ -227,16 +265,23 @@ function StreakQuestionCard({
           </div>
         ) : null}
 
-        {category ? (
-          <div style={{ marginBottom: 10 }}>
-            <CategoryLabel category={category} />
+        {/* Category eyebrow with the authorship marker on the SAME row (right-
+            aligned) to save vertical space. D-D (canon): house/LLM authorship is
+            marked PRE-answer; human shows nothing, never a generic "A friend". */}
+        {category || hasProvenance ? (
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              marginBottom: 10,
+            }}
+          >
+            {category ? <CategoryLabel category={category} /> : <span />}
+            {hasProvenance ? <QuestionProvenance q={question} style={{ margin: 0 }} /> : null}
           </div>
         ) : null}
-
-        {/* D-D (canon): honest authorship PRE-answer — house/LLM marked, human
-            shows nothing, never a generic "A friend" fallback. Self-guards to
-            null when no marker is needed. */}
-        <QuestionProvenance q={question} style={{ margin: '0 0 10px' }} />
 
         <p
           style={{

--- a/src/components/feed/__tests__/FromFriendsStreak.test.tsx
+++ b/src/components/feed/__tests__/FromFriendsStreak.test.tsx
@@ -85,16 +85,37 @@ describe('FromFriendsStreak — header-presence fork (D-C)', () => {
   });
 });
 
-describe('FromFriendsStreak — per-card spent state (Phase 2)', () => {
-  it('renders a seeded (prior-result) card as spent and leaves the others answerable', () => {
+describe('FromFriendsStreak — answered questions resolve in place (Phase 2)', () => {
+  it('removes a correctly-answered question and leaves the rest answerable', () => {
     const html = renderToStaticMarkup(
       <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' }), q('fresh')])} />,
     );
-    // The settled card reads as spent ("Correct"), not as an answer card; only
-    // the fresh question keeps its Answer button. Resolving one card never
-    // collapses the others.
-    expect(html).toContain('Correct');
+    // New paradigm: a correct answer drops out of the streak entirely.
+    expect(html).not.toContain('Question done');
+    expect(html).toContain('Question fresh');
     expect(answerCardCount(html)).toBe(1);
+  });
+
+  it('keeps an incorrectly-answered question as a spent "Not this time" card', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('missed', { priorResult: 'incorrect' }), q('fresh')])}
+      />,
+    );
+    // A miss stays visible (spent), only the fresh one is still answerable.
+    expect(html).toContain('Not this time');
+    expect(html).toContain('Question missed');
+    expect(answerCardCount(html)).toBe(1);
+  });
+
+  it('renders nothing once every question is already correct', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak
+        item={streakItem([q('a', { priorResult: 'correct' }), q('b', { priorResult: 'correct' })])}
+      />,
+    );
+    // The whole streak (header included) disappears when nothing's left to show.
+    expect(html).toBe('');
   });
 });
 


### PR DESCRIPTION
Follow-up to #1151 (merged) — applies the review feedback on the Option C From Friends treatment. Pure render change; budget/server layer untouched.

## Changes

- **Cards nested under the header.** The per-question card stack is now indented under the "{friend} has been on a streak…" heading so the cards read as its children.
- **Attribution inline with the category.** The authorship marker (e.g. `MAID ACASA`) moves onto the category eyebrow row, right-aligned, instead of its own line — saves a line of height. D-D honesty preserved: house/LLM still marked pre-answer, human shows nothing.
- **Correct → gone (new paradigm).** A question the viewer has answered correctly (server-prior or in-session) drops out of the streak entirely — "I got it, I don't need to see it again." A miss stays as a spent "Not this time" card; an unanswered one stays answerable. When nothing's left, the whole streak (header included) disappears.

## Notes

- **No new colors** — existing tokens only; color ratchet unchanged at 147, radius green.
- Tests updated for the removal paradigm (correct removed / miss retained / all-correct → empty).
- **Budget interaction (flagged):** the server still counts a fully-correct bundle in the served 4 and in the "N more from friends" overflow, but the client now renders it as nothing — so a zone can occasionally show fewer cards than the overflow count implies. Excluding viewer-correct bundles from the budget is a server change, out of scope for this render-only PR; happy to file a follow-up.

## Verification

Typecheck clean · eslint clean · color/radius ratchets green · 16 tests passing (`FromFriendsStreak` + `useStreakResolutions` + `FeedListBudget` + `OverflowSubpageSync`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWkzz1x8UHWCh88SV6rumN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWkzz1x8UHWCh88SV6rumN)_