### PR TITLE
Drop redundant questions heading and loosen profile section spacing

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -398,7 +398,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
       ) : null}
 
       {portrait.sectionVisibleTo.knowledge_base ? (
-        <section className="mt-5" aria-label="Knowledge base">
+        <section className="mt-8" aria-label="Knowledge base">
           <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
             Knowledge base
           </p>

--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -307,13 +307,10 @@ export function AuthoredQuestionsFeed({
     const hasMore = questions.length > previewQuestions.length
 
     return (
-      <section className="mt-5" aria-label="Questions">
+      <section className="mt-8" aria-label="Questions">
         <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
           Questions
         </p>
-        <h2 className="mt-1 font-serif text-2xl font-semibold">
-          {friendFirstName}&rsquo;s questions
-        </h2>
 
         {error ? (
           <p className="mt-3 rounded-md border border-[var(--destructive-border)] bg-[var(--destructive-surface)] px-3 py-2 text-sm text-destructive">

--- a/src/components/profile/CommonGround.tsx
+++ b/src/components/profile/CommonGround.tsx
@@ -53,7 +53,7 @@ export function CommonGround({ data, friendFirstName, limit }: CommonGroundProps
   )
 
   return (
-    <section className="mt-5" aria-label="Common ground">
+    <section className="mt-8" aria-label="Common ground">
       <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
         Common ground
       </p>

--- a/src/components/profile/ProfileFriendsSection.tsx
+++ b/src/components/profile/ProfileFriendsSection.tsx
@@ -29,7 +29,7 @@ export function ProfileFriendsSection({
   const hasMore = friends.length > shown.length
 
   return (
-    <section className="mt-5" aria-label="Friends">
+    <section className="mt-8" aria-label="Friends">
       <p className="text-muted-foreground text-xs font-medium tracking-[0.1em] uppercase">
         Friends
       </p>


### PR DESCRIPTION
Mirror the Friends treatment on the Questions preview: remove the "<name>'s questions" <h2> in favor of the existing uppercase eyebrow. Bump the profile dashboard section roots (common ground, knowledge base, friends, questions) from mt-5 to mt-8 so the modules aren't squished together.


Claude-Session: https://claude.ai/code/session_011T7Mwj8HZewH69kt6a1KB3