### PR TITLE
fix(profile): show public sections to non-friend (public) viewers

### DIFF
--- a/src/app/users/[id]/__tests__/page.test.tsx
+++ b/src/app/users/[id]/__tests__/page.test.tsx
@@ -382,12 +382,102 @@ describe('/users/[id] friend profile page', () => {
     // surfaces in the UI as 'public'.
     expect(html).toContain('Previewing your profile as public.')
     expect(html).toContain('href="/users/self-1"')
-    // Stranger short-circuit fires because visibility is 'stranger' — the
-    // page renders the stranger card, gated on the simulated viewer.
-    expect(html).toContain('Become friends to see')
+    // knowledge_base + authored_questions are public, so the public viewer
+    // sees that content rather than the all-gated teaser. friends_list is
+    // still gated, so the "see more" nudge appears.
+    expect(html).toContain('Knowledge base')
+    expect(html).toContain('Become friends to see more of')
     // Owner is previewing as a stranger of themselves — the friend
     // button must NOT render (you can't befriend yourself).
     expect(html).not.toContain('Add friend')
+  })
+
+  it('shows a public viewer the sections the owner marked public', async () => {
+    // Bug fix: a non-friend must see public sections instead of the all-gated
+    // teaser. Here knowledge_base + authored_questions are public; friends_list
+    // is not, so the viewer sees content plus a nudge for the rest.
+    getFriendPortraitDataMock.mockResolvedValueOnce({
+      user: {
+        id: 'jpalay-1',
+        displayName: 'Joshua P',
+        handle: 'jpalay',
+        memberSince: new Date('2026-05-01T00:00:00.000Z'),
+      },
+      visibility: 'stranger',
+      relationship: null,
+      interests: [],
+      sharedInterests: [],
+      viewerSoloInterests: [],
+      friendSoloInterests: [],
+      mutualFriends: [],
+      mutualFriendsOverflow: 0,
+      isOwnerView: false,
+      sectionSettings: null,
+      sectionVisibleTo: {
+        knowledge_base: true,
+        friends_list: false,
+        authored_questions: true,
+      },
+      previewedAs: null,
+    })
+
+    const element = await UserProfilePage({
+      params: Promise.resolve({ id: 'jpalay-1' }),
+      searchParams: Promise.resolve({}),
+    })
+    const html = renderToStaticMarkup(element)
+
+    // The public sections render...
+    expect(html).toContain('Knowledge base')
+    expect(html).toContain('authored-feed')
+    expect(html).toContain('href="/users/jpalay-1/knowledge"')
+    // ...a non-owner public viewer can still send a friend request...
+    expect(html).toContain('Add friend')
+    // ...and is nudged to befriend for the still-gated friends_list.
+    expect(html).toContain('Become friends to see more of')
+    // The all-gated teaser copy must NOT appear.
+    expect(html).not.toContain('knowledge portrait, interests, and authored')
+    // Common ground is relational and stays hidden from a public viewer.
+    expect(html).not.toContain('common-ground')
+  })
+
+  it('shows a public viewer the all-gated teaser when nothing is public', async () => {
+    getFriendPortraitDataMock.mockResolvedValueOnce({
+      user: {
+        id: 'private-1',
+        displayName: 'Priya Private',
+        handle: 'priya',
+        memberSince: new Date('2026-05-01T00:00:00.000Z'),
+      },
+      visibility: 'stranger',
+      relationship: null,
+      interests: [],
+      sharedInterests: [],
+      viewerSoloInterests: [],
+      friendSoloInterests: [],
+      mutualFriends: [],
+      mutualFriendsOverflow: 0,
+      isOwnerView: false,
+      sectionSettings: null,
+      sectionVisibleTo: {
+        knowledge_base: false,
+        friends_list: false,
+        authored_questions: false,
+      },
+      previewedAs: null,
+    })
+
+    const element = await UserProfilePage({
+      params: Promise.resolve({ id: 'private-1' }),
+      searchParams: Promise.resolve({}),
+    })
+    const html = renderToStaticMarkup(element)
+
+    // Full teaser copy, no content sections.
+    expect(html).toContain('knowledge portrait, interests, and authored')
+    expect(html).toContain('Add friend')
+    expect(html).not.toContain('Knowledge base')
+    expect(html).not.toContain('authored-feed')
   })
 
   it('renders the owner self-view with consolidated settings sections', async () => {

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -106,6 +106,19 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
   const isStranger = portrait.visibility === 'stranger';
   const friendFirstName = firstName(portrait.user.displayName);
 
+  // A "stranger" (public / non-friend viewer) may still see whichever sections
+  // the owner marked public. The teaser must only fully gate when NOTHING is
+  // visible; otherwise we fall through to the content view, which already gates
+  // each section by portrait.sectionVisibleTo. Bug fix: public knowledge/
+  // questions were hidden from non-friends because the gate keyed off
+  // friendship alone, never consulting sectionVisibleTo.
+  const visibleSectionCount =
+    (portrait.sectionVisibleTo.knowledge_base ? 1 : 0) +
+    (portrait.sectionVisibleTo.authored_questions ? 1 : 0) +
+    (portrait.sectionVisibleTo.friends_list ? 1 : 0);
+  const strangerSeesNothing = isStranger && visibleSectionCount === 0;
+  const strangerHasGatedSection = isStranger && visibleSectionCount < 3;
+
   // The simulated viewer's label for the banner. 'public' is the new
   // user-facing word for what the preview module still calls 'stranger'.
   const previewBannerLabel = !portrait.previewedAs
@@ -129,8 +142,11 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
     // Common ground compares the viewer's full mastery base to this profile's.
-    // Never rendered on the owner's own profile, so skip the reads there.
-    isOwnerView ? Promise.resolve(null) : getCommonGround(session.userId, portrait.user.id),
+    // Never rendered on the owner's own profile or for a public (stranger)
+    // viewer, so skip the read for both.
+    isOwnerView || isStranger
+      ? Promise.resolve(null)
+      : getCommonGround(session.userId, portrait.user.id),
     // The viewed user's own friends, surfaced (capped) in the Friends module.
     // Gated at render by their friends_list visibility. Skipped on owner view.
     isOwnerView ? Promise.resolve([]) : getFriends(portrait.user.id),
@@ -293,8 +309,10 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
   }
 
   // Stranger short-circuit: non-friend viewers (and the owner previewing
-  // as public) get the minimal teaser card without rich content.
-  if (isStranger) {
+  // as public) with NO public sections get the minimal teaser card. A
+  // stranger who can see at least one public section falls through to the
+  // content view below, which gates each section by sectionVisibleTo.
+  if (strangerSeesNothing) {
     return (
       <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-5">
         {previewBannerLabel ? (
@@ -389,7 +407,22 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
         }
       />
 
-      {!isSelf ? (
+      {/* Mutual friends teaser — shown to a public viewer who has at least one
+          public section (the zero-section case is handled by the short-circuit
+          teaser above). Friends/self get the relational modules instead. */}
+      {isStranger ? (
+        <MutualFriendsSection
+          friends={portrait.mutualFriends}
+          overflowCount={portrait.mutualFriendsOverflow}
+          visibility="stranger"
+          friendFirstName={friendFirstName}
+        />
+      ) : null}
+
+      {/* Common ground is relational and never shown to strangers — it derives
+          from the viewer's knowledge overlap and the teaser intentionally omits
+          it. Friends only (self never saw it). */}
+      {!isStranger && !isSelf ? (
         <CommonGround
           data={commonGround}
           friendFirstName={friendFirstName}
@@ -452,6 +485,14 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
             previewLimit={QUESTIONS_PREVIEW_LIMIT}
           />
         </section>
+      ) : null}
+
+      {/* A public viewer who can see some sections but not all still gets the
+          nudge to befriend for the rest. */}
+      {strangerHasGatedSection ? (
+        <p className="text-muted-foreground mt-6 text-sm">
+          Become friends to see more of {friendFirstName}’s profile.
+        </p>
       ) : null}
     </main>
   );


### PR DESCRIPTION
## The bug

A profile owner who marks their **knowledge base** and **questions** as *public* still had everything hidden from non-friends. A non-friend (or the owner previewing as public) only saw the "Become friends to see {name}'s knowledge portrait, interests, and authored questions" teaser — the public setting was silently ignored.

## Root cause

`src/app/users/[id]/page.tsx` gated the entire rich profile behind friendship:

```ts
const isStranger = portrait.visibility === 'stranger';
...
if (isStranger) { return <teaser/> }
```

`isStranger` keys off relationship state **alone** and never consults `portrait.sectionVisibleTo` — which the server (`server/profile/friend.ts`) already computes correctly via `canViewSection(...)`, resolving `public` sections as visible to *any* viewer. The short-circuit fired before any public section could render.

## The fix

- Only show the all-gated teaser when a public viewer can see **no section at all**. When at least one section is public, fall through to the content view, which already gates each section individually by `sectionVisibleTo`.
- Public viewers keep the stranger chrome (mutual friends, **Add friend**) and get a softer *"Become friends to see more of {name}'s profile"* nudge when some sections remain gated.
- Relational **common ground** stays friends-only, and its query is now skipped for public viewers (was previously fetched but unused for them).

## Behavior note

`knowledge_base` and `authored_questions` default to **public** in the visibility model, so this also corrects the default for everyone: non-friends viewing any profile now see those two sections unless the owner set them to friends/private. `friends_list` defaults to friends-only and is unaffected.

## Tests

- Updated the owner-preview-as-public test to assert the public content now renders (with a "see more" nudge), instead of the all-gated teaser.
- Added two regression tests:
  - a public viewer with public knowledge/questions sees that content + **Add friend** (not the teaser, no common ground)
  - a fully-private profile still shows the all-gated teaser

**Verification:** `npx tsc -p tsconfig.typecheck.json` clean · ESLint 0 errors · all 58 profile/users/component tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QNT9RPuPV5srDSsMFvZV5x

---
_Generated by [Claude Code](https://claude.ai/code/session_01QNT9RPuPV5srDSsMFvZV5x)_