### PR TITLE
Welcome tour (spotlight model) + onboarding-stage dev harness

### DIFF
--- a/src/app/daily/summary/FirstSessionPanel.tsx
+++ b/src/app/daily/summary/FirstSessionPanel.tsx
@@ -109,15 +109,28 @@ type EmailState =
   | { kind: 'idle'; value: string; error: string | null; saving: boolean }
   | { kind: 'saved'; email: string }
 
-export function FirstSessionPanel({ recap }: { recap: FirstSessionRecapView }) {
+export function FirstSessionPanel({
+  recap,
+  preview = false,
+}: {
+  recap: FirstSessionRecapView
+  /**
+   * Read-only replay (dev harness): renders the real panel — including
+   * `recap.beat3` — but suppresses its side effects, so it never records the
+   * one-time "seen" signal or PATCHes reminder settings.
+   */
+  preview?: boolean
+}) {
   // Persist the seen-signal as soon as the panel shows — re-entry, refresh, and
-  // replaying catch-up must never re-trigger it. Fire-and-forget.
+  // replaying catch-up must never re-trigger it. Fire-and-forget. Skipped in
+  // preview so a harness replay never burns the one-time flag.
   useEffect(() => {
+    if (preview) return
     fetch('/api/daily/first-session-recap/seen', {
       method: 'POST',
       credentials: 'include',
     }).catch(() => undefined)
-  }, [])
+  }, [preview])
 
   const [email, setEmail] = useState<EmailState>({
     kind: 'idle',
@@ -195,6 +208,11 @@ export function FirstSessionPanel({ recap }: { recap: FirstSessionRecapView }) {
                   return
                 }
                 setEmail({ ...email, saving: true, error: null })
+                // Preview replay — show the saved state without the PATCH.
+                if (preview) {
+                  setEmail({ kind: 'saved', email: trimmed })
+                  return
+                }
                 const response = await fetch('/api/account/reminders', {
                   method: 'PATCH',
                   credentials: 'include',

--- a/src/app/dev/first-time-player/page.tsx
+++ b/src/app/dev/first-time-player/page.tsx
@@ -1,454 +1,94 @@
 import Link from 'next/link';
-import { type CSSProperties } from 'react';
-import { ChevronLeft, Heart, Info, MoreHorizontal, Share2 } from 'lucide-react';
+import { ChevronLeft, Info } from 'lucide-react';
+
+import { FirstSessionPanel } from '@/app/daily/summary/FirstSessionPanel';
+import type {
+  FirstSessionRecapBeat3,
+  FirstSessionRecapView,
+} from '@/server/daily/first-session-recap';
+
+export const dynamic = 'force-dynamic';
 
 /**
- * Dev tool: preview the first-time player experience.
+ * Dev harness: preview the first-session recap a brand-new player sees after
+ * their very first Daily Five.
  *
- * Linked from the Developer tools section of the profile page. It shows a
- * static, side-effect-free replica of the first-session recap a brand-new
- * player sees after completing their very first Daily Five (see
- * `FirstSessionPanel` / `RoundReminderCard` / `first-session-recap.ts`).
+ * Drives the REAL `FirstSessionPanel` (not a duplicated replica) with a mock
+ * recap, including `recap.beat3` — the social handoff the server computes. The
+ * panel is mounted with `preview`, which suppresses its side effects, so a
+ * replay never records the one-time "seen" signal or PATCHes reminder settings.
  *
- * The live recap is NOT its own page — it renders inline at the very top of the
- * Daily Summary (`src/app/daily/summary/page.tsx`), above the summary header.
- * So this preview reproduces that summary around made-up completed-game content:
- * the first-session panel first, then the summary header and score, the growth
- * recap, a couple of question cards, and the closing card. That way the panel is
- * shown in the context it actually appears in.
- *
- * The real component has side effects — `FirstSessionPanel` fires a "seen"
- * signal on mount and the reminder field PATCHes account settings — so we
- * deliberately do NOT mount the live component here. This page mirrors its
- * markup and copy but renders inert: a look-only preview filled out as if a
- * player had just finished their first five. The first-session card is a single
- * box (congrats + cadence + email-only reminder ask, no dismiss), matching the
- * live `FirstSessionPanel`.
+ * Beat 3 has three branches depending on whether the player arrived via an
+ * inviter (and whether that inviter has played yet); all three are shown here.
  */
 
-// Mirrors RoundReminderCard's `titleStyle` so the reminder card reads identically
-// to the live opt-in. Kept inline (rather than imported) to keep this preview
-// fully decoupled from the side-effectful component.
-const reminderTitleStyle: CSSProperties = {
-  fontFamily: 'var(--font-neutral), system-ui, sans-serif',
-  fontSize: '1.05rem',
-  fontWeight: 600,
-  color: '#111111',
-  textTransform: 'uppercase',
-  letterSpacing: '0.05em',
-};
-
-// Static replica of FirstSessionPanel's `SocialBeat` (Beat 3). Mirrors the live
-// markup/copy for each branch so this preview stays faithful after the panel
-// gained its social beat; rendered inert (links are spans, like the rest of
-// this page). `name` is unused for the no_inviter branch.
-function SocialBeatPreview({
-  kind,
-  name,
-}: {
-  kind: 'inviter_present' | 'inviter_future' | 'no_inviter';
-  name?: string;
-}) {
-  if (kind === 'inviter_present') {
-    return (
-      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
-        <h3 style={reminderTitleStyle}>{name} is already in your game</h3>
-        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-          Some of the questions in your feed are ones {name} answered — look for
-          the{' '}
-          <span className="font-semibold text-[var(--brand-ink)]">Via {name}</span>{' '}
-          label, and answer one back.
-        </p>
-        <p className="mt-3 text-sm leading-6">
-          <span className="text-[var(--brand-link)] underline underline-offset-4">
-            Go to your feed
-          </span>
-        </p>
-      </div>
-    );
-  }
-
-  if (kind === 'inviter_future') {
-    return (
-      <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
-        <h3 style={reminderTitleStyle}>You&apos;re connected with {name}</h3>
-        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-          When {name} plays, their questions will land in your feed marked{' '}
-          <span className="font-semibold text-[var(--brand-ink)]">Via {name}</span>.
-        </p>
-      </div>
-    );
-  }
-
-  // no_inviter — copy is DRAFT, pending review.
-  return (
-    <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
-      <h3 style={reminderTitleStyle}>Joshing is better with a friend in it</h3>
-      <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-        Bring someone you like to outsmart — their questions show up in your feed,
-        and yours in theirs.
-      </p>
-      <p className="mt-3 text-sm leading-6">
-        <span className="text-[var(--brand-link)] underline underline-offset-4">
-          Invite a friend
-        </span>
-      </p>
-    </div>
-  );
+function mockRecap(beat3: FirstSessionRecapBeat3): FirstSessionRecapView {
+  return {
+    type: 'first_session',
+    firstName: 'Sam',
+    beat2: {
+      touchedDomains: ['World Geography', 'Modern Art'],
+      offTheGroundDomain: 'World Geography',
+      newTerritoryDomain: 'Modern Art',
+    },
+    beat3,
+  };
 }
 
-// Mirrors the summary page's section-title style.
-const sectionTitleStyle: CSSProperties = {
-  fontFamily: 'var(--font-neutral), system-ui, sans-serif',
-  fontSize: '0.8rem',
-  fontWeight: 700,
-  color: 'var(--brand-ink)',
-  textTransform: 'uppercase',
-  letterSpacing: '0.1em',
-};
-
-// Made-up completed game: five questions, four correct. Mirrors the
-// QuestionRecap shape the live summary renders, trimmed to what the static
-// cards below need.
-const MOCK_QUESTIONS = [
-  { isCorrect: true, isSkipped: false },
-  { isCorrect: true, isSkipped: false },
-  { isCorrect: false, isSkipped: false },
-  { isCorrect: true, isSkipped: false },
-  { isCorrect: true, isSkipped: false },
-];
-
-const MOCK_CARDS = [
+const BEAT3_VARIANTS: { label: string; note?: string; beat3: FirstSessionRecapBeat3 }[] = [
   {
-    status: 'Correct' as const,
-    domain: 'World Geography',
-    author: 'The House',
-    question: 'Which river flows through the most countries in the world?',
-    youSaid: 'The Danube',
-    answer: 'The Danube',
-    explanation:
-      'The Danube passes through ten countries — more than any other river — from its source in Germany to the Black Sea.',
+    label: 'Inviter already playing',
+    beat3: { kind: 'inviter_present', inviterName: 'Maya' },
   },
   {
-    status: 'Not this time' as const,
-    domain: 'Modern Art',
-    author: 'The House',
-    question: 'Who painted the 1907 work "Les Demoiselles d’Avignon"?',
-    youSaid: 'Henri Matisse',
-    answer: 'Pablo Picasso',
-    explanation:
-      'Picasso’s "Les Demoiselles d’Avignon" is widely seen as a proto-Cubist breakthrough that broke with traditional perspective.',
+    label: "Inviter hasn't played yet",
+    beat3: { kind: 'inviter_future', inviterName: 'Maya' },
+  },
+  {
+    label: 'No inviter on record',
+    note: 'draft copy',
+    beat3: { kind: 'no_inviter' },
   },
 ];
-
-function ResultDots() {
-  return (
-    <div className="flex items-center gap-2" aria-label="Question results">
-      {MOCK_QUESTIONS.map((question, index) => (
-        <span
-          key={index}
-          className="size-2.5 rounded-full border"
-          style={{
-            backgroundColor: question.isSkipped
-              ? 'color-mix(in srgb, var(--brand-ink) 24%, transparent)'
-              : question.isCorrect
-                ? 'color-mix(in srgb, var(--game-correct) 88%, var(--brand-card))'
-                : 'color-mix(in srgb, var(--game-wrong) 78%, var(--brand-card))',
-            borderColor: 'color-mix(in srgb, var(--brand-border) 72%, transparent)',
-            boxShadow: '0 0 0 2px var(--brand-card)',
-          }}
-        />
-      ))}
-    </div>
-  );
-}
-
-function QuestionCard({ card }: { card: (typeof MOCK_CARDS)[number] }) {
-  const isCorrect = card.status === 'Correct';
-  return (
-    <article className="relative overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] p-5 shadow-none">
-      <div
-        className="absolute inset-y-0 left-0 w-1"
-        style={{
-          backgroundColor: isCorrect
-            ? 'var(--game-correct)'
-            : 'color-mix(in srgb, var(--game-wrong) 76%, var(--brand-card))',
-        }}
-      />
-
-      <div className="flex items-start justify-between gap-3 pl-1">
-        <div className="min-w-0">
-          <div className="flex flex-wrap items-center gap-2">
-            <span
-              className="rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold tracking-[0.05em]"
-              style={{
-                borderColor: isCorrect
-                  ? 'color-mix(in srgb, var(--game-correct) 28%, var(--brand-border))'
-                  : 'var(--brand-border)',
-                backgroundColor: isCorrect
-                  ? 'color-mix(in srgb, var(--game-correct) 8%, var(--brand-card))'
-                  : 'color-mix(in srgb, var(--brand-cream-page) 62%, var(--brand-card))',
-                color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink-700)',
-              }}
-            >
-              {card.status}
-            </span>
-            <p className="text-xs leading-5 text-muted-foreground">
-              <span>{card.domain}</span>
-              <span aria-hidden="true"> · </span>
-              <span>by {card.author}</span>
-            </p>
-          </div>
-        </div>
-
-        <span className="text-muted-foreground -mr-2 -mt-2 inline-flex size-10 shrink-0 items-center justify-center rounded-full">
-          <MoreHorizontal className="size-5" />
-        </span>
-      </div>
-
-      <p className="mt-4 pl-1 text-[1.12rem] leading-7 font-medium tracking-[-0.01em] text-[var(--brand-ink)]">
-        {card.question}
-      </p>
-
-      <div className="mt-5 grid gap-3 rounded-md border border-[var(--brand-border)] bg-[var(--brand-cream-page)] p-3 sm:grid-cols-2">
-        <div>
-          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            You said
-          </p>
-          <p className="mt-1 text-sm leading-6 text-[var(--brand-ink)]">{card.youSaid}</p>
-        </div>
-        <div className="border-t border-[var(--brand-border)] pt-3 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-3">
-          <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            Answer
-          </p>
-          <p
-            className="mt-1 text-sm leading-6 font-medium"
-            style={{ color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink)' }}
-          >
-            {card.answer}
-          </p>
-        </div>
-      </div>
-
-      <section className="mt-5 pl-1">
-        <h3 className="text-sm font-semibold text-[var(--brand-ink)]">
-          Why this is the answer
-        </h3>
-        <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-          {card.explanation}
-        </p>
-      </section>
-
-      <div className="mt-5 flex flex-wrap items-center gap-1 border-t border-[var(--brand-border)] pt-3 text-muted-foreground">
-        <span className="inline-flex min-h-9 items-center gap-1.5 rounded-full px-2.5 text-xs">
-          <Heart className="size-4" />
-          React
-        </span>
-        <span className="inline-flex min-h-9 items-center gap-1.5 rounded-full px-2.5 text-xs">
-          <Share2 className="size-4" />
-          Share
-        </span>
-      </div>
-    </article>
-  );
-}
 
 export default function DevFirstTimePlayerPage() {
-  const totalCorrect = MOCK_QUESTIONS.filter((q) => q.isCorrect).length;
-
   return (
     <main className="min-h-dvh bg-[var(--brand-cream-page)] px-4 py-6 text-[var(--brand-ink)]">
-      <div className="mx-auto max-w-3xl">
+      <div className="mx-auto max-w-2xl">
         <Link
-          href="/users/me"
+          href="/dev/onboarding"
           className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
         >
           <ChevronLeft className="size-4" />
-          Back
+          Onboarding stages
         </Link>
 
-        <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">
-          First time player
-        </h1>
+        <h1 className="mt-6 font-serif text-3xl font-semibold leading-tight">First-session recap</h1>
 
-        {/* Information at top: what this preview is and how it differs from the
-            live experience. */}
         <div className="mt-4 flex gap-3 rounded-xl border border-[var(--brand-border)] bg-[var(--brand-card)] p-4 text-card-foreground">
           <Info className="mt-0.5 size-5 shrink-0 text-muted-foreground" />
           <div className="text-sm leading-6 text-muted-foreground">
-            <p className="font-medium text-foreground">
-              What a brand-new player sees.
-            </p>
+            <p className="font-medium text-foreground">The real panel, driven read-only.</p>
             <p className="mt-1">
-              This is the full first-session recap, shown the way it appears in
-              the app: inline at the top of the Daily Summary, on top of a
-              completed game. The made-up game below is a stand-in for the
-              player&apos;s very first Daily Five. It&apos;s a look-only preview:
-              unlike the live panel it doesn&apos;t record the &ldquo;seen&rdquo;
-              signal, and the reminder field doesn&apos;t change any account
-              settings.
+              This mounts the genuine <code>FirstSessionPanel</code> with a mock recap — including
+              the Beat 3 social handoff. It&apos;s a preview: it doesn&apos;t record the
+              &ldquo;seen&rdquo; signal and the reminder field doesn&apos;t change any account
+              settings. Only one Beat 3 branch renders for a given player; all three are shown
+              below.
             </p>
           </div>
         </div>
 
-        {/* Static replica of the Daily Summary header (mirrors
-            src/app/daily/summary/page.tsx) around made-up completed-game content. */}
-        <div className="mt-8 rounded-2xl border border-dashed border-[var(--brand-border)] p-4">
-          <p className="mb-4 text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            Daily Summary · preview
-          </p>
-
-          {/* Inline first-session panel — the actual first-time-player surface,
-              and the very first thing on the page (it sits above the summary
-              header, matching the live ordering). Static replica of
-              FirstSessionPanel: a SINGLE card with the congrats + cadence note
-              and the email-only reminder ask merged in (no dismiss). Sample name
-              stands in for the real player's first name. Inert: the live field
-              PATCHes /api/account/reminders, so here it renders but does
-              nothing. */}
-          <section className="rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
-            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-              First five complete
-            </p>
-            <h2 className="mt-2 font-serif text-2xl leading-tight text-[var(--brand-ink)]">
-              Nice start, Sam.
-            </h2>
-            <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-              New questions come every day at noon — next up Wednesday at noon. You
-              can update your topics anytime on the{' '}
-              <span className="text-[var(--brand-link)] underline underline-offset-4">
-                Shape your next round
-              </span>{' '}
-              page.
-            </p>
-
-            {/* Beat 3 (social). This preview shows the inviter_present branch —
-                the canonical path for a player who arrived via someone's profile
-                link. The other two branches are shown for reference below. */}
-            <SocialBeatPreview kind="inviter_present" name="Maya" />
-
-            <div className="mt-5 border-t border-[var(--brand-border)] pt-5">
-              <h3 style={reminderTitleStyle}>
-                Get notified when the next batch is available
-              </h3>
-              <p className="text-foreground mt-2 text-sm leading-6">
-                We can email you when new questions land.
+        <div className="mt-8 space-y-8">
+          {BEAT3_VARIANTS.map((variant) => (
+            <section key={variant.beat3.kind}>
+              <p className="mb-2 text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
+                Beat 3 · {variant.label}
+                {variant.note ? <span className="text-amber-700"> · {variant.note}</span> : null}
               </p>
-              <form className="mt-4 flex flex-col gap-3 sm:flex-row sm:items-start">
-                <input
-                  type="email"
-                  inputMode="email"
-                  placeholder="you@example.com"
-                  readOnly
-                  className="bg-[var(--brand-field)] flex-1 rounded-lg border border-[var(--accent-gold)] px-3 py-2 text-sm focus:border-[var(--brand-navy)]"
-                />
-                <button type="button" className="btn-primary">
-                  Email me
-                </button>
-              </form>
-              <p className="text-muted-foreground mt-3 text-xs leading-5">
-                We&apos;ll send a confirmation email once email reminders launch.
-              </p>
-            </div>
-          </section>
-
-          <header className="mt-8 pb-2">
-            <span className="text-muted-foreground inline-flex min-h-9 items-center text-sm font-medium">
-              Session recap
-            </span>
-            <div className="mt-4 flex items-start justify-between gap-4">
-              <div>
-                <h2 className="font-serif text-[2.75rem] leading-[0.95] tracking-[-0.03em] text-[var(--brand-ink)] sm:text-5xl">
-                  Today&rsquo;s Five
-                </h2>
-                <p className="mt-4 max-w-xl text-[1.02rem] leading-7 text-[var(--brand-ink-700)]">
-                  You found common ground in World Geography and opened a few new
-                  edges of the map.
-                </p>
-              </div>
-              <p className="shrink-0 pt-2 text-sm font-medium text-[var(--brand-ink-400)]">
-                {totalCorrect} / {MOCK_QUESTIONS.length}
-              </p>
-            </div>
-            <div className="mt-5 flex items-center justify-between gap-3">
-              <ResultDots />
-              <span className="inline-flex min-h-9 items-center gap-2 rounded-full border border-[var(--brand-border)] bg-[var(--brand-card)] px-3 text-sm font-medium text-[var(--brand-ink-700)]">
-                <Share2 className="size-4" />
-                Share your results
-              </span>
-            </div>
-            <p className="text-muted-foreground mt-4 text-sm leading-6 italic">
-              You found new ground in World Geography.
-            </p>
-          </header>
-
-          {/* Growth recap stub — present so the panel reads in its real context. */}
-          <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-4">
-            <h2 style={sectionTitleStyle}>Your Growth Recap</h2>
-            <p className="mt-2 text-sm leading-6 text-[var(--brand-ink-700)]">
-              World Geography and Modern Art both moved up a notch today.
-            </p>
-          </section>
-
-          {/* Today's questions — made-up completed-game cards. */}
-          <section className="mt-8">
-            <div className="mb-4">
-              <h2 className="font-serif text-2xl leading-tight text-[var(--brand-ink)]">
-                Today&rsquo;s questions
-              </h2>
-              <p className="mt-1 text-sm leading-6 text-muted-foreground">
-                A few were yours. A few were new.
-              </p>
-            </div>
-            <div className="space-y-4">
-              {MOCK_CARDS.map((card, index) => (
-                <QuestionCard key={index} card={card} />
-              ))}
-            </div>
-          </section>
-
-          {/* Closing card. */}
-          <section className="mt-8 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-6 text-center">
-            <p className="text-[1.05rem] leading-7 text-[var(--brand-ink-700)]">
-              Wednesday&rsquo;s five arrive at noon.
-            </p>
-            <div className="mt-5 flex flex-col items-center gap-3">
-              <span className="btn-primary w-full sm:w-auto sm:min-w-56">
-                Back home
-              </span>
-              <span className="text-muted-foreground text-sm font-medium underline underline-offset-4">
-                See your knowledge map
-              </span>
-            </div>
-          </section>
-        </div>
-
-        {/* Beat 3 — other social states. The card above shows inviter_present;
-            these are the two branches a player sees instead depending on whether
-            their inviter has played yet, or whether they arrived with no inviter
-            at all. Shown here so every Beat 3 state is reviewable in one place. */}
-        <div className="mt-10 rounded-2xl border border-dashed border-[var(--brand-border)] p-4">
-          <p className="mb-1 text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-            Beat 3 · other social states
-          </p>
-          <p className="mb-4 text-sm leading-6 text-muted-foreground">
-            Only one of these (including the inviter_present card above) renders
-            for a given player.
-          </p>
-
-          <section className="rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
-            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-              Inviter hasn&apos;t played yet
-            </p>
-            <SocialBeatPreview kind="inviter_future" name="Maya" />
-          </section>
-
-          <section className="mt-4 rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] px-5 py-5">
-            <p className="text-[0.68rem] font-semibold tracking-[0.08em] text-muted-foreground uppercase">
-              No inviter on record · <span className="text-amber-700">draft copy</span>
-            </p>
-            <SocialBeatPreview kind="no_inviter" />
-          </section>
+              <FirstSessionPanel recap={mockRecap(variant.beat3)} preview />
+            </section>
+          ))}
         </div>
       </div>
     </main>

--- a/src/app/dev/onboarding/building/WalkthroughAdvance.tsx
+++ b/src/app/dev/onboarding/building/WalkthroughAdvance.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+
+/**
+ * Walkthrough glue: after a beat on the "building your five" state, advance to
+ * the next harness stage (the first-session recap). A manual skip is offered for
+ * impatience. Only mounted in `?walk=1` mode.
+ */
+export function WalkthroughAdvance({
+  nextHref,
+  delayMs = 2800,
+}: {
+  nextHref: string;
+  delayMs?: number;
+}) {
+  const router = useRouter();
+
+  useEffect(() => {
+    const timer = setTimeout(() => router.push(nextHref), delayMs);
+    return () => clearTimeout(timer);
+  }, [router, nextHref, delayMs]);
+
+  return (
+    <div className="fixed inset-x-0 bottom-0 z-50 flex justify-center pb-[calc(1.5rem+env(safe-area-inset-bottom))]">
+      <Link
+        href={nextHref}
+        className="rounded-full border border-[var(--brand-border)] bg-[var(--brand-card)] px-4 py-2 text-sm font-medium text-[var(--brand-ink-700)] shadow-[var(--shadow-card)] hover:text-[var(--brand-ink)]"
+      >
+        Skip to first-session recap →
+      </Link>
+    </div>
+  );
+}

--- a/src/app/dev/onboarding/building/page.tsx
+++ b/src/app/dev/onboarding/building/page.tsx
@@ -1,0 +1,31 @@
+import LoadingScreen from '@/components/LoadingScreen';
+
+import { WalkthroughAdvance } from './WalkthroughAdvance';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * Dev harness: the "building your first five" wait state.
+ *
+ * In the real flow this is the loading screen shown when the player taps Play
+ * before generation has finished (generation kicks off after areas of knowledge,
+ * in the background). Here it renders the live `LoadingScreen`. In `?walk=1`
+ * (full-walkthrough) mode it pauses on the build, then advances to the
+ * first-session recap — the "first time finished" stage. (Real play itself can't
+ * be faithfully stubbed, so the walkthrough brackets it.)
+ */
+export default async function DevBuildingPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ walk?: string }>;
+}) {
+  const params = await searchParams;
+  const walk = params?.walk === '1';
+
+  return (
+    <main className="min-h-dvh">
+      <LoadingScreen fullScreen label="Building your first five…" />
+      {walk ? <WalkthroughAdvance nextHref="/dev/first-time-player" /> : null}
+    </main>
+  );
+}

--- a/src/app/dev/onboarding/intro/page.tsx
+++ b/src/app/dev/onboarding/intro/page.tsx
@@ -6,13 +6,14 @@ import OnboardingFlow, { type PreSeededInterest } from '@/app/onboarding/Onboard
 export const dynamic = 'force-dynamic';
 
 /**
- * Dev harness: replay the real name → call sign → areas-of-knowledge flow.
+ * Dev harness: replay the real setup (name + call sign) → areas-of-knowledge
+ * flow.
  *
- * Mounts the genuine `OnboardingFlow` with `previewMode`, so the name/handle/
+ * Mounts the genuine `OnboardingFlow` with `previewMode`, so the setup and
  * interests steps advance through the actual UI but skip their mutating writes
  * (no PATCH /api/account, no save-interests). Finishing the areas step chains to
- * the welcome-tour preview instead of the live home. Driven by mock invite data
- * so the inviter-seeded path renders.
+ * the welcome-tour preview. Driven by mock invite data so the inviter-seeded
+ * path renders. In `?walk=1` mode the chain carries the walkthrough flag onward.
  */
 
 const MOCK_INTERESTS: PreSeededInterest[] = [
@@ -21,7 +22,15 @@ const MOCK_INTERESTS: PreSeededInterest[] = [
   { domain: '1980s Toys', broadCategory: 'Pop Culture', rationale: null },
 ];
 
-export default function DevOnboardingIntroPage() {
+export default async function DevOnboardingIntroPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ walk?: string }>;
+}) {
+  const params = await searchParams;
+  const walk = params?.walk === '1';
+  const nextHref = walk ? '/dev/welcome-tour?walk=1' : '/dev/welcome-tour';
+
   return (
     <>
       <div className="fixed top-0 right-0 left-0 z-50 flex items-center justify-between gap-3 bg-[var(--brand-ink-950)] px-4 py-2 text-[var(--primary-foreground)]">
@@ -30,12 +39,13 @@ export default function DevOnboardingIntroPage() {
           Stages
         </Link>
         <span className="text-[12px] font-bold tracking-[0.1em] uppercase">
-          Read-only replay · writes stubbed
+          {walk ? 'Full walkthrough · writes stubbed' : 'Read-only replay · writes stubbed'}
         </span>
       </div>
       <div style={{ paddingTop: '2.5rem' }}>
         <OnboardingFlow
           previewMode
+          previewNextHref={nextHref}
           preSeededInterests={MOCK_INTERESTS}
           inviterName="Maya"
           inviteeDisplayName={null}

--- a/src/app/dev/onboarding/page.tsx
+++ b/src/app/dev/onboarding/page.tsx
@@ -1,5 +1,5 @@
 import Link from 'next/link';
-import { ChevronLeft, Compass, Info, Loader2, Sparkles, UserPlus } from 'lucide-react';
+import { ChevronLeft, Compass, Info, Loader2, PlayCircle, Sparkles, UserPlus } from 'lucide-react';
 
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
 
@@ -48,12 +48,24 @@ export default function DevOnboardingHubPage() {
       </div>
 
       <section className="mt-8">
-        <h2 className="mb-3 font-serif text-2xl font-semibold">Stages</h2>
+        <h2 className="mb-3 font-serif text-2xl font-semibold">Full experience</h2>
+        <SettingsGroup>
+          <SettingsRow
+            icon={<PlayCircle className="size-5" />}
+            title="Full signup walkthrough"
+            subtitle="Setup → areas of knowledge → welcome tour → building → first-session recap, chained"
+            href="/dev/onboarding/intro?walk=1"
+          />
+        </SettingsGroup>
+      </section>
+
+      <section className="mt-8">
+        <h2 className="mb-3 font-serif text-2xl font-semibold">Individual stages</h2>
         <SettingsGroup>
           <SettingsRow
             icon={<UserPlus className="size-5" />}
-            title="Name, call sign & areas of knowledge"
-            subtitle="The real setup flow driven with mock invite data (writes are stubbed)"
+            title="Setup & areas of knowledge"
+            subtitle="Name + call sign on one screen, then areas — the real flow, writes stubbed"
             href="/dev/onboarding/intro"
           />
           <SettingsRow

--- a/src/app/dev/welcome-tour/page.tsx
+++ b/src/app/dev/welcome-tour/page.tsx
@@ -10,32 +10,48 @@ export const dynamic = 'force-dynamic';
  *
  * The live tour overlays the real home (mounted by `?welcome=1`). This page
  * stands in a static, side-effect-free home replica carrying all five
- * `data-tour` anchors (five, customize, foryou, friends, shared) plus the
- * closing-panel slot, then mounts `<WelcomeTour forced />`. `forced` bypasses —
- * and never writes — the persisted seen-flag, so replaying here never mutates
- * real state, and every callout resolves to a target (the live home only
- * carries some anchors today; here all five are present).
+ * `data-tour` anchors (five, customize, foryou, friends, shared), plus the
+ * header + closing-panel slots, then mounts `<WelcomeTour forced />`. `forced`
+ * bypasses — and never writes — the persisted seen-flag, so replaying never
+ * mutates real state, and every callout resolves to a target.
  *
- * The closing CTA routes to `/daily` like the real tour. To re-run, reload.
+ * The global app nav (top bar / bottom tabs / FAB) is suppressed here (see
+ * Nav.tsx) and the replica is framed phone-width so the preview reads as the
+ * real mobile app rather than a desktop page.
+ *
+ * In `?walk=1` (full-walkthrough) mode the closing CTA chains into the
+ * building-your-five state instead of `/daily`.
  */
 
 // Generous inter-section spacing so snap & dwell has real scroll distance to
 // travel between callouts (the live home tunes this per-section).
-const SECTION_GAP = { paddingBottom: '34vh' } as const;
+const SECTION_GAP = { paddingBottom: '30vh' } as const;
 
-export default function DevWelcomeTourPage() {
+export default async function DevWelcomeTourPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ walk?: string }>;
+}) {
+  const params = await searchParams;
+  const walk = params?.walk === '1';
+
   return (
     <main className="min-h-dvh bg-[var(--brand-cream-page)] text-[var(--brand-ink)]">
-      <div className="mx-auto max-w-2xl px-4 py-6">
-        <Link
-          href="/dev/onboarding"
-          className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
-        >
-          <ChevronLeft className="size-4" />
-          Onboarding stages
-        </Link>
+      <div className="mx-auto w-full max-w-[420px] px-4 py-4">
+        {!walk ? (
+          <Link
+            href="/dev/onboarding"
+            className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground"
+          >
+            <ChevronLeft className="size-4" />
+            Onboarding stages
+          </Link>
+        ) : null}
 
-        <div className="mt-6 flex flex-col gap-5" style={{ paddingTop: '4vh' }}>
+        {/* Welcome-tour sticky header mounts here. */}
+        <div id="welcome-tour-header-slot" className="-mx-4 mt-3" />
+
+        <div className="mt-4 flex flex-col gap-5">
           {/* Today's Five — carries both the `five` and `customize` anchors. */}
           <div style={SECTION_GAP}>
             <div
@@ -147,7 +163,7 @@ export default function DevWelcomeTourPage() {
       {/* Closing panel mounts here. */}
       <div id="welcome-tour-closer-slot" />
 
-      <WelcomeTour forced />
+      <WelcomeTour forced playHref={walk ? '/dev/onboarding/building?walk=1' : '/daily'} />
     </main>
   );
 }

--- a/src/app/dev/welcome-tour/page.tsx
+++ b/src/app/dev/welcome-tour/page.tsx
@@ -10,23 +10,16 @@ export const dynamic = 'force-dynamic';
  *
  * The live tour overlays the real home (mounted by `?welcome=1`). This page
  * stands in a static, side-effect-free home replica carrying all five
- * `data-tour` anchors (five, customize, foryou, friends, shared), plus the
- * header + closing-panel slots, then mounts `<WelcomeTour forced />`. `forced`
- * bypasses — and never writes — the persisted seen-flag, so replaying never
- * mutates real state, and every callout resolves to a target.
+ * `data-tour` anchors (five, customize, foryou, friends, shared), then mounts
+ * `<WelcomeTour forced />`. `forced` bypasses — and never writes — the persisted
+ * seen-flag, so replaying never mutates real state, and every callout resolves
+ * to a target (the live home carries fewer anchors today).
  *
- * The global app nav (top bar / bottom tabs / FAB) is suppressed here (see
- * Nav.tsx) and the replica is framed phone-width so the preview reads as the
- * real mobile app rather than a desktop page.
- *
- * In `?walk=1` (full-walkthrough) mode the closing CTA chains into the
- * building-your-five state instead of `/daily`.
+ * The tour dims + spotlights each section and pans this `main`. The global app
+ * nav is already suppressed on this route (see Nav.tsx); the replica is framed
+ * phone-width so the preview reads as the real mobile app. In `?walk=1` mode the
+ * closing CTA chains into the building-your-five state instead of `/daily`.
  */
-
-// Generous inter-section spacing so snap & dwell has real scroll distance to
-// travel between callouts (the live home tunes this per-section).
-const SECTION_GAP = { paddingBottom: '30vh' } as const;
-
 export default async function DevWelcomeTourPage({
   searchParams,
 }: {
@@ -37,7 +30,7 @@ export default async function DevWelcomeTourPage({
 
   return (
     <main className="min-h-dvh bg-[var(--brand-cream-page)] text-[var(--brand-ink)]">
-      <div className="mx-auto w-full max-w-[420px] px-4 py-4">
+      <div className="mx-auto flex w-full max-w-[420px] flex-col gap-4 px-3 py-4">
         {!walk ? (
           <Link
             href="/dev/onboarding"
@@ -48,120 +41,104 @@ export default async function DevWelcomeTourPage({
           </Link>
         ) : null}
 
-        {/* Welcome-tour sticky header mounts here. */}
-        <div id="welcome-tour-header-slot" className="-mx-4 mt-3" />
-
-        <div className="mt-4 flex flex-col gap-5">
-          {/* Today's Five — carries both the `five` and `customize` anchors. */}
-          <div style={SECTION_GAP}>
-            <div
-              data-tour="five"
-              className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-4 shadow-[var(--shadow-card)]"
+        {/* Today's Five — carries both the `five` and `customize` anchors. */}
+        <div
+          data-tour="five"
+          className="text-card-foreground w-full rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--feed-card-elevated)] px-4 py-4 shadow-[var(--shadow-card)]"
+        >
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
+              Today&apos;s Five
+            </p>
+            <span
+              data-tour="customize"
+              className="inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-3 py-2 text-[12px] font-bold text-[var(--brand-ink)]"
             >
-              <div className="flex items-center justify-between gap-2">
-                <p className="text-[13px] font-bold tracking-[0.12em] text-[var(--brand-ink-700)] uppercase">
-                  Today&apos;s Five
-                </p>
-                <span
-                  data-tour="customize"
-                  className="inline-flex min-h-11 shrink-0 items-center justify-center gap-1.5 rounded-full border border-[color-mix(in_srgb,var(--brand-border)_60%,transparent)] bg-[var(--brand-cream-page)] px-3 py-2 text-[12px] font-bold text-[var(--brand-ink)]"
-                >
-                  <SlidersHorizontal className="size-4" strokeWidth={2.4} aria-hidden="true" />
-                  Customize
-                </span>
-              </div>
-              <h2 className="mt-1 mb-2 font-serif text-[32px] leading-[40px] font-medium text-[var(--brand-ink)]">
-                Ready when you are!
-              </h2>
-              <div className="mt-3 flex items-center gap-2" aria-hidden="true">
-                {[0, 1, 2, 3, 4].map((dot) => (
-                  <span
-                    key={dot}
-                    className="block size-[11px] rounded-full"
-                    style={{
-                      border: '1px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)',
-                    }}
-                  />
-                ))}
-              </div>
-              <span className="btn-primary mt-4 w-full">Play now</span>
-            </div>
+              <SlidersHorizontal className="size-4" strokeWidth={2.4} aria-hidden="true" />
+              Customize
+            </span>
           </div>
-
-          {/* For You */}
-          <section data-tour="foryou" style={SECTION_GAP}>
-            <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
-              For you
-            </p>
-            <article className="rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4">
-              <p className="text-sm text-[var(--brand-ink-700)]">
-                <span className="font-semibold text-[var(--brand-ink)]">Joshua P</span> sent you a
-                question they wrote
-              </p>
-              <p className="mt-3 mb-4 font-serif text-[1.3rem] leading-snug font-medium text-[var(--brand-ink)]">
-                &ldquo;In the surrey with the fringe on top, what was the dashboard made of?&rdquo;
-              </p>
-              <div className="flex items-center justify-between">
-                <span className="text-sm text-muted-foreground">Dismiss</span>
-                <span className="btn-primary">Answer</span>
-              </div>
-            </article>
-          </section>
-
-          {/* From Friends */}
-          <section data-tour="friends" style={SECTION_GAP}>
-            <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink)] uppercase">
-              From Friends <span className="opacity-60">(Past 7 days)</span>
-            </p>
-            <p className="mb-3 text-xs tracking-[0.04em] text-muted-foreground uppercase">
-              Play the questions your friends have aced.
-            </p>
-            {[
-              'has been on a tear through Tennis Fundamentals, Early 20th Century American History and 3 others',
-              "has been all over 1980's Toys and Early 20th Century American History",
-            ].map((blurb) => (
-              <div
-                key={blurb}
-                className="mb-2 rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4"
-              >
-                <p className="font-serif text-[1.2rem] font-semibold text-[var(--brand-ink)]">
-                  Joshua P
-                </p>
-                <p className="mt-1 text-xs leading-relaxed text-[var(--brand-ink-700)]">{blurb}</p>
-                <div className="mt-2 flex items-center justify-end gap-1">
-                  <span className="text-[13px] font-semibold text-[var(--brand-ink-700)]">
-                    Play
-                  </span>
-                </div>
-              </div>
+          <h2 className="mt-1 mb-2 font-serif text-[32px] leading-[40px] font-medium text-[var(--brand-ink)]">
+            Ready when you are!
+          </h2>
+          <div className="mt-3 flex items-center gap-2" aria-hidden="true">
+            {[0, 1, 2, 3, 4].map((dot) => (
+              <span
+                key={dot}
+                className="block size-[11px] rounded-full"
+                style={{ border: '1px solid color-mix(in srgb, var(--brand-ink) 35%, transparent)' }}
+              />
             ))}
-          </section>
-
-          {/* Shared Ground */}
-          <section data-tour="shared" style={SECTION_GAP}>
-            <div
-              className="rounded-[var(--radius-xs)] p-5"
-              style={{ background: 'color-mix(in srgb, var(--success) 14%, var(--brand-cream-page))' }}
-            >
-              <h3 className="font-serif text-[1.4rem] leading-tight font-semibold text-[var(--brand-ink)]">
-                You and Joshua keep meeting in the same places.
-              </h3>
-              <p className="mt-3 text-xs text-[var(--brand-ink-700)]">
-                American City Nicknames · Bikini Bottom Animated Series
-              </p>
-              <p className="mt-4 text-[11px] font-semibold tracking-[0.08em] text-[var(--brand-ink)] uppercase">
-                Shared ground with 1 friend
-              </p>
-              <span className="mt-3 inline-block border-b border-[var(--brand-ink)] pb-0.5 text-xs font-semibold tracking-[0.05em] text-[var(--brand-ink)] uppercase">
-                Explore your overlap →
-              </span>
-            </div>
-          </section>
+          </div>
+          <span className="btn-primary mt-4 w-full">Play now</span>
         </div>
-      </div>
 
-      {/* Closing panel mounts here. */}
-      <div id="welcome-tour-closer-slot" />
+        <p className="text-center text-[11px] font-semibold tracking-[0.1em] text-[var(--accent-gold)] uppercase">
+          ✦ Your weekly reflection is ready ✦
+        </p>
+
+        {/* For You */}
+        <section data-tour="foryou">
+          <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink-400)] uppercase">
+            For you
+          </p>
+          <article className="rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4">
+            <p className="text-sm text-[var(--brand-ink-700)]">
+              <span className="font-semibold text-[var(--brand-ink)]">Joshua P</span> sent you a
+              question they wrote
+            </p>
+            <p className="mt-3 mb-4 font-serif text-[1.3rem] leading-snug font-medium text-[var(--brand-ink)]">
+              &ldquo;In the surrey with the fringe on top, what was the dashboard made of?&rdquo;
+            </p>
+            <div className="flex items-center justify-between">
+              <span className="text-sm text-muted-foreground">Dismiss</span>
+              <span className="btn-primary">Answer</span>
+            </div>
+          </article>
+        </section>
+
+        {/* From Friends */}
+        <section data-tour="friends">
+          <p className="mb-2 pl-0.5 text-[13px] font-bold tracking-[0.1em] text-[var(--brand-ink)] uppercase">
+            From Friends <span className="opacity-60">(Past 7 days)</span>
+          </p>
+          {[
+            'has been on a tear through Tennis Fundamentals, Early 20th Century American History and 3 others',
+            "has been all over 1980's Toys and Early 20th Century American History",
+          ].map((blurb) => (
+            <div
+              key={blurb}
+              className="mb-2 rounded-[var(--radius-xs)] border border-[var(--brand-border)] bg-[var(--brand-card)] p-4"
+            >
+              <p className="font-serif text-[1.2rem] font-semibold text-[var(--brand-ink)]">
+                Joshua P
+              </p>
+              <p className="mt-1 text-xs leading-relaxed text-[var(--brand-ink-700)]">{blurb}</p>
+              <div className="mt-2 flex items-center justify-end gap-1">
+                <span className="text-[13px] font-semibold text-[var(--brand-ink-700)]">Play</span>
+              </div>
+            </div>
+          ))}
+        </section>
+
+        {/* Shared Ground */}
+        <section data-tour="shared">
+          <div
+            className="rounded-[var(--radius-xs)] p-5"
+            style={{ background: 'color-mix(in srgb, var(--success) 14%, var(--brand-cream-page))' }}
+          >
+            <h3 className="font-serif text-[1.4rem] leading-tight font-semibold text-[var(--brand-ink)]">
+              You and Joshua keep meeting in the same places.
+            </h3>
+            <p className="mt-3 text-xs text-[var(--brand-ink-700)]">
+              American City Nicknames · Bikini Bottom Animated Series
+            </p>
+            <span className="mt-3 inline-block border-b border-[var(--brand-ink)] pb-0.5 text-xs font-semibold tracking-[0.05em] text-[var(--brand-ink)] uppercase">
+              Explore your overlap →
+            </span>
+          </div>
+        </section>
+      </div>
 
       <WelcomeTour forced playHref={walk ? '/dev/onboarding/building?walk=1' : '/daily'} />
     </main>

--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -12,7 +12,7 @@ import { AddTopicField, type AddTopicError } from '@/components/interests/AddTop
 // lands the player straight in /daily. The daily-reminder email opt-in moved
 // off this flow into the post-first-five recap (FirstSessionRecap), so the ask
 // arrives once the player has actually felt the loop.
-type CurrentStep = 'display-name' | 'handle' | 'review'
+type CurrentStep = 'setup' | 'review'
 
 export type ProposedInterest = {
   domain: string
@@ -41,6 +41,12 @@ type OnboardingFlowProps = {
    * the harness drive this real component without burning onboarding state.
    */
   previewMode?: boolean
+  /**
+   * Where the interests step routes after finishing in `previewMode`. Lets the
+   * full-walkthrough harness chain onward (e.g. into the welcome tour) instead
+   * of the live home. Defaults to the standalone welcome-tour preview.
+   */
+  previewNextHref?: string
 }
 
 const DISPLAY_NAME_MIN = 2
@@ -133,13 +139,15 @@ export default function OnboardingFlow({
   initialDisplayName,
   initialHandle,
   previewMode = false,
+  previewNextHref = '/dev/welcome-tour',
 }: OnboardingFlowProps) {
   const router = useRouter()
   const hasInitialDisplayName = Boolean(initialDisplayName?.trim())
   const hasInitialHandle = Boolean(initialHandle?.trim())
   const [currentStep, setCurrentStep] = useState<CurrentStep>(() => {
-    if (!hasInitialDisplayName) return 'display-name'
-    if (!hasInitialHandle) return 'handle'
+    // Name and call sign now share one "setup" screen; only skip it when both
+    // are already on file.
+    if (!hasInitialDisplayName || !hasInitialHandle) return 'setup'
     return 'review'
   })
   const [displayName, setDisplayName] = useState<string>(() =>
@@ -223,7 +231,7 @@ export default function OnboardingFlow({
   )
 
   useEffect(() => {
-    if (currentStep !== 'handle') return
+    if (currentStep !== 'setup') return
 
     const candidate = handle.trim().toLowerCase()
     const controller = new AbortController()
@@ -344,59 +352,17 @@ export default function OnboardingFlow({
     )
   }
 
-  async function submitDisplayName() {
-    const trimmed = displayName.trim().replace(/\s+/g, ' ')
-    if (trimmed.length < DISPLAY_NAME_MIN || trimmed.length > DISPLAY_NAME_MAX) {
+  // Name + call sign now save together from one "setup" screen. Name persists
+  // first, then handle; a handle failure surfaces under the handle field while
+  // the (already-saved) name is kept, so retrying only re-runs the handle PATCH.
+  async function submitSetup() {
+    const trimmedName = displayName.trim().replace(/\s+/g, ' ')
+    if (trimmedName.length < DISPLAY_NAME_MIN || trimmedName.length > DISPLAY_NAME_MAX) {
       setDisplayNameError(
         `Pick something between ${DISPLAY_NAME_MIN} and ${DISPLAY_NAME_MAX} characters.`
       )
       return
     }
-
-    setDisplayNameError(null)
-
-    // Dev harness replay — advance through the real UI without the PATCH.
-    if (previewMode) {
-      setDisplayName(trimmed)
-      if (!handle && !hasInitialHandle) {
-        setHandle(sanitizeForHandle(trimmed))
-      }
-      setCurrentStep(hasInitialHandle ? 'review' : 'handle')
-      return
-    }
-
-    setIsSavingDisplayName(true)
-
-    try {
-      const response = await fetch('/api/account', {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ displayName: trimmed }),
-      })
-      const data = await response.json().catch(() => ({}))
-
-      if (!response.ok) {
-        setDisplayNameError(
-          typeof data?.error === 'string'
-            ? data.error
-            : "We couldn't save that name. Try again."
-        )
-        return
-      }
-
-      setDisplayName(trimmed)
-      if (!handle && !hasInitialHandle) {
-        setHandle(sanitizeForHandle(trimmed))
-      }
-      setCurrentStep(hasInitialHandle ? 'review' : 'handle')
-    } catch {
-      setDisplayNameError("We couldn't save that name. Try again.")
-    } finally {
-      setIsSavingDisplayName(false)
-    }
-  }
-
-  async function submitHandle() {
     const candidate = handle.trim().toLowerCase()
     if (!HANDLE_FORMAT.test(candidate)) {
       setHandleError(
@@ -405,39 +371,56 @@ export default function OnboardingFlow({
       return
     }
 
+    setDisplayNameError(null)
     setHandleError(null)
 
-    // Dev harness replay — advance to review without the PATCH.
+    // Dev harness replay — advance through the real UI without the PATCHes.
     if (previewMode) {
+      setDisplayName(trimmedName)
       setHandle(candidate)
       setCurrentStep('review')
       return
     }
 
-    setIsSavingHandle(true)
-
+    setIsSavingDisplayName(true)
     try {
-      const response = await fetch('/api/account/handle', {
+      const nameResponse = await fetch('/api/account', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ displayName: trimmedName }),
+      })
+      const nameData = await nameResponse.json().catch(() => ({}))
+      if (!nameResponse.ok) {
+        setDisplayNameError(
+          typeof nameData?.error === 'string'
+            ? nameData.error
+            : "We couldn't save that name. Try again."
+        )
+        return
+      }
+      setDisplayName(trimmedName)
+
+      setIsSavingHandle(true)
+      const handleResponse = await fetch('/api/account/handle', {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ handle: candidate }),
       })
-      const data = await response.json().catch(() => ({}))
-
-      if (!response.ok) {
+      const handleData = await handleResponse.json().catch(() => ({}))
+      if (!handleResponse.ok) {
         setHandleError(
-          typeof data?.message === 'string'
-            ? data.message
+          typeof handleData?.message === 'string'
+            ? handleData.message
             : "We couldn't save that handle. Try again."
         )
         return
       }
-
       setHandle(candidate)
       setCurrentStep('review')
     } catch {
-      setHandleError("We couldn't save that handle. Try again.")
+      setHandleError("We couldn't save your details. Try again.")
     } finally {
+      setIsSavingDisplayName(false)
       setIsSavingHandle(false)
     }
   }
@@ -469,7 +452,7 @@ export default function OnboardingFlow({
     // Dev harness replay — skip the save + first-round generation and chain to
     // the next stage (the welcome tour) instead of the live home.
     if (previewMode) {
-      router.push('/dev/welcome-tour')
+      router.push(previewNextHref)
       return
     }
 
@@ -524,28 +507,28 @@ export default function OnboardingFlow({
     <main className="bg-background text-foreground min-h-screen px-4 pt-8 pb-10 sm:px-6 sm:pt-12">
       <section className="mx-auto flex min-h-[calc(100vh-5rem)] w-full max-w-2xl flex-col">
         <div className="flex flex-1 flex-col">
-          {currentStep === 'display-name' ? (
+          {currentStep === 'setup' ? (
             <div className="flex flex-1 flex-col justify-center gap-8">
               <div className="space-y-3">
                 <p className="font-wordmark text-[13px] font-bold tracking-[0.18em] text-[var(--brand-navy)] uppercase">
                   Joshing
                 </p>
                 <StepHeader
-                  title="What should we call you?"
+                  title="Set up your profile"
                   subtitle="Joshing is a daily trivia game you play with friends — questions tuned to what you actually know."
                 />
                 <p className="text-muted-foreground text-sm leading-6">
                   {inviteeDisplayName?.trim()
-                    ? `${displayInviterName} added you as "${inviteeDisplayName.trim()}". Keep it or change it — ${DISPLAY_NAME_MIN} to ${DISPLAY_NAME_MAX} characters.`
-                    : `This is how you'll appear to friends. ${DISPLAY_NAME_MIN} to ${DISPLAY_NAME_MAX} characters.`}
+                    ? `${displayInviterName} added you as "${inviteeDisplayName.trim()}". Set your name and call sign — friends use your @ to find you.`
+                    : 'Pick the name friends see and your call sign — your @ on Joshing.'}
                 </p>
               </div>
 
               <form
-                className="space-y-4"
+                className="space-y-5"
                 onSubmit={(event) => {
                   event.preventDefault()
-                  if (!isSavingDisplayName) void submitDisplayName()
+                  if (!isSavingDisplayName && !isSavingHandle) void submitSetup()
                 }}
               >
                 <label className="block">
@@ -559,53 +542,28 @@ export default function OnboardingFlow({
                     maxLength={DISPLAY_NAME_MAX}
                     value={displayName}
                     onChange={(e) => {
-                      setDisplayName(e.target.value.slice(0, DISPLAY_NAME_MAX))
+                      const next = e.target.value.slice(0, DISPLAY_NAME_MAX)
+                      setDisplayName(next)
                       if (displayNameError) setDisplayNameError(null)
+                      // Seed the call sign from the name until the user edits it.
+                      if (!handleTouched && !hasInitialHandle) {
+                        setHandle(sanitizeForHandle(next))
+                      }
                     }}
                   />
+                  {displayNameError ? (
+                    <p className="text-destructive mt-2 text-sm">{displayNameError}</p>
+                  ) : null}
                 </label>
 
-                {displayNameError ? (
-                  <p className="text-destructive text-sm">{displayNameError}</p>
-                ) : null}
-
-                <button
-                  type="submit"
-                  className="btn-primary w-full"
-                  disabled={
-                    isSavingDisplayName ||
-                    displayName.trim().length < DISPLAY_NAME_MIN
-                  }
-                >
-                  {isSavingDisplayName ? 'Saving...' : 'Continue'}
-                </button>
-              </form>
-            </div>
-          ) : null}
-
-          {currentStep === 'handle' ? (
-            <div className="flex flex-1 flex-col justify-center gap-8">
-              <StepHeader
-                title="Pick your handle"
-                subtitle={`This is your @ on Joshing — friends use it to find you. ${HANDLE_MIN}–${HANDLE_MAX} characters, lowercase letters, numbers, and underscores. Starts with a letter.`}
-              />
-
-              <form
-                className="space-y-4"
-                onSubmit={(event) => {
-                  event.preventDefault()
-                  if (!isSavingHandle) void submitHandle()
-                }}
-              >
                 <label className="block">
-                  <span className="text-sm font-medium">Your handle</span>
+                  <span className="text-sm font-medium">Your call sign</span>
                   <div className="mt-2 flex items-center gap-2">
                     <span className="text-muted-foreground text-base">@</span>
                     <input
                       type="text"
                       className="bg-[var(--brand-field)] placeholder:text-muted-foreground/70 focus:border-[var(--brand-navy)] h-12 w-full rounded-md border border-[var(--accent-gold)] px-3 text-base transition outline-none"
                       placeholder="yourhandle"
-                      autoFocus
                       autoCapitalize="none"
                       autoCorrect="off"
                       spellCheck={false}
@@ -623,47 +581,51 @@ export default function OnboardingFlow({
                       }}
                     />
                   </div>
+                  {handleTouched && handle.length >= HANDLE_MIN ? (
+                    <p
+                      className={`mt-2 text-sm ${
+                        handleStatus.state === 'available'
+                          ? 'text-emerald-600'
+                          : handleStatus.state === 'unavailable'
+                            ? 'text-destructive'
+                            : 'text-muted-foreground'
+                      }`}
+                    >
+                      {handleStatus.state === 'checking'
+                        ? 'Checking…'
+                        : handleStatus.state === 'available'
+                          ? `@${handle} is available.`
+                          : handleStatus.state === 'unavailable'
+                            ? handleStatus.reason === 'taken'
+                              ? 'That call sign is already taken.'
+                              : handleStatus.reason === 'reserved'
+                                ? 'That call sign is reserved.'
+                                : 'Use only lowercase letters, numbers, and underscores. Start with a letter.'
+                            : null}
+                    </p>
+                  ) : null}
+                  {handleError ? (
+                    <p className="text-destructive mt-2 text-sm">{handleError}</p>
+                  ) : null}
                 </label>
 
-                {handleTouched && handle.length >= HANDLE_MIN ? (
-                  <p
-                    className={`text-sm ${
-                      handleStatus.state === 'available'
-                        ? 'text-emerald-600'
-                        : handleStatus.state === 'unavailable'
-                          ? 'text-destructive'
-                          : 'text-muted-foreground'
-                    }`}
-                  >
-                    {handleStatus.state === 'checking'
-                      ? 'Checking…'
-                      : handleStatus.state === 'available'
-                        ? `@${handle} is available.`
-                        : handleStatus.state === 'unavailable'
-                          ? handleStatus.reason === 'taken'
-                            ? 'That handle is already taken.'
-                            : handleStatus.reason === 'reserved'
-                              ? 'That handle is reserved.'
-                              : 'Use only lowercase letters, numbers, and underscores. Start with a letter.'
-                          : null}
-                  </p>
-                ) : null}
-
-                {handleError ? (
-                  <p className="text-destructive text-sm">{handleError}</p>
-                ) : null}
+                <p className="text-muted-foreground text-xs leading-5">
+                  {`${DISPLAY_NAME_MIN}–${DISPLAY_NAME_MAX} characters for your name. Call sign is ${HANDLE_MIN}–${HANDLE_MAX} characters — lowercase letters, numbers, and underscores, starting with a letter.`}
+                </p>
 
                 <button
                   type="submit"
                   className="btn-primary w-full"
                   disabled={
+                    isSavingDisplayName ||
                     isSavingHandle ||
+                    displayName.trim().length < DISPLAY_NAME_MIN ||
                     handle.length < HANDLE_MIN ||
                     handleStatus.state === 'checking' ||
                     handleStatus.state === 'unavailable'
                   }
                 >
-                  {isSavingHandle ? 'Saving…' : 'Continue'}
+                  {isSavingDisplayName || isSavingHandle ? 'Saving…' : 'Continue'}
                 </button>
               </form>
             </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,9 +36,6 @@ export default async function Home({
   return (
     <>
     <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
-      {/* Welcome-tour sticky header mounts here (first in flow, so it can shrink
-          to a sticky bar as the page scrolls). Renders only while active. */}
-      {tourActive ? <div id="welcome-tour-header-slot" className="-mx-4 -mt-6 md:-mt-10" /> : null}
       {/* Top triangle band (Variant4-TOP, 1120x160, grain baked in; lower portion
           transparent so cream shows through). Rendered as a BACKGROUND image, not
           an <img>: background-size:auto pins it to its INTRINSIC size (so its
@@ -129,14 +126,10 @@ export default async function Home({
           )}
         </section>
       </div>
-
-      {/* Welcome-tour closing panel mounts here (last in the home flow, so the
-          tour's final scroll lands on it) and the controller overlay drives the
-          coach-marks. Both render only while the tour is active. `-mx-4` bleeds
-          the dark panel to the column edges; `-mb-32` cancels main's bottom
-          padding so no cream gap trails below it. */}
-      {tourActive ? <div id="welcome-tour-closer-slot" className="-mx-4 -mb-32" /> : null}
     </main>
+    {/* First-run welcome tour — a fixed spotlight overlay over this real home.
+        It dims + spotlights the data-tour sections, pans the page, and hides the
+        global app chrome while it runs. Renders only while active. */}
     {tourActive ? <WelcomeTour /> : null}
     </>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,9 @@ export default async function Home({
   return (
     <>
     <main className="relative mx-auto flex min-h-dvh max-w-2xl flex-col gap-5 px-4 py-6 pb-32 md:py-10">
+      {/* Welcome-tour sticky header mounts here (first in flow, so it can shrink
+          to a sticky bar as the page scrolls). Renders only while active. */}
+      {tourActive ? <div id="welcome-tour-header-slot" className="-mx-4 -mt-6 md:-mt-10" /> : null}
       {/* Top triangle band (Variant4-TOP, 1120x160, grain baked in; lower portion
           transparent so cream shows through). Rendered as a BACKGROUND image, not
           an <img>: background-size:auto pins it to its INTRINSIC size (so its
@@ -129,8 +132,10 @@ export default async function Home({
 
       {/* Welcome-tour closing panel mounts here (last in the home flow, so the
           tour's final scroll lands on it) and the controller overlay drives the
-          coach-marks. Both render only while the tour is active. */}
-      {tourActive ? <div id="welcome-tour-closer-slot" /> : null}
+          coach-marks. Both render only while the tour is active. `-mx-4` bleeds
+          the dark panel to the column edges; `-mb-32` cancels main's bottom
+          padding so no cream gap trails below it. */}
+      {tourActive ? <div id="welcome-tour-closer-slot" className="-mx-4 -mb-32" /> : null}
     </main>
     {tourActive ? <WelcomeTour /> : null}
     </>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -165,6 +165,7 @@ export function Nav({
   return (
     <>
       <header
+        data-app-chrome
         className="z-40 border-b bg-background/95 backdrop-blur"
         aria-label="Primary header"
       >
@@ -208,6 +209,7 @@ export function Nav({
       {showNewGameShortcut ? (
         <button
           type="button"
+          data-app-chrome
           className={[
             'fixed bottom-24 right-5 z-50 grid size-14 place-items-center rounded-full bg-primary text-primary-foreground shadow-lg',
             // The dedicated add-a-question FAB shows on every viewport; the
@@ -225,6 +227,7 @@ export function Nav({
         </button>
       ) : null}
       <nav
+        data-app-chrome
         className="fixed inset-x-0 bottom-0 z-40 border-t bg-background/95 backdrop-blur"
         aria-label="Primary navigation"
         style={{ paddingBottom: 'env(safe-area-inset-bottom)' }}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -126,13 +126,23 @@ export function Nav({
   // floated over the experience.
   const isCeremonyScreen = pathname.startsWith('/ceremony/');
 
+  // The onboarding-harness preview routes are self-contained, isolated replays
+  // (the welcome tour overlays a sample home; the setup replay renders its own
+  // full-screen flow; the building state is a takeover). The global chrome would
+  // clash with the tour's own header/closing panel and read as clutter, so it's
+  // suppressed here — matching /onboarding and /daily. The /dev/onboarding hub
+  // itself keeps the nav.
+  const isOnboardingHarnessPreview =
+    pathname === '/dev/welcome-tour' || pathname.startsWith('/dev/onboarding/');
+
   if (
     pathname === '/onboarding' ||
     pathname.startsWith('/daily') ||
     pathname === '/login' ||
     pathname.startsWith('/invite/') ||
     isGamePlayScreen ||
-    isCeremonyScreen
+    isCeremonyScreen ||
+    isOnboardingHarnessPreview
   ) {
     return null;
   }

--- a/src/components/welcome/WelcomeTour.tsx
+++ b/src/components/welcome/WelcomeTour.tsx
@@ -1,36 +1,30 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
+import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { createPortal } from 'react-dom';
 
-// Client-only readiness without a setState-in-effect: false during SSR, true
-// once hydrated. Portals (and DOM measurement) need the browser document.
-const subscribeNoop = () => () => {};
-const getClientSnapshot = () => true;
-const getServerSnapshot = () => false;
-
 /**
- * Welcome tour — a first-run coach-mark walk over the REAL, live home.
+ * Welcome tour — a first-run guided spotlight over the REAL, live home.
  *
- * Ported from the standalone `welcome-coachmarks.html` prototype into a
- * reusable client component. It does NOT render its own home: it overlays the
- * page that mounts it, locating sections by `data-tour="<id>"` anchors and
- * pointing short callouts at them one at a time. The page settles on each
- * section (scroll-snap), the callout fades while scrolling between sections and
- * rests once settled, and a closing panel at the very bottom drops the player
- * straight into playing their Five.
+ * Ported from the `welcome-coachmarks` spotlight prototype. It takes over the
+ * screen as a fixed overlay, dims the page, and spotlights one real section at a
+ * time (located via `data-tour="<id>"`). An invisible scroll driver advances
+ * through the steps; the home softly pans so each target settles ~40% down, a
+ * white tooltip hugs it, and a closing "Play my Five" bar drops the player
+ * straight into the round.
  *
- * Anchoring is best-effort: steps whose `data-tour` target isn't on the page
- * are skipped (the live home only carries some anchors today; the dev preview
- * at /dev/welcome-tour carries all five). Progress pips reflect only the steps
- * that actually resolve to a target.
+ * The dim + cutout is drawn by a spotlight BOX positioned at the target's
+ * computed rect (transparent interior + a huge box-shadow), not by raising the
+ * real element — so panning `main` (which creates a stacking context) can't trap
+ * the highlight under the scrim. The global app chrome (top bar / bottom tabs /
+ * FAB, tagged `data-app-chrome`) is hidden while the tour runs.
  *
- * Activation/suppression is client-side (no migration): the live home mounts
- * this when it sees `?welcome=1`; once the tour is completed or skipped a
- * one-time flag is persisted to localStorage so it doesn't reappear. The dev
- * preview passes `forced` to bypass — and to never write — that flag, keeping
- * the replay read-only against real state.
+ * Anchoring is best-effort: steps whose target isn't on the page are skipped
+ * (the live home carries some anchors today; the dev preview carries all five).
+ * Activation/suppression is client-side: the live home mounts this on
+ * `?welcome=1` and a localStorage flag suppresses re-runs. `forced` bypasses —
+ * and never writes — that flag for the dev replay.
  */
 
 export type WelcomeTourStep = {
@@ -38,71 +32,57 @@ export type WelcomeTourStep = {
   target: string;
   /** Small-caps eyebrow above the callout copy. */
   label: string;
-  /** The callout body. */
+  /** Callout body. May contain simple <b> emphasis (trusted, static copy). */
   copy: string;
 };
 
 export const WELCOME_TOUR_STORAGE_KEY = 'joshing.welcomeTourSeenAt';
 
 // Canonical five callouts (build brief). Order matters: Today's Five fires
-// before Customize even though Customize lives inside the Five card — the
-// scroll gate below keeps them from competing.
+// before Customize even though Customize lives inside the Five card.
 export const DEFAULT_WELCOME_TOUR_STEPS: WelcomeTourStep[] = [
   {
     target: 'five',
     label: "Today's Five",
-    copy: 'Your five questions for the day show up right here — tap Play to start. A new set lands every afternoon.',
+    copy: 'Your five questions for the day show up <b>right here</b> — tap Play to start. A new set lands every afternoon.',
   },
   {
     target: 'customize',
     label: 'Customize',
-    copy: "Want different topics or harder questions? Change them anytime — it's right here.",
+    copy: "Want different topics, or harder questions? <b>Change them anytime</b> — it's right here.",
   },
   {
     target: 'foryou',
     label: 'For You',
-    copy: "Questions a friend sends or writes just for you land here. Answer back and they'll see how you did.",
+    copy: "Questions a friend sends or writes <b>just for you</b> land here. Answer back and they'll see how you did.",
   },
   {
     target: 'friends',
     label: 'From Friends',
-    copy: 'Questions your friends have aced this week. Jump in on the same ones and see how you stack up.',
+    copy: 'Questions your friends have aced this week. <b>Jump in on the same ones</b> and see how you stack up.',
   },
   {
     target: 'shared',
     label: 'Shared Ground',
-    copy: 'Where you and your friends overlap — and where to find more people to play with.',
+    copy: 'Where you and your friends overlap — and where to <b>find more people</b> to play with.',
   },
 ];
 
 type WelcomeTourCopy = {
-  header: { eyebrow: string; title: string; body: string };
-  barLabel: string;
-  closer: { eyebrow: string; title: string; body: string; cta: string };
+  stripLabel: string;
+  scrollHint: string;
+  playCta: string;
 };
 
 const DEFAULT_COPY: WelcomeTourCopy = {
-  header: {
-    eyebrow: 'Welcome to Joshing',
-    title: "Let's take a quick look around.",
-    body: "Scroll down — we'll point out what's what. Your five are ready whenever you are.",
-  },
-  barLabel: 'A quick tour',
-  closer: {
-    eyebrow: "That's the tour",
-    title: 'Your Five are ready.',
-    body: 'Everything else fills in as you and your friends play. Jump in.',
-    cta: 'Play my Five →',
-  },
+  stripLabel: 'Welcome — a quick tour',
+  scrollHint: 'Scroll to move through ↓',
+  playCta: 'Play my Five →',
 };
 
 type WelcomeTourProps = {
   steps?: WelcomeTourStep[];
   copy?: Partial<WelcomeTourCopy>;
-  /** Element id (rendered in page flow) the sticky header portals into. */
-  headerSlotId?: string;
-  /** Element id (rendered in page flow) the closing panel portals into. */
-  closerSlotId?: string;
   /**
    * Bypass the persisted seen-flag and never write it. Used by the dev preview
    * so a replay never mutates real seen-state.
@@ -121,6 +101,12 @@ type WelcomeTourProps = {
   onClose?: () => void;
 };
 
+// Client-only readiness without a setState-in-effect: false during SSR, true
+// once hydrated.
+const subscribeNoop = () => () => {};
+const getClientSnapshot = () => true;
+const getServerSnapshot = () => false;
+
 /** Clears the persisted seen-flag so the live tour can re-arm (dev affordance). */
 export function clearWelcomeTourSeen(storageKey: string = WELCOME_TOUR_STORAGE_KEY): void {
   try {
@@ -130,30 +116,40 @@ export function clearWelcomeTourSeen(storageKey: string = WELCOME_TOUR_STORAGE_K
   }
 }
 
+const PAN_EASE = 'cubic-bezier(.25,.7,.25,1)';
+
 const SCOPED_STYLE = `
-.welcome-tour-header{position:sticky;top:0;z-index:50;background:var(--brand-ink-950);color:var(--primary-foreground);overflow:hidden;border-bottom-left-radius:var(--radius-xs);border-bottom-right-radius:var(--radius-xs);}
-.welcome-tour-header .wt-inner{position:relative;}
-.welcome-tour-header .wt-big{transition:opacity .3s ease,max-height .35s ease,padding .35s ease;max-height:240px;}
-.welcome-tour-header[data-shrunk="true"] .wt-big{max-height:0;opacity:0;padding-top:0;padding-bottom:0;}
-.welcome-tour-header .wt-bar{display:flex;align-items:center;justify-content:space-between;gap:12px;height:0;opacity:0;overflow:hidden;transition:opacity .3s ease,height .35s ease;}
-.welcome-tour-header[data-shrunk="true"] .wt-bar{height:46px;opacity:1;}
-.welcome-tour-coach{position:fixed;z-index:60;max-width:260px;pointer-events:none;opacity:0;transition:opacity .35s ease,top .45s cubic-bezier(.3,.7,.3,1),left .45s ease;}
-.welcome-tour-coach.is-shown{opacity:1;}
-.welcome-tour-arrow{position:absolute;width:0;height:0;}
-.welcome-tour-coach.arrow-up .welcome-tour-arrow{top:-7px;border-left:8px solid transparent;border-right:8px solid transparent;border-bottom:8px solid var(--brand-ink-950);}
-.welcome-tour-coach.arrow-down .welcome-tour-arrow{bottom:-7px;border-left:8px solid transparent;border-right:8px solid transparent;border-top:8px solid var(--brand-ink-950);}
-.welcome-tour-lit{box-shadow:0 0 0 3px var(--brand-orange),0 0 0 9px color-mix(in srgb, var(--brand-orange) 18%, transparent);border-radius:var(--radius-xs);position:relative;z-index:30;transition:box-shadow .4s ease,border-radius .2s;}
+html.welcome-tour-active{overflow:hidden;}
+html.welcome-tour-active [data-app-chrome]{display:none !important;}
+.welcome-tour-strip{position:fixed;top:0;left:0;right:0;z-index:50;display:flex;align-items:center;justify-content:space-between;gap:12px;background:var(--brand-ink-950);color:var(--primary-foreground);padding:9px 16px;}
+.welcome-tour-strip .wt-wm{font-size:12px;font-weight:600;letter-spacing:.12em;text-transform:uppercase;color:var(--brand-cream);}
+.welcome-tour-strip .wt-skip{font-size:12px;font-weight:600;letter-spacing:.05em;text-transform:uppercase;color:color-mix(in srgb, var(--primary-foreground) 82%, transparent);background:color-mix(in srgb, var(--primary-foreground) 12%, transparent);border:none;border-radius:999px;padding:6px 13px;cursor:pointer;}
 .welcome-tour-pips{display:flex;gap:5px;}
 .welcome-tour-pips i{width:6px;height:6px;border-radius:50%;background:color-mix(in srgb, var(--primary-foreground) 28%, transparent);transition:background .3s;}
 .welcome-tour-pips i.on{background:var(--brand-orange);}
-@media (prefers-reduced-motion:reduce){.welcome-tour-coach,.welcome-tour-lit,.welcome-tour-header .wt-big,.welcome-tour-header .wt-bar{transition:none;}}
+.welcome-tour-spot{position:fixed;z-index:20;border-radius:13px;pointer-events:none;opacity:0;box-shadow:0 0 0 3px var(--brand-orange), 0 0 0 4000px color-mix(in srgb, var(--brand-ink-950) 66%, transparent);transition:opacity .4s ease, top .6s ${PAN_EASE}, left .6s ${PAN_EASE}, width .4s ease, height .4s ease;}
+.welcome-tour-spot.show{opacity:1;}
+.welcome-tour-help{position:fixed;z-index:45;width:248px;opacity:0;pointer-events:none;transition:opacity .35s ease, top .55s ${PAN_EASE}, left .35s ease;}
+.welcome-tour-help.show{opacity:1;}
+.welcome-tour-help .wt-box{background:var(--brand-card);color:var(--brand-ink);border-radius:12px;padding:13px 15px;box-shadow:0 16px 40px -14px color-mix(in srgb, var(--brand-ink-950) 55%, transparent);position:relative;}
+.welcome-tour-help .wt-k{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--brand-orange);margin-bottom:4px;}
+.welcome-tour-help .wt-p{font-size:.97rem;line-height:1.4;color:var(--brand-ink-700);}
+.welcome-tour-help .wt-p b{color:var(--brand-ink);font-weight:600;}
+.welcome-tour-help .wt-arrow{position:absolute;width:0;height:0;}
+.welcome-tour-help.below .wt-arrow{top:-8px;border-left:9px solid transparent;border-right:9px solid transparent;border-bottom:9px solid var(--brand-card);}
+.welcome-tour-help.above .wt-arrow{bottom:-8px;border-left:9px solid transparent;border-right:9px solid transparent;border-top:9px solid var(--brand-card);}
+.welcome-tour-hint{position:fixed;bottom:18px;left:0;right:0;z-index:45;text-align:center;font-size:13px;letter-spacing:.1em;text-transform:uppercase;color:var(--primary-foreground);text-shadow:0 1px 8px color-mix(in srgb, var(--brand-ink-950) 50%, transparent);animation:welcomeTourBob 1.8s ease-in-out infinite;pointer-events:none;}
+@keyframes welcomeTourBob{0%,100%{transform:translateY(0);}50%{transform:translateY(5px);}}
+.welcome-tour-endbar{position:fixed;bottom:0;left:0;right:0;z-index:55;padding:16px 20px calc(22px + env(safe-area-inset-bottom));background:linear-gradient(0deg, var(--brand-ink-950) 70%, color-mix(in srgb, var(--brand-ink-950) 0%, transparent));}
+.welcome-tour-endbar .wt-play{width:100%;display:flex;align-items:center;justify-content:center;gap:9px;background:var(--brand-orange);color:var(--primary-foreground);font-size:1.2rem;font-weight:700;letter-spacing:.03em;border:none;border-radius:13px;padding:17px;cursor:pointer;}
+.welcome-tour-driver{position:fixed;inset:0;z-index:40;overflow-y:scroll;scrollbar-width:none;-webkit-overflow-scrolling:touch;}
+.welcome-tour-driver::-webkit-scrollbar{display:none;}
+@media (prefers-reduced-motion:reduce){.welcome-tour-spot,.welcome-tour-help,.welcome-tour-hint{transition:none;animation:none;}}
 `;
 
 export default function WelcomeTour({
   steps = DEFAULT_WELCOME_TOUR_STEPS,
   copy: copyOverride,
-  headerSlotId = 'welcome-tour-header-slot',
-  closerSlotId = 'welcome-tour-closer-slot',
   forced = false,
   storageKey = WELCOME_TOUR_STORAGE_KEY,
   playHref = '/daily',
@@ -161,35 +157,25 @@ export default function WelcomeTour({
   onClose,
 }: WelcomeTourProps) {
   const router = useRouter();
-  const copy: WelcomeTourCopy = {
-    header: { ...DEFAULT_COPY.header, ...copyOverride?.header },
-    barLabel: copyOverride?.barLabel ?? DEFAULT_COPY.barLabel,
-    closer: { ...DEFAULT_COPY.closer, ...copyOverride?.closer },
-  };
+  const copy: WelcomeTourCopy = { ...DEFAULT_COPY, ...copyOverride };
 
   const isClient = useSyncExternalStore(subscribeNoop, getClientSnapshot, getServerSnapshot);
-  // `closed` collapses the tour after a skip/play; combined with the persisted
-  // seen-flag (read once on the client) it gives `inactive`.
   const [closed, setClosed] = useState(false);
-  const [shrunk, setShrunk] = useState(false);
-  // Index of the current pip-highlighted step (or -1 between/at edges).
-  const [pipIndex, setPipIndex] = useState(-1);
+  // Current step index (drives pips, hint, end bar). -1 before the first place.
+  const [stepIndex, setStepIndex] = useState(-1);
 
-  const headerRef = useRef<HTMLDivElement | null>(null);
-  const coachRef = useRef<HTMLDivElement | null>(null);
-  const coachLabelRef = useRef<HTMLParagraphElement | null>(null);
-  const coachCopyRef = useRef<HTMLParagraphElement | null>(null);
+  const spotRef = useRef<HTMLDivElement | null>(null);
+  const helpRef = useRef<HTMLDivElement | null>(null);
+  const helpKRef = useRef<HTMLParagraphElement | null>(null);
+  const helpPRef = useRef<HTMLParagraphElement | null>(null);
   const arrowRef = useRef<HTMLSpanElement | null>(null);
+  const driverRef = useRef<HTMLDivElement | null>(null);
 
   const currentRef = useRef(-1);
+  const panRef = useRef(0);
   const endedRef = useRef(false);
-  const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Read external (browser) state into render the lint-sanctioned way: a
-  // useSyncExternalStore snapshot returning a STABLE PRIMITIVE, with arrays
-  // derived via useMemo. No setState-in-effect, no ref reads during render.
-
-  // Whether the tour was already seen (persisted flag). `forced` ignores it.
+  // Seen-flag (external state) read the lint-sanctioned way.
   const seen = useSyncExternalStore(
     subscribeNoop,
     () => {
@@ -203,8 +189,7 @@ export default function WelcomeTour({
     () => false,
   );
 
-  // A stable signature of which step targets are present in the DOM ("1"/"0"
-  // per step). Resolves after hydration; all-"0" during SSR.
+  // Stable signature of which step targets are present in the DOM.
   const presenceKey = useSyncExternalStore(
     subscribeNoop,
     () =>
@@ -215,351 +200,236 @@ export default function WelcomeTour({
         .join(''),
     () => steps.map(() => '0').join(''),
   );
-  // Steps with a live target drive the pips + navigation. Fall back to all
-  // steps if nothing resolved yet (SSR / pre-hydration).
   const activeSteps = useMemo(() => {
     const resolved = steps.filter((_, index) => presenceKey[index] === '1');
     return resolved.length > 0 ? resolved : steps;
   }, [steps, presenceKey]);
 
   const inactive = closed || seen;
+  const lastIndex = activeSteps.length - 1;
 
-  const markSeen = useCallback(() => {
-    if (forced) return;
-    try {
-      window.localStorage.setItem(storageKey, new Date().toISOString());
-    } catch {
-      // Best-effort — a write failure just means the tour may show again.
-    }
-  }, [forced, storageKey]);
-
-  const handleClose = useCallback(() => {
-    endedRef.current = true;
-    markSeen();
-    setClosed(true);
-    if (onClose) {
-      onClose();
-    } else if (!forced) {
-      // Strip ?welcome so a refresh doesn't re-enter the tour.
-      router.replace(window.location.pathname);
-    }
-  }, [forced, markSeen, onClose, router]);
-
-  const handlePlay = useCallback(() => {
-    markSeen();
-    if (onPlay) {
-      onPlay();
-    } else {
-      router.push(playHref);
-    }
-  }, [markSeen, onPlay, playHref, router]);
-
-  // Core scroll engine: header shrink, step selection (snap & dwell), and
-  // coach-mark placement. Mirrors the prototype, mutating the coach via refs so
-  // scroll stays cheap; React state only carries the pip index + shrink.
+  // Core engine: hide app chrome, lock scroll, and drive the spotlight + pan
+  // from the invisible scroll driver. Mutates the overlay via refs so scroll
+  // stays cheap; React state only carries the step index.
   useEffect(() => {
     if (inactive || !isClient) return;
 
-    const placeCoach = (step: WelcomeTourStep) => {
-      const el = document.querySelector<HTMLElement>(
-        `[data-tour="${CSS.escape(step.target)}"]`,
-      );
-      const coach = coachRef.current;
-      if (!el || !coach || !coachLabelRef.current || !coachCopyRef.current || !arrowRef.current) {
-        return;
-      }
-      const r = el.getBoundingClientRect();
-      coachLabelRef.current.textContent = step.label;
-      coachCopyRef.current.textContent = step.copy;
-      // Measure before showing.
-      coach.style.visibility = 'hidden';
-      coach.classList.add('is-shown');
-      const cw = Math.min(260, window.innerWidth - 32);
-      coach.style.width = `${cw}px`;
-      const ch = coach.offsetHeight;
-      // Keep the callout inside a safe band: below the sticky welcome bar and
-      // above the app's fixed bottom nav, so it never collides with chrome.
-      const TOP_SAFE = 64;
-      const BOTTOM_SAFE = 96;
-      const roomBelow = window.innerHeight - BOTTOM_SAFE - (r.bottom + 12);
-      const roomAbove = r.top - 12 - TOP_SAFE;
-      const below = roomBelow >= ch || roomBelow >= roomAbove;
-      let top = below ? r.bottom + 12 : r.top - ch - 12;
-      top = Math.max(TOP_SAFE, Math.min(top, window.innerHeight - BOTTOM_SAFE - ch));
-      coach.classList.toggle('arrow-up', below);
-      coach.classList.toggle('arrow-down', !below);
-      // Center on the target, clamp to the viewport; arrow follows the target.
-      let left = r.left + r.width / 2 - cw / 2;
-      left = Math.max(8, Math.min(left, window.innerWidth - cw - 8));
-      coach.style.left = `${left}px`;
-      coach.style.top = `${top}px`;
-      coach.style.visibility = 'visible';
-      let ax = r.left + r.width / 2 - left - 8;
-      ax = Math.max(14, Math.min(ax, cw - 26));
-      arrowRef.current.style.left = `${ax}px`;
-      document
-        .querySelectorAll('[data-tour].welcome-tour-lit')
-        .forEach((node) => node.classList.remove('welcome-tour-lit'));
-      el.classList.add('welcome-tour-lit');
-    };
-
-    const hideCoach = () => {
-      coachRef.current?.classList.remove('is-shown');
-      document
-        .querySelectorAll('[data-tour].welcome-tour-lit')
-        .forEach((node) => node.classList.remove('welcome-tour-lit'));
-    };
-
-    const evaluate = () => {
-      if (endedRef.current) return;
-      setShrunk(window.scrollY > 40);
-
-      const tourSteps = activeSteps;
-
-      // Closing panel in view — retire the callouts and fill the pips.
-      const closer = document.getElementById(closerSlotId);
-      if (closer) {
-        const cr = closer.getBoundingClientRect();
-        if (cr.top < window.innerHeight * 0.6) {
-          hideCoach();
-          setPipIndex(tourSteps.length - 1);
-          currentRef.current = tourSteps.length;
-          markSeen();
-          return;
-        }
-      }
-
-      const cy = window.innerHeight * 0.5;
-      let best = -1;
-      let bestD = Infinity;
-      tourSteps.forEach((step, n) => {
-        const el = document.querySelector<HTMLElement>(
-          `[data-tour="${CSS.escape(step.target)}"]`,
-        );
-        if (!el) return;
-        const r = el.getBoundingClientRect();
-        const mid = r.top + r.height / 2;
-        const d = Math.abs(mid - cy);
-        if (d < bestD && r.bottom > 60 && r.top < window.innerHeight - 60) {
-          bestD = d;
-          best = n;
-        }
-      });
-
-      // Today's Five and Customize share a card, so center-distance can't
-      // separate them — force order: Five until scrolled a bit further in.
-      const fiveIdx = tourSteps.findIndex((s) => s.target === 'five');
-      const custIdx = tourSteps.findIndex((s) => s.target === 'customize');
-      if (fiveIdx !== -1 && custIdx !== -1 && (best === fiveIdx || best === custIdx)) {
-        const fiveEl = document.querySelector<HTMLElement>('[data-tour="five"]');
-        if (fiveEl) {
-          const fr = fiveEl.getBoundingClientRect();
-          const inFiveCard = fr.bottom > 80 && fr.top < window.innerHeight * 0.7;
-          if (inFiveCard) {
-            best = fr.top > window.innerHeight * 0.22 ? fiveIdx : custIdx;
-          }
-        }
-      }
-
-      if (best === -1) {
-        hideCoach();
-        return;
-      }
-
-      if (best !== currentRef.current) {
-        currentRef.current = best;
-        setPipIndex(best);
-        hideCoach(); // hide during the move
-        if (settleTimer.current) clearTimeout(settleTimer.current);
-        settleTimer.current = setTimeout(() => {
-          if (!endedRef.current) placeCoach(tourSteps[best]);
-        }, 180);
-      } else {
-        if (settleTimer.current) clearTimeout(settleTimer.current);
-        settleTimer.current = setTimeout(() => {
-          if (!endedRef.current) placeCoach(tourSteps[best]);
-        }, 120);
-      }
-    };
-
-    // Scroll-snap as a progressive enhancement: opt each resolved target into
-    // snapping at runtime so the live home settles on sections without editing
-    // every section's static CSS.
     const root = document.documentElement;
-    const prevSnapType = root.style.scrollSnapType;
-    root.style.scrollSnapType = 'y proximity';
-    const snapped: HTMLElement[] = [];
-    activeSteps.forEach((step) => {
-      const el = document.querySelector<HTMLElement>(`[data-tour="${CSS.escape(step.target)}"]`);
-      if (el) {
-        el.style.scrollSnapAlign = 'center';
-        el.style.scrollMarginTop = '72px';
-        snapped.push(el);
-      }
-    });
+    const main = document.querySelector('main');
+    const tourSteps = activeSteps;
 
-    let raf = 0;
-    const onScroll = () => {
-      if (raf) return;
-      raf = requestAnimationFrame(() => {
-        raf = 0;
-        evaluate();
-      });
+    const markSeen = () => {
+      if (forced) return;
+      try {
+        window.localStorage.setItem(storageKey, new Date().toISOString());
+      } catch {
+        // best-effort
+      }
     };
-    window.addEventListener('scroll', onScroll, { passive: true });
-    window.addEventListener('resize', onScroll);
-    const initial = setTimeout(evaluate, 200);
+
+    const PAD = 8;
+    // The settled geometry of the active target (viewport coords), shared
+    // between the spotlight (placed immediately) and the tooltip (placed after
+    // the pan settles).
+    const geom = { top: 0, left: 0, width: 0, height: 0 };
+
+    // Pan the home and glide the spotlight to the target. Because the only
+    // transform is translateY on `main`, the target's settled rect is its
+    // current rect shifted by the pan delta — exact, so no mid-pan measurement.
+    const placeSpotlight = (n: number): boolean => {
+      const step = tourSteps[n];
+      const el = document.querySelector<HTMLElement>(`[data-tour="${CSS.escape(step.target)}"]`);
+      const spot = spotRef.current;
+      if (!el || !spot) return false;
+      const r = el.getBoundingClientRect();
+      // Soft pan: move the home so the target settles ~40% down; never past top.
+      const want = window.innerHeight * 0.4;
+      const drift = r.top - want;
+      const newPan = Math.min(0, panRef.current - drift);
+      const delta = newPan - panRef.current;
+      panRef.current = newPan;
+      if (main) main.style.transform = `translateY(${newPan}px)`;
+
+      geom.top = r.top + delta;
+      geom.left = r.left;
+      geom.width = r.width;
+      geom.height = r.height;
+
+      spot.style.top = `${geom.top - PAD}px`;
+      spot.style.left = `${geom.left - PAD}px`;
+      spot.style.width = `${geom.width + PAD * 2}px`;
+      spot.style.height = `${geom.height + PAD * 2}px`;
+      spot.classList.add('show');
+      return true;
+    };
+
+    // After the pan settles, hug the target with the tooltip — flips above/below
+    // by room, clamps to the screen edges, aims the arrow at the target center.
+    const placeHelp = (n: number) => {
+      const step = tourSteps[n];
+      const help = helpRef.current;
+      if (!help || !helpKRef.current || !helpPRef.current || !arrowRef.current) return;
+      helpKRef.current.textContent = step.label;
+      helpPRef.current.innerHTML = step.copy;
+      const hw = Math.min(248, window.innerWidth - 28);
+      help.style.width = `${hw}px`;
+      help.style.visibility = 'hidden';
+      help.classList.add('show');
+      const hh = help.offsetHeight;
+      const below = geom.top < window.innerHeight * 0.5;
+      const top = below ? geom.top + geom.height + PAD + 12 : geom.top - hh - 12;
+      let left = geom.left + geom.width / 2 - hw / 2;
+      left = Math.max(10, Math.min(left, window.innerWidth - hw - 10));
+      help.classList.toggle('below', below);
+      help.classList.toggle('above', !below);
+      help.style.left = `${left}px`;
+      help.style.top = `${top}px`;
+      help.style.visibility = 'visible';
+      let ax = geom.left + geom.width / 2 - left - 9;
+      ax = Math.max(14, Math.min(ax, hw - 26));
+      arrowRef.current.style.left = `${ax}px`;
+    };
+
+    let dwellTimer: ReturnType<typeof setTimeout> | null = null;
+    const goToStep = (n: number) => {
+      if (n === currentRef.current) return;
+      currentRef.current = n;
+      setStepIndex(n);
+      if (n === lastIndex) markSeen();
+      // Hide the tooltip while the page pans; glide the spotlight to the target
+      // immediately, then let the tooltip re-appear once the pan has settled
+      // (dwell), so its placement lands on the target's final position.
+      helpRef.current?.classList.remove('show');
+      const placed = placeSpotlight(n);
+      if (dwellTimer) clearTimeout(dwellTimer);
+      if (placed) {
+        dwellTimer = setTimeout(() => {
+          if (!endedRef.current) placeHelp(n);
+        }, 280);
+      }
+    };
+
+    // Hide app chrome + lock the page; the driver owns scrolling.
+    root.classList.add('welcome-tour-active');
+    if (main) {
+      main.style.transition = `transform .6s ${PAN_EASE}`;
+      main.style.willChange = 'transform';
+    }
+
+    const driver = driverRef.current;
+    const onDrive = () => {
+      if (endedRef.current || !driver) return;
+      const max = driver.scrollHeight - driver.clientHeight;
+      const p = max > 0 ? Math.min(1, Math.max(0, driver.scrollTop / max)) : 0;
+      goToStep(Math.min(lastIndex, Math.floor(p * tourSteps.length * 0.999)));
+    };
+    driver?.addEventListener('scroll', onDrive, { passive: true });
+    const initial = window.setTimeout(() => goToStep(0), 250);
+    const onResize = () => {
+      const n = currentRef.current;
+      if (n >= 0 && placeSpotlight(n)) placeHelp(n);
+    };
+    window.addEventListener('resize', onResize);
 
     return () => {
-      window.removeEventListener('scroll', onScroll);
-      window.removeEventListener('resize', onScroll);
-      if (raf) cancelAnimationFrame(raf);
-      if (settleTimer.current) clearTimeout(settleTimer.current);
+      driver?.removeEventListener('scroll', onDrive);
+      window.removeEventListener('resize', onResize);
       clearTimeout(initial);
-      root.style.scrollSnapType = prevSnapType;
-      snapped.forEach((el) => {
-        el.style.scrollSnapAlign = '';
-        el.style.scrollMarginTop = '';
-        el.classList.remove('welcome-tour-lit');
-      });
+      if (dwellTimer) clearTimeout(dwellTimer);
+      root.classList.remove('welcome-tour-active');
+      if (main) {
+        main.style.transform = '';
+        main.style.transition = '';
+        main.style.willChange = '';
+      }
     };
-  }, [inactive, isClient, closerSlotId, markSeen, activeSteps]);
+  }, [inactive, isClient, activeSteps, lastIndex, forced, storageKey]);
 
   if (inactive || !isClient) return null;
 
-  const header = (
-    <div className="welcome-tour-header" data-shrunk={shrunk} ref={headerRef}>
-      <div className="wt-inner">
-        <div className="wt-big px-5 pt-6 pb-5">
-          <button
-            type="button"
-            onClick={handleClose}
-            className="absolute top-5 right-4 rounded-full px-4 py-1.5 text-[13px] font-semibold tracking-[0.06em] uppercase"
-            style={{
-              color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)',
-              background: 'color-mix(in srgb, var(--primary-foreground) 12%, transparent)',
-            }}
-          >
-            Skip
-          </button>
-          <p
-            className="text-[12px] font-bold tracking-[0.2em] uppercase"
-            style={{ color: 'var(--brand-cream)' }}
-          >
-            {copy.header.eyebrow}
-          </p>
-          <h1 className="mt-1.5 font-serif text-3xl leading-[1.05] font-semibold">
-            {copy.header.title}
-          </h1>
-          <p
-            className="mt-2 text-[0.98rem]"
-            style={{ color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)' }}
-          >
-            {copy.header.body}
-          </p>
-        </div>
-        <div className="wt-bar px-4">
-          <span
-            className="text-[13px] font-bold tracking-[0.1em] uppercase"
-            style={{ color: 'var(--brand-cream)' }}
-          >
-            {copy.barLabel}
-          </span>
-          <div className="welcome-tour-pips" aria-hidden="true">
-            {activeSteps.map((step, n) => (
-              <i key={step.target} className={n <= pipIndex ? 'on' : ''} />
-            ))}
-          </div>
-          <button
-            type="button"
-            onClick={handleClose}
-            className="rounded-full px-4 py-1.5 text-[13px] font-semibold tracking-[0.06em] uppercase"
-            style={{
-              color: 'color-mix(in srgb, var(--primary-foreground) 82%, transparent)',
-              background: 'color-mix(in srgb, var(--primary-foreground) 12%, transparent)',
-            }}
-          >
-            Skip
-          </button>
-        </div>
-      </div>
-    </div>
-  );
-
-  const coach = (
-    <div className="welcome-tour-coach" ref={coachRef} role="status" aria-live="polite">
-      <div
-        className="relative rounded-xl px-4 py-3"
-        style={{
-          background: 'var(--brand-ink-950)',
-          color: 'var(--primary-foreground)',
-          boxShadow: '0 16px 40px -16px color-mix(in srgb, var(--brand-ink) 55%, transparent)',
-        }}
-      >
-        <span className="welcome-tour-arrow" ref={arrowRef} aria-hidden="true" />
-        <p
-          ref={coachLabelRef}
-          className="mb-1 text-[11px] font-bold tracking-[0.1em] uppercase"
-          style={{ color: 'var(--brand-cream)' }}
-        />
-        <p ref={coachCopyRef} className="text-[0.95rem] leading-[1.4]" />
-      </div>
-    </div>
-  );
-
-  const closer = (
-    <section
-      className="flex min-h-[70vh] flex-col justify-center px-6 pt-16"
-      style={{
-        background: 'var(--brand-ink-950)',
-        color: 'var(--primary-foreground)',
-        // Clear the app's fixed bottom nav so the CTA is never hidden behind it.
-        paddingBottom: 'calc(7rem + env(safe-area-inset-bottom))',
-      }}
-    >
-      <p
-        className="text-[13px] font-semibold tracking-[0.14em] uppercase"
-        style={{ color: 'var(--brand-cream)' }}
-      >
-        {copy.closer.eyebrow}
-      </p>
-      <h2 className="mt-2 font-serif text-5xl leading-[1.02] font-semibold">
-        {copy.closer.title}
-      </h2>
-      <p
-        className="mt-3.5 text-[1.15rem] leading-relaxed"
-        style={{ color: 'color-mix(in srgb, var(--primary-foreground) 85%, transparent)' }}
-      >
-        {copy.closer.body}
-      </p>
-      <button
-        type="button"
-        onClick={handlePlay}
-        className="mt-7 w-full rounded-xl py-4 text-[1.25rem] font-bold tracking-[0.03em] transition-transform active:scale-[0.98]"
-        style={{
-          background: 'var(--brand-orange)',
-          color: 'var(--primary-foreground)',
-          boxShadow: '0 14px 30px -12px color-mix(in srgb, var(--brand-orange) 70%, transparent)',
-        }}
-      >
-        {copy.closer.cta}
-      </button>
-    </section>
-  );
-
-  const headerSlot = document.getElementById(headerSlotId);
-  const closerSlot = document.getElementById(closerSlotId);
-
-  return (
+  const overlay = (
     <>
       <style>{SCOPED_STYLE}</style>
-      {/* Header rides an in-flow slot at the top of the page so it pushes
-          content and collapses to a sticky bar — no body-padding hack. The
-          coach is viewport-fixed (portaled to body); the closer sits in its
-          own slot at the bottom of the page flow. */}
-      {headerSlot ? createPortal(header, headerSlot) : null}
-      {createPortal(coach, document.body)}
-      {closerSlot ? createPortal(closer, closerSlot) : null}
+
+      <div className="welcome-tour-strip">
+        <span className="wt-wm">{copy.stripLabel}</span>
+        <div className="welcome-tour-pips" aria-hidden="true">
+          {activeSteps.map((step, n) => (
+            <i key={step.target} className={n <= stepIndex ? 'on' : ''} />
+          ))}
+        </div>
+        <button
+          type="button"
+          className="wt-skip"
+          onClick={() => {
+            endedRef.current = true;
+            if (!forced) {
+              try {
+                window.localStorage.setItem(storageKey, new Date().toISOString());
+              } catch {
+                // best-effort
+              }
+            }
+            setClosed(true);
+            if (onClose) {
+              onClose();
+            } else if (!forced) {
+              router.replace(window.location.pathname);
+            }
+          }}
+        >
+          Skip
+        </button>
+      </div>
+
+      <div className="welcome-tour-spot" ref={spotRef} aria-hidden="true" />
+
+      <div className="welcome-tour-help" ref={helpRef} role="status" aria-live="polite">
+        <div className="wt-box">
+          <span className="wt-arrow" ref={arrowRef} aria-hidden="true" />
+          <p className="wt-k" ref={helpKRef} />
+          <p className="wt-p" ref={helpPRef} />
+        </div>
+      </div>
+
+      {stepIndex < lastIndex ? (
+        <div className="welcome-tour-hint" aria-hidden="true">
+          {copy.scrollHint}
+        </div>
+      ) : null}
+
+      {stepIndex >= lastIndex ? (
+        <div className="welcome-tour-endbar">
+          <button
+            type="button"
+            className="wt-play"
+            onClick={() => {
+              if (!forced) {
+                try {
+                  window.localStorage.setItem(storageKey, new Date().toISOString());
+                } catch {
+                  // best-effort
+                }
+              }
+              if (onPlay) {
+                onPlay();
+              } else {
+                router.push(playHref);
+              }
+            }}
+          >
+            {copy.playCta}
+          </button>
+        </div>
+      ) : null}
+
+      {/* Invisible scroll driver — captures scroll to advance steps. Tall enough
+          to give each step a screenful of travel. */}
+      <div className="welcome-tour-driver" ref={driverRef}>
+        <div style={{ height: `${Math.max(activeSteps.length, 1) * 100}vh` }} />
+      </div>
     </>
   );
+
+  return createPortal(overlay, document.body);
 }

--- a/src/components/welcome/WelcomeTour.tsx
+++ b/src/components/welcome/WelcomeTour.tsx
@@ -99,6 +99,8 @@ const DEFAULT_COPY: WelcomeTourCopy = {
 type WelcomeTourProps = {
   steps?: WelcomeTourStep[];
   copy?: Partial<WelcomeTourCopy>;
+  /** Element id (rendered in page flow) the sticky header portals into. */
+  headerSlotId?: string;
   /** Element id (rendered in page flow) the closing panel portals into. */
   closerSlotId?: string;
   /**
@@ -108,7 +110,12 @@ type WelcomeTourProps = {
   forced?: boolean;
   /** Persisted suppression key (localStorage). */
   storageKey?: string;
-  /** Closing CTA handler. Defaults to routing into the Daily Five (`/daily`). */
+  /**
+   * Where the closing CTA routes. Serializable, so server components can set it
+   * (e.g. the walkthrough chains into the building state). Defaults to `/daily`.
+   */
+  playHref?: string;
+  /** Closing CTA handler. Overrides `playHref` when provided. */
   onPlay?: () => void;
   /** Skip/close handler. Defaults to stripping `?welcome` and staying on home. */
   onClose?: () => void;
@@ -124,8 +131,8 @@ export function clearWelcomeTourSeen(storageKey: string = WELCOME_TOUR_STORAGE_K
 }
 
 const SCOPED_STYLE = `
-.welcome-tour-header{position:fixed;top:0;left:0;right:0;z-index:50;background:var(--brand-ink-950);color:var(--primary-foreground);overflow:hidden;}
-.welcome-tour-header .wt-inner{max-width:42rem;margin:0 auto;position:relative;}
+.welcome-tour-header{position:sticky;top:0;z-index:50;background:var(--brand-ink-950);color:var(--primary-foreground);overflow:hidden;border-bottom-left-radius:var(--radius-xs);border-bottom-right-radius:var(--radius-xs);}
+.welcome-tour-header .wt-inner{position:relative;}
 .welcome-tour-header .wt-big{transition:opacity .3s ease,max-height .35s ease,padding .35s ease;max-height:240px;}
 .welcome-tour-header[data-shrunk="true"] .wt-big{max-height:0;opacity:0;padding-top:0;padding-bottom:0;}
 .welcome-tour-header .wt-bar{display:flex;align-items:center;justify-content:space-between;gap:12px;height:0;opacity:0;overflow:hidden;transition:opacity .3s ease,height .35s ease;}
@@ -145,9 +152,11 @@ const SCOPED_STYLE = `
 export default function WelcomeTour({
   steps = DEFAULT_WELCOME_TOUR_STEPS,
   copy: copyOverride,
+  headerSlotId = 'welcome-tour-header-slot',
   closerSlotId = 'welcome-tour-closer-slot',
   forced = false,
   storageKey = WELCOME_TOUR_STORAGE_KEY,
+  playHref = '/daily',
   onPlay,
   onClose,
 }: WelcomeTourProps) {
@@ -175,7 +184,6 @@ export default function WelcomeTour({
   const currentRef = useRef(-1);
   const endedRef = useRef(false);
   const settleTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const bigHeaderHeight = useRef(0);
 
   // Read external (browser) state into render the lint-sanctioned way: a
   // useSyncExternalStore snapshot returning a STABLE PRIMITIVE, with arrays
@@ -242,9 +250,9 @@ export default function WelcomeTour({
     if (onPlay) {
       onPlay();
     } else {
-      router.push('/daily');
+      router.push(playHref);
     }
-  }, [markSeen, onPlay, router]);
+  }, [markSeen, onPlay, playHref, router]);
 
   // Core scroll engine: header shrink, step selection (snap & dwell), and
   // coach-mark placement. Mirrors the prototype, mutating the coach via refs so
@@ -269,9 +277,15 @@ export default function WelcomeTour({
       const cw = Math.min(260, window.innerWidth - 32);
       coach.style.width = `${cw}px`;
       const ch = coach.offsetHeight;
-      // Above or below the target depending on room.
-      const below = r.top < window.innerHeight * 0.45;
-      const top = below ? r.bottom + 12 : r.top - ch - 12;
+      // Keep the callout inside a safe band: below the sticky welcome bar and
+      // above the app's fixed bottom nav, so it never collides with chrome.
+      const TOP_SAFE = 64;
+      const BOTTOM_SAFE = 96;
+      const roomBelow = window.innerHeight - BOTTOM_SAFE - (r.bottom + 12);
+      const roomAbove = r.top - 12 - TOP_SAFE;
+      const below = roomBelow >= ch || roomBelow >= roomAbove;
+      let top = below ? r.bottom + 12 : r.top - ch - 12;
+      top = Math.max(TOP_SAFE, Math.min(top, window.innerHeight - BOTTOM_SAFE - ch));
       coach.classList.toggle('arrow-up', below);
       coach.classList.toggle('arrow-down', !below);
       // Center on the target, clamp to the viewport; arrow follows the target.
@@ -384,13 +398,6 @@ export default function WelcomeTour({
       }
     });
 
-    // Push page content below the (fixed) header, then collapse with it.
-    const prevBodyPad = document.body.style.paddingTop;
-    const prevBodyTransition = document.body.style.transition;
-    bigHeaderHeight.current = headerRef.current?.offsetHeight ?? 0;
-    document.body.style.transition = 'padding-top .35s ease';
-    document.body.style.paddingTop = `${bigHeaderHeight.current}px`;
-
     let raf = 0;
     const onScroll = () => {
       if (raf) return;
@@ -415,16 +422,8 @@ export default function WelcomeTour({
         el.style.scrollMarginTop = '';
         el.classList.remove('welcome-tour-lit');
       });
-      document.body.style.paddingTop = prevBodyPad;
-      document.body.style.transition = prevBodyTransition;
     };
   }, [inactive, isClient, closerSlotId, markSeen, activeSteps]);
-
-  // Keep body padding in lockstep with the header collapse.
-  useEffect(() => {
-    if (inactive || !isClient) return;
-    document.body.style.paddingTop = shrunk ? '46px' : `${bigHeaderHeight.current}px`;
-  }, [shrunk, inactive, isClient]);
 
   if (inactive || !isClient) return null;
 
@@ -510,8 +509,13 @@ export default function WelcomeTour({
 
   const closer = (
     <section
-      className="flex min-h-[70vh] flex-col justify-center px-6 py-16"
-      style={{ background: 'var(--brand-ink-950)', color: 'var(--primary-foreground)' }}
+      className="flex min-h-[70vh] flex-col justify-center px-6 pt-16"
+      style={{
+        background: 'var(--brand-ink-950)',
+        color: 'var(--primary-foreground)',
+        // Clear the app's fixed bottom nav so the CTA is never hidden behind it.
+        paddingBottom: 'calc(7rem + env(safe-area-inset-bottom))',
+      }}
     >
       <p
         className="text-[13px] font-semibold tracking-[0.14em] uppercase"
@@ -543,14 +547,19 @@ export default function WelcomeTour({
     </section>
   );
 
-  const slot = document.getElementById(closerSlotId);
+  const headerSlot = document.getElementById(headerSlotId);
+  const closerSlot = document.getElementById(closerSlotId);
 
   return (
     <>
       <style>{SCOPED_STYLE}</style>
-      {createPortal(header, document.body)}
+      {/* Header rides an in-flow slot at the top of the page so it pushes
+          content and collapses to a sticky bar — no body-padding hack. The
+          coach is viewport-fixed (portaled to body); the closer sits in its
+          own slot at the bottom of the page flow. */}
+      {headerSlot ? createPortal(header, headerSlot) : null}
       {createPortal(coach, document.body)}
-      {slot ? createPortal(closer, slot) : null}
+      {closerSlot ? createPortal(closer, closerSlot) : null}
     </>
   );
 }


### PR DESCRIPTION
## Summary

A first-run **welcome tour** — a full-screen guided spotlight over the real home — plus a **dev harness** on the profile page to replay every onboarding/first-run stage in isolation. Ported from the approved `welcome-helper` prototype.

Activation is client-side (no DB migration): the live home mounts the tour on `?welcome=1` (onboarding routes there after areas-of-knowledge selection) and a localStorage flag suppresses re-runs.

## Welcome tour (`src/components/welcome/WelcomeTour.tsx`)
- Fixed overlay that **dims the page and spotlights** one real section at a time. The dim + orange-ring cutout is drawn by a spotlight box at the target's computed rect (transparent interior + huge box-shadow), so transform-panning the real `main` can't trap the highlight under the scrim.
- **Scroll advances the helper, not the page**: an invisible scroll driver maps scroll → discrete steps; the home **soft-pans (~0.6s)** only when the next target is below the fold, settling it ~40% down.
- **White tooltip hugs the target** — flips above/below by room, clamps to screen edges, aims its arrow at center. Placement is split from the pan (spotlight glides immediately — exact for a translateY pan; tooltip re-appears after a ~280ms dwell on the settled position).
- Thin top strip (label + progress dots + Skip) and a **"Play my Five →"** end bar into the round. Hides the global app chrome (top bar / bottom tabs / FAB, tagged `data-app-chrome` in `Nav`) while running.
- Anchored to live sections via `data-tour` attributes; missing anchors are skipped gracefully. Live home currently carries `five` / `customize` / `foryou`; the dev preview carries all five.

## Onboarding
- **Name + call sign now share one "Setup" screen** (was two separate steps), matching the brief's "setup (name/callsign)" stage. One form saves name then handle; a `previewMode` stubs the writes for the harness.

## Dev onboarding harness (profile → Developer tools)
- `/dev/onboarding` hub lists every signup / first-run stage as an individually launchable, **read-only** replay against sample data, plus a **"Full signup walkthrough"** that chains setup → areas → welcome tour → building-your-five → first-session recap with stubbed writes.
- `/dev/welcome-tour` — the tour over a phone-framed sample home (all five anchors, `forced`).
- `/dev/onboarding/intro` — the real `OnboardingFlow` driven with `previewMode`.
- `/dev/onboarding/building` — the building-your-five wait state.
- First-session recap now **drives the real `FirstSessionPanel`** (all three `beat3` social-handoff branches) via a new read-only `preview` prop that suppresses the seen-signal POST and the reminder PATCH — instead of a duplicated replica.
- A clearly-separated, confirmed "re-arm the welcome tour" action (clears the local seen-flag only).

Replays never mutate real onboarding completion or seen-state.

## Verification
- `tsc`, ESLint, and the color/spacing/radius/font ratchets all pass.
- Not yet rendered on-device: the tuning knobs (scroll-distance-per-step, pan target, dwell, flip threshold) want an on-device pass against the preview.

## Follow-ups (not in this PR)
- Thread `friends` / `shared` `data-tour` anchors through `FeedList` so the live tour hits all five callouts (it's 3 today; the dev preview shows all five).
- Optionally promote the client seen-flag to a DB column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016HmDdnkC48K1KkXGczjKdv)_