### PR TITLE
B-FRIEND-SEARCH-RATELIMIT-01: rate-limit friend search (Decision A1)

### DIFF
--- a/src/app/api/friends/search/__tests__/route.test.ts
+++ b/src/app/api/friends/search/__tests__/route.test.ts
@@ -1,0 +1,92 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { getSessionMock, searchMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(),
+  searchMock: vi.fn(),
+}))
+
+vi.mock('@/server/auth/session', () => ({
+  getSession: getSessionMock,
+}))
+
+vi.mock('@/server/db/queries/friend-search', () => ({
+  searchFriendByHandleOrPhone: searchMock,
+}))
+
+import { GET, resetFriendSearchRateLimitForTests } from '../route'
+
+function searchRequest(q: string, ip = '203.0.113.7') {
+  return new Request(`https://example.com/api/friends/search?q=${encodeURIComponent(q)}`, {
+    headers: { 'x-forwarded-for': ip },
+  })
+}
+
+describe('GET /api/friends/search rate limiting', () => {
+  beforeEach(() => {
+    resetFriendSearchRateLimitForTests()
+    getSessionMock.mockReset()
+    searchMock.mockReset()
+    getSessionMock.mockResolvedValue({ userId: 'viewer-1' })
+    searchMock.mockResolvedValue(null)
+    delete process.env.FRIEND_SEARCH_THROTTLE_DISABLED
+  })
+
+  it('returns 401 without a session before consuming any budget', async () => {
+    getSessionMock.mockResolvedValueOnce(null)
+    const res = await GET(searchRequest('@alice'))
+    expect(res.status).toBe(401)
+    expect(searchMock).not.toHaveBeenCalled()
+  })
+
+  it('allows up to the per-account limit, then 429s with Retry-After', async () => {
+    for (let i = 0; i < 8; i++) {
+      const res = await GET(searchRequest('@alice'))
+      expect(res.status).toBe(200)
+    }
+    expect(searchMock).toHaveBeenCalledTimes(8)
+
+    const limited = await GET(searchRequest('@alice'))
+    expect(limited.status).toBe(429)
+    expect(Number(limited.headers.get('Retry-After'))).toBeGreaterThan(0)
+    const body = await limited.json()
+    expect(body).toEqual({ error: 'rate_limited', reason: 'account_window' })
+    // The blocked call did not reach the query.
+    expect(searchMock).toHaveBeenCalledTimes(8)
+  })
+
+  it('does not consume budget on invalid input', async () => {
+    // Empty q fails validation -> { match: null } without recording an attempt.
+    for (let i = 0; i < 20; i++) {
+      const res = await GET(searchRequest(''))
+      expect(res.status).toBe(200)
+      expect(await res.json()).toEqual({ match: null })
+    }
+    // A valid query still goes through afterward.
+    const res = await GET(searchRequest('@alice'))
+    expect(res.status).toBe(200)
+    expect(searchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('per-IP limit catches account rotation behind one address', async () => {
+    // Rotate the account on every call so the per-account cap never trips;
+    // the shared IP should still hit the per-IP ceiling (40/min).
+    for (let i = 0; i < 40; i++) {
+      getSessionMock.mockResolvedValueOnce({ userId: `rotating-${i}` })
+      const res = await GET(searchRequest('@alice', '198.51.100.42'))
+      expect(res.status).toBe(200)
+    }
+    getSessionMock.mockResolvedValueOnce({ userId: 'rotating-41' })
+    const limited = await GET(searchRequest('@alice', '198.51.100.42'))
+    expect(limited.status).toBe(429)
+    expect((await limited.json()).reason).toBe('ip_window')
+  })
+
+  it('honors the throttle-disable escape hatch', async () => {
+    process.env.FRIEND_SEARCH_THROTTLE_DISABLED = '1'
+    for (let i = 0; i < 50; i++) {
+      const res = await GET(searchRequest('@alice'))
+      expect(res.status).toBe(200)
+    }
+    expect(searchMock).toHaveBeenCalledTimes(50)
+  })
+})

--- a/src/app/api/friends/search/route.ts
+++ b/src/app/api/friends/search/route.ts
@@ -10,15 +10,138 @@ const querySchema = z.object({
   q: z.string().trim().min(1).max(80),
 })
 
+// D-FRIEND-SEARCH-PRIVACY-01, Decision A1 — rate limiting.
+// The search route resolves a phone/handle to a profile, so unbounded calls
+// are an enumeration engine (walk a number range, harvest match vs match:null).
+// We cap with an in-memory sliding window (the same shape as the invite
+// throttle in src/app/api/friend-invitations/route.ts) on TWO dimensions:
+//   - per-account: the primary limit on a legitimate session.
+//   - per-IP: catches the account-rotation bypass (mint accounts / rotate
+//     sessions to sidestep the per-account cap).
+// Per-IP is intentionally looser than per-account because carrier CGNAT and
+// office NAT put many legitimate users behind one address; an 8/min per-IP cap
+// would false-positive shared egress. Both windows are env-tunable.
+// NOTE: in-memory means per-instance — on multi-instance serverless the
+// effective ceiling scales with instance count. This is the documented Phase-1
+// posture; a durable (Redis/KV-backed) limiter is the Phase-2 upgrade.
+const SEARCH_WINDOW_MS = 1000 * 60
+const SEARCH_PER_ACCOUNT_WINDOW = Number(
+  process.env.FRIEND_SEARCH_PER_ACCOUNT_LIMIT ?? 8
+)
+const SEARCH_PER_IP_WINDOW = Number(
+  process.env.FRIEND_SEARCH_PER_IP_LIMIT ?? 40
+)
+
+const searchAttemptsByAccount = new Map<string, number[]>()
+const searchAttemptsByIp = new Map<string, number[]>()
+
+function pruneWindow(values: number[], nowMs: number, windowMs: number) {
+  return values.filter((value) => nowMs - value < windowMs)
+}
+
+// First hop of x-forwarded-for is the client on Vercel; x-real-ip is the
+// fallback. 'unknown' means no forwarding header was present — we then skip the
+// per-IP dimension entirely rather than lumping every header-less request into
+// one shared bucket (which would throttle legitimate users on the per-account
+// limit's behalf).
+function clientIpFrom(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')
+  if (forwarded) {
+    const first = forwarded.split(',')[0]?.trim()
+    if (first) return first
+  }
+  return request.headers.get('x-real-ip')?.trim() || 'unknown'
+}
+
+type RateLimitVerdict = { reason: 'account_window' | 'ip_window'; retryAfterSeconds: number }
+
+function retryAfterFor(values: number[], nowMs: number): number {
+  const oldest = values.length ? Math.min(...values) : nowMs
+  return Math.max(1, Math.ceil((oldest + SEARCH_WINDOW_MS - nowMs) / 1000))
+}
+
+function checkSearchRateLimit(
+  userId: string,
+  ip: string,
+  now = new Date()
+): RateLimitVerdict | null {
+  if (process.env.FRIEND_SEARCH_THROTTLE_DISABLED === '1') return null
+
+  const nowMs = now.getTime()
+  const accountAttempts = pruneWindow(
+    searchAttemptsByAccount.get(userId) ?? [],
+    nowMs,
+    SEARCH_WINDOW_MS
+  )
+  if (accountAttempts.length >= SEARCH_PER_ACCOUNT_WINDOW) {
+    return { reason: 'account_window', retryAfterSeconds: retryAfterFor(accountAttempts, nowMs) }
+  }
+
+  if (ip !== 'unknown') {
+    const ipAttempts = pruneWindow(
+      searchAttemptsByIp.get(ip) ?? [],
+      nowMs,
+      SEARCH_WINDOW_MS
+    )
+    if (ipAttempts.length >= SEARCH_PER_IP_WINDOW) {
+      return { reason: 'ip_window', retryAfterSeconds: retryAfterFor(ipAttempts, nowMs) }
+    }
+  }
+
+  return null
+}
+
+function recordSearchAttempt(userId: string, ip: string, now = new Date()) {
+  const nowMs = now.getTime()
+  const accountAttempts = pruneWindow(
+    searchAttemptsByAccount.get(userId) ?? [],
+    nowMs,
+    SEARCH_WINDOW_MS
+  )
+  accountAttempts.push(nowMs)
+  searchAttemptsByAccount.set(userId, accountAttempts)
+
+  if (ip !== 'unknown') {
+    const ipAttempts = pruneWindow(
+      searchAttemptsByIp.get(ip) ?? [],
+      nowMs,
+      SEARCH_WINDOW_MS
+    )
+    ipAttempts.push(nowMs)
+    searchAttemptsByIp.set(ip, ipAttempts)
+  }
+}
+
+export function resetFriendSearchRateLimitForTests() {
+  searchAttemptsByAccount.clear()
+  searchAttemptsByIp.clear()
+}
+
 export async function GET(request: Request) {
   const session = await getSession()
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 })
+
+  const ip = clientIpFrom(request)
+  const limited = checkSearchRateLimit(session.userId, ip)
+  if (limited) {
+    return NextResponse.json(
+      { error: 'rate_limited', reason: limited.reason },
+      {
+        status: 429,
+        headers: { 'Retry-After': String(limited.retryAfterSeconds) },
+      }
+    )
+  }
 
   const url = new URL(request.url)
   const parsed = querySchema.safeParse({ q: url.searchParams.get('q') ?? '' })
   if (!parsed.success) {
     return NextResponse.json({ match: null })
   }
+
+  // Count only attempts that actually run a lookup (a valid query). Invalid
+  // input short-circuits above without consuming the budget — it leaks nothing.
+  recordSearchAttempt(session.userId, ip)
 
   const match = await searchFriendByHandleOrPhone(session.userId, parsed.data.q)
   return NextResponse.json({ match })


### PR DESCRIPTION
The friend-search endpoint resolved a phone/handle to a profile with no
rate limiting, making it a working enumeration engine (walk a number
range, harvest match vs match:null). Add an in-memory sliding-window
limiter on the route, mirroring the existing invite throttle:

- per-account window (default 8/min) — primary cap on a real session.
- per-IP window (default 40/min) — closes the account-rotation bypass;
  looser than per-account so CGNAT/office NAT shared egress isn't
  false-positived. Skipped when no forwarding header is present.
- exceed -> 429 with a Retry-After header; invalid input never consumes
  budget; FRIEND_SEARCH_THROTTLE_DISABLED=1 escape hatch for tests/ops.

Scope is Decision A only (per ratification: rate limiting first,
independently mergeable, no schema change). The discoverability gate
(B/C/D) is deliberately deferred so friend-finding keeps working during
the test phase. In-memory means per-instance; a durable limiter is the
Phase-2 upgrade.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Mhwd24CsCRPhxDJB9eRTF4