### PR TITLE
From Friends: streak as a tappable bundle summary → its own page

### DIFF
--- a/src/app/from-friends/PendingPlayablesList.tsx
+++ b/src/app/from-friends/PendingPlayablesList.tsx
@@ -1,27 +1,29 @@
 'use client'
 
-import { useRouter } from 'next/navigation'
-
-import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak'
+import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
+import { formatRelativeTime } from '@/components/feed/visual'
 import type { StreamItem } from '@/lib/activity-stream'
 
-// The full pending-playables queue, answerable in place. Each streak renders
-// through the exact home-zone treatment (B-FROMFRIENDS-STREAK-HEADER-01: a
-// header + per-question answer/dismiss cards in the DirectSentCard register),
-// so the From Friends zone reads identically on Home and on this overflow page.
-// Resolving a question refreshes the router cache so Home recomputes its
-// served top-4 and overflow count on return (D-HOME-PACING-01 §7); the cards
-// themselves stay in place as their in-session spent state.
+// The full From Friends queue, each streak shown as the compact triangle bundle
+// summary (B-FROMFRIENDS-STREAK-PAGE-01) — the exact treatment Home uses — that
+// links into the streak's own page where its questions are answerable. Keeping
+// the overflow list and Home identical means the surface reads the same in both
+// places; the per-streak page is the one place you actually play.
 export function PendingPlayablesList({ items }: { items: StreamItem[] }) {
-  const router = useRouter()
   return (
     <section className="space-y-3">
       {items.map((item) => (
-        <FromFriendsStreak
+        <ActivityStreamItem
           key={item.id}
           item={item}
+          timestamp={formatRelativeTime(item.sortAt)}
+          showTimestamp={false}
           elevated
-          onQuestionResolved={() => router.refresh()}
+          playHref={
+            item.expand?.kind === 'milestone'
+              ? `/from-friends/${encodeURIComponent(item.id)}`
+              : undefined
+          }
         />
       ))}
     </section>

--- a/src/app/from-friends/[streakId]/page.tsx
+++ b/src/app/from-friends/[streakId]/page.tsx
@@ -1,0 +1,39 @@
+import { notFound, redirect } from 'next/navigation';
+
+import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak';
+import { streakPageTitle } from '@/components/feed/streak-meta';
+import { OverflowSubpageHeader } from '@/components/home/OverflowSubpageHeader';
+import { getSession } from '@/server/auth/session';
+import { buildFriendActivityQueue } from '@/server/home/build-edition';
+
+// B-FROMFRIENDS-STREAK-PAGE-01 — a single friend's streak on its own page.
+// Home (and the /from-friends overflow) show each streak as a compact triangle
+// bundle summary; tapping it lands here, where the streak's questions render in
+// the full answer/dismiss card treatment under a "{Friend}'s questions about …"
+// header. The streak id is the StreamItem id, looked up in the same friend-
+// activity queue Home windows from, so the page can never drift from Home.
+export default async function FromFriendsStreakPage({
+  params,
+}: {
+  params: Promise<{ streakId: string }>;
+}) {
+  const { streakId } = await params;
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const items = await buildFriendActivityQueue(session.userId);
+  const streak = items.find((item) => item.id === decodeURIComponent(streakId));
+  // Gone (or never a milestone) → fall back to the overflow list rather than a
+  // hard 404; a streak the viewer has fully exhausted simply isn't here anymore.
+  if (!streak) redirect('/from-friends');
+  if (streak.expand?.kind !== 'milestone') notFound();
+
+  const title = streakPageTitle(streak.expand.friendName, streak.expand.questions);
+
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
+      <OverflowSubpageHeader eyebrow="From Friends" title={title} />
+      <FromFriendsStreak item={streak} elevated headerless />
+    </main>
+  );
+}

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -26,7 +26,6 @@ import { SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
 import { formatRelativeTime, groupItemsByRecency } from '@/components/feed/visual'
 import { pickOpenedNewTerritory, pickOpenedTerritoryDomain } from '@/components/feed/territory'
 import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
-import { FromFriendsStreak } from '@/components/feed/FromFriendsStreak'
 import { PersonActivityCard } from '@/components/activity/PersonActivityCard'
 import { groupActivityByFriend, type GroupInputRow, type GroupedRow } from '@/components/feed/person-grouping'
 import { EditorialFeature } from '@/components/feed/EditorialFeature'
@@ -1760,18 +1759,21 @@ function FeedListContent({
       if (embed?.kind === 'recently_expanding') {
         return <RecentlyExpandingFeature key={`e-${row.item.id}`} embed={embed} />
       }
-      // From Friends milestone streaks render as a header + per-question
-      // answer/dismiss cards (B-FROMFRIENDS-STREAK-HEADER-01) on the home zones
-      // (Home + the /from-friends overflow, both `homeZoneCards`). The flat
-      // /activities log keeps the collapsed one-liner bundle via
-      // ActivityStreamItem below. Server budget is unchanged — whole streaks
-      // only, never split.
+      // From Friends milestone streaks render as a compact triangle bundle
+      // SUMMARY on the home zone (B-FROMFRIENDS-STREAK-PAGE-01): tapping opens the
+      // streak's own page (/from-friends/[id]) — where the questions render in the
+      // full answer/dismiss treatment — rather than expanding inline, so the home
+      // zone stays glanceable. The flat /activities log keeps the in-place expand
+      // (no playHref). Server budget is unchanged — whole streaks only.
       if (row.item.expand?.kind === 'milestone' && homeZoneCards) {
         return (
-          <FromFriendsStreak
+          <ActivityStreamItem
             key={`ff-${row.item.id}`}
             item={row.item}
-            elevated={homeZoneCards}
+            timestamp={formatRelativeTime(row.item.sortAt)}
+            showTimestamp={false}
+            elevated
+            playHref={`/from-friends/${encodeURIComponent(row.item.id)}`}
           />
         )
       }
@@ -2112,7 +2114,7 @@ function FeedListContent({
                     unifiedHome={unifiedHome}
                     prominent
                     windowLabel={bandLabelVisible && bandHasContent ? 'Past 7 days' : undefined}
-                    subtitle="Answer or pass — each question stands on its own."
+                    subtitle="Tap a streak to play your friend's questions."
                   >
                     From Friends
                   </FeedSectionHeading>

--- a/src/components/__tests__/FeedListBudget.test.tsx
+++ b/src/components/__tests__/FeedListBudget.test.tsx
@@ -42,18 +42,13 @@ vi.mock('@/components/feed', () => ({
   visibleFeedCategory: (c: string | null | undefined) => c ?? null,
 }))
 
+// From Friends milestone streaks render as a compact bundle summary through
+// ActivityStreamItem on the home zone now (B-FROMFRIENDS-STREAK-PAGE-01: tap to
+// open the streak's own page); stub it to a marker so this test exercises the
+// budgeted SECTIONING, not the card internals.
 vi.mock('@/components/activity/ActivityStreamItem', () => ({
   ActivityStreamItem: ({ item }: { item: { id: string; friendId?: string | null } }) => (
     <div data-activity={item.id}>activity:{item.id}:{item.friendId ?? 'none'}</div>
-  ),
-}))
-
-// From Friends milestone streaks now render through FromFriendsStreak on the home
-// zones (B-FROMFRIENDS-STREAK-HEADER-01); stub it to a marker so this test
-// exercises the budgeted SECTIONING, not the card internals.
-vi.mock('@/components/feed/FromFriendsStreak', () => ({
-  FromFriendsStreak: ({ item }: { item: { id: string; friendId?: string | null } }) => (
-    <div data-streak={item.id}>streak:{item.id}:{item.friendId ?? 'none'}</div>
   ),
 }))
 
@@ -183,9 +178,9 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html.match(/Past 7 days/g) ?? []).toHaveLength(1)
     expect(html).toContain('Recent activity')
     // From Friends is promoted to a peer of "For you" and carries a descriptive
-    // subtitle beneath its heading — it names the per-card answer/dismiss model,
-    // not a single "Play" (Phase 4).
-    expect(html).toContain('Answer or pass — each question stands on its own')
+    // subtitle beneath its heading — it now names the tap-to-open model
+    // (B-FROMFRIENDS-STREAK-PAGE-01), not inline answering.
+    expect(html).toContain('Tap a streak to play your friend')
     expect(html.indexOf('questions your friends created or sent directly to you')).toBeLessThan(
       html.indexOf('Past 7 days'),
     )
@@ -193,9 +188,10 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html.indexOf('Past 7 days')).toBeGreaterThan(html.indexOf('From Friends'))
     expect(html).toContain('href="/for-you"')
     expect(html).toContain('href="/from-friends"')
-    // Served direct cards and playables both rendered (playables now as streaks).
+    // Served direct cards and playables both rendered (playables now render as
+    // compact bundle summaries via the ActivityStreamItem marker).
     expect(html).toContain('direct:robyn')
-    expect(html).toContain('streak:p0:josh')
+    expect(html).toContain('activity:p0:josh')
     // Texture row rendered, and NO temporal recency bucket heading (§4 removed).
     expect(html).toContain('activity:t0:tex-friend')
     expect(html).not.toContain('Today')
@@ -291,7 +287,7 @@ describe('FeedList — budgeted home edition (D-HOME-PACING-01)', () => {
     expect(html).toContain('Past 7 days')
     // From Friends has content → real rows, no honest empty there.
     expect(html).toContain('From Friends')
-    expect(html).toContain('streak:p0:josh')
+    expect(html).toContain('activity:p0:josh')
     expect(html).not.toContain('No friend activity this week')
     // Recent activity is empty-in-window → hidden outright, no honest empty.
     expect(html).not.toContain('Recent activity')

--- a/src/components/__tests__/OverflowSubpageSync.test.tsx
+++ b/src/components/__tests__/OverflowSubpageSync.test.tsx
@@ -42,18 +42,12 @@ vi.mock('@/components/feed', () => ({
   visibleFeedCategory: (c: string | null | undefined) => c ?? null,
 }))
 
+// From Friends milestone streaks render as a compact bundle summary through
+// ActivityStreamItem on the home zone (B-FROMFRIENDS-STREAK-PAGE-01); stub it to
+// a marker so this round-trip asserts the windowing/sectioning, not the internals.
 vi.mock('@/components/activity/ActivityStreamItem', () => ({
   ActivityStreamItem: ({ item }: { item: { id: string; friendId?: string | null } }) => (
     <div data-activity={item.id}>activity:{item.id}:{item.friendId ?? 'none'}</div>
-  ),
-}))
-
-// From Friends milestone streaks render through FromFriendsStreak on the home
-// zones (B-FROMFRIENDS-STREAK-HEADER-01); stub it to a marker so this round-trip
-// asserts the windowing/sectioning, not the per-card internals.
-vi.mock('@/components/feed/FromFriendsStreak', () => ({
-  FromFriendsStreak: ({ item }: { item: { id: string; friendId?: string | null } }) => (
-    <div data-streak={item.id}>streak:{item.id}:{item.friendId ?? 'none'}</div>
   ),
 }))
 
@@ -179,20 +173,20 @@ describe('overflow subpages — §7 state sync (Home is a window onto the pendin
     const pending = [0, 1, 2, 3, 4, 5].map((i) => bundle(i, [null]))
 
     const before = renderHome([], pending)
-    expect(before).toContain('streak:p0:friend0')
-    expect(before).toContain('streak:p3:friend3')
-    expect(before).not.toContain('streak:p4:friend4') // beyond the served window
+    expect(before).toContain('activity:p0:friend0')
+    expect(before).toContain('activity:p3:friend3')
+    expect(before).not.toContain('activity:p4:friend4') // beyond the served window
     expect(before).toContain('2 more from friends →')
     expect(before).toContain('href="/from-friends"')
 
     // The subpage answer records the viewer's result on p0's last open question.
-    // Unlike the old pending-queue, the bundle does NOT leave — it stays as a
-    // spent card in the same slot, and the overflow count is unchanged.
+    // Unlike the old pending-queue, the bundle does NOT leave the served window —
+    // it stays in the same slot, and the overflow count is unchanged.
     const afterAnswer = [bundle(0, ['correct']), ...pending.slice(1)]
 
     const after = renderHome([], afterAnswer)
-    expect(after).toContain('streak:p0:friend0') // still here (now spent)
-    expect(after).not.toContain('streak:p4:friend4') // still beyond the served window
+    expect(after).toContain('activity:p0:friend0') // still here
+    expect(after).not.toContain('activity:p4:friend4') // still beyond the served window
     expect(after).toContain('2 more from friends →') // count unchanged — nothing was consumed
   })
 })

--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChevronDown, Send } from 'lucide-react';
+import { ChevronDown, ChevronRight, Send } from 'lucide-react';
 import Link from 'next/link';
 import { useState, type CSSProperties, type KeyboardEvent } from 'react';
 
@@ -83,6 +83,7 @@ export function ActivityStreamItem({
   nested = false,
   showTimestamp = true,
   elevated = false,
+  playHref,
   onQuestionResolved,
 }: {
   item: StreamItem;
@@ -100,6 +101,12 @@ export function ActivityStreamItem({
   // page as the thing you can play, while the ambient one-liners stay flat. Off
   // by default (the full /activities log keeps every row flat).
   elevated?: boolean;
+  // When set on a playable milestone bundle (the home From Friends zone + the
+  // /from-friends overflow), the bundle summary becomes a NAVIGATION target: the
+  // whole row links here — the streak's own page (B-FROMFRIENDS-STREAK-PAGE-01) —
+  // instead of expanding its questions inline. Omitted everywhere else (the flat
+  // /activities log keeps the in-place expand).
+  playHref?: string;
   // Fires after a milestone question is resolved in place (answered right or
   // wrong). The pending-playables overflow subpage (B-HOME-OVERFLOW-02 §7)
   // uses it to invalidate the client router cache so Home recomputes its
@@ -126,9 +133,7 @@ export function ActivityStreamItem({
   const [serverAnswered] = useState<Set<string>>(
     () =>
       new Set(
-        (milestoneQuestions ?? [])
-          .filter((q) => q.priorResult !== null)
-          .map((q) => q.questionId),
+        (milestoneQuestions ?? []).filter((q) => q.priorResult !== null).map((q) => q.questionId),
       ),
   );
   // Resolutions captured this session — both correct and "not this time" — keyed
@@ -205,8 +210,12 @@ export function ActivityStreamItem({
   // Matches the FeedCardShell elevated question cards so the two playable
   // surfaces share one "liftable" look. Other activity rows (relationship
   // events, reactions, read-only reveals) stay flat one-liners.
-  const playableCard =
-    elevated && !nested && expandable && expand?.kind === 'milestone';
+  const playableCard = elevated && !nested && expandable && expand?.kind === 'milestone';
+
+  // A playable bundle with a playHref navigates to the streak's page instead of
+  // toggling open inline. (Only playable milestone cards ever navigate; the flat
+  // ambient rows never carry a playHref.)
+  const navigates = Boolean(playHref) && playableCard;
 
   // Only the playable milestone bundles take the elevated cream-card chrome +
   // editorial two-line serif headline on the home feed (the warm fill, light
@@ -225,11 +234,8 @@ export function ActivityStreamItem({
   // actor part off here and render the remainder as the second line. Lines with
   // no leading actor (e.g. "You and Craig both …") fall back to the whole line in
   // the large serif (see the headline render below).
-  const headlineActor =
-    editorialCard && item.line[0]?.t === 'actor' ? item.line[0] : null;
-  const headlinePredicate = headlineActor
-    ? trimLeadingPredicate(item.line.slice(1))
-    : null;
+  const headlineActor = editorialCard && item.line[0]?.t === 'actor' ? item.line[0] : null;
+  const headlinePredicate = headlineActor ? trimLeadingPredicate(item.line.slice(1)) : null;
   // The lower-right affordance is a bare verb that tracks the card's state. The
   // friend's name already headlines the card directly above it, so the link
   // doesn't re-state it — it lands on the action instead. On a playable milestone:
@@ -238,8 +244,7 @@ export function ActivityStreamItem({
   // an expandable texture card (a convergence / send-onward reveal): a quiet
   // "See" → "Close". Non-expandable texture cards carry no affordance row at all
   // (the headline is the whole card).
-  const allAnswered =
-    !!milestoneProgress && milestoneProgress.answered >= milestoneProgress.total;
+  const allAnswered = !!milestoneProgress && milestoneProgress.answered >= milestoneProgress.total;
   const playAffordanceLabel = playableCard
     ? open
       ? 'Close'
@@ -287,143 +292,138 @@ export function ActivityStreamItem({
           // alone.
           { padding: '14px 2px', borderBottom: `1px solid ${RULE}` };
 
-  return (
-    <div id={item.anchorId ?? undefined} style={containerStyle}>
-      <div
-        role={expandable ? 'button' : undefined}
-        tabIndex={expandable ? 0 : undefined}
-        aria-expanded={expandable ? open : undefined}
-        onClick={toggle}
-        onKeyDown={handleKeyDown}
-        style={{
-          display: 'flex',
-          alignItems: 'flex-start',
-          cursor: expandable ? 'pointer' : 'default',
-          WebkitTapHighlightColor: 'transparent',
-        }}
-      >
-        {editorialCard ? (
-          // Elevated home card (playable From Friends milestones only): an
-          // editorial two-line headline — the person's NAME in the large serif,
-          // the rest of the sentence in a medium serif below it — with the
-          // "X of Y questions" progress + a Play affordance in the lower-right.
-          // Recent-activity texture rows do NOT take this branch; they render as
-          // flat one-liners below.
-          <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
-            <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
-              <ActivityIcon spec={iconSpec} seed={item.id} />
-              <div style={{ minWidth: 0, flex: 1 }}>
+  // The tappable header row. When the bundle navigates (playHref), the whole row
+  // is a Link to the streak page; otherwise it's the in-place expand/collapse
+  // button. The inner content is identical either way.
+  const rowInner = (
+    <>
+      {editorialCard ? (
+        // Elevated home card (playable From Friends milestones only): an
+        // editorial two-line headline — the person's NAME in the large serif,
+        // the rest of the sentence in a medium serif below it — with the
+        // "X of Y questions" progress + a Play affordance in the lower-right.
+        // Recent-activity texture rows do NOT take this branch; they render as
+        // flat one-liners below.
+        <div style={{ display: 'flex', flexDirection: 'column', width: '100%' }}>
+          <div style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
+            <ActivityIcon spec={iconSpec} seed={item.id} />
+            <div style={{ minWidth: 0, flex: 1 }}>
+              <p
+                style={{
+                  margin: 0,
+                  fontFamily: 'var(--font-serif)',
+                  fontSize: 22,
+                  lineHeight: 1.15,
+                  letterSpacing: 0.2,
+                  color: INK,
+                }}
+              >
+                {headlineActor ? (
+                  <ActorLink
+                    name={headlineActor.name}
+                    userId={headlineActor.userId}
+                    style={HEADLINE_NAME_STYLE}
+                  />
+                ) : (
+                  <Line parts={item.line} />
+                )}
+              </p>
+              {headlinePredicate && headlinePredicate.length > 0 ? (
                 <p
                   style={{
-                    margin: 0,
+                    margin: '3px 0 0',
                     fontFamily: 'var(--font-serif)',
-                    fontSize: 22,
-                    lineHeight: 1.15,
-                    letterSpacing: 0.2,
-                    color: INK,
+                    fontSize: 16,
+                    lineHeight: 1.4,
+                    color: INK2,
                   }}
                 >
-                  {headlineActor ? (
-                    <ActorLink
-                      name={headlineActor.name}
-                      userId={headlineActor.userId}
-                      style={HEADLINE_NAME_STYLE}
-                    />
-                  ) : (
-                    <Line parts={item.line} />
-                  )}
+                  <Line parts={headlinePredicate} />
                 </p>
-                {headlinePredicate && headlinePredicate.length > 0 ? (
-                  <p
-                    style={{
-                      margin: '3px 0 0',
-                      fontFamily: 'var(--font-serif)',
-                      fontSize: 16,
-                      lineHeight: 1.4,
-                      color: INK2,
-                    }}
-                  >
-                    <Line parts={headlinePredicate} />
-                  </p>
-                ) : null}
-                {milestoneProgress ? (
-                  <p
-                    style={{
-                      margin: '8px 0 0',
-                      fontFamily: FM,
-                      fontSize: 10,
-                      letterSpacing: 1,
-                      color: INK3,
-                    }}
-                  >
-                    {milestoneProgress.total - milestoneProgress.answered} of{' '}
-                    {milestoneProgress.total} questions
-                  </p>
-                ) : null}
-                {/* Texture cards may carry supplementary metadata (a domain, a
+              ) : null}
+              {milestoneProgress ? (
+                <p
+                  style={{
+                    margin: '8px 0 0',
+                    fontFamily: FM,
+                    fontSize: 10,
+                    letterSpacing: 1,
+                    color: INK3,
+                  }}
+                >
+                  {milestoneProgress.total - milestoneProgress.answered} of{' '}
+                  {milestoneProgress.total} questions
+                </p>
+              ) : null}
+              {/* Texture cards may carry supplementary metadata (a domain, a
                     quoted question) as a secondLine — kept in its System mono /
                     serif voice below the headline. Milestones set secondLine
                     null, so this never renders on a From Friends card. */}
-                {item.secondLine ? (
-                  <p
-                    style={{
-                      margin: '6px 0 0',
-                      ...(item.secondLineVoice === 'system'
-                        ? {
-                            fontFamily: 'var(--font-mono)',
-                            fontSize: 11,
-                            textTransform: 'uppercase' as const,
-                            letterSpacing: 1,
-                          }
-                        : {
-                            fontFamily: 'var(--font-serif)',
-                            fontSize: 14,
-                          }),
-                      lineHeight: 1.45,
-                      color: INK2,
-                      display: '-webkit-box',
-                      WebkitLineClamp: 2,
-                      WebkitBoxOrient: 'vertical',
-                      overflow: 'hidden',
-                    }}
-                  >
-                    {item.secondLine}
-                  </p>
-                ) : null}
-              </div>
+              {item.secondLine ? (
+                <p
+                  style={{
+                    margin: '6px 0 0',
+                    ...(item.secondLineVoice === 'system'
+                      ? {
+                          fontFamily: 'var(--font-mono)',
+                          fontSize: 11,
+                          textTransform: 'uppercase' as const,
+                          letterSpacing: 1,
+                        }
+                      : {
+                          fontFamily: 'var(--font-serif)',
+                          fontSize: 14,
+                        }),
+                    lineHeight: 1.45,
+                    color: INK2,
+                    display: '-webkit-box',
+                    WebkitLineClamp: 2,
+                    WebkitBoxOrient: 'vertical',
+                    overflow: 'hidden',
+                  }}
+                >
+                  {item.secondLine}
+                </p>
+              ) : null}
             </div>
-            {/* Lower-right disclosure affordance. The whole card is the button
+          </div>
+          {/* Lower-right disclosure affordance. The whole card is the button
                 (aria-expanded on the wrapper), so this is a styled label, not a
                 nested button; the disclosure arrow flips as the card opens. Only
                 shown when the card actually reveals something (a playable
                 milestone, or an expandable texture card). */}
-            {showCardAffordance ? (
-              <div
+          {showCardAffordance ? (
+            <div
+              style={{
+                display: 'flex',
+                justifyContent: 'flex-end',
+                alignItems: 'center',
+                marginTop: 12,
+              }}
+            >
+              <span
                 style={{
-                  display: 'flex',
-                  justifyContent: 'flex-end',
+                  display: 'inline-flex',
                   alignItems: 'center',
-                  marginTop: 12,
+                  gap: 5,
+                  // Same text treatment as the "Answer →" feed action: the
+                  // sans (Interface voice) at 14px in the link slate, underlined,
+                  // matching the Today's Five card link. A tappable affordance
+                  // never takes the Editorial serif.
+                  fontFamily: 'var(--font-sans)',
+                  fontSize: 14,
+                  fontWeight: 500,
+                  color: 'var(--brand-link)',
+                  textDecoration: 'underline',
+                  textUnderlineOffset: 4,
                 }}
               >
-                <span
-                  style={{
-                    display: 'inline-flex',
-                    alignItems: 'center',
-                    gap: 5,
-                    // Same text treatment as the "Answer →" feed action: the
-                    // sans (Interface voice) at 14px in the link slate, underlined,
-                    // matching the Today's Five card link. A tappable affordance
-                    // never takes the Editorial serif.
-                    fontFamily: 'var(--font-sans)',
-                    fontSize: 14,
-                    fontWeight: 500,
-                    color: 'var(--brand-link)',
-                    textDecoration: 'underline',
-                    textUnderlineOffset: 4,
-                  }}
-                >
-                  {playAffordanceLabel}
+                {playAffordanceLabel}
+                {navigates ? (
+                  // Navigating summary: a static right chevron (goes to a page),
+                  // never the rotating disclosure caret of an inline expander.
+                  <ChevronRight size={16} aria-hidden />
+                ) : (
                   <ChevronDown
                     size={16}
                     aria-hidden
@@ -432,97 +432,132 @@ export function ActivityStreamItem({
                       transform: open ? 'rotate(180deg)' : 'none',
                     }}
                   />
-                </span>
-              </div>
+                )}
+              </span>
+            </div>
+          ) : null}
+        </div>
+      ) : (
+        <>
+          {/* Nested rows carry no shape — the per-person heading holds the one
+            diamond; everything beneath it is a plain indented line. */}
+          {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} open={opened} />}
+
+          <div style={{ minWidth: 0, flex: 1, paddingRight: 12 }}>
+            <p
+              style={{
+                margin: 0,
+                fontSize: 15,
+                lineHeight: 1.5,
+                letterSpacing: 0.2,
+                color: INK,
+              }}
+            >
+              {/* `plain` keeps the whole one-liner in the row's sans face — no
+                serif category run — so the ambient stream reads in one voice. */}
+              <Line parts={item.line} plain />
+            </p>
+            {item.secondLine ? (
+              <p
+                style={{
+                  margin: '2px 0 0',
+                  // Domain/label metadata stays System mono with the caps +
+                  // tracking label signature (§2); everything else stays in the
+                  // row's sans face (no serif), so the stream reads in one voice.
+                  ...(item.secondLineVoice === 'system'
+                    ? {
+                        fontFamily: 'var(--font-mono)',
+                        fontSize: 11,
+                        textTransform: 'uppercase' as const,
+                        letterSpacing: 1,
+                      }
+                    : {
+                        fontSize: 14,
+                      }),
+                  lineHeight: 1.45,
+                  color: INK2,
+                  display: '-webkit-box',
+                  WebkitLineClamp: 2,
+                  WebkitBoxOrient: 'vertical',
+                  overflow: 'hidden',
+                }}
+              >
+                {item.secondLine}
+              </p>
+            ) : null}
+            {milestoneProgress ? (
+              <p
+                style={{
+                  margin: '4px 0 0',
+                  fontFamily: FM,
+                  fontSize: 10,
+                  letterSpacing: 1,
+                  color: INK3,
+                }}
+              >
+                {milestoneProgress.answered} of {milestoneProgress.total} questions
+              </p>
             ) : null}
           </div>
-        ) : (
-          <>
-        {/* Nested rows carry no shape — the per-person heading holds the one
-            diamond; everything beneath it is a plain indented line. */}
-        {nested ? null : <ActivityIcon spec={iconSpec} seed={item.id} open={opened} />}
 
-        <div style={{ minWidth: 0, flex: 1, paddingRight: 12 }}>
-          <p
+          <div
             style={{
-              margin: 0,
-              fontSize: 15,
-              lineHeight: 1.5,
-              letterSpacing: 0.2,
-              color: INK,
+              flexShrink: 0,
+              alignSelf: 'stretch',
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'flex-end',
+              justifyContent: 'space-between',
+              gap: 4,
             }}
           >
-            {/* `plain` keeps the whole one-liner in the row's sans face — no
-                serif category run — so the ambient stream reads in one voice. */}
-            <Line parts={item.line} plain />
-          </p>
-          {item.secondLine ? (
-            <p
-              style={{
-                margin: '2px 0 0',
-                // Domain/label metadata stays System mono with the caps +
-                // tracking label signature (§2); everything else stays in the
-                // row's sans face (no serif), so the stream reads in one voice.
-                ...(item.secondLineVoice === 'system'
-                  ? {
-                      fontFamily: 'var(--font-mono)',
-                      fontSize: 11,
-                      textTransform: 'uppercase' as const,
-                      letterSpacing: 1,
-                    }
-                  : {
-                      fontSize: 14,
-                    }),
-                lineHeight: 1.45,
-                color: INK2,
-                display: '-webkit-box',
-                WebkitLineClamp: 2,
-                WebkitBoxOrient: 'vertical',
-                overflow: 'hidden',
-              }}
-            >
-              {item.secondLine}
-            </p>
-          ) : null}
-          {milestoneProgress ? (
-            <p
-              style={{
-                margin: '4px 0 0',
-                fontFamily: FM,
-                fontSize: 10,
-                letterSpacing: 1,
-                color: INK3,
-              }}
-            >
-              {milestoneProgress.answered} of {milestoneProgress.total} questions
-            </p>
-          ) : null}
-        </div>
+            {/* Metadata recedes to near-invisible (v2 §4): quiet, small timestamp.
+              Hidden entirely on the home feed (showTimestamp=false). */}
+            {showTimestamp ? (
+              <span style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap' }}>
+                {timestamp}
+              </span>
+            ) : null}
+            {/* No disclosure chevron — the whole row is the button (aria-expanded
+              above); the ambient one-liners read clean on the right edge. */}
+          </div>
+        </>
+      )}
+    </>
+  );
 
-        <div
+  return (
+    <div id={item.anchorId ?? undefined} style={containerStyle}>
+      {navigates ? (
+        <Link
+          href={playHref!}
           style={{
-            flexShrink: 0,
-            alignSelf: 'stretch',
             display: 'flex',
-            flexDirection: 'column',
-            alignItems: 'flex-end',
-            justifyContent: 'space-between',
-            gap: 4,
+            alignItems: 'flex-start',
+            textDecoration: 'none',
+            color: 'inherit',
+            WebkitTapHighlightColor: 'transparent',
           }}
         >
-          {/* Metadata recedes to near-invisible (v2 §4): quiet, small timestamp.
-              Hidden entirely on the home feed (showTimestamp=false). */}
-          {showTimestamp ? (
-            <span style={{ fontSize: 12, color: INK3, opacity: 0.6, whiteSpace: 'nowrap' }}>
-              {timestamp}
-            </span>
-          ) : null}
-          {/* No disclosure chevron — the whole row is the button (aria-expanded
-              above); the ambient one-liners read clean on the right edge. */}
+          {rowInner}
+        </Link>
+      ) : (
+        <div
+          role={expandable ? 'button' : undefined}
+          tabIndex={expandable ? 0 : undefined}
+          aria-expanded={expandable ? open : undefined}
+          onClick={toggle}
+          onKeyDown={handleKeyDown}
+          style={{
+            display: 'flex',
+            alignItems: 'flex-start',
+            cursor: expandable ? 'pointer' : 'default',
+            WebkitTapHighlightColor: 'transparent',
+          }}
+        >
+          {rowInner}
         </div>
-          </>
-        )}
-      </div>
+      )}
 
       {item.action ? <ItemAction action={item.action} /> : null}
 
@@ -748,10 +783,7 @@ export function ConvergenceExpansion({
       }}
     >
       {expand.questions.map((q) => (
-        <div
-          key={q.questionId}
-          style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}
-        >
+        <div key={q.questionId} style={{ display: 'flex', alignItems: 'flex-start', gap: 8 }}>
           <p
             style={{
               margin: 0,

--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -46,10 +46,15 @@ const CARD_INDENT = 20;
 export function FromFriendsStreak({
   item,
   elevated = false,
+  headerless = false,
   onQuestionResolved,
 }: {
   item: StreamItem;
   elevated?: boolean;
+  // On the streak's own page (B-FROMFRIENDS-STREAK-PAGE-01) the page header
+  // already names the friend + categories, so the cards render BARE: no internal
+  // streak header, no per-card "via {friend}'s streak" line, no indent.
+  headerless?: boolean;
   // Fires after a card is answered in place. The /from-friends overflow subpage
   // (B-HOME-OVERFLOW-02 §7) uses it to refresh the router cache so Home recomputes
   // its served window on return; Home itself omits it.
@@ -81,7 +86,11 @@ export function FromFriendsStreak({
   // lone-question bundle stands alone with the compact "via {friend}'s streak"
   // line instead. Keyed on the original size so the header doesn't flip to the
   // via-line mid-session as questions resolve away.
-  const showHeader = questions.length >= 2;
+  const showHeader = !headerless && questions.length >= 2;
+  // The per-card "via {friend}'s streak" line stands in for the header on a
+  // single-question bundle — but never in headerless (page) mode, where the page
+  // header carries attribution for the whole streak.
+  const showViaLine = !headerless && !showHeader;
 
   const cards = visible.map((q) => (
     <StreakQuestionCard
@@ -89,7 +98,7 @@ export function FromFriendsStreak({
       question={q}
       friendName={expand.friendName}
       friendId={expand.friendId}
-      showViaLine={!showHeader}
+      showViaLine={showViaLine}
       elevated={elevated}
       resolved={isResolved(q.questionId)}
       resolution={resolutions.get(q.questionId) ?? null}

--- a/src/components/feed/__tests__/FromFriendsStreak.test.tsx
+++ b/src/components/feed/__tests__/FromFriendsStreak.test.tsx
@@ -85,6 +85,30 @@ describe('FromFriendsStreak — header-presence fork (D-C)', () => {
   });
 });
 
+describe('FromFriendsStreak — headerless (streak page) mode', () => {
+  it('drops the streak header AND the per-card via line, rendering bare cards', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak item={streakItem([q('a'), q('b')])} headerless />,
+    );
+    // The page header carries attribution, so the component renders neither the
+    // internal streak header nor a per-card "via {friend}'s streak" line.
+    expect(html).not.toContain('has been on a tear through');
+    expect(html).not.toContain('via ');
+    // The answerable cards (and their category eyebrows) still render.
+    expect(answerCardCount(html)).toBe(2);
+    expect(html).toContain('Question a');
+    expect(html).toContain('Tennis Fundamentals');
+  });
+
+  it('drops the via line for a lone-question bundle too', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak item={streakItem([q('solo')])} headerless />,
+    );
+    expect(html).not.toContain('via ');
+    expect(answerCardCount(html)).toBe(1);
+  });
+});
+
 describe('FromFriendsStreak — answered questions resolve in place (Phase 2)', () => {
   it('removes a correctly-answered question and leaves the rest answerable', () => {
     const html = renderToStaticMarkup(

--- a/src/components/feed/__tests__/streak-meta.test.ts
+++ b/src/components/feed/__tests__/streak-meta.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+
+import type { StreamQuestion } from '@/lib/activity-stream';
+import { categoryPhrase, streakCategories, streakPageTitle } from '../streak-meta';
+
+const q = (questionId: string, domain: string | null): StreamQuestion => ({
+  questionId,
+  text: `Question ${questionId}`,
+  domain,
+  priorResult: null,
+});
+
+describe('streakCategories', () => {
+  it('dedupes domains, preserves order, and drops blanks/nulls', () => {
+    expect(
+      streakCategories([
+        q('a', 'Tennis'),
+        q('b', 'History'),
+        q('c', 'Tennis'), // dup
+        q('d', '   '), // blank
+        q('e', null), // null
+        q('f', 'Reformation'),
+      ]),
+    ).toEqual(['Tennis', 'History', 'Reformation']);
+  });
+});
+
+describe('categoryPhrase', () => {
+  it('handles 0/1/2 and "and N others" for 3+', () => {
+    expect(categoryPhrase([])).toBe('');
+    expect(categoryPhrase(['Tennis'])).toBe('Tennis');
+    expect(categoryPhrase(['Tennis', 'History'])).toBe('Tennis and History');
+    expect(categoryPhrase(['Tennis', 'History', 'Reformation'])).toBe(
+      'Tennis, History and 1 other',
+    );
+    expect(categoryPhrase(['A', 'B', 'C', 'D', 'E'])).toBe('A, B and 3 others');
+  });
+});
+
+describe('streakPageTitle', () => {
+  it('builds "{Friend}’s questions about {categories}"', () => {
+    const title = streakPageTitle('Joshua', [
+      q('a', 'Tennis Fundamentals'),
+      q('b', 'Early 20th Century American History'),
+      q('c', 'English Reformation'),
+      q('d', 'Jazz'),
+      q('e', 'Cinema'),
+    ]);
+    expect(title).toBe(
+      'Joshua’s questions about Tennis Fundamentals, Early 20th Century American History and 3 others',
+    );
+  });
+
+  it('falls back to "{Friend}’s questions" when no category is known', () => {
+    expect(streakPageTitle('Joshua', [q('a', null)])).toBe('Joshua’s questions');
+  });
+
+  it('falls back to a generic name when the friend name is blank', () => {
+    expect(streakPageTitle('  ', [q('a', 'Tennis')])).toBe('Your friend’s questions about Tennis');
+  });
+});

--- a/src/components/feed/streak-meta.ts
+++ b/src/components/feed/streak-meta.ts
@@ -1,0 +1,38 @@
+import type { StreamQuestion } from '@/lib/activity-stream';
+
+// Helpers for the From Friends streak page (B-FROMFRIENDS-STREAK-PAGE-01): the
+// page header names the friend and the categories their streak spans, mirroring
+// the phrasing of the bundle summary line on Home.
+
+// Distinct, order-preserving category labels across a streak's questions.
+export function streakCategories(questions: StreamQuestion[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const q of questions) {
+    const c = q.domain?.trim();
+    if (c && !seen.has(c)) {
+      seen.add(c);
+      out.push(c);
+    }
+  }
+  return out;
+}
+
+// "Tennis Fundamentals, Early 20th Century American History and 3 others" — the
+// same lead-two + "and N others" shape the bundle summary line uses.
+export function categoryPhrase(categories: string[]): string {
+  if (categories.length === 0) return '';
+  if (categories.length === 1) return categories[0]!;
+  if (categories.length === 2) return `${categories[0]} and ${categories[1]}`;
+  const rest = categories.length - 2;
+  return `${categories[0]}, ${categories[1]} and ${rest} other${rest === 1 ? '' : 's'}`;
+}
+
+// The streak page title: "{Friend}'s questions about {categories}", falling back
+// to "{Friend}'s questions" when no category is known.
+export function streakPageTitle(friendName: string, questions: StreamQuestion[]): string {
+  const name = friendName.trim() || 'Your friend';
+  const possessive = `${name}’s`;
+  const phrase = categoryPhrase(streakCategories(questions));
+  return phrase ? `${possessive} questions about ${phrase}` : `${possessive} questions`;
+}


### PR DESCRIPTION
Follow-up to #1151 / #1152 (both merged). The inline streak expansion (header + five answer cards stacked in the home zone) was too heavy for the homepage. This makes the streak a compact, tappable bundle summary that opens onto its own page.

## What changed

- **Home zone** renders each friend's streak as the compact **triangle bundle summary** ("0 of 5 questions"), not the inline five-card expansion. Tapping navigates to the streak's own page rather than expanding inline.
- **New page** `/from-friends/[streakId]`: a back button + header **"{Friend}'s questions about {cat}, {cat} and N others"**, over the streak cards (the #1151/#1152 treatment — relocated here, not discarded).
- **Overflow page** (`/from-friends`) switched to the same compact summaries linking into per-streak pages, so the surface reads identically on Home and in the overflow list.

## How it's wired

- `ActivityStreamItem` gains a `playHref` prop: on a playable milestone bundle the whole summary becomes a `Link` to the streak page (static right chevron) instead of the in-place expander. The flat `/activities` log is untouched (no `playHref` → expands as before). Wired via `Link`, not `useRouter`, so the existing milestone/convergence render tests keep passing.
- `FromFriendsStreak` gains a `headerless` mode for the page — no internal streak header, no per-card "via" line, no indent (the page header carries attribution).
- Title built by a small, tested `streak-meta` helper. The lookup uses the same friend-activity queue Home windows from, so the page can't drift from Home.
- From Friends subtitle copy → "Tap a streak to play your friend's questions."

## Notes

- Server/budget layer untouched (whole streaks only).
- A streak the viewer has fully exhausted (gone from the queue) redirects to the overflow list rather than 404ing.

## Verification

Typecheck + eslint clean · color/font/spacing/radius ratchets green · targeted tests pass (26), incl. the real-`ActivityStreamItem` render tests and new coverage for `headerless` mode + the title helper. The 8 failures in the wider sweep (`api/feed/route.test.ts`, `FriendsHubPage.test.tsx`) are **pre-existing on `dev2`** (a DB-mock chaining issue in `via-answerers.ts`) and unrelated to this change — confirmed by re-running them with this work stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SWkzz1x8UHWCh88SV6rumN

---
_Generated by [Claude Code](https://claude.ai/code/session_01SWkzz1x8UHWCh88SV6rumN)_