### PR TITLE
Share above the bar; portrait Share goes straight to native sheet

### DIFF
--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -8,7 +8,9 @@ import { Skeleton } from '@/components/ui/Skeleton';
 
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard';
 import { PortraitCircles, type PortraitEntry } from '@/components/knowledge/PortraitCircles';
+import { SharePortraitCard } from '@/components/knowledge/SharePortraitCard';
 import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
+import { useSharePortraitCapture } from '@/components/knowledge/useSharePortraitCapture';
 import { RecentlyExpanding, type ExpandingDomain } from '@/components/knowledge/RecentlyExpanding';
 import { AskFriendForDomain } from '@/components/knowledge/AskFriendForDomain';
 import { toCanonicalDomainSlug } from '@/server/profile/domain-slug';
@@ -305,6 +307,39 @@ function KnowledgePageContent() {
   const displayName = 'You';
   const hasAnything = annotatedDomains.length > 0;
 
+  // Share payload for the Knowledge Portrait card, shared by the off-screen
+  // capture card, the direct-share handler, and the modal fallback.
+  const shareDomains = useMemo(
+    () =>
+      topCardDomains.map((domain) => ({
+        canonicalSubcategory: domain.displayName,
+        currentTier: asTier(domain.tier),
+        lifetimePoints: domain.points,
+        iconKey: domain.iconKey,
+        broadCategory: domain.broadCategory,
+      })),
+    [topCardDomains],
+  );
+  const shareOverflowCount = Math.max(
+    0,
+    visibleDomains.filter((domain) => domain.points > 0).length - topCardDomains.length,
+  );
+  const shareTierSignature = data
+    ? `${formatNumber(data.mastery.totalPoints)} knowledge points across ${visibleDomains.length} territories`
+    : '';
+
+  // Pre-capture the portrait image in the background so the card's Share button
+  // can hand it straight to the native share sheet — no intermediate preview.
+  const { cardRef: portraitCardRef, shareNow: sharePortraitNow } = useSharePortraitCapture(
+    topCardDomains.length > 0,
+  );
+  const handlePortraitShare = () => {
+    // Common case: the image is ready, so share it directly. If the user taps
+    // before the background capture finishes, fall back to the preview modal
+    // (which captures on its own mount) rather than failing silently.
+    if (!sharePortraitNow()) setShareModalOpen(true);
+  };
+
   const toggleDomainHidden = async (canonicalSubcategory: string, nextHidden: boolean) => {
     setHideError(null);
     setHidePending(canonicalSubcategory);
@@ -582,8 +617,8 @@ function KnowledgePageContent() {
             iconKey: domain.iconKey,
             broadCategory: domain.broadCategory,
           }))}
-          overflowCount={Math.max(0, visibleDomains.filter((domain) => domain.points > 0).length - topCardDomains.length)}
-          tierSignature={`${formatNumber(data.mastery.totalPoints)} knowledge points across ${visibleDomains.length} territories`}
+          overflowCount={shareOverflowCount}
+          tierSignature={shareTierSignature}
           rarestTerritory={null}
           rarestTerritorySolo={false}
           shareText={`My Joshing knowledge portrait: ${topCardDomains.map((domain) => domain.displayName).join(', ')}`}
@@ -591,7 +626,7 @@ function KnowledgePageContent() {
           shareCardExpiresAt=""
           readOnly
           highlightedSlug={activeSlug}
-          onShareClick={() => setShareModalOpen(true)}
+          onShareClick={handlePortraitShare}
         />
       )}
 
@@ -694,19 +729,28 @@ function KnowledgePageContent() {
         </button>
       </section>
 
+      {/* Off-screen portrait card, snapshotted in the background so the card's
+          Share button can fire the native share sheet without a preview step. */}
+      {topCardDomains.length > 0 ? (
+        <div aria-hidden="true" style={{ position: 'fixed', left: -10000, top: 0, pointerEvents: 'none' }}>
+          <SharePortraitCard
+            ref={portraitCardRef}
+            playerDisplayName={displayName}
+            portraitStatement={yourMind}
+            domains={shareDomains}
+            overflowCount={shareOverflowCount}
+            tierSignature={shareTierSignature}
+          />
+        </div>
+      ) : null}
+
       {shareModalOpen && (
         <SharePortraitModal
           playerDisplayName={displayName}
           portraitStatement={yourMind}
-          domains={topCardDomains.map((domain) => ({
-            canonicalSubcategory: domain.displayName,
-            currentTier: asTier(domain.tier),
-            lifetimePoints: domain.points,
-            iconKey: domain.iconKey,
-            broadCategory: domain.broadCategory,
-          }))}
-          overflowCount={Math.max(0, visibleDomains.filter((domain) => domain.points > 0).length - topCardDomains.length)}
-          tierSignature={`${formatNumber(data.mastery.totalPoints)} knowledge points across ${visibleDomains.length} territories`}
+          domains={shareDomains}
+          overflowCount={shareOverflowCount}
+          tierSignature={shareTierSignature}
           onClose={() => setShareModalOpen(false)}
         />
       )}

--- a/src/components/knowledge/KnowledgeCard.tsx
+++ b/src/components/knowledge/KnowledgeCard.tsx
@@ -78,10 +78,8 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
 
   return (
     <section style={boxStyle} aria-label="Your Knowledge Portrait">
-      <p style={wordmarkStyle}>Joshing</p>
-      <CardTriangleStrip />
       <div style={headerStyle}>
-        <h2 style={titleStyle}>Your Knowledge Portrait</h2>
+        <p style={wordmarkStyle}>Joshing</p>
         {(!props.readOnly || props.onShareClick) && (
           <button
             type="button"
@@ -95,6 +93,8 @@ export function KnowledgeCard(props: KnowledgeCardProps) {
           </button>
         )}
       </div>
+      <CardTriangleStrip />
+      <h2 style={titleStyle}>Your Knowledge Portrait</h2>
 
       <p style={statementStyle}>{props.portraitStatement}</p>
 

--- a/src/components/knowledge/RecentlyExpanding.tsx
+++ b/src/components/knowledge/RecentlyExpanding.tsx
@@ -46,10 +46,8 @@ export function RecentlyExpanding({ domains, playerDisplayName = 'Josh', onNotic
           button[data-expanding-share="true"]:hover { border-color: var(--warm-border-soft); background: var(--warm-cream); transform: translateY(-1px); }
         }
       `}</style>
-      <p style={wordmarkStyle}>Joshing</p>
-      <CardTriangleStrip />
       <div style={headerStyle}>
-        <h2 style={titleStyle}>Recently Expanding</h2>
+        <p style={wordmarkStyle}>Joshing</p>
         {visibleDomains.length > 0 ? (
           <button
             type="button"
@@ -63,6 +61,8 @@ export function RecentlyExpanding({ domains, playerDisplayName = 'Josh', onNotic
           </button>
         ) : null}
       </div>
+      <CardTriangleStrip />
+      <h2 style={titleStyle}>Recently Expanding</h2>
 
       {domains.length === 0 ? (
         <div style={emptyWrapStyle}>

--- a/src/components/knowledge/SharePortraitCard.tsx
+++ b/src/components/knowledge/SharePortraitCard.tsx
@@ -200,6 +200,7 @@ export const SharePortraitCard = forwardRef<HTMLDivElement, SharePortraitCardPro
     return (
       <div ref={ref} style={cardStyle}>
         <p style={wordmarkStyle}>Joshing</p>
+        <div aria-hidden="true" style={triangleStripStyle} />
         <p style={titleStyle}>Your Knowledge Portrait</p>
 
         <p style={statementStyle}>{portraitStatement}</p>
@@ -249,6 +250,20 @@ const wordmarkStyle: CSSProperties = {
   color: INK,
   letterSpacing: '0.01em',
   lineHeight: 1,
+};
+
+// The JOSHING triangle band that sits under the wordmark, mirroring
+// CardTriangleStrip on the live card. The negative inline margin bleeds it to
+// the card's inner border edge; it matches cardStyle's 16px horizontal padding
+// (CardTriangleStrip's own -0.95rem is tied to the live card's padding instead).
+// Same artwork as the live strip so the snapshot keeps the palette consistent.
+const triangleStripStyle: CSSProperties = {
+  height: 16,
+  marginInline: -16,
+  backgroundImage: 'url(/images/Variant4-TOP.png)',
+  backgroundSize: 'cover',
+  backgroundPosition: 'center',
+  backgroundRepeat: 'no-repeat',
 };
 
 const titleStyle: CSSProperties = {

--- a/src/components/knowledge/SharePortraitModal.tsx
+++ b/src/components/knowledge/SharePortraitModal.tsx
@@ -1,57 +1,8 @@
 'use client';
 
-import { useRef, useState, useCallback, useEffect, type CSSProperties } from 'react';
+import { useCallback, useEffect, useState, type CSSProperties } from 'react';
 import { SharePortraitCard, type ShareDomain } from '@/components/knowledge/SharePortraitCard';
-
-// The share card mirrors the on-screen Knowledge Portrait, so the snapshot needs
-// the same three concrete font files the live card resolves through its
-// --font-* variables: Cormorant Garamond (the serif statement), Montserrat (the
-// "Joshing" wordmark) and Josefin Sans (labels). html2canvas can't see the app's
-// hashed Next-font families, so we hand-load these by literal family name.
-const SHARE_FONTS: Array<{ family: string; url: string; weight: string }> = [
-  {
-    family: 'Cormorant Garamond',
-    weight: '500',
-    url: 'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_s06GnM.ttf',
-  },
-  {
-    family: 'Cormorant Garamond',
-    weight: '600',
-    url: 'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_iE9GnM.ttf',
-  },
-  {
-    family: 'Montserrat',
-    weight: '700',
-    url: 'https://fonts.gstatic.com/s/montserrat/v31/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM70w-.ttf',
-  },
-  {
-    family: 'Josefin Sans',
-    weight: '400',
-    url: 'https://fonts.gstatic.com/s/josefinsans/v34/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQXME.ttf',
-  },
-  {
-    family: 'Josefin Sans',
-    weight: '700',
-    url: 'https://fonts.gstatic.com/s/josefinsans/v34/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_N_XXME.ttf',
-  },
-];
-
-async function loadShareFonts(): Promise<void> {
-  if (typeof document === 'undefined') return;
-  // Already loaded? (use the serif statement font as the sentinel)
-  if (document.fonts.check("500 22px 'Cormorant Garamond'")) return;
-  await Promise.all(
-    SHARE_FONTS.map(async ({ family, url, weight }) => {
-      try {
-        const font = new FontFace(family, `url(${url})`, { weight });
-        await font.load();
-        document.fonts.add(font);
-      } catch {
-        // Font load failure is non-fatal; the fallback stack renders instead.
-      }
-    }),
-  );
-}
+import { useSharePortraitCapture } from '@/components/knowledge/useSharePortraitCapture';
 
 type SharePhase = 'idle' | 'done' | 'error';
 
@@ -72,110 +23,29 @@ export function SharePortraitModal({
   tierSignature,
   onClose,
 }: SharePortraitModalProps) {
-  const cardRef = useRef<HTMLDivElement | null>(null);
   const [phase, setPhase] = useState<SharePhase>('idle');
-  const [fontReady, setFontReady] = useState(false);
 
-  // Pre-captured image, produced once on mount so the Share tap can call
-  // navigator.share synchronously (iOS consumes the user-gesture if we await
-  // font/canvas work first, which silently aborts the native sheet).
-  const [shareFile, setShareFile] = useState<File | null>(null);
-  const [dataUrl, setDataUrl] = useState<string | null>(null);
-  const [captureError, setCaptureError] = useState(false);
-  const [isCapturing, setIsCapturing] = useState(false);
-  const captureStartedRef = useRef(false);
-
-  const captureReady = shareFile !== null;
-
-  // Load the portrait fonts on mount
-  useEffect(() => {
-    loadShareFonts().then(() => setFontReady(true)).catch(() => setFontReady(true));
-  }, []);
-
-  // Capture the card to a File (for share) and data URL (for download) exactly
-  // once, after fonts are ready. The ref guard makes this safe against React's
-  // double-invoke and concurrent retries; on failure the guard is released so
-  // the retry affordance can re-run it.
-  const runCapture = useCallback(async () => {
-    if (captureStartedRef.current) return;
-    captureStartedRef.current = true;
-    setCaptureError(false);
-    setIsCapturing(true);
-    try {
-      const node = cardRef.current;
-      if (!node) throw new Error('Portrait card not mounted');
-      const { default: html2canvas } = await import('html2canvas');
-      const canvas = await html2canvas(node, {
-        backgroundColor: '#faf8f2', // raw hex required: html2canvas can't resolve var(); mirrors --warm-paper
-        scale: 3,
-        useCORS: true,
-        logging: false,
-      });
-      const url = canvas.toDataURL('image/png');
-      const blob = await (await fetch(url)).blob();
-      const file = new File([blob], 'joshing-portrait.png', { type: 'image/png' });
-      setDataUrl(url);
-      setShareFile(file);
-    } catch {
-      captureStartedRef.current = false; // allow the retry affordance to re-run
-      setCaptureError(true);
-    } finally {
-      setIsCapturing(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!fontReady || shareFile) return;
-    runCapture();
-  }, [fontReady, shareFile, runCapture]);
-
-  // Trigger the download of the pre-captured image. Returns whether it fired so
-  // callers can decide the resulting phase.
-  const clickDownloadLink = useCallback(() => {
-    if (!dataUrl) return false;
-    const link = document.createElement('a');
-    link.download = 'joshing-portrait.png';
-    link.href = dataUrl;
-    link.click();
-    return true;
-  }, [dataUrl]);
+  // The capture runs in the background as soon as the modal mounts so the Share
+  // tap can call navigator.share synchronously (see useSharePortraitCapture).
+  const {
+    cardRef,
+    captureReady,
+    captureError,
+    isCapturing,
+    runCapture,
+    download,
+    shareNow,
+  } = useSharePortraitCapture(true);
 
   const handleDownload = useCallback(() => {
-    setPhase(clickDownloadLink() ? 'done' : 'error');
-  }, [clickDownloadLink]);
+    setPhase(download() ? 'done' : 'error');
+  }, [download]);
 
-  // Gesture-clean: no await before navigator.share. The pre-captured file is
-  // handed straight to the native sheet.
   const handleShare = useCallback(() => {
-    if (!shareFile) return;
-
-    const canNativeShare =
-      typeof navigator !== 'undefined' &&
-      'share' in navigator &&
-      'canShare' in navigator &&
-      navigator.canShare({ files: [shareFile] });
-
-    if (!canNativeShare) {
-      // No native file share — give the user the image via download instead.
-      handleDownload();
-      return;
-    }
-
-    navigator
-      .share({ files: [shareFile], title: 'My Joshing knowledge portrait' })
-      .then(() => setPhase('done'))
-      .catch((err: unknown) => {
-        if (err instanceof Error && err.name === 'AbortError') {
-          // Real user cancellation — stay silent.
-          setPhase('idle');
-        } else {
-          // Share failed for some other reason — surface it but still get the
-          // user their image via the download fallback.
-          setPhase('error');
-          clickDownloadLink();
-        }
-      });
-  }, [shareFile, handleDownload, clickDownloadLink]);
+    // shareNow is gesture-clean (no await before navigator.share) and falls back
+    // to a download itself if the native sheet is unavailable or errors.
+    if (!shareNow()) setPhase('error');
+  }, [shareNow]);
 
   // Close on overlay click
   const handleOverlayClick = useCallback(

--- a/src/components/knowledge/useSharePortraitCapture.ts
+++ b/src/components/knowledge/useSharePortraitCapture.ts
@@ -1,0 +1,186 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+
+// The share card mirrors the on-screen Knowledge Portrait, so the snapshot needs
+// the same three concrete font files the live card resolves through its
+// --font-* variables: Cormorant Garamond (the serif statement), Montserrat (the
+// "Joshing" wordmark) and Josefin Sans (labels). html2canvas can't see the app's
+// hashed Next-font families, so we hand-load these by literal family name.
+const SHARE_FONTS: Array<{ family: string; url: string; weight: string }> = [
+  {
+    family: 'Cormorant Garamond',
+    weight: '500',
+    url: 'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_s06GnM.ttf',
+  },
+  {
+    family: 'Cormorant Garamond',
+    weight: '600',
+    url: 'https://fonts.gstatic.com/s/cormorantgaramond/v21/co3umX5slCNuHLi8bLeY9MK7whWMhyjypVO7abI26QOD_iE9GnM.ttf',
+  },
+  {
+    family: 'Montserrat',
+    weight: '700',
+    url: 'https://fonts.gstatic.com/s/montserrat/v31/JTUHjIg1_i6t8kCHKm4532VJOt5-QNFgpCuM70w-.ttf',
+  },
+  {
+    family: 'Josefin Sans',
+    weight: '400',
+    url: 'https://fonts.gstatic.com/s/josefinsans/v34/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_DjQXME.ttf',
+  },
+  {
+    family: 'Josefin Sans',
+    weight: '700',
+    url: 'https://fonts.gstatic.com/s/josefinsans/v34/Qw3PZQNVED7rKGKxtqIqX5E-AVSJrOCfjY46_N_XXME.ttf',
+  },
+];
+
+async function loadShareFonts(): Promise<void> {
+  if (typeof document === 'undefined') return;
+  // Already loaded? (use the serif statement font as the sentinel)
+  if (document.fonts.check("500 22px 'Cormorant Garamond'")) return;
+  await Promise.all(
+    SHARE_FONTS.map(async ({ family, url, weight }) => {
+      try {
+        const font = new FontFace(family, `url(${url})`, { weight });
+        await font.load();
+        document.fonts.add(font);
+      } catch {
+        // Font load failure is non-fatal; the fallback stack renders instead.
+      }
+    }),
+  );
+}
+
+export type SharePortraitCapture = {
+  /** Attach to the off-screen / preview SharePortraitCard so it can be snapshotted. */
+  cardRef: RefObject<HTMLDivElement | null>;
+  /** The pre-captured PNG, ready to hand straight to navigator.share. */
+  shareFile: File | null;
+  /** The same snapshot as a data URL, used for the download fallback. */
+  dataUrl: string | null;
+  /** True once the image has been captured and a share can fire synchronously. */
+  captureReady: boolean;
+  captureError: boolean;
+  isCapturing: boolean;
+  /** Manually (re)run the capture — used by the retry affordance. */
+  runCapture: () => Promise<void>;
+  /** Trigger the browser download of the captured image. Returns whether it fired. */
+  download: () => boolean;
+  /**
+   * Gesture-clean native share of the pre-captured image. Must be called from
+   * within a user gesture; there is no await before navigator.share, so the
+   * gesture survives. Returns false if the image isn't captured yet so the
+   * caller can fall back (e.g. open the preview modal).
+   */
+  shareNow: () => boolean;
+};
+
+/**
+ * Owns the html2canvas capture of a Knowledge Portrait card: font loading, the
+ * one-shot snapshot, and the gesture-clean share/download primitives. The capture
+ * runs in the background as soon as `active` is true so a later Share tap can call
+ * navigator.share synchronously (iOS consumes the user-gesture if we await
+ * font/canvas work first, which silently aborts the native sheet).
+ */
+export function useSharePortraitCapture(active = true): SharePortraitCapture {
+  const cardRef = useRef<HTMLDivElement | null>(null);
+  const [fontReady, setFontReady] = useState(false);
+  const [shareFile, setShareFile] = useState<File | null>(null);
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [captureError, setCaptureError] = useState(false);
+  const [isCapturing, setIsCapturing] = useState(false);
+  const captureStartedRef = useRef(false);
+
+  const captureReady = shareFile !== null;
+
+  // Load the portrait fonts once the capture is wanted.
+  useEffect(() => {
+    if (!active || fontReady) return;
+    loadShareFonts()
+      .then(() => setFontReady(true))
+      .catch(() => setFontReady(true));
+  }, [active, fontReady]);
+
+  // Capture the card to a File (for share) and data URL (for download) exactly
+  // once, after fonts are ready. The ref guard makes this safe against React's
+  // double-invoke and concurrent retries; on failure the guard is released so
+  // the retry affordance can re-run it.
+  const runCapture = useCallback(async () => {
+    if (captureStartedRef.current) return;
+    captureStartedRef.current = true;
+    setCaptureError(false);
+    setIsCapturing(true);
+    try {
+      const node = cardRef.current;
+      if (!node) throw new Error('Portrait card not mounted');
+      const { default: html2canvas } = await import('html2canvas');
+      const canvas = await html2canvas(node, {
+        backgroundColor: '#faf8f2', // raw hex required: html2canvas can't resolve var(); mirrors --warm-paper
+        scale: 3,
+        useCORS: true,
+        logging: false,
+      });
+      const url = canvas.toDataURL('image/png');
+      const blob = await (await fetch(url)).blob();
+      const file = new File([blob], 'joshing-portrait.png', { type: 'image/png' });
+      setDataUrl(url);
+      setShareFile(file);
+    } catch {
+      captureStartedRef.current = false; // allow the retry affordance to re-run
+      setCaptureError(true);
+    } finally {
+      setIsCapturing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!active || !fontReady || shareFile) return;
+    runCapture();
+  }, [active, fontReady, shareFile, runCapture]);
+
+  const download = useCallback(() => {
+    if (!dataUrl) return false;
+    const link = document.createElement('a');
+    link.download = 'joshing-portrait.png';
+    link.href = dataUrl;
+    link.click();
+    return true;
+  }, [dataUrl]);
+
+  const shareNow = useCallback(() => {
+    if (!shareFile) return false;
+
+    const canNativeShare =
+      typeof navigator !== 'undefined' &&
+      'share' in navigator &&
+      'canShare' in navigator &&
+      navigator.canShare({ files: [shareFile] });
+
+    if (!canNativeShare) {
+      // No native file share — give the user the image via download instead.
+      download();
+      return true;
+    }
+
+    navigator
+      .share({ files: [shareFile], title: 'My Joshing knowledge portrait' })
+      .catch((err: unknown) => {
+        if (err instanceof Error && err.name === 'AbortError') return; // real cancel — stay silent
+        download(); // share failed for some other reason — still get them the image
+      });
+    return true;
+  }, [shareFile, download]);
+
+  return {
+    cardRef,
+    shareFile,
+    dataUrl,
+    captureReady,
+    captureError,
+    isCapturing,
+    runCapture,
+    download,
+    shareNow,
+  };
+}


### PR DESCRIPTION
Move the Share button above the triangle-strip bar (into the wordmark
row) on both the Knowledge Portrait card and the Recently Expanding tile.

Make the Knowledge Portrait Share button skip the preview modal and go
directly to the native share sheet. The portrait image is pre-captured in
the background (off-screen card) so the share fires synchronously inside
the tap gesture — iOS aborts a share if html2canvas is awaited in-handler.
If the user taps before capture finishes, it falls back to the existing
preview modal. Capture logic is extracted into useSharePortraitCapture and
reused by the modal.

Also render the triangle-strip graphic in the shared portrait image so the
exported PNG matches the on-screen card.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Qgh8iLbFXxj4QQUcFbLo4L