### PR TITLE
feat(knowledge): mastery v2 Phase 1 — pure math core

### DIFF
--- a/src/server/knowledge/__tests__/mastery-v2.test.ts
+++ b/src/server/knowledge/__tests__/mastery-v2.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+// Pure module — no DB, no side effects — so a static import is fine (unlike the
+// parent-mastery test, which dynamic-imports because that module pulls in db).
+import {
+  DEFAULT_POINTS_PER_WEIGHT,
+  PARENT_MASTERY_COVERAGE,
+  computeLeafBar,
+  leafMastered,
+  leafProgress,
+  parentCoverage,
+  parentCoverageFromLeaves,
+} from '@/server/knowledge/mastery-v2';
+
+describe('leafProgress', () => {
+  it('is the clamped fraction of the bar', () => {
+    expect(leafProgress(50, 100)).toBe(0.5);
+    expect(leafProgress(100, 100)).toBe(1);
+    expect(leafProgress(250, 100)).toBe(1); // capped
+  });
+
+  it('is 0 for a non-positive bar or negative earnings', () => {
+    expect(leafProgress(50, 0)).toBe(0);
+    expect(leafProgress(50, -10)).toBe(0);
+    expect(leafProgress(-5, 100)).toBe(0);
+  });
+});
+
+describe('leafMastered', () => {
+  it('is true only at or above a positive bar', () => {
+    expect(leafMastered(100, 100)).toBe(true);
+    expect(leafMastered(120, 100)).toBe(true);
+    expect(leafMastered(99, 100)).toBe(false);
+    expect(leafMastered(100, 0)).toBe(false); // no bar to clear
+  });
+});
+
+describe('computeLeafBar', () => {
+  it('scales the bar by weight × pointsPerWeight', () => {
+    expect(computeLeafBar({ weight: 10 })).toBe(10 * DEFAULT_POINTS_PER_WEIGHT);
+    expect(computeLeafBar({ weight: 3, pointsPerWeight: 50 })).toBe(150);
+  });
+
+  it('a non-positive weight yields a 0 bar', () => {
+    expect(computeLeafBar({ weight: 0 })).toBe(0);
+    expect(computeLeafBar({ weight: -4 })).toBe(0);
+  });
+
+  it('CAPS the bar at reachable supply so a deep-but-thin domain stays masterable', () => {
+    // Deep topic (weight 40 → depthBar 4000) but only 300 points of supply exist.
+    expect(computeLeafBar({ weight: 40, reachableSupplyPoints: 300 })).toBe(300);
+    // Supply above the depth demand does not raise the bar.
+    expect(computeLeafBar({ weight: 2, reachableSupplyPoints: 5000 })).toBe(200);
+    // No cap when supply is omitted / Infinity.
+    expect(computeLeafBar({ weight: 40, reachableSupplyPoints: Infinity })).toBe(4000);
+    expect(computeLeafBar({ weight: 40 })).toBe(4000);
+  });
+});
+
+describe('parentCoverage — smooth (default)', () => {
+  it('is the depth-weighted mean of leaf progress', () => {
+    const { coverage, isMaster } = parentCoverage([
+      { weight: 1, progress: 1 },
+      { weight: 1, progress: 0 },
+    ]);
+    expect(coverage).toBe(0.5); // 1/2
+    expect(isMaster).toBe(false);
+  });
+
+  it('weights a big leaf more than a small one', () => {
+    // Only the big leaf covered: 30/50 = 0.6 — not yet master.
+    expect(
+      parentCoverage([
+        { weight: 30, progress: 1 },
+        { weight: 10, progress: 0 },
+        { weight: 10, progress: 0 },
+      ]).coverage,
+    ).toBeCloseTo(0.6);
+    // Add a second covered leaf: 40/50 = 0.8 — master.
+    const withSecond = parentCoverage([
+      { weight: 30, progress: 1 },
+      { weight: 10, progress: 1 },
+      { weight: 10, progress: 0 },
+    ]);
+    expect(withSecond.coverage).toBeCloseTo(0.8);
+    expect(withSecond.isMaster).toBe(true);
+  });
+
+  it('exactly 75% masters (≥, not >)', () => {
+    expect(parentCoverage([{ weight: 3, progress: 1 }, { weight: 1, progress: 0 }]).isMaster).toBe(
+      true,
+    ); // 3/4 = 0.75
+  });
+
+  it('empty or zero-weight parents read as 0 coverage, not-master', () => {
+    expect(parentCoverage([])).toEqual({ coverage: 0, isMaster: false });
+    expect(parentCoverage([{ weight: 0, progress: 1 }])).toEqual({ coverage: 0, isMaster: false });
+  });
+});
+
+describe('parentCoverage — binary contribution', () => {
+  it('only FULLY mastered leaves count their weight', () => {
+    const smooth = parentCoverage(
+      [
+        { weight: 1, progress: 0.9 },
+        { weight: 1, progress: 0.9 },
+      ],
+      { contribution: 'smooth' },
+    );
+    expect(smooth.coverage).toBeCloseTo(0.9); // partial counts
+
+    const binary = parentCoverage(
+      [
+        { weight: 1, progress: 0.9 },
+        { weight: 1, progress: 0.9 },
+      ],
+      { contribution: 'binary' },
+    );
+    expect(binary.coverage).toBe(0); // neither is fully mastered → nothing counts
+  });
+});
+
+describe('the King Lear scenario (spec §The problem)', () => {
+  it('mastering one leaf never masters the whole parent unless it is ≥75% of the weight', () => {
+    // Tragedy's leaves, weighted by breadth. King Lear fully mastered, rest untouched.
+    const tragedy = parentCoverageFromLeaves([
+      { weight: 15, earnedPoints: 400, leafBar: 300 }, // King Lear — mastered (progress capped to 1)
+      { weight: 20, earnedPoints: 0, leafBar: 400 }, // Hamlet
+      { weight: 12, earnedPoints: 0, leafBar: 300 }, // Macbeth
+      { weight: 10, earnedPoints: 0, leafBar: 250 }, // Othello
+    ]);
+    // 15 / 57 ≈ 0.26 — a real King Lear master, honestly NOT a Tragedy master.
+    expect(tragedy.coverage).toBeCloseTo(15 / 57, 5);
+    expect(tragedy.isMaster).toBe(false);
+  });
+
+  it('the leaf itself is (and stays) mastered regardless of the parent verdict', () => {
+    expect(leafMastered(400, 300)).toBe(true);
+  });
+});
+
+describe('constants', () => {
+  it('the parent bar is 75%', () => {
+    expect(PARENT_MASTERY_COVERAGE).toBe(0.75);
+  });
+});

--- a/src/server/knowledge/mastery-v2.ts
+++ b/src/server/knowledge/mastery-v2.ts
@@ -1,0 +1,142 @@
+/**
+ * Mastery Model v2 — Phase 1: the PURE math core.
+ *
+ * Spec: docs/thinking/MASTERY-MODEL-v2.md. This module is deliberately WIRED TO
+ * NOTHING — no DB, no imports with side effects, no flag reads, no surfaces. It
+ * is the deterministic kernel the later phases build on (depth seeding, the
+ * recompute engine, the read-surface wiring). Everything here is unit-tested and
+ * reversible; nothing it computes is persisted or shown yet.
+ *
+ * The v2 grain split (spec decision 3):
+ *   - LEAF mastery is a demonstrated fact — points ≥ the leaf's bar. Permanent
+ *     (frozen) in the wired phases; here it is just the pure predicate.
+ *   - PARENT mastery is live COVERAGE of its leaves — the depth-weighted share of
+ *     the parent's material that sits in mastered/progressed leaves. It can rise
+ *     or fall as the map grows (spec decision 4). No freeze at this grain.
+ *
+ * Two quantities the spec is careful to keep distinct (refinement #2):
+ *   - "depth" elsewhere in the app = a QUESTION COUNT ("37 Qs", `depthByKey`).
+ *   - a node's WEIGHT here = a topic-size / breadth proxy (Wikidata child-count
+ *     or an LLM depth score, seeded in Phase 2). Never conflate the two.
+ */
+
+/** Spec decision 4: a parent is mastered at ≥ 75% depth-weighted coverage. */
+export const PARENT_MASTERY_COVERAGE = 0.75;
+
+/**
+ * Maps a node's WEIGHT (breadth proxy, e.g. Wikidata child-count or an LLM 1–10
+ * score) to a points bar for the leaf. CALIBRATION-PENDING: Phase 0 (2026-07-04)
+ * showed live points are small (avg ~101, 1 player above 1000 of 212), so this
+ * constant must be tuned against real distributions when the model is wired
+ * (Phase 5/6) — otherwise "mastery" stays unreachable. Kept as a named, override-
+ * able default so callers/tests pin it explicitly rather than depending on it.
+ */
+export const DEFAULT_POINTS_PER_WEIGHT = 100;
+
+function clamp01(x: number): number {
+  if (!Number.isFinite(x) || x <= 0) return 0;
+  return x >= 1 ? 1 : x;
+}
+
+/**
+ * A leaf's points bar = depth demand, CAPPED BY REACHABLE SUPPLY (spec decision
+ * 5): you can never be required to earn more points than the domain's existing
+ * questions can award, so a deep-but-thin domain stays masterable.
+ *
+ *   depthBar          = round(weight · pointsPerWeight)
+ *   leafBar           = min(depthBar, reachableSupplyPoints)   [supply cap]
+ *
+ * Omit `reachableSupplyPoints` (or pass Infinity) to skip the cap — useful for
+ * pure tests and for callers that haven't wired supply yet. A non-positive
+ * weight yields a 0 bar (nothing to master).
+ */
+export function computeLeafBar(input: {
+  weight: number;
+  reachableSupplyPoints?: number;
+  pointsPerWeight?: number;
+}): number {
+  const pointsPerWeight = input.pointsPerWeight ?? DEFAULT_POINTS_PER_WEIGHT;
+  const weight = Number.isFinite(input.weight) && input.weight > 0 ? input.weight : 0;
+  const depthBar = Math.round(weight * pointsPerWeight);
+  const cap = input.reachableSupplyPoints;
+  if (cap === undefined || cap === Infinity) return depthBar;
+  return Math.max(0, Math.min(depthBar, cap));
+}
+
+/**
+ * Leaf progress in [0, 1] — the honest fraction of the bar the player has
+ * earned, clamped for display. A non-positive bar means "no bar to clear" → 0.
+ */
+export function leafProgress(earnedPoints: number, leafBar: number): number {
+  if (!Number.isFinite(leafBar) || leafBar <= 0) return 0;
+  return clamp01(earnedPoints / leafBar);
+}
+
+/**
+ * Leaf mastery predicate — points at or above the bar. This is the grain that
+ * becomes PERMANENT (frozen) in the wired phases; here it is pure.
+ */
+export function leafMastered(earnedPoints: number, leafBar: number): boolean {
+  return Number.isFinite(leafBar) && leafBar > 0 && earnedPoints >= leafBar;
+}
+
+/** One leaf's contribution to its parent: its weight and its [0,1] progress. */
+export type LeafContribution = { weight: number; progress: number };
+
+export type ParentCoverage = {
+  /** Depth-weighted share of the parent's material that is covered, in [0, 1]. */
+  coverage: number;
+  /** coverage ≥ PARENT_MASTERY_COVERAGE. Live — never frozen at this grain. */
+  isMaster: boolean;
+};
+
+/**
+ * Parent COVERAGE = depth-weighted share of the parent's leaves that is covered:
+ *
+ *   coverage = Σ_leaf( weight · contribution(progress) ) / Σ_leaf( weight )
+ *
+ * `contribution` (spec open-knob, smooth recommended):
+ *   - 'smooth' (default): a leaf contributes its weight × its partial progress —
+ *     partial progress across many leaves counts.
+ *   - 'binary': a leaf contributes its full weight only once FULLY mastered
+ *     (progress ≥ 1), else nothing.
+ *
+ * A big leaf outweighs a small one, so mastering one leaf (Hamlet) never masters
+ * the parent (all of Tragedy) unless that one leaf is ≥ 75% of the weight. Empty
+ * or zero-total-weight parents read as 0 coverage, not-master.
+ */
+export function parentCoverage(
+  children: readonly LeafContribution[],
+  options: { contribution?: 'smooth' | 'binary' } = {},
+): ParentCoverage {
+  const mode = options.contribution ?? 'smooth';
+  let weightedCovered = 0;
+  let totalWeight = 0;
+  for (const child of children) {
+    const weight = Number.isFinite(child.weight) && child.weight > 0 ? child.weight : 0;
+    if (weight === 0) continue;
+    totalWeight += weight;
+    const progress = clamp01(child.progress);
+    weightedCovered += mode === 'binary' ? (progress >= 1 ? weight : 0) : weight * progress;
+  }
+  const coverage = totalWeight > 0 ? weightedCovered / totalWeight : 0;
+  return { coverage, isMaster: coverage >= PARENT_MASTERY_COVERAGE };
+}
+
+/** A leaf's raw inputs, before progress is derived. */
+export type LeafState = { weight: number; earnedPoints: number; leafBar: number };
+
+/**
+ * Convenience: parent coverage straight from raw leaf state (weight + earned +
+ * bar), deriving each leaf's progress internally. The shape the wired read path
+ * will use once leaves carry a bar.
+ */
+export function parentCoverageFromLeaves(
+  leaves: readonly LeafState[],
+  options: { contribution?: 'smooth' | 'binary' } = {},
+): ParentCoverage {
+  return parentCoverage(
+    leaves.map((l) => ({ weight: l.weight, progress: leafProgress(l.earnedPoints, l.leafBar) })),
+    options,
+  );
+}


### PR DESCRIPTION
**Phase 1** of the mastery redesign. Spec + phased plan: `docs/thinking/MASTERY-MODEL-v2.md` (PR #1391).

Pure math kernel — **no DB, no side effects, no flag reads, no surfaces, wired to nothing.** This is the deterministic core the later phases build on; nothing it computes is persisted or shown yet, so it's safe to merge independently.

## What's here (`src/server/knowledge/mastery-v2.ts`)
- `leafProgress` / `leafMastered` — the permanent-leaf grain (spec decision 3), as pure predicates.
- `computeLeafBar` — depth demand **capped by reachable supply**, so a deep-but-thin domain stays masterable (spec decision 5).
- `parentCoverage` / `parentCoverageFromLeaves` — depth-weighted coverage, mastered at **≥ 75%** (`PARENT_MASTERY_COVERAGE`); `smooth` (default) or `binary` leaf contribution (the open knob).
- `DEFAULT_POINTS_PER_WEIGHT` — flagged **CALIBRATION-PENDING**: Phase 0 showed live points are small (1 of 212 players above 1000), so this must be tuned when the model is wired (P5/P6) or "mastery" stays unreachable.

## Tests (`__tests__/mastery-v2.test.ts`) — 14, all passing
Includes the **King Lear scenario**: one fully-mastered leaf ⇒ ~26% Tragedy coverage (honestly *not* a parent master) while the leaf itself stays mastered; the supply-cap keeping a deep-but-thin domain masterable; the 75% boundary (≥, not >); and the smooth-vs-binary knob.

Typecheck (`tsc -p tsconfig.typecheck.json`) and eslint clean.

## Not in scope (later phases)
Depth-weight column + seeding (P2), recompute engine + reclassification writer (P3), dropping `edge_type` (P4), wiring into read surfaces + the leaf/parent freeze inversion (P5), flag flip + backfill (P6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)