### PR TITLE
Refactor interests display in onboarding flow

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from 'react'
 import type { ReactNode } from 'react'
 import { useRouter } from 'next/navigation'
-import { X } from 'lucide-react'
 import { AddTopicField, type AddTopicError } from '@/components/interests/AddTopicField'
 
 // Condensed onboarding: name → handle → one interests screen (warm-up is an
@@ -651,26 +650,34 @@ export default function OnboardingFlow({
               </div>
 
               <div className="space-y-3">
-                <p className="text-sm font-medium">Your topics</p>
+                <p className="text-sm font-medium">
+                  Trivia Questions will come from these subjects
+                </p>
                 {selectedInterests.length === 0 ? (
                   <p className="text-muted-foreground text-sm">
                     Nothing yet — add a few below.
                   </p>
                 ) : (
-                  <div className="flex flex-wrap gap-2">
+                  <ul className="flex flex-col gap-2">
                     {selectedInterests.map((interest) => (
-                      <button
+                      <li
                         key={selectedKey(interest)}
-                        type="button"
-                        className="bg-[var(--brand-navy)] inline-flex items-center gap-2 rounded-full py-2 pr-2.5 pl-4 text-sm font-medium text-white transition hover:opacity-90"
-                        onClick={() => removeSelectedInterest(interest)}
-                        aria-label={`Remove ${interest.domain}`}
+                        className="flex items-center justify-between gap-3"
                       >
-                        {interest.domain}
-                        <X className="size-3.5 opacity-80" />
-                      </button>
+                        <span className="text-base font-medium">
+                          {interest.domain}
+                        </span>
+                        <button
+                          type="button"
+                          className="text-muted-foreground hover:text-destructive text-sm font-medium transition-colors"
+                          onClick={() => removeSelectedInterest(interest)}
+                          aria-label={`Remove ${interest.domain}`}
+                        >
+                          Remove
+                        </button>
+                      </li>
                     ))}
-                  </div>
+                  </ul>
                 )}
               </div>
 

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -22,7 +22,7 @@ describe('OnboardingFlow invited interests', () => {
     )
 
     expect(html).toContain('Welcome to Joshing')
-    expect(html).toContain('Your topics')
+    expect(html).toContain('Trivia Questions will come from these subjects')
     expect(html).toContain('1 selected · pick at least 2 more')
     expect(html).toContain('Sondheim')
   })
@@ -41,7 +41,7 @@ describe('OnboardingFlow invited interests', () => {
       />
     )
 
-    expect(html).toContain('Your topics')
+    expect(html).toContain('Trivia Questions will come from these subjects')
     expect(html).toContain('3 selected · add up to 9 more')
     expect(html).toContain('Sondheim')
     expect(html).toContain('Jazz')


### PR DESCRIPTION
## Summary
Updated the interests display in the onboarding flow to improve clarity and usability. Changed the label to better communicate the purpose of topic selection, and refactored the UI from icon-based buttons to a list-based layout with text-based remove actions.

## Key Changes
- Updated the "Your topics" label to "Trivia Questions will come from these subjects" for better context
- Removed the `lucide-react` X icon import (no longer needed)
- Refactored selected interests from a flex-wrapped button layout to a vertical list (`<ul>`) with:
  - Each interest displayed as a list item with the domain name in a larger font
  - Removed the pill-shaped button styling (navy background, rounded-full)
  - Added a separate "Remove" text button aligned to the right with hover state (muted-foreground → destructive color transition)
- Updated test expectations to match the new label text

## Implementation Details
- Changed from `<div className="flex flex-wrap gap-2">` to `<ul className="flex flex-col gap-2">` for better semantic HTML
- Replaced icon-based removal (X icon in button) with explicit "Remove" text for improved accessibility and clarity
- Maintained the same removal functionality via `onClick` handler and `aria-label`
- Updated both component and test file to ensure consistency

https://claude.ai/code/session_01JSV9G1q9FP9DPbkwsrDyXm