### PR TITLE
Display question explanation in catchup flow result

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1142,6 +1142,7 @@ function ResultRow({
                 {correctAnswer}
               </p>
             ) : null}
+            {explainerSentence ? <ExplainerLine text={explainerSentence} /> : null}
           </>
         ) : (
           <>

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -448,7 +448,7 @@ export function useCatchupFlow() {
     setIsResolvingTurn(true);
     setMessages((existing) => [
       ...retireDismissNotices(existing),
-      { id: newMessageId(), kind: 'user', text: 'i give up' },
+      { id: newMessageId(), kind: 'user', text: 'I give up' },
       {
         id: newMessageId(),
         kind: 'result',
@@ -459,6 +459,7 @@ export function useCatchupFlow() {
         correctAnswer: item.correctAnswer,
         consolation: null,
         breadcrumb: null,
+        explanation: item.explanation,
         copyVariant: item.queueAge,
         creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
         creatorIsHouse: item.authorIsHouse ?? false,


### PR DESCRIPTION
## Summary
Adds display of question explanations in the catchup flow when a user gives up on a question. The explanation is now passed through to the result display and rendered in the UI.

## Changes
- **useCatchupFlow.ts**: 
  - Fixed capitalization of "I give up" message (was lowercase "i")
  - Added `explanation: item.explanation` to the result object when user gives up, ensuring the explanation data is available for display
- **GameplayChat.tsx**:
  - Added conditional rendering of `<ExplainerLine>` component in the ResultRow to display the explanation text when available

## Implementation Details
The explanation field from the question item is now threaded through the result object and rendered using the existing `ExplainerLine` component, maintaining consistency with how explanations are displayed elsewhere in the gameplay UI.

https://claude.ai/code/session_01Cou8qmABkaFoXnFyemewCY