### PR TITLE
Fix cross-surface sync for friend requests via derived state

### DIFF
--- a/src/components/home/FriendRequestsSection.tsx
+++ b/src/components/home/FriendRequestsSection.tsx
@@ -62,6 +62,27 @@ type FriendRequestsSectionProps = {
   }
 }
 
+// Derive what the section shows from the latest server props minus the ids the
+// viewer has optimistically cleared from THIS card. Kept pure and exported so
+// the cross-surface sync contract is unit-testable without a DOM: because the
+// visible set is computed from props (not seeded into useState), a
+// router.refresh() fired by the same request's Recent Activity duplicate flows
+// through here and clears this card too. `totalCount` is reduced only by
+// cleared ids still present in `top`, so the "See all" overflow line stays
+// honest in the gap before the refresh lands (and self-corrects once it does,
+// when those ids drop out of `top`).
+export function deriveVisibleRequests(
+  initial: { top: SerializedIncomingRequest[]; totalCount: number },
+  removedIds: ReadonlySet<string>,
+): { requests: SerializedIncomingRequest[]; totalCount: number } {
+  const requests = initial.top.filter((item) => !removedIds.has(item.id))
+  const removedFromTop = initial.top.reduce(
+    (sum, item) => (removedIds.has(item.id) ? sum + 1 : sum),
+    0,
+  )
+  return { requests, totalCount: Math.max(0, initial.totalCount - removedFromTop) }
+}
+
 // Quiet outline/text button — distinguished from the filled Accept by shape and
 // weight (border + lighter weight), never by color alone (canon tripwire).
 const DECLINE_BUTTON_CLASS = [
@@ -136,10 +157,22 @@ function RequestCard({
 
 export default function FriendRequestsSection({ initial }: FriendRequestsSectionProps) {
   const router = useRouter()
-  const [requests, setRequests] = useState<SerializedIncomingRequest[]>(initial.top)
-  const [totalCount, setTotalCount] = useState(initial.totalCount)
+  // Optimistically-cleared request ids. We DERIVE the visible cards from the
+  // latest server props (`initial`) minus this set rather than seeding the list
+  // into useState — that's the fix for the cross-surface sync gap: the same
+  // pending request also shows as a row in the Recent Activity feed, and
+  // accepting/declining it there calls router.refresh(). A useState seed would
+  // ignore the fresh props that refresh delivers, stranding a stale card here
+  // (with dead buttons) until a hard reload. Reading from props keeps this card
+  // in lockstep with the activity-feed row, which already renders straight from
+  // props. The set still gives us instant optimistic removal when the user acts
+  // from THIS card; once the refresh lands, the id drops out of `initial.top`
+  // and the set entry becomes a harmless no-op.
+  const [removedIds, setRemovedIds] = useState<Set<string>>(() => new Set())
   const [pendingId, setPendingId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
+
+  const { requests, totalCount } = deriveVisibleRequests(initial, removedIds)
 
   // Zero-state is invisible: this section simply isn't rendered when there are
   // no pending requests (quiet over loud — no empty chrome).
@@ -156,10 +189,14 @@ export default function FriendRequestsSection({ initial }: FriendRequestsSection
     const result = await submitFriendRequestAction(request.id, action, failureMessage)
 
     if (result.ok) {
-      // Success: remove the card and decrement the local pending total so the
-      // "See all" overflow line stays honest as cards clear.
-      setRequests((current) => current.filter((item) => item.id !== request.id))
-      setTotalCount((current) => Math.max(0, current - 1))
+      // Success: optimistically clear this card. Derived `requests`/`totalCount`
+      // (above) pick this up immediately; once the refresh lands, the id also
+      // drops out of `initial.top` and this entry becomes a no-op.
+      setRemovedIds((current) => {
+        const next = new Set(current)
+        next.add(request.id)
+        return next
+      })
       // Keep the other home surfaces in sync: the same pending request also
       // shows in the Recent Activity stream ("wants to be friends"). Re-render
       // the server components so that duplicate clears too — otherwise it lingers

--- a/src/components/home/__tests__/FriendRequestsSection.test.tsx
+++ b/src/components/home/__tests__/FriendRequestsSection.test.tsx
@@ -16,6 +16,7 @@ vi.mock('next/navigation', () => ({
 }))
 
 import FriendRequestsSection, {
+  deriveVisibleRequests,
   FRIEND_REQUEST_ENDPOINTS,
   submitFriendRequestAction,
   type SerializedIncomingRequest,
@@ -157,39 +158,75 @@ describe('submitFriendRequestAction', () => {
   })
 })
 
-// The component's success/failure transitions are pure: on ok the card is
-// filtered out of local state and the count decremented; on failure the list is
-// untouched and the error surfaced. Mirror that here so a green action test
-// can't mask a broken consumer.
+// The component's success/failure transitions are pure: on ok the acted id is
+// added to the optimistically-removed set; on failure the list is untouched and
+// the error surfaced. The visible set is then derived from props minus that set
+// (deriveVisibleRequests), which is what keeps this card in lockstep with the
+// same request's Recent Activity duplicate across a router.refresh(). Mirror
+// that here so a green action test can't mask a broken consumer.
 describe('FriendRequestsSection state transitions', () => {
   it('removes the acted card and decrements the count on success', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(true, { ok: true }))
-    let requests = [request('a'), request('b'), request('c')]
-    let totalCount = 5
+    const initial = { top: [request('a'), request('b'), request('c')], totalCount: 5 }
+    const removed = new Set<string>()
 
     const result = await submitFriendRequestAction('b', 'accept', 'nope', fetchImpl as typeof fetch)
-    if (result.ok) {
-      requests = requests.filter((item) => item.id !== 'b')
-      totalCount = Math.max(0, totalCount - 1)
-    }
+    if (result.ok) removed.add('b')
 
+    const { requests, totalCount } = deriveVisibleRequests(initial, removed)
     expect(requests.map((r) => r.id)).toEqual(['a', 'c'])
     expect(totalCount).toBe(4)
   })
 
   it('keeps the card and surfaces the error on failure', async () => {
     const fetchImpl = vi.fn(async () => jsonResponse(false, { message: 'Try again.' }))
-    let requests = [request('a'), request('b')]
+    const initial = { top: [request('a'), request('b')], totalCount: 2 }
+    const removed = new Set<string>()
     let error: string | null = null
 
     const result = await submitFriendRequestAction('b', 'ignore', 'nope', fetchImpl as typeof fetch)
-    if (!result.ok) {
-      error = result.message
-    } else {
-      requests = requests.filter((item) => item.id !== 'b')
-    }
+    if (!result.ok) error = result.message
+    else removed.add('b')
 
+    const { requests } = deriveVisibleRequests(initial, removed)
     expect(requests.map((r) => r.id)).toEqual(['a', 'b'])
     expect(error).toBe('Try again.')
+  })
+})
+
+// The cross-surface sync fix: visible cards are DERIVED from the latest server
+// props minus locally-cleared ids — not seeded into useState — so a
+// router.refresh() triggered by accepting/declining the same request in the
+// Recent Activity feed (which re-renders this section with fresh props) clears
+// this card too, instead of stranding a stale one with dead buttons.
+describe('deriveVisibleRequests', () => {
+  it('returns all props verbatim when nothing has been cleared', () => {
+    const initial = { top: [request('a'), request('b')], totalCount: 4 }
+    const { requests, totalCount } = deriveVisibleRequests(initial, new Set())
+    expect(requests.map((r) => r.id)).toEqual(['a', 'b'])
+    expect(totalCount).toBe(4)
+  })
+
+  it('hides a locally-cleared id and decrements the overflow total', () => {
+    const initial = { top: [request('a'), request('b'), request('c')], totalCount: 5 }
+    const { requests, totalCount } = deriveVisibleRequests(initial, new Set(['b']))
+    expect(requests.map((r) => r.id)).toEqual(['a', 'c'])
+    expect(totalCount).toBe(4)
+  })
+
+  it('treats a cleared id as a no-op once the refresh drops it from props', () => {
+    // Simulates the post-router.refresh() render: the server already dropped 'b'
+    // from `top` and decremented `totalCount`, while the removed set still holds
+    // 'b'. The stale set entry must not double-decrement the count.
+    const initial = { top: [request('a'), request('c')], totalCount: 4 }
+    const { requests, totalCount } = deriveVisibleRequests(initial, new Set(['b']))
+    expect(requests.map((r) => r.id)).toEqual(['a', 'c'])
+    expect(totalCount).toBe(4)
+  })
+
+  it('never reports a negative total', () => {
+    const initial = { top: [request('a')], totalCount: 0 }
+    const { totalCount } = deriveVisibleRequests(initial, new Set(['a']))
+    expect(totalCount).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary
Fixes a stale-card bug in the FriendRequestsSection where accepting/declining a request from the Recent Activity feed would leave a dead card in this section until a hard reload. The fix derives visible requests from server props minus locally-cleared ids, rather than seeding them into useState, so router.refresh() updates propagate correctly.

## Key Changes
- **Extracted `deriveVisibleRequests()` function:** Pure utility that computes visible requests by filtering server props (`initial.top`) against a set of optimistically-cleared ids, and decrements `totalCount` only for ids still present in the top list. Exported for unit testing the cross-surface sync contract.
- **Replaced useState seeding with derived state:** Changed from `useState(initial.top)` and `useState(initial.totalCount)` to a single `useState<Set<string>>()` for `removedIds`, then derive `requests` and `totalCount` on every render via `deriveVisibleRequests(initial, removedIds)`. This ensures fresh server props from router.refresh() flow through immediately.
- **Updated optimistic removal logic:** On success, add the request id to `removedIds` instead of filtering the list directly. The derived state picks this up instantly for UI feedback, and once the refresh lands, the id drops out of `initial.top` and the set entry becomes a harmless no-op.
- **Added comprehensive test suite:** Three test groups covering submitFriendRequestAction state transitions (mirrored to the new derived-state model) and deriveVisibleRequests behavior (including the post-refresh no-op case and negative-total guard).

## Implementation Details
- The "See all" overflow count (`totalCount`) stays honest during the gap before refresh lands by only decrementing for ids still in `initial.top`; once the server props update, those ids are gone and the count self-corrects.
- The fix preserves instant optimistic removal (good UX) while keeping this card in lockstep with the same request's Recent Activity duplicate across a router.refresh().
- All logic is pure and testable without a DOM, with detailed comments explaining the cross-surface sync contract.

https://claude.ai/code/session_01SFoAyKeCPhE63E5pi4QFgk