### PR TITLE
feat(knowledge): mastery v2 Phase 4 — drop KnowledgeEdge.edge_type

### DIFF
--- a/drizzle/0110_drop_knowledge_edge_type.sql
+++ b/drizzle/0110_drop_knowledge_edge_type.sql
@@ -1,0 +1,8 @@
+-- 0110: drop KnowledgeEdge.edge_type. The substantive/collection distinction is
+-- removed (docs/thinking/MASTERY-MODEL-v2.md, Phase 4) — every containment edge
+-- is now depth-eligible credit. Prod had 0 collection edges (audit 2026-07-03),
+-- so no existing edge is reinterpreted. The application stops reading the column
+-- as of this change (graph.ts / knowledge-tree.ts / knowledge-graph.ts).
+-- Rollback: ALTER TABLE "KnowledgeEdge" ADD COLUMN "edge_type" text NOT NULL
+--   DEFAULT 'substantive'; (every existing edge was substantive).
+ALTER TABLE "KnowledgeEdge" DROP COLUMN IF EXISTS "edge_type";

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -771,6 +771,13 @@
       "when": 1785974400000,
       "tag": "0109_knowledge_node_weight",
       "breakpoints": true
+    },
+    {
+      "idx": 110,
+      "version": "7",
+      "when": 1786060800000,
+      "tag": "0110_drop_knowledge_edge_type",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -23,7 +23,6 @@ import { AdminTabs } from '@/app/admin/AdminTabs';
 // human act (D-doc §4); the collision path surfaces the existing node instead
 // of minting a sibling — the whole model exists to kill that failure mode.
 
-const EDGE_TYPES = ['substantive', 'collection'] as const;
 
 async function post(body: Record<string, unknown>): Promise<{
   ok: boolean;
@@ -142,10 +141,9 @@ function KnowledgeTreeEditor({
   const { childrenByParent, parentCountByChild, parentsByChild, roots, descendantsOf } = useMemo(() => {
     const childrenByParent = new Map<string, string[]>();
     const parentCountByChild = new Map<string, number>();
-    // All substantive parents per child — powers the "in N trees" jump list.
+    // All parents per child — powers the "in N trees" jump list.
     const parentsByChild = new Map<string, string[]>();
     for (const edge of edges) {
-      if (edge.edgeType !== 'substantive') continue;
       if (!nodeByKey.has(edge.childDomainKey) || !nodeByKey.has(edge.parentDomainKey)) continue;
       const list = childrenByParent.get(edge.parentDomainKey);
       if (list) list.push(edge.childDomainKey);
@@ -1426,7 +1424,7 @@ function ParentSuggestions({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [childLabel]);
 
-  async function ratify(proposal: ParentProposal, edgeType: (typeof EDGE_TYPES)[number]) {
+  async function ratify(proposal: ParentProposal) {
     if (pendingKey) return;
     setPendingKey(proposal.parentDomainKey);
     setError(null);
@@ -1435,7 +1433,6 @@ function ParentSuggestions({
       childDomainKey: childKey,
       parentLabel: proposal.label,
       parentBroadCategory: proposal.broadCategory,
-      edgeType,
       wikidataQid: proposal.qid,
     });
     setPendingKey(null);
@@ -1493,27 +1490,16 @@ function ParentSuggestions({
                 <span className="text-muted-foreground min-w-0 truncate text-xs">{p.description}</span>
               ) : null}
               <span className="ml-auto flex shrink-0 items-center gap-1">
-                {EDGE_TYPES.map((edgeType) => (
-                  <button
-                    key={edgeType}
-                    type="button"
-                    disabled={pendingKey !== null}
-                    onClick={() => void ratify(p, edgeType)}
-                    className="inline-flex min-h-7 items-center rounded-md border px-2 text-xs font-medium disabled:opacity-40"
-                    style={
-                      edgeType === 'substantive'
-                        ? { borderColor: 'var(--success)', color: 'var(--success)' }
-                        : { borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }
-                    }
-                    title={
-                      edgeType === 'substantive'
-                        ? 'Ratify: understanding this child teaches you about the parent (depth counts)'
-                        : 'Ratify as coverage-only grouping'
-                    }
-                  >
-                    {pendingKey === p.parentDomainKey ? '…' : `Ratify ${edgeType}`}
-                  </button>
-                ))}
+                <button
+                  type="button"
+                  disabled={pendingKey !== null}
+                  onClick={() => void ratify(p)}
+                  className="inline-flex min-h-7 items-center rounded-md border px-2 text-xs font-medium disabled:opacity-40"
+                  style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
+                  title="Ratify: draw the containment edge under this parent"
+                >
+                  {pendingKey === p.parentDomainKey ? '…' : 'Ratify'}
+                </button>
                 <button
                   type="button"
                   disabled={pendingKey !== null}
@@ -1878,12 +1864,10 @@ function OrphanCheck({
   const substantiveParentsOfChild = new Map<string, number>();
   for (const edge of edges) {
     childrenOfParent.set(edge.parentDomainKey, (childrenOfParent.get(edge.parentDomainKey) ?? 0) + 1);
-    if (edge.edgeType === 'substantive') {
-      substantiveParentsOfChild.set(
-        edge.childDomainKey,
-        (substantiveParentsOfChild.get(edge.childDomainKey) ?? 0) + 1,
-      );
-    }
+    substantiveParentsOfChild.set(
+      edge.childDomainKey,
+      (substantiveParentsOfChild.get(edge.childDomainKey) ?? 0) + 1,
+    );
   }
   const orphanLeaves = nodes.filter(
     (n) => n.nodeKind !== 'parent' && !substantiveParentsOfChild.has(n.domainKey),
@@ -1921,7 +1905,6 @@ function OrphanCheck({
 function EdgeComposer({ nodes, onDone }: { nodes: KnowledgeNodeRow[]; onDone: () => void }) {
   const [childKey, setChildKey] = useState('');
   const [parentKey, setParentKey] = useState('');
-  const [edgeType, setEdgeType] = useState<(typeof EDGE_TYPES)[number]>('substantive');
   const [pending, setPending] = useState(false);
   const [notice, setNotice] = useState<string | null>(null);
 
@@ -1931,7 +1914,7 @@ function EdgeComposer({ nodes, onDone }: { nodes: KnowledgeNodeRow[]; onDone: ()
     if (pending || !childKey || !parentKey) return;
     setPending(true);
     setNotice(null);
-    const res = await post({ action: 'create_edge', childDomainKey: childKey, parentDomainKey: parentKey, edgeType });
+    const res = await post({ action: 'create_edge', childDomainKey: childKey, parentDomainKey: parentKey });
     setPending(false);
     if (!res.ok) {
       setNotice(
@@ -1976,16 +1959,6 @@ function EdgeComposer({ nodes, onDone }: { nodes: KnowledgeNodeRow[]; onDone: ()
             ))}
           </select>
         </label>
-        <label className="flex flex-col gap-1">
-          <span className="text-muted-foreground text-[0.7rem] uppercase tracking-[0.06em]">Type</span>
-          <select value={edgeType} onChange={(e) => setEdgeType(e.target.value as (typeof EDGE_TYPES)[number])} className={fieldClass}>
-            {EDGE_TYPES.map((t) => (
-              <option key={t} value={t}>
-                {t}
-              </option>
-            ))}
-          </select>
-        </label>
         <button
           type="button"
           onClick={() => void submit()}
@@ -1996,10 +1969,6 @@ function EdgeComposer({ nodes, onDone }: { nodes: KnowledgeNodeRow[]; onDone: ()
           {pending ? 'Drawing…' : 'Draw edge'}
         </button>
       </div>
-      <p className="text-muted-foreground mt-1.5 text-[0.7rem]">
-        substantive = depth counts toward understanding the parent · collection = each member covered
-        lights one slot.
-      </p>
       {/* ADMIN P2 — the impact preview: the §B guarantee stated to the author
           before the commit, with the actual names in it. */}
       {childKey && parentKey && childKey !== parentKey ? (

--- a/src/app/api/admin/knowledge/__tests__/route.test.ts
+++ b/src/app/api/admin/knowledge/__tests__/route.test.ts
@@ -152,25 +152,24 @@ describe('POST /api/admin/knowledge', () => {
     expect(body.existing?.label).toBe('Renaissance Italy'); // surfaced, offer edit
   });
 
-  it('creates a typed edge', async () => {
+  it('creates an edge', async () => {
     const res = await post({
       action: 'create_edge',
       childDomainKey: 'medici family',
       parentDomainKey: 'renaissance italy',
-      edgeType: 'substantive',
     });
     expect(res.status).toBe(201);
     expect(createEdgeMock).toHaveBeenCalledWith(
-      { childDomainKey: 'medici family', parentDomainKey: 'renaissance italy', edgeType: 'substantive' },
+      { childDomainKey: 'medici family', parentDomainKey: 'renaissance italy' },
       'admin-1',
     );
   });
 
   it('maps self-edge to 400 and duplicate to 409', async () => {
     createEdgeMock.mockResolvedValueOnce({ ok: false, reason: 'self_edge' });
-    expect((await post({ action: 'create_edge', childDomainKey: 'x', parentDomainKey: 'x', edgeType: 'substantive' })).status).toBe(400);
+    expect((await post({ action: 'create_edge', childDomainKey: 'x', parentDomainKey: 'x' })).status).toBe(400);
     createEdgeMock.mockResolvedValueOnce({ ok: false, reason: 'duplicate' });
-    expect((await post({ action: 'create_edge', childDomainKey: 'a', parentDomainKey: 'b', edgeType: 'collection' })).status).toBe(409);
+    expect((await post({ action: 'create_edge', childDomainKey: 'a', parentDomainKey: 'b' })).status).toBe(409);
   });
 
   it('deletes exactly one edge pair', async () => {
@@ -180,12 +179,6 @@ describe('POST /api/admin/knowledge', () => {
       { childDomainKey: 'medici family', parentDomainKey: 'renaissance italy' },
       'admin-1',
     );
-  });
-
-  it('rejects an invalid edge type', async () => {
-    const res = await post({ action: 'create_edge', childDomainKey: 'a', parentDomainKey: 'b', edgeType: 'friendly' });
-    expect(res.status).toBe(400);
-    expect(createEdgeMock).not.toHaveBeenCalled();
   });
 
   // ─── ADMIN P3: the two-source proposal queue (Wikidata primary, LLM secondary) ───
@@ -375,18 +368,17 @@ describe('POST /api/admin/knowledge', () => {
     expect(proposeStructureMock).not.toHaveBeenCalled();
   });
 
-  it('ratify creates exactly one edge with the HUMAN-chosen edge type', async () => {
+  it('ratify creates exactly one containment edge', async () => {
     const res = await post({
       action: 'ratify',
       childDomainKey: 'medici family',
       parentLabel: 'Renaissance Italy',
       parentBroadCategory: 'History',
-      edgeType: 'collection',
     });
     expect(res.status).toBe(201);
     expect(ratifyMock).toHaveBeenCalledTimes(1);
     expect(ratifyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ edgeType: 'collection', parentLabel: 'Renaissance Italy' }),
+      expect.objectContaining({ parentLabel: 'Renaissance Italy' }),
       'admin-1',
     );
   });
@@ -396,12 +388,11 @@ describe('POST /api/admin/knowledge', () => {
       action: 'ratify',
       childDomainKey: 'medici family',
       parentLabel: 'Italian Renaissance',
-      edgeType: 'substantive',
       wikidataQid: 'Q4692',
     });
     expect(res.status).toBe(201);
     expect(ratifyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ wikidataQid: 'Q4692', edgeType: 'substantive' }),
+      expect.objectContaining({ wikidataQid: 'Q4692' }),
       'admin-1',
     );
   });
@@ -411,7 +402,6 @@ describe('POST /api/admin/knowledge', () => {
       action: 'ratify',
       childDomainKey: 'medici family',
       parentLabel: 'Italian Renaissance',
-      edgeType: 'substantive',
       wikidataQid: 'not-a-qid',
     });
     expect(res.status).toBe(400);

--- a/src/app/api/admin/knowledge/route.ts
+++ b/src/app/api/admin/knowledge/route.ts
@@ -28,7 +28,6 @@ export const dynamic = 'force-dynamic';
 // surface it and offer edit instead (the anti-fragmentation tripwire).
 
 const nodeKindSchema = z.enum(['leaf', 'parent', 'both']);
-const edgeTypeSchema = z.enum(['substantive', 'collection']);
 const keySchema = z.string().trim().min(1).max(160);
 
 const bodySchema = z.discriminatedUnion('action', [
@@ -55,7 +54,6 @@ const bodySchema = z.discriminatedUnion('action', [
     action: z.literal('create_edge'),
     childDomainKey: keySchema,
     parentDomainKey: keySchema,
-    edgeType: edgeTypeSchema,
   }),
   z.object({
     action: z.literal('delete_edge'),
@@ -69,15 +67,13 @@ const bodySchema = z.discriminatedUnion('action', [
   // a human ratifies.
   z.object({ action: z.literal('propose'), childLabel: z.string().trim().min(1).max(120) }),
   // P3: the human commit. Creates the parent node if it doesn't exist yet
-  // (part of the deliberate ratify act, §4) and draws the typed edge. The
-  // human always picks the edge type — Wikidata's is-a is a hint, not a
-  // verdict. wikidataQid present ⇒ stored on the parent node for provenance.
+  // (part of the deliberate ratify act, §4) and draws the containment edge.
+  // wikidataQid present ⇒ stored on the parent node for provenance.
   z.object({
     action: z.literal('ratify'),
     childDomainKey: keySchema,
     parentLabel: z.string().trim().min(1).max(120),
     parentBroadCategory: z.string().trim().max(80).nullable().optional(),
-    edgeType: edgeTypeSchema,
     wikidataQid: z.string().regex(/^Q\d+$/).nullable().optional(),
   }),
   // Tree-editor verb: attach child under parent — MOVE when moveFrom present
@@ -176,7 +172,6 @@ export async function POST(request: NextRequest) {
         {
           childDomainKey: data.childDomainKey,
           parentDomainKey: data.parentDomainKey,
-          edgeType: data.edgeType,
         },
         session.userId,
       );
@@ -353,7 +348,6 @@ export async function POST(request: NextRequest) {
           childDomainKey: data.childDomainKey,
           parentLabel: data.parentLabel,
           parentBroadCategory: data.parentBroadCategory ?? null,
-          edgeType: data.edgeType,
           wikidataQid: data.wikidataQid ?? null,
         },
         session.userId,

--- a/src/app/knowledge/KnowledgeBubblePage.tsx
+++ b/src/app/knowledge/KnowledgeBubblePage.tsx
@@ -29,7 +29,7 @@ export async function KnowledgeBubblePage() {
   const session = await getSession();
   if (!session) redirect('/login');
 
-  const [{ tree, collections, ownedDomains }, [user]] = await Promise.all([
+  const [{ tree, ownedDomains }, [user]] = await Promise.all([
     getKnowledgeMapData(session.userId),
     db
       .select({ displayName: users.displayName })
@@ -63,7 +63,7 @@ export async function KnowledgeBubblePage() {
           existingLabels={sorted.map((d) => d.displayName)}
         />
       </header>
-      <KnowledgeBubbleMap data={tree} collections={collections} />
+      <KnowledgeBubbleMap data={tree} />
     </main>
   );
 }

--- a/src/app/users/[id]/knowledge/page.tsx
+++ b/src/app/users/[id]/knowledge/page.tsx
@@ -144,7 +144,6 @@ export default async function FriendKnowledgePage({
             <div className="flex h-[60vh] min-h-80 flex-col">
               <KnowledgeBubbleMap
                 data={mapData.tree}
-                collections={mapData.collections}
                 variant="friend"
                 rootTitle={`${friendFirstName}'s peaks`}
               />

--- a/src/components/knowledge/KnowledgeBubbleMap.tsx
+++ b/src/components/knowledge/KnowledgeBubbleMap.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 import { ArrowUp } from 'lucide-react';
 import { hierarchy, pack, type HierarchyCircularNode } from 'd3-hierarchy';
 
-import type { CollectionSummary, KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
+import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import { KnowledgeNodeCard, type SelectedNodeInfo } from '@/components/knowledge/KnowledgeNodeCard';
 
 // B-KNOWLEDGE-TAXONOMY-01 P5 — the nested circle-pack knowledge map, ported
@@ -111,14 +111,12 @@ function buildListSections(tree: KnowledgeTreeNode): ListSection[] {
 
 export function KnowledgeBubbleMap({
   data,
-  collections = [],
   // 'own' = interactive (adds allowed via the card); 'friend' = read-only
   // portrait — the tree carries no ghosts, and the card hides every mutation.
   variant = 'own',
   rootTitle = 'Your peaks',
 }: {
   data: KnowledgeTreeNode;
-  collections?: CollectionSummary[];
   variant?: 'own' | 'friend';
   rootTitle?: string;
 }) {
@@ -579,23 +577,6 @@ export function KnowledgeBubbleMap({
           ))}
         </div>
       )}
-
-      {/* Collection parents (§7) are coverage, not containers — they live in a
-          strip, never in the pack. "You've covered N of M" is the honest voice. */}
-      {collections.length > 0 ? (
-        <div className="flex gap-2 overflow-x-auto py-1.5" role="list" aria-label="Collections covered">
-          {collections.map((c) => (
-            <span
-              key={c.label}
-              role="listitem"
-              className="flex-none whitespace-nowrap rounded-full border px-3 py-1 text-[11px]"
-              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)', background: 'var(--brand-card)' }}
-            >
-              {c.label} · {c.covered} of {c.rosterSize} covered
-            </span>
-          ))}
-        </div>
-      ) : null}
 
       <p className="min-h-5 pt-1.5 text-center font-serif text-[11px] italic text-[var(--text-muted)]" aria-live="polite">
         {!listMode ? hint : ''}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -378,7 +378,6 @@ export async function register() {
           "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
           "child_domain_key" text NOT NULL,
           "parent_domain_key" text NOT NULL,
-          "edge_type" text NOT NULL CHECK ("edge_type" IN ('substantive', 'collection')),
           "created_at" timestamp with time zone NOT NULL DEFAULT now()
         )
       `);

--- a/src/server/db/queries/knowledge-graph.ts
+++ b/src/server/db/queries/knowledge-graph.ts
@@ -12,7 +12,6 @@ import { domainKey } from '@/lib/knowledge/domain-key';
 // existing node must surface that node, never mint a sibling.
 
 export type NodeKind = 'leaf' | 'parent' | 'both';
-export type EdgeType = 'substantive' | 'collection';
 
 export type KnowledgeNodeRow = typeof knowledgeNodes.$inferSelect;
 export type KnowledgeEdgeRow = typeof knowledgeEdges.$inferSelect;
@@ -250,7 +249,7 @@ export type EdgeResult =
   | { ok: false; reason: 'self_edge' | 'unknown_node' | 'duplicate' | 'not_found' };
 
 export async function createKnowledgeEdge(
-  input: { childDomainKey: string; parentDomainKey: string; edgeType: EdgeType },
+  input: { childDomainKey: string; parentDomainKey: string },
   actorUserId: string,
 ): Promise<EdgeResult> {
   if (input.childDomainKey === input.parentDomainKey) {
@@ -287,7 +286,6 @@ export async function ratifyProposedParent(
     childDomainKey: string;
     parentLabel: string;
     parentBroadCategory: string | null;
-    edgeType: EdgeType;
     /** Present when the proposal came from Wikidata — stored on the parent node for provenance/re-query. */
     wikidataQid?: string | null;
   },
@@ -329,7 +327,7 @@ export async function ratifyProposedParent(
   }
 
   return createKnowledgeEdge(
-    { childDomainKey: input.childDomainKey, parentDomainKey: parentKey, edgeType: input.edgeType },
+    { childDomainKey: input.childDomainKey, parentDomainKey: parentKey },
     actorUserId,
   );
 }
@@ -389,7 +387,6 @@ export async function invertKnowledgeEdge(
     {
       childDomainKey: input.parentDomainKey,
       parentDomainKey: input.childDomainKey,
-      edgeType: 'substantive',
     },
     actorUserId,
   );
@@ -425,12 +422,10 @@ export async function attachChild(
     .select({
       childDomainKey: knowledgeEdges.childDomainKey,
       parentDomainKey: knowledgeEdges.parentDomainKey,
-      edgeType: knowledgeEdges.edgeType,
     })
     .from(knowledgeEdges);
   const childrenByParent = new Map<string, string[]>();
   for (const edge of allEdges) {
-    if (edge.edgeType !== 'substantive') continue;
     const list = childrenByParent.get(edge.parentDomainKey);
     if (list) list.push(edge.childDomainKey);
     else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
@@ -451,7 +446,6 @@ export async function attachChild(
     {
       childDomainKey: input.childDomainKey,
       parentDomainKey: input.toParentDomainKey,
-      edgeType: 'substantive',
     },
     actorUserId,
   );
@@ -532,7 +526,7 @@ export async function ratifyStructureGroup(
     const childKey = await ensureNode(childLabel, 'leaf', null, input.broadCategory);
     if (childKey === parentKey) continue;
     const edge = await createKnowledgeEdge(
-      { childDomainKey: childKey, parentDomainKey: parentKey, edgeType: 'substantive' },
+      { childDomainKey: childKey, parentDomainKey: parentKey },
       actorUserId,
     );
     if (edge.ok) edgesCreated += 1; // duplicates are fine — already ratified

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -841,19 +841,18 @@ export const knowledgeNodes = pgTable(
   (table) => [uniqueIndex('KnowledgeNode_domain_key_key').on(table.domainKey)],
 );
 
-// Typed child→parent membership (§7): 'substantive' = depth-eligible credit
-// (you understand the subject); 'collection' = coverage-only (you've covered
-// the set). A leaf may have many parents. Deliberately SEPARATE from
-// DomainRelation above — that is the serving-side near-ness cache keyed on raw
-// canonical_subcategory strings; this is the authored taxonomy keyed on
-// domainKey. Keyed by domain_key, not node id, so edges survive label edits.
+// Child→parent containment membership. Every edge is depth-eligible credit
+// (you understand the subject) — the substantive/collection distinction was
+// dropped 2026-07-04 (migration 0110; prod had 0 collection edges). Deliberately
+// SEPARATE from DomainRelation above — that is the serving-side near-ness cache
+// keyed on raw canonical_subcategory strings; this is the authored taxonomy keyed
+// on domainKey. Keyed by domain_key, not node id, so edges survive label edits.
 export const knowledgeEdges = pgTable(
   'KnowledgeEdge',
   {
     id: id(),
     childDomainKey: text('child_domain_key').notNull(),
     parentDomainKey: text('parent_domain_key').notNull(),
-    edgeType: text('edge_type').$type<'substantive' | 'collection'>().notNull(),
     createdAt: createdAt(),
   },
   (table) => [

--- a/src/server/knowledge/__tests__/graph.test.ts
+++ b/src/server/knowledge/__tests__/graph.test.ts
@@ -15,12 +15,6 @@ type Edge = import('@/server/knowledge/graph').GraphEdge;
 const sub = (child: string, parent: string): Edge => ({
   childDomainKey: child,
   parentDomainKey: parent,
-  edgeType: 'substantive',
-});
-const col = (child: string, parent: string): Edge => ({
-  childDomainKey: child,
-  parentDomainKey: parent,
-  edgeType: 'collection',
 });
 
 // D-doc §2 world: Renaissance Italy's roster.
@@ -65,11 +59,6 @@ describe('rollUpCredit — §5.1 points are points', () => {
     expect(totals.get('shakespeare')).toBe(300); // once — not 600
   });
 
-  it('collection edges never carry points', () => {
-    const edges: Edge[] = [col('hamlet', 'plays starting with h')];
-    const totals = mod.rollUpCredit(new Map([['hamlet', 2500]]), edges);
-    expect(totals.get('plays starting with h')).toBeUndefined();
-  });
 });
 
 describe('parentProgress — §9-A revised (threshold bar + ≥2-corner gate)', () => {
@@ -224,8 +213,8 @@ describe('buildClusterMatcher — P6 Beat 4 cluster overlap (the Josh/Ari fix)',
       ['renaissance italy', 'Renaissance Italy'],
     ]),
     edges: [
-      { childDomainKey: 'medici family', parentDomainKey: 'renaissance italy', edgeType: 'substantive' as const },
-      { childDomainKey: 'renaissance florence', parentDomainKey: 'renaissance italy', edgeType: 'substantive' as const },
+      { childDomainKey: 'medici family', parentDomainKey: 'renaissance italy' },
+      { childDomainKey: 'renaissance florence', parentDomainKey: 'renaissance italy' },
     ],
   };
 
@@ -250,53 +239,6 @@ describe('buildClusterMatcher — P6 Beat 4 cluster overlap (the Josh/Ari fix)',
     expect(noGraph('Chess')).toBeNull();
   });
 
-  it('collection edges never create alignment', () => {
-    const ctx = {
-      nodeKeys: new Set(['hamlet', 'plays starting with h', 'henry v']),
-      labelByKey: new Map([['plays starting with h', 'Plays Starting With H']]),
-      edges: [
-        { childDomainKey: 'hamlet', parentDomainKey: 'plays starting with h', edgeType: 'collection' as const },
-        { childDomainKey: 'henry v', parentDomainKey: 'plays starting with h', edgeType: 'collection' as const },
-      ],
-    };
-    const match = mod.buildClusterMatcher(['Hamlet'], ctx);
-    expect(match('Henry V')).toBeNull(); // knowing Hamlet says nothing about Henry V (§7)
-  });
-});
-
-describe('collectionCoverage — §7 coverage-only', () => {
-  const H_SHELF: Edge[] = [
-    col('hamlet', 'plays starting with h'),
-    col('henry v', 'plays starting with h'),
-    col('hedda gabler', 'plays starting with h'),
-  ];
-
-  it('depth in one member lights exactly one slot', () => {
-    const totals = mod.rollUpCredit(new Map([['hamlet', 2500]]), H_SHELF);
-    // collection totals don't roll — coverage counts credited members directly
-    const covered = mod.collectionMembersCovered(
-      'plays starting with h',
-      new Map([['hamlet', 2500]]),
-      H_SHELF,
-    );
-    expect(covered).toBe(1);
-    expect(mod.collectionCoverage(covered, 3).pct).toBeCloseTo(1 / 3);
-    expect(totals.get('plays starting with h')).toBeUndefined();
-  });
-
-  it('covering all members completes the set', () => {
-    const credits = new Map([
-      ['hamlet', 10],
-      ['henry v', 10],
-      ['hedda gabler', 10],
-    ]);
-    const covered = mod.collectionMembersCovered('plays starting with h', credits, H_SHELF);
-    expect(mod.collectionCoverage(covered, 3).pct).toBe(1);
-  });
-
-  it('empty roster yields zero, not NaN', () => {
-    expect(mod.collectionCoverage(0, 0).pct).toBe(0);
-  });
 });
 
 describe('substantiveDescendants — B-SUPPLY-GRAPH-DEPTH-01 (supply depth walk)', () => {
@@ -310,13 +252,6 @@ describe('substantiveDescendants — B-SUPPLY-GRAPH-DEPTH-01 (supply depth walk)
     expect(descendants.has('cosimo de medici')).toBe(true); // grandchild
     expect(descendants.has('renaissance italy')).toBe(false);
     expect(descendants.size).toBe(6);
-  });
-
-  it('never walks collection edges (members are coverage, not depth)', () => {
-    const edges = [sub('medici family', 'renaissance italy'), col('mona lisa', 'renaissance italy')];
-    const descendants = mod.substantiveDescendants('renaissance italy', edges);
-    expect(descendants.has('mona lisa')).toBe(false);
-    expect(descendants.size).toBe(1);
   });
 
   it('is cycle-safe and diamond-safe', () => {

--- a/src/server/knowledge/__tests__/knowledge-tree.test.ts
+++ b/src/server/knowledge/__tests__/knowledge-tree.test.ts
@@ -23,7 +23,6 @@ const node = (label: string, kind: Node['nodeKind'] = 'leaf', threshold: number 
 const sub = (child: string, parent: string): Edge => ({
   childDomainKey: child.toLowerCase(),
   parentDomainKey: parent.toLowerCase(),
-  edgeType: 'substantive',
 });
 
 const NODES: Node[] = [
@@ -196,35 +195,5 @@ describe('grow-rim — unheld same-field roots as ghost invitations', () => {
   });
 });
 
-describe('collectCollections — §7 coverage strip', () => {
-  const H_NODES = [
-    node('Plays Starting With H', 'parent', null),
-    node('Hamlet'),
-    node('Henry V'),
-    node('Hedda Gabler'),
-  ];
-  const H_EDGES: Edge[] = [
-    { childDomainKey: 'hamlet', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
-    { childDomainKey: 'henry v', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
-    { childDomainKey: 'hedda gabler', parentDomainKey: 'plays starting with h', edgeType: 'collection' },
-  ];
-
-  it('depth in one member lights exactly one slot', () => {
-    const collections = mod.collectCollections(
-      [{ domain: 'Hamlet', points: 2500, mastered: true, broadCategory: 'Literature' }],
-      H_NODES,
-      H_EDGES,
-    );
-    expect(collections).toEqual([{ label: 'Plays Starting With H', covered: 1, rosterSize: 3 }]);
-  });
-
-  it('untouched collections do not appear; collections never enter the packed tree', () => {
-    expect(mod.collectCollections(OWNED, H_NODES, H_EDGES)).toEqual([]);
-    const tree = mod.buildKnowledgeTree(
-      [{ domain: 'Hamlet', points: 2500, mastered: true, broadCategory: 'Literature' }],
-      H_NODES,
-      H_EDGES,
-    );
-    expect(findNode(tree, 'plays starting with h')).toBeNull(); // §7: not a container
-  });
-});
+// collectCollections tests removed 2026-07-04 (migration 0110): the collection
+// edge type and the coverage strip are gone.

--- a/src/server/knowledge/__tests__/parent-mastery.test.ts
+++ b/src/server/knowledge/__tests__/parent-mastery.test.ts
@@ -17,7 +17,6 @@ type Edge = import('@/server/knowledge/graph').GraphEdge;
 const sub = (child: string, parent: string): Edge => ({
   childDomainKey: child,
   parentDomainKey: parent,
-  edgeType: 'substantive',
 });
 
 const PARENT = { domainKey: 'renaissance italy', masteryThreshold: 2000 };

--- a/src/server/knowledge/graph.ts
+++ b/src/server/knowledge/graph.ts
@@ -48,7 +48,6 @@ export type KnowledgeEdgeRow = typeof knowledgeEdges.$inferSelect;
 export type GraphEdge = {
   childDomainKey: string;
   parentDomainKey: string;
-  edgeType: 'substantive' | 'collection';
 };
 
 // Human-set absolute thresholds are the rule (§5); this default only covers a
@@ -115,13 +114,13 @@ export async function resolveFinestNode(
 // ─── pure credit math (no DB — unit-tested with D-doc §2 fixtures) ───────────
 
 /**
- * All substantive ancestors of a node (transitive, cycle-safe, excludes the
- * node itself). Collection edges are not walked — they never carry points.
+ * All ancestors of a node (transitive, cycle-safe, excludes the node itself).
+ * Every containment edge carries points (the collection distinction was dropped
+ * 2026-07-04). Name kept for call-site stability.
  */
 export function substantiveAncestors(nodeKey: string, edges: readonly GraphEdge[]): Set<string> {
   const parentsByChild = new Map<string, string[]>();
   for (const edge of edges) {
-    if (edge.edgeType !== 'substantive') continue;
     const list = parentsByChild.get(edge.childDomainKey);
     if (list) list.push(edge.parentDomainKey);
     else parentsByChild.set(edge.childDomainKey, [edge.parentDomainKey]);
@@ -149,7 +148,6 @@ export function substantiveAncestors(nodeKey: string, edges: readonly GraphEdge[
 export function substantiveDescendants(nodeKey: string, edges: readonly GraphEdge[]): Set<string> {
   const childrenByParent = new Map<string, string[]>();
   for (const edge of edges) {
-    if (edge.edgeType !== 'substantive') continue;
     const list = childrenByParent.get(edge.parentDomainKey);
     if (list) list.push(edge.childDomainKey);
     else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
@@ -199,7 +197,7 @@ export function litCorners(
 ): number {
   let lit = 0;
   for (const edge of edges) {
-    if (edge.parentDomainKey !== parentKey || edge.edgeType !== 'substantive') continue;
+    if (edge.parentDomainKey !== parentKey) continue;
     if ((totals.get(edge.childDomainKey) ?? 0) > 0) lit += 1;
   }
   return lit;
@@ -286,7 +284,6 @@ export async function getClusterContext(): Promise<ClusterContext> {
       .select({
         childDomainKey: knowledgeEdges.childDomainKey,
         parentDomainKey: knowledgeEdges.parentDomainKey,
-        edgeType: knowledgeEdges.edgeType,
       })
       .from(knowledgeEdges),
   ]);
@@ -313,45 +310,12 @@ export function rosterCoverage(
   let total = 0;
   let lit = 0;
   for (const edge of edges) {
-    if (edge.parentDomainKey !== parentKey || edge.edgeType !== 'substantive') continue;
+    if (edge.parentDomainKey !== parentKey) continue;
     total += 1;
     if ((totals.get(edge.childDomainKey) ?? 0) > 0) lit += 1;
   }
   return { lit, total };
 }
 
-export type CollectionCoverage = {
-  covered: number;
-  rosterSize: number;
-  pct: number;
-};
-
-/**
- * Collection parents are pure coverage (§7/§9-A): each distinct member with
- * any credit lights one slot; depth within a member never over-credits. No
- * threshold or corner logic applies.
- */
-export function collectionCoverage(membersCovered: number, rosterSize: number): CollectionCoverage {
-  return {
-    covered: membersCovered,
-    rosterSize,
-    pct: rosterSize > 0 ? Math.min(membersCovered / rosterSize, 1) : 0,
-  };
-}
-
-/**
- * Coverage counter for a collection parent from raw totals: distinct direct
- * collection members with any credit (depth in one member still lights ONE slot).
- */
-export function collectionMembersCovered(
-  parentKey: string,
-  totals: ReadonlyMap<string, number>,
-  edges: readonly GraphEdge[],
-): number {
-  let covered = 0;
-  for (const edge of edges) {
-    if (edge.parentDomainKey !== parentKey || edge.edgeType !== 'collection') continue;
-    if ((totals.get(edge.childDomainKey) ?? 0) > 0) covered += 1;
-  }
-  return covered;
-}
+// collectionCoverage / collectionMembersCovered removed 2026-07-04 (migration
+// 0110): the collection edge type is gone, so there is no coverage-only grain.

--- a/src/server/knowledge/knowledge-tree.ts
+++ b/src/server/knowledge/knowledge-tree.ts
@@ -146,8 +146,9 @@ export function buildKnowledgeTree(
   const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
   const ownedByKey = new Map(owned.map((leaf) => [domainKey(leaf.domain), leaf]));
 
-  const substantive = edges.filter((e) => e.edgeType === 'substantive');
-  // §E home-parent: the FIRST substantive edge is the containment edge.
+  // §E home-parent: the FIRST edge is the containment edge (every edge is
+  // depth-eligible since the collection type was dropped 2026-07-04).
+  const substantive = edges;
   const homeParentByChild = new Map<string, string>();
   const homeChildrenByParent = new Map<string, string[]>();
   for (const edge of substantive) {
@@ -273,18 +274,8 @@ export function buildKnowledgeTree(
     const heldFields = new Set(
       rootChildren.map((child) => child.field).filter((f): f is string => Boolean(f)),
     );
-    // Collection-only parents never rim (§7 — a set to cover, not a territory
-    // to enter): a parent whose child edges are all collection-type.
-    const substantiveParents = new Set(substantive.map((e) => e.parentDomainKey));
-    const collectionOnlyParents = new Set(
-      edges
-        .filter((e) => e.edgeType === 'collection')
-        .map((e) => e.parentDomainKey)
-        .filter((key) => !substantiveParents.has(key)),
-    );
     const rimCandidates = [...nodeByKey.values()].filter((node) => {
       if (homeParentByChild.has(node.domainKey) || isHeld(node.domainKey)) return false;
-      if (collectionOnlyParents.has(node.domainKey)) return false;
       const field = node.fieldHue ?? hueForBroadCategory(node.broadCategory);
       return field !== null && heldFields.has(field);
     });
@@ -305,50 +296,8 @@ export function buildKnowledgeTree(
 // The rim invites, it doesn't crowd — at most this many unheld roots at home.
 export const GROW_RIM_CAP = 3;
 
-export type CollectionSummary = {
-  label: string;
-  covered: number;
-  rosterSize: number;
-};
-
-/**
- * Collection parents (§7) are NOT containers of points, so they never enter
- * the packed view — they render as a coverage strip ("You've covered 2 of 3
- * Plays Starting With 'H'"). Only collections where the player has covered at
- * least one member appear; a wall of untouched sets isn't an invitation, it's
- * noise. Pure; unit-tested.
- */
-export function collectCollections(
-  owned: readonly OwnedLeaf[],
-  nodes: readonly AuthoredNode[],
-  edges: readonly GraphEdge[],
-): CollectionSummary[] {
-  const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
-  const ownedKeys = new Set(
-    owned.filter((leaf) => leaf.points > 0).map((leaf) => domainKey(leaf.domain)),
-  );
-
-  const rosters = new Map<string, { total: number; covered: number }>();
-  for (const edge of edges) {
-    if (edge.edgeType !== 'collection') continue;
-    if (!nodeByKey.has(edge.parentDomainKey)) continue;
-    const entry = rosters.get(edge.parentDomainKey) ?? { total: 0, covered: 0 };
-    entry.total += 1;
-    // Coverage-only: any credit in a member lights ONE slot; depth never
-    // over-credits (§7).
-    if (ownedKeys.has(edge.childDomainKey)) entry.covered += 1;
-    rosters.set(edge.parentDomainKey, entry);
-  }
-
-  return [...rosters.entries()]
-    .filter(([, r]) => r.covered > 0)
-    .map(([key, r]) => ({
-      label: nodeByKey.get(key)?.label ?? key,
-      covered: r.covered,
-      rosterSize: r.total,
-    }))
-    .sort((a, b) => b.covered / b.rosterSize - a.covered / a.rosterSize);
-}
+// collectCollections / CollectionSummary removed 2026-07-04 (migration 0110):
+// the collection edge type is gone, so there is no coverage strip.
 
 /** Sum of REAL points in a subtree — ghosts excluded (unit-test hook). */
 export function sumRealPoints(node: KnowledgeTreeNode): number {
@@ -359,7 +308,6 @@ export function sumRealPoints(node: KnowledgeTreeNode): number {
 
 export type KnowledgeMapData = {
   tree: KnowledgeTreeNode;
-  collections: CollectionSummary[];
   /** The owned, visible domains behind the tree — reused for share-card props. */
   ownedDomains: Array<{
     domain: string;
@@ -403,7 +351,6 @@ export async function getKnowledgeMapData(
   const edges: GraphEdge[] = graph.edges.map((e) => ({
     childDomainKey: e.childDomainKey,
     parentDomainKey: e.parentDomainKey,
-    edgeType: e.edgeType,
   }));
 
   let frozenParents: ReadonlySet<string> = new Set();
@@ -422,7 +369,6 @@ export async function getKnowledgeMapData(
 
   return {
     tree: buildKnowledgeTree(owned, nodes, edges, frozenParents, options),
-    collections: collectCollections(owned, nodes, edges),
     ownedDomains: visible.map((d) => ({
       domain: d.domain,
       displayName: d.displayName || d.domain,


### PR DESCRIPTION
**Phase 4** of the mastery redesign. Spec: `docs/thinking/MASTERY-MODEL-v2.md`. Removes the `substantive`/`collection` edge-type distinction entirely — every containment edge is now depth-eligible credit.

## Behavior-preserving
Prod had **0 collection edges** (audit 2026-07-03), so every filter already passed all edges and every collection path already produced nothing. This is a pure simplification + column drop; **net −247 lines**.

## What changed (16 files)
- **Migration `0110`**: `DROP COLUMN edge_type` (+ journal; the `instrumentation.ts` guard no longer includes it). **Not applied** — run `npm run db:migrate` when ready. Rollback in the SQL header.
- **`schema.ts` / `graph.ts`**: `GraphEdge` loses `edgeType`; `substantiveAncestors`/`Descendants`/`litCorners`/`rosterCoverage` walk every edge; `collectionCoverage` / `collectionMembersCovered` deleted; `getClusterContext` stops selecting the column.
- **`knowledge-tree.ts`**: `substantive = all edges`; the collection-only rim exclusion and `collectCollections`/`CollectionSummary`/the map `collections` field are gone.
- **`knowledge-graph.ts` / `route.ts`**: drop the `EdgeType` type, the `edgeType` param + hardcoded `'substantive'` on create/attach/invert/ratify, the `edgeTypeSchema`, and the cycle-check filter.
- **Client**: `KnowledgeBubbleMap` drops the `collections` prop + coverage strip; both map pages stop passing it; `KnowledgeAdminClient` loses the substantive/collection picker (create-edge + ratify) and the OrphanCheck branch.

## Safety
The one **un-flagged live** consumer — supply-depth rollup (`retrieval-demand.ts`) — already counted substantive-only, so with 0 collection edges it's unaffected.

## Deferred (recorded in the spec)
**Single-parent enforcement** — the Phase-4-0 query showed only **1 of 91** children is multi-parent, so it's nearly free, but it removes an intentional capability; deferred pending your call. Dropping `edge_type` is valid independently (all edges become depth-bearing containment).

## Verification
**62 tests pass** (graph / knowledge-tree / parent-mastery / route — edge fixtures updated, collection-specific tests removed). Typecheck + eslint clean; journal in lockstep (111/111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)