### PR TITLE
Hide FAB on admin pages

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -120,6 +120,7 @@ export function Nav({
   const hidesNewGameShortcut =
     pathname.startsWith('/daily') ||
     pathname.startsWith('/games/') ||
+    pathname.startsWith('/admin') ||
     pathname === '/friends' ||
     isOtherUserProfilePath;
   const showNewGameShortcut = !hidesNewGameShortcut;


### PR DESCRIPTION
Suppress the floating action button on /admin/* routes so the create
shortcut no longer overlays the admin surfaces (crafter, knowledge,
reports, bulk-upload). Header and bottom nav are unchanged.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0167v9J63tQsqrLfgECgBm3K