### PR TITLE
feat(knowledge): mastery v2 Phase 5 (wiring) — v2 read-model on the map

### DIFF
--- a/src/server/knowledge/__tests__/knowledge-tree.test.ts
+++ b/src/server/knowledge/__tests__/knowledge-tree.test.ts
@@ -197,3 +197,28 @@ describe('grow-rim — unheld same-field roots as ghost invitations', () => {
 
 // collectCollections tests removed 2026-07-04 (migration 0110): the collection
 // edge type and the coverage strip are gone.
+
+describe('buildKnowledgeTree — v2 masteredOverride (Phase 5 wiring)', () => {
+  const NODES_V2 = [node('Tragedy', 'parent', null), node('King Lear'), node('Hamlet')];
+  const EDGES_V2 = [sub('King Lear', 'Tragedy'), sub('Hamlet', 'Tragedy')];
+  const OWNED_V2 = [
+    { domain: 'King Lear', points: 3000, mastered: true, broadCategory: 'Literature' },
+    { domain: 'Hamlet', points: 50, mastered: false, broadCategory: 'Literature' },
+  ];
+
+  it('the override REPLACES the per-node master badge (leaf AND parent)', () => {
+    // v2 inverts v1 here: parent + Hamlet mastered, King Lear not.
+    const tree = mod.buildKnowledgeTree(OWNED_V2, NODES_V2, EDGES_V2, new Set(), {
+      masteredOverride: new Set(['tragedy', 'hamlet']),
+    });
+    expect(findNode(tree, 'tragedy')?.mastered).toBe(true);
+    expect(findNode(tree, 'king lear')?.mastered).toBeUndefined(); // v1-mastered, but override off
+    expect(findNode(tree, 'hamlet')?.mastered).toBe(true); // v1 not mastered, override on
+  });
+
+  it('without the override, the v1 grain stands', () => {
+    const tree = mod.buildKnowledgeTree(OWNED_V2, NODES_V2, EDGES_V2);
+    expect(findNode(tree, 'king lear')?.mastered).toBe(true); // v1 leaf-tier
+    expect(findNode(tree, 'hamlet')?.mastered).toBeUndefined();
+  });
+});

--- a/src/server/knowledge/knowledge-tree.ts
+++ b/src/server/knowledge/knowledge-tree.ts
@@ -31,6 +31,10 @@ import {
   getParentMasteryForUser,
   isKnowledgeGraphMasteryEnabled,
 } from '@/server/knowledge/parent-mastery';
+import {
+  getV2MasteryForUser,
+  isKnowledgeMasteryV2Enabled,
+} from '@/server/knowledge/mastery-v2-resolve';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 // Gap-view framing for a substantive parent (D-KNOWLEDGE-MAP-USABILITY-01 C3):
@@ -129,6 +133,14 @@ export type BuildTreeOptions = {
    * on someone else's behalf.
    */
   includeGhosts?: boolean;
+  /**
+   * Mastery v2 (KNOWLEDGE_MASTERY_V2): the set of AUTHORED node keys mastered
+   * under the depth-weighted read-model (leaf ≥ bar / frozen, or parent ≥ 75%
+   * coverage). When present it REPLACES the v1 per-node master badge
+   * (leaf-tier + parentProgress). Un-authored owned leaves (rendered under the
+   * root) keep their v1 leaf-tier badge — v2 only knows authored nodes.
+   */
+  masteredOverride?: ReadonlySet<string>;
 };
 
 export function buildKnowledgeTree(
@@ -216,7 +228,11 @@ export function buildKnowledgeTree(
       ? frozenParents.has(key) ||
         parentProgress(totals.get(key) ?? 0, corners, node.masteryThreshold).isMaster
       : false;
-    const mastered = Boolean(ownedLeaf?.mastered) || parentMastered;
+    // v2 (when the override is present) owns the master badge for authored nodes;
+    // otherwise the v1 grain (leaf-tier OR parent threshold+corners) stands.
+    const mastered = options.masteredOverride
+      ? options.masteredOverride.has(key)
+      : Boolean(ownedLeaf?.mastered) || parentMastered;
 
     // Gap-view framing (C3) — the same numbers the mastery call just used,
     // surfaced so the map can say "6 of 9 · 1,240/2,000 pts" on focus.
@@ -354,7 +370,25 @@ export async function getKnowledgeMapData(
   }));
 
   let frozenParents: ReadonlySet<string> = new Set();
-  if (isKnowledgeGraphMasteryEnabled()) {
+  let masteredOverride: ReadonlySet<string> | undefined;
+  if (isKnowledgeMasteryV2Enabled()) {
+    // v2 read path: depth-weighted coverage over the containment tree. Overrides
+    // the per-node master badge; the v1 gap-view numbers still frame the focus
+    // header for now (a v2 coverage framing is a follow-up). Reachable-supply cap
+    // is not yet wired, so the leaf bar is uncapped depth (also a follow-up).
+    const v2Nodes = graph.nodes.map((n) => ({
+      domainKey: n.domainKey,
+      nodeKind: n.nodeKind,
+      nodeWeight: n.nodeWeight,
+    }));
+    const pointsByKey = new Map<string, number>();
+    for (const leaf of owned) pointsByKey.set(domainKey(leaf.domain), leaf.points);
+    const v2 = await getV2MasteryForUser(userId, v2Nodes, edges, pointsByKey);
+    const mastered = new Set<string>();
+    for (const [key, leaf] of v2.leaves) if (leaf.isMaster) mastered.add(key);
+    for (const [key, parent] of v2.parents) if (parent.isMaster) mastered.add(key);
+    masteredOverride = mastered;
+  } else if (isKnowledgeGraphMasteryEnabled()) {
     const credits = new Map<string, number>();
     for (const leaf of owned) {
       if (leaf.points > 0) credits.set(domainKey(leaf.domain), leaf.points);
@@ -368,7 +402,7 @@ export async function getKnowledgeMapData(
   }
 
   return {
-    tree: buildKnowledgeTree(owned, nodes, edges, frozenParents, options),
+    tree: buildKnowledgeTree(owned, nodes, edges, frozenParents, { ...options, masteredOverride }),
     ownedDomains: visible.map((d) => ({
       domain: d.domain,
       displayName: d.displayName || d.domain,


### PR DESCRIPTION
**Phase 5, the visible step** — wires the v2 read-model into the knowledge-map read path behind `KNOWLEDGE_MASTERY_V2`. **Stacked on #1398** (base = `claude/mastery-v2-phase5-readmodel`), so this diff is only the wiring. v1 stays the default — flag off changes nothing.

## What changed (`knowledge-tree.ts` + test)
- `buildKnowledgeTree` gains an optional **`masteredOverride`** (`BuildTreeOptions`): the set of authored node keys mastered under v2 (leaf ≥ bar / frozen, or parent ≥ 75% coverage). When present it **replaces** the v1 per-node master badge. Un-authored owned leaves under the root keep their v1 leaf-tier badge (v2 only knows authored nodes).
- `getKnowledgeMapData`: when `KNOWLEDGE_MASTERY_V2` is on, resolves v2 via `getV2MasteryForUser` (reads/stamps the leaf-freeze ledger) and passes the override; else the v1 parent-freeze path is unchanged.

## Deliberately deferred (land with the P6 flip)
- The parent focus-header still shows v1 gap-view numbers (points/threshold/corners), not v2 coverage %.
- The **reachable-supply cap** on the leaf bar isn't wired yet (bar is uncapped depth) — the read-model supports it via options.
- `parent-mastery.ts` isn't deleted (still the v1 path).

## Verification
24 tests pass (knowledge-tree + resolve) incl. a new override test (v2 badge inverts v1). Typecheck + eslint clean.

> Note: this commit was recovered via cherry-pick after concurrent activity on a separate admin-weight branch tangled the branch state mid-session; the content is identical and verified green on the infra base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)