### PR TITLE
Suggest a verified answer; keep the strict spread guard (composer + crafter)

### DIFF
--- a/src/components/craft/CreationSurface.tsx
+++ b/src/components/craft/CreationSurface.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 
 import { AutoGrowTextarea } from '@/components/ui/auto-grow-textarea';
 import type { DraftCandidate, DraftTier } from '@/server/crafter/draft-candidates';
@@ -285,16 +285,69 @@ function OwnQuestionCard({
   const [pending, setPending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [keptCount, setKeptCount] = useState(0);
-  // Inline LLM answer check — parity with the machine-draft cards. A verdict is
-  // pinned to the exact (question, answer) pair; editing either makes it stale.
+  // Joshing's suggested answer flow — same model as the regular composer: the
+  // machine suggests a fact-checked answer, you adopt it (verified) or say it's
+  // wrong and supply your own (which you can then check). Crafter-only bits
+  // (difficulty, byline, feeding the pool) stay. There is no sharing here, so the
+  // "verified" badge is informational — every kept question is fact-checked
+  // server-side before it's served regardless.
+  const [suggestedAnswer, setSuggestedAnswer] = useState<string | null>(null);
+  const [answerSource, setAnswerSource] = useState<'author' | 'suggestion' | null>(null);
+  const [suggesting, setSuggesting] = useState(false);
+  const suggestedForRef = useRef<string>('');
+  // Inline LLM answer check for an author override. A verdict is pinned to the
+  // exact (question, answer) pair; editing either makes it stale.
   const [verify, setVerify] = useState<VerifyState>({ status: 'idle' });
+
+  const hasAnswer = answer.trim().length > 0;
+  const usingSuggestion =
+    !!suggestedAnswer && (answerSource === 'suggestion' || answersMatch(answer, suggestedAnswer));
   const currentKey = answerPairKey(questionText, answer);
-  const verdictForCurrent =
-    (verify.status === 'ok' || verify.status === 'unverifiable' || verify.status === 'wrong')
-    && verify.for === currentKey;
 
   const fieldClass =
     'w-full rounded-md border border-[var(--accent-gold)] bg-[var(--brand-field)] px-2 py-1 text-sm focus:border-[var(--brand-navy)]';
+
+  // Ask Joshing for a fact-checked answer to the question. Adopts it into an empty
+  // answer field (never clobbers one you've started typing); deduped per question.
+  async function requestSuggestion() {
+    const q = questionText.trim();
+    if (!q || suggesting || suggestedForRef.current === q) return;
+    suggestedForRef.current = q;
+    setSuggesting(true);
+    try {
+      const res = await fetch('/api/questions/suggest', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ questionText: q }),
+      });
+      const body = (await res.json().catch(() => null)) as { correctAnswer?: string; explanation?: string } | null;
+      if (!res.ok || !body?.correctAnswer) return;
+      setSuggestedAnswer(body.correctAnswer);
+      if (!answer.trim()) {
+        setAnswer(body.correctAnswer);
+        setAnswerSource('suggestion');
+        if (!explainer.trim() && body.explanation) setExplainer(body.explanation);
+      }
+    } catch {
+      // Best-effort — no suggestion just means you type the answer yourself.
+    } finally {
+      setSuggesting(false);
+    }
+  }
+
+  function onAnswerChange(value: string) {
+    setAnswer(value);
+    setAnswerSource('author');
+    setVerify({ status: 'idle' });
+  }
+
+  function useSuggestion() {
+    if (!suggestedAnswer) return;
+    setAnswer(suggestedAnswer);
+    setAnswerSource('suggestion');
+    setVerify({ status: 'idle' });
+  }
 
   // Fail-open: a checker outage resolves to 'error' and never blocks the add.
   async function checkAnswer() {
@@ -323,6 +376,42 @@ function OwnQuestionCard({
     } catch {
       setVerify({ status: 'error' });
     }
+  }
+
+  // Shared verdict display for the on-demand check (used by both the override and
+  // the no-suggestion paths). Stale verdicts (answer edited since) are hidden.
+  function renderCheckVerdict() {
+    if (verify.status === 'checking') {
+      return <p className="text-muted-foreground mt-2 text-xs">Checking the answer with the LLM…</p>;
+    }
+    if (verify.status === 'error') {
+      return <p className="text-muted-foreground mt-2 text-xs">Couldn&apos;t reach the answer checker — try again.</p>;
+    }
+    if (verify.status === 'idle' || verify.for !== currentKey) return null;
+    if (verify.status === 'ok') {
+      return <p className="mt-2 text-xs" style={{ color: 'var(--success)' }}>✓ LLM check: this answer looks correct.</p>;
+    }
+    if (verify.status === 'unverifiable') {
+      return <p className="text-muted-foreground mt-2 text-xs">LLM check: couldn&apos;t verify this one — use your judgement.</p>;
+    }
+    return (
+      <div className="mt-2 rounded-md px-3 py-2 text-xs leading-relaxed" style={{ background: 'var(--warning-surface)', color: 'var(--warning)' }}>
+        <p>⚠ LLM check: this answer looks incorrect for the question.</p>
+        {verify.corrected ? (
+          <>
+            <p className="mt-1">Suggested correct answer: <strong>{verify.corrected}</strong></p>
+            <button
+              type="button"
+              onClick={() => { setAnswer(verify.status === 'wrong' ? (verify.corrected ?? answer) : answer); setVerify({ status: 'idle' }); }}
+              className="mt-2 rounded-md border px-3 py-1 text-xs font-medium"
+              style={{ borderColor: 'var(--warning)', color: 'var(--warning)' }}
+            >
+              Apply suggested answer
+            </button>
+          </>
+        ) : null}
+      </div>
+    );
   }
 
   async function keepOwn() {
@@ -359,6 +448,10 @@ function OwnQuestionCard({
       setQuestionText('');
       setAnswer('');
       setExplainer('');
+      setSuggestedAnswer(null);
+      setAnswerSource(null);
+      setVerify({ status: 'idle' });
+      suggestedForRef.current = '';
       setKeptCount((n) => n + 1);
     } catch {
       setError('Keep failed.');
@@ -394,67 +487,101 @@ function OwnQuestionCard({
           close
         </button>
       </div>
+      <label className="mb-1 block text-[0.7rem] uppercase tracking-[0.06em] text-muted-foreground">Question</label>
       <AutoGrowTextarea
         value={questionText}
         onChange={(e) => setQuestionText(e.target.value)}
+        onBlur={() => void requestSuggestion()}
         placeholder={`Ask something about ${domain}…`}
         className={fieldClass}
         aria-label="Your question"
       />
-      <div className="mt-2 flex items-center gap-2">
-        <span className="text-muted-foreground whitespace-nowrap text-xs">Answer</span>
-        <input
-          type="text"
-          value={answer}
-          onChange={(e) => setAnswer(e.target.value)}
-          className={fieldClass}
-          aria-label="Answer"
-        />
-      </div>
-      <AutoGrowTextarea
-        value={explainer}
-        onChange={(e) => setExplainer(e.target.value)}
-        placeholder="Explainer (optional) — a sentence or two of context"
-        className={`${fieldClass} mt-2`}
-        aria-label="Explainer"
+
+      <label className="mb-1 mt-3 block text-[0.7rem] uppercase tracking-[0.06em] text-muted-foreground">Correct answer</label>
+      <input
+        type="text"
+        value={answer}
+        onChange={(e) => onAnswerChange(e.target.value)}
+        className={fieldClass}
+        aria-label="Answer"
+        placeholder="The answer"
       />
 
-      {/* On-demand LLM answer check — same pass as the machine-draft cards. The
-          verdict is stale once question/answer changes and stops showing. */}
-      {verify.status === 'checking' ? (
-        <p className="text-muted-foreground mt-2 text-xs">Checking the answer with the LLM…</p>
-      ) : verify.status === 'error' ? (
-        <p className="text-muted-foreground mt-2 text-xs">Couldn&apos;t reach the answer checker — try again.</p>
-      ) : verdictForCurrent && verify.status === 'ok' ? (
-        <p className="mt-2 text-xs" style={{ color: 'var(--success)' }}>✓ LLM check: this answer looks correct.</p>
-      ) : verdictForCurrent && verify.status === 'unverifiable' ? (
-        <p className="text-muted-foreground mt-2 text-xs">LLM check: couldn&apos;t verify this one — use your judgement.</p>
-      ) : verdictForCurrent && verify.status === 'wrong' ? (
-        <div
-          className="mt-2 rounded-md px-3 py-2 text-xs leading-relaxed"
-          style={{ background: 'var(--warning-surface)', color: 'var(--warning)' }}
-        >
-          <p>⚠ LLM check: this answer looks incorrect for the question.</p>
-          {verify.corrected ? (
-            <p className="mt-1">
-              Suggested correct answer: <strong>{verify.corrected}</strong>
-            </p>
-          ) : null}
-          {verify.corrected ? (
+      {/* Answer suggestion + verification — mirrors the regular composer. Joshing
+          suggests a fact-checked answer; adopt it (verified) or override & check. */}
+      {suggesting ? (
+        <p className="text-muted-foreground mt-2 text-xs">Suggesting answer…</p>
+      ) : suggestedAnswer ? (
+        !hasAnswer ? (
+          <div className="mt-2 rounded-md border p-3 text-xs" style={{ borderColor: 'var(--border)' }}>
+            <p className="text-muted-foreground uppercase tracking-[0.06em]">Joshing&apos;s answer</p>
+            <p className="mt-1 font-medium text-[var(--brand-ink)]">{suggestedAnswer}</p>
             <button
               type="button"
-              onClick={() => {
-                setAnswer(verify.corrected!);
-                setVerify({ status: 'idle' });
-              }}
+              onClick={useSuggestion}
               className="mt-2 rounded-md border px-3 py-1 text-xs font-medium"
-              style={{ borderColor: 'var(--warning)', color: 'var(--warning)' }}
+              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
             >
-              Apply suggested answer
+              Use Joshing&apos;s answer
+            </button>
+          </div>
+        ) : usingSuggestion ? (
+          <div className="mt-2 text-xs">
+            <p style={{ color: 'var(--success)' }}>✓ Verified — Joshing checked this answer.</p>
+            <p className="text-muted-foreground mt-0.5">Not right? Edit the answer above and check yours.</p>
+          </div>
+        ) : (
+          <div className="mt-2 rounded-md border p-3 text-xs" style={{ borderColor: 'var(--border)' }}>
+            <p className="text-muted-foreground">
+              Your answer differs from Joshing&apos;s (<span className="font-medium text-[var(--brand-ink)]">{suggestedAnswer}</span>). It&apos;s still machine fact-checked before serving — check yours, or use Joshing&apos;s.
+            </p>
+            {renderCheckVerdict()}
+            <div className="mt-2 flex flex-wrap gap-2">
+              <button
+                type="button"
+                onClick={() => void checkAnswer()}
+                disabled={verify.status === 'checking'}
+                className="rounded-md border px-3 py-1 text-xs font-medium disabled:opacity-50"
+                style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+              >
+                Check my answer
+              </button>
+              <button
+                type="button"
+                onClick={useSuggestion}
+                className="rounded-md border px-3 py-1 text-xs font-medium"
+                style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+              >
+                Use Joshing&apos;s answer
+              </button>
+            </div>
+          </div>
+        )
+      ) : hasAnswer ? (
+        // No suggestion (failed or not yet fetched) — still offer an on-demand check.
+        <div className="mt-2">
+          {renderCheckVerdict()}
+          {verify.status !== 'checking' ? (
+            <button
+              type="button"
+              onClick={() => void checkAnswer()}
+              className="mt-2 rounded-md border px-3 py-1 text-xs font-medium"
+              style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
+            >
+              Check answer
             </button>
           ) : null}
         </div>
       ) : null}
+
+      <label className="mb-1 mt-3 block text-[0.7rem] uppercase tracking-[0.06em] text-muted-foreground">Explainer (optional)</label>
+      <AutoGrowTextarea
+        value={explainer}
+        onChange={(e) => setExplainer(e.target.value)}
+        placeholder="A sentence or two of context"
+        className={fieldClass}
+        aria-label="Explainer"
+      />
 
       <div className="mt-3 flex flex-wrap items-center gap-2">
         <select
@@ -476,15 +603,6 @@ function OwnQuestionCard({
           style={{ borderColor: 'var(--success)', color: 'var(--success)' }}
         >
           {pending ? 'Adding…' : 'Add — fact-check queued'}
-        </button>
-        <button
-          type="button"
-          onClick={() => void checkAnswer()}
-          disabled={pending || verify.status === 'checking' || !questionText.trim() || !answer.trim()}
-          className="inline-flex min-h-11 items-center rounded-md border px-4 py-1.5 text-sm font-medium disabled:opacity-50"
-          style={{ borderColor: 'var(--border)', color: 'var(--text-muted)' }}
-        >
-          {verify.status === 'checking' ? 'Checking…' : 'Check answer'}
         </button>
         {keptCount > 0 ? (
           <span className="text-xs" style={{ color: 'var(--success)' }}>
@@ -521,7 +639,12 @@ type VerifyState =
   | { status: 'wrong'; for: string; corrected: string | null };
 
 function answerPairKey(questionText: string, answer: string): string {
-  return `${questionText.trim()} ${answer.trim()}`;
+  return `${questionText.trim()} ${answer.trim()}`;
+}
+
+function answersMatch(a: string, b: string | null): boolean {
+  if (!b) return false;
+  return a.trim().toLowerCase() === b.trim().toLowerCase();
 }
 
 function CandidateCard({


### PR DESCRIPTION
## Why

Tapping **"Use Joshing's answer"** in the composer showed a confusing **"Unverified"** warning, even though that answer had already been fact-checked before it was shown. The underlying model treated *adopting the suggestion* as unverified, and the consumer composer verified answers in a weaker, different way than the crafter surface. This reworks verification around a single, clearer model and makes both surfaces consistent — while preserving a strict guard against a nefarious actor spreading a wrong answer.

## The model

**Joshing suggests a verified answer; the player can say it's wrong.**

- The suggestion is independently fact-checked before it's shown, so **using it is verified** — no more scary warning.
- If the player overrides it with their own answer, that answer is only **verified** (the flag that unlocks broadcast to all friends + forwarding) when it **agrees with Joshing's independent suggestion**.
- An override that *differs* is unverified for spreading — **even if a single on-demand fact-check likes it**. A crafted false premise could fool one verifier, so that check is offered as **advisory help only** and never grants "verified". This is the strict guard.
- Unverified answers remain **save + direct-send only** (no broadcast, recipients can't forward) — unchanged.

## What changed

**Consumer composer (`QuestionForm.tsx`)**
- The suggestion adopts into the answer field as verified (guarded so it never clobbers an answer already being typed).
- The verification status block moved **directly under the Correct answer field** and copy softened from a warning to a status.
- Override path gains an advisory **"Check my answer"** (OK / WRONG + correction / UNVERIFIABLE), which does **not** unlock spreading.
- `isVerifiedAnswer` is the strict gate: verified ⇔ answer agrees with the suggestion (adopt / auto / author-typed match).

**Crafter "write your own question" (`CreationSurface.tsx`)**
- Brought in line with the composer: on question blur, Joshing suggests a fact-checked answer that adopts as verified; the author can override & check.
- Labels/layout aligned (Question / Correct answer / Explainer); crafter-only bits kept (difficulty, byline, feeds the pool). There's no sharing here, so "verified" is informational — every kept question is fact-checked server-side before serving regardless.
- The machine-draft cards' inline "Check answer" is unchanged.
- Fixed a pre-existing stray NUL byte in `answerPairKey`'s template literal that had marked the file binary.

## Tests & checks

- `QuestionForm.test.tsx` `isVerifiedAnswer` suite rewritten for the strict model (adopt/auto/match verified; a differing override never auto-verified).
- Typecheck (`tsconfig.typecheck`) clean · ESLint clean · color/spacing/radius ratchets pass · questions + crafter suites pass.

## Known residual (not addressed here)

The server still **trusts the client's `verified` flag** (`create-payload.ts`) and only backstops the `verified:false + broadcast` combo. A client-bypassing actor could POST `verified:true` with a wrong answer. Fully closing that means **re-running the fact-check server-side on the save path when a question is being broadcast** — a larger change with a real cost/latency trade-off, left for a follow-up.

## Not yet verified in the live app

The changes pass typecheck/lint/tests, but the blur-to-suggest timing and the end-to-end flow haven't been driven in a running app (needs server + DB + LLM). A click-through on a preview is the real confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pe63PzMd5h9pKRiMwetieZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pe63PzMd5h9pKRiMwetieZ)_