### PR TITLE
docs(env): document ADMIN_USER_IDS with sample owner id in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,14 @@ AUTH_SECRET=""
 # ── App ───────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_URL="http://localhost:3000"
 
+# ── Admin (optional) ──────────────────────────────────────────
+# Comma-separated list of users.id values that get owner/admin surfaces:
+# the content-report queue (/admin/reports) and the owner-only LLM Provider
+# test panel on /users/[id]. Exact match after trimming — paste the FULL UUID,
+# no truncation. UNSET ⇒ no admins (fail-closed safe default; non-admins 404).
+# See src/server/auth/admin.ts and src/env-check.ts.
+# ADMIN_USER_IDS="f5ed1c59-3eaa-48d0-b789-2896bc447750"
+
 # ── Phase 5+ only (Twilio — do not add until Phase 5) ────────
 # TWILIO_ACCOUNT_SID=""
 # TWILIO_AUTH_TOKEN=""


### PR DESCRIPTION
Add an Admin section to .env.example documenting the ADMIN_USER_IDS allowlist that gates the content-report queue and the owner-only LLM Provider test panel. Includes the full primary-owner UUID as a copy-ready (commented) sample and notes the fail-closed default.


Claude-Session: https://claude.ai/code/session_015NYD1hcWJj47vZYXfofTmA