### PR TITLE
feat(llm): make the model layer Sonnet-5-ready (central param sanitizer)

### DIFF
--- a/src/lib/__tests__/llm-sanitize.test.ts
+++ b/src/lib/__tests__/llm-sanitize.test.ts
@@ -1,0 +1,83 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// llm.ts transitively imports @/server/db (via recordLlmUsage), which throws at
+// module load without a connection string. The sanitizer is pure; a dummy URL +
+// dynamic import (repo convention) keeps the unit pure.
+let mod: typeof import('@/lib/llm');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/lib/llm');
+});
+
+type Params = Parameters<typeof mod.sanitizeParamsForModel>[0];
+const base = (model: string, extra: Record<string, unknown> = {}) =>
+  ({ model, max_tokens: 100, messages: [{ role: 'user', content: 'hi' }], ...extra }) as unknown as Params;
+const rec = (p: Params) => mod.sanitizeParamsForModel(p) as unknown as Record<string, unknown>;
+
+describe('modelRejectsSamplingParams', () => {
+  it('is true for the Sonnet-5 / Opus-4.7+ / Fable line', () => {
+    for (const m of ['claude-sonnet-5', 'claude-opus-4-7', 'claude-opus-4-8', 'claude-fable-5', 'claude-mythos-5']) {
+      expect(mod.modelRejectsSamplingParams(m)).toBe(true);
+    }
+  });
+  it('is false for Sonnet 4.6, Haiku 4.5, Opus 4.6', () => {
+    for (const m of ['claude-sonnet-4-6', 'claude-haiku-4-5-20251001', 'claude-opus-4-6']) {
+      expect(mod.modelRejectsSamplingParams(m)).toBe(false);
+    }
+  });
+});
+
+describe('modelDefaultsThinkingOn', () => {
+  it('is true only for Sonnet 5 / Mythos 5', () => {
+    expect(mod.modelDefaultsThinkingOn('claude-sonnet-5')).toBe(true);
+    expect(mod.modelDefaultsThinkingOn('claude-mythos-5')).toBe(true);
+    expect(mod.modelDefaultsThinkingOn('claude-sonnet-4-6')).toBe(false);
+    expect(mod.modelDefaultsThinkingOn('claude-opus-4-8')).toBe(false); // Opus 4.8 defaults thinking OFF
+    expect(mod.modelDefaultsThinkingOn('claude-haiku-4-5-20251001')).toBe(false);
+  });
+});
+
+describe('sanitizeParamsForModel', () => {
+  it('leaves Sonnet 4.6 params untouched (same reference)', () => {
+    const p = base('claude-sonnet-4-6', { temperature: 0.2 });
+    expect(mod.sanitizeParamsForModel(p)).toBe(p);
+  });
+
+  it('leaves Haiku params untouched', () => {
+    const p = base('claude-haiku-4-5-20251001', { temperature: 0 });
+    expect(mod.sanitizeParamsForModel(p)).toBe(p);
+  });
+
+  it('strips temperature/top_p/top_k for Sonnet 5 and defaults thinking off', () => {
+    const p = base('claude-sonnet-5', { temperature: 0.3, top_p: 0.9, top_k: 40 });
+    const out = rec(p);
+    expect(out.temperature).toBeUndefined();
+    expect(out.top_p).toBeUndefined();
+    expect(out.top_k).toBeUndefined();
+    expect(out.thinking).toEqual({ type: 'disabled' });
+    expect(out).not.toBe(p); // copied, original untouched
+    expect((p as unknown as Record<string, unknown>).temperature).toBe(0.3);
+  });
+
+  it('strips sampling params for Opus 4.8 but does NOT force thinking (defaults off already)', () => {
+    const p = base('claude-opus-4-8', { temperature: 0 });
+    const out = rec(p);
+    expect(out.temperature).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+  });
+
+  it('respects a caller-specified thinking on Sonnet 5 (no override)', () => {
+    const p = base('claude-sonnet-5', { temperature: 0.3, thinking: { type: 'adaptive' } });
+    const out = rec(p);
+    expect(out.thinking).toEqual({ type: 'adaptive' });
+    expect(out.temperature).toBeUndefined();
+  });
+
+  it('does not add thinking:disabled for Fable (it rejects explicit disabled)', () => {
+    const p = base('claude-fable-5', { temperature: 0.3 });
+    const out = rec(p);
+    expect(out.temperature).toBeUndefined();
+    expect(out.thinking).toBeUndefined();
+  });
+});

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -75,7 +75,28 @@ export type AnswerSuggestionResult = {
   suggested_phrasings?: string[];
 };
 
-export const ANTHROPIC_MODEL = 'claude-sonnet-4-6';
+// Generation/gate model. Env-overridable so the Sonnet 5 upgrade is a single,
+// reversible env flip (ANTHROPIC_MODEL=claude-sonnet-5) after validating on
+// preview — Sonnet 5 is same price at standard ($3/$15), cheaper until 2026-08-31.
+// loggedMessagesCreate sanitizes params per model, so the newer Sonnet-5/Opus-4.7+
+// line (which rejects temperature and defaults thinking ON) is safe to select here
+// without touching the ~15 call sites that pass temperature.
+export const ANTHROPIC_MODEL = process.env.ANTHROPIC_MODEL?.trim() || 'claude-sonnet-4-6';
+
+// Models in the Opus-4.7+ / Sonnet-5 / Fable line REJECT temperature/top_p/top_k
+// (HTTP 400). Callers may keep passing temperature; loggedMessagesCreate strips it
+// for these models. Exported for the param-sanitizer test.
+export function modelRejectsSamplingParams(model: string): boolean {
+  return /opus-4-[78]|sonnet-5|fable|mythos/.test(model);
+}
+// Models that default ADAPTIVE THINKING ON when `thinking` is omitted (Sonnet 5,
+// Mythos 5). Our deterministic structured-output calls don't set `thinking`, and
+// thinking shares the max_tokens budget — leaving it on risks truncating the JSON.
+// loggedMessagesCreate defaults it OFF for these unless a caller opts in. (Fable
+// rejects an explicit `disabled`, but we never select Fable here.)
+export function modelDefaultsThinkingOn(model: string): boolean {
+  return /sonnet-5|mythos/.test(model);
+}
 // Grading is a simple binary task — Haiku is ~5-10x faster than Sonnet with adequate accuracy.
 const GRADING_MODEL = 'claude-haiku-4-5-20251001';
 // Exported so other LLM modules (e.g. interests.ts) use the same canonical ID.
@@ -247,6 +268,33 @@ export const INSTRUCTION_SCOPING_QUALIFIER = `\n\nSCOPING QUALIFIERS: When a que
  * options.timeoutMs for latency-sensitive scopes (grading) or larger replies
  * (batch generation).
  */
+// Make a request payload safe for its target model without touching call sites:
+// strip temperature/top_p/top_k for models that reject them, and default thinking
+// OFF for models that would otherwise turn adaptive thinking on (which shares the
+// max_tokens budget and can truncate structured output). A no-op for the current
+// Sonnet 4.6 / Haiku 4.5 defaults; the fix engages when ANTHROPIC_MODEL is flipped
+// to claude-sonnet-5. Exported for testing.
+export function sanitizeParamsForModel(
+  params: Anthropic.MessageCreateParamsNonStreaming,
+): Anthropic.MessageCreateParamsNonStreaming {
+  const model = String(params.model ?? '');
+  const p = params as unknown as Record<string, unknown>;
+  const needsSamplingStrip = modelRejectsSamplingParams(model)
+    && (p.temperature !== undefined || p.top_p !== undefined || p.top_k !== undefined);
+  const needsThinkingDefault = p.thinking === undefined && modelDefaultsThinkingOn(model);
+  if (!needsSamplingStrip && !needsThinkingDefault) return params;
+  const next = { ...p };
+  if (needsSamplingStrip) {
+    delete next.temperature;
+    delete next.top_p;
+    delete next.top_k;
+  }
+  if (needsThinkingDefault) {
+    next.thinking = { type: 'disabled' };
+  }
+  return next as unknown as Anthropic.MessageCreateParamsNonStreaming;
+}
+
 export async function loggedMessagesCreate(
   client: Anthropic,
   scope: string,
@@ -256,7 +304,7 @@ export async function loggedMessagesCreate(
   const startedAt = Date.now();
   const timeoutMs = options?.timeoutMs ?? DEFAULT_LLM_TIMEOUT_MS;
   try {
-    const response = await client.messages.create(params, {
+    const response = await client.messages.create(sanitizeParamsForModel(params), {
       signal: AbortSignal.timeout(timeoutMs),
     });
     // Telemetry is a side effect — never let a missing/partial usage block


### PR DESCRIPTION
Sonnet 5 (`claude-sonnet-5`) is a capability upgrade at ~no cost change — **$3/$15 standard (same as Sonnet 4.6), $2/$10 intro through 2026-08-31** — but it's a **breaking migration**: it rejects `temperature`/`top_p`/`top_k` (400) and defaults **adaptive thinking ON** (which shares the `max_tokens` budget and can truncate structured output). We pass `temperature` at ~15 call sites and never pass `thinking`.

## Fix — centrally, at the one choke point (not 15 edits)
- **`loggedMessagesCreate` now runs `sanitizeParamsForModel()`**: strips `temperature`/`top_p`/`top_k` for the Opus-4.7+ / Sonnet-5 / Fable line, and defaults `thinking: {type:'disabled'}` for models that would otherwise turn it on (Sonnet 5 / Mythos 5) — **unless the caller opts in**. A no-op for the current Sonnet 4.6 / Haiku 4.5 defaults.
- **`ANTHROPIC_MODEL` is now env-overridable** (default still `claude-sonnet-4-6`), so the upgrade is a **single, reversible env flip**: `ANTHROPIC_MODEL=claude-sonnet-5`.
- 9 unit tests for the sanitizer + the model predicates.

## Safety
**No behavior change on merge** (default unchanged). Flipping the env var makes every Sonnet call Sonnet-5-safe automatically. Recommend validating on a preview deploy before flipping prod; rollback is just clearing the env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)