### PR TITLE
Fix asQueueSlots to salvage valid items from mixed arrays

### DIFF
--- a/src/server/daily/__tests__/catchup-asQueueSlots.test.ts
+++ b/src/server/daily/__tests__/catchup-asQueueSlots.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { asQueueSlots } from '@/server/daily/catchup';
+import { type QueueSlot, queueSlotSchema } from '@/server/daily/types';
+
+// Minimal slot carrying every required field of queueSlotSchema.
+function validSlot(slotIndex: number): QueueSlot {
+  return {
+    slot_index: slotIndex,
+    source: 'bot',
+    domain: 'film_tv',
+    question_text: `Question ${slotIndex}?`,
+    answered: false,
+  };
+}
+
+describe('asQueueSlots', () => {
+  it('returns [] for non-array input', () => {
+    expect(asQueueSlots(null)).toEqual([]);
+    expect(asQueueSlots(undefined)).toEqual([]);
+    expect(asQueueSlots({ slot_index: 0 })).toEqual([]);
+    expect(asQueueSlots('nope')).toEqual([]);
+  });
+
+  it('returns a fully-valid array unchanged', () => {
+    const slots = [validSlot(0), validSlot(1), validSlot(2)];
+    const result = asQueueSlots(slots);
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(slots);
+  });
+
+  it('salvages only the valid slots from a mixed array (exercises the previously-broken path)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const good = validSlot(0);
+    const alsoGood = validSlot(2);
+    // Malformed: missing required `question_text` and wrong-typed `answered`.
+    const malformed = { slot_index: 1, source: 'bot', domain: 'film_tv', answered: 'yes' };
+
+    const result = asQueueSlots([good, malformed, alsoGood]);
+
+    expect(result).toHaveLength(2);
+    expect(result).toEqual([good, alsoGood]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('returns [] when every element is malformed', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = asQueueSlots([{ slot_index: 'x' }, { nope: true }, 42]);
+    expect(result).toEqual([]);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('never returns an element that fails queueSlotSchema.safeParse (regression pin)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const result = asQueueSlots([validSlot(0), { broken: true }, validSlot(1)]);
+    for (const slot of result) {
+      expect(queueSlotSchema.safeParse(slot).success).toBe(true);
+    }
+    warn.mockRestore();
+  });
+});

--- a/src/server/daily/catchup.ts
+++ b/src/server/daily/catchup.ts
@@ -21,11 +21,14 @@ export function isCatchupQueueDate(
 export function asQueueSlots(value: unknown): QueueSlot[] {
   if (!Array.isArray(value)) return [];
   const result = z.array(queueSlotSchema).safeParse(value);
-  if (!result.success) {
-    console.warn('[daily] QueueSlot JSONB failed schema validation', result.error.issues);
-    return value as QueueSlot[];
-  }
-  return result.data;
+  if (result.success) return result.data;
+
+  console.warn('[daily] QueueSlot JSONB failed schema validation', result.error.issues);
+  // Salvage individually-valid slots; never return the rejected array.
+  return value.flatMap((item) => {
+    const one = queueSlotSchema.safeParse(item);
+    return one.success ? [one.data] : [];
+  });
 }
 
 export function dailyQueueItemId(queueId: string, slotIndex: number): string {


### PR DESCRIPTION
## Summary
Fixed a bug in `asQueueSlots()` where the function would return an unvalidated array cast when schema validation failed, instead of salvaging individually-valid slots. This could allow malformed queue slot objects to pass through to downstream code.

## Changes
- **Modified `src/server/daily/catchup.ts`:** Updated `asQueueSlots()` to use `flatMap()` to validate each array element individually when the full array fails schema validation. Valid items are kept; invalid items are filtered out and logged as warnings.
- **Added `src/server/daily/__tests__/catchup-asQueueSlots.test.ts`:** Comprehensive test suite covering:
  - Non-array inputs (returns empty array)
  - Fully-valid arrays (returned unchanged)
  - Mixed arrays with valid and malformed slots (salvages only valid ones)
  - All-malformed arrays (returns empty array)
  - Regression pin ensuring no invalid slots escape validation

## Implementation Details
The previous implementation would return `value as QueueSlot[]` on validation failure, bypassing schema checks entirely. The fix applies `queueSlotSchema.safeParse()` to each element individually, collecting only those that pass validation. This ensures the function never returns slots that would fail `queueSlotSchema.safeParse()`, while maximizing data recovery from partially-corrupted JSONB columns.

https://claude.ai/code/session_013qccEF2yXxn6CcJWJBVdzR