### PR TITLE
feat(mastery): mastery v2 Phase 3 — recompute engine + reclassify writer + validator

### DIFF
--- a/scripts/validate-mastery-recompute.ts
+++ b/scripts/validate-mastery-recompute.ts
@@ -1,0 +1,150 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 3: VALIDATE the recompute
+ * engine against the live aggregate.
+ *
+ * The spec makes PLAYER_MASTERY a rebuildable cache of a projection over
+ * (MASTERY_EVENTS × current taxonomy). Before anything trusts that projection, this
+ * script proves it reproduces today's stored PLAYER_MASTERY: it reads every event,
+ * re-buckets each by its question's CURRENT domain (falling back to the event's
+ * stored snapshot), runs the PURE recomputeMastery, and diffs the result against
+ * the stored rows — by folded domain_key + user.
+ *
+ * READ-ONLY — never writes. A clean (or explainable) diff is the green light for
+ * the persist step and for reclassification-driven recompute (later phases).
+ *
+ * Run from repo root (Node 24):
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/validate-mastery-recompute.ts
+ */
+import pg from 'pg';
+
+import {
+  masteryBucketKey,
+  recomputeMastery,
+  type MasteryEventInput,
+} from '../src/server/mastery/recompute';
+
+const DB_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error('No DIRECT_URL/DATABASE_URL in env');
+  process.exit(1);
+}
+
+type EventRow = {
+  user_id: string;
+  canonical_subcategory: string;
+  question_id: string | null;
+  source_type: string;
+  awarded_points: string | number;
+};
+type StoredRow = { user_id: string; canonical_subcategory: string; total_points: string | number; tier: string };
+
+async function main() {
+  const client = new pg.Client({ connectionString: DB_URL });
+  await client.connect();
+  try {
+    const [events, genQ, authQ, stored] = await Promise.all([
+      client.query<EventRow>(
+        `SELECT user_id, canonical_subcategory, question_id, source_type, awarded_points FROM "MASTERY_EVENTS"`,
+      ),
+      client.query<{ id: string; canonical_subcategory: string }>(
+        `SELECT id, canonical_subcategory FROM "GeneratedQuestion"`,
+      ),
+      client.query<{ id: string; canonical_subcategory: string | null }>(
+        `SELECT id, canonical_subcategory FROM "Question" WHERE canonical_subcategory IS NOT NULL`,
+      ),
+      client.query<StoredRow>(
+        `SELECT user_id, canonical_subcategory, total_points, tier FROM "PLAYER_MASTERY"`,
+      ),
+    ]);
+
+    // Resolver: question id → current domain, from either store (ids are distinct).
+    // --stored-only forces the fallback (bucket by the event's stored snapshot),
+    // which isolates ENGINE correctness (should reproduce PLAYER_MASTERY exactly)
+    // from the v2 POLICY of re-bucketing by the question's current domain.
+    const STORED_ONLY = process.argv.includes('--stored-only');
+    const domainById = new Map<string, string>();
+    for (const r of genQ.rows) domainById.set(r.id, r.canonical_subcategory);
+    for (const r of authQ.rows) if (r.canonical_subcategory) domainById.set(r.id, r.canonical_subcategory);
+    const resolveDomain = (qid: string): string | null =>
+      STORED_ONLY ? null : domainById.get(qid) ?? null;
+
+    const eventInputs: MasteryEventInput[] = events.rows.map((e) => ({
+      userId: e.user_id,
+      canonicalSubcategory: e.canonical_subcategory,
+      questionId: e.question_id,
+      sourceType: e.source_type,
+      awardedPoints: Number(e.awarded_points),
+    }));
+
+    const recomputed = recomputeMastery(eventInputs, resolveDomain);
+
+    // Fold the stored rows to the same (user, domainKey) space.
+    const storedByBucket = new Map<string, { points: number; tier: string; label: string }>();
+    for (const r of stored.rows) {
+      const bucket = masteryBucketKey(r.user_id, r.canonical_subcategory);
+      const prev = storedByBucket.get(bucket);
+      const points = Number(r.total_points);
+      // If two display spellings folded to one key, sum (matches recompute grouping).
+      storedByBucket.set(bucket, {
+        points: (prev?.points ?? 0) + points,
+        tier: r.tier,
+        label: r.canonical_subcategory,
+      });
+    }
+
+    let matched = 0;
+    const pointDiffs: string[] = [];
+    const tierDiffs: string[] = [];
+    const onlyRecomputed: string[] = [];
+    const onlyStored: string[] = [];
+
+    for (const [bucket, entry] of recomputed) {
+      const s = storedByBucket.get(bucket);
+      if (!s) {
+        // A recomputed bucket with 0 net points is not expected to have a stored row.
+        if (Math.round(entry.totalPoints) !== 0) onlyRecomputed.push(`${bucket} (+${Math.round(entry.totalPoints)})`);
+        continue;
+      }
+      const pointsMatch = Math.round(entry.totalPoints) === Math.round(s.points);
+      const tierMatch = entry.tier === s.tier;
+      if (pointsMatch && tierMatch) matched += 1;
+      if (!pointsMatch) pointDiffs.push(`${bucket}: recompute ${Math.round(entry.totalPoints)} vs stored ${Math.round(s.points)}`);
+      if (pointsMatch && !tierMatch) tierDiffs.push(`${bucket}: recompute ${entry.tier} vs stored ${s.tier}`);
+    }
+    for (const [bucket] of storedByBucket) {
+      if (!recomputed.has(bucket)) onlyStored.push(bucket);
+    }
+
+    console.log('\n=== mastery recompute validation (READ-ONLY) ===');
+    console.log(`events: ${events.rows.length}  |  recomputed buckets: ${recomputed.size}  |  stored rows: ${stored.rows.length}`);
+    console.log(`exact matches (points + tier): ${matched}`);
+    console.log(`point diffs:  ${pointDiffs.length}`);
+    console.log(`tier diffs:   ${tierDiffs.length}`);
+    console.log(`only in recompute: ${onlyRecomputed.length}`);
+    console.log(`only in stored:    ${onlyStored.length}`);
+
+    const show = (title: string, rows: string[]) => {
+      if (rows.length === 0) return;
+      console.log(`\n--- ${title} (first 20) ---`);
+      for (const r of rows.slice(0, 20)) console.log(`  ${r}`);
+      if (rows.length > 20) console.log(`  … and ${rows.length - 20} more`);
+    };
+    show('POINT DIFFS', pointDiffs);
+    show('TIER DIFFS', tierDiffs);
+    show('ONLY IN RECOMPUTE', onlyRecomputed);
+    show('ONLY IN STORED', onlyStored);
+
+    console.log(
+      pointDiffs.length === 0 && tierDiffs.length === 0
+        ? '\n✓ recompute reproduces the stored aggregate (any only-in-* rows are expected drift — inspect above).'
+        : '\n⚠ diffs found — inspect before trusting the recompute for a live rebuild.',
+    );
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/server/knowledge/reclassify-questions.ts
+++ b/src/server/knowledge/reclassify-questions.ts
@@ -1,0 +1,71 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 3: ROW-GRANULAR question
+ * reclassification.
+ *
+ * Moves a chosen SET of questions (by id) into a different domain — the "King Lear
+ * splits out of Shakespearean Tragedy" case. Deliberately NOT
+ * merge-domain.ts's applyCorpusRetarget: that path moves a WHOLE label and
+ * consolidates every per-user table because it DISSOLVES a domain. A reclassify
+ * keeps both domains alive and re-homes only specific question rows, so it must
+ * touch ONLY the question rows and NOTHING per-user.
+ *
+ * Columns moved (the complete set — Phase 3 map):
+ *   - GeneratedQuestion.canonical_subcategory + domain_key (must move together).
+ *   - Question.canonical_subcategory (no domain_key column on this table).
+ *
+ * It does NOT touch MASTERY_EVENTS (the immutable log) or any PLAYER_MASTERY /
+ * per-user row. Mastery re-derives from the moved questions via the recompute
+ * engine (recompute.ts) — points are never relocated; they are recomputed. The ids
+ * may belong to either store; each id matches at most one table.
+ */
+
+import { inArray } from 'drizzle-orm';
+
+import { db, generatedQuestions, questions } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+export type ReclassifyResult = {
+  toLabel: string;
+  toKey: string;
+  /** GeneratedQuestion (bank) rows moved. */
+  generatedMoved: number;
+  /** Question (authored) rows moved. */
+  authoredMoved: number;
+};
+
+export async function reclassifyQuestionsByIds(
+  input: { questionIds: readonly string[]; toLabel: string },
+  actorUserId: string,
+): Promise<ReclassifyResult> {
+  const toLabel = input.toLabel.trim();
+  const toKey = domainKey(toLabel);
+  const ids = [...new Set(input.questionIds.filter((id) => id && id.trim()))];
+
+  if (ids.length === 0 || !toLabel) {
+    return { toLabel, toKey, generatedMoved: 0, authoredMoved: 0 };
+  }
+
+  const result = await db.transaction(async (tx) => {
+    const generated = await tx
+      .update(generatedQuestions)
+      .set({ canonicalSubcategory: toLabel, domainKey: toKey })
+      .where(inArray(generatedQuestions.id, ids))
+      .returning({ id: generatedQuestions.id });
+    const authored = await tx
+      .update(questions)
+      .set({ canonicalSubcategory: toLabel })
+      .where(inArray(questions.id, ids))
+      .returning({ id: questions.id });
+    return { generatedMoved: generated.length, authoredMoved: authored.length };
+  });
+
+  console.info('[knowledge-admin] questions reclassified', {
+    actorUserId,
+    toLabel,
+    toKey,
+    requested: ids.length,
+    ...result,
+  });
+
+  return { toLabel, toKey, ...result };
+}

--- a/src/server/mastery/__tests__/recompute.test.ts
+++ b/src/server/mastery/__tests__/recompute.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from 'vitest';
+
+import { masteryBucketKey, recomputeMastery, type MasteryEventInput } from '@/server/mastery/recompute';
+
+const k = masteryBucketKey;
+
+// A resolver backed by a plain map: questionId → current domain label.
+const resolverFrom = (map: Record<string, string>) => (qid: string) => map[qid] ?? null;
+
+const ev = (e: Partial<MasteryEventInput> & Pick<MasteryEventInput, 'userId'>): MasteryEventInput => ({
+  canonicalSubcategory: 'Some Domain',
+  questionId: null,
+  sourceType: 'live_correct',
+  awardedPoints: 0,
+  ...e,
+});
+
+describe('recomputeMastery — projection over current taxonomy', () => {
+  it('sums awarded points per (user, folded domain)', () => {
+    const out = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'Hamlet', awardedPoints: 40 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'Hamlet', awardedPoints: 60 }),
+        ev({ userId: 'u2', canonicalSubcategory: 'Hamlet', awardedPoints: 10 }),
+      ],
+      () => null,
+    );
+    expect(out.get(k('u1', 'Hamlet'))?.totalPoints).toBe(100);
+    expect(out.get(k('u1', 'Hamlet'))?.eventCount).toBe(2);
+    expect(out.get(k('u2', 'Hamlet'))?.totalPoints).toBe(10);
+  });
+
+  it('RE-BUCKETS by the question current domain, not the stored snapshot', () => {
+    // Event was tagged "Shakespearean Tragedy" at write time; its question now
+    // lives in "King Lear" — the points must follow to King Lear.
+    const out = recomputeMastery(
+      [ev({ userId: 'u1', canonicalSubcategory: 'Shakespearean Tragedy', questionId: 'q1', awardedPoints: 50 })],
+      resolverFrom({ q1: 'King Lear' }),
+    );
+    expect(out.has(k('u1', 'Shakespearean Tragedy'))).toBe(false);
+    expect(out.get(k('u1', 'King Lear'))?.totalPoints).toBe(50);
+  });
+
+  it('falls back to the stored snapshot for null or unresolvable question ids', () => {
+    const out = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'Bot Domain', questionId: null, awardedPoints: 5 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'Bot Domain', questionId: 'gone', awardedPoints: 5 }),
+      ],
+      () => null, // nothing resolves
+    );
+    expect(out.get(k('u1', 'Bot Domain'))?.totalPoints).toBe(10);
+  });
+
+  it('folds spelling/case variants of the current domain into one bucket', () => {
+    const out = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'The Golden Girls', awardedPoints: 30 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'the golden girls', awardedPoints: 20 }),
+      ],
+      () => null,
+    );
+    expect(out.size).toBe(1);
+    expect(out.get(k('u1', 'The Golden Girls'))?.totalPoints).toBe(50);
+  });
+
+  it('reproduces the author-credit gate on Mastery via effectiveTier', () => {
+    // 2100 points but no author credit → capped at solid.
+    const noCredit = recomputeMastery(
+      [ev({ userId: 'u1', canonicalSubcategory: 'X', awardedPoints: 2100 })],
+      () => null,
+    );
+    expect(noCredit.get(k('u1', 'X'))?.tier).toBe('solid');
+
+    // 2100 points with ≥20% from ≥2 distinct authored questions → mastery.
+    const credited = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'X', awardedPoints: 1600 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'X', questionId: 'a1', sourceType: 'author_credit', awardedPoints: 300 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'X', questionId: 'a2', sourceType: 'author_credit', awardedPoints: 200 }),
+      ],
+      () => null,
+    );
+    const entry = credited.get(k('u1', 'X'));
+    expect(entry?.totalPoints).toBe(2100);
+    expect(entry?.authorCreditPoints).toBe(500);
+    expect(entry?.authorCreditDistinctQuestions).toBe(2);
+    expect(entry?.tier).toBe('mastery');
+  });
+
+  it('caps at solid when author credit comes from a single question', () => {
+    const out = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'X', awardedPoints: 1500 }),
+        ev({ userId: 'u1', canonicalSubcategory: 'X', questionId: 'a1', sourceType: 'author_credit', awardedPoints: 600 }),
+      ],
+      () => null,
+    );
+    expect(out.get(k('u1', 'X'))?.authorCreditDistinctQuestions).toBe(1);
+    expect(out.get(k('u1', 'X'))?.tier).toBe('solid'); // ≥20% share but <2 distinct
+  });
+
+  it('applies lower tiers from points alone', () => {
+    const out = recomputeMastery(
+      [
+        ev({ userId: 'u1', canonicalSubcategory: 'A', awardedPoints: 50 }), // establishing
+        ev({ userId: 'u2', canonicalSubcategory: 'B', awardedPoints: 250 }), // familiar
+      ],
+      () => null,
+    );
+    expect(out.get(k('u1', 'A'))?.tier).toBe('establishing');
+    expect(out.get(k('u2', 'B'))?.tier).toBe('familiar');
+  });
+});

--- a/src/server/mastery/recompute.ts
+++ b/src/server/mastery/recompute.ts
@@ -1,0 +1,128 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 3: the PURE recompute
+ * engine.
+ *
+ * Spec decision 1: mastery is a PROJECTION of (a player's answer events × the
+ * CURRENT taxonomy), not a movable ledger. MASTERY_EVENTS is the immutable truth;
+ * PLAYER_MASTERY is a rebuildable cache. This function is that projection — given
+ * the raw events and a resolver from questionId → the question's CURRENT domain,
+ * it produces the per-(user, domain) point totals and tier.
+ *
+ * Re-bucketing rule (Phase 0: ~12.5% of events need the fallback):
+ *   - question_id present AND it resolves → the question's CURRENT domain.
+ *   - else (null question_id — bot/personal-daily, domain_merged bookkeeping — or
+ *     an unresolvable id) → the event's STORED canonical_subcategory snapshot.
+ *
+ * Grouping folds via domainKey to match how the live write path converges
+ * same-key territories (resolveToExistingTerritory). Tier uses effectiveTier so
+ * the author-credit gate on Mastery is reproduced. Pure and deterministic — no
+ * I/O; the resolver is injected, so it is unit-tested without a DB.
+ */
+
+import type { MasteryTier } from '@/types/db';
+import { effectiveTier } from '@/server/mastery/tiers';
+import { domainKey } from '@/lib/knowledge/domain-key';
+
+/** The subset of a MASTERY_EVENTS row the projection needs. */
+export type MasteryEventInput = {
+  userId: string;
+  /** The domain snapshot stored on the event at write time — the fallback bucket. */
+  canonicalSubcategory: string;
+  questionId: string | null;
+  /** masterySourceTypeEnum value; only 'author_credit' affects the tier gate. */
+  sourceType: string;
+  awardedPoints: number;
+};
+
+export type RecomputedDomain = {
+  userId: string;
+  /** The folded lookup key the row is grouped under. */
+  domainKey: string;
+  /** A display label for the domain (the current domain the points landed in). */
+  canonicalSubcategory: string;
+  totalPoints: number;
+  authorCreditPoints: number;
+  authorCreditDistinctQuestions: number;
+  tier: MasteryTier;
+  eventCount: number;
+};
+
+const AUTHOR_CREDIT = 'author_credit';
+
+// Bucket separator. UserIds are space-free (cuid/uuid), so a space cannot create
+// an ambiguous split against the folded domainKey that follows it.
+const BUCKET_SEP = ' ';
+
+/**
+ * The map key recomputeMastery groups by: a (user, folded-domain) pair. Exported
+ * so every caller — and the validation script — builds the SAME key from a raw
+ * domain label; the domainKey fold happens here, once.
+ */
+export function masteryBucketKey(userId: string, domainLabel: string): string {
+  return `${userId}${BUCKET_SEP}${domainKey(domainLabel)}`;
+}
+
+/**
+ * Project the events onto the current taxonomy. `resolveDomain(questionId)`
+ * returns the question's CURRENT domain label, or null when the id is unknown
+ * (then the event's stored snapshot stands). Returns one entry per
+ * (user, folded-domain), keyed by masteryBucketKey(userId, domain).
+ */
+export function recomputeMastery(
+  events: readonly MasteryEventInput[],
+  resolveDomain: (questionId: string) => string | null,
+): Map<string, RecomputedDomain> {
+  const out = new Map<string, RecomputedDomain>();
+  const authorQuestionsByBucket = new Map<string, Set<string>>();
+
+  for (const event of events) {
+    // Re-bucket by the question's current domain; fall back to the stored snapshot.
+    let domain = event.canonicalSubcategory;
+    if (event.questionId) {
+      const resolved = resolveDomain(event.questionId);
+      if (resolved && resolved.trim()) domain = resolved;
+    }
+    const bucket = masteryBucketKey(event.userId, domain);
+
+    let entry = out.get(bucket);
+    if (!entry) {
+      entry = {
+        userId: event.userId,
+        domainKey: domainKey(domain),
+        canonicalSubcategory: domain,
+        totalPoints: 0,
+        authorCreditPoints: 0,
+        authorCreditDistinctQuestions: 0,
+        tier: 'establishing',
+        eventCount: 0,
+      };
+      out.set(bucket, entry);
+    }
+
+    const points = Number.isFinite(event.awardedPoints) ? event.awardedPoints : 0;
+    entry.totalPoints += points;
+    entry.eventCount += 1;
+    if (event.sourceType === AUTHOR_CREDIT) {
+      entry.authorCreditPoints += points;
+      if (event.questionId) {
+        let set = authorQuestionsByBucket.get(bucket);
+        if (!set) {
+          set = new Set<string>();
+          authorQuestionsByBucket.set(bucket, set);
+        }
+        set.add(event.questionId);
+      }
+    }
+  }
+
+  for (const [bucket, entry] of out) {
+    entry.authorCreditDistinctQuestions = authorQuestionsByBucket.get(bucket)?.size ?? 0;
+    entry.tier = effectiveTier(
+      entry.totalPoints,
+      entry.authorCreditPoints,
+      entry.authorCreditDistinctQuestions,
+    );
+  }
+
+  return out;
+}


### PR DESCRIPTION
**Phase 3** of the mastery redesign. Spec + phased plan: `docs/thinking/MASTERY-MODEL-v2.md` (PR #1391). Follows Phase 1 (#1392) and Phase 2 (#1393); independent, branches off `main`. **Dark** — reads nothing live, writes nothing on its own; safe to merge alone.

## What's here
- **`recompute.ts`** — `recomputeMastery`: the pure projection of `(MASTERY_EVENTS × current taxonomy) → per-(user, domain) points + tier` (spec decision 1). Re-buckets by the question's current domain; falls back to the event's stored snapshot for null/unresolvable `question_id` (~12.5% of events per Phase 0). `effectiveTier` reproduces the author-credit gate. Exports a shared `masteryBucketKey` so callers/tests/script build the group key identically.
- **`reclassify-questions.ts`** — `reclassifyQuestionsByIds`: row-granular move of a chosen SET of questions (`GeneratedQuestion.canonical_subcategory`+`domain_key`, `Question.canonical_subcategory`). Touches **only** question rows — never per-user tables or `MASTERY_EVENTS`. Deliberately **not** `applyCorpusRetarget` (that dissolves a whole domain).
- **`validate-mastery-recompute.ts`** — read-only parity check against live `PLAYER_MASTERY`, with `--stored-only` to separate engine correctness from the re-bucketing policy.
- **7 unit tests** (re-bucketing, snapshot fallback, folding, author-credit gate). Typecheck + eslint clean.

## ⚠️ Key finding — validated against prod, needs a decision before any live rebuild
The engine is **correct**: in `--stored-only` mode it reproduces `PLAYER_MASTERY` (**185/212 exact**, 2 small point diffs, 23 only-in-stored = declared-but-unplayed 0-point territories).

But re-bucketing by the question's **current domain** does **not** reproduce the aggregate. It moves points from the broad **session/declared** domain a player actually engaged (e.g. "Virginia Woolf") to the question's own **finer tag** (e.g. "Mrs. Dalloway" — which appears only in the recompute at +428). `PLAYER_MASTERY` is keyed by the session domain (stored on the event); the question's own tag is often finer.

**Implication:** "mastery follows the question's current domain" is a real **policy change**, not a lossless recompute — it fragments a player's broad-domain mastery across fine sub-domains. That's only coherent once **P5 parent-coverage rollup** recombines those fine domains under their parent. So: settle this policy (and land rollup) before trusting the recompute for a live `PLAYER_MASTERY` rebuild.

## Not in scope (later phases)
Persisting a rebuild, wiring reclassify to a live admin action + recompute, dropping `edge_type` (P4), the v2 read path + leaf/parent freeze inversion (P5), flag flip (P6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)