### PR TITLE
docs(supply): reconcile refill findings + strategically PAUSE pending finite-set reframe

### DIFF
--- a/B-SUPPLY-REFILL-EFFORT-REPORT.md
+++ b/B-SUPPLY-REFILL-EFFORT-REPORT.md
@@ -1,8 +1,29 @@
 # Grounded Pool-Refill — Full Effort Report (B-SUPPLY-REFILL-*)
 
 **Period:** 2026-06-30 → 2026-07-01
-**Status:** **PAUSED** at 18-user scale (see Disposition). `RETRIEVAL_GROUNDING_ENABLED` remains **`false`** in prod. Verification, the throughput build, adaptive exclusion, a real prod flip + revert, a root-cause diagnostic, and a latency-lever sweep are all complete; the true blocker and the only viable fix are now identified.
+**Status:** **technically UN-BLOCKED, strategically PAUSED** (2026-07-01) — see the **UPDATE** section immediately below, which supersedes the original TL;DR / Disposition. `RETRIEVAL_GROUNDING_ENABLED` remains **`false`** in prod.
 **Supersedes / extends:** `B-SUPPLY-REFILL-FLIP-01-FINDINGS.md` (the mid-effort snapshot). This is the authoritative end-to-end record.
+
+---
+
+## UPDATE (2026-07-01) — technically un-blocked, strategically PAUSED
+
+> **This section supersedes the "PAUSED / async Batch API is the only fix" conclusion in the TL;DR and Disposition below.** Those are preserved **unchanged, as the Sonnet-4.6-era historical record** — read them as history, not as the current disposition.
+
+**1. Throughput is solved — by MODEL, not by architecture. The Batch-API rebuild is RETRACTED.**
+The 65%-timeout catastrophe was a **Sonnet 4.6** phenomenon: the heavy structured-JSON refill call sat at the 120s per-call ceiling, and the same call swung ~25s→>220s within an hour. On **Sonnet 5** (prod generation model since 2026-07-01 via `ANTHROPIC_MODEL`) a full **41-domain run drained in ~165s with ZERO timeouts**. **Do NOT rebuild refill on the async Batch API to "fix throughput" — that conclusion is explicitly withdrawn.** (`B-SUPPLY-REFILL-THROUGHPUT-01` bounded-concurrency also shipped and helps, but the decisive factor was the model.)
+
+**2. Yield is healthy on a FUNDED Sonnet 5 run.**
+The apparent "yield collapse" (34/41 domains persisting nothing) was **credit exhaustion mid-run** (HTTP 400 `CREDITS_EXHAUSTED`), NOT a never-searched (provenance) or parse-failure bug. A funded instrumented diagnostic showed **every domain searched (2–3×) and parsed (1 question each)**. Persist funnel on a broad-domain-heavy slice: 11 generated → 1 uncorroborated, 7 quality-gate drops, **3 persisted (~27%)**. That extrapolates over the ≥5-fact bar — but the ≥5 is still an extrapolation from BROAD domains, which persist more easily than the narrow domains refill exists to serve (see the confirmation gate).
+
+**3. STRATEGIC PAUSE — pending the finite-set product decision (`D-SUPPLY-FINITE-SET-01`, TBD).**
+The refill *works*; it is paused for a **product** reason, not a technical one. A reframe under review may replace *infinite daily top-up* with *finite completable sets* (fill a domain's ~15–30 fan-salient questions once, earn a designation, then graduate/broaden by choice, with opt-in difficulty tiers). That would change what refill is FOR — and change what a confirmation run even confirms. **Do not flip `RETRIEVAL_GROUNDING_ENABLED`, and do not run the ~$2 paid AC-1 confirmation, until `D-SUPPLY-FINITE-SET-01` lands.** Marker: `docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`.
+
+**4. AC-1 confirmation bar (when un-paused):** ≥12 domains **AND** ≥5 persisted facts in one funded run — **with narrow/niche domains (e.g. Spy School Books 1–6) represented among the persisted facts**, not only broad ones (Shakespeare/WTC/Rent persist more easily and would give a false pass). Gated note in `docs/retrieval-flip-checklist.md`.
+
+**5. Two telemetry gaps to close before ANY soak** (see `docs/findings/ledger-telemetry-gaps.md`): (a) web-search spend is not in `LlmUsageEvent` at all (~$1.80 on the 2026-07-01 spike day, invisible); (b) timed-out calls bill tokens Anthropic charges, but `LlmUsageEvent` records only successful responses — on the spike day the ledger saw ~$3 of the ~$7.56 actual. On Sonnet 5 gap (b) largely self-closes (no timeouts); gap (a) is permanent and material.
+
+**6. Model-dependency note for the provider thread.** Refill's **viability** — not just its per-token cost — is model-dependent: Sonnet 5 made a paused feature operable by removing its structural blocker. This belongs in `D-LLM-PROVIDER-ZAI-01`'s evidence: provider choice trades off feature-operability, not only price. Coordinated-but-decoupled — do not merge the threads.
 
 ---
 

--- a/D-SUPPLY-LADDER-UNIFY-01.md
+++ b/D-SUPPLY-LADDER-UNIFY-01.md
@@ -1,5 +1,7 @@
 # D-SUPPLY-LADDER-UNIFY-01 — Decision Record
 
+> **⚠ Under revision — see `docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`.** This ladder assumes **infinite-topup** domains; a **finite-completable-set** reframe under review may reshape rungs 2, 3, and 5. **Do not write build prompts from this doc until that decision lands.**
+
 **Status:** DRAFT — open decisions **A, D, E** require ratification before any build prompt is written. (Decisions **B** and **C** are effectively resolved by live canon — see the Reconciliation note and §5.)
 **Coordinates with (does NOT couple to):** `D-AREA-EXPANSION-01` (now **SETTLED + §9-amended + largely built**) and `D-QUESTION-QUALITY-AGENTS-01` / `B-QUESTION-QUALITY-AGENTS-01`. Shared seams only — see §4 and §7.
 **Migration head at draft:** `0095_player_mastery_rotation_eligible` (live head; `ls drizzle/*.sql | sort | tail -1`). This doc's *flips* introduce no migration; the §4 `needs_review` seam and the §5-A refill-recovery signal may each require a small storage/derivation decision settled at build time (§8) — so "no migration" is no longer an unconditional promise.

--- a/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
+++ b/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
@@ -1,0 +1,28 @@
+# D-SUPPLY-FINITE-SET-01 — PENDING DECISION (not yet ratified)
+
+**Status:** ⏳ **PENDING** — a chat decision with Josh precedes the real D-doc; this is only the visible marker. **Not ratified. Do not build against it, and do not build against the things it blocks.**
+
+**Blocks:** the paid AC-1 refill confirmation run · the refill soak · any `D-SUPPLY-LADDER-UNIFY-01` build prompts.
+
+## The question
+Are knowledge domains **infinite top-up pools** (the current supply-ladder premise — daily refill drains a backlog forever) or **finite completable sets** (a bounded body of ~15–30 fan-salient questions the player *completes*, earns a **designation** for, then **graduates/broadens** by choice — with **opt-in difficulty tiers** so arcane questions are generated rarely and only on demand)?
+
+## Why it matters (what the answer reshapes)
+- **Refill:** "daily backlog-draining cost" → "fill a set once, then stop."
+- **Depth threshold:** stops meaning "too thin to serve," starts meaning "set complete."
+- **Graduation (`D-AREA-EXPANSION-01`, rung 5):** flips from **fallback** (we ran out) to **intended arc** (you mastered it).
+- **Human curation:** Josh vetting ~50 → keeping ~35 may beat automated refill on both cost and quality for vettable domains.
+
+The driving feedback: *"answering ever deeper into one play leads to weirdness and frustration and boredom."* — i.e. infinite depth may be the wrong goal.
+
+## Two inputs Josh owes before ratification
+1. Does the **finite-set model feel right** as the game's direction?
+2. Does Josh want to **personally curate**, or should supply run **hands-off**?
+
+## Interacts with (do NOT build until resolved)
+- `D-SUPPLY-LADDER-UNIFY-01` — rungs 2, 3, and 5 all change.
+- `D-AREA-EXPANSION-01` — graduation's valence flips (fallback → intended arc). *(Do not edit that doc yet; its revision waits on this same decision.)*
+- The AC-1 refill confirmation run · the refill soak (`docs/retrieval-flip-checklist.md`, `B-SUPPLY-REFILL-EFFORT-REPORT.md`).
+
+## Does NOT block
+- The **batch-verify cost characterization** work (`docs/findings/batch-verify-cost-characterization.md`) — that cron is unrelated to this reframe and proceeds independently.

--- a/docs/findings/batch-verify-cost-characterization.md
+++ b/docs/findings/batch-verify-cost-characterization.md
@@ -1,0 +1,42 @@
+# batch-verify cron — cost characterization (read-only, no LLM calls)
+
+**Date:** 2026-07-01 · **Method:** live code + read-only `LlmUsageEvent` queries + the PURE `prefilterForVerification` run over a 600-row recent sample (zero LLM spend). · **Scope:** `/api/cron/batch-verify-questions` (`B-QUESTION-QUALITY-AGENTS-01` Phase 3). **The code is sound** (unstamped-only selection, stamp-on-every-outcome, pure pre-filter, web-as-fallback). The question is **steady-state daily rate and right-sizing**, not correctness.
+
+## Config (confirmed in code)
+- `BATCH_SIZE = 25` **per store** → ≤50 rows scanned/day across `Question` + `GeneratedQuestion`.
+- `VERIFY_CONCURRENCY = 4`, `maxDuration = 300`, schedule `0 10 * * *` (daily).
+- Selection: `verifiedAt IS NULL` (+ not blocked/deleted / not duplicate/expired); every outcome stamps `verifiedAt` + `verificationVerdict`, so rows are scanned once. A verifier **failure** leaves the row unstamped → retried next sweep.
+- Model = `ANTHROPIC_MODEL` (**now Sonnet 5** since the 2026-07-01 flip); web tool = `web_search_20250305`, `WEB_SEARCH_MAX_USES=3`, web-as-fallback.
+
+## Measured numbers
+
+**Ledger (`scope='batch-verify'`), by day:**
+| Day | Calls | Input tok | Output tok |
+|---|---|---|---|
+| 2026-06-30 | 12 | 121,859 | 3,762 |
+| 2026-07-01 | 46 | 517,772 | 11,564 |
+
+Only two days of data (cron is new). 07-01's 46 calls is **near the ~50/day structural max** — i.e. it maxed out both stores' `BATCH_SIZE`.
+
+**New-row rate (verification demand), last 14 days:** `GeneratedQuestion` **368 (~26/day)**, `Question` **236 (~17/day)** — ~43 new rows/day total.
+
+**Pre-filter skip rate (empirical, pure fn over 300 recent rows/store = 600):** **skip 55 (9%)**, route 545 (**91%**). Dimensions among routed: `false_premise` 266, **`extra_fact` 543**.
+
+## Answers to the five questions
+
+1. **Backlog vs steady state.** Too few days to see a clean first-run spike, but 07-01 ran at the cap (46/~50). Steady-state demand ≈ new-rows/day × route-rate ≈ 43 × 0.91 ≈ **~39 verification calls/day**, capped at 50/day. **Per-store is the catch:** `GeneratedQuestion` new-rate **~26/day ≈ its 25/day cap** → generated-question verification is **at/slightly over capacity** (its unstamped backlog does not drain and may creep up ~1/day). `Question` new-rate ~17/day < 25 → **keeps up and drains**.
+2. **Pre-filter skip rate ≈ 9% — LOW.** The pre-filter barely filters. Cause: **`extra_fact` routes 543/600 (≈90%)** because `answerIsMultiFact` fires on any answer containing a comma+word, `(`/`;`, or " and " — which is most answers. `false_premise` is more selective (266). So the pre-filter's spend-saving is small; **the `extra_fact` heuristic is the single biggest cost dial.** For this content (fan-salient, situated questions with descriptive answers), near-universal `extra_fact` routing looks **over-broad**, not well-calibrated.
+3. **Web-fallback rate — not directly measurable** (`usedWeb` is computed in `verifyQuestion` but **not persisted**; the ledger has no web-search column — see `ledger-telemetry-gaps.md`). **Strong indirect signal:** average **~11.3k input tokens/call** (07-01) is very high for a short question + verdict — consistent with **frequent web_search** (results injected into context add thousands of tokens). This suggests the knowledge-first gating is **firing web-search often** on Sonnet, i.e. the "search only when knowledge can't settle it" posture may be weaker in practice than intended. This is the main driver of both the token line and the separate web-search $.
+4. **The `BATCH_SIZE=25` ceiling.** For `Question` (17/day) it is comfortably above new volume (fine). For `GeneratedQuestion` (~26/day) it is **a floor at/under demand** → verification of generated questions never quite catches up. Not catastrophic (~1/day creep), but it means the newest generated rows wait, and a volume increase would widen the gap.
+5. **Right-sizing options (analysis only — nothing changed):**
+   - **Tighten `extra_fact` routing (biggest lever).** `answerIsMultiFact` is near-universal; requiring a stronger adjacent-claim signal (or gating `extra_fact` on the *explanation* carrying claims, not just a comma in the answer) would lift the 9% skip rate materially and cut calls/day the most.
+   - **Add prompt caching.** `verify-question.ts` passes `system: SYSTEM_PROMPT` as a plain string with **no `cache_control`** — every call re-bills the (~1k-token) system prompt uncached. An ephemeral cache breakpoint would shave input cost across all calls.
+   - **Right-size the generated-store cap.** Either raise `BATCH_SIZE` for `GeneratedQuestion` to clear its ~26/day inflow, or accept the small lag deliberately.
+   - **Confirm web behavior on Sonnet 5.** (a) verify `web_search_20250305` (the older tool version) is still accepted by `claude-sonnet-5` — the cron now runs on it; (b) re-check that knowledge-first gating actually holds on Sonnet 5, given the high average input.
+   - **Or leave as-is** if the ~$2/day (below) is acceptable; the cron is correct and demote-only.
+
+## Cost estimate
+07-01 token cost ≈ (517,772 × \$3 + 11,564 × \$15)/1e6 ≈ **\$1.73/day** (Sonnet-tier), + web-search (separate meter; part of the day's \$1.80 web line) ≈ **~\$2/day ≈ ~\$60/month**. At ~18 users this is currently the **single largest recurring LLM line** — larger than the whole question-generation Sonnet spend (~\$9/month). The `extra_fact` over-routing and the frequent web-search are the two things making it so; both are dials, not bugs.
+
+## Recommendation
+Not urgent, not broken — but **before it's treated as steady baseline, tighten `extra_fact` routing and add system-prompt caching**; those two changes likely cut this line substantially without weakening the demote-only safety net. Re-measure after the `extra_fact` change. (Unrelated to the supply-refill pause — this cron proceeds independently.)

--- a/docs/findings/ledger-telemetry-gaps.md
+++ b/docs/findings/ledger-telemetry-gaps.md
@@ -1,0 +1,18 @@
+# `LlmUsageEvent` under-reporting gaps — fix before any refill soak
+
+**Date:** 2026-07-01. **Basis:** the 2026-07-01 spend spike (Anthropic dashboard **\$7.56** token cost + **\$1.80** web search) vs. what our own ledger could see (~\$3). Two structural gaps make `LlmUsageEvent` under-report real spend. **Fix both before the refill soak starts — the soak's weekly \$ number is otherwise a token-only undercount.**
+
+## Gap (a) — web-search spend is uncaptured
+`LlmUsageEvent` (`schema.ts` ~L1465) has **token columns only** (`input/output/cache_read/cache_create_tokens`, `duration_ms`) — **no web-search column.** Web-search cost (≈\$0.01/request) is never ledgered; it lives only in cron report/log lines. Material: **~\$1.80** on the spike day across refill + `batch-verify`. **Permanent gap** — affects the refill AND the `batch-verify` cron (see `batch-verify-cost-characterization.md`, where the average ~11k input tokens/call is strong evidence of frequent, unledgered web-search).
+
+## Gap (b) — aborted-call tokens are uncaptured
+`loggedMessagesCreate` writes the usage row **only after a successful response**; a call that generates tokens and then **times out / aborts** (Anthropic still bills the tokens generated before the abort) throws into the catch path and **records no row.** On the 2026-07-01 refill testing, Sonnet-4.6's ~65% timeout rate meant many ~120s calls burned billed-but-unlogged tokens — the bulk of the ledger↔dashboard gap (ledger saw ~\$3 of ~\$7.56). **On Sonnet 5 this largely self-closes** (no timeouts), but it is documented so nobody re-discovers it the hard way.
+
+## Fix scope (a build, later)
+Persist **web-search request counts** to `LlmUsageEvent` (or a sibling row) so cost derivation (`pricing.ts` / `estimateCostUsd`) includes them; optionally record aborted-call token estimates. This aligns with the **`B-LLM-COST-LATENCY-REPORT-01`** weekly-digest thread (the `LlmCostReport` table, `schema.ts` ~L1491, and `docs/llm-cost-action-plan.md`) and its "no false-confidence \$0 readouts" principle — **cross-reference that work rather than duplicate it.** (Note: the exact doc `D-LLM-COST-LATENCY-REPORT-01` referenced elsewhere does not exist under that name; the real artifacts are the `B-`-tagged feature + `docs/llm-cost-action-plan.md`.)
+
+## GATE
+Must land **before `RETRIEVAL_GROUNDING_ENABLED` soak begins** — otherwise the soak's weekly \$ number is a token-only undercount. **Not** blocking for the AC-1 confirmation run (that reads combined \$ from the cron log line directly).
+
+## Gate updated (2026-07-01, `CC-SUPPLY-HALT-01`)
+The soak this fix gated is **itself PAUSED** pending `D-SUPPLY-FINITE-SET-01` (see `docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`). This fix remains a prerequisite for **any** refill soak — infinite *or* finite; an honest weekly \$ number is needed either way — but it is **not urgent while refill is paused.** Keep for whenever supply resumes.

--- a/docs/retrieval-flip-checklist.md
+++ b/docs/retrieval-flip-checklist.md
@@ -1,5 +1,15 @@
 # Retrieval-grounded pool refill — flip checklist (C6)
 
+> ## ⏸ AC-1 confirmation run — **PAUSED (not just deferred)** — pending the finite-set product decision (`D-SUPPLY-FINITE-SET-01`, TBD)
+>
+> The ~\$2 paid AC-1 confirmation run is **on hold**. The reason is **NOT throughput or yield** — both are resolved: on **Sonnet 5** a full 41-domain run drains in ~165s with **zero timeouts**, and a funded diagnostic showed healthy yield (every domain searched + parsed; ~27% persist on a broad slice). The reason is that this confirmation would validate **infinite-topup** refill, and a **product reframe under review** (`docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`) may replace that with **finite completable sets** (fill once → designation → graduate). Running the confirmation now risks proving a capability we may not want.
+>
+> **Un-pause condition:** the finite-set decision is made.
+> - If it **KEEPS infinite refill** → run the confirmation as specified below. **Bar:** one funded full run, **≥12 domains AND ≥5 persisted facts**, **with narrow/niche domains (e.g. Spy School Books 1–6) represented among the persisted facts** — not only broad domains (Shakespeare/WTC/Rent), which persist more easily and would give a false pass. Watch per-domain persist for the niche targets. Additional precondition: run on a **low-baseline spend day** (a normal ~\$0.30/day baseline observed first — do not stack a paid run on a burn day like the 2026-07-01 \$7.56 spike).
+> - If it **adopts finite sets** → this note is **rewritten**: the bar becomes "one complete set assembled + graduates cleanly," not "backlog drains."
+>
+> On pass (infinite branch) → proceed with the rest of this checklist and flip `RETRIEVAL_GROUNDING_ENABLED` (env only). On fail (niche domains don't persist) → that's a narrow-domain yield problem, not throughput; diagnose before flipping. **Do not run until un-paused.**
+
 The retrieval/embeddings stack (PRD-D-5 B3) is **built and off by default**. BP-7 made the
 off→on transition clean and added the telemetry to read before flipping. This is the
 operational checklist for turning it on — an explicit post-merge decision, never flipped


### PR DESCRIPTION
**Docs only. Zero LLM spend, no flag flips, no runs.** Executes two coordinated prompts (`CC-SUPPLY-COST-RECONCILE-01` + `CC-SUPPLY-HALT-01`) in their harmonized end state.

## Effort report — `B-SUPPLY-REFILL-EFFORT-REPORT.md`
- **Retracts** the "only structural fix is the async Batch API" conclusion. Throughput was a **Sonnet 4.6** timeout phenomenon; on **Sonnet 5** a full 41-domain run drains in **~165s, zero timeouts**.
- **Yield is healthy on a funded run** — the "collapse" was mid-run `CREDITS_EXHAUSTED` 400s, not a search/parse bug. Historical 4.6 findings preserved below as history.
- Top status: **technically un-blocked, strategically PAUSED** pending `D-SUPPLY-FINITE-SET-01`.

## The pause — new marker `docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`
Open product question: **infinite top-up pools vs. finite completable sets** (complete → designation → graduate, opt-in difficulty tiers). Blocks the paid AC-1 run, the soak, and `D-SUPPLY-LADDER-UNIFY-01` build prompts. Two inputs owed by Josh (does finite-set feel right; curate vs hands-off).
- `D-SUPPLY-LADDER-UNIFY-01.md` → under-revision banner.
- `docs/retrieval-flip-checklist.md` → AC-1 note set to **PAUSED** with both un-pause branches + the narrow-domain persist bar.

## Findings (measured, read-only)
- **`docs/findings/batch-verify-cost-characterization.md`** — the batch-verify cron is the largest recurring LLM line (~\$2/day). Pre-filter skip only **~9%** (`extra_fact` over-routes ~90% via `answerIsMultiFact`); generated-question inflow **~26/day at the 25/day cap**; **~11k avg input tok/call** (frequent web-search). Right-sizing: tighten `extra_fact`, add system-prompt caching. Analysis only — no code changed.
- **`docs/findings/ledger-telemetry-gaps.md`** — `LlmUsageEvent` misses web-search \$ and aborted-call tokens (saw ~\$3 of ~\$7.56 on the spike day); pre-soak gate, not urgent while paused.

## Not done here (by design)
`D-SUPPLY-FINITE-SET-01` itself (a chat decision precedes it); `D-AREA-EXPANSION-01` edits (waits on the same decision); any flag flip or paid run. DECISIONS.md's line-23 entry still carries the old "PAUSED/Batch-API" summary — flagged, left for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)