### PR TITLE
feat(feed): add "This is incorrect" / "This is inappropriate" to feed card ⋯ menu

### DIFF
--- a/src/app/api/content-reports/route.ts
+++ b/src/app/api/content-reports/route.ts
@@ -30,7 +30,7 @@ const incorrectSchema = z.object({
   incorrectKind: z.enum(['answer_key', 'premise']),
   note: z.string().trim().min(1),
   suggestedAnswer: z.string().trim().min(1).optional(),
-  surface: z.enum(['round_recap', 'lately_result', 'answered_list']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed']),
   ...target,
 });
 
@@ -42,7 +42,7 @@ const inappropriateSchema = z.object({
   incorrectKind: z.undefined().optional(),
   suggestedAnswer: z.undefined().optional(),
   note: z.string().trim().min(1),
-  surface: z.enum(['round_recap', 'lately_result', 'answered_list']),
+  surface: z.enum(['round_recap', 'lately_result', 'answered_list', 'feed']),
   ...target,
 });
 

--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -31,6 +31,7 @@ import { ActivityStreamItem } from '@/components/activity/ActivityStreamItem'
 import { PersonActivityCard } from '@/components/activity/PersonActivityCard'
 import { groupActivityByFriend, type GroupInputRow, type GroupedRow } from '@/components/feed/person-grouping'
 import { EditorialFeature } from '@/components/feed/EditorialFeature'
+import { ReportReasonSheet } from '@/components/report/ReportReasonSheet'
 import {
   CommonGroundFeature,
   GrowYourCircleFeature,
@@ -973,6 +974,12 @@ function FeedListContent({
     Record<string, 'removed' | 'restored'>
   >({})
   const thumbsdownTimersRef = useRef<Record<string, number>>({})
+  // PRD-D-6 §6.1 — the open content-report sheet ("This is incorrect" /
+  // "This is inappropriate") launched from a feed card's ⋯ menu. One at a time.
+  const [reportSheet, setReportSheet] = useState<{
+    item: FeedApiItem
+    category: 'incorrect' | 'inappropriate'
+  } | null>(null)
   // B-Feed-Swipe-1 — left-swipe / Dismiss collapse a card to an inline bar.
   // View-state only and session-scoped: 'collapsing' plays the exit animation,
   // 'dismissed' shows the bar. Never persisted; never mutes.
@@ -1863,7 +1870,10 @@ function FeedListContent({
         disabled={isBusy}
         onHideCategory={() => void hideCategory(item)}
         onHidePerson={() => void hidePerson(item)}
-        onReport={() => void reportItem(item)}
+        onReportIncorrect={() => setReportSheet({ item, category: 'incorrect' })}
+        onReportInappropriate={() =>
+          setReportSheet({ item, category: 'inappropriate' })
+        }
       />
     )
 
@@ -2289,6 +2299,21 @@ function FeedListContent({
           />
         )
       })() : null}
+      {reportSheet && reportSheet.item.question_id ? (
+        <ReportReasonSheet
+          category={reportSheet.category}
+          target={{ questionId: reportSheet.item.question_id }}
+          surface="feed"
+          onClose={() => setReportSheet(null)}
+          onSubmitted={(category) => {
+            // Incorrect leaves the card in place (the sheet shows its own quiet
+            // ack). Inappropriate hides it from this player immediately and
+            // suppresses propagation — reusing the existing self-hide path so the
+            // PRD §6.2 suppression behavior stays wired (§6.6) until B-Report-3.
+            if (category === 'inappropriate') void reportItem(reportSheet.item)
+          }}
+        />
+      ) : null}
     </>
   )
 }

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Flag, MoreHorizontal, X } from 'lucide-react'
+import { MoreHorizontal, X } from 'lucide-react'
 import {
   type KeyboardEvent,
   type ReactNode,
@@ -28,7 +28,10 @@ export type FeedOverflowMenuProps = {
   disabled?: boolean
   onHideCategory?: () => void
   onHidePerson?: () => void
-  onReport?: () => void
+  // PRD-D-6 §6.6: the two problem-named items replace the old generic "Report".
+  // Both require a question target, so they only render when `question` is set.
+  onReportIncorrect?: () => void
+  onReportInappropriate?: () => void
   children?: ReactNode
 }
 
@@ -49,7 +52,9 @@ export function getFeedOverflowMenuLabels({
     `Hide questions from ${sourceName || 'this person'}`,
     ...(hasQuestion && !isInBank ? ['Add to bank'] : []),
     ...(hasQuestion ? ['Send to friend'] : []),
-    'Report',
+    // The content-report items target a question, so they only appear when one
+    // is present — same gate as Add to bank / Send to friend.
+    ...(hasQuestion ? ['This is incorrect', 'This is inappropriate'] : []),
   ]
 }
 
@@ -83,7 +88,8 @@ export function FeedOverflowMenu({
   disabled = false,
   onHideCategory,
   onHidePerson,
-  onReport,
+  onReportIncorrect,
+  onReportInappropriate,
   children,
 }: FeedOverflowMenuProps) {
   const [open, setOpen] = useState(false)
@@ -193,16 +199,28 @@ export function FeedOverflowMenu({
                 className="text-foreground hover:bg-muted flex min-h-10 w-full items-center rounded-xl px-3 text-left text-sm transition"
               />
             ) : null}
-            <button
-              type="button"
-              role="menuitem"
-              disabled={disabled}
-              onClick={wrapAction(onReport)}
-              className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-10 w-full items-center gap-2 rounded-xl px-3 text-left text-sm transition disabled:opacity-50"
-            >
-              <Flag className="size-4" />
-              Report
-            </button>
+            {question ? (
+              <>
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={disabled}
+                  onClick={wrapAction(onReportIncorrect)}
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-10 w-full items-center rounded-xl px-3 text-left text-sm transition disabled:opacity-50"
+                >
+                  This is incorrect
+                </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  disabled={disabled}
+                  onClick={wrapAction(onReportInappropriate)}
+                  className="text-muted-foreground hover:bg-muted hover:text-foreground flex min-h-10 w-full items-center rounded-xl px-3 text-left text-sm transition disabled:opacity-50"
+                >
+                  This is inappropriate
+                </button>
+              </>
+            ) : null}
             {children}
           </div>
         </div>

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -594,7 +594,8 @@ describe('Feed card category and overflow affordances', () => {
       'Hide questions about Literature',
       'Hide questions from Maya',
       'Send to friend',
-      'Report',
+      'This is incorrect',
+      'This is inappropriate',
     ])
   })
 

--- a/src/components/report/ReportReasonSheet.tsx
+++ b/src/components/report/ReportReasonSheet.tsx
@@ -28,7 +28,7 @@ export function ReportReasonSheet({
 }: {
   category: ReportCategory
   target: ReportReasonTarget
-  surface: 'round_recap' | 'lately_result' | 'answered_list'
+  surface: 'round_recap' | 'lately_result' | 'answered_list' | 'feed'
   onClose: () => void
   // Fires once on a successful submit (including an idempotent duplicate). For
   // 'inappropriate' the parent removes the card from view; for 'incorrect' the card


### PR DESCRIPTION
The content-reporting items previously appeared only on post-reveal surfaces
(Round Recap, Answered list, Lately result). Feed cards — questions a friend
created or sent — had only the vestigial generic "Report" (thumbs-down
self-mute) item.

A question can be internally inconsistent or rest on a false premise
independent of its answer (PRD-D-6's incorrectKind already distinguishes
`premise` from `answer_key`), so both report items are judgeable pre-reveal and
belong on the feed card. Per PRD-D-6 §6.6 the two problem-named items *replace*
the generic "Report" rather than sit alongside it.

- Add a `feed` surface to the content-report API schema and ReportReasonSheet.
- Swap FeedOverflowMenu's "Report" for "This is incorrect" / "This is
  inappropriate" (gated on a question target, like Add to bank / Send to friend).
- Wire both to the shared ReportReasonSheet → /api/content-reports. Inappropriate
  reuses the existing self-hide/suppress path so the card vanishes immediately
  with undo, keeping §6.2 suppression wired until B-Report-3.

No migration: `surface` is free-text in the DB; the enum lives only in Zod.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01QNT9RPuPV5srDSsMFvZV5x