### PR TITLE
feat(llm-ab): default OpenAI flagship to gpt-4.1 + price-map rows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,11 +32,12 @@ ANTHROPIC_API_KEY=""
 # src/server/llm/provider.ts.
 #   OPENAI_MODEL         → Generation, Categorization, Answer suggestion (flagship)
 #   OPENAI_GRADING_MODEL → Grading only (high-volume, cheaper mini)
-# Flagship default is gpt-4.1-mini (cost-first; ~84% cheaper than gpt-4o on a
-# generation workload). Set OPENAI_MODEL=gpt-4.1 (or gpt-4o) for a stricter
-# quality comparison against Sonnet. gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano,
-# and gpt-4o-mini are all priced in src/server/llm/pricing.ts.
-# OPENAI_MODEL="gpt-4.1-mini"
+# Flagship default is gpt-4.1 — flagship-tier for a fair quality comparison
+# against Sonnet, yet cheaper than both gpt-4o and Sonnet per token. Set
+# OPENAI_MODEL=gpt-4.1-mini for pure cost (~84% cheaper on a generation
+# workload), or gpt-4o for the prior baseline. gpt-4o, gpt-4.1, gpt-4.1-mini,
+# gpt-4.1-nano, and gpt-4o-mini are all priced in src/server/llm/pricing.ts.
+# OPENAI_MODEL="gpt-4.1"
 # OPENAI_GRADING_MODEL="gpt-4o-mini"
 
 # ── Voyage AI (embeddings) ────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,11 @@ ANTHROPIC_API_KEY=""
 # src/server/llm/provider.ts.
 #   OPENAI_MODEL         → Generation, Categorization, Answer suggestion (flagship)
 #   OPENAI_GRADING_MODEL → Grading only (high-volume, cheaper mini)
-# OPENAI_MODEL="gpt-4o"
+# Flagship default is gpt-4.1-mini (cost-first; ~84% cheaper than gpt-4o on a
+# generation workload). Set OPENAI_MODEL=gpt-4.1 (or gpt-4o) for a stricter
+# quality comparison against Sonnet. gpt-4o, gpt-4.1, gpt-4.1-mini, gpt-4.1-nano,
+# and gpt-4o-mini are all priced in src/server/llm/pricing.ts.
+# OPENAI_MODEL="gpt-4.1-mini"
 # OPENAI_GRADING_MODEL="gpt-4o-mini"
 
 # ── Voyage AI (embeddings) ────────────────────────────────────

--- a/src/server/llm/pricing.ts
+++ b/src/server/llm/pricing.ts
@@ -11,12 +11,17 @@
  * cache writes at ~1.25x — the two cache_* token buckets on LlmUsageEvent are
  * priced with those multipliers below.
  *
- * The OpenAI numbers are best-effort defaults for the two models the switch
- * defaults to (OPENAI_MODEL=gpt-4o, OPENAI_GRADING_MODEL=gpt-4o-mini). They are
- * NOT verified against a live OpenAI price sheet here — VERIFY against current
- * OpenAI pricing before trusting the OpenAI dollar figures, and add a row for any
- * model you pin via OPENAI_MODEL / OPENAI_GRADING_MODEL. An unknown model falls
- * back to zero cost (and is surfaced as such in the readout) rather than guessing.
+ * The OpenAI numbers were confirmed June 2026 against public pricing aggregators
+ * (OpenAI's own pricing page blocks automated fetch, so these weren't read from
+ * the source sheet directly — glance at your OpenAI billing dashboard before
+ * trusting a figure for a cost-sensitive decision). Add a row for any model you
+ * pin via OPENAI_MODEL / OPENAI_GRADING_MODEL; an unknown model falls back to
+ * zero cost (surfaced as "unpriced" in the readout) rather than guessing.
+ *
+ * Note: the OpenAI completion path (openaiCompleteJsonText) does not record cache
+ * token buckets, so cacheRead/cacheWrite are inert for OpenAI rows (the readout
+ * only ever multiplies them by zero). They're kept at 0 to avoid implying a
+ * precision we don't track.
  */
 
 export type ModelPrice = {
@@ -48,19 +53,41 @@ export const MODEL_PRICING: Record<string, ModelPrice> = {
     cacheWritePerMtok: 1.25,
   },
 
-  // ── OpenAI (UNVERIFIED defaults — confirm against current OpenAI pricing) ──
-  // gpt-4o — flagship surfaces (generation/categorization/suggestion).
+  // ── OpenAI (confirmed June 2026; cache fields inert on this path — see header) ──
+  // gpt-4o — the default OPENAI_MODEL flagship.
   'gpt-4o': {
     inputPerMtok: 2.5,
     outputPerMtok: 10.0,
-    cacheReadPerMtok: 1.25, // gpt-4o cached input (~0.5x); no separate write charge
+    cacheReadPerMtok: 0,
     cacheWritePerMtok: 0,
   },
-  // gpt-4o-mini — grading.
+  // gpt-4o-mini — the default OPENAI_GRADING_MODEL.
   'gpt-4o-mini': {
     inputPerMtok: 0.15,
     outputPerMtok: 0.6,
-    cacheReadPerMtok: 0.075,
+    cacheReadPerMtok: 0,
+    cacheWritePerMtok: 0,
+  },
+  // gpt-4.1 — cheaper than gpt-4o and flagship-tier; the fair-comparison swap.
+  'gpt-4.1': {
+    inputPerMtok: 2.0,
+    outputPerMtok: 8.0,
+    cacheReadPerMtok: 0,
+    cacheWritePerMtok: 0,
+  },
+  // gpt-4.1-mini — ~84% cheaper than gpt-4o on a generation-shaped workload; the
+  // cost/quality sweet spot if a strict Sonnet benchmark isn't the goal.
+  'gpt-4.1-mini': {
+    inputPerMtok: 0.4,
+    outputPerMtok: 1.6,
+    cacheReadPerMtok: 0,
+    cacheWritePerMtok: 0,
+  },
+  // gpt-4.1-nano — cheapest; lowest quality.
+  'gpt-4.1-nano': {
+    inputPerMtok: 0.1,
+    outputPerMtok: 0.4,
+    cacheReadPerMtok: 0,
     cacheWritePerMtok: 0,
   },
 };

--- a/src/server/llm/provider.ts
+++ b/src/server/llm/provider.ts
@@ -32,12 +32,15 @@ const OPENAI_PLACEHOLDER_KEYS = new Set([
 ]);
 
 // Model strings are deploy-time choices, not hardcodes: OpenAI's lineup and
-// pricing move, so the exact model is read from env with a sensible default
-// (see B-LLM-PROVIDER-AB-SWITCH setup §7 — Josh picks the current flagship for a
-// fair quality comparison against Sonnet, and optionally a cheaper mini for the
-// high-volume grading path). Override OPENAI_MODEL / OPENAI_GRADING_MODEL to
-// pin the exact strings without a code change.
-export const OPENAI_FLAGSHIP_MODEL = process.env.OPENAI_MODEL?.trim() || 'gpt-4o';
+// pricing move, so the exact model is read from env with a sensible default.
+// The flagship default is gpt-4.1-mini — the cost/quality trade chosen after the
+// cost readout showed gpt-4o running ~5x the Anthropic arm (see the OpenAI rows
+// in src/server/llm/pricing.ts; gpt-4.1-mini is ~84% cheaper on a generation
+// workload). For a stricter quality comparison against Sonnet, override
+// OPENAI_MODEL to gpt-4.1 (or gpt-4o) — both are priced in the cost map.
+// Grading stays on a cheaper mini for the high-volume path. Override
+// OPENAI_MODEL / OPENAI_GRADING_MODEL to pin the exact strings without a code change.
+export const OPENAI_FLAGSHIP_MODEL = process.env.OPENAI_MODEL?.trim() || 'gpt-4.1-mini';
 export const OPENAI_GRADING_MODEL = process.env.OPENAI_GRADING_MODEL?.trim() || 'gpt-4o-mini';
 
 // Default per-call timeout, mirrors DEFAULT_LLM_TIMEOUT_MS on the Anthropic side

--- a/src/server/llm/provider.ts
+++ b/src/server/llm/provider.ts
@@ -33,14 +33,14 @@ const OPENAI_PLACEHOLDER_KEYS = new Set([
 
 // Model strings are deploy-time choices, not hardcodes: OpenAI's lineup and
 // pricing move, so the exact model is read from env with a sensible default.
-// The flagship default is gpt-4.1-mini — the cost/quality trade chosen after the
-// cost readout showed gpt-4o running ~5x the Anthropic arm (see the OpenAI rows
-// in src/server/llm/pricing.ts; gpt-4.1-mini is ~84% cheaper on a generation
-// workload). For a stricter quality comparison against Sonnet, override
-// OPENAI_MODEL to gpt-4.1 (or gpt-4o) — both are priced in the cost map.
-// Grading stays on a cheaper mini for the high-volume path. Override
-// OPENAI_MODEL / OPENAI_GRADING_MODEL to pin the exact strings without a code change.
-export const OPENAI_FLAGSHIP_MODEL = process.env.OPENAI_MODEL?.trim() || 'gpt-4.1-mini';
+// The flagship default is gpt-4.1 — flagship-tier, so the OpenAI arm stays a fair
+// quality comparison against Sonnet, yet cheaper than both gpt-4o AND Sonnet
+// itself per token (see the OpenAI rows in src/server/llm/pricing.ts). For pure
+// cost over quality, override OPENAI_MODEL to gpt-4.1-mini (~84% cheaper on a
+// generation workload); for the prior baseline, gpt-4o. Grading stays on a
+// cheaper mini for the high-volume path. Override OPENAI_MODEL /
+// OPENAI_GRADING_MODEL to pin the exact strings without a code change.
+export const OPENAI_FLAGSHIP_MODEL = process.env.OPENAI_MODEL?.trim() || 'gpt-4.1';
 export const OPENAI_GRADING_MODEL = process.env.OPENAI_GRADING_MODEL?.trim() || 'gpt-4o-mini';
 
 // Default per-call timeout, mirrors DEFAULT_LLM_TIMEOUT_MS on the Anthropic side


### PR DESCRIPTION
## Why

The cost readout flagged **gpt-4o at ~$0.37 for 10 generation calls** — ~5x the Anthropic arm. This PR switches the OpenAI flagship default to **gpt-4.1** and fills in the price map so every option is priced in the readout.

**Why gpt-4.1 and not the mini:** gpt-4.1 is flagship-tier, so the OpenAI arm stays a *fair quality comparison against Sonnet* — while still being **cheaper than both gpt-4o and Sonnet** per token. (gpt-4.1-mini is far cheaper but a small model, so it'd compare a mini against Sonnet's flagship — a cost win that's partly just buying less model. It's available as an override for a pure-cost run.)

## Per-token prices

| Model | Input $/1M | Output $/1M |
|---|---|---|
| claude-sonnet-4-6 | $3.00 | $15.00 |
| gpt-4o (prior default) | $2.50 | $10.00 |
| **gpt-4.1 (new default)** | **$2.00** | **$8.00** |
| gpt-4.1-mini | $0.40 | $1.60 |
| gpt-4o-mini (grading) | $0.15 | $0.60 |

On the 10-call generation sample (125k in / 5.6k out): gpt-4.1 ≈ **$0.296** vs gpt-4o $0.369 vs Sonnet ~$0.460.

## What

1. **`provider.ts`** — `OPENAI_MODEL` default `gpt-4o` → **`gpt-4.1`**. Grading stays `gpt-4o-mini`. Still opt-in (defaults to Anthropic; OpenAI runs only when a surface is flipped to OpenAI with a valid `OPENAI_API_KEY`).
2. **`pricing.ts`** — verified existing rows (June 2026) and added `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano` so any flagship choice is priced, not "unpriced". OpenAI cache fields set to 0 (inert — that path records no cache buckets).
3. **`.env.example`** — documents the new default + the priced alternatives.

## To run it in prod
After merge + redeploy: gpt-4.1 is the default *if/when* you flip a surface to OpenAI in the panel. Still requires `OPENAI_API_KEY` in Vercel and the surface flipped; no `OPENAI_MODEL` env var unless overriding.

## Notes
- OpenAI's pricing page blocks automated fetch (403); figures from public aggregators that agreed with each other and known rates — glance at the OpenAI billing dashboard before relying on them.
- Typecheck + lint clean; `server/llm` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)