### PR TITLE
D-4: Add gated stranger-discovery affordances (by/via)

### DIFF
--- a/src/app/api/questions/send/route.ts
+++ b/src/app/api/questions/send/route.ts
@@ -129,11 +129,36 @@ export async function POST(request: NextRequest) {
     );
   }
 
+  // D-4 via-attribution (two-hop relay). Stamp the user THIS sender (the
+  // forwarder) received this question from, so the downstream recipient can
+  // discover them ("via {source}"). It's the sourceUserId of the forwarder's
+  // own inbound forward row for this question — NOT propagated from that row's
+  // own viaUserId, so the lookback is capped at exactly one hop above the
+  // forwarder. NULL when the sender authored it or got it organically (no
+  // inbound forward). Earliest inbound row wins (the forwarder's true entry
+  // point). Null it out if the source is the recipient themselves (a "via you"
+  // is pointless). See the D-4 amendment in PRD-D-4-…-SPEC.md.
+  const [inboundForward] = await db
+    .select({ sourceUserId: feedItems.sourceUserId })
+    .from(feedItems)
+    .where(and(
+      eq(feedItems.recipientUserId, session.userId),
+      eq(feedItems.questionId, sendableQuestionId!),
+      eq(feedItems.sourceType, DIRECT_SENT_FEED_SOURCE_TYPE),
+    ))
+    .orderBy(feedItems.sourceEventAt)
+    .limit(1);
+  const viaUserId =
+    inboundForward && inboundForward.sourceUserId !== parsed.recipientUserId
+      ? inboundForward.sourceUserId
+      : null;
+
   const created = await createFeedItem({
     recipientUserId: parsed.recipientUserId,
     questionId: sendableQuestionId!,
     sourceType: DIRECT_SENT_FEED_SOURCE_TYPE,
     sourceUserId: session.userId,
+    viaUserId,
     sourceEventAt: new Date(),
     personalMessage: parsed.personalMessage,
     state: 'active',

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -13,6 +13,7 @@ import {
   FriendAddedCard,
   FriendLikedCard,
   ViaAttribution,
+  DiscoveryAttribution,
   visibleFeedCategory,
   type AnsweredByYouFeedItem,
   type DirectSentFeedItem,
@@ -20,6 +21,7 @@ import {
   type FriendAddedFeedItem,
   type FriendLikedFeedItem,
   type ViaAnswerer,
+  type DiscoveryPerson,
 } from '@/components/feed'
 import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion'
 import { SpeechBubbleIllustration } from '@/components/home/FeedEmptyArt'
@@ -88,6 +90,12 @@ type FeedApiItem = {
   // A distinct field from friend_results (which the answered-card comparison
   // copy reads) so the two can't collide.
   via_answerers?: ViaAnswerer[] | null
+  // D-4 via-attribution: gated stranger-discovery affordances. discovery_author
+  // = the human who wrote the question; discovery_via = the relay source it
+  // reached the viewer through (two hops up). Independent — both, either, or
+  // neither present. Server-gated (stranger-only, opt-in, public questions).
+  discovery_author?: DiscoveryPerson | null
+  discovery_via?: DiscoveryPerson | null
   viewer_answer_status?: { result: 'correct' | 'incorrect' } | null
   endorsement_count?: number | null
   additional_endorsers?: Array<{ userId: string; displayName: string }> | null
@@ -1903,6 +1911,14 @@ function FeedListContent({
         <ViaAttribution answerers={item.via_answerers} />
       ) : undefined
 
+    // D-4 via-attribution: the gated "by {author}" / "via {source}" discovery
+    // affordance. Server emits only the signals that cleared the stranger +
+    // opt-in + public gates; render whatever survived.
+    const discoveryAttribution =
+      item.discovery_author || item.discovery_via ? (
+        <DiscoveryAttribution author={item.discovery_author} via={item.discovery_via} />
+      ) : undefined
+
     // On the home "What's Happening" feed these answerable question cards are
     // the playable rows, interleaved with flat activity one-liners — give them
     // the Tier 1 lift (cream fill + stroke + drop shadow) so they step forward.
@@ -1915,6 +1931,7 @@ function FeedListContent({
           onAnswer={onAnswer}
           onDismiss={onDismiss}
           viaAttribution={viaAttribution}
+          discoveryAttribution={discoveryAttribution}
           elevated={homeZoneCards}
         />
       )
@@ -1926,6 +1943,7 @@ function FeedListContent({
           onAnswer={onAnswer}
           onDismiss={onDismiss}
           viaAttribution={viaAttribution}
+          discoveryAttribution={discoveryAttribution}
           elevated={homeZoneCards}
         />
       )
@@ -1937,6 +1955,7 @@ function FeedListContent({
           onAnswer={onAnswer}
           onDismiss={onDismiss}
           viaAttribution={viaAttribution}
+          discoveryAttribution={discoveryAttribution}
           elevated={homeZoneCards}
         />
       )

--- a/src/components/feed/DirectSentCard.tsx
+++ b/src/components/feed/DirectSentCard.tsx
@@ -12,10 +12,11 @@ type DirectSentCardProps = {
   onAnswer?: () => void
   onDismiss?: () => void
   viaAttribution?: ReactNode
+  discoveryAttribution?: ReactNode
   elevated?: boolean
 }
 
-export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribution, elevated }: DirectSentCardProps) {
+export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribution, discoveryAttribution, elevated }: DirectSentCardProps) {
   const senderName = item.senderName || item.avatarName || 'A friend'
   const senderHref = item.senderHref ?? item.authorHref ?? null
   const authoredBySender = item.authoredBySender === true
@@ -72,6 +73,7 @@ export function DirectSentCard({ item, overflow, onAnswer, onDismiss, viaAttribu
       // Directed wins: the "Sent directly to you" attribution leads; the "Via"
       // answerer line renders below it and must not compete with the sender.
       viaAttribution={viaAttribution}
+      discoveryAttribution={discoveryAttribution}
       elevated={elevated}
     />
   )

--- a/src/components/feed/DiscoveryAttribution.tsx
+++ b/src/components/feed/DiscoveryAttribution.tsx
@@ -1,0 +1,51 @@
+'use client'
+
+import Link from 'next/link'
+
+// D-4 via-attribution: the per-card "by {author}" / "via {source}" stranger-
+// discovery affordance. Each names a stranger worth meeting off this card — the
+// human who wrote the question (author) and/or the relay source it reached you
+// through (via) — and links to their profile, where you can add them. Server-
+// gated (stranger-only, opt-in, public questions); the client just renders
+// whatever survived. Author leads; via second. The server collapses the two to
+// one when they're the same person, so this never shows "by X · via X".
+
+export type DiscoveryPerson = {
+  userId: string
+  displayName: string
+  href: string
+}
+
+function DiscoveryLine({ label, person }: { label: string; person: DiscoveryPerson }) {
+  return (
+    <p className="text-[12px] leading-snug text-[var(--brand-ink-700)]">
+      <span className="opacity-70">{label} </span>
+      <Link
+        href={person.href}
+        className="font-semibold text-[var(--brand-ink)] underline decoration-[var(--brand-rule)] underline-offset-2 hover:decoration-[var(--brand-ink)]"
+      >
+        {person.displayName}
+      </Link>
+      <span className="opacity-50"> · </span>
+      <Link href={person.href} className="font-medium text-[var(--brand-link)] hover:underline">
+        Add friend
+      </Link>
+    </p>
+  )
+}
+
+export function DiscoveryAttribution({
+  author,
+  via,
+}: {
+  author?: DiscoveryPerson | null
+  via?: DiscoveryPerson | null
+}) {
+  if (!author && !via) return null
+  return (
+    <div className="mt-1 space-y-0.5">
+      {author ? <DiscoveryLine label="by" person={author} /> : null}
+      {via ? <DiscoveryLine label="via" person={via} /> : null}
+    </div>
+  )
+}

--- a/src/components/feed/FeedCard.tsx
+++ b/src/components/feed/FeedCard.tsx
@@ -26,6 +26,12 @@ type FeedCardProps = {
    * Answer action. Distinct from the card's own attribution (who sent/authored).
    */
   viaAttribution?: ReactNode
+  /**
+   * D-4 via-attribution: the "by {author}" / "via {source}" stranger-discovery
+   * affordance, rendered just under the card's byline. Distinct from
+   * viaAttribution (who answered) — this names who wrote it / who it came via.
+   */
+  discoveryAttribution?: ReactNode
   dimQuestion?: boolean
   /** Tier 1 "playable" lift on the unified home feed. Forwarded to FeedCardShell. */
   elevated?: boolean
@@ -70,6 +76,7 @@ export function FeedCard({
   headerContent,
   verb,
   viaAttribution,
+  discoveryAttribution,
   dimQuestion,
   elevated,
 }: FeedCardProps) {
@@ -141,6 +148,8 @@ export function FeedCard({
           </div>
           {overflow ? <div className="shrink-0">{overflow}</div> : null}
         </div>
+
+        {discoveryAttribution ? <div className="mt-1.5">{discoveryAttribution}</div> : null}
 
         <QuestionText question={item.question} dim={dimQuestion} />
 

--- a/src/components/feed/FriendAddedCard.tsx
+++ b/src/components/feed/FriendAddedCard.tsx
@@ -11,6 +11,7 @@ type FriendAddedCardProps = {
   onAnswer?: () => void
   onDismiss?: () => void
   viaAttribution?: ReactNode
+  discoveryAttribution?: ReactNode
   className?: string
   elevated?: boolean
 }
@@ -21,6 +22,7 @@ export function FriendAddedCard({
   onAnswer,
   onDismiss,
   viaAttribution,
+  discoveryAttribution,
   className,
   elevated,
 }: FriendAddedCardProps) {
@@ -56,6 +58,7 @@ export function FriendAddedCard({
       answerAsButton
       onDismiss={item.viewerIsAuthor ? undefined : onDismiss}
       viaAttribution={viaAttribution}
+      discoveryAttribution={discoveryAttribution}
       className={className}
       elevated={elevated}
     />

--- a/src/components/feed/FriendLikedCard.tsx
+++ b/src/components/feed/FriendLikedCard.tsx
@@ -9,10 +9,11 @@ type FriendLikedCardProps = {
   onAnswer?: () => void
   onDismiss?: () => void
   viaAttribution?: ReactNode
+  discoveryAttribution?: ReactNode
   elevated?: boolean
 }
 
-export function FriendLikedCard({ item, overflow, onAnswer, onDismiss, viaAttribution, elevated }: FriendLikedCardProps) {
+export function FriendLikedCard({ item, overflow, onAnswer, onDismiss, viaAttribution, discoveryAttribution, elevated }: FriendLikedCardProps) {
   const merged: FriendLikedFeedItem = {
     ...item,
     avatarName: item.avatarName ?? item.friendName,
@@ -26,6 +27,7 @@ export function FriendLikedCard({ item, overflow, onAnswer, onDismiss, viaAttrib
       onDismiss={onDismiss}
       verb="thought you would like this"
       viaAttribution={viaAttribution}
+      discoveryAttribution={discoveryAttribution}
       elevated={elevated}
     />
   )

--- a/src/components/feed/SparkleEnvelope.tsx
+++ b/src/components/feed/SparkleEnvelope.tsx
@@ -31,6 +31,12 @@ type SparkleEnvelopeProps = {
    * (the `signal` line) — they coexist on different fields and never collide.
    */
   viaAttribution?: ReactNode
+  /**
+   * D-4 via-attribution: the "by {author}" / "via {source}" stranger-discovery
+   * affordance, rendered just under the attribution signal (the byline) rather
+   * than at the bottom — it names who wrote it / who it came via, a header fact.
+   */
+  discoveryAttribution?: ReactNode
   className?: string
   /**
    * Card chrome. 'bordered' is the plain hairline-border tile both feed cards
@@ -64,6 +70,7 @@ export function SparkleEnvelope({
   answerLabel = 'Answer →',
   answerAsButton = false,
   viaAttribution,
+  discoveryAttribution,
   className,
   variant = 'triangle',
   elevated = false,
@@ -87,6 +94,7 @@ export function SparkleEnvelope({
             <p className="font-sans text-[15px] leading-[23px] tracking-[0.05em] text-[var(--brand-ink)]">
               {signal}
             </p>
+            {discoveryAttribution ? <div className="mt-1.5">{discoveryAttribution}</div> : null}
           </div>
           {overflow ? <div className="shrink-0">{overflow}</div> : null}
         </div>

--- a/src/components/feed/index.ts
+++ b/src/components/feed/index.ts
@@ -11,6 +11,7 @@ export { FeedDismissButton } from './FeedDismissButton'
 export { FriendAddedCard } from './FriendAddedCard'
 export { FriendLikedCard } from './FriendLikedCard'
 export { ViaAttribution, type ViaAnswerer } from './ViaAttribution'
+export { DiscoveryAttribution, type DiscoveryPerson } from './DiscoveryAttribution'
 export { feedCardPreviewFixtures, mockTypedFeedItems } from './mock-feed-items'
 export { visibleFeedCategory } from './category'
 export type {

--- a/src/server/db/queries/account.ts
+++ b/src/server/db/queries/account.ts
@@ -459,6 +459,24 @@ export async function getNicheMatchDiscoverable(
   return new Set(rows.map((r) => r.id));
 }
 
+// Batched lookup of the forward-relay discovery opt-in flag (D-4 via-attribution).
+// Returns the subset of the supplied ids whose discoverableByForward is currently
+// true. Sibling to getNicheMatchDiscoverable — kept separate so the "via {source}"
+// forward-relay exposure can be gated independently of niche-match. Single query.
+export async function getForwardDiscoverable(
+  userIds: string[],
+): Promise<Set<string>> {
+  if (userIds.length === 0) return new Set();
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(and(
+      inArray(users.id, userIds),
+      eq(users.discoverableByForward, true),
+    ));
+  return new Set(rows.map((r) => r.id));
+}
+
 // Builds a parenthesized SQL value list for `… in (…)`. Empty → `(null)`, which
 // matches no rows (`x in (null)` is never true), so callers can use it
 // unconditionally without a separate empty-set branch.

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -37,6 +37,10 @@ const feedItemCompatibilityColumns = {
   sourceType: feedItems.sourceType,
   sourceUserId: feedItems.sourceUserId,
   sourceResult: feedItems.sourceResult,
+  // D-4 via-attribution (0084). NULL in the compatibility projection so a
+  // preview/prod DB that hasn't applied 0084 yet still reads cleanly (mirrors
+  // sourceAnswerId below); the boot guard backfills the real column.
+  viaUserId: sql<string | null>`NULL`.as('viaUserId'),
   sourceEventAt: feedItems.sourceEventAt,
   personalMessage: feedItems.personalMessage,
   submittedAnswer: feedItems.submittedAnswer,
@@ -53,7 +57,7 @@ function isMissingOptionalFeedColumn(error: unknown): boolean {
   if (pgErrorCode(error) !== '42703') return false;
 
   const message = pgErrorMessage(error) ?? (error instanceof Error ? error.message : String(error));
-  return ['answerResult', 'pointsAwarded', 'masteryDelta', 'sourceAnswerId'].some((column) =>
+  return ['answerResult', 'pointsAwarded', 'masteryDelta', 'sourceAnswerId', 'viaUserId'].some((column) =>
     message.includes(column),
   );
 }

--- a/src/server/feed/__tests__/discovery-attribution.test.ts
+++ b/src/server/feed/__tests__/discovery-attribution.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  composeDiscoveryAttribution,
+  type DiscoveryItemInput,
+  type DiscoveryPerson,
+} from '@/server/feed/discovery-attribution';
+
+const VIEWER = 'viewer';
+
+// A name resolver that returns a stable person for any id (the DB layer would
+// have filtered to resolvable ids before calling compose).
+const person = (userId: string): DiscoveryPerson => ({
+  userId,
+  displayName: userId.toUpperCase(),
+  href: `/users/${userId}`,
+});
+
+function compose(
+  items: DiscoveryItemInput[],
+  opts: {
+    strangers?: string[];
+    authorOptedIn?: string[];
+    forwardOptedIn?: string[];
+  } = {},
+) {
+  return composeDiscoveryAttribution(items, {
+    viewerUserId: VIEWER,
+    strangerIds: new Set(opts.strangers ?? []),
+    authorOptedIn: new Set(opts.authorOptedIn ?? []),
+    forwardOptedIn: new Set(opts.forwardOptedIn ?? []),
+    person,
+  });
+}
+
+describe('composeDiscoveryAttribution', () => {
+  it('surfaces both author and via when each is a stranger + opted-in + public', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: 'maria', viaUserId: 'butt', isPublic: true }],
+      { strangers: ['maria', 'butt'], authorOptedIn: ['maria'], forwardOptedIn: ['butt'] },
+    );
+    expect(result.get('f1')).toEqual({
+      author: person('maria'),
+      via: person('butt'),
+    });
+  });
+
+  it('drops a non-public question entirely (gates both signals)', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: 'maria', viaUserId: 'butt', isPublic: false }],
+      { strangers: ['maria', 'butt'], authorOptedIn: ['maria'], forwardOptedIn: ['butt'] },
+    );
+    expect(result.has('f1')).toBe(false);
+  });
+
+  it('excludes the viewer from their own author/via slots', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: VIEWER, viaUserId: VIEWER, isPublic: true }],
+      { strangers: [VIEWER], authorOptedIn: [VIEWER], forwardOptedIn: [VIEWER] },
+    );
+    expect(result.has('f1')).toBe(false);
+  });
+
+  it('drops a non-stranger (existing relationship) even when opted in', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: 'maria', viaUserId: 'butt', isPublic: true }],
+      { strangers: ['maria'], authorOptedIn: ['maria'], forwardOptedIn: ['butt'] }, // butt not a stranger
+    );
+    expect(result.get('f1')).toEqual({ author: person('maria') });
+  });
+
+  it('drops a stranger who has not opted in', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: 'maria', viaUserId: 'butt', isPublic: true }],
+      { strangers: ['maria', 'butt'], authorOptedIn: [], forwardOptedIn: ['butt'] }, // maria not opted in
+    );
+    expect(result.get('f1')).toEqual({ via: person('butt') });
+  });
+
+  it('collapses to author only when author and via are the same person (author leads)', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: 'butt', viaUserId: 'butt', isPublic: true }],
+      { strangers: ['butt'], authorOptedIn: ['butt'], forwardOptedIn: ['butt'] },
+    );
+    expect(result.get('f1')).toEqual({ author: person('butt') });
+    expect(result.get('f1')?.via).toBeUndefined();
+  });
+
+  it('omits items with neither signal surviving', () => {
+    const result = compose(
+      [{ feedItemId: 'f1', authorUserId: null, viaUserId: null, isPublic: true }],
+      { strangers: [] },
+    );
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/server/feed/discovery-attribution.ts
+++ b/src/server/feed/discovery-attribution.ts
@@ -1,0 +1,169 @@
+/**
+ * D-4 via-attribution — per-card "by {author}" + "via {source}" stranger-
+ * discovery affordances on forwarded feed questions.
+ *
+ * A batched, gated read of the two strangers worth discovering off a feed card:
+ *  - AUTHOR — the human who wrote the question (`Question.creatorId`).
+ *  - VIA — the relay source the question reached the viewer through, two hops up
+ *    (`FeedItem.viaUserId`, stamped at forward time).
+ *
+ * Both ride the SAME D-2 niche-match consent shape (`notifyNicheMatch`): they
+ * surface only when the viewer↔person relationship is `none` (STRANGER gate),
+ * the person has opted in (the flag of the EXPOSED party gates the exposure —
+ * `discoverableByNicheMatch` for the author, `discoverableByForward` for the
+ * relay source), and the question is public. Author leads; if author == via,
+ * a single (author) affordance is shown — never "by X · via X".
+ *
+ * The pure `composeDiscoveryAttribution` is DB-free so the gate/dedupe
+ * invariants are unit-testable without a database. The DB function batches
+ * every lookup (relationships, both opt-in flags, display names) — no N+1.
+ */
+
+import { inArray } from 'drizzle-orm';
+
+import { db, users } from '@/server/db';
+import { getForwardDiscoverable, getNicheMatchDiscoverable } from '@/server/db/queries/account';
+import { getRelationships } from '@/server/db/queries/friend-requests';
+
+/** A resolved discovery target, ready for the wire / a profile link. */
+export type DiscoveryPerson = {
+  userId: string;
+  displayName: string;
+  href: string;
+};
+
+/** The (optional) author + via affordances for one feed item. */
+export type DiscoveryAttribution = {
+  author?: DiscoveryPerson;
+  via?: DiscoveryPerson;
+};
+
+/** Per-feed-item inputs: the candidate author/via ids and the public gate. */
+export type DiscoveryItemInput = {
+  feedItemId: string;
+  /** Question.creatorId — the human author, or null for LLM-origin questions. */
+  authorUserId: string | null;
+  /** FeedItem.viaUserId — the two-hop relay source, or null. */
+  viaUserId: string | null;
+  /** Question.visibility === 'public'. Gates BOTH signals. */
+  isPublic: boolean;
+};
+
+function profileHref(userId: string): string {
+  return `/users/${encodeURIComponent(userId)}`;
+}
+
+/**
+ * Compose the gated author/via affordances for a page of feed items. Pure and
+ * deterministic. Enforces, per item:
+ *  - public-only: a non-public question surfaces neither signal;
+ *  - self-exclusion: the viewer is never surfaced as their own author/via;
+ *  - stranger gate: only ids in `strangerIds` (relationship === 'none') survive;
+ *  - consent: author gated by `authorOptedIn`, via gated by `forwardOptedIn`
+ *    (the flag of the exposed party);
+ *  - dedupe + lead: when author and via are the SAME person, only the author
+ *    affordance is emitted (author leads — they made it).
+ * Items with neither surviving signal are omitted from the result map.
+ */
+export function composeDiscoveryAttribution(
+  items: DiscoveryItemInput[],
+  ctx: {
+    viewerUserId: string;
+    strangerIds: Set<string>;
+    authorOptedIn: Set<string>;
+    forwardOptedIn: Set<string>;
+    person: (userId: string) => DiscoveryPerson | null;
+  },
+): Map<string, DiscoveryAttribution> {
+  const { viewerUserId, strangerIds, authorOptedIn, forwardOptedIn, person } = ctx;
+  const result = new Map<string, DiscoveryAttribution>();
+
+  const qualifies = (userId: string | null, optedIn: Set<string>): DiscoveryPerson | null => {
+    if (!userId || userId === viewerUserId) return null;
+    if (!strangerIds.has(userId)) return null;
+    if (!optedIn.has(userId)) return null;
+    return person(userId);
+  };
+
+  for (const item of items) {
+    if (!item.isPublic) continue;
+    const author = qualifies(item.authorUserId, authorOptedIn);
+    // Author leads: when via is the same person as the author, the author
+    // affordance already covers them — don't also emit a redundant "via X".
+    const via =
+      item.viaUserId && item.viaUserId === item.authorUserId && author
+        ? null
+        : qualifies(item.viaUserId, forwardOptedIn);
+
+    if (!author && !via) continue;
+    const attribution: DiscoveryAttribution = {};
+    if (author) attribution.author = author;
+    if (via) attribution.via = via;
+    result.set(item.feedItemId, attribution);
+  }
+
+  return result;
+}
+
+/**
+ * Batched resolve + gate of the author/via discovery affordances for a page of
+ * feed items. One relationship query, two opt-in flag queries, one name query —
+ * no N+1. Returns an empty map for an empty page.
+ */
+export async function getDiscoveryAttributionForItems(
+  viewerUserId: string,
+  items: DiscoveryItemInput[],
+): Promise<Map<string, DiscoveryAttribution>> {
+  // Candidate ids are only those on PUBLIC questions and not the viewer.
+  const authorIds = new Set<string>();
+  const viaIds = new Set<string>();
+  for (const item of items) {
+    if (!item.isPublic) continue;
+    if (item.authorUserId && item.authorUserId !== viewerUserId) authorIds.add(item.authorUserId);
+    if (item.viaUserId && item.viaUserId !== viewerUserId) viaIds.add(item.viaUserId);
+  }
+  const candidateIds = [...new Set([...authorIds, ...viaIds])];
+  if (candidateIds.length === 0) return new Map();
+
+  // STRANGER gate first — only `none`-relationship candidates can be surfaced;
+  // drop the rest before the (cheaper) flag/name lookups.
+  const relationships = await getRelationships(viewerUserId, candidateIds);
+  const strangerIds = new Set(
+    candidateIds.filter((id) => (relationships.get(id)?.state ?? 'none') === 'none'),
+  );
+  if (strangerIds.size === 0) return new Map();
+
+  const strangerAuthorIds = [...authorIds].filter((id) => strangerIds.has(id));
+  const strangerViaIds = [...viaIds].filter((id) => strangerIds.has(id));
+
+  const [authorOptedIn, forwardOptedIn] = await Promise.all([
+    getNicheMatchDiscoverable(strangerAuthorIds),
+    getForwardDiscoverable(strangerViaIds),
+  ]);
+
+  // Only resolve names for ids that cleared both the stranger gate and a
+  // relevant opt-in flag.
+  const nameIds = [
+    ...new Set([
+      ...strangerAuthorIds.filter((id) => authorOptedIn.has(id)),
+      ...strangerViaIds.filter((id) => forwardOptedIn.has(id)),
+    ]),
+  ];
+  const nameRows = nameIds.length
+    ? await db.select({ id: users.id, displayName: users.displayName }).from(users).where(inArray(users.id, nameIds))
+    : [];
+  const personById = new Map<string, DiscoveryPerson>(
+    nameRows.map((row) => [
+      row.id,
+      { userId: row.id, displayName: row.displayName?.trim() || 'Someone', href: profileHref(row.id) },
+    ]),
+  );
+
+  return composeDiscoveryAttribution(items, {
+    viewerUserId,
+    strangerIds,
+    authorOptedIn,
+    forwardOptedIn,
+    person: (userId) => personById.get(userId) ?? null,
+  });
+}

--- a/src/server/feed/get-feed-page.ts
+++ b/src/server/feed/get-feed-page.ts
@@ -24,6 +24,7 @@ import {
   visibleFeedSourcePredicate,
 } from '@/server/feed/visibility';
 import { getViaAnswerersForQuestions } from '@/server/feed/via-answerers';
+import { getDiscoveryAttributionForItems } from '@/server/feed/discovery-attribution';
 
 const visibleSourcePredicate = visibleFeedSourcePredicate(feedItems);
 
@@ -33,6 +34,8 @@ const feedQuestionSelectColumns = {
   answerText: questions.answerText,
   creatorId: questions.creatorId,
   source: questions.source,
+  // D-4 via-attribution: the public gate for the by/via discovery affordances.
+  visibility: questions.visibility,
   explainerBrief: questions.explainerBrief,
   factualExplanation: questions.factualExplanation,
   canonicalSubcategory: questions.canonicalSubcategory,
@@ -258,6 +261,22 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
     : [];
   const userById = new Map(userRows.map((u) => [u.id, u]));
 
+  // D-4 via-attribution: gated "by {author}" + "via {source}" stranger-discovery
+  // affordances for this page. Batched (relationships + opt-in flags + names) —
+  // see discovery-attribution.ts. Public-gated, stranger-only, consent-gated.
+  const discoveryByItem = await getDiscoveryAttributionForItems(
+    viewerUserId,
+    feed.map((item) => {
+      const question = item.questionId ? questionById.get(item.questionId) : undefined;
+      return {
+        feedItemId: item.id,
+        authorUserId: question?.creatorId ?? null,
+        viaUserId: item.viaUserId ?? null,
+        isPublic: question?.visibility === 'public',
+      };
+    }),
+  );
+
   return {
     viewer_user_id: viewerUserId,
     meta: {
@@ -345,6 +364,13 @@ export async function getFeedPagePayload(viewerUserId: string, options: FeedPage
         // live on different fields and coexist (audit §C9).
         via_answerers:
           (item.questionId && viaAnswerersByQuestion.get(item.questionId)) || null,
+        // D-4 via-attribution: gated stranger-discovery affordances. Author
+        // ("by {author}") and relay source ("via {source}") are independent
+        // signals — both, either, or neither present. Omitted by compactNulls
+        // when absent. Distinct from via_answerers (who answered) and from the
+        // proximate forwarder (source_*).
+        discovery_author: discoveryByItem.get(item.id)?.author ?? null,
+        discovery_via: discoveryByItem.get(item.id)?.via ?? null,
       });
     }),
   };


### PR DESCRIPTION
Implements D-4 via-attribution: per-card "by {author}" and "via {source}" stranger-discovery affordances on forwarded feed questions. These allow viewers to discover and add the question's author and the relay source it reached them through, subject to strict gating (stranger-only, opt-in consent, public questions only).

## Key changes

**Server-side discovery logic** (`src/server/feed/discovery-attribution.ts`):
- Pure `composeDiscoveryAttribution()` function that gates and dedupes author/via signals based on relationship state, consent flags, and visibility
- Batched `getDiscoveryAttributionForItems()` that resolves all candidates in a single pass: relationships query, two opt-in flag queries, one name query (no N+1)
- Author leads; when author and via are the same person, only the author affordance is shown

**Database & queries**:
- Added `getForwardDiscoverable()` query in `src/server/db/queries/account.ts` to batch-check the `discoverableByForward` flag (independent from niche-match discovery)
- Added `viaUserId` column to feed items (stamped at forward time in `src/app/api/questions/send/route.ts`); tracks the two-hop relay source
- Compatibility projection in `src/server/db/queries/feed.ts` nulls `viaUserId` for preview/prod databases that haven't applied migration 0084 yet

**Feed payload & rendering**:
- `getFeedPagePayload()` now includes `discovery_author` and `discovery_via` in the feed item response
- New `DiscoveryAttribution` client component (`src/components/feed/DiscoveryAttribution.tsx`) renders the affordances with profile links and "Add friend" CTAs
- Integrated into `FeedCard`, `SparkleEnvelope`, `DirectSentCard`, `FriendLikedCard`, and `FriendAddedCard` via new `discoveryAttribution` prop
- `FeedList` wires the server signals to the component

**Testing**:
- Comprehensive unit tests in `src/server/feed/__tests__/discovery-attribution.test.ts` covering all gating rules (public-only, self-exclusion, stranger gate, consent, dedupe/lead)

## Implementation details

- The two opt-in flags (`discoverableByNicheMatch` for author, `discoverableByForward` for via) are independent; either or both can gate their respective signals
- `viaUserId` is stamped from the forwarder's own inbound forward row (earliest wins), capped at one hop to prevent transitive relay chains
- Null'd out if the source is the recipient themselves (no "via you" affordances)
- Server gates everything; client just renders what survived, keeping the component simple and testable
- Author affordance uses "by {name}" label; via uses "via {name}" label; both link to profile with "Add friend" secondary action

https://claude.ai/code/session_01DVWsUQ8zAgHnLwa7d4te3N