### PR TITLE
refactor(knowledge): mastery v2 → per-node POINTS threshold (supersedes weight)

### DIFF
--- a/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
+++ b/src/server/knowledge/__tests__/mastery-v2-resolve.test.ts
@@ -13,121 +13,87 @@ beforeAll(async () => {
 type Node = import('@/server/knowledge/mastery-v2-resolve').V2Node;
 type Edge = import('@/server/knowledge/graph').GraphEdge;
 
-const leaf = (key: string, weight: number | null): Node => ({ domainKey: key, nodeKind: 'leaf', nodeWeight: weight });
-const parent = (key: string): Node => ({ domainKey: key, nodeKind: 'parent', nodeWeight: null });
+const leaf = (key: string, threshold: number | null): Node => ({ domainKey: key, nodeKind: 'leaf', masteryThreshold: threshold });
+const parent = (key: string, threshold: number): Node => ({ domainKey: key, nodeKind: 'parent', masteryThreshold: threshold });
 const edge = (child: string, p: string): Edge => ({ childDomainKey: child, parentDomainKey: p });
 
-// Deterministic bars: weight × 100.
-const OPTS = { pointsPerWeight: 100 } as const;
-
-describe('resolveV2Mastery — leaf grain', () => {
-  it('bars scale with weight; progress is the clamped fraction', () => {
-    const { leaves } = mod.resolveV2Mastery(
-      [leaf('king lear', 8), leaf('hamlet', 6)],
+describe('resolveV2Mastery — leaf grain (points ÷ threshold)', () => {
+  it('progress and the 75% master bar', () => {
+    const out = mod.resolveV2Mastery(
+      [leaf('king lear', 1500), leaf('hamlet', 1500)],
       [],
-      new Map([['king lear', 800], ['hamlet', 300]]),
-      new Set(),
-      OPTS,
+      new Map([['king lear', 1200], ['hamlet', 1000]]),
     );
-    expect(leaves.get('king lear')).toMatchObject({ leafBar: 800, progress: 1, isMaster: true });
-    expect(leaves.get('hamlet')).toMatchObject({ leafBar: 600, progress: 0.5, isMaster: false });
+    expect(out.get('king lear')).toMatchObject({ points: 1200, progress: 0.8, isMaster: true }); // 1200 ≥ 1125
+    expect(out.get('hamlet')).toMatchObject({ isMaster: false }); // 1000 < 1125
   });
 
   it('a frozen leaf reads master even with no points', () => {
-    const { leaves } = mod.resolveV2Mastery(
-      [leaf('macbeth', 4)],
-      [],
-      new Map(),
-      new Set(['macbeth']),
-      OPTS,
-    );
-    expect(leaves.get('macbeth')).toMatchObject({ progress: 0, isMaster: true });
+    const out = mod.resolveV2Mastery([leaf('macbeth', 1000)], [], new Map(), new Set(['macbeth']));
+    expect(out.get('macbeth')).toMatchObject({ points: 0, progress: 0, isMaster: true });
   });
 
-  it('caps the bar at reachable supply so a deep-but-thin leaf stays masterable', () => {
-    const { leaves } = mod.resolveV2Mastery(
-      [leaf('spy school', 8)], // weight → bar 800…
-      [],
-      new Map([['spy school', 300]]),
-      new Set(),
-      { ...OPTS, reachableSupplyByKey: new Map([['spy school', 300]]) }, // …capped to 300
-    );
-    expect(leaves.get('spy school')).toMatchObject({ leafBar: 300, isMaster: true });
-  });
-
-  it('falls back to DEFAULT_NODE_WEIGHT for an unseeded (null) node', () => {
-    const { leaves } = mod.resolveV2Mastery([leaf('fresh', null)], [], new Map(), new Set(), OPTS);
-    expect(leaves.get('fresh')?.leafBar).toBe(mod.DEFAULT_NODE_WEIGHT * 100);
+  it('falls back to the default threshold for an unseeded (null) node', () => {
+    const out = mod.resolveV2Mastery([leaf('fresh', null)], [], new Map());
+    expect(out.get('fresh')?.threshold).toBe(mod.DEFAULT_MASTERY_THRESHOLD ?? 1000);
   });
 });
 
-describe('resolveV2Mastery — parent grain (live coverage)', () => {
-  const NODES = [parent('shakespearean tragedy'), leaf('king lear', 8), leaf('hamlet', 6), leaf('macbeth', 4)];
+describe('resolveV2Mastery — parent grain (rolled-up points ÷ own independent threshold)', () => {
+  const NODES = [
+    parent('shakespearean tragedy', 15000), // whole-area threshold — big, independent
+    leaf('king lear', 1500),
+    leaf('hamlet', 1500),
+    leaf('macbeth', 1000),
+  ];
   const EDGES = [
     edge('king lear', 'shakespearean tragedy'),
     edge('hamlet', 'shakespearean tragedy'),
     edge('macbeth', 'shakespearean tragedy'),
   ];
 
+  it('an INCOMPLETE area is not masterable — even fully covering its current leaves', () => {
+    const out = mod.resolveV2Mastery(
+      NODES,
+      EDGES,
+      new Map([['king lear', 1500], ['hamlet', 1500], ['macbeth', 1000]]), // all three maxed
+    );
+    // rolled-up 4000 / 15000 = 0.267 — the area's threshold expects far more leaves.
+    expect(out.get('shakespearean tragedy')).toMatchObject({ points: 4000, isMaster: false });
+    expect(out.get('shakespearean tragedy')!.progress).toBeCloseTo(4000 / 15000);
+  });
+
   it('mastering one leaf does NOT master the parent (King Lear ≠ all of Tragedy)', () => {
-    const { parents } = mod.resolveV2Mastery(NODES, EDGES, new Map([['king lear', 800]]), new Set(), OPTS);
-    // 8 / (8+6+4) = 0.444
-    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(8 / 18);
-    expect(parents.get('shakespearean tragedy')?.isMaster).toBe(false);
+    const out = mod.resolveV2Mastery(NODES, EDGES, new Map([['king lear', 1500]]));
+    expect(out.get('king lear')?.isMaster).toBe(true); // the leaf is mastered…
+    expect(out.get('shakespearean tragedy')?.isMaster).toBe(false); // …the area is not
   });
 
-  it('the fragments RECOMBINE: enough covered leaves cross the 75% bar', () => {
-    const { parents } = mod.resolveV2Mastery(
-      NODES,
-      EDGES,
-      new Map([['king lear', 800], ['hamlet', 600]]), // both mastered
-      new Set(),
-      OPTS,
+  it('a parent masters once its rolled-up points cross 75% of ITS threshold', () => {
+    const out = mod.resolveV2Mastery(
+      [parent('lear cycle', 2000), leaf('king lear', 1500)],
+      [edge('king lear', 'lear cycle')],
+      new Map([['king lear', 1600]]),
     );
-    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(14 / 18); // 0.778
-    expect(parents.get('shakespearean tragedy')?.isMaster).toBe(true);
+    expect(out.get('lear cycle')).toMatchObject({ points: 1600, isMaster: true }); // 1600 ≥ 1500
   });
 
-  it('a frozen descendant leaf contributes in full', () => {
-    const { parents } = mod.resolveV2Mastery(
-      NODES,
-      EDGES,
-      new Map([['king lear', 800]]),
-      new Set(['hamlet']), // frozen, 0 points, still full contribution
-      OPTS,
+  it('points roll up transitively through nested parents', () => {
+    const out = mod.resolveV2Mastery(
+      [parent('tragedy', 5000), parent('lear cycle', 2000), leaf('king lear', 1500)],
+      [edge('lear cycle', 'tragedy'), edge('king lear', 'lear cycle')],
+      new Map([['king lear', 500]]),
     );
-    expect(parents.get('shakespearean tragedy')?.coverage).toBeCloseTo(14 / 18);
+    expect(out.get('tragedy')?.points).toBe(500);
+    expect(out.get('lear cycle')?.points).toBe(500);
   });
 
-  it('coverage rolls up transitively through nested parents', () => {
-    // tragedy → (lear-cycle parent) → king lear leaf
-    const nodes = [parent('tragedy'), parent('lear cycle'), leaf('king lear', 5)];
-    const edges = [edge('lear cycle', 'tragedy'), edge('king lear', 'lear cycle')];
-    const { parents } = mod.resolveV2Mastery(nodes, edges, new Map([['king lear', 500]]), new Set(), OPTS);
-    expect(parents.get('tragedy')?.coverage).toBe(1); // the only descendant leaf is mastered
-    expect(parents.get('lear cycle')?.coverage).toBe(1);
-  });
-
-  it("a 'both' node appears in BOTH grains", () => {
+  it("a 'both' node bears its own points and masters on them", () => {
     const nodes: Node[] = [
-      { domainKey: 'bach', nodeKind: 'both', nodeWeight: 5 },
-      leaf('well-tempered clavier', 4),
+      { domainKey: 'bach', nodeKind: 'both', masteryThreshold: 1000 },
+      leaf('well-tempered clavier', 800),
     ];
-    const edges = [edge('well-tempered clavier', 'bach')];
-    const { leaves, parents } = mod.resolveV2Mastery(nodes, edges, new Map([['bach', 500]]), new Set(), OPTS);
-    expect(leaves.get('bach')?.isMaster).toBe(true); // own points 500 ≥ bar 500
-    expect(parents.has('bach')).toBe(true); // also a container
-  });
-});
-
-describe('reachableSupplyFromDepths', () => {
-  it('converts question counts to a points ceiling and folds label variants', () => {
-    const map = mod.reachableSupplyFromDepths([
-      { label: 'King Lear', questionCount: 4 },
-      { label: 'king lear', questionCount: 2 }, // folds onto the same key
-      { label: 'Hamlet', questionCount: 0 },
-    ]);
-    expect(map.get('king lear')).toBe(6 * mod.REACHABLE_POINTS_PER_QUESTION);
-    expect(map.get('hamlet')).toBe(0);
+    const out = mod.resolveV2Mastery(nodes, [edge('well-tempered clavier', 'bach')], new Map([['bach', 800]]));
+    expect(out.get('bach')).toMatchObject({ points: 800, isMaster: true }); // 800 ≥ 750
   });
 });

--- a/src/server/knowledge/__tests__/mastery-v2.test.ts
+++ b/src/server/knowledge/__tests__/mastery-v2.test.ts
@@ -1,146 +1,42 @@
 import { describe, expect, it } from 'vitest';
 
-// Pure module — no DB, no side effects — so a static import is fine (unlike the
-// parent-mastery test, which dynamic-imports because that module pulls in db).
+// Pure module — no DB, no side effects — so a static import is fine.
 import {
-  DEFAULT_POINTS_PER_WEIGHT,
-  PARENT_MASTERY_COVERAGE,
-  computeLeafBar,
-  leafMastered,
-  leafProgress,
-  parentCoverage,
-  parentCoverageFromLeaves,
+  DEFAULT_MASTERY_THRESHOLD,
+  MASTERY_FRACTION,
+  isMastered,
+  masteryProgress,
 } from '@/server/knowledge/mastery-v2';
 
-describe('leafProgress', () => {
-  it('is the clamped fraction of the bar', () => {
-    expect(leafProgress(50, 100)).toBe(0.5);
-    expect(leafProgress(100, 100)).toBe(1);
-    expect(leafProgress(250, 100)).toBe(1); // capped
+describe('masteryProgress', () => {
+  it('is the clamped fraction of the threshold', () => {
+    expect(masteryProgress(500, 1000)).toBe(0.5);
+    expect(masteryProgress(1000, 1000)).toBe(1);
+    expect(masteryProgress(2500, 1000)).toBe(1); // capped
   });
 
-  it('is 0 for a non-positive bar or negative earnings', () => {
-    expect(leafProgress(50, 0)).toBe(0);
-    expect(leafProgress(50, -10)).toBe(0);
-    expect(leafProgress(-5, 100)).toBe(0);
-  });
-});
-
-describe('leafMastered', () => {
-  it('is true only at or above a positive bar', () => {
-    expect(leafMastered(100, 100)).toBe(true);
-    expect(leafMastered(120, 100)).toBe(true);
-    expect(leafMastered(99, 100)).toBe(false);
-    expect(leafMastered(100, 0)).toBe(false); // no bar to clear
+  it('is 0 for a non-positive threshold or negative points', () => {
+    expect(masteryProgress(500, 0)).toBe(0);
+    expect(masteryProgress(500, -10)).toBe(0);
+    expect(masteryProgress(-5, 1000)).toBe(0);
   });
 });
 
-describe('computeLeafBar', () => {
-  it('scales the bar by weight × pointsPerWeight', () => {
-    expect(computeLeafBar({ weight: 10 })).toBe(10 * DEFAULT_POINTS_PER_WEIGHT);
-    expect(computeLeafBar({ weight: 3, pointsPerWeight: 50 })).toBe(150);
+describe('isMastered — the 75% bar', () => {
+  it('masters at or above 75% of the threshold', () => {
+    expect(isMastered(750, 1000)).toBe(true); // exactly 75%
+    expect(isMastered(900, 1000)).toBe(true);
+    expect(isMastered(749, 1000)).toBe(false);
   });
 
-  it('a non-positive weight yields a 0 bar', () => {
-    expect(computeLeafBar({ weight: 0 })).toBe(0);
-    expect(computeLeafBar({ weight: -4 })).toBe(0);
-  });
-
-  it('CAPS the bar at reachable supply so a deep-but-thin domain stays masterable', () => {
-    // Deep topic (weight 40 → depthBar 4000) but only 300 points of supply exist.
-    expect(computeLeafBar({ weight: 40, reachableSupplyPoints: 300 })).toBe(300);
-    // Supply above the depth demand does not raise the bar.
-    expect(computeLeafBar({ weight: 2, reachableSupplyPoints: 5000 })).toBe(200);
-    // No cap when supply is omitted / Infinity.
-    expect(computeLeafBar({ weight: 40, reachableSupplyPoints: Infinity })).toBe(4000);
-    expect(computeLeafBar({ weight: 40 })).toBe(4000);
-  });
-});
-
-describe('parentCoverage — smooth (default)', () => {
-  it('is the depth-weighted mean of leaf progress', () => {
-    const { coverage, isMaster } = parentCoverage([
-      { weight: 1, progress: 1 },
-      { weight: 1, progress: 0 },
-    ]);
-    expect(coverage).toBe(0.5); // 1/2
-    expect(isMaster).toBe(false);
-  });
-
-  it('weights a big leaf more than a small one', () => {
-    // Only the big leaf covered: 30/50 = 0.6 — not yet master.
-    expect(
-      parentCoverage([
-        { weight: 30, progress: 1 },
-        { weight: 10, progress: 0 },
-        { weight: 10, progress: 0 },
-      ]).coverage,
-    ).toBeCloseTo(0.6);
-    // Add a second covered leaf: 40/50 = 0.8 — master.
-    const withSecond = parentCoverage([
-      { weight: 30, progress: 1 },
-      { weight: 10, progress: 1 },
-      { weight: 10, progress: 0 },
-    ]);
-    expect(withSecond.coverage).toBeCloseTo(0.8);
-    expect(withSecond.isMaster).toBe(true);
-  });
-
-  it('exactly 75% masters (≥, not >)', () => {
-    expect(parentCoverage([{ weight: 3, progress: 1 }, { weight: 1, progress: 0 }]).isMaster).toBe(
-      true,
-    ); // 3/4 = 0.75
-  });
-
-  it('empty or zero-weight parents read as 0 coverage, not-master', () => {
-    expect(parentCoverage([])).toEqual({ coverage: 0, isMaster: false });
-    expect(parentCoverage([{ weight: 0, progress: 1 }])).toEqual({ coverage: 0, isMaster: false });
-  });
-});
-
-describe('parentCoverage — binary contribution', () => {
-  it('only FULLY mastered leaves count their weight', () => {
-    const smooth = parentCoverage(
-      [
-        { weight: 1, progress: 0.9 },
-        { weight: 1, progress: 0.9 },
-      ],
-      { contribution: 'smooth' },
-    );
-    expect(smooth.coverage).toBeCloseTo(0.9); // partial counts
-
-    const binary = parentCoverage(
-      [
-        { weight: 1, progress: 0.9 },
-        { weight: 1, progress: 0.9 },
-      ],
-      { contribution: 'binary' },
-    );
-    expect(binary.coverage).toBe(0); // neither is fully mastered → nothing counts
-  });
-});
-
-describe('the King Lear scenario (spec §The problem)', () => {
-  it('mastering one leaf never masters the whole parent unless it is ≥75% of the weight', () => {
-    // Tragedy's leaves, weighted by breadth. King Lear fully mastered, rest untouched.
-    const tragedy = parentCoverageFromLeaves([
-      { weight: 15, earnedPoints: 400, leafBar: 300 }, // King Lear — mastered (progress capped to 1)
-      { weight: 20, earnedPoints: 0, leafBar: 400 }, // Hamlet
-      { weight: 12, earnedPoints: 0, leafBar: 300 }, // Macbeth
-      { weight: 10, earnedPoints: 0, leafBar: 250 }, // Othello
-    ]);
-    // 15 / 57 ≈ 0.26 — a real King Lear master, honestly NOT a Tragedy master.
-    expect(tragedy.coverage).toBeCloseTo(15 / 57, 5);
-    expect(tragedy.isMaster).toBe(false);
-  });
-
-  it('the leaf itself is (and stays) mastered regardless of the parent verdict', () => {
-    expect(leafMastered(400, 300)).toBe(true);
+  it('never masters on a non-positive threshold', () => {
+    expect(isMastered(1000, 0)).toBe(false);
   });
 });
 
 describe('constants', () => {
-  it('the parent bar is 75%', () => {
-    expect(PARENT_MASTERY_COVERAGE).toBe(0.75);
+  it('the bar is 75% and the default threshold is sane', () => {
+    expect(MASTERY_FRACTION).toBe(0.75);
+    expect(DEFAULT_MASTERY_THRESHOLD).toBeGreaterThan(0);
   });
 });

--- a/src/server/knowledge/knowledge-tree.ts
+++ b/src/server/knowledge/knowledge-tree.ts
@@ -34,9 +34,7 @@ import {
 import {
   getV2MasteryForUser,
   isKnowledgeMasteryV2Enabled,
-  reachableSupplyFromDepths,
 } from '@/server/knowledge/mastery-v2-resolve';
-import { getCorpusLabelDepths } from '@/server/db/queries/crafter-demand';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 // Gap-view framing for a substantive parent (D-KNOWLEDGE-MAP-USABILITY-01 C3):
@@ -374,28 +372,19 @@ export async function getKnowledgeMapData(
   let frozenParents: ReadonlySet<string> = new Set();
   let masteredOverride: ReadonlySet<string> | undefined;
   if (isKnowledgeMasteryV2Enabled()) {
-    // v2 read path: depth-weighted coverage over the containment tree. Overrides
-    // the per-node master badge; the v1 gap-view numbers still frame the focus
-    // header for now (a v2 coverage framing is a follow-up).
+    // v2 read path (points-threshold model): every node's mastery = rolled-up
+    // points ÷ its own threshold ≥ 75%. Overrides the per-node master badge; the
+    // v1 gap-view numbers still frame the focus header for now.
     const v2Nodes = graph.nodes.map((n) => ({
       domainKey: n.domainKey,
       nodeKind: n.nodeKind,
-      nodeWeight: n.nodeWeight,
+      masteryThreshold: n.masteryThreshold,
     }));
     const pointsByKey = new Map<string, number>();
     for (const leaf of owned) pointsByKey.set(domainKey(leaf.domain), leaf.points);
-    // Reachable-supply cap: a leaf's bar can't exceed what its existing questions
-    // can award, so a deep-but-thin domain stays masterable (spec decision 5).
-    const depths = await getCorpusLabelDepths();
-    const reachableSupplyByKey = reachableSupplyFromDepths(
-      depths.map((d) => ({ label: d.label, questionCount: d.machineDepth + d.humanAuthored })),
-    );
-    const v2 = await getV2MasteryForUser(userId, v2Nodes, edges, pointsByKey, {
-      reachableSupplyByKey,
-    });
+    const v2 = await getV2MasteryForUser(userId, v2Nodes, edges, pointsByKey);
     const mastered = new Set<string>();
-    for (const [key, leaf] of v2.leaves) if (leaf.isMaster) mastered.add(key);
-    for (const [key, parent] of v2.parents) if (parent.isMaster) mastered.add(key);
+    for (const [key, entry] of v2) if (entry.isMaster) mastered.add(key);
     masteredOverride = mastered;
   } else if (isKnowledgeGraphMasteryEnabled()) {
     const credits = new Map<string, number>();

--- a/src/server/knowledge/mastery-v2-resolve.ts
+++ b/src/server/knowledge/mastery-v2-resolve.ts
@@ -1,35 +1,30 @@
 /**
- * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md) — Phase 5: the pure READ-MODEL.
+ * Mastery v2 (docs/thinking/MASTERY-MODEL-v2.md "Final model") — the READ-MODEL.
  *
- * Composes node WEIGHT (Phase 2, `node_weight`) and the v2 KERNEL (Phase 1,
- * mastery-v2.ts) over the containment tree (Phase 4, every edge is depth-eligible)
- * into per-node mastery, split by grain (spec decision 3):
+ * Projects a player's per-leaf points onto the containment tree and resolves each
+ * node's mastery against its own POINTS threshold:
+ *   points   = rolled-up points (a leaf's own; a parent's descendant sum)
+ *   progress = points / threshold
+ *   mastered = points ≥ 75% of threshold        (isMastered)
+ * One formula for every node. The only leaf/parent difference:
+ *   - LEAF (and 'both') mastery FREEZES — permanent once earned (the freeze
+ *     ledger); a pure PARENT is LIVE (climbs/falls as the map fills in).
+ *   - Parent thresholds are INDEPENDENT (the LLM's estimate of the whole area),
+ *     not a sum of leaves — so an incomplete area can't be falsely mastered.
  *
- *   - LEAF grain (freeze-able): every point-bearing node (nodeKind leaf | both).
- *     leafBar = f(weight, reachable supply); progress = points/bar; mastered when
- *     frozen OR points ≥ bar. Once a leaf is frozen it reads as master forever.
- *   - PARENT grain (LIVE coverage): a container's depth-weighted coverage of its
- *     descendant point-bearing leaves. Mastered at ≥ 75% (PARENT_MASTERY_COVERAGE).
- *     Never frozen — it rises and falls as the map grows (this is what recombines
- *     the fine sub-domains a question-domain recompute fragments; see the Phase 3
- *     finding in the spec).
- *
- * Pure and deterministic — no DB, no writes. The DB-backed wrapper (reading the
- * leaf-freeze ledger, loading nodes/edges/points) and the surface wiring
- * (buildKnowledgeTree behind KNOWLEDGE_MASTERY_V2) land in the follow-up P5 step.
+ * The pure `resolveV2Mastery` is unit-tested without a DB; `getV2MasteryForUser`
+ * is the thin DB wrapper (reads/stamps the leaf-freeze ledger). Inert until
+ * KNOWLEDGE_MASTERY_V2 flips.
  */
 
 import { eq } from 'drizzle-orm';
 
 import { db, knowledgeLeafMastery } from '@/server/db';
-import { domainKey } from '@/lib/knowledge/domain-key';
-import { substantiveDescendants, type GraphEdge } from '@/server/knowledge/graph';
+import { rollUpCredit, type GraphEdge } from '@/server/knowledge/graph';
 import {
-  computeLeafBar,
-  leafMastered,
-  leafProgress,
-  parentCoverage,
-  type LeafContribution,
+  DEFAULT_MASTERY_THRESHOLD,
+  isMastered,
+  masteryProgress,
 } from '@/server/knowledge/mastery-v2';
 
 function boolEnv(name: string, fallback: boolean): boolean {
@@ -38,132 +33,69 @@ function boolEnv(name: string, fallback: boolean): boolean {
   return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
 }
 
-/** Flag gate for the v2 read path (the follow-up surface wiring reads this). */
+/** Flag gate for the v2 read path. */
 export function isKnowledgeMasteryV2Enabled(): boolean {
   return boolEnv('KNOWLEDGE_GRAPH_ENABLED', false) && boolEnv('KNOWLEDGE_MASTERY_V2', false);
-}
-
-/**
- * Fallback weight for an unseeded node. Every prod node was seeded 2026-07-04, but
- * a node minted after the backfill (before its seed runs) reads null — treat it as
- * mid-weight rather than skew coverage.
- */
-export const DEFAULT_NODE_WEIGHT = 3;
-
-/**
- * Points a typical correct answer awards, used to convert a domain's question
- * COUNT into a reachable-supply points ceiling. 50 = a Moderate first_correct
- * (DIFFICULTY_BASE_POINTS); CALIBRATION-PENDING like DEFAULT_POINTS_PER_WEIGHT.
- */
-export const REACHABLE_POINTS_PER_QUESTION = 50;
-
-/**
- * Build the reachable-supply cap (in points) per folded domain from corpus
- * question counts — a leaf's bar can never exceed what its existing questions
- * can award (spec decision 5: a deep-but-thin domain stays masterable). Folds
- * label variants together via domainKey. Pure.
- */
-export function reachableSupplyFromDepths(
-  depths: readonly { label: string; questionCount: number }[],
-): Map<string, number> {
-  const byKey = new Map<string, number>();
-  for (const d of depths) {
-    const key = domainKey(d.label);
-    const points = Math.max(0, d.questionCount) * REACHABLE_POINTS_PER_QUESTION;
-    byKey.set(key, (byKey.get(key) ?? 0) + points);
-  }
-  return byKey;
 }
 
 export type V2Node = {
   domainKey: string;
   nodeKind: 'leaf' | 'parent' | 'both';
-  nodeWeight: number | null;
+  /** The node's mastery threshold in POINTS (null → the code default). */
+  masteryThreshold: number | null;
 };
 
-export type LeafMastery = {
+export type V2NodeMastery = {
   domainKey: string;
-  leafBar: number;
-  /** 0..1 fraction of the bar earned. */
+  /** The points threshold in effect (seeded value or the default). */
+  threshold: number;
+  /** Rolled-up points (own for a leaf; descendant sum for a parent). */
+  points: number;
+  /** 0..1 fraction of the threshold earned. */
   progress: number;
-  /** frozen (permanent) OR points ≥ bar. */
+  /** points ≥ 75% of threshold, OR (leaf/both only) a frozen master. */
   isMaster: boolean;
 };
 
-export type ParentMastery = {
-  domainKey: string;
-  /** 0..1 depth-weighted coverage of descendant leaves. */
-  coverage: number;
-  /** coverage ≥ PARENT_MASTERY_COVERAGE. Live — never frozen. */
-  isMaster: boolean;
-};
+function thresholdOf(node: V2Node): number {
+  return node.masteryThreshold != null && node.masteryThreshold > 0
+    ? node.masteryThreshold
+    : DEFAULT_MASTERY_THRESHOLD;
+}
 
-export type V2MasteryResult = {
-  leaves: Map<string, LeafMastery>;
-  parents: Map<string, ParentMastery>;
-};
-
-export type ResolveV2Options = {
-  /** Override the weight→points mapping (mastery-v2 DEFAULT_POINTS_PER_WEIGHT otherwise). */
-  pointsPerWeight?: number;
-  /** Per-leaf cap: the points the domain's existing questions can actually award. */
-  reachableSupplyByKey?: ReadonlyMap<string, number>;
-};
+/** A node bears its own points (and its mastery freezes) unless it's a pure parent. */
+function freezeEligible(node: V2Node): boolean {
+  return node.nodeKind !== 'parent';
+}
 
 /**
- * Resolve v2 mastery for a set of authored nodes + containment edges + a player's
- * per-leaf points. `frozenLeaves` are leaves the player has permanently mastered
- * (the leaf-freeze ledger, read by the DB wrapper). Pure — inject everything.
+ * Resolve v2 mastery for the authored nodes + containment edges + a player's
+ * per-leaf points. `frozenLeaves` are leaves permanently mastered (the freeze
+ * ledger). Pure — one entry per node, same formula throughout.
  */
 export function resolveV2Mastery(
   nodes: readonly V2Node[],
   edges: readonly GraphEdge[],
   pointsByKey: ReadonlyMap<string, number>,
   frozenLeaves: ReadonlySet<string> = new Set(),
-  options: ResolveV2Options = {},
-): V2MasteryResult {
-  const nodeByKey = new Map(nodes.map((n) => [n.domainKey, n]));
-  const weightOf = (n: V2Node): number =>
-    n.nodeWeight != null && n.nodeWeight > 0 ? n.nodeWeight : DEFAULT_NODE_WEIGHT;
+): Map<string, V2NodeMastery> {
+  // Every node's rolled-up points: a leaf's own, a parent's descendant sum.
+  const totals = rollUpCredit(pointsByKey, edges);
 
-  // 1) LEAF grain — every point-bearing node (leaf or 'both').
-  const leaves = new Map<string, LeafMastery>();
+  const out = new Map<string, V2NodeMastery>();
   for (const node of nodes) {
-    if (node.nodeKind === 'parent') continue; // pure container, no own points
-    const leafBar = computeLeafBar({
-      weight: weightOf(node),
-      reachableSupplyPoints: options.reachableSupplyByKey?.get(node.domainKey),
-      pointsPerWeight: options.pointsPerWeight,
-    });
-    const points = pointsByKey.get(node.domainKey) ?? 0;
-    leaves.set(node.domainKey, {
+    const threshold = thresholdOf(node);
+    const points = totals.get(node.domainKey) ?? 0;
+    const frozen = freezeEligible(node) && frozenLeaves.has(node.domainKey);
+    out.set(node.domainKey, {
       domainKey: node.domainKey,
-      leafBar,
-      progress: leafProgress(points, leafBar),
-      isMaster: frozenLeaves.has(node.domainKey) || leafMastered(points, leafBar),
+      threshold,
+      points,
+      progress: masteryProgress(points, threshold),
+      isMaster: frozen || isMastered(points, threshold),
     });
   }
-
-  // 2) PARENT grain — LIVE depth-weighted coverage of descendant leaves.
-  const parents = new Map<string, ParentMastery>();
-  for (const node of nodes) {
-    if (node.nodeKind === 'leaf') continue; // not a container
-    const contributions: LeafContribution[] = [];
-    for (const descendantKey of substantiveDescendants(node.domainKey, edges)) {
-      const leaf = leaves.get(descendantKey);
-      if (!leaf) continue; // descendant is a pure parent — no own weight/points
-      const descendantNode = nodeByKey.get(descendantKey);
-      contributions.push({
-        weight: descendantNode ? weightOf(descendantNode) : DEFAULT_NODE_WEIGHT,
-        // A mastered/frozen leaf contributes in full; else its partial progress.
-        progress: leaf.isMaster ? 1 : leaf.progress,
-      });
-    }
-    const { coverage, isMaster } = parentCoverage(contributions);
-    parents.set(node.domainKey, { domainKey: node.domainKey, coverage, isMaster });
-  }
-
-  return { leaves, parents };
+  return out;
 }
 
 // ─── DB-backed wrapper (mirrors parent-mastery.ts's getParentMasteryForUser) ───
@@ -185,26 +117,26 @@ export async function freezeLeafMastery(userId: string, leafKey: string): Promis
 }
 
 /**
- * DB-backed resolve: reads the leaf-freeze ledger, resolves v2 mastery, and stamps
- * any freshly-mastered leaf so it becomes terminal. Flag-off returns pure
- * computation with an empty frozen set and never writes — so this is inert until
- * KNOWLEDGE_MASTERY_V2 flips.
+ * DB-backed resolve: reads the leaf-freeze ledger, resolves, and stamps any
+ * freshly-mastered LEAF/'both' node so it becomes terminal. Flag-off returns pure
+ * computation with an empty frozen set and never writes — inert until the flag.
  */
 export async function getV2MasteryForUser(
   userId: string,
   nodes: readonly V2Node[],
   edges: readonly GraphEdge[],
   pointsByKey: ReadonlyMap<string, number>,
-  options: ResolveV2Options = {},
-): Promise<V2MasteryResult> {
+): Promise<Map<string, V2NodeMastery>> {
   const enabled = isKnowledgeMasteryV2Enabled();
   const frozen = enabled ? await getFrozenLeafKeys(userId) : new Set<string>();
-  const result = resolveV2Mastery(nodes, edges, pointsByKey, frozen, options);
+  const result = resolveV2Mastery(nodes, edges, pointsByKey, frozen);
 
   if (enabled) {
-    for (const [key, leaf] of result.leaves) {
-      if (leaf.isMaster && !frozen.has(key)) {
-        await freezeLeafMastery(userId, key); // best-effort terminal stamp
+    for (const node of nodes) {
+      if (!freezeEligible(node)) continue; // only leaf/'both' mastery freezes
+      const entry = result.get(node.domainKey);
+      if (entry?.isMaster && !frozen.has(node.domainKey)) {
+        await freezeLeafMastery(userId, node.domainKey); // best-effort terminal stamp
       }
     }
   }

--- a/src/server/knowledge/mastery-v2.ts
+++ b/src/server/knowledge/mastery-v2.ts
@@ -1,142 +1,36 @@
 /**
- * Mastery Model v2 — Phase 1: the PURE math core.
+ * Mastery v2 — the pure kernel (points-threshold model; see
+ * docs/thinking/MASTERY-MODEL-v2.md "Final model").
  *
- * Spec: docs/thinking/MASTERY-MODEL-v2.md. This module is deliberately WIRED TO
- * NOTHING — no DB, no imports with side effects, no flag reads, no surfaces. It
- * is the deterministic kernel the later phases build on (depth seeding, the
- * recompute engine, the read-surface wiring). Everything here is unit-tested and
- * reversible; nothing it computes is persisted or shown yet.
+ * Every node carries a mastery threshold in POINTS. Mastery is one formula
+ * everywhere:
+ *   progress = earned points / threshold   (clamped to [0, 1])
+ *   mastered = earned points ≥ 75% of threshold
+ * The only leaf/parent difference is WHOSE points roll up (a leaf's own vs a
+ * parent's descendant sum) and whether it FREEZES — none of which lives here.
  *
- * The v2 grain split (spec decision 3):
- *   - LEAF mastery is a demonstrated fact — points ≥ the leaf's bar. Permanent
- *     (frozen) in the wired phases; here it is just the pure predicate.
- *   - PARENT mastery is live COVERAGE of its leaves — the depth-weighted share of
- *     the parent's material that sits in mastered/progressed leaves. It can rise
- *     or fall as the map grows (spec decision 4). No freeze at this grain.
- *
- * Two quantities the spec is careful to keep distinct (refinement #2):
- *   - "depth" elsewhere in the app = a QUESTION COUNT ("37 Qs", `depthByKey`).
- *   - a node's WEIGHT here = a topic-size / breadth proxy (Wikidata child-count
- *     or an LLM depth score, seeded in Phase 2). Never conflate the two.
+ * Pure and deterministic — no I/O. (This replaces the depth-WEIGHT kernel:
+ * `leafBar`/`parentCoverage`/`node_weight` and the two calibration constants are
+ * gone; the per-node number is now a points threshold directly.)
  */
 
-/** Spec decision 4: a parent is mastered at ≥ 75% depth-weighted coverage. */
-export const PARENT_MASTERY_COVERAGE = 0.75;
+/** Spec: mastered at ≥ 75% of the threshold, identically for leaf and parent. */
+export const MASTERY_FRACTION = 0.75;
 
 /**
- * Maps a node's WEIGHT (breadth proxy, e.g. Wikidata child-count or an LLM 1–10
- * score) to a points bar for the leaf. CALIBRATION-PENDING: Phase 0 (2026-07-04)
- * showed live points are small (avg ~101, 1 player above 1000 of 212), so this
- * constant must be tuned against real distributions when the model is wired
- * (Phase 5/6) — otherwise "mastery" stays unreachable. Kept as a named, override-
- * able default so callers/tests pin it explicitly rather than depending on it.
+ * Default points threshold for a node with no seeded value. Deliberately high so
+ * an unseeded node under-promises rather than handing out cheap mastery.
  */
-export const DEFAULT_POINTS_PER_WEIGHT = 100;
+export const DEFAULT_MASTERY_THRESHOLD = 1000;
 
-function clamp01(x: number): number {
-  if (!Number.isFinite(x) || x <= 0) return 0;
-  return x >= 1 ? 1 : x;
+/** Fraction of the threshold earned, clamped to [0, 1]. A non-positive threshold → 0. */
+export function masteryProgress(points: number, threshold: number): number {
+  if (!Number.isFinite(threshold) || threshold <= 0) return 0;
+  const fraction = points / threshold;
+  return fraction <= 0 ? 0 : fraction >= 1 ? 1 : fraction;
 }
 
-/**
- * A leaf's points bar = depth demand, CAPPED BY REACHABLE SUPPLY (spec decision
- * 5): you can never be required to earn more points than the domain's existing
- * questions can award, so a deep-but-thin domain stays masterable.
- *
- *   depthBar          = round(weight · pointsPerWeight)
- *   leafBar           = min(depthBar, reachableSupplyPoints)   [supply cap]
- *
- * Omit `reachableSupplyPoints` (or pass Infinity) to skip the cap — useful for
- * pure tests and for callers that haven't wired supply yet. A non-positive
- * weight yields a 0 bar (nothing to master).
- */
-export function computeLeafBar(input: {
-  weight: number;
-  reachableSupplyPoints?: number;
-  pointsPerWeight?: number;
-}): number {
-  const pointsPerWeight = input.pointsPerWeight ?? DEFAULT_POINTS_PER_WEIGHT;
-  const weight = Number.isFinite(input.weight) && input.weight > 0 ? input.weight : 0;
-  const depthBar = Math.round(weight * pointsPerWeight);
-  const cap = input.reachableSupplyPoints;
-  if (cap === undefined || cap === Infinity) return depthBar;
-  return Math.max(0, Math.min(depthBar, cap));
-}
-
-/**
- * Leaf progress in [0, 1] — the honest fraction of the bar the player has
- * earned, clamped for display. A non-positive bar means "no bar to clear" → 0.
- */
-export function leafProgress(earnedPoints: number, leafBar: number): number {
-  if (!Number.isFinite(leafBar) || leafBar <= 0) return 0;
-  return clamp01(earnedPoints / leafBar);
-}
-
-/**
- * Leaf mastery predicate — points at or above the bar. This is the grain that
- * becomes PERMANENT (frozen) in the wired phases; here it is pure.
- */
-export function leafMastered(earnedPoints: number, leafBar: number): boolean {
-  return Number.isFinite(leafBar) && leafBar > 0 && earnedPoints >= leafBar;
-}
-
-/** One leaf's contribution to its parent: its weight and its [0,1] progress. */
-export type LeafContribution = { weight: number; progress: number };
-
-export type ParentCoverage = {
-  /** Depth-weighted share of the parent's material that is covered, in [0, 1]. */
-  coverage: number;
-  /** coverage ≥ PARENT_MASTERY_COVERAGE. Live — never frozen at this grain. */
-  isMaster: boolean;
-};
-
-/**
- * Parent COVERAGE = depth-weighted share of the parent's leaves that is covered:
- *
- *   coverage = Σ_leaf( weight · contribution(progress) ) / Σ_leaf( weight )
- *
- * `contribution` (spec open-knob, smooth recommended):
- *   - 'smooth' (default): a leaf contributes its weight × its partial progress —
- *     partial progress across many leaves counts.
- *   - 'binary': a leaf contributes its full weight only once FULLY mastered
- *     (progress ≥ 1), else nothing.
- *
- * A big leaf outweighs a small one, so mastering one leaf (Hamlet) never masters
- * the parent (all of Tragedy) unless that one leaf is ≥ 75% of the weight. Empty
- * or zero-total-weight parents read as 0 coverage, not-master.
- */
-export function parentCoverage(
-  children: readonly LeafContribution[],
-  options: { contribution?: 'smooth' | 'binary' } = {},
-): ParentCoverage {
-  const mode = options.contribution ?? 'smooth';
-  let weightedCovered = 0;
-  let totalWeight = 0;
-  for (const child of children) {
-    const weight = Number.isFinite(child.weight) && child.weight > 0 ? child.weight : 0;
-    if (weight === 0) continue;
-    totalWeight += weight;
-    const progress = clamp01(child.progress);
-    weightedCovered += mode === 'binary' ? (progress >= 1 ? weight : 0) : weight * progress;
-  }
-  const coverage = totalWeight > 0 ? weightedCovered / totalWeight : 0;
-  return { coverage, isMaster: coverage >= PARENT_MASTERY_COVERAGE };
-}
-
-/** A leaf's raw inputs, before progress is derived. */
-export type LeafState = { weight: number; earnedPoints: number; leafBar: number };
-
-/**
- * Convenience: parent coverage straight from raw leaf state (weight + earned +
- * bar), deriving each leaf's progress internally. The shape the wired read path
- * will use once leaves carry a bar.
- */
-export function parentCoverageFromLeaves(
-  leaves: readonly LeafState[],
-  options: { contribution?: 'smooth' | 'binary' } = {},
-): ParentCoverage {
-  return parentCoverage(
-    leaves.map((l) => ({ weight: l.weight, progress: leafProgress(l.earnedPoints, l.leafBar) })),
-    options,
-  );
+/** Mastered when earned points reach the 75% bar of a positive threshold. */
+export function isMastered(points: number, threshold: number): boolean {
+  return Number.isFinite(threshold) && threshold > 0 && points >= MASTERY_FRACTION * threshold;
 }


### PR DESCRIPTION
Implements the revised model (spec PR #1404): **one points threshold per node, mastery = points ÷ threshold ≥ 75%.** Replaces the depth-weight machinery. **Net −323 lines.** Still dark behind `KNOWLEDGE_MASTERY_V2`.

## The whole model, now one formula
- **`mastery-v2.ts`** (kernel): `masteryProgress(points, threshold)` + `isMastered(points, threshold)` at the 75% bar. Deleted `leafBar` / `parentCoverage` / `leafProgress` / `leafMastered` and `DEFAULT_POINTS_PER_WEIGHT`.
- **`mastery-v2-resolve.ts`**: `resolveV2Mastery` rolls points up the tree (`rollUpCredit`) and scores **every** node as `points ÷ its own threshold ≥ 75%` — a single `Map<key, V2NodeMastery>`. `V2Node` carries `masteryThreshold` (was `nodeWeight`). Deleted `reachableSupplyFromDepths` + `REACHABLE_POINTS_PER_QUESTION` + the supply cap. Leaf/'both' mastery **freezes**; pure parents stay **live**.
- **`knowledge-tree.ts`** wiring: v2 nodes carry `masteryThreshold`, override built from the single map; dropped the `getCorpusLabelDepths`/supply-cap calls.

## Key behaviors (tested)
- A **leaf** masters at ≥75% of its points threshold.
- A **parent** masters at ≥75% of its **own** independent (large) threshold → an **incomplete area can't be falsely mastered** (fully covering 3 of an eventual 10 leaves ≈ 27% of Tragedy, not mastered).
- **No supply cap** — thin early supply just means "not masterable yet."

28 tests pass (kernel + resolve + tree). Typecheck + eslint clean.

## Follow-ups (all dark)
1. **Seed points into `mastery_threshold`** per node via the LLM ("points to master {topic}") — needed for the model to be meaningful (leaves currently fall back to the default; parents still hold small v1 bars). Also fixes the miscalibrated values, in the right units.
2. Drop the `node_weight` column + `node-weight.ts` (now vestigial).
3. Turn the admin editor into a points-threshold editor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)