### PR TITLE
P5 follow-ups: bubble-map chrome, friend page, collections strip, grow-rim + dev preview

### DIFF
--- a/src/app/dev/knowledge-map/page.tsx
+++ b/src/app/dev/knowledge-map/page.tsx
@@ -1,0 +1,12 @@
+import { KnowledgeBubblePage } from '@/app/knowledge/KnowledgeBubblePage';
+
+export const dynamic = 'force-dynamic';
+
+// Dev preview for the nested-bubble knowledge map (P5): renders the flag-on
+// experience REGARDLESS of KNOWLEDGE_MAP_PAGE, so it can be exercised from the
+// profile's Developer-tools section before the flag flips. Session-gated
+// inside KnowledgeBubblePage (redirects to /login); the /dev route gate lives
+// in src/app/dev/layout.tsx like every other dev tool.
+export default function DevKnowledgeMapPage() {
+  return <KnowledgeBubblePage />;
+}

--- a/src/app/knowledge/BubblePageChrome.tsx
+++ b/src/app/knowledge/BubblePageChrome.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { Combine, Share2 } from 'lucide-react';
+
+import { SharePortraitModal } from '@/components/knowledge/SharePortraitModal';
+import type { ShareDomain } from '@/components/knowledge/SharePortraitCard';
+
+// P5 follow-up — the share/tidy chrome from the flat knowledge page, on the
+// bubble map. Share opens the existing portrait modal (it captures on mount —
+// same fallback path the flat page uses when its background capture isn't
+// ready). Tidy calls the same /api/knowledge/tidy merge pass, then refreshes
+// so the repacked map reflects any combined domains.
+
+export function BubblePageChrome({
+  playerDisplayName,
+  portraitStatement,
+  domains,
+  overflowCount,
+  tierSignature,
+}: {
+  playerDisplayName: string;
+  portraitStatement: string;
+  domains: ShareDomain[];
+  overflowCount: number;
+  tierSignature: string;
+}) {
+  const router = useRouter();
+  const [shareOpen, setShareOpen] = useState(false);
+  const [tidying, setTidying] = useState(false);
+  const [tidyNotice, setTidyNotice] = useState<string | null>(null);
+
+  async function tidy() {
+    if (tidying) return;
+    setTidying(true);
+    setTidyNotice(null);
+    try {
+      const response = await fetch('/api/knowledge/tidy', { method: 'POST', credentials: 'include' });
+      const body = (await response.json().catch(() => null)) as
+        | { mergesApplied?: number; message?: string }
+        | null;
+      if (!response.ok || typeof body?.mergesApplied !== 'number') {
+        throw new Error(body?.message ?? 'Could not tidy your map.');
+      }
+      setTidyNotice(body.mergesApplied > 0 ? `${body.mergesApplied} domains combined` : 'Nothing to combine');
+      if (body.mergesApplied > 0) router.refresh();
+    } catch (caught) {
+      setTidyNotice(caught instanceof Error ? caught.message : 'Could not tidy your map.');
+    } finally {
+      setTidying(false);
+      window.setTimeout(() => setTidyNotice(null), 3600);
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      {tidyNotice ? (
+        <span className="text-xs text-[var(--text-muted)]" aria-live="polite">
+          {tidyNotice}
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => void tidy()}
+        disabled={tidying}
+        className="inline-flex min-h-9 items-center gap-1.5 rounded-full border px-3 text-[0.7rem] uppercase tracking-[0.08em] disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+        style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)', background: 'var(--brand-card)' }}
+      >
+        <Combine className="size-3.5" aria-hidden />
+        {tidying ? 'Tidying…' : 'Tidy'}
+      </button>
+      {domains.length > 0 ? (
+        <button
+          type="button"
+          onClick={() => setShareOpen(true)}
+          className="inline-flex min-h-9 items-center gap-1.5 rounded-full border px-3 text-[0.7rem] uppercase tracking-[0.08em] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)', background: 'var(--brand-card)' }}
+        >
+          <Share2 className="size-3.5" aria-hidden />
+          Share
+        </button>
+      ) : null}
+
+      {shareOpen ? (
+        <SharePortraitModal
+          playerDisplayName={playerDisplayName}
+          portraitStatement={portraitStatement}
+          domains={domains}
+          overflowCount={overflowCount}
+          tierSignature={tierSignature}
+          onClose={() => setShareOpen(false)}
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/src/app/knowledge/KnowledgeBubblePage.tsx
+++ b/src/app/knowledge/KnowledgeBubblePage.tsx
@@ -1,28 +1,68 @@
+import { eq } from 'drizzle-orm';
 import { redirect } from 'next/navigation';
 
+import { db, users } from '@/server/db';
 import { getSession } from '@/server/auth/session';
-import { getKnowledgeTree } from '@/server/knowledge/knowledge-tree';
+import type { MasteryTier } from '@/types/db';
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { KnowledgeBubbleMap } from '@/components/knowledge/KnowledgeBubbleMap';
 
+import { BubblePageChrome } from './BubblePageChrome';
+
+// The share card's one-line mind statement — same construction the flat
+// portrait surfaces use (top three territories, natural-language joined).
+function buildMindStatement(topDomains: readonly { displayName: string }[]): string {
+  const top = topDomains.slice(0, 3).map((d) => d.displayName);
+  if (top.length >= 2) {
+    return `You're building around ${top.slice(0, -1).join(', ')} and ${top.at(-1)}.`;
+  }
+  if (top.length === 1) return `You're building around ${top[0]}.`;
+  return 'Your mind will take shape as you answer and write questions.';
+}
+
 // B-KNOWLEDGE-TAXONOMY-01 P5 — the flag-on knowledge page: nested circle-pack
-// map over the player's real mastery + the authored graph. Reached only via
-// the KNOWLEDGE_MAP_PAGE gate in page.tsx (dynamic import — never loaded on
-// the off path). Share/tidy chrome from the flat page is a noted follow-up —
-// this phase renders the map direction itself.
+// map over the player's real mastery + the authored graph, with the flat
+// page's share/tidy chrome (P5 follow-up), the collections coverage strip, and
+// the grow-rim. Reached only via the KNOWLEDGE_MAP_PAGE gate in page.tsx
+// (dynamic import — never loaded on the off path) or the /dev preview.
 export async function KnowledgeBubblePage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  const tree = await getKnowledgeTree(session.userId);
+  const [{ tree, collections, ownedDomains }, [user]] = await Promise.all([
+    getKnowledgeMapData(session.userId),
+    db
+      .select({ displayName: users.displayName })
+      .from(users)
+      .where(eq(users.id, session.userId))
+      .limit(1),
+  ]);
+
+  const sorted = [...ownedDomains].sort((a, b) => b.points - a.points);
+  const topDomains = sorted.slice(0, 5);
+  const totalPoints = sorted.reduce((sum, d) => sum + d.points, 0);
 
   return (
     <main className="mx-auto flex h-dvh max-w-3xl flex-col px-4 py-5">
-      <header className="mb-1 flex items-baseline justify-between">
+      <header className="mb-1 flex items-baseline justify-between gap-3">
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
           What you <em className="italic text-[var(--brand-ink-700)]">know</em>
         </h1>
+        <BubblePageChrome
+          playerDisplayName={user?.displayName ?? 'You'}
+          portraitStatement={buildMindStatement(topDomains)}
+          domains={topDomains.map((d) => ({
+            canonicalSubcategory: d.displayName,
+            currentTier: d.tier as MasteryTier,
+            lifetimePoints: d.points,
+            iconKey: d.iconKey,
+            broadCategory: d.broadCategory,
+          }))}
+          overflowCount={Math.max(0, sorted.length - topDomains.length)}
+          tierSignature={`${new Intl.NumberFormat().format(Math.round(totalPoints))} knowledge points across ${sorted.length} territories`}
+        />
       </header>
-      <KnowledgeBubbleMap data={tree} />
+      <KnowledgeBubbleMap data={tree} collections={collections} />
     </main>
   );
 }

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -1,3 +1,5 @@
+import { isKnowledgeMapPageEnabled } from '@/server/knowledge/map-page-flag';
+
 import { KnowledgeFlatClient } from './KnowledgeFlatClient';
 
 export const dynamic = 'force-dynamic';
@@ -8,11 +10,6 @@ export const dynamic = 'force-dynamic';
 // (named export; no other change), and this off-path imports NEITHER new map
 // file. Flag ON: the circle-pack map (knowledge-bubbles direction) renders via
 // a dynamic import, so the map's code never loads on the off path.
-function isKnowledgeMapPageEnabled(): boolean {
-  const raw = process.env.KNOWLEDGE_MAP_PAGE?.trim().toLowerCase();
-  if (raw === undefined || raw === '') return false;
-  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
-}
 
 export default async function KnowledgePage() {
   if (isKnowledgeMapPageEnabled()) {

--- a/src/app/users/[id]/knowledge/page.tsx
+++ b/src/app/users/[id]/knowledge/page.tsx
@@ -1,9 +1,12 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
 
+import { KnowledgeBubbleMap } from '@/components/knowledge/KnowledgeBubbleMap'
 import { KnowledgeCard } from '@/components/knowledge/KnowledgeCard'
 import { PortraitCircles } from '@/components/knowledge/PortraitCircles'
 import { getSession } from '@/server/auth/session'
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree'
+import { isKnowledgeMapPageEnabled } from '@/server/knowledge/map-page-flag'
 import {
   getKnowledgePageData,
   getUserMasteryOverview,
@@ -57,6 +60,12 @@ export default async function FriendKnowledgePage({
     getUserMasteryOverview(portrait.user.id),
     getKnowledgePageData(portrait.user.id),
   ])
+
+  // P5 follow-up: behind the same KNOWLEDGE_MAP_PAGE flag as the own page —
+  // flag off renders the flat portrait exactly as before.
+  const mapData = isKnowledgeMapPageEnabled()
+    ? await getKnowledgeMapData(portrait.user.id, { includeGhosts: false })
+    : null
 
   const visibleDomains = isOwner
     ? pageData.allDomains
@@ -128,7 +137,21 @@ export default async function FriendKnowledgePage({
 
       {hasKnowledge ? (
         <div className="mt-6">
-          <PortraitCircles entries={portraitEntries} />
+          {mapData ? (
+            // P5 follow-up: flag-on, the friend's map renders as the same
+            // nested bubbles — read-only variant (no ghosts, no adopt; their
+            // hidden domains already filtered by the loader).
+            <div className="flex h-[60vh] min-h-80 flex-col">
+              <KnowledgeBubbleMap
+                data={mapData.tree}
+                collections={mapData.collections}
+                variant="friend"
+                rootTitle={`${friendFirstName}'s peaks`}
+              />
+            </div>
+          ) : (
+            <PortraitCircles entries={portraitEntries} />
+          )}
         </div>
       ) : null}
     </main>

--- a/src/components/knowledge/KnowledgeBubbleMap.tsx
+++ b/src/components/knowledge/KnowledgeBubbleMap.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react';
 import { hierarchy, pack, type HierarchyCircularNode } from 'd3-hierarchy';
 
-import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
+import type { CollectionSummary, KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 
 // B-KNOWLEDGE-TAXONOMY-01 P5 — the nested circle-pack knowledge map, ported
 // from the ratified knowledge-bubbles prototype onto the repo's design
@@ -16,6 +16,12 @@ type PackedNode = HierarchyCircularNode<KnowledgeTreeNode>;
 
 function fieldColor(field: string | null | undefined): string {
   return field ? `var(--cat-${field}, var(--brand-ink-400))` : 'var(--brand-ink-400)';
+}
+
+function subscribeReducedMotion(callback: () => void): () => void {
+  const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+  mq.addEventListener('change', callback);
+  return () => mq.removeEventListener('change', callback);
 }
 
 // Adopt endpoint (the territory-adopt path): sets the ghost domain's Daily
@@ -34,7 +40,19 @@ async function adoptDomain(domain: string): Promise<boolean> {
   }
 }
 
-export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
+export function KnowledgeBubbleMap({
+  data,
+  collections = [],
+  // 'own' = interactive (ghost tap adopts); 'friend' = read-only portrait —
+  // the tree already carries no ghosts, and nothing here mutates their state.
+  variant = 'own',
+  rootTitle = 'Your peaks',
+}: {
+  data: KnowledgeTreeNode;
+  collections?: CollectionSummary[];
+  variant?: 'own' | 'friend';
+  rootTitle?: string;
+}) {
   const stageRef = useRef<HTMLDivElement>(null);
   const [size, setSize] = useState<{ w: number; h: number }>({ w: 720, h: 520 });
   const [tree, setTree] = useState<KnowledgeTreeNode>(data);
@@ -42,15 +60,13 @@ export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
   const [flashId, setFlashId] = useState<string | null>(null);
   const [listMode, setListMode] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
-  const [reducedMotion, setReducedMotion] = useState(false);
-
-  useEffect(() => {
-    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
-    setReducedMotion(mq.matches);
-    const onChange = (e: MediaQueryListEvent) => setReducedMotion(e.matches);
-    mq.addEventListener('change', onChange);
-    return () => mq.removeEventListener('change', onChange);
-  }, []);
+  // Media-query state via useSyncExternalStore: correct initial value on the
+  // client, false during SSR, no setState-in-effect cascade.
+  const reducedMotion = useSyncExternalStore(
+    subscribeReducedMotion,
+    () => window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    () => false,
+  );
 
   useEffect(() => {
     const el = stageRef.current;
@@ -176,7 +192,7 @@ export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
                 {i > 0 ? <span aria-hidden style={{ color: 'var(--border)' }}>›</span> : null}
                 {i === crumb.length - 1 ? (
                   <span className="font-medium text-[var(--brand-ink)]">
-                    {node.data.id === 'root' ? 'Your peaks' : node.data.name}
+                    {node.data.id === 'root' ? rootTitle : node.data.name}
                   </span>
                 ) : (
                   <button
@@ -185,7 +201,7 @@ export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
                     className="font-medium underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
                     style={{ color: 'var(--brand-ink-700)' }}
                   >
-                    {node.data.id === 'root' ? 'Your peaks' : node.data.name}
+                    {node.data.id === 'root' ? rootTitle : node.data.name}
                   </button>
                 )}
               </span>
@@ -273,14 +289,14 @@ export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
                     style={{ cursor: 'pointer', outlineOffset: 2 }}
                     onClick={(e) => {
                       e.stopPropagation();
-                      if (d.data.ghost) void addGhost(d);
+                      if (d.data.ghost) { if (variant === 'own') void addGhost(d); }
                       else zoomTo(d);
                     }}
                     onKeyDown={(e) => {
                       if (e.key === 'Enter' || e.key === ' ') {
                         e.preventDefault();
                         e.stopPropagation();
-                        if (d.data.ghost) void addGhost(d);
+                        if (d.data.ghost) { if (variant === 'own') void addGhost(d); }
                         else zoomTo(d);
                       }
                     }}
@@ -366,6 +382,23 @@ export function KnowledgeBubbleMap({ data }: { data: KnowledgeTreeNode }) {
           ))}
         </div>
       )}
+
+      {/* Collection parents (§7) are coverage, not containers — they live in a
+          strip, never in the pack. "You've covered N of M" is the honest voice. */}
+      {collections.length > 0 ? (
+        <div className="flex gap-2 overflow-x-auto py-1.5" role="list" aria-label="Collections covered">
+          {collections.map((c) => (
+            <span
+              key={c.label}
+              role="listitem"
+              className="flex-none whitespace-nowrap rounded-full border px-3 py-1 text-[11px]"
+              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)', background: 'var(--brand-card)' }}
+            >
+              {c.label} · {c.covered} of {c.rosterSize} covered
+            </span>
+          ))}
+        </div>
+      ) : null}
 
       <p className="min-h-5 pt-1.5 text-center font-serif text-[11px] italic text-[var(--text-muted)]" aria-live="polite">
         {notice ?? (!listMode ? hint : '')}

--- a/src/components/profile/settings/AccountActions.tsx
+++ b/src/components/profile/settings/AccountActions.tsx
@@ -269,6 +269,13 @@ export function AccountActions({
         },
         {
           kind: 'link',
+          icon: <Network className="size-5" />,
+          title: 'Knowledge map (bubbles)',
+          subtitle: 'Preview the nested circle-pack knowledge page before the flag flips',
+          href: '/dev/knowledge-map',
+        },
+        {
+          kind: 'link',
           icon: <BarChart3 className="size-5" />,
           title: 'Points diagnostic',
           subtitle: "Inspect a user's mastery events and where points came from",

--- a/src/server/knowledge/__tests__/knowledge-tree.test.ts
+++ b/src/server/knowledge/__tests__/knowledge-tree.test.ts
@@ -124,4 +124,85 @@ describe('buildKnowledgeTree', () => {
     expect(ghost?.value).toBe(mod.GHOST_FOOTPRINT);
     expect(mod.sumRealPoints(ghost!)).toBe(0);
   });
+
+  it('includeGhosts:false (friend variant) renders only held territory — no invitations', () => {
+    const tree = mod.buildKnowledgeTree(OWNED, NODES, EDGES, new Set(), { includeGhosts: false });
+    const parent = findNode(tree, 'renaissance italy');
+    expect((parent!.children ?? []).some((c) => c.ghost)).toBe(false);
+    expect(findNode(tree, 'machiavelli')).toBeNull();
+    expect(mod.sumRealPoints(tree)).toBe(500); // real totals identical either way
+  });
+});
+
+describe('grow-rim — unheld same-field roots as ghost invitations', () => {
+  const nodesWithRim = [
+    ...NODES,
+    node('Tudor England', 'parent', 1500), // unheld root, same 'history' hue
+    node('Baroque Opera', 'parent', 1500), // unheld root, DIFFERENT field
+  ];
+  // Baroque Opera gets a music hue — the rim only invites into fields you
+  // already inhabit.
+  nodesWithRim[nodesWithRim.length - 1] = {
+    ...nodesWithRim[nodesWithRim.length - 1],
+    fieldHue: 'music',
+  };
+
+  it('shows unheld roots sharing a held field, as ghosts, and skips other fields', () => {
+    const tree = mod.buildKnowledgeTree(OWNED, nodesWithRim, EDGES);
+    const tudor = findNode(tree, 'tudor england');
+    expect(tudor?.ghost).toBe(true);
+    expect(tudor?.value).toBe(mod.GHOST_FOOTPRINT);
+    expect(findNode(tree, 'baroque opera')).toBeNull(); // music not inhabited
+  });
+
+  it('the rim is capped and never inflates totals', () => {
+    const many = [
+      ...NODES,
+      ...Array.from({ length: 6 }, (_, i) => node(`History Field ${i}`, 'parent', 1000)),
+    ];
+    const tree = mod.buildKnowledgeTree(OWNED, many, EDGES);
+    const rimGhosts = (tree.children ?? []).filter((c) => c.ghost);
+    expect(rimGhosts.length).toBeLessThanOrEqual(mod.GROW_RIM_CAP);
+    expect(mod.sumRealPoints(tree)).toBe(500);
+  });
+
+  it('friend variant has no rim', () => {
+    const tree = mod.buildKnowledgeTree(OWNED, nodesWithRim, EDGES, new Set(), {
+      includeGhosts: false,
+    });
+    expect(findNode(tree, 'tudor england')).toBeNull();
+  });
+});
+
+describe('collectCollections — §7 coverage strip', () => {
+  const H_NODES = [
+    node('Plays Starting With H', 'parent', null),
+    node('Hamlet'),
+    node('Henry V'),
+    node('Hedda Gabler'),
+  ];
+  const H_EDGES: Edge[] = [
+    { childDomainKey: 'hamlet', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
+    { childDomainKey: 'henry v', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
+    { childDomainKey: 'hedda gabler', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
+  ];
+
+  it('depth in one member lights exactly one slot', () => {
+    const collections = mod.collectCollections(
+      [{ domain: 'Hamlet', points: 2500, mastered: true, broadCategory: 'Literature' }],
+      H_NODES,
+      H_EDGES,
+    );
+    expect(collections).toEqual([{ label: 'Plays Starting With H', covered: 1, rosterSize: 3 }]);
+  });
+
+  it('untouched collections do not appear; collections never enter the packed tree', () => {
+    expect(mod.collectCollections(OWNED, H_NODES, H_EDGES)).toEqual([]);
+    const tree = mod.buildKnowledgeTree(
+      [{ domain: 'Hamlet', points: 2500, mastered: true, broadCategory: 'Literature' }],
+      H_NODES,
+      H_EDGES,
+    );
+    expect(findNode(tree, 'plays starting with h')).toBeNull(); // §7: not a container
+  });
 });

--- a/src/server/knowledge/knowledge-tree.ts
+++ b/src/server/knowledge/knowledge-tree.ts
@@ -96,6 +96,15 @@ export function hueForBroadCategory(broadCategory: string | null): string | null
  * with no authored node land directly under the root — the graph starts
  * nearly empty, and every real territory must still show.
  */
+export type BuildTreeOptions = {
+  /**
+   * Ghosts + grow-rim are OWN-map affordances (tap-to-adopt). A friend's map
+   * is read-only: false renders only what they actually hold — no invitations
+   * on someone else's behalf.
+   */
+  includeGhosts?: boolean;
+};
+
 export function buildKnowledgeTree(
   owned: readonly OwnedLeaf[],
   nodes: readonly AuthoredNode[],
@@ -105,7 +114,9 @@ export function buildKnowledgeTree(
   // today's computed value below the bar — mastery is never revoked. Empty /
   // omitted (flag off) → pure computation, P5 behavior unchanged.
   frozenParents: ReadonlySet<string> = new Set(),
+  options: BuildTreeOptions = {},
 ): KnowledgeTreeNode {
+  const includeGhosts = options.includeGhosts ?? true;
   const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
   const ownedByKey = new Map(owned.map((leaf) => [domainKey(leaf.domain), leaf]));
 
@@ -154,7 +165,7 @@ export function buildKnowledgeTree(
       if (isHeld(childKey)) {
         const built = buildGraphNode(childKey);
         if (built) children.push(built);
-      } else {
+      } else if (includeGhosts) {
         // Unheld sibling → ghost: dashed, footprint-only, zero real points.
         const childNode = nodeByKey.get(childKey);
         if (childNode) {
@@ -215,7 +226,89 @@ export function buildKnowledgeTree(
     });
   }
 
+  // The GROW RIM: unheld authored ROOTS in fields the player already inhabits,
+  // rendered as ghost invitations at the home view — the wider world beyond
+  // what they hold, without promising unbuilt areas (only authored nodes ever
+  // appear). Capped so the rim stays an edge, not a crowd. Own-map only.
+  if (includeGhosts) {
+    const heldFields = new Set(
+      rootChildren.map((child) => child.field).filter((f): f is string => Boolean(f)),
+    );
+    // Collection-only parents never rim (§7 — a set to cover, not a territory
+    // to enter): a parent whose child edges are all collection-type.
+    const substantiveParents = new Set(substantive.map((e) => e.parentDomainKey));
+    const collectionOnlyParents = new Set(
+      edges
+        .filter((e) => e.edgeType === 'collection')
+        .map((e) => e.parentDomainKey)
+        .filter((key) => !substantiveParents.has(key)),
+    );
+    const rimCandidates = [...nodeByKey.values()].filter((node) => {
+      if (homeParentByChild.has(node.domainKey) || isHeld(node.domainKey)) return false;
+      if (collectionOnlyParents.has(node.domainKey)) return false;
+      const field = node.fieldHue ?? hueForBroadCategory(node.broadCategory);
+      return field !== null && heldFields.has(field);
+    });
+    for (const node of rimCandidates.slice(0, GROW_RIM_CAP)) {
+      rootChildren.push({
+        id: node.domainKey,
+        name: node.label,
+        field: node.fieldHue ?? hueForBroadCategory(node.broadCategory),
+        value: GHOST_FOOTPRINT,
+        ghost: true,
+      });
+    }
+  }
+
   return { id: 'root', name: 'Everything', field: null, children: rootChildren };
+}
+
+// The rim invites, it doesn't crowd — at most this many unheld roots at home.
+export const GROW_RIM_CAP = 3;
+
+export type CollectionSummary = {
+  label: string;
+  covered: number;
+  rosterSize: number;
+};
+
+/**
+ * Collection parents (§7) are NOT containers of points, so they never enter
+ * the packed view — they render as a coverage strip ("You've covered 2 of 3
+ * Plays Starting With 'H'"). Only collections where the player has covered at
+ * least one member appear; a wall of untouched sets isn't an invitation, it's
+ * noise. Pure; unit-tested.
+ */
+export function collectCollections(
+  owned: readonly OwnedLeaf[],
+  nodes: readonly AuthoredNode[],
+  edges: readonly GraphEdge[],
+): CollectionSummary[] {
+  const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
+  const ownedKeys = new Set(
+    owned.filter((leaf) => leaf.points > 0).map((leaf) => domainKey(leaf.domain)),
+  );
+
+  const rosters = new Map<string, { total: number; covered: number }>();
+  for (const edge of edges) {
+    if (edge.edgeType !== 'collection') continue;
+    if (!nodeByKey.has(edge.parentDomainKey)) continue;
+    const entry = rosters.get(edge.parentDomainKey) ?? { total: 0, covered: 0 };
+    entry.total += 1;
+    // Coverage-only: any credit in a member lights ONE slot; depth never
+    // over-credits (§7).
+    if (ownedKeys.has(edge.childDomainKey)) entry.covered += 1;
+    rosters.set(edge.parentDomainKey, entry);
+  }
+
+  return [...rosters.entries()]
+    .filter(([, r]) => r.covered > 0)
+    .map(([key, r]) => ({
+      label: nodeByKey.get(key)?.label ?? key,
+      covered: r.covered,
+      rosterSize: r.total,
+    }))
+    .sort((a, b) => b.covered / b.rosterSize - a.covered / a.rosterSize);
 }
 
 /** Sum of REAL points in a subtree — ghosts excluded (unit-test hook). */
@@ -225,20 +318,40 @@ export function sumRealPoints(node: KnowledgeTreeNode): number {
   return own + (node.children ?? []).reduce((sum, child) => sum + sumRealPoints(child), 0);
 }
 
-export async function getKnowledgeTree(userId: string): Promise<KnowledgeTreeNode> {
+export type KnowledgeMapData = {
+  tree: KnowledgeTreeNode;
+  collections: CollectionSummary[];
+  /** The owned, visible domains behind the tree — reused for share-card props. */
+  ownedDomains: Array<{
+    domain: string;
+    displayName: string;
+    points: number;
+    tier: string;
+    iconKey: string;
+    broadCategory: string | null;
+  }>;
+};
+
+// The full map payload for a user. `includeGhosts: false` is the friend/read-
+// only variant: what they hold, nothing tap-to-adopt. Hidden domains are
+// excluded for BOTH variants (the map is a portrait surface, same posture as
+// the flat page's portrait grid).
+export async function getKnowledgeMapData(
+  userId: string,
+  options: BuildTreeOptions = {},
+): Promise<KnowledgeMapData> {
   const [pageData, graph] = await Promise.all([
     getKnowledgePageData(userId),
     listKnowledgeGraph(),
   ]);
 
-  const owned: OwnedLeaf[] = pageData.allDomains
-    .filter((d) => d.points > 0 && !d.isHidden)
-    .map((d) => ({
-      domain: d.displayName || d.domain,
-      points: d.points,
-      mastered: d.tier === 'mastery',
-      broadCategory: d.broadCategory,
-    }));
+  const visible = pageData.allDomains.filter((d) => d.points > 0 && !d.isHidden);
+  const owned: OwnedLeaf[] = visible.map((d) => ({
+    domain: d.displayName || d.domain,
+    points: d.points,
+    mastered: d.tier === 'mastery',
+    broadCategory: d.broadCategory,
+  }));
 
   const nodes: AuthoredNode[] = graph.nodes.map((n) => ({
     domainKey: n.domainKey,
@@ -254,8 +367,6 @@ export async function getKnowledgeTree(userId: string): Promise<KnowledgeTreeNod
     edgeType: e.edgeType,
   }));
 
-  // P4: frozen-aware parent mastery + terminal stamping of fresh crossings.
-  // Flag off → empty frozen set, no writes — P5's pure behavior.
   let frozenParents: ReadonlySet<string> = new Set();
   if (isKnowledgeGraphMasteryEnabled()) {
     const credits = new Map<string, number>();
@@ -270,5 +381,20 @@ export async function getKnowledgeTree(userId: string): Promise<KnowledgeTreeNod
     );
   }
 
-  return buildKnowledgeTree(owned, nodes, edges, frozenParents);
+  return {
+    tree: buildKnowledgeTree(owned, nodes, edges, frozenParents, options),
+    collections: collectCollections(owned, nodes, edges),
+    ownedDomains: visible.map((d) => ({
+      domain: d.domain,
+      displayName: d.displayName || d.domain,
+      points: d.points,
+      tier: d.tier,
+      iconKey: d.iconKey,
+      broadCategory: d.broadCategory,
+    })),
+  };
+}
+
+export async function getKnowledgeTree(userId: string): Promise<KnowledgeTreeNode> {
+  return (await getKnowledgeMapData(userId)).tree;
 }

--- a/src/server/knowledge/map-page-flag.ts
+++ b/src/server/knowledge/map-page-flag.ts
@@ -1,0 +1,8 @@
+// B-KNOWLEDGE-TAXONOMY-01 P5 — the flag gating the nested-bubble knowledge map
+// (own page AND the friend page's read-only variant). Default off: both pages
+// render the flat portrait exactly as before.
+export function isKnowledgeMapPageEnabled(): boolean {
+  const raw = process.env.KNOWLEDGE_MAP_PAGE?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return false;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}


### PR DESCRIPTION
Completes the noted follow-ups from B-KNOWLEDGE-TAXONOMY-01 P5 (#1355), plus the Developer-tools entry Josh asked for. One commit, all behind the existing KNOWLEDGE_MAP_PAGE flag (default off) except the flag-independent dev preview.

## What's in it

- **Share/tidy chrome on the bubble page** — the flat page's SharePortraitModal + `/api/knowledge/tidy` (map repacks after a merge) in the bubble header.
- **Friend knowledge page bubble variant** — behind the same flag: read-only ("{Name}'s peaks", no ghosts/adopt, hidden domains filtered by the existing loader). Flag off → the flat portrait renders exactly as before.
- **Collection parents (D-doc §7)** — never packed, never rimmed; rendered as a coverage strip ("Plays Starting With H · 1 of 3 covered"). Depth in one member lights one slot; untouched sets don't appear.
- **Grow-rim** — up to 3 unheld authored *roots* in fields the player already inhabits, as dashed ghost invitations at the home view. Collection-only parents excluded; never inflates totals; own-map only.
- **`/dev/knowledge-map`** — flag-independent preview of the bubble experience, linked from the profile's Developer-tools section ("Knowledge map (bubbles)").
- Lint fix: `reducedMotion` via `useSyncExternalStore` (new main rule flags setState-in-effect).

## Safety

- Flag off: own + friend knowledge pages byte-identical to today (the off path imports none of the map code; friend page's map branch only evaluates flag-on).
- Ghost/rim adds hit the real territory-adopt endpoint with optimistic revert; friend variant has no mutation paths.
- 69 knowledge tests green (13 new: rim cap, collection non-containment/non-rim, friend no-ghosts, totals-never-inflated); typecheck, lint, and all four design ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD