### PR TITLE
Crafter: attribution dropdown (Maid Acasa / Joshing / me) + write-your-own questions

### DIFF
--- a/src/app/api/admin/craft/__tests__/route.test.ts
+++ b/src/app/api/admin/craft/__tests__/route.test.ts
@@ -97,6 +97,59 @@ describe('POST /api/admin/craft', () => {
     expect('verifiedAt' in params).toBe(false);
   });
 
+  it('attribution=machine keeps under Maid Acasa: creatorId null via daily_generated source', async () => {
+    await post({
+      action: 'keep',
+      domain: 'Tears of the Kingdom',
+      tier: 'deep',
+      questionText: 'Which sage grants the vow of wind?',
+      answer: 'Tulin',
+      machineDraftAnswer: 'Tulin',
+      difficultyEstimate: 'specialist',
+      broadCategory: 'Video Games',
+      attribution: 'machine',
+    });
+    const params = createQuestionMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(params.attributedSource).toBe('daily_generated');
+    // The keeper still signs the decision ledger, byline notwithstanding.
+    expect(recordDecisionMock.mock.calls[0][0]).toMatchObject({ deciderId: 'admin-1' });
+  });
+
+  it('attribution=house keeps under Joshing (house_authored)', async () => {
+    await post({
+      action: 'keep',
+      domain: 'Tears of the Kingdom',
+      tier: 'deep',
+      questionText: 'Which sage grants the vow of wind?',
+      answer: 'Tulin',
+      machineDraftAnswer: 'Tulin',
+      difficultyEstimate: 'specialist',
+      broadCategory: 'Video Games',
+      attribution: 'house',
+    });
+    const params = createQuestionMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(params.attributedSource).toBe('house_authored');
+  });
+
+  it("origin=own is a human-written question — creator_written, still on the vet + batch-verify rail", async () => {
+    const res = await post({
+      action: 'keep',
+      domain: 'Tears of the Kingdom',
+      tier: 'deep',
+      questionText: 'What does Purah call her age-shifting device?',
+      answer: 'The Purah Pad prototype rune',
+      difficultyEstimate: 'moderate',
+      broadCategory: 'Video Games',
+      origin: 'own',
+    });
+    expect(res.status).toBe(201);
+    expect(vetMock).toHaveBeenCalled(); // inline vet still runs
+    const params = createQuestionMock.mock.calls[0][0] as Record<string, unknown>;
+    expect(params.llmSuggestedAnswer).toBeNull(); // creator_written provenance
+    expect(params.verified).toBe(false);
+    expect('verifiedAt' in params).toBe(false); // batch sweep still re-checks
+  });
+
   it('an edited answer keeps llm_edited provenance (verified=false)', async () => {
     await post({
       action: 'keep',

--- a/src/app/api/admin/craft/route.ts
+++ b/src/app/api/admin/craft/route.ts
@@ -60,6 +60,11 @@ const bodySchema = z.discriminatedUnion('action', [
     difficultyEstimate: z.enum(['accessible', 'moderate', 'specialist']),
     broadCategory: z.string().trim().min(1).max(120),
     flags: decisionFlagsSchema,
+    // Public byline: self (default), machine (Maid Acasa), or house (Joshing).
+    attribution: z.enum(['self', 'machine', 'house']).default('self'),
+    // 'own' = the crafter wrote it themselves (no machine draft behind it) —
+    // same rail, same vet, same batch fact-check.
+    origin: z.enum(['machine_draft', 'own']).default('machine_draft'),
   }),
   // The kill verdict, recorded to the decision ledger. Nothing else persists —
   // an unkept candidate still never exists as a servable question; this is
@@ -129,6 +134,8 @@ export async function POST(request: NextRequest) {
         machineDraftAnswer: data.machineDraftAnswer,
         difficultyEstimate: data.difficultyEstimate,
         broadCategory: data.broadCategory,
+        attribution: data.attribution,
+        origin: data.origin,
       });
       // Ledger the human's verdict either way — a keep the vet then blocked is
       // still a keep for teaching purposes. Best-effort by contract.

--- a/src/components/craft/CreationSurface.tsx
+++ b/src/components/craft/CreationSurface.tsx
@@ -11,6 +11,18 @@ import type { DraftCandidate, DraftTier } from '@/server/crafter/draft-candidate
 // machine drafts, the human keeps/kills/edits inline; nothing unkept is ever
 // served; every kept question is fact-checked before reaching players. The
 // player just became a contributor — same tool, honest about it.
+// Public bylines a crafter can keep under. 'machine' and 'house' set
+// creatorId NULL server-side — the keeper still signs the decision ledger,
+// and (a real consequence) CAN then be served the question themselves,
+// since author-exclusion keys on creatorId.
+export type KeepAttribution = 'self' | 'machine' | 'house';
+
+const ATTRIBUTION_LABEL: Record<KeepAttribution, string> = {
+  self: 'me',
+  machine: 'Maid Acasa (the machine)',
+  house: 'Joshing (the house)',
+};
+
 export function CreationSurface({
   domain,
   statsLine,
@@ -28,6 +40,9 @@ export function CreationSurface({
   const [cards, setCards] = useState<CandidateState[]>([]);
   const [drafting, setDrafting] = useState(false);
   const [draftError, setDraftError] = useState<string | null>(null);
+  // Crafter-only byline choice, applied to every keep on this surface. The
+  // player surface always keeps as themselves — that's its whole premise.
+  const [attribution, setAttribution] = useState<KeepAttribution>('self');
   const keptCount = cards.filter((c) => c.status === 'kept').length;
 
   // The deferred LLM doubt pass: candidates render the moment generation
@@ -162,10 +177,39 @@ export function CreationSurface({
           {keptCount} kept
         </span>
       </div>
+      {variant === 'crafter' ? (
+        <div className="mb-4 flex flex-wrap items-center gap-2">
+          <label className="text-muted-foreground text-sm" htmlFor="attribution-select">
+            Questions by
+          </label>
+          <select
+            id="attribution-select"
+            value={attribution}
+            onChange={(e) => setAttribution(e.target.value as KeepAttribution)}
+            className="min-h-11 rounded-md border bg-[var(--brand-field)] px-2 py-1.5 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            style={{ borderColor: 'var(--border)' }}
+          >
+            <option value="self">{ATTRIBUTION_LABEL.self}</option>
+            <option value="machine">{ATTRIBUTION_LABEL.machine}</option>
+            <option value="house">{ATTRIBUTION_LABEL.house}</option>
+          </select>
+          {attribution !== 'self' ? (
+            <span className="text-muted-foreground text-xs">
+              byline: {ATTRIBUTION_LABEL[attribution]} — and you can be served these yourself
+            </span>
+          ) : null}
+        </div>
+      ) : null}
       {draftError ? (
         <p className="mb-3 text-sm" style={{ color: 'var(--danger)' }}>
           {draftError}
         </p>
+      ) : null}
+
+      {/* Write your own — same rail as a kept draft: inline vet now, batch
+          fact-check before it's vouched for. Nothing enters unverified. */}
+      {variant === 'crafter' ? (
+        <OwnQuestionCard domain={domain} tier={tier} endpoint={endpoint} attribution={attribution} />
       ) : null}
 
       <div className="space-y-3">
@@ -176,6 +220,7 @@ export function CreationSurface({
             domain={domain}
             tier={tier}
             endpoint={endpoint}
+            attribution={variant === 'crafter' ? attribution : 'self'}
             onChange={(next) => setCards((prev) => prev.map((c, j) => (j === i ? next : c)))}
           />
         ))}
@@ -214,6 +259,165 @@ type CandidateState = {
   error?: string;
 };
 
+// "I also want the ability to add my own ones here — but still verified by
+// the LLM" (2026-07-03). A blank card on the SAME keep rail as machine
+// drafts: inline vet decides servability now, verifiedAt stays NULL so the
+// batch sweep fact-checks it before it's vouched for. origin='own' records
+// answerSource creator_written (no machine draft behind it).
+function OwnQuestionCard({
+  domain,
+  tier,
+  endpoint,
+  attribution,
+}: {
+  domain: string;
+  tier: DraftTier;
+  endpoint: string;
+  attribution: KeepAttribution;
+}) {
+  const [open, setOpen] = useState(false);
+  const [questionText, setQuestionText] = useState('');
+  const [answer, setAnswer] = useState('');
+  const [explainer, setExplainer] = useState('');
+  const [difficulty, setDifficulty] = useState<'accessible' | 'moderate' | 'specialist'>(
+    tier === 'deep' ? 'specialist' : 'accessible',
+  );
+  const [pending, setPending] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [keptCount, setKeptCount] = useState(0);
+
+  const fieldClass =
+    'w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-2 py-1 text-sm focus:border-[var(--brand-navy)]';
+
+  async function keepOwn() {
+    if (pending || !questionText.trim() || !answer.trim()) return;
+    setPending(true);
+    setError(null);
+    try {
+      const res = await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          action: 'keep',
+          domain,
+          tier,
+          questionText: questionText.trim(),
+          answer: answer.trim(),
+          explainer: explainer.trim() || undefined,
+          difficultyEstimate: difficulty,
+          broadCategory: 'General Knowledge',
+          attribution,
+          origin: 'own',
+        }),
+      });
+      if (res.status === 422) {
+        setError('Failed the content check — not kept.');
+        return;
+      }
+      if (!res.ok) {
+        setError(`Keep failed (${res.status}).`);
+        return;
+      }
+      // Clear for the next one; the count is the receipt.
+      setQuestionText('');
+      setAnswer('');
+      setExplainer('');
+      setKeptCount((n) => n + 1);
+    } catch {
+      setError('Keep failed.');
+    } finally {
+      setPending(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="mb-3 inline-flex min-h-11 w-full items-center justify-center rounded-md border border-dashed px-3 text-sm font-medium"
+        style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+      >
+        + Write your own question{keptCount > 0 ? ` (${keptCount} added)` : ''}
+      </button>
+    );
+  }
+
+  return (
+    <article className="mb-3 rounded-md border p-4 text-sm" style={{ borderColor: 'var(--brand-navy)' }}>
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">
+          your own question · still machine fact-checked before serving
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(false)}
+          className="text-muted-foreground text-xs underline-offset-2 hover:underline"
+        >
+          close
+        </button>
+      </div>
+      <AutoGrowTextarea
+        value={questionText}
+        onChange={(e) => setQuestionText(e.target.value)}
+        placeholder={`Ask something about ${domain}…`}
+        className={fieldClass}
+        aria-label="Your question"
+      />
+      <div className="mt-2 flex items-center gap-2">
+        <span className="text-muted-foreground whitespace-nowrap text-xs">Answer</span>
+        <input
+          type="text"
+          value={answer}
+          onChange={(e) => setAnswer(e.target.value)}
+          className={fieldClass}
+          aria-label="Answer"
+        />
+      </div>
+      <AutoGrowTextarea
+        value={explainer}
+        onChange={(e) => setExplainer(e.target.value)}
+        placeholder="Explainer (optional) — a sentence or two of context"
+        className={`${fieldClass} mt-2`}
+        aria-label="Explainer"
+      />
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <select
+          value={difficulty}
+          onChange={(e) => setDifficulty(e.target.value as typeof difficulty)}
+          className="min-h-11 rounded-md border bg-[var(--brand-field)] px-2 py-1.5 text-sm"
+          style={{ borderColor: 'var(--border)' }}
+          aria-label="Difficulty"
+        >
+          <option value="accessible">accessible (anyone could know)</option>
+          <option value="moderate">moderate (needs real interest)</option>
+          <option value="specialist">specialist (only a fan knows)</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => void keepOwn()}
+          disabled={pending || !questionText.trim() || !answer.trim()}
+          className="inline-flex min-h-11 items-center rounded-md border px-4 py-1.5 text-sm font-medium disabled:opacity-50"
+          style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+        >
+          {pending ? 'Adding…' : 'Add — fact-check queued'}
+        </button>
+        {keptCount > 0 ? (
+          <span className="text-xs" style={{ color: 'var(--success)' }}>
+            {keptCount} added this session
+          </span>
+        ) : null}
+      </div>
+      {error ? (
+        <p className="mt-2 text-[13px]" style={{ color: 'var(--danger)' }}>
+          {error}
+        </p>
+      ) : null}
+    </article>
+  );
+}
+
 const FLAG_LABEL: Record<DraftCandidate['flags'][number]['kind'], string> = {
   factual_suspect: 'machine may be fabricating — verify',
   quality: 'quality gate flagged this',
@@ -226,12 +430,14 @@ function CandidateCard({
   domain,
   tier,
   endpoint,
+  attribution,
   onChange,
 }: {
   state: CandidateState;
   domain: string;
   tier: DraftTier;
   endpoint: string;
+  attribution: KeepAttribution;
   onChange: (next: CandidateState) => void;
 }) {
   const { candidate, status } = state;
@@ -280,6 +486,7 @@ function CandidateCard({
           difficultyEstimate: candidate.difficultyEstimate,
           broadCategory: candidate.broadCategory,
           flags: candidate.flags,
+          attribution,
         }),
       });
       if (res.status === 422) {

--- a/src/server/crafter/keep-candidate.ts
+++ b/src/server/crafter/keep-candidate.ts
@@ -31,6 +31,20 @@ export type KeepCandidateInput = {
   machineDraftAnswer?: string | null;
   difficultyEstimate: 'accessible' | 'moderate' | 'specialist';
   broadCategory: string;
+  /**
+   * Public byline (crafter surface only; the player surface always keeps
+   * 'self'). 'machine' → Maid Acasa, 'house' → Joshing. The keeper still
+   * signs the decision ledger either way; with a non-self attribution the
+   * keeper CAN be served the question (author-exclusion keys on creatorId).
+   */
+  attribution?: 'self' | 'machine' | 'house';
+  /**
+   * 'own' = the human WROTE this question (no machine draft behind it) —
+   * answerSource records creator_written. Verification is identical either
+   * way: inline vet now, batch fact-check before it's vouched for (the
+   * 2026-07-01 decision: nothing added skips LLM verification).
+   */
+  origin?: 'machine_draft' | 'own';
 };
 
 export type KeepCandidateResult =
@@ -58,6 +72,7 @@ export async function keepCandidate(input: KeepCandidateInput): Promise<KeepCand
   const publicScoring = verdictToPublicStatus(verdict);
   const blockedVisibility = verdictToBlockedVisibility(verdict);
 
+  const ownWrite = input.origin === 'own';
   const created = await createQuestion({
     authorId: input.keeperUserId,
     text: input.questionText,
@@ -72,10 +87,16 @@ export async function keepCandidate(input: KeepCandidateInput): Promise<KeepCand
     difficulty: DIFFICULTY_TO_NUMBER[input.difficultyEstimate],
     // verified reflects whether the kept answer is still the machine's
     // suggestion — createQuestion derives answerSource from this pair:
-    // unchanged → 'llm_suggested', keeper-corrected → 'llm_edited'.
-    verified: !input.machineDraftAnswer || input.machineDraftAnswer === input.answer,
-    llmSuggestedAnswer: input.machineDraftAnswer ?? input.answer,
+    // unchanged → 'llm_suggested', keeper-corrected → 'llm_edited'. An
+    // own-written question carries NO machine suggestion → creator_written.
+    verified: !ownWrite && (!input.machineDraftAnswer || input.machineDraftAnswer === input.answer),
+    llmSuggestedAnswer: ownWrite ? null : (input.machineDraftAnswer ?? input.answer),
     critiqueIterations: 0,
+    ...(input.attribution === 'machine'
+      ? { attributedSource: 'daily_generated' as const }
+      : input.attribution === 'house'
+        ? { attributedSource: 'house_authored' as const }
+        : {}),
     publicStatus: publicScoring.publicStatus,
     publicEligibilityScore: publicScoring.publicEligibilityScore,
     publicEligibilityReason: publicScoring.publicEligibilityReason,

--- a/src/server/db/queries/questions.ts
+++ b/src/server/db/queries/questions.ts
@@ -553,6 +553,13 @@ export async function createQuestion(params: {
   visibility?: 'public' | 'friends' | 'private' | 'blocked';
   // B-LLM-PROVIDER-AB-SWITCH B3: which provider categorized this question.
   categorizeProvider?: string | null;
+  // Attribution override (crafter keep): present the question as the machine's
+  // (source 'daily_generated' → "Maid Acasa") or the house's
+  // ('house_authored' → "Joshing") instead of the keeper's. Sets creatorId
+  // NULL — resolveQuestionAuthor treats any non-null creator as human. The
+  // authorId still names who performed the act (kept for the decision ledger
+  // by callers); it just stops being the public byline.
+  attributedSource?: 'daily_generated' | 'house_authored';
 }): Promise<{ id: string }> {
   const visibility = params.visibility ?? 'public';
 
@@ -563,7 +570,8 @@ export async function createQuestion(params: {
 
   const difficulty = numberToDifficulty(params.difficulty);
   const baseValues = {
-    creatorId: params.authorId,
+    creatorId: params.attributedSource ? null : params.authorId,
+    ...(params.attributedSource ? { source: params.attributedSource } : {}),
     questionText: params.text,
     answerText: params.correctAnswer,
     acceptedAlternatives: params.alternateAnswers,


### PR DESCRIPTION
Two crafter-surface asks, one PR:

## 1. "Questions by" dropdown
Pick the public byline for everything you keep: **me** (default, today's behavior), **Maid Acasa** (the machine persona — `source='daily_generated'`, `creatorId=NULL`), or **Joshing** (the house — `house_authored`). The existing `resolveQuestionAuthor` renders the byline everywhere with zero client changes.

Honest mechanics, stated on the surface:
- The **decision ledger still records you** as the keeper — taste-teaching is unaffected by the byline.
- With a non-self byline you **can be served these questions yourself** (author-exclusion keys on `creatorId`) — arguably a feature: you get to play your own curations.

Crafter-only: the invited-player surface always keeps as the player — that's its premise.

## 2. Write your own — still LLM-verified
A "+ Write your own question" card on the crafter surface. Same rail as kept drafts, no exceptions to the 2026-07-01 rule: **inline vet** decides servability immediately, **`verifiedAt` stays NULL** so the batch sweep fact-checks it before the system vouches for it. `origin='own'` records `creator_written` provenance (no phantom machine suggestion). Difficulty defaults from the drafting tier; the card clears after each add and counts your session.

## Spend (asked alongside): already tracked
Every crafting call is metered in `LlmUsageEvent` — scope `crafter-draft` for generation, `batch-verify` for post-keep fact-checks, `vet-question` inline — and itemized in the **Monday cost email** (B-LLM-COST-LATENCY-REPORT-01).

18 route tests green; typecheck, lint, all four ratchets clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wuwrz4zt13B5BJdFgWCpTD