### PR TITLE
Add weekly LLM cost & latency digest (B-LLM-COST-LATENCY-REPORT-01)

### DIFF
--- a/drizzle/0092_llm_cost_report.sql
+++ b/drizzle/0092_llm_cost_report.sql
@@ -1,0 +1,34 @@
+-- B-LLM-COST-LATENCY-REPORT-01 — stored weekly cost & latency digest.
+--
+-- One row per generated digest (Decision B1: a stored markdown digest, written
+-- weekly by /api/cron/llm-cost-report and viewable in the owner-gated readout on
+-- the profile page). The digest is plain-English prose assembled at write time
+-- from LlmUsageEvent token/latency rows; the markdown is the durable artifact
+-- (and the future payload for an emailed digest, Decision B2). Cost itself is
+-- still derived at read time from src/server/llm/pricing.ts — this table stores
+-- the rendered words, not a frozen dollar number, so the snapshot reflects the
+-- price map in effect when the cron ran.
+--
+-- Purely additive: no existing table is altered. This is read-and-report-only
+-- work over data already written by recordLlmUsage — nothing here touches the
+-- LLM call path. RLS is enabled with no policies (the app connects as the owner
+-- role, which bypasses RLS) per B-SECURITY-RLS-01 / migration 0081 — without it
+-- the table would be reachable over Supabase's public Data API. Every statement
+-- is idempotent and mirrored by a defensive guard in src/instrumentation.ts
+-- (precedent: 0091) so a preview/production database that records this migration
+-- without the table present still boots.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "LlmCostReport";
+CREATE TABLE IF NOT EXISTS "LlmCostReport" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "period_start" timestamp with time zone NOT NULL,
+  "period_end" timestamp with time zone NOT NULL,
+  "window_days" integer NOT NULL DEFAULT 7,
+  "markdown" text NOT NULL,
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -645,6 +645,13 @@
       "when": 1784419200000,
       "tag": "0091_llm_usage_event",
       "breakpoints": true
+    },
+    {
+      "idx": 92,
+      "version": "7",
+      "when": 1784505600000,
+      "tag": "0092_llm_cost_report",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/cron/llm-cost-report/route.ts
+++ b/src/app/api/cron/llm-cost-report/route.ts
@@ -1,0 +1,40 @@
+import { NextRequest, NextResponse } from 'next/server';
+
+import { isCronAuthorized } from '@/server/auth/cron';
+import {
+  buildCostLatencyReport,
+  renderCostLatencyReportMarkdown,
+  writeCostReport,
+} from '@/server/db/queries/llm-cost-report';
+
+export const dynamic = 'force-dynamic';
+
+// B-LLM-COST-LATENCY-REPORT-01 — the weekly digest writer (Decision B1/C1).
+// Scheduled Mondays (vercel.json) over the trailing 7 days, with a week-over-week
+// delta and a trailing-30-day total baked into the report. Read-and-report only:
+// it reads LlmUsageEvent rows recordLlmUsage already wrote and stores the rendered
+// markdown. Owner can also trigger it manually (same cron auth) to refresh the
+// stored snapshot on demand.
+const WINDOW_DAYS = 7;
+
+export async function GET(request: NextRequest) {
+  if (!isCronAuthorized(request)) {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const report = await buildCostLatencyReport(WINDOW_DAYS);
+    const markdown = renderCostLatencyReportMarkdown(report);
+    await writeCostReport(report, markdown);
+    return NextResponse.json({
+      stored: true,
+      windowDays: report.windowDays,
+      totalUsd: Number(report.totalUsd.toFixed(4)),
+      surfaces: report.surfaces.length,
+      anyUnpriced: report.anyUnpriced,
+    });
+  } catch (error) {
+    console.error('[llm-cost-report] failed to build/store digest', error);
+    return NextResponse.json({ stored: false, error: 'report_failed' }, { status: 500 });
+  }
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -24,6 +24,7 @@ import { getSession } from '@/server/auth/session';
 import { getProviderSettings } from '@/server/llm/settings';
 import { LlmProviderPanel } from '@/components/profile/settings/LlmProviderPanel';
 import { LlmExperimentReadout, loadLlmExperimentData } from '@/components/profile/settings/LlmExperimentReadout';
+import { LlmCostReportReadout, loadCostReportData } from '@/components/profile/settings/LlmCostReportReadout';
 import {
   getDiscoverability,
   getEditableProfile,
@@ -220,6 +221,8 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
     // B-LLM-PROVIDER-AB-METRICS: load the experiment readout data here (the page
     // is already awaited) and pass it into the sync presentational component.
     const llmExperimentData = isOwner ? await loadLlmExperimentData() : null;
+    // B-LLM-COST-LATENCY-REPORT-01: the plain-English weekly cost & latency digest.
+    const costReportData = isOwner ? await loadCostReportData() : null;
     return (
       <main className="mx-auto flex min-h-dvh max-w-2xl flex-col px-4 py-6 pb-28">
         <ProfileHeaderCard
@@ -297,6 +300,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
 
         {llmProviders ? <LlmProviderPanel initial={llmProviders} /> : null}
         {llmExperimentData ? <LlmExperimentReadout data={llmExperimentData} /> : null}
+        {costReportData ? <LlmCostReportReadout data={costReportData} /> : null}
 
         <AccountActions
           isAdmin={isAdminUser(session.userId)}

--- a/src/components/profile/settings/LlmCostReportReadout.tsx
+++ b/src/components/profile/settings/LlmCostReportReadout.tsx
@@ -1,0 +1,205 @@
+/**
+ * Owner-only readout for the weekly LLM cost & latency digest
+ * (B-LLM-COST-LATENCY-REPORT-01). Same shape as LlmExperimentReadout: an async
+ * loader (loadCostReportData) the awaited page runs, plus a SYNC presentational
+ * component so renderToStaticMarkup / the page test can render it without RSC
+ * async support.
+ *
+ * Renders the report LIVE over the trailing 7 days (always fresh, independent of
+ * whether the Monday cron has run yet) and links it to the cron's durable
+ * snapshot by showing when that last stored digest was written. Shown only for
+ * the owner — the page gates it on ADMIN_USER_IDS, so it does no auth of its own.
+ */
+import {
+  buildCostLatencyReport,
+  readLatestCostReport,
+  type CostLatencyReport,
+} from '@/server/db/queries/llm-cost-report';
+
+const WINDOW_DAYS = 7;
+
+function usd(n: number | null): string {
+  if (n == null) return '—';
+  if (n === 0) return '$0';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function pct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+function ms(n: number | null): string {
+  if (n == null) return '—';
+  if (n < 1000) return `${Math.round(n)}ms`;
+  return `${(n / 1000).toFixed(1)}s`;
+}
+
+function num(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function deltaPhrase(curr: number, prev: number): string {
+  if (prev <= 0) return curr > 0 ? 'no comparable spend last week' : 'flat vs last week';
+  const change = (curr - prev) / prev;
+  if (Math.abs(change) < 0.01) return 'about flat vs last week';
+  return `${change > 0 ? 'up' : 'down'} ${pct(Math.abs(change))} vs last week`;
+}
+
+export type CostReportData = {
+  report: CostLatencyReport | null;
+  latestStoredAt: Date | null;
+};
+
+/**
+ * Build the live report and read the last stored snapshot's timestamp, tolerating
+ * individual failures (a missing table degrades to a soft note rather than
+ * crashing the settings page).
+ */
+export async function loadCostReportData(): Promise<CostReportData> {
+  const [reportR, latestR] = await Promise.allSettled([
+    buildCostLatencyReport(WINDOW_DAYS),
+    readLatestCostReport(),
+  ]);
+  return {
+    report: reportR.status === 'fulfilled' ? reportR.value : null,
+    latestStoredAt:
+      latestR.status === 'fulfilled' && latestR.value ? latestR.value.createdAt : null,
+  };
+}
+
+export function LlmCostReportReadout({ data }: { data: CostReportData }) {
+  const { report, latestStoredAt } = data;
+
+  return (
+    <section className="mb-8">
+      <h2 className="text-muted-foreground mb-1 text-sm font-semibold tracking-wide uppercase">
+        LLM Cost &amp; Latency — Weekly Digest
+      </h2>
+      <p className="text-muted-foreground mb-3 text-xs">
+        Spend and player-facing wait time over the last {WINDOW_DAYS} days, rolled up by surface.
+        Shown live here; the Monday cron stores the same digest as a snapshot.
+        {latestStoredAt
+          ? ` Last stored ${latestStoredAt.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}.`
+          : ' No stored snapshot yet.'}
+      </p>
+
+      {report == null ? (
+        <p className="text-destructive text-xs">Couldn&apos;t build the cost &amp; latency report.</p>
+      ) : (
+        <div className="bg-card text-card-foreground flex flex-col gap-6 rounded-xl border p-4">
+          {/* ── Total + week-over-week ── */}
+          <div>
+            <h3 className="text-sm font-semibold">
+              Total this week — {usd(report.totalUsd)}
+              {report.anyUnpriced ? ' *' : ''}
+            </h3>
+            <p className="text-muted-foreground text-xs">
+              {deltaPhrase(report.totalUsd, report.prevTotalUsd)} · {usd(report.monthUsd)} trailing 30 days
+            </p>
+          </div>
+
+          {/* ── Spend by surface ── */}
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">Where the money went</h3>
+            {report.surfaces.length === 0 ? (
+              <p className="text-muted-foreground text-xs">No LLM spend recorded this week.</p>
+            ) : (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-muted-foreground text-left text-xs">
+                    <th className="py-1 font-medium">Surface</th>
+                    <th className="py-1 text-right font-medium">Calls</th>
+                    <th className="py-1 text-right font-medium">Est. USD</th>
+                    <th className="py-1 text-right font-medium">Share</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.surfaces.map((s) => (
+                    <tr key={s.key} className="border-t">
+                      <td className="py-1">
+                        {s.label}
+                        {s.unpriced ? ' *' : ''}
+                      </td>
+                      <td className="py-1 text-right tabular-nums">{num(s.calls)}</td>
+                      <td className="py-1 text-right tabular-nums">{usd(s.costUsd)}</td>
+                      <td className="py-1 text-right tabular-nums">
+                        {report.totalUsd > 0 ? pct(s.costUsd / report.totalUsd) : '—'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+
+          {/* ── Cost per unit ── */}
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">Cost per unit</h3>
+            <ul className="text-sm">
+              <li className="flex items-baseline justify-between gap-3">
+                <span>Per question generated</span>
+                <span className="text-muted-foreground tabular-nums">
+                  {report.costPerQuestionUsd != null
+                    ? `${usd(report.costPerQuestionUsd)} · ${num(report.questionsGenerated)} made`
+                    : 'no questions generated'}
+                </span>
+              </li>
+              <li className="flex items-baseline justify-between gap-3">
+                <span>Per answer graded</span>
+                <span className="text-muted-foreground tabular-nums">
+                  {report.costPerAnswerGradedUsd != null
+                    ? `${usd(report.costPerAnswerGradedUsd)} · ${num(report.answersGraded)} graded`
+                    : 'no answers graded by the model'}
+                </span>
+              </li>
+            </ul>
+          </div>
+
+          {/* ── Speed ── */}
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">How long players wait</h3>
+            {report.slowestPlayerFacing ? (
+              <p className="text-muted-foreground mb-2 text-xs">
+                Players wait longest on {report.slowestPlayerFacing.label.toLowerCase()}: ~
+                {ms(report.slowestPlayerFacing.avgMs)} average, ~{ms(report.slowestPlayerFacing.p95Ms)} at worst.
+              </p>
+            ) : (
+              <p className="text-muted-foreground mb-2 text-xs">No timed player-facing calls this week.</p>
+            )}
+            {report.latency.some((l) => l.calls > 0) ? (
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="text-muted-foreground text-left text-xs">
+                    <th className="py-1 font-medium">Surface</th>
+                    <th className="py-1 text-right font-medium">Avg</th>
+                    <th className="py-1 text-right font-medium">Worst (p95)</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {report.latency
+                    .filter((l) => l.calls > 0)
+                    .map((l) => (
+                      <tr key={l.key} className="border-t">
+                        <td className="py-1">{l.label}</td>
+                        <td className="py-1 text-right tabular-nums">{ms(l.avgMs)}</td>
+                        <td className="py-1 text-right tabular-nums">{ms(l.p95Ms)}</td>
+                      </tr>
+                    ))}
+                </tbody>
+              </table>
+            ) : null}
+          </div>
+
+          {report.anyUnpriced ? (
+            <p className="text-muted-foreground text-xs italic">
+              * some calls ran on a model with no entry in the price map — the dollar figures are a floor
+              (real spend is at least this much).
+            </p>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1735,8 +1735,23 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at")`);
+      // Migration 0092 (B-LLM-COST-LATENCY-REPORT-01) stores the weekly cost &
+      // latency digest. The llm-cost-report cron would 42P01 on insert if the
+      // migration recorded without the table present. Self-contained; precedent: 0091.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "LlmCostReport" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "period_start" timestamp with time zone NOT NULL,
+          "period_end" timestamp with time zone NOT NULL,
+          "window_days" integer NOT NULL DEFAULT 7,
+          "markdown" text NOT NULL,
+          "created_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "LlmCostReport" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmCostReport_created_at_idx" ON "LlmCostReport" ("created_at")`);
     } catch {
-      // Non-fatal — migrate() creates the tables from 0090/0091 immediately after.
+      // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -1,0 +1,502 @@
+/**
+ * Read-and-report layer for the weekly LLM cost & latency digest
+ * (B-LLM-COST-LATENCY-REPORT-01). A small extension of the
+ * B-LLM-PROVIDER-AB-METRICS telemetry: it reads the same LlmUsageEvent rows that
+ * recordLlmUsage already writes and rolls them up by *surface* (a plain-English
+ * grouping a non-engineer reasons about) instead of by provider+model.
+ *
+ * A deliberately separate sibling file from llm-provider-experiment.ts (O3): the
+ * A/B experiment stays an independently-removable unit, and this report reuses
+ * its pricing (estimateCostUsd) and its table without entangling the two.
+ *
+ * NOTHING here is on an LLM call path — it is pure read-and-report over data
+ * already recorded. Cost is still derived at read time from pricing.ts, so a
+ * price edit reprices history with no backfill.
+ */
+import { and, desc, gte, lt, sql } from 'drizzle-orm';
+
+import { db, generatedQuestions, llmCostReport, llmUsageEvent, masteryEvents } from '@/server/db';
+import { estimateCostUsd } from '@/server/llm/pricing';
+
+// ─── Decision A: the surface taxonomy ────────────────────────────────────────
+
+/**
+ * One plain-English surface bucket and the raw LlmUsageEvent.scope strings that
+ * roll up into it. This single constant IS the mapping — adding a new scope to
+ * the codebase is a one-line edit here (or it falls into "Other / unmapped"
+ * automatically, never silently vanishing).
+ *
+ * `playerFacing` marks surfaces a human waits on live (the live answer-grade
+ * round-trip; interest processing during onboarding). Only these are eligible to
+ * be named as "the slowest player-facing surface" in the digest — a background
+ * pool-refill generation being slow is not something a player ever feels.
+ *
+ * Decision D (verified 2026-06-27): grading records usage under scope 'grade'
+ * (src/lib/llm.ts:734, dispatchLlmText('grade', …) → recordLlmUsage). The
+ * "Grading answers" bucket therefore reads a real figure, not an empty $0.
+ */
+export type SurfaceBucket = {
+  key: string;
+  label: string;
+  scopes: string[];
+  playerFacing: boolean;
+};
+
+export const SURFACE_BUCKETS: SurfaceBucket[] = [
+  {
+    key: 'generate',
+    label: 'Generating questions',
+    playerFacing: false,
+    scopes: ['generate-questions', 'pool-refill-generate', 'multitudes'],
+  },
+  {
+    key: 'quality',
+    label: 'Checking question quality',
+    playerFacing: false,
+    scopes: [
+      'quality-gate',
+      'factual-gate',
+      'critique',
+      'vet-question',
+      'recheck',
+      'difficulty',
+      'batch-dedupe',
+      'history-dedupe',
+    ],
+  },
+  {
+    key: 'grade',
+    label: 'Grading answers',
+    playerFacing: true,
+    scopes: ['grade'],
+  },
+  {
+    key: 'interests',
+    label: 'Understanding interests',
+    playerFacing: true,
+    scopes: [
+      'interests-answerability',
+      'interests-canonicalize',
+      'interests-categorize-domain',
+      'interests-expand',
+      'interests-proofread',
+      'interests-suggest',
+      'interests-suggest-adjacent',
+    ],
+  },
+  {
+    key: 'tagging',
+    label: 'Suggesting / tagging',
+    playerFacing: false,
+    scopes: [
+      'questions-suggest',
+      'suggest-tags',
+      'suggest-answer',
+      'resolve-subcategory',
+      'reconcile-subcategory',
+      'clean-question',
+      'categorize',
+    ],
+  },
+  {
+    key: 'copy',
+    label: 'Writing player-facing copy',
+    playerFacing: false,
+    scopes: ['explainer', 'reflection-explainer', 'inside-joke', 'ceremony-narrative', 'breadcrumb'],
+  },
+];
+
+// Hard requirement (Decision A1): a catch-all so a newly-added scope shows up
+// somewhere rather than disappearing from the spend total.
+export const OTHER_BUCKET: SurfaceBucket = {
+  key: 'other',
+  label: 'Other / unmapped',
+  playerFacing: false,
+  scopes: [],
+};
+
+/** Display/iteration order: the mapped buckets, then the catch-all last. */
+export const ALL_BUCKETS: SurfaceBucket[] = [...SURFACE_BUCKETS, OTHER_BUCKET];
+
+/** Resolve a raw scope string to its surface bucket (catch-all if unmapped). */
+export function bucketForScope(scope: string): SurfaceBucket {
+  return SURFACE_BUCKETS.find((b) => b.scopes.includes(scope)) ?? OTHER_BUCKET;
+}
+
+// A SQL CASE that maps the scope column to a bucket key. Built from the constant
+// above, so the taxonomy stays defined in exactly one place. Every value
+// interpolated here is a compile-time literal from our own code (bucket keys and
+// scope strings) — no user input reaches this raw fragment.
+const bucketCaseSql = sql.raw(
+  `CASE ${SURFACE_BUCKETS.map(
+    (b) => `WHEN "scope" IN (${b.scopes.map((s) => `'${s}'`).join(', ')}) THEN '${b.key}'`,
+  ).join(' ')} ELSE '${OTHER_BUCKET.key}' END`,
+);
+
+// ─── Window helpers ──────────────────────────────────────────────────────────
+
+/**
+ * A trailing window expressed as a half-open [startDaysAgo, endDaysAgo) range,
+ * e.g. the current week is (7, 0) and the prior week is (14, 7). endDaysAgo = 0
+ * means "up to now".
+ */
+function inWindow(startDaysAgo: number, endDaysAgo: number) {
+  const start = gte(llmUsageEvent.createdAt, sql`now() - make_interval(days => ${startDaysAgo})`);
+  if (endDaysAgo <= 0) return start;
+  return and(start, lt(llmUsageEvent.createdAt, sql`now() - make_interval(days => ${endDaysAgo})`));
+}
+
+// ─── Per-surface cost ────────────────────────────────────────────────────────
+
+export type SurfaceCost = {
+  key: string;
+  label: string;
+  playerFacing: boolean;
+  calls: number;
+  costUsd: number;
+  /** True when any model in this bucket has no price row — the figure is a floor. */
+  unpriced: boolean;
+};
+
+/**
+ * Spend per surface over a trailing window, USD derived per (bucket, model) so
+ * each model's tokens are priced with its own rate, then folded to the bucket.
+ * A bucket that contains an unpriced model surfaces `unpriced: true` and its
+ * dollar figure is a floor (priced rows only), never a misleading $0.
+ */
+export async function readSurfaceCost(startDaysAgo: number, endDaysAgo = 0): Promise<SurfaceCost[]> {
+  const rows = await db
+    .select({
+      bucket: bucketCaseSql.mapWith(String).as('bucket'),
+      model: llmUsageEvent.model,
+      calls: sql<number>`count(*)::int`,
+      inputTokens: sql<number>`coalesce(sum(${llmUsageEvent.inputTokens}), 0)::float8`,
+      outputTokens: sql<number>`coalesce(sum(${llmUsageEvent.outputTokens}), 0)::float8`,
+      cacheReadTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheReadTokens}), 0)::float8`,
+      cacheCreateTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheCreateTokens}), 0)::float8`,
+    })
+    .from(llmUsageEvent)
+    .where(inWindow(startDaysAgo, endDaysAgo))
+    .groupBy(bucketCaseSql, llmUsageEvent.model);
+
+  const acc = new Map<string, { calls: number; costUsd: number; unpriced: boolean }>();
+  for (const r of rows) {
+    const est = estimateCostUsd(r.model, {
+      inputTokens: Number(r.inputTokens),
+      outputTokens: Number(r.outputTokens),
+      cacheReadTokens: Number(r.cacheReadTokens),
+      cacheCreateTokens: Number(r.cacheCreateTokens),
+    });
+    const cur = acc.get(r.bucket) ?? { calls: 0, costUsd: 0, unpriced: false };
+    cur.calls += Number(r.calls);
+    if (est.unpriced) cur.unpriced = true;
+    else cur.costUsd += est.usd ?? 0;
+    acc.set(r.bucket, cur);
+  }
+
+  return ALL_BUCKETS.filter((b) => acc.has(b.key)).map((b) => {
+    const v = acc.get(b.key)!;
+    return { key: b.key, label: b.label, playerFacing: b.playerFacing, ...v };
+  });
+}
+
+// ─── Per-surface latency ─────────────────────────────────────────────────────
+
+export type SurfaceLatency = {
+  key: string;
+  label: string;
+  playerFacing: boolean;
+  calls: number;
+  avgMs: number | null;
+  /** p95 via percentile_cont (Decision O2); null when no timed call in the window. */
+  p95Ms: number | null;
+};
+
+/**
+ * Average and p95 wait time per surface over a trailing window. Only rows with a
+ * recorded duration_ms count toward the latency figures (older/partial rows may
+ * lack it). p95 uses percentile_cont, which reads acceptably at this row volume;
+ * if that ever changes, swap to max() with a relabel (O2).
+ */
+export async function readSurfaceLatency(startDaysAgo: number, endDaysAgo = 0): Promise<SurfaceLatency[]> {
+  const rows = await db
+    .select({
+      bucket: bucketCaseSql.mapWith(String).as('bucket'),
+      calls: sql<number>`(count(*) filter (where ${llmUsageEvent.durationMs} is not null))::int`,
+      avgMs: sql<number | null>`avg(${llmUsageEvent.durationMs})::float8`,
+      p95Ms: sql<number | null>`percentile_cont(0.95) within group (order by ${llmUsageEvent.durationMs})::float8`,
+    })
+    .from(llmUsageEvent)
+    .where(inWindow(startDaysAgo, endDaysAgo))
+    .groupBy(bucketCaseSql);
+
+  const byKey = new Map(rows.map((r) => [r.bucket, r]));
+  return ALL_BUCKETS.filter((b) => byKey.has(b.key)).map((b) => {
+    const r = byKey.get(b.key)!;
+    return {
+      key: b.key,
+      label: b.label,
+      playerFacing: b.playerFacing,
+      calls: Number(r.calls),
+      avgMs: r.avgMs != null ? Number(r.avgMs) : null,
+      p95Ms: r.p95Ms != null ? Number(r.p95Ms) : null,
+    };
+  });
+}
+
+// ─── Volume denominators (O1) ────────────────────────────────────────────────
+
+/** Count of bot questions generated in the trailing window — denominator for cost/question. */
+async function countQuestionsGenerated(startDaysAgo: number): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(generatedQuestions)
+    .where(gte(generatedQuestions.createdAt, sql`now() - make_interval(days => ${startDaysAgo})`));
+  return Number(row?.n ?? 0);
+}
+
+/**
+ * Count of answers an LLM actually graded in the window — denominator for
+ * cost/answer-graded. Matches the 'grade' scope's cost: exact-match and give-up
+ * answers carry no llm_provider and never hit a grading LLM call, so excluding
+ * them keeps numerator and denominator on the same population.
+ */
+async function countAnswersGraded(startDaysAgo: number): Promise<number> {
+  const [row] = await db
+    .select({ n: sql<number>`count(*)::int` })
+    .from(masteryEvents)
+    .where(
+      and(
+        sql`${masteryEvents.llmProvider} is not null`,
+        gte(masteryEvents.createdAt, sql`now() - make_interval(days => ${startDaysAgo})`),
+      ),
+    );
+  return Number(row?.n ?? 0);
+}
+
+// ─── Report assembly (Decision E1 content contract) ──────────────────────────
+
+export type CostLatencyReport = {
+  windowDays: number;
+  periodStart: Date;
+  periodEnd: Date;
+  /** Total priced spend this window. */
+  totalUsd: number;
+  /** Prior-window total, for the week-over-week delta. */
+  prevTotalUsd: number;
+  /** Trailing-30-day total, for context. */
+  monthUsd: number;
+  /** True if any surface this window contained an unpriced model. */
+  anyUnpriced: boolean;
+  surfaces: SurfaceCost[];
+  latency: SurfaceLatency[];
+  /** The slowest surface a human waits on live, by p95. Null if none timed. */
+  slowestPlayerFacing: SurfaceLatency | null;
+  questionsGenerated: number;
+  answersGraded: number;
+  costPerQuestionUsd: number | null;
+  costPerAnswerGradedUsd: number | null;
+};
+
+/**
+ * Assemble the full report from the telemetry. One builder feeds both the cron's
+ * stored markdown and the live owner readout, so the two never drift.
+ */
+export async function buildCostLatencyReport(windowDays = 7): Promise<CostLatencyReport> {
+  const now = new Date();
+  const periodStart = new Date(now.getTime() - windowDays * 86_400_000);
+
+  const [surfaces, prev, month, latency, questionsGenerated, answersGraded] = await Promise.all([
+    readSurfaceCost(windowDays, 0),
+    readSurfaceCost(windowDays * 2, windowDays),
+    readSurfaceCost(30, 0),
+    readSurfaceLatency(windowDays, 0),
+    countQuestionsGenerated(windowDays),
+    countAnswersGraded(windowDays),
+  ]);
+
+  const totalUsd = surfaces.reduce((a, s) => a + s.costUsd, 0);
+  const prevTotalUsd = prev.reduce((a, s) => a + s.costUsd, 0);
+  const monthUsd = month.reduce((a, s) => a + s.costUsd, 0);
+  const anyUnpriced = surfaces.some((s) => s.unpriced);
+
+  const sortedSurfaces = [...surfaces].sort((a, b) => b.costUsd - a.costUsd);
+
+  const slowestPlayerFacing =
+    latency
+      .filter((l) => l.playerFacing && l.p95Ms != null)
+      .sort((a, b) => (b.p95Ms ?? 0) - (a.p95Ms ?? 0))[0] ?? null;
+
+  const generateUsd = surfaces.find((s) => s.key === 'generate')?.costUsd ?? 0;
+  const gradeUsd = surfaces.find((s) => s.key === 'grade')?.costUsd ?? 0;
+
+  return {
+    windowDays,
+    periodStart,
+    periodEnd: now,
+    totalUsd,
+    prevTotalUsd,
+    monthUsd,
+    anyUnpriced,
+    surfaces: sortedSurfaces,
+    latency,
+    slowestPlayerFacing,
+    questionsGenerated,
+    answersGraded,
+    costPerQuestionUsd: questionsGenerated > 0 ? generateUsd / questionsGenerated : null,
+    costPerAnswerGradedUsd: answersGraded > 0 ? gradeUsd / answersGraded : null,
+  };
+}
+
+// ─── Markdown rendering (the plain-English digest) ───────────────────────────
+
+function usd(n: number | null): string {
+  if (n == null) return 'unknown';
+  if (n === 0) return '$0';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function pct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+function deltaPhrase(curr: number, prev: number): string {
+  if (prev <= 0) return curr > 0 ? 'no comparable spend last week' : 'flat versus last week';
+  const change = (curr - prev) / prev;
+  if (Math.abs(change) < 0.01) return 'about flat versus last week';
+  const dir = change > 0 ? 'up' : 'down';
+  return `${dir} ${pct(Math.abs(change))} from ${usd(prev)}`;
+}
+
+function ms(n: number | null): string {
+  if (n == null) return '—';
+  if (n < 1000) return `${Math.round(n)}ms`;
+  return `${(n / 1000).toFixed(1)}s`;
+}
+
+function fmtDate(d: Date): string {
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+/**
+ * Render the report as the plain-English digest a non-engineer reads top to
+ * bottom (Decision E1). Deliberately omits the "cheaper option" line (Decision
+ * E2 — held back for separate ratification, as it edges toward recommendation).
+ */
+export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
+  const lines: string[] = [];
+
+  lines.push(`# LLM cost & latency — ${fmtDate(r.periodStart)}–${fmtDate(r.periodEnd)}`);
+  lines.push('');
+
+  // Total + week-over-week.
+  lines.push(`**Total spent this week: ${usd(r.totalUsd)}**, ${deltaPhrase(r.totalUsd, r.prevTotalUsd)}.`);
+  lines.push('');
+  lines.push(`Trailing 30 days: ${usd(r.monthUsd)}.`);
+  lines.push('');
+
+  // Spend by surface, biggest first.
+  lines.push('## Where the money went');
+  lines.push('');
+  if (r.surfaces.length === 0) {
+    lines.push('No LLM spend recorded this week.');
+  } else {
+    for (const s of r.surfaces) {
+      const share = r.totalUsd > 0 ? ` (${pct(s.costUsd / r.totalUsd)})` : '';
+      const flag = s.unpriced ? ' — includes an unpriced model, so this is a floor' : '';
+      lines.push(`- **${s.label}: ${usd(s.costUsd)}**${share}${flag}`);
+    }
+  }
+  lines.push('');
+
+  // Cost per unit (only when a clean denominator exists, per O1).
+  lines.push('## Cost per unit');
+  lines.push('');
+  if (r.costPerQuestionUsd != null) {
+    lines.push(
+      `- Cost per question generated: **${usd(r.costPerQuestionUsd)}** (${r.questionsGenerated.toLocaleString('en-US')} generated)`,
+    );
+  } else {
+    lines.push('- Cost per question generated: no questions generated this week.');
+  }
+  if (r.costPerAnswerGradedUsd != null) {
+    lines.push(
+      `- Cost per answer graded: **${usd(r.costPerAnswerGradedUsd)}** (${r.answersGraded.toLocaleString('en-US')} graded by the model)`,
+    );
+  } else {
+    lines.push('- Cost per answer graded: no answers were graded by the model this week.');
+  }
+  lines.push('');
+
+  // Speed.
+  lines.push('## How long players wait');
+  lines.push('');
+  if (r.slowestPlayerFacing) {
+    const s = r.slowestPlayerFacing;
+    lines.push(
+      `Players wait longest on **${s.label.toLowerCase()}**: ~${ms(s.avgMs)} average, ~${ms(s.p95Ms)} at worst.`,
+    );
+  } else {
+    lines.push('No timed player-facing calls this week.');
+  }
+  lines.push('');
+  const timed = r.latency.filter((l) => l.calls > 0);
+  if (timed.length > 0) {
+    lines.push('| Surface | Avg | Worst (p95) |');
+    lines.push('| --- | --- | --- |');
+    for (const l of timed) {
+      lines.push(`| ${l.label} | ${ms(l.avgMs)} | ${ms(l.p95Ms)} |`);
+    }
+    lines.push('');
+  }
+
+  // Unpriced callout — say it plainly rather than under-reporting.
+  if (r.anyUnpriced) {
+    lines.push('## Heads up');
+    lines.push('');
+    lines.push(
+      'Some calls ran on a model with no price on file, so the dollar figures above are a floor — real spend is at least this much. Add the model to `src/server/llm/pricing.ts` to close the gap.',
+    );
+    lines.push('');
+  }
+
+  return lines.join('\n').trimEnd() + '\n';
+}
+
+// ─── Storage (Decision B1) ───────────────────────────────────────────────────
+
+export type StoredCostReport = {
+  markdown: string;
+  periodStart: Date;
+  periodEnd: Date;
+  windowDays: number;
+  createdAt: Date;
+};
+
+/** Persist one rendered digest. Best-effort would defeat the cron, so this throws. */
+export async function writeCostReport(r: CostLatencyReport, markdown: string): Promise<void> {
+  await db.insert(llmCostReport).values({
+    periodStart: r.periodStart,
+    periodEnd: r.periodEnd,
+    windowDays: r.windowDays,
+    markdown,
+  });
+}
+
+/** The most recently stored digest, or null if the cron has never run. */
+export async function readLatestCostReport(): Promise<StoredCostReport | null> {
+  const [row] = await db
+    .select({
+      markdown: llmCostReport.markdown,
+      periodStart: llmCostReport.periodStart,
+      periodEnd: llmCostReport.periodEnd,
+      windowDays: llmCostReport.windowDays,
+      createdAt: llmCostReport.createdAt,
+    })
+    .from(llmCostReport)
+    .orderBy(desc(llmCostReport.createdAt))
+    .limit(1);
+  return row ?? null;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1379,3 +1379,22 @@ export const llmUsageEvent = pgTable(
     index('LlmUsageEvent_provider_created_at_idx').on(table.provider, table.createdAt),
   ],
 );
+
+// B-LLM-COST-LATENCY-REPORT-01 — stored weekly cost & latency digest. One row
+// per run of /api/cron/llm-cost-report, holding the plain-English markdown the
+// owner reads. The digest is assembled from LlmUsageEvent rows at write time;
+// cost stays read-time-derived (pricing.ts), so the markdown reflects the price
+// map in effect when the cron ran. Read-and-report-only — nothing here is on the
+// LLM call path. Removable as a unit.
+export const llmCostReport = pgTable(
+  'LlmCostReport',
+  {
+    id: id(),
+    periodStart: timestamp('period_start', { withTimezone: true }).notNull(),
+    periodEnd: timestamp('period_end', { withTimezone: true }).notNull(),
+    windowDays: integer('window_days').notNull().default(7),
+    markdown: text('markdown').notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [index('LlmCostReport_created_at_idx').on(table.createdAt)],
+);

--- a/vercel.json
+++ b/vercel.json
@@ -28,6 +28,10 @@
     {
       "path": "/api/cron/pool-refill",
       "schedule": "0 9 * * *"
+    },
+    {
+      "path": "/api/cron/llm-cost-report",
+      "schedule": "0 13 * * 1"
     }
   ]
 }


### PR DESCRIPTION
Extends the B-LLM-PROVIDER-AB-METRICS telemetry with a plain-English weekly
report of LLM spend and player-facing latency, rolled up by surface. Pure
read-and-report over data recordLlmUsage already writes — no LLM call path,
generation, or grading logic is touched.

Decisions implemented:
- A1: seven-surface taxonomy in one mapping constant (SURFACE_BUCKETS) with a
  hard "Other / unmapped" catch-all so a new scope never silently vanishes.
- B1: stored markdown digest, written weekly by /api/cron/llm-cost-report and
  shown live in the owner-gated readout on the profile page.
- C1: trailing 7 days, week-over-week delta, plus a trailing-30-day total.
- D1 (blocker, resolved): grading records usage under scope 'grade'
  (src/lib/llm.ts dispatchLlmText('grade') -> recordLlmUsage), so the
  "Grading answers" bucket reads a real figure, not an empty $0. Verified live.
- E1: total + WoW, spend by surface, cost per question generated / answer
  graded, avg + p95 wait with the slowest player-facing surface named, and an
  unpriced-model callout. E2 cheaper-option line deliberately omitted.

Open questions resolved at build: O1 (denominators = generatedQuestions and
LLM-graded mastery events in-window), O2 (p95 via percentile_cont, labelled),
O3 (new sibling query file llm-cost-report.ts).

New LlmCostReport table (migration 0092) is purely additive, RLS-enabled, and
mirrored by an idempotent boot guard in instrumentation.ts (precedent 0091).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01WSjKawL4u2pwwYRTHs5ERB