### PR TITLE
Redesign ProfileFriendsSection list layout

### DIFF
--- a/src/components/profile/ProfileFriendsSection.tsx
+++ b/src/components/profile/ProfileFriendsSection.tsx
@@ -33,9 +33,6 @@ export function ProfileFriendsSection({
       <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
         Friends
       </p>
-      <h2 className="mt-1 font-serif text-2xl font-semibold">
-        {friendFirstName}&rsquo;s friends
-      </h2>
 
       {shown.length === 0 ? (
         <p className="text-muted-foreground mt-2 text-sm">
@@ -43,14 +40,17 @@ export function ProfileFriendsSection({
         </p>
       ) : (
         <>
-          <ul className="mt-3 flex flex-wrap gap-2">
+          <ul className="border-border mt-3 divide-y rounded-md border">
             {shown.map((friend) => (
               <li key={friend.id}>
                 <Link
                   href={`/users/${friend.id}`}
-                  className="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center rounded-full px-3 py-1 text-sm font-medium"
+                  className="hover:bg-secondary/40 flex items-center justify-between px-4 py-3 text-sm font-medium transition-colors"
                 >
-                  {friend.displayName}
+                  <span>{friend.displayName}</span>
+                  <span aria-hidden="true" className="text-muted-foreground">
+                    &rarr;
+                  </span>
                 </Link>
               </li>
             ))}


### PR DESCRIPTION
## Summary
Refactors the friends list display in the profile section from a horizontal pill-style layout to a vertical list with dividers and arrow indicators.

## Changes
- **Removed** the "Friends" heading (`<h2>`) above the friends list
- **Changed list styling** from horizontal flex layout with gap to a vertical bordered list with dividers:
  - Updated `<ul>` className from `flex flex-wrap gap-2` to `border-border mt-3 divide-y rounded-md border`
- **Updated friend link styling** from pill buttons to full-width list items:
  - Changed from `bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center rounded-full px-3 py-1` to `hover:bg-secondary/40 flex items-center justify-between px-4 py-3`
  - Added `transition-colors` for smooth hover effects
- **Added right arrow indicator** (`→`) to each friend link:
  - Wrapped display name in `<span>` for clarity
  - Added decorative arrow in a separate `<span>` with `aria-hidden="true"` and muted foreground color

## Implementation Details
The redesign maintains the same functionality while improving visual hierarchy and usability. The vertical list format with dividers is more scannable, and the arrow indicators provide clearer affordance for the links. The `justify-between` layout ensures the arrow aligns to the right edge of each list item.

https://claude.ai/code/session_011T7Mwj8HZewH69kt6a1KB3