### PR TITLE
Show explanation on catch-up give-up reveal; capitalize "I give up"

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1142,6 +1142,7 @@ function ResultRow({
                 {correctAnswer}
               </p>
             ) : null}
+            {explainerSentence ? <ExplainerLine text={explainerSentence} /> : null}
           </>
         ) : (
           <>

--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -448,7 +448,7 @@ export function useCatchupFlow() {
     setIsResolvingTurn(true);
     setMessages((existing) => [
       ...retireDismissNotices(existing),
-      { id: newMessageId(), kind: 'user', text: 'i give up' },
+      { id: newMessageId(), kind: 'user', text: 'I give up' },
       {
         id: newMessageId(),
         kind: 'result',
@@ -459,6 +459,7 @@ export function useCatchupFlow() {
         correctAnswer: item.correctAnswer,
         consolation: null,
         breadcrumb: null,
+        explanation: item.explanation,
         copyVariant: item.queueAge,
         creatorName: item.authorName ?? LLM_QUESTION_ATTRIBUTION,
         creatorIsHouse: item.authorIsHouse ?? false,


### PR DESCRIPTION
The "show me the answer" (gave_up) reveal in the catch-up flow promised a plain explainer below the answer in its own comment but never rendered one: ResultRow only computed showDiscoveryExplainer for wrong answers, and skipCurrent built its result message inline without the explanation field that buildCatchupResultMessage includes on the wrong-answer path.

- useCatchupFlow: pass item.explanation through on the gave_up message so the stored explainer reaches ResultRow.
- GameplayChat: render the explainer sentence under the answer in the gaveUp branch, mirroring the correct branch.
- Capitalize the user-facing "i give up" message to "I give up".


Claude-Session: https://claude.ai/code/session_01Cou8qmABkaFoXnFyemewCY