### PR TITLE
Increase scroll driver height to reduce step-skipping

### DIFF
--- a/src/components/welcome/WelcomeTour.tsx
+++ b/src/components/welcome/WelcomeTour.tsx
@@ -424,9 +424,10 @@ export default function WelcomeTour({
       ) : null}
 
       {/* Invisible scroll driver — captures scroll to advance steps. Tall enough
-          to give each step a screenful of travel. */}
+          to give each step ~two screenfuls of travel, so a normal scroll flick
+          doesn't blow past a group. */}
       <div className="welcome-tour-driver" ref={driverRef}>
-        <div style={{ height: `${Math.max(activeSteps.length, 1) * 100}vh` }} />
+        <div style={{ height: `${Math.max(activeSteps.length, 1) * 200}vh` }} />
       </div>
     </>
   );

--- a/src/components/welcome/WelcomeTourScreen.tsx
+++ b/src/components/welcome/WelcomeTourScreen.tsx
@@ -570,7 +570,7 @@ export default function WelcomeTourScreen({
           {/* invisible scroll driver (only meaningful once started). The tall
               spacer sets the scroll distance per step — bigger = less twitchy. */}
           <div className="wts-driver" ref={driverRef} onScroll={onDrive}>
-            <div style={{ height: `${(beats.length + 1) * 160}%` }} />
+            <div style={{ height: `${(beats.length + 1) * 280}%` }} />
           </div>
         </div>
 


### PR DESCRIPTION
## Summary
Increases the scroll distance per step in both the main welcome tour and welcome tour screen components to prevent users from accidentally skipping steps with a normal scroll gesture.

## Changes
- **WelcomeTour.tsx**: Doubled the scroll driver height from `100vh` to `200vh` per step, giving each step ~two screenfuls of travel distance instead of one
- **WelcomeTourScreen.tsx**: Increased the scroll driver height from `160%` to `280%` per beat, reducing the "twitchiness" of step advancement
- Updated comments to clarify the intent: preventing a normal scroll flick from blowing past a group of steps

## Implementation Details
Both changes follow the same pattern: increasing the height multiplier of an invisible scroll driver element that controls step progression. This gives users more scroll distance to traverse before advancing to the next step, making the tour less prone to accidental skipping while maintaining smooth progression through intentional scrolling.

https://claude.ai/code/session_01PjMe7KkBh34hhw3zqAsPAH