### PR TITLE
feat(recovered): graded, non-persisting review (Decision B revision)

### DIFF
--- a/src/app/api/recovered/grade/__tests__/route.test.ts
+++ b/src/app/api/recovered/grade/__tests__/route.test.ts
@@ -1,0 +1,126 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// D-REVIEW-RECOVERED-01 (Decision B / Done-When #3 & #4) — the review grade
+// route grades for real and persists NOTHING. These tests pin:
+//   - a scored verdict returns the result + canonical answer, no writes;
+//   - the route imports neither writeMasteryEvent nor deriveAnswerOutcome;
+//   - an `unscored` grader outcome fails toward the player (503 retry) and is
+//     NEVER returned as a miss (no `isCorrect: false`);
+//   - pool-membership / auth guards.
+
+const { getSessionMock, gradeAnswerMock, getRecoveredGradingQuestionMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
+  gradeAnswerMock: vi.fn(),
+  getRecoveredGradingQuestionMock: vi.fn(),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/grading', () => ({ gradeAnswer: gradeAnswerMock }));
+vi.mock('@/server/db/queries/recovered-questions', () => ({
+  getRecoveredGradingQuestion: getRecoveredGradingQuestionMock,
+}));
+
+import { POST } from '@/app/api/recovered/grade/route';
+
+const GRADABLE = {
+  questionId: 'q-7',
+  questionText: 'Who wrote the Storia d’Italia?',
+  answerText: 'Francesco Guicciardini',
+  acceptedAlternatives: ['Guicciardini'],
+  questionType: 'factual' as const,
+  explanation: 'A Florentine historian and statesman.',
+  creatorNote: null,
+};
+
+function req(body: unknown): NextRequest {
+  return { json: async () => body } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  getSessionMock.mockResolvedValue({ userId: 'user-1', id: 's-1' });
+  getRecoveredGradingQuestionMock.mockResolvedValue(GRADABLE);
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('POST /api/recovered/grade', () => {
+  it('401s without a session', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ questionId: 'q-7', answer: 'x' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('400s on a malformed body', async () => {
+    const res = await POST(req({ answer: 'x' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('404s when the question is not in the viewer recovered pool', async () => {
+    getRecoveredGradingQuestionMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ questionId: 'q-x', answer: 'x' }));
+    expect(res.status).toBe(404);
+    expect(gradeAnswerMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a scored CORRECT verdict with the canonical answer', async () => {
+    gradeAnswerMock.mockResolvedValueOnce({
+      status: 'scored',
+      result: 'correct',
+      consolation: null,
+      confidence: 1,
+      gradedVia: 'exact',
+      gradedProvider: null,
+    });
+    const res = await POST(req({ questionId: 'q-7', answer: 'Guicciardini' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({ isCorrect: true, correctAnswer: 'Francesco Guicciardini' });
+  });
+
+  it('returns a scored WRONG verdict and reveals the answer (no consequence)', async () => {
+    gradeAnswerMock.mockResolvedValueOnce({
+      status: 'scored',
+      result: 'wrong',
+      consolation: 'So close.',
+      confidence: 0.9,
+      gradedVia: 'llm',
+      gradedProvider: 'anthropic',
+    });
+    const res = await POST(req({ questionId: 'q-7', answer: 'Machiavelli' }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.isCorrect).toBe(false);
+    expect(body.correctAnswer).toBe('Francesco Guicciardini');
+    expect(body.consolation).toBe('So close.');
+  });
+
+  it('fails toward the player on an unscored grade — 503 retry, NEVER a miss', async () => {
+    gradeAnswerMock.mockResolvedValueOnce({ status: 'unscored', reason: 'llm_error' });
+    const res = await POST(req({ questionId: 'q-7', answer: 'something' }));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe('grader_unavailable');
+    // The crux: an unscored grade is not rendered as a wrong answer.
+    expect('isCorrect' in body).toBe(false);
+  });
+});
+
+describe('read-only contract — the route runs no persistence tail', () => {
+  it('imports neither writeMasteryEvent nor deriveAnswerOutcome (nor any fan-out)', () => {
+    const routePath = fileURLToPath(new URL('../route.ts', import.meta.url));
+    const source = readFileSync(routePath, 'utf8');
+    // Assert on import MODULE PATHS — they appear only in import statements, so
+    // this verifies "imports neither" without matching the explanatory comment
+    // that names the identifiers in prose.
+    expect(source).not.toContain('mastery/write-mastery-event');
+    expect(source).not.toContain('answers/answer-pipeline');
+    expect(source).not.toContain('feed/create-feed-items-for-answer');
+    expect(source).not.toContain('knowledge/open-domain');
+    // And no call sites either (paren-suffixed; prose uses bare backticks).
+    expect(source).not.toContain('writeMasteryEvent(');
+    expect(source).not.toContain('deriveAnswerOutcome(');
+  });
+});

--- a/src/app/api/recovered/grade/route.ts
+++ b/src/app/api/recovered/grade/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { getRecoveredGradingQuestion } from '@/server/db/queries/recovered-questions';
+import { gradeAnswer } from '@/server/grading';
+
+/**
+ * D-REVIEW-RECOVERED-01 (Decision B) — graded, NON-persisting review submission.
+ *
+ * This route grades a typed answer for real (the same `gradeAnswer` the live
+ * surfaces use) so the reveal is honest, then returns the verdict and STOPS.
+ * It runs none of the persistence tail: deliberately imports neither
+ * `writeMasteryEvent` nor `deriveAnswerOutcome`, writes no `mastery_events`
+ * row, fans out nothing, and touches the mastery system in no direction. The
+ * read-only contract of the surface is preserved here, at the line the doc
+ * draws: grading is fine; persisting the grade is not.
+ *
+ * The question is loaded through `getRecoveredGradingQuestion`, whose inner
+ * join is the pool-membership guard — you can only review what you recovered.
+ */
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({
+  questionId: z.string().min(1),
+  answer: z.string(),
+});
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'validation', message: 'questionId and answer are required' },
+      { status: 400 },
+    );
+  }
+
+  const question = await getRecoveredGradingQuestion(session.userId, parsed.data.questionId);
+  // Not in the viewer's recovered pool (or never existed) — nothing to review.
+  if (!question) return NextResponse.json({ error: 'not_found' }, { status: 404 });
+
+  const grade = await gradeAnswer(
+    parsed.data.answer,
+    question.answerText,
+    question.acceptedAlternatives,
+    question.questionText,
+    question.questionType,
+  );
+
+  // Fail toward the player: a grader outage is an infra event, not a verdict.
+  // Mirror the live "hold for retry" branch — NEVER render an unscored grade as
+  // a wrong answer. The response carries no `isCorrect`, so the UI cannot show
+  // a miss; it surfaces the retry message instead.
+  if (grade.status === 'unscored') {
+    return NextResponse.json(
+      {
+        error: 'grader_unavailable',
+        message:
+          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+      },
+      { status: 503 },
+    );
+  }
+
+  // Scored verdict — return it and discard. No persistence, no mastery write.
+  return NextResponse.json({
+    isCorrect: grade.result === 'correct',
+    consolation: grade.consolation,
+    correctAnswer: question.answerText,
+    explanation: question.explanation,
+    creatorNote: question.creatorNote,
+  });
+}

--- a/src/app/recovered/page.tsx
+++ b/src/app/recovered/page.tsx
@@ -35,7 +35,7 @@ export default async function RecoveredQuestionsPage() {
           The ones you turned around
         </h1>
         <p className="mt-2 text-sm text-muted-foreground">
-          Questions you once missed and later got right. Sit with one, recall the answer, then reveal it.
+          Questions you once missed and later got right. Sit with one, recall the answer, then check yourself.
         </p>
       </header>
 

--- a/src/components/recovered/RecoveredCard.tsx
+++ b/src/components/recovered/RecoveredCard.tsx
@@ -1,18 +1,79 @@
+'use client';
+
+import { Check, X } from 'lucide-react';
+import { useId, useState } from 'react';
+
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
 /**
- * D-REVIEW-RECOVERED-01 (Decision B) — silent self-reveal, no grading.
+ * D-REVIEW-RECOVERED-01 (Decision B) — graded, non-persisting review.
  *
- * The reveal is a native <details> disclosure: show the question, the player
- * recalls in their head, taps to reveal the canonical answer, self-assesses
- * silently, moves on. Nothing is recorded. This is a server component with no
- * client JS and no network on reveal — read-only by construction, so there is
- * no path through which a `mastery_events` row (or any write) could be minted.
+ * The player types an answer and submits; the server grades it for real and
+ * returns the verdict, which is discarded — nothing is written (see the grade
+ * route). The canonical answer is revealed only AFTER a submit (it is never in
+ * the page payload), keeping the interaction "recall, then check."
  *
- * No streak / count / progress register, no color-only distinction (canon
- * tripwires): the category eyebrow is text, the reveal is a labelled control.
+ * Grader-outage handling is mandatory: an `unscored` grade (HTTP 503) surfaces
+ * a warm retry note and reveals nothing as wrong — a miss is never shown for an
+ * answer the grader couldn't score. Verdicts are distinguished by text + icon,
+ * never color alone (canon tripwire).
  */
+
+type Verdict = {
+  isCorrect: boolean;
+  consolation: string | null;
+  correctAnswer: string;
+  explanation: string | null;
+  creatorNote: string | null;
+};
+
+type Phase =
+  | { kind: 'idle' }
+  | { kind: 'submitting' }
+  | { kind: 'graded'; verdict: Verdict }
+  | { kind: 'retry'; message: string };
+
 export function RecoveredCard({ question }: { question: RecoveredQuestion }) {
+  const [value, setValue] = useState('');
+  const [phase, setPhase] = useState<Phase>({ kind: 'idle' });
+  const inputId = useId();
+
+  const loading = phase.kind === 'submitting';
+
+  async function handleSubmit(event: React.FormEvent) {
+    event.preventDefault();
+    if (loading) return;
+    setPhase({ kind: 'submitting' });
+    try {
+      const res = await fetch('/api/recovered/grade', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ questionId: question.questionId, answer: value }),
+      });
+      if (res.status === 503) {
+        const data = await res.json().catch(() => null);
+        // Fail toward the player: hold for retry, reveal nothing as wrong.
+        setPhase({
+          kind: 'retry',
+          message:
+            (data?.message as string | undefined) ??
+            "Couldn't check that just now — give it another go in a moment.",
+        });
+        return;
+      }
+      if (!res.ok) {
+        setPhase({ kind: 'retry', message: 'Something went sideways. Try once more in a moment.' });
+        return;
+      }
+      const verdict = (await res.json()) as Verdict;
+      setPhase({ kind: 'graded', verdict });
+    } catch {
+      setPhase({ kind: 'retry', message: 'Something went sideways. Try once more in a moment.' });
+    }
+  }
+
+  const graded = phase.kind === 'graded' ? phase.verdict : null;
+
   return (
     <article className="card p-4">
       <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
@@ -23,16 +84,53 @@ export function RecoveredCard({ question }: { question: RecoveredQuestion }) {
         {question.questionText}
       </p>
 
-      <details className="group mt-3 text-sm leading-6">
-        <summary className="inline-flex cursor-pointer items-center gap-1 font-medium text-foreground underline underline-offset-2">
-          <span className="group-open:hidden">Reveal the answer</span>
-          <span className="hidden group-open:inline">The answer</span>
-        </summary>
-        <p className="mt-2 font-medium text-foreground">{question.answerText}</p>
-        {question.factualExplanation ? (
-          <p className="mt-2 text-muted-foreground">{question.factualExplanation}</p>
-        ) : null}
-      </details>
+      {graded ? (
+        <div className="mt-3 space-y-2 text-sm">
+          <p className="inline-flex items-center gap-1.5 font-semibold text-foreground">
+            {graded.isCorrect ? (
+              <Check className="size-4" aria-hidden="true" />
+            ) : (
+              <X className="size-4" aria-hidden="true" />
+            )}
+            {graded.isCorrect ? 'You got it' : 'Not quite'}
+          </p>
+          {!graded.isCorrect && graded.consolation ? (
+            <p className="text-muted-foreground">{graded.consolation}</p>
+          ) : null}
+          <p className="font-medium text-foreground">
+            <span className="font-semibold">Answer:</span> {graded.correctAnswer}
+          </p>
+          {graded.explanation ? (
+            <p className="text-muted-foreground">{graded.explanation}</p>
+          ) : null}
+          {graded.creatorNote ? (
+            <p className="text-muted-foreground italic">{graded.creatorNote}</p>
+          ) : null}
+        </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="mt-3">
+          <label htmlFor={inputId} className="sr-only">
+            Your answer
+          </label>
+          <input
+            id={inputId}
+            value={value}
+            onChange={(event) => setValue(event.target.value)}
+            placeholder="Recall it, then type your answer…"
+            disabled={loading}
+            autoComplete="off"
+            className="min-h-11 w-full rounded-xl border border-[var(--accent-gold)] bg-[var(--brand-field)] px-4 text-base outline-none focus:border-[var(--brand-navy)] disabled:opacity-60"
+          />
+          {phase.kind === 'retry' ? (
+            <p role="status" aria-live="polite" className="mt-2 text-sm text-muted-foreground">
+              {phase.message}
+            </p>
+          ) : null}
+          <button type="submit" disabled={loading || !value.trim()} className="btn-primary mt-3">
+            {loading ? 'Checking…' : 'Check my answer'}
+          </button>
+        </form>
+      )}
     </article>
   );
 }

--- a/src/components/recovered/__tests__/RecoveredCard.test.tsx
+++ b/src/components/recovered/__tests__/RecoveredCard.test.tsx
@@ -4,48 +4,45 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { RecoveredCard } from '../RecoveredCard';
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
-// D-REVIEW-RECOVERED-01 (Decision B / Done-When #3) — the reveal performs zero
-// writes. The card is a server component whose reveal is a native <details>
-// disclosure: there is no answer-submission path, no <form>, and no network on
-// reveal, so no `mastery_events` row (or any write) can be minted here.
+// D-REVIEW-RECOVERED-01 (Decision B) — the review card renders a real answer
+// form. Two properties matter on first paint and are DOM-free to assert:
+//   - the canonical answer is NOT in the initial markup (it is revealed only
+//     through the graded submission, keeping the interaction "recall, then
+//     check" — the answer never ships in the page payload);
+//   - rendering issues no network call (no grade until the player submits).
+// The "unscored is never a miss" guarantee lives at the route boundary
+// (route.test.ts): the route returns no `isCorrect` for an unscored grade, so
+// the UI can never receive a miss to render.
 
 const QUESTION: RecoveredQuestion = {
   id: 'me-1',
   questionId: 'q-1',
   questionText: 'Who wrote the Storia d’Italia?',
-  answerText: 'Francesco Guicciardini',
-  factualExplanation: 'A Florentine historian and statesman.',
   category: 'history',
   recoveredAt: new Date('2026-06-01T00:00:00Z'),
 };
 
-describe('RecoveredCard — silent self-reveal, no writes', () => {
-  it('reveals the answer through a native <details>, not a submittable control', () => {
+describe('RecoveredCard — graded answer form', () => {
+  it('renders an answer form, not a pre-revealed answer, and fetches nothing on render', () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal('fetch', fetchSpy);
 
     const html = renderToStaticMarkup(<RecoveredCard question={QUESTION} />);
 
-    // Question and answer both render; the answer sits inside the disclosure.
+    // The question and an input form are present.
     expect(html).toContain(QUESTION.questionText);
-    expect(html).toContain(QUESTION.answerText);
-    expect(html).toContain('<details');
-    expect(html).toContain('<summary');
-    expect(html).toContain('Reveal the answer');
+    expect(html).toContain('<form');
+    expect(html).toContain('<input');
+    expect(html).toContain('Check my answer');
 
-    // No write path: no form, no submit button, and rendering issues no fetch.
-    expect(html).not.toContain('<form');
-    expect(html).not.toContain('type="submit"');
+    // The answer is NOT pre-loaded — RecoveredQuestion carries no answerText,
+    // and nothing leaks an answer into the initial markup.
+    expect(html).not.toContain('Guicciardini');
+    expect(html).not.toContain('Answer:');
+
+    // No grading happens until the player submits.
     expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
-  });
-
-  it('omits the explanation paragraph when there is none', () => {
-    const html = renderToStaticMarkup(
-      <RecoveredCard question={{ ...QUESTION, factualExplanation: null }} />,
-    );
-    expect(html).toContain(QUESTION.answerText);
-    expect(html).not.toContain('A Florentine historian');
   });
 });

--- a/src/server/db/queries/__tests__/recovered-questions.test.ts
+++ b/src/server/db/queries/__tests__/recovered-questions.test.ts
@@ -1,15 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// D-REVIEW-RECOVERED-01 — wiring test for the recovered-questions pool.
+// D-REVIEW-RECOVERED-01 — wiring test for the recovered-questions readers.
 //
 // We mock drizzle as inert node-builders and capture the WHERE / ORDER BY the
-// reader constructs, then assert the exact pool definition (Done-When #1):
+// readers construct, then assert the exact pool definition (Done-When #1):
 //   answer_state = 'first_correct_after_wrong' + question_id IS NOT NULL,
 //   ordered created_at DESC.
 //
-// It also guards the read-only contract (Done-When #3): the db mock exposes
-// insert/update/delete that throw, so any write attempt on this surface fails
-// the test loudly. The pool is built with SELECT and nothing else.
+// It also guards the read-only contract: the db mock exposes
+// insert/update/delete that throw, so any write attempt on these readers fails
+// the test loudly. The pool — and the gradable-question membership load — are
+// built with SELECT and nothing else.
 interface Node {
   op: string;
   column?: unknown;
@@ -21,6 +22,7 @@ interface Node {
 let capturedWhere: Node | null = null;
 let capturedOrderBy: Node | null = null;
 let selectCalls = 0;
+let limitResult: unknown[] = [];
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...parts: Node[]) => ({ op: 'and', parts })),
@@ -42,6 +44,7 @@ vi.mock('@/server/db', () => {
     capturedOrderBy = order;
     return Promise.resolve([]);
   });
+  chain.limit = vi.fn(() => Promise.resolve(limitResult));
   const fail = (op: string) =>
     vi.fn(() => {
       throw new Error(`read-only surface attempted a ${op}`);
@@ -68,14 +71,22 @@ vi.mock('@/server/db', () => {
       id: 'q.id',
       questionText: 'q.questionText',
       answerText: 'q.answerText',
+      acceptedAlternatives: 'q.acceptedAlternatives',
+      questionType: 'q.questionType',
+      explainerFull: 'q.explainerFull',
+      explainerBrief: 'q.explainerBrief',
       factualExplanation: 'q.factualExplanation',
+      creatorNote: 'q.creatorNote',
       canonicalSubcategory: 'q.canonicalSubcategory',
       category: 'q.category',
     },
   };
 });
 
-import { getRecoveredQuestionsForUser } from '@/server/db/queries/recovered-questions';
+import {
+  getRecoveredGradingQuestion,
+  getRecoveredQuestionsForUser,
+} from '@/server/db/queries/recovered-questions';
 
 function flatten(node: Node | null): Node[] {
   if (!node) return [];
@@ -89,6 +100,7 @@ beforeEach(() => {
   capturedWhere = null;
   capturedOrderBy = null;
   selectCalls = 0;
+  limitResult = [];
 });
 afterEach(() => vi.clearAllMocks());
 
@@ -112,9 +124,7 @@ describe('getRecoveredQuestionsForUser — pool definition', () => {
 
   it('scopes to the viewer', async () => {
     await getRecoveredQuestionsForUser(VIEWER);
-    const match = flatten(capturedWhere).find(
-      (n) => n.op === 'eq' && n.column === 'me.userId',
-    );
+    const match = flatten(capturedWhere).find((n) => n.op === 'eq' && n.column === 'me.userId');
     expect(match).toBeDefined();
     expect(match!.value).toBe(VIEWER);
   });
@@ -127,5 +137,48 @@ describe('getRecoveredQuestionsForUser — pool definition', () => {
   it('reads with SELECT only — no insert/update/delete on this surface', async () => {
     await expect(getRecoveredQuestionsForUser(VIEWER)).resolves.toEqual([]);
     expect(selectCalls).toBe(1);
+  });
+});
+
+describe('getRecoveredGradingQuestion — pool-membership guard', () => {
+  it('filters by viewer + recovered state + the specific question id', async () => {
+    await getRecoveredGradingQuestion(VIEWER, 'q-7');
+    const flat = flatten(capturedWhere);
+    expect(flat.find((n) => n.op === 'eq' && n.column === 'me.userId')?.value).toBe(VIEWER);
+    expect(flat.find((n) => n.op === 'eq' && n.column === 'me.answerState')?.value).toBe(
+      'first_correct_after_wrong',
+    );
+    expect(flat.find((n) => n.op === 'eq' && n.column === 'me.questionId')?.value).toBe('q-7');
+  });
+
+  it('returns null when the question is not in the viewer pool', async () => {
+    limitResult = [];
+    await expect(getRecoveredGradingQuestion(VIEWER, 'q-missing')).resolves.toBeNull();
+  });
+
+  it('maps the gradable fields when the question is in the pool', async () => {
+    limitResult = [
+      {
+        questionId: 'q-7',
+        questionText: 'Who wrote the Storia d’Italia?',
+        answerText: 'Francesco Guicciardini',
+        acceptedAlternatives: ['Guicciardini'],
+        questionType: 'factual',
+        explainerFull: 'Full explainer.',
+        explainerBrief: 'Brief.',
+        factualExplanation: 'Fact.',
+        creatorNote: null,
+      },
+    ];
+    const result = await getRecoveredGradingQuestion(VIEWER, 'q-7');
+    expect(result).toEqual({
+      questionId: 'q-7',
+      questionText: 'Who wrote the Storia d’Italia?',
+      answerText: 'Francesco Guicciardini',
+      acceptedAlternatives: ['Guicciardini'],
+      questionType: 'factual',
+      explanation: 'Full explainer.',
+      creatorNote: null,
+    });
   });
 });

--- a/src/server/db/queries/recovered-questions.ts
+++ b/src/server/db/queries/recovered-questions.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray, isNotNull } from 'drizzle-orm';
 
 import { db, masteryEvents, questions } from '@/server/db';
+import type { GradableQuestionType } from '@/server/grading';
 
 /**
  * D-REVIEW-RECOVERED-01 — the "Recovered Questions" review pool (Version A).
@@ -10,14 +11,18 @@ import { db, masteryEvents, questions } from '@/server/db';
  * (computeAnswerState, src/server/answer-state.ts), written at insert time by
  * the shared answer pipeline across all five live answer surfaces.
  *
- * This surface is READ-ONLY by construction. It computes nothing new, writes
- * nothing, and does not touch the mastery system — it is a reflective pool, not
- * a drill. Decisions A–D in the D- doc:
+ * This surface is READ-ONLY. The reflective pool is a SELECT; the review
+ * interaction (Decision B) grades a typed answer for real via `gradeAnswer` but
+ * runs NONE of the persistence tail (no `deriveAnswerOutcome`, no
+ * `writeMasteryEvent`, no feed fan-out, no mastery promotion) — so a review
+ * submission mints zero `mastery_events` rows and never touches mastery.
+ *
+ * Decisions A–D:
  *   A. Pool = whole "ever recovered" set (no latest-state reduction, no
  *      retirement). A question stays even if later re-missed; the moment, not a
  *      current status, is what `first_correct_after_wrong` records.
- *   B. Interaction is silent self-reveal — the reveal lives entirely in the
- *      render (native <details> on the surface), never an answer submission.
+ *   B. Graded, non-persisting answer form (grading lives in the route; this
+ *      module supplies the gradable fields, guarded by pool membership).
  *   C. Ordering is recency: ORDER BY created_at DESC.
  *
  * `answer_state` only carries a value on the `live_correct` / `catchup_correct`
@@ -32,18 +37,34 @@ import { db, masteryEvents, questions } from '@/server/db';
 // where the same naming caveat is documented): these gate by SURFACE, not by
 // correctness. Correctness lives in answer_state.
 const ANSWER_STATE_SOURCE_TYPES = ['live_correct', 'catchup_correct'] as const;
+const RECOVERED_STATE = 'first_correct_after_wrong' as const;
 
 export type RecoveredQuestion = {
   /** mastery_events.id — stable key for the recovered moment. */
   id: string;
   questionId: string;
   questionText: string;
-  answerText: string;
-  factualExplanation: string | null;
   /** Best available display category, already prettified for the eyebrow. */
   category: string;
   /** When the wrong→right moment was recorded. */
   recoveredAt: Date;
+};
+
+/**
+ * The gradable fields for one recovered question, returned ONLY when the
+ * question is in the viewer's recovered pool. The inner join on mastery_events
+ * is the membership guard: a question the viewer never recovered yields null,
+ * so the review route can't be used to grade arbitrary questions. Read-only.
+ */
+export type RecoveredGradingQuestion = {
+  questionId: string;
+  questionText: string;
+  answerText: string;
+  acceptedAlternatives: string[];
+  questionType: GradableQuestionType;
+  /** Revealed alongside the verdict; never sent to the client before a submit. */
+  explanation: string | null;
+  creatorNote: string | null;
 };
 
 const CATEGORY_ENUM_PRETTY: Record<string, string> = {
@@ -68,7 +89,9 @@ function prettifyCategory(canonical: string | null, coarse: string | null): stri
 
 /**
  * Returns the viewer's whole "ever recovered" pool, most recently recovered
- * first. Read-only: a single SELECT, no writes, no mastery coupling.
+ * first. Read-only: a single SELECT, no writes, no mastery coupling. The answer
+ * is deliberately NOT selected here — it is revealed only through the graded
+ * review submission, so it never ships in the page payload before a recall.
  */
 export async function getRecoveredQuestionsForUser(userId: string): Promise<RecoveredQuestion[]> {
   const rows = await db
@@ -76,8 +99,6 @@ export async function getRecoveredQuestionsForUser(userId: string): Promise<Reco
       id: masteryEvents.id,
       questionId: questions.id,
       questionText: questions.questionText,
-      answerText: questions.answerText,
-      factualExplanation: questions.factualExplanation,
       canonicalSubcategory: questions.canonicalSubcategory,
       category: questions.category,
       recoveredAt: masteryEvents.createdAt,
@@ -88,7 +109,7 @@ export async function getRecoveredQuestionsForUser(userId: string): Promise<Reco
       and(
         eq(masteryEvents.userId, userId),
         inArray(masteryEvents.sourceType, ANSWER_STATE_SOURCE_TYPES),
-        eq(masteryEvents.answerState, 'first_correct_after_wrong'),
+        eq(masteryEvents.answerState, RECOVERED_STATE),
         isNotNull(masteryEvents.questionId),
       ),
     )
@@ -98,9 +119,54 @@ export async function getRecoveredQuestionsForUser(userId: string): Promise<Reco
     id: row.id,
     questionId: row.questionId,
     questionText: row.questionText,
-    answerText: row.answerText,
-    factualExplanation: row.factualExplanation,
     category: prettifyCategory(row.canonicalSubcategory, row.category),
     recoveredAt: row.recoveredAt,
   }));
+}
+
+/**
+ * Loads the gradable fields for `questionId` IFF it is in `userId`'s recovered
+ * pool (the inner join on the matching mastery event is the membership guard).
+ * Returns null otherwise. Read-only — the review route grades against these
+ * fields and persists nothing.
+ */
+export async function getRecoveredGradingQuestion(
+  userId: string,
+  questionId: string,
+): Promise<RecoveredGradingQuestion | null> {
+  const [row] = await db
+    .select({
+      questionId: questions.id,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+      acceptedAlternatives: questions.acceptedAlternatives,
+      questionType: questions.questionType,
+      explainerFull: questions.explainerFull,
+      explainerBrief: questions.explainerBrief,
+      factualExplanation: questions.factualExplanation,
+      creatorNote: questions.creatorNote,
+    })
+    .from(masteryEvents)
+    .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+    .where(
+      and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.sourceType, ANSWER_STATE_SOURCE_TYPES),
+        eq(masteryEvents.answerState, RECOVERED_STATE),
+        eq(masteryEvents.questionId, questionId),
+      ),
+    )
+    .limit(1);
+
+  if (!row) return null;
+
+  return {
+    questionId: row.questionId,
+    questionText: row.questionText,
+    answerText: row.answerText,
+    acceptedAlternatives: row.acceptedAlternatives,
+    questionType: row.questionType,
+    explanation: row.explainerFull ?? row.explainerBrief ?? row.factualExplanation ?? null,
+    creatorNote: row.creatorNote ?? null,
+  };
 }


### PR DESCRIPTION
Updates D-REVIEW-RECOVERED-01 to the revised Decision B: a real, graded answer form that reuses the live grader but runs none of the persistence tail.

- src/app/api/recovered/grade/route.ts: POST grades a typed answer via gradeAnswer(...) and STOPS — imports neither writeMasteryEvent nor deriveAnswerOutcome, no feed fan-out, no mastery promotion, zero mastery_events writes. Pool-membership guard (you can only review what you recovered) via getRecoveredGradingQuestion. Grader `unscored` outcome fails toward the player: 503 retry, never returned as a miss.
- RecoveredCard: now a client answer form. The canonical answer is revealed only through the graded response (never shipped in the page payload, so the interaction stays "recall, then check"). Verdicts use text + icon, not color alone. Unscored → warm retry note, no miss shown.
- recovered-questions.ts: list reader no longer selects the answer; adds the read-only membership loader for grading.
- Tests: pool definition + read-only contract; route grades + persists nothing (+ asserts it imports no persistence/fan-out modules); unscored is never a miss; card ships no answer and fetches nothing on render.


Claude-Session: https://claude.ai/code/session_015KbCLADecKeCfJLowd36tj