### PR TITLE
Add welcome tour component and dev onboarding harness

### DIFF
--- a/src/app/dev/onboarding/ResetWelcomeTourButton.tsx
+++ b/src/app/dev/onboarding/ResetWelcomeTourButton.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { RotateCcw } from 'lucide-react';
+import { useState } from 'react';
+
+import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
+import { clearWelcomeTourSeen } from '@/components/welcome/WelcomeTour';
+
+/**
+ * Re-arm the first-run welcome tour by clearing its persisted client flag.
+ *
+ * Scope: this clears ONLY the client-side `localStorage` suppression key, so the
+ * next visit to `/?welcome=1` runs the tour again. It deliberately does NOT
+ * touch real account onboarding state (onboardingComplete,
+ * firstSessionRecapSeenAt) — those live server-side and re-running them is out
+ * of scope for this read-only harness.
+ */
+export function ResetWelcomeTourButton() {
+  const [confirming, setConfirming] = useState(false);
+  const [done, setDone] = useState(false);
+
+  return (
+    <div>
+      <SettingsGroup>
+        <SettingsRow
+          icon={<RotateCcw className="size-5" />}
+          title="Re-arm the welcome tour"
+          subtitle="Clear the local seen-flag so /?welcome=1 runs the tour again"
+          tone="destructive"
+          onClick={() => {
+            setDone(false);
+            setConfirming(true);
+          }}
+        />
+      </SettingsGroup>
+      {confirming ? (
+        <div className="border-destructive/30 bg-card text-card-foreground mt-3 rounded-xl border p-4">
+          <p className="text-sm font-medium">Re-arm the welcome tour on this device?</p>
+          <p className="text-muted-foreground mt-1 text-xs">
+            Clears the local seen-flag only. Does not change any account onboarding state.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              className="btn-danger"
+              onClick={() => {
+                clearWelcomeTourSeen();
+                setConfirming(false);
+                setDone(true);
+              }}
+            >
+              Re-arm tour
+            </button>
+            <button type="button" className="btn-ghost" onClick={() => setConfirming(false)}>
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
+      {done ? (
+        <p className="mt-2 text-sm text-[var(--game-correct)]">
+          Done — open <span className="font-semibold">/?welcome=1</span> to see it again.
+        </p>
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/dev/onboarding/intro/page.tsx
+++ b/src/app/dev/onboarding/intro/page.tsx
@@ -1,0 +1,48 @@
+import Link from 'next/link';
+import { ChevronLeft } from 'lucide-react';
+
+import OnboardingFlow, { type PreSeededInterest } from '@/app/onboarding/OnboardingFlow';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Dev harness: replay the real name → call sign → areas-of-knowledge flow.
+ *
+ * Mounts the genuine `OnboardingFlow` with `previewMode`, so the name/handle/
+ * interests steps advance through the actual UI but skip their mutating writes
+ * (no PATCH /api/account, no save-interests). Finishing the areas step chains to
+ * the welcome-tour preview instead of the live home. Driven by mock invite data
+ * so the inviter-seeded path renders.
+ */
+
+const MOCK_INTERESTS: PreSeededInterest[] = [
+  { domain: 'Tennis Fundamentals', broadCategory: 'Sports', rationale: 'Maya plays a lot of it.' },
+  { domain: 'Early 20th Century American History', broadCategory: 'History', rationale: null },
+  { domain: '1980s Toys', broadCategory: 'Pop Culture', rationale: null },
+];
+
+export default function DevOnboardingIntroPage() {
+  return (
+    <>
+      <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between gap-3 bg-[var(--brand-ink-950)] px-4 py-2 text-[var(--primary-foreground)]">
+        <Link href="/dev/onboarding" className="inline-flex items-center gap-1 text-sm">
+          <ChevronLeft className="size-4" />
+          Stages
+        </Link>
+        <span className="text-[12px] font-bold tracking-[0.1em] uppercase">
+          Read-only replay · writes stubbed
+        </span>
+      </div>
+      <div style={{ paddingTop: '2.5rem' }}>
+        <OnboardingFlow
+          previewMode
+          preSeededInterests={MOCK_INTERESTS}
+          inviterName="Maya"
+          inviteeDisplayName={null}
+          initialDisplayName={null}
+          initialHandle={null}
+        />
+      </div>
+    </>
+  );
+}

--- a/src/app/dev/onboarding/page.tsx
+++ b/src/app/dev/onboarding/page.tsx
@@ -1,0 +1,89 @@
+import Link from 'next/link';
+import { ChevronLeft, Compass, Info, Loader2, Sparkles, UserPlus } from 'lucide-react';
+
+import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
+
+import { ResetWelcomeTourButton } from './ResetWelcomeTourButton';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Dev harness hub: replay every signup / first-run stage on demand.
+ *
+ * Each entry launches a stage in isolation against sample/dev data and is
+ * read-only against real account state — it drives the genuine stage components
+ * (or their faithful previews) without mutating onboarding completion or
+ * seen-flags. Use it to inspect any stage repeatedly without burning the
+ * one-time flags.
+ *
+ * Stages map to the live flow:
+ *   setup (name/callsign) → areas of knowledge → [building your first five] →
+ *   welcome tour → play → first-session recap.
+ */
+export default function DevOnboardingHubPage() {
+  return (
+    <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 pt-10 pb-28">
+      <Link
+        href="/users/me"
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+      >
+        <ChevronLeft className="size-4" />
+        Back
+      </Link>
+
+      <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">Onboarding stages</h1>
+      <p className="mt-2 text-sm text-muted-foreground">
+        Walk through every signup / first-run stage on demand.
+      </p>
+
+      <div className="mt-4 flex gap-3 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-card)] p-4 text-card-foreground">
+        <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
+        <div className="text-sm leading-6 text-muted-foreground">
+          <p className="font-medium text-foreground">Read-only replays.</p>
+          <p className="mt-1">
+            Each stage launches with sample data and won&apos;t mutate your real account&apos;s
+            onboarding completion or seen-state. It&apos;s a preview, not a reset.
+          </p>
+        </div>
+      </div>
+
+      <section className="mt-8">
+        <h2 className="mb-3 font-serif text-2xl font-semibold">Stages</h2>
+        <SettingsGroup>
+          <SettingsRow
+            icon={<UserPlus className="size-5" />}
+            title="Name, call sign & areas of knowledge"
+            subtitle="The real setup flow driven with mock invite data (writes are stubbed)"
+            href="/dev/onboarding/intro"
+          />
+          <SettingsRow
+            icon={<Loader2 className="size-5" />}
+            title="Building your first five"
+            subtitle="The generation / loading wait state shown before the first round"
+            href="/dev/loading-preview"
+          />
+          <SettingsRow
+            icon={<Compass className="size-5" />}
+            title="Welcome tour"
+            subtitle="The first-run coach-marks over a sample home, into Play"
+            href="/dev/welcome-tour"
+          />
+          <SettingsRow
+            icon={<Sparkles className="size-5" />}
+            title="First-session recap"
+            subtitle="The post-first-five recap + Beat 3 social handoff a new player sees"
+            href="/dev/first-time-player"
+          />
+        </SettingsGroup>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 font-serif text-2xl font-semibold">Reset</h2>
+        <p className="text-muted-foreground mb-3 text-sm">
+          Clearly separated from the read-only replays above — this changes local first-run state.
+        </p>
+        <ResetWelcomeTourButton />
+      </section>
+    </main>
+  );
+}

--- a/src/app/dev/welcome-tour/page.tsx
+++ b/src/app/dev/welcome-tour/page.tsx
@@ -1,0 +1,153 @@
+import Link from 'next/link';
+import { ChevronLeft, SlidersHorizontal } from 'lucide-react';
+
+import WelcomeTour from '@/components/welcome/WelcomeTour';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Dev harness: replay the first-run welcome tour in isolation.
+ *
+ * The live tour overlays the real home (mounted by `?welcome=1`). This page
+ * stands in a static, side-effect-free home replica carrying all five
+ * `data-tour` anchors (five, customize, foryou, friends, shared) plus the
+ * closing-panel slot, then mounts `<WelcomeTour forced />`. `forced` bypasses —
+ * and never writes — the persisted seen-flag, so replaying here never mutates
+ * real state, and every callout resolves to a target (the live home only
+ * carries some anchors today; here all five are present).
+ *
+ * The closing CTA routes to `/daily` like the real tour. To re-run, reload.
+ */
+
+// Generous inter-section spacing so snap & dwell has real scroll distance to
+// travel between callouts (the live home tunes this per-section).
+const SECTION_GAP = { paddingBottom: '34vh' } as const;
+
+export default function DevWelcomeTourPage() {
+  return (
+    <main className="min-h-dvh bg-[var(--brand-cream-page)] text-[var(--brand-ink)]">
+      <div className="mx-auto max-w-2xl px-4 py-6">
+        <Link
+          href="/dev/onboarding"
+          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+        >
+          <ChevronLeft className="size-4" />
+          Onboarding stages
+        </Link>
+
+        <div className="mt-6 flex flex-col gap-5" style={{ paddingTop: '4vh' }}>
+          {/* Today's Five — carries both the `five` and `customize` anchors. */}
+          <div style={SECTION_GAP}>
+            <div
+              data-tour="five"
+              className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-4 shadow-[var(--shadow-card)]"
+            >
+              <div className="flex items-center justify-between gap-2">
+                <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
+                  Today&apos;s Five
+                </p>
+                <span
+                  data-tour="customize"
+                  className="inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-3 py-2 text-[12px] font-bold text-[var(--brand-ink)]"
+                >
+                  <SlidersHorizontal className="size-4" strokeWidth={2.4} aria-hidden="true" />
+                  Customize
+                </span>
+              </div>
+              <h2 className="mt-1 mb-2 font-serif text-[32px] leading-[40px] font-medium text-[var(--brand-ink)]">
+                Ready when you are!
+              </h2>
+              <div className="mt-3 flex items-center gap-2" aria-hidden="true">
+                {[0, 1, 2, 3, 4].map((dot) => (
+                  <span
+                    key={dot}
+                    className="block size-[11px] rounded-full"
+                    style={{
+                      border: '1px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)',
+                    }}
+                  />
+                ))}
+              </div>
+              <span className="btn-primary mt-4 w-full">Play now</span>
+            </div>
+          </div>
+
+          {/* For You */}
+          <section data-tour="foryou" style={SECTION_GAP}>
+            <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+              For you
+            </p>
+            <article className="rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4">
+              <p className="text-sm text-[var(--brand-ink-700)]">
+                <span className="font-semibold text-[var(--brand-ink)]">Joshua P</span> sent you a
+                question they wrote
+              </p>
+              <p className="mt-3 mb-4 font-serif text-[1.3rem] leading-snug font-medium text-[var(--brand-ink)]">
+                &ldquo;In the surrey with the fringe on top, what was the dashboard made of?&rdquo;
+              </p>
+              <div className="flex items-center justify-between">
+                <span className="text-sm text-muted-foreground">Dismiss</span>
+                <span className="btn-primary">Answer</span>
+              </div>
+            </article>
+          </section>
+
+          {/* From Friends */}
+          <section data-tour="friends" style={SECTION_GAP}>
+            <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink)] uppercase">
+              From Friends <span className="opacity-60">(Past 7 days)</span>
+            </p>
+            <p className="mb-3 text-xs tracking-[0.04em] text-muted-foreground uppercase">
+              Play the questions your friends have aced.
+            </p>
+            {[
+              'has been on a tear through Tennis Fundamentals, Early 20th Century American History and 3 others',
+              "has been all over 1980's Toys and Early 20th Century American History",
+            ].map((blurb) => (
+              <div
+                key={blurb}
+                className="mb-2 rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4"
+              >
+                <p className="font-serif text-[1.2rem] font-semibold text-[var(--brand-ink)]">
+                  Joshua P
+                </p>
+                <p className="mt-1 text-xs leading-relaxed text-[var(--brand-ink-700)]">{blurb}</p>
+                <div className="mt-2 flex items-center justify-end gap-1">
+                  <span className="text-[13px] font-semibold text-[var(--brand-ink-700)]">
+                    Play
+                  </span>
+                </div>
+              </div>
+            ))}
+          </section>
+
+          {/* Shared Ground */}
+          <section data-tour="shared" style={SECTION_GAP}>
+            <div
+              className="rounded-[var(--radius-xs)] p-5"
+              style={{ background: 'color-mix(in srgb, var(--success) 14%, var(--brand-cream-page))' }}
+            >
+              <h3 className="font-serif text-[1.4rem] leading-tight font-semibold text-[var(--brand-ink)]">
+                You and Joshua keep meeting in the same places.
+              </h3>
+              <p className="mt-3 text-xs text-[var(--brand-ink-700)]">
+                American City Nicknames · Bikini Bottom Animated Series
+              </p>
+              <p className="mt-4 text-[11px] font-semibold tracking-[0.08em] text-[var(--brand-ink)] uppercase">
+                Shared ground with 1 friend
+              </p>
+              <span className="mt-3 inline-block border-b border-[var(--brand-ink)] pb-0.5 text-xs font-semibold tracking-[0.05em] text-[var(--brand-ink)] uppercase">
+                Explore your overlap →
+              </span>
+            </div>
+          </section>
+        </div>
+      </div>
+
+      {/* Closing panel mounts here. */}
+      <div id="welcome-tour-closer-slot" />
+
+      <WelcomeTour forced />
+    </main>
+  );
+}

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -33,6 +33,14 @@ type OnboardingFlowProps = {
   inviteeDisplayName?: string | null
   initialDisplayName?: string | null
   initialHandle?: string | null
+  /**
+   * Read-only replay for the dev onboarding harness. When set, the name, handle,
+   * and interests steps advance through the real UI WITHOUT their mutating
+   * writes (no PATCH /api/account, no POST /api/onboarding/save-interests), and
+   * finishing chains to the next harness stage instead of the live flow. Lets
+   * the harness drive this real component without burning onboarding state.
+   */
+  previewMode?: boolean
 }
 
 const DISPLAY_NAME_MIN = 2
@@ -124,6 +132,7 @@ export default function OnboardingFlow({
   inviteeDisplayName,
   initialDisplayName,
   initialHandle,
+  previewMode = false,
 }: OnboardingFlowProps) {
   const router = useRouter()
   const hasInitialDisplayName = Boolean(initialDisplayName?.trim())
@@ -345,6 +354,17 @@ export default function OnboardingFlow({
     }
 
     setDisplayNameError(null)
+
+    // Dev harness replay — advance through the real UI without the PATCH.
+    if (previewMode) {
+      setDisplayName(trimmed)
+      if (!handle && !hasInitialHandle) {
+        setHandle(sanitizeForHandle(trimmed))
+      }
+      setCurrentStep(hasInitialHandle ? 'review' : 'handle')
+      return
+    }
+
     setIsSavingDisplayName(true)
 
     try {
@@ -385,8 +405,16 @@ export default function OnboardingFlow({
       return
     }
 
-    setIsSavingHandle(true)
     setHandleError(null)
+
+    // Dev harness replay — advance to review without the PATCH.
+    if (previewMode) {
+      setHandle(candidate)
+      setCurrentStep('review')
+      return
+    }
+
+    setIsSavingHandle(true)
 
     try {
       const response = await fetch('/api/account/handle', {
@@ -437,6 +465,14 @@ export default function OnboardingFlow({
     }
 
     setError(null)
+
+    // Dev harness replay — skip the save + first-round generation and chain to
+    // the next stage (the welcome tour) instead of the live home.
+    if (previewMode) {
+      router.push('/dev/welcome-tour')
+      return
+    }
+
     setIsLoading(true)
 
     try {
@@ -471,9 +507,12 @@ export default function OnboardingFlow({
       }).catch(() => {})
 
       // Onboarding is now complete (save-interests set the flag) and the queue
-      // is generating in the background — land the player straight in /daily.
-      // The daily-reminder opt-in now lives in the post-first-five recap.
-      router.push('/daily')
+      // is generating in the background. Land the player on home with the
+      // first-run welcome tour armed (`?welcome=1`); its closing CTA drops them
+      // straight into playing their Five. The tour self-suppresses after one
+      // run, so returning users skip it. The daily-reminder opt-in lives in the
+      // post-first-five recap.
+      router.push('/?welcome=1')
     } catch {
       setError('Unable to save interests.')
     } finally {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,13 +17,24 @@ import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/da
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 import { timeServerWork } from '@/server/lib/server-timing'
+import WelcomeTour from '@/components/welcome/WelcomeTour'
 
 const FEED_PAGE_SIZE = 20
 
-export default async function Home() {
+export default async function Home({
+  searchParams,
+}: {
+  searchParams: Promise<{ welcome?: string }>
+}) {
   const session = await getSession()
+  // First-run welcome tour — coach-marks over this real home. Activated by the
+  // `?welcome=1` param onboarding routes to (client-side; the tour self-
+  // suppresses via localStorage once seen). Signed-in only.
+  const params = await searchParams
+  const tourActive = params?.welcome === '1' && Boolean(session)
 
   return (
+    <>
     <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
       {/* Top triangle band (Variant4-TOP, 1120x160, grain baked in; lower portion
           transparent so cream shows through). Rendered as a BACKGROUND image, not
@@ -105,7 +116,7 @@ export default async function Home() {
           </Suspense>
         ) : null}
 
-        <section id="feed">
+        <section id="feed" data-tour="foryou">
           {session ? (
             <Suspense fallback={null}>
               <FromYourFriendsSection userId={session.userId} />
@@ -115,7 +126,14 @@ export default async function Home() {
           )}
         </section>
       </div>
+
+      {/* Welcome-tour closing panel mounts here (last in the home flow, so the
+          tour's final scroll lands on it) and the controller overlay drives the
+          coach-marks. Both render only while the tour is active. */}
+      {tourActive ? <div id="welcome-tour-closer-slot" /> : null}
     </main>
+    {tourActive ? <WelcomeTour /> : null}
+    </>
   )
 }
 

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -266,7 +266,10 @@ export default function TodaysFiveCard({
       : 'Ready when you are!'
 
   return (
-    <div className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-4 shadow-[var(--shadow-card)]">
+    <div
+      data-tour="five"
+      className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-4 shadow-[var(--shadow-card)]"
+    >
       <div className="flex items-center justify-between gap-2">
         <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
           Today&apos;s Five
@@ -283,6 +286,7 @@ export default function TodaysFiveCard({
             by the eyebrow on narrow widths. */}
         <Link
           href="/daily/setup"
+          data-tour="customize"
           className={CUSTOMIZE_DAILY_LINK_CLASS}
           aria-label="Customize your Daily Five"
         >

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -4,9 +4,11 @@ import { useRouter } from 'next/navigation';
 import {
   BarChart3,
   Code2,
+  Compass,
   FlaskConical,
   Loader2,
   LogOut,
+  Map,
   RefreshCw,
   Smartphone,
   Sparkles,
@@ -173,6 +175,18 @@ export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
               title="Show me the first time player"
               subtitle="Preview the first-session experience a new player sees"
               href="/dev/first-time-player"
+            />
+            <SettingsRow
+              icon={<Map className="size-5" />}
+              title="Replay onboarding stages"
+              subtitle="Walk through every signup / first-run stage on demand (read-only)"
+              href="/dev/onboarding"
+            />
+            <SettingsRow
+              icon={<Compass className="size-5" />}
+              title="Replay the welcome tour"
+              subtitle="The first-run coach-marks over a sample home, into Play"
+              href="/dev/welcome-tour"
             />
             <SettingsRow
               icon={<Smartphone className="size-5" />}

--- a/src/components/welcome/WelcomeTour.tsx
+++ b/src/components/welcome/WelcomeTour.tsx
@@ -1,0 +1,556 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { createPortal } from 'react-dom';
+
+// Client-only readiness without a setState-in-effect: false during SSR, true
+// once hydrated. Portals (and DOM measurement) need the browser document.
+const subscribeNoop = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
+/**
+ * Welcome tour — a first-run coach-mark walk over the REAL, live home.
+ *
+ * Ported from the standalone `welcome-coachmarks.html` prototype into a
+ * reusable client component. It does NOT render its own home: it overlays the
+ * page that mounts it, locating sections by `data-tour="<id>"` anchors and
+ * pointing short callouts at them one at a time. The page settles on each
+ * section (scroll-snap), the callout fades while scrolling between sections and
+ * rests once settled, and a closing panel at the very bottom drops the player
+ * straight into playing their Five.
+ *
+ * Anchoring is best-effort: steps whose `data-tour` target isn't on the page
+ * are skipped (the live home only carries some anchors today; the dev preview
+ * at /dev/welcome-tour carries all five). Progress pips reflect only the steps
+ * that actually resolve to a target.
+ *
+ * Activation/suppression is client-side (no migration): the live home mounts
+ * this when it sees `?welcome=1`; once the tour is completed or skipped a
+ * one-time flag is persisted to localStorage so it doesn't reappear. The dev
+ * preview passes `forced` to bypass — and to never write — that flag, keeping
+ * the replay read-only against real state.
+ */
+
+export type WelcomeTourStep = {
+  /** Matches a `data-tour="<target>"` attribute on the page. */
+  target: string;
+  /** Small-caps eyebrow above the callout copy. */
+  label: string;
+  /** The callout body. */
+  copy: string;
+};
+
+export const WELCOME_TOUR_STORAGE_KEY = 'joshing.welcomeTourSeenAt';
+
+// Canonical five callouts (build brief). Order matters: Today's Five fires
+// before Customize even though Customize lives inside the Five card — the
+// scroll gate below keeps them from competing.
+export const DEFAULT_WELCOME_TOUR_STEPS: WelcomeTourStep[] = [
+  {
+    target: 'five',
+    label: "Today's Five",
+    copy: 'Your five questions for the day show up right here — tap Play to start. A new set lands every afternoon.',
+  },
+  {
+    target: 'customize',
+    label: 'Customize',
+    copy: "Want different topics or harder questions? Change them anytime — it's right here.",
+  },
+  {
+    target: 'foryou',
+    label: 'For You',
+    copy: "Questions a friend sends or writes just for you land here. Answer back and they'll see how you did.",
+  },
+  {
+    target: 'friends',
+    label: 'From Friends',
+    copy: 'Questions your friends have aced this week. Jump in on the same ones and see how you stack up.',
+  },
+  {
+    target: 'shared',
+    label: 'Shared Ground',
+    copy: 'Where you and your friends overlap — and where to find more people to play with.',
+  },
+];
+
+type WelcomeTourCopy = {
+  header: { eyebrow: string; title: string; body: string };
+  barLabel: string;
+  closer: { eyebrow: string; title: string; body: string; cta: string };
+};
+
+const DEFAULT_COPY: WelcomeTourCopy = {
+  header: {
+    eyebrow: 'Welcome to Joshing',
+    title: "Let's take a quick look around.",
+    body: "Scroll down — we'll point out what's what. Your five are ready whenever you are.",
+  },
+  barLabel: 'A quick tour',
+  closer: {
+    eyebrow: "That's the tour",
+    title: 'Your Five are ready.',
+    body: 'Everything else fills in as you and your friends play. Jump in.',
+    cta: 'Play my Five →',
+  },
+};
+
+type WelcomeTourProps = {
+  steps?: WelcomeTourStep[];
+  copy?: Partial<WelcomeTourCopy>;
+  /** Element id (rendered in page flow) the closing panel portals into. */
+  closerSlotId?: string;
+  /**
+   * Bypass the persisted seen-flag and never write it. Used by the dev preview
+   * so a replay never mutates real seen-state.
+   */
+  forced?: boolean;
+  /** Persisted suppression key (localStorage). */
+  storageKey?: string;
+  /** Closing CTA handler. Defaults to routing into the Daily Five (`/daily`). */
+  onPlay?: () => void;
+  /** Skip/close handler. Defaults to stripping `?welcome` and staying on home. */
+  onClose?: () => void;
+};
+
+/** Clears the persisted seen-flag so the live tour can re-arm (dev affordance). */
+export function clearWelcomeTourSeen(storageKey: string = WELCOME_TOUR_STORAGE_KEY): void {
+  try {
+    window.localStorage.removeItem(storageKey);
+  } catch {
+    // localStorage can be unavailable (private mode) — nothing to clear.
+  }
+}
+
+const SCOPED_STYLE = `
+.welcome-tour-header{position:fixed;top:0;left:0;right:0;z-index:50;background:var(--brand-ink-950);color:var(--primary-foreground);overflow:hidden;}
+.welcome-tour-header .wt-inner{max-width:42rem;margin:0 auto;position:relative;}
+.welcome-tour-header .wt-big{transition:opacity .3s ease,max-height .35s ease,padding .35s ease;max-height:240px;}
+.welcome-tour-header[data-shrunk="true"] .wt-big{max-height:0;opacity:0;padding-top:0;padding-bottom:0;}
+.welcome-tour-header .wt-bar{display:flex;align-items:center;justify-content:space-between;gap:12px;height:0;opacity:0;overflow:hidden;transition:opacity .3s ease,height .35s ease;}
+.welcome-tour-header[data-shrunk="true"] .wt-bar{height:46px;opacity:1;}
+.welcome-tour-coach{position:fixed;z-index:60;max-width:260px;pointer-events:none;opacity:0;transition:opacity .35s ease,top .45s cubic-bezier(.3,.7,.3,1),left .45s ease;}
+.welcome-tour-coach.is-shown{opacity:1;}
+.welcome-tour-arrow{position:absolute;width:0;height:0;}
+.welcome-tour-coach.arrow-up .welcome-tour-arrow{top:-7px;border-left:8px solid transparent;border-right:8px solid transparent;border-bottom:8px solid var(--brand-ink-950);}
+.welcome-tour-coach.arrow-down .welcome-tour-arrow{bottom:-7px;border-left:8px solid transparent;border-right:8px solid transparent;border-top:8px solid var(--brand-ink-950);}
+.welcome-tour-lit{box-shadow:0 0 0 3px var(--brand-orange),0 0 0 9px color-mix(in srgb, var(--brand-orange) 18%, transparent);border-radius:var(--radius-xs);position:relative;z-index:30;transition:box-shadow .4s ease,border-radius .2s;}
+.welcome-tour-pips{display:flex;gap:5px;}
+.welcome-tour-pips i{width:6px;height:6px;border-radius:50%;background:color-mix(in srgb, var(--primary-foreground) 28%, transparent);transition:background .3s;}
+.welcome-tour-pips i.on{background:var(--brand-orange);}
+@media (prefers-reduced-motion:reduce){.welcome-tour-coach,.welcome-tour-lit,.welcome-tour-header .wt-big,.welcome-tour-header .wt-bar{transition:none;}}
+`;
+
+export default function WelcomeTour({
+  steps = DEFAULT_WELCOME_TOUR_STEPS,
+  copy: copyOverride,
+  closerSlotId = 'welcome-tour-closer-slot',
+  forced = false,
+  storageKey = WELCOME_TOUR_STORAGE_KEY,
+  onPlay,
+  onClose,
+}: WelcomeTourProps) {
+  const router = useRouter();
+  const copy: WelcomeTourCopy = {
+    header: { ...DEFAULT_COPY.header, ...copyOverride?.header },
+    barLabel: copyOverride?.barLabel ?? DEFAULT_COPY.barLabel,
+    closer: { ...DEFAULT_COPY.closer, ...copyOverride?.closer },
+  };
+
+  const isClient = useSyncExternalStore(subscribeNoop, getClientSnapshot, getServerSnapshot);
+  // `closed` collapses the tour after a skip/play; combined with the persisted
+  // seen-flag (read once on the client) it gives `inactive`.
+  const [closed, setClosed] = useState(false);
+  const [shrunk, setShrunk] = useState(false);
+  // Index of the current pip-highlighted step (or -1 between/at edges).
+  const [pipIndex, setPipIndex] = useState(-1);
+
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const coachRef = useRef<HTMLDivElement | null>(null);
+  const coachLabelRef = useRef<HTMLParagraphElement | null>(null);
+  const coachCopyRef = useRef<HTMLParagraphElement | null>(null);
+  const arrowRef = useRef<HTMLSpanElement | null>(null);
+
+  const currentRef = useRef(-1);
+  const endedRef = useRef(false);
+  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const bigHeaderHeight = useRef(0);
+
+  // Read external (browser) state into render the lint-sanctioned way: a
+  // useSyncExternalStore snapshot returning a STABLE PRIMITIVE, with arrays
+  // derived via useMemo. No setState-in-effect, no ref reads during render.
+
+  // Whether the tour was already seen (persisted flag). `forced` ignores it.
+  const seen = useSyncExternalStore(
+    subscribeNoop,
+    () => {
+      if (forced) return false;
+      try {
+        return Boolean(window.localStorage.getItem(storageKey));
+      } catch {
+        return false;
+      }
+    },
+    () => false,
+  );
+
+  // A stable signature of which step targets are present in the DOM ("1"/"0"
+  // per step). Resolves after hydration; all-"0" during SSR.
+  const presenceKey = useSyncExternalStore(
+    subscribeNoop,
+    () =>
+      steps
+        .map((step) =>
+          document.querySelector(`[data-tour="${CSS.escape(step.target)}"]`) ? '1' : '0',
+        )
+        .join(''),
+    () => steps.map(() => '0').join(''),
+  );
+  // Steps with a live target drive the pips + navigation. Fall back to all
+  // steps if nothing resolved yet (SSR / pre-hydration).
+  const activeSteps = useMemo(() => {
+    const resolved = steps.filter((_, index) => presenceKey[index] === '1');
+    return resolved.length > 0 ? resolved : steps;
+  }, [steps, presenceKey]);
+
+  const inactive = closed || seen;
+
+  const markSeen = useCallback(() => {
+    if (forced) return;
+    try {
+      window.localStorage.setItem(storageKey, new Date().toISOString());
+    } catch {
+      // Best-effort — a write failure just means the tour may show again.
+    }
+  }, [forced, storageKey]);
+
+  const handleClose = useCallback(() => {
+    endedRef.current = true;
+    markSeen();
+    setClosed(true);
+    if (onClose) {
+      onClose();
+    } else if (!forced) {
+      // Strip ?welcome so a refresh doesn't re-enter the tour.
+      router.replace(window.location.pathname);
+    }
+  }, [forced, markSeen, onClose, router]);
+
+  const handlePlay = useCallback(() => {
+    markSeen();
+    if (onPlay) {
+      onPlay();
+    } else {
+      router.push('/daily');
+    }
+  }, [markSeen, onPlay, router]);
+
+  // Core scroll engine: header shrink, step selection (snap & dwell), and
+  // coach-mark placement. Mirrors the prototype, mutating the coach via refs so
+  // scroll stays cheap; React state only carries the pip index + shrink.
+  useEffect(() => {
+    if (inactive || !isClient) return;
+
+    const placeCoach = (step: WelcomeTourStep) => {
+      const el = document.querySelector<HTMLElement>(
+        `[data-tour="${CSS.escape(step.target)}"]`,
+      );
+      const coach = coachRef.current;
+      if (!el || !coach || !coachLabelRef.current || !coachCopyRef.current || !arrowRef.current) {
+        return;
+      }
+      const r = el.getBoundingClientRect();
+      coachLabelRef.current.textContent = step.label;
+      coachCopyRef.current.textContent = step.copy;
+      // Measure before showing.
+      coach.style.visibility = 'hidden';
+      coach.classList.add('is-shown');
+      const cw = Math.min(260, window.innerWidth - 32);
+      coach.style.width = `${cw}px`;
+      const ch = coach.offsetHeight;
+      // Above or below the target depending on room.
+      const below = r.top < window.innerHeight * 0.45;
+      const top = below ? r.bottom + 12 : r.top - ch - 12;
+      coach.classList.toggle('arrow-up', below);
+      coach.classList.toggle('arrow-down', !below);
+      // Center on the target, clamp to the viewport; arrow follows the target.
+      let left = r.left + r.width / 2 - cw / 2;
+      left = Math.max(8, Math.min(left, window.innerWidth - cw - 8));
+      coach.style.left = `${left}px`;
+      coach.style.top = `${top}px`;
+      coach.style.visibility = 'visible';
+      let ax = r.left + r.width / 2 - left - 8;
+      ax = Math.max(14, Math.min(ax, cw - 26));
+      arrowRef.current.style.left = `${ax}px`;
+      document
+        .querySelectorAll('[data-tour].welcome-tour-lit')
+        .forEach((node) => node.classList.remove('welcome-tour-lit'));
+      el.classList.add('welcome-tour-lit');
+    };
+
+    const hideCoach = () => {
+      coachRef.current?.classList.remove('is-shown');
+      document
+        .querySelectorAll('[data-tour].welcome-tour-lit')
+        .forEach((node) => node.classList.remove('welcome-tour-lit'));
+    };
+
+    const evaluate = () => {
+      if (endedRef.current) return;
+      setShrunk(window.scrollY > 40);
+
+      const tourSteps = activeSteps;
+
+      // Closing panel in view — retire the callouts and fill the pips.
+      const closer = document.getElementById(closerSlotId);
+      if (closer) {
+        const cr = closer.getBoundingClientRect();
+        if (cr.top < window.innerHeight * 0.6) {
+          hideCoach();
+          setPipIndex(tourSteps.length - 1);
+          currentRef.current = tourSteps.length;
+          markSeen();
+          return;
+        }
+      }
+
+      const cy = window.innerHeight * 0.5;
+      let best = -1;
+      let bestD = Infinity;
+      tourSteps.forEach((step, n) => {
+        const el = document.querySelector<HTMLElement>(
+          `[data-tour="${CSS.escape(step.target)}"]`,
+        );
+        if (!el) return;
+        const r = el.getBoundingClientRect();
+        const mid = r.top + r.height / 2;
+        const d = Math.abs(mid - cy);
+        if (d < bestD && r.bottom > 60 && r.top < window.innerHeight - 60) {
+          bestD = d;
+          best = n;
+        }
+      });
+
+      // Today's Five and Customize share a card, so center-distance can't
+      // separate them — force order: Five until scrolled a bit further in.
+      const fiveIdx = tourSteps.findIndex((s) => s.target === 'five');
+      const custIdx = tourSteps.findIndex((s) => s.target === 'customize');
+      if (fiveIdx !== -1 && custIdx !== -1 && (best === fiveIdx || best === custIdx)) {
+        const fiveEl = document.querySelector<HTMLElement>('[data-tour="five"]');
+        if (fiveEl) {
+          const fr = fiveEl.getBoundingClientRect();
+          const inFiveCard = fr.bottom > 80 && fr.top < window.innerHeight * 0.7;
+          if (inFiveCard) {
+            best = fr.top > window.innerHeight * 0.22 ? fiveIdx : custIdx;
+          }
+        }
+      }
+
+      if (best === -1) {
+        hideCoach();
+        return;
+      }
+
+      if (best !== currentRef.current) {
+        currentRef.current = best;
+        setPipIndex(best);
+        hideCoach(); // hide during the move
+        if (settleTimer.current) clearTimeout(settleTimer.current);
+        settleTimer.current = setTimeout(() => {
+          if (!endedRef.current) placeCoach(tourSteps[best]);
+        }, 180);
+      } else {
+        if (settleTimer.current) clearTimeout(settleTimer.current);
+        settleTimer.current = setTimeout(() => {
+          if (!endedRef.current) placeCoach(tourSteps[best]);
+        }, 120);
+      }
+    };
+
+    // Scroll-snap as a progressive enhancement: opt each resolved target into
+    // snapping at runtime so the live home settles on sections without editing
+    // every section's static CSS.
+    const root = document.documentElement;
+    const prevSnapType = root.style.scrollSnapType;
+    root.style.scrollSnapType = 'y proximity';
+    const snapped: HTMLElement[] = [];
+    activeSteps.forEach((step) => {
+      const el = document.querySelector<HTMLElement>(`[data-tour="${CSS.escape(step.target)}"]`);
+      if (el) {
+        el.style.scrollSnapAlign = 'center';
+        el.style.scrollMarginTop = '72px';
+        snapped.push(el);
+      }
+    });
+
+    // Push page content below the (fixed) header, then collapse with it.
+    const prevBodyPad = document.body.style.paddingTop;
+    const prevBodyTransition = document.body.style.transition;
+    bigHeaderHeight.current = headerRef.current?.offsetHeight ?? 0;
+    document.body.style.transition = 'padding-top .35s ease';
+    document.body.style.paddingTop = `${bigHeaderHeight.current}px`;
+
+    let raf = 0;
+    const onScroll = () => {
+      if (raf) return;
+      raf = requestAnimationFrame(() => {
+        raf = 0;
+        evaluate();
+      });
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    window.addEventListener('resize', onScroll);
+    const initial = setTimeout(evaluate, 200);
+
+    return () => {
+      window.removeEventListener('scroll', onScroll);
+      window.removeEventListener('resize', onScroll);
+      if (raf) cancelAnimationFrame(raf);
+      if (settleTimer.current) clearTimeout(settleTimer.current);
+      clearTimeout(initial);
+      root.style.scrollSnapType = prevSnapType;
+      snapped.forEach((el) => {
+        el.style.scrollSnapAlign = '';
+        el.style.scrollMarginTop = '';
+        el.classList.remove('welcome-tour-lit');
+      });
+      document.body.style.paddingTop = prevBodyPad;
+      document.body.style.transition = prevBodyTransition;
+    };
+  }, [inactive, isClient, closerSlotId, markSeen, activeSteps]);
+
+  // Keep body padding in lockstep with the header collapse.
+  useEffect(() => {
+    if (inactive || !isClient) return;
+    document.body.style.paddingTop = shrunk ? '46px' : `${bigHeaderHeight.current}px`;
+  }, [shrunk, inactive, isClient]);
+
+  if (inactive || !isClient) return null;
+
+  const header = (
+    <div className="welcome-tour-header" data-shrunk={shrunk} ref={headerRef}>
+      <div className="wt-inner">
+        <div className="wt-big px-5 pt-6 pb-5">
+          <button
+            type="button"
+            onClick={handleClose}
+            className="absolute top-5 right-4 rounded-full px-4 py-1.5 text-[13px] font-semibold tracking-[0.06em] uppercase"
+            style={{
+              color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)',
+              background: 'color-mix(in srgb, var(--primary-foreground) 12%, transparent)',
+            }}
+          >
+            Skip
+          </button>
+          <p
+            className="text-[12px] font-bold tracking-[0.2em] uppercase"
+            style={{ color: 'var(--brand-cream)' }}
+          >
+            {copy.header.eyebrow}
+          </p>
+          <h1 className="mt-1.5 font-serif text-3xl leading-[1.05] font-semibold">
+            {copy.header.title}
+          </h1>
+          <p
+            className="mt-2 text-[0.98rem]"
+            style={{ color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)' }}
+          >
+            {copy.header.body}
+          </p>
+        </div>
+        <div className="wt-bar px-4">
+          <span
+            className="text-[13px] font-bold tracking-[0.1em] uppercase"
+            style={{ color: 'var(--brand-cream)' }}
+          >
+            {copy.barLabel}
+          </span>
+          <div className="welcome-tour-pips" aria-hidden="true">
+            {activeSteps.map((step, n) => (
+              <i key={step.target} className={n <= pipIndex ? 'on' : ''} />
+            ))}
+          </div>
+          <button
+            type="button"
+            onClick={handleClose}
+            className="rounded-full px-4 py-1.5 text-[13px] font-semibold tracking-[0.06em] uppercase"
+            style={{
+              color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)',
+              background: 'color-mix(in srgb, var(--primary-foreground) 12%, transparent)',
+            }}
+          >
+            Skip
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  const coach = (
+    <div className="welcome-tour-coach" ref={coachRef} role="status" aria-live="polite">
+      <div
+        className="relative rounded-xl px-4 py-3"
+        style={{
+          background: 'var(--brand-ink-950)',
+          color: 'var(--primary-foreground)',
+          boxShadow: '0 16px 40px -16px color-mix(in srgb, var(--brand-ink) 55%, transparent)',
+        }}
+      >
+        <span className="welcome-tour-arrow" ref={arrowRef} aria-hidden="true" />
+        <p
+          ref={coachLabelRef}
+          className="mb-1 text-[11px] font-bold tracking-[0.1em] uppercase"
+          style={{ color: 'var(--brand-cream)' }}
+        />
+        <p ref={coachCopyRef} className="text-[0.95rem] leading-[1.4]" />
+      </div>
+    </div>
+  );
+
+  const closer = (
+    <section
+      className="flex min-h-[70vh] flex-col justify-center px-6 py-16"
+      style={{ background: 'var(--brand-ink-950)', color: 'var(--primary-foreground)' }}
+    >
+      <p
+        className="text-[13px] font-semibold tracking-[0.14em] uppercase"
+        style={{ color: 'var(--brand-cream)' }}
+      >
+        {copy.closer.eyebrow}
+      </p>
+      <h2 className="mt-2 font-serif text-5xl leading-[1.02] font-semibold">
+        {copy.closer.title}
+      </h2>
+      <p
+        className="mt-3.5 text-[1.15rem] leading-relaxed"
+        style={{ color: 'color-mix(in srgb, var(--primary-foreground) 85%, transparent)' }}
+      >
+        {copy.closer.body}
+      </p>
+      <button
+        type="button"
+        onClick={handlePlay}
+        className="mt-7 w-full rounded-xl py-4 text-[1.25rem] font-bold tracking-[0.03em] transition-transform active:scale-[0.98]"
+        style={{
+          background: 'var(--brand-orange)',
+          color: 'var(--primary-foreground)',
+          boxShadow: '0 14px 30px -12px color-mix(in srgb, var(--brand-orange) 70%, transparent)',
+        }}
+      >
+        {copy.closer.cta}
+      </button>
+    </section>
+  );
+
+  const slot = document.getElementById(closerSlotId);
+
+  return (
+    <>
+      <style>{SCOPED_STYLE}</style>
+      {createPortal(header, document.body)}
+      {createPortal(coach, document.body)}
+      {slot ? createPortal(closer, slot) : null}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
Introduces a first-run welcome tour component that overlays the home page with coach-mark callouts, guiding new players through key sections. Includes a dev harness for replaying onboarding stages in isolation without mutating real account state.

## Key Changes

**Welcome Tour Component** (`src/components/welcome/WelcomeTour.tsx`)
- New client component that renders fixed header, floating coach-mark callouts, and closing panel
- Anchors to page sections via `data-tour="<id>"` attributes (best-effort; missing targets are skipped)
- Implements scroll-snap and dwell behavior: header shrinks on scroll, callouts fade during transitions and settle when sections stabilize
- Persists seen-flag to localStorage (one-time suppression); `forced` prop bypasses for dev replay
- Exports `DEFAULT_WELCOME_TOUR_STEPS` (five callouts) and `clearWelcomeTourSeen()` utility
- Uses `useSyncExternalStore` for SSR-safe DOM queries and hydration detection
- Scoped CSS with motion-reduce support

**Dev Onboarding Harness**
- `/dev/onboarding` — hub page linking to all stages (read-only replays with stubbed writes)
- `/dev/onboarding/intro` — replays name/handle/interests flow via `OnboardingFlow` with `previewMode`
- `/dev/welcome-tour` — isolated welcome tour replay with all five anchors present and forced mode enabled
- `ResetWelcomeTourButton` — clears localStorage flag to re-arm tour (dev affordance)

**OnboardingFlow Updates** (`src/app/onboarding/OnboardingFlow.tsx`)
- Added `previewMode` prop: when set, name/handle/interests steps advance through real UI without PATCH writes
- Chains to `/dev/welcome-tour` instead of live home when preview mode finishes
- Allows harness to drive genuine component without burning onboarding state

**Home Page Integration** (`src/app/page.tsx`)
- Accepts `?welcome=1` query param (signed-in only)
- Mounts `<WelcomeTour />` when param is present
- Tour self-suppresses via localStorage after first completion

**Settings Navigation** (`src/components/profile/settings/AccountActions.tsx`)
- Added link to `/dev/onboarding` in dev menu

**TodaysFiveCard Updates** (`src/components/TodaysFiveCard.tsx`)
- Added `data-tour="five"` anchor for welcome tour targeting

## Implementation Details

- **Scroll engine:** RAF-throttled scroll listener evaluates step visibility (center-distance), handles Five/Customize disambiguation (scroll-position gate), and manages coach placement with 120–180ms settle delays
- **DOM measurement:** Coach callouts measure after visibility toggle to compute dimensions, then position relative to targets with viewport clamping and arrow alignment
- **Styling:** Scoped CSS injected via `<style>` tag; uses CSS custom properties for theming (brand colors, shadows, transitions)
- **Hydration:** `useSyncExternalStore` with `getServerSnapshot` returning false ensures no hydration mismatch; portal rendering waits for client-side readiness
- **Accessibility:** Coach marked as `role="status" aria-live="polite"`; pips marked `aria-hidden`

https://claude.ai/code/session_016HmDdnkC48K1KkXGczjKdv