### PR TITLE
feat(knowledge): near-ness tree cache — DomainRelation + lazy Haiku builder (0099)

### DIFF
--- a/drizzle/0099_domain_relation.sql
+++ b/drizzle/0099_domain_relation.sql
@@ -1,0 +1,34 @@
+-- D-NEARNESS-LADDER-HYBRID-01 (decision B2) — the global near-ness tree cache.
+--
+-- Stores structural, player-independent domain relations: for a `child_domain`,
+-- the `related_domain`s one step away, labeled by `rung` (sibling / cousin /
+-- parent / grandparent) and tagged by `source` ('curated' | 'llm'). Computed ONCE
+-- per domain by a lazy Haiku call on the shared thinness boundary and read by both
+-- supply (route freed slots to held near rungs) and expansion (offer unheld near
+-- rungs). One row per (child_domain, related_domain).
+--
+-- `rung`/`source` are plain text with CHECK constraints rather than pg enums —
+-- new, small vocabularies, and CHECKs keep the idempotent boot guard trivial (no
+-- CREATE TYPE / ADD VALUE dance).
+--
+-- Purely additive: no existing table is altered. RLS enabled with no policies
+-- (owner role bypasses RLS) per B-SECURITY-RLS-01 / migration 0081. Every statement
+-- is idempotent and mirrored by a defensive guard in src/instrumentation.ts.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS "DomainRelation";
+CREATE TABLE IF NOT EXISTS "DomainRelation" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "child_domain" text NOT NULL,
+  "related_domain" text NOT NULL,
+  "broad_category" text,
+  "rung" text NOT NULL CHECK ("rung" IN ('sibling', 'cousin', 'parent', 'grandparent')),
+  "source" text NOT NULL CHECK ("source" IN ('curated', 'llm')),
+  "created_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+--> statement-breakpoint
+ALTER TABLE "DomainRelation" ENABLE ROW LEVEL SECURITY;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "DomainRelation_child_related_key" ON "DomainRelation" ("child_domain", "related_domain");
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "DomainRelation_child_domain_idx" ON "DomainRelation" ("child_domain");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -694,6 +694,13 @@
       "when": 1785024000000,
       "tag": "0098_retrieval_domain_health",
       "breakpoints": true
+    },
+    {
+      "idx": 99,
+      "version": "7",
+      "when": 1785110400000,
+      "tag": "0099_domain_relation",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -292,6 +292,32 @@ export async function register() {
       // Best-effort pre-create; migrate() creates it on a fresh DB.
     }
 
+    // D-NEARNESS-LADDER-HYBRID-01 (migration 0099): the global near-ness tree cache.
+    // New + isolated; RLS-enabled with no policies (owner role bypasses RLS).
+    // Idempotent so a partially-recorded DB boots before the first tree write.
+    try {
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "DomainRelation" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "child_domain" text NOT NULL,
+          "related_domain" text NOT NULL,
+          "broad_category" text,
+          "rung" text NOT NULL CHECK ("rung" IN ('sibling', 'cousin', 'parent', 'grandparent')),
+          "source" text NOT NULL CHECK ("source" IN ('curated', 'llm')),
+          "created_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "DomainRelation" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "DomainRelation_child_related_key" ON "DomainRelation" ("child_domain", "related_domain")
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "DomainRelation_child_domain_idx" ON "DomainRelation" ("child_domain")
+      `);
+    } catch {
+      // Best-effort pre-create; migrate() creates it on a fresh DB.
+    }
+
     // Migration 0043 renames PlayerMastery.season_points_start to
     // lifetime_points_baseline. If a preview/production database has 0043
     // recorded without the rename actually applied, Drizzle selects against

--- a/src/server/daily/kb-exhaustion.ts
+++ b/src/server/daily/kb-exhaustion.ts
@@ -74,6 +74,16 @@ export function isAreaExpansionParentOverflowEnabled(): boolean {
 }
 
 /**
+ * Master switch for the hybrid near-ness tree (D-NEARNESS-LADDER-HYBRID-01). Off
+ * by default: the lazy Haiku tree call never fires and nothing reads the cache
+ * until an operator enables it. Gates both the build side (populate
+ * DomainRelation) and, later, the supply/expansion read side.
+ */
+export function isNearnessTreeEnabled(): boolean {
+  return boolEnv('NEARNESS_TREE_ENABLED', false);
+}
+
+/**
  * The pool depth (distinct durable facts) below which a domain counts as "thin".
  * Shared verbatim with grounding's poolDepthThreshold so the guard hands a domain
  * to grounded refill at exactly the boundary grounding considers it thin.

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -779,6 +779,30 @@ export const retrievalDomainHealth = pgTable(
   ],
 );
 
+// Global near-ness tree cache (migration 0099, D-NEARNESS-LADDER-HYBRID-01 B2).
+// Structural, player-independent domain relations: for a child_domain, the
+// related_domains one step away by rung (sibling/cousin/parent/grandparent),
+// source-tagged (curated | llm). Computed once per domain by a lazy Haiku call on
+// the shared thinness boundary; read by supply (route to held near rungs) and
+// expansion (offer unheld near rungs). NB: rows are keyed on canonical_subcategory
+// strings — a domain merge/rename must rewrite them (add to the merge routine).
+export const domainRelations = pgTable(
+  'DomainRelation',
+  {
+    id: id(),
+    childDomain: text('child_domain').notNull(),
+    relatedDomain: text('related_domain').notNull(),
+    broadCategory: text('broad_category'),
+    rung: text('rung').$type<'sibling' | 'cousin' | 'parent' | 'grandparent'>().notNull(),
+    source: text('source').$type<'curated' | 'llm'>().notNull(),
+    createdAt: createdAt(),
+  },
+  (table) => [
+    uniqueIndex('DomainRelation_child_related_key').on(table.childDomain, table.relatedDomain),
+    index('DomainRelation_child_domain_idx').on(table.childDomain),
+  ],
+);
+
 export const questionFeedback = pgTable(
   'QuestionFeedback',
   {

--- a/src/server/knowledge/__tests__/nearness-tree.test.ts
+++ b/src/server/knowledge/__tests__/nearness-tree.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// nearness-tree imports @/server/db, which throws at module load without a
+// connection string. parseNearnessTree / shapeDomainRungs are pure; a dummy URL +
+// dynamic import (repo convention) keeps the units pure without a DB.
+let mod: typeof import('@/server/knowledge/nearness-tree');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/knowledge/nearness-tree');
+});
+
+describe('parseNearnessTree', () => {
+  it('parses a well-formed four-rung object', () => {
+    const raw = JSON.stringify({
+      siblings: [{ label: 'Breath of the Wild', broadCategory: 'Video Games' }],
+      cousins: [{ label: 'Metroid Dread', broadCategory: 'Video Games' }],
+      parents: [{ label: 'The Legend of Zelda series', broadCategory: 'Video Games' }],
+      grandparents: [{ label: 'Nintendo franchises', broadCategory: 'Video Games' }],
+    });
+    const t = mod.parseNearnessTree(raw);
+    expect(t.sibling).toEqual([{ label: 'Breath of the Wild', broadCategory: 'Video Games' }]);
+    expect(t.cousin[0].label).toBe('Metroid Dread');
+    expect(t.parent[0].label).toBe('The Legend of Zelda series');
+    expect(t.grandparent[0].label).toBe('Nintendo franchises');
+  });
+
+  it('tolerates markdown fences / surrounding prose (parseJsonObject extracts the object)', () => {
+    const raw = 'Here you go:\n```json\n{ "siblings": [{ "label": "X", "broadCategory": "History" }] }\n```';
+    const t = mod.parseNearnessTree(raw);
+    expect(t.sibling).toEqual([{ label: 'X', broadCategory: 'History' }]);
+    expect(t.parent).toEqual([]);
+  });
+
+  it('drops malformed items and missing rungs without throwing', () => {
+    const raw = JSON.stringify({
+      siblings: [{ label: '  ' }, { label: 'Valid' }, { nope: 1 }, 'string', null],
+      parents: 'not-an-array',
+    });
+    const t = mod.parseNearnessTree(raw);
+    expect(t.sibling).toEqual([{ label: 'Valid', broadCategory: null }]);
+    expect(t.cousin).toEqual([]);
+    expect(t.parent).toEqual([]);
+  });
+
+  it('returns all-empty rungs for non-JSON / non-object input', () => {
+    expect(mod.parseNearnessTree('total garbage')).toEqual({ sibling: [], cousin: [], parent: [], grandparent: [] });
+    expect(mod.parseNearnessTree('[1,2,3]')).toEqual({ sibling: [], cousin: [], parent: [], grandparent: [] });
+  });
+});
+
+describe('shapeDomainRungs', () => {
+  const tree = (over: Partial<Record<'sibling' | 'cousin' | 'parent' | 'grandparent', { label: string; broadCategory: string | null }[]>>) => ({
+    sibling: [], cousin: [], parent: [], grandparent: [], ...over,
+  });
+
+  it('drops a suggestion equal to the child domain (folded key)', () => {
+    const out = mod.shapeDomainRungs(
+      'Tears of the Kingdom',
+      tree({ sibling: [{ label: 'tears of the kingdom', broadCategory: 'Video Games' }, { label: 'Breath of the Wild', broadCategory: 'Video Games' }] }),
+      'llm',
+    );
+    expect(out.map((r) => r.domain)).toEqual(['Breath of the Wild']);
+  });
+
+  it('dedupes across rungs keeping the NEAREST rung', () => {
+    const out = mod.shapeDomainRungs(
+      'A',
+      tree({
+        sibling: [{ label: 'Zelda', broadCategory: null }],
+        parent: [{ label: 'Zelda', broadCategory: null }], // same, farther rung → dropped
+      }),
+      'llm',
+    );
+    expect(out).toEqual([{ domain: 'Zelda', broadCategory: null, rung: 'sibling', source: 'llm' }]);
+  });
+
+  it('caps each rung at four', () => {
+    const six = Array.from({ length: 6 }, (_, i) => ({ label: `S${i}`, broadCategory: null }));
+    const out = mod.shapeDomainRungs('A', tree({ sibling: six }), 'llm');
+    expect(out).toHaveLength(4);
+    expect(out.every((r) => r.rung === 'sibling' && r.source === 'llm')).toBe(true);
+  });
+
+  it('stamps the given source', () => {
+    const out = mod.shapeDomainRungs('A', tree({ parent: [{ label: 'P', broadCategory: 'Philosophy' }] }), 'curated');
+    expect(out[0]).toEqual({ domain: 'P', broadCategory: 'Philosophy', rung: 'parent', source: 'curated' });
+  });
+});

--- a/src/server/knowledge/nearness-tree.ts
+++ b/src/server/knowledge/nearness-tree.ts
@@ -1,0 +1,200 @@
+// D-NEARNESS-LADDER-HYBRID-01 — the global near-ness tree cache (rungs half).
+//
+// For a thin domain, the STRUCTURAL, player-independent rungs one step away:
+// nearest siblings / cousins / a parent / a grandparent. Computed ONCE per domain
+// by a lazy Haiku call (curated-first, decision E1) and cached in DomainRelation
+// (decision B2). The per-player "which rungs are safe to serve" overlay (decision
+// C2) lives elsewhere; this module only produces + reads the universal rungs.
+//
+// Everything here fails OPEN: a missing client, a disabled flag, or a malformed
+// model response yields an empty rung set, never a throw — supply simply falls
+// back to today's behavior (done-when §9).
+import { eq } from 'drizzle-orm';
+
+import {
+  HAIKU_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+} from '@/lib/llm';
+import { db, domainRelations } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
+import { isNearnessTreeEnabled } from '@/server/daily/kb-exhaustion';
+import { CURATED_BROADER_PARENTS } from '@/server/llm/interests';
+
+export type NearnessRung = 'sibling' | 'cousin' | 'parent' | 'grandparent';
+export type DomainRung = { domain: string; broadCategory: string | null; rung: NearnessRung };
+
+const RUNGS: readonly NearnessRung[] = ['sibling', 'cousin', 'parent', 'grandparent'];
+// Rung → the JSON key the tree-generation prompt returns it under.
+const RUNG_KEYS: Record<NearnessRung, string> = {
+  sibling: 'siblings',
+  cousin: 'cousins',
+  parent: 'parents',
+  grandparent: 'grandparents',
+};
+const PER_RUNG_CAP = 4;
+
+type RawSuggestion = { label: string; broadCategory: string | null };
+type StoredRung = DomainRung & { source: 'curated' | 'llm' };
+
+function emptyTree(): Record<NearnessRung, RawSuggestion[]> {
+  return { sibling: [], cousin: [], parent: [], grandparent: [] };
+}
+
+/**
+ * Pure parse of the tree-generation JSON into per-rung suggestion lists. Tolerant:
+ * a non-object, a missing key, or a malformed item yields an empty rung rather
+ * than throwing. Exported for unit testing.
+ */
+export function parseNearnessTree(rawText: string): Record<NearnessRung, RawSuggestion[]> {
+  const result = emptyTree();
+  const obj = parseJsonObject(rawText);
+  if (!obj || typeof obj !== 'object') return result;
+  for (const rung of RUNGS) {
+    const arr = (obj as Record<string, unknown>)[RUNG_KEYS[rung]];
+    if (!Array.isArray(arr)) continue;
+    const items: RawSuggestion[] = [];
+    for (const raw of arr) {
+      if (!raw || typeof raw !== 'object') continue;
+      const label = typeof (raw as { label?: unknown }).label === 'string'
+        ? (raw as { label: string }).label.trim()
+        : '';
+      if (!label) continue;
+      const bcRaw = (raw as { broadCategory?: unknown }).broadCategory;
+      const broadCategory = typeof bcRaw === 'string' && bcRaw.trim() ? bcRaw.trim() : null;
+      items.push({ label, broadCategory });
+    }
+    result[rung] = items;
+  }
+  return result;
+}
+
+/**
+ * Shape parsed suggestions into stored rungs: drop self-references, dedupe by
+ * folded domain key WITHIN a rung and ACROSS rungs (nearest rung wins:
+ * sibling > cousin > parent > grandparent), cap each rung. Pure. Exported for tests.
+ */
+export function shapeDomainRungs(
+  childDomain: string,
+  parsed: Record<NearnessRung, RawSuggestion[]>,
+  source: 'curated' | 'llm',
+): StoredRung[] {
+  const childKey = domainKey(childDomain);
+  const seen = new Set<string>();
+  const out: StoredRung[] = [];
+  for (const rung of RUNGS) {
+    let kept = 0;
+    for (const s of parsed[rung]) {
+      const key = domainKey(s.label);
+      if (!key || key === childKey || seen.has(key)) continue;
+      seen.add(key);
+      out.push({ domain: s.label, broadCategory: s.broadCategory, rung, source });
+      if (++kept >= PER_RUNG_CAP) break;
+    }
+  }
+  return out;
+}
+
+// Read the cached rungs for a domain (empty when never computed).
+export async function getCachedDomainRungs(childDomain: string): Promise<DomainRung[]> {
+  const rows = await db
+    .select({
+      domain: domainRelations.relatedDomain,
+      broadCategory: domainRelations.broadCategory,
+      rung: domainRelations.rung,
+    })
+    .from(domainRelations)
+    .where(eq(domainRelations.childDomain, childDomain));
+  return rows.map((r) => ({ domain: r.domain, broadCategory: r.broadCategory, rung: r.rung }));
+}
+
+// One Haiku call producing all four rungs (A2). Constrained to answerable,
+// specific labels — never bare top-level buckets. Returns the parsed tree; fails
+// open to an empty tree.
+async function generateRungsViaLlm(childDomain: string, broadCategory: string | null): Promise<Record<NearnessRung, RawSuggestion[]>> {
+  const client = getAnthropicClient();
+  if (!client) return emptyTree();
+  const clean = childDomain.trim().replace(/\s+/g, ' ').slice(0, 100);
+  const broadHint = broadCategory ? `\nThe domain sits in the broad category "${broadCategory}".` : '';
+  const systemPrompt = `A player has run a small, specific trivia domain dry. Map its NEAR-NESS TREE — the structural neighbours one step away — so we can serve adjacent questions or offer a graduation. Return four labelled rungs.
+Rules:
+- "siblings": the nearest peers at the SAME level (e.g. for "Tears of the Kingdom": "Breath of the Wild", "Ocarina of Time").
+- "cousins": near-but-not-immediate peers (e.g. "Super Mario Odyssey", "Metroid Dread").
+- "parents": the body of knowledge one level UP that CONTAINS the domain (e.g. "The Legend of Zelda series"). Never a bare bucket like "Video Games".
+- "grandparents": two levels up (e.g. "Nintendo franchises"). Still a named, answerable body — never a bare top-level bucket.
+- Each item must be specific enough to write real trivia about. Do NOT include the player's own domain. No duplicates across rungs.
+- broadCategory is a stable top-level bucket (Music, Film & Television, History, Science, Sports, Pop Culture, Philosophy, Literature, Video Games, etc.). Never "Other" or "General".${broadHint}
+Respond in JSON only, no markdown: { "siblings": [ { "label": "...", "broadCategory": "..." } ], "cousins": [...], "parents": [...], "grandparents": [...] }`;
+  try {
+    const response = await loggedMessagesCreate(client, 'nearness-tree', {
+      model: HAIKU_MODEL,
+      max_tokens: 600,
+      temperature: 0.3,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: clean }],
+    });
+    return parseNearnessTree(extractTextContent(response.content));
+  } catch {
+    return emptyTree();
+  }
+}
+
+// Curated PARENT rungs for known-small domains (curated-first, E1). Empty unless
+// the domain is in the launch curated map.
+function curatedParentRungs(childDomain: string): StoredRung[] {
+  const curated = CURATED_BROADER_PARENTS[childDomain.trim().toLowerCase()];
+  if (!curated || curated.length === 0) return [];
+  return shapeDomainRungs(
+    childDomain,
+    { ...emptyTree(), parent: curated.map((c) => ({ label: c.label, broadCategory: c.broadCategory })) },
+    'curated',
+  );
+}
+
+async function storeRungs(childDomain: string, rungs: StoredRung[]): Promise<void> {
+  if (rungs.length === 0) return;
+  try {
+    await db
+      .insert(domainRelations)
+      .values(rungs.map((r) => ({
+        childDomain,
+        relatedDomain: r.domain,
+        broadCategory: r.broadCategory,
+        rung: r.rung,
+        source: r.source,
+      })))
+      // (child_domain, related_domain) is unique; a concurrent build or a re-run is a no-op.
+      .onConflictDoNothing();
+  } catch (err) {
+    console.warn('[nearness-tree] store failed (best-effort)', {
+      childDomain,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
+/**
+ * Return the near-ness rungs for a domain, computing + caching them on first miss.
+ * Flag-gated (NEARNESS_TREE_ENABLED): when off, or on any failure, returns whatever
+ * is cached (usually empty) — never triggers the LLM and never throws. Curated
+ * parents are layered over the LLM rungs and win on a folded-key collision.
+ */
+export async function getOrBuildDomainRungs(childDomain: string, broadCategory: string | null = null): Promise<DomainRung[]> {
+  const cached = await getCachedDomainRungs(childDomain).catch(() => [] as DomainRung[]);
+  if (cached.length > 0) return cached;
+  if (!isNearnessTreeEnabled()) return cached;
+
+  const parsed = await generateRungsViaLlm(childDomain, broadCategory);
+  const llmRungs = shapeDomainRungs(childDomain, parsed, 'llm');
+  const curated = curatedParentRungs(childDomain);
+
+  // Curated-first: curated parents win on a folded-key collision with LLM rows.
+  const curatedKeys = new Set(curated.map((r) => domainKey(r.domain)));
+  const merged = [...curated, ...llmRungs.filter((r) => !curatedKeys.has(domainKey(r.domain)))];
+  if (merged.length === 0) return cached;
+
+  await storeRungs(childDomain, merged);
+  return merged.map(({ domain, broadCategory: bc, rung }) => ({ domain, broadCategory: bc, rung }));
+}

--- a/src/server/llm/interests.ts
+++ b/src/server/llm/interests.ts
@@ -586,7 +586,10 @@ const VIRTUE_PARENTS: AdjacentDomainSuggestion[] = [
   { label: 'Moral Philosophy', broadCategory: 'Philosophy' },
   { label: 'Virtue Ethics', broadCategory: 'Philosophy' },
 ];
-const CURATED_BROADER_PARENTS: Record<string, AdjacentDomainSuggestion[]> = {
+// Exported so the near-ness tree cache (D-NEARNESS-LADDER-HYBRID-01) can seed its
+// PARENT rung deterministically for these known-small domains before falling back
+// to the LLM (curated-first, decision E1).
+export const CURATED_BROADER_PARENTS: Record<string, AdjacentDomainSuggestion[]> = {
   ...Object.fromEntries(SEVEN_DEADLY_SINS.map((s) => [s.toLowerCase(), SIN_PARENTS])),
   ...Object.fromEntries(SEVEN_HEAVENLY_VIRTUES.map((v) => [v.toLowerCase(), VIRTUE_PARENTS])),
 };


### PR DESCRIPTION
**`D-NEARNESS-LADDER-HYBRID-01` — PR 1 of 2 (foundation, flag-off).** The global "rungs" half of the hybrid near-ness ladder: compute a domain's structural neighbours once and cache them. The per-player overlay + supply/expansion wiring are PR 2.

## What's here
- **Migration 0099 `DomainRelation`** (decision B2 storage): `child_domain`, `related_domain`, `broad_category`, `rung` (sibling/cousin/parent/grandparent — `text` + CHECK, no enum-migration dance), `source` (curated/llm), `created_at`. RLS-enabled, idempotent instrumentation guard, unique `(child_domain, related_domain)`.
- **`nearness-tree.ts`** — `getOrBuildDomainRungs` (cache → curated-first → **one Haiku call** for all four rungs → store), plus pure `parseNearnessTree` / `shapeDomainRungs` (drop self-refs, dedupe across rungs keeping the nearest, cap per rung). **Fails open everywhere** (missing client / disabled flag / bad JSON → empty, never throws — done-when §9).
- Model is **Haiku** (`HAIKU_MODEL`), not Sonnet (§9). Curated-first reuses the now-exported `CURATED_BROADER_PARENTS` to seed the parent rung.
- Flag **`NEARNESS_TREE_ENABLED`** (off) in `kb-exhaustion.ts`, alongside the ladder flags.

## Validation
8 unit tests (pure parse/shape); typecheck + lint clean; journal reconciled (0099).

## Safety
**Nothing reads the cache yet** and the flag is **off**, so the Haiku call never fires. No mastery roll-up (§4). Additive migration.

## Next (PR 2)
Wire the cache into supply — `getExpansionParents` second source + the C2 overlay (territory ∪ answer-history ∪ declared) feeding `selectOverflowParents`; unheld near rungs → game-end expansion offers (D2). Add `DomainRelation` to the domain-merge routine's rewrite scope (B2 note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)