### PR TITLE
feat(daily): default factual gate to Sonnet (FACTUAL_GATE_MODEL-configurable)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,13 @@ DIRECT_URL="postgresql://USER:PASSWORD@HOST:5432/DATABASE"
 
 # ── Anthropic ─────────────────────────────────────────────────
 ANTHROPIC_API_KEY=""
+# Factual gate model (which model fact-checks generated questions for wrong
+# answers / false premises). Defaults to Sonnet (claude-sonnet-4-6) — a 2026-06
+# audit found Haiku-tier misses subtle false premises that Sonnet catches, and
+# the gate runs once per generation batch so a stronger model here is low cost.
+# Override to revert (claude-haiku-4-5-20251001) or for max recall (an Opus id);
+# read at runtime in src/server/daily/generate-questions.ts, no deploy needed.
+# FACTUAL_GATE_MODEL="claude-sonnet-4-6"
 
 # ── OpenAI (LLM provider A/B switch — optional) ───────────────
 # Only used when a surface is flipped to OpenAI in the owner LLM Provider panel.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Project-specific guidance for Claude. Keep this file short; reference, don't dup
 - **Validation:** Zod on every API input. No exceptions.
 - **DB access:** queries belong in `src/server/db/queries/`, not inline in route handlers.
 - **LLM calls:** centralized under `src/server/llm/` (and `src/lib/llm.ts`).
-- **Anthropic model split:** Sonnet (`claude-sonnet-4-6`) for generation; Haiku (`claude-haiku-4-5-20251001`) for grading and categorization. Don't swap these without measuring quality and cost.
+- **Anthropic model split:** Sonnet (`claude-sonnet-4-6`) for generation; Haiku (`claude-haiku-4-5-20251001`) for grading and categorization. Don't swap these without measuring quality and cost. **Measured exception:** the factual gate (`findFactualFailures`) defaults to Sonnet, overridable via `FACTUAL_GATE_MODEL` — a 2026-06 audit found Haiku-tier misses subtle false-premise questions Sonnet catches, and prompt-tweaks at Haiku didn't help; the gate runs once per generation batch, so the cost delta is small.
 - **`_salvaged/`** is excluded from TypeScript (`tsconfig.json`) and ESLint (`eslint.config.mjs`). **Never edit anything inside it.**
 - **`PHONE_HASH_SALT`** is required in production (enforced at boot in `src/instrumentation.ts`). Used by `src/server/lib/phone-hashing.ts` and the client-side hashing path B-Friends-4 will add. Rotating it invalidates every `ContactHash` row and every persisted `User.phone_hash`.
 

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -780,6 +780,27 @@ Return JSON only:
 
 If nothing is wrong, return { "drop_indices": [], "reasons": {} }.${INSTRUCTION_USER_INPUT_GUIDANCE}${INSTRUCTION_SCOPING_QUALIFIER}`;
 
+// Model for the factual gate. Measured 2026-06 (scripts/audit-gate-compare):
+// Haiku-tier misses subtle false-premise questions that Sonnet catches — the
+// "answer is right but the setup embeds a false claim" class (e.g. a TotK
+// question asserting Ganondorf's dragon form draws on Zelda's). Sharpening the
+// gate PROMPT at Haiku tier didn't help (+0/+1); it's a model-tier effect, and
+// Sonnet recovered essentially the full major-defect lift that Opus did. So the
+// gate now defaults to Sonnet. The gate runs once per generation BATCH (not per
+// question), so a stronger model here is a small cost on the highest-leverage
+// check. Override with FACTUAL_GATE_MODEL (e.g. claude-haiku-4-5-20251001 to
+// revert, or an Opus id for max recall) without a deploy.
+const FACTUAL_GATE_MODEL = process.env.FACTUAL_GATE_MODEL?.trim() || ANTHROPIC_MODEL;
+// Opus 4.7/4.8 and Fable removed sampling params — sending `temperature` 400s on
+// them. Haiku 4.5 and Sonnet 4.6 still accept it. Guard so an Opus override of
+// the gate model doesn't break the call.
+function gateModelRejectsTemperature(model: string): boolean {
+  return model.includes('opus-4-7') || model.includes('opus-4-8') || model.includes('fable');
+}
+// Haiku gate timeout is tuned for Haiku's speed; a heavier gate model needs more
+// headroom or it times out and fails open (silently disabling the gate).
+const FACTUAL_GATE_TIMEOUT_MS = FACTUAL_GATE_MODEL === HAIKU_MODEL ? HAIKU_GATE_TIMEOUT_MS : 20_000;
+
 export function parseFactualGateResponse(
   raw: string,
   batchSize: number,
@@ -837,12 +858,13 @@ export async function findFactualFailures(generated: LlmQuestion[]): Promise<{
 
   try {
     const response = await loggedMessagesCreate(client, 'factual-gate', {
-      model: HAIKU_MODEL,
+      model: FACTUAL_GATE_MODEL,
       max_tokens: 500,
-      temperature: 0,
+      // Omit temperature on models that reject sampling params (Opus 4.7/4.8/Fable).
+      ...(gateModelRejectsTemperature(FACTUAL_GATE_MODEL) ? {} : { temperature: 0 }),
       system: FACTUAL_GATE_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userMessage }],
-    }, { timeoutMs: HAIKU_GATE_TIMEOUT_MS });
+    }, { timeoutMs: FACTUAL_GATE_TIMEOUT_MS });
     return parseFactualGateResponse(extractTextContent(response.content), generated.length);
   } catch (err) {
     // Fail open: a Haiku outage should not block the daily queue. A wrong


### PR DESCRIPTION
## Why

The factual gate (`findFactualFailures`) is the step that catches generated questions whose stated answer is wrong **or whose setup embeds a false premise** — the "answer is right, but the framing asserts something untrue" class (the Tears of the Kingdom / Ganondorf question that kicked this off).

A 2026-06 audit (`scripts/audit-gate-compare.mjs`, run over 80 recent pool questions) isolated **prompt vs model tier**:

| Judge | Major false-premise catches over Haiku |
|---|---|
| Sharper PROMPT @ Haiku (same tier) | **+0 / +1** (negligible) |
| Sonnet (same prompt, higher tier) | **+4** |
| Opus (same prompt, frontier) | **+4** |

→ It's a **model-tier** effect, not a prompt problem. **Sonnet recovered essentially the full major-defect lift that Opus did, at a fraction of Opus's cost.** Examples the live Haiku gate passed but Sonnet/Opus flagged: "Zelda was transformed by the dying Rauru" (she swallows her own Secret Stone), and the Ganondorf "draws on the ancient dragon" framing.

## What

- `findFactualFailures` now reads **`FACTUAL_GATE_MODEL`** (default **`claude-sonnet-4-6`**), overridable via env without a deploy — `claude-haiku-4-5-*` to revert, an Opus id for max recall.
- **Temperature omitted** for models that reject sampling params (Opus 4.7/4.8, Fable) so an Opus override doesn't 400.
- **Timeout** raised from the Haiku-tuned gate timeout to 20s for non-Haiku models, so a slower gate model doesn't time out and **fail open** (which silently disables the gate).
- Docs: `.env.example` + `CLAUDE.md` (model-split "measured exception").

## Cost

The gate runs **once per generation batch (~8 questions/call), not per question**, so moving this single high-leverage check to Sonnet is a small cost delta — the cheapest place in the pipeline to spend a stronger model.

## Scope / caveats

- Only the **factual** gate changes. `findQualityFailures` stays on Haiku — possible follow-up.
- Audit was n=80, single-run, LLM-as-judge (some flags are debatable); directionally clear that Haiku-tier is the weak point. The opt-in `factual-gate.test.ts` eval still covers the parse path (unchanged).

## Verification
- Touched-file typecheck clean (the 6 tsc errors are stale `.next` build artifacts for a removed `replay` route, unrelated); `eslint` clean on the gate file; `factual-gate.test.ts` passes (5, 3 eval-skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)