### PR TITLE
feat(knowledge): leaf-first "peaks" view + live three-way view switcher

### DIFF
--- a/src/app/knowledge/KnowledgeBubblePage.tsx
+++ b/src/app/knowledge/KnowledgeBubblePage.tsx
@@ -6,6 +6,7 @@ import { getSession } from '@/server/auth/session';
 import type { MasteryTier } from '@/types/db';
 import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
 import { KnowledgeBubbleMap } from '@/components/knowledge/KnowledgeBubbleMap';
+import { KnowledgeViewSwitcher } from '@/components/knowledge/KnowledgeViewSwitcher';
 
 import { BubblePageChrome } from './BubblePageChrome';
 
@@ -44,6 +45,9 @@ export async function KnowledgeBubblePage() {
 
   return (
     <main className="mx-auto flex h-dvh max-w-3xl flex-col px-4 py-5">
+      <div className="mb-2 flex items-center justify-center">
+        <KnowledgeViewSwitcher current="current" />
+      </div>
       <header className="mb-1 flex items-baseline justify-between gap-3">
         <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
           What you <em className="italic text-[var(--brand-ink-700)]">know</em>

--- a/src/app/knowledge/KnowledgePeaksPage.tsx
+++ b/src/app/knowledge/KnowledgePeaksPage.tsx
@@ -1,0 +1,31 @@
+import { redirect } from 'next/navigation';
+
+import { getSession } from '@/server/auth/session';
+import { getKnowledgeMapData } from '@/server/knowledge/knowledge-tree';
+import { KnowledgePeaksView } from '@/components/knowledge/KnowledgePeaksView';
+import { KnowledgeViewSwitcher } from '@/components/knowledge/KnowledgeViewSwitcher';
+
+// The leaf-first "New" knowledge view: lead with the specific things you're
+// smart at, then roll up to their areas and the siblings you could add. Same
+// tree payload as the bubble map (KnowledgeBubblePage) — this is a different
+// presentation of the same data, selected via ?view=peaks in page.tsx.
+export async function KnowledgePeaksPage() {
+  const session = await getSession();
+  if (!session) redirect('/login');
+
+  const { tree } = await getKnowledgeMapData(session.userId);
+
+  return (
+    <main className="mx-auto flex h-dvh max-w-3xl flex-col px-4 py-5">
+      <div className="mb-2 flex items-center justify-center">
+        <KnowledgeViewSwitcher current="peaks" />
+      </div>
+      <header className="mb-2">
+        <h1 className="font-serif text-2xl font-semibold text-[var(--brand-ink)]">
+          What you <em className="italic text-[var(--brand-ink-700)]">know</em>
+        </h1>
+      </header>
+      <KnowledgePeaksView data={tree} />
+    </main>
+  );
+}

--- a/src/app/knowledge/page.tsx
+++ b/src/app/knowledge/page.tsx
@@ -1,20 +1,45 @@
-import { isKnowledgeMapPageEnabled } from '@/server/knowledge/map-page-flag';
-
 import { KnowledgeFlatClient } from './KnowledgeFlatClient';
+import { KnowledgeViewSwitcher, type KnowledgeView } from '@/components/knowledge/KnowledgeViewSwitcher';
 
 export const dynamic = 'force-dynamic';
 
-// B-KNOWLEDGE-TAXONOMY-01 P5 — flag gate for the nested-bubble knowledge map.
-// Flag OFF (default): the flat portrait page renders exactly as before — the
-// entire previous client page moved verbatim into KnowledgeFlatClient.tsx
-// (named export; no other change), and this off-path imports NEITHER new map
-// file. Flag ON: the circle-pack map (knowledge-bubbles direction) renders via
-// a dynamic import, so the map's code never loads on the off path.
+// The knowledge page now offers three interchangeable views, chosen live via
+// ?view= (replacing the old build-time KNOWLEDGE_MAP_PAGE env gate):
+//   - peaks    (default) → the leaf-first "what you're smart at" gallery
+//   - current            → the nested circle-pack bubble map
+//   - previous           → the flat portrait page that predates the map
+// Each view owns its own header + switcher chrome; only the selected one's
+// server component runs, so we never double-fetch the tree. The friend page
+// keeps its own flag for now — this switch is the owner surface only.
+function parseView(raw: string | string[] | undefined): KnowledgeView {
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  if (value === 'current' || value === 'previous') return value;
+  return 'peaks';
+}
 
-export default async function KnowledgePage() {
-  if (isKnowledgeMapPageEnabled()) {
+export default async function KnowledgePage({
+  searchParams,
+}: {
+  searchParams: Promise<{ view?: string | string[] }>;
+}) {
+  const view = parseView((await searchParams).view);
+
+  if (view === 'current') {
     const { KnowledgeBubblePage } = await import('./KnowledgeBubblePage');
     return <KnowledgeBubblePage />;
   }
-  return <KnowledgeFlatClient />;
+
+  if (view === 'previous') {
+    return (
+      <>
+        <div className="mx-auto flex w-[min(672px,94vw)] items-center justify-center pt-5">
+          <KnowledgeViewSwitcher current="previous" />
+        </div>
+        <KnowledgeFlatClient />
+      </>
+    );
+  }
+
+  const { KnowledgePeaksPage } = await import('./KnowledgePeaksPage');
+  return <KnowledgePeaksPage />;
 }

--- a/src/components/knowledge/KnowledgeBubbleMap.tsx
+++ b/src/components/knowledge/KnowledgeBubbleMap.tsx
@@ -7,6 +7,7 @@ import { hierarchy, pack, type HierarchyCircularNode } from 'd3-hierarchy';
 
 import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
 import { KnowledgeNodeCard, type SelectedNodeInfo } from '@/components/knowledge/KnowledgeNodeCard';
+import { adoptDomain } from '@/components/knowledge/adopt';
 
 // B-KNOWLEDGE-TAXONOMY-01 P5 — the nested circle-pack knowledge map, ported
 // from the ratified knowledge-bubbles prototype onto the repo's design
@@ -29,22 +30,6 @@ function subscribeReducedMotion(callback: () => void): () => void {
   const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
   mq.addEventListener('change', callback);
   return () => mq.removeEventListener('change', callback);
-}
-
-// Adopt endpoint (the territory-adopt path): sets the ghost domain's Daily
-// Five frequency, which folds it into the knowledge base rotation.
-async function adoptDomain(domain: string): Promise<boolean> {
-  try {
-    const res = await fetch('/api/daily/preferences/domain-frequency', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      credentials: 'include',
-      body: JSON.stringify({ domain, frequency: 'sometimes' }),
-    });
-    return res.ok;
-  } catch {
-    return false;
-  }
 }
 
 // One list section per top-level territory: the parent's own framing plus its

--- a/src/components/knowledge/KnowledgePeaksView.tsx
+++ b/src/components/knowledge/KnowledgePeaksView.tsx
@@ -1,0 +1,485 @@
+'use client';
+
+import { useCallback, useMemo, useState, type ReactNode } from 'react';
+import Link from 'next/link';
+import { ArrowUpRight, ChevronRight, Plus, X } from 'lucide-react';
+
+import type { KnowledgeTreeNode } from '@/server/knowledge/knowledge-tree';
+import { adoptDomain } from '@/components/knowledge/adopt';
+
+// D-KNOWLEDGE-MAP-USABILITY-01 (leaf-first follow-up) — the "New" knowledge
+// view. Where the bubble map leads with rolled-up parent clusters, this leads
+// with the specific things you're smart at (Hamlet, the WTC, Wagner's Ring
+// Cycle) as trophies. Tapping a peak shows where it rolls UP to (its parent
+// area) and the sibling areas you could ADD next. Same tree data as the map,
+// same confirmed-add path — nothing here is a new endpoint or new mastery math.
+
+const TOP_PEAKS = 10;
+
+function fieldColor(field: string | null | undefined): string {
+  return field ? `var(--cat-${field}, var(--brand-ink-400))` : 'var(--brand-ink-400)';
+}
+
+function formatPts(value: number): string {
+  return new Intl.NumberFormat().format(Math.round(value));
+}
+
+function quizHref(name: string): string {
+  return `/daily/setup?domainMode=custom&domain=${encodeURIComponent(name)}`;
+}
+
+function isOwnedLeaf(node: KnowledgeTreeNode): boolean {
+  return (
+    !node.ghost && (node.value ?? 0) > 0 && (!node.children || node.children.length === 0)
+  );
+}
+
+type LeafInfo = {
+  node: KnowledgeTreeNode;
+  /** Non-root ancestors, top area → leaf's immediate parent (excludes the leaf). */
+  path: KnowledgeTreeNode[];
+  parent: KnowledgeTreeNode | null;
+  topParent: KnowledgeTreeNode | null;
+};
+
+// One walk of the tree: every owned terminal leaf with its lineage. Parents
+// carry their child roster inline, so siblings (owned + addable ghosts) come
+// straight off `parent.children` at render time.
+function indexLeaves(tree: KnowledgeTreeNode): LeafInfo[] {
+  const out: LeafInfo[] = [];
+  const walk = (node: KnowledgeTreeNode, ancestors: KnowledgeTreeNode[]) => {
+    if (isOwnedLeaf(node)) {
+      const path = ancestors.slice(1); // drop synthetic root
+      out.push({
+        node,
+        path,
+        parent: ancestors.at(-1) ?? null,
+        topParent: path[0] ?? null,
+      });
+    }
+    for (const child of node.children ?? []) walk(child, [...ancestors, node]);
+  };
+  walk(tree, []);
+  return out;
+}
+
+export function KnowledgePeaksView({
+  data,
+  variant = 'own',
+}: {
+  data: KnowledgeTreeNode;
+  variant?: 'own' | 'friend';
+}) {
+  const [tree, setTree] = useState<KnowledgeTreeNode>(data);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [showAll, setShowAll] = useState(false);
+
+  const leaves = useMemo(() => indexLeaves(tree), [tree]);
+  const sorted = useMemo(
+    () => [...leaves].sort((a, b) => (b.node.value ?? 0) - (a.node.value ?? 0)),
+    [leaves],
+  );
+  const top = sorted.slice(0, TOP_PEAKS);
+  const selected = selectedId ? leaves.find((l) => l.node.id === selectedId) ?? null : null;
+
+  // Full picture, grouped by top area — the "see everything" expansion.
+  const groups = useMemo(() => {
+    const byTop = new Map<string, { title: string; field: string | null; leaves: LeafInfo[] }>();
+    const standalone: LeafInfo[] = [];
+    for (const leaf of sorted) {
+      if (leaf.topParent) {
+        const key = leaf.topParent.id;
+        const g = byTop.get(key);
+        if (g) g.leaves.push(leaf);
+        else byTop.set(key, { title: leaf.topParent.name, field: leaf.topParent.field, leaves: [leaf] });
+      } else {
+        standalone.push(leaf);
+      }
+    }
+    const list = [...byTop.values()].sort(
+      (a, b) =>
+        b.leaves.reduce((s, l) => s + (l.node.value ?? 0), 0) -
+        a.leaves.reduce((s, l) => s + (l.node.value ?? 0), 0),
+    );
+    if (standalone.length > 0) list.push({ title: 'More', field: null, leaves: standalone });
+    return list;
+  }, [sorted]);
+
+  // Optimistic confirmed add: flip the ghost sibling into a real leaf so it
+  // jumps from "add next" to owned; revert on failure. Mirrors the bubble map.
+  const adoptNode = useCallback(async (id: string, name: string): Promise<boolean> => {
+    const flip = (node: KnowledgeTreeNode, ghost: boolean, value: number): KnowledgeTreeNode =>
+      node.id === id
+        ? { ...node, ghost: ghost || undefined, value }
+        : { ...node, children: node.children?.map((c) => flip(c, ghost, value)) };
+    setTree((prev) => flip(prev, false, 1));
+    const ok = await adoptDomain(name);
+    if (!ok) setTree((prev) => flip(prev, true, 40));
+    return ok;
+  }, []);
+
+  return (
+    <div className="relative flex min-h-0 flex-1 flex-col">
+      <div className="min-h-0 flex-1 overflow-y-auto pb-40">
+        <p className="pb-3 pt-1 text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+          What you’re smart at
+        </p>
+
+        {top.length === 0 ? (
+          <p className="py-10 text-center font-serif text-[var(--text-muted)]">
+            Answer and write questions and your peaks will show up here.
+          </p>
+        ) : (
+          <div className="grid grid-cols-2 gap-2.5 sm:grid-cols-3">
+            {top.map((leaf) => {
+              const mastered = Boolean(leaf.node.mastered);
+              const active = leaf.node.id === selectedId;
+              return (
+                <button
+                  key={leaf.node.id}
+                  type="button"
+                  onClick={() => setSelectedId(active ? null : leaf.node.id)}
+                  aria-pressed={active}
+                  className="group flex flex-col items-start gap-1.5 rounded-xl border p-3 text-left transition hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  style={{
+                    borderColor: active ? 'var(--brand-navy)' : 'var(--border)',
+                    background: 'var(--brand-card)',
+                    borderLeftWidth: 4,
+                    borderLeftColor: mastered ? 'var(--accent-gold)' : fieldColor(leaf.node.field),
+                  }}
+                >
+                  <span className="font-serif text-[15px] leading-tight text-[var(--brand-ink)]">
+                    {leaf.node.name}
+                  </span>
+                  <span className="mt-auto text-[11px] text-[var(--text-muted)]">
+                    {mastered ? 'Mastery · ' : ''}
+                    {formatPts(leaf.node.value ?? 0)} pts
+                  </span>
+                  {leaf.topParent ? (
+                    <span className="truncate text-[10px] uppercase tracking-[0.06em] text-[var(--text-muted)]">
+                      {leaf.topParent.name}
+                    </span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        {sorted.length > top.length ? (
+          <div className="pt-4">
+            <button
+              type="button"
+              onClick={() => setShowAll((v) => !v)}
+              className="text-sm text-[var(--brand-navy)] underline-offset-2 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+            >
+              {showAll ? 'Show fewer' : `See all ${sorted.length} things you know`}
+            </button>
+          </div>
+        ) : null}
+
+        {showAll ? (
+          <div className="pt-2" aria-label="Everything you know, by area">
+            {groups.map((group) => (
+              <section key={group.title} className="pb-1">
+                <h3 className="flex items-center gap-2 pb-1 pt-3 text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+                  <span
+                    aria-hidden
+                    className="size-2.5 rounded-full"
+                    style={{ background: fieldColor(group.field) }}
+                  />
+                  {group.title}
+                </h3>
+                <div role="list">
+                  {group.leaves.map((leaf) => (
+                    <button
+                      key={leaf.node.id}
+                      type="button"
+                      role="listitem"
+                      onClick={() => setSelectedId(leaf.node.id)}
+                      className="flex w-full items-center gap-2.5 border-b py-2.5 text-left text-sm hover:bg-[var(--brand-card)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                      style={{ borderColor: 'var(--border)' }}
+                    >
+                      <span
+                        aria-hidden
+                        className="size-3 flex-none rounded-full"
+                        style={{
+                          background: leaf.node.mastered
+                            ? 'var(--accent-gold)'
+                            : fieldColor(leaf.node.field),
+                        }}
+                      />
+                      <span className="font-serif text-base text-[var(--brand-ink)]">{leaf.node.name}</span>
+                      <span className="ml-auto text-xs text-[var(--text-muted)]">
+                        {leaf.node.mastered ? 'Mastery · ' : ''}
+                        {formatPts(leaf.node.value ?? 0)} pts
+                      </span>
+                    </button>
+                  ))}
+                </div>
+              </section>
+            ))}
+          </div>
+        ) : null}
+      </div>
+
+      {selected ? (
+        <div className="absolute inset-x-0 bottom-0 z-10 px-1 pb-1">
+          <PeakDetailCard
+            key={selected.node.id}
+            leaf={selected}
+            variant={variant}
+            onClose={() => setSelectedId(null)}
+            onSelectSibling={(id) => setSelectedId(id)}
+            onAdd={variant === 'own' ? adoptNode : async () => false}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+type AddPhase =
+  | { step: 'idle' }
+  | { step: 'confirm'; id: string; name: string }
+  | { step: 'adding'; id: string; name: string }
+  | { step: 'added'; id: string; name: string }
+  | { step: 'failed'; id: string; name: string };
+
+// The leaf-first detail: identity, the rollup PATH, and the sibling roster —
+// owned siblings you can jump to, plus addable ghosts (the "grow it next" move).
+function PeakDetailCard({
+  leaf,
+  variant,
+  onClose,
+  onSelectSibling,
+  onAdd,
+}: {
+  leaf: LeafInfo;
+  variant: 'own' | 'friend';
+  onClose: () => void;
+  onSelectSibling: (id: string) => void;
+  onAdd: (id: string, name: string) => Promise<boolean>;
+}) {
+  const [phase, setPhase] = useState<AddPhase>({ step: 'idle' });
+  const node = leaf.node;
+  const parent = leaf.parent;
+  const siblings = (parent?.children ?? []).filter((c) => c.id !== node.id);
+  const ownedSiblings = siblings.filter((c) => !c.ghost && (c.value ?? 0) > 0);
+  const ghostSiblings = siblings.filter((c) => c.ghost);
+
+  const actionButton =
+    'inline-flex min-h-10 items-center gap-1.5 rounded-full border px-4 text-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
+
+  const confirmAdd = async (id: string, name: string) => {
+    setPhase({ step: 'adding', id, name });
+    const ok = await onAdd(id, name);
+    setPhase({ step: ok ? 'added' : 'failed', id, name });
+  };
+
+  const card = (children: ReactNode) => (
+    <section
+      aria-label={`${node.name} details`}
+      className="rounded-xl border p-4 shadow-lg"
+      style={{ borderColor: 'var(--border)', background: 'var(--brand-card)' }}
+    >
+      {children}
+    </section>
+  );
+
+  // ── Add confirm / added / failed take over the card body (C1) ──────────────
+  if (phase.step !== 'idle') {
+    const { name } = phase;
+    return card(
+      phase.step === 'confirm' ? (
+        <>
+          <p className="font-serif text-base text-[var(--brand-ink)]">
+            Add <strong>{name}</strong> to your map?
+          </p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">
+            Questions will start appearing in your Daily Five.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={() => void confirmAdd(phase.id, name)}
+              className={actionButton}
+              style={{ borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-card)' }}
+            >
+              <Plus className="size-4" aria-hidden /> Add it
+            </button>
+            <button
+              type="button"
+              onClick={() => setPhase({ step: 'idle' })}
+              className={actionButton}
+              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            >
+              Not now
+            </button>
+          </div>
+        </>
+      ) : phase.step === 'adding' ? (
+        <p className="font-serif text-base text-[var(--brand-ink)]" aria-live="polite">
+          Adding {name}…
+        </p>
+      ) : phase.step === 'added' ? (
+        <>
+          <p className="font-serif text-base text-[var(--brand-ink)]" aria-live="polite">
+            <strong>{name}</strong> is on your map.
+          </p>
+          <p className="mt-1 text-sm text-[var(--text-muted)]">
+            Questions will start appearing in your Daily Five — or dive in right now.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <Link
+              href={quizHref(name)}
+              className={actionButton}
+              style={{ borderColor: 'var(--brand-navy)', background: 'var(--brand-navy)', color: 'var(--brand-card)' }}
+            >
+              Quiz me now <ArrowUpRight className="size-4" aria-hidden />
+            </Link>
+            <button
+              type="button"
+              onClick={() => setPhase({ step: 'idle' })}
+              className={actionButton}
+              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            >
+              Done
+            </button>
+          </div>
+        </>
+      ) : (
+        <>
+          <p className="font-serif text-base text-[var(--brand-ink)]" aria-live="polite">
+            Couldn’t add {name} just now.
+          </p>
+          <div className="mt-3 flex gap-2">
+            <button
+              type="button"
+              onClick={() => void confirmAdd(phase.id, name)}
+              className={actionButton}
+              style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={() => setPhase({ step: 'idle' })}
+              className={actionButton}
+              style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+            >
+              Back
+            </button>
+          </div>
+        </>
+      ),
+    );
+  }
+
+  return card(
+    <>
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          {/* Where this rolls up to (leaf-first: the path is the point). */}
+          {leaf.path.length > 0 ? (
+            <p className="flex flex-wrap items-center gap-1 text-[11px] uppercase tracking-[0.06em] text-[var(--text-muted)]">
+              {leaf.path.map((ancestor, i) => (
+                <span key={ancestor.id} className="flex items-center gap-1">
+                  {i > 0 ? <ChevronRight className="size-3" aria-hidden /> : null}
+                  {ancestor.name}
+                </span>
+              ))}
+            </p>
+          ) : null}
+          <p className="mt-1 flex items-center gap-2 font-serif text-lg text-[var(--brand-ink)]">
+            <span
+              aria-hidden
+              className="size-3.5 flex-none rounded-full"
+              style={{ background: node.mastered ? 'var(--accent-gold)' : fieldColor(node.field) }}
+            />
+            <strong className="truncate">{node.name}</strong>
+          </p>
+          <p className="mt-0.5 text-sm text-[var(--text-muted)]">
+            {formatPts(node.value ?? 0)} pts{node.mastered ? ' · Mastery' : ''}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          aria-label="Close"
+          className="grid size-8 flex-none place-items-center rounded-full border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+        >
+          <X className="size-4" aria-hidden />
+        </button>
+      </div>
+
+      {variant === 'own' ? (
+        <div className="mt-3 flex flex-wrap gap-2">
+          <Link
+            href={`/knowledge/${encodeURIComponent(node.name)}`}
+            className={actionButton}
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+          >
+            View details
+          </Link>
+          <Link
+            href={quizHref(node.name)}
+            className={actionButton}
+            style={{ borderColor: 'var(--border)', color: 'var(--brand-ink-700)' }}
+          >
+            Quiz me here
+          </Link>
+        </div>
+      ) : null}
+
+      {/* Siblings — where it sits, and what's next to add inside the same area. */}
+      {parent && (ownedSiblings.length > 0 || ghostSiblings.length > 0) ? (
+        <div className="mt-4 border-t pt-3" style={{ borderColor: 'var(--border)' }}>
+          <p className="text-xs uppercase tracking-[0.08em] text-[var(--text-muted)]">
+            More in {parent.name}
+          </p>
+          {ownedSiblings.length > 0 ? (
+            <div className="mt-2 flex flex-wrap gap-1.5">
+              {ownedSiblings.map((sib) => (
+                <button
+                  key={sib.id}
+                  type="button"
+                  onClick={() => onSelectSibling(sib.id)}
+                  className="inline-flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm hover:shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  style={{ borderColor: 'var(--border)', background: 'var(--brand-card)' }}
+                >
+                  <span
+                    aria-hidden
+                    className="size-3 rounded-full"
+                    style={{ background: sib.mastered ? 'var(--accent-gold)' : fieldColor(sib.field) }}
+                  />
+                  <span className="font-serif text-[var(--brand-ink)]">{sib.name}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
+          {variant === 'own' && ghostSiblings.length > 0 ? (
+            <ul className="mt-2 grid gap-1.5">
+              {ghostSiblings.map((ghost) => (
+                <li key={ghost.id} className="flex items-center justify-between gap-2">
+                  <span className="truncate font-serif text-sm text-[var(--brand-ink)]">
+                    {ghost.name}
+                  </span>
+                  <button
+                    type="button"
+                    onClick={() => setPhase({ step: 'confirm', id: ghost.id, name: ghost.name })}
+                    className="inline-flex min-h-8 flex-none items-center gap-1 rounded-full border px-3 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                    style={{ borderColor: 'var(--brand-navy)', color: 'var(--brand-navy)' }}
+                  >
+                    <Plus className="size-3.5" aria-hidden /> Add
+                  </button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
+    </>,
+  );
+}

--- a/src/components/knowledge/KnowledgeViewSwitcher.tsx
+++ b/src/components/knowledge/KnowledgeViewSwitcher.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+// Live switch between the three knowledge views. Replaces the old server-side
+// KNOWLEDGE_MAP_PAGE env gate: instead of one build-time choice, the player
+// flips between them in the browser via ?view=.
+//   - peaks    → the leaf-first "what you're smart at" gallery (new)
+//   - current  → the nested circle-pack bubble map
+//   - previous → the flat portrait page that predates the map
+export type KnowledgeView = 'peaks' | 'current' | 'previous';
+
+const OPTIONS: ReadonlyArray<{ view: KnowledgeView; label: string }> = [
+  { view: 'peaks', label: 'New' },
+  { view: 'current', label: 'Current' },
+  { view: 'previous', label: 'Previous' },
+];
+
+export function KnowledgeViewSwitcher({ current }: { current: KnowledgeView }) {
+  const pathname = usePathname();
+  return (
+    <nav
+      aria-label="Knowledge view"
+      className="mx-auto flex w-fit items-center gap-0.5 rounded-full border p-0.5"
+      style={{ borderColor: 'var(--border)', background: 'var(--brand-card)' }}
+    >
+      {OPTIONS.map(({ view, label }) => {
+        const active = view === current;
+        return (
+          <Link
+            key={view}
+            href={`${pathname}?view=${view}`}
+            aria-current={active ? 'page' : undefined}
+            scroll={false}
+            className="rounded-full px-3.5 py-1.5 text-[11px] uppercase tracking-[0.08em] transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            style={
+              active
+                ? { background: 'var(--brand-navy)', color: 'var(--brand-card)' }
+                : { color: 'var(--brand-ink-700)' }
+            }
+          >
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/src/components/knowledge/adopt.ts
+++ b/src/components/knowledge/adopt.ts
@@ -1,0 +1,18 @@
+// Shared "adopt a domain" path (the territory-adopt call): sets the domain's
+// Daily Five frequency, which folds it into the knowledge-base rotation. Used
+// by every confirmed-add affordance on the knowledge surfaces (the bubble
+// map's action card and the peaks view's addable siblings), so the network
+// contract lives in exactly one place.
+export async function adoptDomain(domain: string): Promise<boolean> {
+  try {
+    const res = await fetch('/api/daily/preferences/domain-frequency', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ domain, frequency: 'sometimes' }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
The knowledge page led with rolled-up parent clusters (the bubble map),
burying the specific things a player is smart at. Add a leaf-first "New"
view that leads with those peaks as trophies; tapping one shows where it
rolls UP to (its area path) and the sibling areas you could ADD next
(confirmed adopt, same path as the map).

Replace the build-time KNOWLEDGE_MAP_PAGE env gate on the owner page with
a live ?view= switcher across three interchangeable views: peaks (new,
default), current (bubble map), previous (flat portrait). Each view owns
its own header + switcher chrome, so only the selected one's server
component runs and the tree is never double-fetched.

Extract the shared adoptDomain fetch into components/knowledge/adopt.ts so
the bubble map and the peaks view share one network contract. No schema,
API, or mastery-math changes — pure presentation over existing tree data.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y5qAfwScuQkELHKdp3r5yf