### PR TITLE
Admin bulk upload: choose the author from a dropdown of admins

### DIFF
--- a/src/app/admin/bulk-upload/BulkUploadClient.tsx
+++ b/src/app/admin/bulk-upload/BulkUploadClient.tsx
@@ -19,10 +19,20 @@ const SAMPLE_CSV = `question,answer,alternates,explanation,category,subcategory,
 "Which planet is known as the Red Planet?",Mars,,"Iron oxide gives it the colour.",science,Astronomy,1
 "Who wrote ""Hamlet""?","William Shakespeare","Shakespeare|Bill Shakespeare",,literature,Shakespeare,moderate`;
 
+// A selectable admin author (resolved server-side from ADMIN_USER_IDS).
+type AdminAccount = { id: string; displayName: string };
+
 // Deliberately minimal — an internal ops tool, not a product surface.
-export function BulkUploadClient() {
+export function BulkUploadClient({
+  adminAccounts,
+  currentUserId,
+}: {
+  adminAccounts: AdminAccount[];
+  currentUserId: string;
+}) {
   const [file, setFile] = useState<File | null>(null);
   const [text, setText] = useState('');
+  const [authorId, setAuthorId] = useState(currentUserId);
   const [pending, setPending] = useState<'dry' | 'commit' | null>(null);
   const [result, setResult] = useState<UploadResult | null>(null);
   const [error, setError] = useState<string | null>(null);
@@ -44,6 +54,7 @@ export function BulkUploadClient() {
               const form = new FormData();
               form.set('file', file);
               form.set('dryRun', dryRun ? 'true' : 'false');
+              form.set('authorId', authorId);
               return form;
             })(),
           })
@@ -51,7 +62,7 @@ export function BulkUploadClient() {
             method: 'POST',
             credentials: 'include',
             headers: { 'content-type': 'application/json' },
-            body: JSON.stringify({ csv: text, dryRun }),
+            body: JSON.stringify({ csv: text, dryRun, authorId }),
           });
       const data = (await res.json().catch(() => null)) as (UploadResult & { message?: string }) | null;
       if (!res.ok) {
@@ -71,7 +82,8 @@ export function BulkUploadClient() {
       <header className="mb-5">
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Bulk upload questions</h1>
         <p className="text-muted-foreground mt-1 text-sm">
-          Upload a CSV to create questions in bulk. They are saved as verified, public, and attributed to you.
+          Upload a CSV to create questions in bulk. They are saved as verified and public, attributed
+          to the selected admin author.
         </p>
       </header>
 
@@ -95,6 +107,31 @@ export function BulkUploadClient() {
           {SAMPLE_CSV}
         </pre>
       </section>
+
+      <div className="mt-4">
+        <label htmlFor="author" className="text-muted-foreground mb-1 block text-sm">
+          Author
+        </label>
+        <select
+          id="author"
+          value={authorId}
+          onChange={(e) => setAuthorId(e.target.value)}
+          disabled={pending !== null}
+          className="w-full rounded-md border px-3 py-2 text-sm disabled:opacity-50"
+          style={{ borderColor: 'var(--border)', background: 'var(--brand-field)' }}
+        >
+          {adminAccounts.length === 0 ? (
+            <option value={currentUserId}>You</option>
+          ) : (
+            adminAccounts.map((account) => (
+              <option key={account.id} value={account.id}>
+                {account.displayName}
+                {account.id === currentUserId ? ' (you)' : ''}
+              </option>
+            ))
+          )}
+        </select>
+      </div>
 
       <div className="mt-4 flex flex-wrap items-center gap-3">
         <input

--- a/src/app/admin/bulk-upload/page.tsx
+++ b/src/app/admin/bulk-upload/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
+import { getAdminAccounts } from '@/server/db/queries/admin-accounts';
 
 import { BulkUploadClient } from './BulkUploadClient';
 
@@ -14,5 +15,9 @@ export default async function AdminBulkUploadPage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
-  return <BulkUploadClient />;
+  // The author picker lists all admin accounts; the route re-validates the
+  // chosen author against the allowlist, so this is display-only.
+  const adminAccounts = await getAdminAccounts();
+
+  return <BulkUploadClient adminAccounts={adminAccounts} currentUserId={session.userId} />;
 }

--- a/src/app/api/admin/bulk-upload-questions/route.ts
+++ b/src/app/api/admin/bulk-upload-questions/route.ts
@@ -18,7 +18,13 @@ const optionsSchema = z.object({
   dryRun: z.boolean().optional().default(false),
 });
 
-async function readCsv(request: NextRequest): Promise<{ csv: string; dryRun: boolean } | { error: string }> {
+type ReadCsvResult = { csv: string; dryRun: boolean; authorId?: string } | { error: string };
+
+function asOptionalId(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined;
+}
+
+async function readCsv(request: NextRequest): Promise<ReadCsvResult> {
   const contentType = request.headers.get('content-type') ?? '';
 
   if (contentType.includes('multipart/form-data')) {
@@ -29,15 +35,21 @@ async function readCsv(request: NextRequest): Promise<{ csv: string; dryRun: boo
     if (file.size > MAX_CSV_BYTES) return { error: 'file_too_large' };
     const dryRunRaw = form.get('dryRun');
     const dryRun = dryRunRaw === 'true' || dryRunRaw === '1';
-    return { csv: await file.text(), dryRun };
+    return { csv: await file.text(), dryRun, authorId: asOptionalId(form.get('authorId')) };
   }
 
-  // JSON fallback: { csv: string, dryRun?: boolean }
-  const body = (await request.json().catch(() => null)) as { csv?: unknown } | null;
+  // JSON fallback: { csv: string, dryRun?: boolean, authorId?: string }
+  const body = (await request.json().catch(() => null)) as
+    | { csv?: unknown; authorId?: unknown }
+    | null;
   if (!body || typeof body.csv !== 'string') return { error: 'invalid_request' };
   if (Buffer.byteLength(body.csv, 'utf8') > MAX_CSV_BYTES) return { error: 'file_too_large' };
   const opts = optionsSchema.safeParse(body);
-  return { csv: body.csv, dryRun: opts.success ? opts.data.dryRun : false };
+  return {
+    csv: body.csv,
+    dryRun: opts.success ? opts.data.dryRun : false,
+    authorId: asOptionalId(body.authorId),
+  };
 }
 
 export async function POST(request: NextRequest) {
@@ -50,6 +62,14 @@ export async function POST(request: NextRequest) {
   const read = await readCsv(request);
   if ('error' in read) {
     return NextResponse.json({ error: read.error }, { status: 400 });
+  }
+
+  // Author defaults to the uploader; an explicit choice must itself be an admin
+  // (the picker only lists admins, but never trust the client) — otherwise an
+  // admin could attribute questions to any arbitrary user id.
+  const authorId = read.authorId ?? session.userId;
+  if (!isAdminUser(authorId)) {
+    return NextResponse.json({ error: 'invalid_author' }, { status: 400 });
   }
 
   const parsed = parseBulkUploadCsv(read.csv);
@@ -77,7 +97,7 @@ export async function POST(request: NextRequest) {
   for (const row of parsed.rows) {
     try {
       const result = await createQuestion({
-        authorId: session.userId,
+        authorId,
         text: row.text,
         correctAnswer: row.correctAnswer,
         alternateAnswers: row.alternateAnswers,
@@ -111,6 +131,7 @@ export async function POST(request: NextRequest) {
 
   console.info('[admin/bulk-upload] complete', {
     adminId: session.userId,
+    authorId,
     created: created.length,
     skipped: rowErrors.length,
   });

--- a/src/server/db/queries/admin-accounts.ts
+++ b/src/server/db/queries/admin-accounts.ts
@@ -1,0 +1,33 @@
+import { inArray } from 'drizzle-orm';
+
+import { adminUserIds } from '@/server/auth/admin';
+import { db, users } from '@/server/db';
+
+/** A selectable admin author for the bulk-upload tool. */
+export type AdminAccount = { id: string; displayName: string };
+
+/**
+ * Resolve the `ADMIN_USER_IDS` allowlist to real user rows for the author
+ * picker. Allowlist entries that don't resolve to a `users` row are dropped
+ * (a typo'd id is not a valid author, and createQuestion would FK-fail on it),
+ * and the result preserves the allowlist's declared order. Returns [] when the
+ * allowlist is unset/empty.
+ */
+export async function getAdminAccounts(): Promise<AdminAccount[]> {
+  const ids = adminUserIds();
+  if (ids.length === 0) return [];
+
+  const rows = await db
+    .select({ id: users.id, displayName: users.displayName, handle: users.handle })
+    .from(users)
+    .where(inArray(users.id, ids));
+
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return ids
+    .map((id) => byId.get(id))
+    .filter((row): row is NonNullable<typeof row> => row !== undefined)
+    .map((row) => ({
+      id: row.id,
+      displayName: row.displayName?.trim() || (row.handle ? `@${row.handle}` : row.id),
+    }));
+}


### PR DESCRIPTION
## Summary

Lets the uploader pick which admin account is credited as the **author** of the uploaded questions, instead of always attributing them to whoever ran the upload.

## What's included
- **Author dropdown** on `/admin/bulk-upload`, listing all admin accounts and defaulting to the current user. The chosen admin becomes the `creatorId` on every question in the batch (and receives author credit when others answer).
- **`getAdminAccounts()` query** (`src/server/db/queries/admin-accounts.ts`) — resolves `ADMIN_USER_IDS` to user rows (display name / `@handle`, falling back to the id), drops allowlist ids with no user row, and preserves the allowlist's order.
- **Server-side re-validation** in the route: the submitted `authorId` (multipart or JSON) must itself be in the admin allowlist before it's used — the picker only lists admins, but the client is never trusted. Falls back to the session user when none is sent; returns `400 invalid_author` otherwise.

## Notes
- Stacked on #1303 (paste-CSV textarea). Until #1303 merges, this PR's diff also shows the textarea change; once #1303 merges, it reduces to just the author-picker changes. Merges cleanly in either order.
- Typecheck, lint, and the parser unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0169S7k9qfSpQh517UeggQd8)_