### PR TITLE
Show the gameplay question-number marker in catch-up (B-GAMEPLAY-QUESTION-NUMBER-BOX-01)

### DIFF
--- a/src/components/play/__tests__/useCatchupFlow.message.test.tsx
+++ b/src/components/play/__tests__/useCatchupFlow.message.test.tsx
@@ -198,6 +198,27 @@ describe('useCatchupFlow result message (B-9: commentary + aside reach the rende
     expect(rendered).toContain('Undo');
   });
 
+  it('renders the editorial number marker above a catch-up question card (B-GAMEPLAY-QUESTION-NUMBER-BOX-01)', () => {
+    // Catch-up reuses the Daily Five marker: a positional `1.`–`5.` box in the
+    // gutter above the card. Catch-up has no bonus questions, so it is never `✦`.
+    const rendered = html([
+      {
+        id: 'catchup-q-queue-1:0',
+        kind: 'question',
+        assignmentId: 'queue-1:0',
+        questionText: 'Which composer wrote the Goldberg Variations?',
+        creatorName: 'Dana',
+        creatorIsHouse: false,
+        subhead: 'FROM YESTERDAY',
+        numberMarker: { value: 2, bonus: false },
+        badges: [],
+      },
+    ]);
+
+    expect(rendered).toContain('aria-label="Question 2"');
+    expect(rendered).toContain('2.');
+  });
+
   it('renders no aside when the server gated it out (selectInsideJokeForViewer returned null)', () => {
     const rendered = html([
       buildCatchupResultMessage({

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -175,7 +175,7 @@ export function buildCatchupResultMessage(params: {
   };
 }
 
-function questionMessage(item: CatchupQueueItem): ChatMessage {
+function questionMessage(item: CatchupQueueItem, position: number): ChatMessage {
   const badges: NonNullable<Extract<ChatMessage, { kind: 'question' }>['badges']> = [];
   const tier = difficultyEstimateToTierLabel(item.difficultyEstimate);
   if (tier) badges.push({ label: tier });
@@ -190,6 +190,11 @@ function questionMessage(item: CatchupQueueItem): ChatMessage {
     creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
     creatorIsHouse: item.authorIsHouse ?? false,
     subhead: formatQuestionSubhead(item),
+    // B-GAMEPLAY-QUESTION-NUMBER-BOX-01: the same editorial number marker the
+    // Daily Five shows in the gutter above each card. Catch-up plays in rounds of
+    // up to CATCH_UP_BATCH_SIZE, so `position` is the question's 1-based slot in
+    // the current round. Catch-up has no bonus questions, so `bonus` is never set.
+    numberMarker: { value: position, bonus: false },
     badges,
   };
 }
@@ -335,7 +340,10 @@ export function useCatchupFlow() {
     })) return;
 
     introducedItemIdsRef.current.add(currentItem.dailyQueueItemId);
-    setMessages((existing) => [...existing, questionMessage(currentItem)]);
+    // 1-based position within the current round: the count already resolved this
+    // round, plus this one. Matches the Daily Five's 1.–5. numbering.
+    const position = answeredInBatchRef.current + 1;
+    setMessages((existing) => [...existing, questionMessage(currentItem, position)]);
   }, [currentItem, isResolvingTurn, loading, phase]);
 
   const advancePast = useCallback((dailyQueueItemId: string) => {


### PR DESCRIPTION
Catch-up reuses GameplayChatThread but never set `numberMarker`, so the Daily
Five's editorial number box rendered on live play but not on catch-up. Wire it
through `questionMessage`: each catch-up question now carries a 1-based marker
for its slot in the current round (rounds are up to CATCH_UP_BATCH_SIZE), so the
gutter shows `1.`-`5.` exactly as live play does. Position is derived from the
count already resolved this round (answeredInBatchRef + 1) at introduce time.

Catch-up has no bonus questions, so `bonus` is never set (never `✦`). The marker
stays positional and color-agnostic — it never reflects result state.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019zmtAUZzj4CEHgjC6ECvtj