### PR TITLE
Fix the factual gate's silent fail-open (HP false-premise question)

### DIFF
--- a/D-LLM-PROVIDER-AB-AND-GATE-TIER-01.md
+++ b/D-LLM-PROVIDER-AB-AND-GATE-TIER-01.md
@@ -68,16 +68,53 @@ A complementary run to the gate-compare audit above, asking a *different* questi
 - Beethoven sonata "**unusual** four-movement structure" (four movements is not unusual) — `4c257d42-6675-4037-9f50-1ff987bb5633`
 - **Duplicate:** Theodore Roosevelt "trust-buster" generated twice in one batch (~4s apart — a dedup escape); kept `3bcb96fa-ba74-4ff7-a773-e4c2d572b46d`, suppressed `afb817c3-ddeb-4afb-a2b0-5dfabd82f91b`.
 
+## Third finding — the gate was on Sonnet but still failed open (2026-06-29) — [fixed]
+
+A Harry Potter question shipped to production with a false premise: *"Which student receives **fifty points — the largest single award in that sequence** — for the most exceptional display of courage?"* → Neville. In *Philosopher's Stone* Neville received **ten** points (the decisive award) and the **largest** single award was Harry's **sixty**. Classic answer-right / premise-false — exactly this gate's job.
+
+The twist: telemetry (`LlmUsageEvent`, scope `factual-gate`) showed the gate **was** running on **Sonnet** at the generation timestamp, and Sonnet flags this question **5/5** in isolation. So it was neither a tier miss nor a prompt gap. Root cause: **the gate sends the whole over-provisioned batch in one call but capped the response at `max_tokens: 500`.** A single verbose drop reason runs ~270 output tokens; a batch flagging 2+ questions truncates the JSON mid-structure, `parseFactualGateResponse` can't parse it and returns an **empty drop set**, and the entire batch ships **ungated**. Reproduced: a 3-defect batch emits **495** output tokens — right against the old cap. And because `loggedMessagesCreate` logs *after* a successful response, a truncation/timeout fail-open leaves **no usage row** — invisible.
+
+Fix (PR-pending): `FACTUAL_GATE_MAX_TOKENS = 2000` (output is billed per token emitted, so the headroom is free), plus a `stop_reason === 'max_tokens'` guard that logs **"batch passed UNGATED"** loudly so any future truncation is observable instead of silent. Unit tests cover multi-drop parsing and the truncated-JSON fail-open. Sharpening the prompt remains a non-lever (the prompt already catches this on Sonnet). Open follow-up: the catch-block fail-open (timeout/API error) is still silent-but-warned; consider failing **closed** (drop the batch, let the orchestrator top up) since the over-provision makes that recoverable.
+
+**Pool cleanup (done — production writes, reversible, flag-never-delete pattern):**
+- HP "fifty points / largest single award" false premise — bank `17b0f389-a497-4039-9306-a3539f149d15` suppressed (`is_duplicate=true`); promoted live `Question 0417b3b0-4d4c-4ccc-941f-c4a3e569b466` soft-deleted (`deleted_at`). Script: `scripts/suppress-hp-points-false-premise.ts`.
+
+## Fourth finding — false premises live in asserted setup side-facts, not in length (2026-06-29) — [measured; generation rule added]
+
+Prompted by Josh's question — *"would shorter questions help?"* — we turned it into a number rather than guessing. Harness `scripts/audit-assertion-density.ts` (read-only): over a question's `question_text` (the SETUP) it counts an **assertion score** = digits + number-words + years + superlative/exclusivity words, runs the **fixed** Sonnet gate (batched at 6, exercising the raised `max_tokens`) to label flagged/not, and compares. n=120 most-recent non-suppressed bank rows.
+
+| Signal | Result |
+|---|---|
+| Flagged by the fixed gate | **8/120 (6.7%)** — false premises the *truncated* gate had let through (a second, independent cost-of-fail-open readout) |
+| Flag rate, **low** assertion-density tertile (score 0) | **2.5%** (1/40) |
+| Flag rate, **high** assertion-density tertile (score ≥ 1) | **12.5%** (5/40) — **~5× higher** |
+| Mean **words**, flagged vs not | 43.0 vs 36.7 — only ~6 words apart |
+| Mean **assertion score**, flagged vs not | 1.38 vs 1.04 |
+| Confirmed offenders, mean assertion score vs sample median | **2.60 vs 1** |
+
+Conclusions:
+1. **Assertion density beats raw length as a risk signal.** A setup carrying ≥1 asserted side-fact is flagged **~5×** as often; but flagged questions are barely longer (≈6 words), so "make questions shorter" is the wrong instruction — it targets a weak proxy.
+2. **Counts/superlatives are only half the story.** 2 of 5 confirmed offenders (tennis "volley before the net", Beethoven "unusual four-movement structure") score **low** on the quantitative metric — their false premise is **qualitative / relational** (a characterization or asserted link), which a numbers-and-superlatives metric can't see. So the lever must cover BOTH quantitative and qualitative asserted side-facts.
+3. **The HP case is the extreme:** assertion score 7 (p100), 66 words (p100) — both the most assertion-dense and the longest in the sample.
+
+Caveat: single-run LLM-as-judge over post-gate survivors; the 6.7% includes possible judge false positives (the doc's standing caveat) and a human spot-check would prune them. The tertile *contrast* is robust to that since false positives aren't density-correlated.
+
+**Generation-prompt rule added** (`SYSTEM_PROMPT`, "NO GRATUITOUS SIDE-FACTS IN THE SETUP", after TRIVIA-OF-TRIVIA): assert in the setup only what the ask needs AND you are certain of; cut decorative counts/superlatives AND characterization/derivation claims; prefer atmospheric framing (no factual claim) over claim-dense framing; with the HP BAD→GOOD pair. This is **defense in depth upstream of the gate**, not a replacement — it lowers the defect *rate*; the (now un-truncated) gate remains the catch-all. Consistent with "do not rewrite the *gate* prompt" — this changes the **generation** prompt, a different lever.
+
 ## Decisions
 
 - **The provider A/B switch is test instrumentation; default stays Anthropic.** [built] It is *not* the lever for question quality. Keep for measuring generation/grading provider quality at equal tier later, but don't treat a provider flip as a quality fix.
 - **The factual gate defaults to Sonnet**, env-overridable via **`FACTUAL_GATE_MODEL`** (`claude-haiku-4-5-*` to revert, an Opus id for max recall). Temperature omitted for sampling-param-free models (Opus 4.7/4.8, Fable); timeout raised for non-Haiku so a slower gate can't time out and fail open. [decided; PR #1221 open] Rationale: the gate runs once per generation **batch**, so a stronger model on this single high-leverage check is a small cost delta — the cheapest place in the pipeline to spend a stronger model.
 - **Do not rewrite the gate prompt to fix this** — measured non-lever.
+- **The factual gate's `max_tokens` is sized for the whole batch (`FACTUAL_GATE_MAX_TOKENS = 2000`), and `max_tokens` truncation is logged loudly.** [fixed, 2026-06-29] The 500-token cap silently truncated multi-drop responses → parse-fail → empty drop set → batch shipped ungated (the HP false premise's actual root cause). Output is billed per token emitted, so the headroom costs nothing. Do not lower this without re-checking batch-size × per-drop token cost.
+- **Reduce false-premise *rate* at generation, not just at the gate** — the `SYSTEM_PROMPT` "NO GRATUITOUS SIDE-FACTS IN THE SETUP" rule bans non-load-bearing asserted side-facts (quantitative AND qualitative). [added, 2026-06-29] Measured: assertion-density ≈ 5× the flag rate; length is a weak proxy (Fourth finding). Defense-in-depth, not a gate replacement.
+- **"Make questions shorter" is NOT the lever** — measured non-lever (flagged vs clean differ by ~6 words). The lever is *fewer asserted side-facts*, which is what the rule targets.
 - **OpenAI flagship default = gpt-4.1** (see Cost finding). [decided; PR #1219 open]
 
 ## Open / not done
 
 - **Quality gate (`findQualityFailures`) is still Haiku.** Possible follow-up to give it the same `FACTUAL_GATE_MODEL`-style treatment.
+- **The gate's catch-block fail-open (timeout / API error) is still silent-but-warned.** Now that truncation is fixed, consider failing **closed** (drop the batch and let the over-provisioning orchestrator top up) so a transient gate outage can't ship an un-vetted batch. Not done — it changes long-standing fail-open behavior; wants its own decision.
 - **Provider quality A/B at equal tier is still unmeasured.** The switch covers generation/grading, not the gate; the gate is not on the provider switch.
 - **OpenAI gate-tier untested locally** — `OPENAI_API_KEY` is in Vercel only, not `.env.local`, so the audit ran Anthropic tiers (Haiku/Sonnet/Opus) only.
 - **Audit caveats:** n=80, single-run, LLM-as-judge with real false positives; estimated genuine major-defect rate ~low-single-digit % to ~6% of the pool. The audited rows were legacy (`generated_by_provider = null`), i.e. the accumulated pool, not freshly-gated output. A human spot-check would prune judge false positives before banking a rate.

--- a/scripts/audit-assertion-density.ts
+++ b/scripts/audit-assertion-density.ts
@@ -1,0 +1,153 @@
+/**
+ * Read-only evidence run for the "false premises live in asserted setup
+ * side-facts, not in length" hypothesis.
+ *
+ * For a sample of recent bank questions it:
+ *   1. computes two cheap structural metrics on the question_text (the SETUP):
+ *        - words           — length proxy
+ *        - assertionScore  — # of independently-checkable side-claims: digits,
+ *                            number-words, years, and superlative/exclusivity
+ *                            words ("largest", "only", "first", "founded", …).
+ *   2. runs the FIXED Sonnet factual gate (batched at 6 — exercises the raised
+ *      max_tokens) to label each question flagged / not-flagged.
+ *   3. compares flagged vs not on both metrics, and reports flag rate by
+ *      assertion-density tertile.
+ *   4. anchors with the known confirmed false-premise offenders (labeled
+ *      positives) and reports where they sit in the sample's density distribution.
+ *
+ * No writes. Run from repo root:
+ *   npx tsx --env-file=.env --env-file=.env.local scripts/audit-assertion-density.ts
+ *   SAMPLE=120 npx tsx --env-file=.env --env-file=.env.local scripts/audit-assertion-density.ts
+ */
+import { desc, eq, inArray } from 'drizzle-orm';
+
+import { db, generatedQuestions } from '../src/server/db';
+import { findFactualFailures, type LlmQuestion } from '../src/server/daily/generate-questions';
+
+const SAMPLE = Number(process.env.SAMPLE || 120);
+const BATCH = 6;
+
+// Confirmed false-premise offenders (labeled positives) from
+// D-LLM-PROVIDER-AB-AND-GATE-TIER-01.md + today's HP find. Duplicates excluded.
+const KNOWN_OFFENDER_IDS = [
+  '17b0f389-a497-4039-9306-a3539f149d15', // HP "fifty points / largest single award"
+  '3ae575a3-ff02-48dd-bed2-8c86c4566ba5', // tennis volley-before-net premise
+  '651b6f44-f03d-47a6-87d4-24177851b854', // Lewis Hine "founded the NCLC"
+  '23c571e7-e0bf-4274-ab50-25ab20d8623a', // Mozart "Jupiter" Symphony No. 38
+  '4c257d42-6675-4037-9f50-1ff987bb5633', // Beethoven sonata "unusual four-movement structure"
+];
+
+const NUMBER_WORDS =
+  /\b(one|two|three|four|five|six|seven|eight|nine|ten|eleven|twelve|thirteen|fourteen|fifteen|twenty|thirty|forty|fifty|sixty|hundred|thousand|million|billion|dozen|single|pair|triple|once|twice)\b/gi;
+const SUPERLATIVES =
+  /\b(only|sole|solely|first|last|final|largest|biggest|smallest|longest|shortest|highest|lowest|greatest|most|least|best|worst|earliest|latest|unique|original|founded|invented|debut|debuted|premiered?|inaugural|unprecedented|never|always|every|all|none|exactly|precisely)\b/gi;
+const DIGITS = /\d+/g;
+const YEARS = /\b(1[0-9]{3}|20[0-9]{2})\b/g;
+
+function metrics(text: string): { words: number; assertionScore: number } {
+  const words = text.trim().split(/\s+/).filter(Boolean).length;
+  const count = (re: RegExp) => (text.match(re) ?? []).length;
+  // Years counted once under YEARS, not double-counted via DIGITS.
+  const yearHits = count(YEARS);
+  const digitHits = Math.max(0, count(DIGITS) - yearHits);
+  const assertionScore = digitHits + yearHits + count(NUMBER_WORDS) + count(SUPERLATIVES);
+  return { words, assertionScore };
+}
+
+function toLlmQuestion(row: { questionText: string; answer: string; canonicalSubcategory: string }): LlmQuestion {
+  return {
+    canonical_subcategory: row.canonicalSubcategory,
+    broad_category: 'General',
+    question_text: row.questionText,
+    answer: row.answer,
+    explainer: '',
+    difficulty_estimate: 'moderate',
+    fact_key: null,
+    subject_entity: null,
+    sub_angles: [],
+    question_shape: null,
+  };
+}
+
+function mean(xs: number[]): number {
+  return xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+}
+
+function percentileOf(sorted: number[], value: number): number {
+  const below = sorted.filter((x) => x < value).length;
+  return Math.round((below / sorted.length) * 100);
+}
+
+async function main() {
+  const rows = await db
+    .select({
+      id: generatedQuestions.id,
+      questionText: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+    })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.isDuplicate, false))
+    .orderBy(desc(generatedQuestions.createdAt))
+    .limit(SAMPLE);
+
+  console.log(`Sampled ${rows.length} recent non-suppressed bank questions.\n`);
+
+  // Label via the fixed gate, batched.
+  const flagged = new Set<string>();
+  for (let i = 0; i < rows.length; i += BATCH) {
+    const slice = rows.slice(i, i + BATCH);
+    const { toDrop } = await findFactualFailures(slice.map(toLlmQuestion));
+    for (const idx of toDrop) flagged.add(slice[idx]!.id);
+    process.stdout.write(`  gated ${Math.min(i + BATCH, rows.length)}/${rows.length} — flagged so far: ${flagged.size}\n`);
+  }
+
+  const withMetrics = rows.map((r) => ({ ...r, ...metrics(r.questionText), flagged: flagged.has(r.id) }));
+  const pos = withMetrics.filter((r) => r.flagged);
+  const neg = withMetrics.filter((r) => !r.flagged);
+
+  console.log('\n──────── SAMPLE: flagged vs not ────────');
+  console.log(`flagged   n=${pos.length}  mean words=${mean(pos.map((r) => r.words)).toFixed(1)}  mean assertionScore=${mean(pos.map((r) => r.assertionScore)).toFixed(2)}`);
+  console.log(`not       n=${neg.length}  mean words=${mean(neg.map((r) => r.words)).toFixed(1)}  mean assertionScore=${mean(neg.map((r) => r.assertionScore)).toFixed(2)}`);
+
+  // Flag rate by assertion-density tertile.
+  const sortedByScore = [...withMetrics].sort((a, b) => a.assertionScore - b.assertionScore);
+  const third = Math.floor(sortedByScore.length / 3);
+  const low = sortedByScore.slice(0, third);
+  const high = sortedByScore.slice(sortedByScore.length - third);
+  const rate = (g: typeof withMetrics) => (g.length ? (100 * g.filter((r) => r.flagged).length) / g.length : 0);
+  console.log('\n──────── flag rate by assertion-density tertile ────────');
+  console.log(`low  density (score ≤ ${low[low.length - 1]?.assertionScore}):  ${rate(low).toFixed(1)}%  (${low.filter((r) => r.flagged).length}/${low.length})`);
+  console.log(`high density (score ≥ ${high[0]?.assertionScore}):  ${rate(high).toFixed(1)}%  (${high.filter((r) => r.flagged).length}/${high.length})`);
+
+  // Anchor: known confirmed offenders vs the sample distribution.
+  const offenders = await db
+    .select({
+      id: generatedQuestions.id,
+      questionText: generatedQuestions.questionText,
+      answer: generatedQuestions.answer,
+      canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+    })
+    .from(generatedQuestions)
+    .where(inArray(generatedQuestions.id, KNOWN_OFFENDER_IDS));
+
+  const sampleScores = withMetrics.map((r) => r.assertionScore).sort((a, b) => a - b);
+  const sampleWords = withMetrics.map((r) => r.words).sort((a, b) => a - b);
+  console.log('\n──────── KNOWN CONFIRMED OFFENDERS vs sample distribution ────────');
+  for (const o of offenders) {
+    const m = metrics(o.questionText);
+    console.log(
+      `score=${m.assertionScore} (p${percentileOf(sampleScores, m.assertionScore)})  words=${m.words} (p${percentileOf(sampleWords, m.words)})  | ${o.questionText.slice(0, 70)}…`,
+    );
+  }
+  console.log(
+    `\nsample assertionScore: median=${sampleScores[Math.floor(sampleScores.length / 2)]}  offenders mean=${mean(offenders.map((o) => metrics(o.questionText).assertionScore)).toFixed(2)}`,
+  );
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/scripts/suppress-hp-points-false-premise.ts
+++ b/scripts/suppress-hp-points-false-premise.ts
@@ -1,0 +1,95 @@
+/**
+ * One-off cleanup: retire the Harry Potter "house cup points" question whose
+ * stem asserts a false premise — that Neville Longbottom's award was
+ *   "fifty points — the largest single award in that sequence".
+ * In Philosopher's Stone Neville received TEN points (the decisive award), and
+ * the LARGEST single award was Harry's SIXTY. The stated answer (Neville) is
+ * defensible as "the courage award", but the point count is fabricated, and the
+ * row's own explainer is internally scrambled. The factual gate
+ * (findFactualFailures) is meant to catch exactly this "answer-right /
+ * premise-false" class but fails open and missed it; the row was even marked
+ * trust_tier = machine_verified.
+ *
+ * Two scoped writes, both reversible:
+ *   - Question (live, promoted today): soft-delete (deleted_at) — honored by
+ *     every serving path (daily.ts filters isNull(deletedAt)).
+ *   - GeneratedQuestion (bank source): is_duplicate = true — stops re-promotion
+ *     (daily selection filters eq(isDuplicate, false)). It's the only suppress
+ *     flag the bank honors; suppressed_by is left null (no survivor — defect,
+ *     not a dedup loser).
+ *
+ * Usage:
+ *   npx tsx scripts/suppress-hp-points-false-premise.ts            # dry-run
+ *   npx tsx scripts/suppress-hp-points-false-premise.ts --apply
+ */
+
+import 'dotenv/config';
+
+import { and, eq, isNull } from 'drizzle-orm';
+
+import { db, questions, generatedQuestions } from '../src/server/db';
+
+const LIVE_QUESTION_ID = '0417b3b0-4d4c-4ccc-941f-c4a3e569b466';
+const BANK_QUESTION_ID = '17b0f389-a497-4039-9306-a3539f149d15';
+
+const DRY_RUN = !process.argv.includes('--apply');
+
+async function main() {
+  if (DRY_RUN) {
+    console.log('[dry-run] No changes will be made. Pass --apply to mutate.');
+  }
+
+  const [live] = await db
+    .select({
+      id: questions.id,
+      deletedAt: questions.deletedAt,
+      questionText: questions.questionText,
+      answerText: questions.answerText,
+    })
+    .from(questions)
+    .where(eq(questions.id, LIVE_QUESTION_ID));
+
+  const [bank] = await db
+    .select({
+      id: generatedQuestions.id,
+      isDuplicate: generatedQuestions.isDuplicate,
+      factKey: generatedQuestions.factKey,
+    })
+    .from(generatedQuestions)
+    .where(eq(generatedQuestions.id, BANK_QUESTION_ID));
+
+  if (!live) console.warn(`Live Question ${LIVE_QUESTION_ID} not found.`);
+  else
+    console.log(
+      `${live.deletedAt ? 'ALREADY DELETED' : 'will soft-delete'} Question ${live.id} | ${live.answerText} | ${live.questionText.slice(0, 60)}…`,
+    );
+
+  if (!bank) console.warn(`Bank GeneratedQuestion ${BANK_QUESTION_ID} not found.`);
+  else
+    console.log(
+      `${bank.isDuplicate ? 'ALREADY SUPPRESSED' : 'will suppress'} GeneratedQuestion ${bank.id} | fact_key=${bank.factKey}`,
+    );
+
+  if (DRY_RUN) return;
+
+  const deleted = await db
+    .update(questions)
+    .set({ deletedAt: new Date(), updatedAt: new Date() })
+    .where(and(eq(questions.id, LIVE_QUESTION_ID), isNull(questions.deletedAt)))
+    .returning({ id: questions.id });
+  console.log(`Soft-deleted ${deleted.length} live question(s).`);
+
+  const suppressed = await db
+    .update(generatedQuestions)
+    .set({ isDuplicate: true })
+    .where(and(eq(generatedQuestions.id, BANK_QUESTION_ID), eq(generatedQuestions.isDuplicate, false)))
+    .returning({ id: generatedQuestions.id });
+  console.log(`Suppressed ${suppressed.length} bank row(s).`);
+}
+
+main()
+  .then(() => process.exit(0))
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });

--- a/src/lib/__tests__/first-sentence.test.ts
+++ b/src/lib/__tests__/first-sentence.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { firstSentence } from '@/lib/first-sentence'
+
+describe('firstSentence', () => {
+  it('returns the leading sentence', () => {
+    expect(firstSentence('First. Second. Third.')).toBe('First.')
+  })
+
+  it('handles ! and ? terminators', () => {
+    expect(firstSentence('Wow! More text here.')).toBe('Wow!')
+    expect(firstSentence('Really? Yes indeed.')).toBe('Really?')
+  })
+
+  it('does not break on the "St." abbreviation (the regression case)', () => {
+    expect(
+      firstSentence(
+        'The opening chorus of the St. Matthew Passion sets the tone. The rest is detail.',
+      ),
+    ).toBe('The opening chorus of the St. Matthew Passion sets the tone.')
+  })
+
+  it('does not break on common title abbreviations', () => {
+    expect(firstSentence('Composed by Dr. Bach for the service. More here.')).toBe(
+      'Composed by Dr. Bach for the service.',
+    )
+    expect(firstSentence('Written by Mr. and Mrs. Smith. Then they left.')).toBe(
+      'Written by Mr. and Mrs. Smith.',
+    )
+  })
+
+  it('does not break on single-letter initials', () => {
+    expect(firstSentence('A theme by J. S. Bach, reworked later. And so on.')).toBe(
+      'A theme by J. S. Bach, reworked later.',
+    )
+  })
+
+  it('returns the whole string when there is no terminator', () => {
+    expect(firstSentence('no terminator here')).toBe('no terminator here')
+  })
+
+  it('trims surrounding whitespace', () => {
+    expect(firstSentence('  Padded sentence. Next.  ')).toBe('Padded sentence.')
+  })
+})

--- a/src/lib/first-sentence.ts
+++ b/src/lib/first-sentence.ts
@@ -3,8 +3,54 @@
 // End of Session Review (see GameplayChat's ResultRow), so nothing is lost.
 // Shared so the in-game result card and the feed reveal sheet truncate
 // identically.
+
+// Common abbreviations whose trailing period is NOT a sentence end. Without
+// this guard the naive splitter cuts "The opening chorus of the St. Matthew
+// Passion…" at "St.". Matched case-insensitively against the word immediately
+// before a candidate break. Keep the trailing period off the entries here.
+const ABBREVIATIONS = new Set([
+  'st', // St. (Saint / Street) — the case that surfaced this bug
+  'mr',
+  'mrs',
+  'ms',
+  'dr',
+  'prof',
+  'sr',
+  'jr',
+  'vs',
+  'etc',
+  'no',
+  'vol',
+  'op', // Op. (musical opus number)
+  'fig',
+  'gen',
+  'sen',
+  'rep',
+  'gov',
+  'pres',
+])
+
+// Single capital-letter initials ("J. S. Bach", "U. S.") also end in a period
+// followed by a space but never close a sentence.
+function isAbbreviationBreak(textBeforePeriod: string): boolean {
+  const lastWord = textBeforePeriod.match(/(\S+)$/)?.[1] ?? ''
+  if (/^[A-Za-z]$/.test(lastWord)) return true
+  return ABBREVIATIONS.has(lastWord.toLowerCase())
+}
+
 export function firstSentence(text: string): string {
   const trimmed = text.trim()
-  const match = trimmed.match(/^.*?[.!?](?=\s|$)/)
-  return match ? match[0] : trimmed
+  // Walk each candidate terminator and accept the first that is a real sentence
+  // end — i.e. not the period of a known abbreviation or a single initial.
+  const terminator = /[.!?](?=\s|$)/g
+  let match: RegExpExecArray | null
+  while ((match = terminator.exec(trimmed)) !== null) {
+    const end = match.index + 1
+    const before = trimmed.slice(0, match.index)
+    // `!`/`?` are unambiguous; only `.` can be an abbreviation period.
+    if (match[0] !== '.' || !isAbbreviationBreak(before)) {
+      return trimmed.slice(0, end)
+    }
+  }
+  return trimmed
 }

--- a/src/server/daily/__tests__/factual-gate.test.ts
+++ b/src/server/daily/__tests__/factual-gate.test.ts
@@ -46,6 +46,27 @@ describe('parseFactualGateResponse', () => {
     }
   });
 
+  it('parses a multi-drop response intact (the case the raised max_tokens cap protects)', () => {
+    const result = parseFactualGateResponse(
+      '{"drop_indices":[0,2,4],"reasons":{"0":"wrong count","2":"wrong attribution","4":"false premise"}}',
+      5,
+    );
+    expect([...result.toDrop].sort()).toEqual([0, 2, 4]);
+    expect(result.reasons[0]).toBe('wrong count');
+    expect(result.reasons[4]).toBe('false premise');
+  });
+
+  it('returns empty when the JSON is truncated mid-structure (the silent fail-open the token cap prevents)', () => {
+    // A response cut off at max_tokens: every flagged index is silently lost and
+    // the whole batch ships ungated. Raising FACTUAL_GATE_MAX_TOKENS + the
+    // stop_reason guard in findFactualFailures keep this from happening unseen.
+    const truncated =
+      '{"drop_indices":[0,1,2],"reasons":{"0":"Neville received ten points not fifty","1":"the choral finale is the Ninth not the Thi';
+    const result = parseFactualGateResponse(truncated, 3);
+    expect(result.toDrop.size).toBe(0);
+    expect(result.reasons).toEqual({});
+  });
+
   it('truncates very long reason strings', () => {
     const long = 'x'.repeat(500);
     const result = parseFactualGateResponse(

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -140,6 +140,14 @@ GOOD (open recall):
 TRIVIA-OF-TRIVIA RULE:
 Prefer questions of substance — "what is X", "what does X mean", "why does X matter", "who did X" — over questions of mere recall — "what year", "what number", "what label". A date, a count, or a name is worth asking only when that specific fact is itself meaningful; a question that lands on substance is almost always the better question. Lead with the idea, not the index card.
 
+NO GRATUITOUS SIDE-FACTS IN THE SETUP (false-premise floor — ALL tiers):
+The single largest source of broken questions is a FALSE CLAIM smuggled into the setup as decorative scaffolding — a claim the player never has to use, that exists only to sound authoritative. These are dangerous precisely because they are confident and unnecessary: every one is an independently-checkable fact that can be wrong while your asked answer is still right. They come in two forms, BOTH banned unless load-bearing AND certain:
+- QUANTITATIVE — a count, date, year, ordinal, or superlative/exclusivity claim ("fifty points", "the largest", "the first", "the only", "exactly three", "founded", "premiered in 1888").
+- QUALITATIVE / RELATIONAL — a characterization or causal/derivational link asserted as fact ("its unusual four-movement structure", "a rule that bars volleying before the ball crosses the net", "a transformation that draws on the ancient dragon").
+RULE: assert in the setup ONLY what the question actually needs the player to lean on, and only what you are certain is true. If a fact is not essential to the ask, CUT it. When you must include framing, prefer evocative, atmospheric description (which carries no factual claim) over a pile of stated counts, superlatives, and attributions. Setup length is not the problem — asserted side-facts are; a long atmospheric question is safe, a short one with a wrong number is not.
+- BAD (false, unnecessary superlative): "Dumbledore makes last-minute point awards that overturn Slytherin's lead. Which student receives fifty points — the largest single award in that sequence — for standing up to his friends?" → the "fifty points / largest single award" claim is both decorative and false (it was ten points, and the largest award went to someone else); the question works without it.
+- GOOD (same answer, no asserted side-fact): "At the end-of-year feast in Harry's first year, which student does Dumbledore award points to 'for standing up to his friends'?" → "Neville Longbottom"
+
 FAN-SALIENCE RULE (Rule 1 — tier-dependent):
 Do NOT default to the most nameable entity in a work — the character roster, the title, the principal location. Those are wiki-salient (easy to look up, dull to be asked). Chase fan-salient facts instead: the thing a devoted fan of THIS specific work would be delighted to be recognized for knowing — the rewatch-catch, the running joke, the exact wording of a famous line, the specific beat or object fans hold onto. Apply by difficulty tier:
 - specialist and moderate: the question MUST clear fan-salience. A generic "name the entity" question is a FAILURE at these tiers, even if factually correct.
@@ -852,6 +860,18 @@ function gateModelRejectsTemperature(model: string): boolean {
 // Haiku gate timeout is tuned for Haiku's speed; a heavier gate model needs more
 // headroom or it times out and fails open (silently disabling the gate).
 const FACTUAL_GATE_TIMEOUT_MS = FACTUAL_GATE_MODEL === HAIKU_MODEL ? HAIKU_GATE_TIMEOUT_MS : 20_000;
+// Output budget for the gate's JSON verdict. The whole over-provisioned batch is
+// gated in ONE call, and the response lists every dropped index + a one-line
+// reason. A single verbose drop already runs ~270 output tokens, so the old
+// 500-token cap truncated as soon as a batch flagged 2+ questions: the JSON cut
+// off mid-structure, parseFactualGateResponse failed to parse it, and the gate
+// SILENTLY returned an empty drop set — shipping the entire un-vetted batch
+// (this is how the "fifty points" Harry Potter false-premise question reached
+// production despite the gate running on Sonnet, which flags it deterministically).
+// Output is billed per token actually emitted, so this headroom is free unless a
+// response genuinely needs it; the truncation guard below catches any remaining
+// overflow loudly instead of silently.
+const FACTUAL_GATE_MAX_TOKENS = 2000;
 
 export function parseFactualGateResponse(
   raw: string,
@@ -911,12 +931,22 @@ export async function findFactualFailures(generated: LlmQuestion[]): Promise<{
   try {
     const response = await loggedMessagesCreate(client, 'factual-gate', {
       model: FACTUAL_GATE_MODEL,
-      max_tokens: 500,
+      max_tokens: FACTUAL_GATE_MAX_TOKENS,
       // Omit temperature on models that reject sampling params (Opus 4.7/4.8/Fable).
       ...(gateModelRejectsTemperature(FACTUAL_GATE_MODEL) ? {} : { temperature: 0 }),
       system: FACTUAL_GATE_SYSTEM_PROMPT,
       messages: [{ role: 'user', content: userMessage }],
     }, { timeoutMs: FACTUAL_GATE_TIMEOUT_MS });
+    // A max_tokens stop means the JSON verdict was cut off: the parse below will
+    // fail and return an empty set, so the whole batch passes UNGATED. That used
+    // to be invisible. Surface it loudly so the cap can be raised before it
+    // silently disables the gate again.
+    if (response.stop_reason === 'max_tokens') {
+      console.warn(
+        '[daily/generate-questions] factual gate response truncated at max_tokens — batch passed UNGATED',
+        { batchSize: generated.length, maxTokens: FACTUAL_GATE_MAX_TOKENS },
+      );
+    }
     return parseFactualGateResponse(extractTextContent(response.content), generated.length);
   } catch (err) {
     // Fail open: a Haiku outage should not block the daily queue. A wrong


### PR DESCRIPTION
## Why

A Harry Potter question shipped to production with a false premise — *"Which student receives **fifty points — the largest single award in that sequence** …?"* → Neville. In *Philosopher's Stone* Neville got **ten** points and the largest single award was Harry's **sixty**. Answer-right / premise-false: exactly the factual gate's job.

## What the investigation found

- Telemetry (`LlmUsageEvent`, scope `factual-gate`) showed the gate **was running on Sonnet** at the generation timestamp, and Sonnet flags this question **5/5** in isolation — so it was **neither a tier miss nor a prompt gap**.
- **Root cause:** the gate sends the whole over-provisioned batch in one call but capped the response at `max_tokens: 500`. One verbose drop reason ≈ 270 output tokens, so a batch flagging 2+ questions **truncated the JSON → parse failed → empty drop set → the entire batch shipped UNGATED**. Reproduced: a 3-defect batch emits **495** tokens, right against the old cap.
- The fail-open was **invisible**: usage is logged *after* a successful response, so a truncation/timeout leaves no telemetry row.

## Changes

**Gate hardening** (`generate-questions.ts`)
- `FACTUAL_GATE_MAX_TOKENS = 2000` (output is billed per token emitted — the headroom is free).
- Log loudly when `stop_reason === 'max_tokens'` (**"batch passed UNGATED"**) so future truncation is observable.
- Unit tests: multi-drop parsing + the truncated-JSON fail-open.

**Generation defense-in-depth — measured, not guessed**
- Evidence run `scripts/audit-assertion-density.ts` (read-only, n=120): assertion-density tracks gate flags **~5×** (2.5% → 12.5%, low→high tertile) while length barely moves (43 vs 37 words). Half the confirmed offenders carry their false premise in a **qualitative/relational** claim, not a number.
- New `SYSTEM_PROMPT` rule **"NO GRATUITOUS SIDE-FACTS IN THE SETUP"** bans non-load-bearing asserted side-facts (quantitative **and** qualitative) with the HP BAD→GOOD pair. Defense in depth, **not** a gate replacement; distinct from the settled "don't rewrite the *gate* prompt" non-lever.

**Unrelated display fix** (`first-sentence.ts`) — separate commit
- The answer-reveal explainer was clipping at the first period+space, so *"…the **St.** Matthew Passion…"* truncated to *"…the St."*. Now skips known abbreviations and single-letter initials. (This is the originally-reported "answer got cut off" bug.)

**Production remediation** (already applied, reversible)
- `scripts/suppress-hp-points-false-premise.ts`: suppressed the bank row (`is_duplicate`) and soft-deleted the promoted live question. Blast radius was 0 recorded answers.

**Docs** — findings + decisions recorded in `D-LLM-PROVIDER-AB-AND-GATE-TIER-01.md` (third/fourth findings).

## Open follow-up (not in this PR)
The catch-block fail-open (timeout/API error) is still silent-but-warned. Consider failing **closed** (drop the batch; the over-provisioning orchestrator tops up) so a transient gate outage can't ship an un-vetted batch — flagged in the doc as wanting its own decision.

## Test
- `vitest run` on the changed suites: 14 passed / 3 live-eval skipped.
- Typecheck + ESLint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)