### PR TITLE
Use standard Send icon for streak forward affordance

### DIFF
--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { Send } from 'lucide-react';
 import { useState, type ReactNode } from 'react';
 
 import { SendQuestionDrawer } from '@/components/SendQuestionDrawer';
@@ -346,8 +347,14 @@ function StreakQuestionCard({
             gap={12}
             left={<SpentResult resolution={resolution} priorResult={question.priorResult} />}
             right={
-              <FeedActionLink size="sm" onClick={() => setSendOpen(true)}>
-                Send onward →
+              <FeedActionLink
+                size="sm"
+                className="no-underline"
+                onClick={() => setSendOpen(true)}
+                aria-label="Send onward"
+                title="Send onward"
+              >
+                <Send className="size-4" aria-hidden="true" />
               </FeedActionLink>
             }
           />


### PR DESCRIPTION
Replace the "Send onward →" text link on settled streak cards with the
standard lucide Send (paper-airplane) icon already used by
SendQuestionAction, SendQuestionDrawer, and the archive page. Keeps the
FeedActionLink tap target and focus ring, and preserves the "Send onward"
label via aria-label/title for accessibility and existing tests.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011g7RkRS2KiTGifua9arTJN