### PR TITLE
fix(pool): fact_key-aware embedding dedup — recover ~276 falsely-suppressed facts

### DIFF
--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -1757,6 +1757,9 @@ export async function generateDailyQuestions(
       id: row.id,
       origin: 'machine' as const,
       questionText: row.questionText,
+      // fact_key lets the dedup keep DISTINCT facts about the same work instead of
+      // collapsing them on shared vocabulary (the false-suppression bug).
+      factKey: row.factKey ?? null,
     })),
   );
 

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -251,6 +251,7 @@ async function refillDomain(
         id: row.id,
         origin: 'machine',
         questionText: row.questionText,
+        factKey: row.factKey ?? null,
       }).catch(() => undefined);
     } catch (err) {
       console.warn('[pool-refill] persist failed', {

--- a/src/server/db/queries/pool.ts
+++ b/src/server/db/queries/pool.ts
@@ -211,6 +211,10 @@ export interface NearestPoolMatch {
   origin: PoolOrigin;
   /** Cosine similarity in [0,1]; 1 = identical. */
   similarity: number;
+  /** The match's normalized fact_key, when it has one (only machine rows carry
+   *  fact_key; human Question rows return null). Lets the collision matrix treat
+   *  a DIFFERENT fact_key as authoritative evidence the rows are distinct facts. */
+  factKey: string | null;
 }
 
 /**
@@ -227,7 +231,7 @@ export async function findNearestInPool(
 
   const [machineNearest, humanNearest] = await Promise.all([
     db
-      .select({ id: generatedQuestions.id, distance: machineDistance })
+      .select({ id: generatedQuestions.id, distance: machineDistance, factKey: generatedQuestions.factKey })
       .from(generatedQuestions)
       .where(and(
         isNotNull(generatedQuestions.embedding),
@@ -251,10 +255,12 @@ export async function findNearestInPool(
 
   const candidates: NearestPoolMatch[] = [];
   if (machineNearest[0]) {
-    candidates.push({ id: machineNearest[0].id, origin: 'machine', similarity: 1 - Number(machineNearest[0].distance) });
+    candidates.push({ id: machineNearest[0].id, origin: 'machine', similarity: 1 - Number(machineNearest[0].distance), factKey: machineNearest[0].factKey ?? null });
   }
   if (humanNearest[0]) {
-    candidates.push({ id: humanNearest[0].id, origin: 'human', similarity: 1 - Number(humanNearest[0].distance) });
+    // Human Question rows carry no fact_key column → null (falls back to the base
+    // threshold in the collision matrix).
+    candidates.push({ id: humanNearest[0].id, origin: 'human', similarity: 1 - Number(humanNearest[0].distance), factKey: null });
   }
   if (!candidates.length) return null;
   return candidates.reduce((best, c) => (c.similarity > best.similarity ? c : best));

--- a/src/server/pool/__tests__/dedup.test.ts
+++ b/src/server/pool/__tests__/dedup.test.ts
@@ -2,14 +2,17 @@ import { describe, expect, it } from 'vitest';
 
 import {
   DEFAULT_DEDUP_COSINE_THRESHOLD,
+  DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD,
   resolveCollision,
 } from '@/server/pool/dedup';
 import type { NearestPoolMatch } from '@/server/db/queries/pool';
 
 const T = DEFAULT_DEDUP_COSINE_THRESHOLD;
+const DT = DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD;
 const near = (over: Partial<NearestPoolMatch> & Pick<NearestPoolMatch, 'origin'>): NearestPoolMatch => ({
   id: 'existing-1',
   similarity: 0.99,
+  factKey: null,
   ...over,
 });
 
@@ -64,5 +67,53 @@ describe('resolveCollision — the collision matrix (Drift Risk 2)', () => {
       T,
     );
     expect(d.action).toBe('suppress_existing');
+  });
+});
+
+describe('resolveCollision — fact_key-aware threshold (false-suppression fix)', () => {
+  // The bug: distinct facts about one work ("In 'Paradise Lost,' …") embed above
+  // the base 0.92 threshold and were suppressed. When both fact_keys are present
+  // and DIFFER, only near-identical text (>= differentFactThreshold) may suppress.
+  it('does NOT suppress different facts that merely share a work’s vocabulary', () => {
+    const d = resolveCollision(
+      { id: 'new-m', origin: 'machine', factKey: 'pl-mulciber-pandaemonium' },
+      near({ id: 'old-m', origin: 'machine', similarity: 0.95, factKey: 'pl-satan-spear-simile' }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'none' });
+  });
+
+  it('STILL suppresses near-identical text even when the fact_keys differ', () => {
+    // Two phrasings of the same speech that got slightly different fact_key strings
+    // (observed: satan-reign-hell vs satan-reign-hell-speech) — near 1.0 similarity.
+    const d = resolveCollision(
+      { id: 'new-m', origin: 'machine', factKey: 'pl-satan-reign-hell' },
+      near({ id: 'old-m', origin: 'machine', similarity: 0.999, factKey: 'pl-satan-reign-hell-speech' }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-m' });
+  });
+
+  it('suppresses when fact_keys MATCH at the base threshold (same fact)', () => {
+    const d = resolveCollision(
+      { id: 'new-m', origin: 'machine', factKey: 'pl-satan-reign-hell' },
+      near({ id: 'old-m', origin: 'machine', similarity: 0.94, factKey: 'pl-satan-reign-hell' }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-m' });
+  });
+
+  it('falls back to the base threshold when one fact_key is absent', () => {
+    // Human survivors carry no fact_key → the high bar must NOT apply.
+    const d = resolveCollision(
+      { id: 'new-m', origin: 'machine', factKey: 'pl-mulciber-pandaemonium' },
+      near({ id: 'old-h', origin: 'human', similarity: 0.95, factKey: null }),
+      T,
+      DT,
+    );
+    expect(d).toEqual({ action: 'suppress_incoming', survivorId: 'old-h' });
   });
 });

--- a/src/server/pool/dedup.ts
+++ b/src/server/pool/dedup.ts
@@ -39,6 +39,27 @@ export function getDedupCosineThreshold(): number {
   return parsed;
 }
 
+// Higher bar applied when both rows carry a fact_key and the keys DIFFER. Questions
+// about one work share so much vocabulary ("In 'Paradise Lost,' …") that genuinely
+// distinct facts embed ABOVE the base 0.92 threshold and were being falsely
+// suppressed — a 2026-06-27 audit found ~46% of distinct pooled facts hidden this
+// way. Measured separation on the live pool: true same-fact dupes sit ≥0.9996,
+// while different-fact pairs span 0.92–0.98. So when fact_key (the authoritative
+// "same fact?" signal) says the facts DIFFER, only the embedding's same-text
+// backstop should still fire — require near-identity. Override via
+// POOL_DEDUP_DIFFERENT_FACT_THRESHOLD.
+export const DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD = 0.99;
+
+export function getDifferentFactCosineThreshold(): number {
+  const raw = process.env.POOL_DEDUP_DIFFERENT_FACT_THRESHOLD?.trim();
+  if (!raw) return DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) {
+    return DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD;
+  }
+  return parsed;
+}
+
 export type CollisionDecision =
   | { action: 'none' }
   | { action: 'suppress_incoming'; survivorId: string }
@@ -49,12 +70,25 @@ export type CollisionDecision =
  * closest existing pool row (excluding self), or null if none within reach.
  */
 export function resolveCollision(
-  incoming: { id: string; origin: PoolOrigin },
+  incoming: { id: string; origin: PoolOrigin; factKey?: string | null },
   nearest: NearestPoolMatch | null,
   threshold: number,
+  differentFactThreshold: number = getDifferentFactCosineThreshold(),
 ): CollisionDecision {
   if (!nearest) return { action: 'none' };
-  if (nearest.similarity < threshold) return { action: 'none' };
+
+  // When BOTH rows have a fact_key and the keys differ, fact_key is the
+  // authoritative signal that these are distinct facts — only the embedding's
+  // near-identical-text backstop should still suppress, so raise the bar. When
+  // either fact_key is absent (or they match), use the base semantic threshold.
+  const factKeysDiffer =
+    incoming.factKey != null &&
+    nearest.factKey != null &&
+    incoming.factKey !== nearest.factKey;
+  const effectiveThreshold = factKeysDiffer
+    ? Math.max(threshold, differentFactThreshold)
+    : threshold;
+  if (nearest.similarity < effectiveThreshold) return { action: 'none' };
 
   // Human beats machine: the only case where the EXISTING row is suppressed.
   if (incoming.origin === 'human' && nearest.origin === 'machine') {
@@ -80,6 +114,7 @@ export async function embedAndResolveDuplicate(args: {
   id: string;
   origin: PoolOrigin;
   questionText: string;
+  factKey?: string | null;
 }): Promise<void> {
   if (!isEmbeddingEnabled()) return;
   try {
@@ -90,7 +125,7 @@ export async function embedAndResolveDuplicate(args: {
 
     const nearest = await findNearestInPool(embedding, args.id);
     const decision = resolveCollision(
-      { id: args.id, origin: args.origin },
+      { id: args.id, origin: args.origin, factKey: args.factKey ?? null },
       nearest,
       getDedupCosineThreshold(),
     );
@@ -132,7 +167,7 @@ export async function embedAndResolveDuplicate(args: {
  * gate then can't see them) but never blocks generation.
  */
 export async function embedAndResolveDuplicatesBatch(
-  rows: Array<{ id: string; origin: PoolOrigin; questionText: string }>,
+  rows: Array<{ id: string; origin: PoolOrigin; questionText: string; factKey?: string | null }>,
 ): Promise<void> {
   if (!isEmbeddingEnabled() || rows.length === 0) return;
   try {
@@ -146,7 +181,11 @@ export async function embedAndResolveDuplicatesBatch(
       await storePoolEmbedding(row.origin, row.id, embedding);
 
       const nearest = await findNearestInPool(embedding, row.id);
-      const decision = resolveCollision({ id: row.id, origin: row.origin }, nearest, threshold);
+      const decision = resolveCollision(
+        { id: row.id, origin: row.origin, factKey: row.factKey ?? null },
+        nearest,
+        threshold,
+      );
       if (decision.action === 'suppress_incoming') {
         await markPoolDuplicate(row.origin, row.id, decision.survivorId);
         console.info('[pool/dedup] suppressed new near-duplicate', {


### PR DESCRIPTION
## The bug

`resolveCollision` (`src/server/pool/dedup.ts`) suppressed a question as a duplicate whenever its embedding was **≥0.92 cosine** to any existing pool row — **ignoring `fact_key` entirely**. Questions about a single work share so much vocabulary ("In 'Paradise Lost,' …") that *genuinely different facts* (Mulciber building Pandaemonium vs. Satan's spear simile) embed >0.92 and got falsely flagged `is_duplicate`, hiding them from the bank.

A 2026-06-27 audit found **276 of 616 distinct pooled facts fully hidden** this way. This was a primary driver of:
- **short Daily Fives** (the bank couldn't serve ~half the good questions, so the generator kept re-making them → re-suppressed),
- the false **"thin pool" signal** that drives retrieval grounding (domains looked exhausted when they weren't),
- wasted generation/grounding spend.

## The fix (measured, not guessed)

Cosine similarity between each suppressed row and its survivor, split by fact identity:

| | pairs | median | p90 | min |
|---|---|---|---|---|
| same fact (true dupes) | 154 | **1.0000** | 1.0 | 0.9996 |
| different facts (false positives) | 52 | **0.9454** | 0.9836 | 0.9253 |

True dupes are ~identical (≥0.9996); different facts sit at 0.92–0.98. So `fact_key` is the authoritative "same fact?" signal and the embedding is only a same-text backstop:

- `NearestPoolMatch` / `findNearestInPool` now return the match's `fact_key` (human `Question` rows have none → null).
- `resolveCollision` raises the bar to **`DEFAULT_DIFFERENT_FACT_COSINE_THRESHOLD` (0.99**, env `POOL_DEDUP_DIFFERENT_FACT_THRESHOLD`) when both `fact_key`s are present and **differ**; same/absent key keeps the base 0.92. So near-identical text still dedups, distinct facts survive.
- `generate-questions` + `retrieval-grounded` thread each row's `fact_key` through.
- 4 new `resolveCollision` tests (11 total); typecheck + lint clean.

## Backfill — already applied to production

A one-time backfill un-suppressed **one row per fully-hidden `fact_key`** (safe by construction — no two servable rows share a `fact_key`). **276 facts recovered across 63 domains.** Servable depth jumped on exactly the power-user domains behind the short queues: Shakespearean Tragedy 1→**36**, Wagner →**30**, Woolf →**17**, Milton →**14** (the one-off script was run directly, not included here).

## Knock-on for grounding
Those domains are now far above the depth-8 threshold, so they **drop out of grounding demand** — the 63-domain backlog shrinks substantially. Re-run the `?dryRun=1` preview before re-enabling `RETRIEVAL_GROUNDING_ENABLED`; real demand should be much smaller now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)