### PR TITLE
Improve interest removal UI with visual indicator and underline

### DIFF
--- a/src/app/onboarding/OnboardingFlow.tsx
+++ b/src/app/onboarding/OnboardingFlow.tsx
@@ -664,12 +664,18 @@ export default function OnboardingFlow({
                         key={selectedKey(interest)}
                         className="flex items-center gap-3"
                       >
+                        <span
+                          aria-hidden="true"
+                          className="text-muted-foreground text-xs"
+                        >
+                          ▸
+                        </span>
                         <span className="text-base font-medium">
                           {interest.domain}
                         </span>
                         <button
                           type="button"
-                          className="text-muted-foreground hover:text-destructive text-sm font-medium transition-colors"
+                          className="text-muted-foreground hover:text-destructive text-sm font-medium underline transition-colors"
                           onClick={() => removeSelectedInterest(interest)}
                           aria-label={`Remove ${interest.domain}`}
                         >


### PR DESCRIPTION
## Summary
Enhanced the visual design of selected interests in the onboarding flow by adding a bullet point indicator and making the remove button more visually prominent with an underline.

## Changes
- Added a decorative bullet point (▸) before each interest domain name, marked as `aria-hidden` to avoid screen reader duplication
- Added `underline` class to the remove button to make it more clearly interactive and aligned with standard link/button affordances

## Implementation Details
- The bullet point uses a semantic `<span>` with `aria-hidden="true"` to ensure it's purely visual and doesn't affect accessibility
- The underline styling on the remove button improves discoverability of the removal action without requiring hover state
- Both changes maintain the existing color scheme and transition effects

https://claude.ai/code/session_01UZqU8u77Nsj2aiF1zhCCed