### PR TITLE
Remove the "common ground ++" beat from the correct-answer reveal

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1034,8 +1034,8 @@ function ResultRow({
   // not the async breadcrumb — so the line is shown once and never swaps in
   // longer/replacement content after the fact.
   const explainerSentence = explanation ? firstSentence(explanation) : null;
-  // Correct keeps its explainer inline within the verdict block (before the
-  // "common ground" beat); the other reveals render it after the discovery copy.
+  // Correct keeps its explainer inline within the verdict block (right under the
+  // answer); the other reveals render it after the discovery copy.
   const showDiscoveryExplainer = !correct && Boolean(explainerSentence);
   // One unified note beneath the verdict, chosen by PROVENANCE (never answer-
   // state): a human author → their own note as the inverted block; house/LLM →
@@ -1104,8 +1104,8 @@ function ResultRow({
           <>
             {/* Compact, calm success moment: quiet verdict label, the correct
                 answer repeated immediately (even on a right answer) as the focal
-                point, then the light "common ground" beat. The fuller
-                explanation lives in the End of Session Review. */}
+                point, then the one-sentence explainer. The fuller explanation
+                lives in the End of Session Review. */}
             <p style={{ ...verdictLabelStyle, color: 'var(--game-correct)' }}>
               <span aria-hidden>✓</span>
               Locked in.
@@ -1123,17 +1123,6 @@ function ResultRow({
               </p>
             ) : null}
             {explainerSentence ? <ExplainerLine text={explainerSentence} /> : null}
-            <p
-              style={{
-                marginTop: '8px',
-                fontFamily: 'var(--font-mono)',
-                fontSize: '0.62rem',
-                letterSpacing: '0.04em',
-                color: 'color-mix(in srgb, var(--game-correct) 70%, var(--text-muted))',
-              }}
-            >
-              common ground ++
-            </p>
           </>
         ) : gaveUp ? (
           <>

--- a/src/components/play/__tests__/GameplayChat.result.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.result.test.tsx
@@ -38,12 +38,14 @@ function resultMessage(over: Partial<Extract<ChatMessage, { kind: 'result' }>>):
 }
 
 describe('GameplayChat correct-answer treatment (D-5 live thread)', () => {
-  it('shows the compact "Locked in." moment with the answer repeated and the common-ground beat', () => {
+  it('shows the compact "Locked in." moment with the answer repeated', () => {
     const rendered = html([resultMessage({ result: 'correct' })]);
     expect(rendered).toContain('Locked in.');
     // The correct answer is repeated immediately, even on a right answer.
     expect(rendered).toContain('Johann Sebastian Bach');
-    expect(rendered).toContain('common ground ++');
+    // The "common ground ++" beat was removed per owner (2026-06-26): it read as
+    // a social tag but was static copy, not tied to real overlap data.
+    expect(rendered).not.toContain('common ground');
   });
 
   it('shows a one-sentence explainer under a correct answer, trimming the rest to review', () => {


### PR DESCRIPTION
## What

Removes the **"common ground ++"** line that showed under the answer on the correct-answer reveal card (catch-up and gameplay), in `GameplayChat.tsx`.

## Why

On a correct answer the card showed "✓ Locked in." → the answer → a one-sentence explainer → **"common ground ++"**. That last line read like a social/overlap tag, but it was **static copy** — not tied to any real common-ground data. On a card that just means "you got it right," it was confusing. Per owner, remove it.

Nothing else about the reveal changes: the "Locked in." verdict, the repeated answer, and the one-sentence explainer all stay. The beat only ever appeared on correct answers, so wrong/revealed reveals are untouched.

## Changes
- `src/components/play/GameplayChat.tsx` — drop the `common ground ++` `<p>`; refresh two now-stale comments that referenced the beat.
- `src/components/play/__tests__/GameplayChat.result.test.tsx` — the D-5 result-treatment test now asserts the beat is **gone** (`not.toContain('common ground')`) while still checking "Locked in." + the repeated answer.

## Verification
- `vitest run` on the result-treatment suite — 6/6 pass.
- ESLint clean on both files.

## Note — "last question shows no answer"
You also mentioned the last catch-up question doesn't show an answer. I traced the full catch-up flow (`useCatchupFlow.ts`, `GameplayChat` thread, the recap): the answer/explainer renders on every path — inline under the answer for correct, after the discovery copy for wrong/revealed, and again in the round recap ("Answer" + "Why this is the answer"). In the screenshot the last question is cut off at the bottom of the viewport, so its answer card sits just below the fold. I didn't find a code defect, so I left it out of this PR rather than change something speculatively. If you're seeing a genuinely blank answer, tell me: which question, was it answered (correct/wrong/"show me the answer"), and was it the live thread or the recap — and I'll repro and fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mhwd24CsCRPhxDJB9eRTF4)_