### PR TITLE
Retire grade_dispute_filed activity (no actionable surface)

### DIFF
--- a/_docs/D-FEED-INVENTORY-01.md
+++ b/_docs/D-FEED-INVENTORY-01.md
@@ -64,7 +64,7 @@ literal. Quoted verbatim from the `line:` arrays.
 | `follow` | `{friend}` + `' started following you'` | — | Someone followed you | No | (untagged) | friend | Medium |
 | `follow_approved` | `{friend}` + `' accepted your follow'` | — | Your follow request was approved | No | (untagged) | friend | Medium |
 | `invited_friend_played_first_five` | `{friend}` + `' played their first five questions'` | — | An invitee hit the 5-play milestone | No | (untagged) | friend | Low |
-| `grade_dispute_filed` | `{friend}` + `' asked for a re-look at your question'` | `{questionText}` | An answerer disputed your grade | No | (untagged) | friend, questionText | Low. *Not home-eligible.* |
+| `grade_dispute_filed` | `{friend}` + `' asked for a re-look at your question'` | `{questionText}` | An answerer disputed your grade | No | (untagged) | friend, questionText | **RETIRED 2026-06-25** — no longer written (no actionable surface; re-grade lives in the review queue). `filterUtilityActivities` drops historical rows. |
 | `default` (unknown type) | `'Something happened on Joshing'` | — | Fallback for an unmapped type | No | friend-less | — | Should never fire |
 
 > **Home-eligibility filter:** only `HOME_TOP3_ELIGIBLE_TYPES`

--- a/src/app/activities/__tests__/filter-utility-activities.test.ts
+++ b/src/app/activities/__tests__/filter-utility-activities.test.ts
@@ -112,6 +112,32 @@ function declaredPromotedActivity(id: string): ActivityItemView {
   };
 }
 
+function gradeDisputeFiledActivity(id: string): ActivityItemView {
+  return {
+    id,
+    userId: 'viewer-1',
+    type: 'grade_dispute_filed',
+    actorUserId: 'friend-1',
+    referenceId: 'dispute-1',
+    referenceType: 'grade_dispute',
+    read: false,
+    createdAt: new Date('2026-05-24T12:00:00.000Z'),
+    actor: { displayName: 'Sadie' },
+    reference: {
+      gradeDispute: {
+        id: 'dispute-1',
+        questionText: 'A disputed question…',
+        canonicalAnswer: 'answer',
+        submittedAnswer: 'guess',
+        status: 'pending',
+        reviewDecision: 'dispute',
+        reviewReason: null,
+        acceptedAlternative: null,
+      },
+    },
+  };
+}
+
 describe('filterUtilityActivities', () => {
   it('drops received_direct_question when a you_got_them moment covers the same questionId', () => {
     const items = [directQuestionActivity('a-1', 'fi-1', 'q-sondheim')];
@@ -149,6 +175,12 @@ describe('filterUtilityActivities', () => {
 
     const kept = filterUtilityActivities(items, []);
     expect(kept.map((i) => i.id)).toEqual(['a-2']);
+  });
+
+  it('drops grade_dispute_filed (retired — no actionable surface)', () => {
+    const items = [gradeDisputeFiledActivity('gd-1')];
+
+    expect(filterUtilityActivities(items, [])).toEqual([]);
   });
 
   // D-2 dedup non-collision: niche-match is stranger-scoped and Lately moments

--- a/src/app/activities/filter-utility-activities.ts
+++ b/src/app/activities/filter-utility-activities.ts
@@ -33,6 +33,12 @@ export function filterUtilityActivities(
       i.reference.friendAnsweredQuestion?.result === 'correct'
     ) return false;
     if (i.type === 'declared_promoted') return false;
+    // grade_dispute_filed ("{friend} asked for a re-look at your question") is
+    // retired (2026-06-25): the card carried no action the recipient could take
+    // — the re-grade happens in the human-review queue, not on the author's
+    // stream. New rows are no longer written (feed/recheck + milestone/recheck);
+    // this drops any historical rows so they stop surfacing the dead-end card.
+    if (i.type === 'grade_dispute_filed') return false;
     if (
       i.type === 'received_direct_question' &&
       i.reference.directQuestion?.questionId &&

--- a/src/app/api/feed/[feedItemId]/recheck/route.ts
+++ b/src/app/api/feed/[feedItemId]/recheck/route.ts
@@ -2,7 +2,6 @@ import { and, eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
-import { writeActivity } from '@/server/activity/write-activity';
 import { db, feedItems, gradeDisputes, questions } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { getBasePoints } from '@/server/mastery/scoring';
@@ -78,7 +77,7 @@ export async function POST(_request: NextRequest, context: RouteContext) {
       pointsAwarded = getBasePoints(question.calibratedDifficulty ?? question.llmDifficulty ?? null, 'first_correct');
     }
 
-    const disputeId = await db.transaction(async (tx) => {
+    await db.transaction(async (tx) => {
       if (accepted) {
         await tx
           .update(feedItems)
@@ -86,7 +85,7 @@ export async function POST(_request: NextRequest, context: RouteContext) {
           .where(eq(feedItems.id, feedItemId));
       }
 
-      const [inserted] = await tx
+      await tx
         .insert(gradeDisputes)
         .values({
           answerId,
@@ -101,24 +100,16 @@ export async function POST(_request: NextRequest, context: RouteContext) {
           acceptedAlternative: review.acceptedAlternative,
           status: disputeStatus,
           reviewedAt,
-        })
-        .returning({ id: gradeDisputes.id });
-      return inserted?.id ?? null;
+        });
     });
 
-    // §8.22 dispute path: notify the question's author so they can review.
-    // The dispute is the answerer's explicit ask for a second look, which
-    // is the consent gate that lets the author see the literal submitted
-    // text alongside the canonical answer.
-    if (disputeId && question.creatorId && question.creatorId !== session.userId) {
-      await writeActivity({
-        userId: question.creatorId,
-        type: 'grade_dispute_filed',
-        actorUserId: session.userId,
-        referenceId: disputeId,
-        referenceType: 'grade_dispute',
-      });
-    }
+    // §8.22 dispute path: the dispute row routes to the human-review queue
+    // (status 'pending'/'needs_human') on its own. We deliberately do NOT write
+    // a `grade_dispute_filed` activity to the question's author — that card
+    // carried no action the author could take (the re-grade happens in the
+    // review queue, not on the author's stream), so it was retired
+    // (2026-06-25). The daily/recheck path already files disputes without
+    // notifying the author; this brings feed/recheck in line.
 
     if (accepted) {
       await writeMasteryEvent({

--- a/src/app/api/lately/milestone/recheck/route.ts
+++ b/src/app/api/lately/milestone/recheck/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from 'next/server';
 import { z } from 'zod';
 
 import { getSession } from '@/server/auth/session';
-import { writeActivity } from '@/server/activity/write-activity';
 import { db, feedItems, gradeDisputes, questions } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { getBasePoints } from '@/server/mastery/scoring';
@@ -97,7 +96,7 @@ export async function POST(request: NextRequest) {
       pointsAwarded = getBasePoints(question.calibratedDifficulty ?? question.llmDifficulty ?? null, 'first_correct');
     }
 
-    const disputeId = await db.transaction(async (tx) => {
+    await db.transaction(async (tx) => {
       if (accepted) {
         // Flip the synthetic catch-up row to correct so getFeedCatchupItems stops
         // re-surfacing the miss, mirroring the feed recheck route's feedItems write.
@@ -107,7 +106,7 @@ export async function POST(request: NextRequest) {
           .where(eq(feedItems.id, feedItem.id));
       }
 
-      const [inserted] = await tx
+      await tx
         .insert(gradeDisputes)
         .values({
           answerId,
@@ -122,23 +121,14 @@ export async function POST(request: NextRequest) {
           acceptedAlternative: review.acceptedAlternative,
           status: disputeStatus,
           reviewedAt,
-        })
-        .returning({ id: gradeDisputes.id });
-      return inserted?.id ?? null;
+        });
     });
 
-    // §8.22 dispute path: notify the question's author so they can review. The
-    // recheck is the answerer's explicit ask for a second look, which is the
-    // consent gate that lets the author see the literal submitted text.
-    if (disputeId && question.creatorId && question.creatorId !== session.userId) {
-      await writeActivity({
-        userId: question.creatorId,
-        type: 'grade_dispute_filed',
-        actorUserId: session.userId,
-        referenceId: disputeId,
-        referenceType: 'grade_dispute',
-      });
-    }
+    // §8.22 dispute path: the dispute row routes to the human-review queue on
+    // its own. We deliberately do NOT write a `grade_dispute_filed` activity to
+    // the question's author — that card carried no action the author could take
+    // (the re-grade happens in the review queue, not on the author's stream),
+    // so it was retired (2026-06-25). Mirrors feed/recheck and daily/recheck.
 
     if (accepted) {
       await writeMasteryEvent({

--- a/src/lib/activity-types.ts
+++ b/src/lib/activity-types.ts
@@ -39,10 +39,13 @@ export type ActivityItemType =
   | 'friend_answered_your_question'
   | 'authored_question_shared'
   | 'declared_promoted'
-  // §8.22 grade-dispute path: the question's author is notified when an
-  // answerer disputes their wrong-answer grade. The dispute is the
-  // answerer's explicit ask for a second look, which is the consent gate
-  // that exposes their submitted text to the author.
+  // §8.22 grade-dispute path. RETIRED 2026-06-25 — no longer written. This
+  // card ("{friend} asked for a re-look at your question") notified the
+  // question's author when an answerer disputed their grade, but it carried no
+  // action: the re-grade happens in the human-review queue, not on the author's
+  // stream. The write was dropped from feed/recheck + milestone/recheck (daily/
+  // recheck never wrote it), and filterUtilityActivities now drops historical
+  // rows. Retained in the union so those rows still type-check and hydrate.
   | 'grade_dispute_filed'
   // D-2 niche-match discovery (slow-burn organic discovery between strangers
   // through a shared authored question). Two asymmetric writes from


### PR DESCRIPTION
## Summary
Retire the `grade_dispute_filed` activity type, which notified question authors when an answerer disputed their grade. This card carried no actionable surface — the re-grade happens in the human-review queue, not on the author's stream — so it has been removed from the product.

## Changes
- **Stop writing `grade_dispute_filed` activities:** Removed `writeActivity()` calls from `src/app/api/feed/[feedItemId]/recheck/route.ts` and `src/app/api/lately/milestone/recheck/route.ts`. Both routes now file disputes directly to the review queue without notifying the question author. (The daily/recheck path never wrote this activity.)
- **Filter historical rows:** Updated `filterUtilityActivities()` in `src/app/activities/filter-utility-activities.ts` to drop any existing `grade_dispute_filed` rows so they stop surfacing the dead-end card.
- **Update type documentation:** Marked `grade_dispute_filed` in `src/lib/activity-types.ts` as retired (2026-06-25) with rationale. Retained in the union type so historical rows still type-check and hydrate.
- **Test coverage:** Added test case in `src/app/activities/__tests__/filter-utility-activities.test.ts` to verify the filter drops `grade_dispute_filed` activities.
- **Update inventory docs:** Marked the activity as retired in `_docs/D-FEED-INVENTORY-01.md`.

## Implementation details
- Removed the `disputeId` capture and conditional `writeActivity()` block from both recheck routes; disputes now route to the human-review queue on their own via the `status` field.
- The filter uses the same pattern as other retired activities (`declared_promoted`, `friend_answered_your_question` with `result === 'correct'`) — a simple type check that returns `false` to drop the row.
- Comments in both route handlers and the filter explain the retirement rationale and cross-reference the decision date (2026-06-25).

https://claude.ai/code/session_017dDZSuBXFiTaCEtBTokz8v