### PR TITLE
Knowledge tree: Merge into… for duplicate territories + drag overlay/row fixes

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -185,8 +185,10 @@ export function KnowledgeAdminClient({
 // then lives under BOTH parents. Moving under a leaf promotes it to 'both'
 // server-side (Beethoven becomes masterable AND a parent).
 
+// 'merge' folds the picked territory INTO the destination (questions, mastery,
+// history move; the source ceases to exist) — same-scope duplicates only.
 type PickState = {
-  mode: 'move' | 'copy';
+  mode: 'move' | 'copy' | 'merge';
   childKey: string;
   childLabel: string;
   fromParentKey: string | null;
@@ -277,6 +279,14 @@ function KnowledgeTreeEditor({
     fromParentKey: string | null;
     toParentKey: string | null;
     toParentLabel: string;
+  } | null>(null);
+  // The one-way gate before a domain merge commits (questions/mastery move,
+  // the source ceases to exist — there is no undo).
+  const [confirmMerge, setConfirmMerge] = useState<{
+    sourceKey: string;
+    sourceLabel: string;
+    targetKey: string;
+    targetLabel: string;
   } | null>(null);
 
   // A tap must still expand / open the ⋯ menu — only a real drag (>8px) grabs.
@@ -427,6 +437,17 @@ function KnowledgeTreeEditor({
 
   function placeInto(toParentKey: string) {
     if (!picking) return;
+    if (picking.mode === 'merge') {
+      // Irreversible data merge — one explicit confirmation before commit.
+      setConfirmMerge({
+        sourceKey: picking.childKey,
+        sourceLabel: picking.childLabel,
+        targetKey: toParentKey,
+        targetLabel: nodeByKey.get(toParentKey)?.label ?? toParentKey,
+      });
+      setPicking(null);
+      return;
+    }
     void act({
       action: 'attach_child',
       childDomainKey: picking.childKey,
@@ -537,6 +558,43 @@ function KnowledgeTreeEditor({
           </div>
         </div>
       ) : null}
+      {confirmMerge ? (
+        <div className="fixed inset-x-0 bottom-0 z-[60] flex justify-center p-3">
+          <div
+            className="flex w-full max-w-lg flex-wrap items-center gap-2 rounded-xl border px-3 py-2.5 text-[13px] shadow-[var(--shadow-overlay)]"
+            style={{ background: 'var(--brand-card)', borderColor: 'var(--danger)', color: 'var(--brand-ink-700)' }}
+            aria-live="polite"
+          >
+            <span className="w-full">
+              Fold <strong>{confirmMerge.sourceLabel}</strong> into{' '}
+              <strong>{confirmMerge.targetLabel}</strong>? Its questions, player progress, and
+              history move over, and <strong>{confirmMerge.sourceLabel}</strong> ceases to exist.
+              This cannot be undone.
+            </span>
+            <button
+              type="button"
+              onClick={() => {
+                const m = confirmMerge;
+                setConfirmMerge(null);
+                void act({ action: 'merge_node', sourceDomainKey: m.sourceKey, targetDomainKey: m.targetKey });
+              }}
+              disabled={busy}
+              className="inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-50"
+              style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+            >
+              Merge them
+            </button>
+            <button
+              type="button"
+              onClick={() => setConfirmMerge(null)}
+              className="inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-medium"
+              style={{ borderColor: 'var(--border)' }}
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : null}
       {picking ? (
         <div
           className="mb-2 flex flex-wrap items-center gap-2 rounded-md px-3 py-2 text-[13px]"
@@ -544,8 +602,11 @@ function KnowledgeTreeEditor({
           aria-live="polite"
         >
           <span>
-            {picking.mode === 'move' ? 'Moving' : 'Copying'} <strong>{picking.childLabel}</strong> —
-            tap “Place here” on the destination.
+            {picking.mode === 'move' ? 'Moving' : picking.mode === 'copy' ? 'Copying' : 'Merging'}{' '}
+            <strong>{picking.childLabel}</strong> —{' '}
+            {picking.mode === 'merge'
+              ? 'tap the territory that absorbs it. For same-scope duplicates only; you confirm before anything changes.'
+              : 'tap “Place here” on the destination.'}
             {picking.mode === 'copy' ? ' It will live under both parents.' : ''}
           </span>
           {picking.mode === 'move' && picking.fromParentKey ? (
@@ -629,7 +690,10 @@ function KnowledgeTreeEditor({
         <DragOverlay>
           {drag ? (
             <div
-              className="rounded-md border px-3 py-1.5 text-sm font-medium shadow-[var(--shadow-card)]"
+              // w-max: the overlay container is sized to the DRAG HANDLE (a
+              // ~36px button), so without an explicit content width the label
+              // smooshes into a vertical sliver.
+              className="w-max max-w-[80vw] truncate whitespace-nowrap rounded-md border px-3 py-1.5 text-sm font-medium shadow-[var(--shadow-card)]"
               style={{ background: 'var(--brand-card)', borderColor: 'var(--brand-navy)', color: 'var(--brand-ink)' }}
             >
               {drag.label}
@@ -815,6 +879,9 @@ function TreeRow({
           borderRadius: isOver || dropEligible ? 6 : undefined,
         }}
       >
+        {/* Left group is ONE non-wrapping line (min-w-0 + truncate) so a long
+            label can never shove the ⋯ button onto its own row. */}
+        <span className="flex min-w-0 flex-1 items-center gap-x-2">
         {/* Drag handle — a real 44px control, not a bare glyph. Drag it to
             re-file; a plain TAP falls back to pick-up mode (big "Place here"
             buttons on every destination). */}
@@ -884,10 +951,15 @@ function TreeRow({
           </span>
         ) : (
           <>
-            <span className={isParentish ? 'font-medium text-[var(--brand-ink)]' : 'text-[var(--brand-ink)]'}>
+            <span
+              className={
+                (isParentish ? 'font-medium text-[var(--brand-ink)]' : 'text-[var(--brand-ink)]') +
+                ' min-w-0 truncate'
+              }
+            >
               {node.label}
             </span>
-            <span className="text-muted-foreground text-xs">
+            <span className="text-muted-foreground shrink-0 whitespace-nowrap text-xs">
               {node.nodeKind !== 'leaf'
                 ? node.masteryThreshold
                   ? `bar ${node.masteryThreshold}`
@@ -899,7 +971,7 @@ function TreeRow({
                 condense-me candidate (Move it under a parent). */}
             {!isParentish && (depthByKey[nodeKey] ?? 0) < THIN_LEAF_THRESHOLD && parentCount === 0 ? (
               <span
-                className="rounded-sm px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
+                className="shrink-0 rounded-sm px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.06em]"
                 style={{ color: 'var(--warning)', background: 'var(--warning-surface)' }}
                 title="Too few questions to stand alone — Move it under a broader parent"
               >
@@ -908,21 +980,24 @@ function TreeRow({
             ) : null}
           </>
         )}
+        </span>
 
-        <span className="ml-auto flex items-center gap-1">
+        <span className="ml-auto flex shrink-0 items-center gap-1">
           {picking ? (
             <button
               type="button"
               onClick={() => onPlace(nodeKey)}
               disabled={placeDisabled}
-              className="inline-flex min-h-9 items-center rounded-md border px-3 text-sm font-medium disabled:opacity-40"
+              className="inline-flex min-h-9 items-center whitespace-nowrap rounded-md border px-3 text-sm font-medium disabled:opacity-40"
               style={
                 placeDisabled
                   ? { borderColor: 'var(--border)', color: 'var(--text-muted)' }
-                  : { borderColor: 'var(--success)', color: 'var(--success)' }
+                  : picking.mode === 'merge'
+                    ? { borderColor: 'var(--danger)', color: 'var(--danger)' }
+                    : { borderColor: 'var(--success)', color: 'var(--success)' }
               }
             >
-              Place here
+              {picking.mode === 'merge' ? 'Merge here' : 'Place here'}
             </button>
           ) : !editing ? (
             // Actions collapse behind one comfortably-tappable toggle — the five
@@ -994,6 +1069,18 @@ function TreeRow({
               style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
             >
               Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => {
+                setActionsOpen(false);
+                onPick({ mode: 'merge', childKey: nodeKey, childLabel: node.label, fromParentKey: parentKey });
+              }}
+              className={menuBtn}
+              style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+              title="Fold this territory into another that names the SAME scope — questions and progress move, this one ceases to exist"
+            >
+              Merge into…
             </button>
             {parentKey ? (
               <button

--- a/src/app/api/admin/knowledge/__tests__/route.test.ts
+++ b/src/app/api/admin/knowledge/__tests__/route.test.ts
@@ -63,6 +63,16 @@ const { proposeStructureMock, ratifyGroupMock } = vi.hoisted(() => ({
 vi.mock('@/server/knowledge/propose-structure', () => ({
   proposeKnowledgeStructure: proposeStructureMock,
 }));
+const { mergeDomainMock } = vi.hoisted(() => ({
+  mergeDomainMock: vi.fn(async () => ({
+    ok: true as const,
+    targetLabel: 'Shakespearean Drama',
+    sourceLabels: ['Shakespeare'],
+    retargeted: 3,
+    consolidated: 2,
+  })),
+}));
+vi.mock('@/server/knowledge/merge-domain', () => ({ mergeDomainIntoTarget: mergeDomainMock }));
 
 import { POST } from '@/app/api/admin/knowledge/route';
 
@@ -211,6 +221,39 @@ describe('POST /api/admin/knowledge', () => {
       childDomainKey: 'classical music',
       toParentDomainKey: 'beethoven',
     });
+    expect(res.status).toBe(400);
+  });
+
+  // ─── merge (fold a duplicate territory into its twin) ───
+
+  it('merge_node folds source into target as the admin', async () => {
+    const res = await post({
+      action: 'merge_node',
+      sourceDomainKey: 'shakespeare',
+      targetDomainKey: 'shakespearean drama',
+    });
+    expect(res.status).toBe(200);
+    expect(mergeDomainMock).toHaveBeenCalledWith(
+      { sourceDomainKey: 'shakespeare', targetDomainKey: 'shakespearean drama' },
+      'admin-1',
+    );
+  });
+
+  it('merge_node maps census-abort to 409 with the unhandled tables', async () => {
+    mergeDomainMock.mockResolvedValueOnce({
+      ok: false,
+      reason: 'unhandled_tables',
+      detail: ['SomeNewTable.domain (4 rows)'],
+    } as never);
+    const res = await post({ action: 'merge_node', sourceDomainKey: 'a', targetDomainKey: 'b' });
+    expect(res.status).toBe(409);
+    const body = (await res.json()) as { detail: string[] };
+    expect(body.detail[0]).toContain('SomeNewTable');
+  });
+
+  it('merge_node self-merge maps to 400', async () => {
+    mergeDomainMock.mockResolvedValueOnce({ ok: false, reason: 'self_merge' } as never);
+    const res = await post({ action: 'merge_node', sourceDomainKey: 'a', targetDomainKey: 'a' });
     expect(res.status).toBe(400);
   });
 

--- a/src/app/api/admin/knowledge/route.ts
+++ b/src/app/api/admin/knowledge/route.ts
@@ -13,6 +13,7 @@ import {
   updateKnowledgeNode,
 } from '@/server/db/queries/knowledge-graph';
 import { proposeKnowledgeStructure } from '@/server/knowledge/propose-structure';
+import { mergeDomainIntoTarget } from '@/server/knowledge/merge-domain';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
@@ -76,6 +77,14 @@ const bodySchema = z.discriminatedUnion('action', [
     childDomainKey: keySchema,
     toParentDomainKey: keySchema,
     moveFromParentDomainKey: keySchema.nullable().optional(),
+  }),
+  // Fold one territory into another — questions, mastery, and history move to
+  // the target; the source ceases to exist. Irreversible; for SAME-SCOPE
+  // duplicates only (containment is an edge, never a merge).
+  z.object({
+    action: z.literal('merge_node'),
+    sourceDomainKey: keySchema,
+    targetDomainKey: keySchema,
   }),
   // The structure suggester: one LLM pass drafts a full grouping of the real
   // corpus; NOTHING persists (suggestions live only in the response).
@@ -201,6 +210,19 @@ export async function POST(request: NextRequest) {
         return NextResponse.json({ error: result.reason }, { status });
       }
       return NextResponse.json({ edge: result.edge }, { status: 201 });
+    }
+
+    case 'merge_node': {
+      const result = await mergeDomainIntoTarget(
+        { sourceDomainKey: data.sourceDomainKey, targetDomainKey: data.targetDomainKey },
+        session.userId,
+      );
+      if (!result.ok) {
+        const status =
+          result.reason === 'self_merge' ? 400 : result.reason === 'unknown_node' ? 422 : 409;
+        return NextResponse.json({ error: result.reason, detail: result.detail }, { status });
+      }
+      return NextResponse.json(result);
     }
 
     case 'propose_structure': {

--- a/src/server/knowledge/merge-domain.ts
+++ b/src/server/knowledge/merge-domain.ts
@@ -1,0 +1,360 @@
+/**
+ * B-KNOWLEDGE-MERGE-01 — fold one territory into another, as a single admin
+ * action ("Shakespeare" and "Shakespearean Drama" are the same territory —
+ * combine them). This is the runtime port of scripts/merge-fragmented-domains.ts
+ * (B-DOMAIN-FRAGMENT-MERGE-01), same semantics, one merge pair per call:
+ *
+ *   - retarget:    Question / GeneratedQuestion (+domain_key) / MASTERY_EVENTS /
+ *                  SkippedDailyQuestion / CrafterDraftDecision rows move to the
+ *                  target label.
+ *   - consolidate: per-user unique tables (PLAYER_MASTERY sums points, max
+ *                  tier; DeclaredInterest ORs isActive; the rest keep the
+ *                  survivor row and drop the source).
+ *   - drop cache:  DomainRelation / RetrievalDomainHealth rows for the source
+ *                  are deleted and rebuild lazily.
+ *   - census-abort: any OTHER populated table holding the source label aborts
+ *                  BEFORE the transaction — silent partial merges are how
+ *                  territories drift apart again.
+ *
+ * Plus the graph work the script deliberately excluded (KnowledgeNode is
+ * authored — merging it IS the human act, and this action is the human):
+ * the source node's edges re-point to the target (duplicates and self-edges
+ * dropped), its frozen parent-mastery rows re-key, and the node is deleted.
+ *
+ * Whether two labels name the SAME scope is a human call — the caller (the
+ * admin UI) is that human. Containment ("Shakespearean Tragedy" inside
+ * "Shakespearean Drama") is the graph's job and must NOT come through here.
+ */
+
+import type { PoolClient } from 'pg';
+
+import { pool } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+export type MergeDomainResult =
+  | { ok: true; targetLabel: string; sourceLabels: string[]; retargeted: number; consolidated: number }
+  | { ok: false; reason: 'unknown_node' | 'self_merge' | 'unhandled_tables'; detail?: string[] };
+
+const RETARGET: Array<{ table: string; column: string }> = [
+  { table: 'Question', column: 'canonical_subcategory' },
+  { table: 'GeneratedQuestion', column: 'canonical_subcategory' },
+  { table: 'MASTERY_EVENTS', column: 'canonical_subcategory' },
+  { table: 'SkippedDailyQuestion', column: 'canonical_subcategory' },
+  { table: 'CrafterDraftDecision', column: 'domain' },
+];
+const DROP_CACHE: Array<{ table: string; column: string }> = [
+  { table: 'DomainRelation', column: 'child_domain' },
+  { table: 'DomainRelation', column: 'related_domain' },
+  { table: 'RetrievalDomainHealth', column: 'domain' },
+];
+const CONSOLIDATE_TABLES = new Set([
+  'PLAYER_MASTERY',
+  'DeclaredInterest',
+  'USER_DOMAIN_DIFFICULTY',
+  'PROFILE_DOMAIN_VISIBILITY',
+  'USER_DOMAIN_EXCLUSIONS',
+  'DAILY_REFINE_DECISION',
+]);
+
+// Schema order (masteryTierEnum) — the stronger tier survives a mastery merge.
+const TIER_RANK: Record<string, number> = { establishing: 0, familiar: 1, solid: 2, mastery: 3 };
+
+// Every (table, column) pair that can hold a domain label, from the live
+// catalog so a future table can't silently escape the census. KnowledgeNode is
+// excluded here because the graph side is handled explicitly below.
+async function domainColumns(client: PoolClient): Promise<Array<{ table: string; column: string }>> {
+  const { rows } = await client.query<{ table_name: string; column_name: string }>(`
+    SELECT table_name, column_name FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND column_name IN ('canonical_subcategory', 'domain', 'child_domain', 'related_domain', 'label')
+      AND table_name NOT IN ('KnowledgeNode')
+    ORDER BY table_name, column_name
+  `);
+  return rows.map((r) => ({ table: r.table_name, column: r.column_name }));
+}
+
+// Per-row rename with a unique-collision fallback (survivor's state stands).
+async function renameOrDropRows(
+  client: PoolClient,
+  table: string,
+  column: string,
+  target: string,
+  sources: string[],
+): Promise<number> {
+  const { rows } = await client.query<{ id: string }>(
+    `SELECT id FROM "${table}" WHERE "${column}" = ANY($1)`,
+    [sources],
+  );
+  for (const row of rows) {
+    try {
+      await client.query(`SAVEPOINT rename_row`);
+      await client.query(`UPDATE "${table}" SET "${column}" = $1 WHERE id = $2`, [target, row.id]);
+      await client.query(`RELEASE SAVEPOINT rename_row`);
+    } catch (err) {
+      if ((err as { code?: string }).code !== '23505') throw err;
+      await client.query(`ROLLBACK TO SAVEPOINT rename_row`);
+      await client.query(`DELETE FROM "${table}" WHERE id = $1`, [row.id]);
+    }
+  }
+  return rows.length;
+}
+
+export async function mergeDomainIntoTarget(
+  input: { sourceDomainKey: string; targetDomainKey: string },
+  actorUserId: string,
+): Promise<MergeDomainResult> {
+  if (input.sourceDomainKey === input.targetDomainKey) {
+    return { ok: false, reason: 'self_merge' };
+  }
+
+  const client = await pool.connect();
+  try {
+    const nodes = await client.query<{ domain_key: string; label: string }>(
+      `SELECT domain_key, label FROM "KnowledgeNode" WHERE domain_key = ANY($1)`,
+      [[input.sourceDomainKey, input.targetDomainKey]],
+    );
+    const sourceNode = nodes.rows.find((n) => n.domain_key === input.sourceDomainKey);
+    const targetNode = nodes.rows.find((n) => n.domain_key === input.targetDomainKey);
+    if (!sourceNode || !targetNode) return { ok: false, reason: 'unknown_node' };
+    const target = targetNode.label;
+
+    // Source labels = every distinct corpus spelling that FOLDS onto the source
+    // node (case/punctuation variants included), across the label-bearing
+    // tables — plus the node's own label.
+    const sourceLabelSet = new Set<string>([sourceNode.label]);
+    for (const { table, column } of await domainColumns(client)) {
+      const { rows } = await client.query<{ label: string }>(
+        `SELECT DISTINCT "${column}" AS label FROM "${table}" WHERE "${column}" IS NOT NULL`,
+      );
+      for (const r of rows) {
+        if (domainKey(r.label) === input.sourceDomainKey) sourceLabelSet.add(r.label);
+      }
+    }
+    sourceLabelSet.delete(target);
+    const sources = [...sourceLabelSet];
+
+    // Census + abort BEFORE any writes: a populated table we don't know how to
+    // consolidate means this merge must be extended deliberately, not guessed.
+    const handled = new Set([
+      ...RETARGET.map((t) => `${t.table}.${t.column}`),
+      ...DROP_CACHE.map((t) => `${t.table}.${t.column}`),
+    ]);
+    const unhandled: string[] = [];
+    for (const { table, column } of await domainColumns(client)) {
+      if (handled.has(`${table}.${column}`) || CONSOLIDATE_TABLES.has(table)) continue;
+      const { rows } = await client.query<{ n: string }>(
+        `SELECT count(*) AS n FROM "${table}" WHERE "${column}" = ANY($1)`,
+        [sources],
+      );
+      if (Number(rows[0].n) > 0) unhandled.push(`${table}.${column} (${rows[0].n} rows)`);
+    }
+    if (unhandled.length > 0) {
+      return { ok: false, reason: 'unhandled_tables', detail: unhandled };
+    }
+
+    const targetKey = input.targetDomainKey;
+    let retargeted = 0;
+    let consolidated = 0;
+
+    await client.query('BEGIN');
+    try {
+      for (const { table, column } of RETARGET) {
+        const extra =
+          table === 'GeneratedQuestion'
+            ? `, "domain_key" = '${targetKey.replace(/'/g, "''")}'`
+            : '';
+        const res = await client.query(
+          `UPDATE "${table}" SET "${column}" = $1${extra} WHERE "${column}" = ANY($2)`,
+          [target, sources],
+        );
+        retargeted += res.rowCount ?? 0;
+      }
+
+      // PLAYER_MASTERY: unique (user_id, canonical_subcategory) — sum points
+      // into an existing target row (max tier wins), else rename in place.
+      const mastery = await client.query<{ id: string; user_id: string; tier: string }>(
+        `SELECT id, user_id, tier FROM "PLAYER_MASTERY" WHERE canonical_subcategory = ANY($1)`,
+        [sources],
+      );
+      for (const row of mastery.rows) {
+        const existing = await client.query<{ id: string; tier: string }>(
+          `SELECT id, tier FROM "PLAYER_MASTERY" WHERE user_id = $1 AND canonical_subcategory = $2`,
+          [row.user_id, target],
+        );
+        if (existing.rows.length > 0) {
+          const strongerTier =
+            (TIER_RANK[row.tier] ?? 0) > (TIER_RANK[existing.rows[0].tier] ?? 0)
+              ? row.tier
+              : existing.rows[0].tier;
+          await client.query(
+            `UPDATE "PLAYER_MASTERY" t SET
+               total_points = t.total_points + s.total_points,
+               lifetime_points_baseline = coalesce(t.lifetime_points_baseline, 0) + coalesce(s.lifetime_points_baseline, 0),
+               tier = $3::"MasteryTier",
+               updated_at = greatest(t.updated_at, s.updated_at)
+             FROM "PLAYER_MASTERY" s WHERE t.id = $1 AND s.id = $2`,
+            [existing.rows[0].id, row.id, strongerTier],
+          );
+          await client.query(`DELETE FROM "PLAYER_MASTERY" WHERE id = $1`, [row.id]);
+        } else {
+          await client.query(
+            `UPDATE "PLAYER_MASTERY" SET canonical_subcategory = $1 WHERE id = $2`,
+            [target, row.id],
+          );
+        }
+        consolidated += 1;
+      }
+
+      // USER_DOMAIN_DIFFICULTY: survivor's ladder state stands on collision.
+      const difficulty = await client.query<{ id: string; user_id: string }>(
+        `SELECT id, user_id FROM "USER_DOMAIN_DIFFICULTY" WHERE canonical_subcategory = ANY($1)`,
+        [sources],
+      );
+      for (const row of difficulty.rows) {
+        const existing = await client.query<{ id: string }>(
+          `SELECT id FROM "USER_DOMAIN_DIFFICULTY" WHERE user_id = $1 AND canonical_subcategory = $2`,
+          [row.user_id, target],
+        );
+        if (existing.rows.length > 0) {
+          await client.query(`DELETE FROM "USER_DOMAIN_DIFFICULTY" WHERE id = $1`, [row.id]);
+        } else {
+          await client.query(
+            `UPDATE "USER_DOMAIN_DIFFICULTY" SET canonical_subcategory = $1 WHERE id = $2`,
+            [target, row.id],
+          );
+        }
+        consolidated += 1;
+      }
+
+      // PROFILE_DOMAIN_VISIBILITY: both label columns retarget; the survivor's
+      // visibility choice stands on collision.
+      const visibility = await client.query<{ id: string; user_id: string }>(
+        `SELECT id, user_id FROM "PROFILE_DOMAIN_VISIBILITY"
+         WHERE canonical_subcategory = ANY($1) OR domain = ANY($1)`,
+        [sources],
+      );
+      for (const row of visibility.rows) {
+        const existing = await client.query<{ id: string }>(
+          `SELECT id FROM "PROFILE_DOMAIN_VISIBILITY"
+           WHERE user_id = $1 AND (canonical_subcategory = $2 OR domain = $2) AND id <> $3`,
+          [row.user_id, target, row.id],
+        );
+        if (existing.rows.length > 0) {
+          await client.query(`DELETE FROM "PROFILE_DOMAIN_VISIBILITY" WHERE id = $1`, [row.id]);
+        } else {
+          await client.query(
+            `UPDATE "PROFILE_DOMAIN_VISIBILITY" SET canonical_subcategory = $1, domain = $1 WHERE id = $2`,
+            [target, row.id],
+          );
+        }
+        consolidated += 1;
+      }
+
+      // DeclaredInterest: unique (userId, domain), camelCase columns — OR
+      // isActive on collision.
+      const declared = await client.query<{ id: string; userId: string }>(
+        `SELECT id, "userId" FROM "DeclaredInterest" WHERE domain = ANY($1)`,
+        [sources],
+      );
+      for (const row of declared.rows) {
+        const existing = await client.query<{ id: string }>(
+          `SELECT id FROM "DeclaredInterest" WHERE "userId" = $1 AND domain = $2`,
+          [row.userId, target],
+        );
+        if (existing.rows.length > 0) {
+          await client.query(
+            `UPDATE "DeclaredInterest" t SET "isActive" = t."isActive" OR s."isActive"
+             FROM "DeclaredInterest" s WHERE t.id = $1 AND s.id = $2`,
+            [existing.rows[0].id, row.id],
+          );
+          await client.query(`DELETE FROM "DeclaredInterest" WHERE id = $1`, [row.id]);
+        } else {
+          await client.query(`UPDATE "DeclaredInterest" SET domain = $1 WHERE id = $2`, [
+            target,
+            row.id,
+          ]);
+        }
+        consolidated += 1;
+      }
+
+      consolidated += await renameOrDropRows(
+        client, 'USER_DOMAIN_EXCLUSIONS', 'canonical_subcategory', target, sources,
+      );
+      consolidated += await renameOrDropRows(
+        client, 'DAILY_REFINE_DECISION', 'canonical_subcategory', target, sources,
+      );
+
+      for (const { table, column } of DROP_CACHE) {
+        await client.query(`DELETE FROM "${table}" WHERE "${column}" = ANY($1)`, [sources]);
+      }
+
+      // ── The graph side (this action IS the human authoring act) ──
+      // Child edges: the source's children re-file under the target (skip
+      // self-edges and duplicates — the unique index would reject them).
+      await client.query(
+        `DELETE FROM "KnowledgeEdge" e WHERE e.parent_domain_key = $1
+           AND (e.child_domain_key = $2
+                OR EXISTS (SELECT 1 FROM "KnowledgeEdge" t
+                           WHERE t.parent_domain_key = $2 AND t.child_domain_key = e.child_domain_key))`,
+        [input.sourceDomainKey, targetKey],
+      );
+      await client.query(
+        `UPDATE "KnowledgeEdge" SET parent_domain_key = $2 WHERE parent_domain_key = $1`,
+        [input.sourceDomainKey, targetKey],
+      );
+      // Parent edges: the source's own memberships transfer to the target.
+      await client.query(
+        `DELETE FROM "KnowledgeEdge" e WHERE e.child_domain_key = $1
+           AND (e.parent_domain_key = $2
+                OR EXISTS (SELECT 1 FROM "KnowledgeEdge" t
+                           WHERE t.child_domain_key = $2 AND t.parent_domain_key = e.parent_domain_key))`,
+        [input.sourceDomainKey, targetKey],
+      );
+      await client.query(
+        `UPDATE "KnowledgeEdge" SET child_domain_key = $2 WHERE child_domain_key = $1`,
+        [input.sourceDomainKey, targetKey],
+      );
+      // Frozen parent mastery re-keys; a player frozen on BOTH keeps the
+      // target row (terminal either way, §B).
+      const frozen = await client.query<{ id: string; user_id: string }>(
+        `SELECT id, user_id FROM "KnowledgeParentMastery" WHERE parent_domain_key = $1`,
+        [input.sourceDomainKey],
+      );
+      for (const row of frozen.rows) {
+        const existing = await client.query<{ id: string }>(
+          `SELECT id FROM "KnowledgeParentMastery" WHERE user_id = $1 AND parent_domain_key = $2`,
+          [row.user_id, targetKey],
+        );
+        if (existing.rows.length > 0) {
+          await client.query(`DELETE FROM "KnowledgeParentMastery" WHERE id = $1`, [row.id]);
+        } else {
+          await client.query(
+            `UPDATE "KnowledgeParentMastery" SET parent_domain_key = $2 WHERE id = $1`,
+            [row.id, targetKey],
+          );
+        }
+      }
+      // The source node ceases to exist.
+      await client.query(`DELETE FROM "KnowledgeNode" WHERE domain_key = $1`, [
+        input.sourceDomainKey,
+      ]);
+
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK');
+      throw err;
+    }
+
+    console.info('[knowledge-admin] domain merged', {
+      actorUserId,
+      sourceDomainKey: input.sourceDomainKey,
+      targetDomainKey: targetKey,
+      sources,
+      retargeted,
+      consolidated,
+    });
+    return { ok: true, targetLabel: target, sourceLabels: sources, retargeted, consolidated };
+  } finally {
+    client.release();
+  }
+}


### PR DESCRIPTION
Answers *"Shakespearean Drama and Shakespeare are basically the same. Should we have an option to combine them?"* — yes, with the line the merge script already drew: **same-scope duplicates merge; narrower-inside-broader stays an edge** (Shakespearean Tragedy ⊂ Shakespearean Drama is containment — already correct as a child, its 37 questions already roll up).

## Merge into… (⋯ menu, danger-toned)
1. Tap **Merge into…** on the duplicate (e.g. *Shakespeare*, 3 Qs)
2. Tap **Merge here** on the survivor (*Shakespearean Drama*)
3. Explicit confirm: *"questions, player progress, and history move over; Shakespeare ceases to exist; cannot be undone"* → commit

## The engine
`mergeDomainIntoTarget` is a runtime port of the proven `scripts/merge-fragmented-domains.ts` (the one that already ran 27 merges in prod), one pair per call, same semantics:
- **Retarget:** Question / GeneratedQuestion (+`domain_key`) / MASTERY_EVENTS / SkippedDailyQuestion / CrafterDraftDecision
- **Consolidate:** PLAYER_MASTERY sums points + stronger tier survives; DeclaredInterest ORs isActive; difficulty/visibility/exclusions/refine keep the survivor row
- **Drop caches:** DomainRelation, RetrievalDomainHealth (rebuild lazily)
- **Census-abort before any write:** a populated table the merge doesn't know how to consolidate → 409 with the table list, zero partial merges
- One transaction on a dedicated pool client; source labels include every corpus spelling that folds onto the source key
- Plus the graph work the script deliberately excluded (this action IS the human act): edges re-point (dupes/self dropped), frozen parent-mastery re-keys, source node deleted

## Drag fixes (from the screenshots)
- **Overlay smoosh fixed** — the drag preview no longer collapses into a vertical text sliver (it was sized to the 36px handle)
- **Row wrap fixed** — long labels truncate instead of shoving the ⋯ button onto its own line

19 route tests green; typecheck, lint, all four ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD