### PR TITLE
feat(knowledge): LLM points-threshold seeder for mastery v2

### DIFF
--- a/scripts/backfill-mastery-threshold.ts
+++ b/scripts/backfill-mastery-threshold.ts
@@ -1,0 +1,70 @@
+/**
+ * Mastery v2 (points-threshold model; docs/thinking/MASTERY-MODEL-v2.md "Final
+ * model") — seed KnowledgeNode.mastery_threshold (POINTS) via the LLM.
+ *
+ * Every node needs a points threshold: a leaf's "points to master this topic," a
+ * parent's "points to master this whole area." v1 only set thresholds on parents
+ * (small bars like 100–2,000) and left leaves NULL — both are wrong for the new
+ * model. `--all` re-scores every node (recommended once, to replace the v1 parent
+ * bars); the default touches only NULL rows.
+ *
+ * Uses scoreMasteryThresholdPoints (Haiku). Touches ONLY mastery_threshold.
+ *
+ * Read-only by default. From repo root (Node 24):
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-mastery-threshold.ts          # dry-run
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-mastery-threshold.ts --apply
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/backfill-mastery-threshold.ts --all --apply
+ */
+import pg from 'pg';
+
+import { scoreMasteryThresholdPoints } from '../src/server/llm/domain-depth';
+
+const DB_URL = process.env.DIRECT_URL || process.env.DATABASE_URL;
+if (!DB_URL) {
+  console.error('No DIRECT_URL/DATABASE_URL in env');
+  process.exit(1);
+}
+
+const APPLY = process.argv.includes('--apply');
+const ALL = process.argv.includes('--all');
+
+type NodeRow = { id: string; label: string; node_kind: string; mastery_threshold: number | null };
+
+async function main() {
+  const client = new pg.Client({ connectionString: DB_URL });
+  await client.connect();
+  try {
+    const { rows } = await client.query<NodeRow>(
+      ALL
+        ? `SELECT id, label, node_kind, mastery_threshold FROM "KnowledgeNode" ORDER BY node_kind DESC, label`
+        : `SELECT id, label, node_kind, mastery_threshold FROM "KnowledgeNode" WHERE mastery_threshold IS NULL ORDER BY node_kind DESC, label`,
+    );
+
+    console.log(`\n=== mastery_threshold seed — ${APPLY ? 'APPLY' : 'DRY RUN'}${ALL ? ' (--all)' : ''} ===`);
+    console.log(`nodes to seed: ${rows.length}\n     old →  new   kind    label`);
+
+    let changed = 0;
+    for (const node of rows) {
+      const points = await scoreMasteryThresholdPoints(node.label);
+      const shown = points ?? '—(skip)';
+      const old = node.mastery_threshold ?? '·';
+      console.log(`  ${String(old).padStart(6)} → ${String(shown).padStart(6)}  ${node.node_kind.padEnd(6)}  ${node.label}`);
+      if (APPLY && points !== null) {
+        await client.query(`UPDATE "KnowledgeNode" SET mastery_threshold = $1 WHERE id = $2`, [
+          points,
+          node.id,
+        ]);
+        changed += 1;
+      }
+    }
+
+    console.log(`\n${APPLY ? `updated ${changed} rows.` : '(dry run — pass --apply to write)'}`);
+  } finally {
+    await client.end();
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/server/llm/domain-depth.ts
+++ b/src/server/llm/domain-depth.ts
@@ -55,3 +55,54 @@ Respond in JSON only: { "depth": &lt;integer 1-10&gt; }`;
     return null;
   }
 }
+
+export const MIN_MASTERY_THRESHOLD = 300;
+export const MAX_MASTERY_THRESHOLD = 40_000;
+
+/**
+ * Mastery v2 (points-threshold model) — estimate how many POINTS of trivia play
+ * demonstrate mastery of a topic, in the game's own scoring currency (a correct
+ * answer earns ~10 easy / ~50 moderate / ~100 hard). This seeds
+ * `KnowledgeNode.mastery_threshold` for every node — a leaf gets a modest number,
+ * a parent (whole area) a large one. Returns null when unavailable.
+ *
+ * Haiku (categorization tier). FAILS OPEN: absent client / outage / malformed →
+ * null, so the caller leaves the node unseeded (reader falls back to the default).
+ */
+export async function scoreMasteryThresholdPoints(label: string): Promise<number | null> {
+  const clean = label.trim().replace(/\s+/g, ' ').slice(0, 120);
+  if (!clean) return null;
+
+  const client = getAnthropicClient();
+  if (!client) return null;
+
+  const systemPrompt = `Estimate how many POINTS of trivia play demonstrate real MASTERY of a topic.
+Scoring currency: a correct answer earns ~10 (easy), ~50 (moderate), ~100 (hard) — so mastery = correctly answering enough of the topic's questions.
+Judge the topic's real-world SIZE, not its fame. Anchors:
+- a single narrow work or event (one poem, one battle, one minor character): 300–800
+- a focused subject (one novel, one album, a lesser figure): 800–2,000
+- a major figure's body of work, a franchise, a decade of a genre: 2,000–6,000
+- a large field (a national literature, a war, a scientific subfield): 6,000–15,000
+- a vast domain (a whole art form, a science, a millennium of history): 15,000–40,000
+Respond in JSON only: { "points": &lt;integer&gt; }`;
+
+  try {
+    const response = await loggedMessagesCreate(client, 'mastery-threshold-points', {
+      model: HAIKU_MODEL,
+      max_tokens: 40,
+      temperature: 0.1,
+      system: systemPrompt,
+      messages: [{ role: 'user', content: wrapUserInput('topic', clean) }],
+    });
+
+    const parsed = parseJsonObject(extractTextContent(response.content));
+    const raw = parsed?.points ?? parsed?.threshold;
+    const n = typeof raw === 'number' ? raw : Number(raw);
+    if (!Number.isFinite(n)) return null;
+    // Round to the nearest 100 and clamp to a sane band.
+    const rounded = Math.round(n / 100) * 100;
+    return Math.max(MIN_MASTERY_THRESHOLD, Math.min(MAX_MASTERY_THRESHOLD, rounded));
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Enables the points-threshold model (spec #1404, rework #1405) by seeding `KnowledgeNode.mastery_threshold` in **points**. Code only — **not run against prod** (that's a deliberate step once #1405 merges).

## What's here
- **`scoreMasteryThresholdPoints(label)`** (`domain-depth.ts`): a Haiku estimate of "how many points of play demonstrate mastery of {topic}," in the game's own currency (a correct answer earns ~10 / 50 / 100 by difficulty), with real-world-size anchors (single work ~300–800 … vast domain ~15k–40k). Rounded to the nearest 100, clamped to [300, 40 000]. Fails open to null.
- **`scripts/backfill-mastery-threshold.ts`**: seeds every node — dry-run default, `--apply` to write, `--all` to re-score parents' stale v1 bars too. Touches only `mastery_threshold`.

## How it pairs with the model
A **leaf** gets a modest threshold ("points to master King Lear"), a **parent** a large one ("points to master all of Shakespearean Tragedy") — independent, so an incomplete area stays unmasterable until it fills in. That's exactly what the rework's `resolveV2Mastery` scores against.

Typecheck + eslint clean.

## Sequencing
Merge order for the whole v3 line: spec #1404 → rework #1405 → this. Then run the backfill (`--all`) in prod and flip `KNOWLEDGE_MASTERY_V2` in preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)