### PR TITLE
docs(env): document OpenAI provider env vars in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,19 @@ DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
 # ── Anthropic ─────────────────────────────────────────────────
 ANTHROPIC_API_KEY=""
 
+# ── OpenAI (LLM provider A/B switch — optional) ───────────────
+# Only used when a surface is flipped to OpenAI in the owner LLM Provider panel.
+# Missing/invalid key ⇒ the OpenAI branch returns null and falls back to
+# Anthropic. Key must start with sk- (project keys sk-proj-).
+# OPENAI_API_KEY=""
+# Model strings are deploy-time choices (OpenAI's lineup/pricing move), read at
+# runtime with the defaults below — override without a code change. See
+# src/server/llm/provider.ts.
+#   OPENAI_MODEL         → Generation, Categorization, Answer suggestion (flagship)
+#   OPENAI_GRADING_MODEL → Grading only (high-volume, cheaper mini)
+# OPENAI_MODEL="gpt-4o"
+# OPENAI_GRADING_MODEL="gpt-4o-mini"
+
 # ── Voyage AI (embeddings) ────────────────────────────────────
 # Powers the semantic near-duplicate suppression for the question pool
 # (GeneratedQuestion/Question.embedding, voyage-3.5-lite, 1024-dim).


### PR DESCRIPTION
## What

Adds an **OpenAI** section to `.env.example` documenting the env vars used by the LLM provider A/B switch:

- `OPENAI_API_KEY` — required for the OpenAI branch; missing/invalid falls back to Anthropic.
- `OPENAI_MODEL` (default `gpt-4o`) — flagship model for Generation, Categorization, Answer suggestion.
- `OPENAI_GRADING_MODEL` (default `gpt-4o-mini`) — Grading surface only (high-volume, cheaper mini).

## Why

The owner LLM Provider panel only flips *provider* (Anthropic ↔ OpenAI) per surface — it doesn't pick the OpenAI *model*. The model is a deploy-time env choice read at runtime in `src/server/llm/provider.ts`, but none of these three vars were documented in `.env.example` (only `OPENAI_API_KEY` was listed as optional in `env-check.ts`). This makes the model-selection path discoverable.

Docs-only change; no runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NYD1hcWJj47vZYXfofTmA)_