### PR TITLE
feat(llm-ab): quality + cost + flip-log readout for the provider A/B switch

### DIFF
--- a/drizzle/0090_llm_provider_change_log.sql
+++ b/drizzle/0090_llm_provider_change_log.sql
@@ -1,0 +1,33 @@
+-- B-LLM-PROVIDER-AB-METRICS (Part 3) — provider flip log.
+--
+-- Records every owner change to the LLM provider A/B switch, one row per surface
+-- that actually changed, so the experiment's comparison windows are unambiguous:
+-- you can read exactly when grading/generation/etc. flipped and back. Without
+-- this, "the OpenAI window" has to be inferred from log timestamps. Append-only;
+-- written best-effort from the admin PATCH route after the AppSettings write
+-- succeeds (a failed log row must never block a provider change).
+--
+-- Purely additive: no existing table is altered. RLS is enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table would be reachable over Supabase's
+-- public Data API. Every statement is idempotent and mirrored by a defensive
+-- guard in src/instrumentation.ts (precedent: 0087) so a preview/production
+-- database that records this migration without the table present still boots.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "LlmProviderChangeLog";
+CREATE TABLE IF NOT EXISTS "LlmProviderChangeLog" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "surface" text NOT NULL,
+  "from_provider" text NOT NULL,
+  "to_provider" text NOT NULL,
+  "changed_by_user_id" text,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "LlmProviderChangeLog_surface_valid" CHECK (surface IN ('gen', 'categorize', 'suggest', 'grade')),
+  CONSTRAINT "LlmProviderChangeLog_from_valid" CHECK (from_provider IN ('anthropic', 'openai')),
+  CONSTRAINT "LlmProviderChangeLog_to_valid" CHECK (to_provider IN ('anthropic', 'openai'))
+);
+--> statement-breakpoint
+ALTER TABLE "LlmProviderChangeLog" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "LlmProviderChangeLog_created_at_idx" ON "LlmProviderChangeLog" ("created_at");

--- a/drizzle/0091_llm_usage_event.sql
+++ b/drizzle/0091_llm_usage_event.sql
@@ -1,0 +1,37 @@
+-- B-LLM-PROVIDER-AB-METRICS (Part 2) — per-call LLM usage events (cost).
+--
+-- One row per LLM completion (Anthropic or OpenAI), carrying the token counts
+-- already emitted to the [llm] structured logs, but in a queryable table so the
+-- A/B experiment can answer "is OpenAI cheaper on this surface?" without exporting
+-- logs by hand. Cost is NOT stored — it is computed at read time from the token
+-- columns and the price map in src/server/llm/pricing.ts, so a repricing needs no
+-- backfill. Written best-effort, fire-and-forget, off the LLM call's critical
+-- path (telemetry must never block or fail a completion); some rows may be lost
+-- on a cold serverless cutoff, which is acceptable for a cost estimate.
+--
+-- Purely additive: no existing table is altered. RLS is enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01
+-- / migration 0081 — without it the table would be reachable over Supabase's
+-- public Data API. Every statement is idempotent and mirrored by a defensive
+-- guard in src/instrumentation.ts (precedent: 0087) so a preview/production
+-- database that records this migration without the table present still boots.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "LlmUsageEvent";
+CREATE TABLE IF NOT EXISTS "LlmUsageEvent" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "scope" text NOT NULL,
+  "provider" text NOT NULL,
+  "model" text NOT NULL,
+  "input_tokens" integer NOT NULL DEFAULT 0,
+  "output_tokens" integer NOT NULL DEFAULT 0,
+  "cache_read_tokens" integer NOT NULL DEFAULT 0,
+  "cache_create_tokens" integer NOT NULL DEFAULT 0,
+  "duration_ms" integer,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+  CONSTRAINT "LlmUsageEvent_provider_valid" CHECK (provider IN ('anthropic', 'openai'))
+);
+--> statement-breakpoint
+ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -631,6 +631,20 @@
       "when": 1784246400000,
       "tag": "0089_domain_expansion_offer",
       "breakpoints": true
+    },
+    {
+      "idx": 90,
+      "version": "7",
+      "when": 1784332800000,
+      "tag": "0090_llm_provider_change_log",
+      "breakpoints": true
+    },
+    {
+      "idx": 91,
+      "version": "7",
+      "when": 1784419200000,
+      "tag": "0091_llm_usage_event",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/admin/llm-providers/route.ts
+++ b/src/app/api/admin/llm-providers/route.ts
@@ -12,7 +12,8 @@ import { z } from 'zod';
 
 import { isAdminUser } from '@/server/auth/admin';
 import { getSession } from '@/server/auth/session';
-import { getProviderSettings, updateProviderSettings } from '@/server/llm/settings';
+import { getProviderSettings, updateProviderSettings, type ProviderSurface } from '@/server/llm/settings';
+import { writeProviderChanges, type ProviderChange } from '@/server/db/queries/llm-provider-experiment';
 import type { AppSettingsUpdate } from '@/server/db/queries/app-settings';
 
 const providerEnum = z.enum(['anthropic', 'openai']);
@@ -55,6 +56,21 @@ export async function PATCH(request: Request) {
   if (parsed.data.suggest) update.suggestProvider = parsed.data.suggest;
   if (parsed.data.grade) update.gradeProvider = parsed.data.grade;
 
+  // B-LLM-PROVIDER-AB-METRICS Part 3: read the pre-write state so we can log
+  // exactly which surfaces flipped (the experiment's comparison windows depend on
+  // knowing when each surface changed). getProviderSettings() reflects the value
+  // the panel showed; reading it before the write captures the "from" side.
+  const before = await getProviderSettings();
   const providers = await updateProviderSettings(update);
+
+  const surfaces: ProviderSurface[] = ['gen', 'categorize', 'suggest', 'grade'];
+  const changes: ProviderChange[] = surfaces
+    .filter((surface) => providers[surface] !== before[surface])
+    .map((surface) => ({ surface, from: before[surface], to: providers[surface] }));
+  // Awaited (not fire-and-forget): the audit row matters more than the few ms on
+  // this owner-only, low-frequency action, and writeProviderChanges swallows its
+  // own errors so it can never fail the request.
+  await writeProviderChanges(changes, session.userId);
+
   return NextResponse.json({ providers });
 }

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -22,6 +22,7 @@ import { isAdminUser } from '@/server/auth/admin';
 import { getSession } from '@/server/auth/session';
 import { getProviderSettings } from '@/server/llm/settings';
 import { LlmProviderPanel } from '@/components/profile/settings/LlmProviderPanel';
+import { LlmExperimentReadout, loadLlmExperimentData } from '@/components/profile/settings/LlmExperimentReadout';
 import {
   getDiscoverability,
   getEditableProfile,
@@ -196,6 +197,9 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     // dropdowns reflect the DB; skip the read entirely for non-owners.
     const isOwner = isAdminUser(session.userId);
     const llmProviders = isOwner ? await getProviderSettings() : null;
+    // B-LLM-PROVIDER-AB-METRICS: load the experiment readout data here (the page
+    // is already awaited) and pass it into the sync presentational component.
+    const llmExperimentData = isOwner ? await loadLlmExperimentData() : null;
     return (
       <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-28">
         <ProfileHeaderCard
@@ -272,6 +276,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
         </section>
 
         {llmProviders ? <LlmProviderPanel initial={llmProviders} /> : null}
+        {llmExperimentData ? <LlmExperimentReadout data={llmExperimentData} /> : null}
 
         <AccountActions isAdmin={isAdminUser(session.userId)} />
 

--- a/src/components/profile/settings/LlmExperimentReadout.tsx
+++ b/src/components/profile/settings/LlmExperimentReadout.tsx
@@ -1,0 +1,235 @@
+/**
+ * Owner-only readout for the LLM provider A/B experiment
+ * (B-LLM-PROVIDER-AB-METRICS — the read side of Parts 1–3).
+ *
+ * Split into an async loader (loadLlmExperimentData) and a SYNC presentational
+ * component (LlmExperimentReadout). The page — already an async server component
+ * the caller awaits — runs the loader and passes plain data in; keeping the
+ * rendered component synchronous means renderToStaticMarkup (and the page test)
+ * can render it without RSC async support.
+ *
+ * Renders three quiet, system-voice tables — grading/generation quality,
+ * estimated cost, and the recent flip log. Shown only for the owner (the page
+ * gates it on ADMIN_USER_IDS, exactly like LlmProviderPanel), so it attempts no
+ * auth of its own. The loader wraps reads in Promise.allSettled so a missing
+ * table or a transient DB error degrades to a soft note instead of crashing the
+ * settings page.
+ */
+import {
+  readGradingQualityByProvider,
+  readGenerationByProvider,
+  readUsageCostByProvider,
+  readRecentProviderChanges,
+  type GradingQualityByProvider,
+  type GenerationByProvider,
+  type ProviderModelCost,
+  type ProviderChangeRow,
+} from '@/server/db/queries/llm-provider-experiment';
+import type { LlmProvider } from '@/server/llm/provider';
+
+const WINDOW_DAYS = 14;
+
+function providerLabel(p: LlmProvider): string {
+  return p === 'openai' ? 'OpenAI' : 'Anthropic';
+}
+
+function pct(x: number | null): string {
+  return x == null ? '—' : `${(x * 100).toFixed(1)}%`;
+}
+
+function usd(x: number | null): string {
+  if (x == null) return '—';
+  return `$${x.toFixed(x < 1 ? 4 : 2)}`;
+}
+
+function num(x: number): string {
+  return x.toLocaleString('en-US');
+}
+
+const SURFACE_LABELS: Record<string, string> = {
+  gen: 'Generation',
+  categorize: 'Categorization',
+  suggest: 'Answer suggestion',
+  grade: 'Grading',
+};
+
+export type LlmExperimentData = {
+  grading: GradingQualityByProvider[] | null;
+  generation: GenerationByProvider[] | null;
+  cost: ProviderModelCost[] | null;
+  flips: ProviderChangeRow[] | null;
+};
+
+/**
+ * Run all four metric queries concurrently, tolerating individual failures (a
+ * missing table, a transient DB error) — each failed read becomes null, which
+ * the component renders as a soft note. Call from the (async) page; pass the
+ * result to the sync component below.
+ */
+export async function loadLlmExperimentData(): Promise<LlmExperimentData> {
+  const [gradingR, generationR, costR, flipsR] = await Promise.allSettled([
+    readGradingQualityByProvider(WINDOW_DAYS),
+    readGenerationByProvider(),
+    readUsageCostByProvider(WINDOW_DAYS),
+    readRecentProviderChanges(10),
+  ]);
+  return {
+    grading: gradingR.status === 'fulfilled' ? gradingR.value : null,
+    generation: generationR.status === 'fulfilled' ? generationR.value : null,
+    cost: costR.status === 'fulfilled' ? costR.value : null,
+    flips: flipsR.status === 'fulfilled' ? flipsR.value : null,
+  };
+}
+
+export function LlmExperimentReadout({ data }: { data: LlmExperimentData }) {
+  const { grading, generation, cost, flips } = data;
+
+  const totalCost = cost?.reduce((acc, r) => (r.cost.usd != null ? acc + r.cost.usd : acc), 0) ?? 0;
+  const anyUnpriced = cost?.some((r) => r.cost.unpriced) ?? false;
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-muted-foreground mb-1 text-sm font-semibold tracking-wide uppercase">
+        LLM Experiment — Readout
+      </h2>
+      <p className="text-muted-foreground mb-3 text-xs">
+        Quality, cost, and flip history for the provider A/B switch. Quality and cost cover the last{' '}
+        {WINDOW_DAYS} days. Only output produced after this shipped is stamped, so early windows look
+        sparse.
+      </p>
+
+      <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border p-4">
+        {/* ── Grading quality (north-star) ── */}
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">Grading — wrong-answer rate by grader</h3>
+          {grading == null ? (
+            <p className="text-destructive text-xs">Couldn&apos;t read grading metrics.</p>
+          ) : grading.length === 0 ? (
+            <p className="text-muted-foreground text-xs">No LLM-graded answers in the window.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground text-left text-xs">
+                  <th className="py-1 font-medium">Grader</th>
+                  <th className="py-1 text-right font-medium">Graded</th>
+                  <th className="py-1 text-right font-medium">Wrong</th>
+                  <th className="py-1 text-right font-medium">Wrong rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {grading.map((r) => (
+                  <tr key={r.provider} className="border-t">
+                    <td className="py-1">{providerLabel(r.provider)}</td>
+                    <td className="py-1 text-right tabular-nums">{num(r.graded)}</td>
+                    <td className="py-1 text-right tabular-nums">{num(r.wrong)}</td>
+                    <td className="py-1 text-right tabular-nums">{pct(r.wrongRate)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* ── Generation quality ── */}
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">Generation — questions by author provider</h3>
+          {generation == null ? (
+            <p className="text-destructive text-xs">Couldn&apos;t read generation metrics.</p>
+          ) : generation.length === 0 ? (
+            <p className="text-muted-foreground text-xs">No provider-stamped generated questions yet.</p>
+          ) : (
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="text-muted-foreground text-left text-xs">
+                  <th className="py-1 font-medium">Provider</th>
+                  <th className="py-1 text-right font-medium">Questions</th>
+                  <th className="py-1 text-right font-medium">Avg correct rate</th>
+                </tr>
+              </thead>
+              <tbody>
+                {generation.map((r) => (
+                  <tr key={r.provider} className="border-t">
+                    <td className="py-1">{providerLabel(r.provider)}</td>
+                    <td className="py-1 text-right tabular-nums">{num(r.questions)}</td>
+                    <td className="py-1 text-right tabular-nums">{pct(r.avgEmpiricalCorrectRate)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+
+        {/* ── Cost ── */}
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">
+            Estimated cost — {usd(totalCost)} total
+          </h3>
+          {cost == null ? (
+            <p className="text-destructive text-xs">Couldn&apos;t read usage metrics.</p>
+          ) : cost.length === 0 ? (
+            <p className="text-muted-foreground text-xs">No recorded LLM calls in the window.</p>
+          ) : (
+            <>
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-muted-foreground text-left text-xs">
+                    <th className="py-1 font-medium">Provider / model</th>
+                    <th className="py-1 text-right font-medium">Calls</th>
+                    <th className="py-1 text-right font-medium">In tok</th>
+                    <th className="py-1 text-right font-medium">Out tok</th>
+                    <th className="py-1 text-right font-medium">Est. USD</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {cost.map((r) => (
+                    <tr key={`${r.provider}:${r.model}`} className="border-t">
+                      <td className="py-1">
+                        {providerLabel(r.provider)} · <span className="text-muted-foreground">{r.model}</span>
+                      </td>
+                      <td className="py-1 text-right tabular-nums">{num(r.calls)}</td>
+                      <td className="py-1 text-right tabular-nums">{num(r.inputTokens)}</td>
+                      <td className="py-1 text-right tabular-nums">{num(r.outputTokens)}</td>
+                      <td className="py-1 text-right tabular-nums">
+                        {r.cost.unpriced ? '— *' : usd(r.cost.usd)}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {anyUnpriced ? (
+                <p className="text-muted-foreground mt-2 text-xs italic">
+                  * model has no entry in the price map — tokens known, dollar cost unknown.
+                </p>
+              ) : null}
+            </>
+          )}
+        </div>
+
+        {/* ── Flip log ── */}
+        <div>
+          <h3 className="mb-2 text-sm font-semibold">Recent provider flips</h3>
+          {flips == null ? (
+            <p className="text-destructive text-xs">Couldn&apos;t read the flip log.</p>
+          ) : flips.length === 0 ? (
+            <p className="text-muted-foreground text-xs">No provider flips recorded yet.</p>
+          ) : (
+            <ul className="flex flex-col gap-1 text-sm">
+              {flips.map((r, i) => (
+                <li key={`${r.createdAt.toISOString()}-${r.surface}-${i}`} className="flex items-baseline justify-between gap-3">
+                  <span>
+                    {SURFACE_LABELS[r.surface] ?? r.surface}:{' '}
+                    <span className="text-muted-foreground">{providerLabel(r.fromProvider)}</span> →{' '}
+                    {providerLabel(r.toProvider)}
+                  </span>
+                  <span className="text-muted-foreground shrink-0 text-xs tabular-nums">
+                    {r.createdAt.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1643,6 +1643,49 @@ export async function register() {
       // These tables may not exist yet on a fresh database — migrate() creates
       // them (with these columns) before/at this migration.
     }
+
+    // Migrations 0090 + 0091 (B-LLM-PROVIDER-AB-METRICS) create the provider
+    // flip log and per-call usage tables. A preview/production database that
+    // records the migrations without the tables present would 42P01 when the
+    // PATCH route logs a flip or recordLlmUsage() inserts a row. Create them
+    // idempotently (with RLS + indexes). Both are self-contained — they depend
+    // on no other table. Precedent: 0087.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "LlmProviderChangeLog" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "surface" text NOT NULL,
+          "from_provider" text NOT NULL,
+          "to_provider" text NOT NULL,
+          "changed_by_user_id" text,
+          "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+          CONSTRAINT "LlmProviderChangeLog_surface_valid" CHECK (surface IN ('gen', 'categorize', 'suggest', 'grade')),
+          CONSTRAINT "LlmProviderChangeLog_from_valid" CHECK (from_provider IN ('anthropic', 'openai')),
+          CONSTRAINT "LlmProviderChangeLog_to_valid" CHECK (to_provider IN ('anthropic', 'openai'))
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "LlmProviderChangeLog" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmProviderChangeLog_created_at_idx" ON "LlmProviderChangeLog" ("created_at")`);
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "LlmUsageEvent" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "scope" text NOT NULL,
+          "provider" text NOT NULL,
+          "model" text NOT NULL,
+          "input_tokens" integer NOT NULL DEFAULT 0,
+          "output_tokens" integer NOT NULL DEFAULT 0,
+          "cache_read_tokens" integer NOT NULL DEFAULT 0,
+          "cache_create_tokens" integer NOT NULL DEFAULT 0,
+          "duration_ms" integer,
+          "created_at" timestamp with time zone NOT NULL DEFAULT now(),
+          CONSTRAINT "LlmUsageEvent_provider_valid" CHECK (provider IN ('anthropic', 'openai'))
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at")`);
+    } catch {
+      // Non-fatal — migrate() creates the tables from 0090/0091 immediately after.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -23,6 +23,7 @@ import {
   OPENAI_GRADING_MODEL,
   openaiCompleteJsonText,
 } from '@/server/llm/provider';
+import { recordLlmUsage } from '@/server/db/queries/llm-provider-experiment';
 import { textContainsAnswer } from '@/server/questions/self-answering';
 
 export type { LlmProvider };
@@ -265,6 +266,19 @@ export async function loggedMessagesCreate(
       output_tokens: usage?.output_tokens ?? 0,
       cache_read_tokens: usage?.cache_read_input_tokens ?? 0,
       cache_create_tokens: usage?.cache_creation_input_tokens ?? 0,
+    });
+    // B-LLM-PROVIDER-AB-METRICS Part 2: persist the same usage to a queryable
+    // table for the cost rollup. Fire-and-forget — recordLlmUsage swallows its
+    // own errors, so this can never turn a successful completion into a failure.
+    void recordLlmUsage({
+      scope,
+      provider: 'anthropic',
+      model: params.model,
+      inputTokens: usage?.input_tokens ?? 0,
+      outputTokens: usage?.output_tokens ?? 0,
+      cacheReadTokens: usage?.cache_read_input_tokens ?? 0,
+      cacheCreateTokens: usage?.cache_creation_input_tokens ?? 0,
+      durationMs: Date.now() - startedAt,
     });
     return response;
   } catch (error) {

--- a/src/server/db/queries/llm-provider-experiment.ts
+++ b/src/server/db/queries/llm-provider-experiment.ts
@@ -1,0 +1,254 @@
+/**
+ * Read/write layer for the LLM provider A/B experiment metrics
+ * (B-LLM-PROVIDER-AB-METRICS). Three concerns, one removable unit:
+ *
+ *   Part 1 (quality)  — readGradingQualityByProvider / readGenerationByProvider
+ *   Part 2 (cost)     — recordLlmUsage (write) / readUsageCostByProvider (read)
+ *   Part 3 (flip log) — writeProviderChanges (write) / readRecentProviderChanges
+ *
+ * Every write path here is best-effort: telemetry and audit rows must never block
+ * or fail an LLM completion or a provider flip. Reads are owner-only (gated at the
+ * page/route that calls them), windowed by `days` where a time window is meaningful.
+ */
+import { and, desc, gte, isNotNull, sql } from 'drizzle-orm';
+
+import { db, generatedQuestions, llmProviderChangeLog, llmUsageEvent, masteryEvents } from '@/server/db';
+import { estimateCostUsd, type CostEstimate } from '@/server/llm/pricing';
+import type { LlmProvider } from '@/server/llm/provider';
+import type { ProviderSurface } from '@/server/llm/settings';
+
+// ─── Part 2: cost — write ────────────────────────────────────────────────────
+
+export type LlmUsageRecord = {
+  scope: string;
+  provider: LlmProvider;
+  model: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheCreateTokens?: number;
+  durationMs?: number;
+};
+
+/**
+ * Record one LLM call's token usage. Best-effort and self-contained — swallows
+ * its own errors so a telemetry write can never turn a successful completion into
+ * a failure. Callers fire-and-forget: `void recordLlmUsage({...})`.
+ */
+export async function recordLlmUsage(event: LlmUsageRecord): Promise<void> {
+  try {
+    await db.insert(llmUsageEvent).values({
+      scope: event.scope,
+      provider: event.provider,
+      model: event.model,
+      inputTokens: Math.max(0, Math.round(event.inputTokens || 0)),
+      outputTokens: Math.max(0, Math.round(event.outputTokens || 0)),
+      cacheReadTokens: Math.max(0, Math.round(event.cacheReadTokens || 0)),
+      cacheCreateTokens: Math.max(0, Math.round(event.cacheCreateTokens || 0)),
+      durationMs: event.durationMs != null ? Math.max(0, Math.round(event.durationMs)) : null,
+    });
+  } catch (error) {
+    console.warn('[llm/usage] recordLlmUsage failed (telemetry only)', {
+      scope: event.scope,
+      provider: event.provider,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// ─── Part 2: cost — read ─────────────────────────────────────────────────────
+
+export type ProviderModelCost = {
+  provider: LlmProvider;
+  model: string;
+  calls: number;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+  cost: CostEstimate;
+};
+
+/**
+ * Token usage grouped by provider + model over the last `days`, with the USD cost
+ * derived from the price map. Rows whose model has no price row come back with
+ * `cost.unpriced === true` (dollar figure unknown, not zero).
+ */
+export async function readUsageCostByProvider(days = 14): Promise<ProviderModelCost[]> {
+  const rows = await db
+    .select({
+      provider: llmUsageEvent.provider,
+      model: llmUsageEvent.model,
+      calls: sql<number>`count(*)::int`,
+      inputTokens: sql<number>`coalesce(sum(${llmUsageEvent.inputTokens}), 0)::float8`,
+      outputTokens: sql<number>`coalesce(sum(${llmUsageEvent.outputTokens}), 0)::float8`,
+      cacheReadTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheReadTokens}), 0)::float8`,
+      cacheCreateTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheCreateTokens}), 0)::float8`,
+    })
+    .from(llmUsageEvent)
+    .where(gte(llmUsageEvent.createdAt, sql`now() - make_interval(days => ${days})`))
+    .groupBy(llmUsageEvent.provider, llmUsageEvent.model)
+    .orderBy(llmUsageEvent.provider, llmUsageEvent.model);
+
+  return rows.map((r) => ({
+    provider: r.provider as LlmProvider,
+    model: r.model,
+    calls: Number(r.calls),
+    inputTokens: Number(r.inputTokens),
+    outputTokens: Number(r.outputTokens),
+    cacheReadTokens: Number(r.cacheReadTokens),
+    cacheCreateTokens: Number(r.cacheCreateTokens),
+    cost: estimateCostUsd(r.model, {
+      inputTokens: Number(r.inputTokens),
+      outputTokens: Number(r.outputTokens),
+      cacheReadTokens: Number(r.cacheReadTokens),
+      cacheCreateTokens: Number(r.cacheCreateTokens),
+    }),
+  }));
+}
+
+// ─── Part 1: quality — grading ───────────────────────────────────────────────
+
+export type GradingQualityByProvider = {
+  provider: LlmProvider;
+  graded: number;
+  wrong: number;
+  /** Share of graded answers marked incorrect, 0..1, or null when graded === 0. */
+  wrongRate: number | null;
+};
+
+/**
+ * Wrong-answer rate per GRADING provider over the last `days` — the experiment's
+ * north-star. Only counts MASTERY_EVENTS rows that an LLM actually graded
+ * (llm_provider not null) and that carry a scored answer_state. `answer_state`
+ * value 'incorrect' is the wrong case; the other three are correct.
+ */
+export async function readGradingQualityByProvider(days = 14): Promise<GradingQualityByProvider[]> {
+  const rows = await db
+    .select({
+      provider: masteryEvents.llmProvider,
+      graded: sql<number>`count(*)::int`,
+      wrong: sql<number>`(count(*) filter (where ${masteryEvents.answerState} = 'incorrect'))::int`,
+    })
+    .from(masteryEvents)
+    .where(
+      and(
+        isNotNull(masteryEvents.llmProvider),
+        isNotNull(masteryEvents.answerState),
+        gte(masteryEvents.createdAt, sql`now() - make_interval(days => ${days})`),
+      ),
+    )
+    .groupBy(masteryEvents.llmProvider)
+    .orderBy(masteryEvents.llmProvider);
+
+  return rows.map((r) => {
+    const graded = Number(r.graded);
+    const wrong = Number(r.wrong);
+    return {
+      provider: r.provider as LlmProvider,
+      graded,
+      wrong,
+      wrongRate: graded > 0 ? wrong / graded : null,
+    };
+  });
+}
+
+// ─── Part 1: quality — generation ────────────────────────────────────────────
+
+export type GenerationByProvider = {
+  provider: LlmProvider;
+  questions: number;
+  /** Mean empirical correct rate of generated questions that have been played, or null. */
+  avgEmpiricalCorrectRate: number | null;
+};
+
+/**
+ * Question counts per GENERATING provider, with the mean empirical correct rate
+ * (a downstream quality proxy: questions a provider wrote that real players got
+ * right). All-time over stamped rows — generation provenance only exists post-B3,
+ * so there is no pre-experiment noise to window out.
+ */
+export async function readGenerationByProvider(): Promise<GenerationByProvider[]> {
+  const rows = await db
+    .select({
+      provider: generatedQuestions.generatedByProvider,
+      questions: sql<number>`count(*)::int`,
+      avgEmpiricalCorrectRate: sql<number | null>`avg(${generatedQuestions.empiricalCorrectRate})::float8`,
+    })
+    .from(generatedQuestions)
+    .where(isNotNull(generatedQuestions.generatedByProvider))
+    .groupBy(generatedQuestions.generatedByProvider)
+    .orderBy(generatedQuestions.generatedByProvider);
+
+  return rows.map((r) => ({
+    provider: r.provider as LlmProvider,
+    questions: Number(r.questions),
+    avgEmpiricalCorrectRate: r.avgEmpiricalCorrectRate != null ? Number(r.avgEmpiricalCorrectRate) : null,
+  }));
+}
+
+// ─── Part 3: flip log — write ────────────────────────────────────────────────
+
+export type ProviderChange = {
+  surface: ProviderSurface;
+  from: LlmProvider;
+  to: LlmProvider;
+};
+
+/**
+ * Append one flip-log row per surface that actually changed. Best-effort — a
+ * failed audit write must never block the provider change that already landed.
+ */
+export async function writeProviderChanges(
+  changes: ProviderChange[],
+  changedByUserId: string | null,
+): Promise<void> {
+  if (changes.length === 0) return;
+  try {
+    await db.insert(llmProviderChangeLog).values(
+      changes.map((c) => ({
+        surface: c.surface,
+        fromProvider: c.from,
+        toProvider: c.to,
+        changedByUserId,
+      })),
+    );
+  } catch (error) {
+    console.warn('[llm/flip-log] writeProviderChanges failed (audit only)', {
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+// ─── Part 3: flip log — read ─────────────────────────────────────────────────
+
+export type ProviderChangeRow = {
+  surface: string;
+  fromProvider: LlmProvider;
+  toProvider: LlmProvider;
+  changedByUserId: string | null;
+  createdAt: Date;
+};
+
+/** The most recent `limit` provider flips, newest first. */
+export async function readRecentProviderChanges(limit = 10): Promise<ProviderChangeRow[]> {
+  const rows = await db
+    .select({
+      surface: llmProviderChangeLog.surface,
+      fromProvider: llmProviderChangeLog.fromProvider,
+      toProvider: llmProviderChangeLog.toProvider,
+      changedByUserId: llmProviderChangeLog.changedByUserId,
+      createdAt: llmProviderChangeLog.createdAt,
+    })
+    .from(llmProviderChangeLog)
+    .orderBy(desc(llmProviderChangeLog.createdAt))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    surface: r.surface,
+    fromProvider: r.fromProvider as LlmProvider,
+    toProvider: r.toProvider as LlmProvider,
+    changedByUserId: r.changedByUserId,
+    createdAt: r.createdAt,
+  }));
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1330,3 +1330,52 @@ export const appSettings = pgTable(
     check('AppSettings_grade_provider_valid', sql`grade_provider IN ('anthropic', 'openai')`),
   ],
 );
+
+// ─── LLM provider A/B metrics (B-LLM-PROVIDER-AB-METRICS) ─────────────────────
+// Append-only log of every owner flip of the provider switch (Part 3), one row
+// per surface that changed. Makes the experiment's comparison windows explicit:
+// you can read exactly when grading/generation/etc. flipped. Written best-effort
+// from the admin PATCH route after the AppSettings write. Removable as a unit.
+export const llmProviderChangeLog = pgTable(
+  'LlmProviderChangeLog',
+  {
+    id: id(),
+    surface: text('surface').notNull(),
+    fromProvider: text('from_provider').notNull(),
+    toProvider: text('to_provider').notNull(),
+    changedByUserId: text('changed_by_user_id'),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    check('LlmProviderChangeLog_surface_valid', sql`surface IN ('gen', 'categorize', 'suggest', 'grade')`),
+    check('LlmProviderChangeLog_from_valid', sql`from_provider IN ('anthropic', 'openai')`),
+    check('LlmProviderChangeLog_to_valid', sql`to_provider IN ('anthropic', 'openai')`),
+    index('LlmProviderChangeLog_created_at_idx').on(table.createdAt),
+  ],
+);
+
+// Per-call LLM usage events (Part 2 — cost). One row per completion (either
+// provider) carrying the token counts already in the [llm] logs, but queryable.
+// Cost is NOT stored — it's derived at read time from src/server/llm/pricing.ts
+// so a repricing needs no backfill. Written best-effort/fire-and-forget off the
+// LLM call's critical path; some rows may be lost on a cold cutoff (acceptable
+// for an estimate). Removable as a unit.
+export const llmUsageEvent = pgTable(
+  'LlmUsageEvent',
+  {
+    id: id(),
+    scope: text('scope').notNull(),
+    provider: text('provider').notNull(),
+    model: text('model').notNull(),
+    inputTokens: integer('input_tokens').notNull().default(0),
+    outputTokens: integer('output_tokens').notNull().default(0),
+    cacheReadTokens: integer('cache_read_tokens').notNull().default(0),
+    cacheCreateTokens: integer('cache_create_tokens').notNull().default(0),
+    durationMs: integer('duration_ms'),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    check('LlmUsageEvent_provider_valid', sql`provider IN ('anthropic', 'openai')`),
+    index('LlmUsageEvent_provider_created_at_idx').on(table.provider, table.createdAt),
+  ],
+);

--- a/src/server/llm/pricing.ts
+++ b/src/server/llm/pricing.ts
@@ -1,0 +1,96 @@
+/**
+ * Per-model list pricing for the LLM provider A/B cost rollup
+ * (B-LLM-PROVIDER-AB-METRICS, Part 2).
+ *
+ * Cost is computed at read time (not stored on LlmUsageEvent rows) so a price
+ * change needs no backfill — update the numbers here and historical rows reprice
+ * automatically. Prices are USD per 1,000,000 tokens.
+ *
+ * The Anthropic numbers are list prices verified against the claude-api skill's
+ * model table (2026-06). Cache reads bill at ~0.1x the base input rate; 5-minute
+ * cache writes at ~1.25x — the two cache_* token buckets on LlmUsageEvent are
+ * priced with those multipliers below.
+ *
+ * The OpenAI numbers are best-effort defaults for the two models the switch
+ * defaults to (OPENAI_MODEL=gpt-4o, OPENAI_GRADING_MODEL=gpt-4o-mini). They are
+ * NOT verified against a live OpenAI price sheet here — VERIFY against current
+ * OpenAI pricing before trusting the OpenAI dollar figures, and add a row for any
+ * model you pin via OPENAI_MODEL / OPENAI_GRADING_MODEL. An unknown model falls
+ * back to zero cost (and is surfaced as such in the readout) rather than guessing.
+ */
+
+export type ModelPrice = {
+  /** USD per 1M input (uncached) tokens. */
+  inputPerMtok: number;
+  /** USD per 1M output tokens. */
+  outputPerMtok: number;
+  /** USD per 1M cache-read tokens (~0.1x input for Anthropic; 0 where N/A). */
+  cacheReadPerMtok: number;
+  /** USD per 1M cache-write tokens (~1.25x input for Anthropic 5m TTL; 0 where N/A). */
+  cacheWritePerMtok: number;
+};
+
+// Keyed by the exact model string passed to the provider SDK.
+export const MODEL_PRICING: Record<string, ModelPrice> = {
+  // ── Anthropic (verified, claude-api skill model table) ──
+  // Sonnet 4.6 — generation.
+  'claude-sonnet-4-6': {
+    inputPerMtok: 3.0,
+    outputPerMtok: 15.0,
+    cacheReadPerMtok: 0.3, // ~0.1x input
+    cacheWritePerMtok: 3.75, // ~1.25x input (5m TTL)
+  },
+  // Haiku 4.5 — grading + categorization.
+  'claude-haiku-4-5-20251001': {
+    inputPerMtok: 1.0,
+    outputPerMtok: 5.0,
+    cacheReadPerMtok: 0.1,
+    cacheWritePerMtok: 1.25,
+  },
+
+  // ── OpenAI (UNVERIFIED defaults — confirm against current OpenAI pricing) ──
+  // gpt-4o — flagship surfaces (generation/categorization/suggestion).
+  'gpt-4o': {
+    inputPerMtok: 2.5,
+    outputPerMtok: 10.0,
+    cacheReadPerMtok: 1.25, // gpt-4o cached input (~0.5x); no separate write charge
+    cacheWritePerMtok: 0,
+  },
+  // gpt-4o-mini — grading.
+  'gpt-4o-mini': {
+    inputPerMtok: 0.15,
+    outputPerMtok: 0.6,
+    cacheReadPerMtok: 0.075,
+    cacheWritePerMtok: 0,
+  },
+};
+
+export type UsageTokens = {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheCreateTokens: number;
+};
+
+export type CostEstimate = {
+  /** Total estimated USD, or null when the model isn't in MODEL_PRICING. */
+  usd: number | null;
+  /** True when the model has no price row — the dollar figure is unknown, not zero. */
+  unpriced: boolean;
+};
+
+/**
+ * Estimate the USD cost of a single call's token usage. Returns `unpriced: true`
+ * (and `usd: null`) for a model absent from MODEL_PRICING so the readout can show
+ * "tokens known, $ unknown" rather than a misleading $0.
+ */
+export function estimateCostUsd(model: string, tokens: UsageTokens): CostEstimate {
+  const price = MODEL_PRICING[model];
+  if (!price) return { usd: null, unpriced: true };
+  const usd =
+    (tokens.inputTokens / 1_000_000) * price.inputPerMtok +
+    (tokens.outputTokens / 1_000_000) * price.outputPerMtok +
+    (tokens.cacheReadTokens / 1_000_000) * price.cacheReadPerMtok +
+    (tokens.cacheCreateTokens / 1_000_000) * price.cacheWritePerMtok;
+  return { usd, unpriced: false };
+}

--- a/src/server/llm/provider.ts
+++ b/src/server/llm/provider.ts
@@ -16,6 +16,8 @@
 
 import OpenAI from 'openai';
 
+import { recordLlmUsage } from '@/server/db/queries/llm-provider-experiment';
+
 // The single source of truth for which provider a surface routes to. Anthropic
 // is always the default; OpenAI is the opt-in test arm.
 export type LlmProvider = 'anthropic' | 'openai';
@@ -138,6 +140,17 @@ export async function openaiCompleteJsonText(opts: {
       duration_ms: Date.now() - startedAt,
       input_tokens: usage?.prompt_tokens ?? 0,
       output_tokens: usage?.completion_tokens ?? 0,
+    });
+    // B-LLM-PROVIDER-AB-METRICS Part 2: persist usage for the cost rollup.
+    // Fire-and-forget — recordLlmUsage swallows its own errors. (OpenAI's
+    // chat-completions usage has no separate cache buckets on this path.)
+    void recordLlmUsage({
+      scope: opts.scope,
+      provider: 'openai',
+      model: opts.model,
+      inputTokens: usage?.prompt_tokens ?? 0,
+      outputTokens: usage?.completion_tokens ?? 0,
+      durationMs: Date.now() - startedAt,
     });
     return response.choices[0]?.message?.content ?? '';
   } catch (error) {


### PR DESCRIPTION
## Why

The LLM provider A/B switch (`B-LLM-PROVIDER-AB-SWITCH`) stamped provider provenance but shipped **no reader** — the experiment produced data nobody could see. This adds the missing read side, in the three parts requested.

## What

### Part 1 — Quality (read-only, over existing provenance columns)
- **Grading north-star:** wrong-answer rate per *grading* provider — `MASTERY_EVENTS.llm_provider` × `answer_state` (`incorrect` = wrong), windowed to 14 days.
- **Generation:** question counts + mean empirical correct rate per *generating* provider — `GeneratedQuestion.generated_by_provider`.

### Part 2 — Cost (new `LlmUsageEvent` table, migration 0091)
- Persists the token counts already emitted to the `[llm]` logs, in a queryable table — written **best-effort / fire-and-forget** from `loggedMessagesCreate` (Anthropic) and `openaiCompleteJsonText` (OpenAI), so telemetry can never block or fail a completion.
- Cost is **derived at read time** from a per-model price map (`src/server/llm/pricing.ts`), so a repricing needs no backfill. Anthropic prices verified against the model table; **OpenAI prices are documented, flagged-to-verify defaults** — unknown models render as “tokens known, $ unknown” rather than a misleading $0.

### Part 3 — Flip log (new `LlmProviderChangeLog` table, migration 0090)
- Records every owner flip (one row per surface that changed) from the admin `PATCH /api/admin/llm-providers` route, so the experiment’s comparison windows are unambiguous (no more inferring “the OpenAI window” from log timestamps).

### Readout UI
- Owner-only `LlmExperimentReadout` mounted on `/users/[id]`, just below the existing provider panel (same `ADMIN_USER_IDS` gate).
- Split into an **async loader** (run from the already-awaited page) + a **sync presentational component** so `renderToStaticMarkup`/the page test render it without RSC async support. Reads use `Promise.allSettled` so a missing table or transient DB error degrades to a soft note instead of crashing settings.

## Safety / parity
- Both migrations are **purely additive, idempotent, RLS-enabled** (owner-role bypass, no policies — per `B-SECURITY-RLS-01`), **journaled** (idx 90/91, monotonic `when`), and mirrored by **instrumentation boot guards** (0087 precedent).
- Schema ↔ SQL ↔ guard three-way parity confirmed by the `drizzle-migration-reviewer` agent (**verdict: pass**).

## Verification
- `npx tsc -p tsconfig.typecheck.json` — 0 errors
- `npm run lint` (touched files) — clean
- Suites green: page (`users/[id]`, 11), `server/llm`, `grading`, `api/admin` (17)

## Notes
- Builds on provenance already merged to `dev2` (0088); independent of PRs #1206/#1208.
- The cost table adds one best-effort insert per LLM call — fire-and-forget, errors swallowed, off the critical path. Acceptable for a test feature; some rows may be lost on a cold serverless cutoff (documented in the migration header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015NYD1hcWJj47vZYXfofTmA)_