### PR TITLE
Difficulty: retool 'accessible' to be person-anchored, not domain-anchored

### DIFF
--- a/src/lib/llm.ts
+++ b/src/lib/llm.ts
@@ -1245,7 +1245,7 @@ Examples:
 List detection: If the question asks for multiple items, set is_list to true and suggest min_list_items.
 
 Difficulty estimate rules (for factual questions only; return null for personal/ambiguous):
-"accessible": Most educated adults would know this — common knowledge, cultural touchstone, or widely-known fact.
+"accessible": Most educated adults would know this — common knowledge, cultural touchstone, or widely-known fact. Person-anchored, not field-anchored: the most famous fact WITHIN a specialist field is still not accessible if outsiders have never met it.
 "moderate": Requires some specific interest or knowledge in the topic area.
 "specialist": Only enthusiasts or experts in a particular field would know this.
 

--- a/src/server/adaptive-difficulty.ts
+++ b/src/server/adaptive-difficulty.ts
@@ -128,7 +128,14 @@ export function mapAdaptiveLevelToDifficultyHint(level: number): AdaptiveDifficu
     return {
       targetCorrectRate: 0.78,
       difficultyLabel: 'approachable trivia',
-      promptHint: 'Target roughly a 78% correct rate. Write questions someone with a passing interest in the domain would recognize — lean on its well-known landmarks and the facts anyone who has encountered it would have met, not deep cuts.',
+      // Person-anchored, NOT domain-anchored (retooled 2026-07-03): the old
+      // "the domain's well-known landmarks" wording let the model treat the
+      // most famous fact WITHIN a niche as accessible (Brunelleschi's
+      // double-shell dome is the landmark of Renaissance architecture — and
+      // almost nobody off the street knows it). Accessible means the PERSON
+      // is ordinary, not that the fact ranks high within its field.
+      promptHint:
+        'Target roughly a 78% correct rate. Anchor to a random adult with NO particular interest in this domain — general cultural knowledge that happens to touch it, answerable from school, headlines, or everyday life. The most famous fact WITHIN a niche field is still not accessible if outsiders have never met it. Example for "Renaissance Florence": ✓ "Florence is the capital of which Italian region?" (Tuscany) · ✗ "Who engineered the double-shell dome of Florence Cathedral?" (Brunelleschi — famous within the field, unknown outside it; that is moderate at best).',
       estimate: 'accessible',
     };
   }

--- a/src/server/daily/generate-questions.ts
+++ b/src/server/daily/generate-questions.ts
@@ -158,6 +158,9 @@ Do NOT default to the most nameable entity in a work — the character roster, t
 - specialist and moderate: the question MUST clear fan-salience. A generic "name the entity" question is a FAILURE at these tiers, even if factually correct.
 - accessible: fan-salience is PREFERRED but NOT required. Easy facts are allowed to stay simple — forcing delight onto a trivially easy fact produces strained, contorted questions. An accessible question need only clear Rule 2 below. Do not make accessible questions harder to satisfy this rule.
 
+WHAT "accessible" MEANS (difficulty_estimate calibration — person-anchored, not domain-anchored):
+Accessible = a random adult with NO particular interest in this domain could plausibly answer it from school, headlines, or everyday life. The most famous fact WITHIN a niche field is still NOT accessible if outsiders have never met it. For the domain "Renaissance Florence": "Florence is the capital of which Italian region?" (Tuscany) is accessible; "Who engineered the double-shell dome of Florence Cathedral?" (Brunelleschi) is NOT — that is the field's own landmark, famous inside it and unknown outside it, so label it moderate or specialist.
+
 STRIP-THE-DOMAIN TEST (Rule 2 — hard floor, ALL tiers including accessible):
 Before emitting, mentally remove the work's title from the question. If what remains could appear in any generic trivia app, the question is too generic — revise it. The angle, not just the subject, must be specific to the work.
 - PASSES: "In American Psycho, what color is Paul Allen's business card?" — strip the title and the angle is still specific to the work.


### PR DESCRIPTION
*"I guarantee that an incredibly small portion of the population will know who Brunelleschi is, let alone the double dome construction. Accessible is like: in what region in Italy is Florence."*

Exactly right — and the model was faithfully following a wrong instruction. The accessible rubric said to lean on **"the domain's well-known landmarks"**, so the most famous fact *within* a niche field read as accessible. Brunelleschi's dome IS the landmark of Renaissance architecture; almost nobody outside the field knows it.

## The retool — one principle, three places
**Accessible = a random adult with NO particular interest in the domain could plausibly answer it** (school, headlines, everyday life). The most famous fact within a niche is still not accessible if outsiders have never met it.

- **`adaptive-difficulty.ts`** (the <1.5 rung — feeds every generation path, including the crafter's shallow tier): rewritten hint with the example pair baked in — ✓ *"Florence is the capital of which Italian region?"* (Tuscany) · ✗ *"Who engineered the double-shell dome of Florence Cathedral?"* (Brunelleschi → moderate at best).
- **`generate-questions.ts`** system prompt: a "WHAT accessible MEANS" calibration block, so the model's own `difficulty_estimate` labels are anchored the same way.
- **`llm.ts`** suggest-answer rubric: "person-anchored, not field-anchored" clause.

Prompt-only — no schema or flow changes; takes effect on the next generation batch. 304 daily tests green; typecheck + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD