### PR TITLE
Fix empty Friends module when owner previews profile as a friend

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -132,8 +132,11 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     // Never rendered on the owner's own profile, so skip the reads there.
     isOwnerView ? Promise.resolve(null) : getCommonGround(session.userId, portrait.user.id),
     // The viewed user's own friends, surfaced (capped) in the Friends module.
-    // Gated at render by their friends_list visibility. Skipped on owner view.
-    isOwnerView ? Promise.resolve([]) : getFriends(portrait.user.id),
+    // Gated at render by their friends_list visibility. Needed whenever the
+    // friend content view renders — including when the owner previews their
+    // own profile as a friend — so skip only on the owner's self-management
+    // view (no active preview), which never shows the module.
+    ownerSelfView ? Promise.resolve([]) : getFriends(portrait.user.id),
     // Fetch one past the preview cap so the feed knows whether to show the
     // "view all" link without a separate count query.
     getAuthoredQuestionsForUser({


### PR DESCRIPTION
The friend content view (and its Friends module) renders when the effective viewer is a friend, which includes the owner using ?previewAs=friend. But the friends query was skipped whenever isOwnerView was true, so the preview always showed an empty list ("hasn't added any friends yet") even for accounts with many friends.

Gate the skip on ownerSelfView (owner AND no active preview) instead, so the module is populated during preview while the owner's own self-management view — which never renders the module — still skips it.


Claude-Session: https://claude.ai/code/session_011T7Mwj8HZewH69kt6a1KB3