### PR TITLE
Carry typed name into hub invite handoff

### DIFF
--- a/src/components/FriendsHubPage.tsx
+++ b/src/components/FriendsHubPage.tsx
@@ -14,10 +14,17 @@ export default function FriendsHubPage() {
     window.dispatchEvent(new CustomEvent('friend-invitations:create-new', { detail }));
   }
 
-  // No-match invite from the lookup. A US number can seed the SMS invite; a
+  // No-match invite from the lookup. A US number seeds the SMS invite's phone
+  // field; a typed name seeds the invite's Name field so it isn't retyped. A
   // handle isn't a phone (or a real name), so it opens the invite flow blank.
   function handleLookupInvite(query: string, classification: QueryClassification) {
-    openInviteFlow(classification === 'phone' ? { phone: query } : {});
+    if (classification === 'phone') {
+      openInviteFlow({ phone: query });
+    } else if (classification === 'name') {
+      openInviteFlow({ inviteeDisplayName: query });
+    } else {
+      openInviteFlow({});
+    }
   }
 
   return (


### PR DESCRIPTION
When a lookup resolves to no-match for a typed name, seed the invite's
Name field with the typed text via inviteeDisplayName so the user does
not retype it. Phone behavior unchanged; handle/empty still open blank.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01ENG4kvW9W2QScu6KmUowwM