### PR TITLE
Add top margin to Revisit section on user profile

### DIFF
--- a/src/app/users/[id]/page.tsx
+++ b/src/app/users/[id]/page.tsx
@@ -234,7 +234,7 @@ export default async function UserProfilePage({ params, searchParams }: UserProf
           editable
         />
 
-        <section className="mb-8">
+        <section className="mt-8 mb-8">
           <h2 className="mb-3 font-serif text-2xl font-semibold">Revisit</h2>
           <SettingsGroup>
             <SettingsRow


### PR DESCRIPTION
## Summary
Adds top margin (`mt-8`) to the "Revisit" section on the user profile page to improve vertical spacing and visual hierarchy.

## Changes
- Added `mt-8` class to the section element containing the "Revisit" heading and settings, complementing the existing `mb-8` bottom margin for consistent spacing above and below the section.

## Details
This is a minor spacing adjustment to the user profile layout. The section now has symmetric vertical margins (`mt-8 mb-8`), improving the visual balance between the section above it and the Revisit section itself.

https://claude.ai/code/session_01LcbBFzyiQDGKPXjGoCbJ4T