### PR TITLE
Ratify D-SUPPLY-FINITE-SET-01: finite completable sets, cost-routed curation

### DIFF
--- a/D-SUPPLY-FINITE-SET-01.md
+++ b/D-SUPPLY-FINITE-SET-01.md
@@ -1,0 +1,118 @@
+# D-SUPPLY-FINITE-SET-01 — Finite completable sets, cost-routed curation
+
+**Status:** ✅ **RATIFIED** 2026-07-05 (Josh, in chat). Supersedes
+`docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md` (now resolved).
+Unblocks the `D-SUPPLY-LADDER-UNIFY-01` rework and forces a revision of
+`D-AREA-EXPANSION-01` (graduation valence). Does not, by itself, un-pause the
+paid refill run — see §6.
+
+## The decision (two answers + two additions)
+
+### 1. Topics are FINITE COMPLETABLE SETS, and completion invites authorship.
+A knowledge domain is a **bounded body of ~15–30 fan-salient questions** — the
+ones a real fan of that topic would genuinely enjoy — not an infinite top-up
+pool. A player **completes** the set, earns a **designation** (a durable badge),
+and is then **invited to graduate** (a neighbor/parent topic) *and* **to author
+their own questions** for the topic they just mastered.
+
+- **Completion is a trophy, not a failure.** "Running out" — today an awkward
+  state the guard hides — becomes the intended arc: master → badge → branch out.
+  This directly answers the driving feedback ("answering ever deeper into one
+  play leads to weirdness, frustration and boredom"): we stop mining a topic past
+  its fan-salient core.
+- **Completion → contribution (Josh's addition).** At the trophy moment the
+  player is offered the authoring door: "you know this world — add the questions
+  you wish were here." Reuses the existing invited-author flow
+  (`B-CRAFTER-LIFECYCLE-01`, the `/invited` takeover + `/craft/[domain]` surface);
+  a completed player is the highest-signal candidate to author, and their
+  additions **grow the set** for the next player (finite ≠ frozen — see §4).
+- **Arcane questions are opt-in.** The fan-salient core is the default set; deep
+  cuts are generated rarely and only on a player's explicit "go deeper" — not
+  ground out automatically. (Maps onto the crafter "deep cuts" tier that exists.)
+
+### 2. Curation is COST-ROUTED hybrid (Josh's second answer).
+Not blanket-curate, not blanket-hands-off. **A human curates the domains that
+are expensive or unreliable for the machine to generate + verify; cheap,
+reliable domains fill themselves.**
+
+- **"Expensive/unreliable" is a computed per-domain signal**, from telemetry we
+  already collect (no new instrumentation):
+  - **demotion rate** — `verification_verdict='demoted'` over verified rows,
+    grouped by `canonical_subcategory`. High demotion ⇒ the machine keeps minting
+    wrong facts here ⇒ human-vetting ~50→keep ~20 beats regenerate-and-catch.
+  - **verify web-search rate** — domains where the verifier can't settle from
+    knowledge and falls to `web_search` (`web_search_requests > 0` on
+    `scope='batch-verify'` ledger rows, once attributable per domain). Niche /
+    fandom / current-events ⇒ expensive to verify.
+  - **draft/ask-to-answer kill rate** — low machine yield ⇒ expensive to fill.
+  These combine into a **curation-worthiness score** per domain.
+- **Routing:** score above a tunable threshold → the domain is flagged
+  **curate** and surfaced in the crafter "where your craft is wanted" worklist
+  (which already ranks active domains by demand × thinness — this adds a
+  cost-risk dimension). Below threshold → **auto-fill** (machine generates the
+  set, gates filter, no human in the loop).
+- **The expensive set and the authorship-invite set are the same set** — a
+  niche fandom domain is both where the machine is unreliable *and* where a
+  just-completed superfan is the ideal author. The two additions converge.
+
+## What "finite" changes (the mechanics)
+
+- **Depth threshold** stops meaning "too thin to serve" and starts meaning
+  **"set complete."** The `RETRIEVAL_POOL_DEPTH_THRESHOLD` / kb-exhaustion guard
+  is reinterpreted: reaching target depth = the set is done, trigger the trophy,
+  not "keep generating."
+- **Set size** is per-domain, seeded from the node's authored **mastery weight**
+  (`node_weight`, already seeded on 116 nodes) — a deeper topic (weight 9) gets a
+  bigger target set than a shallow one (weight 2). This reuses mastery-v2's weight
+  as the set-size signal, not just the mastery bar.
+- **Refill** flips from "drain a daily backlog forever" to **"fill each set once,
+  then stop."** A completed set is not re-refilled. This collapses the recurring
+  refill cost to a bounded, one-time-per-domain cost.
+- **Graduation** (`D-AREA-EXPANSION-01`, rung 5) flips valence: **fallback → the
+  intended arc.** That doc must be revised (do not treat graduation as "we ran
+  out" anymore).
+
+## Finite ≠ frozen (how sets grow)
+
+A set is bounded *at any moment*, not permanently sealed:
+- **Human authorship extends it** — completed players + curators add questions,
+  so a beloved topic's set organically grows past its machine-generated core.
+- **Opt-in depth extends it** — a player asking to "go deeper" mints arcane
+  questions on demand, appended to their view of the set.
+- **Re-completion** — when a set grows after a player completed it, they're
+  notified there's more (a light re-engagement hook, not a treadmill).
+
+## Build implications (phased; each independently mergeable)
+
+- **P1 — Curation-worthiness score (read-only):** per-domain demotion + verify-
+  web + kill-rate rollup; surface as a column/sort in the crafter worklist. No
+  behavior change; validates the routing signal before it gates anything.
+- **P2 — Set-completion state:** reinterpret depth-reached as "complete" for
+  auto-fill domains; wire the trophy/designation + the authorship-invite door at
+  completion (reuse the invited-author takeover). Flag-gated.
+- **P3 — Refill re-scope:** refill fills to target-set-size then stops per domain;
+  completed sets excluded. Folds into the `D-SUPPLY-LADDER-UNIFY-01` rework.
+- **P4 — Curation routing live:** the score gates which domains enter the crafter
+  worklist as "curate" vs auto-fill.
+- Revise `D-AREA-EXPANSION-01` (graduation valence) alongside P2.
+
+## Open knobs (tune later; do not block the build)
+
+- Target set size as a function of `node_weight` (linear? floor/ceiling 15/30?).
+- Curation-worthiness threshold + the weight of each signal (demotion vs web vs
+  yield) — calibrate against the crafter's own kept/killed ledger.
+- Whether opt-in deep cuts count toward a *second* designation tier.
+- Re-completion notification cadence (avoid it becoming a treadmill by the back
+  door).
+
+## Interacts with
+
+- `D-SUPPLY-LADDER-UNIFY-01` — now UNBLOCKED; rungs 2/3/5 rewrite against finite
+  sets (fill-once refill, complete-not-thin threshold, graduation-as-arc).
+- `D-AREA-EXPANSION-01` — graduation valence flips; revise with P2.
+- `B-CRAFTER-LIFECYCLE-01` — the authorship-invite and curation surfaces already
+  exist; this decision points real routing at them.
+- Mastery-v2 (`node_weight`) — reused as the set-size signal.
+- The paid AC-1 refill run / soak — still paused pending the P3 re-scope; refill
+  as it stands (infinite drain) is now the *wrong shape*, so do not run the
+  old-shape confirmation — rebuild it fill-once first.

--- a/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
+++ b/docs/decisions-pending/D-SUPPLY-FINITE-SET-01-PENDING.md
@@ -1,28 +1,17 @@
-# D-SUPPLY-FINITE-SET-01 — PENDING DECISION (not yet ratified)
+# D-SUPPLY-FINITE-SET-01 — RESOLVED (see the ratified doc)
 
-**Status:** ⏳ **PENDING** — a chat decision with Josh precedes the real D-doc; this is only the visible marker. **Not ratified. Do not build against it, and do not build against the things it blocks.**
+**Status:** ✅ **RATIFIED 2026-07-05.** This pending marker is closed. The real
+decision lives at `D-SUPPLY-FINITE-SET-01.md` (repo root).
 
-**Blocks:** the paid AC-1 refill confirmation run · the refill soak · any `D-SUPPLY-LADDER-UNIFY-01` build prompts.
+**The answers Josh gave:**
+1. **Finite completable sets ("trophy"), and completion invites authorship** —
+   ~15–30 fan-salient questions per topic; complete → designation → graduate AND
+   author your own; arcane questions opt-in only.
+2. **Cost-routed hybrid curation** — a human curates domains that are expensive/
+   unreliable to generate+verify (high demotion, needs web-search, low yield);
+   cheap reliable domains auto-fill. The expensive set and the authorship-invite
+   set coincide.
 
-## The question
-Are knowledge domains **infinite top-up pools** (the current supply-ladder premise — daily refill drains a backlog forever) or **finite completable sets** (a bounded body of ~15–30 fan-salient questions the player *completes*, earns a **designation** for, then **graduates/broadens** by choice — with **opt-in difficulty tiers** so arcane questions are generated rarely and only on demand)?
-
-## Why it matters (what the answer reshapes)
-- **Refill:** "daily backlog-draining cost" → "fill a set once, then stop."
-- **Depth threshold:** stops meaning "too thin to serve," starts meaning "set complete."
-- **Graduation (`D-AREA-EXPANSION-01`, rung 5):** flips from **fallback** (we ran out) to **intended arc** (you mastered it).
-- **Human curation:** Josh vetting ~50 → keeping ~35 may beat automated refill on both cost and quality for vettable domains.
-
-The driving feedback: *"answering ever deeper into one play leads to weirdness and frustration and boredom."* — i.e. infinite depth may be the wrong goal.
-
-## Two inputs Josh owes before ratification
-1. Does the **finite-set model feel right** as the game's direction?
-2. Does Josh want to **personally curate**, or should supply run **hands-off**?
-
-## Interacts with (do NOT build until resolved)
-- `D-SUPPLY-LADDER-UNIFY-01` — rungs 2, 3, and 5 all change.
-- `D-AREA-EXPANSION-01` — graduation's valence flips (fallback → intended arc). *(Do not edit that doc yet; its revision waits on this same decision.)*
-- The AC-1 refill confirmation run · the refill soak (`docs/retrieval-flip-checklist.md`, `B-SUPPLY-REFILL-EFFORT-REPORT.md`).
-
-## Does NOT block
-- The **batch-verify cost characterization** work (`docs/findings/batch-verify-cost-characterization.md`) — that cron is unrelated to this reframe and proceeds independently.
+See the ratified doc for mechanics, the per-domain curation-worthiness signal,
+the "finite ≠ frozen" growth model, and the phased build (P1 score → P2
+completion+trophy → P3 refill re-scope → P4 routing).


### PR DESCRIPTION
Ratifies the supply-model decision that's been blocking `D-SUPPLY-LADDER-UNIFY-01` and the refill re-scope for a week. Docs-only.

## Josh's two answers (2026-07-05)

**1. Finite completable sets ("trophy"), and completion invites authorship.** A topic is a bounded ~15–30 fan-salient questions, not an infinite pool. Complete it → earn a designation → be invited to graduate to a neighbor topic **and** to author your own questions for the one you just mastered. Arcane questions are opt-in only. This directly answers the "answering ever deeper leads to weirdness and boredom" feedback and turns "running out" from a hidden failure into the intended arc.

**2. Cost-routed hybrid curation.** Not blanket-curate, not blanket-hands-off — a human curates the domains that are *expensive or unreliable* for the machine (high demotion rate, needs web-search to verify, low draft yield → surfaced in the crafter "where your craft is wanted" worklist); cheap reliable domains auto-fill. The expensive-to-verify set and the ideal-superfan-author set coincide, so the two additions reinforce each other.

## What it re-shapes

- **Refill:** infinite daily drain → fill each set once, then stop. (The old-shape paid refill run is now the *wrong shape* — rebuild fill-once first; do not run AC-1 as-is.)
- **Depth threshold:** "too thin to serve" → "set complete" (trigger the trophy).
- **Set size:** seeded from the authored `node_weight` (deeper topic = bigger set) — reuses mastery-v2.
- **Graduation** (`D-AREA-EXPANSION-01`): fallback → intended arc (forces that doc's revision).
- **Finite ≠ frozen:** human authorship + opt-in depth grow a beloved set over time.

## Contents

- `D-SUPPLY-FINITE-SET-01.md` (ratified) — mechanics, the per-domain curation-worthiness signal (from existing telemetry: demotion rate + verify-web rate + kill rate), the growth model, and the phased build (P1 score → P2 completion+trophy → P3 refill re-scope → P4 routing).
- The pending marker is closed with a pointer.

No code. Unblocks the supply-ladder rework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V