### PR TITLE
docs: reconcile phased plan + Phase 3 finding + Phase 4 scope

### DIFF
--- a/docs/thinking/MASTERY-MODEL-v2.md
+++ b/docs/thinking/MASTERY-MODEL-v2.md
@@ -96,6 +96,96 @@ the live schema + a prod audit (0 collection edges).
   itself has a depth signal.
 - `leafBar` shape: exact function of `(depth, reachable supply)`.
 
+## Refinements from the current-code map (2026-07-04)
+
+Three parallel read-only investigations mapped the live system. Four things that
+change the plan:
+
+1. **The leaf bar is a NEW coupling.** Leaf tiers today are driven by a flat
+   constant `TIER_THRESHOLD_POINTS` (establishing 0 / familiar 100 / solid 1000 /
+   mastery 2000, `src/server/mastery/tiers.ts:4`). `KnowledgeNode.mastery_threshold`
+   feeds ONLY the parent rollup, never leaves (Phase 0: **0/77 leaves** have a
+   threshold set). So "depth sets the leaf bar" introduces depth into leaf math
+   that does not exist today — a larger change than decision #5 implied.
+2. **"Depth" is a taken word — use "weight"/"mass".** The admin tree's "N Qs" is
+   `depthByKey`, a question COUNT. The v2 depth-weight is a different quantity;
+   name it node **weight** to avoid the collision.
+3. **Seed source is Wikidata child-count / LLM, NOT Wikipedia section-count.**
+   `src/server/knowledge/wikidata.ts` explicitly forbids scraping Wikipedia's
+   graph and already provides a wired breadth proxy —
+   `getWikidataStructure(label).children.length` (P279 child count), cached, no
+   new HTTP. Seed = **Wikidata child-count first, Haiku LLM depth score fallback**
+   for non-Wikidata topics. (Revises decision #5's "section-count or LLM".)
+4. **Dropping `edge_type` is low-risk in prod but has a UI tail.** Its one
+   un-flagged live consumer is supply-depth rollup (`retrieval-demand.ts:168`),
+   which already counts substantive-only — and prod has 0 collection edges, so
+   collapsing changes no live behavior. BUT the collection-only surfaces
+   (`collectCollections`, `collectionMembersCovered`, the coverage-strip UI) must
+   be **deliberately removed**, not just filtered.
+
+Storage note (revises decision #5): prefer a **dedicated `node_weight` column**
+over overloading `mastery_threshold`, so v1 parent-bar semantics stay intact
+during v1/v2 coexistence (additive nullable migration).
+
+## Build plan (phased)
+
+Each phase is independently mergeable; risk rises with phase number; every
+irreversible step (migration, recompute, flag flip) is late and flag-gated.
+Logic (P1–P3) is proven before schema/surfaces (P4–P5).
+
+- **Phase 0 — Validation queries (no code). ✅ RAN 2026-07-04** (results below).
+- **Phase 1 — Pure v2 math** (zero DB, unit-tested): `leafProgress =
+  min(1, earned/leafBar)`, `parentCoverage = Σ(weight·leafProgress)/Σweight`,
+  mastered ≥ 0.75, `leafBar = f(depth, reachableSupply)`. Tests mirror
+  `parent-mastery.test.ts`. Wired to nothing.
+- **Phase 2 — Node weight: storage + seeding** (behind flag, no live read
+  change): add `node_weight` column (additive nullable migration); seed in
+  `createKnowledgeNode` (`knowledge-graph.ts:134`) + backfill script (model on
+  `backfill-domain-key.ts`); source Wikidata child-count → LLM fallback;
+  human-editable via the admin "bar" field extended to weight.
+- **Phase 3 — Recompute engine + reclassification writer** (script-first, behind
+  flag): rebuild `PLAYER_MASTERY` from `MASTERY_EVENTS × current taxonomy` with
+  the null-`question_id` fallback (re-bucket by the question's current domain
+  where present, else the event's stored label); validate it reproduces today's
+  aggregate before trusting. Then `reclassifyQuestionsByIds` (updates only the 3
+  question columns, never per-user tables) + a `reclassify_questions` admin action
+  off the `list_questions` panel.
+- **Phase 4 — Drop `edge_type` / single-parent tree** (schema migration): remove
+  edge-type branches (`graph.ts:124/152/202/316/353`,
+  `knowledge-tree.ts:149/281/333`), deliberately remove collection-only UI, drop
+  the column + update the `instrumentation.ts:376` boot guard. Decide
+  single-parent enforcement here.
+- **Phase 5 — Wire v2 into read surfaces** (behind `KNOWLEDGE_MASTERY_V2`, v1
+  default): replace the inline parent calc (`knowledge-tree.ts:212`) with v2
+  coverage; leaf progress uses the depth-capped bar; **invert the freeze** (freeze
+  the leaf, compute the parent live); retire/repurpose `KnowledgeParentMastery`.
+- **Phase 6 — Flip + backfill + validate**: backfill weights (P2), run recompute
+  (P3), decide leaf-freeze grandfather backfill, flip flag preview→prod, verify no
+  lost leaf mastery.
+
+### Phase 0 results (prod, 2026-07-04)
+
+- **Seeding is tiny.** 113 nodes: 26 parents (all have a threshold), **77 leaves
+  (0 have one)**, 10 "both" (1 set). Node-weight seeding ≈ 113 Wikidata/LLM calls,
+  ~86 starting from nothing — cheap, cacheable. Confirms refinement #1.
+- **Recompute feasible; ~12.5% of events need the label fallback.** 1,345
+  `MASTERY_EVENTS`: 1,177 (87.5%) carry a `question_id` → re-bucketable by current
+  domain; 168 (12.5%) are null-`question_id` → fall back to the event's stored
+  label (72 `domain_merged` bookkeeping, inherently label-only; 96 bot/
+  personal-daily `live_correct`/`catchup_correct` with `questionId:null`). Small,
+  clear rule.
+- **Almost nobody is near mastery — migration blast radius is near-zero.** 212
+  `PLAYER_MASTERY` rows: 138 establishing, 73 familiar, **1 solid, 0 mastery**
+  (max 1,396, avg 101 vs the 1000/2000 bars). The P6 grandfather concern is nearly
+  moot (no high-tier players to protect) — but v2 bars need calibrating for this
+  scale or "mastery" stays unreachable.
+- **Reclassification earns its keep, bounded.** Of 1,257 bank questions, **111
+  (~8.8%)** are tagged at a node that IS a parent (has children) → candidates to
+  push into a child. Real, not a backlog. (35 parent keys, 89 child keys across
+  the 84 edges.)
+
+Net: nothing in Phase 0 blocks the plan.
+
 ## Migration / supersession
 
 - **Revises `parent-mastery.ts`.** The terminal parent-freeze ledger

--- a/docs/thinking/MASTERY-MODEL-v2.md
+++ b/docs/thinking/MASTERY-MODEL-v2.md
@@ -134,16 +134,16 @@ irreversible step (migration, recompute, flag flip) is late and flag-gated.
 Logic (P1–P3) is proven before schema/surfaces (P4–P5).
 
 - **Phase 0 — Validation queries (no code). ✅ RAN 2026-07-04** (results below).
-- **Phase 1 — Pure v2 math** (zero DB, unit-tested): `leafProgress =
+- **Phase 1 — Pure v2 math** ✅ SHIPPED (PR #1392) (zero DB, unit-tested): `leafProgress =
   min(1, earned/leafBar)`, `parentCoverage = Σ(weight·leafProgress)/Σweight`,
   mastered ≥ 0.75, `leafBar = f(depth, reachableSupply)`. Tests mirror
   `parent-mastery.test.ts`. Wired to nothing.
-- **Phase 2 — Node weight: storage + seeding** (behind flag, no live read
+- **Phase 2 — Node weight: storage + seeding** ✅ SHIPPED (PR #1393; migration 0109; backfill applied to all 113 nodes 2026-07-04) (behind flag, no live read
   change): add `node_weight` column (additive nullable migration); seed in
   `createKnowledgeNode` (`knowledge-graph.ts:134`) + backfill script (model on
   `backfill-domain-key.ts`); source Wikidata child-count → LLM fallback;
   human-editable via the admin "bar" field extended to weight.
-- **Phase 3 — Recompute engine + reclassification writer** (script-first, behind
+- **Phase 3 — Recompute engine + reclassification writer** ✅ SHIPPED (PR #1394; engine + `reclassifyQuestionsByIds` + validator — see the **Phase 3 finding** below) (script-first, behind
   flag): rebuild `PLAYER_MASTERY` from `MASTERY_EVENTS × current taxonomy` with
   the null-`question_id` fallback (re-bucket by the question's current domain
   where present, else the event's stored label); validate it reproduces today's
@@ -185,6 +185,74 @@ Logic (P1–P3) is proven before schema/surfaces (P4–P5).
   the 84 edges.)
 
 Net: nothing in Phase 0 blocks the plan.
+
+### Phase 3 finding (prod, 2026-07-04): the recompute POLICY is not lossless
+
+Validating `recomputeMastery` against live `PLAYER_MASTERY`
+(`scripts/validate-mastery-recompute.ts`) surfaced a decision that GATES the live
+rebuild:
+
+- **The engine is correct.** In `--stored-only` mode (bucket by the event's stored
+  snapshot) it reproduces `PLAYER_MASTERY`: **185/212 exact**, 2 small point diffs,
+  23 only-in-stored (declared-but-unplayed 0-point territories).
+- **But re-bucketing by the question's CURRENT domain does NOT reproduce it.**
+  `PLAYER_MASTERY` is keyed by the **session/declared** domain a player engaged
+  (e.g. "Virginia Woolf"); individual questions carry **finer own tags** (a "Mrs.
+  Dalloway" question served under a Woolf session). Recomputing by question-domain
+  moves those points out of Woolf into Mrs. Dalloway (+428 in one case).
+
+**Consequence:** "mastery follows the question's current domain" (decision 1's
+re-bucketing) is a real POLICY change, not a lossless recompute — it **fragments**
+a player's broad-domain mastery across fine sub-domains. It is only coherent once
+**P5 parent-coverage rollup** recombines those fine domains under their parent.
+**Do not run a live rebuild until (a) this policy is chosen and (b) rollup lands.**
+Open decision: mastery follows the question's own tag (needs rollup) vs. the
+session domain (reproduces today, but then reclassification can't re-home
+already-earned points — the whole reason for the recompute).
+
+## Phase 4 scope — drop `edge_type` / single-parent tree
+
+Prereq confirmed: **0 collection edges in prod** (audit 2026-07-03), so the DATA
+change is free; the risk is code/UI surface, not data. Re-confirm the 0-count at
+migration time.
+
+**A. Simplify pure branches** (each becomes a no-op filter once every edge is
+substantive): `graph.ts` `substantiveAncestors` (:124), `substantiveDescendants`
+(:152), `litCorners` (:202), `rosterCoverage` (:316), `collectionMembersCovered`
+(:353); `knowledge-tree.ts` home-parent containment (:149), grow-rim collection
+exclusion (:281), `collectCollections` (:333).
+
+**B. Remove collection-only surfaces** (no substantive equivalent — DELETE, don't
+just filter): `graph.ts` `collectionCoverage` / `collectionMembersCovered` /
+`collectCollections`; the `collections` array in `knowledge-tree.ts`; the
+`collections` prop + coverage-strip render in
+`components/knowledge/KnowledgeBubbleMap.tsx`.
+
+**C. Schema / DDL** (migration 0110): `ALTER TABLE "KnowledgeEdge" DROP COLUMN
+"edge_type"` + drop the CHECK; remove `edgeType` from `schema.ts:850`; remove the
+`edge_type IN (...)` from the `instrumentation.ts:376` boot-guard CREATE TABLE.
+
+**D. Admin write layer**: `knowledge-graph.ts` `EdgeType` type (:15) + hardcoded
+`edgeType: 'substantive'` on attach/ratify (:388/:450/:531); `route.ts`
+`edgeTypeSchema` + edge create/ratify inputs; `KnowledgeAdminClient.tsx` edge-type
+picker + ratify buttons (:1429/:1496-1514/:1881/:1924/:1934/:1981).
+
+**E. The one LIVE consumer — verify no-op**: supply-depth rollup
+`getDurablePoolDepthForDomains` (`retrieval-demand.ts:168`) already counts
+substantive-only; with 0 collection edges, dropping the type changes nothing.
+
+**F. Single-parent enforcement — the open decision.** The spec wants a
+single-parent containment tree so "parent = sum of its leaves" doesn't
+double-count a shared leaf. Options: (1) enforce now — unique constraint on
+`child_domain_key` + a migration to resolve existing multi-parent leaves; (2)
+defer — drop only `edge_type` now, keep multi-parent, tackle single-parent in P5.
+**Phase-4-0 query RAN (prod, 2026-07-04): only 1 of 91 children has >1 parent**
+(max 2) — so enforcing single-parent now is nearly free (resolve one leaf +
+add the unique constraint). Recommend option (1).
+
+**Sequencing (within P4):** code first (stop reading `edge_type`: A+B+D), THEN the
+migration (C), so no deploy window reads a dropped column. Low data risk; the real
+work is deleting the collection-coverage UI cleanly + the single-parent call.
 
 ## Migration / supersession
 


### PR DESCRIPTION
Doc-only follow-up to `docs/thinking/MASTERY-MODEL-v2.md`. No code.

## Why this reconciles main
The phased build plan + Phase 0 results were **stranded**: PR #1391 merged at the original spec commit *before* those additions were pushed to its branch. This cherry-picks them back onto main, so the doc is whole again — then adds the new material.

## What's added
- **P1/P2/P3 marked SHIPPED** (PRs #1392 / #1393 / #1394; migration `0109` + node weights backfilled to all 113 nodes on 2026-07-04).
- **Phase 3 finding** (validated against prod): the recompute engine is *correct* (reproduces `PLAYER_MASTERY` in `--stored-only` mode, 185/212 exact), but re-bucketing by the question's **current domain** is a **policy change, not a lossless recompute** — it fragments broad-domain mastery (Virginia Woolf → Mrs. Dalloway). Gated on P5 rollup; the open decision is written down.
- **Phase 4 scope** (drop `edge_type`): full blast radius (pure-branch simplifications, the collection-only UI to delete, DDL/migration, admin layer), the single **live** consumer to re-verify, and the single-parent decision — with the **Phase-4-0 query result** (only **1 of 91** children is multi-parent → enforcing single-parent is nearly free; recommend doing it in P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)