### PR TITLE
Remove offset shadow from CreatorNote ink block

### DIFF
--- a/src/components/CreatorNote.tsx
+++ b/src/components/CreatorNote.tsx
@@ -57,10 +57,12 @@ export function CreatorNote({
           style={{
             background: 'var(--warm-ink)',
             color: 'var(--warm-cream)',
-            // House-card language: hard 1.5px border + 4×4 offset shadow, no blur
-            // (matches ShareCard/OverlapMap). The shadow casts INK onto the page.
+            // The inverted ink fill alone carries the "loud" weight here. We do
+            // NOT use the house-card 4×4 offset shadow (ShareCard/OverlapMap):
+            // that pattern casts an INK shadow against a CREAM card face, but this
+            // block is itself ink-filled, so a same-color offset just reads as a
+            // lopsided bottom-right edge rather than a shadow.
             border: '1.5px solid var(--warm-ink)',
-            boxShadow: '4px 4px 0 var(--warm-ink)',
             borderRadius: 4,
             padding: '14px 16px',
           }}


### PR DESCRIPTION
## Summary
Removes the 4×4 offset shadow from the CreatorNote component's ink-filled block and updates the accompanying comment to explain why this pattern doesn't apply here.

## Changes
- **Removed `boxShadow: '4px 4px 0 var(--warm-ink)'`** from the CreatorNote style object
- **Updated inline comment** to clarify that the house-card shadow pattern (used in ShareCard/OverlapMap) casts an ink shadow *onto* a cream card face, creating visual depth. Since CreatorNote's block is itself ink-filled, applying the same offset shadow in the same color reads as a lopsided edge rather than a shadow effect.
- The inverted ink fill now carries the visual weight alone, which is sufficient for the component's design intent.

## Implementation Details
The change aligns CreatorNote's visual treatment with its ink-on-cream color scheme. The 1.5px border remains to maintain definition, but the offset shadow is removed because it doesn't produce the intended shadow effect when applied to an ink-filled element (as opposed to a cream card with an ink shadow cast onto it).

https://claude.ai/code/session_01GS15H9vjjoPodS6iobAYzB