### PR TITLE
Admin: bulk upload questions from CSV

### DIFF
--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -15,6 +15,7 @@ import {
   Sparkles,
   Sprout,
   Sun,
+  Upload,
   UserPlus,
 } from 'lucide-react';
 import type { ReactNode } from 'react';
@@ -285,6 +286,26 @@ export function AccountActions({
         },
       ],
     },
+    // Admin-only content ops. The /admin/bulk-upload route is itself gated by
+    // ADMIN_USER_IDS (404 for everyone else), so we only surface the link to
+    // admins — no point showing a non-admin a row that 404s. The rest of the
+    // dev-tools section stays ungated (see DEV_TOOLS_UNGATED).
+    ...(isAdmin
+      ? [
+          {
+            eyebrow: 'Admin',
+            tools: [
+              {
+                kind: 'link',
+                icon: <Upload className="size-5" />,
+                title: 'Bulk upload questions',
+                subtitle: 'Create questions in bulk from a CSV',
+                href: '/admin/bulk-upload',
+              },
+            ],
+          } satisfies DevToolGroup,
+        ]
+      : []),
   ];
 
   // null/undefined => the server couldn't run the route-exists check; fail open.

--- a/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
+++ b/src/components/profile/settings/__tests__/AccountActions.dev-tools.test.tsx
@@ -39,4 +39,14 @@ describe('AccountActions — dev-tools grouping & availability', () => {
     const html = renderToStaticMarkup(<AccountActions isAdmin availableToolHrefs={[]} />);
     expect(html).toContain('Create test game');
   });
+
+  it('surfaces the admin bulk-upload link only to admins', () => {
+    const adminHtml = renderToStaticMarkup(<AccountActions isAdmin />);
+    expect(adminHtml).toContain('Bulk upload questions');
+    expect(adminHtml).toContain('href="/admin/bulk-upload"');
+
+    // Non-admins (the ungated section still renders, but the Admin group does not).
+    const nonAdminHtml = renderToStaticMarkup(<AccountActions isAdmin={false} />);
+    expect(nonAdminHtml).not.toContain('Bulk upload questions');
+  });
 });

--- a/src/server/dev/__tests__/tool-availability.test.ts
+++ b/src/server/dev/__tests__/tool-availability.test.ts
@@ -19,6 +19,8 @@ describe('getExistingDevToolHrefs', () => {
     expect(hrefs).toContain('/dev/onboarding/intro');
     // The one tool that lives outside /dev.
     expect(hrefs).toContain('/daily/summary/expand-preview');
+    // The admin-only bulk CSV upload tool, also outside /dev.
+    expect(hrefs).toContain('/admin/bulk-upload');
   });
 
   it('does not invent routes that have no page', () => {

--- a/src/server/dev/tool-availability.ts
+++ b/src/server/dev/tool-availability.ts
@@ -38,6 +38,12 @@ export function getExistingDevToolHrefs(): string[] | null {
       hrefs.push('/daily/summary/expand-preview');
     }
 
+    // Admin-only content tool surfaced in the dev-tools section (the bulk CSV
+    // question upload lives under /admin, gated by ADMIN_USER_IDS).
+    if (hasPage(path.join(appDir, 'admin', 'bulk-upload'))) {
+      hrefs.push('/admin/bulk-upload');
+    }
+
     // Nested onboarding-harness stage. The /dev/onboarding hub page was
     // consolidated into the profile dev-tools section, so its parent folder no
     // longer has its own page — but the dev-tools UI still links straight to the


### PR DESCRIPTION
## Summary

Adds an admin-only tool to create questions in bulk from a CSV file, and links it from the profile Developer-tools section.

## What's included

**Parsing + validation** (`src/server/questions/bulk-upload.ts`)
- Self-contained RFC 4180-style CSV tokenizer (quoted fields, `""` escapes, commas/newlines inside quotes, CRLF, leading BOM) — no new dependency.
- Per-row Zod validation mapping each row to `createQuestion` params. Required columns: `question`, `answer`. Optional: `alternates` (`|`-separated), `explanation`, `category`, `subcategory`, `difficulty` (1–5 or accessible/moderate/specialist). Header aliases accepted case-insensitively.
- Sane defaults (unknown/blank category → General Knowledge; difficulty → moderate), a 1000-row cap, and per-row error collection so one bad row doesn't sink the batch.

**API route** (`src/app/api/admin/bulk-upload-questions/route.ts`)
- Gated by `isAdminUser` — non-admins get **404**, matching the repo's fail-closed admin convention.
- Accepts a multipart file upload or a JSON `{ csv }` body (5MB cap), with a `dryRun` preview mode.
- Inserts rows sequentially via the existing `createQuestion` helper (verified, public, attributed to the uploading admin), respecting the capped DB pool.

**Admin UI** (`src/app/admin/bulk-upload/`)
- Server page with the same admin gate, plus a minimal client with format help, a sample CSV, "Validate (dry run)", and a per-line error report. Styled to match the existing admin reports tool.

**Dev-tools link** (`src/components/profile/settings/AccountActions.tsx`, `src/server/dev/tool-availability.ts`)
- Surfaces the tool from the profile Developer-tools section, gated to admins so non-admins don't see a row that 404s.
- Registers `/admin/bulk-upload` in the dev-tool route-availability scan so it isn't dimmed as "Unavailable" in dev/preview.

## Tests
- Unit tests for the CSV tokenizer and row validation (`bulk-upload.test.ts`).
- Updated `AccountActions.dev-tools` and `tool-availability` tests to cover the new admin link.
- All affected tests pass; new files typecheck and lint clean.

## Notes
- Uploaded questions are attributed to the **uploading admin** (verified + public + added to their bank). House/editorial attribution is not wired in — happy to add a per-upload "house authored" toggle as a follow-up if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169S7k9qfSpQh517UeggQd8)_