### PR TITLE
Keep answered streak questions visible, forwardable, and reportable

### DIFF
--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -2,6 +2,8 @@
 
 import { useState } from 'react';
 
+import { SendQuestionDrawer } from '@/components/SendQuestionDrawer';
+import { AnsweredRowActions } from '@/components/questions/AnsweredRowActions';
 import {
   ActorLink,
   Line,
@@ -70,17 +72,17 @@ export function FromFriendsStreak({
 
   if (!expand || expand.kind !== 'milestone' || questions.length === 0) return null;
 
-  // New paradigm: a question the viewer has gotten CORRECT drops out of the
-  // streak entirely (server-prior or in-session) — "I got it, I don't need to
-  // see it again." A miss stays as a spent card; an unanswered one stays
-  // answerable. When nothing's left to show, the whole streak (header included)
-  // disappears.
-  const answeredCorrect = (q: StreamQuestion): boolean => {
-    const r = resolutions.get(q.questionId);
-    return r ? r.isCorrect : q.priorResult === 'correct';
-  };
-  const visible = questions.filter((q) => !answeredCorrect(q));
-  if (visible.length === 0) return null;
+  // A question the viewer has already answered STAYS in the streak as a settled
+  // card: correct reads "✓ Correct", a miss reads "Not this time", and either way
+  // the card offers a "Send onward" affordance so the viewer can forward it to
+  // someone else (request 2026-06-22). This replaces the earlier treatment that
+  // dropped answered-correct questions out of the streak entirely — the viewer
+  // wanted to SEE what they got right and be able to pass it on, not have it
+  // vanish silently. Server-side exhaustion is unchanged: a bundle with no
+  // still-answerable questions never reaches the client (build-stream keeps only
+  // bundles whose remaining-unanswered count is > 0), so a fully-played streak
+  // still disappears on the next load — it just no longer disappears mid-session
+  // the instant its last question is answered.
 
   // D-C: a streak whose ORIGINAL bundle holds ≥2 questions gets the header; a
   // lone-question bundle stands alone with the compact "via {friend}'s streak"
@@ -92,7 +94,7 @@ export function FromFriendsStreak({
   // header carries attribution for the whole streak.
   const showViaLine = !headerless && !showHeader;
 
-  const cards = visible.map((q) => (
+  const cards = questions.map((q) => (
     <StreakQuestionCard
       key={q.questionId}
       question={q}
@@ -225,6 +227,9 @@ function StreakQuestionCard({
   const answer = useMilestoneAnswer(question, onResolved);
   // Dismiss is view-state only ("pass"): collapse the card to an undo bar.
   const [passed, setPassed] = useState(false);
+  // Forwarding a settled question: the "Send onward" affordance opens the same
+  // SendQuestionDrawer the convergence / your-question reveals use.
+  const [sendOpen, setSendOpen] = useState(false);
 
   const category = question.domain?.trim() || null;
   const hasProvenance = questionProvenance(question) !== null;
@@ -274,21 +279,31 @@ function StreakQuestionCard({
           </div>
         ) : null}
 
-        {/* Category eyebrow with the authorship marker on the SAME row (right-
-            aligned) to save vertical space. D-D (canon): house/LLM authorship is
-            marked PRE-answer; human shows nothing, never a generic "A friend". */}
-        {category || hasProvenance ? (
-          <div
-            style={{
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'space-between',
-              gap: 8,
-              marginBottom: 10,
-            }}
-          >
-            {category ? <CategoryLabel category={category} /> : <span />}
-            {hasProvenance ? <QuestionProvenance q={question} style={{ margin: 0 }} /> : null}
+        {/* Top row: the category eyebrow (left) and the ⋯ report menu pinned to
+            the upper-right corner — the entry point to flag this question as
+            incorrect or inappropriate. The authorship marker no longer rides this
+            row; it drops to its own second line below so the corner is free for
+            the report affordance. */}
+        <div
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            gap: 8,
+            marginBottom: hasProvenance ? 4 : 10,
+          }}
+        >
+          {category ? <CategoryLabel category={category} /> : <span />}
+          <AnsweredRowActions
+            target={{ questionId: question.questionId }}
+            surface="lately_result"
+          />
+        </div>
+        {/* Second level: honest authorship (D-D canon: house/LLM marked
+            PRE-answer; a human author shows nothing, never a generic "A friend"). */}
+        {hasProvenance ? (
+          <div style={{ marginBottom: 10 }}>
+            <QuestionProvenance q={question} style={{ margin: 0 }} />
           </div>
         ) : null}
 
@@ -306,7 +321,17 @@ function StreakQuestionCard({
         </p>
 
         {spent ? (
-          <SpentResult resolution={resolution} priorResult={question.priorResult} />
+          // Settled: show the graded result, and offer forwarding the question
+          // onward to someone else (the viewer answered it, so it's no longer
+          // theirs to answer — but it's still theirs to pass on).
+          <div
+            style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}
+          >
+            <SpentResult resolution={resolution} priorResult={question.priorResult} />
+            <FeedActionLink size="sm" onClick={() => setSendOpen(true)}>
+              Send onward →
+            </FeedActionLink>
+          </div>
         ) : (
           <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
             <FeedDismissButton onClick={() => setPassed(true)} />
@@ -317,6 +342,11 @@ function StreakQuestionCard({
         )}
       </div>
       {spent ? null : answer.sheets}
+      <SendQuestionDrawer
+        isOpen={sendOpen}
+        onClose={() => setSendOpen(false)}
+        question={{ id: question.questionId, text: question.text, domain: question.domain ?? '' }}
+      />
     </>
   );
 }

--- a/src/components/feed/__tests__/FromFriendsStreak.test.tsx
+++ b/src/components/feed/__tests__/FromFriendsStreak.test.tsx
@@ -110,36 +110,63 @@ describe('FromFriendsStreak — headerless (streak page) mode', () => {
 });
 
 describe('FromFriendsStreak — answered questions resolve in place (Phase 2)', () => {
-  it('removes a correctly-answered question and leaves the rest answerable', () => {
+  it('keeps a correctly-answered question as a spent "✓ Correct" card with a Send-onward affordance', () => {
     const html = renderToStaticMarkup(
       <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' }), q('fresh')])} />,
     );
-    // New paradigm: a correct answer drops out of the streak entirely.
-    expect(html).not.toContain('Question done');
+    // The answered-correct question stays visible as a settled card (it is no
+    // longer answerable but it IS forwardable), only the fresh one is playable.
+    expect(html).toContain('Question done');
+    expect(html).toContain('✓ Correct');
+    expect(html).toContain('Send onward');
     expect(html).toContain('Question fresh');
     expect(answerCardCount(html)).toBe(1);
   });
 
-  it('keeps an incorrectly-answered question as a spent "Not this time" card', () => {
+  it('keeps an incorrectly-answered question as a spent "Not this time" card with a Send-onward affordance', () => {
     const html = renderToStaticMarkup(
       <FromFriendsStreak
         item={streakItem([q('missed', { priorResult: 'incorrect' }), q('fresh')])}
       />,
     );
-    // A miss stays visible (spent), only the fresh one is still answerable.
+    // A miss stays visible (spent) and forwardable, only the fresh one is still answerable.
     expect(html).toContain('Not this time');
     expect(html).toContain('Question missed');
+    expect(html).toContain('Send onward');
     expect(answerCardCount(html)).toBe(1);
   });
 
-  it('renders nothing once every question is already correct', () => {
+  it('keeps every already-answered question visible as a forwardable spent card', () => {
     const html = renderToStaticMarkup(
       <FromFriendsStreak
         item={streakItem([q('a', { priorResult: 'correct' }), q('b', { priorResult: 'correct' })])}
       />,
     );
-    // The whole streak (header included) disappears when nothing's left to show.
-    expect(html).toBe('');
+    // The streak no longer collapses to nothing when all its questions are
+    // answered — each settled question reads as correct and can be sent onward.
+    expect(html).not.toBe('');
+    expect(html).toContain('Question a');
+    expect(html).toContain('Question b');
+    expect(html).toContain('✓ Correct');
+    expect(html).toContain('Send onward');
+    // None are answerable any more.
+    expect(answerCardCount(html)).toBe(0);
+  });
+});
+
+describe('FromFriendsStreak — report affordance + author placement', () => {
+  it('renders a report (⋯) control in the upper-right corner of every card', () => {
+    const html = renderToStaticMarkup(<FromFriendsStreak item={streakItem([q('a'), q('b')])} />);
+    // The ⋯ menu (AnsweredRowActions) is the entry point to flag a question as
+    // incorrect or inappropriate — one per card.
+    expect((html.match(/aria-label="More actions"/g) ?? []).length).toBe(2);
+  });
+
+  it('keeps the report control even on a settled (spent) card', () => {
+    const html = renderToStaticMarkup(
+      <FromFriendsStreak item={streakItem([q('done', { priorResult: 'correct' })])} />,
+    );
+    expect(html).toContain('aria-label="More actions"');
   });
 });
 


### PR DESCRIPTION
In a friend's From Friends streak, a question the viewer had already
answered correctly was deleted from the streak outright (and the whole
streak collapsed once every question was answered). The viewer never saw
what they got and had no way to pass it on.

Now every answered question stays as a settled card: correct reads
"✓ Correct", a miss reads "Not this time", and either way the card offers
a "Send onward" affordance (the shared SendQuestionDrawer) so the viewer
can forward it. Still-answerable cards keep Answer/Dismiss. Server-side
exhaustion is unchanged — a fully-played bundle still drops on the next
load — it just no longer vanishes mid-session the instant its last
question is answered.

Also move the author/provenance marker off the card's top row down to its
own second line, freeing the upper-right corner for the ⋯ report menu
(AnsweredRowActions → incorrect / inappropriate), so a question can be
flagged as wrong or inappropriate before or after answering.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012o8XwsLLcW9zS3DhBjoTVK