### PR TITLE
feat(admin/knowledge): supply columns — points available + where questions are hard to find

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -47,10 +47,12 @@ export function KnowledgeAdminClient({
   nodes,
   edges,
   depthByKey,
+  pointsByKey,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
+  pointsByKey: Record<string, number>;
 }) {
   const router = useRouter();
 
@@ -63,10 +65,11 @@ export function KnowledgeAdminClient({
         <AdminTabs active="knowledge" />
         <p className="text-muted-foreground mt-3 text-sm leading-relaxed">
           The territory structure — human-authored, always. Nodes are leaves/parents. Each row
-          shows its <strong>mastery weight</strong> (<em>wt</em> — the depth/mass of the topic,
-          1–10, color-coded shallow→deep; it scales mastery for leaves and each node&apos;s share
-          of a parent&apos;s coverage) and its question count (<em>Qs</em>, rolled up through the
-          subtree for parents). Nothing here touches questions or any player&apos;s mastery.
+          shows its <strong>mastery threshold</strong> (<em>pts</em> — the points to master the
+          topic, color-coded by size; edit it via ⋯), its question count (<em>Qs</em>), and the
+          points currently <em>avail</em>able there (difficulty-weighted) — the latter two rolled
+          up through the subtree for parents. Nothing here touches questions or any player&apos;s
+          mastery.
         </p>
       </header>
 
@@ -76,6 +79,7 @@ export function KnowledgeAdminClient({
         nodes={nodes}
         edges={edges}
         depthByKey={depthByKey}
+        pointsByKey={pointsByKey}
         onDone={() => router.refresh()}
       />
 
@@ -141,11 +145,13 @@ function KnowledgeTreeEditor({
   nodes,
   edges,
   depthByKey,
+  pointsByKey,
   onDone,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
+  pointsByKey: Record<string, number>;
   onDone: () => void;
 }) {
   const nodeByKey = useMemo(() => new Map(nodes.map((n) => [n.domainKey, n])), [nodes]);
@@ -720,6 +726,7 @@ function KnowledgeTreeEditor({
                 ancestors={new Set()}
                 nodeByKey={nodeByKey}
                 depthByKey={depthByKey}
+                pointsByKey={pointsByKey}
                 childrenByParent={childrenByParent}
                 parentCountByChild={parentCountByChild}
                 parentsByChild={parentsByChild}
@@ -785,6 +792,7 @@ function TreeRow({
   ancestors,
   nodeByKey,
   depthByKey,
+  pointsByKey,
   childrenByParent,
   parentCountByChild,
   parentsByChild,
@@ -808,6 +816,7 @@ function TreeRow({
   ancestors: Set<string>;
   nodeByKey: Map<string, KnowledgeNodeRow>;
   depthByKey: Record<string, number>;
+  pointsByKey: Record<string, number>;
   childrenByParent: Map<string, string[]>;
   parentCountByChild: Map<string, number>;
   parentsByChild: Map<string, string[]>;
@@ -1048,6 +1057,12 @@ function TreeRow({
               </span>
               <span className="text-muted-foreground" title="Questions in this area">
                 {depthByKey[nodeKey] ?? 0} Qs
+              </span>
+              <span
+                className="text-muted-foreground"
+                title="Points currently available here (difficulty-weighted, rolled up) — eyeball against the threshold"
+              >
+                {(pointsByKey[nodeKey] ?? 0).toLocaleString()} avail
               </span>
             </span>
             {/* Multi-parent chip: tap to see every place this territory lives
@@ -1307,6 +1322,7 @@ function TreeRow({
               ancestors={new Set([...ancestors, nodeKey])}
               nodeByKey={nodeByKey}
               depthByKey={depthByKey}
+              pointsByKey={pointsByKey}
               childrenByParent={childrenByParent}
               parentCountByChild={parentCountByChild}
               parentsByChild={parentsByChild}

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -48,11 +48,13 @@ export function KnowledgeAdminClient({
   edges,
   depthByKey,
   pointsByKey,
+  genStatsByKey,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
+  genStatsByKey: Record<string, { total: number; dupes: number }>;
 }) {
   const router = useRouter();
 
@@ -68,8 +70,9 @@ export function KnowledgeAdminClient({
           shows its <strong>mastery threshold</strong> (<em>pts</em> — the points to master the
           topic, color-coded by size; edit it via ⋯), its question count (<em>Qs</em>), and the
           points currently <em>avail</em>able there (difficulty-weighted) — the latter two rolled
-          up through the subtree for parents. Nothing here touches questions or any player&apos;s
-          mastery.
+          up through the subtree for parents. A <em>⟳ dup</em> flag marks where new questions are
+          hard to find (a high share of generations come back duplicates). Nothing here touches
+          questions or any player&apos;s mastery.
         </p>
       </header>
 
@@ -80,6 +83,7 @@ export function KnowledgeAdminClient({
         edges={edges}
         depthByKey={depthByKey}
         pointsByKey={pointsByKey}
+        genStatsByKey={genStatsByKey}
         onDone={() => router.refresh()}
       />
 
@@ -141,17 +145,31 @@ function thresholdColor(points: number): string {
   return 'var(--danger)'; // large
 }
 
+// "Hard to find questions" heat: the share of a domain's GENERATED questions that
+// came back DUPLICATES. A high share means the generator keeps repeating itself —
+// the topic's fresh facts are drying up, so new questions are hard to source (vs
+// a domain like Shakespearean Tragedy where they still come easily). Only shown
+// when there's a real sample AND it's actually hard (≥ 50%), so the tree
+// highlights only the territories that need authoring attention.
+const HARD_TO_SOURCE_MIN_SAMPLE = 10;
+const HARD_TO_SOURCE_MIN_RATE = 0.5;
+function dupRateColor(rate: number): string {
+  return rate >= 0.65 ? 'var(--danger)' : 'var(--accent-gold)'; // ≥65% red; 50–65% gold
+}
+
 function KnowledgeTreeEditor({
   nodes,
   edges,
   depthByKey,
   pointsByKey,
+  genStatsByKey,
   onDone,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
+  genStatsByKey: Record<string, { total: number; dupes: number }>;
   onDone: () => void;
 }) {
   const nodeByKey = useMemo(() => new Map(nodes.map((n) => [n.domainKey, n])), [nodes]);
@@ -727,6 +745,7 @@ function KnowledgeTreeEditor({
                 nodeByKey={nodeByKey}
                 depthByKey={depthByKey}
                 pointsByKey={pointsByKey}
+                genStatsByKey={genStatsByKey}
                 childrenByParent={childrenByParent}
                 parentCountByChild={parentCountByChild}
                 parentsByChild={parentsByChild}
@@ -793,6 +812,7 @@ function TreeRow({
   nodeByKey,
   depthByKey,
   pointsByKey,
+  genStatsByKey,
   childrenByParent,
   parentCountByChild,
   parentsByChild,
@@ -817,6 +837,7 @@ function TreeRow({
   nodeByKey: Map<string, KnowledgeNodeRow>;
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
+  genStatsByKey: Record<string, { total: number; dupes: number }>;
   childrenByParent: Map<string, string[]>;
   parentCountByChild: Map<string, number>;
   parentsByChild: Map<string, string[]>;
@@ -1064,6 +1085,22 @@ function TreeRow({
               >
                 {(pointsByKey[nodeKey] ?? 0).toLocaleString()} avail
               </span>
+              {(() => {
+                const g = genStatsByKey[nodeKey];
+                if (!g || g.total < HARD_TO_SOURCE_MIN_SAMPLE) return null;
+                const rate = g.dupes / g.total;
+                if (rate < HARD_TO_SOURCE_MIN_RATE) return null; // only flag where it's hard
+                const pct = Math.round(rate * 100);
+                return (
+                  <span
+                    className="font-medium"
+                    style={{ color: dupRateColor(rate) }}
+                    title={`${pct}% of generated questions here are duplicates — new ones are hard to find (${g.dupes}/${g.total} generated)`}
+                  >
+                    ⟳ {pct}% dup
+                  </span>
+                );
+              })()}
             </span>
             {/* Multi-parent chip: tap to see every place this territory lives
                 and jump to any of them. */}
@@ -1323,6 +1360,7 @@ function TreeRow({
               nodeByKey={nodeByKey}
               depthByKey={depthByKey}
               pointsByKey={pointsByKey}
+              genStatsByKey={genStatsByKey}
               childrenByParent={childrenByParent}
               parentCountByChild={parentCountByChild}
               parentsByChild={parentsByChild}

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -2,7 +2,11 @@ import { notFound } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
-import { getCorpusLabelDepths, getCorpusLabelPoints } from '@/server/db/queries/crafter-demand';
+import {
+  getCorpusLabelDepths,
+  getCorpusLabelGenStats,
+  getCorpusLabelPoints,
+} from '@/server/db/queries/crafter-demand';
 import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
@@ -18,7 +22,7 @@ export default async function AdminKnowledgePage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
-  const [{ nodes, edges }, corpusDepths, corpusPoints] = await Promise.all([
+  const [{ nodes, edges }, corpusDepths, corpusPoints, corpusGenStats] = await Promise.all([
     listKnowledgeGraph(),
     // Per-label question depth (machine + human), so the tree can flag
     // territories too thin to stand alone ("this is too small — condense it").
@@ -26,6 +30,9 @@ export default async function AdminKnowledgePage() {
     // Per-label points currently available (difficulty-weighted), shown next to
     // Qs so a curator can eyeball it against the node's mastery threshold.
     getCorpusLabelPoints(),
+    // Per-label generation exhaustion (total produced + duplicates), so the tree
+    // can flag where NEW questions are hard to find (high duplicate share).
+    getCorpusLabelGenStats(),
   ]);
   const ownDepthByKey: Record<string, number> = {};
   for (const entry of corpusDepths) {
@@ -34,6 +41,13 @@ export default async function AdminKnowledgePage() {
   const ownPointsByKey: Record<string, number> = {};
   for (const entry of corpusPoints) {
     ownPointsByKey[domainKey(entry.label)] = (ownPointsByKey[domainKey(entry.label)] ?? 0) + entry.points;
+  }
+  const ownGenByKey: Record<string, { total: number; dupes: number }> = {};
+  for (const entry of corpusGenStats) {
+    const key = domainKey(entry.label);
+    const acc = (ownGenByKey[key] ??= { total: 0, dupes: 0 });
+    acc.total += entry.total;
+    acc.dupes += entry.dupes;
   }
 
   // Rolled-up Qs for display: questions are filed under LEAF labels, so a
@@ -48,6 +62,7 @@ export default async function AdminKnowledgePage() {
   }
   const depthByKey: Record<string, number> = { ...ownDepthByKey };
   const pointsByKey: Record<string, number> = { ...ownPointsByKey };
+  const genStatsByKey: Record<string, { total: number; dupes: number }> = {};
   for (const node of nodes) {
     const key = node.domainKey;
     const descendants = new Set<string>();
@@ -60,12 +75,17 @@ export default async function AdminKnowledgePage() {
     }
     let depthSum = ownDepthByKey[key] ?? 0;
     let pointsSum = ownPointsByKey[key] ?? 0;
+    let genTotal = ownGenByKey[key]?.total ?? 0;
+    let genDupes = ownGenByKey[key]?.dupes ?? 0;
     for (const d of descendants) {
       depthSum += ownDepthByKey[d] ?? 0;
       pointsSum += ownPointsByKey[d] ?? 0;
+      genTotal += ownGenByKey[d]?.total ?? 0;
+      genDupes += ownGenByKey[d]?.dupes ?? 0;
     }
     depthByKey[key] = depthSum;
     pointsByKey[key] = pointsSum;
+    genStatsByKey[key] = { total: genTotal, dupes: genDupes };
   }
 
   return (
@@ -74,6 +94,7 @@ export default async function AdminKnowledgePage() {
       edges={edges}
       depthByKey={depthByKey}
       pointsByKey={pointsByKey}
+      genStatsByKey={genStatsByKey}
     />
   );
 }

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -2,7 +2,7 @@ import { notFound } from 'next/navigation';
 
 import { getSession } from '@/server/auth/session';
 import { isAdminUser } from '@/server/auth/admin';
-import { getCorpusLabelDepths } from '@/server/db/queries/crafter-demand';
+import { getCorpusLabelDepths, getCorpusLabelPoints } from '@/server/db/queries/crafter-demand';
 import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
@@ -18,15 +18,22 @@ export default async function AdminKnowledgePage() {
   const session = await getSession();
   if (!session || !isAdminUser(session.userId)) notFound();
 
-  const [{ nodes, edges }, corpusDepths] = await Promise.all([
+  const [{ nodes, edges }, corpusDepths, corpusPoints] = await Promise.all([
     listKnowledgeGraph(),
     // Per-label question depth (machine + human), so the tree can flag
     // territories too thin to stand alone ("this is too small — condense it").
     getCorpusLabelDepths(),
+    // Per-label points currently available (difficulty-weighted), shown next to
+    // Qs so a curator can eyeball it against the node's mastery threshold.
+    getCorpusLabelPoints(),
   ]);
   const ownDepthByKey: Record<string, number> = {};
   for (const entry of corpusDepths) {
     ownDepthByKey[domainKey(entry.label)] = entry.machineDepth + entry.humanAuthored;
+  }
+  const ownPointsByKey: Record<string, number> = {};
+  for (const entry of corpusPoints) {
+    ownPointsByKey[domainKey(entry.label)] = (ownPointsByKey[domainKey(entry.label)] ?? 0) + entry.points;
   }
 
   // Rolled-up Qs for display: questions are filed under LEAF labels, so a
@@ -40,6 +47,7 @@ export default async function AdminKnowledgePage() {
     else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
   }
   const depthByKey: Record<string, number> = { ...ownDepthByKey };
+  const pointsByKey: Record<string, number> = { ...ownPointsByKey };
   for (const node of nodes) {
     const key = node.domainKey;
     const descendants = new Set<string>();
@@ -50,10 +58,22 @@ export default async function AdminKnowledgePage() {
       descendants.add(child);
       stack.push(...(childrenByParent.get(child) ?? []));
     }
-    let sum = ownDepthByKey[key] ?? 0;
-    for (const d of descendants) sum += ownDepthByKey[d] ?? 0;
-    depthByKey[key] = sum;
+    let depthSum = ownDepthByKey[key] ?? 0;
+    let pointsSum = ownPointsByKey[key] ?? 0;
+    for (const d of descendants) {
+      depthSum += ownDepthByKey[d] ?? 0;
+      pointsSum += ownPointsByKey[d] ?? 0;
+    }
+    depthByKey[key] = depthSum;
+    pointsByKey[key] = pointsSum;
   }
 
-  return <KnowledgeAdminClient nodes={nodes} edges={edges} depthByKey={depthByKey} />;
+  return (
+    <KnowledgeAdminClient
+      nodes={nodes}
+      edges={edges}
+      depthByKey={depthByKey}
+      pointsByKey={pointsByKey}
+    />
+  );
 }

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -148,6 +148,43 @@ export async function getCorpusLabelDepths(): Promise<ClusterLabel[]> {
   return [...byLabel.values()];
 }
 
+// Difficulty-weighted POINTS a domain's current questions can award — the
+// "reachable points" a curator eyeballs against a node's mastery threshold (is
+// this area even earnable yet?). First-correct points by tier (accessible 10 /
+// moderate 50 / specialist 100; unknown tier → moderate). The MACHINE side is
+// deduped by fact_key (a player answers each fact once), matching the distinct-
+// factKey depth metric; the HUMAN side is every servable authored question.
+// Keyed by raw label — the caller folds/rolls up through the tree, same as depth.
+export async function getCorpusLabelPoints(): Promise<Array<{ label: string; points: number }>> {
+  const tierPts = sql`CASE "difficulty_estimate" WHEN 'specialist' THEN 100 WHEN 'moderate' THEN 50 WHEN 'accessible' THEN 10 ELSE 50 END`;
+  const [machine, human] = await Promise.all([
+    db.execute(sql`
+      SELECT canonical_subcategory AS label, SUM(pts)::int AS points FROM (
+        SELECT DISTINCT ON (fact_key) canonical_subcategory, (${tierPts}) AS pts
+        FROM "GeneratedQuestion"
+        WHERE is_duplicate = false AND fact_key IS NOT NULL AND canonical_subcategory IS NOT NULL
+        ORDER BY fact_key
+      ) t
+      GROUP BY canonical_subcategory
+    `),
+    db.execute(sql`
+      SELECT canonical_subcategory AS label, SUM(${tierPts})::int AS points
+      FROM "Question"
+      WHERE creator_id IS NOT NULL AND deleted_at IS NULL AND visibility <> 'blocked'
+        AND canonical_subcategory IS NOT NULL
+      GROUP BY canonical_subcategory
+    `),
+  ]);
+
+  const byLabel = new Map<string, number>();
+  for (const r of [...machine.rows, ...human.rows] as Array<{ label: string; points: number | string }>) {
+    const label = typeof r.label === 'string' ? r.label.trim() : '';
+    if (!label) continue;
+    byLabel.set(label, (byLabel.get(label) ?? 0) + Number(r.points ?? 0));
+  }
+  return [...byLabel.entries()].map(([label, points]) => ({ label, points }));
+}
+
 /**
  * For each worklist domain, the corpus labels that are lexical siblings —
  * domainKey-equal (typographic variants) or trigram-similar at the converge

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -185,6 +185,34 @@ export async function getCorpusLabelPoints(): Promise<Array<{ label: string; poi
   return [...byLabel.entries()].map(([label, points]) => ({ label, points }));
 }
 
+// Generation EXHAUSTION per domain: how many questions the generator has produced
+// (total) and how many came back DUPLICATES. A high duplicate share means the
+// generator keeps repeating itself — the topic's fresh facts are drying up, so
+// NEW questions are hard to find (the opposite of a domain where they come
+// easily). Raw counts, keyed by raw label — the caller folds/rolls up and derives
+// the rate, so a parent reflects its whole subtree.
+export async function getCorpusLabelGenStats(): Promise<
+  Array<{ label: string; total: number; dupes: number }>
+> {
+  const rows = await db
+    .select({
+      label: generatedQuestions.canonicalSubcategory,
+      total: sql<number>`count(*)::int`,
+      dupes: sql<number>`count(*) filter (where ${generatedQuestions.isDuplicate})::int`,
+    })
+    .from(generatedQuestions)
+    .where(isNotNull(generatedQuestions.canonicalSubcategory))
+    .groupBy(generatedQuestions.canonicalSubcategory);
+
+  const out: Array<{ label: string; total: number; dupes: number }> = [];
+  for (const r of rows) {
+    const label = r.label?.trim();
+    if (!label) continue;
+    out.push({ label, total: Number(r.total), dupes: Number(r.dupes) });
+  }
+  return out;
+}
+
 /**
  * For each worklist domain, the corpus labels that are lexical siblings —
  * domainKey-equal (typographic variants) or trigram-similar at the converge


### PR DESCRIPTION
Two supply-visibility signals on every knowledge-tree row, so a curator can see not just *how much* is there but *how earnable* and *how sourceable* it is.

### 1. `{N} avail` — points currently available
Difficulty-weighted points the domain's current questions can award (accessible 10 / moderate 50 / specialist 100; machine side deduped by `fact_key`, human side every servable authored Q). Rolled up through the subtree for parents. Eyeball it against the node's mastery threshold — is this area even earnable yet?

### 2. `⟳ {pct}% dup` — where new questions are hard to find
The share of a domain's **generated** questions that came back **duplicates**. High = the generator keeps repeating itself → fresh facts are drying up → new Qs are hard to source. Shown only when the sample is real (≥10 generated) **and** it's actually hard (≥50% dup), so the tree highlights only the territories needing authoring attention. Gold ≥50%, red ≥65%.

**Why dup-rate, not timeouts:** `RetrievalDomainHealth` (consecutive timeouts) is the obvious "struggling" signal but is **empty in prod right now** (0 domains struggling — refill's been healthy/paused). Duplicate rate has real spread and directly means "hard to find *new* questions":

| Domain | dup rate | note |
|---|--:|---|
| Harry Potter Book 3 | 75% | 12 gen → 3 usable (small, exhausted) |
| Ancient Roman History | 65% | |
| Spy School Books 1-6 | 60% | |
| **Shakespearean Tragedy** | **41%** | *not flagged* — "easy to get q here" ✓ |

## Files
- `crafter-demand.ts`: `getCorpusLabelPoints()` + `getCorpusLabelGenStats()`.
- `page.tsx`: rolls both up the subtree alongside depth; passes `pointsByKey` + `genStatsByKey`.
- `KnowledgeAdminClient`: threads both through the three layers, renders the two indicators, refreshes the stale "wt 1–10" header copy.

Typecheck + eslint + color ratchet clean. Verified against prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)