### PR TITLE
Knowledge structure suggester — the machine drafts, you verify

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -96,6 +96,8 @@ export function KnowledgeAdminClient({
         </p>
       </header>
 
+      <StructureSuggester graphIsEmpty={nodes.length === 0} onDone={() => router.refresh()} />
+
       <NodeForm onDone={() => router.refresh()} />
 
       <OrphanCheck nodes={nodes} edges={edges} />
@@ -155,6 +157,228 @@ export function KnowledgeAdminClient({
         )}
       </section>
     </main>
+  );
+}
+
+// The structure suggester — the answer to "I don't even know what to do":
+// one click asks the machine to DRAFT a grouping of the real corpus (the
+// domains players actually hold), and each proposed group becomes a reviewable
+// card — tune the bar, untick children that don't belong, Accept or Dismiss.
+// §4 holds: proposals persist nothing; every node/edge is minted by Accept.
+type SuggestedGroup = {
+  parentLabel: string;
+  broadCategory: string | null;
+  suggestedThreshold: number;
+  children: Array<{ label: string; machineDepth: number; humanAuthored: number }>;
+};
+
+function StructureSuggester({
+  graphIsEmpty,
+  onDone,
+}: {
+  graphIsEmpty: boolean;
+  onDone: () => void;
+}) {
+  const [groups, setGroups] = useState<SuggestedGroup[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [meta, setMeta] = useState<{ corpusSize: number; alreadyStructured: number } | null>(null);
+
+  async function suggest() {
+    if (loading) return;
+    setLoading(true);
+    setError(null);
+    const res = await post({ action: 'propose_structure' });
+    setLoading(false);
+    if (!res.ok) {
+      setError(
+        res.status === 503
+          ? 'The machine is unavailable right now — try again shortly.'
+          : `Suggestion failed (${res.status}).`,
+      );
+      return;
+    }
+    const body = res.body as unknown as {
+      groups: SuggestedGroup[];
+      corpusSize: number;
+      alreadyStructured: number;
+    } | null;
+    setGroups(body?.groups ?? []);
+    setMeta(body ? { corpusSize: body.corpusSize, alreadyStructured: body.alreadyStructured } : null);
+  }
+
+  return (
+    <section
+      className="rounded-md border p-4 text-sm"
+      style={{ borderColor: graphIsEmpty ? 'var(--brand-navy)' : 'var(--border)' }}
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="font-serif text-lg font-semibold text-[var(--brand-ink)]">
+            {graphIsEmpty ? 'Start here' : 'Suggest more structure'}
+          </h2>
+          <p className="text-muted-foreground mt-0.5 text-[13px] leading-relaxed">
+            {graphIsEmpty
+              ? 'The machine drafts a structure from the territories players actually hold; you review each group — tune the bar, untick what doesn’t belong, accept or dismiss. Nothing is saved until you accept.'
+              : 'Draft groupings for territories not yet in the graph. You verify every group before anything is saved.'}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void suggest()}
+          disabled={loading}
+          className="inline-flex min-h-11 items-center rounded-md border px-4 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+        >
+          {loading ? 'Drafting a structure…' : groups === null ? 'Suggest a structure' : 'Suggest again'}
+        </button>
+      </div>
+      {loading ? (
+        <p className="text-muted-foreground mt-2 text-xs">
+          Reading the corpus and grouping territories — this takes up to a minute.
+        </p>
+      ) : null}
+      {error ? (
+        <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+      {groups !== null && !loading ? (
+        groups.length === 0 ? (
+          <p className="text-muted-foreground mt-2 text-[13px]">
+            Nothing left to group{meta && meta.alreadyStructured > 0 ? ` — ${meta.alreadyStructured} labels are already structured` : ''}.
+          </p>
+        ) : (
+          <div className="mt-3 space-y-3">
+            {meta ? (
+              <p className="text-muted-foreground text-xs">
+                {groups.length} group{groups.length === 1 ? '' : 's'} proposed from {meta.corpusSize}{' '}
+                unstructured territories. Accept the ones that ring true.
+              </p>
+            ) : null}
+            {groups.map((group) => (
+              <SuggestedGroupCard
+                key={group.parentLabel}
+                group={group}
+                onResolved={() => {
+                  setGroups((prev) => prev?.filter((g) => g.parentLabel !== group.parentLabel) ?? null);
+                  onDone();
+                }}
+                onDismiss={() =>
+                  setGroups((prev) => prev?.filter((g) => g.parentLabel !== group.parentLabel) ?? null)
+                }
+              />
+            ))}
+          </div>
+        )
+      ) : null}
+    </section>
+  );
+}
+
+function SuggestedGroupCard({
+  group,
+  onResolved,
+  onDismiss,
+}: {
+  group: SuggestedGroup;
+  onResolved: () => void;
+  onDismiss: () => void;
+}) {
+  const [threshold, setThreshold] = useState(String(group.suggestedThreshold));
+  const [checked, setChecked] = useState<Record<string, boolean>>(
+    Object.fromEntries(group.children.map((c) => [c.label, true])),
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const selectedCount = group.children.filter((c) => checked[c.label]).length;
+
+  async function accept() {
+    if (pending || selectedCount === 0) return;
+    setPending(true);
+    setError(null);
+    const res = await post({
+      action: 'ratify_structure_group',
+      parentLabel: group.parentLabel,
+      broadCategory: group.broadCategory,
+      masteryThreshold: threshold.trim() ? Number(threshold) : null,
+      childLabels: group.children.filter((c) => checked[c.label]).map((c) => c.label),
+    });
+    setPending(false);
+    if (!res.ok) {
+      setError(`Accept failed (${res.status}).`);
+      return;
+    }
+    onResolved();
+  }
+
+  return (
+    <div className="rounded-md border p-3" style={{ borderColor: 'var(--border)' }}>
+      <div className="flex flex-wrap items-center gap-2">
+        <span className="font-serif text-base font-semibold text-[var(--brand-ink)]">
+          {group.parentLabel}
+        </span>
+        {group.broadCategory ? (
+          <span className="text-muted-foreground text-xs">· {group.broadCategory}</span>
+        ) : null}
+        <label className="ml-auto flex items-center gap-1.5 text-xs text-[var(--brand-ink-700)]">
+          Mastery bar
+          <input
+            value={threshold}
+            onChange={(e) => setThreshold(e.target.value.replace(/[^0-9]/g, ''))}
+            className="w-20 rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-2 py-1 text-sm focus:border-[var(--brand-navy)]"
+            inputMode="numeric"
+            aria-label={`Mastery threshold for ${group.parentLabel}`}
+          />
+          pts
+        </label>
+      </div>
+      <ul className="mt-2 space-y-1">
+        {group.children.map((child) => (
+          <li key={child.label} className="flex items-center gap-2 text-[13px]">
+            <label className="flex cursor-pointer items-center gap-2">
+              <input
+                type="checkbox"
+                checked={checked[child.label] ?? false}
+                onChange={(e) => setChecked((prev) => ({ ...prev, [child.label]: e.target.checked }))}
+              />
+              <span className="text-[var(--brand-ink)]">{child.label}</span>
+            </label>
+            <span className="text-muted-foreground text-xs">
+              {child.machineDepth + child.humanAuthored} questions
+            </span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-2.5 flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          onClick={() => void accept()}
+          disabled={pending || selectedCount < 1}
+          className="inline-flex min-h-9 items-center rounded-md border px-3 py-1 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+        >
+          {pending ? 'Accepting…' : `Accept ${selectedCount} of ${group.children.length}`}
+        </button>
+        <button
+          type="button"
+          onClick={onDismiss}
+          disabled={pending}
+          className="inline-flex min-h-9 items-center rounded-md border px-3 py-1 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+        >
+          Dismiss
+        </button>
+        <span className="text-muted-foreground text-xs">
+          accepting creates the parent, its leaves, and substantive edges
+        </span>
+      </div>
+      {error ? (
+        <p className="mt-1.5 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+    </div>
   );
 }
 

--- a/src/app/api/admin/knowledge/__tests__/route.test.ts
+++ b/src/app/api/admin/knowledge/__tests__/route.test.ts
@@ -34,8 +34,31 @@ vi.mock('@/server/db/queries/knowledge-graph', () => ({
   createKnowledgeEdge: createEdgeMock,
   deleteKnowledgeEdge: deleteEdgeMock,
   ratifyProposedParent: ratifyMock,
+  ratifyStructureGroup: ratifyGroupMock,
 }));
 vi.mock('@/server/knowledge/nearness-tree', () => ({ getOrBuildDomainRungs: rungsMock }));
+const { proposeStructureMock, ratifyGroupMock } = vi.hoisted(() => ({
+  proposeStructureMock: vi.fn(async () => ({
+    ok: true as const,
+    groups: [
+      {
+        parentLabel: 'Renaissance Italy',
+        broadCategory: 'History',
+        suggestedThreshold: 1200,
+        children: [
+          { label: 'Medici Family', machineDepth: 9, humanAuthored: 0 },
+          { label: 'Florentine Art', machineDepth: 4, humanAuthored: 0 },
+        ],
+      },
+    ],
+    corpusSize: 12,
+    alreadyStructured: 3,
+  })),
+  ratifyGroupMock: vi.fn(async () => ({ ok: true as const, parentKey: 'renaissance italy', edgesCreated: 2 })),
+}));
+vi.mock('@/server/knowledge/propose-structure', () => ({
+  proposeKnowledgeStructure: proposeStructureMock,
+}));
 
 import { POST } from '@/app/api/admin/knowledge/route';
 
@@ -143,6 +166,45 @@ describe('POST /api/admin/knowledge', () => {
     const res = await post({ action: 'propose', childLabel: 'Medici Family' });
     expect(res.status).toBe(200);
     expect(((await res.json()) as { proposals: unknown[] }).proposals).toEqual([]);
+  });
+
+  // ─── the structure suggester ───
+
+  it('propose_structure returns draft groups and commits NOTHING', async () => {
+    const res = await post({ action: 'propose_structure' });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { groups: Array<{ parentLabel: string }> };
+    expect(body.groups[0].parentLabel).toBe('Renaissance Italy');
+    expect(createNodeMock).not.toHaveBeenCalled();
+    expect(createEdgeMock).not.toHaveBeenCalled();
+    expect(ratifyGroupMock).not.toHaveBeenCalled(); // suggestions never auto-commit (§4)
+  });
+
+  it('ratify_structure_group is the human commit, with the tuned threshold', async () => {
+    const res = await post({
+      action: 'ratify_structure_group',
+      parentLabel: 'Renaissance Italy',
+      broadCategory: 'History',
+      masteryThreshold: 1500, // human tuned it up from the suggested 1200
+      childLabels: ['Medici Family', 'Florentine Art'],
+    });
+    expect(res.status).toBe(201);
+    expect(ratifyGroupMock).toHaveBeenCalledWith(
+      {
+        parentLabel: 'Renaissance Italy',
+        broadCategory: 'History',
+        masteryThreshold: 1500,
+        childLabels: ['Medici Family', 'Florentine Art'],
+      },
+      'admin-1',
+    );
+  });
+
+  it('non-admins get 404 from the suggester too', async () => {
+    isAdminUserMock.mockReturnValue(false);
+    const res = await post({ action: 'propose_structure' });
+    expect(res.status).toBe(404);
+    expect(proposeStructureMock).not.toHaveBeenCalled();
   });
 
   it('ratify creates exactly one edge with the HUMAN-chosen edge type', async () => {

--- a/src/app/api/admin/knowledge/route.ts
+++ b/src/app/api/admin/knowledge/route.ts
@@ -8,8 +8,10 @@ import {
   createKnowledgeNode,
   deleteKnowledgeEdge,
   ratifyProposedParent,
+  ratifyStructureGroup,
   updateKnowledgeNode,
 } from '@/server/db/queries/knowledge-graph';
+import { proposeKnowledgeStructure } from '@/server/knowledge/propose-structure';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
@@ -64,6 +66,18 @@ const bodySchema = z.discriminatedUnion('action', [
     parentLabel: z.string().trim().min(1).max(120),
     parentBroadCategory: z.string().trim().max(80).nullable().optional(),
     edgeType: edgeTypeSchema,
+  }),
+  // The structure suggester: one LLM pass drafts a full grouping of the real
+  // corpus; NOTHING persists (suggestions live only in the response).
+  z.object({ action: z.literal('propose_structure') }),
+  // The human's Accept on one proposed group — mints parent + child nodes and
+  // substantive edges on the normal rails, with the human-tuned threshold.
+  z.object({
+    action: z.literal('ratify_structure_group'),
+    parentLabel: z.string().trim().min(1).max(120),
+    broadCategory: z.string().trim().max(80).nullable().optional(),
+    masteryThreshold: z.number().int().min(100).max(1_000_000).nullable().optional(),
+    childLabels: z.array(z.string().trim().min(1).max(120)).min(1).max(12),
   }),
 ]);
 
@@ -160,6 +174,37 @@ export async function POST(request: NextRequest) {
       } catch {
         return NextResponse.json({ proposals: [] });
       }
+    }
+
+    case 'propose_structure': {
+      const result = await proposeKnowledgeStructure();
+      if (!result.ok) {
+        const status = result.reason === 'corpus_empty' ? 200 : 503;
+        return NextResponse.json(
+          result.reason === 'corpus_empty'
+            ? { groups: [], corpusSize: 0, alreadyStructured: 0 }
+            : { error: result.reason },
+          { status },
+        );
+      }
+      return NextResponse.json({
+        groups: result.groups,
+        corpusSize: result.corpusSize,
+        alreadyStructured: result.alreadyStructured,
+      });
+    }
+
+    case 'ratify_structure_group': {
+      const result = await ratifyStructureGroup(
+        {
+          parentLabel: data.parentLabel,
+          broadCategory: data.broadCategory ?? null,
+          masteryThreshold: data.masteryThreshold ?? null,
+          childLabels: data.childLabels,
+        },
+        session.userId,
+      );
+      return NextResponse.json(result, { status: 201 });
     }
 
     case 'ratify': {

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -72,7 +72,9 @@ function heatFor(activePlayers: number, machineDepth: number, humanAuthored: num
 // machine = distinct durable fact keys (same as getDurablePoolDepthForDomains),
 // human = live creator-authored canonical questions. One scan each — the corpus
 // is ~250 labels at current scale, so clustering happens in memory.
-async function getCorpusLabelDepths(): Promise<ClusterLabel[]> {
+// Exported for the knowledge-structure suggester (propose-structure.ts), which
+// drafts taxonomy groups over the same corpus this worklist reads.
+export async function getCorpusLabelDepths(): Promise<ClusterLabel[]> {
   const [machineRows, humanRows] = await Promise.all([
     db
       .select({

--- a/src/server/db/queries/knowledge-graph.ts
+++ b/src/server/db/queries/knowledge-graph.ts
@@ -235,6 +235,62 @@ export async function ratifyProposedParent(
   );
 }
 
+// Structure-suggester ratify (§4: the Accept click IS the human commit): mint
+// the parent (kind 'parent', human-tuned threshold), ensure a leaf node for
+// each accepted child (they're REAL corpus labels — the node is the label's
+// entry into the graph), and draw substantive edges. Existing nodes are reused
+// via the collision path — never duplicated.
+export async function ratifyStructureGroup(
+  input: {
+    parentLabel: string;
+    broadCategory: string | null;
+    masteryThreshold: number | null;
+    childLabels: string[];
+  },
+  actorUserId: string,
+): Promise<{ ok: true; parentKey: string; edgesCreated: number }> {
+  const ensureNode = async (
+    label: string,
+    nodeKind: NodeKind,
+    masteryThreshold: number | null,
+    broadCategory: string | null,
+  ): Promise<string> => {
+    const created = await createKnowledgeNode(
+      { label, nodeKind, masteryThreshold, broadCategory, fieldHue: null },
+      actorUserId,
+    );
+    if (created.ok) return created.node.domainKey;
+    if (created.reason === 'domain_key_collision') return created.existing.domainKey;
+    return domainKey(label);
+  };
+
+  const parentKey = await ensureNode(
+    input.parentLabel,
+    'parent',
+    input.masteryThreshold,
+    input.broadCategory,
+  );
+
+  let edgesCreated = 0;
+  for (const childLabel of input.childLabels) {
+    const childKey = await ensureNode(childLabel, 'leaf', null, input.broadCategory);
+    if (childKey === parentKey) continue;
+    const edge = await createKnowledgeEdge(
+      { childDomainKey: childKey, parentDomainKey: parentKey, edgeType: 'substantive' },
+      actorUserId,
+    );
+    if (edge.ok) edgesCreated += 1; // duplicates are fine — already ratified
+  }
+
+  console.info('[knowledge-admin] structure group ratified', {
+    actorUserId,
+    parent: input.parentLabel,
+    children: input.childLabels.length,
+    edgesCreated,
+  });
+  return { ok: true, parentKey, edgesCreated };
+}
+
 // Deleting an edge is structure-editing, not content removal — the hard delete
 // is intentional (the no-hard-delete canon protects player content; an edge is
 // an authored relation a human may retract). Exactly the (child, parent) pair.

--- a/src/server/knowledge/__tests__/propose-structure.test.ts
+++ b/src/server/knowledge/__tests__/propose-structure.test.ts
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+let mod: typeof import('@/server/knowledge/propose-structure');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/knowledge/propose-structure');
+});
+
+const CORPUS = new Map([
+  ['medici family', { label: 'Medici Family', machineDepth: 9, humanAuthored: 0 }],
+  ['renaissance florence', { label: 'Renaissance Florence', machineDepth: 12, humanAuthored: 1 }],
+  ['florentine art', { label: 'Florentine Art', machineDepth: 4, humanAuthored: 0 }],
+  ['tennis', { label: 'Tennis', machineDepth: 22, humanAuthored: 11 }],
+]);
+
+describe('parseProposedStructure — grounding guardrails', () => {
+  it('keeps groups whose children are real corpus labels (fold-matched)', () => {
+    const raw = JSON.stringify({
+      groups: [
+        {
+          parent: 'Renaissance Italy',
+          broad_category: 'History',
+          suggested_threshold: 1200,
+          // en-dash variant still folds onto the real label
+          children: ['Medici Family', 'Renaissance – Florence', 'Florentine Art'],
+        },
+      ],
+    });
+    const groups = mod.parseProposedStructure(raw, CORPUS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].parentLabel).toBe('Renaissance Italy');
+    expect(groups[0].children.map((c) => c.label)).toEqual([
+      'Medici Family',
+      'Renaissance Florence', // the REAL corpus label, not the LLM's variant
+      'Florentine Art',
+    ]);
+    expect(groups[0].suggestedThreshold).toBe(1200);
+  });
+
+  it('drops invented children — and the group if fewer than 2 survive', () => {
+    const raw = JSON.stringify({
+      groups: [
+        {
+          parent: 'Italian History',
+          suggested_threshold: 900,
+          children: ['Medici Family', 'The Borgias', 'Papal States'], // 2 invented
+        },
+      ],
+    });
+    const groups = mod.parseProposedStructure(raw, CORPUS);
+    expect(groups).toHaveLength(0); // only 1 real child survived → discarded
+  });
+
+  it('a bad threshold falls back to children × 300', () => {
+    const raw = JSON.stringify({
+      groups: [
+        {
+          parent: 'Renaissance Italy',
+          suggested_threshold: -5,
+          children: ['Medici Family', 'Florentine Art'],
+        },
+      ],
+    });
+    const groups = mod.parseProposedStructure(raw, CORPUS);
+    expect(groups[0].suggestedThreshold).toBe(600);
+  });
+
+  it('rejects self-parenting, duplicate children, duplicate parents, and non-JSON', () => {
+    const raw = JSON.stringify({
+      groups: [
+        {
+          parent: 'Medici Family', // also a child below — self filtered out
+          suggested_threshold: 800,
+          children: ['Medici Family', 'Florentine Art', 'Florentine Art', 'Renaissance Florence'],
+        },
+        {
+          parent: 'Medici – Family', // duplicate parent by fold
+          suggested_threshold: 800,
+          children: ['Tennis', 'Florentine Art'],
+        },
+      ],
+    });
+    const groups = mod.parseProposedStructure(raw, CORPUS);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].children.map((c) => c.label)).toEqual(['Florentine Art', 'Renaissance Florence']);
+    expect(mod.parseProposedStructure('not json', CORPUS)).toEqual([]);
+  });
+});

--- a/src/server/knowledge/propose-structure.ts
+++ b/src/server/knowledge/propose-structure.ts
@@ -1,0 +1,179 @@
+/**
+ * B-KNOWLEDGE-ADMIN follow-up — the structure suggester. The blank-form CRUD
+ * surface asks a human to invent a taxonomy from nothing; this inverts it per
+ * D-KNOWLEDGE-TAXONOMY-MODEL-01 §4: the machine DRAFTS a structure from the
+ * corpus the players actually inhabit, and the human verifies group by group.
+ * Nothing here writes anything — proposals exist only in the response; every
+ * node and edge is minted by the human's Accept click on the normal rails.
+ *
+ * Grounding rule: proposed CHILDREN must be copied exactly from the real
+ * corpus labels supplied (the LLM may not invent leaves — inventing labels is
+ * the fragmentation failure mode this whole model kills). Proposed PARENTS may
+ * be new labels; that's the taxonomy being born. Suggested thresholds are
+ * prefills for the human to tune (§5 — the bar is a human judgment).
+ */
+
+import {
+  ANTHROPIC_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+import { getCorpusLabelDepths } from '@/server/db/queries/crafter-demand';
+import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+export type ProposedChild = {
+  label: string;
+  machineDepth: number;
+  humanAuthored: number;
+};
+
+export type ProposedGroup = {
+  parentLabel: string;
+  broadCategory: string | null;
+  suggestedThreshold: number;
+  children: ProposedChild[];
+};
+
+export type ProposeStructureResult =
+  | { ok: true; groups: ProposedGroup[]; corpusSize: number; alreadyStructured: number }
+  | { ok: false; reason: 'llm_unavailable' | 'nothing_parsed' | 'corpus_empty' };
+
+const MAX_CORPUS_LABELS = 250;
+const MAX_GROUPS = 24;
+const PROPOSE_TIMEOUT_MS = Math.max(15_000, Number(process.env.KNOWLEDGE_PROPOSE_TIMEOUT_MS ?? 60_000));
+
+const SYSTEM_PROMPT = `You are drafting a knowledge taxonomy for a trivia game. You are given the REAL domain labels players hold, each with its question depth. Group them under parent territories a curious person would recognize as coherent bodies of knowledge.
+
+Rules:
+- children arrays must contain labels COPIED EXACTLY from the provided list. Never invent, rename, or merge child labels.
+- Each group needs 2–8 children that genuinely belong to the SAME body of knowledge (understanding the parent means understanding its children — e.g. "Renaissance Italy" over "Medici Family" + "Florentine Art"). Do NOT force groupings; a label that fits nowhere is simply omitted.
+- Parent labels should be natural territory names (title case), specific enough to mean something ("Renaissance Italy", not "History").
+- A provided label may itself serve as the parent of other provided labels when that is the true relationship.
+- suggested_threshold: the mastery points bar for the parent — roughly 300 points per child, more for genuinely broad subjects, rounded to a clean number.
+- broad_category: one of Literature, Music, Film & TV, History, Science, Sports, Technology, Philosophy, Pop Culture, Food, Architecture, Language — the parent's field.
+- Reuse the ALREADY-STRUCTURED parents listed (if any) instead of proposing near-duplicates of them.
+
+Return ONLY JSON:
+{ "groups": [ { "parent": "...", "broad_category": "...", "suggested_threshold": 1200, "children": ["...", "..."] } ] }`;
+
+/** Pure parse + validation — exported for unit tests. Children not present in
+ *  the corpus (by domainKey fold) are dropped; groups left with <2 children are
+ *  discarded; output capped. */
+export function parseProposedStructure(
+  raw: string,
+  corpus: ReadonlyMap<string, ProposedChild>, // keyed by domainKey
+): ProposedGroup[] {
+  const parsed = parseJsonObject(raw);
+  if (!parsed || !Array.isArray(parsed.groups)) return [];
+
+  const seenParents = new Set<string>();
+  const groups: ProposedGroup[] = [];
+  for (const item of parsed.groups) {
+    if (!item || typeof item !== 'object') continue;
+    const rec = item as Record<string, unknown>;
+    const parentLabel = typeof rec.parent === 'string' ? rec.parent.trim() : '';
+    if (!parentLabel || parentLabel.length > 120) continue;
+    const parentKey = domainKey(parentLabel);
+    if (seenParents.has(parentKey)) continue;
+
+    const rawChildren = Array.isArray(rec.children) ? rec.children : [];
+    const children: ProposedChild[] = [];
+    const seenChildren = new Set<string>();
+    for (const child of rawChildren) {
+      if (typeof child !== 'string') continue;
+      const key = domainKey(child);
+      if (key === parentKey || seenChildren.has(key)) continue;
+      const real = corpus.get(key);
+      if (!real) continue; // invented label — the one unforgivable move
+      seenChildren.add(key);
+      children.push(real);
+    }
+    if (children.length < 2) continue;
+
+    const threshold = Number(rec.suggested_threshold);
+    seenParents.add(parentKey);
+    groups.push({
+      parentLabel,
+      broadCategory:
+        typeof rec.broad_category === 'string' && rec.broad_category.trim()
+          ? rec.broad_category.trim()
+          : null,
+      suggestedThreshold:
+        Number.isFinite(threshold) && threshold >= 100 && threshold <= 1_000_000
+          ? Math.round(threshold)
+          : children.length * 300,
+      children,
+    });
+    if (groups.length >= MAX_GROUPS) break;
+  }
+  return groups;
+}
+
+export async function proposeKnowledgeStructure(): Promise<ProposeStructureResult> {
+  const client = getAnthropicClient();
+  if (!client) return { ok: false, reason: 'llm_unavailable' };
+
+  const [labelDepths, graph] = await Promise.all([getCorpusLabelDepths(), listKnowledgeGraph()]);
+
+  // Only labels not yet structured (no edge in either direction) need grouping.
+  const edgedKeys = new Set(
+    graph.edges.flatMap((e) => [e.childDomainKey, e.parentDomainKey]),
+  );
+  const candidates = labelDepths
+    .filter((entry) => !edgedKeys.has(domainKey(entry.label)))
+    .sort((a, b) => b.machineDepth + b.humanAuthored - (a.machineDepth + a.humanAuthored))
+    .slice(0, MAX_CORPUS_LABELS);
+  if (candidates.length === 0) return { ok: false, reason: 'corpus_empty' };
+
+  const corpus = new Map<string, ProposedChild>(
+    candidates.map((entry) => [
+      domainKey(entry.label),
+      { label: entry.label, machineDepth: entry.machineDepth, humanAuthored: entry.humanAuthored },
+    ]),
+  );
+
+  const existingParents = graph.nodes
+    .filter((n) => n.nodeKind !== 'leaf')
+    .map((n) => n.label)
+    .slice(0, 40);
+
+  const userMessage = [
+    wrapUserInput(
+      'domain_labels',
+      candidates.map((c) => `${c.label} (${c.machineDepth + c.humanAuthored} questions)`).join('\n'),
+    ),
+    existingParents.length > 0
+      ? wrapUserInput('already_structured_parents', existingParents.join('\n'))
+      : '',
+    'Group these into parent territories. JSON only.',
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const response = await loggedMessagesCreate(
+    client,
+    'knowledge-structure-proposal',
+    {
+      model: ANTHROPIC_MODEL,
+      max_tokens: 4000,
+      temperature: 0.2,
+      system: SYSTEM_PROMPT,
+      messages: [{ role: 'user', content: userMessage }],
+    },
+    { timeoutMs: PROPOSE_TIMEOUT_MS },
+  );
+
+  const groups = parseProposedStructure(extractTextContent(response.content), corpus);
+  if (groups.length === 0) return { ok: false, reason: 'nothing_parsed' };
+
+  return {
+    ok: true,
+    groups,
+    corpusSize: candidates.length,
+    alreadyStructured: labelDepths.length - candidates.length,
+  };
+}


### PR DESCRIPTION
Fixes the /admin/knowledge cold-start UX: instead of blank-form authoring, one click drafts a full taxonomy from the real corpus and every group is verified by a human before anything is saved (D-KNOWLEDGE-TAXONOMY-MODEL-01 §4 preserved end-to-end).

## The flow
1. Open /admin/knowledge — with an empty graph, **"Start here"** leads the page.
2. **Suggest a structure** → one Sonnet call over the territories players actually hold (only unstructured labels sent).
3. Each proposed group is a card: parent name, **editable mastery bar** (prefilled ~300 pts/child), children with checkboxes and their real question counts.
4. **Accept** mints the parent, its leaf nodes, and substantive edges on the existing collision-safe rails. **Dismiss** discards. Nothing persists without the click.

## Grounding guardrails (as tests)
- Proposed children must fold onto real corpus labels — invented labels are dropped; a group with <2 survivors is discarded entirely.
- The LLM's spelling variants resolve to the real corpus label (en-dash fixture).
- Self-parenting, duplicate parents/children filtered; bad thresholds fall back to children × 300.
- `propose_structure` commits nothing (asserted); non-admins 404.

81 tests green across knowledge + admin-knowledge suites; typecheck, lint, ratchets clean. One shared-file touch: exported `getCorpusLabelDepths` from crafter-demand (one-line, additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD