### PR TITLE
Sonnet-5 consolidation + expensive-subject dashboard & notification

### DIFF
--- a/src/app/admin/crafter/CrafterClient.tsx
+++ b/src/app/admin/crafter/CrafterClient.tsx
@@ -257,6 +257,17 @@ function DomainRow({ row, onCraft }: { row: CrafterWorklistRow; onCraft: () => v
                 you love this
               </span>
             ) : null}
+            {/* D-SUPPLY-FINITE-SET-01: this subject crossed the "too expensive
+                for the machine" line — human curation beats auto-fill here. */}
+            {row.expensiveToMachine ? (
+              <span
+                className="rounded-sm border px-1.5 py-0.5 text-[0.6rem] font-semibold uppercase tracking-[0.08em]"
+                style={{ borderColor: 'var(--danger)', color: 'var(--danger)' }}
+                title={`Expensive for the machine — curate this (${row.expensiveReason ?? 'costly to generate'})`}
+              >
+                expensive · curate
+              </span>
+            ) : null}
             <span className="text-[0.65rem] uppercase tracking-[0.06em]" style={{ color: heatColor(row.heat) }}>
               {HEAT_LABEL[row.heat]}
             </span>

--- a/src/server/daily/enrich-variants.ts
+++ b/src/server/daily/enrich-variants.ts
@@ -25,6 +25,7 @@
 // question still ships with its original key), it never blocks or drops.
 
 import {
+  ANTHROPIC_MODEL,
   INSTRUCTION_SCOPING_QUALIFIER,
   INSTRUCTION_USER_INPUT_GUIDANCE,
   extractTextContent,
@@ -40,12 +41,14 @@ export interface EnrichVariantsItem {
   explainer: string;
 }
 
-// Default to the generation tier (Sonnet) — judging answer equivalence needs the
-// same reasoning the generator and factual gate use; Haiku is too lenient/broad
-// here and would risk polluting keys. Overridable without a deploy, mirroring
-// FACTUAL_GATE_MODEL. Resolved lazily so tests can stub the model id.
+// Default to the generation tier — judging answer equivalence needs the same
+// reasoning the generator and factual gate use; Haiku is too lenient/broad here
+// and would risk polluting keys. Inherits ANTHROPIC_MODEL (Sonnet 5 in prod, the
+// central flag) rather than pinning a version, so a model flip carries here too;
+// overridable without a deploy, mirroring FACTUAL_GATE_MODEL. Resolved lazily so
+// tests can stub the model id.
 function enrichModel(): string {
-  return process.env.ENRICH_VARIANTS_MODEL?.trim() || 'claude-sonnet-4-6';
+  return process.env.ENRICH_VARIANTS_MODEL?.trim() || ANTHROPIC_MODEL;
 }
 
 function enrichEnabled(): boolean {

--- a/src/server/db/queries/__tests__/crafter-demand-clusters.test.ts
+++ b/src/server/db/queries/__tests__/crafter-demand-clusters.test.ts
@@ -21,7 +21,13 @@ vi.mock('@/server/knowledge/converge-domain', () => ({
   getConvergeTrgmThreshold: () => 0.55,
 }));
 
-import { buildLabelClusters, futilityScore, type ClusterLabel } from '@/server/db/queries/crafter-demand';
+import {
+  buildLabelClusters,
+  curationVerdict,
+  futilityScore,
+  CURATION_FUTILITY_THRESHOLD,
+  type ClusterLabel,
+} from '@/server/db/queries/crafter-demand';
 
 const THRESHOLD = 0.55;
 
@@ -86,5 +92,46 @@ describe('futilityScore', () => {
 
   it('below the sample floor (rate=null) the machine is presumed fine', () => {
     expect(futilityScore({ demotionRate: null, generationStruggling: false })).toBe(0);
+  });
+});
+
+// D-SUPPLY-FINITE-SET-01: the "too expensive → curate it" threshold that drives
+// the crafter dashboard badge and the weekly notification.
+describe('curationVerdict', () => {
+  it('a low-demotion, healthy domain is NOT expensive', () => {
+    const v = curationVerdict({ demotionRate: 0.1, generationStruggling: false });
+    expect(v.expensive).toBe(false);
+    expect(v.reason).toBeNull();
+  });
+
+  it('a high demotion rate crosses the line with a % reason', () => {
+    const v = curationVerdict({ demotionRate: 0.64, generationStruggling: false });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('64% demoted');
+  });
+
+  it('generation timing out crosses the line on its own', () => {
+    // struggling bump (0.5) alone clears 0.34, even with no verdict sample.
+    const v = curationVerdict({ demotionRate: null, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('generation timing out');
+  });
+
+  it('names both causes when both fire', () => {
+    const v = curationVerdict({ demotionRate: 0.5, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('50% demoted; generation timing out');
+  });
+
+  it('does not fabricate a % reason when the rate is below the threshold but struggling pushes it over', () => {
+    // demotionRate 0.1 alone wouldn't cross; the 0.5 struggling bump does. The
+    // reason must not claim "10% demoted" as a cause — only the timeout.
+    const v = curationVerdict({ demotionRate: 0.1, generationStruggling: true });
+    expect(v.expensive).toBe(true);
+    expect(v.reason).toBe('generation timing out');
+  });
+
+  it('the threshold is the documented value', () => {
+    expect(CURATION_FUTILITY_THRESHOLD).toBe(0.34);
   });
 });

--- a/src/server/db/queries/crafter-demand.ts
+++ b/src/server/db/queries/crafter-demand.ts
@@ -61,6 +61,15 @@ export type CrafterWorklistRow = {
   machineDemoted: number; // …of those, pulled as wrong
   demotionRate: number | null; // demoted/verified; null below the sample floor
   generationStruggling: boolean; // refill has been timing out here (health row)
+  /**
+   * D-SUPPLY-FINITE-SET-01 curation routing: TRUE when this subject has crossed
+   * the "too expensive for the machine" line (futility ≥ threshold) — it should
+   * be human-curated, not left to auto-fill. Drives the crafter dashboard badge
+   * and the weekly "subjects that got expensive" notification. `expensiveReason`
+   * is a short human string ('64% demoted' / 'generation timing out').
+   */
+  expensiveToMachine: boolean;
+  expensiveReason: string | null;
 };
 
 // Thresholds are deliberately small-scale (18-user era) and transparent — tune
@@ -88,6 +97,101 @@ export function futilityScore(row: {
   generationStruggling: boolean;
 }): number {
   return (row.demotionRate ?? 0) + (row.generationStruggling ? 0.5 : 0);
+}
+
+// The "too expensive for the machine → curate it" line (D-SUPPLY-FINITE-SET-01
+// cost-routed curation). Crossed by EITHER a high demotion rate (a third+ of the
+// machine's verified questions here are wrong — re-generating just re-mints
+// junk) OR generation timing out at all (the 0.5 struggling bump alone clears
+// it — the machine can't even produce here). Small-scale, tune by eye.
+export const CURATION_FUTILITY_THRESHOLD = 0.34;
+
+/**
+ * Whether a subject has crossed the curation line, with a short human reason.
+ * Pure and exported for tests + the weekly notification. Only speaks when there
+ * is a real signal: a demotion rate needs the sample floor (FUTILITY_MIN_VERIFIED),
+ * so a domain flagged solely on `generationStruggling` reads as a timeout, not a
+ * fabricated failure rate.
+ */
+export function curationVerdict(row: {
+  demotionRate: number | null;
+  generationStruggling: boolean;
+}): { expensive: boolean; reason: string | null } {
+  if (futilityScore(row) < CURATION_FUTILITY_THRESHOLD) return { expensive: false, reason: null };
+  const parts: string[] = [];
+  if (row.demotionRate != null && row.demotionRate >= CURATION_FUTILITY_THRESHOLD) {
+    parts.push(`${Math.round(row.demotionRate * 100)}% demoted`);
+  }
+  if (row.generationStruggling) parts.push('generation timing out');
+  return { expensive: true, reason: parts.join('; ') || 'costly to generate' };
+}
+
+export type ExpensiveDomain = {
+  domain: string;
+  reason: string;
+  demotionRate: number | null;
+  generationStruggling: boolean;
+};
+
+/**
+ * GLOBAL curation-worthiness scan (D-SUPPLY-FINITE-SET-01) — every subject that
+ * has crossed the "too expensive for the machine" line, corpus-wide (not scoped
+ * to one crafter's active domains like getCrafterWorklist). Powers the weekly
+ * "subjects that got expensive" notification in the LLM cost report. Read-only,
+ * pure threshold over the same two signals the worklist uses:
+ *   - per-domain machine demotion rate (needs the FUTILITY_MIN_VERIFIED sample),
+ *   - refill generation timing out (RetrievalDomainHealth).
+ * Sorted by futility, worst first.
+ */
+export async function getExpensiveDomains(): Promise<ExpensiveDomain[]> {
+  const [verdictRows, healthRows] = await Promise.all([
+    db
+      .select({
+        domain: generatedQuestions.canonicalSubcategory,
+        verified: sql<number>`count(*)::int`,
+        demoted: sql<number>`count(*) filter (where ${generatedQuestions.verificationVerdict} = 'demoted')::int`,
+      })
+      .from(generatedQuestions)
+      .where(isNotNull(generatedQuestions.verificationVerdict))
+      .groupBy(generatedQuestions.canonicalSubcategory),
+    db
+      .select({
+        domain: retrievalDomainHealth.domain,
+        consecutiveTimeouts: retrievalDomainHealth.consecutiveTimeouts,
+      })
+      .from(retrievalDomainHealth)
+      .where(gte(retrievalDomainHealth.consecutiveTimeouts, STRUGGLING_TIMEOUTS)),
+  ]);
+
+  const struggling = new Set(healthRows.map((r) => r.domain).filter(Boolean) as string[]);
+  const out: ExpensiveDomain[] = [];
+  const seen = new Set<string>();
+
+  for (const r of verdictRows) {
+    if (!r.domain) continue;
+    const verified = Number(r.verified);
+    const demoted = Number(r.demoted);
+    const demotionRate = verified >= FUTILITY_MIN_VERIFIED ? demoted / verified : null;
+    const generationStruggling = struggling.has(r.domain);
+    const v = curationVerdict({ demotionRate, generationStruggling });
+    if (v.expensive) {
+      out.push({ domain: r.domain, reason: v.reason ?? 'costly to generate', demotionRate, generationStruggling });
+      seen.add(r.domain);
+    }
+  }
+  // Domains that time out so hard they have no verdict rows at all (the machine
+  // can't even produce here) — the clearest curate case; include them too.
+  for (const domain of struggling) {
+    if (seen.has(domain)) continue;
+    const v = curationVerdict({ demotionRate: null, generationStruggling: true });
+    out.push({ domain, reason: v.reason ?? 'generation timing out', demotionRate: null, generationStruggling: true });
+  }
+
+  return out.sort(
+    (a, b) =>
+      futilityScore({ demotionRate: b.demotionRate, generationStruggling: b.generationStruggling }) -
+      futilityScore({ demotionRate: a.demotionRate, generationStruggling: a.generationStruggling }),
+  );
 }
 
 function heatFor(activePlayers: number, machineDepth: number, humanAuthored: number): CrafterWorklistHeat {
@@ -348,6 +452,10 @@ export async function getCrafterWorklist(
     const verdicts = verdictsByDomain.get(row.domain);
     const machineVerified = verdicts ? Number(verdicts.verified) : 0;
     const machineDemoted = verdicts ? Number(verdicts.demoted) : 0;
+    const demotionRate =
+      machineVerified >= FUTILITY_MIN_VERIFIED ? machineDemoted / machineVerified : null;
+    const generationStruggling = strugglingDomains.has(row.domain);
+    const verdict = curationVerdict({ demotionRate, generationStruggling });
     return {
       domain: row.domain,
       activePlayers: row.activePlayers,
@@ -361,9 +469,10 @@ export async function getCrafterWorklist(
       heat: heatFor(row.activePlayers, clusterMachineDepth, clusterHumanAuthored),
       machineVerified,
       machineDemoted,
-      demotionRate:
-        machineVerified >= FUTILITY_MIN_VERIFIED ? machineDemoted / machineVerified : null,
-      generationStruggling: strugglingDomains.has(row.domain),
+      demotionRate,
+      generationStruggling,
+      expensiveToMachine: verdict.expensive,
+      expensiveReason: verdict.reason,
     };
   });
 

--- a/src/server/db/queries/llm-cost-report.ts
+++ b/src/server/db/queries/llm-cost-report.ts
@@ -17,6 +17,7 @@ import { and, desc, gte, inArray, isNotNull, lt, sql } from 'drizzle-orm';
 
 import { adminUserIds } from '@/server/auth/admin';
 import { db, generatedQuestions, llmCostReport, llmUsageEvent, masteryEvents, users } from '@/server/db';
+import { getExpensiveDomains, type ExpensiveDomain } from '@/server/db/queries/crafter-demand';
 import { estimateCostUsd } from '@/server/llm/pricing';
 
 // ─── Decision A: the surface taxonomy ────────────────────────────────────────
@@ -301,6 +302,13 @@ export type CostLatencyReport = {
   answersGraded: number;
   costPerQuestionUsd: number | null;
   costPerAnswerGradedUsd: number | null;
+  /**
+   * D-SUPPLY-FINITE-SET-01 cost-routed curation: subjects that crossed the "too
+   * expensive for the machine" line (high demotion / generation timing out) and
+   * should be human-curated. The weekly notification half of the crafter
+   * dashboard badge. Worst first.
+   */
+  expensiveDomains: ExpensiveDomain[];
 };
 
 /**
@@ -311,14 +319,16 @@ export async function buildCostLatencyReport(windowDays = 7): Promise<CostLatenc
   const now = new Date();
   const periodStart = new Date(now.getTime() - windowDays * 86_400_000);
 
-  const [surfaces, prev, month, latency, questionsGenerated, answersGraded] = await Promise.all([
-    readSurfaceCost(windowDays, 0),
-    readSurfaceCost(windowDays * 2, windowDays),
-    readSurfaceCost(30, 0),
-    readSurfaceLatency(windowDays, 0),
-    countQuestionsGenerated(windowDays),
-    countAnswersGraded(windowDays),
-  ]);
+  const [surfaces, prev, month, latency, questionsGenerated, answersGraded, expensiveDomains] =
+    await Promise.all([
+      readSurfaceCost(windowDays, 0),
+      readSurfaceCost(windowDays * 2, windowDays),
+      readSurfaceCost(30, 0),
+      readSurfaceLatency(windowDays, 0),
+      countQuestionsGenerated(windowDays),
+      countAnswersGraded(windowDays),
+      getExpensiveDomains().catch(() => [] as ExpensiveDomain[]),
+    ]);
 
   const totalUsd = surfaces.reduce((a, s) => a + s.costUsd, 0);
   const prevTotalUsd = prev.reduce((a, s) => a + s.costUsd, 0);
@@ -350,6 +360,7 @@ export async function buildCostLatencyReport(windowDays = 7): Promise<CostLatenc
     answersGraded,
     costPerQuestionUsd: questionsGenerated > 0 ? generateUsd / questionsGenerated : null,
     costPerAnswerGradedUsd: answersGraded > 0 ? gradeUsd / answersGraded : null,
+    expensiveDomains,
   };
 }
 
@@ -453,6 +464,24 @@ export function renderCostLatencyReportMarkdown(r: CostLatencyReport): string {
     lines.push('| --- | --- | --- |');
     for (const l of timed) {
       lines.push(`| ${l.label} | ${ms(l.avgMs)} | ${ms(l.p95Ms)} |`);
+    }
+    lines.push('');
+  }
+
+  // Subjects that got expensive for the machine — the notification half of the
+  // crafter dashboard badge (D-SUPPLY-FINITE-SET-01 cost-routed curation). These
+  // are where human authoring beats paying to re-generate junk.
+  if (r.expensiveDomains.length > 0) {
+    lines.push('## Subjects too expensive for the machine — curate these');
+    lines.push('');
+    lines.push(
+      'The machine keeps producing wrong or unservable questions here (or can’t generate at all). Author them by hand instead of paying to re-generate — they’re flagged in the crafter worklist:',
+    );
+    for (const d of r.expensiveDomains.slice(0, 15)) {
+      lines.push(`- **${d.domain}** — ${d.reason}`);
+    }
+    if (r.expensiveDomains.length > 15) {
+      lines.push(`- …and ${r.expensiveDomains.length - 15} more`);
     }
     lines.push('');
   }

--- a/src/server/profile/multitudes.ts
+++ b/src/server/profile/multitudes.ts
@@ -1,9 +1,12 @@
 import Anthropic from '@anthropic-ai/sdk';
-import { loggedMessagesCreate } from '@/lib/llm';
+import { ANTHROPIC_MODEL, loggedMessagesCreate } from '@/lib/llm';
 import type { MasteryTier } from '@/types/db';
 import type { PortraitState } from '@/server/profile/portrait';
 
-const MODEL = 'claude-sonnet-4-6';
+// Inherit the central generation model (Sonnet 5 in prod) rather than pinning a
+// version, so a model flip carries here too. Prose-only, no schema — the tier
+// doesn't matter much, but there's no reason to leave it stranded on 4.6.
+const MODEL = ANTHROPIC_MODEL;
 const SYSTEM_PROMPT = "You are writing a one-line identity statement for a player in a trivia game where knowledge is identity. Their strongest territories are listed. Write a single sentence — 12 to 25 words — that names their intellectual world with warmth and specificity. Tone: a well-written author bio, not a stats report. Never say 'you are' — the sentence should read like a caption. Specific nouns, not abstractions. The sentence should make the player feel recognized, not evaluated.";
 
 type CacheValue = {


### PR DESCRIPTION
Two supply/cost items from the "do it all" sweep.

## 1. Sonnet-5 consolidation
Points the last two 4.6-pinned scopes (`enrich-variants`, `multitudes`) at `ANTHROPIC_MODEL` — Sonnet 5 in prod. Captures the intro-pricing window (through Aug 31) and lets a future model flip carry everywhere. (Also documents that the quality/factual gate prompts are under the cache minimums — ~2,900 / ~550 tok — so the audited "zero cache on Haiku gates" is expected, not fixable; verify already caches.)

## 2. Expensive-subject dashboard + notification (D-SUPPLY-FINITE-SET-01 P1)
Answers "I want a dashboard/notification when a subject gets too expensive to generate + verify." The crafter worklist already *ranked* by machine futility (demotion rate + generation-timeout penalty); this adds the missing **threshold** and both surfacings:

- **`curationVerdict` + `CURATION_FUTILITY_THRESHOLD` (0.34)** — a subject crosses the "curate, don't auto-fill" line when a third+ of its verified machine questions are demoted, or generation is timing out at all. Pure + unit-tested; the reason string never fabricates a % it didn't cross on.
- **Dashboard:** a red `expensive · curate` badge on the crafter worklist row, reason on hover.
- **Notification:** `getExpensiveDomains()` (global, read-only) feeds a new *"Subjects too expensive for the machine — curate these"* section in the weekly LLM cost-report email.

Read-only — no auto-fill-vs-curate gate yet (that's finite-set P4). Nothing crosses the line in prod today (worst is 25% demotion, refill off), so the alert correctly stays quiet until a subject actually gets costly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SrEnXchnUG6EVzVsUEB63V