### PR TITLE
Onboarding: emphasize subjects heading, tighten Remove links, route to overview

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -650,8 +650,8 @@ export default function OnboardingFlow({
               </div>
 
               <div className="space-y-3">
-                <p className="text-sm font-medium">
-                  Trivia Questions will come from these subjects
+                <p className="font-serif text-2xl leading-tight font-semibold text-balance text-[var(--ink)] sm:text-3xl">
+                  Your trivia questions will come from these subjects
                 </p>
                 {selectedInterests.length === 0 ? (
                   <p className="text-muted-foreground text-sm">
@@ -662,7 +662,7 @@ export default function OnboardingFlow({
                     {selectedInterests.map((interest) => (
                       <li
                         key={selectedKey(interest)}
-                        className="flex items-center justify-between gap-3"
+                        className="flex items-center gap-3"
                       >
                         <span className="text-base font-medium">
                           {interest.domain}

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -64,7 +64,7 @@ describe('OnboardingFlow invited interests', () => {
 })
 
 describe('OnboardingFlow display-name gate', () => {
-  it('renders the name step first when no displayName is set', () => {
+  it('renders the setup step first when no displayName is set', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         preSeededInterests={[
@@ -74,11 +74,11 @@ describe('OnboardingFlow display-name gate', () => {
       />
     )
 
-    expect(html).toContain('What should we call you?')
+    expect(html).toContain('Set up your profile')
     expect(html).not.toContain('suggested these for you.')
   })
 
-  it('prefills the input with the invitee name from the invitation', () => {
+  it('prefills the name input with the invitee name the inviter entered', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         preSeededInterests={[]}
@@ -87,8 +87,9 @@ describe('OnboardingFlow display-name gate', () => {
       />
     )
 
-    expect(html).toContain('What should we call you?')
+    expect(html).toContain('Set up your profile')
     expect(html).toContain('value="Morgan Lee"')
+    // The subtitle attributes the pre-filled name to the inviter.
     expect(html).toContain('Alex Inviter')
   })
 
@@ -97,11 +98,11 @@ describe('OnboardingFlow display-name gate', () => {
       <OnboardingFlow preSeededInterests={[]} inviterName={null} />
     )
 
-    expect(html).toContain('What should we call you?')
-    expect(html).toContain("This is how you&#x27;ll appear to friends.")
+    expect(html).toContain('Set up your profile')
+    expect(html).toContain('Pick the name friends see')
   })
 
-  it('skips the name step when the user already has a displayName', () => {
+  it('skips the setup step when the user already has a displayName and handle', () => {
     const html = renderToStaticMarkup(
       <OnboardingFlow
         preSeededInterests={[]}
@@ -110,7 +111,7 @@ describe('OnboardingFlow display-name gate', () => {
       />
     )
 
-    expect(html).not.toContain('What should we call you?')
+    expect(html).not.toContain('Set up your profile')
     expect(html).toContain('Welcome to Joshing')
   })
 })

--- a/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
+++ b/src/app/onboarding/__tests__/OnboardingFlow.test.tsx
@@ -22,7 +22,7 @@ describe('OnboardingFlow invited interests', () => {
     )
 
     expect(html).toContain('Welcome to Joshing')
-    expect(html).toContain('Trivia Questions will come from these subjects')
+    expect(html).toContain('Your trivia questions will come from these subjects')
     expect(html).toContain('1 selected · pick at least 2 more')
     expect(html).toContain('Sondheim')
   })
@@ -41,7 +41,7 @@ describe('OnboardingFlow invited interests', () => {
       />
     )
 
-    expect(html).toContain('Trivia Questions will come from these subjects')
+    expect(html).toContain('Your trivia questions will come from these subjects')
     expect(html).toContain('3 selected · add up to 9 more')
     expect(html).toContain('Sondheim')
     expect(html).toContain('Jazz')

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -10,6 +10,7 @@ import { MissedQuestionsCard } from '@/components/home/MissedQuestionsCard'
 import { DailyReminderInterlude } from '@/components/home/DailyReminderInterlude'
 import { getSession } from '@/server/auth/session'
 import { getReminderState } from '@/server/db/queries/account'
+import { getPreSeededInterestsForUser } from '@/server/db/queries/users'
 import { buildHomeEdition } from '@/server/home/build-edition'
 import { DAILY_QUEUE_SIZE, isRoundComplete, type QueueSlot } from '@/server/daily/types'
 import { getBonusSlots } from '@/server/daily/bonus'
@@ -32,6 +33,14 @@ export default async function Home({
   // suppresses via localStorage once seen). Signed-in only.
   const params = await searchParams
   const tourActive = params?.welcome === '1' && Boolean(session)
+  // Personalize the first-run overview with the inviter's name (the For-You
+  // sample reads it), falling back to "a friend" when there's no invitation.
+  // Only queried on the one-time welcome path so the normal home render is
+  // untouched.
+  const welcomeInviterName =
+    tourActive && session
+      ? (await getPreSeededInterestsForUser(session.userId)).inviterName
+      : null
 
   return (
     <>
@@ -131,7 +140,7 @@ export default async function Home({
         overview (its own mock home + intro + dual end), shown as a fixed overlay.
         Activated by the `?welcome=1` param onboarding routes to; it self-
         suppresses via localStorage once seen. Renders only while active. */}
-    {tourActive ? <WelcomeTourScreen /> : null}
+    {tourActive ? <WelcomeTourScreen inviterName={welcomeInviterName} /> : null}
     </>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ import { getCatchupQuestions, getTodaysDailyQueue } from '@/server/db/queries/da
 import { getLatestUnviewedCeremony, getNextCeremonyAt } from '@/server/db/queries/ceremony'
 import { getNextDailyResetBoundary } from '@/lib/games/timezone'
 import { timeServerWork } from '@/server/lib/server-timing'
-import WelcomeTour from '@/components/welcome/WelcomeTour'
+import WelcomeTourScreen from '@/components/welcome/WelcomeTourScreen'
 
 const FEED_PAGE_SIZE = 20
 
@@ -127,10 +127,11 @@ export default async function Home({
         </section>
       </div>
     </main>
-    {/* First-run welcome tour — a fixed spotlight overlay over this real home.
-        It dims + spotlights the data-tour sections, pans the page, and hides the
-        global app chrome while it runs. Renders only while active. */}
-    {tourActive ? <WelcomeTour /> : null}
+    {/* First-run welcome tour — the self-contained "first time experience"
+        overview (its own mock home + intro + dual end), shown as a fixed overlay.
+        Activated by the `?welcome=1` param onboarding routes to; it self-
+        suppresses via localStorage once seen. Renders only while active. */}
+    {tourActive ? <WelcomeTourScreen /> : null}
     </>
   )
 }

--- a/src/components/welcome/WelcomeTourScreen.tsx
+++ b/src/components/welcome/WelcomeTourScreen.tsx
@@ -106,6 +106,20 @@ export default function WelcomeTourScreen({
 }: WelcomeTourScreenProps) {
   const router = useRouter();
   const isClient = useSyncExternalStore(subscribeNoop, getClientSnapshot, getServerSnapshot);
+  // Self-suppress once seen (live mount via `?welcome=1`). `forced` (dev replay)
+  // bypasses and never reads the flag.
+  const seen = useSyncExternalStore(
+    subscribeNoop,
+    () => {
+      if (forced) return false;
+      try {
+        return Boolean(window.localStorage.getItem(storageKey));
+      } catch {
+        return false;
+      }
+    },
+    () => false,
+  );
   const inviter = inviterName?.trim() ? inviterName.trim() : 'a friend';
 
   const beats: Beat[] = useMemo(
@@ -338,7 +352,7 @@ export default function WelcomeTourScreen({
     router.push(href);
   };
 
-  if (!isClient) return null;
+  if (!isClient || (!forced && seen)) return null;
 
   return (
     <div className="wts-root">


### PR DESCRIPTION
- Make "Your trivia questions will come from these subjects" a prominent
  serif heading (was a small label).
- Move the per-topic "Remove" links in next to the topic name instead of
  pushing them to the far edge.
- "Start with these" now lands on the self-contained first-time-experience
  overview (WelcomeTourScreen) instead of the spotlight tour over the live
  home; the overview self-suppresses via localStorage once seen.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_016ZG3dth5k2YynKUbY3t73Y