### PR TITLE
Add admin bulk CSV question upload

### DIFF
--- a/src/app/admin/bulk-upload/BulkUploadClient.tsx
+++ b/src/app/admin/bulk-upload/BulkUploadClient.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useState } from 'react';
+
+// Per-line error returned by /api/admin/bulk-upload-questions.
+type RowError = { line: number; message: string };
+
+type UploadResult = {
+  dryRun: boolean;
+  total: number;
+  valid?: number;
+  invalid?: number;
+  created: number;
+  skipped?: number;
+  rowErrors: RowError[];
+};
+
+const SAMPLE_CSV = `question,answer,alternates,explanation,category,subcategory,difficulty
+"Which planet is known as the Red Planet?",Mars,,"Iron oxide gives it the colour.",science,Astronomy,1
+"Who wrote ""Hamlet""?","William Shakespeare","Shakespeare|Bill Shakespeare",,literature,Shakespeare,moderate`;
+
+// Deliberately minimal — an internal ops tool, not a product surface.
+export function BulkUploadClient() {
+  const [file, setFile] = useState<File | null>(null);
+  const [pending, setPending] = useState<'dry' | 'commit' | null>(null);
+  const [result, setResult] = useState<UploadResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  async function submit(dryRun: boolean) {
+    if (!file || pending) return;
+    setPending(dryRun ? 'dry' : 'commit');
+    setError(null);
+    setResult(null);
+    try {
+      const form = new FormData();
+      form.set('file', file);
+      form.set('dryRun', dryRun ? 'true' : 'false');
+      const res = await fetch('/api/admin/bulk-upload-questions', {
+        method: 'POST',
+        credentials: 'include',
+        body: form,
+      });
+      const data = (await res.json().catch(() => null)) as (UploadResult & { message?: string }) | null;
+      if (!res.ok) {
+        setError(data?.message ?? `Upload failed (${res.status}).`);
+        setPending(null);
+        return;
+      }
+      setResult(data);
+    } catch {
+      setError('Upload failed.');
+    }
+    setPending(null);
+  }
+
+  return (
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+      <header className="mb-5">
+        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Bulk upload questions</h1>
+        <p className="text-muted-foreground mt-1 text-sm">
+          Upload a CSV to create questions in bulk. They are saved as verified, public, and attributed to you.
+        </p>
+      </header>
+
+      <section className="rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
+        <h2 className="font-medium text-[var(--brand-ink)]">CSV format</h2>
+        <ul className="text-muted-foreground mt-2 list-disc space-y-1 pl-5">
+          <li>
+            Required columns: <code>question</code>, <code>answer</code>.
+          </li>
+          <li>
+            Optional: <code>alternates</code> (separate with <code>|</code>), <code>explanation</code>,{' '}
+            <code>category</code>, <code>subcategory</code>, <code>difficulty</code> (1–5 or
+            accessible/moderate/specialist).
+          </li>
+          <li>Unknown categories fall back to General Knowledge. Max 1000 rows per upload.</li>
+        </ul>
+        <pre
+          className="mt-3 overflow-x-auto rounded-md border p-3 text-[0.7rem] text-[var(--brand-ink-700)]"
+          style={{ borderColor: 'var(--border)', background: 'var(--brand-field)' }}
+        >
+          {SAMPLE_CSV}
+        </pre>
+      </section>
+
+      <div className="mt-4 flex flex-wrap items-center gap-3">
+        <input
+          type="file"
+          accept=".csv,text/csv"
+          onChange={(e) => {
+            setFile(e.target.files?.[0] ?? null);
+            setResult(null);
+            setError(null);
+          }}
+          className="min-w-0 flex-1 text-sm"
+        />
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void submit(true)}
+          disabled={!file || pending !== null}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--border)' }}
+        >
+          {pending === 'dry' ? 'Validating…' : 'Validate (dry run)'}
+        </button>
+        <button
+          type="button"
+          onClick={() => void submit(false)}
+          disabled={!file || pending !== null}
+          className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+        >
+          {pending === 'commit' ? 'Uploading…' : 'Upload'}
+        </button>
+      </div>
+
+      {error ? (
+        <p className="mt-3 text-sm" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+
+      {result ? (
+        <section className="mt-4 rounded-md border p-4 text-sm" style={{ borderColor: 'var(--border)' }}>
+          <h2 className="font-medium text-[var(--brand-ink)]">
+            {result.dryRun ? 'Dry run results' : 'Upload complete'}
+          </h2>
+          <p className="text-muted-foreground mt-1">
+            {result.dryRun ? (
+              <>
+                {result.valid ?? 0} valid · {result.invalid ?? 0} with errors · {result.total} total rows
+              </>
+            ) : (
+              <>
+                Created {result.created} · skipped {result.skipped ?? 0} · {result.total} total rows
+              </>
+            )}
+          </p>
+          {result.rowErrors.length > 0 ? (
+            <div className="mt-3">
+              <p className="font-medium text-[var(--brand-ink)]">Row errors</p>
+              <ul className="mt-1 space-y-1">
+                {result.rowErrors.map((err) => (
+                  <li key={err.line} style={{ color: 'var(--danger)' }}>
+                    Line {err.line}: {err.message}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ) : (
+            <p className="mt-2 text-[var(--brand-ink-700)]">No row errors.</p>
+          )}
+        </section>
+      ) : null}
+    </main>
+  );
+}

--- a/src/app/admin/bulk-upload/page.tsx
+++ b/src/app/admin/bulk-upload/page.tsx
@@ -1,0 +1,18 @@
+import { notFound } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+
+import { BulkUploadClient } from './BulkUploadClient';
+
+export const dynamic = 'force-dynamic';
+
+// Admin-only CSV bulk question upload. Reachable ONLY to ADMIN_USER_IDS members;
+// everyone else (incl. authenticated non-admins) gets Next's 404 — the route's
+// existence is not revealed. Unset env ⇒ no admins ⇒ always 404.
+export default async function AdminBulkUploadPage() {
+  const session = await getSession();
+  if (!session || !isAdminUser(session.userId)) notFound();
+
+  return <BulkUploadClient />;
+}

--- a/src/app/api/admin/bulk-upload-questions/route.ts
+++ b/src/app/api/admin/bulk-upload-questions/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { getSession } from '@/server/auth/session';
+import { isAdminUser } from '@/server/auth/admin';
+import { createQuestion } from '@/server/db/queries/questions';
+import { MAX_BULK_UPLOAD_ROWS, parseBulkUploadCsv } from '@/server/questions/bulk-upload';
+
+export const dynamic = 'force-dynamic';
+
+// Upper bound on the raw payload to keep a single request bounded even before
+// we count rows. ~5MB of CSV comfortably holds MAX_BULK_UPLOAD_ROWS rows.
+const MAX_CSV_BYTES = 5 * 1024 * 1024;
+
+const optionsSchema = z.object({
+  // dryRun validates + reports without writing anything — lets an admin preview
+  // the parse result before committing.
+  dryRun: z.boolean().optional().default(false),
+});
+
+async function readCsv(request: NextRequest): Promise<{ csv: string; dryRun: boolean } | { error: string }> {
+  const contentType = request.headers.get('content-type') ?? '';
+
+  if (contentType.includes('multipart/form-data')) {
+    const form = await request.formData().catch(() => null);
+    if (!form) return { error: 'invalid_form' };
+    const file = form.get('file');
+    if (!(file instanceof File)) return { error: 'no_file' };
+    if (file.size > MAX_CSV_BYTES) return { error: 'file_too_large' };
+    const dryRunRaw = form.get('dryRun');
+    const dryRun = dryRunRaw === 'true' || dryRunRaw === '1';
+    return { csv: await file.text(), dryRun };
+  }
+
+  // JSON fallback: { csv: string, dryRun?: boolean }
+  const body = (await request.json().catch(() => null)) as { csv?: unknown } | null;
+  if (!body || typeof body.csv !== 'string') return { error: 'invalid_request' };
+  if (Buffer.byteLength(body.csv, 'utf8') > MAX_CSV_BYTES) return { error: 'file_too_large' };
+  const opts = optionsSchema.safeParse(body);
+  return { csv: body.csv, dryRun: opts.success ? opts.data.dryRun : false };
+}
+
+export async function POST(request: NextRequest) {
+  const session = await getSession();
+  // Non-admins (and the unauthenticated) get 404 — never reveal the route exists.
+  if (!session || !isAdminUser(session.userId)) {
+    return NextResponse.json({ error: 'not_found' }, { status: 404 });
+  }
+
+  const read = await readCsv(request);
+  if ('error' in read) {
+    return NextResponse.json({ error: read.error }, { status: 400 });
+  }
+
+  const parsed = parseBulkUploadCsv(read.csv);
+  if (!parsed.ok) {
+    return NextResponse.json({ error: 'parse_failed', message: parsed.error }, { status: 400 });
+  }
+
+  if (read.dryRun) {
+    return NextResponse.json({
+      dryRun: true,
+      total: parsed.rows.length + parsed.errors.length,
+      valid: parsed.rows.length,
+      invalid: parsed.errors.length,
+      created: 0,
+      rowErrors: parsed.errors,
+    });
+  }
+
+  const created: { line: number; id: string }[] = [];
+  const insertErrors: { line: number; message: string }[] = [];
+
+  // Sequential inserts: createQuestion does an embedding/dedup pass per row and
+  // the DB pool is capped (max 5), so a bounded sequential loop is the safe
+  // shape. MAX_BULK_UPLOAD_ROWS keeps total work in check.
+  for (const row of parsed.rows) {
+    try {
+      const result = await createQuestion({
+        authorId: session.userId,
+        text: row.text,
+        correctAnswer: row.correctAnswer,
+        alternateAnswers: row.alternateAnswers,
+        explanation: row.explanation,
+        category: row.category,
+        broadCategory: row.broadCategory,
+        subcategory: row.canonicalSubcategory,
+        canonicalSubcategory: row.canonicalSubcategory,
+        domain: row.canonicalSubcategory,
+        difficulty: row.difficulty,
+        // Admin-uploaded questions are trusted: verified + creator-written.
+        verified: true,
+        critiqueIterations: 0,
+        visibility: 'public',
+      });
+      created.push({ line: row.line, id: result.id });
+    } catch (error) {
+      console.error('[admin/bulk-upload] row insert failed', {
+        line: row.line,
+        adminId: session.userId,
+        message: error instanceof Error ? error.message : String(error),
+      });
+      insertErrors.push({
+        line: row.line,
+        message: error instanceof Error ? error.message : 'insert failed',
+      });
+    }
+  }
+
+  const rowErrors = [...parsed.errors, ...insertErrors].sort((a, b) => a.line - b.line);
+
+  console.info('[admin/bulk-upload] complete', {
+    adminId: session.userId,
+    created: created.length,
+    skipped: rowErrors.length,
+  });
+
+  return NextResponse.json({
+    dryRun: false,
+    total: parsed.rows.length + parsed.errors.length,
+    created: created.length,
+    skipped: rowErrors.length,
+    createdIds: created.map((c) => c.id),
+    rowErrors,
+    limit: MAX_BULK_UPLOAD_ROWS,
+  });
+}

--- a/src/server/questions/__tests__/bulk-upload.test.ts
+++ b/src/server/questions/__tests__/bulk-upload.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_BULK_UPLOAD_ROWS,
+  parseBulkUploadCsv,
+  parseCsvRecords,
+} from '@/server/questions/bulk-upload';
+
+describe('parseCsvRecords', () => {
+  it('parses simple rows', () => {
+    expect(parseCsvRecords('a,b,c\n1,2,3')).toEqual([
+      ['a', 'b', 'c'],
+      ['1', '2', '3'],
+    ]);
+  });
+
+  it('handles quoted fields with commas, newlines, and escaped quotes', () => {
+    const csv = 'q,a\n"Hello, world","He said ""hi""\nthen left"';
+    expect(parseCsvRecords(csv)).toEqual([
+      ['q', 'a'],
+      ['Hello, world', 'He said "hi"\nthen left'],
+    ]);
+  });
+
+  it('handles CRLF line endings and a trailing newline', () => {
+    expect(parseCsvRecords('a,b\r\n1,2\r\n')).toEqual([
+      ['a', 'b'],
+      ['1', '2'],
+    ]);
+  });
+
+  it('strips a leading BOM', () => {
+    expect(parseCsvRecords('﻿q,a\n1,2')).toEqual([
+      ['q', 'a'],
+      ['1', '2'],
+    ]);
+  });
+});
+
+describe('parseBulkUploadCsv', () => {
+  it('parses a valid file with required + optional columns', () => {
+    const csv = [
+      'question,answer,alternates,explanation,category,subcategory,difficulty',
+      '"Who wrote Hamlet?","William Shakespeare","Shakespeare|Bill",,"literature","Shakespeare","moderate"',
+    ].join('\n');
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({
+      line: 2,
+      text: 'Who wrote Hamlet?',
+      correctAnswer: 'William Shakespeare',
+      alternateAnswers: ['Shakespeare', 'Bill'],
+      explanation: null,
+      category: 'literature',
+      broadCategory: 'Literature',
+      canonicalSubcategory: 'Shakespeare',
+      difficulty: 3,
+    });
+  });
+
+  it('accepts header aliases and is case-insensitive', () => {
+    const csv = 'Q,Correct Answer\n"2+2?","4"';
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0]).toMatchObject({ text: '2+2?', correctAnswer: '4' });
+  });
+
+  it('fails when required columns are missing', () => {
+    const result = parseBulkUploadCsv('question,explanation\nfoo,bar');
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.error).toContain('answer');
+  });
+
+  it('fails on an empty file', () => {
+    const result = parseBulkUploadCsv('');
+    expect(result.ok).toBe(false);
+  });
+
+  it('defaults category to general_knowledge and difficulty to 3', () => {
+    const result = parseBulkUploadCsv('question,answer\n"Q?","A"');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows[0]).toMatchObject({
+      category: 'general_knowledge',
+      broadCategory: 'General Knowledge',
+      canonicalSubcategory: 'General Knowledge',
+      difficulty: 3,
+    });
+  });
+
+  it('maps difficulty words and numbers', () => {
+    const csv = [
+      'question,answer,difficulty',
+      '"Q1","A",accessible',
+      '"Q2","A",5',
+      '"Q3","A",specialist',
+    ].join('\n');
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows.map((r) => r.difficulty)).toEqual([1, 5, 5]);
+  });
+
+  it('reports per-row errors without failing the whole upload', () => {
+    const csv = [
+      'question,answer,difficulty',
+      '"Good?","A",2',
+      '"","Missing question",2',
+      '"Bad difficulty","A",nine',
+    ].join('\n');
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows).toHaveLength(1);
+    expect(result.errors).toHaveLength(2);
+    expect(result.errors[0].line).toBe(3);
+    expect(result.errors[1].line).toBe(4);
+    expect(result.errors[1].message).toContain('difficulty');
+  });
+
+  it('rejects too many alternate answers', () => {
+    const csv = 'question,answer,alternates\n"Q?","A","a|b|c|d|e|f|g"';
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows).toHaveLength(0);
+    expect(result.errors[0].message).toContain('alternate');
+  });
+
+  it('skips entirely-blank lines', () => {
+    const csv = 'question,answer\n"Q?","A"\n,\n';
+    const result = parseBulkUploadCsv(csv);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.rows).toHaveLength(1);
+    expect(result.errors).toHaveLength(0);
+  });
+
+  it('fails when exceeding the row cap', () => {
+    const lines = ['question,answer'];
+    for (let i = 0; i < MAX_BULK_UPLOAD_ROWS + 1; i++) lines.push(`"Q${i}","A"`);
+    const result = parseBulkUploadCsv(lines.join('\n'));
+    expect(result.ok).toBe(false);
+  });
+});

--- a/src/server/questions/bulk-upload.ts
+++ b/src/server/questions/bulk-upload.ts
@@ -1,0 +1,274 @@
+/**
+ * Admin bulk CSV question upload — pure parsing + per-row validation.
+ *
+ * Kept free of DB/LLM/Next imports so it is unit-testable in isolation; the route
+ * (`/api/admin/bulk-upload-questions`) calls `parseBulkUploadCsv` and then feeds
+ * each validated row straight into `createQuestion`. Admin-only, so we trust the
+ * uploader and skip the LLM categorize/vet pipeline the authored route runs —
+ * category/subcategory/difficulty come from the CSV (or sane defaults) instead.
+ */
+import { z } from 'zod';
+
+import {
+  broadCategoryDisplayName,
+  normalizeBroadQuestionCategoryOrDefault,
+  normalizeCanonicalSubcategory,
+  type BroadQuestionCategory,
+} from '@/lib/question-categorization';
+import { MAX_ALTERNATE_ANSWERS } from '@/lib/questions-types';
+
+/** Hard cap on data rows per upload — keeps a single request bounded. */
+export const MAX_BULK_UPLOAD_ROWS = 1000;
+
+/** Alternate answers are split on `|` within a single CSV cell. */
+export const ALTERNATE_ANSWER_DELIMITER = '|';
+
+/**
+ * Canonical column name → accepted header aliases (matched case-insensitively,
+ * trimmed, with internal whitespace and `_`/`-` collapsed). `question` and
+ * `answer` are required; the rest are optional.
+ */
+const COLUMN_ALIASES: Record<string, readonly string[]> = {
+  question: ['question', 'questiontext', 'q'],
+  answer: ['answer', 'answertext', 'correctanswer', 'a'],
+  alternates: ['alternates', 'alternateanswers', 'alternatives', 'accepted', 'acceptedalternatives'],
+  explanation: ['explanation', 'factualexplanation', 'explainer'],
+  category: ['category', 'broadcategory'],
+  subcategory: ['subcategory', 'canonicalsubcategory', 'domain', 'topic'],
+  difficulty: ['difficulty', 'difficultyestimate', 'level'],
+};
+
+const REQUIRED_COLUMNS = ['question', 'answer'] as const;
+
+/** A single fully-validated row, shaped for `createQuestion`. */
+export type BulkUploadRow = {
+  /** 1-based source line number (header is line 1; first data row is line 2). */
+  line: number;
+  text: string;
+  correctAnswer: string;
+  alternateAnswers: string[];
+  explanation: string | null;
+  category: BroadQuestionCategory;
+  broadCategory: string;
+  canonicalSubcategory: string;
+  /** Numeric difficulty (1=accessible, 3=moderate, 5=specialist) for createQuestion. */
+  difficulty: number;
+};
+
+export type BulkUploadRowError = { line: number; message: string };
+
+export type BulkUploadParseResult =
+  | { ok: false; error: string }
+  | { ok: true; rows: BulkUploadRow[]; errors: BulkUploadRowError[] };
+
+function normalizeHeader(raw: string): string {
+  return raw
+    .trim()
+    .toLowerCase()
+    .replace(/[\s_-]+/g, '');
+}
+
+/**
+ * RFC 4180-ish CSV tokenizer: handles quoted fields, `""` escaped quotes,
+ * commas and newlines inside quotes, and both LF and CRLF line endings. Returns
+ * one string[] per record. A leading UTF-8 BOM is stripped.
+ */
+export function parseCsvRecords(input: string): string[][] {
+  const text = input.charCodeAt(0) === 0xfeff ? input.slice(1) : input;
+  const records: string[][] = [];
+  let field = '';
+  let record: string[] = [];
+  let inQuotes = false;
+  let sawAnyChar = false;
+
+  const pushField = () => {
+    record.push(field);
+    field = '';
+  };
+  const pushRecord = () => {
+    pushField();
+    records.push(record);
+    record = [];
+  };
+
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    sawAnyChar = true;
+    if (inQuotes) {
+      if (ch === '"') {
+        if (text[i + 1] === '"') {
+          field += '"';
+          i++;
+        } else {
+          inQuotes = false;
+        }
+      } else {
+        field += ch;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      pushField();
+    } else if (ch === '\n') {
+      pushRecord();
+    } else if (ch === '\r') {
+      // swallow; the following \n (if any) triggers the record break
+    } else {
+      field += ch;
+    }
+  }
+
+  // Flush the final record unless the input ended exactly on a newline (no
+  // trailing empty record) or was entirely empty.
+  if (field.length > 0 || record.length > 0 || (sawAnyChar && text[text.length - 1] !== '\n' && text[text.length - 1] !== '\r')) {
+    pushRecord();
+  }
+
+  return records;
+}
+
+const rowSchema = z.object({
+  question: z.string().trim().min(1, 'question is empty').max(2000, 'question exceeds 2000 characters'),
+  answer: z.string().trim().min(1, 'answer is empty').max(1000, 'answer exceeds 1000 characters'),
+  alternates: z.string().optional().default(''),
+  explanation: z.string().optional().default(''),
+  category: z.string().optional().default(''),
+  subcategory: z.string().optional().default(''),
+  difficulty: z.string().optional().default(''),
+});
+
+const DIFFICULTY_WORDS: Record<string, number> = {
+  accessible: 1,
+  easy: 1,
+  moderate: 3,
+  medium: 3,
+  specialist: 5,
+  hard: 5,
+};
+
+function parseDifficulty(raw: string): number | { error: string } {
+  const value = raw.trim().toLowerCase();
+  if (!value) return 3; // default: moderate
+  if (value in DIFFICULTY_WORDS) return DIFFICULTY_WORDS[value];
+  const n = Number(value);
+  if (Number.isInteger(n) && n >= 1 && n <= 5) return n;
+  return { error: `difficulty must be 1-5 or accessible/moderate/specialist (got "${raw.trim()}")` };
+}
+
+function parseAlternates(raw: string): string[] {
+  return raw
+    .split(ALTERNATE_ANSWER_DELIMITER)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/**
+ * Parse and validate a full CSV upload. A structural problem (no header row, a
+ * missing required column, too many rows) fails the whole upload with `ok:false`.
+ * Otherwise returns the valid rows plus a per-line error list — callers decide
+ * whether to insert the good rows or abort on any error.
+ */
+export function parseBulkUploadCsv(input: string): BulkUploadParseResult {
+  const records = parseCsvRecords(input);
+  if (records.length === 0) {
+    return { ok: false, error: 'The file is empty.' };
+  }
+
+  const headerRow = records[0];
+  // Map each canonical column to its index in the header row.
+  const headerIndex: Partial<Record<string, number>> = {};
+  headerRow.forEach((cell, idx) => {
+    const normalized = normalizeHeader(cell);
+    for (const [canonical, aliases] of Object.entries(COLUMN_ALIASES)) {
+      if (headerIndex[canonical] === undefined && aliases.includes(normalized)) {
+        headerIndex[canonical] = idx;
+      }
+    }
+  });
+
+  const missing = REQUIRED_COLUMNS.filter((col) => headerIndex[col] === undefined);
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error: `Missing required column${missing.length > 1 ? 's' : ''}: ${missing.join(', ')}. Expected a header row with at least "question" and "answer".`,
+    };
+  }
+
+  const dataRecords = records.slice(1);
+  if (dataRecords.length > MAX_BULK_UPLOAD_ROWS) {
+    return {
+      ok: false,
+      error: `Too many rows: ${dataRecords.length}. The limit is ${MAX_BULK_UPLOAD_ROWS} per upload.`,
+    };
+  }
+
+  const rows: BulkUploadRow[] = [];
+  const errors: BulkUploadRowError[] = [];
+
+  dataRecords.forEach((record, idx) => {
+    const line = idx + 2; // +1 for header, +1 for 1-based
+    // Skip entirely-blank lines (common trailing artifact) silently.
+    if (record.every((cell) => cell.trim() === '')) return;
+
+    const cellAt = (col: string): string => {
+      const at = headerIndex[col];
+      return at === undefined ? '' : (record[at] ?? '');
+    };
+
+    const parsed = rowSchema.safeParse({
+      question: cellAt('question'),
+      answer: cellAt('answer'),
+      alternates: cellAt('alternates'),
+      explanation: cellAt('explanation'),
+      category: cellAt('category'),
+      subcategory: cellAt('subcategory'),
+      difficulty: cellAt('difficulty'),
+    });
+
+    if (!parsed.success) {
+      errors.push({ line, message: parsed.error.issues.map((i) => i.message).join('; ') });
+      return;
+    }
+
+    const data = parsed.data;
+    const difficulty = parseDifficulty(data.difficulty);
+    if (typeof difficulty !== 'number') {
+      errors.push({ line, message: difficulty.error });
+      return;
+    }
+
+    const alternateAnswers = parseAlternates(data.alternates);
+    if (alternateAnswers.length > MAX_ALTERNATE_ANSWERS) {
+      errors.push({
+        line,
+        message: `Too many alternate answers (${alternateAnswers.length}); max is ${MAX_ALTERNATE_ANSWERS}.`,
+      });
+      return;
+    }
+
+    const category = normalizeBroadQuestionCategoryOrDefault(data.category || undefined);
+    const broadCategory = broadCategoryDisplayName(category);
+    // Fall back to the broad-category label when no specific subcategory is
+    // supplied, mirroring how the authored route always writes a non-empty
+    // canonicalSubcategory.
+    const canonicalSubcategory = data.subcategory.trim()
+      ? normalizeCanonicalSubcategory(data.subcategory)
+      : broadCategory;
+
+    rows.push({
+      line,
+      text: data.question.trim(),
+      correctAnswer: data.answer.trim(),
+      alternateAnswers,
+      explanation: data.explanation.trim() || null,
+      category,
+      broadCategory,
+      canonicalSubcategory,
+      difficulty,
+    });
+  });
+
+  return { ok: true, rows, errors };
+}


### PR DESCRIPTION
Adds an admin-only tool to create questions in bulk from a CSV file.

- src/server/questions/bulk-upload.ts: RFC4180-ish CSV tokenizer plus
  per-row Zod validation that maps each row to createQuestion params.
  Required columns question/answer; optional alternates/explanation/
  category/subcategory/difficulty with header aliases and sane defaults.
  1000-row cap; per-row errors collected without failing the batch.
- src/app/api/admin/bulk-upload-questions/route.ts: POST handler gated by
  isAdminUser (404 for non-admins), accepts multipart file or JSON, with
  a dryRun preview mode. Inserts verified/public questions sequentially.
- src/app/admin/bulk-upload: server page (admin gate) + minimal client UI
  with format help, dry-run validation, and a per-line error report.
- Unit tests for the parser and validation.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0169S7k9qfSpQh517UeggQd8