### PR TITLE
Separate bell badge (activity) from Friends tab badge (requests)

### DIFF
--- a/src/app/activities/MarkActivitiesRead.tsx
+++ b/src/app/activities/MarkActivitiesRead.tsx
@@ -18,10 +18,10 @@ export function MarkActivitiesRead() {
       }),
     ]).then(() => {
       // Refresh the server components on this route so the activity list
-      // reflects the just-written read/opened state. (The nav bell badge now
-      // counts only pending friend requests, sourced from /api/nav — it is
-      // unaffected by opening the bell and clears when a request is accepted
-      // or declined.)
+      // reflects the just-written read/opened state. Opening Lately also
+      // advances lastActivityBellOpenedAt (via /api/activities/opened), which
+      // is the floor getBellBadgeCount uses — so the nav bell badge clears once
+      // /api/nav refetches.
       router.refresh();
     });
   }, [router]);

--- a/src/app/api/nav/route.ts
+++ b/src/app/api/nav/route.ts
@@ -2,25 +2,28 @@ import { NextResponse } from 'next/server';
 
 import { getSession } from '@/server/auth/session';
 import { getUserOnboardingProfile } from '@/server/db/queries/users';
+import { getBellBadgeCount } from '@/server/db/queries/activity';
 import { getIncomingFollowRequestCount } from '@/server/db/queries/friends';
 import { getNewDiscoveryStatus } from '@/server/db/queries/contact-hashes';
 
 export const dynamic = 'force-dynamic';
 
 // Nav badge summary: the display name (for the account-initials avatar), the
-// bell badge count (pending friend requests awaiting approval — and only those),
-// and whether the Friends tab should show its discovery dot. The root layout
-// used to await these three queries before streaming any HTML on every hard
-// navigation; Nav now fetches them client-side after mount so the page shell
-// streams immediately and the badges pop in slightly later. No request input, so
-// there's nothing to Zod-validate (matches the sibling
-// /api/friends/has-new-discovery probe).
+// bell badge count (unseen activity that has rolled off Home — the bell links
+// to /activities "Lately"), the pending friend-request count (badged on the
+// Friends tab, where requests are accepted/declined), and whether the Friends
+// tab should also show its discovery dot. The root layout used to await these
+// queries before streaming any HTML on every hard navigation; Nav now fetches
+// them client-side after mount so the page shell streams immediately and the
+// badges pop in slightly later. No request input, so there's nothing to
+// Zod-validate (matches the sibling /api/friends/has-new-discovery probe).
 export async function GET() {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
 
-  const [profile, bellBadgeCount, discoveryStatus] = await Promise.all([
+  const [profile, bellBadgeCount, friendRequestCount, discoveryStatus] = await Promise.all([
     getUserOnboardingProfile(session.userId),
+    getBellBadgeCount(session.userId).catch(() => 0),
     getIncomingFollowRequestCount(session.userId).catch(() => 0),
     getNewDiscoveryStatus(session.userId).catch(() => ({ hasNew: false, count: 0 })),
   ]);
@@ -29,6 +32,7 @@ export async function GET() {
     userId: session.userId,
     displayName: profile?.displayName ?? null,
     bellBadgeCount,
+    friendRequestCount,
     friendsDotVisible: discoveryStatus.hasNew,
   });
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -53,11 +53,13 @@ export function Nav({
   initialUserId = null,
   initialDisplayName = null,
   bellBadgeCount = 0,
+  friendRequestCount = 0,
   friendsDotVisible = false,
 }: {
   initialUserId?: string | null;
   initialDisplayName?: string | null;
   bellBadgeCount?: number;
+  friendRequestCount?: number;
   friendsDotVisible?: boolean;
 }) {
   const pathname = usePathname();
@@ -71,6 +73,7 @@ export function Nav({
   // them from GET /api/nav once mounted. Badges pop in slightly late by design.
   const [displayName, setDisplayName] = useState(initialDisplayName);
   const [badgeCount, setBadgeCount] = useState(bellBadgeCount);
+  const [friendRequests, setFriendRequests] = useState(friendRequestCount);
   const [friendsDot, setFriendsDot] = useState(friendsDotVisible);
 
   useEffect(() => {
@@ -78,12 +81,22 @@ export function Nav({
     let active = true;
     fetch('/api/nav', { credentials: 'include' })
       .then((response) => (response.ok ? response.json() : null))
-      .then((data: { displayName?: string | null; bellBadgeCount?: number; friendsDotVisible?: boolean } | null) => {
-        if (!active || !data) return;
-        setDisplayName(data.displayName ?? null);
-        setBadgeCount(typeof data.bellBadgeCount === 'number' ? data.bellBadgeCount : 0);
-        setFriendsDot(Boolean(data.friendsDotVisible));
-      })
+      .then(
+        (
+          data: {
+            displayName?: string | null;
+            bellBadgeCount?: number;
+            friendRequestCount?: number;
+            friendsDotVisible?: boolean;
+          } | null,
+        ) => {
+          if (!active || !data) return;
+          setDisplayName(data.displayName ?? null);
+          setBadgeCount(typeof data.bellBadgeCount === 'number' ? data.bellBadgeCount : 0);
+          setFriendRequests(typeof data.friendRequestCount === 'number' ? data.friendRequestCount : 0);
+          setFriendsDot(Boolean(data.friendsDotVisible));
+        },
+      )
       .catch(() => {});
     return () => {
       active = false;
@@ -179,11 +192,11 @@ export function Nav({
           </Link>
           <div className="flex items-center gap-1">
             <Link
-              href="/friends"
+              href="/activities"
               aria-label={
                 showBadge
-                  ? `Friend requests, ${badgeCount} pending`
-                  : 'Friend requests'
+                  ? `Lately, ${badgeCount} new update${badgeCount === 1 ? '' : 's'}`
+                  : 'Lately'
               }
               className="relative inline-flex min-h-11 min-w-11 items-center justify-center rounded-md text-muted-foreground transition hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
             >
@@ -248,10 +261,20 @@ export function Nav({
                 ? pathname === '/'
                 : pathname.startsWith(href);
 
+            // The Friends tab carries the pending friend-request count (the
+            // count the bell used to badge). Announce it to screen readers via
+            // an explicit label; otherwise the visible "Friends" text is the
+            // accessible name.
+            const showFriendRequests = label === 'Friends' && friendRequests > 0;
+            const tabAriaLabel = showFriendRequests
+              ? `Friends, ${friendRequests} pending friend request${friendRequests === 1 ? '' : 's'}`
+              : undefined;
+
             return (
               <Link
                 key={href}
                 href={href}
+                aria-label={tabAriaLabel}
                 aria-current={active ? 'page' : undefined}
                 role="listitem"
                 className={[
@@ -272,9 +295,20 @@ export function Nav({
                       fill={active && label === 'Home' ? 'currentColor' : 'none'}
                     />
                   )}
-                  {/* Discovery indicator for the Friends tab — muted neutral
-                      so it doesn't compete with the bell badge accent. */}
-                  {friendsDot && label === 'Friends' ? (
+                  {/* Friends-tab indicators. Pending friend requests are the
+                      actionable signal, so they take the accent count pill
+                      (mirrors the bell's old treatment). Otherwise the muted
+                      neutral discovery dot shows when there's someone new to
+                      find — never both, so the tab corner stays uncluttered. */}
+                  {showFriendRequests ? (
+                    <span
+                      className="absolute -right-2 -top-1 grid min-w-[18px] items-center rounded-full px-1.5 text-center font-mono text-[9px] font-semibold leading-[14px] text-[var(--brand-card)]"
+                      style={{ backgroundColor: 'var(--destructive)' }}
+                      aria-hidden="true"
+                    >
+                      {formatBadgeCount(friendRequests)}
+                    </span>
+                  ) : friendsDot && label === 'Friends' ? (
                     <span
                       className="absolute -right-1 -top-1 size-2 rounded-full"
                       style={{ backgroundColor: 'var(--brand-ink-400)' }}

--- a/src/server/db/queries/activity.ts
+++ b/src/server/db/queries/activity.ts
@@ -994,16 +994,15 @@ export async function markActivityBellOpened(userId: string): Promise<void> {
 }
 
 /**
- * NOTE: No longer wired to the nav bell badge. The badge now counts ONLY
- * pending friend requests (see getIncomingFollowRequestCount in
- * queries/friends.ts, consumed by /api/nav). This "rolled-off-Home activity"
- * count is retained for potential reuse but is not currently rendered anywhere.
+ * The nav bell badge count (consumed by /api/nav). The bell links to
+ * /activities ("Lately"); pending friend requests are badged separately on the
+ * Friends tab (see getIncomingFollowRequestCount in queries/friends.ts).
  *
- * Original semantics: events that have rolled off Home's top-3 RecentActivity
- * AND fired since the user last opened the bell — "there's value here you can't
- * see from Home." If an event is still visible on Home, the count stays quiet.
- * If the bell has never been opened (NULL), the floor is the activity 90-day
- * cutoff via activityCutoff(). Returns the raw count.
+ * Semantics: events that have rolled off Home's top-3 RecentActivity AND fired
+ * since the user last opened the bell — "there's value here you can't see from
+ * Home." If an event is still visible on Home, the count stays quiet. If the
+ * bell has never been opened (NULL), the floor is the activity 90-day cutoff
+ * via activityCutoff(). Returns the raw count.
  */
 export async function getBellBadgeCount(userId: string): Promise<number> {
   const [userRow] = await db


### PR DESCRIPTION
## Summary
Decouples the navigation bell badge from pending friend requests by introducing a separate badge on the Friends tab. The bell now badges unseen activity that has rolled off Home (linking to `/activities` "Lately"), while pending friend requests are badged on the Friends tab where they're actioned.

## Key Changes
- **Nav component (`src/components/Nav.tsx`)**
  - Added `friendRequestCount` prop and state to track pending friend requests separately from bell badge count
  - Updated `/api/nav` fetch to include `friendRequestCount` in response type
  - Changed bell link from `/friends` to `/activities` with updated aria-label ("Lately" instead of "Friend requests")
  - Added friend-request count badge to Friends tab (accent pill, mirrors bell's old treatment)
  - Preserved discovery dot on Friends tab but made it mutually exclusive with request count (never both, keeps tab corner uncluttered)
  - Added explicit aria-label to Friends tab link when pending requests exist

- **Nav API endpoint (`src/app/api/nav/route.ts`)**
  - Added `getBellBadgeCount` import and call to fetch unseen activity count
  - Updated response to include both `bellBadgeCount` (activity) and `friendRequestCount` (requests)
  - Updated endpoint documentation to clarify the new badge semantics

- **Activity query (`src/server/db/queries/activity.ts`)**
  - Updated `getBellBadgeCount` documentation to reflect its new purpose: events rolled off Home that fired since last bell open (not friend requests)

- **Activities route (`src/app/activities/MarkActivitiesRead.tsx`)**
  - Updated comment to clarify that opening Lately advances `lastActivityBellOpenedAt`, which is the floor `getBellBadgeCount` uses

## Implementation Details
- The bell badge now sources from `getBellBadgeCount()` (activity rolled off Home), while the Friends tab badge sources from `getIncomingFollowRequestCount()` (pending requests)
- Both badges use the same accent styling (destructive color, count pill) but on different nav elements
- The discovery dot on Friends tab only shows when there are no pending requests, preventing visual clutter
- Screen reader announcements updated: bell announces "Lately, N new update(s)", Friends tab announces "Friends, N pending friend request(s)" when applicable

https://claude.ai/code/session_01GpjeNMmVSsz8huCCUZQPpC