### PR TITLE
Add reportTarget to catch-up items for content reporting

### DIFF
--- a/src/app/api/daily/catchup/route.ts
+++ b/src/app/api/daily/catchup/route.ts
@@ -33,6 +33,7 @@ export async function GET() {
       authorName: item.authorName,
       authorId: item.authorId,
       authorIsHouse: item.authorIsHouse,
+      reportTarget: item.reportTarget,
     })),
     introCopy: first
       ? formatCatchUpSessionThreadIntro(items.length, first.queueDate, last?.queueDate)

--- a/src/app/daily/catchup/page.tsx
+++ b/src/app/daily/catchup/page.tsx
@@ -12,6 +12,7 @@ import { useCatchupFlow, type CatchupBatchRecord } from '@/components/play/useCa
 import { AuthorName } from '@/components/AuthorName';
 import { EditorialBadge } from '@/components/EditorialBadge';
 import { CreatorNote, pickCreatorNote } from '@/components/CreatorNote';
+import { AnsweredRowActions } from '@/components/questions/AnsweredRowActions';
 import { CATCH_UP_EMPTY_COPY } from '@/server/play/catch-up-copy';
 
 export default function DailyCatchupPage() {
@@ -344,6 +345,10 @@ function CatchupResultDots({ records }: { records: CatchupBatchRecord[] }) {
 
 function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
   const [isExplainerOpen, setIsExplainerOpen] = useState(false);
+  // Parity with the daily-summary recap (round_recap surface): a card the viewer
+  // reports as inappropriate vanishes — the card going away is the feedback. An
+  // "incorrect" report leaves the card in place (the sheet acknowledges it itself).
+  const [isHidden, setIsHidden] = useState(false);
 
   const isCorrect = record.outcome === 'correct';
   const isRevealed = record.outcome === 'revealed';
@@ -362,38 +367,56 @@ function RoundRecapCard({ record }: { record: CatchupBatchRecord }) {
     creatorNote: record.authorNote,
   });
 
+  // Reported inappropriate → the card vanishes (the removal is the feedback,
+  // matching the daily-summary round_recap surface). Incorrect leaves it in place.
+  if (isHidden) return null;
+
   return (
     <article className="relative overflow-hidden rounded-lg border border-[var(--brand-border)] bg-[var(--brand-card)] p-5 shadow-none">
       <div className="absolute inset-y-0 left-0 w-1" style={{ backgroundColor: accentColor }} />
 
-      <div className="flex flex-wrap items-center gap-2 pl-1">
-        <span
-          className="rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold tracking-[0.05em]"
-          style={{
-            borderColor: isCorrect
-              ? 'color-mix(in srgb, var(--game-correct) 28%, var(--brand-border))'
-              : 'var(--brand-border)',
-            backgroundColor: isCorrect
-              ? 'color-mix(in srgb, var(--game-correct) 8%, var(--brand-card))'
-              : 'color-mix(in srgb, var(--brand-cream-page) 62%, var(--brand-card))',
-            color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink-700)',
-          }}
-        >
-          {statusLabel}
-        </span>
-        <p className="text-xs leading-5 text-[var(--brand-ink-400)]">
-          <span>{record.domainDisplayName}</span>
-          {record.authorName ? (
-            <>
-              <span aria-hidden="true"> · </span>
-              <span>by </span>
-              {/* Parity with the daily-five summary: human authors link to their
-                  profile; house/editorial render plain text + the Editorial badge. */}
-              <AuthorName name={record.authorName} authorId={record.authorId} />
-              {record.authorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
-            </>
-          ) : null}
-        </p>
+      <div className="flex items-start justify-between gap-3 pl-1">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span
+            className="rounded-full border px-2.5 py-1 text-[0.68rem] font-semibold tracking-[0.05em]"
+            style={{
+              borderColor: isCorrect
+                ? 'color-mix(in srgb, var(--game-correct) 28%, var(--brand-border))'
+                : 'var(--brand-border)',
+              backgroundColor: isCorrect
+                ? 'color-mix(in srgb, var(--game-correct) 8%, var(--brand-card))'
+                : 'color-mix(in srgb, var(--brand-cream-page) 62%, var(--brand-card))',
+              color: isCorrect ? 'var(--game-correct)' : 'var(--brand-ink-700)',
+            }}
+          >
+            {statusLabel}
+          </span>
+          <p className="text-xs leading-5 text-[var(--brand-ink-400)]">
+            <span>{record.domainDisplayName}</span>
+            {record.authorName ? (
+              <>
+                <span aria-hidden="true"> · </span>
+                <span>by </span>
+                {/* Parity with the daily-five summary: human authors link to their
+                    profile; house/editorial render plain text + the Editorial badge. */}
+                <AuthorName name={record.authorName} authorId={record.authorId} />
+                {record.authorIsHouse ? <EditorialBadge style={{ marginLeft: '6px' }} /> : null}
+              </>
+            ) : null}
+          </p>
+        </div>
+        {/* ⋯ menu: "This is incorrect" / "This is inappropriate" → the shared
+            ReportReasonSheet. Hidden for items that arrived without a report
+            target (none of the three catch-up sources omit it today). */}
+        {record.reportTarget ? (
+          <AnsweredRowActions
+            target={record.reportTarget}
+            surface="round_recap"
+            onReportSubmitted={(category) => {
+              if (category === 'inappropriate') setIsHidden(true);
+            }}
+          />
+        ) : null}
       </div>
 
       <p className="mt-4 pl-1 text-[1.12rem] leading-7 font-medium tracking-[-0.01em] text-[var(--brand-ink)]">

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -18,6 +18,7 @@ import {
   type CatchUpSubmitParsedError,
 } from '@/server/play/catch-up-submit-error';
 import { shouldIntroduceCatchUpQuestion } from '@/server/play/catch-up-turn-sequencing';
+import { type ReportReasonTarget } from '@/components/report/ReportReasonSheet';
 
 export type CatchupQueueItem = {
   dailyQueueItemId: string;
@@ -40,6 +41,12 @@ export type CatchupQueueItem = {
   authorId?: string | null;
   /** D-3: the author is the non-human house/editorial author (renders the Editorial badge, no relational copy). */
   authorIsHouse?: boolean;
+  /**
+   * Content-report target for the recap ⋯ menu. Curated/bank + feed items carry
+   * `questionId`; LLM-origin daily items carry `generatedQuestionId`. Optional so a
+   * stale client payload without it just hides the report menu rather than crashing.
+   */
+  reportTarget?: ReportReasonTarget;
 };
 
 export type CatchupAnswerResponse = {
@@ -108,6 +115,12 @@ export type CatchupBatchRecord = {
    * the fuller note here so it is never lost.
    */
   authorNote: string | null;
+  /**
+   * Content-report target the recap ⋯ menu reports against. Threaded from the
+   * queue item so "This is incorrect" / "This is inappropriate" land a
+   * ContentReport on the right FK. Null when the item arrived without one.
+   */
+  reportTarget: ReportReasonTarget | null;
 };
 
 /**
@@ -465,6 +478,7 @@ export function useCatchupFlow() {
         authorId: item.authorId ?? null,
         authorIsHouse: item.authorIsHouse ?? false,
         authorNote: null,
+        reportTarget: item.reportTarget ?? null,
       });
     }, 1200);
   }, [currentItem, finishTurn, isResolvingTurn, submitting]);
@@ -687,6 +701,7 @@ export function useCatchupFlow() {
           authorId: item.authorId ?? null,
           authorIsHouse: item.authorIsHouse ?? false,
           authorNote: data.creatorNote ?? null,
+          reportTarget: item.reportTarget ?? null,
         });
       }, 1200);
     } catch {

--- a/src/components/questions/AnsweredRowActions.tsx
+++ b/src/components/questions/AnsweredRowActions.tsx
@@ -14,9 +14,14 @@ import { ReportReasonSheet, type ReportReasonTarget } from '@/components/report/
 export function AnsweredRowActions({
   target,
   surface = 'answered_list',
+  onReportSubmitted,
 }: {
   target: ReportReasonTarget;
   surface?: 'round_recap' | 'lately_result' | 'answered_list';
+  // Optional: fires once on a successful report so a surface can react (e.g. the
+  // round-recap hides a card reported as inappropriate, matching daily-summary).
+  // The answered-list caller omits it and the menu just closes, as before.
+  onReportSubmitted?: (category: 'incorrect' | 'inappropriate') => void;
 }) {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [reportCategory, setReportCategory] = useState<'incorrect' | 'inappropriate' | null>(null);
@@ -52,7 +57,7 @@ export function AnsweredRowActions({
       </button>
 
       {isMenuOpen ? (
-        <div className="fixed inset-0 z-[55] flex items-end justify-center bg-black/20 px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
+        <div className="fixed inset-0 z-[55] flex items-end justify-center bg-[color-mix(in_srgb,var(--brand-ink)_20%,transparent)] px-3 pt-16 pb-3 sm:absolute sm:inset-auto sm:right-0 sm:mt-2 sm:block sm:bg-transparent sm:p-0">
           <button
             type="button"
             className="absolute inset-0 cursor-default sm:hidden"
@@ -107,7 +112,10 @@ export function AnsweredRowActions({
           target={target}
           surface={surface}
           onClose={() => setReportCategory(null)}
-          onSubmitted={() => setReportCategory(null)}
+          onSubmitted={(category) => {
+            setReportCategory(null);
+            onReportSubmitted?.(category);
+          }}
         />
       ) : null}
     </div>

--- a/src/server/db/queries/__tests__/catchup-report-target.test.ts
+++ b/src/server/db/queries/__tests__/catchup-report-target.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// reportTarget wiring for daily catch-up. getCatchupQuestions flattens both
+// curated/bank slots and LLM-generated slots into one `questionId` string, so the
+// content-report path can't tell which FK (questions.id vs generatedQuestions.id)
+// the id belongs to. The added `reportTarget` carries that distinction. This test
+// drives the read with one canonical slot and one generated slot and asserts each
+// output item reports against the correct target — a generated id must NEVER land
+// under `questionId` (it would violate ContentReport's FK + one-target CHECK).
+const { TABLES, rowsByTable } = vi.hoisted(() => ({
+  TABLES: {
+    dailyQueues: { id: 'dq.id', userId: 'dq.userId', queueDate: 'dq.queueDate' },
+    questions: { id: 'q.id', visibility: 'visibility', creatorId: 'creatorId', deletedAt: 'deletedAt', broadCategory: 'broadCategory', category: 'category' },
+    generatedQuestions: { id: 'gq.id', userId: 'gq.userId' },
+    feedItems: { id: 'fi.id', recipientUserId: 'fi.recip', state: 'fi.state', answerResult: 'fi.res', catchupResolvedAt: 'fi.resolved', sourceEventAt: 'fi.evt', questionId: 'fi.q' },
+    contentReports: { questionId: 'cr.q', generatedQuestionId: 'cr.gq', category: 'cr.category', status: 'cr.status' },
+    users: { id: 'u.id', displayName: 'u.name' },
+  },
+  rowsByTable: new Map<unknown, unknown[]>(),
+}));
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  ne: vi.fn((column, value) => ({ op: 'ne', column, value })),
+  or: vi.fn((...parts) => ({ op: 'or', parts })),
+  and: vi.fn((...parts) => ({ op: 'and', parts })),
+  asc: vi.fn((column) => ({ op: 'asc', column })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  gte: vi.fn((column, value) => ({ op: 'gte', column, value })),
+  lte: vi.fn((column, value) => ({ op: 'lte', column, value })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
+  notExists: vi.fn((query) => ({ op: 'notExists', query })),
+  sql: vi.fn(() => ({ op: 'sql', as: vi.fn(() => ({ op: 'sqlAs' })) })),
+}));
+
+vi.mock('@/server/db', () => {
+  const rowsFor = (table: unknown) => (rowsByTable.get(table) ?? []) as unknown[];
+  const makeChain = () => {
+    let fromTable: unknown = null;
+    const chain: Record<string, unknown> = {
+      select: vi.fn(() => chain),
+      from: vi.fn((t: unknown) => {
+        fromTable = t;
+        return chain;
+      }),
+      innerJoin: vi.fn(() => chain),
+      leftJoin: vi.fn(() => chain),
+      orderBy: vi.fn(() => chain),
+      limit: vi.fn(() => Promise.resolve(rowsFor(fromTable))),
+      where: vi.fn(() => chain),
+      then: (resolve: (r: unknown[]) => unknown) => resolve(rowsFor(fromTable)),
+    };
+    return chain;
+  };
+  return {
+    db: { select: vi.fn(() => makeChain()) },
+    dailyQueues: TABLES.dailyQueues,
+    questions: TABLES.questions,
+    generatedQuestions: TABLES.generatedQuestions,
+    feedItems: TABLES.feedItems,
+    contentReports: TABLES.contentReports,
+    users: TABLES.users,
+    dailyPreferences: {}, declaredInterests: {}, masteryEvents: {}, playerMastery: {},
+    skippedDailyQuestions: {}, userDomainExclusions: {},
+  };
+});
+
+vi.mock('@/lib/games/timezone', () => ({
+  getDailyAssignmentBounds: () => ({ assignmentDateStr: '2026-06-16', assignmentDate: new Date('2026-06-16T00:00:00Z') }),
+}));
+vi.mock('@/server/play/catch-up-eligibility', () => ({
+  isCatchUpQueueDateEligible: () => true,
+  isCatchUpSlotEligible: () => true,
+  catchUpExpiresAt: () => '2026-07-01',
+  expiresWithin24Hours: () => false,
+  queueAgeInDays: () => 0,
+}));
+vi.mock('@/server/daily/catchup', () => ({
+  CATCHUP_LOOKBACK_DAYS: 30,
+  asQueueSlots: (v: unknown) => (Array.isArray(v) ? v : []),
+  // Distinct dispatch ids per slot so neither item is dropped by sequencing.
+  dailyQueueItemId: (queueId: string, slotIndex: number) => `${queueId}:${slotIndex}`,
+  feedCatchupItemId: (id: string) => `feed:${id}`,
+  minusUtcDays: () => new Date('2026-06-01T00:00:00Z'),
+}));
+
+import { getCatchupQuestions } from '@/server/db/queries/daily';
+
+beforeEach(() => {
+  rowsByTable.clear();
+  rowsByTable.set(TABLES.dailyQueues, [
+    {
+      id: 'queue-1',
+      queueDate: '2026-06-10',
+      slots: [
+        { slot_index: 0, question_id: 'cq-1', answered: true },
+        { slot_index: 1, generated_question_id: 'gq-1', answered: true },
+      ],
+    },
+  ]);
+  rowsByTable.set(TABLES.questions, [
+    {
+      id: 'cq-1',
+      questionText: 'Curated bank question?',
+      answerText: 'Bank answer',
+      acceptedAlternatives: [],
+      canonicalSubcategory: 'Wine Production and Marketing',
+      broadCategory: 'Food and Drink',
+      category: 'Food',
+      calibratedDifficulty: null,
+      llmDifficulty: null,
+      difficultyEstimate: 'moderate',
+      explainerFullWrong: null,
+      explainerFull: 'Because.',
+      explainerBrief: null,
+      factualExplanation: null,
+      questionType: 'factual',
+      creatorId: null,
+      source: 'curated_sent',
+      deletedAt: null,
+      visibility: 'public',
+    },
+  ]);
+  rowsByTable.set(TABLES.generatedQuestions, [
+    {
+      id: 'gq-1',
+      questionText: 'LLM generated question?',
+      answer: 'Generated answer',
+      explainer: 'Because.',
+      canonicalSubcategory: 'Wine Production and Marketing',
+      broadCategory: 'Food and Drink',
+      basePoints: 3,
+      difficultyEstimate: 'moderate',
+    },
+  ]);
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('getCatchupQuestions reportTarget discriminator', () => {
+  it('reports a curated/bank slot against questionId and a generated slot against generatedQuestionId', async () => {
+    const items = await getCatchupQuestions('viewer-1');
+
+    const bank = items.find((item) => item.questionId === 'cq-1');
+    const generated = items.find((item) => item.questionId === 'gq-1');
+
+    expect(bank?.reportTarget).toEqual({ questionId: 'cq-1' });
+    // The generated id must travel as generatedQuestionId, never as questionId —
+    // otherwise the ContentReport insert points at the wrong (or no) FK.
+    expect(generated?.reportTarget).toEqual({ generatedQuestionId: 'gq-1' });
+  });
+});

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -124,6 +124,17 @@ export type CatchupQueueItem = {
    * with no relational copy. Set explicitly (not inferred from the name string).
    */
   authorIsHouse: boolean;
+  /**
+   * The target a content report (incorrect / inappropriate) points at, mirroring
+   * daily-summary and archive. Exactly one id is set — curated/bank and feed
+   * questions carry `questionId` (a `questions.id`), LLM-origin daily questions
+   * carry `generatedQuestionId` (a `generatedQuestions.id`). The flat `questionId`
+   * field above can't disambiguate the two FK targets, so the report path reads
+   * this instead of guessing.
+   */
+  reportTarget:
+    | { questionId: string; generatedQuestionId?: undefined }
+    | { generatedQuestionId: string; questionId?: undefined };
 };
 
 export type CatchupQuestion = CatchupQueueItem;
@@ -637,6 +648,7 @@ async function getDailyCatchupItems(
           authorName: null, // daily-generated: LLM origin, no human author
           authorId: null,
           authorIsHouse: false,
+          reportTarget: { generatedQuestionId: slot.generated_question_id },
         } satisfies CatchupQuestion;
       }
 
@@ -678,6 +690,7 @@ async function getDailyCatchupItems(
         questionType: question.questionType,
         authorId: question.creatorId ?? null,
         ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
+        reportTarget: { questionId: slot.question_id },
       } satisfies CatchupQuestion;
     })
     .filter((question): question is CatchupQuestion => Boolean(question));
@@ -761,6 +774,7 @@ async function getFeedCatchupItems(
         questionType: question.questionType,
         authorId: question.creatorId ?? null,
         ...resolveAuthorDisplay(question.creatorId, question.source, question.creatorId ? authorNameById.get(question.creatorId) ?? null : null),
+        reportTarget: { questionId: question.id },
       } satisfies CatchupQuestion;
     })
     .filter((item): item is CatchupQuestion => Boolean(item));


### PR DESCRIPTION
## Summary
Adds content-report targeting to catch-up recap cards, enabling viewers to report questions as "incorrect" or "inappropriate" with the same UX as daily-summary and archive surfaces. The key challenge: `getCatchupQuestions` flattens curated/bank and LLM-generated slots into a single `questionId` field, but content reports need to distinguish which foreign key (questions.id vs generatedQuestions.id) the id belongs to. A new `reportTarget` discriminator field solves this.

## Changes

- **`src/server/db/queries/daily.ts`**: Added `reportTarget` field to `CatchupQueueItem` type. Set to `{ questionId }` for curated/bank and feed items, `{ generatedQuestionId }` for LLM-origin daily items. Populated in `getDailyCatchupItems` and `getFeedCatchupItems`.

- **`src/server/db/queries/__tests__/catchup-report-target.test.ts`** (new): Test suite verifying that curated slots report against `questionId` and generated slots report against `generatedQuestionId`, ensuring generated ids never land under the wrong FK.

- **`src/app/daily/catchup/page.tsx`**: 
  - Imported `AnsweredRowActions` component
  - Added `isHidden` state to `RoundRecapCard` to hide cards reported as inappropriate (matching daily-summary behavior)
  - Restructured header layout to accommodate the ⋯ menu button
  - Wired `AnsweredRowActions` with `onReportSubmitted` callback to hide card on inappropriate reports

- **`src/components/questions/AnsweredRowActions.tsx`**:
  - Added optional `onReportSubmitted` callback prop to allow surfaces to react to successful reports
  - Updated overlay color to use CSS `color-mix` for consistency
  - Threaded callback through to `ReportReasonSheet.onSubmitted`

- **`src/components/play/useCatchupFlow.ts`**: 
  - Added `reportTarget` field to `CatchupQueueItem` and `CatchupBatchRecord` types
  - Threaded `reportTarget` through the flow from queue items to batch records

- **`src/app/api/daily/catchup/route.ts`**: Included `reportTarget` in the API response payload

## Implementation Details

The `reportTarget` field uses a discriminated union type to ensure exactly one id is set:
```typescript
reportTarget:
  | { questionId: string; generatedQuestionId?: undefined }
  | { generatedQuestionId: string; questionId?: undefined }
```

This prevents accidental misrouting of generated question ids to the `questions` FK. The field is optional in the client types (`CatchupQueueItem`) for forward compatibility with stale payloads, but always present in the server response.

Inappropriate reports hide the card immediately (the removal is the feedback), while incorrect reports leave it in place—matching the daily-summary round_recap surface behavior.

https://claude.ai/code/session_01BXk7R2jNaus9RfaS3nYnfn