### PR TITLE
Fix zombie cookie trap by making logout idempotent

### DIFF
--- a/src/__tests__/middleware.test.ts
+++ b/src/__tests__/middleware.test.ts
@@ -95,7 +95,10 @@ describe('proxy (invitation gate)', () => {
       expect(res.headers.get('x-middleware-next')).toBe('1')
     })
 
-    it('redirects an onboarded user away from /login', async () => {
+    it('passes an onboarded user through to /login (the page does the DB-checked redirect home)', async () => {
+      // The proxy no longer bounces /login on signature-only claims: that
+      // trapped "zombie" cookies (valid JWT, no DB session row). The login
+      // page now redirects genuinely-authenticated users home via getSession.
       readSessionClaimsMock.mockResolvedValueOnce({
         userId: 'u1',
         sessionId: 's1',
@@ -103,8 +106,9 @@ describe('proxy (invitation gate)', () => {
         onboardingComplete: true,
       })
       const res = await proxy(makeRequest('/login', { cookie: 'valid.jwt' }))
-      expect(res.status).toBe(307)
-      expect(res.headers.get('location')).toMatch(/\/$/)
+      expect(res.status).toBe(200)
+      expect(res.headers.get('x-middleware-next')).toBe('1')
+      expect(res.headers.get('location')).toBeNull()
     })
 
     it('redirects an onboarded user away from /onboarding', async () => {

--- a/src/app/api/account/logout/__tests__/route.test.ts
+++ b/src/app/api/account/logout/__tests__/route.test.ts
@@ -1,26 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { getSessionMock, destroySessionMock } = vi.hoisted(() => ({
-  getSessionMock: vi.fn(),
+const { destroySessionMock } = vi.hoisted(() => ({
   destroySessionMock: vi.fn(),
 }));
 
 vi.mock('@/server/auth/session', () => ({
-  getSession: getSessionMock,
   destroySession: destroySessionMock,
 }));
 
 import { POST } from '@/app/api/account/logout/route';
 
-describe('POST /api/account/logout (B-LOGOUT-CONFIRM-FIX-01)', () => {
+describe('POST /api/account/logout', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    getSessionMock.mockReset();
     destroySessionMock.mockReset();
   });
 
   it('destroys the session (clears joshing_session cookie) for an authed user', async () => {
-    getSessionMock.mockResolvedValueOnce({ id: 's1', userId: 'u1' });
     destroySessionMock.mockResolvedValueOnce(undefined);
 
     const res = await POST();
@@ -30,12 +26,16 @@ describe('POST /api/account/logout (B-LOGOUT-CONFIRM-FIX-01)', () => {
     await expect(res.json()).resolves.toEqual({ ok: true });
   });
 
-  it('returns 401 and does not touch the session when there is no session', async () => {
-    getSessionMock.mockResolvedValueOnce(null);
+  // Idempotent: a "zombie" cookie (valid JWT signature, no DB session row)
+  // resolves to no session, but logout must still clear the cookie so the user
+  // can escape the signed-out-but-cookie-present trap. It must NOT 401.
+  it('still clears the cookie and returns ok when there is no valid session', async () => {
+    destroySessionMock.mockResolvedValueOnce(undefined);
 
     const res = await POST();
 
-    expect(res.status).toBe(401);
-    expect(destroySessionMock).not.toHaveBeenCalled();
+    expect(destroySessionMock).toHaveBeenCalledTimes(1);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
   });
 });

--- a/src/app/api/account/logout/route.ts
+++ b/src/app/api/account/logout/route.ts
@@ -1,14 +1,23 @@
 import { NextResponse } from 'next/server';
 
-import { destroySession, getSession } from '@/server/auth/session';
+import { destroySession } from '@/server/auth/session';
 
+/**
+ * Log out. Idempotent by design: ALWAYS clears the `joshing_session` cookie
+ * (and deletes the matching DB row if one exists), regardless of whether the
+ * cookie currently resolves to a valid session.
+ *
+ * Previously this gated on `getSession()` and returned 401 when no valid
+ * session was found — which made logout refuse to clear a "zombie" cookie: a
+ * validly-signed JWT whose DB session row is gone (secret rotation, deleted/
+ * expired row, DB reset). Such a cookie passes the Edge proxy's signature-only
+ * gate but fails the server's DB-checked `getSession()`, leaving the user
+ * "logged in at the edge, logged out at the server": the signed-out home
+ * renders, `/api/feed` 401s, and the proxy bars `/login`. Refusing to clear
+ * the cookie on a missing session meant the user could never escape that state.
+ * Clearing unconditionally breaks the loop. Mirrors /api/auth/logout.
+ */
 export async function POST() {
-  const session = await getSession();
-
-  if (!session) {
-    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-  }
-
   await destroySession();
 
   return NextResponse.json({ ok: true });

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,6 +1,8 @@
 import { Suspense } from 'react';
+import { redirect } from 'next/navigation';
 
 import TriangleBackground from '@/components/TriangleBackground';
+import { getSession } from '@/server/auth/session';
 import { getInvitePrefillByToken } from '@/server/friends/invitations';
 import { resolveInviteLink } from '@/server/friends/user-invite-token';
 
@@ -51,6 +53,15 @@ type LoginPageProps = {
 };
 
 export default async function LoginPage({ searchParams }: LoginPageProps) {
+  // Redirect genuinely-authenticated visitors home. This is the DB-checked
+  // (getSession) counterpart to the redirect the Edge proxy used to do on
+  // signature alone — moved here so a "zombie" cookie (valid JWT, no DB
+  // session row) is NOT bounced back to a signed-out home but instead reaches
+  // this login form, where signing in mints a fresh cookie and escapes the
+  // trap. See src/proxy.ts.
+  const session = await getSession();
+  if (session) redirect('/');
+
   const params = await searchParams;
   const invitationToken = readInvitationToken(params);
   const userInvite = readUserInvite(params);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -101,9 +101,17 @@ export async function middleware(request: NextRequest) {
     pathname.startsWith('/api/auth/')
 
   if (claims.onboardingComplete) {
-    if (isLoginPage || isOnboardingPage) {
+    if (isOnboardingPage) {
       return tagTiming(NextResponse.redirect(new URL('/', request.url)), startedAt)
     }
+    // /login is intentionally NOT redirected here. These claims are verified
+    // from the JWT signature alone (no DB lookup), so they can outlive the DB
+    // session — a "zombie" cookie after secret rotation, a deleted/expired
+    // session row, or a DB reset. Bouncing /login -> / on signature alone
+    // traps such a session: server getSession() (DB-checked) says logged-out,
+    // so the home renders signed-out and /api/feed 401s, yet the proxy bars
+    // the one recovery surface. The login page redirects genuinely
+    // authenticated users home itself, via a DB-checked getSession().
     return tagTiming(NextResponse.next(), startedAt)
   }
 


### PR DESCRIPTION
## Summary
Fixes a critical authentication state trap where users with "zombie" cookies (valid JWT signature but no corresponding DB session row) could become permanently stuck: unable to log in (proxy blocks `/login`), unable to access the app (server returns 401), and unable to log out (logout refused to clear the cookie).

The fix makes logout idempotent by unconditionally clearing the `joshing_session` cookie regardless of session validity, and moves the signature-only redirect logic from the proxy to the login page where it can be paired with a DB-checked session lookup.

## Key Changes

- **`src/app/api/account/logout/route.ts`**: Removed the `getSession()` check that gated logout on a valid session. Now unconditionally calls `destroySession()` to clear the cookie, mirroring `/api/auth/logout` behavior. Added detailed comment explaining the zombie cookie trap and why idempotency is required.

- **`src/app/api/account/logout/__tests__/route.test.ts`**: Updated tests to verify idempotent behavior—logout now succeeds (200) and clears the cookie even when no valid session exists, rather than returning 401.

- **`src/app/login/page.tsx`**: Added DB-checked `getSession()` call that redirects genuinely-authenticated users home. This replaces the proxy's signature-only redirect, allowing zombie cookies to reach the login form where users can sign in fresh and escape the trap.

- **`src/proxy.ts`**: Removed the redirect of authenticated users away from `/login`. Added comment explaining that signature-only claims can outlive the DB session, and that the login page now handles the DB-checked redirect itself.

- **`src/__tests__/middleware.test.ts`**: Updated test expectations—the proxy now passes authenticated users through to `/login` (status 200, no redirect) instead of bouncing them home (307).

## Implementation Details

The root cause was a layered authentication check: the Edge proxy verified JWT signatures only, while the server verified both signature and DB session existence. A zombie cookie would pass the proxy but fail the server, and the old logout endpoint refused to clear it without a valid session.

The solution leverages the fact that the login page is the one place where a user with a zombie cookie can recover: they can sign in fresh. By moving the authenticated-user redirect from the proxy (signature-only) to the login page (DB-checked), we allow zombie cookies through to the form, and by making logout unconditionally clear the cookie, we ensure users can always escape the trap.

https://claude.ai/code/session_01GGibZuMpBEeBAkuyFUs7Uj