### PR TITLE
Improve menu dismissal in AnsweredRowActions with pointer events

### DIFF
--- a/src/components/questions/AnsweredRowActions.tsx
+++ b/src/components/questions/AnsweredRowActions.tsx
@@ -27,8 +27,15 @@ export function AnsweredRowActions({
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') setIsMenuOpen(false);
     };
+    const onPointerDown = (e: PointerEvent) => {
+      if (!menuRef.current?.contains(e.target as Node)) setIsMenuOpen(false);
+    };
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    document.addEventListener('pointerdown', onPointerDown);
+    return () => {
+      document.removeEventListener('keydown', onKey);
+      document.removeEventListener('pointerdown', onPointerDown);
+    };
   }, [isMenuOpen]);
 
   return (
@@ -45,13 +52,10 @@ export function AnsweredRowActions({
       </button>
 
       {isMenuOpen ? (
-        <div
-          className="fixed inset-0 z-[55] flex items-end justify-center px-3 pt-16 pb-3 sm:items-start sm:pt-24"
-          style={{ background: 'rgba(0,0,0,0.2)' }}
-        >
+        <div className="fixed inset-0 z-[55] flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
           <button
             type="button"
-            className="absolute inset-0 cursor-default"
+            className="absolute inset-0 cursor-default sm:hidden"
             aria-label="Close menu"
             onClick={() => setIsMenuOpen(false)}
           />


### PR DESCRIPTION
## Summary
Enhanced the menu dismissal behavior in `AnsweredRowActions` by adding pointer event detection to close the menu when clicking outside of it, while also improving the responsive layout and styling of the menu overlay.

## Key Changes
- **Added pointer event listener:** Implemented `pointerdown` event handler to detect clicks outside the menu and close it, complementing the existing Escape key handler
- **Improved menu ref checking:** The pointer handler checks if the click target is within the menu ref to prevent closing when interacting with the menu itself
- **Responsive menu layout:** Updated the menu container to use `sm:absolute` positioning on desktop instead of fixed overlay, allowing it to appear as a dropdown next to the trigger button
- **Simplified styling:** Replaced inline `style` prop with Tailwind's `bg-black/20` utility class for consistency
- **Conditional overlay:** The backdrop button (`.absolute.inset-0`) is now hidden on desktop (`sm:hidden`) since the menu uses absolute positioning there

## Implementation Details
- Both event listeners are properly cleaned up in the effect's return function to prevent memory leaks
- The pointer event approach is more reliable than relying solely on click events for dismissing overlays
- The responsive design maintains the full-screen overlay behavior on mobile while using a traditional dropdown on desktop

https://claude.ai/code/session_01PN1h23G7oGYpHebcCRzC5U