### PR TITLE
Separate profile sections into distinct bands

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -398,8 +398,11 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
       ) : null}
 
       {portrait.sectionVisibleTo.knowledge_base ? (
-        <section className="mt-8" aria-label="Knowledge base">
-          <h2 className="font-serif text-xl font-semibold">Knowledge base</h2>
+        <section
+          className="mt-8 border-t border-[var(--brand-rule)] pt-8"
+          aria-label="Knowledge base"
+        >
+          <h2 className="font-serif text-2xl font-semibold">Knowledge base</h2>
           {!isSelf && topDomains.length > 0 ? (
             <div className="mt-3">
               <KnowledgeCard

--- a/src/components/profile/AuthoredQuestionsFeed.tsx
+++ b/src/components/profile/AuthoredQuestionsFeed.tsx
@@ -307,8 +307,11 @@ export function AuthoredQuestionsFeed({
     const hasMore = questions.length > previewQuestions.length
 
     return (
-      <section className="mt-8" aria-label="Questions">
-        <h2 className="font-serif text-xl font-semibold">Questions</h2>
+      <section
+        className="mt-8 border-t border-[var(--brand-rule)] pt-8"
+        aria-label="Questions"
+      >
+        <h2 className="font-serif text-2xl font-semibold">Questions</h2>
 
         {error ? (
           <p className="mt-3 rounded-md border border-[var(--destructive-border)] bg-[var(--destructive-surface)] px-3 py-2 text-sm text-destructive">

--- a/src/components/profile/CommonGround.tsx
+++ b/src/components/profile/CommonGround.tsx
@@ -53,8 +53,11 @@ export function CommonGround({ data, friendFirstName, limit }: CommonGroundProps
   )
 
   return (
-    <section className="mt-8" aria-label="Common ground">
-      <h2 className="font-serif text-xl font-semibold">Common ground</h2>
+    <section
+      className="mt-8 border-t border-[var(--brand-rule)] pt-8"
+      aria-label="Common ground"
+    >
+      <h2 className="font-serif text-2xl font-semibold">Common ground</h2>
       <p className="text-muted-foreground mt-1 text-sm leading-6">{headline}</p>
 
       {isEmpty ? null : (

--- a/src/components/profile/ProfileFriendsSection.tsx
+++ b/src/components/profile/ProfileFriendsSection.tsx
@@ -29,8 +29,11 @@ export function ProfileFriendsSection({
   const hasMore = friends.length > shown.length
 
   return (
-    <section className="mt-8" aria-label="Friends">
-      <h2 className="font-serif text-xl font-semibold">Friends</h2>
+    <section
+      className="mt-8 border-t border-[var(--brand-rule)] pt-8"
+      aria-label="Friends"
+    >
+      <h2 className="font-serif text-2xl font-semibold">Friends</h2>
 
       {shown.length === 0 ? (
         <p className="text-muted-foreground mt-2 text-sm">


### PR DESCRIPTION
The dashboard modules flowed together with only whitespace between them, making the page hard to parse. Give each section a full-width divider rule and generous top padding so they read as distinct bands, and bump the section headings from text-xl to text-2xl so they anchor each area.


Claude-Session: https://claude.ai/code/session_011T7Mwj8HZewH69kt6a1KB3