### PR TITLE
fix(retrieval): stop pool-refill timing out on every domain

### DIFF
--- a/docs/retrieval-flip-checklist.md
+++ b/docs/retrieval-flip-checklist.md
@@ -33,10 +33,18 @@ If thin+active domains and frequent fall-throughs show up in those numbers, flip
       currently scheduled only by Vercel Hobby's best-effort cron (09:00 UTC) — the
       unreliability the workflow exists to avoid. The route is idempotent and capped, so
       dual scheduling is safe.
-- [ ] Sanity-check spend knobs (all pre-set with safe defaults, `retrieval-config.ts`):
-      `RETRIEVAL_DAILY_USD_CEILING` ($2 hard stop), `RETRIEVAL_MAX_SEARCHES_PER_QUESTION`
-      (3), `RETRIEVAL_QUESTIONS_PER_DOMAIN` (3), `RETRIEVAL_POOL_DEPTH_THRESHOLD` (8),
-      `RETRIEVAL_MAX_DOMAINS_PER_RUN` (50).
+- [ ] Sanity-check spend / throughput knobs (all pre-set with safe defaults,
+      `retrieval-config.ts`): `RETRIEVAL_DAILY_USD_CEILING` ($2 hard stop),
+      `RETRIEVAL_MAX_SEARCHES_PER_QUESTION` (3), `RETRIEVAL_QUESTIONS_PER_DOMAIN` (1),
+      `RETRIEVAL_POOL_DEPTH_THRESHOLD` (8), `RETRIEVAL_MAX_DOMAINS_PER_RUN` (50),
+      `RETRIEVAL_CALL_TIMEOUT_MS` (120000). **Per-call latency note:** a grounded
+      call runs `MAX_SEARCHES_PER_QUESTION * QUESTIONS_PER_DOMAIN` web searches in
+      one request and must finish within `RETRIEVAL_CALL_TIMEOUT_MS`; too-tight a
+      timeout (or too-high a per-call search count) aborts EVERY domain and
+      persists nothing — the 2026-06 outage. Keep the timeout comfortably under the
+      route's 300s `maxDuration` so several domains still fit per run, and only
+      raise `QUESTIONS_PER_DOMAIN` once you've confirmed real call latencies leave
+      headroom (watch `[llm] error … scope: 'pool-refill-generate'`).
 - [ ] **Spend caps (do this BEFORE flipping `RETRIEVAL_GROUNDING_ENABLED`):**
       - **Hard global cap — set an Anthropic Console org monthly spend limit.** This is
         the only cap that bounds *everything* (per-user generation + gates + grounding

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -38,8 +38,16 @@ export type RetrievalConfig = {
   /** Searches the model may run per generated question (maps to web_search
    *  max_uses, multiplied by questions-per-call). */
   maxSearchesPerQuestion: number;
-  /** How many questions to ask for per domain in a single grounded call. */
+  /** How many questions to ask for per domain in a single grounded call. Kept
+   *  low by default: each call must finish within callTimeoutMs, and an agentic
+   *  web-search loop scales with maxSearchesPerQuestion * questionsPerDomain. */
   questionsPerDomain: number;
+  /** Per-call timeout (ms) for the grounded generation request. A web-search
+   *  generation does multiple search round-trips inside one call, so it needs
+   *  far more than a plain batch; too tight and EVERY domain aborts with
+   *  "Request was aborted" and persists nothing (the 2026-06 outage). Must stay
+   *  comfortably under the route's maxDuration (300s) so several domains fit. */
+  callTimeoutMs: number;
   /** A domain is "thin" (eligible for refill) when its durable pool depth — the
    *  count of non-duplicate, fact-keyed machine rows — is below this. */
   poolDepthThreshold: number;
@@ -74,7 +82,14 @@ export function getRetrievalConfig(): RetrievalConfig {
     dailyUsdCeiling: numEnv('RETRIEVAL_DAILY_USD_CEILING', 2),
     monthlyUsdCeiling: numEnv('LLM_MONTHLY_USD_CEILING', 0),
     maxSearchesPerQuestion: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_SEARCHES_PER_QUESTION', 3))),
-    questionsPerDomain: Math.max(1, Math.round(numEnv('RETRIEVAL_QUESTIONS_PER_DOMAIN', 3))),
+    // Default 1 (was 3): a 3-question call issued up to 9 web searches and blew
+    // past the old 60s timeout on every domain (2026-06 outage — 0 persisted).
+    // One corroborated question per domain per run is the reliable unit; the
+    // backlog mechanism spreads domains across runs and depth accrues over runs.
+    questionsPerDomain: Math.max(1, Math.round(numEnv('RETRIEVAL_QUESTIONS_PER_DOMAIN', 1))),
+    // Default 120s (was a hardcoded 60s): a web-search generation needs room for
+    // several search round-trips. Floored at 10s; keep under maxDuration (300s).
+    callTimeoutMs: Math.min(290_000, Math.max(10_000, Math.round(numEnv('RETRIEVAL_CALL_TIMEOUT_MS', 120_000)))),
     poolDepthThreshold: Math.max(1, Math.round(numEnv('RETRIEVAL_POOL_DEPTH_THRESHOLD', 8))),
     activeLookbackDays: Math.max(1, Math.round(numEnv('RETRIEVAL_ACTIVE_LOOKBACK_DAYS', 14))),
     maxDomainsPerRun: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_DOMAINS_PER_RUN', 50))),

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -32,10 +32,6 @@ import {
   type RetrievalConfig,
 } from '@/server/daily/retrieval-config';
 
-// Web search adds round-trips inside the single (server-tool) generation call,
-// so it tolerates more latency than a plain generation batch. Still bounded so a
-// stalled call can't eat the cron's whole budget.
-const RETRIEVAL_CALL_TIMEOUT_MS = 60_000;
 // Durable pool content (B1 §5.1, D8): machine bank no longer expires by age, so
 // seed rows get a far-future expiry rather than the per-user daily-reset value —
 // the bank ignores expiry for serving, and this keeps any age-based cleanup from
@@ -120,8 +116,12 @@ async function generateGroundedForDomain(
     tools: [{ type: 'web_search_20260209', name: 'web_search', max_uses: maxUses }],
   } as unknown as Anthropic.MessageCreateParamsNonStreaming;
 
+  // Web search adds round-trips inside the single (server-tool) generation call,
+  // so it tolerates more latency than a plain batch. Configurable + bounded
+  // (config.callTimeoutMs) so a stalled call can't eat the cron's whole budget,
+  // but isn't so tight that every domain aborts (the 2026-06 outage).
   const response = await loggedMessagesCreate(client, 'pool-refill-generate', params, {
-    timeoutMs: RETRIEVAL_CALL_TIMEOUT_MS,
+    timeoutMs: config.callTimeoutMs,
   });
 
   const usage = response.usage as


### PR DESCRIPTION
## The bug

Retrieval-grounded pool-refill has been **enabled and running daily but persisting 0 questions**. Production logs (09:00 UTC crons on 2026-06-28 and 2026-06-29) show every domain aborting, then the function 504-ing:

```
[llm] error { scope: 'pool-refill-generate', model: 'claude-sonnet-4-6',
              duration_ms: 60002, timeout_ms: 60000, message: 'Request was aborted.' }
[pool-refill] domain refill failed { domain: 'Mrs. Dalloway', error: 'Request was aborted.' }
...
[GET] /api/cron/pool-refill status=504
```

The system pool-owner account (`6d3c8553-…`) owns **0** generated questions as a result — the shared bank never deepens, so per-user builds keep falling through to fresh Sonnet generation (the very cost the feature exists to avoid).

## Root cause

One `pool-refill-generate` call asks Sonnet to run `maxSearchesPerQuestion × questionsPerDomain` web searches (**3 × 3 = 9** by default) *and* generate 3 corroborated questions in a single request. That agentic web-search loop routinely exceeds the **hardcoded 60s** timeout (`RETRIEVAL_CALL_TIMEOUT_MS = 60_000`), so the call aborts before returning → `questions.length === 0` → nothing persisted → the function 504s after ~5 domains.

## The fix

- **Make the per-call timeout env-configurable** — `RETRIEVAL_CALL_TIMEOUT_MS`, default **120s** (was a hardcoded 60s), floored at 10s and capped at 290s to stay under the route's 300s `maxDuration`.
- **Lower the default `RETRIEVAL_QUESTIONS_PER_DOMAIN` 3 → 1** so each call issues far fewer searches and finishes comfortably within the timeout. One corroborated question per domain per run is the reliable unit; the existing backlog mechanism spreads domains across runs and depth accrues over runs.
- Document both knobs + the per-call latency trap in `docs/retrieval-flip-checklist.md`.

## Scope / follow-up

Throughput is still bounded by the 300s `maxDuration` (domains run sequentially), so a large backlog drains over several daily runs **by design** — matching the original "one-time drain over 2–4 weeks" expectation. Faster draining (intra-run concurrency or higher cron frequency) is a deliberate follow-up, not in this PR.

## Verification

- [x] Typecheck clean (`tsconfig.typecheck.json`)
- [ ] After deploy: 09:00 UTC pool-refill run completes without 504; `[cron/pool-refill] run complete` shows `questionsPersisted > 0`; rows accrue under `6d3c8553-…` and `depthByDomain` rises on thin domains
- [ ] Bank hit-rate dashboard fall-through rate trends down over subsequent daily cycles

🤖 Generated with [Claude Code](https://claude.com/claude-code)