### PR TITLE
Persist streak "View Answer" as a give-up (Daily Five parity)

### DIFF
--- a/src/app/api/lately/milestone/answer/__tests__/route.test.ts
+++ b/src/app/api/lately/milestone/answer/__tests__/route.test.ts
@@ -223,6 +223,36 @@ describe('POST /api/lately/milestone/answer', () => {
     })
   })
 
+  it('give-up (View Answer): not graded, zero points, no catch-up row, returns the answer', async () => {
+    setupDbChain()
+
+    const res = await POST(
+      jsonRequest({ questionId: 'canonical-q-1', gave_up: true }) as never,
+    )
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.isCorrect).toBe(false)
+    expect(body.pointsAwarded).toBe(0)
+    expect(body.correctAnswer).toBe('A')
+    // Never graded — the reveal isn't an attempt.
+    expect(gradeAnswerMock).not.toHaveBeenCalled()
+    // Persists as a miss so priorResult flips and the card can't be re-answered…
+    expect(writeMasteryEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({ answerState: 'incorrect', pointsAwarded: 0 }),
+    )
+    // …but opens NO catch-up second swing (parity with the Daily Five give-up).
+    expect(insertedRows).toHaveLength(0)
+    expect(createFeedItemsForFriendsFromAnswerMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects an empty submission with no give-up flag', async () => {
+    setupDbChain()
+    const res = await POST(
+      jsonRequest({ questionId: 'canonical-q-1', submitted_answer: '' }) as never,
+    )
+    expect(res.status).toBe(400)
+  })
+
   it('grader outage: 503 hold, nothing persisted', async () => {
     setupDbChain()
     gradeAnswerMock.mockResolvedValueOnce({ status: 'unscored', reason: 'llm_error' })

--- a/src/app/api/lately/milestone/answer/route.ts
+++ b/src/app/api/lately/milestone/answer/route.ts
@@ -12,6 +12,7 @@ import { getSeededPlayQuestions } from '@/server/db/queries/lately';
 import { parseQuestionSource, resolveAuthorDisplay } from '@/lib/questions-types';
 import { createFeedItemsForFriendsFromAnswer } from '@/server/feed/create-feed-items-for-answer';
 import { gradeAnswer } from '@/server/grading';
+import type { LlmProvider } from '@/server/llm/provider';
 import { promoteDeclaredToDemonstrated } from '@/server/knowledge/open-domain';
 import { awardAuthorCredit } from '@/server/mastery/author-credit';
 import { canonicalPointsForAnswer } from '@/lib/game-constants';
@@ -30,10 +31,19 @@ type MasteryTier = 'establishing' | 'familiar' | 'solid' | 'mastery';
 // which scores 0 base points. There is no FeedItem row to update (a milestone is
 // not a feed item for the viewer), so this route does everything the feed answer
 // route does EXCEPT that feedItems write.
-const answerSchema = z.object({
-  questionId: z.string().trim().min(1),
-  submitted_answer: z.string().trim().min(1),
-});
+// A normal answer carries a non-empty submission. A "View Answer" give-up
+// (parity with the Daily Five's "Show me the answer") carries gave_up:true and
+// no submission: it isn't graded, records as a miss with no points, and does
+// NOT open a catch-up second swing — seeing the answer consumes the question.
+const answerSchema = z
+  .object({
+    questionId: z.string().trim().min(1),
+    submitted_answer: z.string().trim().min(1).optional(),
+    gave_up: z.boolean().optional(),
+  })
+  .refine((d) => d.gave_up === true || (d.submitted_answer?.length ?? 0) > 0, {
+    message: 'submitted_answer or gave_up is required',
+  });
 
 export async function POST(request: NextRequest) {
   const session = await getSession();
@@ -46,7 +56,8 @@ export async function POST(request: NextRequest) {
       { status: 400 },
     );
   }
-  const submittedAnswer = parsed.data.submitted_answer;
+  const gaveUp = parsed.data.gave_up === true;
+  const submittedAnswer = parsed.data.submitted_answer ?? '';
 
   // Authorization is by construction: getSeededPlayQuestions only resolves
   // questions that appear in THIS viewer's own derived milestones. A tampered
@@ -71,25 +82,32 @@ export async function POST(request: NextRequest) {
   }
 
   const domain = question.canonicalSubcategory || question.broadCategory || question.category;
-  const grade = await gradeAnswer(
-    submittedAnswer,
-    question.answerText,
-    question.acceptedAlternatives,
-    question.questionText,
-    question.questionType,
-  );
-  // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
-  if (grade.status === 'unscored') {
-    return NextResponse.json(
-      {
-        error: 'grader_unavailable',
-        message:
-          "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
-      },
-      { status: 503 },
+  // A give-up ("View Answer") isn't graded — it records as a miss with no
+  // points, exactly like the Daily Five's "Show me the answer".
+  let isCorrect = false;
+  let gradedProvider: LlmProvider | null = null;
+  if (!gaveUp) {
+    const grade = await gradeAnswer(
+      submittedAnswer,
+      question.answerText,
+      question.acceptedAlternatives,
+      question.questionText,
+      question.questionType,
     );
+    // Fail toward the player (B4 Phase 4 / Drift Risk 2): hold a grader outage for retry.
+    if (grade.status === 'unscored') {
+      return NextResponse.json(
+        {
+          error: 'grader_unavailable',
+          message:
+            "Our answer-checker is taking a quick breather. Your answer wasn't scored — give it another go in a moment.",
+        },
+        { status: 503 },
+      );
+    }
+    isCorrect = grade.result === 'correct';
+    gradedProvider = grade.gradedProvider;
   }
-  const isCorrect = grade.result === 'correct';
 
   // F2.3 parity with the feed route: state-adjusted credit against prior history
   // on this canonical question — full for first_correct, 0.25x for recovery,
@@ -127,8 +145,9 @@ export async function POST(request: NextRequest) {
     eventQuestionId: question.id,
     basePoints,
     weight: awardsMasteryCredit ? 1 : 0,
-    // B-LLM-PROVIDER-AB-SWITCH B3: grader provenance (grade is scored here).
-    llmProvider: grade.gradedProvider,
+    // B-LLM-PROVIDER-AB-SWITCH B3: grader provenance (null on a give-up, which
+    // is never graded).
+    llmProvider: gradedProvider,
   }).catch((error: unknown) => {
     console.warn('[lately/milestone/answer] failed to write mastery event', {
       error: error instanceof Error ? error.message : 'unknown',
@@ -193,11 +212,14 @@ export async function POST(request: NextRequest) {
       'correct',
       `milestone:${question.id}:${session.userId}`,
     ));
-  } else {
+  } else if (!gaveUp) {
     // A milestone is a read-derived roll-up, not a feed card, so a wrong answer
     // here leaves no FeedItem — and catch up only surfaces incorrect, unresolved
     // FeedItem rows (getFeedCatchupItems). Write a synthetic answered/incorrect
     // row so the existing feed catch-up pipeline gives the viewer a second swing.
+    // A give-up is skipped: seeing the answer consumes the question, so it must
+    // not come back as a catch-up second swing (parity with the Daily Five,
+    // where "Show me the answer" offers no recheck).
     // state='answered' keeps it OUT of the actionable feed (which only shows
     // active/skipped), and the deterministic sourceAnswerId + onConflictDoNothing
     // guarantees one row per (viewer, question): re-missing never resets the

--- a/src/app/api/questions/[id]/answer/route.ts
+++ b/src/app/api/questions/[id]/answer/route.ts
@@ -44,29 +44,6 @@ function parseBody(value: unknown): { submittedAnswer: string } | null {
   return submittedAnswer ? { submittedAnswer } : null;
 }
 
-// Reveal a public question's answer for the "View Answer" peek on a From
-// Friends streak card (which is keyed by questionId, not a feed-item id, so the
-// feed answer-reveal GET doesn't apply). No body — the path param is the only
-// input, matching the sibling feed reveal GET. Gated to public, non-deleted,
-// non-blocked questions: the same visibility the streak surface itself requires,
-// so this exposes nothing the viewer couldn't already be shown.
-export async function GET(_request: NextRequest, context: RouteContext) {
-  const session = await getSession();
-  if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
-
-  const { id: questionId } = await context.params;
-  const [question] = await db
-    .select({ answerText: questions.answerText, visibility: questions.visibility })
-    .from(questions)
-    .where(and(eq(questions.id, questionId), isNull(questions.deletedAt)))
-    .limit(1);
-
-  if (!question || question.visibility !== 'public') {
-    return NextResponse.json({ error: 'not_found' }, { status: 404 });
-  }
-  return NextResponse.json({ answer: question.answerText });
-}
-
 export async function POST(request: NextRequest, context: RouteContext) {
   const session = await getSession();
   if (!session) return NextResponse.json({ error: 'unauthorized' }, { status: 401 });

--- a/src/components/feed/FromFriendsStreak.tsx
+++ b/src/components/feed/FromFriendsStreak.tsx
@@ -266,25 +266,32 @@ function StreakQuestionCard({
   const answer = useMilestoneAnswer(question, onResolved);
   // Dismiss is view-state only ("pass"): collapse the card to an undo bar.
   const [passed, setPassed] = useState(false);
-  // "View Answer" peek — reveal the correct answer inline. Seeing it consumes
-  // the card exactly like the game's "Show me the answer" (play-client's
-  // consumeCurrentAndAdvance): once revealed the card is no longer answerable.
-  // View-state only, like the game's client-side give-up — nothing is persisted.
+  // "View Answer" — reveal the correct answer inline. Seeing it consumes the
+  // question exactly like the Daily Five's "Show me the answer": it PERSISTS as a
+  // give-up (a miss with no points, no catch-up second swing) via the milestone
+  // answer route, so on reload the card comes back settled — never answerable
+  // again. The same POST returns the answer we show inline. The card is consumed
+  // only on a successful give-up; an error leaves it answerable so the viewer can
+  // retry or just answer it.
   const [revealed, setRevealed] = useState<
     { status: 'loading' | 'loaded' | 'error'; answer?: string | null } | null
   >(null);
+  const consumed = revealed !== null && revealed.status !== 'error';
 
   function revealAnswer() {
-    if (revealed) return;
+    if (revealed && revealed.status !== 'error') return;
     setRevealed({ status: 'loading' });
     void (async () => {
       try {
-        const res = await fetch(`/api/questions/${question.questionId}/answer`, {
-          method: 'GET',
+        const res = await fetch('/api/lately/milestone/answer', {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ questionId: question.questionId, gave_up: true }),
         });
         if (!res.ok) throw new Error(String(res.status));
-        const data = (await res.json()) as { answer: string | null };
-        setRevealed({ status: 'loaded', answer: data.answer });
+        const data = (await res.json()) as { correctAnswer?: string | null };
+        setRevealed({ status: 'loaded', answer: data.correctAnswer ?? null });
       } catch {
         setRevealed({ status: 'error' });
       }
@@ -425,8 +432,9 @@ function StreakQuestionCard({
                 <span style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>
                   <FeedDismissButton onClick={() => setPassed(true)} />
                   {/* Once the answer is seen the card is consumed, so the peek
-                      link drops away with the Answer button. */}
-                  {revealed ? null : (
+                      link drops away with the Answer button. An errored reveal
+                      keeps the link so the viewer can retry. */}
+                  {consumed ? null : (
                     <>
                       <span aria-hidden style={{ color: INK3, fontSize: 14 }}>
                         |
@@ -439,7 +447,7 @@ function StreakQuestionCard({
                 </span>
               }
               right={
-                revealed ? (
+                consumed ? (
                   <span />
                 ) : (
                   <button type="button" className="btn-primary" onClick={answer.open}>


### PR DESCRIPTION
## Summary

Follow-up to the merged "View Answer" work (#1351, #1356). On a **From Friends streak** card, tapping **View Answer** now *persists* like the Daily Five's "Show me the answer": the reveal survives a reload and the card is never answerable again — instead of being session-only.

Previously the streak reveal was a plain read (a throwaway `GET /api/questions/[id]/answer`), so reloading brought the card back answerable. This routes it through a real give-up instead.

## Key changes

- **`/api/lately/milestone/answer`** — accepts `{ gave_up: true }` with no submission. A give-up is **not graded**, records as a **miss with zero points**, and **does not** write the `milestone_missed` catch-up row (seeing the answer consumes the question, so it must not resurface as a second swing — matching the Daily Five, where "Show me the answer" offers no recheck). The same response returns `correctAnswer`, which the card shows inline.
- **`FromFriendsStreak.tsx`** — View Answer POSTs the give-up (persisting) rather than a read. The card is consumed only on a **successful** give-up; an error leaves it answerable so the viewer can retry or just answer it.
- **`/api/questions/[id]/answer`** — removes the throwaway `GET` reveal added in the earlier streak change; the give-up POST both persists and returns the answer, so it's no longer needed.

## Why it works

A streak question's `priorResult` is derived from the viewer's `masteryEvents`. Recording the give-up as an incorrect answer (zero points, no credit) flips `priorResult` to `incorrect`, so on the next load the question renders as a settled/spent card rather than an answerable one — the same substrate the Daily Five give-up uses.

## Tests

- Milestone give-up path: not graded, zero points, no catch-up row, returns the answer.
- Empty submission with no `gave_up` flag is rejected (400).

## Known limitation

On reload the consumed card reads as a spent **"Not this time"** card (its record is an incorrect/give-up) and doesn't re-show the answer text — the streak's `priorResult` is only `correct | incorrect | null`, with no distinct "revealed" state. A dedicated **"Revealed"** spent state (distinct label + answer retained across reload) would be a larger schema/query/render change and is left as a possible follow-up.

https://claude.ai/code/session_01GahqF8S1QeEZr8ZUWSRP5J

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GahqF8S1QeEZr8ZUWSRP5J)_