### PR TITLE
fix(supply): record refill domain health incrementally (not at end-of-run)

### DIFF
--- a/src/server/daily/__tests__/budgeted-concurrency.test.ts
+++ b/src/server/daily/__tests__/budgeted-concurrency.test.ts
@@ -137,4 +137,53 @@ describe('runBudgetedConcurrent', () => {
     expect(results).toHaveLength(0);
     expect(backlog).toBe(0);
   });
+
+  it('calls onSettle once per item with its settled result (survives a mid-run kill)', async () => {
+    const settled: Array<{ item: string; usd: number }> = [];
+    await runBudgetedConcurrent(
+      ['a', 'b', 'c'],
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => okResult(item === 'b' ? 0.2 : 0.1),
+      errResult,
+      (item, result) => {
+        // Fires per item as it settles — so on an abrupt caller timeout, the items
+        // that already settled have been recorded even though the run never returns.
+        settled.push({ item, usd: result.usd });
+      },
+    );
+    expect(settled).toHaveLength(3);
+    expect(settled.map((s) => s.item).sort()).toEqual(['a', 'b', 'c']);
+    expect(settled.find((s) => s.item === 'b')?.usd).toBe(0.2);
+  });
+
+  it('onSettle receives the onError-mapped result for a failed item', async () => {
+    const settled: Array<{ item: string; failed: boolean }> = [];
+    await runBudgetedConcurrent(
+      ['ok', 'boom'],
+      { concurrency: 2, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async (item) => {
+        if (item === 'boom') throw new Error('kaboom');
+        return okResult(0.1);
+      },
+      () => errResult(),
+      (item, result) => {
+        settled.push({ item, failed: 'failed' in result && result.failed === true });
+      },
+    );
+    expect(settled.find((s) => s.item === 'boom')?.failed).toBe(true);
+    expect(settled.find((s) => s.item === 'ok')?.failed).toBe(false);
+  });
+
+  it('a throwing onSettle never sinks the run', async () => {
+    const { results } = await runBudgetedConcurrent(
+      ITEMS,
+      { concurrency: 3, perItemReservation: 0, ceiling: 100, costOf: (r) => r.usd },
+      async () => okResult(0.1),
+      errResult,
+      () => {
+        throw new Error('onSettle blew up');
+      },
+    );
+    expect(results).toHaveLength(ITEMS.length);
+  });
 });

--- a/src/server/daily/budgeted-concurrency.ts
+++ b/src/server/daily/budgeted-concurrency.ts
@@ -34,6 +34,13 @@ export async function runBudgetedConcurrent<T, R>(
   },
   run: (item: T) => Promise<R>,
   onError: (item: T, err: unknown) => R,
+  // Called after each item settles (success or error), BEFORE the worker pulls the
+  // next item. Use this for per-item side effects that must survive an abrupt
+  // caller timeout (e.g. a serverless 300s maxDuration) — a batched
+  // record-at-the-end never runs when the run is killed mid-flight. Awaited so the
+  // side effect completes before the slot is reused; must be best-effort itself
+  // (a throw here is swallowed so one bad write never sinks the run).
+  onSettle?: (item: T, result: R) => void | Promise<void>,
 ): Promise<BudgetedRunResult<R>> {
   const results: R[] = [];
   let committed = 0;
@@ -63,6 +70,13 @@ export async function runBudgetedConcurrent<T, R>(
       }
       committed += opts.costOf(result);
       results.push(result);
+      if (onSettle) {
+        try {
+          await onSettle(item, result);
+        } catch {
+          // Best-effort per-item side effect — never sink the run.
+        }
+      }
     }
   };
 

--- a/src/server/daily/retrieval-grounded.ts
+++ b/src/server/daily/retrieval-grounded.ts
@@ -438,16 +438,18 @@ export async function runPoolRefill(opts: { dryRun?: boolean } = {}): Promise<Po
         timedOut: isTimeoutError(err),
       };
     },
+    // Adaptive timeout exclusion (B-SUPPLY-REFILL-THROUGHPUT-01 follow-up): record
+    // each domain's outcome AS IT SETTLES, not at end-of-run — the run is killed at
+    // the route's 300s maxDuration long before a batched end-of-run write could
+    // fire (2 waves x ~120s > 300s), so a chronically-timing-out domain would never
+    // accumulate the timeouts that eventually exclude it. Per-domain + best-effort.
+    (domain, result) =>
+      recordDomainRefillHealth([
+        { domain, timedOut: result.timedOut === true, completed: result.generated > 0 },
+      ]),
   );
   results.forEach(accumulate);
   report.backlogRemaining = backlog;
-
-  // Adaptive timeout exclusion (B-SUPPLY-REFILL-THROUGHPUT-01 follow-up): record
-  // each processed domain's outcome so chronically-timing-out domains drop out of
-  // getThinActiveDomains next run. Best-effort — never sinks the run.
-  await recordDomainRefillHealth(
-    results.map((r) => ({ domain: r.domain, timedOut: r.timedOut === true, completed: r.generated > 0 })),
-  ).catch(() => undefined);
 
   return report;
 }


### PR DESCRIPTION
Fixes a catch-22 the prod flip (2026-07-01) exposed in the adaptive timeout exclusion (PR #1341): `recordDomainRefillHealth` ran once at the **end** of `runPoolRefill`, but a real run **always 504s at the 300s `maxDuration`** before reaching it (2 waves × ~120s > 300s). So `RetrievalDomainHealth` stayed empty and the exclusion could never learn which domains chronically time out.

**Fix:** add an `onSettle` hook to `runBudgetedConcurrent` (fires after each item settles, before the next is pulled) and record that domain's health there. A domain's timeout is now persisted ~120s in, so domains that settled before the kill are recorded and the exclusion accumulates across runs. Per-domain + best-effort (a throwing `onSettle` never sinks the run).

Tests: `onSettle` fires once per item with its settled result, receives the `onError`-mapped result for failures, and a throwing `onSettle` doesn't sink the run. 25 tests pass; typecheck + lint clean.

Grounding stays **off** in prod; no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)