### PR TITLE
feat(supply): B-SUPPLY-REFILL-THROUGHPUT-01 — bounded-concurrency pool refill

### DIFF
--- a/src/server/daily/__tests__/budgeted-concurrency.test.ts
+++ b/src/server/daily/__tests__/budgeted-concurrency.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { runBudgetedConcurrent } from '@/server/daily/budgeted-concurrency';
+
+const ITEMS = ['a', 'b', 'c', 'd', 'e', 'f'];
+const okResult = (usd: number) => ({ usd });
+const errResult = () => ({ usd: 0, failed: true });
+
+describe('runBudgetedConcurrent', () => {
+  it('processes every item when the budget allows, with zero backlog', async () => {
+    const { results, backlog } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 3, perItemReservation: 0.03, ceiling: 100, costOf: (r) => r.usd },
+      async () => okResult(0.1),
+      errResult,
+    );
+    expect(results).toHaveLength(ITEMS.length);
+    expect(backlog).toBe(0);
+  });
+
+  it('never exceeds the concurrency cap in flight', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(peak).toBe(2);
+  });
+
+  it('stops launching at the budget ceiling and reports the unserved backlog', async () => {
+    // ceiling 0.25, each item commits 0.10, reservation 0.10 → guard blocks once
+    // committed reaches 0.20 (0.20 + 0.10 > 0.25). So 2 items run, 4 are backlog.
+    const ran: string[] = [];
+    const { results, backlog } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 1, perItemReservation: 0.1, ceiling: 0.25, costOf: (r) => r.usd },
+      async (item) => {
+        ran.push(item);
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(results).toHaveLength(2);
+    expect(ran).toEqual(['a', 'b']);
+    expect(backlog).toBe(4);
+  });
+
+  it('overshoots the ceiling by at most concurrency × reservation', async () => {
+    // With concurrency 3 and reservation 0.10, up to 3 calls launch before any
+    // commits, so the run may process ceiling/reservation + (concurrency-1) items.
+    const { results } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 3, perItemReservation: 0.1, ceiling: 0.1, costOf: (r) => r.usd },
+      async () => {
+        // Hold all three workers until they have all claimed an item.
+        await new Promise((r) => setTimeout(r, 5));
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    // ceiling fits exactly 1 by reservation, but up to concurrency launch together.
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it('maps a rejected item to onError and keeps processing the rest', async () => {
+    const { results } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => {
+        if (item === 'c') throw new Error('boom');
+        return okResult(0.1);
+      },
+      () => errResult(),
+    );
+    expect(results).toHaveLength(ITEMS.length);
+    expect(results.filter((r) => 'failed' in r && r.failed)).toHaveLength(1);
+  });
+
+  it('a slow item does not stall the others (faster workers drain the queue)', async () => {
+    const completionOrder: string[] = [];
+    await runBudgetedConcurrent(
+      ['slow', 'f1', 'f2', 'f3'],
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => {
+        await new Promise((r) => setTimeout(r, item === 'slow' ? 50 : 2));
+        completionOrder.push(item);
+        return okResult(0);
+      },
+      errResult,
+    );
+    // The slow item starts first but finishes last; the fast ones complete while
+    // it is still running, proving the second worker kept pulling.
+    expect(completionOrder[completionOrder.length - 1]).toBe('slow');
+    expect(completionOrder.slice(0, 3).sort()).toEqual(['f1', 'f2', 'f3']);
+  });
+
+  it('degrades to sequential at concurrency 1', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 1, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 2));
+        inFlight -= 1;
+        return okResult(0);
+      },
+      errResult,
+    );
+    expect(peak).toBe(1);
+  });
+
+  it('handles an empty item list without launching work', async () => {
+    let calls = 0;
+    const { results, backlog } = await runBudgetedConcurrent(
+      [] as string[],
+      { concurrency: 4, perItemReservation: 0.1, ceiling: 1, costOf: (r) => r.usd },
+      async () => {
+        calls += 1;
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(calls).toBe(0);
+    expect(results).toHaveLength(0);
+    expect(backlog).toBe(0);
+  });
+});

--- a/src/server/daily/budgeted-concurrency.ts
+++ b/src/server/daily/budgeted-concurrency.ts
@@ -1,0 +1,72 @@
+// Generic bounded-concurrency runner with a USD-style budget guard
+// (B-SUPPLY-REFILL-THROUGHPUT-01). Pure — no db / network / env — so it is unit
+// testable in isolation. Used by the pool-refill cron, where each item is a
+// domain whose grounded web-search call runs 60-120s: a SEQUENTIAL run drained
+// only ~2-3 items inside the route's 300s budget (verification 2026-06-30, ~65%
+// of items timed out), so we process a few at once.
+//
+// Guard semantics: a worker launches the next item only while
+// `committed + perItemReservation <= ceiling`, where `committed` is the running
+// sum of each settled result's cost. With up to `concurrency` calls in flight,
+// the total can overshoot the ceiling by at most `concurrency × perItemReservation`
+// — bounded and accepted (callers keep a hard monthly backstop above this). A
+// worker that finishes a cheap/fast item immediately pulls the next, so a slow
+// item never stalls the others.
+
+export type BudgetedRunResult<R> = {
+  /** Settled results, in completion order. */
+  results: R[];
+  /** Items never launched because the ceiling was reached (unserved demand). */
+  backlog: number;
+};
+
+export async function runBudgetedConcurrent<T, R>(
+  items: readonly T[],
+  opts: {
+    /** Max items in flight at once (floored at 1). */
+    concurrency: number;
+    /** Stop launching once committed + this would cross the ceiling. */
+    perItemReservation: number;
+    /** Budget ceiling in the same unit as perItemReservation / costOf. */
+    ceiling: number;
+    /** Actual cost of a settled result, added to committed spend. */
+    costOf: (result: R) => number;
+  },
+  run: (item: T) => Promise<R>,
+  onError: (item: T, err: unknown) => R,
+): Promise<BudgetedRunResult<R>> {
+  const results: R[] = [];
+  let committed = 0;
+  let nextIndex = 0;
+  let backlog = 0;
+  let ceilingHit = false;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      // Claim the next item under the budget guard. There is no await between the
+      // guard and the index bump, so the check-and-claim is atomic on the JS thread.
+      if (nextIndex >= items.length) return;
+      if (committed + opts.perItemReservation > opts.ceiling) {
+        if (!ceilingHit) {
+          ceilingHit = true;
+          backlog = items.length - nextIndex;
+        }
+        return;
+      }
+      const item = items[nextIndex];
+      nextIndex += 1;
+      let result: R;
+      try {
+        result = await run(item);
+      } catch (err) {
+        result = onError(item, err);
+      }
+      committed += opts.costOf(result);
+      results.push(result);
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(Math.floor(opts.concurrency) || 1, items.length || 1));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return { results, backlog };
+}

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -57,6 +57,13 @@ export type RetrievalConfig = {
   /** Cap on domains processed in a single run (belt-and-braces alongside the
    *  USD ceiling). */
   maxDomainsPerRun: number;
+  /** How many domains to refill CONCURRENTLY (B-SUPPLY-REFILL-THROUGHPUT-01). The
+   *  agentic web-search call runs 60-120s, so a sequential run drains only ~2-3
+   *  domains inside the route's 300s budget. Running several at once keeps the
+   *  budget productive. Capped low to stay within the Postgres pool (max:5 in
+   *  src/server/db/index.ts) — each in-flight domain borrows a connection for its
+   *  reads/writes. */
+  maxConcurrentDomains: number;
   /** Minimum distinct non-denied source hosts required to keep a grounded
    *  question (corroboration floor; Drift Risk 2). */
   minCorroboratingSources: number;
@@ -93,6 +100,10 @@ export function getRetrievalConfig(): RetrievalConfig {
     poolDepthThreshold: Math.max(1, Math.round(numEnv('RETRIEVAL_POOL_DEPTH_THRESHOLD', 8))),
     activeLookbackDays: Math.max(1, Math.round(numEnv('RETRIEVAL_ACTIVE_LOOKBACK_DAYS', 14))),
     maxDomainsPerRun: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_DOMAINS_PER_RUN', 50))),
+    // Default 4: keeps one connection of headroom under the max:5 Postgres pool
+    // while turning the sequential ~2-3 domains/run into ~4× the throughput.
+    // Floored at 1 (degrades to sequential); capped at 8 to never starve the pool.
+    maxConcurrentDomains: Math.min(8, Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_CONCURRENT_DOMAINS', 4)))),
     minCorroboratingSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_CORROBORATING_SOURCES', 2))),
     minReputableSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_REPUTABLE_SOURCES', 1))),
   };

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -18,6 +18,7 @@ import {
   type GroundedLlmQuestion,
 } from '@/server/daily/generate-questions';
 import { askToAnswerBatch, resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
+import { runBudgetedConcurrent } from '@/server/daily/budgeted-concurrency';
 import { getMonthToDateLlmSpendUsd } from '@/server/db/queries/llm-provider-experiment';
 import { assessCorroboration, getReputationLists } from '@/server/daily/source-reputation';
 import { resolveDailyBasePoints } from '@/server/daily/types';
@@ -331,19 +332,30 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
   const maxSearchesPerCall = config.maxSearchesPerQuestion * config.questionsPerDomain;
   const perCallWorstCaseUsd = maxSearchesPerCall * USD_PER_WEB_SEARCH;
 
-  for (let i = 0; i < domains.length; i += 1) {
-    if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
-      // Ceiling reached — everything still in the list is unserved demand.
-      report.backlogRemaining = domains.length - i;
-      break;
-    }
+  // Fold one settled domain (success or failure) into the run report. In the real
+  // path this runs over the worker results AFTER they settle (not concurrently),
+  // so the report totals are assembled in one pass.
+  const accumulate = (r: DomainRefillResult): void => {
+    report.perDomain.push(r);
+    report.domainsProcessed += 1;
+    report.usdSpent += r.usd;
+    report.webSearches += r.webSearches;
+    report.questionsPersisted += r.persisted;
+    report.dropped.uncorroborated += r.droppedUncorroborated;
+    report.dropped.qualityGate += r.droppedQualityGate;
+    report.dropped.duplicateFact += r.droppedDuplicateFact;
+  };
 
-    const { domain } = domains[i];
-
-    if (dryRun) {
-      // Preview only: project this call's worst-case search spend, issue nothing.
-      report.perDomain.push({
-        domain,
+  if (dryRun) {
+    // Preview only: project each call's worst-case search spend sequentially,
+    // issue nothing, and stop at the ceiling like a real run would.
+    for (let i = 0; i < domains.length; i += 1) {
+      if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
+        report.backlogRemaining = domains.length - i;
+        break;
+      }
+      accumulate({
+        domain: domains[i].domain,
         persisted: 0,
         webSearches: maxSearchesPerCall,
         usd: perCallWorstCaseUsd,
@@ -352,32 +364,36 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         droppedQualityGate: 0,
         droppedDuplicateFact: 0,
       });
-      report.domainsProcessed += 1;
-      report.usdSpent += perCallWorstCaseUsd;
-      report.webSearches += maxSearchesPerCall;
-      continue;
     }
+    return report;
+  }
 
-    // Preconditions are guaranteed by the early return above on a real run;
-    // narrow them for the type checker (and stay defensive).
-    if (!client || !config.systemUserId) continue;
-    try {
-      const domainResult = await refillDomain(client, domain, config, config.systemUserId);
-      report.perDomain.push(domainResult);
-      report.domainsProcessed += 1;
-      report.usdSpent += domainResult.usd;
-      report.webSearches += domainResult.webSearches;
-      report.questionsPersisted += domainResult.persisted;
-      report.dropped.uncorroborated += domainResult.droppedUncorroborated;
-      report.dropped.qualityGate += domainResult.droppedQualityGate;
-      report.dropped.duplicateFact += domainResult.droppedDuplicateFact;
-    } catch (err) {
+  // Real run. Preconditions are guaranteed by the blocker early-return above;
+  // narrow them here for the type checker (and stay defensive).
+  if (!client || !config.systemUserId) return report;
+  const liveClient = client;
+  const systemUserId = config.systemUserId;
+
+  // Bounded-concurrency domain processing (B-SUPPLY-REFILL-THROUGHPUT-01). A
+  // sequential run drained only ~2-3 domains inside the route's 300s budget and
+  // slow domains starved (verification 2026-06-30, ~65% of domains time out at
+  // callTimeoutMs). Running a few at once keeps the budget productive.
+  const { results, backlog } = await runBudgetedConcurrent(
+    domains.map((d) => d.domain),
+    {
+      concurrency: config.maxConcurrentDomains,
+      perItemReservation: perCallWorstCaseUsd,
+      ceiling: config.dailyUsdCeiling,
+      costOf: (r: DomainRefillResult) => r.usd,
+    },
+    (domain) => refillDomain(liveClient, domain, config, systemUserId),
+    (domain, err): DomainRefillResult => {
       // A single domain failing (timeout / parse / API) must not sink the run.
       console.warn('[pool-refill] domain refill failed', {
         domain,
         error: err instanceof Error ? err.message : String(err),
       });
-      report.perDomain.push({
+      return {
         domain,
         persisted: 0,
         webSearches: 0,
@@ -386,9 +402,11 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         droppedUncorroborated: 0,
         droppedQualityGate: 0,
         droppedDuplicateFact: 0,
-      });
-    }
-  }
+      };
+    },
+  );
+  results.forEach(accumulate);
+  report.backlogRemaining = backlog;
 
   return report;
 }


### PR DESCRIPTION
The prerequisite to the grounded-refill flip. Verification (PR #1336, `B-SUPPLY-REFILL-FLIP-01-FINDINGS.md`) found the refill blocked on **throughput, not quality**: ~65% of thin domains time out at the 120s per-call limit, and the **sequential** run drained only ~2–3 domains inside the cron's 300s budget — so slow domains never deepened.

## Change
Process domains with a **bounded worker pool** instead of one-at-a-time.

- **`budgeted-concurrency.ts`** — new generic, dependency-free `runBudgetedConcurrent` helper: up to `concurrency` workers; a worker launches the next item only while `committed + one worst-case reservation ≤ ceiling` (bounded overshoot ≤ `concurrency × reservation`); a fast worker immediately pulls the next so a slow/timed-out item never stalls the others; per-item errors map via `onError` so one bad domain never sinks the run. **8 unit tests.**
- **`retrieval-grounded.ts`** — `runPoolRefill` uses the helper for the real path; dry-run stays a sequential projection.
- **`retrieval-config.ts`** — new `RETRIEVAL_MAX_CONCURRENT_DOMAINS` (default **4**, capped 1..8). 4 keeps one connection of headroom under the `max:5` Supabase pool.

## Validation
- ✅ Unit: 8 new tests + existing `retrieval-grounded` / `retrieval-flag-off` tests pass (18 total).
- ✅ Lint + typecheck clean (only pre-existing stale `.next/types` `/replay` errors).
- ✅ Wiring smoke (4 domains, concurrency 4, vs prod DB): worker pool runs, handles errors, assembles the report without crashing; budget guard holds.
- ⏳ **Pending:** end-to-end concurrent completion/throughput measurement + the canonical niche-domain (*Spy School Books 1–6*) completion check — the daily Anthropic usage limit was reached during testing (resets 00:00 UTC). Recommend running once on a Vercel preview (real `us-west-2` latency) before the flip.

## Safety
`RETRIEVAL_GROUNDING_ENABLED` stays **OFF** (this PR doesn't flip it); `NARROW_KB_GUARD_ENABLED` untouched (S5). No migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)