### PR TITLE
fix(daily): keep +2 bonus (friend) domains out of the core top-5 until adopted

### DIFF
--- a/drizzle/0094_player_mastery_rotation_eligible.sql
+++ b/drizzle/0094_player_mastery_rotation_eligible.sql
@@ -1,0 +1,25 @@
+-- B-DOMAIN-BONUS-ROTATION-01 — keep +2 bonus (friend) domains out of the core
+-- top-5 rotation until the player adopts them.
+--
+-- A friend-sourced +2 bonus question is answered through the same mastery path as
+-- a core question, so answering one used to mint a `demonstrated` PLAYER_MASTERY
+-- row that getKnowledgeBase then served in the main five on later days — a
+-- domain the player never put on their list silently leaking into the top five.
+--
+-- `rotation_eligible` tags whether a demonstrated domain may feed the core
+-- rotation. It defaults TRUE so every existing row and every core/feed/declared
+-- write stays eligible exactly as before; only a brand-new row first created by a
+-- +2 bonus answer is written FALSE (see writeMasteryEvent). getKnowledgeBase
+-- excludes a demonstrated row only when rotation_eligible IS FALSE *and* the
+-- player hasn't adopted it (a non-resting domain frequency) *and* it isn't a
+-- declared interest — so adopting it (Often / Sometimes / Blue Moon) or declaring
+-- it re-includes it.
+--
+-- Purely additive: no existing column is touched and the default keeps current
+-- behaviour for every existing row. Idempotent and mirrored by a defensive guard
+-- in src/instrumentation.ts (precedent: the territory_type guard, migration 0035).
+--
+-- Rollback:
+--   ALTER TABLE "PLAYER_MASTERY" DROP COLUMN IF EXISTS "rotation_eligible";
+ALTER TABLE "PLAYER_MASTERY"
+  ADD COLUMN IF NOT EXISTS "rotation_eligible" boolean NOT NULL DEFAULT true;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -659,6 +659,13 @@
       "when": 1784592000000,
       "tag": "0093_recovered_set_aside",
       "breakpoints": true
+    },
+    {
+      "idx": 94,
+      "version": "7",
+      "when": 1784678400000,
+      "tag": "0094_player_mastery_rotation_eligible",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/daily/answer/route.ts
+++ b/src/app/api/daily/answer/route.ts
@@ -13,6 +13,7 @@ import {
 import { deriveAnswerOutcome, recordAnswerSideEffects } from '@/server/answers/answer-pipeline';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { type QueueSlot } from '@/server/daily/types';
+import { isBonusSlot } from '@/server/daily/bonus';
 import { asQueueSlots } from '@/server/daily/catchup';
 import { resolveDailyBasePoints } from '@/server/daily/types';
 import { resolveEffectiveDifficulty } from '@/server/daily/empirical-difficulty';
@@ -513,6 +514,9 @@ export async function POST(request: NextRequest) {
         answerState: masteryAnswerState,
         pointsAwarded,
         sourceType: 'daily',
+        // B-DOMAIN-BONUS-ROTATION-01: a +2 bonus (friend-sourced) domain stays out
+        // of the core rotation until adopted — see writeMasteryEvent.
+        isBonus: isBonusSlot(slot),
         sourceId: `${queue.id}:${parsed.slotIndex}`,
         broadCategory: question.broadCategory,
         eventQuestionId: canonicalQuestionId,

--- a/src/app/api/daily/catchup/answer/route.ts
+++ b/src/app/api/daily/catchup/answer/route.ts
@@ -14,6 +14,7 @@ import {
   replaceQueueSlot,
 } from '@/server/daily/catchup';
 import { type QueueSlot } from '@/server/daily/types';
+import { isBonusSlot } from '@/server/daily/bonus';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { awardAuthorCredit, isAuthorCreditEligible } from '@/server/mastery/author-credit';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
@@ -307,6 +308,9 @@ async function handleDailyCatchupAnswer({
       answerState: masteryAnswerState,
       pointsAwarded,
       sourceType: 'catchup',
+      // B-DOMAIN-BONUS-ROTATION-01: a recovered +2 bonus slot stays out of the
+      // core rotation until adopted, same as the live daily/answer path.
+      isBonus: isBonusSlot(slot),
       sourceId: catchupItem.dailyQueueItemId,
       broadCategory: catchupItem.broadCategory,
       eventQuestionId: canonicalQuestionId,

--- a/src/app/daily/page.tsx
+++ b/src/app/daily/page.tsx
@@ -572,6 +572,10 @@ export default function DailyPage() {
           creatorIsHouse: slot.source === 'house',
           canonicalSubcategory: slot.domain,
           openedTerritoryDomain: openedTerritoryBySlot[slot.slot_index] ?? null,
+          // Daily territory cards are bonus-only after the gate above, so the
+          // domain is NOT yet in rotation — the card opens as an opt-in, not an
+          // already-added "remove?" (B-DOMAIN-BONUS-ROTATION-01).
+          openedTerritoryAdopted: false,
           recheckAction:
             slot.answer_state === 'incorrect' && !gaveUp && !slot.recheck_status
               ? { onSubmit: () => requestRecheck(slot.slot_index) }
@@ -697,12 +701,16 @@ export default function DailyPage() {
         setSubmitNotice(null);
 
         const isCorrect = Boolean(body.isCorrect ?? body.correct);
-        // A correct answer in an unfamiliar domain default-adds it to the KB
-        // (B-1). The server reports the freshly-opened domain on masteryDelta;
-        // stash it per-slot so the reveal can surface the "Added — remove?" undo.
+        // The "new territory" reveal card (Often / Sometimes / Blue Moon / Never)
+        // is the ADOPTION moment for a friend-sourced +2 bonus domain — it belongs
+        // in the bonus area, never on a core top-5 slot. A core domain is already
+        // declared/adopted, so it never needs this card. Gate it to bonus slots
+        // (B-DOMAIN-BONUS-ROTATION-01); the server parks the bonus domain out of
+        // rotation until the player picks a non-resting frequency here.
         // Client-only — deliberately not persisted into the QueueSlot schema.
         const masteryDelta = body.masteryDelta ?? body.mastery_delta;
-        const openedDomain = isCorrect ? pickOpenedTerritoryDomain(masteryDelta) : null;
+        const openedDomain =
+          isCorrect && isBonusSlot(currentSlot) ? pickOpenedTerritoryDomain(masteryDelta) : null;
         if (openedDomain) {
           setOpenedTerritoryBySlot((existing) => ({
             ...existing,

--- a/src/components/feed/NewTerritoryUndo.tsx
+++ b/src/components/feed/NewTerritoryUndo.tsx
@@ -21,6 +21,13 @@ const GOLD_INK = 'var(--accent-gold-ink)';
 // come up — Often / Sometimes / Blue Moon / Never — via a segmented control that
 // saves on tap. No Undo is needed: the control is self-reversible (re-tap another
 // tier). Used on both reveal surfaces.
+//
+// B-DOMAIN-BONUS-ROTATION-01: on the daily +2 BONUS surface the domain is NOT
+// auto-added to rotation — it's parked out of the core five until the player
+// adopts it. There `adopted={false}` opens the control on "Never" (its real
+// state: on the map, not yet asked), so picking any other tier is the explicit
+// opt-in. The mastery row already exists, so the "Added to your knowledge base"
+// lead still holds (knowledge base = your map, which includes resting domains).
 const FREQUENCY_HINT: Record<TerritoryFrequency, string> = {
   often: 'Shows up most in your rounds.',
   sometimes: 'Stays in normal rotation.',
@@ -31,12 +38,22 @@ const FREQUENCY_HINT: Record<TerritoryFrequency, string> = {
 export function NewTerritoryUndo({
   domain,
   category,
+  adopted = true,
 }: {
   domain: string;
   category?: string | null;
+  /**
+   * Whether this domain is already in rotation (B-1 default-add). True on the
+   * feed/core surfaces. The daily +2 bonus surface passes false: the domain is
+   * parked out of rotation, so the control opens on "Never" and any other tier
+   * is the explicit opt-in (B-DOMAIN-BONUS-ROTATION-01).
+   */
+  adopted?: boolean;
 }) {
-  // Freshly-added domains start in the default rotation ('sometimes').
-  const [selected, setSelected] = useState<TerritoryFrequency>('sometimes');
+  // Adopted (default-add) domains start in the default 'sometimes' rotation; a
+  // not-yet-adopted bonus domain opens on 'resting' so any tier the player taps —
+  // including 'sometimes' — actually writes the adoption.
+  const [selected, setSelected] = useState<TerritoryFrequency>(adopted ? 'sometimes' : 'resting');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState(false);
   const label = category || domain;

--- a/src/components/feed/__tests__/NewTerritoryUndo.test.tsx
+++ b/src/components/feed/__tests__/NewTerritoryUndo.test.tsx
@@ -35,4 +35,27 @@ describe('NewTerritoryUndo (knowledge-preference thread card)', () => {
     // No longer the old rounded-2xl settings-style shell.
     expect(rendered).not.toContain('rounded-2xl');
   });
+
+  // B-DOMAIN-BONUS-ROTATION-01: on the daily +2 bonus surface the domain is NOT
+  // yet in rotation, so the control must open on "Never" (its true state) and any
+  // other tier is the explicit opt-in. The selected tier's helper hint is rendered
+  // in the markup, so it doubles as a witness for the initial selection.
+  it('opens on Never (opt-in) for a not-yet-adopted bonus domain', () => {
+    const bonus = renderToStaticMarkup(
+      <NewTerritoryUndo domain="zelda" category="The Legend of Zelda" adopted={false} />,
+    );
+    // Resting hint == initial selection is "Never" (apostrophe is HTML-escaped in
+    // the static markup, so match the unambiguous prefix).
+    expect(bonus).toContain('Stays on your map, but');
+    expect(bonus).not.toContain('Stays in normal rotation.');
+  });
+
+  it('opens on Sometimes (default-add) when the domain is already adopted', () => {
+    const adopted = renderToStaticMarkup(
+      <NewTerritoryUndo domain="zelda" category="The Legend of Zelda" adopted />,
+    );
+    // Sometimes hint == initial selection is "Sometimes" (the B-1 default).
+    expect(adopted).toContain('Stays in normal rotation.');
+    expect(adopted).not.toContain('Stays on your map, but');
+  });
 });

--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -103,6 +103,14 @@ export type ChatMessage =
       canonicalSubcategory?: string | null;
       /** B-1 — domain newly opened in the KB by this correct answer; surfaces the "Added [Domain] — remove?" undo. */
       openedTerritoryDomain?: string | null;
+      /**
+       * B-DOMAIN-BONUS-ROTATION-01 — whether the opened domain is already in
+       * rotation. Defaults true (the B-1 default-add surfaces). The daily bonus
+       * surface passes false: a +2 bonus domain is parked out of rotation until
+       * the player adopts it here, so the card opens as an opt-in (Never preset)
+       * rather than an already-added "remove?".
+       */
+      openedTerritoryAdopted?: boolean;
       /** Author's why — commentary the question's author attached at creation, revealed on answer (correct or incorrect). */
       authorNote?: string | null;
       /** Question's stored factual explainer. Rendered as a fallback below the verdict when no breadcrumb arrives (e.g. feed-sourced catch-up items, or when /api/breadcrumb times out). */
@@ -996,6 +1004,7 @@ function ResultRow({
   recheckAction,
   canonicalSubcategory,
   openedTerritoryDomain,
+  openedTerritoryAdopted = true,
   domId,
 }: {
   result: 'correct' | 'wrong' | 'expired' | 'gave_up';
@@ -1017,6 +1026,7 @@ function ResultRow({
   pointsLabel?: string | null;
   recheckAction?: RecheckAction | null;
   openedTerritoryDomain?: string | null;
+  openedTerritoryAdopted?: boolean;
   /** DOM id for the reveal root so the page can scroll a freshly-revealed result into view (MISC-4). */
   domId?: string;
 }) {
@@ -1297,7 +1307,11 @@ function ResultRow({
         {note ? <CreatorNote text={note.text} provenance={note.provenance} /> : null}
       </ThreadCard>
       {correct && openedTerritoryDomain ? (
-        <NewTerritoryUndo domain={openedTerritoryDomain} category={canonicalSubcategory} />
+        <NewTerritoryUndo
+          domain={openedTerritoryDomain}
+          category={canonicalSubcategory}
+          adopted={openedTerritoryAdopted}
+        />
       ) : null}
       {reactionPrompt ? <QuestionReactionPrompt prompt={reactionPrompt} /> : null}
     </div>
@@ -1561,6 +1575,7 @@ export function GameplayChatThread({
                 pointsLabel={m.pointsLabel}
                 recheckAction={m.recheckAction}
                 openedTerritoryDomain={m.openedTerritoryDomain}
+                openedTerritoryAdopted={m.openedTerritoryAdopted}
               />
             );
           case 'session_complete':

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -180,6 +180,13 @@ export async function register() {
         ALTER TABLE "PLAYER_MASTERY"
           ADD COLUMN IF NOT EXISTS "territory_type" "public"."TerritoryType" DEFAULT 'demonstrated' NOT NULL
       `);
+      // B-DOMAIN-BONUS-ROTATION-01 (migration 0094): gate +2 bonus domains out of
+      // the core rotation until adopted. Additive, default true → no behaviour
+      // change for existing rows.
+      await db.execute(sql`
+        ALTER TABLE "PLAYER_MASTERY"
+          ADD COLUMN IF NOT EXISTS "rotation_eligible" boolean NOT NULL DEFAULT true
+      `);
       await db.execute(sql`
         DO $$ BEGIN
           IF EXISTS (

--- a/src/lib/knowledge/__tests__/rotation-eligibility.test.ts
+++ b/src/lib/knowledge/__tests__/rotation-eligibility.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { masteryDomainFeedsRotation } from '@/lib/knowledge/rotation-eligibility';
+
+describe('masteryDomainFeedsRotation (B-DOMAIN-BONUS-ROTATION-01)', () => {
+  it('keeps a bonus-only domain OUT of the core rotation until claimed', () => {
+    // Freshly opened by a +2 bonus answer: rotation_eligible=false, not declared,
+    // no frequency set. This is the leak the fix closes.
+    expect(
+      masteryDomainFeedsRotation({ rotationEligible: false, declared: false, adopted: false }),
+    ).toBe(false);
+  });
+
+  it('re-includes a bonus domain once the player ADOPTS it (any non-resting frequency)', () => {
+    expect(
+      masteryDomainFeedsRotation({ rotationEligible: false, declared: false, adopted: true }),
+    ).toBe(true);
+  });
+
+  it('re-includes a bonus domain once the player DECLARES it', () => {
+    expect(
+      masteryDomainFeedsRotation({ rotationEligible: false, declared: true, adopted: false }),
+    ).toBe(true);
+  });
+
+  it('always keeps a rotation-eligible domain (core/feed/declared play, or legacy rows)', () => {
+    // Legacy + every non-bonus surface write defaults rotation_eligible=true, so
+    // existing demonstrated domains are never dropped by the new guard.
+    expect(
+      masteryDomainFeedsRotation({ rotationEligible: true, declared: false, adopted: false }),
+    ).toBe(true);
+  });
+});

--- a/src/lib/knowledge/rotation-eligibility.ts
+++ b/src/lib/knowledge/rotation-eligibility.ts
@@ -1,0 +1,26 @@
+/**
+ * B-DOMAIN-BONUS-ROTATION-01 — does a demonstrated-mastery domain feed the core
+ * Daily Five rotation?
+ *
+ * A friend-sourced +2 bonus answer records mastery like any other (so stats and
+ * the player's "map" count it), but the row is written rotation_eligible=false so
+ * the domain can't silently leak into the core five. It rejoins the rotation only
+ * once the player has a real claim on it:
+ *
+ *   - rotationEligible — earned it through core/feed/declared play (or it's a
+ *     legacy row, where the column defaults true), OR
+ *   - declared        — it's an active declared interest, OR
+ *   - adopted         — the player set a non-resting frequency (Often / Sometimes
+ *                       / Blue Moon) on the bonus reveal card. Blue Moon counts:
+ *                       it rotates, just rarely. Only "Never" (resting) / unset
+ *                       leaves a bonus-only domain parked.
+ *
+ * Pure + db-free so it can be unit-tested without the query layer.
+ */
+export function masteryDomainFeedsRotation(input: {
+  rotationEligible: boolean;
+  declared: boolean;
+  adopted: boolean;
+}): boolean {
+  return input.rotationEligible || input.declared || input.adopted;
+}

--- a/src/server/db/queries/daily.ts
+++ b/src/server/db/queries/daily.ts
@@ -17,6 +17,7 @@ import {
 import { getDailyAssignmentBounds } from '@/lib/games/timezone';
 import type { GradableQuestionType } from '@/server/grading';
 import { getActiveDeclaredInterests } from '@/server/db/queries/declared-interests';
+import { getDailyPreferences } from '@/server/db/queries/daily-preferences';
 import { notBlockedGeneratedByContentReport, notSuppressedByContentReport } from '@/server/db/queries/content-reports';
 import { notBlocked } from '@/server/feed/visibility';
 import { pgErrorCode } from '@/server/db/pg-error';
@@ -44,6 +45,7 @@ import {
 import { getBasePoints } from '@/server/mastery/scoring';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import { domainKey } from '@/lib/knowledge/domain-key';
+import { masteryDomainFeedsRotation } from '@/lib/knowledge/rotation-eligibility';
 
 function asQueueSlotDifficulty(
   value: string | null | undefined,
@@ -235,6 +237,7 @@ async function getPlayerMasteryKnowledgeRows(userId: string) {
         territoryType: playerMastery.territoryType,
         totalPoints: playerMastery.totalPoints,
         tier: playerMastery.tier,
+        rotationEligible: playerMastery.rotationEligible,
       })
       .from(playerMastery)
       .where(eq(playerMastery.userId, userId))
@@ -242,6 +245,9 @@ async function getPlayerMasteryKnowledgeRows(userId: string) {
   } catch (error) {
     if (pgErrorCode(error) !== '42703') throw error;
 
+    // territory_type and/or rotation_eligible not present yet (pre-migration on a
+    // partially-recorded DB). Fail open: every domain stays demonstrated and
+    // rotation-eligible, i.e. the pre-B-DOMAIN-BONUS-ROTATION-01 behaviour.
     const rows = await db
       .select({
         domain: playerMastery.canonicalSubcategory,
@@ -253,16 +259,21 @@ async function getPlayerMasteryKnowledgeRows(userId: string) {
       .where(eq(playerMastery.userId, userId))
       .orderBy(asc(playerMastery.canonicalSubcategory));
 
-    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const }));
+    return rows.map((row) => ({
+      ...row,
+      territoryType: 'demonstrated' as const,
+      rotationEligible: true,
+    }));
   }
 }
 
 export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDomain[]> {
-  const [masteryRows, declaredRows, excludedDomains, correctCountsByDomain] = await Promise.all([
+  const [masteryRows, declaredRows, excludedDomains, correctCountsByDomain, preferences] = await Promise.all([
     getPlayerMasteryKnowledgeRows(userId),
     getActiveDeclaredInterests(userId),
     getExcludedKnowledgeDomains(userId),
     getCorrectAnswerCountsByDomain(userId),
+    getDailyPreferences(userId),
   ]);
 
   const isExcluded = (domain: string, broadCategory: string | null): boolean => {
@@ -271,6 +282,20 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     return false;
   };
 
+  // B-DOMAIN-BONUS-ROTATION-01: a demonstrated domain first opened by a +2 bonus
+  // answer carries rotation_eligible=false. It may still feed the core five if the
+  // player has since DECLARED it or ADOPTED it — set any non-resting frequency
+  // (Often / Sometimes / Blue Moon) on the bonus reveal card. Keys are lowercased
+  // to match the rest of this function.
+  const declaredKeys = new Set(
+    declaredRows.map((row) => normalizeDomain(row.domain).toLowerCase()).filter(Boolean),
+  );
+  const adoptedKeys = new Set(
+    Object.entries(preferences.domainPreferenceFrequency)
+      .filter(([, frequency]) => frequency !== 'resting')
+      .map(([domain]) => domain.toLowerCase()),
+  );
+
   const domainsByKey = new Map<string, KnowledgeBaseDomain>();
 
   for (const row of masteryRows) {
@@ -278,6 +303,18 @@ export async function getKnowledgeBase(userId: string): Promise<KnowledgeBaseDom
     if (!domain) continue;
     const key = domain.toLowerCase();
     if (isExcluded(domain, row.broadCategory)) continue;
+    // Park a bonus-only domain out of the core rotation until adopted or declared.
+    // Existing/legacy rows are rotation_eligible=true (column default) and so are
+    // never skipped here.
+    if (
+      !masteryDomainFeedsRotation({
+        rotationEligible: row.rotationEligible,
+        declared: declaredKeys.has(key),
+        adopted: adoptedKeys.has(key),
+      })
+    ) {
+      continue;
+    }
     domainsByKey.set(key, {
       domain,
       broadCategory: row.broadCategory,

--- a/src/server/db/queries/knowledge.ts
+++ b/src/server/db/queries/knowledge.ts
@@ -171,7 +171,7 @@ async function getPlayerMasteryRows(userId: string, orderByPoints = false): Prom
         .from(playerMastery)
         .where(eq(playerMastery.userId, userId));
 
-    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const }));
+    return rows.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true }));
   }
 }
 
@@ -213,7 +213,7 @@ async function getPlayerMasteryRowsBulk(
       .from(playerMastery)
       .where(inArray(playerMastery.userId, ids))
       .orderBy(desc(playerMastery.totalPoints));
-    rows = raw.map((row) => ({ ...row, territoryType: 'demonstrated' as const }));
+    rows = raw.map((row) => ({ ...row, territoryType: 'demonstrated' as const, rotationEligible: true }));
   }
 
   for (const row of rows) {

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -462,6 +462,12 @@ export const playerMastery = pgTable(
     tierReachedAt: timestamp('tier_reached_at', { withTimezone: true }),
     lifetimePointsBaseline: doublePrecision('lifetime_points_baseline').notNull().default(0),
     territoryType: territoryTypeEnum('territory_type').notNull().default('demonstrated'),
+    // B-DOMAIN-BONUS-ROTATION-01: may this demonstrated domain feed the core
+    // top-5 rotation? Defaults true (existing + core/feed/declared rows stay
+    // eligible); a row first minted by a +2 bonus answer is written false so a
+    // friend's domain can't leak into the main five until the player adopts it
+    // (a non-resting frequency) or declares it. See getKnowledgeBase.
+    rotationEligible: boolean('rotation_eligible').notNull().default(true),
     updatedAt: updatedAt(),
   },
   (table) => [

--- a/src/server/mastery/write-mastery-event.ts
+++ b/src/server/mastery/write-mastery-event.ts
@@ -23,6 +23,13 @@ export type WriteMasteryEventParams = {
   basePoints?: number;
   weight?: number;
   answeredByUserId?: string | null;
+  // B-DOMAIN-BONUS-ROTATION-01: true when this answer came from a Daily Five +2
+  // BONUS slot (a friend-sourced domain). A bonus answer still records mastery
+  // (stats/profile count it) but a domain it newly opens is parked
+  // rotation_eligible=false so it can't leak into the core top-5 until the player
+  // adopts it (a non-resting frequency) or declares it. A core/feed/declared
+  // answer (the default, isBonus falsy) always (re)earns rotation eligibility.
+  isBonus?: boolean;
   // B-LLM-PROVIDER-AB-SWITCH B3: provider that GRADED this answer ('anthropic'|
   // 'openai'), or null when the grade never hit an LLM (exact-match/give-up) or
   // the write isn't from a grading path (author/curator credit, backfill, etc.).
@@ -227,6 +234,9 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
           tier: nextTier,
           tierReachedAt: tierChanged ? new Date() : null,
           lifetimePointsBaseline: 0,
+          // A brand-new domain opened by a +2 bonus answer is parked out of the
+          // core rotation; every other surface (core/feed/declared) earns it.
+          rotationEligible: !params.isBonus,
           updatedAt: new Date(),
         })
         .onConflictDoUpdate({
@@ -236,6 +246,10 @@ export async function writeMasteryEvent(params: WriteMasteryEventParams): Promis
             totalPoints: nextTotalPoints,
             tier: nextTier,
             tierReachedAt: tierChanged ? new Date() : existing?.tierReachedAt ?? null,
+            // A non-bonus answer UPGRADES a previously bonus-only domain into the
+            // rotation; a bonus answer never downgrades an already-eligible row,
+            // so only set the flag from the non-bonus path.
+            ...(params.isBonus ? {} : { rotationEligible: true }),
             updatedAt: new Date(),
           },
         });


### PR DESCRIPTION
## Problem

A player reported getting a run of **Zelda** questions in their main top-5 — a domain they never put on their list — plus the "Often / Blue Moon" frequency prompt showing up there.

Root cause (two surface-blind spots, both confirmed in code):

1. **Silent promotion.** In "mix it up" mode the main five draws from declared interests **+** demonstrated mastery. The +2 bonus area serves **friends'** domains. But answering *any* question — bonus included — recorded a `demonstrated` `PLAYER_MASTERY` row with no surface tag and no threshold, so a single bonus tap on a friend's Zelda question made it eligible for the core five on later days.
2. **Surface-blind prompt.** The new-territory adoption prompt (`openedNewTerritory`) fired purely on "domain new + correct", with no awareness of bonus vs core — so it could land on a top-5 slot.

## Fix — `B-DOMAIN-BONUS-ROTATION-01`

A bonus answer still records mastery (stats/profile count it) but the domain is **parked out of the core rotation until adopted** — pick any non-resting frequency (Often / Sometimes / Blue Moon) on the bonus reveal card, or declare it. Scoped strictly to the daily +2 bonus path; feed/milestone/core behaviour is unchanged.

| Change | File |
|---|---|
| `PLAYER_MASTERY.rotation_eligible` column (default `true` → no change for existing rows) | `drizzle/0094_…sql`, `schema.ts`, journal, `instrumentation.ts` guard |
| Bonus answer writes `rotation_eligible=false`; core/feed/declared upgrade to `true`; bonus never downgrades | `write-mastery-event.ts` (`isBonus` param) |
| Thread `isBonus` from the answered slot via `isBonusSlot` | daily + catchup `answer/route.ts` |
| `getKnowledgeBase` excludes a bonus-only domain unless declared or adopted | `daily.ts` + pure `rotation-eligibility.ts` predicate |
| Adoption prompt gated to bonus slots; bonus card opens on "Never" (opt-in) | `daily/page.tsx`, `GameplayChat.tsx`, `NewTerritoryUndo.tsx` |

## Verification

- Typecheck clean (only pre-existing stale `.next` `replay` route-type noise, unrelated).
- ESLint clean on all touched files.
- **67 tests pass** across touched suites, incl. 8 new (eligibility predicate + the bonus card's opt-in default).
- Migration approved by `drizzle-migration-reviewer`: gapless numbering, journal `when` ordering correct, purely additive/safe, idempotent guard present, fail-open 42703 fallbacks.

## Follow-ups (not in this PR)

- A recovered **catchup** bonus slot parks the domain correctly, but the catchup surface doesn't render the adoption card — such a domain would be adopted via Game settings rather than inline.
- Optional server-side log/metric when a bonus domain is adopted into rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)