### PR TITLE
Ledger web-search spend & add claude-sonnet-5 pricing

### DIFF
--- a/docs/findings/ledger-telemetry-gaps.md
+++ b/docs/findings/ledger-telemetry-gaps.md
@@ -1,5 +1,16 @@
 # `LlmUsageEvent` under-reporting gaps — fix before any refill soak
 
+> **UPDATE (2026-07-02): gap (a) is CLOSED.** Migration `0105` adds
+> `web_search_requests` to `LlmUsageEvent`; `loggedMessagesCreate` populates it from
+> `usage.server_tool_use.web_search_requests`, and `estimateCostUsd` prices it at
+> $0.01/request — so `getMonthToDateLlmSpendUsd`, the weekly cost report, and the
+> admin readout now include web-search $ for rows written after 0105. (Pre-0105 rows
+> read as 0 — historical months remain a token-only floor.) The same change added a
+> `claude-sonnet-5` price row, closing a third, undocumented gap: since the
+> 2026-07-01 model flip every Sonnet 5 call had been "unpriced" ($0) in the ledger.
+> Gap (b) below (aborted-call tokens) remains open but largely self-closes on
+> Sonnet 5.
+
 **Date:** 2026-07-01. **Basis:** the 2026-07-01 spend spike (Anthropic dashboard **\$7.56** token cost + **\$1.80** web search) vs. what our own ledger could see (~\$3). Two structural gaps make `LlmUsageEvent` under-report real spend. **Fix both before the refill soak starts — the soak's weekly \$ number is otherwise a token-only undercount.**
 
 ## Gap (a) — web-search spend is uncaptured

--- a/docs/llm-cost-action-plan.md
+++ b/docs/llm-cost-action-plan.md
@@ -1,5 +1,28 @@
 # LLM cost — action plan
 
+> ## ⚠️ STATUS (2026-07-02) — partially SUPERSEDED; do not execute below-the-line steps blindly
+>
+> - **Step 0 (spend caps):** `LLM_MONTHLY_USD_CEILING=42` is set in prod, but the code
+>   enforces it **only on the retrieval-grounded refill run** (`retrieval-grounded.ts`),
+>   which is paused/off — the daily generation chain and batch-verify have **no runtime
+>   cap**. The Anthropic Console org-level hard limit (this step's second half) has no
+>   recorded confirmation — verify it exists; it is the only backstop independent of
+>   ledger bugs.
+> - **Step 1 (commentary → Haiku):** ✅ shipped (`ae6d12e`, `COMMENTARY_MODEL`).
+> - **Step 2 (carry-forward):** coded, default-off (`DAILY_TOPUP_CARRYFORWARD_ENABLED`);
+>   confirm the prod env var is actually set.
+> - **Step 4 (pool-refill flip):** ❌ **SUPERSEDED — do not flip.** Attempted 2026-07-01,
+>   reverted, and strategically PAUSED behind `D-SUPPLY-FINITE-SET-01`
+>   (`docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md`,
+>   `B-SUPPLY-REFILL-EFFORT-REPORT.md`). `RETRIEVAL_GROUNDING_ENABLED` stays `false`.
+> - **Step 5 (monitor threshold):** moot until a hit-rate lever actually lands.
+> - **What the plan missed:** the **batch-verify cron** is now the single largest
+>   *recurring* LLM line (~$2/day ≈ $60/mo at 18 users — above the $42 ceiling, uncapped)
+>   — see `docs/findings/batch-verify-cost-characterization.md`. Its two dials
+>   (tighten `extra_fact` routing; system-prompt caching — the caching landed 2026-07-02)
+>   and the ledger gaps (`docs/findings/ledger-telemetry-gaps.md`; web-search ledgering
+>   landed 2026-07-02 as migration 0105) supersede this plan's remaining steps.
+
 One-day-startable plan to bend the LLM cost curve, sequenced so each change is
 verified before the next. Generation is ~68% of spend and today runs ~73%
 fall-through to fresh Sonnet (measured 2026-06-28); the goal is to (a) cap

--- a/docs/thinking/PRE-BUILD-VALIDATION.md
+++ b/docs/thinking/PRE-BUILD-VALIDATION.md
@@ -102,6 +102,7 @@ Run this (Supabase) on a representative quiet day (no manual refill testing) —
 
 ```sql
 with pricing (model, in_rate, out_rate, cread_rate, cwrite_rate) as (values
+  ('claude-sonnet-5',3.0,15.0,0.30,3.75),  -- prod model since 2026-07-01; sticker rate (intro $2/$10 through 2026-08-31)
   ('claude-sonnet-4-6',3.0,15.0,0.30,3.75),('claude-haiku-4-5-20251001',1.0,5.0,0.10,1.25),
   ('gpt-4o',2.5,10.0,0.0,0.0),('gpt-4o-mini',0.15,0.6,0.0,0.0),('gpt-4.1',2.0,8.0,0.0,0.0),
   ('gpt-4.1-mini',0.4,1.6,0.0,0.0),('gpt-4.1-nano',0.1,0.4,0.0,0.0)),

--- a/drizzle/0105_llm_usage_web_search.sql
+++ b/drizzle/0105_llm_usage_web_search.sql
@@ -1,0 +1,9 @@
+-- 0105: LlmUsageEvent gains web_search_requests — the per-call count of Anthropic
+-- server-side web_search invocations (billed ~$0.01/request, a separate meter from
+-- tokens). Closes ledger gap (a) from docs/findings/ledger-telemetry-gaps.md: the
+-- batch-verify cron and the (paused) grounded refill both search the web, but the
+-- token-only ledger made that spend invisible to getMonthToDateLlmSpendUsd, the
+-- monthly cap, and the cost readouts. Additive column with a DEFAULT, safe on a
+-- non-empty table. Rollback: ALTER TABLE "LlmUsageEvent" DROP COLUMN
+-- "web_search_requests"; (readers treat a missing column as pre-0105 rows = 0).
+ALTER TABLE "LlmUsageEvent" ADD COLUMN IF NOT EXISTS "web_search_requests" integer NOT NULL DEFAULT 0;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -736,6 +736,13 @@
       "when": 1785542400000,
       "tag": "0104_knowledge_parent_mastery",
       "breakpoints": true
+    },
+    {
+      "idx": 105,
+      "version": "7",
+      "when": 1785628800000,
+      "tag": "0105_llm_usage_web_search",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1983,6 +1983,13 @@ export async function register() {
       `);
       await db.execute(sql`ALTER TABLE "LlmUsageEvent" ENABLE ROW LEVEL SECURITY`);
       await db.execute(sql`CREATE INDEX IF NOT EXISTS "LlmUsageEvent_provider_created_at_idx" ON "LlmUsageEvent" ("provider", "created_at")`);
+      // Migration 0105: per-call web-search request count, so search spend
+      // (~$0.01/request, a separate Anthropic meter) is ledgered instead of
+      // invisible (ledger-telemetry-gaps.md gap (a)). Additive with a DEFAULT —
+      // same repair rationale as the 0100 verification_reason guard.
+      await db.execute(sql`
+        ALTER TABLE "LlmUsageEvent" ADD COLUMN IF NOT EXISTS "web_search_requests" integer NOT NULL DEFAULT 0
+      `);
       // Migration 0092 (B-LLM-COST-LATENCY-REPORT-01) stores the weekly cost &
       // latency digest. The llm-cost-report cron would 42P01 on insert if the
       // migration recorded without the table present. Self-contained; precedent: 0091.

--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -312,6 +312,13 @@ export async function loggedMessagesCreate(
     // silently degrades callers to their fallback path). Real non-streaming
     // responses always include usage; guarding keeps logging robust.
     const usage = response.usage;
+    // Server-side web_search count (0105): billed ~$0.01/request on a separate
+    // meter from tokens; without ledgering it, batch-verify/refill spend
+    // under-reports (ledger-telemetry-gaps.md gap (a)). Defensive read — the
+    // field is absent entirely when the request declared no server tools.
+    const webSearchRequests =
+      (usage as { server_tool_use?: { web_search_requests?: number } } | undefined)
+        ?.server_tool_use?.web_search_requests ?? 0;
     console.info('[llm]', {
       scope,
       model: params.model,
@@ -320,6 +327,7 @@ export async function loggedMessagesCreate(
       output_tokens: usage?.output_tokens ?? 0,
       cache_read_tokens: usage?.cache_read_input_tokens ?? 0,
       cache_create_tokens: usage?.cache_creation_input_tokens ?? 0,
+      web_search_requests: webSearchRequests,
     });
     // B-LLM-PROVIDER-AB-METRICS Part 2: persist the same usage to a queryable
     // table for the cost rollup. Fire-and-forget — recordLlmUsage swallows its
@@ -332,6 +340,7 @@ export async function loggedMessagesCreate(
       outputTokens: usage?.output_tokens ?? 0,
       cacheReadTokens: usage?.cache_read_input_tokens ?? 0,
       cacheCreateTokens: usage?.cache_creation_input_tokens ?? 0,
+      webSearchRequests,
       durationMs: Date.now() - startedAt,
     });
     return response;

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -175,6 +175,7 @@ export async function readSurfaceCost(startDaysAgo: number, endDaysAgo = 0): Pro
       outputTokens: sql<number>`coalesce(sum(${llmUsageEvent.outputTokens}), 0)::float8`,
       cacheReadTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheReadTokens}), 0)::float8`,
       cacheCreateTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheCreateTokens}), 0)::float8`,
+      webSearchRequests: sql<number>`coalesce(sum(${llmUsageEvent.webSearchRequests}), 0)::float8`,
     })
     .from(llmUsageEvent)
     .where(inWindow(startDaysAgo, endDaysAgo))
@@ -187,6 +188,7 @@ export async function readSurfaceCost(startDaysAgo: number, endDaysAgo = 0): Pro
       outputTokens: Number(r.outputTokens),
       cacheReadTokens: Number(r.cacheReadTokens),
       cacheCreateTokens: Number(r.cacheCreateTokens),
+      webSearchRequests: Number(r.webSearchRequests),
     });
     const cur = acc.get(r.bucket) ?? { calls: 0, costUsd: 0, unpriced: false };
     cur.calls += Number(r.calls);

--- a/src/server/db/queries/llm-provider-experiment.ts
+++ b/src/server/db/queries/llm-provider-experiment.ts
@@ -27,6 +27,8 @@ export type LlmUsageRecord = {
   outputTokens: number;
   cacheReadTokens?: number;
   cacheCreateTokens?: number;
+  /** Anthropic server-side web_search request count (0105). OpenAI path omits it. */
+  webSearchRequests?: number;
   durationMs?: number;
 };
 
@@ -45,6 +47,7 @@ export async function recordLlmUsage(event: LlmUsageRecord): Promise<void> {
       outputTokens: Math.max(0, Math.round(event.outputTokens || 0)),
       cacheReadTokens: Math.max(0, Math.round(event.cacheReadTokens || 0)),
       cacheCreateTokens: Math.max(0, Math.round(event.cacheCreateTokens || 0)),
+      webSearchRequests: Math.max(0, Math.round(event.webSearchRequests || 0)),
       durationMs: event.durationMs != null ? Math.max(0, Math.round(event.durationMs)) : null,
     });
   } catch (error) {
@@ -66,6 +69,7 @@ export type ProviderModelCost = {
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreateTokens: number;
+  webSearchRequests: number;
   cost: CostEstimate;
 };
 
@@ -84,6 +88,7 @@ export async function readUsageCostByProvider(days = 14): Promise<ProviderModelC
       outputTokens: sql<number>`coalesce(sum(${llmUsageEvent.outputTokens}), 0)::float8`,
       cacheReadTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheReadTokens}), 0)::float8`,
       cacheCreateTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheCreateTokens}), 0)::float8`,
+      webSearchRequests: sql<number>`coalesce(sum(${llmUsageEvent.webSearchRequests}), 0)::float8`,
     })
     .from(llmUsageEvent)
     .where(gte(llmUsageEvent.createdAt, sql`now() - make_interval(days => ${days})`))
@@ -98,11 +103,13 @@ export async function readUsageCostByProvider(days = 14): Promise<ProviderModelC
     outputTokens: Number(r.outputTokens),
     cacheReadTokens: Number(r.cacheReadTokens),
     cacheCreateTokens: Number(r.cacheCreateTokens),
+    webSearchRequests: Number(r.webSearchRequests),
     cost: estimateCostUsd(r.model, {
       inputTokens: Number(r.inputTokens),
       outputTokens: Number(r.outputTokens),
       cacheReadTokens: Number(r.cacheReadTokens),
       cacheCreateTokens: Number(r.cacheCreateTokens),
+      webSearchRequests: Number(r.webSearchRequests),
     }),
   }));
 }
@@ -110,10 +117,11 @@ export async function readUsageCostByProvider(days = 14): Promise<ProviderModelC
 /**
  * Total estimated USD spend on LLM calls for the CURRENT calendar month (UTC),
  * from the LlmUsageEvent ledger. Backs the retrieval-grounding monthly budget cap
- * (LLM_MONTHLY_USD_CEILING). Token cost only — Anthropic server-side web_search is
- * billed separately and is additionally bounded by RETRIEVAL_DAILY_USD_CEILING per
- * run. Unpriced models contribute 0 (cost unknown, not assumed). Resilient:
- * returns 0 on a query failure so a telemetry hiccup never hard-blocks a caller.
+ * (LLM_MONTHLY_USD_CEILING). Tokens + ledgered web-search requests (0105) — rows
+ * written before 0105 carry web_search_requests = 0, so historical months remain
+ * a token-only floor. Unpriced models contribute 0 (cost unknown, not assumed).
+ * Resilient: returns 0 on a query failure so a telemetry hiccup never
+ * hard-blocks a caller.
  */
 export async function getMonthToDateLlmSpendUsd(): Promise<number> {
   try {
@@ -124,6 +132,7 @@ export async function getMonthToDateLlmSpendUsd(): Promise<number> {
         outputTokens: sql<number>`coalesce(sum(${llmUsageEvent.outputTokens}), 0)::float8`,
         cacheReadTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheReadTokens}), 0)::float8`,
         cacheCreateTokens: sql<number>`coalesce(sum(${llmUsageEvent.cacheCreateTokens}), 0)::float8`,
+        webSearchRequests: sql<number>`coalesce(sum(${llmUsageEvent.webSearchRequests}), 0)::float8`,
       })
       .from(llmUsageEvent)
       .where(gte(llmUsageEvent.createdAt, sql`date_trunc('month', now() at time zone 'utc')`))
@@ -136,6 +145,7 @@ export async function getMonthToDateLlmSpendUsd(): Promise<number> {
         outputTokens: Number(r.outputTokens),
         cacheReadTokens: Number(r.cacheReadTokens),
         cacheCreateTokens: Number(r.cacheCreateTokens),
+        webSearchRequests: Number(r.webSearchRequests),
       });
       if (!cost.unpriced && cost.usd) total += cost.usd;
     }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1605,6 +1605,11 @@ export const llmUsageEvent = pgTable(
     outputTokens: integer('output_tokens').notNull().default(0),
     cacheReadTokens: integer('cache_read_tokens').notNull().default(0),
     cacheCreateTokens: integer('cache_create_tokens').notNull().default(0),
+    // Anthropic server-side web_search request count (billed ~$0.01/request, a
+    // separate meter from tokens). 0105 closes ledger gap (a) from
+    // docs/findings/ledger-telemetry-gaps.md: refill + batch-verify search spend
+    // was previously invisible to every ledger-derived $ number.
+    webSearchRequests: integer('web_search_requests').notNull().default(0),
     durationMs: integer('duration_ms'),
     createdAt: createdAt(),
   },

--- a/src/server/llm/pricing.ts
+++ b/src/server/llm/pricing.ts
@@ -38,6 +38,17 @@ export type ModelPrice = {
 // Keyed by the exact model string passed to the provider SDK.
 export const MODEL_PRICING: Record<string, ModelPrice> = {
   // ── Anthropic (verified, claude-api skill model table) ──
+  // Sonnet 5 — prod generation model since the 2026-07-01 ANTHROPIC_MODEL flip.
+  // Sticker price ($3/$15); Anthropic bills an introductory $2/$10 through
+  // 2026-08-31, so ledger-derived $ slightly OVER-estimates the actual bill until
+  // then — the safe direction for the monthly spend cap. Without this row every
+  // Sonnet 5 call was "unpriced" ($0 in getMonthToDateLlmSpendUsd and the readout).
+  'claude-sonnet-5': {
+    inputPerMtok: 3.0,
+    outputPerMtok: 15.0,
+    cacheReadPerMtok: 0.3, // ~0.1x input
+    cacheWritePerMtok: 3.75, // ~1.25x input (5m TTL)
+  },
   // Sonnet 4.6 — generation.
   'claude-sonnet-4-6': {
     inputPerMtok: 3.0,
@@ -92,11 +103,21 @@ export const MODEL_PRICING: Record<string, ModelPrice> = {
   },
 };
 
+/**
+ * Anthropic server-side web_search: $10 per 1,000 requests (a separate meter from
+ * tokens; verified against the Anthropic pricing page, 2026-07). Provider-flat —
+ * the rate does not vary by model.
+ */
+export const WEB_SEARCH_USD_PER_REQUEST = 0.01;
+
 export type UsageTokens = {
   inputTokens: number;
   outputTokens: number;
   cacheReadTokens: number;
   cacheCreateTokens: number;
+  /** Anthropic server-side web_search request count (0105). Optional: older call
+   *  sites and OpenAI rows simply omit it. */
+  webSearchRequests?: number;
 };
 
 export type CostEstimate = {
@@ -109,7 +130,9 @@ export type CostEstimate = {
 /**
  * Estimate the USD cost of a single call's token usage. Returns `unpriced: true`
  * (and `usd: null`) for a model absent from MODEL_PRICING so the readout can show
- * "tokens known, $ unknown" rather than a misleading $0.
+ * "tokens known, $ unknown" rather than a misleading $0. (An unpriced row's
+ * web-search $ is also withheld — the row's total is unknown, so a partial figure
+ * would read as complete.)
  */
 export function estimateCostUsd(model: string, tokens: UsageTokens): CostEstimate {
   const price = MODEL_PRICING[model];
@@ -118,6 +141,7 @@ export function estimateCostUsd(model: string, tokens: UsageTokens): CostEstimat
     (tokens.inputTokens / 1_000_000) * price.inputPerMtok +
     (tokens.outputTokens / 1_000_000) * price.outputPerMtok +
     (tokens.cacheReadTokens / 1_000_000) * price.cacheReadPerMtok +
-    (tokens.cacheCreateTokens / 1_000_000) * price.cacheWritePerMtok;
+    (tokens.cacheCreateTokens / 1_000_000) * price.cacheWritePerMtok +
+    (tokens.webSearchRequests ?? 0) * WEB_SEARCH_USD_PER_REQUEST;
   return { usd, unpriced: false };
 }

--- a/src/server/quality/verify-question.ts
+++ b/src/server/quality/verify-question.ts
@@ -125,7 +125,11 @@ export async function verifyQuestion(input: VerifyInput): Promise<VerifyResult |
         model: ANTHROPIC_MODEL,
         max_tokens: 1024,
         temperature: 0,
-        system: SYSTEM_PROMPT,
+        // Ephemeral cache breakpoint: the same ~1k-token system prompt is re-sent
+        // on every one of the cron's ≤50 calls/day, so re-billing it uncached is
+        // pure waste (batch-verify-cost-characterization.md). A no-op below the
+        // model's minimum cacheable prefix size — never an error.
+        system: [{ type: 'text' as const, text: SYSTEM_PROMPT, cache_control: { type: 'ephemeral' as const } }],
         messages: [{ role: 'user', content: buildUserMessage(input) }],
         ...(tools ? { tools } : {}),
       },


### PR DESCRIPTION
Closes ledger gap (a) from `docs/findings/ledger-telemetry-gaps.md`: Anthropic server-side web-search spend was previously invisible to cost tracking. Also fixes an undocumented gap where every `claude-sonnet-5` call (prod model since 2026-07-01) was unpriced in the ledger.

## Key changes

- **Migration 0105:** Add `web_search_requests` column to `LlmUsageEvent` table to capture per-call Anthropic server-side web-search invocation count (billed ~$0.01/request on a separate meter from tokens).

- **Pricing updates:**
  - Add `claude-sonnet-5` price row ($3/$15 sticker; Anthropic bills introductory $2/$10 through 2026-08-31).
  - Define `WEB_SEARCH_USD_PER_REQUEST = 0.01` constant.

- **Cost estimation:** Update `estimateCostUsd()` to include web-search request cost in total USD calculation.

- **Ledger population:** 
  - `loggedMessagesCreate()` extracts `usage.server_tool_use.web_search_requests` from Anthropic response and logs/records it.
  - `recordLlmUsage()` persists web-search request count to database.

- **Cost queries:** Update `readUsageCostByProvider()` and `getMonthToDateLlmSpendUsd()` to sum and price web-search requests alongside token costs. Pre-0105 rows read as 0, so historical months remain a token-only floor.

- **System prompt caching:** Add ephemeral cache control to `verifyQuestion()` system prompt to avoid re-billing the same ~1k-token prompt on every batch-verify call (cost-characterization identified batch-verify as the largest recurring LLM line at ~$2/day).

- **Documentation:** Update `docs/llm-cost-action-plan.md` with 2026-07-02 status; update `docs/findings/ledger-telemetry-gaps.md` to mark gap (a) as closed and document the Sonnet 5 pricing fix.

## Implementation notes

- Web-search request count is optional in `UsageTokens` type; older call sites and OpenAI rows omit it (defaults to 0).
- Unpriced models still contribute 0 to cost estimates; their web-search $ is also withheld so partial figures don't read as complete.
- Boot-time guard in `src/instrumentation.ts` applies the migration idempotently with `IF NOT EXISTS` and `DEFAULT 0`, safe on non-empty tables.

https://claude.ai/code/session_01Qda7d1h1sCgBqV68UESD8A