### PR TITLE
Fix loading-moment artifact overflowing the card

### DIFF
--- a/src/components/LoadingScreen.tsx
+++ b/src/components/LoadingScreen.tsx
@@ -261,22 +261,22 @@ export default function LoadingScreen({
           // content centered — so the loader never resizes as items rotate
           // (B-LOADING-MOMENT-01, owner-approved bounded growth; centered overlay
           // ⇒ nothing on the page shifts). `line-clamp-3` guards an overlong stem.
-          <div className="relative mx-auto mt-4 flex h-24 max-w-[17rem] flex-col items-center justify-center text-center">
+          <div className="relative mx-auto mt-4 flex h-24 w-full max-w-[17rem] flex-col items-center justify-center text-center">
             <div
               key={index}
-              className={`flex flex-col items-center justify-center ${rotating ? "loading-message" : ""}`}
+              className={`flex w-full flex-col items-center justify-center ${rotating ? "loading-message" : ""}`}
             >
               {currentItem.kind === "moment" ? (
                 <>
-                  <p className="font-sans text-[11px] font-medium tracking-[0.16em] uppercase text-[var(--warm-ink)]/60">
+                  <p className="w-full font-sans text-[11px] font-medium tracking-[0.16em] uppercase text-[var(--warm-ink)]/60">
                     {currentItem.moment.label}
                   </p>
-                  <p className="mt-1.5 line-clamp-3 font-serif text-lg leading-snug text-[var(--brand-ink-950)]">
+                  <p className="mt-1.5 line-clamp-3 w-full break-words font-serif text-lg leading-snug text-[var(--brand-ink-950)]">
                     {currentItem.moment.artifact}
                   </p>
                 </>
               ) : (
-                <p className="font-sans text-sm font-normal tracking-wider uppercase text-[var(--warm-ink)]/75">
+                <p className="w-full font-sans text-sm font-normal tracking-wider uppercase text-[var(--warm-ink)]/75">
                   {currentItem.text}
                 </p>
               )}


### PR DESCRIPTION
The artifact line on the JOSHING loading card spilled past both edges of
the box instead of wrapping inside it. The artifact <p> sits in nested
flex columns that both use items-center; with no explicit width on the
children, align-items: center sized each <p> to its content width (the
full unwrapped line) rather than the 17rem container, so line-clamp-3
had no width to wrap against and the text rendered as one long line.

Give the flex children w-full so the artifact wraps within max-w-[17rem],
and add break-words to guard a long unbreakable token (e.g. a deepest-cut
question stem).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_018E5bwhPpSGHFb9gV8ozqhT