### PR TITLE
Ceremony: let tall beats scroll instead of clipping

### DIFF
--- a/src/app/ceremony/[ceremonyId]/page.tsx
+++ b/src/app/ceremony/[ceremonyId]/page.tsx
@@ -170,6 +170,13 @@ function Eyebrow({ children, color }: { children: ReactNode; color: string }) {
 }
 
 function Shell({ th, children }: { th: RoomTheme; children: ReactNode }) {
+  // A room centers its content when it fits, but a tall beat (long question
+  // text, a long domain list) can exceed the viewport. `justify-content: center`
+  // would clip the overflow off both edges with no way to read it, so instead we
+  // let the room scroll and center via auto margins on the child — auto margins
+  // collapse to 0 when content overflows, keeping the top reachable rather than
+  // clipped. Extra top/bottom padding clears the pips and the "tap to continue"
+  // hint. Vertical drags scroll; a tap still advances (handled on <main>).
   return (
     <div
       className="ceremony-room-in"
@@ -179,11 +186,14 @@ function Shell({ th, children }: { th: RoomTheme; children: ReactNode }) {
         background: th.bg,
         display: 'flex',
         flexDirection: 'column',
-        justifyContent: 'center',
-        padding: '36px 30px',
+        overflowY: 'auto',
+        WebkitOverflowScrolling: 'touch',
+        padding: '72px 30px calc(72px + env(safe-area-inset-bottom))',
       }}
     >
-      <div className="mx-auto w-full max-w-md">{children}</div>
+      <div className="w-full max-w-md" style={{ margin: 'auto' }}>
+        {children}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Each ceremony "room" vertically-centered its content with
justify-content:center inside an overflow-hidden main. When a beat's
content exceeded the viewport (long question text in the "worked through"
room, a long domain list in the alignment room) it overflowed both edges
and was clipped with no way to read the rest.

Make each room scroll: center with auto margins on the child (which
collapse to 0 on overflow, keeping the top reachable) instead of
justify-content on the parent, and set overflow-y:auto. Bump top/bottom
padding so scrolled content clears the pips and the tap-to-continue hint.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TBLAQspVaQyTBeYj72XVTr