### PR TITLE
feat(knowledge): wire near-ness tree into supply (C2 overlay + held-rung routing)

### DIFF
--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -53,11 +53,14 @@ import { planFirstRunDomains } from '@/server/daily/first-run-seeding';
 import {
   isAreaExpansionParentOverflowEnabled,
   isNarrowKbGuardEnabled,
+  isNearnessTreeEnabled,
   narrowKbThinnessThreshold,
   selectOverflowParents,
   selectUngroundedExcludedDomains,
 } from '@/server/daily/kb-exhaustion';
 import { getExpansionParents } from '@/server/knowledge/open-domain';
+import { getOrBuildDomainRungs } from '@/server/knowledge/nearness-tree';
+import { getHeldDomainKeys } from '@/server/db/queries/nearness-overlay';
 import { getDurablePoolDepthForDomains } from '@/server/db/queries/retrieval-demand';
 import { reconcileProposedDomain } from '@/lib/questions/categorization';
 import { domainKey } from '@/lib/knowledge/domain-key';
@@ -2256,6 +2259,39 @@ export async function generateDailyQuestionsFromKnowledgeBase(
             console.info('[daily/kb-exhaustion] routed thin domains to expansion parents', {
               userId,
               parents: routed,
+            });
+          }
+        }
+
+        // Near-ness ladder routing (D-NEARNESS-LADDER-HYBRID-01, D2). Route each
+        // thin domain's freed slot to a NEAR domain the player already HOLDS
+        // (sibling/cousin/parent/grandparent from the cached tree, filtered by the
+        // C2 overlay: territory ∪ answer-history ∪ declared). Unheld near rungs are
+        // NOT borrowed here — they surface as game-end expansion offers instead. The
+        // lazy tree build fires here, on the thin-crossing (decision E1). Gated
+        // independently; already inside the guard's fail-open try/catch.
+        if (isNearnessTreeEnabled()) {
+          const heldKeys = await getHeldDomainKeys(userId);
+          const isHeld = (domain: string) =>
+            heldKeys.has(domainKey(domain)) || territoryByDomain.has(domain);
+          const nearRouted: string[] = [];
+          for (const thin of excluded) {
+            const rungs = await getOrBuildDomainRungs(thin);
+            const routed = selectOverflowParents(
+              rungs.map((r) => r.domain),
+              isHeld,
+              (domain) =>
+                bankFilledDomains.has(domain)
+                || domainsForLlm.includes(domain)
+                || nearRouted.includes(domain),
+            );
+            nearRouted.push(...routed);
+          }
+          if (nearRouted.length > 0) {
+            domainsForLlm.push(...nearRouted);
+            console.info('[daily/nearness] routed thin domains to held near rungs', {
+              userId,
+              near: nearRouted,
             });
           }
         }

--- a/src/server/db/queries/nearness-overlay.ts
+++ b/src/server/db/queries/nearness-overlay.ts
@@ -1,0 +1,43 @@
+// D-NEARNESS-LADDER-HYBRID-01 (decision C2) — the per-player "held" overlay.
+//
+// Which near rungs are SAFE to serve this player? The rungs themselves are global
+// (DomainRelation); "held" is per-player and derived from data we already hold —
+// no LLM call. A rung counts as held when the player has ANSWERED IT CORRECTLY
+// (live or catch-up) or ACTIVELY DECLARED it. The caller ORs this with the
+// in-scope territory map (playerMastery), completing the C2 set:
+//   territory ∪ answer-history ∪ declared-interest.
+//
+// Returns FOLDED domain keys (domainKey) so a near-rung label compares correctly
+// against differently-punctuated stored strings. Free DB reads; fails open to an
+// empty set at the call site.
+import { and, eq, inArray } from 'drizzle-orm';
+
+import { db, declaredInterests, masteryEvents } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+// Correct-answer mastery event sources (the "demonstrated footing" signal).
+const CORRECT_SOURCE_TYPES = ['live_correct', 'catchup_correct'] as const;
+
+export async function getHeldDomainKeys(userId: string): Promise<Set<string>> {
+  const [answered, declared] = await Promise.all([
+    db
+      .selectDistinct({ domain: masteryEvents.canonicalSubcategory })
+      .from(masteryEvents)
+      .where(and(
+        eq(masteryEvents.userId, userId),
+        inArray(masteryEvents.sourceType, [...CORRECT_SOURCE_TYPES]),
+      )),
+    db
+      .select({ domain: declaredInterests.domain })
+      .from(declaredInterests)
+      .where(and(
+        eq(declaredInterests.userId, userId),
+        eq(declaredInterests.isActive, true),
+      )),
+  ]);
+
+  const keys = new Set<string>();
+  for (const row of answered) if (row.domain) keys.add(domainKey(row.domain));
+  for (const row of declared) if (row.domain) keys.add(domainKey(row.domain));
+  return keys;
+}

--- a/src/server/mastery/ceremony.ts
+++ b/src/server/mastery/ceremony.ts
@@ -6,6 +6,7 @@ import {
   dailyPreferences,
   db,
   declaredInterests,
+  domainRelations,
   feedDismissedDomains,
   generatedQuestions,
   masteryEvents,
@@ -602,6 +603,20 @@ export async function applyMergesForUser(
         .update(skippedDailyQuestions)
         .set({ canonicalSubcategory: target })
         .where(and(eq(skippedDailyQuestions.userId, userId), inArray(skippedDailyQuestions.canonicalSubcategory, sourceDomains)));
+
+      // D-NEARNESS-LADDER-HYBRID-01 (B2): the merged-away domains' cached near-ness
+      // rungs are now stale — drop any DomainRelation referencing them (as child OR
+      // related). The survivor's tree rebuilds lazily on its next thin-crossing.
+      // DomainRelation is a GLOBAL cache (not user-scoped); deleting here is
+      // idempotent — a later user's merge of the same pair simply finds none.
+      if (sourceDomains.length > 0) {
+        await tx
+          .delete(domainRelations)
+          .where(or(
+            inArray(domainRelations.childDomain, sourceDomains),
+            inArray(domainRelations.relatedDomain, sourceDomains),
+          ));
+      }
 
       const declaredSourceRows = await tx
         .select({ isActive: declaredInterests.isActive })


### PR DESCRIPTION
**`D-NEARNESS-LADDER-HYBRID-01` — PR 2 of the slate (supply-side wiring, flag-off).** Plugs the cached tree (PR 1, #1346) into the live overflow seam.

## What's here
- **`nearness-overlay.ts`** — `getHeldDomainKeys(userId)`: the C2 overlay's data half (answered-correct ∪ active declared, folded keys). The caller ORs it with the in-scope territory map → `territory ∪ answer-history ∪ declared`.
- **`generate-questions.ts`** — next to the existing expansion-parent overflow, route each thin (excluded) domain's freed slot to a **near domain the player HOLDS** (sibling/cousin/parent/grandparent from `getOrBuildDomainRungs`, filtered via `selectOverflowParents` + the C2 overlay). **Unheld near rungs are NOT borrowed (D2).** The lazy tree build fires here on the thin-crossing (E1). Gated by `isNearnessTreeEnabled()`, inside the guard's fail-open try/catch.
- **`ceremony.ts` `applyMergesForUser`** — drop stale `DomainRelation` rows for merged-away domains (B2 note); the survivor's tree rebuilds lazily.

## Validation
`selectOverflowParents` already unit-tests the D2 guarantee (unheld → not routed); 33 tests pass across kb-exhaustion / ceremony-merge / nearness-tree; typecheck + lint clean.

## Safety
`NEARNESS_TREE_ENABLED` **off** → no behavior change until enabled (the tree call never fires, nothing routes). No mastery roll-up (§4). No migration.

## Next
D2's other half — surfacing **unheld** near rungs as **game-end expansion offers** (the B-AREA-EXPANSION chooser reading the cached tree) — is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)