### PR TITLE
Fix answered feed cards getting buried in the Answered tab

### DIFF
--- a/drizzle/0085_feed_item_answered_at.sql
+++ b/drizzle/0085_feed_item_answered_at.sql
@@ -1,0 +1,42 @@
+-- FeedItem.answeredAt — the time the recipient actually answered the card.
+--
+-- Why this exists: the Answered archive (src/server/db/queries/archive.ts,
+-- readFeedItems) sorts feed answers by an "answeredAt" that, until now, fell
+-- back to FeedItem.sourceEventAt — the time the question was SENT — whenever it
+-- could not find a matching MASTERY_EVENTS row for the feed item. That lookup
+-- misses in a normal case (the (source_type, question_id, answered_by_user_id)
+-- dedupe in writeMasteryEvent skips a second 'live_correct' event when the user
+-- already answered the same canonical question elsewhere), so a card SENT long
+-- ago but ANSWERED recently sorted as if it were old and dropped below the
+-- 50-item first page of the Answered tab — looking "missing".
+--
+-- The fix stamps a true answer timestamp on the FeedItem itself, at answer time
+-- (feed/answer and lately/milestone/answer), and reads sort/recency from it.
+--
+-- Additive, nullable, no default — only set when an item is answered. Existing
+-- answered rows are backfilled from the matching MASTERY_EVENTS.created_at where
+-- one exists (correct/first-time answers); rows with no recoverable event keep
+-- NULL and the read still falls back to sourceEventAt, preserving prior behavior
+-- for them. All statements idempotent. Mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0084) so a preview/production DB that
+-- records this migration without the column present still gets it on next boot.
+--
+-- Rollback:
+--   ALTER TABLE "FeedItem" DROP COLUMN IF EXISTS "answeredAt";
+
+ALTER TABLE "FeedItem"
+  ADD COLUMN IF NOT EXISTS "answeredAt" timestamptz;
+
+-- Backfill the answer time from the per-submission MASTERY_EVENTS row. The feed
+-- answer pipeline writes answer_id = 'feed:{feedItemId}:{questionId}:{userId}'
+-- with session_context = 'feed'; that key uniquely identifies the submission, so
+-- this fills one true answer time per recoverable answered item. Only touches
+-- NULLs, so it is safe to re-run.
+UPDATE "FeedItem" fi
+SET "answeredAt" = me."created_at"
+FROM "MASTERY_EVENTS" me
+WHERE fi."answeredAt" IS NULL
+  AND fi."state" = 'answered'
+  AND fi."questionId" IS NOT NULL
+  AND me."session_context" = 'feed'
+  AND me."answer_id" = 'feed:' || fi."id" || ':' || fi."questionId" || ':' || fi."recipientUserId";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -596,6 +596,13 @@
       "when": 1783814400000,
       "tag": "0084_via_attribution",
       "breakpoints": true
+    },
+    {
+      "idx": 85,
+      "version": "7",
+      "when": 1783900800000,
+      "tag": "0085_feed_item_answered_at",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/feed/[feedItemId]/answer/route.ts
+++ b/src/app/api/feed/[feedItemId]/answer/route.ts
@@ -208,6 +208,10 @@ export async function POST(request: NextRequest, context: RouteContext) {
         state: 'answered',
         submittedAnswer: parsed.submittedAnswer,
         answerResult: isCorrect ? 'correct' : 'incorrect',
+        // True answer time — the Answered archive sorts on this so a card sent
+        // long ago but answered now surfaces at the top, not buried by send-time.
+        // A direct_sent retry re-stamps it, reflecting the latest attempt.
+        answeredAt: new Date(),
         pointsAwarded: pointsAwarded,
         masteryDelta: masteryDelta as Record<string, unknown>,
       })

--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -216,6 +216,9 @@ export async function POST(request: NextRequest) {
           sourceEventAt: new Date(),
           submittedAnswer,
           answerResult: 'incorrect',
+          // The miss is recorded as the answer event; stamp the answer time so the
+          // Answered archive sorts it by when it was answered, not send-time.
+          answeredAt: new Date(),
           sourceAnswerId: `milestone-miss:${question.id}`,
           state: 'answered',
         })

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -338,6 +338,23 @@ export async function register() {
       // User / FeedItem may not exist yet — migrate() handles initial creation.
     }
 
+    // Migration 0085 adds FeedItem.answeredAt — the true answer time the Answered
+    // archive (readFeedItems) sorts on, replacing the sourceEventAt (send-time)
+    // fallback that buried recently-answered cards below the first page. A
+    // preview/production DB that records 0085 without the column present would
+    // break the answer writes (feed/answer, lately/milestone/answer set it) and
+    // the archive read; pre-apply it idempotently (precedent: 0084's viaUserId
+    // guard above). The historical backfill is left to migrate() — it is not
+    // needed for read safety.
+    try {
+      await db.execute(sql`
+        ALTER TABLE "FeedItem"
+          ADD COLUMN IF NOT EXISTS "answeredAt" timestamptz
+      `);
+    } catch {
+      // FeedItem table may not exist yet — migrate() handles initial creation.
+    }
+
     // Migration 0028 adds the Category.general_knowledge enum value and migration
     // 0030 uses it as a default/backfill value. Drizzle wraps all pending Postgres
     // migrations in one transaction, but Postgres requires a newly-added enum value

--- a/src/server/db/queries/archive.ts
+++ b/src/server/db/queries/archive.ts
@@ -331,7 +331,11 @@ async function readFeedItems(userId: string, source?: ArchiveSource): Promise<Ar
       correctAnswer: question.answerText,
       explanation: questionExplanation(question),
       pointsAwarded: correctEvent ? Number(correctEvent.awardedPoints ?? 0) : 0,
-      answeredAt: (correctEvent?.createdAt ?? feedItem.sourceEventAt).toISOString(),
+      // Prefer the stamped answer time (0085) so a card sent long ago but answered
+      // recently sorts by when it was answered. correctEvent.createdAt is an
+      // equivalent answer time when present; sourceEventAt (send-time) is the
+      // last-resort fallback only for pre-0085 rows with no recoverable answer time.
+      answeredAt: (feedItem.answeredAt ?? correctEvent?.createdAt ?? feedItem.sourceEventAt).toISOString(),
       isInBank: false,
       myRating: null,
       canUseQuestionActions: true,

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1106,6 +1106,12 @@ export const feedItems = pgTable(
     personalMessage: text('personalMessage'),
     submittedAnswer: text('submittedAnswer'),
     answerResult: text('answerResult').$type<'correct' | 'incorrect'>(),
+    // The time the recipient actually answered this card. Stamped at answer time
+    // (feed/answer, lately/milestone/answer) and used as the answeredAt sort key
+    // in the Answered archive (readFeedItems). Nullable: NULL means not yet
+    // answered, or a pre-0085 answered row with no recoverable answer time — the
+    // archive falls back to sourceEventAt for those.
+    answeredAt: timestamp('answeredAt', { withTimezone: true }),
     pointsAwarded: doublePrecision('pointsAwarded'),
     masteryDelta: jsonb('masteryDelta').$type<Record<string, unknown> | null>(),
     sourceAnswerId: text('sourceAnswerId'),


### PR DESCRIPTION
The Answered archive (readFeedItems) sorted feed answers by an
"answeredAt" that fell back to FeedItem.sourceEventAt — the time the
card was SENT — whenever it couldn't find a matching MASTERY_EVENTS row
for the item. That lookup misses in a normal case: writeMasteryEvent
dedupes on (source_type, question_id, answered_by_user_id), so a second
'live_correct' event is skipped when the user already answered the same
canonical question elsewhere. A card sent long ago but answered recently
then sorted as if it were old and dropped below the 50-item first page,
so it looked like answered feed questions were missing.

Add FeedItem.answeredAt, stamp the true answer time at answer time
(feed/answer and the milestone-miss insert), and sort/derive the
archive's answeredAt from it. Existing answered rows are backfilled from
the matching MASTERY_EVENTS.created_at; rows with no recoverable event
keep the prior sourceEventAt fallback.

- drizzle/0085_feed_item_answered_at.sql: additive nullable column + backfill
- schema.ts: FeedItem.answeredAt
- instrumentation.ts: defensive ADD COLUMN guard (precedent 0084)
- feed/answer + lately/milestone/answer: stamp answeredAt
- archive.ts: prefer feedItem.answeredAt for the sort key

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SHuPeVutfRvBnpmssJx9c8