### PR TITLE
Group dev tools by category and add route-existence check

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -15,6 +15,7 @@ import { ProfileFriendsSection } from '@/components/profile/ProfileFriendsSectio
 import { SectionVisibilityToggle } from '@/components/profile/SectionVisibilityToggle';
 import { SettingsGroup, SettingsRow } from '@/components/profile/SettingsRow';
 import { AccountActions } from '@/components/profile/settings/AccountActions';
+import { getExistingDevToolHrefs } from '@/server/dev/tool-availability';
 import { NotificationsForm } from '@/components/profile/settings/NotificationsForm';
 import { PrivacyForm } from '@/components/profile/settings/PrivacyForm';
 import { formatUsPhoneInput } from '@/lib/phone-e164';
@@ -297,7 +298,10 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
         {llmProviders ? <LlmProviderPanel initial={llmProviders} /> : null}
         {llmExperimentData ? <LlmExperimentReadout data={llmExperimentData} /> : null}
 
-        <AccountActions isAdmin={isAdminUser(session.userId)} />
+        <AccountActions
+          isAdmin={isAdminUser(session.userId)}
+          availableToolHrefs={getExistingDevToolHrefs()}
+        />
 
         <footer className="text-muted-foreground mt-auto pt-6 text-center text-xs">
           <Link href="/terms" className="font-medium underline-offset-4 hover:underline">

--- a/src/components/profile/SettingsRow.tsx
+++ b/src/components/profile/SettingsRow.tsx
@@ -14,6 +14,10 @@ type CommonProps = {
   title: string;
   subtitle: string;
   tone?: 'default' | 'destructive';
+  // When true the row renders as a non-interactive, dimmed entry with an
+  // "Unavailable" pill instead of the chevron — used by the dev-tools route
+  // existence check to show a tool whose target page isn't in this build.
+  unavailable?: boolean;
 };
 
 type LinkProps = CommonProps & { href: string; onClick?: never; disabled?: never };
@@ -31,6 +35,14 @@ export function SettingsRow(props: LinkProps | ButtonProps): ReactNode {
       ? 'bg-destructive/10 text-destructive'
       : 'bg-muted text-foreground/70';
 
+  const trailing = props.unavailable ? (
+    <span className="flex-none rounded-full bg-muted px-2 py-0.5 font-mono text-[0.62rem] font-semibold uppercase tracking-[0.06em] text-muted-foreground">
+      Unavailable
+    </span>
+  ) : (
+    <ChevronRight className="size-5 flex-none text-muted-foreground" />
+  );
+
   const body = (
     <>
       <span
@@ -45,12 +57,26 @@ export function SettingsRow(props: LinkProps | ButtonProps): ReactNode {
         </span>
         <span className="mt-0.5 text-sm text-muted-foreground">{props.subtitle}</span>
       </span>
-      <ChevronRight className="size-5 flex-none text-muted-foreground" />
+      {trailing}
     </>
   );
 
   const rowClass =
     'flex w-full items-center gap-4 px-4 py-4 text-left transition-colors hover:bg-muted/60 disabled:cursor-not-allowed disabled:opacity-60';
+
+  // Unavailable rows never navigate or fire their handler — render an inert,
+  // dimmed entry regardless of whether href or onClick was supplied.
+  if (props.unavailable) {
+    return (
+      <div
+        className="flex w-full items-center gap-4 px-4 py-4 text-left opacity-50"
+        aria-disabled="true"
+        title="This tool's route isn't available in this build."
+      >
+        {body}
+      </div>
+    );
+  }
 
   if ('href' in props && props.href) {
     return (

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -16,6 +16,7 @@ import {
   Sprout,
   Sun,
 } from 'lucide-react';
+import type { ReactNode } from 'react';
 import { useState } from 'react';
 
 import { clearCachedLoadingMomentPayload } from '@/components/loading-moment/client-cache';
@@ -55,6 +56,22 @@ export async function logoutAndRedirect(navigate: (url: string) => void): Promis
 // matching /dev route gate lives in src/app/dev/layout.tsx; revert both together.
 const DEV_TOOLS_UNGATED = true;
 
+// A single developer tool. Link tools open a route (and participate in the
+// route-exists availability check); action tools fire an inline handler and are
+// always available.
+type DevTool =
+  | { kind: 'link'; icon: ReactNode; title: string; subtitle: string; href: string }
+  | {
+      kind: 'action';
+      icon: ReactNode;
+      title: string;
+      subtitle: string;
+      onClick: () => void;
+      disabled?: boolean;
+    };
+
+type DevToolGroup = { eyebrow: string; tools: DevTool[] };
+
 /**
  * `isAdmin` normally gates the Developer-tools section via the ADMIN_USER_IDS
  * allowlist (the caller computes it from `isAdminUser(session.userId)`).
@@ -62,8 +79,20 @@ const DEV_TOOLS_UNGATED = true;
  * is bypassed and the section renders for any profile owner. This component only
  * mounts in the owner self-view, so the tools are never exposed on other
  * people's profiles either way.
+ *
+ * `availableToolHrefs` is the set of dev-tool routes the server found on disk
+ * (see getExistingDevToolHrefs). A tool whose href is absent renders dimmed and
+ * inert. `null`/`undefined` means the server couldn't run the check (e.g. a
+ * production bundle without the source tree) — fail open and treat every tool
+ * as available.
  */
-export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
+export function AccountActions({
+  isAdmin = false,
+  availableToolHrefs,
+}: {
+  isAdmin?: boolean;
+  availableToolHrefs?: string[] | null;
+}) {
   const showDeveloperTools = DEV_TOOLS_UNGATED || isAdmin;
   const router = useRouter();
   const [confirmingLogout, setConfirmingLogout] = useState(false);
@@ -140,86 +169,156 @@ export function AccountActions({ isAdmin = false }: { isAdmin?: boolean }) {
     }
   }
 
+  // Grouped, eyebrow-labelled dev tools. Order within each group is
+  // intentional (most-used first). The first-time-experience group collects the
+  // onboarding / first-run preview tools so they read as one family.
+  const devToolGroups: DevToolGroup[] = [
+    {
+      eyebrow: 'First-time experience',
+      tools: [
+        {
+          kind: 'link',
+          icon: <Sparkles className="size-5" />,
+          title: 'Show me the first time player',
+          subtitle: 'Preview the first-session experience a new player sees',
+          href: '/dev/first-time-player',
+        },
+        {
+          kind: 'link',
+          icon: <Map className="size-5" />,
+          title: 'Replay onboarding stages',
+          subtitle: 'Walk through every signup / first-run stage on demand (read-only)',
+          href: '/dev/onboarding',
+        },
+        {
+          kind: 'link',
+          icon: <Compass className="size-5" />,
+          title: 'Replay the welcome tour',
+          subtitle: 'The first-run coach-marks over a sample home, into Play',
+          href: '/dev/welcome-tour',
+        },
+        {
+          kind: 'link',
+          icon: <Smartphone className="size-5" />,
+          title: 'Phone-first invite login',
+          subtitle: 'Preview the invite login screens without sending an invite',
+          href: '/dev/invite-login',
+        },
+        {
+          kind: 'link',
+          icon: <Hourglass className="size-5" />,
+          title: 'Preview the loading screen',
+          subtitle: 'Cycle every Loading Moment card + the sparse fallback, no real load',
+          href: '/dev/loading-preview',
+        },
+      ],
+    },
+    {
+      eyebrow: 'Game & session',
+      tools: [
+        {
+          kind: 'action',
+          icon: <FlaskConical className="size-5" />,
+          title: resettingGame ? 'Resetting…' : 'Create test game',
+          subtitle: "Reset today's game and play again",
+          onClick: () => void createTestGame(),
+          disabled: resettingGame,
+        },
+        {
+          kind: 'link',
+          icon: <RefreshCw className="size-5" />,
+          title: 'Reset session',
+          subtitle: 'Clear current session data',
+          href: '/dev/reset-session',
+        },
+        {
+          kind: 'link',
+          icon: <Sun className="size-5" />,
+          title: 'Trigger noon reset',
+          subtitle: 'Simulate daily reset',
+          href: '/dev/noon-reset',
+        },
+      ],
+    },
+    {
+      eyebrow: 'Diagnostics & flags',
+      tools: [
+        {
+          kind: 'link',
+          icon: <Code2 className="size-5" />,
+          title: 'View staging flags',
+          subtitle: 'See feature flag status',
+          href: '/dev/flags',
+        },
+        {
+          kind: 'link',
+          icon: <BarChart3 className="size-5" />,
+          title: 'Points diagnostic',
+          subtitle: "Inspect a user's mastery events and where points came from",
+          href: '/dev/points-diagnostic',
+        },
+        {
+          kind: 'link',
+          icon: <Sprout className="size-5" />,
+          title: 'Expansion offer card',
+          subtitle: 'Preview the post-daily-Five “branch out” card',
+          href: '/daily/summary/expand-preview',
+        },
+        {
+          kind: 'link',
+          icon: <BarChart3 className="size-5" />,
+          title: 'Expansion offer funnel',
+          subtitle: 'How often the “branch out” offer triggers, resolves, and pends',
+          href: '/dev/expansion-offer',
+        },
+      ],
+    },
+  ];
+
+  // null/undefined => the server couldn't run the route-exists check; fail open.
+  const isToolAvailable = (href: string) =>
+    availableToolHrefs == null || availableToolHrefs.includes(href);
+
+  function renderTool(tool: DevTool) {
+    if (tool.kind === 'action') {
+      return (
+        <SettingsRow
+          key={tool.title}
+          icon={tool.icon}
+          title={tool.title}
+          subtitle={tool.subtitle}
+          onClick={tool.onClick}
+          disabled={tool.disabled}
+        />
+      );
+    }
+    return (
+      <SettingsRow
+        key={tool.href}
+        icon={tool.icon}
+        title={tool.title}
+        subtitle={tool.subtitle}
+        href={tool.href}
+        unavailable={!isToolAvailable(tool.href)}
+      />
+    );
+  }
+
   return (
     <>
       {showDeveloperTools ? (
         <section className="mb-8">
           <h2 className="mb-3 font-serif text-2xl font-semibold">Developer tools</h2>
-          <SettingsGroup>
-            <SettingsRow
-              icon={<FlaskConical className="size-5" />}
-              title={resettingGame ? 'Resetting…' : 'Create test game'}
-              subtitle="Reset today's game and play again"
-              onClick={() => void createTestGame()}
-              disabled={resettingGame}
-            />
-            <SettingsRow
-              icon={<RefreshCw className="size-5" />}
-              title="Reset session"
-              subtitle="Clear current session data"
-              href="/dev/reset-session"
-            />
-            <SettingsRow
-              icon={<Sun className="size-5" />}
-              title="Trigger noon reset"
-              subtitle="Simulate daily reset"
-              href="/dev/noon-reset"
-            />
-            <SettingsRow
-              icon={<Code2 className="size-5" />}
-              title="View staging flags"
-              subtitle="See feature flag status"
-              href="/dev/flags"
-            />
-            <SettingsRow
-              icon={<BarChart3 className="size-5" />}
-              title="Points diagnostic"
-              subtitle="Inspect a user's mastery events and where points came from"
-              href="/dev/points-diagnostic"
-            />
-            <SettingsRow
-              icon={<Hourglass className="size-5" />}
-              title="Preview the loading screen"
-              subtitle="Cycle every Loading Moment card + the sparse fallback, no real load"
-              href="/dev/loading-preview"
-            />
-            <SettingsRow
-              icon={<Sparkles className="size-5" />}
-              title="Show me the first time player"
-              subtitle="Preview the first-session experience a new player sees"
-              href="/dev/first-time-player"
-            />
-            <SettingsRow
-              icon={<Map className="size-5" />}
-              title="Replay onboarding stages"
-              subtitle="Walk through every signup / first-run stage on demand (read-only)"
-              href="/dev/onboarding"
-            />
-            <SettingsRow
-              icon={<Compass className="size-5" />}
-              title="Replay the welcome tour"
-              subtitle="The first-run coach-marks over a sample home, into Play"
-              href="/dev/welcome-tour"
-            />
-            <SettingsRow
-              icon={<Smartphone className="size-5" />}
-              title="Phone-first invite login"
-              subtitle="Preview the invite login screens without sending an invite"
-              href="/dev/invite-login"
-            />
-            <SettingsRow
-              icon={<Sprout className="size-5" />}
-              title="Expansion offer card"
-              subtitle="Preview the post-daily-Five “branch out” card"
-              href="/daily/summary/expand-preview"
-            />
-            <SettingsRow
-              icon={<BarChart3 className="size-5" />}
-              title="Expansion offer funnel"
-              subtitle="How often the “branch out” offer triggers, resolves, and pends"
-              href="/dev/expansion-offer"
-            />
-          </SettingsGroup>
+          <div className="flex flex-col gap-5">
+            {devToolGroups.map((group) => (
+              <div key={group.eyebrow}>
+                <p className="text-muted-foreground mb-2 px-1 font-mono text-[0.62rem] font-semibold tracking-[0.06em] uppercase">
+                  {group.eyebrow}
+                </p>
+                <SettingsGroup>{group.tools.map(renderTool)}</SettingsGroup>
+              </div>
+            ))}
+          </div>
           {resetGameError ? (
             <p className="text-destructive mt-2 text-sm">{resetGameError}</p>
           ) : null}

--- a/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
+++ b/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), refresh: vi.fn() }),
+}));
+
+import { AccountActions } from '../AccountActions';
+
+/**
+ * The Developer-tools section is grouped under eyebrow labels, and each link
+ * tool participates in a route-exists check driven by `availableToolHrefs`.
+ */
+describe('AccountActions — dev-tools grouping & availability', () => {
+  it('renders the three eyebrow groups', () => {
+    const html = renderToStaticMarkup(<AccountActions isAdmin />);
+    expect(html).toContain('First-time experience');
+    expect(html).toContain('Game &amp; session');
+    expect(html).toContain('Diagnostics &amp; flags');
+  });
+
+  it('fails open (no Unavailable pill) when availableToolHrefs is omitted', () => {
+    const html = renderToStaticMarkup(<AccountActions isAdmin />);
+    expect(html).not.toContain('Unavailable');
+  });
+
+  it('marks a tool Unavailable when its href is absent from the available set', () => {
+    // Provide a set that omits /dev/flags — it should render dimmed/inert.
+    const html = renderToStaticMarkup(
+      <AccountActions isAdmin availableToolHrefs={['/dev/first-time-player']} />,
+    );
+    expect(html).toContain('Unavailable');
+    // The available one is a real link; the omitted one is not.
+    expect(html).toContain('href="/dev/first-time-player"');
+    expect(html).not.toContain('href="/dev/flags"');
+  });
+
+  it('always renders the inline action tool (Create test game) regardless of the available set', () => {
+    const html = renderToStaticMarkup(<AccountActions isAdmin availableToolHrefs={[]} />);
+    expect(html).toContain('Create test game');
+  });
+});

--- a/src/server/dev/__tests__/tool-availability.test.ts
+++ b/src/server/dev/__tests__/tool-availability.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+
+import { getExistingDevToolHrefs } from '../tool-availability';
+
+/**
+ * The route-exists check backs the "Unavailable" state on the Developer-tools
+ * section. It scans the real `src/app` tree, so these assertions double as a
+ * guard that the dev routes the UI links to still exist on disk.
+ */
+describe('getExistingDevToolHrefs', () => {
+  const hrefs = getExistingDevToolHrefs();
+
+  it('finds real /dev routes that the dev-tools UI links to', () => {
+    expect(hrefs).not.toBeNull();
+    expect(hrefs).toContain('/dev/first-time-player');
+    expect(hrefs).toContain('/dev/onboarding');
+    expect(hrefs).toContain('/dev/flags');
+    // The one tool that lives outside /dev.
+    expect(hrefs).toContain('/daily/summary/expand-preview');
+  });
+
+  it('does not invent routes that have no page', () => {
+    expect(hrefs).not.toContain('/dev/this-route-does-not-exist');
+  });
+});

--- a/src/server/dev/tool-availability.ts
+++ b/src/server/dev/tool-availability.ts
@@ -1,0 +1,45 @@
+import { existsSync, readdirSync } from 'node:fs';
+import path from 'node:path';
+
+// Route-exists check for the Developer-tools section (AccountActions). Each dev
+// tool links to an App Router page; this scans the filesystem for the pages
+// that actually exist so the UI can dim tools whose route hasn't been built
+// (or has been removed). Returns the set of hrefs that resolve to a real page.
+//
+// FAIL OPEN: returns `null` on any error. In a production serverless bundle the
+// `src/app` source tree may not be present at runtime, and we never want to
+// hide a working tool because the scan couldn't read the source — the caller
+// treats `null` as "assume everything is available". The check is therefore
+// most meaningful in dev/preview, which is exactly where a WIP tool whose route
+// doesn't exist yet would be added.
+
+const PAGE_FILES = ['page.tsx', 'page.ts', 'page.jsx', 'page.js'];
+
+function hasPage(dir: string): boolean {
+  return PAGE_FILES.some((file) => existsSync(path.join(dir, file)));
+}
+
+export function getExistingDevToolHrefs(): string[] | null {
+  try {
+    const appDir = path.join(process.cwd(), 'src', 'app');
+    const devDir = path.join(appDir, 'dev');
+    const hrefs: string[] = [];
+
+    // Every `/dev/<name>` route folder that contains a page.
+    for (const entry of readdirSync(devDir, { withFileTypes: true })) {
+      if (entry.isDirectory() && hasPage(path.join(devDir, entry.name))) {
+        hrefs.push(`/dev/${entry.name}`);
+      }
+    }
+
+    // The one dev tool that lives outside /dev (the expansion-offer card
+    // preview is nested under the real daily-summary route).
+    if (hasPage(path.join(appDir, 'daily', 'summary', 'expand-preview'))) {
+      hrefs.push('/daily/summary/expand-preview');
+    }
+
+    return hrefs;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
Reorganizes the Developer-tools section in AccountActions to group related tools under eyebrow labels (First-time experience, Game & session, Diagnostics & flags) and adds a server-side route-existence check that dims tools whose target pages aren't present in the current build.

## Key Changes
- **Dev tool grouping:** Refactored the flat list of 12 dev tools into three semantic groups with eyebrow labels. Tools are reordered within groups by usage frequency.
- **Route-existence check:** Added `getExistingDevToolHrefs()` in `src/server/dev/tool-availability.ts` that scans the `src/app` filesystem to find which dev routes actually exist. Returns `null` on error (fail-open behavior for production bundles without source tree).
- **Unavailable state:** Extended `SettingsRow` with an `unavailable` prop that renders a dimmed, non-interactive row with an "Unavailable" pill instead of the chevron. Link tools participate in the availability check; action tools (like "Create test game") are always available.
- **Type safety:** Introduced `DevTool` and `DevToolGroup` discriminated union types to distinguish link tools (which have `href`) from action tools (which have `onClick`).
- **Integration:** Updated the profile page (`src/app/users/[id]/page.tsx`) to call `getExistingDevToolHrefs()` and pass the result to `AccountActions` via the new `availableToolHrefs` prop.
- **Tests:** Added comprehensive test coverage for grouping, availability logic, and the route-scan function.

## Implementation Details
- The route scan checks for `page.tsx`, `page.ts`, `page.jsx`, or `page.js` in each directory under `/dev`, plus the special case of `/daily/summary/expand-preview`.
- Availability defaults to "all available" when `availableToolHrefs` is `null` or `undefined`, ensuring tools don't disappear if the server-side check fails.
- The "Unavailable" pill uses the same mono/uppercase styling as the eyebrow labels for visual consistency.
- Inline action tools (currently just "Create test game") bypass the availability check entirely since they don't depend on a route existing.

https://claude.ai/code/session_019sCRir85d7ycxtsKHQUegp