### PR TITLE
feat(daily): seed generation with admin-authored example questions

### DIFF
--- a/src/server/daily/__tests__/prompt-context-signals.test.ts
+++ b/src/server/daily/__tests__/prompt-context-signals.test.ts
@@ -99,3 +99,56 @@ describe('buildUserPrompt — cultural anchor block (Q3d)', () => {
     }
   });
 });
+
+describe('buildUserPrompt — admin example anchors (ground truth)', () => {
+  const examplesFor = (
+    examples?: ReadonlyMap<string, ReadonlyArray<{ questionText: string; answerText: string }>>,
+    domains: string[] = ['Spy School Books 1-6'],
+  ) =>
+    buildUserPrompt(
+      domains,
+      domains.length,
+      noPrev,
+      noPrev,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      examples,
+    );
+
+  it('renders authored examples for round domains as canon anchors', () => {
+    const out = examplesFor(
+      new Map([
+        [
+          'Spy School Books 1-6',
+          [
+            { questionText: 'What is the CIA academy disguised as?', answerText: 'a science magnet school' },
+            { questionText: "Who is Ben Ripley's classmate-turned-mole?", answerText: 'Murray Hill' },
+          ],
+        ],
+      ]),
+    );
+    expect(out).toContain('HUMAN-AUTHORED EXAMPLES');
+    expect(out).toContain('a science magnet school');
+    expect(out).toContain('Murray Hill');
+  });
+
+  it('omits the whole block when no examples are provided', () => {
+    expect(examplesFor(undefined)).not.toContain('HUMAN-AUTHORED EXAMPLES');
+    expect(examplesFor(new Map())).not.toContain('HUMAN-AUTHORED EXAMPLES');
+  });
+
+  it('includes examples only for domains in the round', () => {
+    const out = examplesFor(
+      new Map([['Wagner\'s Ring Cycle', [{ questionText: 'Q-wagner', answerText: 'A-wagner' }]]]),
+      ['Weimar Cinema'],
+    );
+    expect(out).not.toContain('HUMAN-AUTHORED EXAMPLES');
+    expect(out).not.toContain('Q-wagner');
+  });
+});

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -24,6 +24,7 @@ import {
   updateAdaptiveLevel,
 } from '@/server/adaptive-difficulty';
 import {
+  getAuthoredExamplesForDomains,
   getAuthoredQuestionTexts,
   getKnowledgeBase,
   getRecentAnsweredAnswerKeys,
@@ -46,6 +47,7 @@ import {
 import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { getCulturalAnchor, type CulturalAnchor } from '@/server/db/queries/account';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { adminUserIds } from '@/server/auth/admin';
 import { planFirstRunDomains } from '@/server/daily/first-run-seeding';
 import {
   isNarrowKbGuardEnabled,
@@ -337,6 +339,15 @@ export type DomainStrength = {
   correctAnswerCount: number;
 };
 
+// How many admin-authored example questions to feed the prompt per domain. Kept to
+// a small HANDFUL on purpose: a few examples anchor the model's facts and register;
+// more just crowds the prompt with diminishing returns (and, across a multi-domain
+// round, adds up). Few-shot grounding wants variety, not volume.
+const DOMAIN_EXAMPLE_LIMIT = 3;
+
+// Per-domain human-authored (question, answer) examples used as generation anchors.
+export type DomainExamples = ReadonlyMap<string, ReadonlyArray<{ questionText: string; answerText: string }>>;
+
 export function buildUserPrompt(
   domains: string[],
   count: number,
@@ -350,6 +361,11 @@ export function buildUserPrompt(
   domainTerritoryTypes?: ReadonlyMap<string, TerritoryType>,
   domainStrengths?: ReadonlyMap<string, DomainStrength>,
   culturalAnchor?: CulturalAnchor | null,
+  // Per-domain human-authored example questions (question + answer), used as
+  // GROUND-TRUTH anchors so the model writes new questions grounded in real canon
+  // instead of inventing facts for domains it doesn't truly know. See
+  // getAuthoredExamplesForDomains / DOMAIN_EXAMPLE_LIMIT.
+  domainExamples?: ReadonlyMap<string, ReadonlyArray<{ questionText: string; answerText: string }>>,
 ): string {
   const prevBlock = prev.length > 0
     ? prev
@@ -483,7 +499,26 @@ ${perDomain.join('\n')}`;
     }
   }
 
-  return `${domainSection}${calibration}${difficultyHint}${territoryHint}${strengthHint}${anchorHint}${subAnglesHint}
+  let examplesHint = '';
+  if (domainExamples && domainExamples.size > 0) {
+    const perDomain: string[] = [];
+    for (const domain of domains) {
+      const examples = domainExamples.get(domain);
+      if (examples && examples.length > 0) {
+        const lines = examples
+          .slice(0, DOMAIN_EXAMPLE_LIMIT)
+          .map((ex) => `  Q: ${ex.questionText}\n     A: ${ex.answerText}`)
+          .join('\n');
+        perDomain.push(`[${domain}]\n${lines}`);
+      }
+    }
+    if (perDomain.length > 0) {
+      examplesHint = `\n\nHUMAN-AUTHORED EXAMPLES — ground truth for these domains. A person who knows the material wrote these, so treat their facts as CANON. Write NEW questions about DIFFERENT facts in the same spirit, specificity, and register. Anchor every claim to the actual work as these examples reflect it — do NOT invent names, places, or events a real fan could not confirm. (Do not reuse these exact facts; they are in the avoid list.)
+${wrapUserInput('domain_examples', perDomain.join('\n\n'))}`;
+    }
+  }
+
+  return `${domainSection}${calibration}${difficultyHint}${territoryHint}${strengthHint}${anchorHint}${subAnglesHint}${examplesHint}
 
 Previously generated questions to avoid repeating (do not re-ask any of these facts, even rephrased). Each entry is prefixed with [<source domain>]. The user's domains may overlap in subject matter — for example, a fact about Mrs. Dalloway already asked under "Virginia Woolf's Novels and Essays" is still off limits when generating for "Mrs. Dalloway", and vice versa. A fact already covered under ANY of the user's domains must not be re-asked under ANY domain:
 ${wrapUserInput('recent_questions', prevBlock)}
@@ -1257,6 +1292,7 @@ async function callLlmOnce(
   domainStrengths?: ReadonlyMap<string, DomainStrength>,
   culturalAnchor?: CulturalAnchor | null,
   provider: LlmProvider = 'anthropic',
+  domainExamples?: DomainExamples,
 ): Promise<LlmQuestion[]> {
   const userPrompt = buildUserPrompt(
     domains,
@@ -1271,6 +1307,7 @@ async function callLlmOnce(
     domainTerritoryTypes,
     domainStrengths,
     culturalAnchor,
+    domainExamples,
   );
 
   // OpenAI branch (B-LLM-PROVIDER-AB-SWITCH B1): same prompt text, only the
@@ -1337,7 +1374,11 @@ export async function generateDailyQuestions(
   // orchestrator can draw on them as a last resort rather than serving a short
   // queue (see the under-difficulty handling below and queue-orchestrator's
   // backfill chain).
-  options: { underDifficultyReserve?: GeneratedQuestionRow[]; provider?: LlmProvider } = {},
+  options: {
+    underDifficultyReserve?: GeneratedQuestionRow[];
+    provider?: LlmProvider;
+    domainExamples?: DomainExamples;
+  } = {},
 ): Promise<GeneratedQuestionRow[]> {
   if (count <= 0 || domains.length === 0) return [];
 
@@ -1345,6 +1386,7 @@ export async function generateDailyQuestions(
   // every chunk — never re-resolved per question. Defaults to Anthropic; B2
   // makes the caller pass the global setting instead of the literal below.
   const provider: LlmProvider = options.provider ?? 'anthropic';
+  const domainExamples = options.domainExamples;
 
   // Avoid list ordering: newest first so the slice in buildUserPrompt keeps
   // recency. extraAvoidTexts (caller-supplied, e.g. same-batch peers) goes
@@ -1380,6 +1422,7 @@ export async function generateDailyQuestions(
         domainStrengths,
         culturalAnchor,
         provider,
+        domainExamples,
       );
       if (out.length > 0) return out;
       console.warn('[daily/generate-questions] chunk returned no usable questions, retrying', {
@@ -1399,6 +1442,7 @@ export async function generateDailyQuestions(
         domainStrengths,
         culturalAnchor,
         provider,
+        domainExamples,
       );
     } catch (err) {
       // A single chunk failing (timeout / aborted) must not sink the batch —
@@ -2033,6 +2077,18 @@ export async function generateDailyQuestionsFromKnowledgeBase(
 
   const subAnglesByDomain = await getRecentSubAnglesByDomain(userId, domainsForRound).catch(() => undefined);
 
+  // Admin-authored example questions per domain — ground-truth anchors fed into
+  // the generation prompt so the model writes from real canon instead of inventing
+  // facts for domains it doesn't truly know (the niche-domain hallucination fix,
+  // e.g. "Spy School"). Scoped to ADMIN_USER_IDS: a seed is treated as canon, so
+  // only a trusted author may anchor a domain. Resilient: a miss (or no admins /
+  // no examples) just means no examples block this round.
+  const domainExamples = await getAuthoredExamplesForDomains(
+    domainsForRound,
+    DOMAIN_EXAMPLE_LIMIT,
+    adminUserIds(),
+  ).catch(() => new Map<string, Array<{ questionText: string; answerText: string }>>());
+
   // Fold recently-answered canonical texts (domain-scoped, capped) into the
   // avoid list ahead of the generated history, so a fact the player answered
   // yesterday on a friend's / house / forwarded question isn't re-created as a
@@ -2147,6 +2203,7 @@ export async function generateDailyQuestionsFromKnowledgeBase(
       {
         underDifficultyReserve: options.underDifficultyReserve,
         provider: genProvider,
+        domainExamples,
       },
     );
   }

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -2211,6 +2211,54 @@ export async function getAuthoredQuestionTexts(
   }));
 }
 
+/**
+ * Up to `perDomainLimit` authored questions per domain (from the given `authorIds`
+ * only), as (question, answer) pairs, for seeding generation. These are
+ * GROUND-TRUTH anchors fed into buildUserPrompt so the model writes NEW questions
+ * grounded in real canon instead of inventing details — the fix for niche domains
+ * it doesn't truly know (e.g. "Spy School"). Scoped to a TRUSTED author allowlist
+ * (callers pass adminUserIds()) on purpose: a seed is treated as canon, so an
+ * untrusted author's mistake must never become a generation anchor. Empty
+ * `authorIds` → no seeds (the feature is inert until an admin authors examples).
+ * Non-deleted, non-blocked; newest first; domains with no examples are absent.
+ */
+export async function getAuthoredExamplesForDomains(
+  domains: readonly string[],
+  perDomainLimit: number,
+  authorIds: readonly string[],
+): Promise<Map<string, Array<{ questionText: string; answerText: string }>>> {
+  const result = new Map<string, Array<{ questionText: string; answerText: string }>>();
+  if (domains.length === 0 || perDomainLimit <= 0 || authorIds.length === 0) return result;
+
+  const rows = await db
+    .select({
+      domain: canonicalQuestions.canonicalSubcategory,
+      questionText: canonicalQuestions.questionText,
+      answerText: canonicalQuestions.answerText,
+    })
+    .from(canonicalQuestions)
+    .where(and(
+      inArray(canonicalQuestions.canonicalSubcategory, [...domains]),
+      inArray(canonicalQuestions.creatorId, [...authorIds]),
+      isNull(canonicalQuestions.deletedAt),
+      ne(canonicalQuestions.visibility, 'blocked'),
+    ))
+    .orderBy(desc(canonicalQuestions.createdAt));
+
+  for (const row of rows) {
+    if (!row.domain) continue;
+    const existing = result.get(row.domain);
+    if (existing) {
+      if (existing.length < perDomainLimit) {
+        existing.push({ questionText: row.questionText, answerText: row.answerText });
+      }
+    } else {
+      result.set(row.domain, [{ questionText: row.questionText, answerText: row.answerText }]);
+    }
+  }
+  return result;
+}
+
 export async function getAnsweredDailyCount(queue: DailyQueueRow): Promise<number> {
   return asQueueSlots(queue.slots).filter((slot) => slot.answered).length;
 }


### PR DESCRIPTION
## Why

Niche domains the model doesn't truly know — like **"Spy School Books 1-6"** — produce hallucinated questions because the model invents canon (the "Academy of Evil" / Georgetown failures earlier this week). Web grounding helps where coverage exists, but the most reliable fix is **your own real examples**: write a few correct questions for a domain, and the model writes more grounded in actual canon instead of making things up.

## What it does

When generating for a domain, the prompt now includes a small set of **admin-authored example questions** for that domain as ground-truth anchors:

> **HUMAN-AUTHORED EXAMPLES — ground truth…** Write NEW questions about DIFFERENT facts in the same spirit… do NOT invent names a real fan could not confirm.

- **`getAuthoredExamplesForDomains(domains, perDomainLimit, authorIds)`** — per-domain `(question, answer)` pairs, **scoped to a trusted author allowlist** (`adminUserIds()`). A seed is treated as canon, so an untrusted author's mistake can never become a generation anchor. Empty allowlist / no examples → the feature is **inert**.
- **`buildUserPrompt`** gains a `domainExamples` param that renders the block (wrapped as untrusted input) for the round's domains only; threaded through `callLlmOnce` → `generateDailyQuestions` options.
- **`DOMAIN_EXAMPLE_LIMIT = 3`** — a small handful anchors facts + register; more just crowds the prompt with diminishing returns.

## Scope answers (from the design conversation)
- **Whose questions?** Admin/owner only (`ADMIN_USER_IDS`) — not anyone's, by design.
- **General or Spy-School-only?** General — every domain you author examples for benefits. Facts ground their own domain; the *craft* lifts register everywhere (via the existing global style exemplars).
- **Overwhelming the LLM?** No — capped at 3/domain, and only domains you've authored for get a block.

## Notes
- Inert until you author questions for a domain — nothing changes for domains without admin examples.
- Tests cover the prompt rendering (present / absent / scoped-to-round). Typecheck + lint clean; full daily suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)