### PR TITLE
feat(knowledge): Lever A — "broad domain serving narrow" detector in …

### DIFF
--- a/src/app/api/cron/domain-fragmentation-report/route.ts
+++ b/src/app/api/cron/domain-fragmentation-report/route.ts
@@ -1,7 +1,10 @@
 import { NextRequest, NextResponse } from 'next/server';
 
 import { isCronAuthorized } from '@/server/auth/cron';
-import { getDomainFragmentationCandidates } from '@/server/db/queries/domain-fragmentation';
+import {
+  getDomainFragmentationCandidates,
+  getNarrowlyServedDomains,
+} from '@/server/db/queries/domain-fragmentation';
 import { resolveCostReportRecipient } from '@/server/db/queries/llm-cost-report';
 import { sendEmail } from '@/server/email/client';
 import { buildDomainFragmentationEmailTemplate } from '@/server/email/templates/domain-fragmentation';
@@ -21,22 +24,32 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const pairs = await getDomainFragmentationCandidates();
+    const [pairs, narrowDomains] = await Promise.all([
+      getDomainFragmentationCandidates(),
+      getNarrowlyServedDomains(),
+    ]);
+    const total = pairs.length + narrowDomains.length;
 
-    if (pairs.length === 0) {
-      console.info('[domain-fragmentation-report] no candidates above threshold; skipping email');
-      return NextResponse.json({ candidates: 0, emailed: false, reason: 'no_candidates' });
+    if (total === 0) {
+      console.info('[domain-fragmentation-report] nothing above threshold; skipping email');
+      return NextResponse.json({ candidates: 0, narrowDomains: 0, emailed: false, reason: 'no_candidates' });
     }
 
     const recipient = await resolveCostReportRecipient();
     if (!recipient) {
-      console.warn('[domain-fragmentation-report] candidates found but no recipient resolved', {
+      console.warn('[domain-fragmentation-report] items found but no recipient resolved', {
         candidates: pairs.length,
+        narrowDomains: narrowDomains.length,
       });
-      return NextResponse.json({ candidates: pairs.length, emailed: false, reason: 'no_recipient' });
+      return NextResponse.json({
+        candidates: pairs.length,
+        narrowDomains: narrowDomains.length,
+        emailed: false,
+        reason: 'no_recipient',
+      });
     }
 
-    const template = buildDomainFragmentationEmailTemplate(pairs);
+    const template = buildDomainFragmentationEmailTemplate({ pairs, narrowDomains });
     const sent = await sendEmail({
       to: recipient.to,
       subject: template.subject,
@@ -45,15 +58,22 @@ export async function GET(request: NextRequest) {
     });
 
     if (!sent.ok) {
-      console.warn('[domain-fragmentation-report] candidates found but email send failed', {
+      console.warn('[domain-fragmentation-report] items found but email send failed', {
         candidates: pairs.length,
+        narrowDomains: narrowDomains.length,
         message: sent.message,
       });
-      return NextResponse.json({ candidates: pairs.length, emailed: false, reason: sent.reason });
+      return NextResponse.json({
+        candidates: pairs.length,
+        narrowDomains: narrowDomains.length,
+        emailed: false,
+        reason: sent.reason,
+      });
     }
 
     return NextResponse.json({
       candidates: pairs.length,
+      narrowDomains: narrowDomains.length,
       emailed: true,
       emailSource: recipient.source,
     });

--- a/src/server/db/queries/domain-fragmentation.ts
+++ b/src/server/db/queries/domain-fragmentation.ts
@@ -102,3 +102,94 @@ export async function getDomainFragmentationCandidates(
   }
   return pairs;
 }
+
+/**
+ * Lever A — "broad domain serving narrow" detector. Reuses the per-question
+ * sub_angles the generator already emits: within a domain, if one facet tag
+ * dominates a large share of the pool, the domain is leaning narrow (e.g. a
+ * "Shakespearean Tragedy" pool that is mostly Hamlet). The reactive sub-angle
+ * coverage loop pushes breadth over time; this just makes a regression VISIBLE
+ * so a human can check whether the pool genuinely spans the domain's range.
+ * Read-only. Based on GeneratedQuestion (sub_angles lives there).
+ */
+export type NarrowDomain = {
+  domain: string;
+  depth: number;
+  topAngle: string;
+  topAngleCount: number;
+  /** topAngleCount / depth, 0..1. */
+  topAngleShare: number;
+  distinctAngles: number;
+};
+
+const DEFAULT_NARROW_MIN_DEPTH = 8;
+const DEFAULT_NARROW_SHARE_THRESHOLD = 0.5;
+
+function readUnitEnv(name: string, fallback: number): number {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0 || parsed > 1) return fallback;
+  return parsed;
+}
+
+export async function getNarrowlyServedDomains(
+  opts: { minDepth?: number; shareThreshold?: number; limit?: number } = {},
+): Promise<NarrowDomain[]> {
+  const minDepth =
+    opts.minDepth ?? (Number(process.env.DOMAIN_NARROW_MIN_DEPTH) || DEFAULT_NARROW_MIN_DEPTH);
+  const shareThreshold =
+    opts.shareThreshold ?? readUnitEnv('DOMAIN_NARROW_SHARE_THRESHOLD', DEFAULT_NARROW_SHARE_THRESHOLD);
+  const limit = opts.limit ?? 25;
+
+  const result = await db.execute(sql`
+    with dq as (
+      select id, canonical_subcategory as domain, sub_angles
+      from "GeneratedQuestion"
+      where canonical_subcategory is not null and canonical_subcategory <> ''
+    ),
+    domain_counts as (
+      select domain, count(*)::int as depth from dq group by domain
+    ),
+    angle_counts as (
+      select dq.domain, angle, count(distinct dq.id)::int as q_with_angle
+      from dq, unnest(dq.sub_angles) as angle
+      where angle is not null and angle <> ''
+      group by dq.domain, angle
+    ),
+    ranked as (
+      select ac.domain, ac.angle, ac.q_with_angle,
+             row_number() over (partition by ac.domain order by ac.q_with_angle desc, ac.angle) as rn,
+             count(*) over (partition by ac.domain)::int as distinct_angles
+      from angle_counts ac
+    )
+    select r.domain, dc.depth, r.angle as top_angle, r.q_with_angle, r.distinct_angles,
+           round((r.q_with_angle::numeric / dc.depth), 2) as top_share
+    from ranked r
+    join domain_counts dc on dc.domain = r.domain
+    where r.rn = 1
+      and dc.depth >= ${minDepth}
+      and (r.q_with_angle::numeric / dc.depth) >= ${shareThreshold}
+    order by top_share desc, dc.depth desc
+    limit ${limit}
+  `);
+
+  type NarrowRow = {
+    domain: string;
+    depth: number;
+    top_angle: string;
+    q_with_angle: number;
+    distinct_angles: number;
+    top_share: number;
+  };
+  const rows = (result as unknown as { rows?: NarrowRow[] }).rows ?? (result as unknown as NarrowRow[]);
+
+  return rows.map((r) => ({
+    domain: r.domain,
+    depth: Number(r.depth),
+    topAngle: r.top_angle,
+    topAngleCount: Number(r.q_with_angle),
+    topAngleShare: Number(r.top_share),
+    distinctAngles: Number(r.distinct_angles),
+  }));
+}

--- a/src/server/email/templates/__tests__/domain-fragmentation.test.ts
+++ b/src/server/email/templates/__tests__/domain-fragmentation.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildDomainFragmentationEmailTemplate } from '@/server/email/templates/domain-fragmentation';
-import type { FragmentationPair } from '@/server/db/queries/domain-fragmentation';
+import type { FragmentationPair, NarrowDomain } from '@/server/db/queries/domain-fragmentation';
 
 const pair = (over: Partial<FragmentationPair> = {}): FragmentationPair => ({
   domainA: 'Spy School',
@@ -12,34 +12,60 @@ const pair = (over: Partial<FragmentationPair> = {}): FragmentationPair => ({
   ...over,
 });
 
+const narrow = (over: Partial<NarrowDomain> = {}): NarrowDomain => ({
+  domain: 'Shakespearean Tragedy',
+  depth: 20,
+  topAngle: 'Hamlet',
+  topAngleCount: 14,
+  topAngleShare: 0.7,
+  distinctAngles: 5,
+  ...over,
+});
+
+const build = (pairs: FragmentationPair[], narrowDomains: NarrowDomain[] = []) =>
+  buildDomainFragmentationEmailTemplate({ pairs, narrowDomains });
+
 describe('buildDomainFragmentationEmailTemplate', () => {
-  it('renders an all-clear message when there are no candidates', () => {
-    const out = buildDomainFragmentationEmailTemplate([]);
+  it('renders an all-clear message when both sections are empty', () => {
+    const out = build([], []);
     expect(out.subject).toMatch(/nothing to look at/i);
-    expect(out.text).toMatch(/No near-duplicate/i);
+    expect(out.text).toMatch(/no near-duplicate/i);
     expect(out.html).toContain('<p>');
   });
 
-  it('pluralizes the subject by candidate count', () => {
-    expect(buildDomainFragmentationEmailTemplate([pair()]).subject).toMatch(/1 cluster\b/);
-    expect(buildDomainFragmentationEmailTemplate([pair(), pair()]).subject).toMatch(/2 clusters\b/);
+  it('summarizes both section counts in the subject', () => {
+    expect(build([pair()]).subject).toMatch(/1 merge cluster\b/);
+    expect(build([pair(), pair()]).subject).toMatch(/2 merge clusters\b/);
+    expect(build([], [narrow()]).subject).toMatch(/1 breadth flag\b/);
+    expect(build([pair()], [narrow()]).subject).toMatch(/1 merge cluster \+ 1 breadth flag/);
   });
 
-  it('lists each pair with depths and a rounded similarity percentage', () => {
-    const out = buildDomainFragmentationEmailTemplate([pair()]);
+  it('lists each merge pair with depths and a rounded similarity percentage', () => {
+    const out = build([pair()]);
     expect(out.text).toContain('Spy School (9)');
     expect(out.text).toContain('Evil Spy School (4)');
     expect(out.text).toContain('62%');
     expect(out.html).toContain('62%');
   });
 
-  it('HTML-escapes domain names so a stray "&"/"<" cannot break the markup', () => {
-    const out = buildDomainFragmentationEmailTemplate([
-      pair({ domainA: 'Rock & Roll', domainB: 'Rock <Roll>' }),
-    ]);
+  it('lists each breadth flag with depth, facet count, dominant facet and share', () => {
+    const out = build([], [narrow()]);
+    expect(out.text).toContain('Shakespearean Tragedy');
+    expect(out.text).toContain('20 q');
+    expect(out.text).toContain('5 facets');
+    expect(out.text).toContain('70%');
+    expect(out.text).toContain('Hamlet');
+    expect(out.html).toContain('70%');
+  });
+
+  it('HTML-escapes domain and facet names so a stray "&"/"<" cannot break markup', () => {
+    const out = build(
+      [pair({ domainA: 'Rock & Roll', domainB: 'Rock <Roll>' })],
+      [narrow({ topAngle: 'Q&A <facet>' })],
+    );
     expect(out.html).toContain('Rock &amp; Roll');
     expect(out.html).toContain('Rock &lt;Roll&gt;');
-    // Raw text keeps the literal characters.
+    expect(out.html).toContain('Q&amp;A &lt;facet&gt;');
     expect(out.text).toContain('Rock & Roll');
   });
 });

--- a/src/server/email/templates/domain-fragmentation.ts
+++ b/src/server/email/templates/domain-fragmentation.ts
@@ -1,9 +1,14 @@
-import type { FragmentationPair } from '@/server/db/queries/domain-fragmentation';
+import type { FragmentationPair, NarrowDomain } from '@/server/db/queries/domain-fragmentation';
 
 export type DomainFragmentationEmail = {
   subject: string;
   html: string;
   text: string;
+};
+
+export type DomainReviewInput = {
+  pairs: FragmentationPair[];
+  narrowDomains: NarrowDomain[];
 };
 
 function escapeHtml(value: string): string {
@@ -14,59 +19,68 @@ function escapeHtml(value: string): string {
     .replace(/"/g, '&quot;');
 }
 
-function pct(similarity: number): string {
-  return `${Math.round(similarity * 100)}%`;
+function pct(fraction: number): string {
+  return `${Math.round(fraction * 100)}%`;
 }
 
 /**
- * Weekly "domains that may want merging" digest. Each pair is a judgment call the
- * automated reconcile deliberately left alone — the owner decides merge vs keep.
- * Pure render; the cron resolves the recipient and sends.
+ * Weekly domain-review digest with two sections:
+ *   1. Merge clusters — near-duplicate labels the reconcile left for a human call.
+ *   2. Breadth flags (Lever A) — broad domains leaning heavily on one facet.
+ * Either section may be empty. Pure render; the cron resolves recipient + sends.
  */
 export function buildDomainFragmentationEmailTemplate(
-  pairs: FragmentationPair[],
+  input: DomainReviewInput,
 ): DomainFragmentationEmail {
-  const subject =
-    pairs.length === 0
-      ? 'Domain review: nothing to look at this week'
-      : `Domain review: ${pairs.length} cluster${pairs.length === 1 ? '' : 's'} to eyeball`;
+  const { pairs, narrowDomains } = input;
 
-  if (pairs.length === 0) {
+  const subjectParts: string[] = [];
+  if (pairs.length > 0) {
+    subjectParts.push(`${pairs.length} merge cluster${pairs.length === 1 ? '' : 's'}`);
+  }
+  if (narrowDomains.length > 0) {
+    subjectParts.push(`${narrowDomains.length} breadth flag${narrowDomains.length === 1 ? '' : 's'}`);
+  }
+  const subject =
+    subjectParts.length === 0
+      ? 'Domain review: nothing to look at this week'
+      : `Domain review: ${subjectParts.join(' + ')}`;
+
+  if (subjectParts.length === 0) {
     const text =
-      'No near-duplicate domain clusters crossed the review threshold this week. Tier-1 prevention is holding.';
-    return {
-      subject,
-      text,
-      html: `<p>${escapeHtml(text)}</p>`,
-    };
+      'No near-duplicate domain clusters and no broad-but-narrow domains crossed the review threshold this week. Tier-1 prevention is holding.';
+    return { subject, text, html: `<p>${escapeHtml(text)}</p>` };
   }
 
-  const intro =
-    'These domain pairs look similar but were not auto-merged — each is a judgment call. ' +
-    'If a pair is the same scope, reply and I’ll merge them; if they’re genuinely different ' +
-    '(a specific work vs its genre, two siblings), leave them.';
+  // ── Section 1: merge clusters ──────────────────────────────────────────────
+  const textBlocks: string[] = [];
+  const htmlBlocks: string[] = [];
 
-  const textLines = pairs.map(
-    (p, i) =>
-      `${i + 1}. ${p.domainA} (${p.depthA}) ≈ ${p.domainB} (${p.depthB})  —  ${pct(p.similarity)} similar`,
-  );
-  const text = `${intro}\n\n${textLines.join('\n')}\n\n(Number in parentheses = how many questions are filed under that label.)`;
+  if (pairs.length > 0) {
+    const intro =
+      'These domain pairs look similar but were not auto-merged — each is a judgment call. ' +
+      'If a pair is the same scope, reply and I’ll merge them; if they’re genuinely different ' +
+      '(a specific work vs its genre, two siblings), leave them.';
+    const lines = pairs.map(
+      (p, i) =>
+        `${i + 1}. ${p.domainA} (${p.depthA}) ≈ ${p.domainB} (${p.depthB})  —  ${pct(p.similarity)} similar`,
+    );
+    textBlocks.push(`MERGE CLUSTERS\n${intro}\n\n${lines.join('\n')}`);
 
-  const rows = pairs
-    .map(
-      (p) => `
+    const rows = pairs
+      .map(
+        (p) => `
       <tr>
         <td style="padding:6px 10px;border-bottom:1px solid #eee;">${escapeHtml(p.domainA)} <span style="color:#888;">(${p.depthA})</span></td>
         <td style="padding:6px 10px;border-bottom:1px solid #eee;color:#888;">&asymp;</td>
         <td style="padding:6px 10px;border-bottom:1px solid #eee;">${escapeHtml(p.domainB)} <span style="color:#888;">(${p.depthB})</span></td>
         <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;color:#555;">${pct(p.similarity)}</td>
       </tr>`,
-    )
-    .join('');
-
-  const html = `
-    <div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:640px;">
-      <p>${escapeHtml(intro)}</p>
+      )
+      .join('');
+    htmlBlocks.push(`
+      <h3 style="font-size:15px;margin:0 0 4px;">Merge clusters</h3>
+      <p style="margin:0 0 8px;">${escapeHtml(intro)}</p>
       <table style="border-collapse:collapse;width:100%;font-size:14px;">
         <thead>
           <tr style="text-align:left;color:#888;font-size:12px;">
@@ -77,8 +91,51 @@ export function buildDomainFragmentationEmailTemplate(
           </tr>
         </thead>
         <tbody>${rows}</tbody>
-      </table>
-      <p style="color:#888;font-size:12px;">Depth = questions filed under that label. Generated by the weekly domain-fragmentation cron.</p>
+      </table>`);
+  }
+
+  // ── Section 2: breadth flags (Lever A) ─────────────────────────────────────
+  if (narrowDomains.length > 0) {
+    const intro =
+      'These broad domains lean heavily on a single facet — they may be serving narrow ' +
+      '(e.g. a "Shakespearean Tragedy" pool that is mostly one play). Worth checking whether ' +
+      'the pool genuinely spans the domain’s range, or wants more breadth generated.';
+    const lines = narrowDomains.map(
+      (d, i) =>
+        `${i + 1}. ${d.domain} (${d.depth} q, ${d.distinctAngles} facets) — ${pct(d.topAngleShare)} are "${d.topAngle}"`,
+    );
+    textBlocks.push(`BREADTH FLAGS\n${intro}\n\n${lines.join('\n')}`);
+
+    const rows = narrowDomains
+      .map(
+        (d) => `
+      <tr>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee;">${escapeHtml(d.domain)} <span style="color:#888;">(${d.depth}q · ${d.distinctAngles} facets)</span></td>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee;">${escapeHtml(d.topAngle)}</td>
+        <td style="padding:6px 10px;border-bottom:1px solid #eee;text-align:right;color:#555;">${pct(d.topAngleShare)}</td>
+      </tr>`,
+      )
+      .join('');
+    htmlBlocks.push(`
+      <h3 style="font-size:15px;margin:18px 0 4px;">Breadth flags</h3>
+      <p style="margin:0 0 8px;">${escapeHtml(intro)}</p>
+      <table style="border-collapse:collapse;width:100%;font-size:14px;">
+        <thead>
+          <tr style="text-align:left;color:#888;font-size:12px;">
+            <th style="padding:6px 10px;">Domain (depth · facets)</th>
+            <th style="padding:6px 10px;">Dominant facet</th>
+            <th style="padding:6px 10px;text-align:right;">Share</th>
+          </tr>
+        </thead>
+        <tbody>${rows}</tbody>
+      </table>`);
+  }
+
+  const text = `${textBlocks.join('\n\n')}\n\n(Depth = questions filed under that label.)`;
+  const html = `
+    <div style="font-family:system-ui,-apple-system,Segoe UI,sans-serif;max-width:640px;">
+      ${htmlBlocks.join('\n')}
+      <p style="color:#888;font-size:12px;margin-top:14px;">Depth = questions filed under that label. Generated by the weekly domain-fragmentation cron.</p>
     </div>`;
 
   return { subject, html, text };


### PR DESCRIPTION
…the weekly digest

Add getNarrowlyServedDomains(): reuse the per-question sub_angles the generator already emits to flag any domain (depth >= 8) where one facet covers >= 50% of the pool — a broad domain that may be serving narrow (e.g. a "Shakespearean Tragedy" pool that is mostly Hamlet). The weekly domain-fragmentation email now renders a second "Breadth flags" section alongside the merge clusters; the cron sends when EITHER section is non-empty. Read-only; thresholds env-tunable.


Claude-Session: https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V