### PR TITLE
feat(supply): adaptive timeout exclusion for pool refill (0098)

### DIFF
--- a/drizzle/0098_retrieval_domain_health.sql
+++ b/drizzle/0098_retrieval_domain_health.sql
@@ -1,0 +1,26 @@
+-- B-SUPPLY-REFILL-THROUGHPUT-01 follow-up — per-domain refill health for adaptive
+-- timeout exclusion. runPoolRefill records whether each domain's grounded call
+-- completed or timed out; getThinActiveDomains then skips domains that have timed
+-- out >= a threshold number of times consecutively and are still within a cooldown,
+-- so the capped cron budget stops being spent on chronically-slow (typically broad)
+-- domains that never complete, and focuses on domains that actually persist. A
+-- domain is retried after the cooldown; a completed generation resets its counter.
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (the app connects as the owner role, which bypasses RLS) per B-SECURITY-RLS-01 /
+-- migration 0081. Every statement is idempotent and mirrored by a defensive guard
+-- in src/instrumentation.ts (precedent: 0097).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "RetrievalDomainHealth";
+CREATE TABLE IF NOT EXISTS "RetrievalDomainHealth" (
+  "domain" text PRIMARY KEY,
+  "consecutive_timeouts" integer NOT NULL DEFAULT 0,
+  "last_timeout_at" timestamp with time zone,
+  "last_success_at" timestamp with time zone,
+  "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "RetrievalDomainHealth" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "RetrievalDomainHealth_cooldown_idx" ON "RetrievalDomainHealth" ("consecutive_timeouts", "last_timeout_at");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -687,6 +687,13 @@
       "when": 1784937600000,
       "tag": "0097_quality_report",
       "breakpoints": true
+    },
+    {
+      "idx": 98,
+      "version": "7",
+      "when": 1785024000000,
+      "tag": "0098_retrieval_domain_health",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -270,6 +270,28 @@ export async function register() {
       // Best-effort pre-create; migrate() creates it on a fresh DB.
     }
 
+    // B-SUPPLY-REFILL-THROUGHPUT-01 follow-up (migration 0098): per-domain refill
+    // health for adaptive timeout exclusion. New + isolated; RLS-enabled with no
+    // policies (owner role bypasses RLS). Idempotent so a partially-recorded DB
+    // still boots before runPoolRefill's first upsert (precedent: 0097).
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "RetrievalDomainHealth" (
+          "domain" text PRIMARY KEY,
+          "consecutive_timeouts" integer NOT NULL DEFAULT 0,
+          "last_timeout_at" timestamp with time zone,
+          "last_success_at" timestamp with time zone,
+          "updated_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "RetrievalDomainHealth" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "RetrievalDomainHealth_cooldown_idx" ON "RetrievalDomainHealth" ("consecutive_timeouts", "last_timeout_at")
+      `);
+    } catch {
+      // Best-effort pre-create; migrate() creates it on a fresh DB.
+    }
+
     // Migration 0043 renames PlayerMastery.season_points_start to
     // lifetime_points_baseline. If a preview/production database has 0043
     // recorded without the rename actually applied, Drizzle selects against

--- a/src/server/daily/__tests__/retrieval-timeout-exclusion.test.ts
+++ b/src/server/daily/__tests__/retrieval-timeout-exclusion.test.ts
@@ -1,0 +1,42 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// retrieval-grounded imports @/server/db, which throws at module load without a
+// connection string. isTimeoutError is pure; a dummy URL + dynamic import (repo
+// convention) keeps the unit pure without a DB.
+let mod: typeof import('@/server/daily/retrieval-grounded');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/daily/retrieval-grounded');
+});
+
+describe('isTimeoutError', () => {
+  it('classifies the real per-call abort (AbortSignal.timeout) as a timeout', () => {
+    // Shape observed in prod logs: name "Error", message "Request was aborted."
+    expect(mod.isTimeoutError({ name: 'Error', message: 'Request was aborted.' })).toBe(true);
+    expect(mod.isTimeoutError(new Error('Request was aborted.'))).toBe(true);
+  });
+
+  it('classifies AbortError / TimeoutError by name', () => {
+    expect(mod.isTimeoutError({ name: 'AbortError', message: 'The operation was aborted' })).toBe(true);
+    expect(mod.isTimeoutError({ name: 'TimeoutError', message: 'signal timed out' })).toBe(true);
+  });
+
+  it('classifies "timed out" / "timeout" messages as timeouts', () => {
+    expect(mod.isTimeoutError(new Error('Request timed out after 120000ms'))).toBe(true);
+    expect(mod.isTimeoutError(new Error('socket timeout'))).toBe(true);
+  });
+
+  it('does NOT classify non-timeout API/parse errors as timeouts', () => {
+    expect(mod.isTimeoutError(new Error('400 invalid_request_error: bad params'))).toBe(false);
+    expect(mod.isTimeoutError(new Error('Unexpected token in JSON'))).toBe(false);
+    expect(mod.isTimeoutError({ name: 'TypeError', message: 'x is not a function' })).toBe(false);
+  });
+
+  it('is safe on null / undefined / odd shapes', () => {
+    expect(mod.isTimeoutError(null)).toBe(false);
+    expect(mod.isTimeoutError(undefined)).toBe(false);
+    expect(mod.isTimeoutError('some random failure')).toBe(false); // bare string, no timeout words
+    expect(mod.isTimeoutError({})).toBe(false);
+  });
+});

--- a/src/server/daily/retrieval-config.ts
+++ b/src/server/daily/retrieval-config.ts
@@ -64,6 +64,14 @@ export type RetrievalConfig = {
    *  src/server/db/index.ts) — each in-flight domain borrows a connection for its
    *  reads/writes. */
   maxConcurrentDomains: number;
+  /** Adaptive timeout exclusion (B-SUPPLY-REFILL-THROUGHPUT-01 follow-up). A domain
+   *  that times out this many times CONSECUTIVELY is skipped from refill demand for
+   *  timeoutCooldownDays — so the budget stops being spent on chronically-slow
+   *  (broad) domains that never complete. 0 disables the exclusion. */
+  timeoutExcludeThreshold: number;
+  /** How long (days) a chronically-timing-out domain stays excluded before it is
+   *  retried once more. A completed generation resets its timeout counter. */
+  timeoutCooldownDays: number;
   /** Minimum distinct non-denied source hosts required to keep a grounded
    *  question (corroboration floor; Drift Risk 2). */
   minCorroboratingSources: number;
@@ -104,6 +112,11 @@ export function getRetrievalConfig(): RetrievalConfig {
     // while turning the sequential ~2-3 domains/run into ~4× the throughput.
     // Floored at 1 (degrades to sequential); capped at 8 to never starve the pool.
     maxConcurrentDomains: Math.min(8, Math.max(1, Math.round(numEnv('RETRIEVAL_MAX_CONCURRENT_DOMAINS', 4)))),
+    // Default 3: after 3 consecutive timeouts a domain is skipped for the cooldown.
+    // Broad domains (Shakespeare, etc.) time out reliably; niche ones complete, so
+    // this focuses the budget on domains that actually persist. 0 disables it.
+    timeoutExcludeThreshold: Math.max(0, Math.round(numEnv('RETRIEVAL_TIMEOUT_EXCLUDE_THRESHOLD', 3))),
+    timeoutCooldownDays: Math.max(1, Math.round(numEnv('RETRIEVAL_TIMEOUT_COOLDOWN_DAYS', 7))),
     minCorroboratingSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_CORROBORATING_SOURCES', 2))),
     minReputableSources: Math.max(1, Math.round(numEnv('RETRIEVAL_MIN_REPUTABLE_SOURCES', 1))),
   };

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -26,6 +26,7 @@ import { resolveDailyBasePoints } from '@/server/daily/types';
 import {
   getDomainPoolAvoidLists,
   getThinActiveDomains,
+  recordDomainRefillHealth,
 } from '@/server/db/queries/retrieval-demand';
 import {
   USD_PER_WEB_SEARCH,
@@ -42,6 +43,23 @@ const DURABLE_EXPIRY = new Date('2999-01-01T00:00:00.000Z');
 // How many existing pool facts per domain to feed the avoid list.
 const AVOID_LIST_LIMIT = 60;
 
+// Whether an error thrown by the grounded generation call is a per-call TIMEOUT
+// (the AbortSignal.timeout in loggedMessagesCreate) rather than a parse/API error.
+// Only timeouts feed the adaptive timeout-exclusion counter; a transient API error
+// should not mark a domain chronically-slow. Exported for unit testing.
+export function isTimeoutError(err: unknown): boolean {
+  if (!err) return false;
+  const e = err as { name?: unknown; message?: unknown };
+  const name = typeof e.name === 'string' ? e.name : '';
+  const message = typeof e.message === 'string' ? e.message : String(err);
+  return (
+    name === 'AbortError' ||
+    name === 'TimeoutError' ||
+    /\baborted\b/i.test(message) ||
+    /\btimed?[\s-]?out\b/i.test(message)
+  );
+}
+
 export type DomainRefillResult = {
   domain: string;
   persisted: number;
@@ -51,6 +69,9 @@ export type DomainRefillResult = {
   droppedUncorroborated: number;
   droppedQualityGate: number;
   droppedDuplicateFact: number;
+  /** True when the grounded generation call aborted on the per-call timeout — feeds
+   *  the adaptive timeout-exclusion health record (B-SUPPLY-REFILL-THROUGHPUT-01). */
+  timedOut?: boolean;
 };
 
 export type PoolRefillReport = {
@@ -332,6 +353,8 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
     depthThreshold: config.poolDepthThreshold,
     activeLookbackDays: config.activeLookbackDays,
     limit: config.maxDomainsPerRun,
+    excludeTimeoutThreshold: config.timeoutExcludeThreshold,
+    timeoutCooldownDays: config.timeoutCooldownDays,
   });
   report.domainsConsidered = domains.length;
 
@@ -412,11 +435,19 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         droppedUncorroborated: 0,
         droppedQualityGate: 0,
         droppedDuplicateFact: 0,
+        timedOut: isTimeoutError(err),
       };
     },
   );
   results.forEach(accumulate);
   report.backlogRemaining = backlog;
+
+  // Adaptive timeout exclusion (B-SUPPLY-REFILL-THROUGHPUT-01 follow-up): record
+  // each processed domain's outcome so chronically-timing-out domains drop out of
+  // getThinActiveDomains next run. Best-effort — never sinks the run.
+  await recordDomainRefillHealth(
+    results.map((r) => ({ domain: r.domain, timedOut: r.timedOut === true, completed: r.generated > 0 })),
+  ).catch(() => undefined);
 
   return report;
 }

--- a/src/server/db/queries/retrieval-demand.ts
+++ b/src/server/db/queries/retrieval-demand.ts
@@ -1,6 +1,6 @@
-import { and, desc, eq, inArray, isNotNull, sql } from 'drizzle-orm';
+import { and, desc, eq, gte, inArray, isNotNull, sql } from 'drizzle-orm';
 
-import { db, generatedQuestions } from '@/server/db';
+import { db, generatedQuestions, retrievalDomainHealth } from '@/server/db';
 import { isGenericSubcategory } from '@/server/questions/canonical-subcategory';
 import type { RecentDailyQuestionEntry, RecentFactKeyEntry } from '@/server/db/queries/daily';
 
@@ -22,6 +22,10 @@ export async function getThinActiveDomains(opts: {
   depthThreshold: number;
   activeLookbackDays: number;
   limit: number;
+  /** Adaptive timeout exclusion (0/undefined disables): drop domains that have
+   *  timed out this many times consecutively and are still within the cooldown. */
+  excludeTimeoutThreshold?: number;
+  timeoutCooldownDays?: number;
 }): Promise<ThinActiveDomain[]> {
   const sinceMs = Date.now() - opts.activeLookbackDays * 24 * 60 * 60 * 1000;
   const since = new Date(sinceMs);
@@ -42,15 +46,76 @@ export async function getThinActiveDomains(opts: {
       sql`max(${generatedQuestions.createdAt}) >= ${since} and count(distinct ${generatedQuestions.factKey}) < ${opts.depthThreshold}`,
     );
 
+  // Adaptive timeout exclusion (B-SUPPLY-REFILL-THROUGHPUT-01 follow-up): drop
+  // domains still cooling off after repeated timeouts BEFORE the cap, so a
+  // chronically-slow domain doesn't keep consuming a refill slot every run. The
+  // exclusion only affects refill demand — getDurablePoolDepthForDomains (the
+  // guard / expansion) is untouched.
+  const coolingOff = await getCoolingOffDomains(opts.excludeTimeoutThreshold, opts.timeoutCooldownDays);
+
   return rows
     .map((row) => ({
       domain: row.domain,
       depth: Number(row.depth),
       lastActivity: row.lastActivity instanceof Date ? row.lastActivity : new Date(row.lastActivity),
     }))
-    .filter((row) => !isGenericSubcategory(row.domain))
+    .filter((row) => !isGenericSubcategory(row.domain) && !coolingOff.has(row.domain))
     .sort((a, b) => a.depth - b.depth || b.lastActivity.getTime() - a.lastActivity.getTime())
     .slice(0, opts.limit);
+}
+
+// Domains currently excluded from refill demand because they have timed out
+// `threshold`+ times consecutively and are still within `cooldownDays`. Empty when
+// the feature is disabled (threshold <= 0) or nothing qualifies.
+async function getCoolingOffDomains(threshold?: number, cooldownDays?: number): Promise<Set<string>> {
+  if (!threshold || threshold <= 0) return new Set();
+  const cutoff = new Date(Date.now() - Math.max(1, cooldownDays ?? 7) * 24 * 60 * 60 * 1000);
+  const rows = await db
+    .select({ domain: retrievalDomainHealth.domain })
+    .from(retrievalDomainHealth)
+    .where(and(
+      gte(retrievalDomainHealth.consecutiveTimeouts, threshold),
+      gte(retrievalDomainHealth.lastTimeoutAt, cutoff),
+    ));
+  return new Set(rows.map((r) => r.domain));
+}
+
+// Record each processed domain's refill outcome for the adaptive timeout
+// exclusion. A timeout increments the consecutive-timeout counter; a completed
+// generation resets it to zero; a domain that neither timed out nor generated
+// (rare empty result) is left unchanged. Best-effort and per-domain isolated —
+// a health write must never sink the refill run.
+export async function recordDomainRefillHealth(
+  outcomes: readonly { domain: string; timedOut: boolean; completed: boolean }[],
+): Promise<void> {
+  for (const o of outcomes) {
+    try {
+      if (o.timedOut) {
+        await db.execute(sql`
+          insert into "RetrievalDomainHealth" ("domain", "consecutive_timeouts", "last_timeout_at", "updated_at")
+          values (${o.domain}, 1, now(), now())
+          on conflict ("domain") do update set
+            "consecutive_timeouts" = "RetrievalDomainHealth"."consecutive_timeouts" + 1,
+            "last_timeout_at" = now(),
+            "updated_at" = now()
+        `);
+      } else if (o.completed) {
+        await db.execute(sql`
+          insert into "RetrievalDomainHealth" ("domain", "consecutive_timeouts", "last_success_at", "updated_at")
+          values (${o.domain}, 0, now(), now())
+          on conflict ("domain") do update set
+            "consecutive_timeouts" = 0,
+            "last_success_at" = now(),
+            "updated_at" = now()
+        `);
+      }
+    } catch (err) {
+      console.warn('[pool-refill] recordDomainRefillHealth failed (best-effort)', {
+        domain: o.domain,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
 }
 
 // Durable machine-pool depth (distinct non-duplicate, fact-keyed rows) for a

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -759,6 +759,26 @@ export const generatedQuestions = pgTable(
   ],
 );
 
+// Per-domain retrieval-refill health (migration 0098, B-SUPPLY-REFILL-THROUGHPUT-01
+// follow-up). runPoolRefill records whether each domain's grounded call completed
+// or timed out; getThinActiveDomains skips domains that have timed out
+// consecutively >= a threshold and are still within a cooldown, so the capped cron
+// budget stops being spent on chronically-slow (broad) domains that never complete.
+export const retrievalDomainHealth = pgTable(
+  'RetrievalDomainHealth',
+  {
+    // canonical_subcategory of the domain (matches generatedQuestions.canonicalSubcategory).
+    domain: text('domain').primaryKey(),
+    consecutiveTimeouts: integer('consecutive_timeouts').notNull().default(0),
+    lastTimeoutAt: timestamp('last_timeout_at', { withTimezone: true }),
+    lastSuccessAt: timestamp('last_success_at', { withTimezone: true }),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index('RetrievalDomainHealth_cooldown_idx').on(table.consecutiveTimeouts, table.lastTimeoutAt),
+  ],
+);
+
 export const questionFeedback = pgTable(
   'QuestionFeedback',
   {


### PR DESCRIPTION
`B-SUPPLY-REFILL-THROUGHPUT-01` follow-up. Concurrency validation (PR #1337) showed **broad domains time out at 120s every run** (Shakespeare, Rent, Music Man, Well-Tempered Clavier, Modernist Fiction) — they issue more web searches, so they never complete and waste a worker slot each run.

## Fix — skip chronically-timing-out domains
- **`RetrievalDomainHealth`** table (migration **0098**, RLS-enabled, idempotent instrumentation guard) — `consecutive_timeouts` + `last_timeout_at` / `last_success_at`.
- **`runPoolRefill`** records each processed domain's outcome (`recordDomainRefillHealth`): a timeout increments the counter, a completed generation resets it. Best-effort, per-domain isolated.
- **`getThinActiveDomains`** skips domains with `consecutive_timeouts >= threshold` still within the cooldown, **before the cap** — so the budget goes to domains that complete. Only refill demand is affected; `getDurablePoolDepthForDomains` (guard/expansion) is untouched.
- **Config:** `RETRIEVAL_TIMEOUT_EXCLUDE_THRESHOLD` (default **3**, `0` disables), `RETRIEVAL_TIMEOUT_COOLDOWN_DAYS` (default **7**). `isTimeoutError` classifies the per-call abort vs API/parse errors.

## Validation
- Unit: `isTimeoutError` coverage (timeouts vs API/parse/odd shapes) — 5 tests; existing retrieval + budgeted-concurrency tests still pass (23 total).
- Typecheck + lint clean; journal reconciled (`0098`).
- **Live end-to-end** (prod data): marking a demand domain as 3 consecutive timeouts drops it at threshold 3, keeps it at threshold 4 (boundary), and keeps it when disabled. Table created in prod DB.

## Safety
`RETRIEVAL_GROUNDING_ENABLED` stays **false** in code; `NARROW_KB_GUARD_ENABLED` untouched. Additive migration, no existing table altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)