### PR TITLE
Fix layout direction in RefineItemCard for sm+ screens

### DIFF
--- a/src/components/review/RefineItemCard.tsx
+++ b/src/components/review/RefineItemCard.tsx
@@ -17,11 +17,10 @@ const actionStyle: CSSProperties = {
 const ACTION_CLASS =
   'inline-flex min-h-11 cursor-pointer items-center justify-center self-start rounded-[var(--radius-xs)] border px-4 text-sm font-semibold transition hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-60 sm:self-auto';
 
-// Action verb sits on the left on the sm+ row (flex-row-reverse puts the
-// trailing button at the start), while mobile keeps the natural text-then-action
-// stack.
+// Action verb sits on the right on the sm+ row (the trailing button keeps its
+// natural end position), while mobile keeps the natural text-then-action stack.
 const ROW_CLASS =
-  'flex flex-col gap-3 py-4 sm:flex-row-reverse sm:items-center sm:justify-between sm:gap-4';
+  'flex flex-col gap-3 py-4 sm:flex-row sm:items-center sm:justify-between sm:gap-4';
 
 export function RefineItemCard({ item, queueId }: { item: RefineItem; queueId: string }) {
   // Navigational nudge (add_territories): links out instead of staging a


### PR DESCRIPTION
## Summary
Corrects the flex layout direction in `RefineItemCard` to properly position the action button on the right side of the card on small+ screens, while maintaining the natural text-then-action stack on mobile.

## Changes
- Removed `flex-row-reverse` from the `ROW_CLASS` and replaced it with `flex-row`
- Updated the accompanying comment to accurately reflect the new layout behavior: the action verb now sits on the right (its natural end position) rather than being reversed to the left
- This ensures consistent visual hierarchy across responsive breakpoints without needing to reverse the flex direction

## Implementation Details
The previous implementation used `flex-row-reverse` to position the trailing button at the start of the row, which required reversing the natural DOM order. The updated approach uses standard `flex-row` with `justify-between`, allowing the button to remain in its natural end position while maintaining proper spacing and alignment on sm+ screens.

https://claude.ai/code/session_01KTURf9Rp4r6wiyP3kaXqLv