### PR TITLE
Add Recovered Questions review pool (D-REVIEW-RECOVERED-01)

### DIFF
--- a/src/app/recovered/page.tsx
+++ b/src/app/recovered/page.tsx
@@ -1,0 +1,57 @@
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+
+import { RecoveredCard } from '@/components/recovered/RecoveredCard';
+import { getSession } from '@/server/auth/session';
+import { getRecoveredQuestionsForUser } from '@/server/db/queries/recovered-questions';
+
+/**
+ * D-REVIEW-RECOVERED-01 — the Recovered-Questions review surface (Version A).
+ *
+ * A personal, profile-resident, read-only pool of the questions the viewer got
+ * wrong and then later got right. Self-initiated from the profile — never
+ * pushed, no "due" badge, no streak, no denominator. The whole page is a server
+ * component with no client JS: the reveal is a native <details> on each card,
+ * so this surface mints no writes (see RecoveredCard / the query module).
+ */
+export const dynamic = 'force-dynamic';
+
+export default async function RecoveredQuestionsPage() {
+  const session = await getSession();
+  if (!session) notFound();
+
+  const recovered = await getRecoveredQuestionsForUser(session.userId);
+
+  return (
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6 pb-20">
+      <header>
+        <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
+          <Link href="/" className="underline underline-offset-2">HOME</Link>
+          {' / '}
+          <Link href="/users/me" className="underline underline-offset-2">PROFILE</Link>
+          {' / REVISIT'}
+        </p>
+        <h1 className="mt-3 font-serif text-4xl font-semibold leading-tight text-foreground">
+          The ones you turned around
+        </h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Questions you once missed and later got right. Sit with one, recall the answer, then reveal it.
+        </p>
+      </header>
+
+      {recovered.length === 0 ? (
+        // Cold-start register (Decision D): discovery-framed, not a failure /
+        // "nothing here" note. Most players (and every new player) land here.
+        <section className="mt-10 flex min-h-48 items-center justify-center text-center text-sm text-muted-foreground">
+          The ones you turned around will gather here as you play.
+        </section>
+      ) : (
+        <section className="mt-6 space-y-3">
+          {recovered.map((question) => (
+            <RecoveredCard key={question.id} question={question} />
+          ))}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { Brain, Globe, type LucideIcon, Pencil, Users as UsersIcon } from 'lucide-react';
+import { Brain, Globe, type LucideIcon, Pencil, RotateCcw, Users as UsersIcon } from 'lucide-react';
 import Link from 'next/link';
 import { headers } from 'next/headers';
 import { notFound } from 'next/navigation';
@@ -233,6 +233,18 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
           memberSince={portrait.user.memberSince}
           editable
         />
+
+        <section className="mb-8">
+          <h2 className="mb-3 font-serif text-2xl font-semibold">Revisit</h2>
+          <SettingsGroup>
+            <SettingsRow
+              icon={<RotateCcw className="size-5" />}
+              title="The ones you turned around"
+              subtitle="Questions you once missed and later got right. Recall, then reveal."
+              href="/recovered"
+            />
+          </SettingsGroup>
+        </section>
 
         <section className="mb-8">
           <h2 className="mb-3 font-serif text-2xl font-semibold">Privacy</h2>

--- a/src/components/recovered/RecoveredCard.tsx
+++ b/src/components/recovered/RecoveredCard.tsx
@@ -1,0 +1,38 @@
+import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
+
+/**
+ * D-REVIEW-RECOVERED-01 (Decision B) — silent self-reveal, no grading.
+ *
+ * The reveal is a native <details> disclosure: show the question, the player
+ * recalls in their head, taps to reveal the canonical answer, self-assesses
+ * silently, moves on. Nothing is recorded. This is a server component with no
+ * client JS and no network on reveal — read-only by construction, so there is
+ * no path through which a `mastery_events` row (or any write) could be minted.
+ *
+ * No streak / count / progress register, no color-only distinction (canon
+ * tripwires): the category eyebrow is text, the reveal is a labelled control.
+ */
+export function RecoveredCard({ question }: { question: RecoveredQuestion }) {
+  return (
+    <article className="card p-4">
+      <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
+        {question.category}
+      </p>
+
+      <p className="mt-2 font-serif text-lg font-medium leading-snug text-foreground">
+        {question.questionText}
+      </p>
+
+      <details className="group mt-3 text-sm leading-6">
+        <summary className="inline-flex cursor-pointer items-center gap-1 font-medium text-foreground underline underline-offset-2">
+          <span className="group-open:hidden">Reveal the answer</span>
+          <span className="hidden group-open:inline">The answer</span>
+        </summary>
+        <p className="mt-2 font-medium text-foreground">{question.answerText}</p>
+        {question.factualExplanation ? (
+          <p className="mt-2 text-muted-foreground">{question.factualExplanation}</p>
+        ) : null}
+      </details>
+    </article>
+  );
+}

--- a/src/components/recovered/__tests__/RecoveredCard.test.tsx
+++ b/src/components/recovered/__tests__/RecoveredCard.test.tsx
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { RecoveredCard } from '../RecoveredCard';
+import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
+
+// D-REVIEW-RECOVERED-01 (Decision B / Done-When #3) — the reveal performs zero
+// writes. The card is a server component whose reveal is a native <details>
+// disclosure: there is no answer-submission path, no <form>, and no network on
+// reveal, so no `mastery_events` row (or any write) can be minted here.
+
+const QUESTION: RecoveredQuestion = {
+  id: 'me-1',
+  questionId: 'q-1',
+  questionText: 'Who wrote the Storia d’Italia?',
+  answerText: 'Francesco Guicciardini',
+  factualExplanation: 'A Florentine historian and statesman.',
+  category: 'history',
+  recoveredAt: new Date('2026-06-01T00:00:00Z'),
+};
+
+describe('RecoveredCard — silent self-reveal, no writes', () => {
+  it('reveals the answer through a native <details>, not a submittable control', () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+
+    const html = renderToStaticMarkup(<RecoveredCard question={QUESTION} />);
+
+    // Question and answer both render; the answer sits inside the disclosure.
+    expect(html).toContain(QUESTION.questionText);
+    expect(html).toContain(QUESTION.answerText);
+    expect(html).toContain('<details');
+    expect(html).toContain('<summary');
+    expect(html).toContain('Reveal the answer');
+
+    // No write path: no form, no submit button, and rendering issues no fetch.
+    expect(html).not.toContain('<form');
+    expect(html).not.toContain('type="submit"');
+    expect(fetchSpy).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('omits the explanation paragraph when there is none', () => {
+    const html = renderToStaticMarkup(
+      <RecoveredCard question={{ ...QUESTION, factualExplanation: null }} />,
+    );
+    expect(html).toContain(QUESTION.answerText);
+    expect(html).not.toContain('A Florentine historian');
+  });
+});

--- a/src/server/db/queries/__tests__/recovered-questions.test.ts
+++ b/src/server/db/queries/__tests__/recovered-questions.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// D-REVIEW-RECOVERED-01 — wiring test for the recovered-questions pool.
+//
+// We mock drizzle as inert node-builders and capture the WHERE / ORDER BY the
+// reader constructs, then assert the exact pool definition (Done-When #1):
+//   answer_state = 'first_correct_after_wrong' + question_id IS NOT NULL,
+//   ordered created_at DESC.
+//
+// It also guards the read-only contract (Done-When #3): the db mock exposes
+// insert/update/delete that throw, so any write attempt on this surface fails
+// the test loudly. The pool is built with SELECT and nothing else.
+interface Node {
+  op: string;
+  column?: unknown;
+  value?: unknown;
+  values?: unknown;
+  parts?: Node[];
+}
+
+let capturedWhere: Node | null = null;
+let capturedOrderBy: Node | null = null;
+let selectCalls = 0;
+
+vi.mock('drizzle-orm', () => ({
+  and: vi.fn((...parts: Node[]) => ({ op: 'and', parts })),
+  eq: vi.fn((column, value) => ({ op: 'eq', column, value })),
+  desc: vi.fn((column) => ({ op: 'desc', column })),
+  inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
+  isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+}));
+
+vi.mock('@/server/db', () => {
+  const chain: Record<string, unknown> = {};
+  chain.from = vi.fn(() => chain);
+  chain.innerJoin = vi.fn(() => chain);
+  chain.where = vi.fn((cond: Node) => {
+    capturedWhere = cond;
+    return chain;
+  });
+  chain.orderBy = vi.fn((order: Node) => {
+    capturedOrderBy = order;
+    return Promise.resolve([]);
+  });
+  const fail = (op: string) =>
+    vi.fn(() => {
+      throw new Error(`read-only surface attempted a ${op}`);
+    });
+  return {
+    db: {
+      select: vi.fn(() => {
+        selectCalls += 1;
+        return chain;
+      }),
+      insert: fail('insert'),
+      update: fail('update'),
+      delete: fail('delete'),
+    },
+    masteryEvents: {
+      id: 'me.id',
+      userId: 'me.userId',
+      sourceType: 'me.sourceType',
+      answerState: 'me.answerState',
+      questionId: 'me.questionId',
+      createdAt: 'me.createdAt',
+    },
+    questions: {
+      id: 'q.id',
+      questionText: 'q.questionText',
+      answerText: 'q.answerText',
+      factualExplanation: 'q.factualExplanation',
+      canonicalSubcategory: 'q.canonicalSubcategory',
+      category: 'q.category',
+    },
+  };
+});
+
+import { getRecoveredQuestionsForUser } from '@/server/db/queries/recovered-questions';
+
+function flatten(node: Node | null): Node[] {
+  if (!node) return [];
+  if (node.op === 'and') return (node.parts ?? []).flatMap(flatten);
+  return [node];
+}
+
+const VIEWER = 'viewer-1';
+
+beforeEach(() => {
+  capturedWhere = null;
+  capturedOrderBy = null;
+  selectCalls = 0;
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('getRecoveredQuestionsForUser — pool definition', () => {
+  it('filters on answer_state = first_correct_after_wrong', async () => {
+    await getRecoveredQuestionsForUser(VIEWER);
+    const match = flatten(capturedWhere).find(
+      (n) => n.op === 'eq' && n.column === 'me.answerState',
+    );
+    expect(match).toBeDefined();
+    expect(match!.value).toBe('first_correct_after_wrong');
+  });
+
+  it('guards question_id IS NOT NULL', async () => {
+    await getRecoveredQuestionsForUser(VIEWER);
+    const match = flatten(capturedWhere).find(
+      (n) => n.op === 'isNotNull' && n.column === 'me.questionId',
+    );
+    expect(match).toBeDefined();
+  });
+
+  it('scopes to the viewer', async () => {
+    await getRecoveredQuestionsForUser(VIEWER);
+    const match = flatten(capturedWhere).find(
+      (n) => n.op === 'eq' && n.column === 'me.userId',
+    );
+    expect(match).toBeDefined();
+    expect(match!.value).toBe(VIEWER);
+  });
+
+  it('orders by created_at DESC (recency, Decision C)', async () => {
+    await getRecoveredQuestionsForUser(VIEWER);
+    expect(capturedOrderBy).toEqual({ op: 'desc', column: 'me.createdAt' });
+  });
+
+  it('reads with SELECT only — no insert/update/delete on this surface', async () => {
+    await expect(getRecoveredQuestionsForUser(VIEWER)).resolves.toEqual([]);
+    expect(selectCalls).toBe(1);
+  });
+});

--- a/src/server/db/queries/recovered-questions.ts
+++ b/src/server/db/queries/recovered-questions.ts
@@ -1,0 +1,106 @@
+import { and, desc, eq, inArray, isNotNull } from 'drizzle-orm';
+
+import { db, masteryEvents, questions } from '@/server/db';
+
+/**
+ * D-REVIEW-RECOVERED-01 — the "Recovered Questions" review pool (Version A).
+ *
+ * The pool is every question for which the viewer has a
+ * `first_correct_after_wrong` answer-state event: the wrong→right moment
+ * (computeAnswerState, src/server/answer-state.ts), written at insert time by
+ * the shared answer pipeline across all five live answer surfaces.
+ *
+ * This surface is READ-ONLY by construction. It computes nothing new, writes
+ * nothing, and does not touch the mastery system — it is a reflective pool, not
+ * a drill. Decisions A–D in the D- doc:
+ *   A. Pool = whole "ever recovered" set (no latest-state reduction, no
+ *      retirement). A question stays even if later re-missed; the moment, not a
+ *      current status, is what `first_correct_after_wrong` records.
+ *   B. Interaction is silent self-reveal — the reveal lives entirely in the
+ *      render (native <details> on the surface), never an answer submission.
+ *   C. Ordering is recency: ORDER BY created_at DESC.
+ *
+ * `answer_state` only carries a value on the `live_correct` / `catchup_correct`
+ * source types, and `question_id` is nullable on mastery_events — hence the
+ * source-type narrowing, the `question_id IS NOT NULL` guard, and the inner
+ * join, so no orphan rows surface. Filter + ordering are covered by the
+ * existing (user_id, source_type, answer_state, created_at) composite index;
+ * no migration, no new columns, no new tables.
+ */
+
+// The surface source types that carry an answer_state (see the Lately reader,
+// where the same naming caveat is documented): these gate by SURFACE, not by
+// correctness. Correctness lives in answer_state.
+const ANSWER_STATE_SOURCE_TYPES = ['live_correct', 'catchup_correct'] as const;
+
+export type RecoveredQuestion = {
+  /** mastery_events.id — stable key for the recovered moment. */
+  id: string;
+  questionId: string;
+  questionText: string;
+  answerText: string;
+  factualExplanation: string | null;
+  /** Best available display category, already prettified for the eyebrow. */
+  category: string;
+  /** When the wrong→right moment was recorded. */
+  recoveredAt: Date;
+};
+
+const CATEGORY_ENUM_PRETTY: Record<string, string> = {
+  music: 'music',
+  literature: 'literature',
+  history: 'history',
+  film_tv: 'film & TV',
+  sport: 'sport',
+  science: 'science',
+  philosophy: 'philosophy',
+  pop_culture: 'pop culture',
+  language: 'language',
+  general_knowledge: 'general knowledge',
+};
+
+function prettifyCategory(canonical: string | null, coarse: string | null): string {
+  const trimmed = canonical?.trim();
+  if (trimmed) return trimmed;
+  if (coarse && CATEGORY_ENUM_PRETTY[coarse]) return CATEGORY_ENUM_PRETTY[coarse];
+  return 'something';
+}
+
+/**
+ * Returns the viewer's whole "ever recovered" pool, most recently recovered
+ * first. Read-only: a single SELECT, no writes, no mastery coupling.
+ */
+export async function getRecoveredQuestionsForUser(userId: string): Promise<RecoveredQuestion[]> {
+  const rows = await db
+    .select({
+      id: masteryEvents.id,
+      questionId: questions.id,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+      factualExplanation: questions.factualExplanation,
+      canonicalSubcategory: questions.canonicalSubcategory,
+      category: questions.category,
+      recoveredAt: masteryEvents.createdAt,
+    })
+    .from(masteryEvents)
+    .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+    .where(
+      and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.sourceType, ANSWER_STATE_SOURCE_TYPES),
+        eq(masteryEvents.answerState, 'first_correct_after_wrong'),
+        isNotNull(masteryEvents.questionId),
+      ),
+    )
+    .orderBy(desc(masteryEvents.createdAt));
+
+  return rows.map((row) => ({
+    id: row.id,
+    questionId: row.questionId,
+    questionText: row.questionText,
+    answerText: row.answerText,
+    factualExplanation: row.factualExplanation,
+    category: prettifyCategory(row.canonicalSubcategory, row.category),
+    recoveredAt: row.recoveredAt,
+  }));
+}


### PR DESCRIPTION
## Summary
Implements the "Recovered Questions" review surface — a read-only, personal pool of questions the viewer got wrong and later got right. This is a reflective review surface with no writes, no mastery coupling, and no client-side interaction beyond native `<details>` disclosure.

## Changes

### Query & Data Layer
- **`src/server/db/queries/recovered-questions.ts`** — New query module that fetches the viewer's complete "ever recovered" set:
  - Filters on `answer_state = 'first_correct_after_wrong'` (the wrong→right moment recorded by the shared answer pipeline)
  - Guards `question_id IS NOT NULL` to prevent orphan rows
  - Scopes to the authenticated user
  - Orders by `created_at DESC` (recency, Decision C)
  - Leverages existing composite index `(user_id, source_type, answer_state, created_at)` — no new migrations or schema changes
  - Returns `RecoveredQuestion` type with prettified category display
  - Read-only by construction: single SELECT, no writes

### UI Components
- **`src/components/recovered/RecoveredCard.tsx`** — Server component that renders a single recovered question:
  - Displays question text and category eyebrow
  - Uses native `<details>` disclosure for silent self-reveal (no form, no submit, no network call)
  - Shows canonical answer and optional factual explanation on reveal
  - Zero writes: no `mastery_events` row minted on reveal

- **`src/app/recovered/page.tsx`** — New page route (`/recovered`):
  - Server component with `force-dynamic` to ensure fresh data
  - Requires authentication (redirects to 404 if not logged in)
  - Displays the full recovered pool, most recent first
  - Cold-start messaging when pool is empty (Decision D: discovery-framed, not a failure state)

### Navigation
- **`src/app/users/[id]/page.tsx`** — Added "Revisit" section to user profile with link to `/recovered`:
  - New `RotateCcw` icon from lucide-react
  - Subtitle explains the pool's purpose

### Testing
- **`src/server/db/queries/__tests__/recovered-questions.test.ts`** — Comprehensive wiring test:
  - Mocks drizzle-orm and db to capture WHERE/ORDER BY clauses
  - Asserts exact pool definition: `answer_state = 'first_correct_after_wrong'` + `question_id IS NOT NULL` + user scoping + `created_at DESC` ordering
  - Guards read-only contract: db mock exposes insert/update/delete that throw, ensuring no writes on this surface

- **`src/components/recovered/__tests__/RecoveredCard.test.tsx`** — Component test:
  - Verifies silent self-reveal via native `<details>` (no form, no submit button, no fetch)
  - Confirms answer and explanation render correctly
  - Tests omission of explanation when null

## Implementation Notes
- **No new migrations:** Uses existing `mastery_events` and `questions` tables; filters leverage the existing composite index
- **Read-only by construction:** Single SELECT query, no insert/update/delete paths; reveal is a native disclosure with zero network activity
- **Decision A (whole "ever recovered" set):** No latest-state reduction or retirement — a question stays in the pool even if later re-missed; the moment is what matters
- **Decision B (silent self-reveal):** Reveal lives entirely in the render (`<details>`), never an answer submission
- **Decision C (recency ordering):** `ORDER BY created_at DESC`
- **Decision D (cold-start messaging):** Discovery-framed empty state, not a failure message

https://claude.ai/code/session_015KbCLADecKeCfJLowd36tj