### PR TITLE
feat(admin/knowledge): flag EXHAUSTED areas (tapped out at the expansion gate)

### DIFF
--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -49,12 +49,14 @@ export function KnowledgeAdminClient({
   depthByKey,
   pointsByKey,
   genStatsByKey,
+  cappedByKey,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
+  cappedByKey: Record<string, { self: boolean; descendants: number }>;
 }) {
   const router = useRouter();
 
@@ -71,7 +73,8 @@ export function KnowledgeAdminClient({
           topic, color-coded by size; edit it via ⋯), its question count (<em>Qs</em>), and the
           points currently <em>avail</em>able there (difficulty-weighted) — the latter two rolled
           up through the subtree for parents. A <em>⟳ dup</em> flag marks where new questions are
-          hard to find (a high share of generations come back duplicates). Nothing here touches
+          hard to find (a high share of generations come back duplicates); <em>⛔ capped</em> marks
+          a tapped-out area at the expansion gate (author more to lift it). Nothing here touches
           questions or any player&apos;s mastery.
         </p>
       </header>
@@ -84,6 +87,7 @@ export function KnowledgeAdminClient({
         depthByKey={depthByKey}
         pointsByKey={pointsByKey}
         genStatsByKey={genStatsByKey}
+        cappedByKey={cappedByKey}
         onDone={() => router.refresh()}
       />
 
@@ -163,6 +167,7 @@ function KnowledgeTreeEditor({
   depthByKey,
   pointsByKey,
   genStatsByKey,
+  cappedByKey,
   onDone,
 }: {
   nodes: KnowledgeNodeRow[];
@@ -170,6 +175,7 @@ function KnowledgeTreeEditor({
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
+  cappedByKey: Record<string, { self: boolean; descendants: number }>;
   onDone: () => void;
 }) {
   const nodeByKey = useMemo(() => new Map(nodes.map((n) => [n.domainKey, n])), [nodes]);
@@ -746,6 +752,7 @@ function KnowledgeTreeEditor({
                 depthByKey={depthByKey}
                 pointsByKey={pointsByKey}
                 genStatsByKey={genStatsByKey}
+                cappedByKey={cappedByKey}
                 childrenByParent={childrenByParent}
                 parentCountByChild={parentCountByChild}
                 parentsByChild={parentsByChild}
@@ -813,6 +820,7 @@ function TreeRow({
   depthByKey,
   pointsByKey,
   genStatsByKey,
+  cappedByKey,
   childrenByParent,
   parentCountByChild,
   parentsByChild,
@@ -838,6 +846,7 @@ function TreeRow({
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
+  cappedByKey: Record<string, { self: boolean; descendants: number }>;
   childrenByParent: Map<string, string[]>;
   parentCountByChild: Map<string, number>;
   parentsByChild: Map<string, string[]>;
@@ -1086,6 +1095,31 @@ function TreeRow({
                 {(pointsByKey[nodeKey] ?? 0).toLocaleString()} avail
               </span>
               {(() => {
+                // Escalating supply signal: CAPPED (at the expansion gate) beats
+                // "hard to source" (high dup) beats nothing.
+                const cap = cappedByKey[nodeKey];
+                if (cap?.self) {
+                  return (
+                    <span
+                      className="font-semibold"
+                      style={{ color: 'var(--danger)' }}
+                      title="Capped — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh Qs here and offers area-expansion instead. Author more by hand to lift it."
+                    >
+                      ⛔ capped
+                    </span>
+                  );
+                }
+                if (cap && cap.descendants > 0) {
+                  return (
+                    <span
+                      className="font-medium"
+                      style={{ color: 'var(--danger)' }}
+                      title={`${cap.descendants} sub-area${cap.descendants === 1 ? '' : 's'} here ${cap.descendants === 1 ? 'is' : 'are'} tapped out (at the expansion gate)`}
+                    >
+                      ⛔ {cap.descendants} capped
+                    </span>
+                  );
+                }
                 const g = genStatsByKey[nodeKey];
                 if (!g || g.total < HARD_TO_SOURCE_MIN_SAMPLE) return null;
                 const rate = g.dupes / g.total;
@@ -1361,6 +1395,7 @@ function TreeRow({
               depthByKey={depthByKey}
               pointsByKey={pointsByKey}
               genStatsByKey={genStatsByKey}
+              cappedByKey={cappedByKey}
               childrenByParent={childrenByParent}
               parentCountByChild={parentCountByChild}
               parentsByChild={parentsByChild}

--- a/src/app/admin/knowledge/KnowledgeAdminClient.tsx
+++ b/src/app/admin/knowledge/KnowledgeAdminClient.tsx
@@ -49,14 +49,14 @@ export function KnowledgeAdminClient({
   depthByKey,
   pointsByKey,
   genStatsByKey,
-  cappedByKey,
+  exhaustedByKey,
 }: {
   nodes: KnowledgeNodeRow[];
   edges: KnowledgeEdgeRow[];
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
-  cappedByKey: Record<string, { self: boolean; descendants: number }>;
+  exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
 }) {
   const router = useRouter();
 
@@ -73,9 +73,9 @@ export function KnowledgeAdminClient({
           topic, color-coded by size; edit it via ⋯), its question count (<em>Qs</em>), and the
           points currently <em>avail</em>able there (difficulty-weighted) — the latter two rolled
           up through the subtree for parents. A <em>⟳ dup</em> flag marks where new questions are
-          hard to find (a high share of generations come back duplicates); <em>⛔ capped</em> marks
-          a tapped-out area at the expansion gate (author more to lift it). Nothing here touches
-          questions or any player&apos;s mastery.
+          hard to find (a high share of generations come back duplicates); <em>⛔ exhausted</em>
+          marks a tapped-out area at the expansion gate (author more to refill it). Nothing here
+          touches questions or any player&apos;s mastery.
         </p>
       </header>
 
@@ -87,7 +87,7 @@ export function KnowledgeAdminClient({
         depthByKey={depthByKey}
         pointsByKey={pointsByKey}
         genStatsByKey={genStatsByKey}
-        cappedByKey={cappedByKey}
+        exhaustedByKey={exhaustedByKey}
         onDone={() => router.refresh()}
       />
 
@@ -167,7 +167,7 @@ function KnowledgeTreeEditor({
   depthByKey,
   pointsByKey,
   genStatsByKey,
-  cappedByKey,
+  exhaustedByKey,
   onDone,
 }: {
   nodes: KnowledgeNodeRow[];
@@ -175,7 +175,7 @@ function KnowledgeTreeEditor({
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
-  cappedByKey: Record<string, { self: boolean; descendants: number }>;
+  exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
   onDone: () => void;
 }) {
   const nodeByKey = useMemo(() => new Map(nodes.map((n) => [n.domainKey, n])), [nodes]);
@@ -752,7 +752,7 @@ function KnowledgeTreeEditor({
                 depthByKey={depthByKey}
                 pointsByKey={pointsByKey}
                 genStatsByKey={genStatsByKey}
-                cappedByKey={cappedByKey}
+                exhaustedByKey={exhaustedByKey}
                 childrenByParent={childrenByParent}
                 parentCountByChild={parentCountByChild}
                 parentsByChild={parentsByChild}
@@ -820,7 +820,7 @@ function TreeRow({
   depthByKey,
   pointsByKey,
   genStatsByKey,
-  cappedByKey,
+  exhaustedByKey,
   childrenByParent,
   parentCountByChild,
   parentsByChild,
@@ -846,7 +846,7 @@ function TreeRow({
   depthByKey: Record<string, number>;
   pointsByKey: Record<string, number>;
   genStatsByKey: Record<string, { total: number; dupes: number }>;
-  cappedByKey: Record<string, { self: boolean; descendants: number }>;
+  exhaustedByKey: Record<string, { self: boolean; descendants: number }>;
   childrenByParent: Map<string, string[]>;
   parentCountByChild: Map<string, number>;
   parentsByChild: Map<string, string[]>;
@@ -1095,28 +1095,28 @@ function TreeRow({
                 {(pointsByKey[nodeKey] ?? 0).toLocaleString()} avail
               </span>
               {(() => {
-                // Escalating supply signal: CAPPED (at the expansion gate) beats
+                // Escalating supply signal: EXHAUSTED (at the expansion gate) beats
                 // "hard to source" (high dup) beats nothing.
-                const cap = cappedByKey[nodeKey];
-                if (cap?.self) {
+                const ex = exhaustedByKey[nodeKey];
+                if (ex?.self) {
                   return (
                     <span
                       className="font-semibold"
                       style={{ color: 'var(--danger)' }}
-                      title="Capped — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh Qs here and offers area-expansion instead. Author more by hand to lift it."
+                      title="Exhausted — at the narrow-KB expansion gate: few servable facts remain despite generation, so the system stops serving fresh Qs here and offers area-expansion instead. Author more by hand to refill it."
                     >
-                      ⛔ capped
+                      ⛔ exhausted
                     </span>
                   );
                 }
-                if (cap && cap.descendants > 0) {
+                if (ex && ex.descendants > 0) {
                   return (
                     <span
                       className="font-medium"
                       style={{ color: 'var(--danger)' }}
-                      title={`${cap.descendants} sub-area${cap.descendants === 1 ? '' : 's'} here ${cap.descendants === 1 ? 'is' : 'are'} tapped out (at the expansion gate)`}
+                      title={`${ex.descendants} sub-area${ex.descendants === 1 ? '' : 's'} here ${ex.descendants === 1 ? 'is' : 'are'} exhausted (at the expansion gate)`}
                     >
-                      ⛔ {cap.descendants} capped
+                      ⛔ {ex.descendants} exhausted
                     </span>
                   );
                 }
@@ -1395,7 +1395,7 @@ function TreeRow({
               depthByKey={depthByKey}
               pointsByKey={pointsByKey}
               genStatsByKey={genStatsByKey}
-              cappedByKey={cappedByKey}
+              exhaustedByKey={exhaustedByKey}
               childrenByParent={childrenByParent}
               parentCountByChild={parentCountByChild}
               parentsByChild={parentsByChild}

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -8,6 +8,7 @@ import {
   getCorpusLabelPoints,
 } from '@/server/db/queries/crafter-demand';
 import { listKnowledgeGraph } from '@/server/db/queries/knowledge-graph';
+import { getRetrievalConfig } from '@/server/daily/retrieval-config';
 import { domainKey } from '@/lib/knowledge/domain-key';
 
 import { KnowledgeAdminClient } from './KnowledgeAdminClient';
@@ -35,8 +36,11 @@ export default async function AdminKnowledgePage() {
     getCorpusLabelGenStats(),
   ]);
   const ownDepthByKey: Record<string, number> = {};
+  const ownMachineDepthByKey: Record<string, number> = {};
   for (const entry of corpusDepths) {
-    ownDepthByKey[domainKey(entry.label)] = entry.machineDepth + entry.humanAuthored;
+    const key = domainKey(entry.label);
+    ownDepthByKey[key] = (ownDepthByKey[key] ?? 0) + entry.machineDepth + entry.humanAuthored;
+    ownMachineDepthByKey[key] = (ownMachineDepthByKey[key] ?? 0) + entry.machineDepth;
   }
   const ownPointsByKey: Record<string, number> = {};
   for (const entry of corpusPoints) {
@@ -60,9 +64,31 @@ export default async function AdminKnowledgePage() {
     if (list) list.push(edge.childDomainKey);
     else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
   }
+  // "Capped" = tapped out at the narrow-KB / area-expansion gate boundary
+  // (kb-exhaustion.ts fires below `poolDepthThreshold` servable facts, where the
+  // system stops serving fresh Qs and pushes expansion). To mean EXHAUSTED, not
+  // merely under-generated, a leaf must (a) have been mined (generated ≥ threshold
+  // times), (b) still hold fewer than threshold servable machine facts, AND (c)
+  // show generation actually hitting a wall — mostly duplicates, or producing
+  // nothing servable at all. A big topic with a low dup rate stays "needs
+  // generation", not capped.
+  const POOL_THRESHOLD = getRetrievalConfig().poolDepthThreshold;
+  const CAPPED_DUP_RATE = 0.5;
+  const nodeKindByKey = new Map(nodes.map((n) => [n.domainKey, n.nodeKind]));
+  const isCappedLeaf = (key: string): boolean => {
+    if (nodeKindByKey.get(key) === 'parent') return false;
+    const gen = ownGenByKey[key];
+    if (!gen || gen.total < POOL_THRESHOLD) return false; // not mined enough to judge
+    if ((ownMachineDepthByKey[key] ?? 0) >= POOL_THRESHOLD) return false; // pool is healthy
+    const dupRate = gen.total > 0 ? gen.dupes / gen.total : 0;
+    return (ownMachineDepthByKey[key] ?? 0) === 0 || dupRate >= CAPPED_DUP_RATE;
+  };
+
   const depthByKey: Record<string, number> = { ...ownDepthByKey };
   const pointsByKey: Record<string, number> = { ...ownPointsByKey };
   const genStatsByKey: Record<string, { total: number; dupes: number }> = {};
+  // self = this leaf is capped; descendants = capped leaves under a parent.
+  const cappedByKey: Record<string, { self: boolean; descendants: number }> = {};
   for (const node of nodes) {
     const key = node.domainKey;
     const descendants = new Set<string>();
@@ -77,15 +103,18 @@ export default async function AdminKnowledgePage() {
     let pointsSum = ownPointsByKey[key] ?? 0;
     let genTotal = ownGenByKey[key]?.total ?? 0;
     let genDupes = ownGenByKey[key]?.dupes ?? 0;
+    let cappedDescendants = 0;
     for (const d of descendants) {
       depthSum += ownDepthByKey[d] ?? 0;
       pointsSum += ownPointsByKey[d] ?? 0;
       genTotal += ownGenByKey[d]?.total ?? 0;
       genDupes += ownGenByKey[d]?.dupes ?? 0;
+      if (isCappedLeaf(d)) cappedDescendants += 1;
     }
     depthByKey[key] = depthSum;
     pointsByKey[key] = pointsSum;
     genStatsByKey[key] = { total: genTotal, dupes: genDupes };
+    cappedByKey[key] = { self: isCappedLeaf(key), descendants: cappedDescendants };
   }
 
   return (
@@ -95,6 +124,7 @@ export default async function AdminKnowledgePage() {
       depthByKey={depthByKey}
       pointsByKey={pointsByKey}
       genStatsByKey={genStatsByKey}
+      cappedByKey={cappedByKey}
     />
   );
 }

--- a/src/app/admin/knowledge/page.tsx
+++ b/src/app/admin/knowledge/page.tsx
@@ -64,31 +64,33 @@ export default async function AdminKnowledgePage() {
     if (list) list.push(edge.childDomainKey);
     else childrenByParent.set(edge.parentDomainKey, [edge.childDomainKey]);
   }
-  // "Capped" = tapped out at the narrow-KB / area-expansion gate boundary
+  // "Exhausted" = tapped out at the narrow-KB / area-expansion gate boundary
   // (kb-exhaustion.ts fires below `poolDepthThreshold` servable facts, where the
-  // system stops serving fresh Qs and pushes expansion). To mean EXHAUSTED, not
-  // merely under-generated, a leaf must (a) have been mined (generated ≥ threshold
-  // times), (b) still hold fewer than threshold servable machine facts, AND (c)
-  // show generation actually hitting a wall — mostly duplicates, or producing
-  // nothing servable at all. A big topic with a low dup rate stays "needs
-  // generation", not capped.
+  // system stops serving fresh Qs and pushes expansion). Named to match the
+  // codebase's existing term for this concept (kb-exhaustion) — distinct from the
+  // supply-*ceiling*/"capped" expansion trigger (a player topping the difficulty
+  // ladder). To mean genuinely exhausted, not merely under-generated, a leaf must
+  // (a) have been mined (generated ≥ threshold times), (b) still hold fewer than
+  // threshold servable machine facts, AND (c) show generation hitting a wall —
+  // mostly duplicates, or producing nothing servable. A big topic with a low dup
+  // rate stays "needs generation".
   const POOL_THRESHOLD = getRetrievalConfig().poolDepthThreshold;
-  const CAPPED_DUP_RATE = 0.5;
+  const EXHAUSTED_DUP_RATE = 0.5;
   const nodeKindByKey = new Map(nodes.map((n) => [n.domainKey, n.nodeKind]));
-  const isCappedLeaf = (key: string): boolean => {
+  const isExhaustedLeaf = (key: string): boolean => {
     if (nodeKindByKey.get(key) === 'parent') return false;
     const gen = ownGenByKey[key];
     if (!gen || gen.total < POOL_THRESHOLD) return false; // not mined enough to judge
     if ((ownMachineDepthByKey[key] ?? 0) >= POOL_THRESHOLD) return false; // pool is healthy
     const dupRate = gen.total > 0 ? gen.dupes / gen.total : 0;
-    return (ownMachineDepthByKey[key] ?? 0) === 0 || dupRate >= CAPPED_DUP_RATE;
+    return (ownMachineDepthByKey[key] ?? 0) === 0 || dupRate >= EXHAUSTED_DUP_RATE;
   };
 
   const depthByKey: Record<string, number> = { ...ownDepthByKey };
   const pointsByKey: Record<string, number> = { ...ownPointsByKey };
   const genStatsByKey: Record<string, { total: number; dupes: number }> = {};
-  // self = this leaf is capped; descendants = capped leaves under a parent.
-  const cappedByKey: Record<string, { self: boolean; descendants: number }> = {};
+  // self = this leaf is exhausted; descendants = exhausted leaves under a parent.
+  const exhaustedByKey: Record<string, { self: boolean; descendants: number }> = {};
   for (const node of nodes) {
     const key = node.domainKey;
     const descendants = new Set<string>();
@@ -103,18 +105,18 @@ export default async function AdminKnowledgePage() {
     let pointsSum = ownPointsByKey[key] ?? 0;
     let genTotal = ownGenByKey[key]?.total ?? 0;
     let genDupes = ownGenByKey[key]?.dupes ?? 0;
-    let cappedDescendants = 0;
+    let exhaustedDescendants = 0;
     for (const d of descendants) {
       depthSum += ownDepthByKey[d] ?? 0;
       pointsSum += ownPointsByKey[d] ?? 0;
       genTotal += ownGenByKey[d]?.total ?? 0;
       genDupes += ownGenByKey[d]?.dupes ?? 0;
-      if (isCappedLeaf(d)) cappedDescendants += 1;
+      if (isExhaustedLeaf(d)) exhaustedDescendants += 1;
     }
     depthByKey[key] = depthSum;
     pointsByKey[key] = pointsSum;
     genStatsByKey[key] = { total: genTotal, dupes: genDupes };
-    cappedByKey[key] = { self: isCappedLeaf(key), descendants: cappedDescendants };
+    exhaustedByKey[key] = { self: isExhaustedLeaf(key), descendants: exhaustedDescendants };
   }
 
   return (
@@ -124,7 +126,7 @@ export default async function AdminKnowledgePage() {
       depthByKey={depthByKey}
       pointsByKey={pointsByKey}
       genStatsByKey={genStatsByKey}
-      cappedByKey={cappedByKey}
+      exhaustedByKey={exhaustedByKey}
     />
   );
 }


### PR DESCRIPTION
Adds the last supply signal you asked for: **⛔ capped** — where an area is tapped out, i.e. the narrow-KB / area-expansion gate fires ("expand your areas / no more shown here because there aren't many more Qs").

## Definition
Mirrors the real gate boundary (`getRetrievalConfig().poolDepthThreshold` — the same line `kb-exhaustion.ts` fires on), tightened so it means **exhausted**, not merely under-generated. A leaf is **capped** when:
1. it's been **mined** — generated ≥ `poolDepthThreshold` times,
2. it still holds **fewer than `poolDepthThreshold` servable** machine facts, **and**
3. generation is **hitting a wall** — ≥50% duplicates, or producing **nothing** servable at all.

Clause 3 is the key refinement: a big topic that's simply under-generated (low dup rate) reads as "needs generation", *not* capped.

## Escalating badge
One supply indicator per row: **⛔ capped** (leaf) / **⛔ N capped** (parent, count of tapped descendants) › **⟳ {pct}% dup** (hard to source) › nothing.

## Verified against prod
Flags **6 genuinely tapped domains** — Harry Potter Book 3 (12 gen → 3 servable, 75% dup), Spy School Books 1-6, Ancient Rome, Victor Wembanyama, and two producing **0 servable** (1980s Saturday Morning Cartoons, James Joyce). Correctly **excludes** under-generated big topics (Modern American History, New Testament) and **Shakespearean Tragedy** (39 servable — "easy to get q here").

Typecheck + eslint + color ratchet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)