### PR TITLE
feat(grading): close the answer-key completeness loop for multi-answer questions

### DIFF
--- a/src/app/api/daily/catchup/recheck/route.ts
+++ b/src/app/api/daily/catchup/recheck/route.ts
@@ -1,0 +1,298 @@
+import { and, eq } from 'drizzle-orm';
+import { after, NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { updateDomainDifficultyOnAnswer } from '@/server/adaptive-difficulty';
+import { getSession } from '@/server/auth/session';
+import { dailyQueues, db, generatedQuestions, gradeDisputes, questions } from '@/server/db';
+import {
+  asQueueSlots,
+  findQueueSlotBySlotIndex,
+  parseCatchupItemId,
+  replaceQueueSlot,
+} from '@/server/daily/catchup';
+import { type QueueSlot } from '@/server/daily/types';
+import { isBonusSlot } from '@/server/daily/bonus';
+import { recheckAnswerWithLLM } from '@/server/llm/recheck';
+import { recordAcceptedAlternative } from '@/server/answers/record-accepted-alternative';
+import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
+import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
+import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
+import { canonicalPointsForAnswer } from '@/lib/game-constants';
+
+export const dynamic = 'force-dynamic';
+
+// Recheck (appeal a wrong grade) for a CATCH-UP attempt on a Daily Five slot.
+//
+// Why a separate route from /api/daily/recheck: catch-up re-answers a missed or
+// wrong slot WITHOUT touching the live verdict — it writes its own
+// `catchup_answer_state` / `catchup_submitted_answer` on the slot and leaves
+// `answer_state` / `submitted_answer` (the live-round result) untouched. The
+// daily recheck route keys off those live fields and bails on a catch-up slot
+// (`!slot.answered` → "Answer the question before requesting a recheck"), so a
+// catch-up mis-grade had NO appeal path at all. This route operates on the
+// `catchup_*` fields and, on accept, flips `catchup_answer_state` to 'correct'
+// (the live verdict still stays put), exactly mirroring how the catch-up answer
+// route records its outcome.
+//
+// Scope: daily-surface catch-up only. Feed-surface catch-up does not persist the
+// catch-up submission text (handleFeedCatchupAnswer only stamps catchupResolvedAt
+// + answerResult), so there is no catch-up answer to recheck — the original feed
+// answer is appealable through /api/feed/{feedItemId}/recheck instead.
+
+type RecheckErrorCode = 'unauthorized' | 'validation' | 'not_found' | 'invalid_state' | 'question_not_found' | 'unexpected';
+
+function errorResponse(status: number, error: RecheckErrorCode, message: string) {
+  return NextResponse.json({ error, message }, { status });
+}
+
+const bodySchema = z.object({
+  dailyQueueItemId: z.string().min(1),
+});
+
+export async function POST(request: NextRequest) {
+  try {
+    const session = await getSession();
+    if (!session) return errorResponse(401, 'unauthorized', 'Please sign in to request a recheck.');
+
+    const parsed = bodySchema.safeParse(await request.json().catch(() => null));
+    if (!parsed.success) return errorResponse(400, 'validation', 'dailyQueueItemId is required');
+
+    const dispatch = parseCatchupItemId(parsed.data.dailyQueueItemId);
+    if (!dispatch) return errorResponse(400, 'validation', 'dailyQueueItemId is malformed');
+    if (dispatch.surface !== 'daily') {
+      // Feed-surface catch-up has no persisted catch-up submission to recheck;
+      // the original feed answer is appealable via /api/feed/{id}/recheck.
+      return errorResponse(400, 'invalid_state', 'This catch-up item is not eligible for recheck here.');
+    }
+
+    const [queue] = await db
+      .select()
+      .from(dailyQueues)
+      .where(and(eq(dailyQueues.id, dispatch.queueId), eq(dailyQueues.userId, session.userId)))
+      .limit(1);
+    if (!queue) return errorResponse(404, 'not_found', 'We could not find that Daily Five queue.');
+
+    const slots = asQueueSlots(queue.slots);
+    const slot = findQueueSlotBySlotIndex(slots, dispatch.slotIndex);
+    if (!slot) return errorResponse(400, 'validation', 'slot_index out of range');
+    if (!slot.catchup_answered_at || !slot.catchup_submitted_answer) {
+      return errorResponse(400, 'invalid_state', 'Answer the catch-up question before requesting a recheck.');
+    }
+    if (slot.catchup_answer_state === 'correct') {
+      return errorResponse(400, 'invalid_state', 'That catch-up answer is already marked correct.');
+    }
+    if (slot.catchup_recheck_status) {
+      return errorResponse(400, 'invalid_state', 'That catch-up answer has already been rechecked.');
+    }
+    if (!slot.generated_question_id && !slot.question_id) {
+      return errorResponse(400, 'invalid_state', 'That catch-up slot has no question to recheck.');
+    }
+
+    // Resolve the answer key for the reviewer. Bot slots carry their alternatives
+    // on the GeneratedQuestion (acceptable_variants); friend/house slots on the
+    // canonical Question (accepted_alternatives).
+    let acceptedAlternatives: string[] = [];
+    let domain = slot.domain;
+    let broadCategory: string | null = slot.broad_category ?? null;
+    if (slot.generated_question_id) {
+      const [row] = await db
+        .select({
+          acceptableVariants: generatedQuestions.acceptableVariants,
+          canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+          broadCategory: generatedQuestions.broadCategory,
+        })
+        .from(generatedQuestions)
+        .where(eq(generatedQuestions.id, slot.generated_question_id))
+        .limit(1);
+      acceptedAlternatives = row?.acceptableVariants ?? [];
+      domain = row?.canonicalSubcategory || slot.domain;
+      broadCategory = row?.broadCategory ?? broadCategory;
+    } else if (slot.question_id) {
+      const [row] = await db
+        .select({
+          acceptedAlternatives: questions.acceptedAlternatives,
+          canonicalSubcategory: questions.canonicalSubcategory,
+          broadCategory: questions.broadCategory,
+          deletedAt: questions.deletedAt,
+        })
+        .from(questions)
+        .where(eq(questions.id, slot.question_id))
+        .limit(1);
+      if (!row || row.deletedAt) {
+        return errorResponse(404, 'question_not_found', 'We could not find that catch-up question.');
+      }
+      acceptedAlternatives = row.acceptedAlternatives ?? [];
+      domain = row.canonicalSubcategory || slot.domain;
+      broadCategory = row.broadCategory ?? broadCategory;
+    }
+
+    const canonicalAnswer = slot.reveal_canonical_answer ?? '';
+    const review = await recheckAnswerWithLLM({
+      questionText: slot.question_text,
+      canonicalAnswer,
+      submittedAnswer: slot.catchup_submitted_answer,
+      // Daily-generated slots are factual by construction; friend slots are also
+      // graded factually on the catch-up path (parity with the catch-up answer
+      // route, which passes the stored type — generated rows have none).
+      questionType: 'factual',
+      acceptedAlternatives,
+    });
+
+    const accepted = review.decision === 'accept';
+    // A disputed answer key reads as "taking another look", not a rejection.
+    const recheckStatus = accepted ? 'accepted' : review.decision === 'reject' ? 'rejected' : 'needs_human';
+    const disputeStatus = accepted ? 'alternative_added' : 'pending';
+    const reviewedAt = accepted ? new Date() : null;
+
+    // Catch-up scoring uses the shared canonical scorer with the catch-up surface
+    // weight (D-RECOVERY-SCORING-UNIFY-01), same as the catch-up answer route.
+    const pointsAwarded = accepted
+      ? canonicalPointsForAnswer({
+          difficulty: slot.difficulty_estimate ?? null,
+          answerState: 'first_correct',
+          catchUp: true,
+        })
+      : 0;
+
+    // Persist a bot slot's GeneratedQuestion to a canonical Question first: the
+    // dispute row's questionId must reference questions.id, and the answer-key
+    // write-back + mastery event key on the canonical id. Mirrors daily/recheck.
+    let canonicalQuestionId: string | null = slot.question_id ?? null;
+    const generatedQuestionId = slot.generated_question_id ?? null;
+    if (generatedQuestionId && !canonicalQuestionId) {
+      let persistAttempt = 0;
+      while (persistAttempt < 2 && canonicalQuestionId === null) {
+        persistAttempt += 1;
+        try {
+          const persisted = await persistGeneratedQuestion(generatedQuestionId, domain);
+          canonicalQuestionId = persisted.questionId;
+        } catch (error) {
+          const finalAttempt = persistAttempt >= 2;
+          console.warn(
+            finalAttempt
+              ? '[daily/catchup/recheck] persistGeneratedQuestion failed after retry; canonical id will be backfilled later'
+              : '[daily/catchup/recheck] persistGeneratedQuestion failed; retrying once',
+            {
+              generatedQuestionId,
+              attempt: persistAttempt,
+              error: error instanceof Error ? error.message : String(error),
+            },
+          );
+        }
+      }
+    }
+
+    const nextSlots = replaceQueueSlot(slots, dispatch.slotIndex, (item) => ({
+      ...item,
+      // Record the appeal outcome in the catch-up fields ONLY — the live-round
+      // verdict (answer_state/submitted_answer/awarded_points) stays untouched,
+      // same invariant the catch-up answer route preserves.
+      catchup_answer_state: accepted ? 'correct' : 'incorrect',
+      catchup_awarded_points: accepted ? pointsAwarded : item.catchup_awarded_points ?? 0,
+      catchup_recheck_status: recheckStatus,
+      catchup_recheck_reason: review.reason,
+    } satisfies QueueSlot));
+
+    await db.transaction(async (tx) => {
+      await tx.update(dailyQueues).set({ slots: nextSlots }).where(eq(dailyQueues.id, queue.id));
+
+      // Fall back to the generated id so the dispute still records a traceable
+      // anchor if canonical persistence failed for a bot slot.
+      const disputeQuestionId = canonicalQuestionId ?? generatedQuestionId ?? slot.question_id!;
+      await tx
+        .insert(gradeDisputes)
+        .values({
+          answerId: `catchup-recheck:${queue.id}:${dispatch.slotIndex}:${session.userId}`,
+          questionId: disputeQuestionId,
+          creatorId: session.userId,
+          submittedAnswer: slot.catchup_submitted_answer ?? '',
+          canonicalAnswer,
+          questionText: slot.question_text,
+          surface: 'daily_catchup',
+          reviewDecision: review.decision,
+          reviewReason: review.reason,
+          acceptedAlternative: review.acceptedAlternative,
+          status: disputeStatus,
+          reviewedAt,
+        })
+        .onConflictDoUpdate({
+          target: gradeDisputes.answerId,
+          set: {
+            canonicalAnswer,
+            questionText: slot.question_text,
+            surface: 'daily_catchup',
+            reviewDecision: review.decision,
+            reviewReason: review.reason,
+            acceptedAlternative: review.acceptedAlternative,
+            status: disputeStatus,
+            reviewedAt,
+          },
+        });
+    });
+
+    let masteryDelta = null;
+    if (accepted) {
+      // Fix 2: fold the accepted alternative into the answer key (canonical row +
+      // originating generated row) so the same answer is never wronged again.
+      await recordAcceptedAlternative({
+        canonicalQuestionId,
+        generatedQuestionId,
+        alternative: review.acceptedAlternative,
+      });
+
+      masteryDelta = await writeMasteryEvent({
+        userId: session.userId,
+        questionId: generatedQuestionId ?? canonicalQuestionId ?? `${queue.id}:${dispatch.slotIndex}`,
+        domain,
+        answerState: 'first_correct',
+        pointsAwarded,
+        sourceType: 'catchup',
+        isBonus: isBonusSlot(slot),
+        sourceId: `${queue.id}:${dispatch.slotIndex}:recheck`,
+        broadCategory,
+        eventQuestionId: canonicalQuestionId,
+        basePoints: pointsAwarded,
+        weight: 1,
+      }).catch((error) => {
+        console.warn('[daily/catchup/recheck] writeMasteryEvent failed', error);
+        return null;
+      });
+
+      await updateDomainDifficultyOnAnswer(session.userId, domain, true).catch((error) => {
+        console.warn('[daily/catchup/recheck] updateDomainDifficultyOnAnswer failed', error);
+      });
+
+      if (canonicalQuestionId) {
+        try {
+          const propagationKey = generatedQuestionId ?? canonicalQuestionId;
+          after(() => createFeedItemsForFriendsFromAnswer(
+            session.userId,
+            canonicalQuestionId,
+            'correct',
+            `catchup:${propagationKey}:${session.userId}`,
+          ));
+        } catch (error) {
+          console.warn('[daily/catchup/recheck] feed propagation failed', {
+            generatedQuestionId,
+            canonicalQuestionId,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
+      }
+    }
+
+    return NextResponse.json({
+      accepted,
+      status: recheckStatus,
+      reason: review.reason,
+      acceptedAlternative: review.acceptedAlternative,
+      pointsAwarded,
+      correctAnswer: canonicalAnswer,
+      masteryDelta,
+    });
+  } catch (error) {
+    console.error('[daily/catchup/recheck] unexpected', error);
+    return errorResponse(500, 'unexpected', 'Could not recheck that answer.');
+  }
+}

--- a/src/app/api/daily/recheck/route.ts
+++ b/src/app/api/daily/recheck/route.ts
@@ -11,6 +11,7 @@ import { isGenericCanonicalAnswer, normalizeCanonicalAnswerLabel } from '@/serve
 import { suggestAnswer } from '@/lib/llm';
 import { getProviderSettings } from '@/server/llm/settings';
 import { recheckAnswerWithLLM } from '@/server/llm/recheck';
+import { recordAcceptedAlternative } from '@/server/answers/record-accepted-alternative';
 import { persistGeneratedQuestion } from '@/server/questions/persist-generated-question';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 
@@ -257,6 +258,15 @@ export async function POST(request: NextRequest) {
 
     let masteryDelta = null;
     if (accepted) {
+      // Fix 2: fold the accepted alternative into the answer key (canonical row,
+      // plus the originating generated row for the live daily grade path) so the
+      // same correct-but-unlisted answer is never wronged again. Best-effort.
+      await recordAcceptedAlternative({
+        canonicalQuestionId,
+        generatedQuestionId: question.generatedId,
+        alternative: review.acceptedAlternative,
+      });
+
       masteryDelta = await writeMasteryEvent({
         userId: session.userId,
         questionId: question.generatedId ?? question.canonicalId ?? canonicalQuestionId ?? `${queue.id}:${parsed.slotIndex}`,

--- a/src/app/api/feed/[feedItemId]/recheck/route.ts
+++ b/src/app/api/feed/[feedItemId]/recheck/route.ts
@@ -6,6 +6,7 @@ import { db, feedItems, gradeDisputes, questions } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { getBasePoints } from '@/server/mastery/scoring';
 import { recheckAnswerWithLLM } from '@/server/llm/recheck';
+import { recordAcceptedAlternative } from '@/server/answers/record-accepted-alternative';
 
 export const dynamic = 'force-dynamic';
 
@@ -112,6 +113,15 @@ export async function POST(_request: NextRequest, context: RouteContext) {
     // notifying the author; this brings feed/recheck in line.
 
     if (accepted) {
+      // Fix 2: fold the accepted alternative into the question's answer key so
+      // the same correct-but-unlisted answer is never wronged (and re-appealed)
+      // again. Best-effort; never throws.
+      await recordAcceptedAlternative({
+        canonicalQuestionId: question.id,
+        generatedQuestionId: question.generatedQuestionId,
+        alternative: review.acceptedAlternative,
+      });
+
       await writeMasteryEvent({
         userId: session.userId,
         questionId: question.id,

--- a/src/app/api/lately/milestone/recheck/route.ts
+++ b/src/app/api/lately/milestone/recheck/route.ts
@@ -7,6 +7,7 @@ import { db, feedItems, gradeDisputes, questions } from '@/server/db';
 import { writeMasteryEvent } from '@/server/mastery/write-mastery-event';
 import { getBasePoints } from '@/server/mastery/scoring';
 import { recheckAnswerWithLLM } from '@/server/llm/recheck';
+import { recordAcceptedAlternative } from '@/server/answers/record-accepted-alternative';
 
 export const dynamic = 'force-dynamic';
 
@@ -131,6 +132,14 @@ export async function POST(request: NextRequest) {
     // so it was retired (2026-06-25). Mirrors feed/recheck and daily/recheck.
 
     if (accepted) {
+      // Fix 2: fold the accepted alternative into the question's answer key so
+      // the same correct-but-unlisted answer is never wronged again.
+      await recordAcceptedAlternative({
+        canonicalQuestionId: question.id,
+        generatedQuestionId: question.generatedQuestionId,
+        alternative: review.acceptedAlternative,
+      });
+
       await writeMasteryEvent({
         userId: session.userId,
         questionId: question.id,

--- a/src/server/answers/record-accepted-alternative.ts
+++ b/src/server/answers/record-accepted-alternative.ts
@@ -1,0 +1,116 @@
+/**
+ * Fix 2 (recheck write-back) — fold an accepted appeal's alternative answer into
+ * the question's stored answer key so the SAME correct-but-unlisted answer never
+ * has to be appealed twice.
+ *
+ * Background: the first-pass grader (src/server/grading.ts) grades a submission
+ * ONLY against the canonical answer + accepted_alternatives — it never reasons
+ * about whether some other answer would also be correct for the question. When a
+ * question has more than one genuinely-correct answer but only one is encoded
+ * (e.g. "remove Data's arm" vs "shut Data off"), a correct answer to the
+ * OTHER valid response is marked wrong until a human/LLM appeal (recheck) accepts
+ * it. The recheck routes used to record that accepted alternative only on the
+ * GradeDispute row (status 'alternative_added') — the answer key itself was never
+ * updated, so the next player giving the same answer was wronged again. This
+ * helper closes that loop: an accepted recheck appends the alternative to the
+ * question's answer key, making the fix permanent and global.
+ *
+ * Best-effort by contract: it never throws (a write-back failure must not turn an
+ * accepted recheck into an error for the player), and it dedups against the
+ * existing key using the SAME normalization the fast-path grader uses, so it can
+ * never add an entry the grader would already have matched.
+ */
+
+import { eq } from 'drizzle-orm';
+
+import { db, generatedQuestions, questions } from '@/server/db';
+import { normalizeForMatch } from '@/server/grading';
+
+// An accepted-alternative is an ANSWER KEY entry, not a sentence. The recheck
+// reviewer is asked to return the submission "normalized for future accepted
+// alternatives", but defend against a runaway value polluting the key (and, with
+// it, every future grade's leniency surface).
+const MAX_ALTERNATIVE_LENGTH = 120;
+
+/** Append `candidate` to `existing` unless the answer + existing entries already
+ *  cover it under fast-path normalization. Returns the new array, or null when
+ *  nothing should change. */
+function withAlternative(
+  answer: string,
+  existing: string[],
+  candidate: string,
+): string[] | null {
+  const norm = normalizeForMatch(candidate);
+  if (!norm) return null;
+  const known = new Set<string>([normalizeForMatch(answer), ...existing.map(normalizeForMatch)]);
+  if (known.has(norm)) return null;
+  return [...existing, candidate];
+}
+
+/**
+ * Persist an accepted recheck's alternative into the question's answer key.
+ *
+ * Writes the canonical `Question.accepted_alternatives` (what feed/milestone and
+ * cross-surface grading read) and, when the recheck resolved a bot question, the
+ * originating `GeneratedQuestion.acceptable_variants` too (what the live daily
+ * path grades against before promotion). Both writes dedup independently.
+ */
+export async function recordAcceptedAlternative(params: {
+  canonicalQuestionId: string | null;
+  generatedQuestionId?: string | null;
+  alternative: string | null | undefined;
+}): Promise<void> {
+  const candidate = params.alternative?.trim();
+  if (!candidate || candidate.length > MAX_ALTERNATIVE_LENGTH) return;
+
+  try {
+    if (params.canonicalQuestionId) {
+      const [row] = await db
+        .select({
+          answerText: questions.answerText,
+          acceptedAlternatives: questions.acceptedAlternatives,
+        })
+        .from(questions)
+        .where(eq(questions.id, params.canonicalQuestionId))
+        .limit(1);
+      if (row) {
+        const next = withAlternative(row.answerText, row.acceptedAlternatives ?? [], candidate);
+        if (next) {
+          await db
+            .update(questions)
+            .set({ acceptedAlternatives: next, updatedAt: new Date() })
+            .where(eq(questions.id, params.canonicalQuestionId));
+        }
+      }
+    }
+
+    if (params.generatedQuestionId) {
+      const [row] = await db
+        .select({
+          answer: generatedQuestions.answer,
+          acceptableVariants: generatedQuestions.acceptableVariants,
+        })
+        .from(generatedQuestions)
+        .where(eq(generatedQuestions.id, params.generatedQuestionId))
+        .limit(1);
+      if (row) {
+        const next = withAlternative(row.answer, row.acceptableVariants ?? [], candidate);
+        if (next) {
+          await db
+            .update(generatedQuestions)
+            .set({ acceptableVariants: next })
+            .where(eq(generatedQuestions.id, params.generatedQuestionId));
+        }
+      }
+    }
+  } catch (error) {
+    // Best-effort: the player already saw their answer accepted. A failed
+    // write-back just means the next player with the same answer appeals again —
+    // never surface it as a recheck failure.
+    console.warn('[recordAcceptedAlternative] write-back failed', {
+      canonicalQuestionId: params.canonicalQuestionId,
+      generatedQuestionId: params.generatedQuestionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/src/server/daily/__tests__/budgeted-concurrency.test.ts
+++ b/src/server/daily/__tests__/budgeted-concurrency.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from 'vitest';
+
+import { runBudgetedConcurrent } from '@/server/daily/budgeted-concurrency';
+
+const ITEMS = ['a', 'b', 'c', 'd', 'e', 'f'];
+const okResult = (usd: number) => ({ usd });
+const errResult = () => ({ usd: 0, failed: true });
+
+describe('runBudgetedConcurrent', () => {
+  it('processes every item when the budget allows, with zero backlog', async () => {
+    const { results, backlog } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 3, perItemReservation: 0.03, ceiling: 100, costOf: (r) => r.usd },
+      async () => okResult(0.1),
+      errResult,
+    );
+    expect(results).toHaveLength(ITEMS.length);
+    expect(backlog).toBe(0);
+  });
+
+  it('never exceeds the concurrency cap in flight', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 5));
+        inFlight -= 1;
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(peak).toBe(2);
+  });
+
+  it('stops launching at the budget ceiling and reports the unserved backlog', async () => {
+    // ceiling 0.25, each item commits 0.10, reservation 0.10 → guard blocks once
+    // committed reaches 0.20 (0.20 + 0.10 > 0.25). So 2 items run, 4 are backlog.
+    const ran: string[] = [];
+    const { results, backlog } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 1, perItemReservation: 0.1, ceiling: 0.25, costOf: (r) => r.usd },
+      async (item) => {
+        ran.push(item);
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(results).toHaveLength(2);
+    expect(ran).toEqual(['a', 'b']);
+    expect(backlog).toBe(4);
+  });
+
+  it('overshoots the ceiling by at most concurrency × reservation', async () => {
+    // With concurrency 3 and reservation 0.10, up to 3 calls launch before any
+    // commits, so the run may process ceiling/reservation + (concurrency-1) items.
+    const { results } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 3, perItemReservation: 0.1, ceiling: 0.1, costOf: (r) => r.usd },
+      async () => {
+        // Hold all three workers until they have all claimed an item.
+        await new Promise((r) => setTimeout(r, 5));
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    // ceiling fits exactly 1 by reservation, but up to concurrency launch together.
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results.length).toBeLessThanOrEqual(3);
+  });
+
+  it('maps a rejected item to onError and keeps processing the rest', async () => {
+    const { results } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => {
+        if (item === 'c') throw new Error('boom');
+        return okResult(0.1);
+      },
+      () => errResult(),
+    );
+    expect(results).toHaveLength(ITEMS.length);
+    expect(results.filter((r) => 'failed' in r && r.failed)).toHaveLength(1);
+  });
+
+  it('a slow item does not stall the others (faster workers drain the queue)', async () => {
+    const completionOrder: string[] = [];
+    await runBudgetedConcurrent(
+      ['slow', 'f1', 'f2', 'f3'],
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => {
+        await new Promise((r) => setTimeout(r, item === 'slow' ? 50 : 2));
+        completionOrder.push(item);
+        return okResult(0);
+      },
+      errResult,
+    );
+    // The slow item starts first but finishes last; the fast ones complete while
+    // it is still running, proving the second worker kept pulling.
+    expect(completionOrder[completionOrder.length - 1]).toBe('slow');
+    expect(completionOrder.slice(0, 3).sort()).toEqual(['f1', 'f2', 'f3']);
+  });
+
+  it('degrades to sequential at concurrency 1', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 1, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async () => {
+        inFlight += 1;
+        peak = Math.max(peak, inFlight);
+        await new Promise((r) => setTimeout(r, 2));
+        inFlight -= 1;
+        return okResult(0);
+      },
+      errResult,
+    );
+    expect(peak).toBe(1);
+  });
+
+  it('handles an empty item list without launching work', async () => {
+    let calls = 0;
+    const { results, backlog } = await runBudgetedConcurrent(
+      [] as string[],
+      { concurrency: 4, perItemReservation: 0.1, ceiling: 1, costOf: (r) => r.usd },
+      async () => {
+        calls += 1;
+        return okResult(0.1);
+      },
+      errResult,
+    );
+    expect(calls).toBe(0);
+    expect(results).toHaveLength(0);
+    expect(backlog).toBe(0);
+  });
+});

--- a/src/server/daily/__tests__/enrich-variants.test.ts
+++ b/src/server/daily/__tests__/enrich-variants.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// enrich-variants.ts only depends on @/lib/llm (no DB). Mock it to drive the
+// single batched enrichment call deterministically and exercise the fail-open
+// contract.
+const llmMock = vi.hoisted(() => ({
+  loggedMessagesCreate: vi.fn(),
+  getAnthropicClient: vi.fn(() => ({}) as unknown),
+}));
+
+vi.mock('@/lib/llm', () => ({
+  INSTRUCTION_SCOPING_QUALIFIER: '',
+  INSTRUCTION_USER_INPUT_GUIDANCE: '',
+  extractTextContent: (content: unknown) => String((content as { text: string }).text),
+  parseJsonObject: (raw: string) => {
+    try {
+      const parsed = JSON.parse(raw);
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : null;
+    } catch {
+      return null;
+    }
+  },
+  wrapUserInput: (_tag: string, body: string) => body,
+  getAnthropicClient: llmMock.getAnthropicClient,
+  loggedMessagesCreate: llmMock.loggedMessagesCreate,
+}));
+
+const { enrichAcceptableVariants, parseEnrichResponse, mergeVariants } = await import(
+  '@/server/daily/enrich-variants'
+);
+
+function item(answer: string) {
+  return { questionText: 'q', answer, explainer: 'e' };
+}
+
+function response(json: object) {
+  return { content: { text: JSON.stringify(json) }, stop_reason: 'end_turn' };
+}
+
+beforeEach(() => {
+  llmMock.getAnthropicClient.mockReturnValue({});
+  llmMock.loggedMessagesCreate.mockReset();
+  delete process.env.ENRICH_VARIANTS_ENABLED;
+});
+
+afterEach(() => {
+  delete process.env.ENRICH_VARIANTS_ENABLED;
+  vi.restoreAllMocks();
+});
+
+describe('parseEnrichResponse', () => {
+  const items = [item('removes Data arm'), item('gluteus maximus')];
+
+  it('maps additional answers by index', () => {
+    const out = parseEnrichResponse(
+      JSON.stringify({ variants: { '0': ['switches Data off', 'powers Data down'] } }),
+      items.length,
+      items,
+    );
+    expect(out.get(0)).toEqual(['switches Data off', 'powers Data down']);
+    expect(out.has(1)).toBe(false);
+  });
+
+  it('drops out-of-range indices and non-array values', () => {
+    const out = parseEnrichResponse(
+      JSON.stringify({ variants: { '5': ['x'], '0': 'not-an-array' } }),
+      items.length,
+      items,
+    );
+    expect(out.size).toBe(0);
+  });
+
+  it('dedups case-insensitively against the stored answer', () => {
+    const out = parseEnrichResponse(
+      JSON.stringify({ variants: { '0': ['Removes Data Arm', 'switches Data off'] } }),
+      items.length,
+      items,
+    );
+    // The stored answer re-stated is dropped; only the genuinely-new answer stays.
+    expect(out.get(0)).toEqual(['switches Data off']);
+  });
+
+  it('drops over-long entries and caps the count at four', () => {
+    const long = 'a'.repeat(200);
+    const out = parseEnrichResponse(
+      JSON.stringify({ variants: { '0': [long, 'a1', 'a2', 'a3', 'a4', 'a5'] } }),
+      items.length,
+      items,
+    );
+    expect(out.get(0)).toEqual(['a1', 'a2', 'a3', 'a4']);
+  });
+
+  it('returns an empty map on malformed JSON or a non-object variants field', () => {
+    expect(parseEnrichResponse('not json', items.length, items).size).toBe(0);
+    expect(
+      parseEnrichResponse(JSON.stringify({ variants: ['nope'] }), items.length, items).size,
+    ).toBe(0);
+  });
+});
+
+describe('mergeVariants', () => {
+  it('unions lists, trims, and dedups case-insensitively preserving order', () => {
+    expect(mergeVariants(['Gold', ' the hoard '], ['gold', 'Nibelung gold'])).toEqual([
+      'Gold',
+      'the hoard',
+      'Nibelung gold',
+    ]);
+  });
+
+  it('tolerates undefined lists and drops empties', () => {
+    expect(mergeVariants(undefined, ['a', '', '  '], undefined)).toEqual(['a']);
+  });
+});
+
+describe('enrichAcceptableVariants (fail-open contract)', () => {
+  it('returns an empty map when no client is configured', async () => {
+    llmMock.getAnthropicClient.mockReturnValue(null);
+    const out = await enrichAcceptableVariants([item('x')]);
+    expect(out.size).toBe(0);
+    expect(llmMock.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty map when disabled via env', async () => {
+    process.env.ENRICH_VARIANTS_ENABLED = 'false';
+    const out = await enrichAcceptableVariants([item('x')]);
+    expect(out.size).toBe(0);
+    expect(llmMock.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty map for an empty batch without calling the model', async () => {
+    const out = await enrichAcceptableVariants([]);
+    expect(out.size).toBe(0);
+    expect(llmMock.loggedMessagesCreate).not.toHaveBeenCalled();
+  });
+
+  it('parses the model verdict on the happy path', async () => {
+    llmMock.loggedMessagesCreate.mockResolvedValue(
+      response({ variants: { '0': ['switches Data off'] } }),
+    );
+    const out = await enrichAcceptableVariants([item('removes Data arm')]);
+    expect(out.get(0)).toEqual(['switches Data off']);
+  });
+
+  it('fails open to an empty map when the model call throws', async () => {
+    llmMock.loggedMessagesCreate.mockRejectedValue(new Error('boom'));
+    const out = await enrichAcceptableVariants([item('x')]);
+    expect(out.size).toBe(0);
+  });
+});

--- a/src/server/daily/budgeted-concurrency.ts
+++ b/src/server/daily/budgeted-concurrency.ts
@@ -1,0 +1,72 @@
+// Generic bounded-concurrency runner with a USD-style budget guard
+// (B-SUPPLY-REFILL-THROUGHPUT-01). Pure — no db / network / env — so it is unit
+// testable in isolation. Used by the pool-refill cron, where each item is a
+// domain whose grounded web-search call runs 60-120s: a SEQUENTIAL run drained
+// only ~2-3 items inside the route's 300s budget (verification 2026-06-30, ~65%
+// of items timed out), so we process a few at once.
+//
+// Guard semantics: a worker launches the next item only while
+// `committed + perItemReservation <= ceiling`, where `committed` is the running
+// sum of each settled result's cost. With up to `concurrency` calls in flight,
+// the total can overshoot the ceiling by at most `concurrency × perItemReservation`
+// — bounded and accepted (callers keep a hard monthly backstop above this). A
+// worker that finishes a cheap/fast item immediately pulls the next, so a slow
+// item never stalls the others.
+
+export type BudgetedRunResult<R> = {
+  /** Settled results, in completion order. */
+  results: R[];
+  /** Items never launched because the ceiling was reached (unserved demand). */
+  backlog: number;
+};
+
+export async function runBudgetedConcurrent<T, R>(
+  items: readonly T[],
+  opts: {
+    /** Max items in flight at once (floored at 1). */
+    concurrency: number;
+    /** Stop launching once committed + this would cross the ceiling. */
+    perItemReservation: number;
+    /** Budget ceiling in the same unit as perItemReservation / costOf. */
+    ceiling: number;
+    /** Actual cost of a settled result, added to committed spend. */
+    costOf: (result: R) => number;
+  },
+  run: (item: T) => Promise<R>,
+  onError: (item: T, err: unknown) => R,
+): Promise<BudgetedRunResult<R>> {
+  const results: R[] = [];
+  let committed = 0;
+  let nextIndex = 0;
+  let backlog = 0;
+  let ceilingHit = false;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      // Claim the next item under the budget guard. There is no await between the
+      // guard and the index bump, so the check-and-claim is atomic on the JS thread.
+      if (nextIndex >= items.length) return;
+      if (committed + opts.perItemReservation > opts.ceiling) {
+        if (!ceilingHit) {
+          ceilingHit = true;
+          backlog = items.length - nextIndex;
+        }
+        return;
+      }
+      const item = items[nextIndex];
+      nextIndex += 1;
+      let result: R;
+      try {
+        result = await run(item);
+      } catch (err) {
+        result = onError(item, err);
+      }
+      committed += opts.costOf(result);
+      results.push(result);
+    }
+  };
+
+  const workerCount = Math.max(1, Math.min(Math.floor(opts.concurrency) || 1, items.length || 1));
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return { results, backlog };
+}

--- a/src/server/daily/enrich-variants.ts
+++ b/src/server/daily/enrich-variants.ts
@@ -1,0 +1,192 @@
+// Answer-key enrichment gate (Fix 3) — prevent multi-answer questions from
+// shipping with an incomplete key.
+//
+// The first-pass grader (src/server/grading.ts) grades a submission ONLY against
+// the stored answer + accepted_alternatives; it never reasons about whether some
+// OTHER answer would also be correct for the question. So when a generated
+// question genuinely has more than one correct answer but only one is encoded —
+// e.g. "In TNG's 'The Measure of a Man,' what does Riker do that shocks the
+// courtroom?" where both "detaches Data's arm" AND "switches Data off" are
+// correct, and the question's own explainer names both — a player giving the
+// other valid answer is marked wrong until they appeal.
+//
+// ask-to-answer (src/server/daily/ask-to-answer.ts) does NOT cover this: it
+// captures the same answer phrased differently (cold solvers converging on one
+// answer), and treats genuinely-divergent-but-both-correct answers as instability
+// — it would not promote them into the key. This gate is the additive piece: it
+// asks, per question, for the OTHER answers a strict-but-fair grader must accept,
+// and merges them into acceptable_variants at persist time.
+//
+// Safety: this produces UNVERIFIED alternates (unlike ask-to-answer variants,
+// which the judge deemed equivalent). The prompt is therefore deliberately
+// strict — only answers that are unambiguously, independently correct answers to
+// the question AS WORDED, never broader/vaguer forms or merely-related facts.
+// Fail-open like every other generation gate: an outage adds nothing (the
+// question still ships with its original key), it never blocks or drops.
+
+import {
+  INSTRUCTION_SCOPING_QUALIFIER,
+  INSTRUCTION_USER_INPUT_GUIDANCE,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+export interface EnrichVariantsItem {
+  questionText: string;
+  answer: string;
+  explainer: string;
+}
+
+// Default to the generation tier (Sonnet) — judging answer equivalence needs the
+// same reasoning the generator and factual gate use; Haiku is too lenient/broad
+// here and would risk polluting keys. Overridable without a deploy, mirroring
+// FACTUAL_GATE_MODEL. Resolved lazily so tests can stub the model id.
+function enrichModel(): string {
+  return process.env.ENRICH_VARIANTS_MODEL?.trim() || 'claude-sonnet-4-6';
+}
+
+function enrichEnabled(): boolean {
+  const raw = process.env.ENRICH_VARIANTS_ENABLED?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return true;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+// Opus 4.7/4.8 and Fable reject sampling params — sending `temperature` 400s.
+function modelRejectsTemperature(model: string): boolean {
+  return model.includes('opus-4-7') || model.includes('opus-4-8') || model.includes('fable');
+}
+
+const ENRICH_TIMEOUT_MS = 20_000;
+const ENRICH_MAX_TOKENS = 2000;
+// An accepted alternative is an answer-key entry, not a sentence; cap length and
+// count so an over-eager model can't bloat the key (and every future grade's
+// leniency surface).
+const MAX_VARIANTS_PER_ITEM = 4;
+const MAX_VARIANT_LENGTH = 120;
+
+const ENRICH_SYSTEM_PROMPT = `You harden the answer key for trivia questions whose phrasing admits more than one correct answer.
+
+For each item you get the question, the stored canonical answer, and an explainer. List ONLY additional answers that a fair grader MUST accept as fully correct for the question AS WORDED — distinct correct responses, not rephrasings of the stored answer (the grader already handles spelling/abbreviation/word-order variants itself).
+
+Add an answer ONLY when:
+- It is an unambiguously, independently correct answer to exactly what the question asks (e.g. the question describes an act with two equally-valid descriptions, or names a thing that has a second accepted name the stored answer omitted), AND
+- The explainer or the question itself supports it as correct.
+
+NEVER add:
+- A broader, vaguer, or partial form of the stored answer (e.g. "a horse" for "Bucephalus", "gluteus" for "gluteus maximus").
+- A merely-related, adjacent, or "also true but not what was asked" fact.
+- A rephrasing, abbreviation, alternate spelling, or translation of the stored answer (the grader handles those).
+- Anything you are not confident a strict grader should accept. When in doubt, add nothing.
+
+Most questions have exactly one correct answer — for those, return an empty list. Be conservative: a wrong entry here makes the grader accept genuinely-wrong answers forever, which is worse than a missing one.
+
+Return JSON only:
+{ "variants": { "<index>": ["<additional correct answer>", ...] } }
+Omit any index with no additions. Each answer must be SHORT (an answer, not a sentence).${INSTRUCTION_USER_INPUT_GUIDANCE}${INSTRUCTION_SCOPING_QUALIFIER}`;
+
+export function parseEnrichResponse(
+  raw: string,
+  batchSize: number,
+  items: EnrichVariantsItem[],
+): Map<number, string[]> {
+  const out = new Map<number, string[]>();
+  const parsed = parseJsonObject(raw);
+  if (!parsed) return out;
+  const variants = parsed.variants;
+  if (!variants || typeof variants !== 'object' || Array.isArray(variants)) return out;
+
+  for (const [key, value] of Object.entries(variants as Record<string, unknown>)) {
+    const idx = Number.parseInt(key, 10);
+    if (!Number.isInteger(idx) || idx < 0 || idx >= batchSize) continue;
+    if (!Array.isArray(value)) continue;
+
+    // Dedup case-insensitively against the stored answer and within the list, so
+    // we never re-add the canonical answer or a duplicate.
+    const stored = items[idx].answer.trim().toLowerCase();
+    const seen = new Set<string>([stored]);
+    const cleaned: string[] = [];
+    for (const entry of value) {
+      if (typeof entry !== 'string') continue;
+      const trimmed = entry.trim();
+      const lower = trimmed.toLowerCase();
+      if (!trimmed || trimmed.length > MAX_VARIANT_LENGTH || seen.has(lower)) continue;
+      seen.add(lower);
+      cleaned.push(trimmed);
+      if (cleaned.length >= MAX_VARIANTS_PER_ITEM) break;
+    }
+    if (cleaned.length > 0) out.set(idx, cleaned);
+  }
+  return out;
+}
+
+/**
+ * Enumerate additional genuinely-correct answers for each question and return
+ * them keyed by batch index, for merging into `acceptable_variants` at persist
+ * time. One batched call per generation batch (cost parity with the factual
+ * gate). Fail-open: returns an empty map when disabled, when no client is
+ * configured, or on any LLM/parse failure.
+ */
+export async function enrichAcceptableVariants(
+  items: EnrichVariantsItem[],
+): Promise<Map<number, string[]>> {
+  if (!enrichEnabled() || items.length === 0) return new Map();
+  const client = getAnthropicClient();
+  if (!client) return new Map();
+
+  const model = enrichModel();
+  const body = items
+    .map(
+      (q, i) =>
+        `[${i}] q=${q.questionText}\n    a=${q.answer}\n    explainer=${q.explainer}`,
+    )
+    .join('\n\n');
+
+  try {
+    const response = await loggedMessagesCreate(
+      client,
+      'enrich-variants',
+      {
+        model,
+        max_tokens: ENRICH_MAX_TOKENS,
+        ...(modelRejectsTemperature(model) ? {} : { temperature: 0 }),
+        system: ENRICH_SYSTEM_PROMPT,
+        messages: [{ role: 'user', content: wrapUserInput('batch', body) }],
+      },
+      { timeoutMs: ENRICH_TIMEOUT_MS },
+    );
+    if (response.stop_reason === 'max_tokens') {
+      // A truncated verdict parses to an empty/partial map — the batch just ships
+      // with its original keys. Surface it so the cap can be raised if it recurs.
+      console.warn('[daily/enrich-variants] response truncated at max_tokens — some keys not enriched', {
+        batchSize: items.length,
+        maxTokens: ENRICH_MAX_TOKENS,
+      });
+    }
+    return parseEnrichResponse(extractTextContent(response.content), items.length, items);
+  } catch (err) {
+    console.warn('[daily/enrich-variants] enrichment failed', {
+      error: err instanceof Error ? err.message : String(err),
+    });
+    return new Map();
+  }
+}
+
+/** Union two variant lists with case-insensitive dedup, capping the result.
+ *  Used at the persist loop to merge ask-to-answer variants with enrichment. */
+export function mergeVariants(...lists: (string[] | undefined)[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const list of lists) {
+    for (const entry of list ?? []) {
+      const trimmed = entry.trim();
+      const lower = trimmed.toLowerCase();
+      if (!trimmed || seen.has(lower)) continue;
+      seen.add(lower);
+      out.push(trimmed);
+    }
+  }
+  return out;
+}

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -77,6 +77,7 @@ import { embedTexts, isEmbeddingEnabled } from '@/server/llm/embeddings';
 import { resolveDailyBasePoints } from './types';
 import { STYLE_EXEMPLAR_BLOCK } from './exemplars';
 import { askToAnswerBatch, resolveMachineTrustTier } from './ask-to-answer';
+import { enrichAcceptableVariants, mergeVariants } from './enrich-variants';
 
 // Cap the recent question-text block at this many entries inside the prompt.
 // The full recent history (up to 200) is still used to derive the fact-key
@@ -1726,7 +1727,11 @@ export async function generateDailyQuestions(
   // one they corroborate earns machine_verified. Runs in parallel with the aside
   // precompute; fails open (drops/verifies nothing on an LLM outage). Scoped to
   // the rows we will actually persist rather than the full generated batch.
-  const [, askResult] = await Promise.all([
+  // Answer-key enrichment (Fix 3): enumerate OTHER genuinely-correct answers for
+  // multi-answer questions and merge them into acceptable_variants at persist.
+  // Distinct from ask-to-answer (which captures the same answer rephrased);
+  // additive, batched, and fail-open. Runs in the same parallel wave.
+  const [, askResult, enrichByIndex] = await Promise.all([
     Promise.all(
       toPersist.map(async (question) => {
         const aside = await generateInsideJoke({
@@ -1740,6 +1745,9 @@ export async function generateDailyQuestions(
     ),
     askToAnswerBatch(
       toPersist.map((q) => ({ questionText: q.question_text, answer: q.answer })),
+    ),
+    enrichAcceptableVariants(
+      toPersist.map((q) => ({ questionText: q.question_text, answer: q.answer, explainer: q.explainer })),
     ),
   ]);
   if (askResult.toDrop.size > 0) {
@@ -1823,7 +1831,12 @@ export async function generateDailyQuestions(
         generatedByProvider: provider,
         trustTier,
         askToAnswerVerified,
-        acceptableVariants: askResult.variantsByIndex.get(persistIndex) ?? [],
+        // Union the ask-to-answer rephrasings (judge-verified equivalent) with the
+        // enrichment gate's additional distinct-but-correct answers (Fix 3).
+        acceptableVariants: mergeVariants(
+          askResult.variantsByIndex.get(persistIndex),
+          enrichByIndex.get(persistIndex),
+        ),
         expiresAt,
         usedInQueue: false,
       })

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -57,6 +57,13 @@ export type RetrievalConfig = {
   /** Cap on domains processed in a single run (belt-and-braces alongside the
    *  USD ceiling). */
   maxDomainsPerRun: number;
+  /** How many domains to refill CONCURRENTLY (B-SUPPLY-REFILL-THROUGHPUT-01). The
+   *  agentic web-search call runs 60-120s, so a sequential run drains only ~2-3
+   *  domains inside the route's 300s budget. Running several at once keeps the
+   *  budget productive. Capped low to stay within the Postgres pool (max:5 in
+   *  src/server/db/index.ts) — each in-flight domain borrows a connection for its
+   *  reads/writes. */
+  maxConcurrentDomains: number;
   /** Minimum distinct non-denied source hosts required to keep a grounded
    *  question (corroboration floor; Drift Risk 2). */
   minCorroboratingSources: number;
@@ -93,6 +100,10 @@ export function getRetrievalConfig(): RetrievalConfig {
     poolDepthThreshold: Math.max(1, Math.round(numEnv('RETRIEVAL_POOL_DEPTH_THRESHOLD', 8))),
     activeLookbackDays: Math.max(1, Math.round(numEnv('RETRIEVAL_ACTIVE_LOOKBACK_DAYS', 14))),
     maxDomainsPerRun: Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_DOMAINS_PER_RUN', 50))),
+    // Default 4: keeps one connection of headroom under the max:5 Postgres pool
+    // while turning the sequential ~2-3 domains/run into ~4× the throughput.
+    // Floored at 1 (degrades to sequential); capped at 8 to never starve the pool.
+    maxConcurrentDomains: Math.min(8, Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_CONCURRENT_DOMAINS', 4)))),
     minCorroboratingSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_CORROBORATING_SOURCES', 2))),
     minReputableSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_REPUTABLE_SOURCES', 1))),
   };

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -18,6 +18,7 @@ import {
   type GroundedLlmQuestion,
 } from '@/server/daily/generate-questions';
 import { askToAnswerBatch, resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
+import { enrichAcceptableVariants, mergeVariants } from '@/server/daily/enrich-variants';
 import { runBudgetedConcurrent } from '@/server/daily/budgeted-concurrency';
 import { getMonthToDateLlmSpendUsd } from '@/server/db/queries/llm-provider-experiment';
 import { assessCorroboration, getReputationLists } from '@/server/daily/source-reputation';
@@ -204,6 +205,12 @@ async function refillDomain(
   );
   result.droppedQualityGate += askResult.toDrop.size;
 
+  // Answer-key enrichment (Fix 3): additional genuinely-correct answers for
+  // multi-answer questions, merged into acceptable_variants below. Fail-open.
+  const enrichByIndex = await enrichAcceptableVariants(
+    screened.map((q) => ({ questionText: q.question_text, answer: q.answer, explainer: q.explainer })),
+  );
+
   const seenFactKeys = new Set<string>();
   for (let i = 0; i < screened.length; i += 1) {
     const q = screened[i];
@@ -240,7 +247,10 @@ async function refillDomain(
           sourceRefs: q.source_refs,
           trustTier,
           askToAnswerVerified,
-          acceptableVariants: askResult.variantsByIndex.get(i) ?? [],
+          acceptableVariants: mergeVariants(
+            askResult.variantsByIndex.get(i),
+            enrichByIndex.get(i),
+          ),
           expiresAt: DURABLE_EXPIRY,
           usedInQueue: false,
         })

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -18,6 +18,7 @@ import {
   type GroundedLlmQuestion,
 } from '@/server/daily/generate-questions';
 import { askToAnswerBatch, resolveMachineTrustTier } from '@/server/daily/ask-to-answer';
+import { runBudgetedConcurrent } from '@/server/daily/budgeted-concurrency';
 import { getMonthToDateLlmSpendUsd } from '@/server/db/queries/llm-provider-experiment';
 import { assessCorroboration, getReputationLists } from '@/server/daily/source-reputation';
 import { resolveDailyBasePoints } from '@/server/daily/types';
@@ -331,19 +332,30 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
   const maxSearchesPerCall = config.maxSearchesPerQuestion * config.questionsPerDomain;
   const perCallWorstCaseUsd = maxSearchesPerCall * USD_PER_WEB_SEARCH;
 
-  for (let i = 0; i < domains.length; i += 1) {
-    if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
-      // Ceiling reached — everything still in the list is unserved demand.
-      report.backlogRemaining = domains.length - i;
-      break;
-    }
+  // Fold one settled domain (success or failure) into the run report. In the real
+  // path this runs over the worker results AFTER they settle (not concurrently),
+  // so the report totals are assembled in one pass.
+  const accumulate = (r: DomainRefillResult): void => {
+    report.perDomain.push(r);
+    report.domainsProcessed += 1;
+    report.usdSpent += r.usd;
+    report.webSearches += r.webSearches;
+    report.questionsPersisted += r.persisted;
+    report.dropped.uncorroborated += r.droppedUncorroborated;
+    report.dropped.qualityGate += r.droppedQualityGate;
+    report.dropped.duplicateFact += r.droppedDuplicateFact;
+  };
 
-    const { domain } = domains[i];
-
-    if (dryRun) {
-      // Preview only: project this call's worst-case search spend, issue nothing.
-      report.perDomain.push({
-        domain,
+  if (dryRun) {
+    // Preview only: project each call's worst-case search spend sequentially,
+    // issue nothing, and stop at the ceiling like a real run would.
+    for (let i = 0; i < domains.length; i += 1) {
+      if (report.usdSpent + perCallWorstCaseUsd > config.dailyUsdCeiling) {
+        report.backlogRemaining = domains.length - i;
+        break;
+      }
+      accumulate({
+        domain: domains[i].domain,
         persisted: 0,
         webSearches: maxSearchesPerCall,
         usd: perCallWorstCaseUsd,
@@ -352,32 +364,36 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         droppedQualityGate: 0,
         droppedDuplicateFact: 0,
       });
-      report.domainsProcessed += 1;
-      report.usdSpent += perCallWorstCaseUsd;
-      report.webSearches += maxSearchesPerCall;
-      continue;
     }
+    return report;
+  }
 
-    // Preconditions are guaranteed by the early return above on a real run;
-    // narrow them for the type checker (and stay defensive).
-    if (!client || !config.systemUserId) continue;
-    try {
-      const domainResult = await refillDomain(client, domain, config, config.systemUserId);
-      report.perDomain.push(domainResult);
-      report.domainsProcessed += 1;
-      report.usdSpent += domainResult.usd;
-      report.webSearches += domainResult.webSearches;
-      report.questionsPersisted += domainResult.persisted;
-      report.dropped.uncorroborated += domainResult.droppedUncorroborated;
-      report.dropped.qualityGate += domainResult.droppedQualityGate;
-      report.dropped.duplicateFact += domainResult.droppedDuplicateFact;
-    } catch (err) {
+  // Real run. Preconditions are guaranteed by the blocker early-return above;
+  // narrow them here for the type checker (and stay defensive).
+  if (!client || !config.systemUserId) return report;
+  const liveClient = client;
+  const systemUserId = config.systemUserId;
+
+  // Bounded-concurrency domain processing (B-SUPPLY-REFILL-THROUGHPUT-01). A
+  // sequential run drained only ~2-3 domains inside the route's 300s budget and
+  // slow domains starved (verification 2026-06-30, ~65% of domains time out at
+  // callTimeoutMs). Running a few at once keeps the budget productive.
+  const { results, backlog } = await runBudgetedConcurrent(
+    domains.map((d) => d.domain),
+    {
+      concurrency: config.maxConcurrentDomains,
+      perItemReservation: perCallWorstCaseUsd,
+      ceiling: config.dailyUsdCeiling,
+      costOf: (r: DomainRefillResult) => r.usd,
+    },
+    (domain) => refillDomain(liveClient, domain, config, systemUserId),
+    (domain, err): DomainRefillResult => {
       // A single domain failing (timeout / parse / API) must not sink the run.
       console.warn('[pool-refill] domain refill failed', {
         domain,
         error: err instanceof Error ? err.message : String(err),
       });
-      report.perDomain.push({
+      return {
         domain,
         persisted: 0,
         webSearches: 0,
@@ -386,9 +402,11 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         droppedUncorroborated: 0,
         droppedQualityGate: 0,
         droppedDuplicateFact: 0,
-      });
-    }
-  }
+      };
+    },
+  );
+  results.forEach(accumulate);
+  report.backlogRemaining = backlog;
 
   return report;
 }

--- a/src/server/daily/types.ts
+++ b/src/server/daily/types.ts
@@ -107,6 +107,15 @@ export const queueSlotSchema = z.object({
   recheck_status: z.enum(['accepted', 'rejected', 'needs_human']).optional(),
   /** Short player-facing explanation from the recheck reviewer. */
   recheck_reason: z.string().nullish(),
+  /**
+   * Catch-up appeal state — kept SEPARATE from the live `recheck_status` above,
+   * mirroring how `catchup_answer_state` is kept separate from `answer_state`. A
+   * catch-up attempt graded wrong can be appealed once; an 'accepted' verdict
+   * flips `catchup_answer_state` to 'correct' (the live verdict stays put).
+   */
+  catchup_recheck_status: z.enum(['accepted', 'rejected', 'needs_human']).optional(),
+  /** Short player-facing explanation from the catch-up recheck reviewer. */
+  catchup_recheck_reason: z.string().nullish(),
 });
 
 export type QueueSlotSource = z.infer<typeof queueSlotSourceSchema>;

--- a/src/server/grading.ts
+++ b/src/server/grading.ts
@@ -62,7 +62,7 @@ export type GradeOutcome = ScoredGrade | UnscoredGrade;
  * article is dropped (e.g. "The Eroica" ≡ "Eroica") but interior articles are
  * kept so distinct answers like "Vitamin A" don't collapse onto "Vitamin".
  */
-function normalizeForMatch(value: string): string {
+export function normalizeForMatch(value: string): string {
   return value
     .normalize('NFD')
     .replace(/[̀-ͯ]/g, '') // strip diacritics: "Beyoncé" → "Beyonce"


### PR DESCRIPTION
## What & why

The first-pass grader scores a submission **only** against the stored answer + `accepted_alternatives` — it never reasons about whether some *other* answer would also be correct. So a question with more than one genuinely-correct answer but only one encoded (e.g. "detaches Data's arm" vs "switches Data off") wrongs every player who gives the other valid answer until they appeal, and the appeal never updates the key — so the next player is wronged again.

This PR closes that loop end-to-end with three related fixes.

### Fix 2 — recheck write-back
An accepted recheck now folds the accepted alternative back into the question's answer key:
- canonical `Question.accepted_alternatives` (what feed/milestone + cross-surface grading read), and
- the originating `GeneratedQuestion.acceptable_variants` (what the live daily path grades against before promotion).

Wired into the **daily**, **feed**, and **milestone** recheck routes. Best-effort by contract: dedups under the fast-path grader's own normalization (`grading.ts` `normalizeForMatch` is now exported) and never throws — a write-back failure can't turn an accepted recheck into a player-facing error.

### Fix 3 — answer-key enrichment gate
A generation-time gate (`enrich-variants.ts`) that asks, per question, for the other answers a strict-but-fair grader must accept and merges them into `acceptable_variants` at persist time. Fail-open; covered by a 12-case test suite.

### Catch-up recheck route
New `/api/daily/catchup/recheck` route plus the `catchup_recheck_status` / `catchup_recheck_reason` `QueueSlot` schema fields it reads and writes — kept **separate** from the live `recheck_status` (mirrors how `catchup_answer_state` is kept separate from `answer_state`).

## Verification
- `npx tsc -p tsconfig.typecheck.json` — clean on all touched `src/` files (only pre-existing stale `.next/` `replay` validator errors remain, untouched here).
- ESLint — clean on all touched files.
- `enrich-variants` suite — 12/12 green.

## Note on base
Branched off `claude/supply-refill-throughput` because the `retrieval-grounded.ts` working edit sits on top of that branch's commit. Targeting `main` per request — if supply-refill **#1337** hasn't merged yet, its commit will also appear in this diff; it drops out once #1337 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
