### PR TITLE
Soften the completed Today's Five card

### DIFF
--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -361,50 +361,54 @@ export default function TodaysFiveCard({
       ) : null}
 
       {isComplete ? (
-        <div className="mt-3 space-y-2.5">
-          {missedCount > 0 ? (
-            // Branch A — outstanding catch-up questions own the only button here;
-            // the home page suppresses the standalone Catch up card to match.
-            // Faded-sage fill (sage border / forest-green text) — calmer and more
-            // inviting than the old orange outline, still clearly secondary to the
-            // day's primary Play. Built from --domain-science / --game-correct.
+        missedCount > 0 ? (
+          // Branch A — outstanding catch-up questions own the only button here;
+          // the home page suppresses the standalone Catch up card to match.
+          // Faded-sage fill (sage border / forest-green text) — calmer and more
+          // inviting than the old orange outline, still clearly secondary to the
+          // day's primary Play. Built from --domain-science / --game-correct.
+          // Recap stays link-weight below the button (backward-looking, no arrow).
+          <div className="mt-3 space-y-2.5">
             <Link
               href="/daily/catchup"
               className="flex min-h-12 w-full items-center justify-center rounded-[var(--radius-xs)] border border-[color-mix(in_srgb,var(--domain-science)_55%,transparent)] bg-[color-mix(in_srgb,var(--domain-science)_22%,transparent)] text-base font-bold tracking-[0.04em] text-[var(--game-correct)] transition-colors hover:bg-[color-mix(in_srgb,var(--domain-science)_32%,transparent)]"
             >
               {`Play (${missedCount}) Missed Question${missedCount === 1 ? '' : 's'}`}
             </Link>
-          ) : (
-            // Branch B — nothing left to catch up on (daily five AND any catch-up
-            // questions done). This is the calmest completed state, so it carries
-            // no button: the day's work is finished. The forward nudge is a quiet
-            // link outward to grow your circle, routing to the canonical
-            // /friends/find destination ("Find friends →" elsewhere in the app).
-            <>
-              <Link
-                href="/friends/find"
-                className="block text-sm font-medium text-[var(--brand-link)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
-              >
-                Find friends →
-              </Link>
-              <Link
-                href="/questions?create=1&intent=bank"
-                className="block text-sm font-medium text-[var(--brand-ink-400)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
-              >
-                Add a question to your bank
-              </Link>
-            </>
-          )}
-
-          {/* Recap is link-weight in both branches — never a button, and
-              backward-looking, so no forward arrow. */}
-          <Link
-            href="/daily/summary"
-            className="block text-sm font-medium text-[var(--brand-link)] underline underline-offset-4"
-          >
-            See today&apos;s recap
-          </Link>
-        </div>
+            <Link
+              href="/daily/summary"
+              className="block text-sm font-medium text-[var(--brand-link)] underline underline-offset-4"
+            >
+              See today&apos;s recap
+            </Link>
+          </div>
+        ) : (
+          // Branch B — nothing left to catch up on (daily five AND any catch-up
+          // questions done). This is the calmest completed state, so it carries
+          // no button: the day's work is finished. All three nudges sit on one
+          // quiet link row (wraps on narrow widths) — Find friends routes to the
+          // canonical /friends/find destination ("Find friends →" elsewhere).
+          <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2 text-sm font-medium">
+            <Link
+              href="/friends/find"
+              className="text-[var(--brand-link)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
+            >
+              Find friends →
+            </Link>
+            <Link
+              href="/questions?create=1&intent=bank"
+              className="text-[var(--brand-ink-400)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
+            >
+              Add a question to your bank
+            </Link>
+            <Link
+              href="/daily/summary"
+              className="text-[var(--brand-link)] underline underline-offset-4"
+            >
+              See today&apos;s recap
+            </Link>
+          </div>
+        )
       ) : (
         <>
           <Link

--- a/src/components/TodaysFiveCard.tsx
+++ b/src/components/TodaysFiveCard.tsx
@@ -375,27 +375,23 @@ export default function TodaysFiveCard({
               {`Play (${missedCount}) Missed Question${missedCount === 1 ? '' : 's'}`}
             </Link>
           ) : (
-            // Branch B — nothing left to catch up on; turn the player outward.
-            // "Send a friend a question" routes to the existing recipient-first
-            // authoring flow (CreateChooser's "send to specific people" intent).
+            // Branch B — nothing left to catch up on (daily five AND any catch-up
+            // questions done). This is the calmest completed state, so it carries
+            // no button: the day's work is finished. The forward nudge is a quiet
+            // link outward to grow your circle, routing to the canonical
+            // /friends/find destination ("Find friends →" elsewhere in the app).
             <>
               <Link
-                href="/questions?create=1&intent=specific"
-                className="btn-primary w-full"
+                href="/friends/find"
+                className="block text-sm font-medium text-[var(--brand-link)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
               >
-                Send a friend a question →
+                Find friends →
               </Link>
-              {/* Outward invite beat — quiet support copy under the primary
-                  action, framing the send as a way into friends' questions and
-                  knowledge while the next round is crafted. */}
-              <p className="text-xs leading-5 text-[var(--brand-ink-400)]">
-                Invite friends to see their questions and knowledge.
-              </p>
               <Link
                 href="/questions?create=1&intent=bank"
                 className="block text-sm font-medium text-[var(--brand-ink-400)] underline underline-offset-4 transition-colors hover:text-[var(--brand-ink)]"
               >
-                or add one to your bank
+                Add a question to your bank
               </Link>
             </>
           )}


### PR DESCRIPTION
## What

Reworks the **completed** state of the Today's Five card (`src/components/TodaysFiveCard.tsx`) so the all-done state reads as finished rather than pushing another big CTA.

The completed progression is now:

1. **Five not done** → big blue "Play now" / "Resume round" button *(unchanged)*
2. **Five done, catch-up questions remain** → lighter green "Play (N) Missed Questions" button *(unchanged)*
3. **Everything done (five + catch-up)** → **no button** — a subtle link stack instead:
   - **Find friends →** (routes to `/friends/find`, the app's canonical find-friends destination)
   - **Add a question to your bank**
   - **See today's recap** *(unchanged)*

Also updates the editorial headline for the no-misses completed branch from `Today, done.` → **`More questions, on the way`** to point forward (it pairs with the existing "Five new today at 1 PM" line).

## Why

The old completed state jumped straight from a big blue daily-five button to a green catch-up button to *another* big blue "Send a friend a question" button. The final, nothing-left state should feel calm and finished — a quiet nudge to grow your circle, not a third heavy CTA.

## Notes

- This removes the standalone "Send a friend a question →" action from the fully-complete state in favor of "Find friends →". Happy to keep both as subtle links if preferred.
- No tests asserted the changed copy/markup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Nkh4UwqscJ9eFTfGakxxD

---
_Generated by [Claude Code](https://claude.ai/code/session_014Nkh4UwqscJ9eFTfGakxxD)_