### PR TITLE
Make every friendship-forming path bidirectional (mutual)

### DIFF
--- a/src/server/friends/__tests__/friendships.test.ts
+++ b/src/server/friends/__tests__/friendships.test.ts
@@ -84,9 +84,9 @@ beforeEach(() => {
   authoredBackfillMock.mockClear()
 })
 
-describe('createOrReusePendingFriendshipRequest backfill', () => {
-  it('backfills the followee\'s activity into the follower\'s feed when auto-approved', async () => {
-    // No existing edge, public target -> auto-approved edge is created.
+describe('createOrReusePendingFriendshipRequest', () => {
+  it('forms a MUTUAL friendship when the target is public (both edges, both cards, both feeds)', async () => {
+    // No existing edge, public target -> auto-approved + follow-back.
     dbMock._selectQueue.push([], [{ followPrivacy: 'public' }])
     state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }
 
@@ -96,11 +96,24 @@ describe('createOrReusePendingFriendshipRequest backfill', () => {
     })
 
     expect(result.state).toBe('auto_approved')
-    expect(answerBackfillMock).toHaveBeenCalledTimes(1)
+    // Forward edge insert + the mutual follow-back edge upsert.
+    expect(dbMock.insert).toHaveBeenCalledTimes(2)
+    // Both connection cards: the target learns they were added; the requester
+    // gets the "now connected" card.
+    expect(writeActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: FOLLOWEE, type: 'follow', actorUserId: FOLLOWER }),
+    )
+    expect(writeActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: FOLLOWER, type: 'follow_mutual', actorUserId: FOLLOWEE }),
+    )
+    // Both feeds seeded, both content types.
+    expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWER, recipientUserId: FOLLOWEE })
     expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWEE, recipientUserId: FOLLOWER })
+    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWER, recipientUserId: FOLLOWEE })
+    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWEE, recipientUserId: FOLLOWER })
   })
 
-  it('does NOT backfill when the request lands pending (private target)', async () => {
+  it('lands pending with NO mutual edge or backfill when the target requires approval', async () => {
     dbMock._selectQueue.push([], [{ followPrivacy: 'private' }])
     state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'pending' }
 
@@ -110,10 +123,15 @@ describe('createOrReusePendingFriendshipRequest backfill', () => {
     })
 
     expect(result.state).toBe('created')
+    expect(dbMock.insert).toHaveBeenCalledTimes(1) // only the pending forward edge
+    expect(writeActivityMock).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: FOLLOWEE, type: 'follow_request', actorUserId: FOLLOWER }),
+    )
     expect(answerBackfillMock).not.toHaveBeenCalled()
+    expect(authoredBackfillMock).not.toHaveBeenCalled()
   })
 
-  it('does NOT backfill when the edge already exists (already_following)', async () => {
+  it('does NOT re-form or backfill when an approved edge already exists (already_following)', async () => {
     dbMock._selectQueue.push([{ id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }])
 
     const result = await createOrReusePendingFriendshipRequest({
@@ -122,7 +140,9 @@ describe('createOrReusePendingFriendshipRequest backfill', () => {
     })
 
     expect(result.state).toBe('already_following')
+    expect(dbMock.insert).not.toHaveBeenCalled()
     expect(answerBackfillMock).not.toHaveBeenCalled()
+    expect(authoredBackfillMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -37,6 +37,33 @@ function requestContextForSuggestedInterests(suggestedInterests: string[]): Frie
   return suggestedInterests.length > 0 ? { suggestedInterests } : null
 }
 
+// Upsert a single approved follow edge. Idempotent via the (followerId,
+// followeeId) unique constraint: a pending or already-approved edge settles to
+// approved. This is the "back" edge that makes a follow MUTUAL — a friendship is
+// bidirectional, so every friendship-forming path approves both directions.
+async function ensureApprovedFollowEdge(followerId: string, followeeId: string, now: Date): Promise<void> {
+  await db
+    .insert(follows)
+    .values({ followerId, followeeId, state: 'approved', approvedAt: now })
+    .onConflictDoUpdate({
+      target: [follows.followerId, follows.followeeId],
+      set: { state: 'approved', approvedAt: now },
+    })
+}
+
+// Seed BOTH friends' feeds with each other's recent correct answers AND public
+// authored questions — what would have propagated had the mutual edge existed
+// when they answered/authored. Each call is best-effort internally and cannot
+// throw, so none can affect the friendship write.
+async function backfillMutualFeeds(userAId: string, userBId: string): Promise<void> {
+  await Promise.all([
+    backfillFollowedUserFeedItems({ answererUserId: userAId, recipientUserId: userBId }),
+    backfillFollowedUserFeedItems({ answererUserId: userBId, recipientUserId: userAId }),
+    backfillAuthoredQuestionsFeedItems({ authorUserId: userAId, recipientUserId: userBId }),
+    backfillAuthoredQuestionsFeedItems({ authorUserId: userBId, recipientUserId: userAId }),
+  ])
+}
+
 /**
  * Follow `inviteeUserId`. If the target's followPrivacy is `public` the edge is
  * approved immediately; otherwise it lands `pending` for the target to approve.
@@ -96,23 +123,43 @@ export async function createOrReusePendingFriendshipRequest({
 
   if (!edge) throw new Error('Follow could not be created')
 
-  await writeActivity({
-    userId: followeeId,
-    type: autoApprove ? 'follow' : 'follow_request',
-    actorUserId: followerId,
-    referenceId: edge.id,
-    referenceType: 'follow',
-  })
-
-  // Friend-add backfill: a freshly approved follow seeds the follower's feed
-  // with the followee's recent activity (what would have propagated had the edge
-  // already existed). Only the auto-approved (public-target) branch creates an
-  // approved edge here; the pending branch backfills on approval instead. The
-  // backfill is best-effort internally — it cannot throw.
   if (autoApprove) {
-    await backfillFollowedUserFeedItems({
-      answererUserId: followeeId,
-      recipientUserId: followerId,
+    // Public target: the request is approved immediately. A friendship is
+    // bidirectional, so also approve the target's follow-back edge — adding a
+    // public account makes the two MUTUAL friends, not a one-way follower.
+    await ensureApprovedFollowEdge(followeeId, followerId, now)
+
+    await Promise.all([
+      // The target learns the requester added them; the requester gets the
+      // matching "now connected" card.
+      writeActivity({
+        userId: followeeId,
+        type: 'follow',
+        actorUserId: followerId,
+        referenceId: edge.id,
+        referenceType: 'follow',
+      }),
+      writeActivity({
+        userId: followerId,
+        type: 'follow_mutual',
+        actorUserId: followeeId,
+        referenceId: edge.id,
+        referenceType: 'follow',
+      }),
+    ])
+
+    // Seed both feeds with each other's recent answers + public authored
+    // questions (what would have propagated had the edge already existed).
+    await backfillMutualFeeds(followerId, followeeId)
+  } else {
+    // approval_required target: the request lands pending. The friendship — and
+    // its mutual edge, cards, and backfill — forms when the target accepts.
+    await writeActivity({
+      userId: followeeId,
+      type: 'follow_request',
+      actorUserId: followerId,
+      referenceId: edge.id,
+      referenceType: 'follow',
     })
   }
 
@@ -147,23 +194,10 @@ export async function acceptPendingFriendshipRequest({
   if (!edge) return null
 
   // Mutual-accept: accepting a "wants to be friends" request makes the two
-  // FRIENDS, not just a one-way follower — so create/approve the accepter's
-  // follow-back edge too. Without this the accepter lands in a one-way
-  // `follows_you` state (the profile still offers "Add friend" and the pair
-  // never become mutual). Idempotent via the (followerId, followeeId) unique
-  // constraint: an existing pending/approved reverse edge settles to approved.
-  await db
-    .insert(follows)
-    .values({
-      followerId: userId,
-      followeeId: edge.followerId,
-      state: 'approved',
-      approvedAt: now,
-    })
-    .onConflictDoUpdate({
-      target: [follows.followerId, follows.followeeId],
-      set: { state: 'approved', approvedAt: now },
-    })
+  // FRIENDS, not just a one-way follower — so approve the accepter's follow-back
+  // edge too. Without this the accepter lands in a one-way `follows_you` state
+  // (the profile still offers "Add friend" and the pair never become mutual).
+  await ensureApprovedFollowEdge(userId, edge.followerId, now)
 
   // The requester learns their request was accepted; the accepter gets a
   // matching "you're now connected" card (today only the requester got one).
@@ -184,30 +218,10 @@ export async function acceptPendingFriendshipRequest({
     }),
   ])
 
-  // Friend-add backfill: now that it's a MUTUAL follow, seed BOTH feeds with the
-  // other person's recent correct answers AND their public authored questions —
-  // what would have propagated had the edge existed when they answered/authored.
-  // The accepter's side (recipient = followee) is the fix for "I accepted but my
-  // feed didn't change" — previously only the requester's feed was seeded. Each
-  // call is best-effort internally and cannot throw, so none can affect approval.
-  await Promise.all([
-    backfillFollowedUserFeedItems({
-      answererUserId: edge.followeeId,
-      recipientUserId: edge.followerId,
-    }),
-    backfillFollowedUserFeedItems({
-      answererUserId: edge.followerId,
-      recipientUserId: edge.followeeId,
-    }),
-    backfillAuthoredQuestionsFeedItems({
-      authorUserId: edge.followeeId,
-      recipientUserId: edge.followerId,
-    }),
-    backfillAuthoredQuestionsFeedItems({
-      authorUserId: edge.followerId,
-      recipientUserId: edge.followeeId,
-    }),
-  ])
+  // Now that it's a MUTUAL follow, seed BOTH feeds. The accepter's side is the
+  // fix for "I accepted but my feed didn't change" — previously only the
+  // requester's feed was seeded.
+  await backfillMutualFeeds(edge.followerId, edge.followeeId)
 
   return edge
 }


### PR DESCRIPTION
## Summary

Follow-up to the mutual-friendship work already in `main` (accept now makes friends mutual, writes a "now connected" card, and backfills both feeds). This closes the **last remaining one-way path**: adding a **public** account.

When you add someone whose follow-privacy is `public`, the request auto-approves — but it previously created only a one-way follow (you → them). A friendship is bidirectional, so this makes that path mutual too, consistent with accept and with invitation auto-friendships (which were already mutual).

## Changes (`src/server/friends/friendships.ts`)
- Extract two shared helpers:
  - `ensureApprovedFollowEdge(follower, followee, now)` — idempotent follow-back edge upsert (settles a pending/approved edge to approved via the `(followerId, followeeId)` unique constraint).
  - `backfillMutualFeeds(a, b)` — seeds both feeds with each other's recent correct answers **and** public authored questions.
- `acceptPendingFriendshipRequest` refactored to use both helpers (behavior unchanged).
- `createOrReusePendingFriendshipRequest` auto-approve branch now: approves the follow-back edge, writes both connection cards (`follow` to the target, `follow_mutual` to the requester), and seeds both feeds. `approval_required` targets still land **pending** and form the mutual friendship on accept (the consent gate is preserved — no auto follow-back before acceptance).

## Audit
Grepped every write to the `follows` table — all are centralized in `friendships.ts`. After this change, all three friendship-forming paths (accept, public auto-approve, invitation) create both approved edges. Unfollow (`removeFriendship`) is intentionally left directional.

## Tests
`createOrReusePendingFriendshipRequest` now asserts the public path forms both edges, both cards, and both feeds; the pending and already-following paths form neither. typecheck + lint clean; friendships/invitations/backfill/activity-stream suites green (53 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tw5kqZjPZqbd4ZVNkgpcj8)_