### PR TITLE
fix(friends): gate feed/question visibility on mutual friendship, not one-way follow

### DIFF
--- a/src/server/db/queries/__tests__/question-visibility.test.ts
+++ b/src/server/db/queries/__tests__/question-visibility.test.ts
@@ -25,6 +25,12 @@ vi.mock('drizzle-orm', () => ({
   notInArray: vi.fn((column, values) => ({ op: 'notInArray', column, values })),
 }));
 
+// The mutual-friendship gate aliases the Follow table (one alias per direction).
+// Identity alias is enough for the structural assertions here.
+vi.mock('drizzle-orm/pg-core', () => ({
+  alias: vi.fn((table) => table),
+}));
+
 function makeChain(rows: unknown[] = []) {
   const chain: Record<string, unknown> = {};
   for (const method of ['select', 'from', 'innerJoin', 'where', 'orderBy', 'limit']) {
@@ -82,8 +88,8 @@ describe('feedItemVisibilityPredicate (direct_sent exemption)', () => {
   });
 });
 
-describe('questionVisibilityPredicate (D-1 Stage 4)', () => {
-  it('admits public questions unconditionally and gates friends on an approved viewer→author follow', () => {
+describe('questionVisibilityPredicate (Phase 1: friend = mutual)', () => {
+  it('admits public questions unconditionally and gates friends on a MUTUAL approved follow (both directions)', () => {
     const predicate = questionVisibilityPredicate('viewer-1') as { op: string; parts: unknown[] };
 
     expect(predicate.op).toBe('or');
@@ -91,7 +97,7 @@ describe('questionVisibilityPredicate (D-1 Stage 4)', () => {
     // Branch 1: public is always visible.
     expect(predicate.parts).toContainEqual({ op: 'eq', column: 'questions.visibility', value: 'public' });
 
-    // Branch 2: friends-visible AND an EXISTS over an approved follow edge.
+    // Branch 2: friends-visible AND a mutual-friendship gate.
     const friendsBranch = predicate.parts.find(
       (p): p is { op: string; parts: unknown[] } =>
         typeof p === 'object' && p !== null && (p as { op?: string }).op === 'and',
@@ -99,10 +105,18 @@ describe('questionVisibilityPredicate (D-1 Stage 4)', () => {
     expect(friendsBranch).toBeDefined();
     expect(friendsBranch!.parts).toContainEqual({ op: 'eq', column: 'questions.visibility', value: 'friends' });
 
-    const existsClause = friendsBranch!.parts.find(
+    // The mutual gate is a nested AND of TWO approved-follow EXISTS clauses — one
+    // per direction. A single one-directional EXISTS (the old behavior) would
+    // leak a non-friend's 'friends'-visibility question and is caught here.
+    const mutualGate = friendsBranch!.parts.find(
+      (p): p is { op: string; parts: unknown[] } =>
+        typeof p === 'object' && p !== null && (p as { op?: string }).op === 'and',
+    );
+    expect(mutualGate).toBeDefined();
+    const existsClauses = mutualGate!.parts.filter(
       (p): p is { op: string } => typeof p === 'object' && p !== null && (p as { op?: string }).op === 'exists',
     );
-    expect(existsClause).toBeDefined();
+    expect(existsClauses).toHaveLength(2);
   });
 
   it('never admits private to another viewer (no private branch)', () => {

--- a/src/server/db/queries/feed.ts
+++ b/src/server/db/queries/feed.ts
@@ -1,6 +1,7 @@
-import { and, count, desc, eq, exists, inArray, isNull, lt, ne, notExists, notInArray, or, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, lt, ne, notExists, notInArray, or, sql } from 'drizzle-orm';
 
-import { db, feedDismissedDomains, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
+import { db, feedDismissedDomains, feedItems, masteryEvents, questions, users } from '@/server/db';
+import { mutualFollowApproved } from '@/server/db/queries/follow-visibility';
 import { ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES, notBlocked, visibleFeedSourcePredicate } from '@/server/feed/visibility';
 import { pgErrorCode, pgErrorMessage } from '@/server/db/pg-error';
 
@@ -256,11 +257,11 @@ function feedCursorPredicate(cursor: FeedCursor | null | undefined) {
 }
 
 // Render-time question visibility (D-1 Stage 4). 'public' renders for anyone;
-// 'friends' is followers-only and renders only when the viewer follows the
-// author (an approved follow edge viewer -> author); 'private' is author-only
-// and never reaches another viewer's feed (the author is also excluded by
-// viewerNotAuthorPredicate). Under the directional follow model, "the author's
-// followers" == users with an approved follow edge pointing at the author.
+// 'friends' is friends-only and renders only when the viewer and the author are
+// MUTUAL friends (an approved follow edge in BOTH directions); 'private' is
+// author-only and never reaches another viewer's feed (the author is also
+// excluded by viewerNotAuthorPredicate). Phase 1: "friend" is bidirectional, so
+// a one-directional follow does NOT unlock a 'friends'-visibility question.
 // Exported so the empty-state diagnostic counts in get-feed-page.ts apply the
 // identical rule and stay in sync with what actually renders.
 export function questionVisibilityPredicate(viewerUserId: string) {
@@ -268,16 +269,7 @@ export function questionVisibilityPredicate(viewerUserId: string) {
     eq(questions.visibility, 'public'),
     and(
       eq(questions.visibility, 'friends'),
-      exists(
-        db
-          .select({ one: sql`1` })
-          .from(follows)
-          .where(and(
-            eq(follows.followerId, viewerUserId),
-            eq(follows.followeeId, questions.creatorId),
-            eq(follows.state, 'approved'),
-          )),
-      ),
+      mutualFollowApproved(viewerUserId, questions.creatorId, 'question_visibility'),
     ),
   )!;
 }

--- a/src/server/db/queries/follow-visibility.ts
+++ b/src/server/db/queries/follow-visibility.ts
@@ -1,0 +1,55 @@
+import { and, eq, exists, sql } from 'drizzle-orm';
+import { alias, type AnyPgColumn } from 'drizzle-orm/pg-core';
+
+import { db, follows } from '@/server/db';
+
+// Phase 1 relationship model: "friend" means a MUTUAL (bidirectional) follow —
+// an approved Follow edge in BOTH directions. Visibility of a user's content
+// (From-Friends feed, friend-answered milestones, friends-only questions) is
+// gated on friendship, NOT on a single one-directional approved edge.
+//
+// The directional Follow table is intentionally RETAINED (a future phase
+// re-introduces asymmetric following); these helpers are the seam. When
+// following returns, relax the visibility gate from `mutualFollowApproved` back
+// to a single `approvedFollowExists` at the call sites that should allow it.
+
+/**
+ * SQL predicate: an approved Follow edge `follower -> followee` exists. Either
+ * argument may be a literal user id or a column reference (so it correlates to
+ * the outer query). `aliasName` must be unique within the query.
+ */
+export function approvedFollowExists(
+  followerId: AnyPgColumn | string,
+  followeeId: AnyPgColumn | string,
+  aliasName: string,
+) {
+  const edge = alias(follows, aliasName);
+  return exists(
+    db
+      .select({ one: sql`1` })
+      .from(edge)
+      .where(
+        and(
+          eq(edge.followerId, followerId),
+          eq(edge.followeeId, followeeId),
+          eq(edge.state, 'approved'),
+        ),
+      ),
+  );
+}
+
+/**
+ * SQL predicate: `viewerId` and the user in `otherUserColumn` are MUTUAL friends
+ * — an approved Follow edge exists in BOTH directions. `aliasPrefix` must be
+ * unique within the query (two follow aliases are derived from it).
+ */
+export function mutualFollowApproved(
+  viewerId: string,
+  otherUserColumn: AnyPgColumn,
+  aliasPrefix: string,
+) {
+  return and(
+    approvedFollowExists(viewerId, otherUserColumn, `${aliasPrefix}_fwd`),
+    approvedFollowExists(otherUserColumn, viewerId, `${aliasPrefix}_rev`),
+  );
+}

--- a/src/server/db/queries/lately.ts
+++ b/src/server/db/queries/lately.ts
@@ -25,6 +25,7 @@ import {
   type TrustTier,
 } from '@/server/daily/verification-gating';
 import { db, feedItems, follows, masteryEvents, questions, users } from '@/server/db';
+import { approvedFollowExists } from '@/server/db/queries/follow-visibility';
 import { ALWAYS_VISIBLE_MAIN_FEED_SOURCE_TYPES, SOCIAL_FEED_SOURCE_TYPE, notBlockedForViewer } from '@/server/feed/visibility';
 
 export type LatelyDirection = 'they_got_you' | 'you_got_them';
@@ -206,8 +207,9 @@ export async function getLatelyMilestones(
       answeredAt: feedItems.sourceEventAt,
     })
     .from(feedItems)
-    // sourceUserId ∈ {people I follow}: inner-join the approved follow edge so a
-    // friend_answered row from someone I don't follow is dropped at the DB.
+    // sourceUserId ∈ {my friends}: inner-join the forward approved follow edge
+    // (viewer -> friend); the reverse edge is required in WHERE so a milestone
+    // only surfaces for a MUTUAL friend, never a one-directional follow.
     .innerJoin(
       follows,
       and(
@@ -225,6 +227,8 @@ export async function getLatelyMilestones(
         eq(feedItems.sourceResult, 'correct'),
         isNotNull(feedItems.questionId),
         gte(feedItems.sourceEventAt, windowStart),
+        // Reverse half of the mutual-friendship gate (friend -> viewer approved).
+        approvedFollowExists(feedItems.sourceUserId, userId, 'milestone_mutual'),
         // Safety hard-block: blocked questions never anchor a milestone (the
         // owner exception is moot here — viewer-authored is excluded below).
         notBlockedForViewer(userId),
@@ -368,6 +372,9 @@ export async function getFriendActivity(
       viaName: viaUser.displayName,
     })
     .from(feedItems)
+    // Forward half of the friendship check: viewer -> friend approved. The
+    // reverse half (friend -> viewer) is enforced in WHERE so a one-directional
+    // approved edge can't leak a non-friend's activity (Phase 1: friend = mutual).
     .innerJoin(
       follows,
       and(
@@ -386,6 +393,10 @@ export async function getFriendActivity(
         eq(feedItems.sourceResult, 'correct'),
         isNotNull(feedItems.questionId),
         gte(feedItems.sourceEventAt, windowStart),
+        // Reverse half of the mutual-friendship gate: the friend must follow the
+        // viewer back. Together with the forward join above this requires an
+        // approved edge in BOTH directions.
+        approvedFollowExists(feedItems.sourceUserId, userId, 'from_friends_mutual'),
         // Safety hard-block: a blocked question must not resurface in the
         // From-Friends log, except to its own author (a friend answering the
         // viewer's own question lands here as a spent card) — the owner exception.

--- a/src/server/feed/create-feed-items-for-answer.ts
+++ b/src/server/feed/create-feed-items-for-answer.ts
@@ -3,7 +3,7 @@ import { and, eq, inArray, isNotNull, isNull } from 'drizzle-orm';
 import { db, feedDismissedDomains, feedItems, masteryEvents, questionFeedback, questionRatings, questions } from '@/server/db';
 import { writeActivity } from '@/server/activity/write-activity';
 import { getNicheMatchDiscoverable } from '@/server/db/queries/account';
-import { getFollowers } from '@/server/db/queries/friends';
+import { getFriends } from '@/server/db/queries/friends';
 import { getRelationship } from '@/server/db/queries/friend-requests';
 import { rollOffOldItems } from '@/server/db/queries/feed';
 import { isQuestionReportSuppressed } from '@/server/db/queries/content-reports';
@@ -101,9 +101,10 @@ async function _createFeedItemsForFriendsFromAnswer(
   // failure can't abort the friend fan-out that follows.
   await notifyNicheMatch(userId, questionId, question.creatorId, sourceAnswerId);
 
-  // friend_answered fan-out reaches my followers — people who follow me see
-  // that I answered correctly (directional follow model, D-1 Stage 3).
-  const friends = await getFollowers(userId);
+  // friend_answered fan-out reaches my MUTUAL friends — people I'm bidirectionally
+  // friends with see that I answered correctly. Phase 1 has no asymmetric
+  // following, so a one-directional follower is not an audience for this.
+  const friends = await getFriends(userId);
   if (friends.length === 0) {
     await notifyPreviousAnswerers(userId, questionId);
     return;

--- a/src/server/friends/__tests__/friendships.test.ts
+++ b/src/server/friends/__tests__/friendships.test.ts
@@ -6,14 +6,14 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 //  2. accept: approving a request makes the two MUTUAL friends — it upserts the
 //     accepter's follow-back edge, writes BOTH connection cards (follow_approved
 //     to the requester, follow_mutual to the accepter), and seeds BOTH feeds with
-//     each other's answers AND authored questions. Getting the direction wrong
-//     would seed the wrong person, so it is the highest-value thing to pin.
+//     each other's recent correct ANSWERS (only — authored questions are NOT
+//     backfilled). Getting the direction wrong would seed the wrong person, so it
+//     is the highest-value thing to pin.
 
-const { dbMock, state, writeActivityMock, softDeleteActivityMock, answerBackfillMock, authoredBackfillMock } = vi.hoisted(() => {
+const { dbMock, state, writeActivityMock, softDeleteActivityMock, answerBackfillMock } = vi.hoisted(() => {
   const writeActivityMock = vi.fn(async () => undefined)
   const softDeleteActivityMock = vi.fn(async () => undefined)
   const answerBackfillMock = vi.fn(async () => ({ created: 0 }))
-  const authoredBackfillMock = vi.fn(async () => ({ created: 0 }))
   const state = {
     // The row returned by createOrReusePendingFriendshipRequest's pre-check
     // select (an existing edge) and the inserted/updated edge.
@@ -58,7 +58,7 @@ const { dbMock, state, writeActivityMock, softDeleteActivityMock, answerBackfill
     })),
   }
 
-  return { dbMock, state, writeActivityMock, softDeleteActivityMock, answerBackfillMock, authoredBackfillMock }
+  return { dbMock, state, writeActivityMock, softDeleteActivityMock, answerBackfillMock }
 })
 
 vi.mock('@/server/db', () => ({
@@ -74,7 +74,6 @@ vi.mock('@/server/activity/write-activity', () => ({
 
 vi.mock('@/server/feed/backfill-inviter-feed', () => ({
   backfillFollowedUserFeedItems: answerBackfillMock,
-  backfillAuthoredQuestionsFeedItems: authoredBackfillMock,
 }))
 
 import {
@@ -99,36 +98,34 @@ beforeEach(() => {
   writeActivityMock.mockClear()
   softDeleteActivityMock.mockClear()
   answerBackfillMock.mockClear()
-  authoredBackfillMock.mockClear()
 })
 
 describe('createOrReusePendingFriendshipRequest', () => {
-  it('forms a MUTUAL friendship when the target is public (both edges, both cards, both feeds)', async () => {
-    // No existing edge, public target -> auto-approved + follow-back.
+  it('requires an explicit accept even when the target is public (Phase 1: no auto-approve)', async () => {
+    // Phase 1 (friend = bidirectional, no asymmetric following): the public
+    // auto-approve path is gated off, so a public target lands PENDING like any
+    // other request — no mutual edge, no connection cards, no backfill until the
+    // target accepts.
     dbMock._selectQueue.push([], [{ followPrivacy: 'public' }])
-    state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'approved' }
+    state.returnedEdge = { id: 'edge-1', followerId: FOLLOWER, followeeId: FOLLOWEE, state: 'pending' }
 
     const result = await createOrReusePendingFriendshipRequest({
       inviterUserId: FOLLOWER,
       inviteeUserId: FOLLOWEE,
     })
 
-    expect(result.state).toBe('auto_approved')
-    // Forward edge insert + the mutual follow-back edge upsert.
-    expect(dbMock.insert).toHaveBeenCalledTimes(2)
-    // Both connection cards: the target learns they were added; the requester
-    // gets the "now connected" card.
+    expect(result.state).toBe('created')
+    // Only the pending forward edge — no mutual follow-back upsert.
+    expect(dbMock.insert).toHaveBeenCalledTimes(1)
+    // The target gets a request to approve; nobody gets a "now connected" card.
     expect(writeActivityMock).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: FOLLOWEE, type: 'follow', actorUserId: FOLLOWER }),
+      expect.objectContaining({ userId: FOLLOWEE, type: 'follow_request', actorUserId: FOLLOWER }),
     )
-    expect(writeActivityMock).toHaveBeenCalledWith(
-      expect.objectContaining({ userId: FOLLOWER, type: 'follow_mutual', actorUserId: FOLLOWEE }),
+    expect(writeActivityMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'follow_mutual' }),
     )
-    // Both feeds seeded, both content types.
-    expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWER, recipientUserId: FOLLOWEE })
-    expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWEE, recipientUserId: FOLLOWER })
-    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWER, recipientUserId: FOLLOWEE })
-    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWEE, recipientUserId: FOLLOWER })
+    // No feeds seeded until acceptance.
+    expect(answerBackfillMock).not.toHaveBeenCalled()
   })
 
   it('lands pending with NO mutual edge or backfill when the target requires approval', async () => {
@@ -146,7 +143,6 @@ describe('createOrReusePendingFriendshipRequest', () => {
       expect.objectContaining({ userId: FOLLOWEE, type: 'follow_request', actorUserId: FOLLOWER }),
     )
     expect(answerBackfillMock).not.toHaveBeenCalled()
-    expect(authoredBackfillMock).not.toHaveBeenCalled()
   })
 
   it('does NOT re-form or backfill when an approved edge already exists (already_following)', async () => {
@@ -160,7 +156,6 @@ describe('createOrReusePendingFriendshipRequest', () => {
     expect(result.state).toBe('already_following')
     expect(dbMock.insert).not.toHaveBeenCalled()
     expect(answerBackfillMock).not.toHaveBeenCalled()
-    expect(authoredBackfillMock).not.toHaveBeenCalled()
   })
 })
 
@@ -185,13 +180,10 @@ describe('acceptPendingFriendshipRequest', () => {
       expect.objectContaining({ userId: FOLLOWEE, type: 'follow_mutual', actorUserId: FOLLOWER }),
     )
 
-    // Answer backfill BOTH directions.
+    // Answer backfill BOTH directions (the only backfill — authored questions
+    // are intentionally NOT seeded).
     expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWEE, recipientUserId: FOLLOWER })
     expect(answerBackfillMock).toHaveBeenCalledWith({ answererUserId: FOLLOWER, recipientUserId: FOLLOWEE })
-
-    // Authored-question backfill BOTH directions.
-    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWEE, recipientUserId: FOLLOWER })
-    expect(authoredBackfillMock).toHaveBeenCalledWith({ authorUserId: FOLLOWER, recipientUserId: FOLLOWEE })
 
     // The now-resolved "wants to be friends" row is cleared at the source.
     expect(softDeleteActivityMock).toHaveBeenCalledWith(
@@ -208,7 +200,6 @@ describe('acceptPendingFriendshipRequest', () => {
     expect(dbMock.insert).not.toHaveBeenCalled()
     expect(writeActivityMock).not.toHaveBeenCalled()
     expect(answerBackfillMock).not.toHaveBeenCalled()
-    expect(authoredBackfillMock).not.toHaveBeenCalled()
   })
 })
 

--- a/src/server/friends/friendships.ts
+++ b/src/server/friends/friendships.ts
@@ -2,10 +2,7 @@ import { and, eq } from 'drizzle-orm'
 
 import { softDeleteActivityByReference, writeActivity } from '@/server/activity/write-activity'
 import { db, follows, users } from '@/server/db'
-import {
-  backfillAuthoredQuestionsFeedItems,
-  backfillFollowedUserFeedItems,
-} from '@/server/feed/backfill-inviter-feed'
+import { backfillFollowedUserFeedItems } from '@/server/feed/backfill-inviter-feed'
 
 export type Follow = typeof follows.$inferSelect
 
@@ -51,16 +48,19 @@ async function ensureApprovedFollowEdge(followerId: string, followeeId: string, 
     })
 }
 
-// Seed BOTH friends' feeds with each other's recent correct answers AND public
-// authored questions — what would have propagated had the mutual edge existed
-// when they answered/authored. Each call is best-effort internally and cannot
-// throw, so none can affect the friendship write.
+// Seed BOTH friends' feeds with each other's recent CORRECT ANSWERS — what would
+// have propagated to the From-Friends band had the mutual edge existed when they
+// answered. We deliberately do NOT backfill each other's authored questions:
+// From Friends is an answered-questions surface (it never shows an "author card"),
+// and dumping a new friend's back catalogue into the main "For You" feed (where
+// `authored_shared` rows render) was an unwanted flood. A friend's authored
+// questions still reach you the intended ways — they deliberately "share with all
+// friends" at creation, or another mutual friend answers one. Each call is
+// best-effort internally and cannot throw, so it can't affect the friendship write.
 async function backfillMutualFeeds(userAId: string, userBId: string): Promise<void> {
   await Promise.all([
     backfillFollowedUserFeedItems({ answererUserId: userAId, recipientUserId: userBId }),
     backfillFollowedUserFeedItems({ answererUserId: userBId, recipientUserId: userAId }),
-    backfillAuthoredQuestionsFeedItems({ authorUserId: userAId, recipientUserId: userBId }),
-    backfillAuthoredQuestionsFeedItems({ authorUserId: userBId, recipientUserId: userAId }),
   ])
 }
 
@@ -129,7 +129,12 @@ export async function createOrReusePendingFriendshipRequest({
     .from(users)
     .where(eq(users.id, followeeId))
     .limit(1)
-  const autoApprove = target?.followPrivacy === 'public'
+  // Phase 1 (friend = bidirectional, no asymmetric following): every friend
+  // request requires an explicit accept. The public-account auto-approve path
+  // below is RETAINED but gated off behind this flag until following returns —
+  // flip the flag back on at that point. Product decision 2026-06-26.
+  const ALLOW_PUBLIC_AUTO_APPROVE: boolean = false
+  const autoApprove = ALLOW_PUBLIC_AUTO_APPROVE && target?.followPrivacy === 'public'
 
   const [edge] = await db
     .insert(follows)
@@ -308,9 +313,11 @@ export async function cancelPendingFriendshipRequest({
 }
 
 /**
- * Unfollow: delete the viewer's outbound follow edge. This is directional — it
- * only removes my follow of them; their follow of me (if any) is untouched.
- * `friendshipId` is my outbound edge id.
+ * Unfriend: delete BOTH directional follow edges between the viewer and the
+ * other user. Phase 1 "friend = bidirectional", so removing a friend fully
+ * severs the relationship rather than leaving the other side as a one-way
+ * follower. `friendshipId` is my outbound edge id; the reverse edge is resolved
+ * from it. (When asymmetric following returns, this becomes a one-edge delete.)
  */
 export async function removeFriendship({
   friendshipId,
@@ -324,7 +331,15 @@ export async function removeFriendship({
     .where(and(eq(follows.id, friendshipId), eq(follows.followerId, userId)))
     .returning()
 
-  return edge ?? null
+  if (!edge) return null
+
+  // Sever the reverse edge (other -> viewer) so neither side retains a dangling
+  // one-directional follow.
+  await db
+    .delete(follows)
+    .where(and(eq(follows.followerId, edge.followeeId), eq(follows.followeeId, userId)))
+
+  return edge
 }
 
 /**


### PR DESCRIPTION
## Why

Phase 1 relationship model: **\"friend\" means a MUTUAL (bidirectional) follow.** The directional `Follow` table is retained for a future asymmetric-following phase, but no visibility surface should treat a one-directional approved edge as friendship.

Two bugs, same root cause (content gated on a one-way `Follow` edge):

1. **Seeing a non-friend's content** — viewer follows Craig (approved) while Craig's reverse request is still *pending*; Craig isn't a mutual friend, yet his activity showed in the viewer's **From Friends** feed.
2. **\"For You\" flood** — friending someone ran a backfill that dumped their past *authored* questions into the main **For You** feed as `authored_shared` rows.

## Changes

- **New helpers** `approvedFollowExists` / `mutualFollowApproved` (`src/server/db/queries/follow-visibility.ts`) — the single seam to relax when asymmetric following returns.
- **Visibility gated on mutual friendship:**
  - From Friends feed + \"friend answered\" milestones (`lately.ts`)
  - Friends-only questions — `questionVisibilityPredicate` (`feed.ts`)
  - Answer fan-out — `create-feed-items-for-answer.ts` now uses `getFriends` (mutual) instead of `getFollowers` (one-way)
- **Symmetric unfriend** — `removeFriendship` deletes both edges.
- **No public auto-approve** — every friend request requires an explicit accept (flag-gated for when following returns).
- **No authored-question backfill on friend-add** — it flooded For You, and From Friends is an answered-questions surface (never shows an author card). Recent *correct answers* are still backfilled; deliberate \"share with all friends\" broadcasts are untouched.

## Test plan

- Updated `friendships.test.ts` and `question-visibility.test.ts` to the new semantics — green.
- Feed / friends / friend-activity suites pass; lint + typecheck clean on touched files.
- (Pre-existing `route.test.ts` failures on a broken `via-answerers` mock are unrelated — confirmed by stashing these changes.)

## Follow-up (not in this PR)

11 historical `authored_shared` rows (`sourceAnswerId LIKE 'authored-backfill:%'`) across 3 users remain from the old backfill. A scoped one-shot `DELETE` can purge them once approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V