### PR TITLE
Craft & review: auto-growing text fields + untruncated verifier reasons

### DIFF
--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
+import { AutoGrowTextarea } from '@/components/ui/auto-grow-textarea';
+
 import type { AdminReviewReport, BlockedReviewItem } from '@/server/db/queries/content-reports';
 import type { MachineDemotionReviewItem } from '@/server/db/queries/machine-demotions';
 import { LLM_QUESTION_ATTRIBUTION } from '@/lib/questions-types';
@@ -462,10 +464,9 @@ function EditPanel({
       ) : null}
       <label className="block">
         <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">Question</span>
-        <textarea
+        <AutoGrowTextarea
           value={questionText}
           onChange={(e) => edited(setQuestionText)(e.target.value)}
-          rows={2}
           className={fieldClass}
         />
       </label>
@@ -483,10 +484,9 @@ function EditPanel({
           <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
             Explanation (optional)
           </span>
-          <textarea
+          <AutoGrowTextarea
             value={explanation}
             onChange={(e) => edited(setExplanation)(e.target.value)}
-            rows={2}
             className={fieldClass}
           />
         </label>

--- a/src/components/craft/CreationSurface.tsx
+++ b/src/components/craft/CreationSurface.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 
+import { AutoGrowTextarea } from '@/components/ui/auto-grow-textarea';
 import type { DraftCandidate, DraftTier } from '@/server/crafter/draft-candidates';
 
 // B-CRAFTER-LIFECYCLE-01 — the creation surface, shared by BOTH audiences:
@@ -354,10 +355,9 @@ function CandidateCard({
         ))}
       </div>
 
-      <textarea
+      <AutoGrowTextarea
         value={questionText}
         onChange={(e) => setQuestionText(e.target.value)}
-        rows={2}
         className={fieldClass}
         aria-label="Question"
       />
@@ -371,10 +371,9 @@ function CandidateCard({
           aria-label="Answer"
         />
       </div>
-      <textarea
+      <AutoGrowTextarea
         value={explainer}
         onChange={(e) => setExplainer(e.target.value)}
-        rows={2}
         className={`${fieldClass} mt-2`}
         aria-label="Explainer"
       />

--- a/src/components/ui/auto-grow-textarea.tsx
+++ b/src/components/ui/auto-grow-textarea.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+/**
+ * A textarea that grows to fit its content (and keeps growing as you type),
+ * so a long question or explanation is never trapped behind a 2-row scroll —
+ * "I can't see the full answer" (2026-07-03). DOM-measured because iOS Safari
+ * doesn't support CSS field-sizing yet; direct style mutation, no state.
+ */
+export function AutoGrowTextarea({
+  value,
+  minRows = 2,
+  className,
+  ...props
+}: Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'rows'> & {
+  value: string;
+  minRows?: number;
+}) {
+  const ref = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    el.style.height = 'auto';
+    // +2 covers the border so the last line never clips into a scrollbar.
+    el.style.height = `${el.scrollHeight + 2}px`;
+  }, [value]);
+
+  return (
+    <textarea
+      ref={ref}
+      value={value}
+      rows={minRows}
+      className={`${className ?? ''} resize-none overflow-hidden`}
+      {...props}
+    />
+  );
+}

--- a/src/server/quality/__tests__/verify-question.test.ts
+++ b/src/server/quality/__tests__/verify-question.test.ts
@@ -19,10 +19,10 @@ describe('parseVerifyVerdict', () => {
     expect(mod.parseVerifyVerdict('{"verdict":"unverifiable","reason":"no source"}')?.outcome).toBe('unverifiable');
   });
 
-  it('keeps the reason and truncates it', () => {
-    const long = 'x'.repeat(500);
+  it('keeps the reason and truncates it at 500 (200 cut verdicts mid-word)', () => {
+    const long = 'x'.repeat(700);
     const r = mod.parseVerifyVerdict(`{"verdict":"demoted","reason":"${long}"}`);
-    expect(r?.reason.length).toBe(200);
+    expect(r?.reason.length).toBe(500);
   });
 
   it('returns null for an unknown verdict or malformed JSON', () => {

--- a/src/server/quality/verify-question.ts
+++ b/src/server/quality/verify-question.ts
@@ -86,7 +86,10 @@ export function parseVerifyVerdict(raw: string): { outcome: 'ok' | 'demoted' | '
   if (!parsed) return null;
   const v = parsed.verdict;
   if (v !== 'ok' && v !== 'demoted' && v !== 'unverifiable') return null;
-  const reason = typeof parsed.reason === 'string' ? parsed.reason.trim().slice(0, 200) : '';
+  // 500, not 200 — the old cap cut verdicts mid-word on the crafter flags and
+  // review queue ("…Tom Mooney and Warren Bil"), losing the reasoning the
+  // human needs to act on the flag.
+  const reason = typeof parsed.reason === 'string' ? parsed.reason.trim().slice(0, 500) : '';
   return { outcome: v, reason: reason || v };
 }
 


### PR DESCRIPTION
*"I can't see the full answer"* — two clipping bugs on the draft-review cards:

1. **Auto-growing fields.** Question/explainer textareas were fixed 2-row scroll traps. A new shared `AutoGrowTextarea` (DOM-measured; iOS Safari doesn't support CSS `field-sizing` yet) sizes to its content on mount and as you type. Applied to the crafter creation surface **and** the review queue's edit modal.

2. **Full verifier reasons.** Verdict reasons were sliced at 200 chars, cutting the reasoning mid-word ("…Tom Mooney and Warren Bil") on crafter flags and the review queue — exactly the text a human needs to judge the flag. Cap raised to 500.

34 quality tests green; typecheck, lint, all four ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD