### PR TITLE
Review-queue undo toast (staged commits) + larger edit textarea

### DIFF
--- a/src/app/admin/reports/AdminReportsClient.tsx
+++ b/src/app/admin/reports/AdminReportsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { AutoGrowTextarea } from '@/components/ui/auto-grow-textarea';
@@ -15,6 +15,28 @@ import { AdminTabs } from '@/app/admin/AdminTabs';
 // machine demotions merged into one list — same card shape, different provenance
 // chip and different "concern" source) and the BLOCKED / actioned list
 // (un-block / reverse). Both expose admin-only context.
+//
+// Undo (staged commit): the one-tap queue actions (uphold, dismiss, restore,
+// retire, un-block) have NO server-side inverse — dismiss can't re-open,
+// restore/retire can't re-demote — so a true undo can't be "act now, reverse
+// later." Instead the action is STAGED: the card hides optimistically, a toast
+// offers Undo, and the POST fires only when the window lapses — or immediately
+// when another action is staged or the page hides (keepalive), so nothing is
+// lost. Undo simply cancels the send. The modal's edit flows (re-run / approve
+// / save) stay immediate: they're deliberate multi-step acts with their own
+// gating, not mis-tappable one-liners.
+
+const UNDO_WINDOW_MS = 6000;
+
+type StagedAction = {
+  /** The card this hides while pending — 'report:'/'demotion:'/'blocked:' keyed. */
+  key: string;
+  /** Toast copy, e.g. "Report upheld". */
+  label: string;
+  /** The exact /api/admin/content-reports payload to send on commit. */
+  body: Record<string, unknown>;
+};
+
 export function AdminReportsClient({
   reports,
   demotions,
@@ -24,29 +46,114 @@ export function AdminReportsClient({
   demotions: MachineDemotionReviewItem[];
   blocked: BlockedReviewItem[];
 }) {
+  const router = useRouter();
   const [view, setView] = useState<'open' | 'blocked'>('open');
   // Optimistic clear: an actioned card leaves immediately and the count ticks
   // down, while router.refresh() reconciles with the server in the background.
   // Keyed by the card's stable id ('report:<id>' / 'demotion:<qid>').
   const [cleared, setCleared] = useState<Set<string>>(new Set());
   const clear = (key: string) => setCleared((prev) => new Set(prev).add(key));
+  const unclear = (key: string) =>
+    setCleared((prev) => {
+      const next = new Set(prev);
+      next.delete(key);
+      return next;
+    });
+
+  // The one undoable action; its card is hidden while the toast counts down.
+  const [staged, setStaged] = useState<StagedAction | null>(null);
+  const [toastError, setToastError] = useState<string | null>(null);
+  const timerRef = useRef<number | null>(null);
+  // Mirror for the pagehide flush — event handlers must not read stale state.
+  const stagedRef = useRef<StagedAction | null>(null);
+  useEffect(() => {
+    stagedRef.current = staged;
+  }, [staged]);
+
+  const clearTimer = () => {
+    if (timerRef.current !== null) {
+      window.clearTimeout(timerRef.current);
+      timerRef.current = null;
+    }
+  };
+
+  async function commitStaged(action: StagedAction) {
+    clearTimer();
+    setStaged((current) => (current?.key === action.key ? null : current));
+    clear(action.key); // stays hidden through the POST + background refresh
+    const err = await postAdminAction(action.body);
+    if (err) {
+      // Nothing changed server-side — surface the failure and bring the card
+      // back so the action isn't silently lost.
+      unclear(action.key);
+      setToastError(`${action.label} — ${err.toLowerCase().replace(/\.$/, '')} The card is back below.`);
+      return;
+    }
+    router.refresh();
+  }
+
+  function stageAction(action: StagedAction) {
+    setToastError(null);
+    // One pending action at a time: acting again flushes the previous one now.
+    const prior = stagedRef.current;
+    clearTimer();
+    if (prior) void commitStaged(prior);
+    setStaged(action);
+    timerRef.current = window.setTimeout(() => void commitStaged(action), UNDO_WINDOW_MS);
+  }
+
+  function undoStaged() {
+    clearTimer();
+    setStaged(null);
+  }
+
+  // Leaving the page must not swallow a staged action — send it keepalive.
+  // The ref is nulled and the timer killed FIRST: a client-side nav unmounts
+  // this component but leaves timers running, and the timer firing after the
+  // keepalive send would double-post.
+  useEffect(() => {
+    const flushOnHide = () => {
+      const pending = stagedRef.current;
+      if (!pending) return;
+      stagedRef.current = null;
+      if (timerRef.current !== null) {
+        window.clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      setStaged(null);
+      void fetch('/api/admin/content-reports', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        keepalive: true,
+        body: JSON.stringify(pending.body),
+      });
+    };
+    window.addEventListener('pagehide', flushOnHide);
+    return () => {
+      window.removeEventListener('pagehide', flushOnHide);
+      flushOnHide(); // unmount (client-side nav) flushes too
+    };
+  }, []);
+
+  const hiddenKey = (key: string) => cleared.has(key) || staged?.key === key;
 
   // One queue, two streams. Player inappropriate reports stay pinned first
   // (high-priority, matching the query's ordering); everything else — incorrect
   // reports and machine demotions — merges oldest-first so the longest-suppressed
   // content is reviewed soonest.
   const inappropriate = reports.filter(
-    (r) => r.category === 'inappropriate' && !cleared.has(`report:${r.id}`),
+    (r) => r.category === 'inappropriate' && !hiddenKey(`report:${r.id}`),
   );
   const rest: Array<
     | { kind: 'report'; at: number; report: AdminReviewReport }
     | { kind: 'demotion'; at: number; item: MachineDemotionReviewItem }
   > = [
     ...reports
-      .filter((r) => r.category !== 'inappropriate' && !cleared.has(`report:${r.id}`))
+      .filter((r) => r.category !== 'inappropriate' && !hiddenKey(`report:${r.id}`))
       .map((report) => ({ kind: 'report' as const, at: new Date(report.createdAt).getTime(), report })),
     ...demotions
-      .filter((item) => !cleared.has(`demotion:${item.questionId}`))
+      .filter((item) => !hiddenKey(`demotion:${item.questionId}`))
       .map((item) => ({
         kind: 'demotion' as const,
         at: item.verifiedAt ? new Date(item.verifiedAt).getTime() : 0,
@@ -83,7 +190,12 @@ export function AdminReportsClient({
           ) : (
             <>
               {inappropriate.map((report) => (
-                <ReportRow key={report.id} report={report} onCleared={() => clear(`report:${report.id}`)} />
+                <ReportRow
+                  key={report.id}
+                  report={report}
+                  onCleared={() => clear(`report:${report.id}`)}
+                  onStage={stageAction}
+                />
               ))}
               {rest.map((entry) =>
                 entry.kind === 'report' ? (
@@ -91,12 +203,14 @@ export function AdminReportsClient({
                     key={entry.report.id}
                     report={entry.report}
                     onCleared={() => clear(`report:${entry.report.id}`)}
+                    onStage={stageAction}
                   />
                 ) : (
                   <DemotionRow
                     key={entry.item.questionId}
                     item={entry.item}
                     onCleared={() => clear(`demotion:${entry.item.questionId}`)}
+                    onStage={stageAction}
                   />
                 ),
               )}
@@ -108,12 +222,57 @@ export function AdminReportsClient({
           {blocked.length === 0 ? (
             <p className="text-muted-foreground text-sm">Nothing blocked.</p>
           ) : (
-            blocked.map((item) => (
-              <BlockedRow key={`${item.target.table}:${item.target.id}`} item={item} />
-            ))
+            blocked.map((item) =>
+              hiddenKey(`blocked:${item.target.table}:${item.target.id}`) ? null : (
+                <BlockedRow
+                  key={`${item.target.table}:${item.target.id}`}
+                  item={item}
+                  onStage={stageAction}
+                />
+              ),
+            )
           )}
         </div>
       )}
+
+      {staged || toastError ? (
+        <div
+          className="fixed inset-x-0 bottom-24 z-[60] flex justify-center px-4"
+          role="status"
+          aria-live="polite"
+        >
+          <div
+            className="flex max-w-full items-center gap-3 rounded-full border px-4 py-2.5 text-sm shadow-lg"
+            style={{ background: 'var(--brand-card)', borderColor: 'var(--border)' }}
+          >
+            {toastError ? (
+              <>
+                <span style={{ color: 'var(--danger)' }}>{toastError}</span>
+                <button
+                  type="button"
+                  onClick={() => setToastError(null)}
+                  className="font-semibold underline underline-offset-2"
+                  style={{ color: 'var(--brand-ink-700)' }}
+                >
+                  Dismiss
+                </button>
+              </>
+            ) : staged ? (
+              <>
+                <span className="text-[var(--brand-ink)]">{staged.label}</span>
+                <button
+                  type="button"
+                  onClick={undoStaged}
+                  className="font-semibold underline underline-offset-2"
+                  style={{ color: 'var(--brand-navy)' }}
+                >
+                  Undo
+                </button>
+              </>
+            ) : null}
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }
@@ -464,8 +623,11 @@ function EditPanel({
       ) : null}
       <label className="block">
         <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">Question</span>
+        {/* A generous starting canvas ("the edit area needs to be much larger",
+            2026-07-03) — auto-grow still takes over past six lines. */}
         <AutoGrowTextarea
           value={questionText}
+          minRows={6}
           onChange={(e) => edited(setQuestionText)(e.target.value)}
           className={fieldClass}
         />
@@ -486,6 +648,7 @@ function EditPanel({
           </span>
           <AutoGrowTextarea
             value={explanation}
+            minRows={3}
             onChange={(e) => edited(setExplanation)(e.target.value)}
             className={fieldClass}
           />
@@ -587,35 +750,43 @@ function EditPanel({
   );
 }
 
-function ReportRow({ report, onCleared }: { report: AdminReviewReport; onCleared: () => void }) {
+function ReportRow({
+  report,
+  onCleared,
+  onStage,
+}: {
+  report: AdminReviewReport;
+  onCleared: () => void;
+  onStage: (action: StagedAction) => void;
+}) {
   const router = useRouter();
   const [reviewReason, setReviewReason] = useState('');
-  const [pending, setPending] = useState<'uphold' | 'dismiss' | null>(null);
   const [editing, setEditing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // On success the card leaves the list immediately (optimistic), then a
-  // background refresh reconciles with the server.
+  // Modal flows (approve / save) land immediately: the card leaves the list
+  // (optimistic), then a background refresh reconciles with the server.
   function resolved() {
     onCleared();
     router.refresh();
   }
 
-  async function act(action: 'uphold' | 'dismiss') {
-    if (pending) return;
-    setPending(action);
-    setError(null);
-    const err = await postAdminAction({
-      reportId: report.id,
-      action,
-      reviewReason: reviewReason.trim() || undefined,
+  // One-tap actions stage instead of posting — the parent's undo toast owns
+  // the send (and any failure surfacing).
+  function act(action: 'uphold' | 'dismiss') {
+    onStage({
+      key: `report:${report.id}`,
+      label:
+        action === 'uphold'
+          ? report.category === 'inappropriate'
+            ? 'Report upheld — content removed'
+            : 'Report upheld'
+          : 'Report dismissed',
+      body: {
+        reportId: report.id,
+        action,
+        reviewReason: reviewReason.trim() || undefined,
+      },
     });
-    if (err) {
-      setError(err);
-      setPending(null);
-      return;
-    }
-    resolved();
   }
 
   const kindLabel =
@@ -697,39 +868,31 @@ function ReportRow({ report, onCleared }: { report: AdminReviewReport; onCleared
           />
           <button
             type="button"
-            onClick={() => void act('uphold')}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            onClick={() => act('uphold')}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
           >
-            {pending === 'uphold' ? 'Upholding…' : 'Uphold'}
+            Uphold
           </button>
           {/* Edit → re-run → approve works on BOTH stores now (B-REVIEW-RERUN-01):
               a reworked generated question re-verifies and returns to the bank. */}
           <button
             type="button"
             onClick={() => setEditing(true)}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
           >
             Edit &amp; re-run
           </button>
           <button
             type="button"
-            onClick={() => void act('dismiss')}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            onClick={() => act('dismiss')}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--border)' }}
           >
-            {pending === 'dismiss' ? 'Dismissing…' : 'Dismiss'}
+            Dismiss
           </button>
         </div>
-      ) : null}
-      {error ? (
-        <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>
-          {error}
-        </p>
       ) : null}
     </article>
   );
@@ -739,28 +902,29 @@ function ReportRow({ report, onCleared }: { report: AdminReviewReport; onCleared
 // the verifier and the "concern" block is the verifier's stored reason instead
 // of a reporter note. Actions: restore (verifier was wrong), edit (verifier was
 // right — fix it), retire (right, not worth fixing; soft/reversible).
-function DemotionRow({ item, onCleared }: { item: MachineDemotionReviewItem; onCleared: () => void }) {
+function DemotionRow({
+  item,
+  onCleared,
+  onStage,
+}: {
+  item: MachineDemotionReviewItem;
+  onCleared: () => void;
+  onStage: (action: StagedAction) => void;
+}) {
   const router = useRouter();
-  const [pending, setPending] = useState<'restore' | 'retire' | null>(null);
   const [editing, setEditing] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   function resolved() {
     onCleared();
     router.refresh();
   }
 
-  async function act(action: 'restore_demoted' | 'retire_demoted') {
-    if (pending) return;
-    setPending(action === 'restore_demoted' ? 'restore' : 'retire');
-    setError(null);
-    const err = await postAdminAction({ action, questionId: item.questionId });
-    if (err) {
-      setError(err);
-      setPending(null);
-      return;
-    }
-    resolved();
+  function act(action: 'restore_demoted' | 'retire_demoted') {
+    onStage({
+      key: `demotion:${item.questionId}`,
+      label: action === 'restore_demoted' ? 'Restored to circulation' : 'Retired (recoverable)',
+      body: { action, questionId: item.questionId },
+    });
   }
 
   const authorLabel = item.authorIsHouse
@@ -826,37 +990,29 @@ function DemotionRow({ item, onCleared }: { item: MachineDemotionReviewItem; onC
         <div className="mt-3 flex flex-wrap items-center gap-2">
           <button
             type="button"
-            onClick={() => void act('restore_demoted')}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            onClick={() => act('restore_demoted')}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
           >
-            {pending === 'restore' ? 'Restoring…' : 'Restore — verifier was wrong'}
+            Restore — verifier was wrong
           </button>
           <button
             type="button"
             onClick={() => setEditing(true)}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
           >
             Edit
           </button>
           <button
             type="button"
-            onClick={() => void act('retire_demoted')}
-            disabled={pending !== null}
-            className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+            onClick={() => act('retire_demoted')}
+            className="rounded-md border px-3 py-1.5 text-sm font-medium"
             style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
           >
-            {pending === 'retire' ? 'Retiring…' : 'Retire (recoverable)'}
+            Retire (recoverable)
           </button>
         </div>
-      ) : null}
-      {error ? (
-        <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>
-          {error}
-        </p>
       ) : null}
     </article>
   );
@@ -873,28 +1029,26 @@ function authorBadge(item: BlockedReviewItem): { label: string; tone: 'human' | 
   return { label: `Human · ${item.authorName}`, tone: 'human' };
 }
 
-function BlockedRow({ item }: { item: BlockedReviewItem }) {
-  const router = useRouter();
+function BlockedRow({
+  item,
+  onStage,
+}: {
+  item: BlockedReviewItem;
+  onStage: (action: StagedAction) => void;
+}) {
   const [reviewReason, setReviewReason] = useState('');
   const [confirming, setConfirming] = useState(false);
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  async function unblock() {
-    if (pending) return;
-    setPending(true);
-    setError(null);
-    const err = await postAdminAction({
-      action: 'reverse',
-      target: item.target,
-      reviewReason: reviewReason.trim() || undefined,
+  function unblock() {
+    onStage({
+      key: `blocked:${item.target.table}:${item.target.id}`,
+      label: 'Un-blocked — back in circulation',
+      body: {
+        action: 'reverse',
+        target: item.target,
+        reviewReason: reviewReason.trim() || undefined,
+      },
     });
-    if (err) {
-      setError(err.replace('Action', 'Un-block'));
-      setPending(false);
-      return;
-    }
-    router.refresh();
   }
 
   const badge = authorBadge(item);
@@ -956,21 +1110,16 @@ function BlockedRow({ item }: { item: BlockedReviewItem }) {
             />
             <button
               type="button"
-              onClick={() => void unblock()}
-              disabled={pending}
-              className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              onClick={unblock}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium"
               style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
             >
-              {pending ? 'Un-blocking…' : 'Confirm un-block'}
+              Confirm un-block
             </button>
             <button
               type="button"
-              onClick={() => {
-                setConfirming(false);
-                setError(null);
-              }}
-              disabled={pending}
-              className="rounded-md border px-3 py-1.5 text-sm font-medium disabled:opacity-50"
+              onClick={() => setConfirming(false)}
+              className="rounded-md border px-3 py-1.5 text-sm font-medium"
               style={{ borderColor: 'var(--border)' }}
             >
               Cancel
@@ -978,11 +1127,6 @@ function BlockedRow({ item }: { item: BlockedReviewItem }) {
           </div>
         </div>
       )}
-      {error ? (
-        <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>
-          {error}
-        </p>
-      ) : null}
     </article>
   );
 }


### PR DESCRIPTION
## What this is

Undo for the admin Review queue + a larger edit canvas. (The knowledge-map work originally on this branch already landed on `main` via #1378; the branch was re-authored on top of main's newer review screen — the modal Edit & re-run flow, `AutoGrowTextarea`, and the optimistic `cleared` set are all preserved.)

## Undo toast (staged commits)

The one-tap queue actions — **uphold, dismiss, restore, retire, un-block** — were fire-and-forget, and dismiss/restore/retire have **no server-side inverse**, so "act now, reverse later" would be a fake undo. Instead the action is **staged**: the card hides optimistically, a bottom toast offers **Undo** for 6 seconds, and the POST fires only when the window lapses.

- Acting on another card flushes the pending action immediately (one staged action at a time).
- pagehide/unmount flushes via keepalive fetch with the timer killed first, so a client-side nav can't double-post.
- A failed send surfaces in the toast and the card returns — never silently lost.
- Committed keys ride the existing optimistic `cleared` set, so an actioned card never flashes back between POST and refresh.
- The modal's edit flows (re-run / approve / save) stay immediate — deliberate, gated, multi-step acts, not mis-tappable one-liners.

## Larger edit canvas

The edit modal's question field starts at six rows (explanation at three) instead of two — `AutoGrowTextarea` still grows past that with content.

## Verification

- `npx tsc -p tsconfig.typecheck.json` clean; ESLint 0 errors (React-compiler rules included); color/spacing/radius/font ratchets pass.
- Full vitest on this base: 1964 passed; the single failing suite (`FriendsHubPage` copy assertions) fails identically on `main` — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QgKC4YfUcRvnVKEaRSTLqs