### PR TITLE
feat(knowledge): mastery v2 P5 follow-up — reachable-supply cap on the leaf bar

### DIFF
--- a/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
+++ b/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
@@ -119,3 +119,15 @@ describe('resolveV2Mastery — parent grain (live coverage)', () => {
     expect(parents.has('bach')).toBe(true); // also a container
   });
 });
+
+describe('reachableSupplyFromDepths', () => {
+  it('converts question counts to a points ceiling and folds label variants', () => {
+    const map = mod.reachableSupplyFromDepths([
+      { label: 'King Lear', questionCount: 4 },
+      { label: 'king lear', questionCount: 2 }, // folds onto the same key
+      { label: 'Hamlet', questionCount: 0 },
+    ]);
+    expect(map.get('king lear')).toBe(6 * mod.REACHABLE_POINTS_PER_QUESTION);
+    expect(map.get('hamlet')).toBe(0);
+  });
+});

--- a/src/server/knowledge/knowledge-tree.ts
+++ b/src/server/knowledge/knowledge-tree.ts
@@ -34,7 +34,9 @@ import {
 import {
   getV2MasteryForUser,
   isKnowledgeMasteryV2Enabled,
+  reachableSupplyFromDepths,
 } from '@/server/knowledge/mastery-v2-resolve';
+import { getCorpusLabelDepths } from '@/server/db/queries/crafter-demand';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 // Gap-view framing for a substantive parent (D-KNOWLEDGE-MAP-USABILITY-01 C3):
@@ -374,8 +376,7 @@ export async function getKnowledgeMapData(
   if (isKnowledgeMasteryV2Enabled()) {
     // v2 read path: depth-weighted coverage over the containment tree. Overrides
     // the per-node master badge; the v1 gap-view numbers still frame the focus
-    // header for now (a v2 coverage framing is a follow-up). Reachable-supply cap
-    // is not yet wired, so the leaf bar is uncapped depth (also a follow-up).
+    // header for now (a v2 coverage framing is a follow-up).
     const v2Nodes = graph.nodes.map((n) => ({
       domainKey: n.domainKey,
       nodeKind: n.nodeKind,
@@ -383,7 +384,15 @@ export async function getKnowledgeMapData(
     }));
     const pointsByKey = new Map<string, number>();
     for (const leaf of owned) pointsByKey.set(domainKey(leaf.domain), leaf.points);
-    const v2 = await getV2MasteryForUser(userId, v2Nodes, edges, pointsByKey);
+    // Reachable-supply cap: a leaf's bar can't exceed what its existing questions
+    // can award, so a deep-but-thin domain stays masterable (spec decision 5).
+    const depths = await getCorpusLabelDepths();
+    const reachableSupplyByKey = reachableSupplyFromDepths(
+      depths.map((d) => ({ label: d.label, questionCount: d.machineDepth + d.humanAuthored })),
+    );
+    const v2 = await getV2MasteryForUser(userId, v2Nodes, edges, pointsByKey, {
+      reachableSupplyByKey,
+    });
     const mastered = new Set<string>();
     for (const [key, leaf] of v2.leaves) if (leaf.isMaster) mastered.add(key);
     for (const [key, parent] of v2.parents) if (parent.isMaster) mastered.add(key);

--- a/src/server/knowledge/mastery-v2-resolve.ts
+++ b/src/server/knowledge/mastery-v2-resolve.ts
@@ -22,6 +22,7 @@
 import { eq } from 'drizzle-orm';
 
 import { db, knowledgeLeafMastery } from '@/server/db';
+import { domainKey } from '@/lib/knowledge/domain-key';
 import { substantiveDescendants, type GraphEdge } from '@/server/knowledge/graph';
 import {
   computeLeafBar,
@@ -48,6 +49,31 @@ export function isKnowledgeMasteryV2Enabled(): boolean {
  * mid-weight rather than skew coverage.
  */
 export const DEFAULT_NODE_WEIGHT = 3;
+
+/**
+ * Points a typical correct answer awards, used to convert a domain's question
+ * COUNT into a reachable-supply points ceiling. 50 = a Moderate first_correct
+ * (DIFFICULTY_BASE_POINTS); CALIBRATION-PENDING like DEFAULT_POINTS_PER_WEIGHT.
+ */
+export const REACHABLE_POINTS_PER_QUESTION = 50;
+
+/**
+ * Build the reachable-supply cap (in points) per folded domain from corpus
+ * question counts — a leaf's bar can never exceed what its existing questions
+ * can award (spec decision 5: a deep-but-thin domain stays masterable). Folds
+ * label variants together via domainKey. Pure.
+ */
+export function reachableSupplyFromDepths(
+  depths: readonly { label: string; questionCount: number }[],
+): Map<string, number> {
+  const byKey = new Map<string, number>();
+  for (const d of depths) {
+    const key = domainKey(d.label);
+    const points = Math.max(0, d.questionCount) * REACHABLE_POINTS_PER_QUESTION;
+    byKey.set(key, (byKey.get(key) ?? 0) + points);
+  }
+  return byKey;
+}
 
 export type V2Node = {
   domainKey: string;


### PR DESCRIPTION
**P5 follow-up** — closes the "deep-but-thin domains stay masterable" gap (spec decision 5) in the live v2 read path. Still **dark** behind `KNOWLEDGE_MASTERY_V2` — only runs when the flag is on, so no cost on the default path.

## What changed
- `mastery-v2-resolve.ts`: `REACHABLE_POINTS_PER_QUESTION` (50 = a Moderate `first_correct` from `DIFFICULTY_BASE_POINTS`; **CALIBRATION-PENDING**) + `reachableSupplyFromDepths` — a pure helper turning per-domain question **count** into a points ceiling, folding label variants via `domainKey`.
- `getKnowledgeMapData` (v2 branch): loads corpus depths (`getCorpusLabelDepths`), builds `reachableSupplyByKey`, and passes it to `getV2MasteryForUser`. Now a leaf's bar can never exceed what its existing questions can award — a 40-question domain can't demand 8,000 points.

The read-model already had the cap logic + test (Phase 5); this wires the real per-domain supply into the map.

## Verification
25 tests pass (incl. a new `reachableSupplyFromDepths` test — count→points + variant folding). Typecheck + eslint clean.

## Note
`getCorpusLabelDepths` adds one grouped scan to the map render, but only when the flag is on — worth a perf glance at the P6 flip.

## Remaining before live
- P5 follow-ups: v2 coverage % in the focus header; retire `parent-mastery.ts`.
- **P6**: flag flip + prod recompute/backfill (+ the leaf-freeze backfill decision), gated on the confirmed policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)