### PR TITLE
B-LOADING-MOMENT-01 — The Loading Moment (in-place)

### DIFF
--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -20,7 +20,7 @@ import {
 import { GeometricProgress } from '@/components/play/GeometricProgress';
 import { AnswerInputBar } from '@/components/play/AnswerInputBar';
 import LoadingScreen from '@/components/LoadingScreen';
-import { useLoadingMoment } from '@/components/loading-moment/useLoadingMoment';
+import { useLoadingMoments } from '@/components/loading-moment/useLoadingMoment';
 import { categoryLabel, type InsideJokeKind } from '@/lib/questions-types';
 import { DAILY_QUEUE_SIZE, hasPendingSlot, type QueueSlot } from '@/server/daily/types';
 import { getBonusCount, getCoreSlots, getSlotPresence, isBonusSlot } from '@/server/daily/bonus';
@@ -192,10 +192,10 @@ export default function DailyPage() {
   // Non-null while we're auto-retrying queue generation; drives the friendly
   // "still working (attempt N/4)" loading label instead of a bare error.
   const [generatingAttempt, setGeneratingAttempt] = useState<number | null>(null);
-  // The Loading Moment, surfaced only while a real session-generation wait is in
-  // progress (the long-wait surface, C-7). Reads cached-only data; null until the
-  // wait clears the minimum threshold, and null on a cold cache → plain state.
-  const loadingMoment = useLoadingMoment(loading && generatingAttempt != null);
+  // Loading Moments interleaved into the craft phrases while a real session-
+  // generation wait is in progress (the long-wait surface, C-7). Reads cached-
+  // only data; empty on a cold cache → the loader just rotates the craft phrases.
+  const loadingMoments = useLoadingMoments(loading && generatingAttempt != null);
   const [pausedAfterSlotIndex, setPausedAfterSlotIndex] = useState<number | null>(null);
   const [pendingGiveUp, setPendingGiveUp] = useState(false);
   const [openedTerritoryBySlot, setOpenedTerritoryBySlot] = useState<Record<number, string>>({});
@@ -906,7 +906,7 @@ export default function DailyPage() {
             <LoadingScreen
               fullScreen
               messages={GENERATING_MESSAGES}
-              loadingMoment={loadingMoment}
+              loadingMoments={loadingMoments}
             />
           ) : (
             <LoadingScreen fullScreen label="Loading today" />

--- a/src/app/dev/loading-preview/LoadingPreview.tsx
+++ b/src/app/dev/loading-preview/LoadingPreview.tsx
@@ -3,23 +3,46 @@
 import * as React from "react";
 
 import LoadingScreen from "@/components/LoadingScreen";
+import type { ResolvedLoadingMoment } from "@/components/loading-moment/types";
 
 import { PREVIEW_STATES, resolvePreviewState } from "./preview-states";
 
 /**
  * Dev-only forced preview of the Loading Moment surface (B-LOADING-MOMENT-01).
- * Cycles every card type plus the sparse / cold-start fallback and the plain
- * state, with NO real load. Each sample is run through the real selector (see
- * `preview-states`) so the preview shows true selector output, not hand-mocked
- * copy.
  *
- * Preview-only: this never touches the real loading path. Gated to admins by
- * the /dev route layout and the profile Developer-tools section.
+ * Two modes:
+ *  - "single": inspect one card (or the sparse fallback / plain state), static.
+ *  - "interleaved" (preview 2): watch the live rotation — craft phrases woven
+ *    with the insight cards, cycling at the same rate as the words.
+ *
+ * Each sample runs through the real selector (see `preview-states`) so the
+ * preview shows true output, not hand-mocked copy. Preview-only: never touches
+ * the real loading path. Gated to admins by the /dev layout + profile section.
  */
+
+// The same craft phrases the real session-generation loader rotates.
+const CRAFT_MESSAGES = [
+  "Crafting your bespoke questions",
+  "Finding the right multitudes",
+  "Reading the room",
+  "Tuning the difficulty",
+];
+
+// Every resolvable insight card (excludes the plain state and the sparse
+// fallback) — the set woven into the craft phrases in interleaved mode.
+const INTERLEAVED_MOMENTS: ResolvedLoadingMoment[] = PREVIEW_STATES.filter(
+  (s) => s.key !== "plain" && s.key !== "sparse",
+)
+  .map(resolvePreviewState)
+  .filter((m): m is ResolvedLoadingMoment => m !== null);
+
 export function LoadingPreview({ initialKey }: { initialKey?: string }) {
   const initialIndex = Math.max(
     0,
     PREVIEW_STATES.findIndex((s) => s.key === initialKey),
+  );
+  const [mode, setMode] = React.useState<"single" | "interleaved">(
+    initialKey === "interleaved" ? "interleaved" : "single",
   );
   const [index, setIndex] = React.useState(initialIndex);
   const state = PREVIEW_STATES[index];
@@ -27,25 +50,48 @@ export function LoadingPreview({ initialKey }: { initialKey?: string }) {
 
   return (
     <div className="relative min-h-screen w-full">
-      <LoadingScreen
-        fullScreen
-        messages={["Crafting your bespoke questions"]}
-        loadingMoment={moment}
-      />
+      {mode === "interleaved" ? (
+        <LoadingScreen
+          fullScreen
+          messages={CRAFT_MESSAGES}
+          loadingMoments={INTERLEAVED_MOMENTS}
+        />
+      ) : (
+        <LoadingScreen
+          fullScreen
+          messages={["Crafting your bespoke questions"]}
+          loadingMoment={moment}
+        />
+      )}
 
       {/* Preview chrome — sits above the loader; not part of the surface. */}
       <div className="fixed inset-x-0 bottom-0 z-[70] flex flex-col items-center gap-2 bg-black/70 px-4 py-3 text-white">
         <p className="font-sans text-xs tracking-wide uppercase opacity-80">
-          Loading-moment preview · {state.label}
+          Loading-moment preview ·{" "}
+          {mode === "interleaved" ? "Interleaved rotation (preview 2)" : state.label}
         </p>
         <div className="flex flex-wrap justify-center gap-1.5">
+          <button
+            type="button"
+            onClick={() => setMode("interleaved")}
+            className={`rounded px-2 py-1 font-sans text-[11px] ${
+              mode === "interleaved" ? "bg-white text-black" : "bg-white/15 text-white hover:bg-white/30"
+            }`}
+          >
+            ▶ interleaved
+          </button>
           {PREVIEW_STATES.map((s, i) => (
             <button
               key={s.key}
               type="button"
-              onClick={() => setIndex(i)}
+              onClick={() => {
+                setMode("single");
+                setIndex(i);
+              }}
               className={`rounded px-2 py-1 font-sans text-[11px] ${
-                i === index ? "bg-white text-black" : "bg-white/15 text-white hover:bg-white/30"
+                mode === "single" && i === index
+                  ? "bg-white text-black"
+                  : "bg-white/15 text-white hover:bg-white/30"
               }`}
             >
               {s.key}

--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -13,15 +13,24 @@ type LoadingScreenProps = {
   className?: string;
   fullScreen?: boolean;
   /**
-   * The Loading Moment to show IN PLACE of the rotating copy (B-LOADING-MOMENT-01).
-   * When a resolved moment is passed it occupies the existing copy slot — System
-   * label + Editorial artifact — instead of the rotating phrase. When `null` or
-   * omitted, the plain loading state renders exactly as it does today (C-3). The
-   * caller resolves this from cached-only data off the critical path; this
-   * component never fetches.
+   * A SINGLE Loading Moment shown statically in the copy slot, no rotation
+   * (B-LOADING-MOMENT-01). Used to inspect one card (the dev preview). When
+   * `null`/omitted the plain state renders as today (C-3).
    */
   loadingMoment?: ResolvedLoadingMoment | null;
+  /**
+   * Loading Moments to INTERLEAVE with the rotating craft phrases — craft word,
+   * insight, craft word, insight … — cycling at the same rate as the words
+   * (MESSAGE_CYCLE_MS). The sequence is craft-first, so a wait shorter than one
+   * cycle only ever shows a craft phrase (long-waits-only, C-7). Resolved from
+   * cached-only data off the critical path; this component never fetches.
+   */
+  loadingMoments?: ResolvedLoadingMoment[];
 };
+
+type RotationItem =
+  | { kind: "message"; text: string }
+  | { kind: "moment"; moment: ResolvedLoadingMoment };
 
 // The default rotating copy — evocative of what's happening behind the curtain
 // rather than a bare "Loading". Shown when neither `label` nor `messages` is
@@ -141,28 +150,48 @@ export default function LoadingScreen({
   className,
   fullScreen = false,
   loadingMoment = null,
+  loadingMoments,
 }: LoadingScreenProps) {
   const triangles = React.useMemo(() => buildTriangles(), []);
   const reducedMotion = usePrefersReducedMotion();
 
-  // A caller-supplied `label` is a single fixed message; otherwise rotate
-  // through `messages` (or the curated defaults). One item ⇒ no rotation.
-  const rotation = React.useMemo(
-    () => messages ?? (label != null ? [label] : DEFAULT_MESSAGES),
-    [messages, label],
-  );
-  const rotating = rotation.length > 1 && !reducedMotion;
+  // The rotation sequence. Three modes:
+  //  - `loadingMoments` present → INTERLEAVE craft phrases with insight cards,
+  //    craft-first (so a short wait shows only a craft phrase, C-7).
+  //  - a single `loadingMoment` → that card alone, static (the per-card preview).
+  //  - otherwise → the craft phrases (or `label`/defaults), exactly as before.
+  const sequence = React.useMemo<RotationItem[]>(() => {
+    const msgs = messages ?? (label != null ? [label] : DEFAULT_MESSAGES);
+    if (loadingMoments && loadingMoments.length > 0) {
+      const out: RotationItem[] = [];
+      const n = Math.max(msgs.length, loadingMoments.length);
+      for (let i = 0; i < n; i++) {
+        out.push({ kind: "message", text: msgs[i % msgs.length] });
+        out.push({ kind: "moment", moment: loadingMoments[i % loadingMoments.length] });
+      }
+      return out;
+    }
+    if (loadingMoment) return [{ kind: "moment", moment: loadingMoment }];
+    return msgs.map((text) => ({ kind: "message", text }));
+  }, [messages, label, loadingMoments, loadingMoment]);
+
+  const rotating = sequence.length > 1 && !reducedMotion;
 
   const [index, setIndex] = React.useState(0);
   React.useEffect(() => {
     if (!rotating) return;
     const id = window.setInterval(() => {
-      setIndex((i) => (i + 1) % rotation.length);
+      setIndex((i) => (i + 1) % sequence.length);
     }, MESSAGE_CYCLE_MS);
     return () => window.clearInterval(id);
-  }, [rotating, rotation.length]);
+  }, [rotating, sequence.length]);
 
-  const current = rotation[Math.min(index, rotation.length - 1)] ?? rotation[0];
+  const currentItem = sequence[Math.min(index, sequence.length - 1)] ?? sequence[0];
+  // Whether the sequence contains any card — drives the taller, fixed-height
+  // slot so the card never resizes the loader as items rotate.
+  const hasMoment = sequence.some((item) => item.kind === "moment");
+  const ariaText =
+    currentItem.kind === "moment" ? currentItem.moment.artifact : currentItem.text;
 
   const wrapperClass = [
     "isolate flex items-center justify-center overflow-hidden bg-[var(--brand-cream-page)]",
@@ -180,7 +209,7 @@ export default function LoadingScreen({
       role="status"
       aria-live="polite"
       aria-busy="true"
-      aria-label={loadingMoment ? loadingMoment.artifact : `${current}…`}
+      aria-label={hasMoment ? ariaText : `${ariaText}…`}
     >
       <svg
         className="absolute inset-0 h-full w-full"
@@ -225,27 +254,33 @@ export default function LoadingScreen({
           className="mx-auto mt-4 h-0.5 w-[60px] rounded-full bg-[var(--accent-gold)]"
           aria-hidden="true"
         />
-        {loadingMoment ? (
-          // The Loading Moment, in the existing copy slot. System-voice label
-          // (Josefin Sans, small-caps) above the Editorial artifact (Cormorant
-          // serif). Replaces the rotating phrase; same slot, same position. The
-          // plain state below is untouched, so a no-card load looks identical.
-          //
-          // The slot is a FIXED height (h-24), sized to the tallest (3-line)
-          // artifact, with the label + artifact centered within it. Every card
-          // type therefore renders at the same height, so the card does not
-          // resize as cards rotate (B-LOADING-MOMENT-01, owner-approved bounded
-          // growth: the card is taller than the plain state, but uniform across
-          // moments and still a centered overlay — nothing on the page shifts).
-          // `line-clamp-3` is a guard so an unusually long stem can never spill
-          // past the fixed slot.
+        {hasMoment ? (
+          // The copy slot holds either an insight card (System label + Editorial
+          // artifact) or, when interleaved, a craft phrase between cards. It is a
+          // FIXED height (h-24), sized to the tallest (3-line) artifact, with the
+          // content centered — so the loader never resizes as items rotate
+          // (B-LOADING-MOMENT-01, owner-approved bounded growth; centered overlay
+          // ⇒ nothing on the page shifts). `line-clamp-3` guards an overlong stem.
           <div className="relative mx-auto mt-4 flex h-24 max-w-[17rem] flex-col items-center justify-center text-center">
-            <p className="font-sans text-[11px] font-medium tracking-[0.16em] uppercase text-[var(--warm-ink)]/60">
-              {loadingMoment.label}
-            </p>
-            <p className="mt-1.5 line-clamp-3 font-serif text-lg leading-snug text-[var(--brand-ink-950)]">
-              {loadingMoment.artifact}
-            </p>
+            <div
+              key={index}
+              className={`flex flex-col items-center justify-center ${rotating ? "loading-message" : ""}`}
+            >
+              {currentItem.kind === "moment" ? (
+                <>
+                  <p className="font-sans text-[11px] font-medium tracking-[0.16em] uppercase text-[var(--warm-ink)]/60">
+                    {currentItem.moment.label}
+                  </p>
+                  <p className="mt-1.5 line-clamp-3 font-serif text-lg leading-snug text-[var(--brand-ink-950)]">
+                    {currentItem.moment.artifact}
+                  </p>
+                </>
+              ) : (
+                <p className="font-sans text-sm font-normal tracking-wider uppercase text-[var(--warm-ink)]/75">
+                  {currentItem.text}
+                </p>
+              )}
+            </div>
           </div>
         ) : (
         <p className="relative mx-auto mt-4 flex h-6 items-baseline justify-center font-sans text-sm font-normal tracking-wider uppercase text-[var(--warm-ink)]/75">
@@ -254,11 +289,11 @@ export default function LoadingScreen({
               key={index}
               className="loading-message inline-flex items-baseline gap-1"
             >
-              {current}
+              {currentItem.kind === "message" ? currentItem.text : ""}
             </span>
           ) : (
             <span className="inline-flex items-baseline gap-1">
-              <span>{current}</span>
+              <span>{currentItem.kind === "message" ? currentItem.text : ""}</span>
               <span className="ml-0.5 inline-flex gap-0.5" aria-hidden="true">
                 <span
                   className="triangle-loader-dot inline-block"

--- a/src/components/loading-moment/selectLoadingMoment.ts
+++ b/src/components/loading-moment/selectLoadingMoment.ts
@@ -94,7 +94,7 @@ const BUILDERS: Record<
       ? {
           kind: "waiting-discovery",
           label: LABEL.FROM_YOUR_FRIENDS,
-          artifact: `${p.waitingDiscovery!.friendName.trim()} just added a question about ${p.waitingDiscovery!.subcategory.trim()} — only you'd get it.`,
+          artifact: `${p.waitingDiscovery!.friendName.trim()} just added a new question in ${p.waitingDiscovery!.subcategory.trim()}.`,
         }
       : null,
 };

--- a/src/components/loading-moment/useLoadingMoment.ts
+++ b/src/components/loading-moment/useLoadingMoment.ts
@@ -7,40 +7,36 @@ import { resolveLoadingMomentWithRotation } from "./rotation";
 import type { ResolvedLoadingMoment } from "./types";
 
 /**
- * The minimum wait before a Loading Moment is allowed to appear (C-7): short
- * waits never earn a moment. Session generation routinely runs longer than
- * this, so a real generation wait surfaces a card while a fast one stays plain.
- */
-export const LOADING_MOMENT_MIN_WAIT_MS = 900;
-
-/**
- * Resolve a Loading Moment for an active long wait, reading cached-only data.
+ * Resolve the Loading Moments to interleave into an active long wait, reading
+ * cached-only data.
  *
- * Returns null until the wait has lasted `LOADING_MOMENT_MIN_WAIT_MS` (so a
- * short wait never flashes a card), then resolves exactly one moment from the
- * cached payload + client-session rotation. Reading the cache is synchronous —
- * no fetch on the loading path (C-1). A cold/stale cache resolves to null, and
- * the plain loading state renders unchanged (C-3).
+ * Returns an array (empty until resolved) suitable for `LoadingScreen`'s
+ * `loadingMoments` interleave. Reading the cache is synchronous — no fetch on
+ * the loading path (C-1). A cold/stale cache resolves to an empty array, so the
+ * loader just rotates the plain craft phrases (C-3). The interleave is
+ * craft-first, so a wait shorter than one rotation cycle never reaches a card
+ * (long-waits-only, C-7) — no extra delay needed here.
  *
  * `active` should be true only while a qualifying long wait is in progress
- * (e.g. session generation); pass false on short waits so no moment is gated in.
+ * (e.g. session generation); pass false on short waits.
  */
-export function useLoadingMoment(active: boolean): ResolvedLoadingMoment | null {
-  const [moment, setMoment] = React.useState<ResolvedLoadingMoment | null>(null);
+export function useLoadingMoments(active: boolean): ResolvedLoadingMoment[] {
+  const [moments, setMoments] = React.useState<ResolvedLoadingMoment[]>([]);
 
   React.useEffect(() => {
     if (!active) return;
+    // Resolve just after mount (not in the effect body) so the sequence is built
+    // before the first rotation tick, and the cache read stays off render.
     const id = window.setTimeout(() => {
       const payload = readCachedLoadingMomentPayload();
-      setMoment(resolveLoadingMomentWithRotation(payload));
-    }, LOADING_MOMENT_MIN_WAIT_MS);
-    // Clear the timer and reset on deactivation/unmount, so a finished wait
-    // never leaves a stale card mounted and the next wait re-resolves fresh.
+      const resolved = resolveLoadingMomentWithRotation(payload);
+      setMoments(resolved ? [resolved] : []);
+    }, 0);
     return () => {
       window.clearTimeout(id);
-      setMoment(null);
+      setMoments([]);
     };
   }, [active]);
 
-  return moment;
+  return moments;
 }


### PR DESCRIPTION
Implements `B-LOADING-MOMENT-01` against `D-LOADING-MOMENT-SURFACE-01`: a small, true artifact drawn from the player's own knowledge portrait that fills long loading waits — never a score, never a ranking.

## What's here

**Selector + taxonomy** (`src/components/loading-moment/`)
- Typed set of the six D-doc card kinds, each with a per-card eligibility gate and a cached-only read.
- Pure `selectLoadingMoment` implementing the fallback ladder, the truth gate (never emits a card whose fact is absent/empty/stale), and the sparse / cold-start default (the exact locked string *"Your knowledge map starts filling in as you play."*).
- Client-session anti-repeat rotation (no write on the loading path).

**In-place render** (`LoadingScreen.tsx`)
- Renders a moment in the existing copy slot — System-voice label (Josefin Sans) over the Editorial artifact (Cormorant Garamond).
- Per owner decision, the centered card grows a fixed amount (plain 166px → every moment 238px, uniform) and stays centered, so nothing on the page shifts. Plain state is byte-identical when no moment is shown.
- **Interleave mode**: weaves the insight cards *with* the existing craft phrases ("Reading the room", …) in one rotation at the same cadence (`MESSAGE_CYCLE_MS`), craft-first so a short wait only shows a craft phrase (C-7). One fixed height for all frames → no pulsing.

**Live wiring (C-1-safe)**
- Producer (`src/server/loading-moment/build-payload.ts`) assembles the payload off the critical path from the existing mastery overview; populates **deepest territory** when a domain clears the portrait threshold, leaves the rest deferred (truth gate).
- `/api/loading-moment` (session-gated) is primed once per session from the home page (`LoadingMomentPrimer`, on idle) into a Zod-validated sessionStorage cache.
- The loader reads that cache **synchronously** via `useLoadingMoments` — no fetch/await/query on the loading path (grep-verified). Cold/stale cache → plain state (C-3).

**Admin preview** — a "Preview the loading screen" link in the existing `ADMIN_USER_IDS`-gated Developer-tools section opens `/dev/loading-preview`, a forced cycler over every card type, the sparse fallback, the plain state, and an "interleaved" live-rotation mode (preview 2).

## Constraints honored
- C-1 no fetch on the loading path · C-2 truth gate · C-3 no latency added · C-4 no competition register (banned-word scan) / color-independent labels · C-5 anti-repeat · C-7 long-waits-only.

## Tests
Selector (gates, ladder, sparse, truth gate, banned-word scan, rotation), producer truth gate, preview-states resolution, cycler render, and the gated link. Typecheck + lint clean.

## Notes / deviations
- **Card height**: the in-place card is taller than today's plain card (owner-approved bounded growth; centered overlay ⇒ no page reflow). This consciously supersedes the brief's "zero added height".
- **Interleaving** departs from the D-doc's "one card per load" — owner-directed.
- **Live coverage**: only the deepest-territory card is populated live this pass; cards 2–6 are deferred (no rarity signal; overlap is pairwise-only; the rest need dedicated reads). The selector already tolerates absence, so a later build lights them up by populating the payload.
- The Developer-tools section is currently temp-ungated repo-wide (`DEV_TOOLS_UNGATED`); the link inherits that same gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7M5c3UUZbVfaWnZkESwbR

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7M5c3UUZbVfaWnZkESwbR)_