### PR TITLE
feat(ceremony): bold full-bleed weekly reflection redesign

### DIFF
--- a/src/app/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/ceremony/[ceremonyId]/page.tsx
@@ -1,36 +1,48 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type CSSProperties, type ReactNode } from 'react';
 import { useParams, useRouter } from 'next/navigation';
-import { Check, Share2, X } from 'lucide-react';
+import { Share2, X } from 'lucide-react';
 
 import { ShareCard } from '@/components/ShareCard';
-import { getPortraitDomainColor } from '@/components/knowledge/PortraitCircles';
+import { usePrefersReducedMotion } from '@/components/feed/usePrefersReducedMotion';
 import { KNOWLEDGE_TIER_LABEL } from '@/server/profile/knowledge-tier-copy';
 import type { MasteryTier } from '@/types/db';
 
+// ─────────────────────────────────────────────────────────────────────────────
+// JOSHING — Weekly Ceremony (solo reflection), bold full-bleed redesign.
+// Each beat is its own saturated, full-bleed "room"; type reverses to light on
+// color. Ink-on-cream is broken on purpose. One staggered reveal per room, tap
+// to advance (tap the left third to step back). Colors come from the
+// --ceremony-* token ramp in globals.css — no inline hex. Cadence is WEEKLY.
+//
+// Rooms (silently omitted when their beat is empty; opener + closer always
+// present so the story never collapses to one screen):
+//   opener · mastered (or friend-fallback) · discovered · learned (beat6) ·
+//   shaped · alignment · gave (or friend-fallback) · closer
+// ─────────────────────────────────────────────────────────────────────────────
+
+type CeremonyMode = 'solo' | 'duo' | 'group';
+
+type Opener = { weekIndex: number; questionsRight: number; sessionsPlayed: number };
 type Beat1 = { domain: string; fromTier: MasteryTier; toTier: MasteryTier }[];
-type Beat2FriendItem = { domain: string; questionCount: number; correctCount: number };
-type Beat2 = {
-  friendMediated: Beat2FriendItem[];
-  authored: { domain: string }[];
-  promoted: { domain: string }[];
-};
+type Beat2Item = { domain: string; questionCount: number; correctCount: number; via?: string | null };
+type Beat2 = { friendMediated: Beat2Item[]; authored: { domain: string }[]; promoted: { domain: string }[] };
 type Beat3 = { userId: string; displayName: string; contributionCount: number }[];
 type Beat4 = { userId: string; displayName: string; sharedDomains: string[] };
 type Beat5 = {
   totalCreatorPoints: number;
+  totalAnswered?: number;
   topQuestion: { text: string; answeredCount: number } | null;
 };
 type Beat6 = { domain: string; questionText: string; correctAnswer: string }[];
 type Beat1FriendFallback = { friendName: string; count: number; domains: string[] };
 type Beat5FriendFallback = { friendName: string; totalCreatorPoints: number };
 
-type CeremonyMode = 'solo' | 'duo' | 'group';
-
 type BeatsPayload = {
   cycleStart: string;
   cycleEnd: string;
+  opener?: Opener | null;
   mode?: CeremonyMode;
   beat1: Beat1 | null;
   beat1FriendFallback?: Beat1FriendFallback | null;
@@ -42,383 +54,553 @@ type BeatsPayload = {
   beat6?: Beat6 | null;
 };
 
-type CeremonyRow = {
-  id: string;
-  beatsPayload: BeatsPayload;
+type CeremonyRow = { id: string; beatsPayload: BeatsPayload };
+
+// ── Fonts (loaded app-wide via next/font; reference the tokens) ──────────────
+const SERIF = 'var(--font-serif)';
+const SANS = 'var(--font-sans)';
+const MONO = 'var(--font-mono)';
+
+// ── Per-room theme (token-backed) ───────────────────────────────────────────
+type RoomTheme = { bg: string; fg: string; accent: string; sub: string };
+function roomTheme(name: string): RoomTheme {
+  return {
+    bg: `var(--ceremony-${name}-bg)`,
+    fg: `var(--ceremony-${name}-fg)`,
+    accent: `var(--ceremony-${name}-accent)`,
+    sub: `var(--ceremony-${name}-sub)`,
+  };
+}
+const TH = {
+  open: roomTheme('open'),
+  mastered: roomTheme('mastered'),
+  discovered: roomTheme('discovered'),
+  learned: roomTheme('learned'),
+  shaped: roomTheme('shaped'),
+  alignment: roomTheme('alignment'),
+  gave: roomTheme('gave'),
+  close: roomTheme('close'),
 };
 
-type BeatView =
-  | { id: 1; content: Beat1 }
-  | { id: '1-friend'; content: Beat1FriendFallback }
-  | { id: 2; content: Beat2 }
-  | { id: 3; content: Beat3 }
-  | { id: 4; content: Beat4 }
-  | { id: 5; content: Beat5 }
-  | { id: '5-friend'; content: Beat5FriendFallback }
-  | { id: 6; content: Beat6 };
+// ── Motion helpers (reduced-motion aware) ────────────────────────────────────
+// Both hooks only ever call setState inside an async callback (rAF / interval),
+// never synchronously in the effect body — the reduced-motion and inactive
+// cases are derived at return time instead (react-hooks/set-state-in-effect).
 
-function joinList(values: string[]) {
+// Eased count-up. Returns the target immediately under reduced motion.
+function useCountUp(target: number, run: boolean, reduced: boolean, ms = 1000): number {
+  const [n, setN] = useState(0);
+  useEffect(() => {
+    if (!run || reduced) return;
+    let raf = 0;
+    let start = 0;
+    const tick = (t: number) => {
+      if (!start) start = t;
+      const p = Math.min((t - start) / ms, 1);
+      setN(Math.round(target * (1 - Math.pow(1 - p, 3))));
+      if (p < 1) raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(raf);
+  }, [run, target, ms, reduced]);
+  if (!run) return 0;
+  if (reduced) return target;
+  return n;
+}
+
+// Incrementing step while a room is active; gates the staggered reveal. Each
+// room mounts fresh (only the current room renders), so the ticker starts at 0
+// on mount. Under reduced motion every step is revealed at once.
+function useTicker(active: boolean, reduced: boolean, ms = 950): number {
+  const [t, setT] = useState(0);
+  useEffect(() => {
+    if (!active || reduced) return;
+    const id = window.setInterval(() => setT((x) => x + 1), ms);
+    return () => window.clearInterval(id);
+  }, [active, ms, reduced]);
+  if (!active) return 0;
+  if (reduced) return 99;
+  return t;
+}
+
+function Reveal({
+  show,
+  delay = 0,
+  reduced,
+  children,
+  style,
+}: {
+  show: boolean;
+  delay?: number;
+  reduced: boolean;
+  children: ReactNode;
+  style?: CSSProperties;
+}) {
+  return (
+    <div
+      style={{
+        opacity: show ? 1 : 0,
+        transform: show ? 'translateY(0)' : 'translateY(16px)',
+        transition: reduced
+          ? 'none'
+          : `opacity .65s ease ${delay}s, transform .65s cubic-bezier(.2,.7,.2,1) ${delay}s`,
+        ...style,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Eyebrow({ children, color }: { children: ReactNode; color: string }) {
+  return (
+    <div
+      style={{
+        fontFamily: MONO,
+        fontSize: 11,
+        letterSpacing: 4,
+        textTransform: 'uppercase',
+        color,
+        marginBottom: 20,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Shell({ th, children }: { th: RoomTheme; children: ReactNode }) {
+  return (
+    <div
+      className="ceremony-room-in"
+      style={{
+        position: 'absolute',
+        inset: 0,
+        background: th.bg,
+        display: 'flex',
+        flexDirection: 'column',
+        justifyContent: 'center',
+        padding: '36px 30px',
+      }}
+    >
+      <div className="mx-auto w-full max-w-md">{children}</div>
+    </div>
+  );
+}
+
+function joinList(values: string[]): string {
   if (values.length <= 2) return values.join(' and ');
   return `${values.slice(0, -1).join(', ')}, and ${values[values.length - 1]}`;
 }
 
-// Beat D (Demonstrated): name up to two domains, then tuck the rest behind
-// "and {n} more" per D-REFLECTION-COPY-01 Beat D.
-function provedList(values: string[]) {
-  if (values.length <= 2) return joinList(values);
-  return `${values[0]}, ${values[1]}, and ${values.length - 2} more`;
-}
-
-function questionLabel(count: number) {
-  return count === 1 ? 'question' : 'questions';
-}
-
-// Beat B quiet hierarchy: question count rendered as dots (•, ••), capped so a
-// busy domain doesn't run off the line.
-function dots(count: number) {
-  return '•'.repeat(Math.min(Math.max(count, 1), 5));
-}
-
-// "+{n} more" disclosure (Phase 2 hierarchy): show the first `initial` items,
-// tuck the rest behind a tappable reveal. stopPropagation keeps the tap from
-// advancing the story.
-function MoreReveal<T>({
-  items,
-  initial,
-  className,
-  renderItem,
-}: {
-  items: T[];
-  initial: number;
-  className?: string;
-  renderItem: (item: T, index: number) => React.ReactNode;
-}) {
-  const [expanded, setExpanded] = useState(false);
-  const visible = expanded ? items : items.slice(0, initial);
-  const remainder = items.length - visible.length;
+// ── Rooms ────────────────────────────────────────────────────────────────────
+function OpenRoom({ active, reduced, opener, weekLabel }: { active: boolean; reduced: boolean; opener: Opener; weekLabel: string }) {
+  const th = TH.open;
+  const t = useTicker(active, reduced, 700);
+  const n = useCountUp(opener.questionsRight, active && t >= 2, reduced);
   return (
-    <>
-      {visible.length > 0 ? <div className={className}>{visible.map(renderItem)}</div> : null}
-      {remainder > 0 ? (
-        <button
-          type="button"
-          className="mt-3 text-sm text-stone-400 underline underline-offset-4 transition hover:text-stone-200"
-          onClick={(event) => {
-            event.stopPropagation();
-            setExpanded(true);
-          }}
-        >
-          +{remainder} more
-        </button>
-      ) : null}
-    </>
-  );
-}
-
-// Beat C inline list: middle-dot-separated domain names, overflow tucked.
-function InlineDomains({ domains, initial }: { domains: string[]; initial: number }) {
-  const [expanded, setExpanded] = useState(false);
-  const visible = expanded ? domains : domains.slice(0, initial);
-  const remainder = domains.length - visible.length;
-  return (
-    <p className="font-serif text-xl text-stone-100 sm:text-2xl">
-      {visible.join('  ·  ')}
-      {remainder > 0 ? (
-        <button
-          type="button"
-          className="ml-3 align-middle text-sm text-stone-400 underline underline-offset-4 transition hover:text-stone-200"
-          onClick={(event) => {
-            event.stopPropagation();
-            setExpanded(true);
-          }}
-        >
-          +{remainder} more
-        </button>
-      ) : null}
-    </p>
-  );
-}
-
-type CeremonyCircleColor = {
-  core: string;
-  mid: string;
-  rim: string;
-  glow: string;
-};
-
-const CEREMONY_CIRCLE_COLORS: CeremonyCircleColor[] = [
-  { core: '#ffe6a3', mid: '#f6b94a', rim: '#c96f1e', glow: '#f6b94a' },
-  { core: '#c6f4ff', mid: '#56c7e8', rim: '#137ca7', glow: '#56c7e8' },
-  { core: '#f0d0ff', mid: '#b675f0', rim: '#7143bc', glow: '#b675f0' },
-  { core: '#c8ffd8', mid: '#5fd38a', rim: '#23865a', glow: '#5fd38a' },
-  { core: '#ffd2df', mid: '#f06d94', rim: '#b72f62', glow: '#f06d94' },
-  { core: '#d9e5ff', mid: '#779df2', rim: '#355cb8', glow: '#779df2' },
-  { core: '#ffe2c3', mid: '#f29a4b', rim: '#b95b21', glow: '#f29a4b' },
-  { core: '#d8fff8', mid: '#5bd4c5', rim: '#208a80', glow: '#5bd4c5' },
-];
-
-function ceremonyCircleColor(domain: string): CeremonyCircleColor {
-  let hash = 0;
-  for (let i = 0; i < domain.length; i += 1) {
-    hash = ((hash << 5) - hash + domain.charCodeAt(i)) | 0;
-  }
-  return CEREMONY_CIRCLE_COLORS[Math.abs(hash) % CEREMONY_CIRCLE_COLORS.length]!;
-}
-
-function CeremonyCircle({
-  domain,
-  size = 72,
-  scale = 1,
-}: {
-  domain: string;
-  size?: number;
-  scale?: number;
-}) {
-  const color = ceremonyCircleColor(domain);
-  const fallbackColor = getPortraitDomainColor(domain);
-  const circleSize = Math.round(size * scale);
-  return (
-    <span
-      aria-hidden
-      className="inline-grid shrink-0 place-items-center"
-      style={{ width: size, height: size }}
-    >
-      <span
-        className="block rounded-full"
-        style={{
-          width: circleSize,
-          height: circleSize,
-          background: color.mid,
-          border: `1px solid color-mix(in srgb, ${color.mid} 62%, ${fallbackColor.primary} 38%)`,
-        }}
-      />
-    </span>
-  );
-}
-
-function beatViews(payload: BeatsPayload): BeatView[] {
-  const views: BeatView[] = [];
-  if (payload.beat1) views.push({ id: 1, content: payload.beat1 });
-  else if (payload.beat1FriendFallback)
-    views.push({ id: '1-friend', content: payload.beat1FriendFallback });
-  if (payload.beat2) views.push({ id: 2, content: payload.beat2 });
-  if (payload.beat6) views.push({ id: 6, content: payload.beat6 });
-  if (payload.beat3) views.push({ id: 3, content: payload.beat3 });
-  if (payload.beat4) views.push({ id: 4, content: payload.beat4 });
-  if (payload.beat5) views.push({ id: 5, content: payload.beat5 });
-  else if (payload.beat5FriendFallback)
-    views.push({ id: '5-friend', content: payload.beat5FriendFallback });
-  return views;
-}
-
-function Beat({ beat, mode }: { beat: BeatView; mode?: CeremonyMode }) {
-  if (beat.id === '1-friend') {
-    const { friendName, count, domains } = beat.content;
-    return (
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-          {friendName} leveled up this week.
-        </h1>
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          You didn&rsquo;t cross a tier this week. {friendName} crossed {count} in{' '}
-          {joinList(domains)}.
-        </p>
-      </div>
-    );
-  }
-
-  if (beat.id === '5-friend') {
-    return (
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-          {beat.content.friendName} taught the room.
-        </h1>
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          You didn&rsquo;t earn author credit this week. {beat.content.friendName}&rsquo;s questions
-          earned {beat.content.totalCreatorPoints} points for others.
-        </p>
-      </div>
-    );
-  }
-
-  if (beat.id === 1) {
-    const grewCount = beat.content.length;
-    const [lead, ...rest] = beat.content;
-    return (
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-          You leveled up.
-        </h1>
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          {grewCount} {grewCount === 1 ? 'territory' : 'territories'} grew this week.
-        </p>
-        <div className="mx-auto mt-10 max-w-md text-left">
-          {lead ? (
-            <p className="font-serif text-2xl font-semibold text-stone-50 sm:text-3xl">
-              {lead.domain}{' '}
-              <span className="text-stone-400">
-                — now {KNOWLEDGE_TIER_LABEL[lead.toTier].toLowerCase()}
-              </span>
-            </p>
-          ) : null}
-          <MoreReveal
-            items={rest}
-            initial={2}
-            className="mt-3 space-y-1.5"
-            renderItem={(crossing) => (
-              <p key={`${crossing.domain}-${crossing.toTier}`} className="text-base text-stone-300">
-                {crossing.domain}{' '}
-                <span className="text-stone-500">
-                  — now {KNOWLEDGE_TIER_LABEL[crossing.toTier].toLowerCase()}
-                </span>
-              </p>
-            )}
-          />
+    <Shell th={th}>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <Eyebrow color={th.accent}>
+          Week {opener.weekIndex} · {weekLabel}
+        </Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 54, lineHeight: 1.04, fontWeight: 500, color: th.fg, marginBottom: 30 }}>
+          Seven days of
+          <br />
+          knowing things.
         </div>
-      </div>
-    );
-  }
+      </Reveal>
+      <Reveal show={active && t >= 2} reduced={reduced}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 14 }}>
+          <span style={{ fontFamily: SERIF, fontSize: 96, fontWeight: 600, color: th.accent, lineHeight: 1 }}>{n}</span>
+          <span style={{ fontFamily: SANS, fontSize: 15, color: th.sub, maxWidth: 120 }}>questions you got right</span>
+        </div>
+      </Reveal>
+    </Shell>
+  );
+}
 
-  if (beat.id === 2) {
-    const { friendMediated, authored, promoted } = beat.content;
-    return (
-      <div className="mx-auto max-w-3xl space-y-16 text-center">
-        {friendMediated.length > 0 && (
-          <div>
-            <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-              Your friends took you somewhere new.
-            </h1>
-            <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-              {friendMediated.length} {friendMediated.length === 1 ? 'place' : 'places'} this week —
-              starting with {friendMediated[0]!.domain}.
-            </p>
-            <div className="mx-auto mt-10 max-w-md text-left">
-              <p className="font-serif text-2xl font-semibold text-stone-50 sm:text-3xl">
-                {friendMediated[0]!.domain}{' '}
-                <span className="ml-1 align-middle text-base text-stone-400">
-                  {dots(friendMediated[0]!.questionCount)}
-                </span>
-              </p>
-              <MoreReveal
-                items={friendMediated.slice(1)}
-                initial={2}
-                className="mt-3 space-y-1.5"
-                renderItem={(item) => (
-                  <p key={item.domain} className="text-base text-stone-300">
-                    {item.domain}{' '}
-                    <span className="ml-1 text-sm text-stone-500">{dots(item.questionCount)}</span>
-                  </p>
-                )}
-              />
-            </div>
+function MasteredRoom({ active, reduced, list }: { active: boolean; reduced: boolean; list: Beat1 }) {
+  const th = TH.mastered;
+  const t = useTicker(active, reduced, 1100);
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>What you mastered</Eyebrow>
+      </Reveal>
+      {list.map((m, i) => (
+        <Reveal key={`${m.domain}-${m.toTier}`} show={active && t >= i} reduced={reduced} style={{ marginBottom: 28 }}>
+          <div style={{ fontFamily: SANS, fontSize: 13, letterSpacing: 1, color: th.sub, marginBottom: 6 }}>
+            {KNOWLEDGE_TIER_LABEL[m.fromTier]} <span style={{ color: th.accent }}>→</span> {KNOWLEDGE_TIER_LABEL[m.toTier]}
           </div>
-        )}
-        {authored.length > 0 && (
-          <div>
-            <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-              You declared new territory.
-            </h1>
-            <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-              {authored.length} {authored.length === 1 ? 'place' : 'places'} opened from questions you
-              wrote.
-            </p>
-            <div className="mx-auto mt-8 max-w-xl">
-              <InlineDomains domains={authored.map((item) => item.domain)} initial={4} />
-            </div>
+          <div style={{ fontFamily: SERIF, fontSize: i === 0 ? 52 : 38, fontWeight: 600, lineHeight: 1, color: th.fg }}>
+            {m.domain}
           </div>
-        )}
-        {promoted.length > 0 && (
-          <div>
-            <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-              Your territory came to life.
-            </h1>
-            <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-              A friend answered questions you wrote and proved you knew{' '}
-              {provedList(promoted.map((item) => item.domain))}.
-            </p>
-          </div>
-        )}
-      </div>
-    );
-  }
+        </Reveal>
+      ))}
+    </Shell>
+  );
+}
 
-  if (beat.id === 6) {
-    return (
-      <div className="mx-auto max-w-3xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-          What you discovered this week.
-        </h1>
-        <div className="mx-auto mt-12 grid max-w-2xl gap-8 text-left">
-          {beat.content.map((item, index) => (
-            <div key={`${item.domain}-${index}`} className="flex items-start gap-5">
-              <CeremonyCircle domain={item.domain} size={64} scale={0.85} />
-              <div className="min-w-0">
-                <p className="font-serif text-xl leading-8 font-semibold text-stone-50">
-                  {item.questionText}
-                </p>
-                <p className="mt-2 text-base text-stone-300">{item.correctAnswer}</p>
+function MasteredFallbackRoom({ active, reduced, fallback }: { active: boolean; reduced: boolean; fallback: Beat1FriendFallback }) {
+  const th = TH.mastered;
+  const t = useTicker(active, reduced, 900);
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>This week</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 48, fontWeight: 600, lineHeight: 1.02, color: th.fg, marginBottom: 18 }}>
+          {fallback.friendName} leveled up.
+        </div>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ fontFamily: SANS, fontSize: 16, lineHeight: 1.5, color: th.sub }}>
+          You didn&rsquo;t cross a tier this week. {fallback.friendName} crossed {fallback.count} in {joinList(fallback.domains)}.
+        </div>
+      </Reveal>
+    </Shell>
+  );
+}
+
+function DiscoveredRoom({ active, reduced, beat2 }: { active: boolean; reduced: boolean; beat2: Beat2 }) {
+  const th = TH.discovered;
+  const t = useTicker(active, reduced, 950);
+  const items = beat2.friendMediated.length
+    ? beat2.friendMediated
+    : [...beat2.authored, ...beat2.promoted].map((d) => ({ domain: d.domain, via: null as string | null }));
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>What you discovered</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 30, fontWeight: 500, color: th.fg, marginBottom: 26, lineHeight: 1.1 }}>
+          New ground entered your map.
+        </div>
+      </Reveal>
+      {items.slice(0, 4).map((d, i) => (
+        <Reveal key={d.domain} show={active && t >= i + 1} reduced={reduced} style={{ marginBottom: 16 }}>
+          <div style={{ fontFamily: SERIF, fontSize: 26, color: th.accent, fontWeight: 600, lineHeight: 1.05 }}>{d.domain}</div>
+          {d.via ? (
+            <div style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 15, color: th.sub }}>
+              from a question {d.via} sent you
+            </div>
+          ) : null}
+        </Reveal>
+      ))}
+    </Shell>
+  );
+}
+
+function LearnedRoom({ active, reduced, beat6 }: { active: boolean; reduced: boolean; beat6: Beat6 }) {
+  const th = TH.learned;
+  const t = useTicker(active, reduced, 1000);
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>What you worked through</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 28, fontWeight: 500, color: th.fg, marginBottom: 26, lineHeight: 1.12 }}>
+          Things you didn&rsquo;t have
+          <br />
+          a week ago.
+        </div>
+      </Reveal>
+      {beat6.map((item, i) => (
+        <Reveal key={`${item.domain}-${i}`} show={active && t >= i + 1} reduced={reduced} style={{ marginBottom: 18 }}>
+          <div style={{ fontFamily: SERIF, fontSize: 20, fontWeight: 600, color: th.fg, lineHeight: 1.25 }}>{item.questionText}</div>
+          <div style={{ fontFamily: SANS, fontSize: 14, color: th.accent, marginTop: 4 }}>{item.correctAnswer}</div>
+        </Reveal>
+      ))}
+    </Shell>
+  );
+}
+
+function ShapedRoom({ active, reduced, list }: { active: boolean; reduced: boolean; list: Beat3 }) {
+  const th = TH.shaped;
+  const t = useTicker(active, reduced, 1000);
+  const label = (count: number) => (count === 1 ? 'question' : 'questions');
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>Who shaped your map</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 28, fontWeight: 500, color: th.fg, marginBottom: 26, lineHeight: 1.15 }}>
+          Your week was built
+          <br />
+          by other people.
+        </div>
+      </Reveal>
+      {list.map((s, i) => (
+        <Reveal key={s.userId} show={active && t >= i + 1} reduced={reduced} style={{ marginBottom: 18 }}>
+          <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+            <span style={{ fontFamily: SERIF, fontSize: 34, fontWeight: 600, color: th.accent, lineHeight: 1, minWidth: 18 }}>{i + 1}</span>
+            <div>
+              <div style={{ fontFamily: SERIF, fontSize: 28, fontWeight: 600, color: th.fg, lineHeight: 1 }}>{s.displayName}</div>
+              <div style={{ fontFamily: SANS, fontSize: 13.5, color: th.sub, marginTop: 3 }}>
+                contributed {s.contributionCount} {label(s.contributionCount)} you got right
               </div>
             </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
+          </div>
+        </Reveal>
+      ))}
+    </Shell>
+  );
+}
 
-  if (beat.id === 3) {
-    const heading =
-      mode === 'solo'
-        ? 'Questions that shaped your cycle.'
-        : 'These people gave you a chance to learn more.';
-    return (
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">{heading}</h1>
-        <div className="mt-10 space-y-4 text-lg text-stone-200 sm:text-xl">
-          {beat.content.map((contributor) => (
-            <p key={contributor.userId}>
-              {contributor.displayName} contributed {contributor.contributionCount}{' '}
-              {questionLabel(contributor.contributionCount)}.
-            </p>
-          ))}
-        </div>
-      </div>
-    );
-  }
-
-  if (beat.id === 4) {
-    return (
-      <div className="mx-auto max-w-2xl text-center">
-        <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-          You and {beat.content.displayName} see the world similarly.
-        </h1>
-        <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-          You both know {joinList(beat.content.sharedDomains)}.
-        </p>
-      </div>
-    );
-  }
-
+function AlignmentRoom({ active, reduced, a }: { active: boolean; reduced: boolean; a: Beat4 }) {
+  const th = TH.alignment;
+  const t = useTicker(active, reduced, 900);
   return (
-    <div className="mx-auto max-w-2xl text-center">
-      <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-        You taught people things.
-      </h1>
-      <p className="mx-auto mt-8 max-w-2xl text-lg leading-8 text-stone-200 sm:text-xl">
-        Your questions earned {beat.content.totalCreatorPoints} points for others this week.
-      </p>
-      {beat.content.topQuestion ? (
-        <p className="mx-auto mt-6 max-w-xl text-base leading-7 text-stone-300">
-          Your most-played: &ldquo;{beat.content.topQuestion.text}&rdquo;
-        </p>
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>Your closest alignment</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SANS, fontSize: 14, letterSpacing: 1, color: th.sub, marginBottom: 8 }}>You and</div>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 80, fontWeight: 600, color: th.accent, lineHeight: 0.95, marginBottom: 24 }}>{a.displayName}</div>
+      </Reveal>
+      <Reveal show={active && t >= 2} reduced={reduced}>
+        <div style={{ fontFamily: SANS, fontSize: 14, letterSpacing: 1, color: th.sub, marginBottom: 10 }}>most aligned in</div>
+        {a.sharedDomains.map((d) => (
+          <div key={d} style={{ fontFamily: SERIF, fontSize: 28, fontWeight: 500, color: th.fg, lineHeight: 1.2 }}>{d}</div>
+        ))}
+      </Reveal>
+    </Shell>
+  );
+}
+
+function GaveRoom({ active, reduced, g }: { active: boolean; reduced: boolean; g: Beat5 }) {
+  const th = TH.gave;
+  const t = useTicker(active, reduced, 1000);
+  const pts = useCountUp(Math.round(g.totalCreatorPoints), active && t >= 1, reduced);
+  const answered = g.totalAnswered ?? g.topQuestion?.answeredCount ?? 0;
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>What you gave</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 30, fontWeight: 500, color: th.fg, marginBottom: 24, lineHeight: 1.15 }}>
+          {answered} of your questions
+          <br />
+          were answered by friends.
+        </div>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, marginBottom: 26 }}>
+          <span style={{ fontFamily: SERIF, fontSize: 88, fontWeight: 600, color: th.accent, lineHeight: 1 }}>{pts}</span>
+          <span style={{ fontFamily: SANS, fontSize: 14, color: th.sub }}>
+            points you gave the
+            <br />
+            people around you
+          </span>
+        </div>
+      </Reveal>
+      {g.topQuestion ? (
+        <Reveal show={active && t >= 2} reduced={reduced}>
+          <div style={{ fontFamily: SANS, fontSize: 12, letterSpacing: 1, color: th.sub, marginBottom: 4 }}>YOUR MOST-PLAYED</div>
+          <div style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 18, color: th.fg, lineHeight: 1.25 }}>
+            &ldquo;{g.topQuestion.text}&rdquo;
+          </div>
+        </Reveal>
       ) : null}
+    </Shell>
+  );
+}
+
+function GaveFallbackRoom({ active, reduced, fallback }: { active: boolean; reduced: boolean; fallback: Beat5FriendFallback }) {
+  const th = TH.gave;
+  const t = useTicker(active, reduced, 900);
+  return (
+    <Shell th={th}>
+      <Reveal show={active} reduced={reduced}>
+        <Eyebrow color={th.accent}>What you gave</Eyebrow>
+      </Reveal>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 44, fontWeight: 600, lineHeight: 1.04, color: th.fg, marginBottom: 18 }}>
+          {fallback.friendName} taught the room.
+        </div>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ fontFamily: SANS, fontSize: 16, lineHeight: 1.5, color: th.sub }}>
+          You didn&rsquo;t earn author credit this week. {fallback.friendName}&rsquo;s questions earned{' '}
+          {fallback.totalCreatorPoints} points for others.
+        </div>
+      </Reveal>
+    </Shell>
+  );
+}
+
+function CloseRoom({
+  active,
+  reduced,
+  weekIndex,
+  shareLoading,
+  onShare,
+  onDone,
+  onReplay,
+}: {
+  active: boolean;
+  reduced: boolean;
+  weekIndex: number | null;
+  shareLoading: boolean;
+  onShare: (e: React.MouseEvent) => void;
+  onDone: (e: React.MouseEvent) => void;
+  onReplay: (e: React.MouseEvent) => void;
+}) {
+  const th = TH.close;
+  const t = useTicker(active, reduced, 700);
+  return (
+    <Shell th={th}>
+      <Reveal show={active && t >= 0} reduced={reduced}>
+        <div style={{ fontFamily: MONO, fontSize: 11, letterSpacing: 4, color: th.accent, marginBottom: 18 }}>
+          {weekIndex ? `WEEK ${weekIndex}` : 'THIS WEEK'}
+        </div>
+      </Reveal>
+      <Reveal show={active && t >= 1} reduced={reduced}>
+        <div style={{ fontFamily: SERIF, fontSize: 46, fontWeight: 500, color: th.fg, lineHeight: 1.05, marginBottom: 14 }}>
+          This is who you
+          <br />
+          were this week.
+        </div>
+        <div style={{ fontFamily: SERIF, fontStyle: 'italic', fontSize: 18, color: th.sub, marginBottom: 34 }}>
+          See you next Sunday.
+        </div>
+      </Reveal>
+      <Reveal show={active && t >= 2} reduced={reduced} style={{ width: '100%' }}>
+        <button
+          type="button"
+          onClick={onShare}
+          disabled={shareLoading}
+          style={{
+            display: 'flex',
+            width: '100%',
+            alignItems: 'center',
+            justifyContent: 'center',
+            gap: 8,
+            background: 'var(--ceremony-open-bg)',
+            color: 'var(--ceremony-paper)',
+            fontFamily: SANS,
+            fontSize: 13,
+            letterSpacing: 3,
+            padding: '15px 0',
+            cursor: 'pointer',
+            marginBottom: 12,
+            boxShadow: `3px 3px 0 ${th.accent}`,
+            border: 'none',
+          }}
+        >
+          <Share2 className="size-4" />
+          {shareLoading ? 'OPENING…' : 'SHARE THIS WEEK'}
+        </button>
+        <button
+          type="button"
+          onClick={onDone}
+          style={{
+            width: '100%',
+            border: `1.5px solid ${th.fg}`,
+            background: 'transparent',
+            color: th.fg,
+            fontFamily: SANS,
+            fontSize: 13,
+            letterSpacing: 3,
+            padding: '15px 0',
+            cursor: 'pointer',
+            marginBottom: 12,
+          }}
+        >
+          DONE
+        </button>
+        <button
+          type="button"
+          onClick={onReplay}
+          style={{
+            width: '100%',
+            background: 'transparent',
+            border: 'none',
+            color: th.sub,
+            fontFamily: MONO,
+            fontSize: 11,
+            letterSpacing: 3,
+            cursor: 'pointer',
+          }}
+        >
+          REPLAY
+        </button>
+      </Reveal>
+    </Shell>
+  );
+}
+
+// ── Chrome ───────────────────────────────────────────────────────────────────
+function Pips({ n, total, fg }: { n: number; total: number; fg: string }) {
+  return (
+    <div
+      className="absolute right-0 left-0 z-10 flex justify-center gap-1.5"
+      style={{ top: 'max(1.25rem, env(safe-area-inset-top))' }}
+    >
+      {Array.from({ length: total }).map((_, i) => (
+        <span
+          key={i}
+          style={{
+            width: i === n ? 16 : 5,
+            height: 4,
+            borderRadius: 4,
+            background: fg,
+            opacity: i === n ? 0.95 : 0.32,
+            transition: 'all .3s',
+          }}
+        />
+      ))}
     </div>
   );
 }
+
+function Hint({ fg, show }: { fg: string; show: boolean }) {
+  if (!show) return null;
+  return (
+    <div
+      className="ceremony-hint-pulse absolute right-0 left-0 z-10 text-center"
+      style={{
+        bottom: 'max(1.5rem, env(safe-area-inset-bottom))',
+        fontFamily: MONO,
+        fontSize: 10,
+        letterSpacing: 3,
+        color: fg,
+        opacity: 0.5,
+      }}
+    >
+      TAP TO CONTINUE →
+    </div>
+  );
+}
+
+function formatRange(start: string, end: string): string {
+  try {
+    const fmt = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+    return `${fmt.format(new Date(`${start}T00:00:00`))} – ${fmt.format(new Date(`${end}T00:00:00`))}`;
+  } catch {
+    return `${start} – ${end}`;
+  }
+}
+
+type Room = { key: string; theme: RoomTheme; render: (active: boolean) => ReactNode };
 
 export default function CeremonyPage() {
   const router = useRouter();
   const params = useParams<{ ceremonyId: string }>();
   const ceremonyId = params.ceremonyId;
+  const reduced = usePrefersReducedMotion();
+
   const [ceremony, setCeremony] = useState<CeremonyRow | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
@@ -441,47 +623,97 @@ export default function CeremonyPage() {
         if (!cancelled) setCeremony(body.ceremony);
       })
       .catch((caught) => {
-        if (!cancelled)
-          setError(caught instanceof Error ? caught.message : 'Could not load this ceremony.');
+        if (!cancelled) setError(caught instanceof Error ? caught.message : 'Could not load this ceremony.');
       });
 
-    fetch(`/api/ceremony/${ceremonyId}/viewed`, { method: 'POST', credentials: 'include' }).catch(
-      () => undefined,
-    );
+    fetch(`/api/ceremony/${ceremonyId}/viewed`, { method: 'POST', credentials: 'include' }).catch(() => undefined);
     return () => {
       cancelled = true;
     };
   }, [ceremonyId]);
 
-  const beats = useMemo(() => (ceremony ? beatViews(ceremony.beatsPayload) : []), [ceremony]);
-  const isEnd = currentIndex >= beats.length;
+  const payload = ceremony?.beatsPayload ?? null;
 
-  function advance() {
-    if (!ceremony || isEnd) return;
-    setCurrentIndex((value) => Math.min(value + 1, beats.length));
-  }
+  const rooms = useMemo<Room[]>(() => {
+    if (!payload) return [];
+    const list: Room[] = [];
+    const weekLabel = formatRange(payload.cycleStart, payload.cycleEnd);
 
-  function goBack() {
-    setCurrentIndex((value) => Math.max(value - 1, 0));
-  }
+    if (payload.opener) {
+      const opener = payload.opener;
+      list.push({ key: 'open', theme: TH.open, render: (a) => <OpenRoom active={a} reduced={reduced} opener={opener} weekLabel={weekLabel} /> });
+    }
+    if (payload.beat1 && payload.beat1.length) {
+      const b1 = payload.beat1;
+      list.push({ key: 'mastered', theme: TH.mastered, render: (a) => <MasteredRoom active={a} reduced={reduced} list={b1} /> });
+    } else if (payload.beat1FriendFallback) {
+      const fb = payload.beat1FriendFallback;
+      list.push({ key: 'mastered-fallback', theme: TH.mastered, render: (a) => <MasteredFallbackRoom active={a} reduced={reduced} fallback={fb} /> });
+    }
+    if (payload.beat2 && (payload.beat2.friendMediated.length || payload.beat2.authored.length || payload.beat2.promoted.length)) {
+      const b2 = payload.beat2;
+      list.push({ key: 'discovered', theme: TH.discovered, render: (a) => <DiscoveredRoom active={a} reduced={reduced} beat2={b2} /> });
+    }
+    if (payload.beat6 && payload.beat6.length) {
+      const b6 = payload.beat6;
+      list.push({ key: 'learned', theme: TH.learned, render: (a) => <LearnedRoom active={a} reduced={reduced} beat6={b6} /> });
+    }
+    if (payload.beat3 && payload.beat3.length) {
+      const b3 = payload.beat3;
+      list.push({ key: 'shaped', theme: TH.shaped, render: (a) => <ShapedRoom active={a} reduced={reduced} list={b3} /> });
+    }
+    if (payload.beat4 && payload.beat4.sharedDomains.length) {
+      const b4 = payload.beat4;
+      list.push({ key: 'alignment', theme: TH.alignment, render: (a) => <AlignmentRoom active={a} reduced={reduced} a={b4} /> });
+    }
+    if (payload.beat5) {
+      const b5 = payload.beat5;
+      list.push({ key: 'gave', theme: TH.gave, render: (a) => <GaveRoom active={a} reduced={reduced} g={b5} /> });
+    } else if (payload.beat5FriendFallback) {
+      const fb = payload.beat5FriendFallback;
+      list.push({ key: 'gave-fallback', theme: TH.gave, render: (a) => <GaveFallbackRoom active={a} reduced={reduced} fallback={fb} /> });
+    }
 
-  function exit() {
-    router.push('/');
-  }
+    list.push({
+      key: 'close',
+      theme: TH.close,
+      render: (a) => (
+        <CloseRoom
+          active={a}
+          reduced={reduced}
+          weekIndex={payload.opener?.weekIndex ?? null}
+          shareLoading={shareLoading}
+          onShare={share}
+          onDone={(e) => {
+            e.stopPropagation();
+            router.push('/');
+          }}
+          onReplay={(e) => {
+            e.stopPropagation();
+            setCurrentIndex(0);
+          }}
+        />
+      ),
+    });
+    return list;
+    // share/router are stable enough for this memo; shareLoading is the only
+    // value the closer reads that changes, and it's in the deps.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [payload, reduced, shareLoading]);
 
-  // Story-style tap navigation: a tap on the left third steps back a beat, a
-  // tap anywhere else advances. Buttons inside beats stopPropagation, so this
-  // only fires on the backdrop.
+  const index = Math.min(currentIndex, Math.max(rooms.length - 1, 0));
+  const isLast = index >= rooms.length - 1;
+
   function handleTap(event: React.MouseEvent<HTMLElement>) {
     const width = event.currentTarget.clientWidth;
     if (width > 0 && event.clientX < width * 0.3) {
-      goBack();
+      setCurrentIndex((value) => Math.max(value - 1, 0));
     } else {
-      advance();
+      setCurrentIndex((value) => Math.min(value + 1, rooms.length - 1));
     }
   }
 
-  async function share(event: React.MouseEvent<HTMLButtonElement>) {
+  async function share(event: React.MouseEvent) {
     event.stopPropagation();
     setShareLoading(true);
     try {
@@ -505,81 +737,53 @@ export default function CeremonyPage() {
     setToast('Link copied');
   }
 
-  function saveImageHint() {
-    setToast('Long-press the card to save it.');
-  }
-
   if (error) {
     return (
-      <main className="grid min-h-dvh place-items-center bg-stone-950 px-6 text-center text-stone-100">
-        <p className="text-sm text-stone-300">{error}</p>
+      <main className="grid min-h-dvh place-items-center px-6 text-center" style={{ background: TH.open.bg, color: TH.open.fg }}>
+        <p className="text-sm" style={{ color: TH.open.sub }}>{error}</p>
       </main>
     );
   }
 
-  if (!ceremony) {
+  if (!ceremony || rooms.length === 0) {
     return (
-      <main className="grid min-h-dvh place-items-center bg-stone-950 px-6 text-center text-stone-100">
-        <p className="text-sm text-stone-300">Loading your week...</p>
+      <main className="grid min-h-dvh place-items-center px-6 text-center" style={{ background: TH.open.bg, color: TH.open.fg }}>
+        <p className="text-sm" style={{ color: TH.open.sub }}>Loading your week…</p>
       </main>
     );
   }
+
+  const current = rooms[index]!;
 
   return (
     <main
-      className="relative grid min-h-dvh cursor-pointer place-items-center overflow-hidden bg-stone-950 px-6 py-16 text-stone-50"
+      className="relative min-h-dvh cursor-pointer overflow-hidden"
+      style={{ background: current.theme.bg }}
       onClick={handleTap}
     >
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_50%_20%,rgba(245,240,232,0.12),transparent_36%),linear-gradient(180deg,#1c1917_0%,#0c0a09_100%)]" />
+      <Pips n={index} total={rooms.length} fg={current.theme.fg} />
 
       <button
         type="button"
         aria-label="Exit"
-        className="absolute top-[max(1.25rem,env(safe-area-inset-top))] right-5 z-20 grid size-11 place-items-center rounded-full text-stone-300 transition hover:bg-white/10 hover:text-stone-50"
+        className="absolute z-20 grid size-11 place-items-center rounded-full transition hover:bg-white/10"
+        style={{ top: 'max(1.25rem, env(safe-area-inset-top))', right: '1.25rem', color: current.theme.fg }}
         onClick={(event) => {
           event.stopPropagation();
-          exit();
+          router.push('/');
         }}
       >
-        <X className="size-7" />
+        <X className="size-6" />
       </button>
-      <div className="relative z-10 w-full">
-        {isEnd ? (
-          <div className="mx-auto max-w-2xl text-center">
-            <h1 className="font-serif text-5xl font-semibold tracking-normal sm:text-7xl">
-              That&rsquo;s your week.
-            </h1>
-            <p className="mt-8 text-lg text-stone-200 sm:text-xl">See you next Sunday.</p>
-            <div className="mt-10 flex flex-col justify-center gap-3 sm:flex-row">
-              <button
-                type="button"
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-stone-500 px-5 text-sm text-stone-50"
-                onClick={share}
-                disabled={shareLoading}
-              >
-                <Share2 className="size-4" />
-                {shareLoading ? 'Opening...' : 'Share'}
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-12 items-center justify-center rounded-md bg-stone-100 px-5 text-sm font-medium text-stone-950"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  router.push('/');
-                }}
-              >
-                Done
-              </button>
-            </div>
-          </div>
-        ) : (
-          <Beat beat={beats[currentIndex]!} mode={ceremony.beatsPayload.mode} />
-        )}
-      </div>
+
+      {current.render(true)}
+
+      <Hint fg={current.theme.fg} show={!isLast} />
 
       {shareUrl ? (
         <div
-          className="fixed inset-0 z-30 flex items-center justify-center overflow-y-auto bg-stone-950/80 px-5 py-8"
+          className="fixed inset-0 z-30 flex items-center justify-center overflow-y-auto px-5 py-8"
+          style={{ background: 'rgba(10, 31, 61, 0.86)' }}
           role="dialog"
           aria-modal="true"
           aria-label="Share your week"
@@ -595,8 +799,7 @@ export default function CeremonyPage() {
               cycleStart={ceremony.beatsPayload.cycleStart}
               cycleEnd={ceremony.beatsPayload.cycleEnd}
             />
-
-            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-3">
+            <div className="grid w-full grid-cols-1 gap-3 sm:grid-cols-2">
               <button
                 type="button"
                 className="inline-flex h-12 items-center justify-center gap-2 rounded-md bg-stone-100 px-4 text-sm font-medium text-stone-950"
@@ -605,22 +808,11 @@ export default function CeremonyPage() {
                   copyShareUrl().catch(() => setToast('Could not copy link.'));
                 }}
               >
-                <Check className="size-4" />
                 Copy link
               </button>
               <button
                 type="button"
-                className="inline-flex h-12 items-center justify-center rounded-md border border-stone-500 px-4 text-sm text-stone-50"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  saveImageHint();
-                }}
-              >
-                Save image
-              </button>
-              <button
-                type="button"
-                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-stone-500 px-4 text-sm text-stone-50"
+                className="inline-flex h-12 items-center justify-center gap-2 rounded-md border border-stone-400 px-4 text-sm text-stone-50"
                 onClick={(event) => {
                   event.stopPropagation();
                   setShareUrl(null);
@@ -637,24 +829,6 @@ export default function CeremonyPage() {
       {toast ? (
         <div className="fixed bottom-6 left-1/2 z-40 -translate-x-1/2 rounded-full bg-stone-100 px-4 py-2 text-sm font-medium text-stone-950 shadow-lg">
           {toast}
-        </div>
-      ) : null}
-
-      {!isEnd && beats.length > 0 ? (
-        <div
-          className="absolute right-0 left-0 z-10 flex justify-center gap-2"
-          style={{ bottom: 'max(1.75rem, env(safe-area-inset-bottom))' }}
-        >
-          {beats.map((beat, index) => (
-            <span
-              key={beat.id}
-              className={
-                index === currentIndex
-                  ? 'h-2 w-8 rounded-full bg-stone-50'
-                  : 'h-2 w-2 rounded-full bg-stone-500'
-              }
-            />
-          ))}
         </div>
       ) : null}
     </main>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -303,6 +303,53 @@
     --exploring-accent-red:  #c9564d;
     --exploring-accent-gold: #a98a4c;
     --exploring-accent-blue: #65a8bb;
+    /* ── Weekly ceremony — full-bleed editorial "rooms" (D-CEREMONY-WEEKLY-…) ──
+       Each ceremony beat renders as its own saturated, full-bleed ground with
+       reversed (cream/light) type. Ink-on-cream is BROKEN here on purpose — that
+       single-surface rule was the source of the old presentation's anemia. These
+       are NOT category hues (--cat-*) and carry no category meaning; they are
+       per-beat presentation grounds. One token group per room:
+         -bg     full-bleed ground
+         -fg     on-color body/heading text
+         -accent highlight (numbers, arrows, lead domain)
+         -sub    muted on-color (eyebrow detail, captions)
+       The previous page hardcoded this palette inline (the CEREMONY_CIRCLE_COLORS
+       hex array + a literal gradient — the color-ratchet's named top offender);
+       tokenizing here is the single source of truth. Fallback rooms reuse the
+       mastered / gave groups. */
+    --ceremony-paper:            #f5f0e8;  /* shared light surface (closer)        */
+    --ceremony-open-bg:          var(--brand-ink);     /* navy #0a1f3d            */
+    --ceremony-open-fg:          var(--ceremony-paper);
+    --ceremony-open-accent:      #c08a2e;   /* ochre                              */
+    --ceremony-open-sub:         rgba(245, 240, 232, 0.72);
+    --ceremony-mastered-bg:      #b5432a;   /* terracotta                         */
+    --ceremony-mastered-fg:      #fff4e8;
+    --ceremony-mastered-accent:  #ffd9a0;
+    --ceremony-mastered-sub:     rgba(255, 244, 232, 0.78);
+    --ceremony-discovered-bg:     #1f4a37;  /* forest                             */
+    --ceremony-discovered-fg:     #eaf5ee;
+    --ceremony-discovered-accent: #a8e0bb;
+    --ceremony-discovered-sub:    rgba(234, 245, 238, 0.78);
+    --ceremony-learned-bg:        #5a2e2a;  /* deep umber — beat6 "worked through" */
+    --ceremony-learned-fg:        #f7ece8;
+    --ceremony-learned-accent:    #e8b59c;
+    --ceremony-learned-sub:       rgba(247, 236, 232, 0.78);
+    --ceremony-shaped-bg:         #3a1d4d;  /* plum                               */
+    --ceremony-shaped-fg:         #f3ecf7;
+    --ceremony-shaped-accent:     #e0b8f0;
+    --ceremony-shaped-sub:        rgba(243, 236, 247, 0.78);
+    --ceremony-alignment-bg:      #10324a;  /* deep teal-navy                     */
+    --ceremony-alignment-fg:      #e8f2f8;
+    --ceremony-alignment-accent:  #8fd0ec;
+    --ceremony-alignment-sub:     rgba(232, 242, 248, 0.78);
+    --ceremony-gave-bg:           #c08a2e;  /* ochre (ink-on-color)               */
+    --ceremony-gave-fg:           #1f1404;
+    --ceremony-gave-accent:       var(--brand-ink);
+    --ceremony-gave-sub:          rgba(31, 20, 4, 0.7);
+    --ceremony-close-bg:          var(--ceremony-paper);
+    --ceremony-close-fg:          var(--brand-ink);
+    --ceremony-close-accent:      #b5432a;
+    --ceremony-close-sub:         rgba(10, 31, 61, 0.62);
     --font-neutral: var(--font-sans-body, ui-sans-serif, system-ui, -apple-system, sans-serif);
     /* System voice (STYLE-GUIDE-TYPE §2). The typewriter face (Courier New) was
        retired app-wide — the System voice now shares the sans (Montserrat) and is
@@ -566,6 +613,11 @@
   .result-reveal {
     animation: none !important;
   }
+
+  .ceremony-room-in,
+  .ceremony-hint-pulse {
+    animation: none !important;
+  }
 }
 
 /* Safari/Chrome paint autofilled fields with their own UA background — a muddy
@@ -595,6 +647,26 @@ select:-webkit-autofill {
     0% { transform: translate3d(0, 8px, 0) scale(0.96); opacity: 0; }
     45% { transform: translate3d(0, -3px, 0) scale(1.02); opacity: 1; }
     100% { transform: translate3d(0, 0, 0) scale(1); opacity: 1; }
+}
+
+/* Weekly ceremony rooms (D-CEREMONY-WEEKLY-…). `ceremony-room-in` cross-fades a
+   beat's saturated ground as it mounts; `ceremony-hint-pulse` breathes the
+   "tap to continue" cue. The per-element staggered reveal is handled inline in
+   the page (opacity/transform transitions), so only these two live here. Both
+   are disabled under prefers-reduced-motion below. */
+@keyframes ceremony-room-in {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+.ceremony-room-in {
+  animation: ceremony-room-in 0.45s ease;
+}
+@keyframes ceremony-hint-pulse {
+  0%, 100% { opacity: 0.5; }
+  50%      { opacity: 0.15; }
+}
+.ceremony-hint-pulse {
+  animation: ceremony-hint-pulse 2s infinite;
 }
 
 /* TESTING ONLY — flat mode (driven by the dev design bar's "Flat" toggle; see

--- a/src/components/ShareCard.tsx
+++ b/src/components/ShareCard.tsx
@@ -85,7 +85,7 @@ export const ShareCard = forwardRef<HTMLDivElement, ShareCardProps>(
       <div ref={ref} style={{ ...cardStyle, ...dimensions }}>
         <div style={topStyle}>
           <div>
-            <p style={kickerStyle}>JOSHING · TWO WEEKS</p>
+            <p style={kickerStyle}>JOSHING · THIS WEEK</p>
             <p style={dateStyle}>{formatRange(cycleStart, cycleEnd)}</p>
           </div>
           <p style={nameStyle}>{userName}</p>

--- a/src/server/ceremony/__tests__/payload-validation.test.ts
+++ b/src/server/ceremony/__tests__/payload-validation.test.ts
@@ -129,4 +129,35 @@ describe('beatsPayloadSchema (F3.5)', () => {
     })
     expect(result.success).toBe(false)
   })
+
+  it('accepts the redesign fields: opener, friendMediated.via, beat5.totalAnswered', () => {
+    const result = beatsPayloadSchema.safeParse({
+      ...WELL_FORMED,
+      opener: { weekIndex: 14, questionsRight: 22, sessionsPlayed: 6 },
+      beat2: {
+        friendMediated: [{ domain: 'jazz', questionCount: 3, correctCount: 2, via: 'Maya' }],
+        authored: [],
+        promoted: [],
+      },
+      beat5: {
+        totalCreatorPoints: 42,
+        totalAnswered: 9,
+        topQuestion: { text: 'Q?', answeredCount: 7 },
+      },
+    })
+    expect(result.success).toBe(true)
+  })
+
+  it('still accepts payloads omitting the redesign fields (pre-redesign corpus)', () => {
+    // WELL_FORMED has no opener, no via on friendMediated, no totalAnswered.
+    expect(beatsPayloadSchema.safeParse(WELL_FORMED).success).toBe(true)
+  })
+
+  it('rejects a malformed opener (questionsRight must be a number)', () => {
+    const result = beatsPayloadSchema.safeParse({
+      ...WELL_FORMED,
+      opener: { weekIndex: 14, questionsRight: 'lots', sessionsPlayed: 6 },
+    })
+    expect(result.success).toBe(false)
+  })
 })

--- a/src/server/ceremony/compute-beats.ts
+++ b/src/server/ceremony/compute-beats.ts
@@ -37,6 +37,10 @@ const beat2Schema = z.object({
       domain: z.string(),
       questionCount: z.number(),
       correctCount: z.number(),
+      // The friend whose question(s) most opened this domain for the user.
+      // Additive (.optional()) so payloads written before the redesign — which
+      // had no friend attribution — still validate on read.
+      via: z.string().nullable().optional(),
     }),
   ),
   authored: z.array(z.object({ domain: z.string() })),
@@ -59,9 +63,21 @@ const beat4Schema = z.object({
 
 const beat5Schema = z.object({
   totalCreatorPoints: z.number(),
+  // Total times the user's questions were answered by friends this cycle (one
+  // per author-credit event). Additive (.optional()) for read-lenience on the
+  // pre-redesign corpus.
+  totalAnswered: z.number().optional(),
   topQuestion: z
     .object({ text: z.string(), answeredCount: z.number() })
     .nullable(),
+});
+
+// Opener stats for the ceremony's first room. Additive + nullable().optional()
+// so the pre-redesign corpus (no opener) still validates on read.
+const openerSchema = z.object({
+  weekIndex: z.number(),
+  questionsRight: z.number(),
+  sessionsPlayed: z.number(),
 });
 
 // Friend-fallback shapes: when a user has zero activity for Beat1/Beat5 in the
@@ -93,6 +109,7 @@ const beat6Schema = z.array(
 export const beatsPayloadSchema = z.object({
   cycleStart: z.string(),
   cycleEnd: z.string(),
+  opener: openerSchema.nullable().optional(),
   mode: z.enum(['solo', 'duo', 'group']).optional(),
   mergeNote: z
     .object({
@@ -117,7 +134,12 @@ export const beatsPayloadSchema = z.object({
 });
 
 export type Beat1Mastered = { domain: string; fromTier: MasteryTier; toTier: MasteryTier }[];
-export type Beat2DiscoveredItem = { domain: string; questionCount: number; correctCount: number };
+export type Beat2DiscoveredItem = {
+  domain: string;
+  questionCount: number;
+  correctCount: number;
+  via?: string | null;
+};
 export type Beat2Discovered = {
   friendMediated: Beat2DiscoveredItem[];
   authored: { domain: string }[];
@@ -127,7 +149,13 @@ export type Beat3Shaped = { userId: string; displayName: string; contributionCou
 export type Beat4Alignment = { userId: string; displayName: string; sharedDomains: string[] };
 export type Beat5Gave = {
   totalCreatorPoints: number;
+  totalAnswered?: number;
   topQuestion: { text: string; answeredCount: number } | null;
+};
+export type CeremonyOpener = {
+  weekIndex: number;
+  questionsRight: number;
+  sessionsPlayed: number;
 };
 
 export type Beat1FriendFallback = { friendName: string; count: number; domains: string[] };
@@ -138,6 +166,9 @@ export type Beat6Learned = Beat6LearnedItem[];
 export type BeatsPayload = {
   cycleStart: string;
   cycleEnd: string;
+  /** Stats for the ceremony opener room (week number, correct answers, days
+   * played in the cycle). Optional so the pre-redesign corpus stays valid. */
+  opener?: CeremonyOpener | null;
   /**
    * F3.2: classifies the ceremony as solo / duo / group based on the count
    * of friends who actively answered in the cycle. Drives copy variants and
@@ -239,7 +270,7 @@ async function computeBeat2(userId: string, cycleStart: Date, cycleEndExclusive:
         lt(joshingGameResponses.answeredAt, cycleEndExclusive),
       )),
     db
-      .select({ question: questions })
+      .select({ question: questions, sourceUserId: feedItems.sourceUserId })
       .from(feedItems)
       .innerJoin(questions, eq(feedItems.questionId, questions.id))
       .where(and(
@@ -270,24 +301,54 @@ async function computeBeat2(userId: string, cycleStart: Date, cycleEndExclusive:
   ]);
 
   const byDomain = new Map<string, { domain: string; questionCount: number; correctCount: number }>();
-  const add = (domain: string, correct: boolean) => {
+  // domain → (contributorId → count): the friend whose question(s) opened each
+  // domain. Self-authored questions don't count as a "via" (you didn't discover
+  // it from a friend), so the user's own id is skipped.
+  const contributorsByDomain = new Map<string, Map<string, number>>();
+  const add = (domain: string, correct: boolean, contributorId: string | null) => {
     if (declaredDomains.has(domain)) return;
     const current = byDomain.get(domain) ?? { domain, questionCount: 0, correctCount: 0 };
     current.questionCount += 1;
     if (correct) current.correctCount += 1;
     byDomain.set(domain, current);
+    if (contributorId && contributorId !== userId) {
+      const counts = contributorsByDomain.get(domain) ?? new Map<string, number>();
+      counts.set(contributorId, (counts.get(contributorId) ?? 0) + 1);
+      contributorsByDomain.set(domain, counts);
+    }
   };
 
   gameAnswers.forEach((row) => {
     const domain = domainFor(row.question);
-    if (domain) add(domain, row.isCorrect === true);
+    if (domain) add(domain, row.isCorrect === true, row.question.creatorId);
   });
   feedAnswers.forEach((row) => {
     const domain = domainFor(row.question);
-    if (domain) add(domain, correctQuestionIds.has(row.question.id));
+    if (domain) add(domain, correctQuestionIds.has(row.question.id), row.sourceUserId);
   });
 
-  const friendMediated = [...byDomain.values()].sort((a, b) => b.questionCount - a.questionCount || a.domain.localeCompare(b.domain));
+  // Resolve the top contributor per domain to a display name in one batch query.
+  const topContributorByDomain = new Map<string, string>();
+  for (const [domain, counts] of contributorsByDomain) {
+    const [top] = [...counts.entries()].sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]));
+    if (top) topContributorByDomain.set(domain, top[0]);
+  }
+  const viaIds = [...new Set(topContributorByDomain.values())];
+  const viaNameById = new Map<string, string>();
+  if (viaIds.length > 0) {
+    const viaRows = await db
+      .select({ id: users.id, displayName: users.displayName })
+      .from(users)
+      .where(inArray(users.id, viaIds));
+    viaRows.forEach((row) => viaNameById.set(row.id, row.displayName?.trim() || 'A friend'));
+  }
+
+  const friendMediated = [...byDomain.values()]
+    .sort((a, b) => b.questionCount - a.questionCount || a.domain.localeCompare(b.domain))
+    .map((item) => {
+      const viaId = topContributorByDomain.get(item.domain);
+      return { ...item, via: viaId ? (viaNameById.get(viaId) ?? null) : null };
+    });
 
   const seenAuthored = new Set<string>();
   const authored = authoredDeclared
@@ -438,6 +499,9 @@ async function computeBeat5(userId: string, cycleStart: Date, cycleEndExclusive:
 
   if (rows.length === 0) return null;
   const totalCreatorPoints = Math.round(rows.reduce((sum, row) => sum + Number(row.awardedPoints ?? 0), 0) * 10) / 10;
+  // One author_credit row == one friend answering one of your questions, so the
+  // row count is the total times your questions were answered this cycle.
+  const totalAnswered = rows.length;
   const byQuestion = new Map<string, { text: string; answeredCount: number }>();
   rows.forEach((row) => {
     if (!row.questionId || !row.questionText) return;
@@ -446,7 +510,7 @@ async function computeBeat5(userId: string, cycleStart: Date, cycleEndExclusive:
     byQuestion.set(row.questionId, current);
   });
   const [topQuestion] = [...byQuestion.values()].sort((a, b) => b.answeredCount - a.answeredCount);
-  return { totalCreatorPoints, topQuestion: topQuestion ?? null };
+  return { totalCreatorPoints, totalAnswered, topQuestion: topQuestion ?? null };
 }
 
 /**
@@ -715,9 +779,52 @@ async function countActiveAnsweringPlayers(
   return rows.length + 1;
 }
 
+/**
+ * Opener room stats: the user's week number (since signup), distinct questions
+ * answered correctly this cycle, and distinct days played. `weekIndex` derives
+ * from the account age in 7-day steps (cadence is weekly — see fire-ceremony.ts).
+ */
+async function computeOpener(
+  userId: string,
+  cycleStart: Date,
+  cycleEndExclusive: Date,
+  cycleEnd: Date,
+): Promise<CeremonyOpener> {
+  const [userRow] = await db
+    .select({ createdAt: users.createdAt })
+    .from(users)
+    .where(eq(users.id, userId))
+    .limit(1);
+
+  const [stats] = await db
+    .select({
+      questionsRight: sql<number>`count(distinct ${masteryEvents.questionId}) filter (where ${masteryEvents.answerState} in ('first_correct', 'first_correct_after_wrong', 'repeat_correct'))`,
+      sessionsPlayed: sql<number>`count(distinct date_trunc('day', ${masteryEvents.createdAt}))`,
+    })
+    .from(masteryEvents)
+    .where(and(
+      eq(masteryEvents.userId, userId),
+      gte(masteryEvents.createdAt, cycleStart),
+      lt(masteryEvents.createdAt, cycleEndExclusive),
+    ));
+
+  const createdAt = userRow?.createdAt ?? cycleEnd;
+  const weekIndex = Math.max(
+    1,
+    Math.floor((cycleEnd.getTime() - createdAt.getTime()) / (7 * 86_400_000)) + 1,
+  );
+
+  return {
+    weekIndex,
+    questionsRight: Number(stats?.questionsRight ?? 0),
+    sessionsPlayed: Number(stats?.sessionsPlayed ?? 0),
+  };
+}
+
 export async function computeBeats(userId: string, cycleStart: Date, cycleEnd: Date): Promise<BeatsPayload> {
   const cycleEndExclusive = endExclusive(cycleEnd);
-  const [beat1, beat2, beat3, beat4, beat5, beat6, activeAnsweringPlayers] = await Promise.all([
+  const [opener, beat1, beat2, beat3, beat4, beat5, beat6, activeAnsweringPlayers] = await Promise.all([
+    computeOpener(userId, cycleStart, cycleEndExclusive, cycleEnd),
     computeBeat1(userId, cycleStart, cycleEndExclusive),
     computeBeat2(userId, cycleStart, cycleEndExclusive),
     computeBeat3(userId, cycleStart, cycleEndExclusive),
@@ -744,6 +851,7 @@ export async function computeBeats(userId: string, cycleStart: Date, cycleEnd: D
   return {
     cycleStart: toIsoDate(cycleStart),
     cycleEnd: toIsoDate(cycleEnd),
+    opener,
     mode,
     beat1,
     beat1FriendFallback,


### PR DESCRIPTION
Rebuild the weekly ceremony presentation layer as saturated, full-bleed "rooms" — one per beat, with reversed (light-on-color) type, a staggered reveal, and count-up numbers. Replaces the prior dark stone-palette story.

- globals.css: add a tokenized --ceremony-* color ramp (per-room bg/fg/ accent/sub) plus ceremony-room-in / ceremony-hint-pulse keyframes, both reduced-motion guarded. Removes the page's hardcoded hex palette (the color ratchet's named top offender) — off-system count drops.
- compute-beats: extend the payload with opener stats (weekIndex, questionsRight, sessionsPlayed), a `via` friend attribution on beat2.friendMediated, and totalAnswered on beat5. All additive + optional so the pre-redesign corpus still validates on read.
- page: render the rooms from the live payload; preserve beat6 and the beat1/beat5 friend fallbacks; simplify mode to one neutral treatment (beat3/beat4 still suppressed when empty). Fonts route through the --font-* tokens (drops the retired Courier New + the injected font link). Reuses the shared usePrefersReducedMotion hook and the existing ShareCard closer + share-token flow.
- ShareCard: fix the stale "TWO WEEKS" kicker (cadence is weekly).
- tests: cover the new payload fields and read-lenience for old payloads.


Claude-Session: https://claude.ai/code/session_011Dw9m1MgTxbUHUGZ8semXo