### PR TITLE
Recovered review: set a question aside to demote it to the bottom

### DIFF
--- a/drizzle/0093_recovered_set_aside.sql
+++ b/drizzle/0093_recovered_set_aside.sql
@@ -1,0 +1,33 @@
+-- D-REVIEW-RECOVERED-01 — per-user "set aside" for recovered-review questions.
+--
+-- A reversible soft-dismiss at the QUESTION level for the "ones you turned
+-- around" surface. An active row (reinstatedAt IS NULL) demotes that question to
+-- the bottom of the viewer's recovered list (and dims it in the UI); restoring
+-- sets reinstatedAt = now(). The partial unique index keeps at most one active
+-- row per (userId, questionId), so a question can't be set aside twice. Mirrors
+-- FeedDismissedDomain (migrations 0012/0021) exactly.
+--
+-- Purely additive: no existing table is altered, and the recovered surface is
+-- otherwise read-only. RLS is enabled with no policies (the app connects as the
+-- owner role, which bypasses RLS) per B-SECURITY-RLS-01 / migration 0081 —
+-- without it the table would be reachable over Supabase's public Data API. Every
+-- statement is idempotent and mirrored by a defensive guard in
+-- src/instrumentation.ts (precedent: 0021's FeedDismissedDomain guard).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "RecoveredSetAside";
+CREATE TABLE IF NOT EXISTS "RecoveredSetAside" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+  "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+  "setAsideAt" timestamp with time zone NOT NULL DEFAULT now(),
+  "reinstatedAt" timestamp with time zone
+);
+--> statement-breakpoint
+ALTER TABLE "RecoveredSetAside" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "RecoveredSetAside_userId_idx" ON "RecoveredSetAside" ("userId");
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "recovered_set_aside_active_unique"
+  ON "RecoveredSetAside" ("userId", "questionId")
+  WHERE "reinstatedAt" IS NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -652,6 +652,13 @@
       "when": 1784505600000,
       "tag": "0092_llm_cost_report",
       "breakpoints": true
+    },
+    {
+      "idx": 93,
+      "version": "7",
+      "when": 1784592000000,
+      "tag": "0093_recovered_set_aside",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/recovered/set-aside/__tests__/route.test.ts
+++ b/src/app/api/recovered/set-aside/__tests__/route.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextRequest } from 'next/server';
+
+// D-REVIEW-RECOVERED-01 — the set-aside route is a thin, auth-guarded wrapper
+// over the reversible soft-dismiss helpers. POST sets a question aside, DELETE
+// restores it; both validate `questionId` and 401 without a session.
+
+const { getSessionMock, setAsideMock, restoreMock } = vi.hoisted(() => ({
+  getSessionMock: vi.fn(async () => ({ userId: 'user-1', id: 's-1' })),
+  setAsideMock: vi.fn(async () => {}),
+  restoreMock: vi.fn(async () => {}),
+}));
+
+vi.mock('@/server/auth/session', () => ({ getSession: getSessionMock }));
+vi.mock('@/server/db/queries/recovered-questions', () => ({
+  setAsideRecoveredQuestion: setAsideMock,
+  restoreRecoveredQuestion: restoreMock,
+}));
+
+import { DELETE, POST } from '@/app/api/recovered/set-aside/route';
+
+function req(body: unknown): NextRequest {
+  return { json: async () => body } as unknown as NextRequest;
+}
+
+beforeEach(() => {
+  getSessionMock.mockResolvedValue({ userId: 'user-1', id: 's-1' });
+});
+afterEach(() => vi.clearAllMocks());
+
+describe('POST /api/recovered/set-aside', () => {
+  it('401s without a session', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    const res = await POST(req({ questionId: 'q-7' }));
+    expect(res.status).toBe(401);
+    expect(setAsideMock).not.toHaveBeenCalled();
+  });
+
+  it('400s on a malformed body', async () => {
+    const res = await POST(req({}));
+    expect(res.status).toBe(400);
+    expect(setAsideMock).not.toHaveBeenCalled();
+  });
+
+  it('sets the question aside for the viewer', async () => {
+    const res = await POST(req({ questionId: 'q-7' }));
+    expect(res.status).toBe(200);
+    expect(setAsideMock).toHaveBeenCalledWith('user-1', 'q-7');
+  });
+});
+
+describe('DELETE /api/recovered/set-aside', () => {
+  it('401s without a session', async () => {
+    getSessionMock.mockResolvedValueOnce(null);
+    const res = await DELETE(req({ questionId: 'q-7' }));
+    expect(res.status).toBe(401);
+    expect(restoreMock).not.toHaveBeenCalled();
+  });
+
+  it('restores the question for the viewer', async () => {
+    const res = await DELETE(req({ questionId: 'q-7' }));
+    expect(res.status).toBe(200);
+    expect(restoreMock).toHaveBeenCalledWith('user-1', 'q-7');
+  });
+});

--- a/src/app/api/recovered/set-aside/route.ts
+++ b/src/app/api/recovered/set-aside/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import {
+  restoreRecoveredQuestion,
+  setAsideRecoveredQuestion,
+} from '@/server/db/queries/recovered-questions';
+
+/**
+ * D-REVIEW-RECOVERED-01 — set a recovered-review question aside (POST) or
+ * restore it (DELETE). A reversible per-user soft-dismiss that demotes the
+ * question to the bottom of the viewer's recovered list; it writes only the
+ * RecoveredSetAside row and touches nothing in the mastery system. Mirrors the
+ * feed dismiss-domain route.
+ */
+export const dynamic = 'force-dynamic';
+
+const bodySchema = z.object({ questionId: z.string().min(1) });
+
+function parseQuestionId(value: unknown): string | null {
+  const parsed = bodySchema.safeParse(value);
+  return parsed.success ? parsed.data.questionId : null;
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const questionId = parseQuestionId(await request.json().catch(() => null));
+  if (!questionId) {
+    return NextResponse.json(
+      { error: 'validation', message: 'questionId is required' },
+      { status: 400 },
+    );
+  }
+
+  await setAsideRecoveredQuestion(session.userId, questionId);
+  return NextResponse.json({ ok: true });
+}
+
+export async function DELETE(request: NextRequest) {
+  const session = await getSession();
+  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+
+  const questionId = parseQuestionId(await request.json().catch(() => null));
+  if (!questionId) {
+    return NextResponse.json(
+      { error: 'validation', message: 'questionId is required' },
+      { status: 400 },
+    );
+  }
+
+  await restoreRecoveredQuestion(session.userId, questionId);
+  return NextResponse.json({ ok: true });
+}

--- a/src/components/recovered/RecoveredCard.tsx
+++ b/src/components/recovered/RecoveredCard.tsx
@@ -1,19 +1,22 @@
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
+import { SetAsideButton } from './SetAsideButton';
+
 /**
  * D-REVIEW-RECOVERED-01 (Decision B) — no-check reveal.
  *
  * The player reads the question, recalls the answer in their head, then reveals
  * the canonical answer to check themselves. There is no grader and no verdict:
  * the system never scores what they typed — it just shows the answer. The
- * reveal is a native <details>, so this is a pure server component with no
- * client JS and no network round-trip, and the surface mints no writes (see the
- * query module). The answer ships collapsed and is revealed only on demand,
- * keeping the interaction "recall, then check yourself."
+ * reveal is a native <details>, server-rendered; the only client JS is the
+ * "Set aside" action (SetAsideButton).
+ *
+ * A set-aside question is demoted to the bottom of the list (ordering lives in
+ * the query) and dimmed here, with the action flipped to "Restore".
  */
 export function RecoveredCard({ question }: { question: RecoveredQuestion }) {
   return (
-    <article className="card p-4">
+    <article className={`card p-4${question.setAside ? ' opacity-60' : ''}`}>
       <p className="font-mono text-[0.62rem] uppercase tracking-[0.06em] text-muted-foreground">
         {question.category}
       </p>
@@ -40,6 +43,10 @@ export function RecoveredCard({ question }: { question: RecoveredQuestion }) {
           ) : null}
         </div>
       </details>
+
+      <div className="mt-3 flex justify-end">
+        <SetAsideButton questionId={question.questionId} setAside={question.setAside} />
+      </div>
     </article>
   );
 }

--- a/src/components/recovered/SetAsideButton.tsx
+++ b/src/components/recovered/SetAsideButton.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { ArrowDownToLine, Undo2 } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+import { useState, useTransition } from 'react';
+
+/**
+ * D-REVIEW-RECOVERED-01 — the only client JS on the recovered surface: a small
+ * action that sets a question aside (demote to the bottom) or restores it. It
+ * POSTs/DELETEs to /api/recovered/set-aside and refreshes the server component
+ * so the new ordering and dimming render from the source of truth. The button
+ * holds a pending state across both the request and the refresh.
+ */
+export function SetAsideButton({
+  questionId,
+  setAside,
+}: {
+  questionId: string;
+  setAside: boolean;
+}) {
+  const router = useRouter();
+  const [sending, setSending] = useState(false);
+  const [isRefreshing, startTransition] = useTransition();
+  const busy = sending || isRefreshing;
+
+  async function toggle() {
+    if (busy) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/recovered/set-aside', {
+        method: setAside ? 'DELETE' : 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ questionId }),
+      });
+      if (res.ok) {
+        startTransition(() => router.refresh());
+      }
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      disabled={busy}
+      className="inline-flex items-center gap-1.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline disabled:opacity-50"
+    >
+      {setAside ? (
+        <>
+          <Undo2 className="size-3.5" aria-hidden="true" />
+          Restore
+        </>
+      ) : (
+        <>
+          <ArrowDownToLine className="size-3.5" aria-hidden="true" />
+          Set aside
+        </>
+      )}
+    </button>
+  );
+}

--- a/src/components/recovered/__tests__/RecoveredCard.test.tsx
+++ b/src/components/recovered/__tests__/RecoveredCard.test.tsx
@@ -4,6 +4,9 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { RecoveredCard } from '../RecoveredCard';
 import type { RecoveredQuestion } from '@/server/db/queries/recovered-questions';
 
+// The set-aside action (the card's only client island) reads the app router.
+vi.mock('next/navigation', () => ({ useRouter: () => ({ refresh: vi.fn() }) }));
+
 // D-REVIEW-RECOVERED-01 (Decision B) — the review card is a no-check reveal.
 // The system never grades a typed answer; it just shows the canonical answer on
 // demand. Two properties matter and are DOM-free to assert:
@@ -20,6 +23,7 @@ const QUESTION: RecoveredQuestion = {
   answer: 'Francesco Guicciardini',
   explanation: 'A Florentine historian and statesman.',
   creatorNote: null,
+  setAside: false,
 };
 
 describe('RecoveredCard — no-check reveal', () => {
@@ -44,9 +48,23 @@ describe('RecoveredCard — no-check reveal', () => {
     expect(html).not.toContain('<input');
     expect(html).not.toContain('Check my answer');
 
-    // Pure render — no network round-trip.
+    // Pure render — no network round-trip on first paint.
     expect(fetchSpy).not.toHaveBeenCalled();
 
     vi.unstubAllGlobals();
+  });
+
+  it('offers "Set aside" by default and "Restore" once set aside (dimmed)', () => {
+    const active = renderToStaticMarkup(<RecoveredCard question={QUESTION} />);
+    expect(active).toContain('Set aside');
+    expect(active).not.toContain('Restore');
+
+    const setAside = renderToStaticMarkup(
+      <RecoveredCard question={{ ...QUESTION, setAside: true }} />,
+    );
+    expect(setAside).toContain('Restore');
+    expect(setAside).not.toContain('Set aside');
+    // Set-aside cards are visually de-emphasized.
+    expect(setAside).toContain('opacity-60');
   });
 });

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1753,6 +1753,31 @@ export async function register() {
     } catch {
       // Non-fatal — migrate() creates the tables from 0090/0091/0092 immediately after.
     }
+    // Migration 0093 (D-REVIEW-RECOVERED-01) adds the per-user "set aside" table
+    // for the recovered-review surface. The recovered page reads it on every load
+    // and would 42P01 if the migration recorded without the table present.
+    // Self-contained; precedent: 0021's FeedDismissedDomain guard above.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "RecoveredSetAside" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "userId" text NOT NULL REFERENCES "User"("id") ON DELETE CASCADE,
+          "questionId" text NOT NULL REFERENCES "Question"("id") ON DELETE CASCADE,
+          "setAsideAt" timestamp with time zone NOT NULL DEFAULT now(),
+          "reinstatedAt" timestamp with time zone
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "RecoveredSetAside" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`CREATE INDEX IF NOT EXISTS "RecoveredSetAside_userId_idx" ON "RecoveredSetAside" ("userId")`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "recovered_set_aside_active_unique"
+        ON "RecoveredSetAside" ("userId", "questionId")
+        WHERE "reinstatedAt" IS NULL
+      `);
+    } catch {
+      // Fresh databases may not have User/Question yet — migrate() creates all
+      // three in normal migration order.
+    }
     } // end if (runBootGuards)
     const guardChainMs = runBootGuards ? Date.now() - guardChainStartedAt : 0;
 

--- a/src/server/db/queries/__tests__/recovered-questions.test.ts
+++ b/src/server/db/queries/__tests__/recovered-questions.test.ts
@@ -1,16 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// D-REVIEW-RECOVERED-01 — wiring test for the recovered-questions readers.
+// D-REVIEW-RECOVERED-01 — wiring tests for the recovered-questions readers and
+// the set-aside mutations.
 //
-// We mock drizzle as inert node-builders and capture the WHERE / ORDER BY the
-// readers construct, then assert the exact pool definition (Done-When #1):
-//   answer_state = 'first_correct_after_wrong' + question_id IS NOT NULL,
-//   ordered created_at DESC.
-//
-// It also guards the read-only contract: the db mock exposes
-// insert/update/delete that throw, so any write attempt on these readers fails
-// the test loudly. The pool — and the gradable-question membership load — are
-// built with SELECT and nothing else.
+// The drizzle layer is mocked as inert builders that record the WHERE / ORDER BY
+// and resolve to canned rows. We assert:
+//   - the pool definition (answer_state = first_correct_after_wrong +
+//     question_id IS NOT NULL, ordered created_at DESC);
+//   - set-aside questions carry the flag and sort to the bottom;
+//   - the set-aside / restore mutations issue the expected insert / update.
 interface Node {
   op: string;
   column?: unknown;
@@ -19,10 +17,15 @@ interface Node {
   parts?: Node[];
 }
 
-let capturedWhere: Node | null = null;
+let capturedWheres: Node[] = [];
 let capturedOrderBy: Node | null = null;
 let selectCalls = 0;
-let limitResult: unknown[] = [];
+let selectQueue: unknown[][] = [];
+let insertCalls = 0;
+let insertValues: unknown = null;
+let updateCalls = 0;
+let updateSet: unknown = null;
+let deleteCalls = 0;
 
 vi.mock('drizzle-orm', () => ({
   and: vi.fn((...parts: Node[]) => ({ op: 'and', parts })),
@@ -30,60 +33,87 @@ vi.mock('drizzle-orm', () => ({
   desc: vi.fn((column) => ({ op: 'desc', column })),
   inArray: vi.fn((column, values) => ({ op: 'inArray', column, values })),
   isNotNull: vi.fn((column) => ({ op: 'isNotNull', column })),
+  isNull: vi.fn((column) => ({ op: 'isNull', column })),
 }));
 
-vi.mock('@/server/db', () => {
-  const chain: Record<string, unknown> = {};
-  chain.from = vi.fn(() => chain);
-  chain.innerJoin = vi.fn(() => chain);
-  chain.where = vi.fn((cond: Node) => {
-    capturedWhere = cond;
-    return chain;
-  });
-  chain.orderBy = vi.fn((order: Node) => {
-    capturedOrderBy = order;
-    return Promise.resolve([]);
-  });
-  chain.limit = vi.fn(() => Promise.resolve(limitResult));
-  const fail = (op: string) =>
-    vi.fn(() => {
-      throw new Error(`read-only surface attempted a ${op}`);
+function builder(resolved: unknown) {
+  const node: Record<string, unknown> = {};
+  const passthrough = (capture?: (arg: unknown) => void) =>
+    vi.fn((arg: unknown) => {
+      capture?.(arg);
+      return node;
     });
-  return {
-    db: {
-      select: vi.fn(() => {
-        selectCalls += 1;
-        return chain;
-      }),
-      insert: fail('insert'),
-      update: fail('update'),
-      delete: fail('delete'),
-    },
-    masteryEvents: {
-      id: 'me.id',
-      userId: 'me.userId',
-      sourceType: 'me.sourceType',
-      answerState: 'me.answerState',
-      questionId: 'me.questionId',
-      createdAt: 'me.createdAt',
-    },
-    questions: {
-      id: 'q.id',
-      questionText: 'q.questionText',
-      answerText: 'q.answerText',
-      acceptedAlternatives: 'q.acceptedAlternatives',
-      questionType: 'q.questionType',
-      explainerFull: 'q.explainerFull',
-      explainerBrief: 'q.explainerBrief',
-      factualExplanation: 'q.factualExplanation',
-      creatorNote: 'q.creatorNote',
-      canonicalSubcategory: 'q.canonicalSubcategory',
-      category: 'q.category',
-    },
-  };
-});
+  node.from = passthrough();
+  node.innerJoin = passthrough();
+  node.leftJoin = passthrough();
+  node.where = passthrough((cond) => capturedWheres.push(cond as Node));
+  node.orderBy = passthrough((order) => {
+    capturedOrderBy = order as Node;
+  });
+  node.limit = passthrough();
+  node.values = passthrough((v) => {
+    insertValues = v;
+  });
+  node.set = passthrough((v) => {
+    updateSet = v;
+  });
+  // Thenable so `await` at any terminal (.where / .orderBy / .limit / .values …)
+  // resolves to this call's canned rows.
+  node.then = (onFulfilled: (value: unknown) => unknown) => onFulfilled(resolved);
+  return node;
+}
 
-import { getRecoveredQuestionsForUser } from '@/server/db/queries/recovered-questions';
+vi.mock('@/server/db', () => ({
+  db: {
+    select: vi.fn(() => {
+      selectCalls += 1;
+      return builder(selectQueue.length ? selectQueue.shift() : []);
+    }),
+    insert: vi.fn(() => {
+      insertCalls += 1;
+      return builder(undefined);
+    }),
+    update: vi.fn(() => {
+      updateCalls += 1;
+      return builder(undefined);
+    }),
+    delete: vi.fn(() => {
+      deleteCalls += 1;
+      return builder(undefined);
+    }),
+  },
+  masteryEvents: {
+    id: 'me.id',
+    userId: 'me.userId',
+    sourceType: 'me.sourceType',
+    answerState: 'me.answerState',
+    questionId: 'me.questionId',
+    createdAt: 'me.createdAt',
+  },
+  questions: {
+    id: 'q.id',
+    questionText: 'q.questionText',
+    answerText: 'q.answerText',
+    canonicalSubcategory: 'q.canonicalSubcategory',
+    category: 'q.category',
+    explainerFull: 'q.explainerFull',
+    explainerBrief: 'q.explainerBrief',
+    factualExplanation: 'q.factualExplanation',
+    creatorNote: 'q.creatorNote',
+  },
+  recoveredSetAside: {
+    id: 'rsa.id',
+    userId: 'rsa.userId',
+    questionId: 'rsa.questionId',
+    reinstatedAt: 'rsa.reinstatedAt',
+  },
+}));
+
+import {
+  getRecoveredQuestionsForUser,
+  restoreRecoveredQuestion,
+  setAsideRecoveredQuestion,
+} from '@/server/db/queries/recovered-questions';
 
 function flatten(node: Node | null): Node[] {
   if (!node) return [];
@@ -91,37 +121,59 @@ function flatten(node: Node | null): Node[] {
   return [node];
 }
 
+function allWhereNodes(): Node[] {
+  return capturedWheres.flatMap(flatten);
+}
+
 const VIEWER = 'viewer-1';
 
+function poolRow(over: Partial<Record<string, unknown>> = {}) {
+  return {
+    id: 'me-1',
+    questionId: 'q-1',
+    questionText: 'Who wrote the Storia d’Italia?',
+    canonicalSubcategory: 'history',
+    category: 'general_knowledge',
+    recoveredAt: new Date('2026-06-01T00:00:00Z'),
+    answerText: 'Francesco Guicciardini',
+    explainerFull: 'Full explainer.',
+    explainerBrief: 'Brief.',
+    factualExplanation: 'Fact.',
+    creatorNote: null,
+    ...over,
+  };
+}
+
 beforeEach(() => {
-  capturedWhere = null;
+  capturedWheres = [];
   capturedOrderBy = null;
   selectCalls = 0;
-  limitResult = [];
+  selectQueue = [];
+  insertCalls = 0;
+  insertValues = null;
+  updateCalls = 0;
+  updateSet = null;
+  deleteCalls = 0;
 });
 afterEach(() => vi.clearAllMocks());
 
 describe('getRecoveredQuestionsForUser — pool definition', () => {
   it('filters on answer_state = first_correct_after_wrong', async () => {
     await getRecoveredQuestionsForUser(VIEWER);
-    const match = flatten(capturedWhere).find(
-      (n) => n.op === 'eq' && n.column === 'me.answerState',
-    );
+    const match = allWhereNodes().find((n) => n.op === 'eq' && n.column === 'me.answerState');
     expect(match).toBeDefined();
     expect(match!.value).toBe('first_correct_after_wrong');
   });
 
   it('guards question_id IS NOT NULL', async () => {
     await getRecoveredQuestionsForUser(VIEWER);
-    const match = flatten(capturedWhere).find(
-      (n) => n.op === 'isNotNull' && n.column === 'me.questionId',
-    );
+    const match = allWhereNodes().find((n) => n.op === 'isNotNull' && n.column === 'me.questionId');
     expect(match).toBeDefined();
   });
 
   it('scopes to the viewer', async () => {
     await getRecoveredQuestionsForUser(VIEWER);
-    const match = flatten(capturedWhere).find((n) => n.op === 'eq' && n.column === 'me.userId');
+    const match = allWhereNodes().find((n) => n.op === 'eq' && n.column === 'me.userId');
     expect(match).toBeDefined();
     expect(match!.value).toBe(VIEWER);
   });
@@ -131,49 +183,63 @@ describe('getRecoveredQuestionsForUser — pool definition', () => {
     expect(capturedOrderBy).toEqual({ op: 'desc', column: 'me.createdAt' });
   });
 
-  it('reads with SELECT only — no insert/update/delete on this surface', async () => {
-    await expect(getRecoveredQuestionsForUser(VIEWER)).resolves.toEqual([]);
-    expect(selectCalls).toBe(1);
+  it('issues no insert/update/delete on the read path', async () => {
+    await getRecoveredQuestionsForUser(VIEWER);
+    expect(insertCalls).toBe(0);
+    expect(updateCalls).toBe(0);
+    expect(deleteCalls).toBe(0);
   });
 });
 
-describe('getRecoveredQuestionsForUser — ships the answer for the no-check reveal', () => {
-  it('maps the answer and explainer fields so the card can reveal them', async () => {
-    // The pool reader resolves through orderBy; stub it to return one row.
-    const { db } = (await import('@/server/db')) as unknown as {
-      db: { select: ReturnType<typeof vi.fn> };
-    };
-    db.select.mockImplementationOnce(() => {
-      selectCalls += 1;
-      return {
-        from: () => ({
-          innerJoin: () => ({
-            where: () => ({
-              orderBy: () =>
-                Promise.resolve([
-                  {
-                    id: 'me-1',
-                    questionId: 'q-7',
-                    questionText: 'Who wrote the Storia d’Italia?',
-                    canonicalSubcategory: 'history',
-                    category: 'general_knowledge',
-                    recoveredAt: new Date('2026-06-01T00:00:00Z'),
-                    answerText: 'Francesco Guicciardini',
-                    explainerFull: 'Full explainer.',
-                    explainerBrief: 'Brief.',
-                    factualExplanation: 'Fact.',
-                    creatorNote: null,
-                  },
-                ]),
-            }),
-          }),
-        }),
-      };
-    });
-
+describe('getRecoveredQuestionsForUser — set-aside flag and ordering', () => {
+  it('maps the answer/explainer fields for the reveal', async () => {
+    selectQueue = [[poolRow()], []]; // pool rows, then active set-aside ids
     const [row] = await getRecoveredQuestionsForUser(VIEWER);
     expect(row.answer).toBe('Francesco Guicciardini');
     expect(row.explanation).toBe('Full explainer.');
     expect(row.creatorNote).toBeNull();
+    expect(row.setAside).toBe(false);
+  });
+
+  it('flags set-aside questions and demotes them to the bottom', async () => {
+    selectQueue = [
+      [
+        poolRow({ id: 'me-a', questionId: 'q-a' }),
+        poolRow({ id: 'me-b', questionId: 'q-b' }), // this one is set aside
+        poolRow({ id: 'me-c', questionId: 'q-c' }),
+      ],
+      [{ questionId: 'q-b' }], // active set-aside ids
+    ];
+    const result = await getRecoveredQuestionsForUser(VIEWER);
+    expect(result.map((q) => q.questionId)).toEqual(['q-a', 'q-c', 'q-b']);
+    expect(result.find((q) => q.questionId === 'q-b')!.setAside).toBe(true);
+    expect(result.find((q) => q.questionId === 'q-a')!.setAside).toBe(false);
+  });
+});
+
+describe('setAsideRecoveredQuestion', () => {
+  it('inserts an active row when none exists', async () => {
+    selectQueue = [[]]; // existing-active check returns nothing
+    await setAsideRecoveredQuestion(VIEWER, 'q-7');
+    expect(insertCalls).toBe(1);
+    expect(insertValues).toEqual({ userId: VIEWER, questionId: 'q-7' });
+  });
+
+  it('is a no-op when already set aside', async () => {
+    selectQueue = [[{ id: 'rsa-1' }]]; // an active row already exists
+    await setAsideRecoveredQuestion(VIEWER, 'q-7');
+    expect(insertCalls).toBe(0);
+  });
+});
+
+describe('restoreRecoveredQuestion', () => {
+  it('marks the active row reinstated for the viewer + question', async () => {
+    await restoreRecoveredQuestion(VIEWER, 'q-7');
+    expect(updateCalls).toBe(1);
+    expect((updateSet as { reinstatedAt: Date }).reinstatedAt).toBeInstanceOf(Date);
+    const flat = allWhereNodes();
+    expect(flat.find((n) => n.op === 'eq' && n.column === 'rsa.userId')?.value).toBe(VIEWER);
+    expect(flat.find((n) => n.op === 'eq' && n.column === 'rsa.questionId')?.value).toBe('q-7');
+    expect(flat.find((n) => n.op === 'isNull' && n.column === 'rsa.reinstatedAt')).toBeDefined();
   });
 });

--- a/src/server/db/queries/recovered-questions.ts
+++ b/src/server/db/queries/recovered-questions.ts
@@ -1,6 +1,7 @@
-import { and, desc, eq, inArray, isNotNull } from 'drizzle-orm';
+import { and, desc, eq, inArray, isNotNull, isNull } from 'drizzle-orm';
 
-import { db, masteryEvents, questions } from '@/server/db';
+import { db, masteryEvents, questions, recoveredSetAside } from '@/server/db';
+import { pgErrorCode } from '@/server/db/pg-error';
 
 /**
  * D-REVIEW-RECOVERED-01 — the "Recovered Questions" review pool (Version A).
@@ -53,6 +54,8 @@ export type RecoveredQuestion = {
   /** Revealed alongside the answer when present. */
   explanation: string | null;
   creatorNote: string | null;
+  /** The viewer has set this one aside — it sorts to the bottom and dims. */
+  setAside: boolean;
 };
 
 const CATEGORY_ENUM_PRETTY: Record<string, string> = {
@@ -76,40 +79,65 @@ function prettifyCategory(canonical: string | null, coarse: string | null): stri
 }
 
 /**
- * Returns the viewer's whole "ever recovered" pool, most recently recovered
- * first. Read-only: a single SELECT, no writes, no mastery coupling. The answer
- * and explainer ship with the pool so the card can reveal them client-side with
- * no further round-trip and no grading — they sit collapsed until the player
- * chooses to check themselves.
+ * The viewer's active set-aside question ids (reinstatedAt IS NULL). Read-only,
+ * and resilient to the table not existing yet: a pre-migration database returns
+ * an empty set rather than failing the whole recovered page (mirrors
+ * getDismissedDomains' 42P01 handling).
+ */
+async function getSetAsideQuestionIds(userId: string): Promise<Set<string>> {
+  try {
+    const rows = await db
+      .select({ questionId: recoveredSetAside.questionId })
+      .from(recoveredSetAside)
+      .where(and(eq(recoveredSetAside.userId, userId), isNull(recoveredSetAside.reinstatedAt)));
+    return new Set(rows.map((r) => r.questionId));
+  } catch (error) {
+    if (pgErrorCode(error) === '42P01') return new Set(); // table not yet migrated
+    throw error;
+  }
+}
+
+/**
+ * Returns the viewer's whole "ever recovered" pool. Read-only: SELECTs only, no
+ * mastery coupling. The answer and explainer ship with the pool so the card can
+ * reveal them client-side with no further round-trip and no grading — they sit
+ * collapsed until the player chooses to check themselves.
+ *
+ * Ordering: most recently recovered first, but questions the viewer has SET
+ * ASIDE are demoted to the bottom (recency preserved within each group). The
+ * card dims a set-aside question and offers to restore it.
  */
 export async function getRecoveredQuestionsForUser(userId: string): Promise<RecoveredQuestion[]> {
-  const rows = await db
-    .select({
-      id: masteryEvents.id,
-      questionId: questions.id,
-      questionText: questions.questionText,
-      canonicalSubcategory: questions.canonicalSubcategory,
-      category: questions.category,
-      recoveredAt: masteryEvents.createdAt,
-      answerText: questions.answerText,
-      explainerFull: questions.explainerFull,
-      explainerBrief: questions.explainerBrief,
-      factualExplanation: questions.factualExplanation,
-      creatorNote: questions.creatorNote,
-    })
-    .from(masteryEvents)
-    .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
-    .where(
-      and(
-        eq(masteryEvents.userId, userId),
-        inArray(masteryEvents.sourceType, ANSWER_STATE_SOURCE_TYPES),
-        eq(masteryEvents.answerState, RECOVERED_STATE),
-        isNotNull(masteryEvents.questionId),
-      ),
-    )
-    .orderBy(desc(masteryEvents.createdAt));
+  const [rows, setAsideIds] = await Promise.all([
+    db
+      .select({
+        id: masteryEvents.id,
+        questionId: questions.id,
+        questionText: questions.questionText,
+        canonicalSubcategory: questions.canonicalSubcategory,
+        category: questions.category,
+        recoveredAt: masteryEvents.createdAt,
+        answerText: questions.answerText,
+        explainerFull: questions.explainerFull,
+        explainerBrief: questions.explainerBrief,
+        factualExplanation: questions.factualExplanation,
+        creatorNote: questions.creatorNote,
+      })
+      .from(masteryEvents)
+      .innerJoin(questions, eq(questions.id, masteryEvents.questionId))
+      .where(
+        and(
+          eq(masteryEvents.userId, userId),
+          inArray(masteryEvents.sourceType, ANSWER_STATE_SOURCE_TYPES),
+          eq(masteryEvents.answerState, RECOVERED_STATE),
+          isNotNull(masteryEvents.questionId),
+        ),
+      )
+      .orderBy(desc(masteryEvents.createdAt)),
+    getSetAsideQuestionIds(userId),
+  ]);
 
-  return rows.map((row) => ({
+  const mapped: RecoveredQuestion[] = rows.map((row) => ({
     id: row.id,
     questionId: row.questionId,
     questionText: row.questionText,
@@ -118,5 +146,50 @@ export async function getRecoveredQuestionsForUser(userId: string): Promise<Reco
     answer: row.answerText,
     explanation: row.explainerFull ?? row.explainerBrief ?? row.factualExplanation ?? null,
     creatorNote: row.creatorNote ?? null,
+    setAside: setAsideIds.has(row.questionId),
   }));
+
+  // Demote set-aside questions to the bottom; recency order is already in place
+  // within each group from the ORDER BY, and a stable partition preserves it.
+  return [...mapped.filter((q) => !q.setAside), ...mapped.filter((q) => q.setAside)];
+}
+
+/**
+ * Set a recovered question aside for the viewer (reversible soft-dismiss). A
+ * no-op if it is already set aside. The partial unique index guarantees at most
+ * one active row per (user, question). Mirrors dismissDomain.
+ */
+export async function setAsideRecoveredQuestion(userId: string, questionId: string): Promise<void> {
+  const [existing] = await db
+    .select({ id: recoveredSetAside.id })
+    .from(recoveredSetAside)
+    .where(
+      and(
+        eq(recoveredSetAside.userId, userId),
+        eq(recoveredSetAside.questionId, questionId),
+        isNull(recoveredSetAside.reinstatedAt),
+      ),
+    )
+    .limit(1);
+
+  if (existing) return;
+
+  await db.insert(recoveredSetAside).values({ userId, questionId });
+}
+
+/**
+ * Restore a set-aside recovered question (un-demote it) by marking the active
+ * row reinstated. A no-op if it was not set aside. Mirrors reinstateDomain.
+ */
+export async function restoreRecoveredQuestion(userId: string, questionId: string): Promise<void> {
+  await db
+    .update(recoveredSetAside)
+    .set({ reinstatedAt: new Date() })
+    .where(
+      and(
+        eq(recoveredSetAside.userId, userId),
+        eq(recoveredSetAside.questionId, questionId),
+        isNull(recoveredSetAside.reinstatedAt),
+      ),
+    );
 }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1279,6 +1279,29 @@ export const feedDismissedDomains = pgTable(
   ],
 );
 
+// Per-user "set aside" for recovered-review questions (D-REVIEW-RECOVERED-01).
+// A reversible soft-dismiss at the QUESTION level: an active row (reinstatedAt
+// IS NULL) demotes that question to the bottom of the viewer's recovered list
+// and dims it. Restoring sets reinstatedAt = now(); setting aside again inserts
+// a fresh active row. Mirrors FeedDismissedDomain exactly (the partial unique
+// index keeps at most one active row per (user, question)).
+export const recoveredSetAside = pgTable(
+  'RecoveredSetAside',
+  {
+    id: id(),
+    userId: text('userId').notNull().references(() => users.id, { onDelete: 'cascade' }),
+    questionId: text('questionId').notNull().references(() => questions.id, { onDelete: 'cascade' }),
+    setAsideAt: timestamp('setAsideAt', { withTimezone: true }).notNull().defaultNow(),
+    reinstatedAt: timestamp('reinstatedAt', { withTimezone: true }),
+  },
+  (table) => [
+    index('RecoveredSetAside_userId_idx').on(table.userId),
+    uniqueIndex('recovered_set_aside_active_unique')
+      .on(table.userId, table.questionId)
+      .where(sql`${table.reinstatedAt} IS NULL`),
+  ],
+);
+
 export const friendInvitations = pgTable(
   'FriendInvitation',
   {


### PR DESCRIPTION
Each "ones you turned around" card now has a "Set aside" action for questions you don't value. A set-aside question sorts to the bottom of the list and dims, with the action flipped to "Restore" — fully reversible.

Mirrors the FeedDismissedDomain soft-dismiss precedent at the question level:
- New RecoveredSetAside table (migration 0093 + journal + idempotent boot guard in instrumentation.ts): one active row per (userId, questionId), reinstatedAt-nullable with a partial unique index, RLS enabled.
- getRecoveredQuestionsForUser carries a `setAside` flag and demotes set-aside questions to the bottom (recency preserved within each group); getSetAsideQuestionIds is resilient to the table not existing yet (42P01).
- setAsideRecoveredQuestion / restoreRecoveredQuestion helpers, exposed via POST/DELETE /api/recovered/set-aside.
- SetAsideButton is the surface's only client island; it refreshes the server component so ordering/dimming render from the source of truth.

Tests cover the pool definition, the set-aside flag + ordering, both mutations, and the route guards.


Claude-Session: https://claude.ai/code/session_01SLkutdiekz6sv5ovPQozs9