### PR TITLE
Fix admin pages' content being clipped by the fixed bottom nav

### DIFF
--- a/src/app/admin/bulk-upload/BulkUploadClient.tsx
+++ b/src/app/admin/bulk-upload/BulkUploadClient.tsx
@@ -78,7 +78,7 @@ export function BulkUploadClient({
   }
 
   return (
-    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
       <header className="mb-5">
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">Bulk upload questions</h1>
         <p className="text-muted-foreground mt-1 text-sm">

--- a/src/app/admin/crafter/CrafterClient.tsx
+++ b/src/app/admin/crafter/CrafterClient.tsx
@@ -38,7 +38,7 @@ export function CrafterClient({
   }
 
   return (
-    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
       <header className="mb-5">
         <h1 className="mb-3 font-serif text-2xl font-semibold text-[var(--brand-ink)]">Crafter</h1>
         <AdminTabs active="crafter" needingReviewCount={needingReviewCount} />

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -81,7 +81,7 @@ export function KnowledgeAdminClient({
   }, [edges]);
 
   return (
-    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
       <header className="mb-5">
         <h1 className="mb-3 font-serif text-2xl font-semibold text-[var(--brand-ink)]">
           Knowledge graph

--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -45,7 +45,7 @@ export function AdminReportsClient({
   const openCount = reports.length + demotions.length;
 
   return (
-    <main className="mx-auto min-h-dvh max-w-3xl px-4 py-6">
+    <main className="mx-auto min-h-dvh max-w-3xl px-4 pt-6 pb-24">
       <header className="mb-5">
         <h1 className="mb-3 font-serif text-2xl font-semibold text-[var(--brand-ink)]">
           Review queue


### PR DESCRIPTION
Nav.tsx's fixed bottom tab bar and FAB aren't suppressed on /admin/*
routes, but the four admin client components only had py-6 (24px)
of bottom padding, so the last rows of content (e.g. Rosters on
/admin/knowledge) were hidden behind the nav with no way to scroll
past it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Xt4rTD7evUjaZyM9y4qkHA