### PR TITLE
Email the weekly LLM cost &amp; latency digest (B3)

### DIFF
--- a/src/app/api/cron/llm-cost-report/route.ts
+++ b/src/app/api/cron/llm-cost-report/route.ts
@@ -6,15 +6,16 @@ import {
   renderCostLatencyReportMarkdown,
   writeCostReport,
 } from '@/server/db/queries/llm-cost-report';
+import { sendCostReportEmail } from '@/server/email/send-cost-report';
 
 export const dynamic = 'force-dynamic';
 
-// B-LLM-COST-LATENCY-REPORT-01 — the weekly digest writer (Decision B1/C1).
+// B-LLM-COST-LATENCY-REPORT-01 — the weekly digest writer (Decisions B3/C1).
 // Scheduled Mondays (vercel.json) over the trailing 7 days, with a week-over-week
 // delta and a trailing-30-day total baked into the report. Read-and-report only:
-// it reads LlmUsageEvent rows recordLlmUsage already wrote and stores the rendered
-// markdown. Owner can also trigger it manually (same cron auth) to refresh the
-// stored snapshot on demand.
+// it reads LlmUsageEvent rows recordLlmUsage already wrote, stores the rendered
+// markdown, then emails it to LLM_COST_REPORT_EMAIL if configured. Owner can also
+// trigger it manually (same cron auth) to refresh the snapshot / resend on demand.
 const WINDOW_DAYS = 7;
 
 export async function GET(request: NextRequest) {
@@ -26,12 +27,22 @@ export async function GET(request: NextRequest) {
     const report = await buildCostLatencyReport(WINDOW_DAYS);
     const markdown = renderCostLatencyReportMarkdown(report);
     await writeCostReport(report, markdown);
+
+    // Best-effort email (Decision B3) — a send failure must not fail the stored
+    // digest, which is the durable artifact. sendCostReportEmail never throws.
+    const email = await sendCostReportEmail(report, markdown);
+    if (!email.ok && email.reason === 'send_failed') {
+      console.warn('[llm-cost-report] digest stored but email send failed', { message: email.message });
+    }
+
     return NextResponse.json({
       stored: true,
       windowDays: report.windowDays,
       totalUsd: Number(report.totalUsd.toFixed(4)),
       surfaces: report.surfaces.length,
       anyUnpriced: report.anyUnpriced,
+      emailed: email.ok,
+      emailReason: email.ok ? undefined : email.reason,
     });
   } catch (error) {
     console.error('[llm-cost-report] failed to build/store digest', error);

--- a/src/app/api/cron/llm-cost-report/route.ts
+++ b/src/app/api/cron/llm-cost-report/route.ts
@@ -42,6 +42,7 @@ export async function GET(request: NextRequest) {
       surfaces: report.surfaces.length,
       anyUnpriced: report.anyUnpriced,
       emailed: email.ok,
+      emailSource: email.ok ? email.source : undefined,
       emailReason: email.ok ? undefined : email.reason,
     });
   } catch (error) {

--- a/src/components/profile/settings/LlmCostReportReadout.tsx
+++ b/src/components/profile/settings/LlmCostReportReadout.tsx
@@ -79,8 +79,8 @@ export function LlmCostReportReadout({ data }: { data: CostReportData }) {
       </h2>
       <p className="text-muted-foreground mb-3 text-xs">
         Spend and player-facing wait time over the last {WINDOW_DAYS} days, rolled up by surface.
-        Shown live here; the Monday cron stores the same digest and emails it (when
-        LLM_COST_REPORT_EMAIL is set).
+        Shown live here; the Monday cron stores the same digest and emails it to your
+        admin account (or LLM_COST_REPORT_EMAIL, if set).
         {latestStoredAt
           ? ` Last stored ${latestStoredAt.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}.`
           : ' No stored snapshot yet.'}

--- a/src/components/profile/settings/LlmCostReportReadout.tsx
+++ b/src/components/profile/settings/LlmCostReportReadout.tsx
@@ -79,7 +79,8 @@ export function LlmCostReportReadout({ data }: { data: CostReportData }) {
       </h2>
       <p className="text-muted-foreground mb-3 text-xs">
         Spend and player-facing wait time over the last {WINDOW_DAYS} days, rolled up by surface.
-        Shown live here; the Monday cron stores the same digest as a snapshot.
+        Shown live here; the Monday cron stores the same digest and emails it (when
+        LLM_COST_REPORT_EMAIL is set).
         {latestStoredAt
           ? ` Last stored ${latestStoredAt.toLocaleString('en-US', { dateStyle: 'medium', timeStyle: 'short' })}.`
           : ' No stored snapshot yet.'}

--- a/src/env-check.ts
+++ b/src/env-check.ts
@@ -13,7 +13,10 @@ const REQUIRED_ENV_VARS = [
 // OPENAI_API_KEY (B-LLM-PROVIDER-AB-SWITCH): only needed when a provider toggle is
 // flipped to OpenAI. The feature defaults to Anthropic, so unset is fine — server
 // boots and every surface stays on Anthropic. Never promote to REQUIRED.
-const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL', 'ADMIN_USER_IDS', 'OPENAI_API_KEY'] as const;
+// LLM_COST_REPORT_EMAIL (B-LLM-COST-LATENCY-REPORT-01, B3): recipient for the weekly
+// cost & latency digest email. Unset ⇒ the cron still stores the digest and simply
+// skips the email. Never promote to REQUIRED.
+const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL', 'ADMIN_USER_IDS', 'OPENAI_API_KEY', 'LLM_COST_REPORT_EMAIL'] as const;
 
 export default function checkEnv() {
   const jwtSecret = process.env.JWT_SECRET?.trim() || process.env.AUTH_SECRET?.trim();

--- a/src/env-check.ts
+++ b/src/env-check.ts
@@ -13,9 +13,9 @@ const REQUIRED_ENV_VARS = [
 // OPENAI_API_KEY (B-LLM-PROVIDER-AB-SWITCH): only needed when a provider toggle is
 // flipped to OpenAI. The feature defaults to Anthropic, so unset is fine — server
 // boots and every surface stays on Anthropic. Never promote to REQUIRED.
-// LLM_COST_REPORT_EMAIL (B-LLM-COST-LATENCY-REPORT-01, B3): recipient for the weekly
-// cost & latency digest email. Unset ⇒ the cron still stores the digest and simply
-// skips the email. Never promote to REQUIRED.
+// LLM_COST_REPORT_EMAIL (B-LLM-COST-LATENCY-REPORT-01, B3): OPTIONAL override for the
+// weekly cost & latency digest recipient. Unset ⇒ the digest emails to the admin
+// account's email (ADMIN_USER_IDS); set it to redirect elsewhere. Never promote to REQUIRED.
 const OPTIONAL_ENV_VARS = ['NEXT_PUBLIC_APP_URL', 'ADMIN_USER_IDS', 'OPENAI_API_KEY', 'LLM_COST_REPORT_EMAIL'] as const;
 
 export default function checkEnv() {

--- a/src/server/auth/admin.ts
+++ b/src/server/auth/admin.ts
@@ -7,13 +7,17 @@
  * every caller 404s — the correct safe default. Callers that fail this check must
  * return 404 (never 403): the route's existence is not revealed to non-admins.
  */
-export function isAdminUser(userId: string | null | undefined): boolean {
-  if (!userId) return false;
+/** The parsed `ADMIN_USER_IDS` allowlist, in declared order. Empty when unset. */
+export function adminUserIds(): string[] {
   const raw = process.env.ADMIN_USER_IDS?.trim();
-  if (!raw) return false;
+  if (!raw) return [];
   return raw
     .split(',')
     .map((id) => id.trim())
-    .filter(Boolean)
-    .includes(userId);
+    .filter(Boolean);
+}
+
+export function isAdminUser(userId: string | null | undefined): boolean {
+  if (!userId) return false;
+  return adminUserIds().includes(userId);
 }

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -13,9 +13,10 @@
  * already recorded. Cost is still derived at read time from pricing.ts, so a
  * price edit reprices history with no backfill.
  */
-import { and, desc, gte, lt, sql } from 'drizzle-orm';
+import { and, desc, gte, inArray, isNotNull, lt, sql } from 'drizzle-orm';
 
-import { db, generatedQuestions, llmCostReport, llmUsageEvent, masteryEvents } from '@/server/db';
+import { adminUserIds } from '@/server/auth/admin';
+import { db, generatedQuestions, llmCostReport, llmUsageEvent, masteryEvents, users } from '@/server/db';
 import { estimateCostUsd } from '@/server/llm/pricing';
 
 // ─── Decision A: the surface taxonomy ────────────────────────────────────────
@@ -483,6 +484,43 @@ export async function writeCostReport(r: CostLatencyReport, markdown: string): P
     windowDays: r.windowDays,
     markdown,
   });
+}
+
+// ─── Email recipient resolution (Decision B3) ────────────────────────────────
+
+export type CostReportRecipient = {
+  to: string;
+  /** Where the address came from, for the cron's response + logs. */
+  source: 'env' | 'admin_verified' | 'admin_unverified';
+};
+
+/**
+ * Decide who the weekly digest emails to (the choice ratified for B3):
+ *   1. LLM_COST_REPORT_EMAIL if set — an explicit override always wins.
+ *   2. otherwise the email on the ADMIN_USER_IDS account — the same allowlist
+ *      that gates the readout — preferring a verified address over an unverified
+ *      one. No separate config needed for the common "email it to me" case.
+ *
+ * Returns null when nothing resolves (no override and no admin has an email on
+ * file), so the cron skips the send and still stores its digest.
+ */
+export async function resolveCostReportRecipient(): Promise<CostReportRecipient | null> {
+  const override = process.env.LLM_COST_REPORT_EMAIL?.trim();
+  if (override) return { to: override, source: 'env' };
+
+  const ids = adminUserIds();
+  if (ids.length === 0) return null;
+
+  const rows = await db
+    .select({ email: users.email, emailVerified: users.emailVerified })
+    .from(users)
+    .where(and(inArray(users.id, ids), isNotNull(users.email)))
+    // Prefer a verified address; among equals, the DB order is fine — one owner.
+    .orderBy(desc(users.emailVerified));
+
+  const row = rows.find((r) => r.email && r.email.trim());
+  if (!row?.email) return null;
+  return { to: row.email.trim(), source: row.emailVerified ? 'admin_verified' : 'admin_unverified' };
 }
 
 /** The most recently stored digest, or null if the cron has never run. */

--- a/src/server/email/send-cost-report.ts
+++ b/src/server/email/send-cost-report.ts
@@ -1,4 +1,8 @@
-import type { CostLatencyReport } from '@/server/db/queries/llm-cost-report';
+import {
+  resolveCostReportRecipient,
+  type CostLatencyReport,
+  type CostReportRecipient,
+} from '@/server/db/queries/llm-cost-report';
 
 import { sendEmail } from './client';
 import { buildCostReportEmailTemplate } from './templates/llm-cost-report';
@@ -8,27 +12,32 @@ import { buildCostReportEmailTemplate } from './templates/llm-cost-report';
  * (B-LLM-COST-LATENCY-REPORT-01, Decision B3 — store AND email). Reuses the
  * existing Resend client; no new email dependency.
  *
- * Recipient is LLM_COST_REPORT_EMAIL (optional). Unset ⇒ this is a no-op
- * ('not_configured'), so the cron still stores its digest and never fails just
- * because email isn't wired up. Never throws — returns a discriminated result
- * the caller folds into its response, exactly like sendVerificationEmail.
+ * Recipient comes from resolveCostReportRecipient: the LLM_COST_REPORT_EMAIL
+ * override if set, else the admin account's email. No recipient resolves ⇒ this
+ * is a no-op ('no_recipient'), so the cron still stores its digest and never
+ * fails just because email isn't wired up. Never throws — returns a discriminated
+ * result the caller folds into its response, like sendVerificationEmail.
  */
 export type SendCostReportEmailResult =
-  | { ok: true; id: string | null }
-  | { ok: false; reason: 'not_configured' | 'send_failed'; message: string };
+  | { ok: true; id: string | null; source: CostReportRecipient['source'] }
+  | { ok: false; reason: 'no_recipient' | 'send_failed'; message: string };
 
 export async function sendCostReportEmail(
   report: CostLatencyReport,
   markdown: string,
 ): Promise<SendCostReportEmailResult> {
-  const to = process.env.LLM_COST_REPORT_EMAIL?.trim();
-  if (!to) {
-    return { ok: false, reason: 'not_configured', message: 'LLM_COST_REPORT_EMAIL not set' };
+  const recipient = await resolveCostReportRecipient();
+  if (!recipient) {
+    return {
+      ok: false,
+      reason: 'no_recipient',
+      message: 'no LLM_COST_REPORT_EMAIL override and no admin account email on file',
+    };
   }
 
   const template = buildCostReportEmailTemplate({ report, markdown });
   const sendResult = await sendEmail({
-    to,
+    to: recipient.to,
     subject: template.subject,
     html: template.html,
     text: template.text,
@@ -37,5 +46,5 @@ export async function sendCostReportEmail(
   if (!sendResult.ok) {
     return { ok: false, reason: 'send_failed', message: sendResult.message };
   }
-  return { ok: true, id: sendResult.id };
+  return { ok: true, id: sendResult.id, source: recipient.source };
 }

--- a/src/server/email/send-cost-report.ts
+++ b/src/server/email/send-cost-report.ts
@@ -1,0 +1,41 @@
+import type { CostLatencyReport } from '@/server/db/queries/llm-cost-report';
+
+import { sendEmail } from './client';
+import { buildCostReportEmailTemplate } from './templates/llm-cost-report';
+
+/**
+ * Email the weekly LLM cost & latency digest to the operator
+ * (B-LLM-COST-LATENCY-REPORT-01, Decision B3 — store AND email). Reuses the
+ * existing Resend client; no new email dependency.
+ *
+ * Recipient is LLM_COST_REPORT_EMAIL (optional). Unset ⇒ this is a no-op
+ * ('not_configured'), so the cron still stores its digest and never fails just
+ * because email isn't wired up. Never throws — returns a discriminated result
+ * the caller folds into its response, exactly like sendVerificationEmail.
+ */
+export type SendCostReportEmailResult =
+  | { ok: true; id: string | null }
+  | { ok: false; reason: 'not_configured' | 'send_failed'; message: string };
+
+export async function sendCostReportEmail(
+  report: CostLatencyReport,
+  markdown: string,
+): Promise<SendCostReportEmailResult> {
+  const to = process.env.LLM_COST_REPORT_EMAIL?.trim();
+  if (!to) {
+    return { ok: false, reason: 'not_configured', message: 'LLM_COST_REPORT_EMAIL not set' };
+  }
+
+  const template = buildCostReportEmailTemplate({ report, markdown });
+  const sendResult = await sendEmail({
+    to,
+    subject: template.subject,
+    html: template.html,
+    text: template.text,
+  });
+
+  if (!sendResult.ok) {
+    return { ok: false, reason: 'send_failed', message: sendResult.message };
+  }
+  return { ok: true, id: sendResult.id };
+}

--- a/src/server/email/templates/llm-cost-report.ts
+++ b/src/server/email/templates/llm-cost-report.ts
@@ -1,0 +1,179 @@
+import type { CostLatencyReport } from '@/server/db/queries/llm-cost-report';
+
+/**
+ * Email template for the weekly LLM cost & latency digest
+ * (B-LLM-COST-LATENCY-REPORT-01, Decision B3 — store AND email). An owner-only
+ * operational digest, not a player-facing send: quiet, table-led, on-brand.
+ *
+ * The plain-text body IS the already-rendered markdown digest (the same words
+ * stored in LlmCostReport), so the text part never drifts from the stored
+ * artifact. The HTML part is a light branded rendering of the same structured
+ * report. No unsubscribe footer — this goes to the operator, not a list.
+ */
+
+// Brand palette — inlined from src/app/globals.css, same as daily-reminder.ts
+// (mail clients can't read CSS custom properties). Keep in lockstep.
+const CREAM = '#fcf8f2';
+const CARD = '#fdfcfb';
+const INK = '#0a1f3d';
+const INK_SOFT = '#3a4a5f';
+const INK_FAINT = '#8a8a8a';
+const RULE = '#e9e2d2';
+
+const SERIF = "Georgia,'Times New Roman',serif";
+const SANS = "'Montserrat',-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif";
+
+function usd(n: number | null): string {
+  if (n == null) return '—';
+  if (n === 0) return '$0';
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  if (n < 1) return `$${n.toFixed(3)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function pct(n: number): string {
+  return `${Math.round(n * 100)}%`;
+}
+
+function ms(n: number | null): string {
+  if (n == null) return '—';
+  if (n < 1000) return `${Math.round(n)}ms`;
+  return `${(n / 1000).toFixed(1)}s`;
+}
+
+function num(n: number): string {
+  return n.toLocaleString('en-US');
+}
+
+function fmtDate(d: Date): string {
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+}
+
+function deltaPhrase(curr: number, prev: number): string {
+  if (prev <= 0) return curr > 0 ? 'no comparable spend last week' : 'flat vs last week';
+  const change = (curr - prev) / prev;
+  if (Math.abs(change) < 0.01) return 'about flat vs last week';
+  return `${change > 0 ? 'up' : 'down'} ${pct(Math.abs(change))} vs last week`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function eyebrow(label: string): string {
+  return `<tr><td style="font-family:${SANS};font-size:11px;letter-spacing:0.14em;text-transform:uppercase;color:${INK_FAINT};padding:18px 0 10px;">${escapeHtml(label)}</td></tr>`;
+}
+
+function th(label: string, align: 'left' | 'right'): string {
+  return `<th align="${align}" style="font-family:${SANS};font-size:11px;color:${INK_FAINT};font-weight:600;text-transform:uppercase;letter-spacing:0.04em;padding:0 0 6px;border-bottom:1px solid ${RULE};">${escapeHtml(label)}</th>`;
+}
+
+function td(value: string, align: 'left' | 'right'): string {
+  return `<td align="${align}" style="font-family:${SERIF};font-size:15px;color:${INK};padding:6px 0;border-bottom:1px solid ${RULE};">${value}</td>`;
+}
+
+export function buildCostReportEmailTemplate(params: {
+  report: CostLatencyReport;
+  markdown: string;
+}): { subject: string; html: string; text: string } {
+  const { report: r, markdown } = params;
+  const range = `${fmtDate(r.periodStart)}–${fmtDate(r.periodEnd)}`;
+  const subject = `LLM cost & latency — ${usd(r.totalUsd)} this week (${range})`;
+
+  // Spend-by-surface rows.
+  const surfaceRows =
+    r.surfaces.length === 0
+      ? `<tr><td style="font-family:${SERIF};font-size:15px;color:${INK_SOFT};padding:6px 0;">No LLM spend recorded this week.</td></tr>`
+      : r.surfaces
+          .map((s) => {
+            const share = r.totalUsd > 0 ? pct(s.costUsd / r.totalUsd) : '—';
+            const label = escapeHtml(s.label) + (s.unpriced ? ' *' : '');
+            return `<tr>${td(label, 'left')}${td(num(s.calls), 'right')}${td(usd(s.costUsd), 'right')}${td(share, 'right')}</tr>`;
+          })
+          .join('');
+
+  // Latency rows (only timed surfaces).
+  const timed = r.latency.filter((l) => l.calls > 0);
+  const latencyRows = timed
+    .map((l) => `<tr>${td(escapeHtml(l.label), 'left')}${td(ms(l.avgMs), 'right')}${td(ms(l.p95Ms), 'right')}</tr>`)
+    .join('');
+
+  const slowest = r.slowestPlayerFacing
+    ? `Players wait longest on <strong>${escapeHtml(r.slowestPlayerFacing.label.toLowerCase())}</strong>: ~${ms(
+        r.slowestPlayerFacing.avgMs,
+      )} average, ~${ms(r.slowestPlayerFacing.p95Ms)} at worst.`
+    : 'No timed player-facing calls this week.';
+
+  const perQuestion =
+    r.costPerQuestionUsd != null
+      ? `${usd(r.costPerQuestionUsd)} <span style="color:${INK_FAINT};">· ${num(r.questionsGenerated)} made</span>`
+      : `<span style="color:${INK_FAINT};">no questions generated</span>`;
+  const perGrade =
+    r.costPerAnswerGradedUsd != null
+      ? `${usd(r.costPerAnswerGradedUsd)} <span style="color:${INK_FAINT};">· ${num(r.answersGraded)} graded</span>`
+      : `<span style="color:${INK_FAINT};">no answers graded by the model</span>`;
+
+  const unpricedNote = r.anyUnpriced
+    ? `<tr><td style="font-family:${SANS};font-size:12px;font-style:italic;color:${INK_FAINT};padding-top:18px;">* some calls ran on a model with no price on file — the dollar figures are a floor (real spend is at least this much).</td></tr>`
+    : '';
+
+  const html = `<!doctype html>
+<html lang="en">
+  <body style="margin:0;padding:0;background:${CREAM};font-family:${SERIF};color:${INK};">
+    <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="background:${CREAM};padding:40px 16px;">
+      <tr><td align="center">
+        <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0" style="max-width:560px;background:${CARD};border:1px solid ${RULE};border-radius:12px;">
+          <tr><td style="padding:32px;">
+            <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+              <tr><td style="font-family:${SANS};font-size:13px;letter-spacing:0.04em;color:${INK_SOFT};padding-bottom:14px;">Joshing · LLM cost & latency</td></tr>
+              <tr><td style="font-family:${SERIF};font-size:28px;line-height:1.25;font-weight:700;color:${INK};padding-bottom:8px;">${usd(
+                r.totalUsd,
+              )} this week</td></tr>
+              <tr><td style="font-family:${SERIF};font-size:16px;line-height:1.5;color:${INK_SOFT};padding-bottom:4px;">${escapeHtml(
+                range,
+              )} · ${escapeHtml(deltaPhrase(r.totalUsd, r.prevTotalUsd))}</td></tr>
+              <tr><td style="font-family:${SERIF};font-size:14px;color:${INK_FAINT};">Trailing 30 days: ${usd(
+                r.monthUsd,
+              )}</td></tr>
+
+              ${eyebrow('Where the money went')}
+              <tr><td>
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                  <tr>${th('Surface', 'left')}${th('Calls', 'right')}${th('Est. USD', 'right')}${th('Share', 'right')}</tr>
+                  ${surfaceRows}
+                </table>
+              </td></tr>
+
+              ${eyebrow('Cost per unit')}
+              <tr><td style="font-family:${SERIF};font-size:15px;color:${INK};padding:2px 0;">Per question generated — ${perQuestion}</td></tr>
+              <tr><td style="font-family:${SERIF};font-size:15px;color:${INK};padding:2px 0;">Per answer graded — ${perGrade}</td></tr>
+
+              ${eyebrow('How long players wait')}
+              <tr><td style="font-family:${SERIF};font-size:15px;line-height:1.6;color:${INK};padding-bottom:8px;">${slowest}</td></tr>
+              ${
+                timed.length > 0
+                  ? `<tr><td>
+                <table role="presentation" width="100%" cellspacing="0" cellpadding="0" border="0">
+                  <tr>${th('Surface', 'left')}${th('Avg', 'right')}${th('Worst (p95)', 'right')}</tr>
+                  ${latencyRows}
+                </table>
+              </td></tr>`
+                  : ''
+              }
+
+              ${unpricedNote}
+            </table>
+          </td></tr>
+        </table>
+      </td></tr>
+    </table>
+  </body>
+</html>`;
+
+  return { subject, html, text: markdown };
+}


### PR DESCRIPTION
Follow-on to #1274 (the stored digest, already merged). Adds Decision **B3** — store **and** email — on top of B1, reusing the existing Resend client (no new email dependency).

## What this adds
- **Email template** (`templates/llm-cost-report.ts`) — owner-only operational digest. The plain-text body **is** the stored markdown (so it can't drift from the `LlmCostReport` snapshot); the HTML is a light, on-brand rendering of the same structured report.
- **`sendCostReportEmail`** — mirrors `sendVerificationEmail`: never throws, returns a discriminated result. Best-effort in the cron, so a send failure logs but never fails the stored digest (the durable artifact).
- **Recipient resolution** (`resolveCostReportRecipient`) — defaults to the admin account's email so it works with nothing to set:
  1. `LLM_COST_REPORT_EMAIL` override, if set — explicit redirect always wins.
  2. else the `ADMIN_USER_IDS` account's email, preferring a verified address.
  3. else null → cron skips the send and still stores the digest.
- Adds `adminUserIds()` to `auth/admin.ts` as the single parse of the allowlist; `isAdminUser` delegates to it.
- `LLM_COST_REPORT_EMAIL` registered as an **optional override** in `env-check`.
- Cron response now reports `emailed` + `emailSource` (`env` | `admin_verified` | `admin_unverified`).

## To receive it
Nothing required if your `ADMIN_USER_IDS` account has a (verified) email on file — the Monday cron will email it there. Set `LLM_COST_REPORT_EMAIL` only to redirect elsewhere. Reuses the same Resend setup (`RESEND_API_KEY` + verified `EMAIL_FROM`) that powers daily reminders.

## Verification
`tsc -p tsconfig.typecheck.json` clean · ESLint clean on all changed files. Not exercised: a real Resend delivery and the HTML rendering in a mail client (no key/recipient in the build env) — the first cron run is the first real send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSjKawL4u2pwwYRTHs5ERB

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSjKawL4u2pwwYRTHs5ERB)_