### PR TITLE
fix: vertically center numeral in question number box

### DIFF
--- a/src/components/play/QuestionNumberMarker.tsx
+++ b/src/components/play/QuestionNumberMarker.tsx
@@ -41,6 +41,13 @@ const BONUS_FONT_SIZE = 42;
 // Optical nudge: pad the numeral left ~12% of the font size so the trailing
 // period doesn't visually shove the numeral off-center.
 const CORE_LEFT_PAD = Math.round(CORE_FONT_SIZE * 0.12);
+// Vertical optical nudge. Cormorant Garamond reserves generous space above its
+// glyphs (for accents), and the trailing period adds ink at the baseline, so
+// with line-height 1 the numeral is centered by its line box but reads LOW.
+// Lift the glyph ~8% of the em to optically center the visible ink. In em so it
+// scales with the font size; applied to the inner glyph span only (the box and
+// its accessible label are unaffected).
+const NUMERAL_NUDGE_Y = '-0.08em';
 
 const boxBaseStyle: CSSProperties = {
   display: 'inline-flex',
@@ -100,7 +107,9 @@ export function QuestionNumberMarker({
         paddingLeft: CORE_LEFT_PAD,
       }}
     >
-      <span aria-hidden>{value}.</span>
+      <span aria-hidden style={{ transform: `translateY(${NUMERAL_NUDGE_Y})` }}>
+        {value}.
+      </span>
     </span>
   );
 }


### PR DESCRIPTION
The core numeral (e.g. "3.") read low in the --ink box. Cormorant
Garamond reserves generous space above its glyphs and the trailing
period adds ink at the baseline, so with line-height 1 the numeral was
centered by its line box rather than by its visible ink. Add a vertical
optical nudge (~8% em, the counterpart to the existing CORE_LEFT_PAD
horizontal nudge) applied to the inner glyph span only.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W79VzLYvvVMULtjq8it3P4