### PR TITLE
Refine card: switch action button to success green & reorder on desktop

### DIFF
--- a/src/components/review/RefineItemCard.tsx
+++ b/src/components/review/RefineItemCard.tsx
@@ -6,17 +6,22 @@ import type { CSSProperties } from 'react';
 
 import type { RefineItem } from '@/server/refine/types';
 
-// Warm accent from the library (--brand-orange) for the single action verb.
+// Standard success green (--success) for the single affirmative action verb.
+// Same tint proportions the orange accent used, just re-hued to green.
 const actionStyle: CSSProperties = {
-  color: 'var(--brand-orange)',
-  borderColor: 'color-mix(in srgb, var(--brand-orange) 38%, var(--brand-border))',
-  background: 'color-mix(in srgb, var(--brand-orange) 8%, transparent)',
+  color: 'var(--success)',
+  borderColor: 'color-mix(in srgb, var(--success) 38%, var(--brand-border))',
+  background: 'color-mix(in srgb, var(--success) 8%, transparent)',
 };
 
 const ACTION_CLASS =
   'inline-flex min-h-11 cursor-pointer items-center justify-center self-start rounded-[var(--radius-xs)] border px-4 text-sm font-semibold transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:self-auto';
 
-const ROW_CLASS = 'flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4';
+// Action verb sits on the left on the sm+ row (flex-row-reverse puts the
+// trailing button at the start), while mobile keeps the natural text-then-action
+// stack.
+const ROW_CLASS =
+  'flex flex-col gap-3 py-4 sm:flex-row-reverse sm:items-center sm:justify-between sm:gap-4';
 
 export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: string }) {
   // Navigational nudge (add_territories): links out instead of staging a


### PR DESCRIPTION
## Summary
Updates the RefineItemCard component to use the success green color scheme for the action button and reorders the layout on desktop viewports to place the action button on the left side of the row.

## Changes
- **Color scheme:** Changed action button styling from warm orange (`--brand-orange`) to success green (`--success`), maintaining the same tint proportions (38% for border, 8% for background)
- **Layout reordering:** Applied `flex-row-reverse` on `sm+` breakpoints to position the action button at the start of the row on desktop, while mobile retains the natural text-then-action stack
- **Documentation:** Added clarifying comments explaining the color rationale and layout behavior across breakpoints

## Implementation details
The color change aligns the affirmative action verb with the success semantic, while the layout reordering improves visual hierarchy on larger screens by leading with the actionable element. The `flex-row-reverse` approach preserves the mobile-first natural reading order without requiring additional responsive markup.

https://claude.ai/code/session_01WUsHWwuaLVa4bRgKXAaXML