### PR TITLE
Fix dead Accept button on already-accepted friend requests

### DIFF
--- a/src/app/activities/FriendRequestActions.tsx
+++ b/src/app/activities/FriendRequestActions.tsx
@@ -28,12 +28,18 @@ export function FriendRequestActions({
         }
       )
 
-      if (!response.ok) {
-        setError('Could not update this note.')
+      // A 404 means this request is no longer pending — it was already accepted
+      // or declined elsewhere (the "Wants to connect" card, the /friends hub, or
+      // another tab) and this Recent Activity row is just a stale duplicate. The
+      // end state the tap was reaching for already holds, so this is NOT an
+      // error: refresh so the now-settled card clears, rather than stranding a
+      // dead button behind a confusing message.
+      if (response.ok || response.status === 404) {
+        router.refresh()
         return
       }
 
-      router.refresh()
+      setError('Could not update this request.')
     } finally {
       setPendingAction(null)
     }

--- a/src/components/home/FriendRequestsSection.tsx
+++ b/src/components/home/FriendRequestsSection.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { useState } from 'react'
 
 // Serialized at the RSC boundary: createdAt is an ISO string (mirrors how the
@@ -38,6 +39,13 @@ export async function submitFriendRequestAction(
       credentials: 'include',
     })
     const body = (await response.json().catch(() => null)) as { message?: string } | null
+    // A 404 means the request is no longer pending — it was already accepted or
+    // declined (from the Recent Activity duplicate, the /friends hub, or another
+    // tab). The desired end state already holds, so treat it as success and let
+    // the caller clear the now-stale card instead of surfacing a scary error.
+    if (response.status === 404) {
+      return { ok: true }
+    }
     if (!response.ok) {
       return { ok: false, message: body?.message ?? failureMessage }
     }
@@ -127,6 +135,7 @@ function RequestCard({
 }
 
 export default function FriendRequestsSection({ initial }: FriendRequestsSectionProps) {
+  const router = useRouter()
   const [requests, setRequests] = useState<SerializedIncomingRequest[]>(initial.top)
   const [totalCount, setTotalCount] = useState(initial.totalCount)
   const [pendingId, setPendingId] = useState<string | null>(null)
@@ -151,6 +160,11 @@ export default function FriendRequestsSection({ initial }: FriendRequestsSection
       // "See all" overflow line stays honest as cards clear.
       setRequests((current) => current.filter((item) => item.id !== request.id))
       setTotalCount((current) => Math.max(0, current - 1))
+      // Keep the other home surfaces in sync: the same pending request also
+      // shows in the Recent Activity stream ("wants to be friends"). Re-render
+      // the server components so that duplicate clears too — otherwise it lingers
+      // and its Accept button 404s on the now-settled request.
+      router.refresh()
     } else {
       // Failure: the card stays put and we surface an inline error.
       setError(result.message)

--- a/src/components/home/__tests__/FriendRequestsSection.test.tsx
+++ b/src/components/home/__tests__/FriendRequestsSection.test.tsx
@@ -8,6 +8,13 @@ vi.mock('next/link', () => ({
   ),
 }))
 
+// The component refreshes the server tree after a successful action (to clear
+// the same request's Recent Activity duplicate), so it reads from the app
+// router. Provide a no-op so the static-render tests have a router in context.
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}))
+
 import FriendRequestsSection, {
   FRIEND_REQUEST_ENDPOINTS,
   submitFriendRequestAction,
@@ -26,9 +33,10 @@ function request(id: string, overrides: Partial<SerializedIncomingRequest> = {})
   }
 }
 
-function jsonResponse(ok: boolean, body: unknown): Response {
+function jsonResponse(ok: boolean, body: unknown, status = ok ? 200 : 400): Response {
   return {
     ok,
+    status,
     json: async () => body,
   } as unknown as Response
 }
@@ -127,6 +135,17 @@ describe('submitFriendRequestAction', () => {
     const fetchImpl = vi.fn(async () => jsonResponse(false, { message: 'Already handled.' }))
     const result = await submitFriendRequestAction('req-1', 'accept', 'fallback', fetchImpl as typeof fetch)
     expect(result).toEqual({ ok: false, message: 'Already handled.' })
+  })
+
+  it('treats a 404 (no longer pending) as an idempotent success', async () => {
+    // The request was already accepted/declined elsewhere — the end state the
+    // tap wanted already holds, so the caller should clear the stale card rather
+    // than surface an error.
+    const fetchImpl = vi.fn(async () =>
+      jsonResponse(false, { error: 'not_found', message: 'No pending friend request was found.' }, 404),
+    )
+    const result = await submitFriendRequestAction('req-1', 'accept', 'fallback', fetchImpl as typeof fetch)
+    expect(result).toEqual({ ok: true })
   })
 
   it('falls back to the failure message when the request throws', async () => {


### PR DESCRIPTION
The same pending friend request surfaces on Home in two places: the
"Wants to connect" card (FriendRequestsSection) and the Recent Activity
stream ("wants to be friends", FriendRequestActions). Accepting in one
surface only updated that surface's local state without re-rendering the
server tree, so the duplicate lingered. Tapping Accept on the stale card
hit the accept route, which 404s once the follow is no longer pending,
and the component surfaced a misleading "Could not update this note."
behind a button that appeared to do nothing.

- FriendRequestActions: treat a 404 (no longer pending) as a terminal
  success and refresh, clearing the stale card instead of erroring; fix
  the inaccurate error copy.
- FriendRequestsSection: make the shared accept/decline helper idempotent
  on 404, and router.refresh() after a successful action so the Recent
  Activity duplicate and overflow count re-render in lockstep.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JxbhuBjMAjqVE3gviN6fGv