### PR TITLE
feat(db): 0084 via-attribution schema (FeedItem.viaUserId + User.discoverable_by_forward)

### DIFF
--- a/drizzle/0084_via_attribution.sql
+++ b/drizzle/0084_via_attribution.sql
@@ -1,0 +1,45 @@
+-- D-4 via-attribution — relay "via {source}" discovery on forwarded questions.
+--
+-- Adds two pieces the D-4 amendment specifies
+-- (PRD-D-4-LATELY-MILESTONES-AND-PLUS2-REFRAME-SPEC.md, "Author + relay via"):
+--
+--   1. FeedItem.viaUserId — the user the FORWARDER got the question from (two
+--      hops above the recipient). Stamped at forward time in /api/questions/send
+--      as the forwarder's own sourceUserId; NULL when the forwarder authored the
+--      question or received it organically. Drives the "via {source}" stranger-
+--      discovery affordance. Nullable FK to User with ON DELETE SET NULL so a
+--      deleted via-user cleanly drops the attribution rather than blocking the
+--      delete. A covering index mirrors the 0079 treatment of the other FeedItem
+--      FKs (so deleting a User doesn't seq-scan FeedItem).
+--
+--   2. User.discoverable_by_forward — the consent flag of the EXPOSED party that
+--      gates the "via" exposure (D-2-style asymmetric gate). TEST-PHASE DEFAULT
+--      true, mirroring discoverable_by_niche_match (0059); the production default
+--      is an OPEN DECISION to revisit after the test. Additive boolean with a
+--      DEFAULT — the safe case per CLAUDE.md (the default applies to every
+--      existing row, no backfill pass needed).
+--
+-- All statements are additive and idempotent. No CONCURRENTLY: the runtime
+-- migrator wraps statements in a transaction (matching every other index
+-- migration here). Mirrored by a defensive guard in src/instrumentation.ts
+-- (precedent: 0080) so a preview/production DB that records this migration
+-- without the columns present still gets them on next boot.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS "FeedItem_viaUserId_idx";
+--   ALTER TABLE "FeedItem" DROP CONSTRAINT IF EXISTS "FeedItem_viaUserId_User_id_fk";
+--   ALTER TABLE "FeedItem" DROP COLUMN IF EXISTS "viaUserId";
+--   ALTER TABLE "User" DROP COLUMN IF EXISTS "discoverable_by_forward";
+
+ALTER TABLE "User"
+  ADD COLUMN IF NOT EXISTS "discoverable_by_forward" boolean NOT NULL DEFAULT true;
+
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "viaUserId" text;
+
+DO $$ BEGIN
+  ALTER TABLE "FeedItem" ADD CONSTRAINT "FeedItem_viaUserId_User_id_fk"
+    FOREIGN KEY ("viaUserId") REFERENCES "public"."User"("id") ON DELETE set null ON UPDATE no action;
+EXCEPTION WHEN duplicate_object THEN null; END $$;
+
+CREATE INDEX IF NOT EXISTS "FeedItem_viaUserId_idx" ON "FeedItem" ("viaUserId");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -589,6 +589,13 @@
       "when": 1783728000000,
       "tag": "0083_fk_covering_indexes",
       "breakpoints": true
+    },
+    {
+      "idx": 84,
+      "version": "7",
+      "when": 1783814400000,
+      "tag": "0084_via_attribution",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -315,6 +315,29 @@ export async function register() {
       // Question table may not exist yet — migrate() handles initial creation.
     }
 
+    // Migration 0084 adds FeedItem.viaUserId (the two-hop forward-relay source,
+    // D-4 via-attribution) and User.discoverable_by_forward (its consent gate).
+    // A preview/production DB that records 0084 without these columns present
+    // would break feed reads that select viaUserId and the discoverability gate;
+    // pre-apply them idempotently (precedent: 0080's author_deleted guard above).
+    // The FK constraint is not re-added here — migrate() adds it on fresh DBs and
+    // it is not needed for read safety.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "User"
+          ADD COLUMN IF NOT EXISTS "discoverable_by_forward" boolean NOT NULL DEFAULT true
+      `);
+      await db.execute(sql`
+        ALTER TABLE "FeedItem"
+          ADD COLUMN IF NOT EXISTS "viaUserId" text
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "FeedItem_viaUserId_idx" ON "FeedItem" ("viaUserId")
+      `);
+    } catch {
+      // User / FeedItem may not exist yet — migrate() handles initial creation.
+    }
+
     // Migration 0028 adds the Category.general_knowledge enum value and migration
     // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
     // migrations in one transaction, but Postgres requires a newly-added enum value

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -233,6 +233,14 @@ export const users = pgTable(
     // revisit after the test; do not assume default-ON as the shipping default.
     // See drizzle/0059_niche_match_discoverability.sql.
     discoverableByNicheMatch: boolean('discoverable_by_niche_match').notNull().default(true),
+    // D-4 via-attribution: gates the "via {source}" forward-relay discovery
+    // exposure — the flag of the EXPOSED party (whoever the question was forwarded
+    // from) controls whether their identity surfaces to a downstream stranger
+    // recipient. Sibling to discoverable_by_niche_match, kept separate so
+    // forward-relay exposure opts out independently of niche-match. TEST-PHASE
+    // default ON (mirrors niche-match); the production default is an OPEN DECISION
+    // to revisit after the test. See the D-4 amendment.
+    discoverableByForward: boolean('discoverable_by_forward').notNull().default(true),
     // D-1 Stage 3 — gate on new followers. Default approval_required; public is opt-in.
     followPrivacy: followPrivacyEnum('follow_privacy').notNull().default('approval_required'),
     phoneHash: text('phone_hash'),
@@ -1084,6 +1092,15 @@ export const feedItems = pgTable(
     joshingGameId: text('joshingGameId').references(() => joshingGames.id, { onDelete: 'set null' }),
     sourceType: text('sourceType').notNull(),
     sourceUserId: text('sourceUserId').notNull().references(() => users.id),
+    // D-4 via-attribution: the user the FORWARDER got this question from — two
+    // hops above the recipient. Stamped at forward time in /api/questions/send as
+    // the forwarder's own sourceUserId (no lineage propagation); NULL when the
+    // forwarder authored it or got it organically (no inbound forward row).
+    // Drives the "via {source}" stranger-discovery affordance, gated by the
+    // via-person's discoverableByForward flag. ON DELETE set null so a deleted
+    // via-user cleanly drops the attribution. See the D-4 amendment in
+    // PRD-D-4-LATELY-MILESTONES-AND-PLUS2-REFRAME-SPEC.md.
+    viaUserId: text('viaUserId').references(() => users.id, { onDelete: 'set null' }),
     sourceResult: text('sourceResult').$type<'correct' | 'incorrect' | null>(),
     sourceEventAt: timestamp('sourceEventAt', { withTimezone: true }).notNull().defaultNow(),
     personalMessage: text('personalMessage'),
@@ -1105,6 +1122,9 @@ export const feedItems = pgTable(
     index('FeedItem_questionId_idx').on(table.questionId),
     index('FeedItem_sourceUserId_idx').on(table.sourceUserId),
     index('FeedItem_joshingGameId_idx').on(table.joshingGameId),
+    // Covering index for the viaUserId FK (mirrors the B-PERF-03 / 0079 treatment
+    // of the other FeedItem FKs) so deleting a User doesn't seq-scan FeedItem.
+    index('FeedItem_viaUserId_idx').on(table.viaUserId),
   ],
 );
 


### PR DESCRIPTION
Implements the DB schema for the D-4 **via-attribution** amendment (the spec for which is already on `dev2` via #1156/#1157).

## What this adds

- **`FeedItem.viaUserId`** — nullable FK → `User.id`, `ON DELETE SET NULL`, with a covering index (mirrors the 0079 FK-index treatment). Holds the **two-hop relay source** (who the forwarder got the question from); to be stamped at forward time in `/api/questions/send` as the forwarder's own `sourceUserId`. NULL when the forwarder authored it or received it organically.
- **`User.discoverable_by_forward`** — `boolean NOT NULL DEFAULT true`. Consent gate for the `"via {source}"` exposure (test-phase default ON, mirroring `discoverable_by_niche_match`; production default is an open decision).

## How it's built (repo conventions)

- Hand-written `drizzle/0084_via_attribution.sql` (additive, idempotent, with rollback) + journal entry `idx 84` — lockstep verified (85 SQL = 85 journal).
- Idempotent boot guard in `src/instrumentation.ts` (precedent: 0080) so a partially-recorded preview/prod DB still gets the columns on next boot.
- `npx tsc -p tsconfig.typecheck.json` passes.

## Apply

Additive + reversible. Auto-applies on the next `dev2` deploy boot via `instrumentation.ts`, or run `npm run db:migrate` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)