### PR TITLE
Cap Blue Moon domains at 1/round + 'see less often' menu control

### DIFF
--- a/src/components/FeedList.tsx
+++ b/src/components/FeedList.tsx
@@ -1012,6 +1012,7 @@ function FeedListContent({
   const [busyId, setBusyId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const [hideToast, setHideToast] = useState<{ category: string } | null>(null)
+  const [freqToast, setFreqToast] = useState<{ domain: string } | null>(null)
   // "From Friends" starts capped to its most recent few milestone cards; each
   // "View more" reveals another batch. View-state only — never persisted.
   const [fromFriendsVisibleCount, setFromFriendsVisibleCount] = useState(
@@ -1352,6 +1353,39 @@ function FeedListContent({
         caught instanceof Error
           ? caught.message
           : 'Could not hide that category.'
+      )
+    } finally {
+      setBusyId(null)
+    }
+  }, [])
+
+  // Gentle down-weight (owner direction): nudge this domain to "Blue Moon" in the
+  // Daily Five so it shows up rarely, instead of a hard hide. Unlike hideCategory
+  // this leaves the feed card in place — it changes future Daily Five frequency,
+  // not feed membership. The API merges server-side and rebuilds untouched queues.
+  const seeLessOften = useCallback(async (item: FeedApiItem) => {
+    const domain = item.domain_pill
+    if (!domain) return
+    setBusyId(item.id)
+    setError(null)
+    try {
+      const response = await fetch('/api/daily/preferences/domain-frequency', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ domain, frequency: 'blue_moon' }),
+      })
+      if (!response.ok) {
+        const body = await response.json().catch(() => null)
+        throw new Error(body?.message ?? 'Could not update that preference.')
+      }
+      setFreqToast({ domain })
+      window.setTimeout(() => {
+        setFreqToast((current) => (current?.domain === domain ? null : current))
+      }, 4500)
+    } catch (caught) {
+      setError(
+        caught instanceof Error ? caught.message : 'Could not update that preference.'
       )
     } finally {
       setBusyId(null)
@@ -1868,7 +1902,7 @@ function FeedListContent({
         }
         isInBank={item.is_in_bank}
         disabled={isBusy}
-        onHideCategory={() => void hideCategory(item)}
+        onSeeLessOften={() => void seeLessOften(item)}
         onHidePerson={() => void hidePerson(item)}
         onReportIncorrect={() => setReportSheet({ item, category: 'incorrect' })}
         onReportInappropriate={() =>
@@ -2018,6 +2052,25 @@ function FeedListContent({
             className="text-foreground text-xs font-medium not-italic underline-offset-4 hover:underline"
           >
             Manage on your knowledge page →
+          </Link>
+        </div>
+      ) : null}
+
+      {freqToast ? (
+        <div
+          role="status"
+          aria-live="polite"
+          className="text-muted-foreground mb-3 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-dashed px-3 py-2 text-sm italic"
+        >
+          <span>
+            You&apos;ll see questions about{' '}
+            {visibleFeedCategory(freqToast.domain) ?? freqToast.domain} less often.
+          </span>
+          <Link
+            href="/daily/setup"
+            className="text-foreground text-xs font-medium not-italic underline-offset-4 hover:underline"
+          >
+            Adjust in Game settings →
           </Link>
         </div>
       ) : null}

--- a/src/components/feed/FeedActions.tsx
+++ b/src/components/feed/FeedActions.tsx
@@ -26,7 +26,9 @@ export type FeedOverflowMenuProps = {
   question?: FeedOverflowQuestion | null
   isInBank?: boolean
   disabled?: boolean
-  onHideCategory?: () => void
+  // Gentle down-weight: nudge this domain to "Blue Moon" (see it rarely) instead
+  // of a hard hide. Replaces the old onHideCategory per owner direction.
+  onSeeLessOften?: () => void
   onHidePerson?: () => void
   // PRD-D-6 §6.6: the two problem-named items replace the old generic "Report".
   // Both require a question target, so they only render when `question` is set.
@@ -48,7 +50,7 @@ export function getFeedOverflowMenuLabels({
 }) {
   const visibleCategory = visibleFeedCategory(category)
   return [
-    ...(visibleCategory ? [`Hide questions about ${visibleCategory}`] : []),
+    ...(visibleCategory ? [`See questions about ${visibleCategory} less often`] : []),
     `Hide questions from ${sourceName || 'this person'}`,
     ...(hasQuestion && !isInBank ? ['Add to bank'] : []),
     ...(hasQuestion ? ['Send to friend'] : []),
@@ -86,7 +88,7 @@ export function FeedOverflowMenu({
   question,
   isInBank = false,
   disabled = false,
-  onHideCategory,
+  onSeeLessOften,
   onHidePerson,
   onReportIncorrect,
   onReportInappropriate,
@@ -171,9 +173,9 @@ export function FeedOverflowMenu({
             {visibleCategory ? (
               <MenuButton
                 disabled={disabled}
-                onClick={wrapAction(onHideCategory)}
+                onClick={wrapAction(onSeeLessOften)}
               >
-                Hide questions about {visibleCategory}
+                See questions about {visibleCategory} less often
               </MenuButton>
             ) : null}
             <MenuButton disabled={disabled} onClick={wrapAction(onHidePerson)}>

--- a/src/components/feed/__tests__/FeedCards.test.tsx
+++ b/src/components/feed/__tests__/FeedCards.test.tsx
@@ -591,7 +591,7 @@ describe('Feed card category and overflow affordances', () => {
         isInBank: true,
       })
     ).toEqual([
-      'Hide questions about Literature',
+      'See questions about Literature less often',
       'Hide questions from Maya',
       'Send to friend',
       'This is incorrect',

--- a/src/server/daily/__tests__/diversity-cap.test.ts
+++ b/src/server/daily/__tests__/diversity-cap.test.ts
@@ -224,6 +224,42 @@ describe('fillDailyQueueForUser — intra-day diversity cap', () => {
     expect(totalSlots).toBe(DAILY_QUEUE_SIZE);
   });
 
+  it('caps a "blue_moon" subcategory at 1 per round, including friend questions', async () => {
+    // Blue Moon means "see rarely" — a friend authoring two questions in a Blue
+    // Moon domain must not take two of the five slots. The shared diversity gate
+    // runs over authored/friend picks (unlike the frequency weighting, which only
+    // steers generated domains), so the cap of 1 reaches them.
+    mocks.getDailyPreferences.mockResolvedValue({
+      difficulty: 'adaptive',
+      domainMode: 'random',
+      selectedDomains: [],
+      domainPreferenceFrequency: { Hamlet: 'blue_moon' },
+    });
+    mocks.pickEligibleAuthoredQuestions.mockResolvedValue([
+      authoredPick('h1', 'Hamlet'),
+      authoredPick('h2', 'Hamlet'),
+    ]);
+    // Distinct generated domains finish the diverse five around the single Hamlet.
+    mocks.generateDailyQuestionsFromKnowledgeBase.mockResolvedValue([
+      genq('j1', 'Jazz'),
+      genq('a1', 'Astronomy'),
+      genq('c1', 'Cartography'),
+      genq('b1', 'Botany'),
+    ]);
+
+    await fillDailyQueueForUser(USER);
+
+    const hamletSlots = persistedSlots().filter(
+      (slot) => slot.source === 'friend' && slot.domain === 'Hamlet',
+    );
+    // Only ONE Hamlet slot — the 2nd was deflected (Blue Moon cap = 1), not two as
+    // the base cap would allow.
+    expect(hamletSlots).toHaveLength(1);
+    // The queue is still full; generation backfilled the slot the cap freed.
+    const core = persistedSlots().filter((slot) => !slot.presence_source_id);
+    expect(core).toHaveLength(DAILY_QUEUE_SIZE);
+  });
+
   it('exempts an "often"-marked subcategory from the cap (Game settings honored)', async () => {
     // The player explicitly asked to see lots of Botany. The diversity cap must NOT
     // throttle a topic the player deliberately requested — "often" is exempt, so a

--- a/src/server/daily/queue-orchestrator.ts
+++ b/src/server/daily/queue-orchestrator.ts
@@ -418,21 +418,35 @@ async function buildDailyQueueForUser(userId: string): Promise<void> {
         )
       : DAILY_QUEUE_SIZE;
 
-  // In concert with the Game settings page: a subcategory the player explicitly
-  // marked "often" is EXEMPT from the diversity cap (bounded only by the queue
-  // size), so the cap never throttles a topic the player deliberately asked to see
-  // a lot of. The cap exists to break up runs the player did NOT request — and an
-  // explicit "often" IS that request, so it wins. ("resting" is already removed from
-  // allowedSubcategories upstream; "sometimes"/"blue_moon"/unset keep the base cap.)
+  // In concert with the Game settings page, the diversity cap is frequency-aware
+  // at both ends:
+  //   • "often"    → EXEMPT (bounded only by queue size). The cap exists to break
+  //                  up runs the player did NOT request; an explicit "often" IS
+  //                  that request, so it wins.
+  //   • "blue_moon"→ capped at 1 per round. "See rarely" must mean a Blue Moon
+  //                  domain can't take two of the five slots — and because THIS
+  //                  shared gate also runs over friend-authored picks (unlike the
+  //                  frequency *weighting*, which only steers generated domains),
+  //                  this is the one lever that stops a friend's questions in a
+  //                  Blue Moon domain from doubling up. Starvation is impossible:
+  //                  a deflected 2nd pick goes to the reserve and is backfilled if
+  //                  the queue would otherwise come up short.
+  //   • "sometimes"/unset → the base cap (2, scaled up only for very thin KBs).
+  //   • "resting"  → already removed from allowedSubcategories upstream.
   // Keys are lowercased to match how restingDomains is built above and how the gate
   // normalizes each subcategory.
+  const freqEntries = Object.entries(preferences.domainPreferenceFrequency ?? {});
   const oftenDomains = new Set(
-    Object.entries(preferences.domainPreferenceFrequency ?? {})
-      .filter(([, frequency]) => frequency === 'often')
-      .map(([domain]) => domain.toLowerCase()),
+    freqEntries.filter(([, frequency]) => frequency === 'often').map(([domain]) => domain.toLowerCase()),
   );
-  const capForSubcategory = (normalizedSubcategory: string): number =>
-    oftenDomains.has(normalizedSubcategory) ? DAILY_QUEUE_SIZE : baseDiversityCap;
+  const blueMoonDomains = new Set(
+    freqEntries.filter(([, frequency]) => frequency === 'blue_moon').map(([domain]) => domain.toLowerCase()),
+  );
+  const capForSubcategory = (normalizedSubcategory: string): number => {
+    if (oftenDomains.has(normalizedSubcategory)) return DAILY_QUEUE_SIZE;
+    if (blueMoonDomains.has(normalizedSubcategory)) return 1;
+    return baseDiversityCap;
+  };
   const diversityGate = makeSubcategoryDiversityGate(capForSubcategory);
 
   // Answer-cooldown gate (B-DEDUP-ANSWER-COOLDOWN, Tier 1). Deflects any pick —


### PR DESCRIPTION
## Why

Two issues surfaced from a real round: it served **two Tears of the Kingdom questions** even though Zelda is set to **Blue Moon** ("see rarely"). Root cause:

- The intra-day diversity cap is a flat **`DAILY_QUEUE_MAX_PER_SUBCATEGORY = 2`**, and the shared gate only special-cased `often` (exempt) — it did nothing to *tighten* `blue_moon`.
- Both questions were **friend-authored**; friend questions bypass the frequency *weighting* entirely, so the shared cap was the only lever on them — and at 2, both got through.

Plus: the card menu only offered hard **Hide** for a topic, when a gentle down-weight is the better default.

## Changes

**1. Blue Moon → max 1 per round** (`queue-orchestrator.ts`)
`capForSubcategory` is now frequency-aware at both ends: `often` exempt (unchanged), **`blue_moon` → 1**, `sometimes`/unset → base cap (2). Since the shared gate runs over friend-authored picks too, this reaches them — a friend's Blue Moon questions can no longer double up. Starvation-safe (the reserve backfills if a deflection would short the queue). New test: two friend-authored questions in a `blue_moon` domain → only 1 admitted.

**2. "See less often" replaces topic-Hide** (`FeedActions.tsx` + `FeedList.tsx`)
The card menu's *"Hide questions about [domain]"* becomes **"See questions about [domain] less often"**, wired to the existing `domain-frequency` API → sets the domain to Blue Moon and rebuilds untouched queues. Unlike Hide it leaves the card in the feed (a Daily-Five frequency nudge, not a feed removal) and confirms with a toast. Person-hide + report options unchanged.

## Tests
Feed suite 93/93, diversity-cap 7/7 (incl. the new Blue Moon case), tsc/lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)