### PR TITLE
feat(daily): recalibrate the per-domain difficulty floor

### DIFF
--- a/src/server/__tests__/adaptive-difficulty.test.ts
+++ b/src/server/__tests__/adaptive-difficulty.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/server/db', () => ({
   db: {},
@@ -13,6 +13,7 @@ import {
   applyFocusFloor,
   computeDomainDifficultyStep,
   computeSupplyCorrection,
+  focusDomainMinDifficulty,
   mapAdaptiveLevelToDifficultyHint,
   type DomainDifficultyState,
 } from '@/server/adaptive-difficulty';
@@ -43,20 +44,59 @@ describe('applyAdaptiveLevelAdjustment — global adaptive level', () => {
   });
 });
 
-describe('applyFocusFloor — opted-in domains start at least Familiar', () => {
-  it('raises an accessible seed to moderate for a focus domain', () => {
-    // A player who stated this area of focus (or accepted it from a friend)
-    // should never open on "Establishing" trivia.
-    expect(applyFocusFloor('accessible', true)).toBe('moderate');
+describe('applyFocusFloor — opted-in domains, env-tunable floor', () => {
+  it('defaults to NO raise (floor accessible): an accessible focus seed stays accessible', () => {
+    // RECALIBRATED 2026-06-28: the focus floor defaults to 'accessible', so a focus
+    // domain no longer blanket-starts at moderate. Skilled players still seed up via
+    // the adaptive-level seed (consulted before this floor); the streak ladder climbs.
+    expect(applyFocusFloor('accessible', true)).toBe('accessible');
   });
 
-  it('leaves accessible alone when the domain is not a focus area', () => {
+  it('raises to an explicitly-passed floor (the "never below floor" property holds)', () => {
+    expect(applyFocusFloor('accessible', true, 'moderate')).toBe('moderate');
+    expect(applyFocusFloor('accessible', true, 'specialist')).toBe('specialist');
+    expect(applyFocusFloor('moderate', true, 'specialist')).toBe('specialist');
+  });
+
+  it('ignores the floor for non-focus domains, and never lowers an already-higher seed', () => {
     expect(applyFocusFloor('accessible', false)).toBe('accessible');
-  });
-
-  it('never lowers a seed that already sits above the floor', () => {
+    expect(applyFocusFloor('accessible', false, 'specialist')).toBe('accessible');
     expect(applyFocusFloor('moderate', true)).toBe('moderate');
     expect(applyFocusFloor('specialist', true)).toBe('specialist');
+  });
+});
+
+describe('focusDomainMinDifficulty — env knob', () => {
+  const KEY = 'FOCUS_DOMAIN_MIN_DIFFICULTY';
+  const saved = process.env[KEY];
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  it('defaults to accessible when unset or garbage', () => {
+    delete process.env[KEY];
+    expect(focusDomainMinDifficulty()).toBe('accessible');
+    process.env[KEY] = 'nonsense';
+    expect(focusDomainMinDifficulty()).toBe('accessible');
+  });
+
+  it('honors a valid override (restores the old moderate-floor behaviour)', () => {
+    process.env[KEY] = 'moderate';
+    expect(focusDomainMinDifficulty()).toBe('moderate');
+    expect(applyFocusFloor('accessible', true)).toBe('moderate');
+    process.env[KEY] = 'specialist';
+    expect(focusDomainMinDifficulty()).toBe('specialist');
+  });
+});
+
+describe('computeSupplyCorrection — easy declared domain can now settle accessible', () => {
+  it('pulls a stuck-moderate easy domain down to accessible when the floor is accessible', () => {
+    expect(computeSupplyCorrection('moderate', 'accessible', 'accessible')).toBe('accessible');
+  });
+
+  it('the OLD moderate floor would have kept it pinned at moderate (no correction)', () => {
+    expect(computeSupplyCorrection('moderate', 'accessible', 'moderate')).toBeNull();
   });
 });
 

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -197,23 +197,37 @@ function seedDifficultyFromAdaptiveLevel(level: number): ServedDifficulty {
 }
 
 /**
- * Minimum first-contact difficulty for a domain the player explicitly opted
- * into — either by stating it as an area of focus or by accepting one shared by
- * a friend. Someone who raised their hand for a topic finds "Establishing"
- * (accessible) trivia condescendingly easy, so we floor the *seed* at "Familiar"
- * (moderate) for ANY focus domain (declared or demonstrated). This sets only the
- * starting point. What happens to the floor afterwards is signal-keyed: a
- * DECLARED domain also holds this as a hard *erosion* floor (the two-incorrect
- * step-down can't drop below it), while a DEMONSTRATED domain can still step
- * down to accessible (PRD-D-5 §5.2, D3 — the erosion floor is declared-only).
+ * Minimum first-contact / erosion difficulty for a domain the player opted into
+ * (declared focus, or a friend-shared domain). It floors the *seed* (and, for a
+ * DECLARED domain, the *erosion* step-down — PRD-D-5 §5.2, D3) so the difficulty
+ * machinery never requests below this for a focus domain.
+ *
+ * RECALIBRATED 2026-06-28: defaults to 'accessible' (i.e. effectively OFF). The
+ * old hard 'moderate' floor blanket-pinned every focus domain to ≥moderate, which
+ * (a) BURIED genuinely-good easy questions — they landed below the requested tier
+ * and were deflected to the under-difficulty reserve — and (b) pressured the
+ * generator to write "deep cut / specialist" questions for naturally-easy topics
+ * (a kids'-book series, a sitcom), a driver of hallucinated false canon. Climbing
+ * is now left to the signal-keyed levers that already exist — the adaptive-level
+ * seed (skilled players still START at moderate/specialist), the two-correct
+ * streak ladder, empirical re-labelling, and supply recalibration — rather than a
+ * blanket floor. Override via FOCUS_DOMAIN_MIN_DIFFICULTY (set 'moderate' to
+ * restore the old behaviour, no deploy).
  */
-const FOCUS_DOMAIN_MIN_DIFFICULTY: ServedDifficulty = 'moderate';
+export function focusDomainMinDifficulty(): ServedDifficulty {
+  const raw = process.env.FOCUS_DOMAIN_MIN_DIFFICULTY?.trim();
+  return raw === 'moderate' || raw === 'specialist' || raw === 'accessible' ? raw : 'accessible';
+}
 
-export function applyFocusFloor(difficulty: ServedDifficulty, isFocusDomain: boolean): ServedDifficulty {
+export function applyFocusFloor(
+  difficulty: ServedDifficulty,
+  isFocusDomain: boolean,
+  floor: ServedDifficulty = focusDomainMinDifficulty(),
+): ServedDifficulty {
   if (!isFocusDomain) return difficulty;
-  return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(FOCUS_DOMAIN_MIN_DIFFICULTY)
+  return DIFFICULTY_LADDER.indexOf(difficulty) >= DIFFICULTY_LADDER.indexOf(floor)
     ? difficulty
-    : FOCUS_DOMAIN_MIN_DIFFICULTY;
+    : floor;
 }
 
 /**
@@ -393,7 +407,7 @@ export async function updateDomainDifficultyOnAnswer(
   // floor, demonstrated domains step down freely (default 'accessible' floor).
   const declaredDomains = await getDeclaredDomainSet(userId, [canonicalSubcategory]);
   const floor: ServedDifficulty = declaredDomains.has(canonicalSubcategory)
-    ? FOCUS_DOMAIN_MIN_DIFFICULTY
+    ? focusDomainMinDifficulty()
     : 'accessible';
   const next = computeDomainDifficultyStep(existing, isCorrect, floor);
 
@@ -487,7 +501,7 @@ export async function recalibrateDomainDifficultyToSupply(
   for (const domain of domains) {
     const delivered = deliveredByDomain.get(domain)!;
     const floor: ServedDifficulty = declaredDomains.has(domain)
-      ? FOCUS_DOMAIN_MIN_DIFFICULTY
+      ? focusDomainMinDifficulty()
       : 'accessible';
     const floorIdx = DIFFICULTY_LADDER.indexOf(floor);
     const target = DIFFICULTY_LADDER[Math.max(floorIdx, DIFFICULTY_LADDER.indexOf(delivered))];

--- a/src/server/daily/__tests__/difficulty-floor-gate.test.ts
+++ b/src/server/daily/__tests__/difficulty-floor-gate.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
 
 // generate-questions.ts imports @/server/db, which throws at module load without
 // a connection string. findUnderDifficultyQuestions never touches the DB; a dummy
@@ -116,5 +116,31 @@ describe('findUnderDifficultyQuestions', () => {
       'adaptive',
     );
     expect([...result.toDrop].sort()).toEqual([0]);
+  });
+});
+
+describe('findUnderDifficultyQuestions — MAX_TIER_SHORTFALL env knob', () => {
+  const KEY = 'MAX_TIER_SHORTFALL';
+  const saved = process.env[KEY];
+  afterEach(() => {
+    if (saved === undefined) delete process.env[KEY];
+    else process.env[KEY] = saved;
+  });
+
+  const specialistRequestedAccessibleReturned = () =>
+    findUnderDifficultyQuestions(
+      [q('Sesame Street', 'accessible')],
+      new Map([['Sesame Street', 'challenging']]), // → specialist (a 2-rung miss)
+      'adaptive',
+    );
+
+  it('default (unset → 1): the 2-rung miss is flagged', () => {
+    delete process.env[KEY];
+    expect([...specialistRequestedAccessibleReturned().toDrop]).toEqual([0]);
+  });
+
+  it('MAX_TIER_SHORTFALL=2: the same 2-rung miss is tolerated (not flagged)', () => {
+    process.env[KEY] = '2';
+    expect(specialistRequestedAccessibleReturned().toDrop.size).toBe(0);
   });
 });

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -19,6 +19,7 @@ import { getNextDailyResetBoundary } from '@/lib/games/timezone';
 import { db, generatedQuestions } from '@/server/db';
 import { embedAndResolveDuplicatesBatch } from '@/server/pool/dedup';
 import {
+  focusDomainMinDifficulty,
   getDomainDifficultyOverrides,
   mapAdaptiveLevelToDifficultyHint,
   updateAdaptiveLevel,
@@ -922,8 +923,14 @@ const DIFFICULTY_TIER_LADDER: LlmQuestion['difficulty_estimate'][] = [
 
 // One rung of slack: the adaptive target is a soft aim and the tiers overlap, so
 // a single-rung miss (e.g. specialist requested, moderate returned) is tolerated.
-// A two-rung miss is not — it's a question that doesn't belong in the slot.
-const MAX_TIER_SHORTFALL = 1;
+// A two-rung miss is not — it's a question that doesn't belong in the slot. Env
+// knob (default 1, unchanged) is a transition escape hatch: bump to 2 if a domain
+// whose stored tier hasn't recalibrated down yet still buries good accessible
+// content. Pairs with the FOCUS_DOMAIN_MIN_DIFFICULTY recalibration.
+function maxTierShortfall(): number {
+  const parsed = Number(process.env.MAX_TIER_SHORTFALL);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : 1;
+}
 
 // Map a requested difficulty preference — either a per-domain adaptive override
 // or the player's fixed global preference — to a ladder index. Keys with no
@@ -969,6 +976,7 @@ export function findUnderDifficultyQuestions(
 ): { toDrop: Set<number>; reasons: Record<number, string> } {
   const toDrop = new Set<number>();
   const reasons: Record<number, string> = {};
+  const maxShortfall = maxTierShortfall();
 
   // Normalize override keys so a returned canonical_subcategory differing only by
   // case/whitespace from the requested domain still resolves its override.
@@ -991,7 +999,7 @@ export function findUnderDifficultyQuestions(
     if (estimateIdx < 0) continue; // unrecognized estimate — not ours to judge.
 
     const shortfall = requestedIdx - estimateIdx;
-    if (shortfall > MAX_TIER_SHORTFALL) {
+    if (shortfall > maxShortfall) {
       toDrop.add(i);
       reasons[i] =
         `difficulty "${q.difficulty_estimate}" is ${shortfall} tiers below requested "${DIFFICULTY_TIER_LADDER[requestedIdx]}" for ${q.canonical_subcategory}`.slice(
@@ -2071,12 +2079,16 @@ export async function generateDailyQuestionsFromKnowledgeBase(
   // a domain falls through to LLM generation, which incidentally adds new rows
   // back into the pool. Spans accessible/moderate/specialist so harder slots
   // are reused too, not just warm-ups.
-  // Tier-adjacent fallback floors (BP-7 / C5): declared territory floors at
-  // 'moderate' (the D2/D3 erosion floor — never condescend), demonstrated at
-  // 'accessible'. Derived from the knowledgeBase already in hand.
+  // Tier-adjacent fallback floors (BP-7 / C5): how far DOWN the bank may reach when
+  // the requested tier is scarce. Tied to focusDomainMinDifficulty() so the bank's
+  // fallback floor tracks the (recalibrated, env-tunable) focus floor — declared
+  // domains now fall back to 'accessible' by default instead of stopping at
+  // 'moderate', so a tapped-out easy domain reuses its easy bank stock instead of
+  // burning a fresh generation. Demonstrated domains already floor at 'accessible'.
+  const declaredBankFloor = focusDomainMinDifficulty() as BankDifficulty;
   const bankFallbackFloors = new Map<string, BankDifficulty>();
   for (const entry of knowledgeBase) {
-    bankFallbackFloors.set(entry.domain, entry.territoryType === 'declared' ? 'moderate' : 'accessible');
+    bankFallbackFloors.set(entry.domain, entry.territoryType === 'declared' ? declaredBankFloor : 'accessible');
   }
 
   const bankPicks = await pickBankPicksForDomains(


### PR DESCRIPTION
## Why

A user noticed good "easy" questions seem overlooked in the Daily Five, and wondered if the difficulty meter buries good content. Investigation confirmed it — for **generated** questions — and traced it to one lever: the hard **`FOCUS_DOMAIN_MIN_DIFFICULTY = 'moderate'` floor**, which pinned every declared/focus topic to request ≥ moderate. That:
- **buried genuinely-good easy questions** (they landed below the requested tier → deflected to the last-resort under-difficulty reserve), and
- **pressured the generator to write "deep-cut/specialist" questions for naturally-easy topics** (a kids' book series, a sitcom) — a driver of the hallucinated false canon found earlier (Spy School "Academy of Evil").

It was also the one thing blocking the existing self-correcting levers (supply recalibration, the bank's tier-adjacent fallback) from letting an easy domain settle at accessible.

## What changed (3 small, env-reversible knobs — no schema, no new machinery)

- **`adaptive-difficulty.ts`** — `FOCUS_DOMAIN_MIN_DIFFICULTY` constant → exported `focusDomainMinDifficulty()` reading the env, **default `'accessible'`** (floor effectively off). `applyFocusFloor` gains an optional floor arg; the erosion floor + supply-recalibration clamp consume it. Climbing is now signal-driven: the adaptive-level seed (skilled players still **start** moderate/specialist), the 2-correct streak ladder, and empirical re-labelling. Set `FOCUS_DOMAIN_MIN_DIFFICULTY=moderate` to restore old behavior, no deploy.
- **`generate-questions.ts`** — `MAX_TIER_SHORTFALL` → `maxTierShortfall()` env knob (**default 1, unchanged**) as a tuning escape hatch; the bank tier-adjacent fallback floor (`bankFallbackFloors`) now tracks `focusDomainMinDifficulty()`, so the **bank also falls back to easy** when harder tiers are scarce.

## Scope / non-goals
- **Authored/uploaded questions are unaffected** — they bypass the difficulty floor entirely (served by social-tier/recency) and keep their own assigned difficulty + points.
- **CSV/upload difficulty unchanged** (owner's call): uploads keep getting app-assessed difficulty + empirical recalibration.
- **"Fall back to easy when harder is scarce"** was largely already implemented (under-difficulty reserve + supply recalibration + bank tier-adjacent) — it was just blocked by the same `'moderate'` floor; this unblocks all three.

## Risk + mitigation
A declared domain a player is expert in could *seed* easy on first contact. Mitigated: the adaptive-level seed already starts experienced players at moderate/specialist before the floor is consulted; the streak ladder climbs in one session; and `FOCUS_DOMAIN_MIN_DIFFICULTY=moderate` reverts instantly via env. Roll out unset in preview, watch the deflection telemetry, then prod.

## Tests
Updated `applyFocusFloor` expectations for the new default + added env-knob coverage (`focusDomainMinDifficulty`, `MAX_TIER_SHORTFALL`) and a `computeSupplyCorrection` case (easy declared domain now settles accessible). Typecheck + lint clean; daily + adaptive suites green (254 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)