### PR TITLE
Close the answer-key completeness loop for multi-answer questions

### DIFF
--- a/src/components/play/useCatchupFlow.ts
+++ b/src/components/play/useCatchupFlow.ts
@@ -78,9 +78,9 @@ type CatchupLoadResponse = {
   introCopy?: string;
 };
 
-// Shape returned by POST /api/daily/recheck. Catch-up reuses that route for
-// daily-queue-backed items (their dailyQueueItemId is `${queueId}:${slotIndex}`,
-// exactly the route's inputs); feed-backed catch-up items are not rechecked here.
+// Shape returned by POST /api/daily/catchup/recheck (daily-queue-backed items
+// only; feed-backed catch-up items carry no recheck affordance). Mirrors the
+// /api/daily/recheck response shape.
 type DailyRecheckResponse = {
   accepted?: boolean;
   status?: string;
@@ -598,10 +598,13 @@ export function useCatchupFlow() {
     }
   }, [advancePast, applyCatchupSubmitFailure, currentItem, isResolvingTurn, items.length, submitting, undismissItem]);
 
-  // Re-grade a wrong daily-slot answer via the shared /api/daily/recheck route.
-  // On accept we flip this turn's tally + recap entry to correct; GameplayChat's
-  // ResultRow surfaces the returned message inline. Feed-backed items never reach
-  // here (their recheckAction is null), so the daily route's queue lookup holds.
+  // Re-grade a wrong CATCH-UP answer via /api/daily/catchup/recheck. The live
+  // /api/daily/recheck route operates on a slot's live-round fields and bails on
+  // a catch-up-only slot (`!slot.answered` → "answer it first"), so it could not
+  // appeal a catch-up mis-grade at all; the catch-up route reads the catchup_*
+  // fields instead. On accept we flip this turn's tally + recap entry to correct;
+  // GameplayChat's ResultRow surfaces the returned message inline. Feed-backed
+  // items never reach here (their recheckAction is null).
   const requestRecheck = useCallback(
     async (item: CatchupQueueItem): Promise<RecheckActionResult> => {
       const parsed = parseCatchupItemId(item.dailyQueueItemId);
@@ -611,11 +614,11 @@ export function useCatchupFlow() {
 
       let response: Response;
       try {
-        response = await fetch('/api/daily/recheck', {
+        response = await fetch('/api/daily/catchup/recheck', {
           method: 'POST',
           headers: { 'content-type': 'application/json' },
           credentials: 'include',
-          body: JSON.stringify({ queue_id: parsed.queueId, slot_index: parsed.slotIndex }),
+          body: JSON.stringify({ dailyQueueItemId: item.dailyQueueItemId }),
         });
       } catch {
         return { accepted: false, message: 'Could not recheck that answer.' };
@@ -679,7 +682,7 @@ export function useCatchupFlow() {
       const resultMessageId = newMessageId();
       resultPostedItemIdsRef.current.add(item.dailyQueueItemId);
       // Only wrong, daily-queue-backed answers get a recheck button — feed-backed
-      // catch-up items aren't supported by /api/daily/recheck.
+      // catch-up items aren't supported by /api/daily/catchup/recheck.
       const recheckAction: RecheckAction | null =
         !isCorrect && parseCatchupItemId(item.dailyQueueItemId)?.surface === 'daily'
           ? { onSubmit: () => requestRecheck(item) }


### PR DESCRIPTION
## What this does

The first-pass grader scores a submission **only** against the stored answer + `accepted_alternatives` — it never reasons about whether some *other* answer would also be correct. So a question with more than one valid answer but only one encoded (e.g. TNG's "Measure of a Man": both *detaches Data's arm* and *switches Data off* are correct, and the explainer names both) marks the other valid answer wrong. This closes that loop at three layers.

### Fix 1 — Catch-up answers can finally be appealed
Catch-up records its outcome in separate slot fields (`catchup_answer_state`, `catchup_submitted_answer`) and leaves the live verdict untouched. The recheck button posted to `/api/daily/recheck`, which reads the *live* fields and bails on a catch-up-only slot (`!slot.answered` → "answer it first") — so a catch-up mis-grade had **no appeal path at all**.
- New `POST /api/daily/catchup/recheck` operating on the `catchup_*` fields; on accept it flips `catchup_answer_state` to `correct` (live verdict stays put), mirroring `daily/recheck`'s mastery/dispute/feed tail.
- `catchup_recheck_status` / `catchup_recheck_reason` added to the `QueueSlot` schema (JSONB — no migration).
- Client (`useCatchupFlow.ts`) pointed at the new route.

### Fix 2 — Accepted appeals repair the answer key permanently
`recordAcceptedAlternative` appends an accepted alternative to `Question.accepted_alternatives` (and the originating `GeneratedQuestion.acceptable_variants`), deduped with the **same normalization the fast-path grader uses**, length-guarded, best-effort. Wired into all four recheck routes. The next player giving the same answer is graded right with no second appeal.

### Fix 3 — Generation enriches multi-answer keys up front
`enrichAcceptableVariants` — one batched Sonnet call per generation batch (cost parity with the factual gate), beside `askToAnswerBatch` in `generate-questions.ts` and `retrieval-grounded.ts`. Strictly prompted to add only genuinely-correct distinct answers (never vaguer forms or rephrasings), fail-open, merged into `acceptable_variants` at persist.

Also: the *Measure of a Man* question was patched directly in the DB so it's correct for everyone now.

## Validation
- `npx tsc -p tsconfig.typecheck.json` clean (only pre-existing `.next/replay` validator noise).
- ESLint clean; new `enrich-variants.test.ts` (12 tests) + touched-area suites green (50 passing).

## Note on scope
This branch is stacked on the in-flight supply-refill / quality work, so the diff to `main` includes those commits too — intended to land together. The net-new grading commits are `84f34000` and `daefc0da`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012XT3vCvhVfApr31VDFrD1F
