### PR TITLE
Fix confusing "0 of 3 questions" progress on fully-answered streak cards

### DIFF
--- a/src/components/activity/ActivityStreamItem.tsx
+++ b/src/components/activity/ActivityStreamItem.tsx
@@ -346,8 +346,16 @@ export function ActivityStreamItem({
                     color: INK3,
                   }}
                 >
-                  {milestoneProgress.total - milestoneProgress.answered} of{' '}
-                  {milestoneProgress.total} questions
+                  {/* While questions remain, count down what's still
+                      answerable ("1 of 3 questions"), in lockstep with the solid
+                      bundle triangles. Once every question is answered, the
+                      remaining count is 0 — so read it as a settled completion
+                      ("All 3 answered") rather than the bare "0 of 3 questions",
+                      which read as "no questions" to players who had in fact
+                      gotten every one (request 2026-06-23). */}
+                  {allAnswered
+                    ? `All ${milestoneProgress.total} answered`
+                    : `${milestoneProgress.total - milestoneProgress.answered} of ${milestoneProgress.total} questions`}
                 </p>
               ) : null}
               {/* Texture cards may carry supplementary metadata (a domain, a

--- a/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
+++ b/src/components/activity/__tests__/MilestoneStreamItem.test.tsx
@@ -138,6 +138,29 @@ describe('ActivityStreamItem — playable milestone card on the home feed', () =
     expect(html).toContain('1 of 3 questions');
     expect(html).not.toContain('2 of 3 questions');
   });
+
+  it('reads as a settled completion once every question is answered, not "0 of N questions"', () => {
+    // A bundle whose questions are all already attempted (right or wrong) reaches
+    // the card with 0 remaining. The progress line must read as a completion
+    // ("All 3 answered"), not the bare "0 of 3 questions" — which read as "no
+    // questions" to a player who had in fact gotten every one.
+    const allAnsweredExpand: Extract<StreamExpand, { kind: 'milestone' }> = {
+      ...EXPAND,
+      questions: QUESTIONS.map((q) => ({ ...q, priorResult: q.priorResult ?? 'correct' })),
+    };
+    const html = renderToStaticMarkup(
+      <ActivityStreamItem
+        item={{ ...MILESTONE_ITEM, expand: allAnsweredExpand }}
+        timestamp="2:00 PM"
+        elevated
+        showTimestamp={false}
+      />,
+    );
+    expect(html).toContain('All 3 answered');
+    expect(html).not.toContain('0 of 3 questions');
+    // The affordance flips to Revisit once they're all done.
+    expect(html).toContain('Revisit');
+  });
 });
 
 describe('ActivityStreamItem — collapsed bundle summary expands in place (not a page link)', () => {


### PR DESCRIPTION
The playable From Friends milestone card on the home feed showed its
progress as the REMAINING count ("{total - answered} of {total}
questions"). Once a viewer answered every question in a bundle, that read
"0 of 3 questions" — which scans as "no questions" to someone who had in
fact gotten all of them. The affordance already flips to "Revisit" in
this state, so the count was the only piece left reading wrong.

Read the all-answered case as a settled completion ("All N answered")
instead. The remaining-count copy is unchanged while questions are still
answerable, so the live countdown still tracks the solid bundle
triangles.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01BzN4WtqKFTAKzC8jusxxh9