### PR TITLE
fix(play): stop double-printing the explainer on give-up reveals

### DIFF
--- a/src/components/play/GameplayChat.tsx
+++ b/src/components/play/GameplayChat.tsx
@@ -1142,7 +1142,9 @@ function ResultRow({
                 {correctAnswer}
               </p>
             ) : null}
-            {explainerSentence ? <ExplainerLine text={explainerSentence} /> : null}
+            {/* The explainer is rendered once by the shared discovery block below
+                (showDiscoveryExplainer covers every !correct reveal, incl. gave_up).
+                Rendering it here too double-printed the answer on give-up. */}
           </>
         ) : (
           <>

--- a/src/components/play/__tests__/GameplayChat.result.test.tsx
+++ b/src/components/play/__tests__/GameplayChat.result.test.tsx
@@ -93,6 +93,22 @@ describe('GameplayChat correct-answer treatment (D-5 live thread)', () => {
     expect(rendered).not.toContain('“Angiosperms');
   });
 
+  it('renders the give-up explainer exactly once (regression: was double-printed)', () => {
+    // The gave_up branch used to render the explainer itself AND the shared
+    // discovery block rendered it again (showDiscoveryExplainer is true for every
+    // !correct reveal), so the answer's "why" printed twice on give-up.
+    const needle = 'feigned illness to expose the asylum';
+    const rendered = html([
+      resultMessage({
+        result: 'gave_up',
+        submitted: '',
+        correctAnswer: 'Nellie Bly',
+        explanation: `Nellie Bly ${needle}.`,
+      }),
+    ]);
+    expect(rendered.split(needle).length - 1).toBe(1);
+  });
+
   it('keeps the explainer and shows the "Between us!" wink below it on a discovery reveal', () => {
     const rendered = html([
       resultMessage({


### PR DESCRIPTION
## The bug
On a "give up / show me the answer" reveal, the answer's explainer paragraph rendered **twice** back-to-back under "The answer" (seen on the catch-up screen).

## Cause
`ResultRow` rendered the explainer in two places for a `gave_up` result:
1. inside the `gave_up` branch of the card, and
2. the shared discovery block below it, gated on `showDiscoveryExplainer = !correct && explainerSentence` — which is **also true for `gave_up`**.

So `gave_up` printed it twice. (`correct` renders once in its own branch; `wrong` renders once via the shared block — both already fine.)

## Fix
Drop the in-branch render in the `gave_up` branch and let the shared discovery block render it once — same placement, and consistent with the `wrong` case. Net change: one JSX line removed.

## Tests
- New regression test asserts the explainer renders **exactly once** for a `gave_up` result (the existing `gave_up` test used `toContain`, which passed even when doubled).
- Full play suite green (27 tests); lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)