### PR TITLE
feat(knowledge): mastery v2 Phase 5 infra — read-model + leaf-freeze ledger

### DIFF
--- a/drizzle/0111_knowledge_leaf_mastery.sql
+++ b/drizzle/0111_knowledge_leaf_mastery.sql
@@ -1,0 +1,16 @@
+-- 0111: KnowledgeLeafMastery — the LEAF-mastery freeze ledger (Mastery v2,
+-- docs/thinking/MASTERY-MODEL-v2.md decision 3), the grain inversion of
+-- KnowledgeParentMastery. A row = the moment a player permanently mastered a
+-- leaf; leaf mastery is terminal, while parent mastery is computed LIVE and never
+-- frozen. New + isolated; RLS-enabled with no policies (owner role bypasses RLS)
+-- per B-SECURITY-RLS-01. Dark until KNOWLEDGE_MASTERY_V2.
+-- Rollback: DROP TABLE "KnowledgeLeafMastery";
+CREATE TABLE IF NOT EXISTS "KnowledgeLeafMastery" (
+  "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+  "user_id" text NOT NULL REFERENCES "User"("id"),
+  "leaf_domain_key" text NOT NULL,
+  "mastered_at" timestamp with time zone NOT NULL DEFAULT now()
+);
+ALTER TABLE "KnowledgeLeafMastery" ENABLE ROW LEVEL SECURITY;
+CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_leaf_key" ON "KnowledgeLeafMastery" ("user_id", "leaf_domain_key");
+CREATE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_id_idx" ON "KnowledgeLeafMastery" ("user_id");

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -778,6 +778,13 @@
       "when": 1786060800000,
       "tag": "0110_drop_knowledge_edge_type",
       "breakpoints": true
+    },
+    {
+      "idx": 111,
+      "version": "7",
+      "when": 1786147200000,
+      "tag": "0111_knowledge_leaf_mastery",
+      "breakpoints": true
     }
   ]
 }

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -410,6 +410,24 @@ export async function register() {
       await db.execute(sql`
         CREATE INDEX IF NOT EXISTS "KnowledgeParentMastery_user_id_idx" ON "KnowledgeParentMastery" ("user_id")
       `);
+      // Mastery v2 (migration 0111): the leaf-mastery freeze ledger — same
+      // idempotent shape as the parent ledger above.
+      await db.execute(sql`
+        CREATE TABLE IF NOT EXISTS "KnowledgeLeafMastery" (
+          "id" text PRIMARY KEY DEFAULT gen_random_uuid()::text NOT NULL,
+          "user_id" text NOT NULL REFERENCES "User"("id"),
+          "leaf_domain_key" text NOT NULL,
+          "mastered_at" timestamp with time zone NOT NULL DEFAULT now()
+        )
+      `);
+      await db.execute(sql`ALTER TABLE "KnowledgeLeafMastery" ENABLE ROW LEVEL SECURITY`);
+      await db.execute(sql`
+        CREATE UNIQUE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_leaf_key"
+          ON "KnowledgeLeafMastery" ("user_id", "leaf_domain_key")
+      `);
+      await db.execute(sql`
+        CREATE INDEX IF NOT EXISTS "KnowledgeLeafMastery_user_id_idx" ON "KnowledgeLeafMastery" ("user_id")
+      `);
     } catch {
       // Best-effort pre-create; migrate() creates them on a fresh DB.
     }

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -881,6 +881,25 @@ export const knowledgeParentMastery = pgTable(
   ],
 );
 
+// Mastery v2 (migration 0111) — the LEAF-mastery freeze ledger, the grain
+// inversion of KnowledgeParentMastery (docs/thinking/MASTERY-MODEL-v2.md,
+// decision 3). A row = the moment a player permanently mastered a leaf. Leaf
+// mastery is terminal; parent mastery, by contrast, is computed LIVE and never
+// frozen. Dark until KNOWLEDGE_MASTERY_V2.
+export const knowledgeLeafMastery = pgTable(
+  'KnowledgeLeafMastery',
+  {
+    id: id(),
+    userId: text('user_id').notNull().references(() => users.id),
+    leafDomainKey: text('leaf_domain_key').notNull(),
+    masteredAt: timestamp('mastered_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex('KnowledgeLeafMastery_user_leaf_key').on(table.userId, table.leafDomainKey),
+    index('KnowledgeLeafMastery_user_id_idx').on(table.userId),
+  ],
+);
+
 export const questionFeedback = pgTable(
   'QuestionFeedback',
   {

--- a/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
+++ b/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
@@ -1,0 +1,121 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+
+// resolve imports graph.ts → @/server/db, which throws at load without a
+// connection string. The functions never touch the DB; dummy URL + dynamic
+// import keeps the unit pure (repo convention, see parent-mastery.test.ts).
+let mod: typeof import('@/server/knowledge/mastery-v2-resolve');
+
+beforeAll(async () => {
+  process.env.DATABASE_URL ??= 'postgres://user:pass@localhost:5432/joshing_test';
+  mod = await import('@/server/knowledge/mastery-v2-resolve');
+});
+
+type Node = import('@/server/knowledge/mastery-v2-resolve').V2Node;
+type Edge = import('@/server/knowledge/graph').GraphEdge;
+
+const leaf = (key: string, weight: number | null): Node => ({ domainKey: key, nodeKind: 'leaf', nodeWeight: weight });
+const parent = (key: string): Node => ({ domainKey: key, nodeKind: 'parent', nodeWeight: null });
+const edge = (child: string, p: string): Edge => ({ childDomainKey: child, parentDomainKey: p });
+
+// Deterministic bars: weight × 100.
+const OPTS = { pointsPerWeight: 100 } as const;
+
+describe('resolveV2Mastery — leaf grain', () => {
+  it('bars scale with weight; progress is the clamped fraction', () => {
+    const { leaves } = mod.resolveV2Mastery(
+      [leaf('king lear', 8), leaf('hamlet', 6)],
+      [],
+      new Map([['king lear', 800], ['hamlet', 300]]),
+      new Set(),
+      OPTS,
+    );
+    expect(leaves.get('king lear')).toMatchObject({ leafBar: 800, progress: 1, isMaster: true });
+    expect(leaves.get('hamlet')).toMatchObject({ leafBar: 600, progress: 0.5, isMaster: false });
+  });
+
+  it('a frozen leaf reads master even with no points', () => {
+    const { leaves } = mod.resolveV2Mastery(
+      [leaf('macbeth', 4)],
+      [],
+      new Map(),
+      new Set(['macbeth']),
+      OPTS,
+    );
+    expect(leaves.get('macbeth')).toMatchObject({ progress: 0, isMaster: true });
+  });
+
+  it('caps the bar at reachable supply so a deep-but-thin leaf stays masterable', () => {
+    const { leaves } = mod.resolveV2Mastery(
+      [leaf('spy school', 8)], // weight → bar 800…
+      [],
+      new Map([['spy school', 300]]),
+      new Set(),
+      { ...OPTS, reachableSupplyByKey: new Map([['spy school', 300]]) }, // …capped to 300
+    );
+    expect(leaves.get('spy school')).toMatchObject({ leafBar: 300, isMaster: true });
+  });
+
+  it('falls back to DEFAULT_NODE_WEIGHT for an unseeded (null) node', () => {
+    const { leaves } = mod.resolveV2Mastery([leaf('fresh', null)], [], new Map(), new Set(), OPTS);
+    expect(leaves.get('fresh')?.leafBar).toBe(mod.DEFAULT_NODE_WEIGHT * 100);
+  });
+});
+
+describe('resolveV2Mastery — parent grain (live coverage)', () => {
+  const NODES = [parent('shakespearean tragedy'), leaf('king lear', 8), leaf('hamlet', 6), leaf('macbeth', 4)];
+  const EDGES = [
+    edge('king lear', 'shakespearean tragedy'),
+    edge('hamlet', 'shakespearean tragedy'),
+    edge('macbeth', 'shakespearean tragedy'),
+  ];
+
+  it('mastering one leaf does NOT master the parent (King Lear ≠ all of Tragedy)', () => {
+    const { parents } = mod.resolveV2Mastery(NODES, EDGES, new Map([['king lear', 800]]), new Set(), OPTS);
+    // 8 / (8+6+4) = 0.444
+    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(8 / 18);
+    expect(parents.get('shakespearean tragedy')?.isMaster).toBe(false);
+  });
+
+  it('the fragments RECOMBINE: enough covered leaves cross the 75% bar', () => {
+    const { parents } = mod.resolveV2Mastery(
+      NODES,
+      EDGES,
+      new Map([['king lear', 800], ['hamlet', 600]]), // both mastered
+      new Set(),
+      OPTS,
+    );
+    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(14 / 18); // 0.778
+    expect(parents.get('shakespearean tragedy')?.isMaster).toBe(true);
+  });
+
+  it('a frozen descendant leaf contributes in full', () => {
+    const { parents } = mod.resolveV2Mastery(
+      NODES,
+      EDGES,
+      new Map([['king lear', 800]]),
+      new Set(['hamlet']), // frozen, 0 points, still full contribution
+      OPTS,
+    );
+    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(14 / 18);
+  });
+
+  it('coverage rolls up transitively through nested parents', () => {
+    // tragedy → (lear-cycle parent) → king lear leaf
+    const nodes = [parent('tragedy'), parent('lear cycle'), leaf('king lear', 5)];
+    const edges = [edge('lear cycle', 'tragedy'), edge('king lear', 'lear cycle')];
+    const { parents } = mod.resolveV2Mastery(nodes, edges, new Map([['king lear', 500]]), new Set(), OPTS);
+    expect(parents.get('tragedy')?.coverage).toBe(1); // the only descendant leaf is mastered
+    expect(parents.get('lear cycle')?.coverage).toBe(1);
+  });
+
+  it("a 'both' node appears in BOTH grains", () => {
+    const nodes: Node[] = [
+      { domainKey: 'bach', nodeKind: 'both', nodeWeight: 5 },
+      leaf('well-tempered clavier', 4),
+    ];
+    const edges = [edge('well-tempered clavier', 'bach')];
+    const { leaves, parents } = mod.resolveV2Mastery(nodes, edges, new Map([['bach', 500]]), new Set(), OPTS);
+    expect(leaves.get('bach')?.isMaster).toBe(true); // own points 500 ≥ bar 500
+    expect(parents.has('bach')).toBe(true); // also a container
+  });
+});

--- a/src/server/knowledge/mastery-v2-resolve.ts
+++ b/src/server/knowledge/mastery-v2-resolve.ts
@@ -19,6 +19,9 @@
  * (buildKnowledgeTree behind KNOWLEDGE_MASTERY_V2) land in the follow-up P5 step.
  */
 
+import { eq } from 'drizzle-orm';
+
+import { db, knowledgeLeafMastery } from '@/server/db';
 import { substantiveDescendants, type GraphEdge } from '@/server/knowledge/graph';
 import {
   computeLeafBar,
@@ -135,4 +138,49 @@ export function resolveV2Mastery(
   }
 
   return { leaves, parents };
+}
+
+// ─── DB-backed wrapper (mirrors parent-mastery.ts's getParentMasteryForUser) ───
+
+export async function getFrozenLeafKeys(userId: string): Promise<Set<string>> {
+  const rows = await db
+    .select({ leafDomainKey: knowledgeLeafMastery.leafDomainKey })
+    .from(knowledgeLeafMastery)
+    .where(eq(knowledgeLeafMastery.userId, userId));
+  return new Set(rows.map((r) => r.leafDomainKey));
+}
+
+// Idempotent stamp — the unique (user, leaf) index makes a re-master a no-op.
+export async function freezeLeafMastery(userId: string, leafKey: string): Promise<void> {
+  await db
+    .insert(knowledgeLeafMastery)
+    .values({ userId, leafDomainKey: leafKey })
+    .onConflictDoNothing();
+}
+
+/**
+ * DB-backed resolve: reads the leaf-freeze ledger, resolves v2 mastery, and stamps
+ * any freshly-mastered leaf so it becomes terminal. Flag-off returns pure
+ * computation with an empty frozen set and never writes — so this is inert until
+ * KNOWLEDGE_MASTERY_V2 flips.
+ */
+export async function getV2MasteryForUser(
+  userId: string,
+  nodes: readonly V2Node[],
+  edges: readonly GraphEdge[],
+  pointsByKey: ReadonlyMap<string, number>,
+  options: ResolveV2Options = {},
+): Promise<V2MasteryResult> {
+  const enabled = isKnowledgeMasteryV2Enabled();
+  const frozen = enabled ? await getFrozenLeafKeys(userId) : new Set<string>();
+  const result = resolveV2Mastery(nodes, edges, pointsByKey, frozen, options);
+
+  if (enabled) {
+    for (const [key, leaf] of result.leaves) {
+      if (leaf.isMaster && !frozen.has(key)) {
+        await freezeLeafMastery(userId, key); // best-effort terminal stamp
+      }
+    }
+  }
+  return result;
 }

--- a/src/server/knowledge/mastery-v2-resolve.ts
+++ b/src/server/knowledge/mastery-v2-resolve.ts
@@ -1,0 +1,138 @@
+/**
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 5: the pure READ-MODEL.
+ *
+ * Composes node WEIGHT (Phase 2, `node_weight`) and the v2 KERNEL (Phase 1,
+ * mastery-v2.ts) over the containment tree (Phase 4, every edge is depth-eligible)
+ * into per-node mastery, split by grain (spec decision 3):
+ *
+ *   - LEAF grain (freeze-able): every point-bearing node (nodeKind leaf | both).
+ *     leafBar = f(weight, reachable supply); progress = points/bar; mastered when
+ *     frozen OR points ≥ bar. Once a leaf is frozen it reads as master forever.
+ *   - PARENT grain (LIVE coverage): a container's depth-weighted coverage of its
+ *     descendant point-bearing leaves. Mastered at ≥ 75% (PARENT_MASTERY_COVERAGE).
+ *     Never frozen — it rises and falls as the map grows (this is what recombines
+ *     the fine sub-domains a question-domain recompute fragments; see the Phase 3
+ *     finding in the spec).
+ *
+ * Pure and deterministic — no DB, no writes. The DB-backed wrapper (reading the
+ * leaf-freeze ledger, loading nodes/edges/points) and the surface wiring
+ * (buildKnowledgeTree behind KNOWLEDGE_MASTERY_V2) land in the follow-up P5 step.
+ */
+
+import { substantiveDescendants, type GraphEdge } from '@/server/knowledge/graph';
+import {
+  computeLeafBar,
+  leafMastered,
+  leafProgress,
+  parentCoverage,
+  type LeafContribution,
+} from '@/server/knowledge/mastery-v2';
+
+function boolEnv(name: string, fallback: boolean): boolean {
+  const raw = process.env[name]?.trim().toLowerCase();
+  if (raw === undefined || raw === '') return fallback;
+  return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+}
+
+/** Flag gate for the v2 read path (the follow-up surface wiring reads this). */
+export function isKnowledgeMasteryV2Enabled(): boolean {
+  return boolEnv('KNOWLEDGE_GRAPH_ENABLED', false) && boolEnv('KNOWLEDGE_MASTERY_V2', false);
+}
+
+/**
+ * Fallback weight for an unseeded node. Every prod node was seeded 2026-07-04, but
+ * a node minted after the backfill (before its seed runs) reads null — treat it as
+ * mid-weight rather than skew coverage.
+ */
+export const DEFAULT_NODE_WEIGHT = 3;
+
+export type V2Node = {
+  domainKey: string;
+  nodeKind: 'leaf' | 'parent' | 'both';
+  nodeWeight: number | null;
+};
+
+export type LeafMastery = {
+  domainKey: string;
+  leafBar: number;
+  /** 0..1 fraction of the bar earned. */
+  progress: number;
+  /** frozen (permanent) OR points ≥ bar. */
+  isMaster: boolean;
+};
+
+export type ParentMastery = {
+  domainKey: string;
+  /** 0..1 depth-weighted coverage of descendant leaves. */
+  coverage: number;
+  /** coverage ≥ PARENT_MASTERY_COVERAGE. Live — never frozen. */
+  isMaster: boolean;
+};
+
+export type V2MasteryResult = {
+  leaves: Map<string, LeafMastery>;
+  parents: Map<string, ParentMastery>;
+};
+
+export type ResolveV2Options = {
+  /** Override the weight→points mapping (mastery-v2 DEFAULT_POINTS_PER_WEIGHT otherwise). */
+  pointsPerWeight?: number;
+  /** Per-leaf cap: the points the domain's existing questions can actually award. */
+  reachableSupplyByKey?: ReadonlyMap<string, number>;
+};
+
+/**
+ * Resolve v2 mastery for a set of authored nodes + containment edges + a player's
+ * per-leaf points. `frozenLeaves` are leaves the player has permanently mastered
+ * (the leaf-freeze ledger, read by the DB wrapper). Pure — inject everything.
+ */
+export function resolveV2Mastery(
+  nodes: readonly V2Node[],
+  edges: readonly GraphEdge[],
+  pointsByKey: ReadonlyMap<string, number>,
+  frozenLeaves: ReadonlySet<string> = new Set(),
+  options: ResolveV2Options = {},
+): V2MasteryResult {
+  const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
+  const weightOf = (n: V2Node): number =>
+    n.nodeWeight != null && n.nodeWeight > 0 ? n.nodeWeight : DEFAULT_NODE_WEIGHT;
+
+  // 1) LEAF grain — every point-bearing node (leaf or 'both').
+  const leaves = new Map<string, LeafMastery>();
+  for (const node of nodes) {
+    if (node.nodeKind === 'parent') continue; // pure container, no own points
+    const leafBar = computeLeafBar({
+      weight: weightOf(node),
+      reachableSupplyPoints: options.reachableSupplyByKey?.get(node.domainKey),
+      pointsPerWeight: options.pointsPerWeight,
+    });
+    const points = pointsByKey.get(node.domainKey) ?? 0;
+    leaves.set(node.domainKey, {
+      domainKey: node.domainKey,
+      leafBar,
+      progress: leafProgress(points, leafBar),
+      isMaster: frozenLeaves.has(node.domainKey) || leafMastered(points, leafBar),
+    });
+  }
+
+  // 2) PARENT grain — LIVE depth-weighted coverage of descendant leaves.
+  const parents = new Map<string, ParentMastery>();
+  for (const node of nodes) {
+    if (node.nodeKind === 'leaf') continue; // not a container
+    const contributions: LeafContribution[] = [];
+    for (const descendantKey of substantiveDescendants(node.domainKey, edges)) {
+      const leaf = leaves.get(descendantKey);
+      if (!leaf) continue; // descendant is a pure parent — no own weight/points
+      const descendantNode = nodeByKey.get(descendantKey);
+      contributions.push({
+        weight: descendantNode ? weightOf(descendantNode) : DEFAULT_NODE_WEIGHT,
+        // A mastered/frozen leaf contributes in full; else its partial progress.
+        progress: leaf.isMaster ? 1 : leaf.progress,
+      });
+    }
+    const { coverage, isMaster } = parentCoverage(contributions);
+    parents.set(node.domainKey, { domainKey: node.domainKey, coverage, isMaster });
+  }
+
+  return { leaves, parents };
+}


### PR DESCRIPTION
**Phase 5 infrastructure** (two commits) — the v2 read-model plus the freeze-inversion plumbing. Spec: `docs/thinking/MASTERY-MODEL-v2.md`. **Flag-gated and inert** — wired to no surface yet, so nothing changes live. Safe to merge.

Builds on all merged phases: composes **node weight** (P2) + the **v2 kernel** (P1) over the **containment tree** (P4).

## 1 — pure read-model (`mastery-v2-resolve.ts`)
`resolveV2Mastery`, the grain split (decision 3):
- **LEAF (freeze-able):** `leafBar = f(weight, reachable supply)`; `progress = points/bar`; mastered when frozen OR points ≥ bar.
- **PARENT (LIVE coverage):** depth-weighted coverage of descendant leaves, mastered at **≥ 75%**. Never frozen — this is what **recombines** the fragments a question-domain recompute creates (the Phase 3 finding), which is why the policy you confirmed is coherent.

Plus `isKnowledgeMasteryV2Enabled()` (`KNOWLEDGE_MASTERY_V2`, off) and `DEFAULT_NODE_WEIGHT`.

## 2 — freeze ledger + DB wrapper
- **Migration `0111`**: `KnowledgeLeafMastery` — the leaf-freeze ledger, the grain inversion of `KnowledgeParentMastery` (mirrors the 0104 shape + guard). **Not applied** — run `npm run db:migrate` when ready.
- `getFrozenLeafKeys` / `freezeLeafMastery` / `getV2MasteryForUser` — mirrors `getParentMasteryForUser`: reads the ledger, resolves, stamps freshly-mastered leaves as terminal. Flag-off = pure computation, never writes.

## Tests
9 read-model unit tests (King Lear case, fragments recombining across 75%, frozen-leaf full contribution, supply cap, transitive rollup, `'both'` nodes). Typecheck + eslint clean; journal 112/112.

## Remaining P5 (its own PR — the visible step)
Wire `getV2MasteryForUser` into `buildKnowledgeTree` behind the flag, compute reachable-supply per leaf, retire the parent-freeze path. Isolated because it touches the live map read path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)