### PR TITLE
Move nav bell badge from activity count to pending friend requests

### DIFF
--- a/src/app/activities/MarkActivitiesRead.tsx
+++ b/src/app/activities/MarkActivitiesRead.tsx
@@ -17,12 +17,11 @@ export function MarkActivitiesRead() {
         credentials: 'include',
       }),
     ]).then(() => {
-      // The bell badge count is computed server-side in the root layout
-      // (getBellBadgeCount in layout.tsx) and passed into Nav as a prop. The
-      // root layout is preserved across navigations and does not re-run after
-      // these POSTs, so without an explicit refresh the badge keeps showing
-      // the stale pre-open count until the next hard render. Refresh re-runs
-      // the server layout so the badge clears in place.
+      // Refresh the server components on this route so the activity list
+      // reflects the just-written read/opened state. (The nav bell badge now
+      // counts only pending friend requests, sourced from /api/nav — it is
+      // unaffected by opening the bell and clears when a request is accepted
+      // or declined.)
       router.refresh();
     });
   }, [router]);

--- a/src/app/api/nav/route.ts
+++ b/src/app/api/nav/route.ts
@@ -2,25 +2,26 @@ import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
-import { getBellBadgeCount } from '@/server/db/queries/activity';
+import { getIncomingFollowRequestCount } from '@/server/db/queries/friends';
 import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes';
 
 export const dynamic = 'force-dynamic';
 
 // Nav badge summary: the display name (for the account-initials avatar), the
-// activity-bell unread count, and whether the Friends tab should show its
-// discovery dot. The root layout used to await these three queries before
-// streaming any HTML on every hard navigation; Nav now fetches them client-side
-// after mount so the page shell streams immediately and the badges pop in
-// slightly later. No request input, so there's nothing to Zod-validate (matches
-// the sibling /api/friends/has-new-discovery probe).
+// bell badge count (pending friend requests awaiting approval — and only those),
+// and whether the Friends tab should show its discovery dot. The root layout
+// used to await these three queries before streaming any HTML on every hard
+// navigation; Nav now fetches them client-side after mount so the page shell
+// streams immediately and the badges pop in slightly later. No request input, so
+// there's nothing to Zod-validate (matches the sibling
+// /api/friends/has-new-discovery probe).
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
   const [profile, bellBadgeCount, discoveryStatus] = await Promise.all([
     getUserOnboardingProfile(session.userId),
-    getBellBadgeCount(session.userId).catch(() => 0),
+    getIncomingFollowRequestCount(session.userId).catch(() => 0),
     getNewDiscoveryStatus(session.userId).catch(() => ({ hasNew: false, count: 0 })),
   ]);
 

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -178,11 +178,11 @@ export function Nav({
           </Link>
           <div className="flex items-center gap-1">
             <Link
-              href="/activities"
+              href="/friends"
               aria-label={
                 showBadge
-                  ? `Activity, ${badgeCount} pending friend request${badgeCount === 1 ? '' : 's'}`
-                  : 'Activity'
+                  ? `Friend requests, ${badgeCount} pending`
+                  : 'Friend requests'
               }
               className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -180,7 +180,9 @@ export function Nav({
             <Link
               href="/activities"
               aria-label={
-                showBadge ? `Activity, ${badgeCount} unread` : 'Activity'
+                showBadge
+                  ? `Activity, ${badgeCount} pending friend request${badgeCount === 1 ? '' : 's'}`
+                  : 'Activity'
               }
               className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -994,14 +994,16 @@ export async function markActivityBellOpened(userId: string): Promise<void> {
 }
 
 /**
- * Bell badge count = events that have rolled off Home's top-3 RecentActivity
- * AND fired since the user last opened the bell.
+ * NOTE: No longer wired to the nav bell badge. The badge now counts ONLY
+ * pending friend requests (see getIncomingFollowRequestCount in
+ * queries/friends.ts, consumed by /api/nav). This "rolled-off-Home activity"
+ * count is retained for potential reuse but is not currently rendered anywhere.
  *
- * Semantics: "there's value here you can't see from Home." If an event is
- * still visible on Home, the badge stays quiet. If the bell has never been
- * opened (NULL), the floor is the activity 90-day cutoff via activityCutoff().
- *
- * Returns the raw count; the UI caps the displayed string at "99+".
+ * Original semantics: events that have rolled off Home's top-3 RecentActivity
+ * AND fired since the user last opened the bell — "there's value here you can't
+ * see from Home." If an event is still visible on Home, the count stays quiet.
+ * If the bell has never been opened (NULL), the floor is the activity 90-day
+ * cutoff via activityCutoff(). Returns the raw count.
  */
 export async function getBellBadgeCount(userId: string): Promise<number> {
   const [userRow] = await db

--- a/src/server/db/queries/friends.ts
+++ b/src/server/db/queries/friends.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, inArray, or, sql } from 'drizzle-orm';
+import { and, asc, count, desc, eq, inArray, or, sql } from 'drizzle-orm';
 import { alias } from 'drizzle-orm/pg-core';
 
 import {
@@ -473,6 +473,20 @@ export function selectHomeFriendRequests(
 export async function getHomeFriendRequests(userId: string): Promise<HomeFriendRequests> {
   const hub = await getFriendsHub(userId)
   return selectHomeFriendRequests(hub.incomingRequests)
+}
+
+/**
+ * Count of pending inbound follow requests awaiting the user's approval — the
+ * same set the home "Wants to connect" section and /friends surface, but as a
+ * bare count. This is what the nav bell badge shows: only friend requests, not
+ * the broader activity stream. Backed by the (followeeId, state) index.
+ */
+export async function getIncomingFollowRequestCount(userId: string): Promise<number> {
+  const [row] = await db
+    .select({ value: count() })
+    .from(follows)
+    .where(and(eq(follows.followeeId, userId), eq(follows.state, 'pending')))
+  return row?.value ?? 0
 }
 
 /**


### PR DESCRIPTION
## Summary
Refactors the nav bell badge to display pending friend request count instead of unread activity count. The badge now links to `/friends` and shows only requests awaiting user approval, providing clearer intent and reducing unnecessary activity stream polling.

## Changes
- **Nav badge source:** Replaced `getBellBadgeCount()` (activity-based) with `getIncomingFollowRequestCount()` (friend requests only) in `/api/nav`
- **New query helper:** Added `getIncomingFollowRequestCount()` in `src/server/db/queries/friends.ts` — counts pending inbound follows via the `(followeeId, state)` index
- **Nav link target:** Changed bell icon link from `/activities` to `/friends`
- **Aria labels:** Updated to reflect "Friend requests, N pending" instead of "Activity, N unread"
- **Documentation:** Updated comments in `activity.ts` to note `getBellBadgeCount()` is no longer wired to the nav badge (retained for potential reuse); clarified the new badge semantics in `/api/nav` route comments
- **Activity refresh logic:** Simplified comment in `MarkActivitiesRead.tsx` to reflect that opening the bell no longer affects the nav badge (which now sources from friend requests, not activity state)

## Implementation details
- The new `getIncomingFollowRequestCount()` query is backed by the existing `(followeeId, state)` index on the `follows` table, ensuring efficient lookups
- The `/api/nav` endpoint continues to fetch three values (profile, badge count, discovery status) in parallel; only the badge source changed
- Error handling preserved: both queries fall back to sensible defaults (0 for badge count) if they fail

https://claude.ai/code/session_01SLLrmK3WSVKNxZy1yHxkqg