### PR TITLE
feat(knowledge): mastery v2 Phase 2 — node_weight column + depth seeding

### DIFF
--- a/drizzle/0109_knowledge_node_weight.sql
+++ b/drizzle/0109_knowledge_node_weight.sql
@@ -1,0 +1,10 @@
+-- 0109: KnowledgeNode gains node_weight — the Mastery v2 DEPTH WEIGHT
+-- (docs/thinking/MASTERY-MODEL-v2.md): a topic-size / breadth proxy on a ~1–10
+-- scale, seeded from Wikidata child-count (with an LLM fallback) and
+-- human-overridable. Distinct from mastery_threshold (the v1 parent bar) and
+-- from the "N Qs" depth (a question count). Nullable — unseeded nodes simply
+-- have none, and nothing reads it yet (dark until the Phase 5 v2 read path).
+-- Additive, safe on a non-empty table.
+-- Rollback: ALTER TABLE "KnowledgeNode" DROP COLUMN "node_weight";
+-- (readers treat a missing/NULL value as "unseeded — fall back to default").
+ALTER TABLE "KnowledgeNode" ADD COLUMN IF NOT EXISTS "node_weight" integer;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -764,6 +764,13 @@
       "when": 1785888000000,
       "tag": "0108_domain_reference_passage",
       "breakpoints": true
+    },
+    {
+      "idx": 109,
+      "version": "7",
+      "when": 1785974400000,
+      "tag": "0109_knowledge_node_weight",
+      "breakpoints": true
     }
   ]
 }

--- a/scripts/backfill-node-weight.ts
+++ b/scripts/backfill-node-weight.ts
@@ -1,0 +1,84 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) Phase 2 — seed
+ * KnowledgeNode.node_weight for existing nodes.
+ *
+ * New nodes are seeded at creation (the admin route). This backfills the ones
+ * that predate the column — Phase 0 (2026-07-04) counted ~86 unseeded (77 leaves
+ * + 9 "both"). For each null-weight node it computes a depth weight via
+ * computeNodeWeight (Wikidata child-count → LLM fallback; the SAME path the route
+ * uses) and, with --apply, writes it. It touches ONLY node_weight — never labels,
+ * edges, mastery, or questions.
+ *
+ * NOTE: computing calls Wikidata (free) and occasionally Haiku (cheap) even in
+ * dry-run, so the report shows the values that WOULD be written. By default only
+ * NULL-weight rows are touched; --all re-seeds every node (human overrides are
+ * lost — use deliberately).
+ *
+ * Read-only by default. Run from repo root (Node 24):
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-node-weight.ts          # dry-run report
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-node-weight.ts --apply   # write
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-node-weight.ts --all --apply
+ *
+ * Idempotent: re-running without --all reports 0 remaining (every row is seeded).
+ */
+import pg from 'pg';
+
+import { computeNodeWeight } from '../src/server/knowledge/node-weight';
+
+const DB_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error('No DIRECT_URL/DATABASE_URL in env');
+  process.exit(1);
+}
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+
+type NodeRow = { id: string; label: string; node_weight: number | null };
+
+async function main() {
+  const client = new pg.Client({ connectionString: DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<NodeRow>(
+      ALL
+        ? `SELECT id, label, node_weight FROM "KnowledgeNode" ORDER BY label`
+        : `SELECT id, label, node_weight FROM "KnowledgeNode" WHERE node_weight IS NULL ORDER BY label`,
+    );
+
+    console.log(`\n=== node_weight backfill — ${APPLY ? 'APPLY' : 'DRY RUN'}${ALL ? ' (--all)' : ''} ===`);
+    console.log(`nodes to seed: ${rows.length}\n`);
+
+    const bySource = { wikidata: 0, llm: 0, none: 0 };
+    let changed = 0;
+
+    for (const node of rows) {
+      const { weight, source } = await computeNodeWeight(node.label);
+      bySource[source] += 1;
+      const shown = weight ?? '—(unseeded)';
+      console.log(`  ${String(shown).padStart(11)}  [${source.padEnd(8)}]  ${node.label}`);
+
+      if (APPLY && weight !== null) {
+        await client.query(`UPDATE "KnowledgeNode" SET node_weight = $1 WHERE id = $2`, [
+          weight,
+          node.id,
+        ]);
+        changed += 1;
+      }
+    }
+
+    console.log(`\nby source — wikidata: ${bySource.wikidata}, llm: ${bySource.llm}, none: ${bySource.none}`);
+    if (APPLY) {
+      console.log(`updated ${changed} rows.`);
+    } else {
+      console.log('\n(no writes — pass --apply to execute)');
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/api/admin/knowledge/route.ts
+++ b/src/app/api/admin/knowledge/route.ts
@@ -16,6 +16,7 @@ import {
 } from '@/server/db/queries/knowledge-graph';
 import { proposeKnowledgeStructure } from '@/server/knowledge/propose-structure';
 import { mergeDomainIntoTarget } from '@/server/knowledge/merge-domain';
+import { computeNodeWeight } from '@/server/knowledge/node-weight';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 export const dynamic = 'force-dynamic';
@@ -38,6 +39,7 @@ const bodySchema = z.discriminatedUnion('action', [
     masteryThreshold: z.number().int().min(1).max(1_000_000).nullable().optional(),
     broadCategory: z.string().trim().max(80).nullable().optional(),
     fieldHue: z.string().trim().max(40).nullable().optional(),
+    nodeWeight: z.number().int().min(1).max(10).nullable().optional(),
   }),
   z.object({
     action: z.literal('edit_node'),
@@ -47,6 +49,7 @@ const bodySchema = z.discriminatedUnion('action', [
     masteryThreshold: z.number().int().min(1).max(1_000_000).nullable().optional(),
     broadCategory: z.string().trim().max(80).nullable().optional(),
     fieldHue: z.string().trim().max(40).nullable().optional(),
+    nodeWeight: z.number().int().min(1).max(10).nullable().optional(),
   }),
   z.object({
     action: z.literal('create_edge'),
@@ -133,6 +136,9 @@ export async function POST(request: NextRequest) {
 
   switch (data.action) {
     case 'create_node': {
+      // Mastery v2: seed the depth weight when the admin didn't set one
+      // (Wikidata child-count → LLM fallback; null when neither resolves).
+      const nodeWeight = data.nodeWeight ?? (await computeNodeWeight(data.label)).weight;
       const result = await createKnowledgeNode(
         {
           label: data.label,
@@ -140,6 +146,7 @@ export async function POST(request: NextRequest) {
           masteryThreshold: data.masteryThreshold ?? null,
           broadCategory: data.broadCategory ?? null,
           fieldHue: data.fieldHue ?? null,
+          nodeWeight,
         },
         session.userId,
       );

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -368,6 +368,11 @@ export async function register() {
       await db.execute(sql`
         ALTER TABLE "KnowledgeNode" ADD COLUMN IF NOT EXISTS "wikidata_qid" text
       `);
+      // Mastery v2 (migration 0109): depth-weight seed on each node. Additive
+      // nullable column — same repair rationale as the 0107 wikidata_qid guard.
+      await db.execute(sql`
+        ALTER TABLE "KnowledgeNode" ADD COLUMN IF NOT EXISTS "node_weight" integer
+      `);
       await db.execute(sql`
         CREATE TABLE IF NOT EXISTS "KnowledgeEdge" (
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,

--- a/src/server/db/queries/knowledge-graph.ts
+++ b/src/server/db/queries/knowledge-graph.ts
@@ -110,6 +110,8 @@ export type CreateNodeInput = {
   fieldHue: string | null;
   /** Wikidata provenance (ADMIN-01 P3) — set when the node is ratified from a Wikidata proposal. */
   wikidataQid?: string | null;
+  /** Mastery v2 depth weight (1–10); seeded at the route boundary or set by an admin. Null = unseeded. */
+  nodeWeight?: number | null;
 };
 
 export type NodeResult =
@@ -144,6 +146,7 @@ export async function createKnowledgeNode(
         broadCategory: input.broadCategory,
         fieldHue: input.fieldHue,
         wikidataQid: input.wikidataQid ?? null,
+        nodeWeight: input.nodeWeight ?? null,
       })
       .returning();
     console.info('[knowledge-admin] node created', { actorUserId, label: input.label, key });
@@ -200,6 +203,7 @@ export async function updateKnowledgeNode(
       ...(input.masteryThreshold !== undefined ? { masteryThreshold: input.masteryThreshold } : {}),
       ...(input.broadCategory !== undefined ? { broadCategory: input.broadCategory } : {}),
       ...(input.fieldHue !== undefined ? { fieldHue: input.fieldHue } : {}),
+      ...(input.nodeWeight !== undefined ? { nodeWeight: input.nodeWeight } : {}),
     })
     .where(eq(knowledgeNodes.id, input.id))
     .returning();

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -830,6 +830,12 @@ export const knowledgeNodes = pgTable(
     // Wikidata provenance (ADMIN-01 P3): the QID this node was ratified from.
     // NULL for manually-authored / LLM-proposed nodes.
     wikidataQid: text('wikidata_qid'),
+    // Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) DEPTH WEIGHT: a topic-size /
+    // breadth proxy on a ~1–10 scale, seeded from Wikidata child-count (LLM
+    // fallback) and human-overridable. Distinct from mastery_threshold (the v1
+    // parent bar) and from "N Qs" depth (a question count). NULL → unseeded; read
+    // by nothing yet (dark until the v2 read path in Phase 5).
+    nodeWeight: integer('node_weight'),
     createdAt: createdAt(),
   },
   (table) => [uniqueIndex('KnowledgeNode_domain_key_key').on(table.domainKey)],

--- a/src/server/knowledge/__tests__/node-weight.test.ts
+++ b/src/server/knowledge/__tests__/node-weight.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  MAX_NODE_WEIGHT,
+  MIN_NODE_WEIGHT,
+  computeNodeWeight,
+  weightFromChildCount,
+} from '@/server/knowledge/node-weight';
+
+describe('weightFromChildCount', () => {
+  it('grows fast at the low end and saturates at the ceiling', () => {
+    expect(weightFromChildCount(0)).toBe(1); // no breadth → floor
+    expect(weightFromChildCount(1)).toBe(2);
+    expect(weightFromChildCount(3)).toBe(3);
+    expect(weightFromChildCount(50)).toBe(7);
+    expect(weightFromChildCount(500)).toBe(MAX_NODE_WEIGHT); // clamps at 10
+    expect(weightFromChildCount(100_000)).toBe(MAX_NODE_WEIGHT);
+  });
+
+  it('never returns below the floor for junk input', () => {
+    expect(weightFromChildCount(-5)).toBe(MIN_NODE_WEIGHT);
+    expect(weightFromChildCount(NaN)).toBe(MIN_NODE_WEIGHT);
+  });
+});
+
+describe('computeNodeWeight — source order & fail-open', () => {
+  it('uses Wikidata child-count when it resolves (no LLM call)', async () => {
+    let llmCalled = false;
+    const result = await computeNodeWeight('Shakespearean Tragedy', {
+      wikidataChildCount: async () => 50,
+      llmDepthScore: async () => {
+        llmCalled = true;
+        return 5;
+      },
+    });
+    expect(result).toEqual({ weight: 7, source: 'wikidata' });
+    expect(llmCalled).toBe(false);
+  });
+
+  it('falls back to the LLM when Wikidata does not resolve', async () => {
+    const result = await computeNodeWeight('Spy School Books 1-6', {
+      wikidataChildCount: async () => null,
+      llmDepthScore: async () => 4,
+    });
+    expect(result).toEqual({ weight: 4, source: 'llm' });
+  });
+
+  it('falls back to the LLM when Wikidata throws (fail-open)', async () => {
+    const result = await computeNodeWeight('X', {
+      wikidataChildCount: async () => {
+        throw new Error('wikidata down');
+      },
+      llmDepthScore: async () => 8,
+    });
+    expect(result).toEqual({ weight: 8, source: 'llm' });
+  });
+
+  it('clamps an out-of-range LLM score', async () => {
+    const hi = await computeNodeWeight('X', {
+      wikidataChildCount: async () => null,
+      llmDepthScore: async () => 99,
+    });
+    expect(hi.weight).toBe(MAX_NODE_WEIGHT);
+  });
+
+  it('returns unseeded (null) when neither source resolves', async () => {
+    const result = await computeNodeWeight('X', {
+      wikidataChildCount: async () => null,
+      llmDepthScore: async () => null,
+    });
+    expect(result).toEqual({ weight: null, source: 'none' });
+  });
+
+  it('returns unseeded for a blank label without calling any source', async () => {
+    let touched = false;
+    const result = await computeNodeWeight('   ', {
+      wikidataChildCount: async () => {
+        touched = true;
+        return 10;
+      },
+    });
+    expect(result).toEqual({ weight: null, source: 'none' });
+    expect(touched).toBe(false);
+  });
+});

--- a/src/server/knowledge/node-weight.ts
+++ b/src/server/knowledge/node-weight.ts
@@ -1,0 +1,90 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 2: node DEPTH-WEIGHT
+ * seeding.
+ *
+ * A node's weight is a topic-size / breadth proxy on a 1–10 scale, seeded once at
+ * node creation (and backfillable) and human-overridable. It is stored in
+ * KnowledgeNode.node_weight (migration 0109) and read by NOTHING yet — the v2 read
+ * path is Phase 5. Distinct from mastery_threshold (the v1 parent bar) and from
+ * "N Qs" depth (a question count).
+ *
+ * Source order (spec refinement #3): Wikidata P279 child-count first (already
+ * wired, cached, no new HTTP), LLM depth score as fallback for the hyper-specific
+ * territories Wikidata can't resolve. Both normalize to the same 1–10 scale.
+ *
+ * The pure normalization (`weightFromChildCount`) and the dependency-injected
+ * orchestrator are unit-tested without network or LLM.
+ */
+
+import { getWikidataStructure } from '@/server/knowledge/wikidata';
+import { scoreDomainDepth } from '@/server/llm/domain-depth';
+
+export const MIN_NODE_WEIGHT = 1;
+export const MAX_NODE_WEIGHT = 10;
+
+export type NodeWeightSource = 'wikidata' | 'llm' | 'none';
+export type NodeWeightResult = { weight: number | null; source: NodeWeightSource };
+
+function clampWeight(n: number): number {
+  return Math.max(MIN_NODE_WEIGHT, Math.min(MAX_NODE_WEIGHT, Math.round(n)));
+}
+
+/**
+ * Map a Wikidata P279 (subclass-of) direct child count to a 1–10 breadth score.
+ * Log-shaped so breadth grows fast at the low end and saturates: 0→1, 3→3, 7→4,
+ * ~50→7, ~500→10. CALIBRATION-PENDING — the shape is a tunable knob (like
+ * mastery-v2's DEFAULT_POINTS_PER_WEIGHT); it feeds nothing until Phase 5.
+ */
+export function weightFromChildCount(children: number): number {
+  const n = Number.isFinite(children) && children > 0 ? children : 0;
+  return clampWeight(1 + Math.log2(1 + n));
+}
+
+export type ComputeNodeWeightDeps = {
+  /** Direct Wikidata subclass child count for a label, or null if unresolved. */
+  wikidataChildCount?: (label: string) => Promise<number | null>;
+  /** LLM depth score 1–10, or null if unavailable. */
+  llmDepthScore?: (label: string) => Promise<number | null>;
+};
+
+const defaultWikidataChildCount = async (label: string): Promise<number | null> => {
+  const structure = await getWikidataStructure(label);
+  return structure ? structure.children.length : null;
+};
+
+/**
+ * Seed a node's depth weight for a label. Wikidata child-count first; LLM depth
+ * score fallback; null (unseeded) when neither resolves. Each source fails open —
+ * a fault in one falls through to the next, never throws. Deps are injectable for
+ * pure tests.
+ */
+export async function computeNodeWeight(
+  label: string,
+  deps: ComputeNodeWeightDeps = {},
+): Promise<NodeWeightResult> {
+  const clean = label.trim();
+  if (!clean) return { weight: null, source: 'none' };
+
+  const wikidataChildCount = deps.wikidataChildCount ?? defaultWikidataChildCount;
+  const llmDepthScore = deps.llmDepthScore ?? scoreDomainDepth;
+
+  try {
+    const children = await wikidataChildCount(clean);
+    if (children !== null && Number.isFinite(children)) {
+      return { weight: weightFromChildCount(children), source: 'wikidata' };
+    }
+  } catch {
+    // fall through to the LLM
+  }
+
+  try {
+    const score = await llmDepthScore(clean);
+    if (score !== null && Number.isFinite(score)) {
+      return { weight: clampWeight(score), source: 'llm' };
+    }
+  } catch {
+    // fall through to unseeded
+  }
+
+  return { weight: null, source: 'none' };
+}

--- a/src/server/llm/domain-depth.ts
+++ b/src/server/llm/domain-depth.ts
@@ -1,0 +1,57 @@
+import {
+  HAIKU_MODEL,
+  extractTextContent,
+  getAnthropicClient,
+  loggedMessagesCreate,
+  parseJsonObject,
+  wrapUserInput,
+} from '@/lib/llm';
+
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) depth-weight LLM FALLBACK.
+ *
+ * The node-weight seed prefers Wikidata child-count; this covers the topics
+ * Wikidata can't resolve (hyper-specific Joshing territories — "Spy School Books
+ * 1-6"). Returns a breadth/depth score on a 1–10 scale ("how much is there to
+ * know about this topic?"), or null when unavailable.
+ *
+ * Haiku per the categorization/grading model split (CLAUDE.md). FAILS OPEN: an
+ * absent client, an outage, or a malformed response returns null so the caller
+ * simply leaves the node unseeded (readers fall back to the code default).
+ */
+export async function scoreDomainDepth(label: string): Promise<number | null> {
+  const clean = label.trim().replace(/\s+/g, ' ').slice(0, 120);
+  if (!clean) return null;
+
+  const client = getAnthropicClient();
+  if (!client) return null;
+
+  const systemPrompt = `Rate how much there is to know about a trivia topic — its breadth and depth — on an integer scale from 1 to 10.
+This is a TOPIC-SIZE judgement, independent of how popular it is:
+- 1-2: a single narrow thing — one short poem, one minor character, one small event.
+- 3-4: a focused subject — one novel, one album, one battle, one lesser figure.
+- 5-6: a substantial subject — a major author's body of work, a film franchise, a decade of a genre.
+- 7-8: a large field — a national literature, a musical era, a war, a scientific discipline's subfield.
+- 9-10: a vast domain — an entire art form, a whole science, a millennium of history.
+Judge the topic's real-world size, not its fame (a huge fandom does not make a topic deep).
+Respond in JSON only: { "depth": &lt;integer 1-10&gt; }`;
+
+  try {
+    // ~250 tokens — below Haiku's 2048 cache threshold; plain string system.
+    const response = await loggedMessagesCreate(client, 'node-weight-depth', {
+      model: HAIKU_MODEL,
+      max_tokens: 40,
+      temperature: 0.1,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: wrapUserInput('topic', clean) }],
+    });
+
+    const parsed = parseJsonObject(extractTextContent(response.content));
+    const raw = parsed?.depth ?? parsed?.score;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(n)) return null;
+    return Math.max(1, Math.min(10, Math.round(n)));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
**Phase 2** of the mastery redesign. Spec + phased plan: `docs/thinking/MASTERY-MODEL-v2.md` (PR #1391). Follows Phase 1 (pure math, PR #1392) — independent, branches off `main`.

Adds the **depth-weight substrate**. Still dark: `node_weight` is written and editable but **read by nothing** (the v2 read path is Phase 5), so this is safe to merge on its own.

## Decisions used (from the plan)
- **Dedicated `node_weight` column** — not overloading `mastery_threshold`, so v1 parent-bar semantics stay intact during coexistence.
- **Wikidata-child-count-first seeding, LLM fallback.**

## What's here
- **Migration `0109`** — additive nullable `KnowledgeNode.node_weight` (integer) + journal entry + idempotent `instrumentation.ts` guard (precedent: `0107` wikidata_qid). **Not applied** — run `npm run db:migrate` when ready.
- **`node-weight.ts`** — `computeNodeWeight`: Wikidata P279 child-count first (reuses `getWikidataStructure`, cached, no new HTTP) → **Haiku depth-score fallback** (`llm/domain-depth.ts`) for the hyper-specific topics Wikidata can't resolve; both normalize to a **1–10** scale. `weightFromChildCount` is pure + tunable (**CALIBRATION-PENDING**). Every source fails open.
- **Seeded at creation** (admin `create_node`) and **human-overridable** (`create_node`/`edit_node` accept `nodeWeight`; threaded through `createKnowledgeNode`/`updateKnowledgeNode`).
- **`scripts/backfill-node-weight.ts`** — seeds the ~86 pre-column nodes (Phase 0 count); dry-run default, `--apply` to write; touches only `node_weight`.

## Tests / checks
8 new unit tests (source order, fail-open on Wikidata throw, LLM clamp, blank-label guard) — **22 total** across the v2 kernel. Typecheck (`tsc -p tsconfig.typecheck.json`) + eslint clean.

## Not in scope (later phases)
Recompute engine + reclassification writer (P3), dropping `edge_type` (P4), wiring `node_weight` into the read path + the leaf/parent freeze inversion (P5), flag flip + backfill run (P6). A client edit field for the weight is a small fast-follow — the server already accepts overrides via `edit_node`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)