### PR TITLE
B-LOADING-MOMENT-01 — scope the Loading Moment cache to the session

### DIFF
--- a/src/app/login/LoginPanel.tsx
+++ b/src/app/login/LoginPanel.tsx
@@ -5,6 +5,7 @@ import type { FormEvent } from 'react';
 import Image from 'next/image';
 import { useRouter, useSearchParams } from 'next/navigation';
 
+import { clearCachedLoadingMomentPayload } from '@/components/loading-moment/client-cache';
 import { formatUsPhoneInput } from '@/lib/phone-e164';
 
 const US_E164_REGEX = /^\+1\d{10}$/;
@@ -457,6 +458,11 @@ export default function LoginPanel({
         setLoading(false);
         return;
       }
+
+      // A new session is now established for this tab. Drop any Loading Moment
+      // payload cached by a previous user so it can never leak across accounts
+      // (the loading screen reads the cache without knowing the current user).
+      clearCachedLoadingMomentPayload();
 
       const identity = readVerifiedIdentity(data);
       setVerifiedIdentity(identity);

--- a/src/components/loading-moment/__tests__/client-cache.test.ts
+++ b/src/components/loading-moment/__tests__/client-cache.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  clearCachedLoadingMomentPayload,
+  readCachedLoadingMomentPayload,
+} from "../client-cache";
+
+const STORAGE_KEY = "joshing.loadingMoment.v1";
+
+function fakeStorage() {
+  const map = new Map<string, string>();
+  return {
+    getItem: (k: string) => (map.has(k) ? (map.get(k) as string) : null),
+    setItem: (k: string, v: string) => void map.set(k, v),
+    removeItem: (k: string) => void map.delete(k),
+    has: (k: string) => map.has(k),
+  };
+}
+
+afterEach(() => vi.unstubAllGlobals());
+
+describe("loading-moment client cache", () => {
+  it("reads a stored payload, and clear() removes it (cross-user guard)", () => {
+    const storage = fakeStorage();
+    vi.stubGlobal("window", { sessionStorage: storage });
+    storage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ generatedAt: 123, deepestTerritory: { subcategory: "Italian Renaissance" } }),
+    );
+
+    expect(readCachedLoadingMomentPayload()?.deepestTerritory?.subcategory).toBe(
+      "Italian Renaissance",
+    );
+
+    clearCachedLoadingMomentPayload();
+    expect(storage.has(STORAGE_KEY)).toBe(false);
+    expect(readCachedLoadingMomentPayload()).toBeNull();
+  });
+
+  it("returns null when nothing is cached", () => {
+    vi.stubGlobal("window", { sessionStorage: fakeStorage() });
+    expect(readCachedLoadingMomentPayload()).toBeNull();
+  });
+
+  it("rejects a malformed or mistyped payload", () => {
+    const storage = fakeStorage();
+    vi.stubGlobal("window", { sessionStorage: storage });
+
+    storage.setItem(STORAGE_KEY, "{ not json");
+    expect(readCachedLoadingMomentPayload()).toBeNull();
+
+    storage.setItem(STORAGE_KEY, JSON.stringify({ deepestTerritory: { subcategory: 123 } }));
+    expect(readCachedLoadingMomentPayload()).toBeNull();
+  });
+
+  it("is SSR-safe (no window) — read returns null, clear is a no-op", () => {
+    // No window stubbed → typeof window === "undefined".
+    expect(readCachedLoadingMomentPayload()).toBeNull();
+    expect(() => clearCachedLoadingMomentPayload()).not.toThrow();
+  });
+});

--- a/src/components/loading-moment/client-cache.ts
+++ b/src/components/loading-moment/client-cache.ts
@@ -69,6 +69,23 @@ export async function primeLoadingMomentPayload(): Promise<void> {
   }
 }
 
+/**
+ * Clear the cached payload and reset the prime guard. Call at every auth
+ * boundary (login + logout) so a user can never read a payload cached by a
+ * previous user in the same browser tab — sessionStorage outlives a soft
+ * logout/login, and the loading screen reads the cache without knowing who the
+ * current user is. After this, the next prime re-fetches for the new session.
+ */
+export function clearCachedLoadingMomentPayload(): void {
+  primed = false;
+  if (typeof window === "undefined") return;
+  try {
+    window.sessionStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // sessionStorage may be unavailable — non-fatal.
+  }
+}
+
 /** Test-only: reset the once-per-session prime guard. */
 export function resetLoadingMomentPrimeGuard(): void {
   primed = false;

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -18,6 +18,7 @@ import {
 } from 'lucide-react';
 import { useState } from 'react';
 
+import { clearCachedLoadingMomentPayload } from '@/components/loading-moment/client-cache';
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
 
 /**
@@ -39,6 +40,10 @@ export async function logoutAndRedirect(navigate: (url: string) => void): Promis
   if (!response.ok && response.status !== 401) {
     throw new Error('Could not log out.');
   }
+
+  // Drop any cached Loading Moment payload so the next user in this tab can't
+  // read it (sessionStorage outlives logout; the loader doesn't know the user).
+  clearCachedLoadingMomentPayload();
 
   navigate('/login');
 }


### PR DESCRIPTION
Follow-up to #1230 (merged). Closes the one cross-user edge in the Loading Moment cache.

## Problem
The Loading Moment payload is cached in `sessionStorage`, which outlives a soft logout/login in the same browser tab — and the loading screen reads the cache **without knowing who the current user is**. On a shared tab, a user could briefly read a payload cached by a previous user.

(Note: this only affects the generic *deepest-territory* line — a brand-new user still can't get a personalized insight, because the producer + selector truth gates require real, threshold-passing data.)

## Fix
Clear the cache at both auth boundaries, so a user can never read a prior user's payload before their own prime runs:
- on successful `verify-otp` — the **single** session-creating client path (`LoginPanel`), before the new user can reach any loading screen;
- on logout (`logoutAndRedirect`), for tidiness.

Adds `clearCachedLoadingMomentPayload()` (removes the storage key + resets the prime guard).

## Tests
`client-cache.test.ts` — read/clear round-trip (cross-user guard), empty cache, malformed/mistyped payload rejection, and SSR-safety. Typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7M5c3UUZbVfaWnZkESwbR

---
_Generated by [Claude Code](https://claude.ai/code/session_01B7M5c3UUZbVfaWnZkESwbR)_