### PR TITLE
Verify at scale: unbreak Batch API mode, tighten the prefilter, clear the backlog

### DIFF
--- a/docs/findings/SCALE-READINESS-2026-07-05.md
+++ b/docs/findings/SCALE-READINESS-2026-07-05.md
@@ -1,0 +1,82 @@
+# Scale-readiness review — question generation & verification
+
+**Date:** 2026-07-05 · **Method:** live prod DB (read-only aggregates), Axiom `vercel` log drain, Vercel env/deploy state, docs pricing page, and a full code map of both pipelines. · **Companion fixes landed with this doc:** the Batch-API `custom_id` bug, the prefilter explanation-path tightening, and the one-time backlog blitz (see §7).
+
+## TL;DR
+
+Generation is healthy and cheap (~$0.014/question). **Verification was the scaling wall** — a ~50/day synchronous cap under a ~26/day inflow, a growing backlog, and the built escape hatch (Batch API mode) silently broken. As of this doc the wall is removed: the Batch path works (bug fixed, first real batches submitted), the prefilter routes 78.5% instead of 94.3%, and the actionable backlog is being cleared for ~$3. The remaining scale levers are pricing/caching hygiene and one strategic decision (`D-SUPPLY-FINITE-SET-01`) that sets whether cost stays linear in players.
+
+## 1. Baseline (2026-07-05)
+
+| Metric | Value |
+|---|---|
+| Users / weekly answerers | 18 / 6 |
+| Answers, last 7d | 167 |
+| GeneratedQuestion total / servable / fresh-unused | 1,270 / 760 / 177 |
+| Question total / human-authored | 766 / 139 |
+| LLM spend | wk 6/22: **$3.87** (908 calls) → wk 6/29: **~$16–21 list** (1,804 calls; experiment-driven, not player-driven) |
+| Cost per generated question | **$0.014** (weekly digest) |
+| `LLM_MONTHLY_USD_CEILING` | $42 — last week's pace annualizes past it; raise or expect throttling |
+
+## 2. Generation
+
+Paths: daily on-demand (3-pass cron, time-budgeted rounds, six inline gates + ask-to-answer), pool refill (grounded web-search, flag-gated), crafter/authored (gates-as-flags, decision ledger feedback), reference-grounded anchor (built, flag-off).
+
+**Findings:**
+- **Sonnet 5 wins the A/B on everything measured**: generation 10.5s vs 15.3s avg, verify 3.7s vs 7.8s, refill 41 domains/165s/0 timeouts (vs 65% timeout catastrophe on 4.6), demotion parity (13.2% vs 13.3%). **Intro pricing $2/$10 per MTok through 2026-08-31** (list $3/$15; new tokenizer ≈ +30% tokens → net ~13% cheaper at intro). Some scopes still run 4.6 (factual gate default, parts of verify/inside-joke/enrich) — finish the consolidation before the intro window closes.
+- **The refill "pause" is not real in telemetry**: 155 non-dry cron invocations in 7d, 16×200, **10×504 + 2×500 dying at the 300s `maxDuration`**, plus live `pool-refill-generate` ledger rows. Reconcile posture vs reality; if refill stays on, it needs the Batch API architecture (the 504s prove sync can't hold even at this scale).
+- **No `generated_by_model` on question rows** — provider only (mostly NULL). Model-level quality A/Bs are impossible until a column is added and stamped at persist.
+
+## 3. Verification
+
+Layers: inline gates at generation → ask-to-answer (`machine_verified` tier) → inline Haiku vet for authored keeps → daily batch-verify cron (demote-only) → crafter gate-calibration ledger.
+
+**The wall, quantified (pre-fix):**
+- Raw unverified: 833 GQ + 636 Q. **Correction:** 826 of the GQ rows are *expired* bank stock the cron rightly ignores — the actionable backlog was **643** (636 Q + 7 live GQ).
+- Sync capacity 25/store/day vs ~26/day GQ inflow → backlog structurally never drains; cron p95 already 97s of 300s.
+- ~$2/day (~$60/mo) — the single largest recurring LLM line, driven by a prefilter that routed 94.3% of rows (the `explanationCarriesClaims` length/any-signal heuristic) and frequent web search.
+
+**Why the Batch API mode never fired (two independent causes, both found today):**
+1. `BATCH_VERIFY_ASYNC_ENABLED=true` was added to prod env only hours before this review — env vars bind at deploy, and no flag-bearing deployment had served the 10:00 UTC cron yet.
+2. **The real bug:** `encodeVerifyCustomId` used `q:<uuid>` — the Batches API rejects `custom_id` outside `^[a-zA-Z0-9_-]{1,64}$`, so every submit would have thrown `invalid_request_error`, been caught, logged, and returned 200. Unit tests mocked the API and never saw the pattern. Fixed to `q_<uuid>` (decode tolerates the legacy form); regression test asserts the pattern.
+
+**Prefilter fix (this PR):** the explanation path now routes only *adjacent* claims — a signal **kind** absent from stem+answer, or a claim-dense (≥2 kinds) explainer; length alone never routes; the `count` regex no longer double-fires on years. Measured on 1,200 recent prod rows:
+
+| variant | skip | route | extra_fact |
+|---|---|---|---|
+| legacy (both hatches) | 5.7% | 94.3% | 94.1% |
+| answer-tightening only (prior default) | 5.9% | 94.1% | 93.8% |
+| **strict (new default)** | **21.5%** | **78.5%** | **63.3%** |
+
+190/1,200 rows flip route→skip; eyeballed flips are explainers restating the asked fact (no leaked checkable claims). Escape hatch: `PREFILTER_EXPLANATION_LEGACY=true` (no deploy needed).
+
+## 4. Infrastructure
+
+- **Vercel:** Pro; `maxDuration=300` is the binding constraint on all sync LLM batch jobs (refill 504s; verify p95 97s). Batch API sidesteps it. `daily-assignments` p95 75s is fine (soft-deadline pattern).
+- **Supabase:** `max:5` pool pins every concurrency knob at 4; becomes the next ceiling at ~10× users (daily-assignment fan-out). Not urgent.
+- **Axiom:** `vercel` drain only; `LlmUsageEvent` is the real telemetry (good). Aborted-call tokens still unledgered (self-heals on Sonnet 5).
+- Hygiene: web-search tool version drift (refill `20260209` vs verify `20250305`); `/api/cron/prompt-proposal` unscheduled; `VOYAGE_API_KEY` unprovisioned (semantic dedup off — deterministic guards only).
+
+## 5. Cost model & projection
+
+Current: ~$3/weekly-active/week, mostly experiment overhead. With the fixes in §7 plus Sonnet-5 consolidation and cache breakpoints on the Haiku gate prompts (quality/vet/grade/dedupe ran ~1.2M input tokens/14d with **zero** cache), the player-proportional core projects to **$0.30–0.50/weekly-active/week**. Verification capacity via Batch API is effectively unbounded (100k requests/batch; ~24h latency is fine for a demote-only background net).
+
+What bends the curve vs. moves it: **`D-SUPPLY-FINITE-SET-01`** (still unratified). Infinite top-up pools ⇒ cost scales with play-time forever; finite completable sets (~15–30/territory) cap per-domain cost at a constant. Every prerequisite now exists (authored graph, node weights, mastery-v2, fragmentation fixed, crafter pipeline).
+
+## 6. Ranked recommendations
+
+1. ~~Fire the Batch verify path + backlog blitz~~ **DONE with this PR** (§7).
+2. Finish Sonnet-5 consolidation before Aug 31 (intro pricing).
+3. ~~Tighten the prefilter explanation path~~ **DONE with this PR** (§3).
+4. Cache breakpoints on Haiku gate + remaining verify prompts (audit the 4,096-token Haiku cache minimum per prompt).
+5. Flip fandom-grounding Consumer B (verifier domain allowlist), then Consumer A after the finite-set call — attacks the 13% demotion rate at the source.
+6. Reconcile refill posture; if kept on, rebuild on Batch API.
+7. Hygiene batch: `generated_by_model` column, `VOYAGE_API_KEY`, web-search version unification, schedule-or-delete `prompt-proposal`, revisit the $42 ceiling.
+8. Ratify the finite-set decision.
+
+## 7. Actions taken alongside this doc (2026-07-05)
+
+- **`custom_id` bug fixed** (`verify-batch.ts`): colon → underscore; legacy-tolerant decode; pattern regression test.
+- **Prefilter explanation path tightened** (`verification-prefilter.ts`): adjacent-claims heuristic + `PREFILTER_EXPLANATION_LEGACY` hatch; measurement script extended to three variants (`scripts/measure-prefilter-skip-rate.ts`).
+- **Backlog blitz executed** (`scripts/verify-backlog-blitz.ts`, reusable): 643 actionable rows → 135 stamped `skipped` free, 508 submitted as two Batch-API batches (`msgbatch_01VXkDri…` ×500, `msgbatch_01KJpYCc…` ×8, ~$3 est.); harvested via `--harvest` or by the daily cron (its submit phase waits for in-flight runs, so no double-billing).
+- First real `VerifyBatchRun` rows recorded; the daily cron's async mode is now genuinely operational.

--- a/docs/findings/batch-verify-cost-characterization.md
+++ b/docs/findings/batch-verify-cost-characterization.md
@@ -1,5 +1,23 @@
 # batch-verify cron — cost characterization (read-only, no LLM calls)
 
+> **UPDATE (2026-07-05): the §5 "explanation path" lever landed and MOVED the
+> needle — and the Batch API mode had a submit-blocking bug, now fixed.**
+> 1. **Explanation-path tightening** (`explanationCarriesAdjacentClaims`): routes
+>    only NOVEL-kind or claim-dense (≥2 kinds) explainers; length alone never
+>    routes; the `count` signal no longer double-fires on years. Measured on
+>    1,200 recent rows: **skip 5.7% → 21.5%, extra_fact 94.1% → 63.3%**
+>    (190/1,200 route→skip; flips eyeballed — no leaked claims). Escape hatch
+>    `PREFILTER_EXPLANATION_LEGACY=true`.
+> 2. **Batch mode was silently broken**: `custom_id` used a colon (`q:<uuid>`),
+>    which the Batches API rejects (`^[a-zA-Z0-9_-]{1,64}$`) — every submit threw,
+>    was caught, and returned 200. Fixed to `q_<uuid>` (legacy-tolerant decode) +
+>    a pattern regression test. First real batches submitted 2026-07-05 via the
+>    backlog blitz (`scripts/verify-backlog-blitz.ts`).
+> 3. **Backlog correction:** of the 833 "unverified" GeneratedQuestion rows, 826
+>    were EXPIRED (never re-servable; the cron rightly ignores them). The
+>    actionable backlog was 643, now cleared/in-flight.
+> See docs/findings/SCALE-READINESS-2026-07-05.md for the full review.
+
 > **UPDATE (2026-07-02): the three cost dials this doc named have landed.**
 > 1. **System-prompt caching** — `buildVerifyRequestParams` now sends the system
 >    prompt with an ephemeral `cache_control` breakpoint (live in both modes).

--- a/scripts/measure-prefilter-skip-rate.ts
+++ b/scripts/measure-prefilter-skip-rate.ts
@@ -33,10 +33,13 @@ type VariantTally = {
   extraFact: number;
 };
 
-function tallyVariant(rows: SampleRow[], legacyExtraFact: boolean): VariantTally {
+function tallyVariant(
+  rows: SampleRow[],
+  options: { legacyExtraFact?: boolean; legacyExplanation?: boolean },
+): VariantTally {
   const t: VariantTally = { skipped: 0, routed: 0, falsePremise: 0, extraFact: 0 };
   for (const row of rows) {
-    const d = prefilterForVerification(row, { legacyExtraFact });
+    const d = prefilterForVerification(row, options);
     if (!d.needsVerification) {
       t.skipped += 1;
       continue;
@@ -83,15 +86,19 @@ async function main() {
     ...generatedRows.map((r) => ({ ...r, store: 'GeneratedQuestion' as const })),
   ];
 
-  const legacy = tallyVariant(sample, true);
-  const strict = tallyVariant(sample, false);
+  // Three variants, cumulative: full legacy → answer tightening only (the
+  // 2026-07-03 near-no-op) → answer + explanation tightening (2026-07-05).
+  const legacy = tallyVariant(sample, { legacyExtraFact: true, legacyExplanation: true });
+  const answerOnly = tallyVariant(sample, { legacyExplanation: true });
+  const strict = tallyVariant(sample, {});
   const n = sample.length;
 
   console.log(`\nSample: ${n} rows (${questionRows.length} Question + ${generatedRows.length} GeneratedQuestion, most recent)\n`);
-  console.log('variant   skip           route          false_premise  extra_fact');
+  console.log('variant        skip           route          false_premise  extra_fact');
   for (const [name, t] of [
-    ['legacy ', legacy],
-    ['strict ', strict],
+    ['legacy      ', legacy],
+    ['answer-only ', answerOnly],
+    ['strict      ', strict],
   ] as const) {
     console.log(
       `${name}   ${String(t.skipped).padStart(4)} (${pct(t.skipped, n).padStart(6)})  ` +
@@ -103,19 +110,24 @@ async function main() {
 
   // Rows whose overall decision flipped route→skip: the spend actually saved.
   const flipped = sample.filter((row) => {
-    const wasRouted = prefilterForVerification(row, { legacyExtraFact: true }).needsVerification;
+    const wasRouted = prefilterForVerification(row, {
+      legacyExtraFact: true,
+      legacyExplanation: true,
+    }).needsVerification;
     const nowRouted = prefilterForVerification(row).needsVerification;
     return wasRouted && !nowRouted;
   });
   console.log(
     `\nroute→skip under tightening: ${flipped.length} rows (${pct(flipped.length, n)}) — ` +
-      `each was a paid verify call/day of demand; eyeball a few below for anything that LOOKS claim-bearing:`,
+      `each was a paid verify call/day of demand; eyeball for anything that LOOKS claim-bearing ` +
+      `(explainer shown — the tightened router's input):`,
   );
-  for (const row of flipped.slice(0, 10)) {
+  for (const row of flipped.slice(0, 15)) {
     console.log(`  [${row.store}] Q: ${row.questionText.slice(0, 90)}`);
     console.log(`      A: ${row.answer.slice(0, 90)}`);
+    if (row.explanation) console.log(`      E: ${row.explanation.slice(0, 110)}`);
   }
-  if (flipped.length > 10) console.log(`  … and ${flipped.length - 10} more`);
+  if (flipped.length > 15) console.log(`  … and ${flipped.length - 15} more`);
 }
 
 main()

--- a/scripts/verify-backlog-blitz.ts
+++ b/scripts/verify-backlog-blitz.ts
@@ -1,0 +1,180 @@
+/**
+ * One-time verification backlog blitz over the Message Batches API
+ * (scale-readiness follow-up, 2026-07-05: ~1,469 rows sat verifiedAt IS NULL
+ * against a 50/day sync cap — a wall-clock problem, not a cost problem).
+ *
+ * Reuses the EXACT production primitives — prefilterForVerification (tightened),
+ * submitVerifyBatch / harvestVerifyBatches, and the same verdict patch helpers —
+ * so semantics are identical to the cron's async mode; this script only removes
+ * the daily size cap. Runs it submits are recorded in VerifyBatchRun, so the
+ * daily cron sees them in flight, won't double-submit, and can itself harvest
+ * them (its submit phase is gated on runsStillProcessing === 0).
+ *
+ * Read-only by default. Run from repo root:
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts            # dry-run census + cost estimate
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts --submit   # stamp skips + submit routed rows in chunks
+ *   node --import tsx --env-file=.env --env-file=.env.local scripts/verify-backlog-blitz.ts --harvest  # harvest ended batches + stamp verdicts
+ *
+ * Fail-open contract preserved: an errored/expired/unparseable result stamps
+ * nothing and the row is re-picked by a later submission.
+ */
+import 'dotenv/config';
+
+import { and, eq, gt, isNull, ne } from 'drizzle-orm';
+
+import { getAnthropicClient } from '../src/lib/llm';
+import { db, generatedQuestions, pool, questions } from '../src/server/db';
+import {
+  prefilterForVerification,
+} from '../src/server/quality/verification-prefilter';
+import {
+  harvestVerifyBatches,
+  submitVerifyBatch,
+  type BatchRowInput,
+} from '../src/server/quality/verify-batch';
+import {
+  verdictToGeneratedPatch,
+  verdictToQuestionPatch,
+} from '../src/server/quality/verify-question';
+
+const SUBMIT = process.argv.includes('--submit');
+const HARVEST = process.argv.includes('--harvest');
+// Moderate chunks: a failed create loses one chunk, not the whole blitz.
+const CHUNK = 500;
+
+type PendingRow = {
+  id: string;
+  questionText: string;
+  answer: string;
+  explanation: string | null;
+  canonicalSubcategory: string | null;
+  broadCategory: string | null;
+};
+
+async function selectAllPending(now: Date): Promise<{ q: PendingRow[]; g: PendingRow[] }> {
+  const [q, g] = await Promise.all([
+    db
+      .select({
+        id: questions.id,
+        questionText: questions.questionText,
+        answer: questions.answerText,
+        explanation: questions.factualExplanation,
+        canonicalSubcategory: questions.canonicalSubcategory,
+        broadCategory: questions.broadCategory,
+      })
+      .from(questions)
+      .where(and(isNull(questions.verifiedAt), ne(questions.visibility, 'blocked'), isNull(questions.deletedAt))),
+    db
+      .select({
+        id: generatedQuestions.id,
+        questionText: generatedQuestions.questionText,
+        answer: generatedQuestions.answer,
+        explanation: generatedQuestions.explainer,
+        canonicalSubcategory: generatedQuestions.canonicalSubcategory,
+        broadCategory: generatedQuestions.broadCategory,
+      })
+      .from(generatedQuestions)
+      .where(and(
+        isNull(generatedQuestions.verifiedAt),
+        eq(generatedQuestions.isDuplicate, false),
+        gt(generatedQuestions.expiresAt, now),
+      )),
+  ]);
+  return { q: q as PendingRow[], g: g as PendingRow[] };
+}
+
+async function main() {
+  const now = new Date();
+  const { q, g } = await selectAllPending(now);
+
+  // Prefilter census (tightened heuristics — this script runs the working tree).
+  const routed: BatchRowInput[] = [];
+  const skips: Array<{ store: 'q' | 'g'; id: string }> = [];
+  for (const [store, rows] of [['q', q], ['g', g]] as const) {
+    for (const row of rows) {
+      const d = prefilterForVerification(
+        { questionText: row.questionText, answer: row.answer, explanation: row.explanation },
+      );
+      if (!d.needsVerification) skips.push({ store, id: row.id });
+      else routed.push({ store, rowId: row.id, questionText: row.questionText, answer: row.answer, explanation: row.explanation, canonicalSubcategory: row.canonicalSubcategory, broadCategory: row.broadCategory, dimensions: d.dimensions });
+    }
+  }
+
+  console.log(`pending: Question=${q.length} GeneratedQuestion=${g.length} total=${q.length + g.length}`);
+  console.log(`prefilter: skip=${skips.length} route=${routed.length}`);
+  // ~4k input tok/row measured; batch = 50% off; Sonnet 5 intro $2/$10 → ~$1/$5 batched.
+  console.log(`rough batched cost estimate: $${((routed.length * 4000 * 1 + routed.length * 300 * 5) / 1e6).toFixed(2)} + web searches`);
+
+  if (HARVEST) {
+    const client = getAnthropicClient();
+    if (!client) throw new Error('no anthropic client');
+    const summary = await harvestVerifyBatches(client, now);
+    let stamped = 0;
+    let stampFailures = 0;
+    for (const v of summary.verdicts) {
+      try {
+        if (v.store === 'q') {
+          await db.update(questions).set(verdictToQuestionPatch(v.outcome, now, v.reason)).where(eq(questions.id, v.rowId));
+        } else {
+          await db.update(generatedQuestions).set(verdictToGeneratedPatch(v.outcome, now, v.reason)).where(eq(generatedQuestions.id, v.rowId));
+        }
+        stamped += 1;
+      } catch (error) {
+        stampFailures += 1;
+        console.warn('stamp failed', v.store, v.rowId, error instanceof Error ? error.message : error);
+      }
+    }
+    const byOutcome = summary.verdicts.reduce<Record<string, number>>((acc, v) => {
+      acc[v.outcome] = (acc[v.outcome] ?? 0) + 1;
+      return acc;
+    }, {});
+    console.log('harvest:', {
+      runsChecked: summary.runsChecked,
+      runsHarvested: summary.runsHarvested,
+      runsStillProcessing: summary.runsStillProcessing,
+      runsFailed: summary.runsFailed,
+      resultFailures: summary.resultFailures,
+      stamped,
+      stampFailures,
+      byOutcome,
+    });
+    return;
+  }
+
+  if (!SUBMIT) {
+    console.log('\nDRY RUN — pass --submit to stamp skips and submit batches, --harvest to collect verdicts.');
+    return;
+  }
+
+  // Stamp the free skips first (identical to the cron's skip handling).
+  let skipped = 0;
+  for (const s of skips) {
+    try {
+      if (s.store === 'q') {
+        await db.update(questions).set(verdictToQuestionPatch('skipped', now)).where(eq(questions.id, s.id));
+      } else {
+        await db.update(generatedQuestions).set(verdictToGeneratedPatch('skipped', now)).where(eq(generatedQuestions.id, s.id));
+      }
+      skipped += 1;
+    } catch (error) {
+      console.warn('skip stamp failed', s.store, s.id, error instanceof Error ? error.message : error);
+    }
+  }
+  console.log(`stamped ${skipped}/${skips.length} skips (zero LLM cost)`);
+
+  const client = getAnthropicClient();
+  if (!client) throw new Error('no anthropic client');
+  for (let i = 0; i < routed.length; i += CHUNK) {
+    const chunk = routed.slice(i, i + CHUNK);
+    const { providerBatchId, requestCount } = await submitVerifyBatch(client, chunk);
+    console.log(`submitted chunk ${1 + i / CHUNK}: ${requestCount} requests → ${providerBatchId}`);
+  }
+  console.log('\nAll batches submitted. Re-run with --harvest once ended (typically <1h), or let the daily cron harvest.');
+}
+
+main()
+  .catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  })
+  .finally(() => void pool.end());

--- a/src/app/api/cron/batch-verify-questions/route.ts
+++ b/src/app/api/cron/batch-verify-questions/route.ts
@@ -37,12 +37,20 @@ const ASYNC_BATCH_SIZE = Math.max(1, Number(process.env.BATCH_VERIFY_ASYNC_BATCH
 // Each worker holds an LLM (and maybe a web-search) call in flight.
 const VERIFY_CONCURRENCY = 4;
 
-// Operational escape hatch for the 2026-07 extra_fact tightening: set
-// PREFILTER_EXTRA_FACT_LEGACY=true to restore the pre-tightening routing
-// (any comma/paren/"and" in the answer routes) without a deploy.
+// Operational escape hatches for the 2026-07 prefilter tightenings, both
+// restorable without a deploy: PREFILTER_EXTRA_FACT_LEGACY=true restores the
+// pre-tightening ANSWER routing (any comma/paren/"and" routes);
+// PREFILTER_EXPLANATION_LEGACY=true restores the pre-tightening EXPLANATION
+// routing (any one signal OR length ≥140 routes — the measured ~90% router).
 function prefilterOptions(): PrefilterOptions {
-  const raw = process.env.PREFILTER_EXTRA_FACT_LEGACY?.trim().toLowerCase();
-  return { legacyExtraFact: raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on' };
+  const flag = (name: string) => {
+    const raw = process.env[name]?.trim().toLowerCase();
+    return raw === 'true' || raw === '1' || raw === 'yes' || raw === 'on';
+  };
+  return {
+    legacyExtraFact: flag('PREFILTER_EXTRA_FACT_LEGACY'),
+    legacyExplanation: flag('PREFILTER_EXPLANATION_LEGACY'),
+  };
 }
 
 type PendingRow = {

--- a/src/server/quality/__tests__/verification-prefilter.test.ts
+++ b/src/server/quality/__tests__/verification-prefilter.test.ts
@@ -99,7 +99,8 @@ describe('prefilterForVerification — tightened extra_fact answer heuristic (20
   });
 
   it('claim-bearing explanations still route regardless of the answer shape', () => {
-    // The explanation path is untouched by the tightening.
+    // Survives BOTH tightenings: the explainer's year claim is a kind the
+    // question+answer never carried (novel adjacent claim).
     const d = decide(
       'Who painted the ceiling of the Sistine Chapel?',
       'Michelangelo',
@@ -113,6 +114,66 @@ describe('prefilterForVerification — tightened extra_fact answer heuristic (20
     const input = { questionText: 'What items does Ben buy at the store?', answer: 'Bread, eggs and milk' };
     const strict = prefilterForVerification(input);
     const legacy = prefilterForVerification(input, { legacyExtraFact: true });
+    expect(strict.needsVerification).toBe(false);
+    expect(legacy.needsVerification).toBe(true);
+    if (legacy.needsVerification) expect(legacy.dimensions).toContain('extra_fact');
+  });
+});
+
+describe('prefilterForVerification — tightened explanation heuristic (2026-07-05)', () => {
+  it('no longer routes an explanation that merely restates the asked fact-kind', () => {
+    // The stem/answer are ABOUT a year; the explainer's only signal is that same
+    // year. That's context, not an adjacent claim — under the legacy heuristic
+    // this routed to a paid verify (any one signal).
+    const d = decide(
+      'In what year did the Titanic sink?',
+      '1912',
+      'The Titanic sank in 1912 after striking an iceberg, and the disaster prompted sweeping changes to maritime safety law.',
+    );
+    expect(d.needsVerification).toBe(false);
+  });
+
+  it('no longer routes long pure-prose explanations (length is not a claim)', () => {
+    // ≥140 chars but zero assertion signals — legacy routed on length alone.
+    const d = decide(
+      'What is the capital of France?',
+      'Paris',
+      'Paris has long been celebrated as a global center of art, fashion, gastronomy and culture, and its cafe-lined boulevards draw countless visitors from far beyond its borders.',
+    );
+    expect(d.needsVerification).toBe(false);
+  });
+
+  it('still routes an explanation that volunteers a NOVEL claim kind', () => {
+    // Question asks a "who"; the explainer volunteers a date — a checkable
+    // adjacent claim the question never asked about.
+    const d = decide(
+      'Who wrote The Waste Land?',
+      'T. S. Eliot',
+      'T. S. Eliot published The Waste Land in 1922, and it quickly became one of the most influential poems of the modernist movement.',
+    );
+    expect(d.needsVerification).toBe(true);
+    if (d.needsVerification) expect(d.dimensions).toContain('extra_fact');
+  });
+
+  it('still routes a claim-dense explainer (two-plus signal kinds)', () => {
+    const d = decide(
+      "What is the title of Beethoven's Third Symphony?",
+      'Eroica',
+      'Beethoven composed the Eroica in 1804 and it was the first of his symphonies to break with classical convention.',
+    );
+    expect(d.needsVerification).toBe(true);
+    if (d.needsVerification) expect(d.dimensions).toContain('extra_fact');
+  });
+
+  it('the legacy explanation hatch restores the old routing', () => {
+    const input = {
+      questionText: 'In what year did the Titanic sink?',
+      answer: '1912',
+      explanation:
+        'The Titanic sank in 1912 after striking an iceberg, and the disaster prompted sweeping changes to maritime safety law.',
+    };
+    const strict = prefilterForVerification(input);
+    const legacy = prefilterForVerification(input, { legacyExplanation: true });
     expect(strict.needsVerification).toBe(false);
     expect(legacy.needsVerification).toBe(true);
     if (legacy.needsVerification) expect(legacy.dimensions).toContain('extra_fact');

--- a/src/server/quality/__tests__/verify-batch.test.ts
+++ b/src/server/quality/__tests__/verify-batch.test.ts
@@ -17,11 +17,25 @@ describe('verify custom_id codec', () => {
     }
   });
 
+  it('emits only characters the Batches API accepts (^[a-zA-Z0-9_-]{1,64}$)', () => {
+    // Regression for the 2026-07-05 prod finding: the original colon separator
+    // was REJECTED by the real API at submit — every async run silently no-oped.
+    for (const store of ['q', 'g'] as const) {
+      const encoded = encodeVerifyCustomId(store, 'a4f0c2de-1b3c-4d5e-8f90-0123456789ab');
+      expect(encoded).toMatch(/^[a-zA-Z0-9_-]{1,64}$/);
+    }
+  });
+
+  it('still decodes the legacy colon form defensively', () => {
+    expect(decodeVerifyCustomId('q:row-1')).toEqual({ store: 'q', rowId: 'row-1' });
+  });
+
   it('rejects malformed custom_ids instead of guessing a store', () => {
     expect(decodeVerifyCustomId('x:abc')).toBeNull();
     expect(decodeVerifyCustomId('q')).toBeNull();
     expect(decodeVerifyCustomId('')).toBeNull();
     expect(decodeVerifyCustomId('q:')).toBeNull();
+    expect(decodeVerifyCustomId('q_')).toBeNull();
   });
 });
 

--- a/src/server/quality/verification-prefilter.ts
+++ b/src/server/quality/verification-prefilter.ts
@@ -99,17 +99,64 @@ function isOpinionAdjacent(text: string): boolean {
   return OPINION_RE.test(text);
 }
 
-// The explanation carries adjacent claims when it is more than a terse restatement
-// of the answer — long enough to assert something of its own, with assertion
-// signals or substantial independent prose.
-function explanationCarriesClaims(
+// LEGACY (pre-2026-07-05): substance ≈ claims — ≥60 chars AND (any one signal OR
+// ≥140 chars). MEASURED as the dominant ~90% router (cost-characterization §5
+// retraction): trivia explainers nearly always clear one of those bars — every
+// explainer mentions a year or runs long — so extra_fact routed almost every row
+// and the pre-filter skipped only ~9%. Kept callable for the escape hatch and
+// the before/after measurement script.
+export function explanationCarriesClaimsLegacy(
   explanation: string | null | undefined,
-  _answer: string,
 ): boolean {
   if (!explanation) return false;
   const trimmed = explanation.trim();
   if (trimmed.length < 60) return false; // too short to carry an independent claim
   return signalKinds(trimmed).size >= 1 || trimmed.length >= 140;
+}
+
+// TIGHTENED (2026-07-05): length is prose, not a claim — and a single signal of
+// the same KIND the question/answer already carries is context (restating the
+// asked fact), not an ADJACENT claim. Route only when the explanation asserts
+// something checkable BEYOND the question+answer:
+//   - a signal kind ABSENT from stem+answer (a genuinely new claim category —
+//     e.g. the question asks a "who" and the explainer volunteers a date), or
+//   - two-plus distinct signal kinds (a claim-dense explainer — where wrong
+//     adjacent facts live).
+// Kind-level comparison is deliberately coarse (stem 1804 / explainer 1799 both
+// read as 'year' and would skip) — this is a demote-only BACKGROUND net behind
+// the factual gate and ask-to-answer, and the spend guarantee only pays out on
+// skips. The measurement script prints route→skip flips for eyeballing.
+// signalKinds with the year/count double-fire collapsed: the 'count' pattern
+// greedily matches ANY number followed by a word — including the year itself
+// ("in 1912 after…") — so every explainer mentioning a year read as two kinds
+// (year + count) and looked claim-dense. Keep 'count' only when a NON-year
+// number (or word-number) also matches. Local to the explanation path — the
+// stem/premise router keeps the original, deliberately conservative behavior.
+function effectiveKinds(text: string): Set<string> {
+  const kinds = signalKinds(text);
+  if (kinds.has('year') && kinds.has('count')) {
+    const withoutYears = text.replace(/\b(1\d{3}|20\d{2})\b/g, ' ');
+    if (!new RegExp(`\\b(\\d+|${WORD_NUMBERS})\\s+\\w+`, 'i').test(withoutYears)) {
+      kinds.delete('count');
+    }
+  }
+  return kinds;
+}
+
+export function explanationCarriesAdjacentClaims(
+  explanation: string | null | undefined,
+  stem: string,
+  answer: string,
+): boolean {
+  if (!explanation) return false;
+  const trimmed = explanation.trim();
+  if (trimmed.length < 60) return false; // too short to carry an independent claim
+  const explKinds = effectiveKinds(trimmed);
+  if (explKinds.size === 0) return false; // pure prose — nothing checkable
+  if (explKinds.size >= 2) return true; // claim-dense
+  const contextKinds = effectiveKinds(`${stem} ${answer}`);
+  for (const kind of explKinds) if (!contextKinds.has(kind)) return true; // novel kind
+  return false;
 }
 
 // The answer bundles an extra descriptor ("Eroica (Beethoven's Third, dedicated to
@@ -145,6 +192,13 @@ export type PrefilterOptions = {
    * before/after comparison. Default false (tightened heuristic).
    */
   legacyExtraFact?: boolean;
+  /**
+   * Use the pre-2026-07-05 explanation heuristic (any one signal OR length ≥140
+   * routes — the measured ~90% router). Operational escape hatch only — the cron
+   * passes this from PREFILTER_EXPLANATION_LEGACY; the measurement script uses it
+   * for the before/after comparison. Default false (adjacent-claims heuristic).
+   */
+  legacyExplanation?: boolean;
 };
 
 /**
@@ -178,12 +232,16 @@ export function prefilterForVerification(
   if (premiseBearing) dimensions.push('false_premise');
 
   // extra_fact: the explanation or the answer carries adjacent claims. The answer
-  // side requires bundling + an assertion signal (tightened 2026-07) unless the
-  // legacy escape hatch is on.
+  // side requires bundling + an assertion signal (tightened 2026-07); the
+  // explanation side requires a NOVEL or claim-dense assertion (tightened
+  // 2026-07-05 — the measured ~90% router). Each has its own legacy hatch.
   const answerRoutes = options?.legacyExtraFact
     ? answerIsMultiFact(answer)
     : answerCarriesAdjacentClaim(answer);
-  if (explanationCarriesClaims(input.explanation, answer) || answerRoutes) {
+  const explanationRoutes = options?.legacyExplanation
+    ? explanationCarriesClaimsLegacy(input.explanation)
+    : explanationCarriesAdjacentClaims(input.explanation, stem, answer);
+  if (explanationRoutes || answerRoutes) {
     dimensions.push('extra_fact');
   }
 

--- a/src/server/quality/verify-batch.ts
+++ b/src/server/quality/verify-batch.ts
@@ -43,14 +43,19 @@ export function isBatchVerifyAsyncEnabled(): boolean {
 /** 'q' = Question, 'g' = GeneratedQuestion — encoded into the batch custom_id. */
 export type VerifyStore = 'q' | 'g';
 
+// The Batches API constrains custom_id to ^[a-zA-Z0-9_-]{1,64}$ — a colon
+// separator is REJECTED at submit (invalid_request_error), which is exactly how
+// the async mode silently no-oped in prod (submit threw on every run; the cron
+// caught, logged, and returned 200). Underscore is in the allowed class and
+// unambiguous before a UUID. Decode tolerates the legacy colon form defensively.
 export function encodeVerifyCustomId(store: VerifyStore, rowId: string): string {
-  return `${store}:${rowId}`;
+  return `${store}_${rowId}`;
 }
 
 export function decodeVerifyCustomId(
   customId: string,
 ): { store: VerifyStore; rowId: string } | null {
-  const match = /^([qg]):(.+)$/.exec(customId);
+  const match = /^([qg])[_:](.+)$/.exec(customId);
   if (!match) return null;
   return { store: match[1] as VerifyStore, rowId: match[2] };
 }


### PR DESCRIPTION
## What

Items 1 and 3 of the scale-readiness review — the full report ships in this PR as `docs/findings/SCALE-READINESS-2026-07-05.md`.

### 1. Batch API verify mode was silently broken — fixed

`encodeVerifyCustomId` produced `q:<uuid>`, but the Batches API constrains `custom_id` to `^[a-zA-Z0-9_-]{1,64}$`. Every async submit threw `invalid_request_error`, was caught, logged, and the cron returned 200 — a perfect silent no-op (unit tests mocked the API and never hit the pattern; `VerifyBatchRun` stayed empty). Now `q_<uuid>`, with a legacy-tolerant decode and a regression test asserting the API's pattern.

### 2. Prefilter explanation path tightened (the measured ~90% router)

Per the cost-characterization §5 retraction, the real router was `explanationCarriesClaims` (any one signal OR length ≥140 — every trivia explainer clears one). New default routes only **adjacent** claims: a signal *kind* absent from stem+answer, or a claim-dense (≥2 kinds) explainer. Length never routes; the `count` regex no longer double-fires on years ("in 1912 after…" ≠ year + count).

**Measured on 1,200 recent prod rows** (`scripts/measure-prefilter-skip-rate.ts`, now 3-variant):

| variant | skip | route | extra_fact |
|---|---|---|---|
| legacy | 5.7% | 94.3% | 94.1% |
| answer-tightening only (prior default) | 5.9% | 94.1% | 93.8% |
| **strict (new)** | **21.5%** | **78.5%** | **63.3%** |

All 190 route→skip flips print with their explainers for eyeballing — sampled clean (explainers restating the asked fact). Escape hatch: `PREFILTER_EXPLANATION_LEGACY=true`, no deploy needed, mirroring `PREFILTER_EXTRA_FACT_LEGACY`.

### 3. Backlog blitz — executed

`scripts/verify-backlog-blitz.ts` (dry-run default) reuses the production primitives (`submitVerifyBatch`/`harvestVerifyBatches`/patch helpers) without the daily cap. Run 2026-07-05:
- **Backlog correction:** 826 of the 833 "unverified" bank rows were *expired* (never re-servable; the cron rightly excludes them). Actionable backlog = **643**.
- 135 stamped `skipped` free by the tightened prefilter; **508 submitted** as two batches (`msgbatch_01VXkDri…` ×500, `msgbatch_01KJpYCc…` ×8, ~$3 at batch+intro pricing).
- The daily cron's submit phase waits for in-flight runs, so no double-billing; either the cron or `--harvest` stamps the verdicts.

## Verify

348 tests pass (quality + api suites), typecheck and lint clean. First real `VerifyBatchRun` rows exist in prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V