### PR TITLE
feat(admin/knowledge): mastery weight on every row + edit it inline

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -62,11 +62,11 @@ export function KnowledgeAdminClient({
         </h1>
         <AdminTabs active="knowledge" />
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
-          The territory structure — human-authored, always. Nodes are leaves/parents; a parent&apos;s
-          <strong> mastery threshold</strong> is its absolute points bar (Medici ~100, Italian
-          Renaissance ~2000). Edges are typed: <em>substantive</em> (depth counts toward
-          understanding) vs <em>collection</em> (coverage only). Nothing here touches questions or
-          any player&apos;s mastery.
+          The territory structure — human-authored, always. Nodes are leaves/parents. Each row
+          shows its <strong>mastery weight</strong> (<em>wt</em> — the depth/mass of the topic,
+          1–10, color-coded shallow→deep; it scales mastery for leaves and each node&apos;s share
+          of a parent&apos;s coverage) and its question count (<em>Qs</em>, rolled up through the
+          subtree for parents). Nothing here touches questions or any player&apos;s mastery.
         </p>
       </header>
 
@@ -124,6 +124,19 @@ type PickState = {
 // to condense it upward (Move it under a parent). Matches the exhaustion
 // story: a thin leaf gets played out fast.
 const THIN_LEAF_THRESHOLD = 6;
+
+// Node-weight heat scale (mastery v2 mass, 1–10): every node — leaf AND
+// parent — carries a weight that scales its mastery (the leaf bar, and its
+// share of a parent's coverage). Color it by magnitude so a curator can scan
+// how deep each territory is at a glance (shallow → deep). The authored range
+// is 1–9 (avg ~4–6). Tokens follow the crafter admin's heat convention
+// (success/gold/danger as a magnitude ramp on an internal ops surface), not
+// grading semantics. Called "weight"/"mass", never "depth" — "N Qs" owns that.
+function nodeWeightColor(weight: number): string {
+  if (weight <= 3) return 'var(--success)'; // shallow
+  if (weight <= 6) return 'var(--accent-gold)'; // moderate
+  return 'var(--danger)'; // deep
+}
 
 function KnowledgeTreeEditor({
   nodes,
@@ -821,7 +834,7 @@ function TreeRow({
   const [childLabel, setChildLabel] = useState('');
   const [editing, setEditing] = useState(false);
   const [editLabel, setEditLabel] = useState('');
-  const [editBar, setEditBar] = useState('');
+  const [editWeight, setEditWeight] = useState('');
   const [rowError, setRowError] = useState<string | null>(null);
 
   const node = nodeByKey.get(nodeKey); // not a hook — safe before the hooks below
@@ -882,7 +895,10 @@ function TreeRow({
       action: 'edit_node',
       id: node!.id,
       label: editLabel.trim() || undefined,
-      masteryThreshold: editBar.trim() ? Number(editBar) : null,
+      // Edit the v2 mastery WEIGHT (1–10). masteryThreshold is intentionally
+      // omitted — the query leaves any existing value untouched, so this repurposes
+      // the field to weight without nulling a parent's legacy v1 bar.
+      nodeWeight: editWeight.trim() ? Math.min(10, Math.max(1, Number(editWeight))) : null,
     });
     if (!res.ok) {
       setRowError(
@@ -993,12 +1009,13 @@ function TreeRow({
               aria-label="Label"
             />
             <input
-              value={editBar}
-              onChange={(e) => setEditBar(e.target.value.replace(/[^0-9]/g, ''))}
-              placeholder="bar"
+              value={editWeight}
+              onChange={(e) => setEditWeight(e.target.value.replace(/[^0-9]/g, ''))}
+              placeholder="wt 1–10"
               inputMode="numeric"
+              maxLength={2}
               className="w-16 rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-2 py-0.5 text-sm"
-              aria-label="Mastery bar"
+              aria-label="Mastery weight (1–10)"
             />
             <button type="button" onClick={() => void saveEdit()} className={smallBtn} style={{ borderColor: 'var(--success)', color: 'var(--success)' }}>
               Save
@@ -1017,12 +1034,26 @@ function TreeRow({
             >
               {node.label}
             </span>
-            <span className="text-muted-foreground shrink-0 whitespace-nowrap text-xs">
-              {node.nodeKind !== 'leaf'
-                ? node.masteryThreshold
-                  ? `bar ${node.masteryThreshold}`
-                  : 'bar unset'
-                : `${depthByKey[nodeKey] ?? 0} Qs`}
+            {/* Two facts under every name (leaves included): the node's
+                mastery WEIGHT (v2 mass — color-coded by how deep the territory
+                is; scales the leaf bar and the node's share of parent
+                coverage) and the question count (rolled up through the subtree
+                for parents). */}
+            <span className="flex shrink-0 items-center gap-2 whitespace-nowrap text-xs">
+              <span
+                className="font-medium"
+                style={{ color: node.nodeWeight ? nodeWeightColor(node.nodeWeight) : 'var(--warning)' }}
+                title={
+                  node.nodeWeight
+                    ? `Mastery weight: ${node.nodeWeight}/10 (depth/mass — scales mastery)`
+                    : 'No weight set — tap ⋯ to set one'
+                }
+              >
+                {node.nodeWeight ? `wt ${node.nodeWeight}` : 'wt —'}
+              </span>
+              <span className="text-muted-foreground" title="Questions in this area">
+                {depthByKey[nodeKey] ?? 0} Qs
+              </span>
             </span>
             {/* Multi-parent chip: tap to see every place this territory lives
                 and jump to any of them. */}
@@ -1135,7 +1166,7 @@ function TreeRow({
                 setActionsOpen(false);
                 setEditing(true);
                 setEditLabel(node.label);
-                setEditBar(node.masteryThreshold?.toString() ?? '');
+                setEditWeight(node.nodeWeight?.toString() ?? '');
               }}
               className={menuBtn}
               style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -24,9 +24,35 @@ export default async function AdminKnowledgePage() {
     // territories too thin to stand alone ("this is too small — condense it").
     getCorpusLabelDepths(),
   ]);
-  const depthByKey: Record<string, number> = {};
+  const ownDepthByKey: Record<string, number> = {};
   for (const entry of corpusDepths) {
-    depthByKey[domainKey(entry.label)] = entry.machineDepth + entry.humanAuthored;
+    ownDepthByKey[domainKey(entry.label)] = entry.machineDepth + entry.humanAuthored;
+  }
+
+  // Rolled-up Qs for display: questions are filed under LEAF labels, so a
+  // parent's own count is ~0 — its meaningful "questions in this area" is the
+  // sum over its subtree. Leaves have no children, so their rolled value
+  // equals their own count (the thin-leaf check downstream stays correct).
+  const childrenByParent = new Map<string, string[]>();
+  for (const edge of edges) {
+    const list = childrenByParent.get(edge.parentDomainKey);
+    if (list) list.push(edge.childDomainKey);
+    else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
+  }
+  const depthByKey: Record<string, number> = { ...ownDepthByKey };
+  for (const node of nodes) {
+    const key = node.domainKey;
+    const descendants = new Set<string>();
+    const stack = [...(childrenByParent.get(key) ?? [])];
+    while (stack.length > 0) {
+      const child = stack.pop()!;
+      if (child === key || descendants.has(child)) continue; // cycle/diamond guard
+      descendants.add(child);
+      stack.push(...(childrenByParent.get(child) ?? []));
+    }
+    let sum = ownDepthByKey[key] ?? 0;
+    for (const d of descendants) sum += ownDepthByKey[d] ?? 0;
+    depthByKey[key] = sum;
   }
 
   return <KnowledgeAdminClient nodes={nodes} edges={edges} depthByKey={depthByKey} />;


### PR DESCRIPTION
Surfaces the v2 `node_weight` on the admin knowledge tree and makes it editable — so leaves finally carry a mastery number (v1 gave them none: 0/79 leaves have a `mastery_threshold`).

Resurrects the stranded work from closed PR #1397 (`folds #1397 into v2 line`), re-applied cleanly onto current `main` (which now has all of P1–P5). Original commit preserved.

## What it does
- **Display:** every row (leaves included) shows `wt {node_weight}`, color-coded by magnitude (≤3 green / 4–6 gold / ≥7 red — prod spread 41/28/44) next to its rolled-up **Qs** count. Parents sum their subtree (questions file under leaf labels, so a parent's own count is ~0); leaves show their own count. Labeled "wt"/mass, never "depth" (spec refinement #2 — "Qs" owns that word).
- **Edit:** the row's inline number field now edits `node_weight` (1–10, clamped) via `edit_node`'s `nodeWeight` input. `masteryThreshold` is omitted from the payload, so the query's conditional update leaves any existing parent bar untouched. The separate structure-group / parent-threshold paths are unchanged.

## Verification (on current main)
Typecheck + eslint clean; color ratchet clean (70/180). Touches only the two admin files (`KnowledgeAdminClient.tsx`, `page.tsx`) — no overlap with the dark v2 read-path work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)